### PR TITLE
Rework onboarding code and add REST controller for integration with the OBW

### DIFF
--- a/modules/ppcp-api-client/src/Repository/class-partnerreferralsdata.php
+++ b/modules/ppcp-api-client/src/Repository/class-partnerreferralsdata.php
@@ -74,12 +74,13 @@ class PartnerReferralsData {
 		return array(
 			'partner_config_override' => array(
 				'partner_logo_url'       => 'https://connect.woocommerce.com/images/woocommerce_logo.png',
-				'return_url'             => admin_url(
-					'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway'
+				'return_url'             => apply_filters(
+					'woocommerce_paypal_payments_partner_config_override_return_url',
+					admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' )
 				),
-				'return_url_description' => __(
-					'Return to your shop.',
-					'woocommerce-paypal-payments'
+				'return_url_description' => apply_filters(
+					'woocommerce_paypal_payments_partner_config_override_return_url_description',
+					__( 'Return to your shop.', 'woocommerce-paypal-payments' )
 				),
 				'show_add_credit_card'   => true,
 			),

--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\Onboarding\Assets\OnboardingAssets;
 use WooCommerce\PayPalCommerce\Onboarding\Endpoint\LoginSellerEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingRenderer;
+use WooCommerce\PayPalCommerce\Onboarding\Onboarding_REST_Controller;
 
 return array(
 	'api.sandbox-host'                          => static function ( $container ): string {
@@ -206,5 +207,8 @@ return array(
 			$partner_referrals,
 			$partner_referrals_sandbox
 		);
+	},
+	'onboarding.rest'                           => static function( $container ) : Onboarding_REST_Controller {
+		return new Onboarding_REST_Controller( $container );
 	},
 );

--- a/modules/ppcp-onboarding/src/Assets/class-onboardingassets.php
+++ b/modules/ppcp-onboarding/src/Assets/class-onboardingassets.php
@@ -51,7 +51,7 @@ class OnboardingAssets {
 		LoginSellerEndpoint $login_seller_endpoint
 	) {
 
-		$this->module_url            = $module_url;
+		$this->module_url            = untrailingslashit( $module_url );
 		$this->state                 = $state;
 		$this->login_seller_endpoint = $login_seller_endpoint;
 	}
@@ -78,9 +78,6 @@ class OnboardingAssets {
 			1,
 			true
 		);
-		if ( ! $this->should_render_onboarding_script() ) {
-			return false;
-		}
 
 		$url = $this->module_url . '/assets/js/onboarding.js';
 		wp_register_script(
@@ -94,8 +91,9 @@ class OnboardingAssets {
 			'ppcp-onboarding',
 			'PayPalCommerceGatewayOnboarding',
 			array(
-				'endpoint' => home_url( \WC_AJAX::get_endpoint( LoginSellerEndpoint::ENDPOINT ) ),
-				'nonce'    => wp_create_nonce( $this->login_seller_endpoint::nonce() ),
+				'endpoint'      => home_url( \WC_AJAX::get_endpoint( LoginSellerEndpoint::ENDPOINT ) ),
+				'nonce'         => wp_create_nonce( $this->login_seller_endpoint::nonce() ),
+				'paypal_js_url' => 'https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js',
 			)
 		);
 

--- a/modules/ppcp-onboarding/src/Assets/class-onboardingassets.php
+++ b/modules/ppcp-onboarding/src/Assets/class-onboardingassets.php
@@ -90,14 +90,23 @@ class OnboardingAssets {
 		wp_localize_script(
 			'ppcp-onboarding',
 			'PayPalCommerceGatewayOnboarding',
-			array(
-				'endpoint'      => home_url( \WC_AJAX::get_endpoint( LoginSellerEndpoint::ENDPOINT ) ),
-				'nonce'         => wp_create_nonce( $this->login_seller_endpoint::nonce() ),
-				'paypal_js_url' => 'https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js',
-			)
+			$this->get_script_data()
 		);
 
 		return true;
+	}
+
+	/**
+	 * Returns the data associated to the onboarding script.
+	 *
+	 * @return array
+	 */
+	public function get_script_data() {
+		return array(
+			'endpoint'      => home_url( \WC_AJAX::get_endpoint( LoginSellerEndpoint::ENDPOINT ) ),
+			'nonce'         => wp_create_nonce( $this->login_seller_endpoint::nonce() ),
+			'paypal_js_url' => 'https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js',
+		);
 	}
 
 	/**

--- a/modules/ppcp-onboarding/src/Render/class-onboardingrenderer.php
+++ b/modules/ppcp-onboarding/src/Render/class-onboardingrenderer.php
@@ -53,33 +53,35 @@ class OnboardingRenderer {
 	}
 
 	/**
+	 * Returns the action URL for the onboarding button/link.
+	 *
+	 * @param boolean $is_production Whether the production or sandbox button should be rendered.
+	 * @return string URL.
+	 */
+	public function get_signup_link( bool $is_production ) {
+		$args = array(
+			'displayMode' => 'minibrowser',
+		);
+
+		$url = $is_production ? $this->production_partner_referrals->signup_link() : $this->sandbox_partner_referrals->signup_link();
+		$url = add_query_arg( $args, $url );
+
+		return $url;
+	}
+
+	/**
 	 * Renders the "Connect to PayPal" button.
 	 *
 	 * @param bool $is_production Whether the production or sandbox button should be rendered.
 	 */
 	public function render( bool $is_production ) {
 		try {
-			$args = array(
-				'displayMode' => 'minibrowser',
+			$this->render_button(
+				$this->get_signup_link( $is_production ),
+				$is_production ? 'connect-to-production' : 'connect-to-sandbox',
+				$is_production ? __( 'Connect to PayPal', 'woocommerce-paypal-payments' ) : __( 'Connect to PayPal Sandbox', 'woocommerce-paypal-payments' ),
+				$is_production ? 'production' : 'sandbox'
 			);
-
-			$url   = $is_production ? $this->production_partner_referrals->signup_link() : $this->sandbox_partner_referrals->signup_link();
-			$url   = add_query_arg( $args, $url );
-			$id    = $is_production ? 'connect-to-production' : 'connect-to-sandbox';
-			$label = $is_production ? __( 'Connect to PayPal', 'woocommerce-paypal-payments' ) : __( 'Connect to PayPal Sandbox', 'woocommerce-paypal-payments' );
-				$this->render_button(
-					$url,
-					$id,
-					$label
-				);
-
-			$script_url = 'https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js'; ?>
-			<script>document.querySelectorAll('[data-paypal-onboard-complete=onboardingCallback]').forEach( (element) => { element.addEventListener('click', (e) => {if ('undefined' === typeof PAYPAL ) e.preventDefault(); }) });</script>
-			<script
-					id="paypal-js"
-					src="<?php echo esc_url( $script_url ); ?>"
-			></script>
-			<?php
 		} catch ( RuntimeException $exception ) {
 			esc_html_e(
 				'We could not properly connect to PayPal. Please reload the page to continue',
@@ -94,14 +96,16 @@ class OnboardingRenderer {
 	 * @param string $url The url of the button.
 	 * @param string $id The ID of the button.
 	 * @param string $label The button text.
+	 * @param string $env The environment ('production' or 'sandbox').
 	 */
-	private function render_button( string $url, string $id, string $label ) {
+	private function render_button( string $url, string $id, string $label, string $env ) {
 		?>
 					<a
 							target="_blank"
 							class="button-primary"
 							id="<?php echo esc_attr( $id ); ?>"
-							data-paypal-onboard-complete="onboardingCallback"
+							data-paypal-onboard-complete="ppcp_onboarding_<?php echo esc_attr( $env ); ?>Callback"
+							data-paypal-onboard-button="true"
 							href="<?php echo esc_url( $url ); ?>"
 							data-paypal-button="true"
 					>

--- a/modules/ppcp-onboarding/src/class-onboarding-rest-controller.php
+++ b/modules/ppcp-onboarding/src/class-onboarding-rest-controller.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Onboarding REST controller.
+ *
+ * @package WooCommerce\PayPalCommerce\Onboarding
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Onboarding;
+
+use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+/**
+ * Exposes and handles REST routes related to onboarding.
+ */
+class Onboarding_REST_Controller {
+
+	/**
+	 * REST namespace.
+	 *
+	 * @var string
+	 */
+	protected $rest_namespace = 'wc-paypal/v1';
+
+	/**
+	 * REST base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'onboarding';
+
+	/**
+	 * Module container with access to plugin services.
+	 *
+	 * @var ContainerInterface
+	 */
+	private $container = null;
+
+	/**
+	 * Used to temporarily store URL arguments to add to the return URL associated to a signup link.
+	 *
+	 * @var array
+	 */
+	private $return_url_args = array();
+
+
+	/**
+	 * OnboardingRESTController constructor.
+	 *
+	 * @param ContainerInterface $container Module container with access to plugin services.
+	 */
+	public function __construct( ContainerInterface $container ) {
+		$this->container = $container;
+	}
+
+	/**
+	 * Registers REST routes under 'wc-paypal/v1/onboarding'.
+	 * Specifically:
+	 * - `/onboarding/get-params`, which returns information useful to display an onboarding button.
+	 * - `/onboarding/get-status`, which returns information about the current environment and its onboarding state.
+	 * - `/onboarding/set-credentials`, which allows setting merchant/API credentials.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->rest_namespace,
+			'/' . $this->rest_base . '/get-params',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'get_params' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+
+		register_rest_route(
+			$this->rest_namespace,
+			'/' . $this->rest_base . '/get-status',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'get_status' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+
+		register_rest_route(
+			$this->rest_namespace,
+			'/' . $this->rest_base . '/set-credentials',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'set_credentials' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * Validate the requester's permissions.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return bool
+	 */
+	public function check_permission( $request ) {
+		return current_user_can( 'install_plugins' );
+	}
+
+	/**
+	 * Callback for the `/onboarding/get-params` endpoint.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return array
+	 */
+	public function get_params( $request ) {
+		$params = $request->get_json_params();
+
+		$environment = ( isset( $params['environment'] ) && in_array( $params['environment'], array( 'production', 'sandbox' ), true ) ) ? $params['environment'] : 'sandbox';
+
+		return array(
+			'scriptURL'               => trailingslashit( $this->container->get( 'onboarding.url' ) ) . 'assets/js/onboarding.js',
+			'scriptData'              => $this->container->get( 'onboarding.assets' )->get_script_data(),
+			'environment'             => $environment,
+			'onboardCompleteCallback' => 'ppcp_onboarding_' . $environment . 'Callback',
+			'signupLink'              => $this->generate_signup_link( $environment, ( ! empty( $params['returnUrlArgs'] ) ? $params['returnUrlArgs'] : array() ) ),
+		);
+	}
+
+	/**
+	 * Callback for the `/onboarding/get-status` endpoint.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return array
+	 */
+	public function get_status( $request ) {
+		$environment = $this->container->get( 'onboarding.environment' );
+		$state       = $this->container->get( 'onboarding.state' );
+
+		return array(
+			'environment' => $environment->current_environment(),
+			'onboarded'   => ( $state->current_state() >= State::STATE_ONBOARDED ),
+			'state'       => $this->get_onboarding_state_name( $state->current_state() ),
+			'sandbox'     => array(
+				'state'     => $this->get_onboarding_state_name( $state->sandbox_state() ),
+				'onboarded' => ( $state->sandbox_state() >= State::STATE_ONBOARDED ),
+			),
+			'production'  => array(
+				'state'     => $this->get_onboarding_state_name( $state->production_state() ),
+				'onboarded' => ( $state->production_state() >= State::STATE_ONBOARDED ),
+			),
+		);
+	}
+
+	/**
+	 * Callback for the `/onboarding/set-credentials` endpoint.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @return WP_Error|array
+	 */
+	public function set_credentials( $request ) {
+		static $credential_keys = array(
+			'merchant_id',
+			'merchant_email',
+			'client_id',
+			'client_secret',
+		);
+
+		// Sanitize params.
+		$params = array_filter( array_map( 'trim', $request->get_json_params() ) );
+
+		// Validate 'environment'.
+		if ( empty( $params['environment'] ) || ! in_array( $params['environment'], array( 'sandbox', 'production' ), true ) ) {
+			return new \WP_Error(
+				'woocommerce_paypal_payments_invalid_environment',
+				sprintf(
+					/* translators: placeholder is an arbitrary string. */
+					__( 'Environment "%s" is invalid. Use "sandbox" or "production".', 'woocommerce-paypal-payments' ),
+					isset( $params['environment'] ) ? $params['environment'] : ''
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Validate the other fields.
+		$missing_keys = array_values( array_diff( $credential_keys, array_keys( $params ) ) );
+		if ( $missing_keys ) {
+			return new \WP_Error(
+				'woocommerce_paypal_payments_credentials_incomplete',
+				sprintf(
+					/* translators: placeholder is a comma-separated list of fields. */
+					__( 'Credentials are incomplete. Missing fields: %s.', 'woocommerce-paypal-payments' ),
+					implode( ', ', $missing_keys )
+				),
+				array(
+					'missing_fields' => $missing_keys,
+					'status'         => 400,
+				)
+			);
+		}
+
+		$settings     = $this->container->get( 'wcgateway.settings' );
+		$skip_persist = true;
+
+		// Enable gateway.
+		if ( ! $settings->has( 'enabled' ) || ! $settings->get( 'enabled' ) ) {
+			$settings->set( 'enabled', true );
+			$skip_persist = false;
+		}
+
+		foreach ( WC()->payment_gateways->payment_gateways() as $gateway ) {
+			if ( PayPalGateway::ID === $gateway->id ) {
+				$gateway->update_option( 'enabled', 'yes' );
+				break;
+			}
+		}
+
+		// Update settings.
+		$sandbox_on = ( 'sandbox' === $params['environment'] );
+		if ( ! $settings->has( 'sandbox_on' ) || ( (bool) $settings->get( 'sandbox_on' ) !== $sandbox_on ) ) {
+			$settings->set( 'sandbox_on', $sandbox_on );
+			$skip_persist = false;
+		}
+
+		foreach ( $credential_keys as $key ) {
+			$value   = $params[ $key ];
+			$env_key = $key . '_' . $params['environment'];
+
+			if ( ! $settings->has( $key ) || ! $settings->has( $env_key ) || $settings->get( $key ) !== $value || $settings->get( $env_key ) !== $value ) {
+				$settings->set( $key, $value );
+				$settings->set( $env_key, $value );
+				$skip_persist = false;
+			}
+		}
+
+		if ( $skip_persist ) {
+			return array();
+		}
+
+		$settings->set( 'products_dcc_enabled', null );
+
+		if ( ! $settings->persist() ) {
+			return new \WP_Error(
+				'woocommerce_paypal_payments_credentials_not_saved',
+				__( 'An error occurred while saving the credentials.', 'woocommerce-paypal-payments' ),
+				array(
+					'status' => 500,
+				)
+			);
+		}
+
+		$webhook_registrar = $this->container->get( 'webhook.registrar' );
+		$webhook_registrar->unregister();
+		$webhook_registrar->register();
+
+		return array();
+	}
+
+	/**
+	 * Appends URL parameters stored in this class to a given URL.
+	 *
+	 * @hooked woocommerce_paypal_payments_partner_config_override_return_url - 10
+	 * @param string $url URL.
+	 * @return string The URL with the stored URL parameters added to it.
+	 */
+	public function add_args_to_return_url( $url ) {
+		return add_query_arg( $this->return_url_args, $url );
+	}
+
+	/**
+	 * Translates an onboarding state to a string.
+	 *
+	 * @param int $state An onboarding state to translate as returned by {@link State} methods.
+	 * @return string A string representing the state: "start", "progressive" or "onboarded".
+	 * @see State::current_state(), State::sandbox_state(), State::production_state().
+	 */
+	public function get_onboarding_state_name( $state ) {
+		$name = 'unknown';
+
+		switch ( absint( $state ) ) {
+			case State::STATE_START:
+				$name = 'start';
+				break;
+			case State::STATE_PROGRESSIVE:
+				$name = 'progressive';
+				break;
+			case State::STATE_ONBOARDED:
+				$name = 'onboarded';
+				break;
+			default:
+				break;
+
+		}
+
+		return $name;
+	}
+
+	/**
+	 * Generates a signup link for onboarding for a given environment and optionally adding certain URL arguments
+	 * to the URL users are redirected after completing the onboarding flow.
+	 *
+	 * @param string $environment The environment to use. Either 'sandbox' or 'production'. Defaults to 'sandbox'.
+	 * @param array  $url_args An array of URL arguments to add to the return URL via {@link add_query_arg()}.
+	 * @return string
+	 */
+	private function generate_signup_link( $environment = 'sandbox', $url_args = array() ) {
+		$this->return_url_args = ( ! empty( $url_args ) && is_array( $url_args ) ) ? $url_args : array();
+
+		if ( $this->return_url_args ) {
+			add_filter( 'woocommerce_paypal_payments_partner_config_override_return_url', array( $this, 'add_args_to_return_url' ) );
+		}
+
+		$link = $this->container->get( 'onboarding.render' )->get_signup_link( 'production' === $environment );
+
+		if ( $this->return_url_args ) {
+			remove_filter( 'woocommerce_paypal_payments_partner_config_override_return_url', array( $this, 'add_args_to_return_url' ) );
+			$this->return_url_args = array();
+		}
+
+		return $link;
+	}
+
+}

--- a/modules/ppcp-onboarding/src/class-onboardingmodule.php
+++ b/modules/ppcp-onboarding/src/class-onboardingmodule.php
@@ -41,7 +41,6 @@ class OnboardingModule implements ModuleInterface {
 	 * @param ContainerInterface|null $container The container.
 	 */
 	public function run( ContainerInterface $container = null ) {
-
 		$asset_loader = $container->get( 'onboarding.assets' );
 		/**
 		 * The OnboardingAssets.
@@ -100,6 +99,10 @@ class OnboardingModule implements ModuleInterface {
 				$endpoint->handle_request();
 			}
 		);
+
+		// Initialize REST routes at the appropriate time.
+		$rest_controller = $container->get( 'onboarding.rest' );
+		add_action( 'rest_api_init', array( $rest_controller, 'register_routes' ) );
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Settings/class-settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settings.php
@@ -69,7 +69,7 @@ class Settings implements ContainerInterface {
 	 */
 	public function persist() {
 
-		update_option( self::KEY, $this->settings );
+		return update_option( self::KEY, $this->settings );
 	}
 
 

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -117,10 +117,14 @@ class SettingsListener {
 			$this->settings->set( 'merchant_email_production', $merchant_email );
 		}
 		$this->settings->persist();
-		$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' );
+
+		do_action( 'woocommerce_paypal_payments_onboarding_before_redirect' );
+
+		$redirect_url = apply_filters( 'woocommerce_paypal_payments_onboarding_redirect_url', admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ) );
 		if ( ! $this->settings->has( 'client_id' ) || ! $this->settings->get( 'client_id' ) ) {
-			$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-onboarding-error=1' );
+			$redirect_url = add_query_arg( 'ppcp-onboarding-error', '1', $redirect_url );
 		}
+
 		wp_safe_redirect( $redirect_url, 302 );
 		exit;
 	}


### PR DESCRIPTION
**Issue:** https://github.com/woocommerce/woocommerce-admin/issues/5788

- - -

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
This PR refactors some of the code in the on-boarding module in order to expose certain internal details that are needed by WooCommerce's onboarding wizard. Also, in order to workaround several limitations in PayPal's `partner.js` (such as the inability to trigger the popup for dynamically loaded buttons, certain issues with Firefox, etc.), `onboarding.js` was heavily modified too.

To permit integration with WooCommerce's onboarding wizard, a REST controller was also added. In particular, this controller exposes the following routes:

- **`/wc-paypal/v1/onboarding/get-params`** [POST]
  Returns information useful for presenting the user with a [sign-up link/button](https://developer.paypal.com/docs/platforms/seller-onboarding/build-onboarding/#2-embed-sign-up-link).

  - Parameters (JSON):
    - `environment`: either 'sandbox' or 'production'. Optional. Defaults to 'sandbox'.
  - Response (JSON):
    - `environment`: Environment for which the parameters apply.
    - `scriptURL`: URL to the `onboarding.js` script.
    - `scriptData`: Data required by the `onboarding.js` script. Should be added to the `PayPalCommerceGatewayOnboarding` variable in the global context.
    - `onboardCompleteCallback`: Value to be used for the `data-paypal-onboard-complete` attribute in the sign-up link or button.
    - `signupLink`: Generated sign-up link. Final redirect URL defaults to the settings page.
- **`/wc-paypal/v1/onboarding/get-status`** [GET]
  Returns information about the current onboarding status.

  - Parameters (JSON): N/A.
  - Response (JSON):
    - `environment`: Current environment.
    - `onboarded`: `true` if onboarded was completed for the current environment.
    - `state`: Textual representation of the current onboarding status ("start", "progressive", "onboarded").
    - `sandbox.onboarded`: Same as  `onboarded` but for the "sandbox" environment in particular.
    - `sandbox.state`: Same as `state` but for the "sandbox" environment in particular.
    - `production.onboarded`: Same as  `onboarded` but for the "production" environment in particular.
    - `production.state`: Same as `state` but for the "production" environment in particular.
- **`/wc-paypal/v1/onboarding/set-credentials`** [POST]
  Allows setting credentials for a given environment and also enables the gateway.

  - Parameters (JSON):
    - `environment`: Environment the credentials apply to. Required.
    - `merchant_id`: Merchant ID. Required.
    - `merchant_email`: Merchant e-mail. Required.
    - `client_id`: API Client ID. Required.
    - `client_secret`: API Client Secret. Required.
  - Response (JSON): Empty or error in case of error (missing fields etc.).

### Steps to test:

#### Make sure the usual onboarding flow works correctly
1. Go to WC > Settings > Payments > PayPal.
1. Disconnect (if connected).
1. Click "Connect to PayPal" or "Connect to PayPal Sandbox" (depending on whether you have sandbox enabled or not).
1. A popup should appear and you should be able to complete the onboarding flow.
1. After clicking to return to the site at the final step of the process, you should be back at the settings screen, with all credential fields correctly filled out.
1. Perform a test purchase from the frontend to confirm.
1. (Optional) Repeat the above but for the other mode (sandbox/production).

#### Test the REST endpoints
1. Go to WC > Settings > Advanced > REST API and create an API key for testing. It should be for a user with sufficient access (i.e. "install_plugins" capability).
1. Keep key and secret handy.
1. Make sure the endpoints work correctly. Test with different inputs. Some example requests:

   cURL command|Expected output
   --|--
   `curl -X GET https://SITE/wp-json/wc-paypal/v1/onboarding/get-status -u API_KEY:API_SECRET`|Onboarding status as described above|
   `curl -X POST https://SITE/wp-json/wc-paypal/v1/onboarding/get-params -u API_KEY:API_SECRET`|Onboarding parameters (signup link, environment, etc.) as describe above|
   `curl -X POST https://SITE/wp-json/wc-paypal/v1/onboarding/set-credentials -u API_KEY:API_SECRET -H 'content-type: application/json' -d '{"environment":"whatever"}'`|Error due to invalid environment.
   `curl -X POST https://SITE/wp-json/wc-paypal/v1/onboarding/set-credentials -u API_KEY:API_SECRET -H 'content-type: application/json' -d '{"environment":"sandbox","merchant_id":"MERCHANTID","client_id":"CLIENTID"}'`|Error due to missing fields "merchant_email" and "client_secret".
   `curl -X POST https://SITE/wp-json/wc-paypal/v1/onboarding/set-credentials -u API_KEY:API_SECRET -H 'content-type: application/json' -d '{"environment":"sandbox","merchant_id":"MERCHANTID","merchant_email":"MERCHANTEMAIL","client_id":"CLIENTID","client_secret":"CLIENTSECRET"}'`|No error. Confirm credentials were set on the settings screen.