### PR TITLE
Validate checkout form before sending request to PayPal

### DIFF
--- a/modules/ppcp-api-client/src/Repository/class-cartrepository.php
+++ b/modules/ppcp-api-client/src/Repository/class-cartrepository.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Repository;
 
-use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -163,7 +163,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 
 			$this->set_bn_code( $data );
 			$needs_shipping          = WC()->cart && WC()->cart->needs_shipping();
-			$shipping_address_is_fix = $needs_shipping && 'checkout' === $data['context'] ? true : false;
+			$shipping_address_is_fix = $needs_shipping && 'checkout' === $data['context'];
 			$order                   = $this->api_endpoint->create(
 				$purchase_units,
 				$this->payer( $data, $wc_order ),

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -151,9 +151,9 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 */
 	public function handle_request(): bool {
 		try {
-			$data     = $this->request_data->read_request( $this->nonce() );
+			$data                      = $this->request_data->read_request( $this->nonce() );
 			$this->parsed_request_data = $data;
-			$wc_order = null;
+			$wc_order                  = null;
 			if ( 'pay-now' === $data['context'] ) {
 				$wc_order = wc_get_order( (int) $data['order_id'] );
 				if ( ! is_a( $wc_order, \WC_Order::class ) ) {
@@ -180,9 +180,9 @@ class CreateOrderEndpoint implements EndpointInterface {
 				$this->validate_paynow_form( $data['form'] );
 			}
 
-			//if we are here so the context is not 'checkout' as it exits before. Therefore, a PayPal order is not created yet.
-			//It would be a good idea to refactor the checkout process in the future.
-			$order = $this->create_paypal_order($wc_order);
+			// if we are here so the context is not 'checkout' as it exits before. Therefore, a PayPal order is not created yet.
+			// It would be a good idea to refactor the checkout process in the future.
+			$order = $this->create_paypal_order( $wc_order );
 			wp_send_json_success( $order->to_array() );
 			return true;
 		} catch ( \RuntimeException $error ) {
@@ -194,8 +194,8 @@ class CreateOrderEndpoint implements EndpointInterface {
 					'details' => is_a( $error, PayPalApiException::class ) ? $error->details() : array(),
 				)
 			);
-		} catch (\Exception $exception){
-			wc_add_notice($exception->getMessage(), 'error');
+		} catch ( \Exception $exception ) {
+			wc_add_notice( $exception->getMessage(), 'error' );
 		}
 
 		return false;
@@ -208,7 +208,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 *
 	 * @throws RuntimeException If create order request fails.
 	 */
-	private function create_paypal_order(\WC_Order $wc_order = null): Order {
+	private function create_paypal_order( \WC_Order $wc_order = null ): Order {
 		$needs_shipping          = WC()->cart && WC()->cart->needs_shipping();
 		$shipping_address_is_fix = $needs_shipping && 'checkout' === $this->parsed_request_data['context'];
 
@@ -225,7 +225,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	/**
 	 * Returns the Payer entity based on the request data.
 	 *
-	 * @param array     $data The request data.
+	 * @param array          $data The request data.
 	 * @param \WC_Order|null $wc_order The order.
 	 *
 	 * @return Payer|null
@@ -280,11 +280,11 @@ class CreateOrderEndpoint implements EndpointInterface {
 			$payee_preferred = $this->settings->has( 'payee_preferred' ) && $this->settings->get( 'payee_preferred' ) ?
 				PaymentMethod::PAYEE_PREFERRED_IMMEDIATE_PAYMENT_REQUIRED
 				: PaymentMethod::PAYEE_PREFERRED_UNRESTRICTED;
-		} catch (NotFoundException $exception){
+		} catch ( NotFoundException $exception ) {
 			$payee_preferred = PaymentMethod::PAYEE_PREFERRED_UNRESTRICTED;
 		}
-		
-		$payment_method  = new PaymentMethod( $payee_preferred );
+
+		$payment_method = new PaymentMethod( $payee_preferred );
 		return $payment_method;
 	}
 
@@ -295,7 +295,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 *
 	 * @throws \Exception On Error.
 	 */
-	private function process_checkout_form(string $form_values ) {
+	private function process_checkout_form( string $form_values ) {
 		$form_values = explode( '&', $form_values );
 
 		$parsed_values = array();

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -203,7 +203,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 
 	/**
 	 * Creates the order in the PayPal, uses data from WC order if provided.
-	 * 
+	 *
 	 * @param \WC_Order|null $wc_order WC order to get data from.
 	 *
 	 * @return Order Created PayPal order.

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -141,7 +141,6 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * Handles the request.
 	 *
 	 * @return bool
-	 * @throws \WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException In case a setting was not found.
 	 */
 	public function handle_request(): bool {
 		try {
@@ -185,8 +184,11 @@ class CreateOrderEndpoint implements EndpointInterface {
 					'details' => is_a( $error, PayPalApiException::class ) ? $error->details() : array(),
 				)
 			);
-			return false;
+		} catch (\Exception $exception){
+			wc_add_notice($exception->getMessage(), 'error');
 		}
+
+		return false;
 	}
 
 	/**

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -89,13 +89,6 @@ class CreateOrderEndpoint implements EndpointInterface {
 	private $early_order_handler;
 
 	/**
-	 * The current PayPal order in a process.
-	 *
-	 * @var Order|null
-	 */
-	private $order;
-
-	/**
 	 * Data from the request.
 	 *
 	 * @var array
@@ -183,7 +176,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 			$order = $this->create_paypal_order($wc_order);
 
 			if ( 'checkout' === $data['context'] ) {
-					$this->process_checkout_form( $data['form'], $order );
+					$this->process_checkout_form( $data['form'] );
 			}
 			if ( 'pay-now' === $data['context'] && get_option( 'woocommerce_terms_page_id', '' ) !== '' ) {
 				$this->validate_paynow_form( $data['form'] );
@@ -297,12 +290,10 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * Prepare the Request parameter and process the checkout form and validate it.
 	 *
 	 * @param string $form_values The values of the form.
-	 * @param Order  $order The Order.
 	 *
 	 * @throws \Exception On Error.
 	 */
-	private function process_checkout_form(string $form_values, Order $order ) {
-		$this->order = $order;
+	private function process_checkout_form(string $form_values ) {
 		$form_values = explode( '&', $form_values );
 
 		$parsed_values = array();
@@ -354,8 +345,6 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * @return array
 	 */
 	public function after_checkout_validation( array $data, \WP_Error $errors ): array {
-
-		$order = $this->order;
 		if ( ! $errors->errors ) {
 
 			/**

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -202,6 +202,8 @@ class CreateOrderEndpoint implements EndpointInterface {
 	}
 
 	/**
+	 * Creates the order in the PayPal, uses data from WC order if provided.
+	 * 
 	 * @param \WC_Order|null $wc_order WC order to get data from.
 	 *
 	 * @return Order Created PayPal order.

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -173,7 +173,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 				$shipping_address_is_fix
 			);
 			if ( 'checkout' === $data['context'] ) {
-					$this->validate_checkout_form( $data['form'], $order );
+					$this->process_checkout_form( $data['form'], $order );
 			}
 			if ( 'pay-now' === $data['context'] && get_option( 'woocommerce_terms_page_id', '' ) !== '' ) {
 				$this->validate_paynow_form( $data['form'] );
@@ -263,7 +263,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 *
 	 * @throws \Exception On Error.
 	 */
-	private function validate_checkout_form( string $form_values, Order $order ) {
+	private function process_checkout_form(string $form_values, Order $order ) {
 		$this->order = $order;
 		$form_values = explode( '&', $form_values );
 

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -173,14 +173,16 @@ class CreateOrderEndpoint implements EndpointInterface {
 
 			$this->set_bn_code( $data );
 
-			$order = $this->create_paypal_order($wc_order);
-
 			if ( 'checkout' === $data['context'] ) {
 					$this->process_checkout_form( $data['form'] );
 			}
 			if ( 'pay-now' === $data['context'] && get_option( 'woocommerce_terms_page_id', '' ) !== '' ) {
 				$this->validate_paynow_form( $data['form'] );
 			}
+
+			//if we are here so the context is not 'checkout' as it exits before. Therefore, a PayPal order is not created yet.
+			//It would be a good idea to refactor the checkout process in the future.
+			$order = $this->create_paypal_order($wc_order);
 			wp_send_json_success( $order->to_array() );
 			return true;
 		} catch ( \RuntimeException $error ) {
@@ -224,7 +226,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * Returns the Payer entity based on the request data.
 	 *
 	 * @param array     $data The request data.
-	 * @param \WC_Order $wc_order The order.
+	 * @param \WC_Order|null $wc_order The order.
 	 *
 	 * @return Payer|null
 	 */

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -245,12 +245,16 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * Returns the PaymentMethod object for the order.
 	 *
 	 * @return PaymentMethod
-	 * @throws \WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException In case a setting would not be found.
 	 */
 	private function payment_method() : PaymentMethod {
-		$payee_preferred = $this->settings->has( 'payee_preferred' ) && $this->settings->get( 'payee_preferred' ) ?
-			PaymentMethod::PAYEE_PREFERRED_IMMEDIATE_PAYMENT_REQUIRED
-			: PaymentMethod::PAYEE_PREFERRED_UNRESTRICTED;
+		try {
+			$payee_preferred = $this->settings->has( 'payee_preferred' ) && $this->settings->get( 'payee_preferred' ) ?
+				PaymentMethod::PAYEE_PREFERRED_IMMEDIATE_PAYMENT_REQUIRED
+				: PaymentMethod::PAYEE_PREFERRED_UNRESTRICTED;
+		} catch (NotFoundException $exception){
+			$payee_preferred = PaymentMethod::PAYEE_PREFERRED_UNRESTRICTED;
+		}
+		
 		$payment_method  = new PaymentMethod( $payee_preferred );
 		return $payment_method;
 	}

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -347,6 +347,8 @@ class CreateOrderEndpoint implements EndpointInterface {
 	public function after_checkout_validation( array $data, \WP_Error $errors ): array {
 		if ( ! $errors->errors ) {
 
+			$order = $this->create_paypal_order();
+
 			/**
 			 * In case we are onboarded and everything is fine with the \WC_Order
 			 * we want this order to be created. We will intercept it and leave it

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -130,9 +130,7 @@ return array(
 	'wcgateway.order-processor'                    => static function ( $container ): OrderProcessor {
 
 		$session_handler              = $container->get( 'session.handler' );
-		$cart_repository              = $container->get( 'api.repository.cart' );
 		$order_endpoint               = $container->get( 'api.endpoint.order' );
-		$payments_endpoint            = $container->get( 'api.endpoint.payments' );
 		$order_factory                = $container->get( 'api.factory.order' );
 		$threed_secure                = $container->get( 'button.helper.three-d-secure' );
 		$authorized_payments_processor = $container->get( 'wcgateway.processor.authorized-payments' );
@@ -142,9 +140,7 @@ return array(
 
 		return new OrderProcessor(
 			$session_handler,
-			$cart_repository,
 			$order_endpoint,
-			$payments_endpoint,
 			$order_factory,
 			$threed_secure,
 			$authorized_payments_processor,

--- a/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
@@ -33,7 +33,7 @@ trait ProcessPaymentTrait {
 		$wc_order = wc_get_order( $order_id );
 		if ( ! is_a( $wc_order, \WC_Order::class ) ) {
 			wc_add_notice(
-				__('Couldn\'t find order to process', 'woocommerce-paypal-payments' ),
+				__( 'Couldn\'t find order to process', 'woocommerce-paypal-payments' ),
 				'error'
 			);
 

--- a/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
@@ -24,7 +24,6 @@ trait ProcessPaymentTrait {
 	 * @return array
 	 */
 	public function process_payment( $order_id ) {
-		global $woocommerce;
 
 		$failure_data = array(
 			'result'   => 'failure',
@@ -55,7 +54,7 @@ trait ProcessPaymentTrait {
 		//phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		try {
-			if ( $this->order_processor->process( $wc_order, $woocommerce ) ) {
+			if ( $this->order_processor->process( $wc_order ) ) {
 				$this->session_handler->destroy_session_data();
 				return array(
 					'result'   => 'success',

--- a/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
@@ -21,13 +21,19 @@ trait ProcessPaymentTrait {
 	 *
 	 * @param int $order_id The WooCommerce order id.
 	 *
-	 * @return array|null
+	 * @return array
 	 */
 	public function process_payment( $order_id ) {
 		global $woocommerce;
+
+		$failure_data = array(
+			'result'   => 'failure',
+			'redirect' => wc_get_checkout_url(),
+		);
+
 		$wc_order = wc_get_order( $order_id );
 		if ( ! is_a( $wc_order, \WC_Order::class ) ) {
-			return null;
+			return $failure_data;
 		}
 
 		/**
@@ -63,7 +69,7 @@ trait ProcessPaymentTrait {
 						__( 'Please use a different payment method.', 'woocommerce-paypal-payments' ),
 						'error'
 					);
-					return null;
+					return $failure_data;
 				}
 				return array(
 					'result'   => 'success',
@@ -75,7 +81,7 @@ trait ProcessPaymentTrait {
 		} catch ( RuntimeException $error ) {
 			$this->session_handler->destroy_session_data();
 			wc_add_notice( $error->getMessage(), 'error' );
-			return null;
+			return $failure_data;
 		}
 
 		wc_add_notice(
@@ -83,6 +89,6 @@ trait ProcessPaymentTrait {
 			'error'
 		);
 
-		return null;
+		return $failure_data;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
@@ -33,6 +33,11 @@ trait ProcessPaymentTrait {
 
 		$wc_order = wc_get_order( $order_id );
 		if ( ! is_a( $wc_order, \WC_Order::class ) ) {
+			wc_add_notice(
+				__('Couldn\'t find order to process', 'woocommerce-paypal-payments' ),
+				'error'
+			);
+
 			return $failure_data;
 		}
 

--- a/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
@@ -11,11 +11,9 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
-use WooCommerce\PayPalCommerce\ApiClient\Repository\CartRepository;
 use WooCommerce\PayPalCommerce\Button\Helper\ThreeDSecure;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -41,25 +39,11 @@ class OrderProcessor {
 	private $session_handler;
 
 	/**
-	 * The Cart Repository.
-	 *
-	 * @var CartRepository
-	 */
-	private $cart_repository;
-
-	/**
 	 * The Order Endpoint.
 	 *
 	 * @var OrderEndpoint
 	 */
 	private $order_endpoint;
-
-	/**
-	 * The Payments Endpoint.
-	 *
-	 * @var PaymentsEndpoint
-	 */
-	private $payments_endpoint;
 
 	/**
 	 * The Order Factory.
@@ -107,9 +91,7 @@ class OrderProcessor {
 	 * OrderProcessor constructor.
 	 *
 	 * @param SessionHandler              $session_handler The Session Handler.
-	 * @param CartRepository              $cart_repository The Cart Repository.
 	 * @param OrderEndpoint               $order_endpoint The Order Endpoint.
-	 * @param PaymentsEndpoint            $payments_endpoint The Payments Endpoint.
 	 * @param OrderFactory                $order_factory The Order Factory.
 	 * @param ThreeDSecure                $three_d_secure The ThreeDSecure Helper.
 	 * @param AuthorizedPaymentsProcessor $authorized_payments_processor The Authorized Payments Processor.
@@ -119,9 +101,7 @@ class OrderProcessor {
 	 */
 	public function __construct(
 		SessionHandler $session_handler,
-		CartRepository $cart_repository,
 		OrderEndpoint $order_endpoint,
-		PaymentsEndpoint $payments_endpoint,
 		OrderFactory $order_factory,
 		ThreeDSecure $three_d_secure,
 		AuthorizedPaymentsProcessor $authorized_payments_processor,
@@ -131,9 +111,7 @@ class OrderProcessor {
 	) {
 
 		$this->session_handler               = $session_handler;
-		$this->cart_repository               = $cart_repository;
 		$this->order_endpoint                = $order_endpoint;
-		$this->payments_endpoint             = $payments_endpoint;
 		$this->order_factory                 = $order_factory;
 		$this->threed_secure                 = $three_d_secure;
 		$this->authorized_payments_processor = $authorized_payments_processor;

--- a/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
@@ -189,7 +189,7 @@ class OrderProcessor {
 			$wc_order->update_meta_data( PayPalGateway::CAPTURED_META_KEY, 'true' );
 			$wc_order->update_status( 'processing' );
 		}
-		wc()->cart->empty_cart();
+		WC()->cart->empty_cart();
 		$this->session_handler->destroy_session_data();
 		$this->last_error = '';
 		return true;

--- a/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
@@ -123,11 +123,11 @@ class OrderProcessor {
 	/**
 	 * Processes a given WooCommerce order and captured/authorizes the connected PayPal orders.
 	 *
-	 * @param \WC_Order    $wc_order The WooCommerce order.
+	 * @param \WC_Order $wc_order The WooCommerce order.
 	 *
 	 * @return bool
 	 */
-	public function process( \WC_Order $wc_order): bool {
+	public function process( \WC_Order $wc_order ): bool {
 		$order = $this->session_handler->order();
 		if ( ! $order ) {
 			return false;

--- a/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
@@ -146,11 +146,10 @@ class OrderProcessor {
 	 * Processes a given WooCommerce order and captured/authorizes the connected PayPal orders.
 	 *
 	 * @param \WC_Order    $wc_order The WooCommerce order.
-	 * @param \WooCommerce $woocommerce The WooCommerce object.
 	 *
 	 * @return bool
 	 */
-	public function process( \WC_Order $wc_order, \WooCommerce $woocommerce ): bool {
+	public function process( \WC_Order $wc_order): bool {
 		$order = $this->session_handler->order();
 		if ( ! $order ) {
 			return false;
@@ -212,7 +211,7 @@ class OrderProcessor {
 			$wc_order->update_meta_data( PayPalGateway::CAPTURED_META_KEY, 'true' );
 			$wc_order->update_status( 'processing' );
 		}
-		$woocommerce->cart->empty_cart();
+		wc()->cart->empty_cart();
 		$this->session_handler->destroy_session_data();
 		$this->last_error = '';
 		return true;

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -6,20 +6,19 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
 use Woocommerce\PayPalCommerce\ApiClient\Entity\Capture;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
-use WooCommerce\PayPalCommerce\ApiClient\Repository\CartRepository;
 use WooCommerce\PayPalCommerce\Button\Helper\ThreeDSecure;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use Mockery;
+use function Brain\Monkey\Functions\when;
 
 class OrderProcessorTest extends TestCase
 {
@@ -78,8 +77,6 @@ class OrderProcessorTest extends TestCase
         $sessionHandler
             ->expects('destroy_session_data');
 
-        $cartRepository = Mockery::mock(CartRepository::class);
-
         $orderEndpoint = Mockery::mock(OrderEndpoint::class);
         $orderEndpoint
             ->expects('patch_order_with')
@@ -89,8 +86,6 @@ class OrderProcessorTest extends TestCase
             ->expects('authorize')
             ->with($currentOrder)
             ->andReturn($currentOrder);
-
-        $paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
 
         $orderFactory = Mockery::mock(OrderFactory::class);
         $orderFactory
@@ -111,9 +106,7 @@ class OrderProcessorTest extends TestCase
 
         $testee = new OrderProcessor(
             $sessionHandler,
-            $cartRepository,
             $orderEndpoint,
-            $paymentsEndpoint,
             $orderFactory,
             $threeDSecure,
             $authorizedPaymentProcessor,
@@ -126,6 +119,9 @@ class OrderProcessorTest extends TestCase
         $cart
             ->expects('empty_cart');
         $woocommerce = Mockery::mock(\WooCommerce::class);
+        when('WC')
+			->justReturn($woocommerce);
+
         $woocommerce->cart = $cart;
 
         $wcOrder
@@ -149,7 +145,9 @@ class OrderProcessorTest extends TestCase
         $wcOrder
             ->expects('update_status')
             ->with('on-hold', 'Awaiting payment.');
-        $this->assertTrue($testee->process($wcOrder, $woocommerce));
+
+
+        $this->assertTrue($testee->process($wcOrder));
     }
 
     public function testCapture() {
@@ -198,7 +196,6 @@ class OrderProcessorTest extends TestCase
             ->andReturn($currentOrder);
         $sessionHandler
             ->expects('destroy_session_data');
-        $cartRepository = Mockery::mock(CartRepository::class);
         $orderEndpoint = Mockery::mock(OrderEndpoint::class);
         $orderEndpoint
             ->expects('patch_order_with')
@@ -208,7 +205,6 @@ class OrderProcessorTest extends TestCase
             ->expects('capture')
             ->with($currentOrder)
             ->andReturn($currentOrder);
-        $paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
         $orderFactory = Mockery::mock(OrderFactory::class);
         $orderFactory
             ->expects('from_wc_order')
@@ -221,14 +217,24 @@ class OrderProcessorTest extends TestCase
             ->shouldReceive('has')
             ->andReturnFalse();
 
+        $cart = Mockery::mock(\WC_Cart::class);
+        $cart
+			->shouldReceive('empty_cart');
+
+        $woocommerce = Mockery::Mock(\Woocommerce::class);
+		$woocommerce
+			->shouldReceive('__get')
+			->with('cart')
+			->set('cart', $cart);
+        when('WC')
+			->justReturn($woocommerce);
+
 		$logger = Mockery::mock(LoggerInterface::class);
 
 
 		$testee = new OrderProcessor(
             $sessionHandler,
-            $cartRepository,
             $orderEndpoint,
-            $paymentsEndpoint,
             $orderFactory,
             $threeDSecure,
             $authorizedPaymentProcessor,
@@ -242,6 +248,9 @@ class OrderProcessorTest extends TestCase
             ->expects('empty_cart');
         $woocommerce = Mockery::mock(\WooCommerce::class);
         $woocommerce->cart = $cart;
+
+        when('WC')
+			->justReturn($woocommerce);
 
         $wcOrder
             ->expects('update_meta_data')
@@ -265,7 +274,7 @@ class OrderProcessorTest extends TestCase
         $wcOrder
             ->expects('update_status')
             ->with('processing', 'Payment received.');
-        $this->assertTrue($testee->process($wcOrder, $woocommerce));
+        $this->assertTrue($testee->process($wcOrder));
     }
 
     public function testError() {
@@ -316,9 +325,7 @@ class OrderProcessorTest extends TestCase
         $sessionHandler
             ->expects('order')
             ->andReturn($currentOrder);
-        $cartRepository = Mockery::mock(CartRepository::class);
         $orderEndpoint = Mockery::mock(OrderEndpoint::class);
-        $paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
         $orderFactory = Mockery::mock(OrderFactory::class);
         $threeDSecure = Mockery::mock(ThreeDSecure::class);
         $authorizedPaymentProcessor = Mockery::mock(AuthorizedPaymentsProcessor::class);
@@ -328,9 +335,7 @@ class OrderProcessorTest extends TestCase
 
 		$testee = new OrderProcessor(
             $sessionHandler,
-            $cartRepository,
             $orderEndpoint,
-            $paymentsEndpoint,
             $orderFactory,
             $threeDSecure,
             $authorizedPaymentProcessor,
@@ -338,10 +343,6 @@ class OrderProcessorTest extends TestCase
             $logger,
             false
         );
-
-        $cart = Mockery::mock(\WC_Cart::class);
-        $woocommerce = Mockery::mock(\WooCommerce::class);
-        $woocommerce->cart = $cart;
 
         $wcOrder
             ->expects('update_meta_data')
@@ -355,7 +356,8 @@ class OrderProcessorTest extends TestCase
                 PayPalGateway::INTENT_META_KEY,
                 $orderIntent
             );
-        $this->assertFalse($testee->process($wcOrder, $woocommerce));
+        
+        $this->assertFalse($testee->process($wcOrder));
         $this->assertNotEmpty($testee->last_error());
     }
 

--- a/tests/PHPUnit/WcGateway/Repository/ApplicationContextRepositoryTest.php
+++ b/tests/PHPUnit/WcGateway/Repository/ApplicationContextRepositoryTest.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-namespace WooCommerce\PayPalCommerce\ApiClient\Repository;
+namespace WooCommerce\PayPalCommerce\WcGateway\Repository;
 
 use Hamcrest\Matchers;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
+use WooCommerce\PayPalCommerce\ApiClient\Repository\ApplicationContextRepository;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery\MockInterface;
 use Psr\Container\ContainerInterface;
@@ -25,8 +26,6 @@ class ApplicationContextRepositoryTest extends TestCase
         array $expected
     ): void
     {
-        $brandName = 'Acme Corp.';
-
         // Config
         foreach ($container as $key => $value) {
             $this->buildTestee()[0]->shouldReceive('has')

--- a/tests/PHPUnit/WcGateway/Repository/CartRepositoryTest.php
+++ b/tests/PHPUnit/WcGateway/Repository/CartRepositoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace WooCommerce\PayPalCommerce\ApiClient\Repository;
+namespace WooCommerce\PayPalCommerce\WcGateway\Repository;
 
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: [PCP-75](https://inpsyde.atlassian.net/browse/PCP-75).

---

### Description
Changes the create order process so the checkout form validated before sending create order request to PayPal. This prevents cases of sending incomplete data to PayPal and getting errors from there.

### Steps to test:
1. Add any product to the cart.
2. Go to the checkout page.
3. Select PayPal as a payment method.
4. Fill the checkout form except for one required field (e.g. City/Town).
5. Submit the checkout.

You should see the standard WooCommerce error like "**Town / City is a required field.**" instead of an error like 
"[UNPROCESSABLE_ENTITY] The requested action could not be performed..." that is returned from PayPal.


### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Fix - Checkout form validation.

Closes #115.
