### PR TITLE
Pcp 63

### DIFF
--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -215,9 +215,9 @@ class CreateOrderEndpoint implements EndpointInterface {
 				$number = preg_replace( '/[^0-9]/', '', $number );
 				$number = substr( $number, 0, 14 );
 				$data['payer']['phone']['phone_number']['national_number'] = $number;
-				if( empty($data['payer']['phone']['phone_number']['national_number'] ) ) {
-				    unset($data['payer']['phone']);
-                }
+				if ( empty( $data['payer']['phone']['phone_number']['national_number'] ) ) {
+					unset( $data['payer']['phone'] );
+				}
 			}
 
 			$payer = $this->payer_factory->from_paypal_response( json_decode( wp_json_encode( $data['payer'] ) ) );

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentMethod;
@@ -16,7 +17,6 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\CartRepository;
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Helper\EarlyOrderHandler;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
@@ -215,7 +215,11 @@ class CreateOrderEndpoint implements EndpointInterface {
 				$number = preg_replace( '/[^0-9]/', '', $number );
 				$number = substr( $number, 0, 14 );
 				$data['payer']['phone']['phone_number']['national_number'] = $number;
+				if( empty($data['payer']['phone']['phone_number']['national_number'] ) ) {
+				    unset($data['payer']['phone']);
+                }
 			}
+
 			$payer = $this->payer_factory->from_paypal_response( json_decode( wp_json_encode( $data['payer'] ) ) );
 		}
 		return $payer;

--- a/patchwork.json
+++ b/patchwork.json
@@ -1,0 +1,5 @@
+{
+  "redefinable-internals": [
+   "json_decode"
+  ]
+}

--- a/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
 
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use ReflectionClass;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\CartRepository;
 use WooCommerce\PayPalCommerce\Button\Helper\EarlyOrderHandler;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
