### PR TITLE
make sure shipping is needed when setting up application context.

### DIFF
--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -162,7 +162,8 @@ class CreateOrderEndpoint implements EndpointInterface {
 			}
 
 			$this->set_bn_code( $data );
-			$shipping_address_is_fix = 'checkout' === $data['context'] ? true : false;
+			$needs_shipping          = WC()->cart && WC()->cart->needs_shipping();
+			$shipping_address_is_fix = $needs_shipping && 'checkout' === $data['context'] ? true : false;
 			$order                   = $this->api_endpoint->create(
 				$purchase_units,
 				$this->payer( $data, $wc_order ),


### PR DESCRIPTION
When no shipping zones are defined the WC_Order which is patched later will not contain a shipping address. When we set up the order with a fixed shipping address from file, this will result in an API error. Therefore, we need to check upfront, if shipping is needed.
