### PR TITLE
do not use comma seperator when using number_format

### DIFF
--- a/modules/ppcp-api-client/src/Entity/class-amount.php
+++ b/modules/ppcp-api-client/src/Entity/class-amount.php
@@ -74,7 +74,7 @@ class Amount {
 	public function to_array(): array {
 		$amount = array(
 			'currency_code' => $this->currency_code(),
-			'value'         => number_format( $this->value(), 2 ),
+			'value'         => number_format( $this->value(), 2, '.', '' ),
 		);
 		if ( $this->breakdown() && count( $this->breakdown()->to_array() ) ) {
 			$amount['breakdown'] = $this->breakdown()->to_array();

--- a/modules/ppcp-api-client/src/Entity/class-money.php
+++ b/modules/ppcp-api-client/src/Entity/class-money.php
@@ -65,7 +65,7 @@ class Money {
 	public function to_array(): array {
 		return array(
 			'currency_code' => $this->currency_code(),
-			'value'         => number_format( $this->value(), 2 ),
+			'value'         => number_format( $this->value(), 2, '.', '' ),
 		);
 	}
 }


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #84

---

### Description
`number_format()` add a comma as a thousands separator by default ([see docs](https://www.php.net/manual/de/function.number-format.php)). The PayPal API does not expect thousand seperators and rejects such values in the `Money` object ([see docs](https://developer.paypal.com/docs/api/orders/v2/#definition-money)).

This PR replaces the default `,` with an empty string.

### Steps to test:
Try to reproduce #84 

### Changelog entry
> Fixes a bug where items with a value of more than 1,000.00 USD where not purchaseable through the plugin

Closes #84
