### PR TITLE
Release 1.2.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 1.2.1 - 2021-03-08 =
+* Fix - Address compatibility issue with Jetpack.
+
 = 1.2.0 - 2021-03-08 =
 * Add - Rework onboarding code and add REST controller for integration with the OBW. #121
 * Fix - Remove spinner on click, on cancel and on error. #124

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0",
     "require": {
         "dhii/module-interface": "0.1",
-        "psr/container": "^1.0",
+        "psr/container": "1.0.0",
         "container-interop/service-provider": "^0.4.0",
         "dhii/containers": "v0.1.0-alpha1",
         "dhii/wp-containers": "v0.1.0-alpha1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.6
 Requires PHP: 7.0
-Stable tag: 1.2.0
+Stable tag: 1.2.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -57,6 +57,9 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.2.1 =
+* Fix - Address compatibility issue with Jetpack.
 
 = 1.2.0 =
 * Add - Rework onboarding code and add REST controller for integration with the OBW. #121

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, PayPal Credit, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.2.0
+ * Version:     1.2.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0


### PR DESCRIPTION
We need to release 1.2.1 to fix a problem with one of our dependencies:

`Psr\Container` 1.1.0 adds a [typehint to `Psr\Container\ContainerInterface::has()`](https://github.com/php-fig/container/blob/9fc7aab7a78057a124384358ebae8a1711b6f6fc/src/ContainerInterface.php#L35) which is not present in [`Dhii\Collection\HasCapableInterface`](https://github.com/Dhii/collections-interface/blob/7c7c4b4459dda9e6db406860d99916d0cee58ccf/src/HasCapableInterface.php#L28).
The incompatible signature should result in a PHP warning/error, but thanks to an "interesting" PHP bug, it doesn't always appear. It does, however, when Jetpack is enabled:

<img width="751" alt="Screen Shot 2021-03-08 at 3 52 21 PM" src="https://user-images.githubusercontent.com/184724/110379672-1f2b2a80-8025-11eb-88b1-42a2a0ffe916.png">

Given `Psr\Container` version 1.0.0 still has the old signature, I'm making this particular version a hard dependency for the time being.