### PR TITLE
Show WC message on account creating error

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -40,8 +40,17 @@ class CheckoutActionHandler {
                 if (!data.success) {
                     spinner.unblock();
                     //handle both messages sent from Woocommerce (data.messages) and this plugin (data.data.message)
-                    const message = typeof(data.messages) !== 'undefined' ? data.messages : data.data.message;
-                    errorHandler.message(message, true);
+                    if (typeof(data.messages) !== 'undefined' )
+                    {
+                        const domParser = new DOMParser();
+                        errorHandler.appendPreparedErrorMessageElement(
+                            domParser.parseFromString(data.messages, 'text/html')
+                                .querySelector('ul')
+                        );
+                    } else {
+                        errorHandler.message(data.data.message, true);
+                    }
+
                     return;
                 }
                 const input = document.createElement('input');

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -39,7 +39,9 @@ class CheckoutActionHandler {
             }).then(function (data) {
                 if (!data.success) {
                     spinner.unblock();
-                    errorHandler.message(data.data.message, true);
+                    //handle both messages sent from Woocommerce (data.messages) and this plugin (data.data.message)
+                    const message = typeof(data.messages) !== 'undefined' ? data.messages : data.data.message;
+                    errorHandler.message(message, true);
                     return;
                 }
                 const input = document.createElement('input');

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -39,7 +39,7 @@ class CheckoutActionHandler {
             }).then(function (data) {
                 if (!data.success) {
                     spinner.unblock();
-                    errorHandler.message(data.data.message, true);
+                    errorHandler.message(data.messages);
                     return;
                 }
                 const input = document.createElement('input');

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -39,7 +39,7 @@ class CheckoutActionHandler {
             }).then(function (data) {
                 if (!data.success) {
                     spinner.unblock();
-                    errorHandler.message(data.messages);
+                    errorHandler.message(data.data.message, true);
                     return;
                 }
                 const input = document.createElement('input');

--- a/modules/ppcp-button/resources/js/modules/ErrorHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ErrorHandler.js
@@ -15,6 +15,15 @@ class ErrorHandler {
         this.message(this.genericErrorText)
     }
 
+    appendPreparedErrorMessageElement(errorMessageElement)
+    {
+        if(this.messagesList === null) {
+            this.prepareMessagesList();
+        }
+
+        this.messagesList.replaceWith(errorMessageElement);
+    }
+
     message(text, persist = false)
     {
         if(! typeof String || text.length === 0){

--- a/modules/ppcp-button/resources/js/modules/ErrorHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ErrorHandler.js
@@ -4,6 +4,7 @@ class ErrorHandler {
     {
         this.genericErrorText = genericErrorText;
         this.wrapper = document.querySelector('.woocommerce-notices-wrapper');
+        this.messagesList = document.querySelector('ul.woocommerce-error');
     }
 
     genericError() {
@@ -16,7 +17,14 @@ class ErrorHandler {
 
     message(text, persist = false)
     {
-        let messagesList = this.prepareMessagesList();
+        if(! typeof String || text.length === 0){
+            throw new Error('A new message text must be a non-empty string.');
+        }
+
+        if(this.messagesList === null){
+            this.prepareMessagesList();
+        }
+
         if (persist) {
             this.wrapper.classList.add('ppcp-persist');
         } else {
@@ -24,23 +32,19 @@ class ErrorHandler {
         }
 
         let messageNode = this.prepareMessagesListItem(text);
-        messagesList.appendChild(messageNode);
+        this.messagesList.appendChild(messageNode);
 
         jQuery.scroll_to_notices(jQuery('.woocommerce-notices-wrapper'))
     }
 
     prepareMessagesList()
     {
-        let messagesList = document.querySelector('ul.woocommerce-error');
-
-        if(messagesList === null){
-            messagesList = document.createElement('ul');
-            messagesList.setAttribute('class', 'woocommerce-error');
-            messagesList.setAttribute('role', 'alert');
-            this.wrapper.appendChild(messagesList);
+        if(this.messagesList === null){
+            this.messagesList = document.createElement('ul');
+            this.messagesList.setAttribute('class', 'woocommerce-error');
+            this.messagesList.setAttribute('role', 'alert');
+            this.wrapper.appendChild(this.messagesList);
         }
-
-        return messagesList;
     }
 
     prepareMessagesListItem(message)

--- a/modules/ppcp-button/resources/js/modules/ErrorHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ErrorHandler.js
@@ -16,14 +16,39 @@ class ErrorHandler {
 
     message(text, persist = false)
     {
-        this.wrapper.classList.add('woocommerce-error');
+        let messagesList = this.prepareMessagesList();
         if (persist) {
             this.wrapper.classList.add('ppcp-persist');
         } else {
             this.wrapper.classList.remove('ppcp-persist');
         }
-        this.wrapper.innerHTML = this.sanitize(text);
+
+        let messageNode = this.prepareMessagesListItem(text);
+        messagesList.appendChild(messageNode);
+
         jQuery.scroll_to_notices(jQuery('.woocommerce-notices-wrapper'))
+    }
+
+    prepareMessagesList()
+    {
+        let messagesList = document.querySelector('ul.woocommerce-error');
+
+        if(messagesList === null){
+            messagesList = document.createElement('ul');
+            messagesList.setAttribute('class', 'woocommerce-error');
+            messagesList.setAttribute('role', 'alert');
+            this.wrapper.appendChild(messagesList);
+        }
+
+        return messagesList;
+    }
+
+    prepareMessagesListItem(message)
+    {
+        const li = document.createElement('li');
+        li.innerHTML = message;
+
+        return li;
     }
 
     sanitize(text)

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -163,7 +163,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 
 			$this->set_bn_code( $data );
 			$needs_shipping          = WC()->cart && WC()->cart->needs_shipping();
-			$shipping_address_is_fix = $needs_shipping && 'checkout' === $data['context'] ? true : false;
+			$shipping_address_is_fix = $needs_shipping && 'checkout' === $data['context'];
 			$order                   = $this->api_endpoint->create(
 				$purchase_units,
 				$this->payer( $data, $wc_order ),

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -173,7 +173,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 				$shipping_address_is_fix
 			);
 			if ( 'checkout' === $data['context'] ) {
-					$this->validate_checkout_form( $data['form'], $order );
+					$this->process_checkout_form( $data['form'], $order );
 			}
 			if ( 'pay-now' === $data['context'] && get_option( 'woocommerce_terms_page_id', '' ) !== '' ) {
 				$this->validate_paynow_form( $data['form'] );
@@ -263,7 +263,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 *
 	 * @throws \Exception On Error.
 	 */
-	private function validate_checkout_form( string $form_values, Order $order ) {
+	private function process_checkout_form( string $form_values, Order $order ) {
 		$this->order = $order;
 		$form_values = explode( '&', $form_values );
 


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: [PCP-100](https://inpsyde.atlassian.net/browse/PCP-100).

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Show original message from WC when trying to create a new account with an existing email.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Add a product to the cart and go to the WooCoommerce checkout as a guest customer.
2. For the email field use the email that already used for a registered user.
3. Select the checkbox in the bottom of the form to create a new account.
4. Try to complete the checkout using one of the plugin's payments options.

You should see the original WooCommerce error saying the account of already registered instead of a generic message saying something went wrong. 


### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
* Fix - Display proper error message on checkout when trying to create an account with the already used email.
