### PR TITLE
Remove disabling credit for UK

### DIFF
--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -731,14 +731,6 @@ class SmartButton implements SmartButtonInterface {
 			$disable_funding[] = 'card';
 		}
 
-		/**
-		 * Disable card for UK.
-		 */
-		$region  = wc_get_base_location();
-		$country = $region['country'];
-		if ( 'GB' === $country ) {
-			$disable_funding[] = 'credit';
-		}
 		$params['disable-funding'] = implode( ',', array_unique( $disable_funding ) );
 
 		$smart_button_url = add_query_arg( $params, 'https://www.paypal.com/sdk/js' );


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: [PCP-96](https://inpsyde.atlassian.net/browse/PCP-96).
---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Unblock credit as a funding source for UK merchants so Pay Later will be available.

### Steps to test:
I wasn't able to test it, this button just doesn't appear. Probably, this is because it should be enabled by PayPal after a personal request to support. From the [docs](https://developer.paypal.com/docs/business/pay-later/#buttons): 
_Note: The Pay Later button is currently available to US merchants only. If you are a UK merchant and want to enable the Pay Later button, please contact business customer support..._

But in theory, these steps may help to test this PR if the button will be enabled by PayPal.

1. Do onboarding to your test shop using a UK sandbox merchant account.
2. ~~Go to the developer.paypal.com and enable Credit in the setting of the merchant account you used for onboarding.~~ 
Don't enable Credit in the settings of merchant account. This enables PayPal Credit and disables Pay in 3.
3. Set United Kingdom as store location in the Woocommerce settings.
4. Select United Kingdom as client location on checkout.

This should be enough, but additionally, you may try:
* use UK client account for testing;
* use UK IP when testing;
* use an anonymous mode in your browser so no cookies or other data could influence the country detection.


### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Add - Pay Later button is unblocked for UK merchants.
