### PR TITLE
force the 3d secure layer above the woocommerce loading layer

### DIFF
--- a/modules/ppcp-button/resources/css/hosted-fields.scss
+++ b/modules/ppcp-button/resources/css/hosted-fields.scss
@@ -3,3 +3,7 @@
   max-height: 25px;
   display: inline-block;
 }
+
+.payments-sdk-contingency-handler {
+  z-index: 1000 !important;
+}


### PR DESCRIPTION
Fixes #63 