### PR TITLE
Move `oomphinc/composer-installers-extender` to `require-dev`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "dhii/module-interface": "0.1",
         "psr/container": "^1.0",
-        "oomphinc/composer-installers-extender": "^1.1",
         "container-interop/service-provider": "^0.4.0",
         "dhii/containers": "v0.1.0-alpha1",
         "dhii/wp-containers": "v0.1.0-alpha1",
@@ -17,7 +16,8 @@
     "require-dev": {
         "woocommerce/woocommerce-sniffs": "^0.1.0",
         "phpunit/phpunit": "^9.1",
-        "brain/monkey": "^2.4"
+        "brain/monkey": "^2.4",
+        "oomphinc/composer-installers-extender": "^1.1"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Move `oomphinc/composer-installers-extender` to `require-dev` because of error on Composer v2. 