### PR TITLE
Change onboarding flow

### DIFF
--- a/modules/ppcp-api-client/src/Repository/class-partnerreferralsdata.php
+++ b/modules/ppcp-api-client/src/Repository/class-partnerreferralsdata.php
@@ -72,7 +72,6 @@ class PartnerReferralsData {
 	private function default_data(): array {
 
 		return array(
-			'email'                   => $this->merchant_email,
 			'partner_config_override' => array(
 				'partner_logo_url'       => 'https://connect.woocommerce.com/images/woocommerce_logo.png',
 				'return_url'             => admin_url(

--- a/modules/ppcp-onboarding/assets/css/onboarding.css
+++ b/modules/ppcp-onboarding/assets/css/onboarding.css
@@ -4,7 +4,8 @@
 
 #field-client_secret,
 #field-client_id,
-#field-merchant_id {
+#field-merchant_id,
+#field-merchant_email{
 	display: none;
 }
 

--- a/modules/ppcp-onboarding/assets/js/onboarding.js
+++ b/modules/ppcp-onboarding/assets/js/onboarding.js
@@ -38,6 +38,9 @@ function onboardingCallback(authCode, sharedId) {
  */
 const checkBoxOnClick = (event) => {
 	const value = event.target.checked;
+	if (event.target.getAttribute('id') === 'ppcp-sandbox_on') {
+		toggleConnectButtons(! value);
+	}
 	event.preventDefault();
 	event.stopPropagation();
 	setTimeout( () => {
@@ -46,31 +49,20 @@ const checkBoxOnClick = (event) => {
 	);
 }
 
-const sandboxSwitch = (element) => {
-
-	const toggleConnectButtons = (showProduction) => {
-		if (showProduction) {
-			document.querySelector('#connect-to-production').style.display = '';
-			document.querySelector('#connect-to-sandbox').style.display = 'none';
-			return;
-		}
-		document.querySelector('#connect-to-production').style.display = 'none';
-		document.querySelector('#connect-to-sandbox').style.display = '';
+const toggleConnectButtons = (showProduction) => {
+	if (showProduction) {
+		document.querySelector('#connect-to-production').style.display = '';
+		document.querySelector('#connect-to-sandbox').style.display = 'none';
+		return;
 	}
-	toggleConnectButtons(! element.checked);
-
-	element.addEventListener(
-		'change',
-		(event) => {
-			toggleConnectButtons(! element.checked);
-		}
-	);
-};
+	document.querySelector('#connect-to-production').style.display = 'none';
+	document.querySelector('#connect-to-sandbox').style.display = '';
+}
 
 (() => {
 	const sandboxSwitchElement = document.querySelector('#ppcp-sandbox_on');
 	if (sandboxSwitchElement) {
-		sandboxSwitch(sandboxSwitchElement);
+		toggleConnectButtons(! sandboxSwitchElement.checked);
 	}
 
 	document.querySelectorAll('#mainform input[type="checkbox"]').forEach(

--- a/modules/ppcp-onboarding/assets/js/onboarding.js
+++ b/modules/ppcp-onboarding/assets/js/onboarding.js
@@ -25,3 +25,31 @@ function onboardingCallback(authCode, sharedId) {
 			}
 		);
 }
+
+const sandboxSwitch = (element) => {
+
+	const toggleConnectButtons = (showProduction) => {
+		if (showProduction) {
+			document.querySelector('#connect-to-production').style.display = '';
+			document.querySelector('#connect-to-sandbox').style.display = 'none';
+			return;
+		}
+		document.querySelector('#connect-to-production').style.display = 'none';
+		document.querySelector('#connect-to-sandbox').style.display = '';
+	}
+	toggleConnectButtons(! element.checked);
+
+	element.addEventListener(
+		'change',
+		(event) => {
+			toggleConnectButtons(! element.checked);
+		}
+	);
+};
+
+(() => {
+	const sandboxSwitchElement = document.querySelector('#ppcp-sandbox_on');
+	if (sandboxSwitchElement) {
+		sandboxSwitch(sandboxSwitchElement);
+	}
+})();

--- a/modules/ppcp-onboarding/assets/js/onboarding.js
+++ b/modules/ppcp-onboarding/assets/js/onboarding.js
@@ -28,6 +28,24 @@ function onboardingCallback(authCode, sharedId) {
 		);
 }
 
+/**
+ * Since the PayPal modal will redirect the user a dirty form
+ * provokes an alert if the user wants to leave the page. Since the user
+ * needs to toggle the sandbox switch, we disable this dirty state with the
+ * following workaround for checkboxes.
+ *
+ * @param event
+ */
+const checkBoxOnClick = (event) => {
+	const value = event.target.checked;
+	event.preventDefault();
+	event.stopPropagation();
+	setTimeout( () => {
+		event.target.checked = value;
+		},1
+	);
+}
+
 const sandboxSwitch = (element) => {
 
 	const toggleConnectButtons = (showProduction) => {
@@ -54,4 +72,11 @@ const sandboxSwitch = (element) => {
 	if (sandboxSwitchElement) {
 		sandboxSwitch(sandboxSwitchElement);
 	}
+
+	document.querySelectorAll('#mainform input[type="checkbox"]').forEach(
+		(checkbox) => {
+			checkbox.addEventListener('click', checkBoxOnClick);
+		}
+	);
+
 })();

--- a/modules/ppcp-onboarding/assets/js/onboarding.js
+++ b/modules/ppcp-onboarding/assets/js/onboarding.js
@@ -1,4 +1,5 @@
 function onboardingCallback(authCode, sharedId) {
+	const sandboxSwitchElement = document.querySelector('#ppcp-sandbox_on')
 	fetch(
 		PayPalCommerceGatewayOnboarding.endpoint,
 		{
@@ -10,7 +11,8 @@ function onboardingCallback(authCode, sharedId) {
 				{
 					authCode: authCode,
 					sharedId: sharedId,
-					nonce: PayPalCommerceGatewayOnboarding.nonce
+					nonce: PayPalCommerceGatewayOnboarding.nonce,
+					env: sandboxSwitchElement && sandboxSwitchElement.checked ? 'sandbox' : 'production'
 				}
 			)
 		}

--- a/modules/ppcp-onboarding/assets/js/settings.js
+++ b/modules/ppcp-onboarding/assets/js/settings.js
@@ -65,6 +65,7 @@ const groupToggleSelect = (selector, group) => {
         (event) => {
             event.preventDefault();
             document.querySelector('#field-toggle_manual_input').style.display = 'none';
+            document.querySelector('#field-merchant_email').style.display = 'table-row';
             document.querySelector('#field-merchant_id').style.display = 'table-row';
             document.querySelector('#field-client_id').style.display = 'table-row';
             document.querySelector('#field-client_secret').style.display = 'table-row';

--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -20,12 +20,10 @@ use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingRenderer;
 use WpOop\TransientCache\CachePoolFactory;
 
 return array(
+	'api.sandbox-host'                 => static function ( $container ): string {
 
-	'api.host'                         => static function ( $container ): string {
 		$state       = $container->get( 'onboarding.state' );
-		$environment = $container->get( 'onboarding.environment' );
 
-		// ToDo: Correct the URLs.
 		/**
 		 * The Environment and State variables.
 		 *
@@ -33,17 +31,37 @@ return array(
 		 * @var State $state
 		 */
 		if ( $state->current_state() >= State::STATE_ONBOARDED ) {
-			if ( $environment->current_environment_is( Environment::SANDBOX ) ) {
-				return 'https://api.sandbox.paypal.com';
-			}
 			return 'https://api.sandbox.paypal.com';
 		}
-
-		// ToDo: Real connect.woocommerce.com.
-		if ( $environment->current_environment_is( Environment::SANDBOX ) ) {
-			return 'http://connect-woo.wpcust.com';
-		}
+		// ToDo: Real connect.woocommerce.com sandbox link.
 		return 'http://connect-woo.wpcust.com';
+	},
+	'api.production-host'                 => static function ( $container ): string {
+
+		$state       = $container->get( 'onboarding.state' );
+
+		/**
+		 * The Environment and State variables.
+		 *
+		 * @var Environment $environment
+		 * @var State $state
+		 */
+		if ( $state->current_state() >= State::STATE_ONBOARDED ) {
+			return 'https://api.paypal.com';
+		}
+		// ToDo: Real connect.woocommerce.com production link.
+		return 'http://connect-woo.wpcust.com';
+	},
+	'api.host'                         => static function ( $container ): string {
+		$environment = $container->get( 'onboarding.environment' );
+
+		/**
+		 * The Environment and State variables.
+		 *
+		 * @var Environment $environment
+		 */
+		return $environment->current_environment_is( Environment::SANDBOX )
+			? (string) $container->get('api.sandbox-host') : (string) $container->get('api.production-host');
 
 	},
 	'api.paypal-host'                  => function( $container ) : string {

--- a/modules/ppcp-onboarding/src/Assets/class-onboardingassets.php
+++ b/modules/ppcp-onboarding/src/Assets/class-onboardingassets.php
@@ -133,7 +133,7 @@ class OnboardingAssets {
 			return false;
 		}
 
-		$should_render = $this->state->current_state() === State::STATE_PROGRESSIVE;
+		$should_render = $this->state->current_state() === State::STATE_START;
 		return $should_render;
 	}
 }

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -164,17 +164,6 @@ return array(
 			'</button>'
 		);
 
-		$merchant_email_text = sprintf(
-			// translators: %1$s is the email address %2$s and %3$s are button tags.
-			__(
-				'You are connected with your email address %1$s.
-                If you want to change this settings, please click %2$sReset%3$s',
-				'paypal-payments-for-woocommerce'
-			),
-			$settings->has( 'merchant_email' ) ? '<mark>' . $settings->get( 'merchant_email' ) . '</mark>' : '',
-			'<button name="save" value="reset">',
-			'</button>'
-		);
 		$fields              = array(
 			'ppcp_onboarding'            => array(
 				'title'        => __( 'Connect to PayPal', 'paypal-payments-for-woocommerce' ),
@@ -217,19 +206,9 @@ return array(
 				'default'      => '',
 				'screens'      => array(
 					State::STATE_START,
-				),
-				'requirements' => array(),
-				'gateway'      => 'paypal',
-			),
-			'merchant_email_info'        => array(
-				'title'        => __( 'Email address', 'paypal-payments-for-woocommerce' ),
-				'type'         => 'ppcp-text',
-				'text'         => $merchant_email_text,
-				'screens'      => array(
 					State::STATE_PROGRESSIVE,
 					State::STATE_ONBOARDED,
 				),
-				'hidden'       => 'merchant_email',
 				'requirements' => array(),
 				'gateway'      => 'paypal',
 			),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -197,13 +197,10 @@ return array(
 				'requirements' => array(),
 				'gateway'      => 'paypal',
 			),
-			'merchant_email'             => array(
-				'title'        => __( 'Email address', 'paypal-payments-for-woocommerce' ),
-				'type'         => 'text',
-				'required'     => true,
-				'desc_tip'     => true,
-				'description'  => __( 'The email address of your PayPal account.', 'paypal-payments-for-woocommerce' ),
-				'default'      => '',
+			'toggle_manual_input'        => array(
+				'type'         => 'ppcp-text',
+				'title'        => __( 'Manual mode', 'paypal-payments-for-woocommerce' ),
+				'text'         => '<button id="ppcp[toggle_manual_input]">' . __( 'Toggle to manual credential input', 'paypal-payments-for-woocommerce' ) . '</button>',
 				'screens'      => array(
 					State::STATE_START,
 					State::STATE_PROGRESSIVE,
@@ -212,10 +209,13 @@ return array(
 				'requirements' => array(),
 				'gateway'      => 'paypal',
 			),
-			'toggle_manual_input'        => array(
-				'type'         => 'ppcp-text',
-				'title'        => __( 'Manual mode', 'paypal-payments-for-woocommerce' ),
-				'text'         => '<button id="ppcp[toggle_manual_input]">' . __( 'Toggle to manual credential input', 'paypal-payments-for-woocommerce' ) . '</button>',
+			'merchant_email'             => array(
+				'title'        => __( 'Email address', 'paypal-payments-for-woocommerce' ),
+				'type'         => 'text',
+				'required'     => true,
+				'desc_tip'     => true,
+				'description'  => __( 'The email address of your PayPal account.', 'paypal-payments-for-woocommerce' ),
+				'default'      => '',
 				'screens'      => array(
 					State::STATE_START,
 					State::STATE_PROGRESSIVE,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -180,7 +180,7 @@ return array(
 				'title'        => __( 'Connect to PayPal', 'paypal-payments-for-woocommerce' ),
 				'type'         => 'ppcp_onboarding',
 				'screens'      => array(
-					State::STATE_PROGRESSIVE,
+					State::STATE_START,
 				),
 				'requirements' => array(),
 				'gateway'      => 'paypal',

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -495,7 +495,6 @@ return array(
 				'description'  => __( 'Enable logging of unexpected behavior. This can also log private data and should only be enabled in a development or stage environment.', 'paypal-payments-for-woocommerce' ),
 				'default'      => false,
 				'screens'      => array(
-					State::STATE_START,
 					State::STATE_PROGRESSIVE,
 					State::STATE_ONBOARDED,
 				),
@@ -509,7 +508,6 @@ return array(
 				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to seperate those installations. Please do not use numbers in your prefix.', 'paypal-payments-for-woocommerce' ),
 				'default'      => 'WC-',
 				'screens'      => array(
-					State::STATE_START,
 					State::STATE_PROGRESSIVE,
 					State::STATE_ONBOARDED,
 				),

--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -165,7 +165,9 @@ class PayPalGateway extends \WC_Payment_Gateway {
 				'type' => 'ppcp',
 			),
 		);
-		if ( $this->is_credit_card_tab() ) {
+
+		$should_show_enabled_checkbox = ! $this->is_credit_card_tab() && ( $this->config->has( 'merchant_email' ) && $this->config->get( 'merchant_email' ) );
+		if ( ! $should_show_enabled_checkbox ) {
 			unset( $this->form_fields['enabled'] );
 		}
 	}

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -97,8 +97,9 @@ class SettingsListener {
 		 * phpcs:disable WordPress.Security.NonceVerification.Missing
 		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
 		 */
-		if ( isset( $_GET['merchantIdInPayPal'] ) ) {
+		if ( isset( $_GET['merchantIdInPayPal'] ) && isset( $_GET['merchantId'] )  ) {
 			$this->settings->set( 'merchant_id', sanitize_text_field( wp_unslash( $_GET['merchantIdInPayPal'] ) ) );
+			$this->settings->set( 'merchant_email', sanitize_text_field( wp_unslash( $_GET['merchantId'] ) ) );
 			$this->settings->persist();
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Missing

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -97,7 +97,7 @@ class SettingsListener {
 		 * phpcs:disable WordPress.Security.NonceVerification.Missing
 		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
 		 */
-		if ( isset( $_GET['merchantIdInPayPal'] ) && isset( $_GET['merchantId'] )  ) {
+		if ( isset( $_GET['merchantIdInPayPal'] ) && isset( $_GET['merchantId'] ) ) {
 			$this->settings->set( 'merchant_id', sanitize_text_field( wp_unslash( $_GET['merchantIdInPayPal'] ) ) );
 			$this->settings->set( 'merchant_email', sanitize_text_field( wp_unslash( $_GET['merchantId'] ) ) );
 			$this->settings->persist();


### PR DESCRIPTION
Fixes #21 

With the new onboarding flow, you do not need to enter an email address any longer before the "Connect button" appears.
Since this button appears now on a page, where we are not certain about the environment (sandbox or production), we need to render two different buttons. Depending on the state of the sandbox checkbox, we show either the production or the sandbox button.

Since changing a value in an input field the state of the page is dirty. After going through the PayPal modal dialogue the PayPal JavaScript performs a `location.href`, which would prompt an alert by the browser if you really want to leave the page. A workaround has been provided, so the user can switch between sandbox and production without this alert showing up.

The enable gateway checkbox will appear now on a later stage, as - going through the PayPal onboarding process - the value wouldn't be saved.