### PR TITLE
Delete `oomphinc/composer-installers-extender`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "require-dev": {
         "woocommerce/woocommerce-sniffs": "^0.1.0",
         "phpunit/phpunit": "^9.1",
-        "brain/monkey": "^2.4",
-        "oomphinc/composer-installers-extender": "^1.1"
+        "brain/monkey": "^2.4"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Delete `oomphinc/composer-installers-extender` because of error on Composer v2.