### PR TITLE
Add “Settings” link to Plugins screen

### DIFF
--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -85,4 +85,21 @@ define( 'PAYPAL_INTEGRATION_DATE', '2020-10-13' );
 		}
 	);
 
+	// Add "Settings" link to Plugins screen.
+	add_filter(
+		'plugin_action_links_' . plugin_basename( __FILE__ ),
+		function( $links ) {
+			array_unshift(
+				$links,
+				sprintf(
+					'<a href="%1$s">%2$s</a>',
+					admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+					__( 'Settings', 'woocommerce-paypal-payments' )
+				)
+			);
+
+			return $links;
+		}
+	);
+
 } )();


### PR DESCRIPTION
Adds a "Settings" link inside the plugin row on the Plugins screen, for consistency with other extensions, including PPXO.

<img width="1186" alt="Screen Shot 2020-10-14 at 16 51 57" src="https://user-images.githubusercontent.com/184724/96038563-ab05a580-0e3d-11eb-9584-0c1f309e4eb5.png">
