### PR TITLE
Release/1.0.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Changelog ***
 
+= 1.0.4 - 2021-01-18 =
+* Fix - Payment buttons only visible on order-pay site when Mini Cart is enabled; payment fails. #96
+* Fix - High volume of failed calls to /v1/notifications/webhooks #93
+* Fix - GB country has ACDC blocked. #91
+
 = 1.0.3 - 2020-11-30 =
 * Fix - Order with Payment received when Hosted Fields transaction is declined. #88
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 1.0.4 - 2021-01-18 =
+* Fix - Check if WooCommerce is active before initialize. #99
 * Fix - Payment buttons only visible on order-pay site when Mini Cart is enabled; payment fails. #96
 * Fix - High volume of failed calls to /v1/notifications/webhooks #93
 * Fix - GB country has ACDC blocked. #91

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -59,6 +59,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 == Changelog ==
 
 = 1.0.4 =
+* Fix - Check if WooCommerce is active before initialize. #99
 * Fix - Payment buttons only visible on order-pay site when Mini Cart is enabled; payment fails. #96
 * Fix - High volume of failed calls to /v1/notifications/webhooks #93
 * Fix - GB country has ACDC blocked. #91

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.6
 Requires PHP: 7.0
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -57,6 +57,11 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.0.4 =
+* Fix - Payment buttons only visible on order-pay site when Mini Cart is enabled; payment fails. #96
+* Fix - High volume of failed calls to /v1/notifications/webhooks #93
+* Fix - GB country has ACDC blocked. #91
 
 = 1.0.3 =
 * Fix - Order with Payment received when Hosted Fields transaction is declined. #88

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, PayPal Credit, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.0.3
+ * Version:     1.0.4
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -7,6 +7,8 @@
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
+ * WC requires at least: 3.9
+ * WC tested up to: 4.9
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce


### PR DESCRIPTION
* Fix - Check if WooCommerce is active before initialize. #99
* Fix - Payment buttons only visible on order-pay site when Mini Cart is enabled; payment fails. #96
* Fix - High volume of failed calls to /v1/notifications/webhooks #93
* Fix - GB country has ACDC blocked. #91