### PR TITLE
Release/1.0.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 *** Changelog ***
 
+= 1.0.1 - 2020-11-04 =
+* Fix - PayPal Smart buttons don't load when using a production/live account and `WP_Debug` is turned on/true. #66
+* Fix - [Card Processing] SCA/Visa Verification form loads underneath the Checkout blockUI element. #63
+* Fix - Attempting to checkout without country selected results in unexpected error message. #67
+* Fix - Remove ability to change shipping address on PayPal from checkout page. #72
+* Fix - Amount value should be a string when send to the api. #76
+* Fix - "The value of a field does not conform to the expected format" error when using certain e-mail addresses. #56
+* Fix - HTML tags in Product description. #79
+
 = 1.0.0 - 2020-10-15 =
 * Initial release.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 1.0.1 - 2020-11-04 =
+= 1.0.1 - 2020-11-05 =
 * Fix - PayPal Smart buttons don't load when using a production/live account and `WP_Debug` is turned on/true. #66
 * Fix - [Card Processing] SCA/Visa Verification form loads underneath the Checkout blockUI element. #63
 * Fix - Attempting to checkout without country selected results in unexpected error message. #67

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "prebuild": "rm -rf ./vendor",
     "build": "composer install --no-dev && npm run build:dev && npm run archive",
     "prearchive": "rm -rf $npm_package_name.zip",
-    "archive": "composer archive --file=$npm_package_name --format=zip && npm run archive:cleanup",
-    "archive:cleanup": "zip -d $npm_package_name.zip tests/\\* .github/\\* wordpress_org_assets/\\* modules/ppcp-button/node_modules/\\* \\*.DS_Store README.md .gitattributes .gitignore .travis.yml composer.json composer.lock package.json yarn.lock phpunit.xml.dist .phpunit.result.cache phpcs.xml.dist modules/ppcp-button/.babelrc modules/ppcp-button/package.json modules/ppcp-button/webpack.config.js modules/ppcp-button/yarn.lock vendor/\\*/.idea/\\* vendor/\\*/.gitignore vendor/\\*/.gitattributes vendor/\\*/.travis.yml",
-    "postarchive": "rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name"
+    "archive": "zip -r $npm_package_name.zip . -x **.git/\\* **node_modules/\\*",
+    "postarchive": "npm run archive:cleanup && rm -rf $npm_package_name && unzip $npm_package_name.zip -d $npm_package_name && rm $npm_package_name.zip && zip -r $npm_package_name.zip $npm_package_name && rm -rf $npm_package_name",
+    "archive:cleanup": "zip -d $npm_package_name.zip tests/\\* .github/\\* wordpress_org_assets/\\* \\*.DS_Store README.md .gitattributes .gitignore .travis.yml composer.json composer.lock package.json yarn.lock phpunit.xml.dist .phpunit.result.cache phpcs.xml.dist modules/ppcp-button/.babelrc modules/ppcp-button/package.json modules/ppcp-button/webpack.config.js modules/ppcp-button/yarn.lock vendor/\\*/.idea/\\* vendor/\\*/.gitignore vendor/\\*/.gitattributes vendor/\\*/.travis.yml"
   },
   "dependencies": {
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 7.0
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -58,5 +58,14 @@ Follow the steps below to connect the plugin to your PayPal account:
 
 == Changelog ==
 
-= 1.0 =
+= 1.0.1 =
+* Fix - PayPal Smart buttons don't load when using a production/live account and `WP_Debug` is turned on/true. #66
+* Fix - [Card Processing] SCA/Visa Verification form loads underneath the Checkout blockUI element. #63
+* Fix - Attempting to checkout without country selected results in unexpected error message. #67
+* Fix - Remove ability to change shipping address on PayPal from checkout page. #72
+* Fix - Amount value should be a string when send to the api. #76
+* Fix - "The value of a field does not conform to the expected format" error when using certain e-mail addresses. #56
+* Fix - HTML tags in Product description. #79
+
+= 1.0.0 =
 * Initial release.

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, PayPal Credit, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.0.0
+ * Version:     1.0.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0


### PR DESCRIPTION
* Fix - PayPal Smart buttons don't load when using a production/live account and `WP_Debug` is turned on/true. #66
* Fix - [Card Processing] SCA/Visa Verification form loads underneath the Checkout blockUI element. #63
* Fix - Attempting to checkout without country selected results in unexpected error message. #67
* Fix - Remove ability to change shipping address on PayPal from checkout page. #72
* Fix - Amount value should be a string when send to the api. #76
* Fix - "The value of a field does not conform to the expected format" error when using certain e-mail addresses. #56
* Fix - HTML tags in Product description. #79