-use Mockery;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 use function Brain\Monkey\Functions\expect;
 
 class CreateOrderEndpointTest extends TestCase
 {
-
+    use MockeryPHPUnitIntegration;
     /**
      * @dataProvider dataForTestPhoneNumber
      * @test
@@ -28,34 +28,22 @@ class CreateOrderEndpointTest extends TestCase
      * @param $data
      * @param $expectedResult
      */
-    public function payerVerifiesPhoneNumber($data, $expectedResult) {
-        $request_data = Mockery::mock(RequestData::class);
-		$cart_repository = Mockery::mock(CartRepository::class);
-		$purchase_unit_factory = Mockery::mock(PurchaseUnitFactory::class);
-		$order_endpoint = Mockery::mock(OrderEndpoint::class);
-		$payer_factory = Mockery::mock(PayerFactory::class);
-		$session_handler = Mockery::mock(SessionHandler::class);
-		$settings = Mockery::mock(Settings::class);
-		$early_order_handler = Mockery::mock(EarlyOrderHandler::class);
+    public function payerVerifiesPhoneNumber($data, $expectedResult)
+    {
+        list($payer_factory, $testee) = $this->mockTestee();
 
-        $testee = new CreateOrderEndpoint(
-            $request_data,
-		$cart_repository,
-		$purchase_unit_factory,
-		$order_endpoint,
-		$payer_factory,
-		$session_handler,
-		$settings,
-		$early_order_handler
-        );
-        $reflector = new ReflectionClass( CreateOrderEndpoint::class );
-        $method = $reflector->getMethod( 'payer' );
-        $method->setAccessible( true );
+        $method = $this->testPrivateMethod(CreateOrderEndpoint::class, 'payer');
+        $dataString = wp_json_encode($expectedResult['payer']);
+        $dataObj = json_decode(wp_json_encode($expectedResult['payer']));
+
+        expect('wp_json_encode')->once()->with($expectedResult['payer'])
+            ->andReturn($dataString);
+        expect('json_decode')->once()->with($dataString)->andReturn($dataObj);
 
 
-        $payer = $method->invokeArgs( $testee, array( $data ) );
-        $this->assertEquals($expectedResult, $payer);
+        $payer_factory->expects('from_paypal_response')->with($dataObj);
 
+        $method->invokeArgs($testee, array($data));
     }
 
     public function dataForTestPhoneNumber() : array {
@@ -65,20 +53,131 @@ class CreateOrderEndpointTest extends TestCase
                 [
                     'context' => 'none',
                     'payer'=>[
+                        'name'=>['given_name'=>'testName'],
                         'phone'=>[
                             'phone_number'=>[
-                                'national_number'=>'123456789876'
+                                'national_number'=>''
                             ]
                         ]
                     ]
                 ],
                 [
-                    [
-                        'context' => 'none',
-                        'payer'=>[]
+                    'context' => 'none',
+                    'payer' => [
+                        'name' => ['given_name' => 'testName']
+                    ]
+                ]
+            ],
+            'tooLongStringPhone' => [
+                [
+                    'context' => 'none',
+                    'payer'=>[
+                        'name'=>['given_name'=>'testName'],
+                        'phone'=>[
+                            'phone_number'=>[
+                                'national_number'=>'43241341234123412341234123123412341'
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'context' => 'none',
+                    'payer'=>[
+                        'name'=>['given_name'=>'testName'],
+                        'phone'=>[
+                            'phone_number'=>[
+                                'national_number'=>'43241341234123'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'removeNonISOStringPhone' => [
+                [
+                    'context' => 'none',
+                    'payer'=>[
+                        'name'=>['given_name'=>'testName'],
+                        'phone'=>[
+                            'phone_number'=>[
+                                'national_number'=>'432a34as73737373'
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'context' => 'none',
+                    'payer'=>[
+                        'name'=>['given_name'=>'testName'],
+                        'phone'=>[
+                            'phone_number'=>[
+                                'national_number'=>'4323473737373'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'notNumbersStringPhone' => [
+                [
+                    'context' => 'none',
+                    'payer'=>[
+                        'name'=>['given_name'=>'testName'],
+                        'phone'=>[
+                            'phone_number'=>[
+                                'national_number'=>'this is_notaPhone'
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'context' => 'none',
+                    'payer'=>[
+                        'name'=>['given_name'=>'testName']
                     ]
                 ]
             ]
         ];
+    }
+
+    /**
+     * @return array
+     */
+    protected function mockTestee()
+    {
+        $request_data = Mockery::mock(RequestData::class);
+        $cart_repository = Mockery::mock(CartRepository::class);
+        $purchase_unit_factory = Mockery::mock(PurchaseUnitFactory::class);
+        $order_endpoint = Mockery::mock(OrderEndpoint::class);
+        $payer_factory = Mockery::mock(PayerFactory::class);
+        $session_handler = Mockery::mock(SessionHandler::class);
+        $settings = Mockery::mock(Settings::class);
+        $early_order_handler = Mockery::mock(EarlyOrderHandler::class);
+
+        $testee = new CreateOrderEndpoint(
+            $request_data,
+            $cart_repository,
+            $purchase_unit_factory,
+            $order_endpoint,
+            $payer_factory,
+            $session_handler,
+            $settings,
+            $early_order_handler
+        );
+        return array($payer_factory, $testee);
+    }
+
+    /**
+     * @param $class
+     *
+     * @param $method
+     *
+     * @return \ReflectionMethod
+     * @throws \ReflectionException
+     */
+    protected function testPrivateMethod($class, $method)
+    {
+        $reflector = new ReflectionClass($class);
+        $method = $reflector->getMethod($method);
+        $method->setAccessible(true);
+        return $method;
     }
 }

--- a/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Endpoint;
+
+
+use ReflectionClass;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Repository\CartRepository;
+use WooCommerce\PayPalCommerce\Button\Helper\EarlyOrderHandler;
+use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\TestCase;
+use Mockery;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+use function Brain\Monkey\Functions\expect;
+
+class CreateOrderEndpointTest extends TestCase
+{
+
+    /**
+     * @dataProvider dataForTestPhoneNumber
+     * @test
+     *
+     * @param $data
+     * @param $expectedResult
+     */
+    public function payerVerifiesPhoneNumber($data, $expectedResult) {
+        $request_data = Mockery::mock(RequestData::class);
+		$cart_repository = Mockery::mock(CartRepository::class);
+		$purchase_unit_factory = Mockery::mock(PurchaseUnitFactory::class);
+		$order_endpoint = Mockery::mock(OrderEndpoint::class);
+		$payer_factory = Mockery::mock(PayerFactory::class);
+		$session_handler = Mockery::mock(SessionHandler::class);
+		$settings = Mockery::mock(Settings::class);
+		$early_order_handler = Mockery::mock(EarlyOrderHandler::class);
+
+        $testee = new CreateOrderEndpoint(
+            $request_data,
+		$cart_repository,
+		$purchase_unit_factory,
+		$order_endpoint,
+		$payer_factory,
+		$session_handler,
+		$settings,
+		$early_order_handler
+        );
+        $reflector = new ReflectionClass( CreateOrderEndpoint::class );
+        $method = $reflector->getMethod( 'payer' );
+        $method->setAccessible( true );
+
+
+        $payer = $method->invokeArgs( $testee, array( $data ) );
+        $this->assertEquals($expectedResult, $payer);
+
+    }
+
+    public function dataForTestPhoneNumber() : array {
+
+        return [
+            'emptyStringPhone' => [
+                [
+                    'context' => 'none',
+                    'payer'=>[
+                        'phone'=>[
+                            'phone_number'=>[
+                                'national_number'=>'123456789876'
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    [
+                        'context' => 'none',
+                        'payer'=>[]
+                    ]
+                ]
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #102

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
When the payer object has a phone number that is set but it's empty then we will not send that phone number, so we unset it from the object

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1.Send a WooCommerce order with the phone number empty (send an empty string)
2.The API will throw errors regarding the phone number string length

### Changelog entry
> Unset phone if empty string

Closes #102 .
