### PR TITLE
Rename PayPal Credit to PayLater

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WooCommerce PayPal Payments
 
-PayPal's latest complete payments processing solution. Accept PayPal, PayPal Credit, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
+PayPal's latest complete payments processing solution. Accept PayPal, PayPal Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WooCommerce PayPal Payments
 
-PayPal's latest complete payments processing solution. Accept PayPal, PayPal Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
+PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
 
 ## Requirements
 

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ Stable tag: 1.1.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-PayPal's latest payments processing solution. Accept PayPal, PayPal Credit, credit/debit cards, alternative digital wallets and bank accounts.
+PayPal's latest payments processing solution. Accept PayPal, PayPal PayLater, credit/debit cards, alternative digital wallets and bank accounts.
 
 == Description ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ Stable tag: 1.1.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-PayPal's latest payments processing solution. Accept PayPal, PayPal PayLater, credit/debit cards, alternative digital wallets and bank accounts.
+PayPal's latest payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets and bank accounts.
 
 == Description ==
 

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
- * Description: PayPal's latest complete payments processing solution. Accept PayPal, PayPal Credit, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
+ * Description: PayPal's latest complete payments processing solution. Accept PayPal, PayPal Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
  * Version:     1.1.0
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
- * Description: PayPal's latest complete payments processing solution. Accept PayPal, PayPal Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
+ * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
  * Version:     1.1.0
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: [PCP-98](https://inpsyde.atlassian.net/browse/PCP-98).

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Change PapPal's service name from Credit to Pay Later.
### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Go to the WordPress plugins page and check the plugin description contains PayPal Pay Later but doesn't contain PayPal Credit.
2. Check the readme.txt file and make sure it mentions PayPal Pay Later but not PayPal Credit.
3. Check the README.md file and make sure it mentions PayPal Pay Later but not PayPal Credit.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Fix - PayPal Credit renamed to PayPal Pay Later.

Closes #112.
