### PR TITLE
sanitize checkout form data

### DIFF
--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -256,10 +256,20 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * @throws \Exception On Error.
 	 */
 	private function validate_checkout_form( string $form_values, Order $order ) {
-		$this->order   = $order;
-		$parsed_values = wp_parse_args( $form_values );
-		$_POST         = $parsed_values;
-		$_REQUEST      = $parsed_values;
+		$this->order = $order;
+		$form_values = explode( '&', $form_values );
+
+		$parsed_values = array();
+		foreach ( $form_values as $field ) {
+			$field = explode( '=', $field );
+
+			if ( count( $field ) !== 2 ) {
+				continue;
+			}
+			$parsed_values[ $field[0] ] = $field[1];
+		}
+		$_POST    = $parsed_values;
+		$_REQUEST = $parsed_values;
 
 		add_filter(
 			'woocommerce_after_checkout_validation',

--- a/modules/ppcp-button/src/Endpoint/class-requestdata.php
+++ b/modules/ppcp-button/src/Endpoint/class-requestdata.php
@@ -81,10 +81,18 @@ class RequestData {
 		$data = array();
 		foreach ( (array) $assoc_array as $raw_key => $raw_value ) {
 			if ( ! is_array( $raw_value ) ) {
-				$data[ sanitize_text_field( urldecode( (string) $raw_key ) ) ] = sanitize_text_field( urldecode( (string) $raw_value ) );
+				/**
+				 * The 'form' key is preserved for url encoded data and needs different
+				 * sanitization.
+				 */
+				if ( 'form' !== $raw_key ) {
+					$data[ sanitize_text_field( (string) $raw_key ) ] = sanitize_text_field( (string) $raw_value );
+				} else {
+					$data[ sanitize_text_field( (string) $raw_key ) ] = sanitize_text_field( urldecode( (string) $raw_value ) );
+				}
 				continue;
 			}
-			$data[ sanitize_text_field( urldecode( (string) $raw_key ) ) ] = $this->sanitize( $raw_value );
+			$data[ sanitize_text_field( (string) $raw_key ) ] = $this->sanitize( $raw_value );
 		}
 		return $data;
 	}


### PR DESCRIPTION
Fixes #56

The problem was in the sanitization of the incoming data. The form data of the checkout (checked terms etc.) are urlencoded while the default data is not. This issue has been addressed in this PR.