### PR TITLE
Remove spinner on click, on cancel and on error

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -19,9 +19,6 @@ class CheckoutActionHandler {
             const errorHandler = this.errorHandler;
 
             const formSelector = this.config.context === 'checkout' ? 'form.checkout' : 'form#order_review';
-            spinner.setTarget(formSelector);
-            spinner.block();
-
             const formValues = jQuery(formSelector).serialize();
 
             return fetch(this.config.ajax.create_order.endpoint, {
@@ -53,13 +50,10 @@ class CheckoutActionHandler {
         return {
             createOrder,
             onApprove:onApprove(this, this.errorHandler, this.spinner),
-            onClick: () => {
-                spinner.unblock();
-            },
             onCancel: () => {
                 spinner.unblock();
             },
-            onError: (error) => {
+            onError: () => {
                 this.errorHandler.genericError();
                 spinner.unblock();
             }

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -53,8 +53,15 @@ class CheckoutActionHandler {
         return {
             createOrder,
             onApprove:onApprove(this, this.errorHandler, this.spinner),
+            onClick: () => {
+                spinner.unblock();
+            },
+            onCancel: () => {
+                spinner.unblock();
+            },
             onError: (error) => {
                 this.errorHandler.genericError();
+                spinner.unblock();
             }
         }
     }

--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -115,6 +115,9 @@ class CreditCardRenderer {
                         payload.orderID = payload.orderId;
                         this.spinner.unblock();
                         return contextConfig.onApprove(payload);
+                    }).catch(() => {
+                        this.spinner.unblock();
+                        this.errorHandler.genericError()
                     });
                 } else {
                     this.spinner.unblock();


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: [PCP-95](https://inpsyde.atlassian.net/browse/PCP-95).

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Unblock the UI on checkout when the user interaction is needed or may be needed. 

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
**Credit cards fields are available**
1. Add any product to the cart and go to the checkout.
2. Click the black Debit or Credit Card button and wait until the fields are rendered.
3. Make sure you can fill this field (no overlay with spinner above the fields).

**After cancelling PayPal payment the UI is unblocked**
1. Add any product to the cart and go to the checkout.
2. Click PayPal yellow button to pay with the PayPal.
3. Wait until a new window will be opened and then close it.
4. The checkout should be unblocked (no overlay with spinner).


### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Fix - Overlay blocks Credit Card fields.
* Fix - Overlay blocks checkout after cancelling PayPal payment.

