### PR TITLE
Fix pay later messaging options

### DIFF
--- a/modules/ppcp-onboarding/assets/js/settings.js
+++ b/modules/ppcp-onboarding/assets/js/settings.js
@@ -33,6 +33,11 @@ document.addEventListener(
 
                     if('ppcp-message_product_enabled' === event.target.getAttribute('id')){
                         updateProductMessageFields();
+                        return;
+                    }
+
+                    if('ppcp-message_cart_enabled' === event.target.getAttribute('id')){
+                        updateCartMessageFields();
                     }
 
                 }
@@ -124,6 +129,35 @@ document.addEventListener(
                     {
                         value:'flex',
                         selector:'#field-message_product_flex_color'
+                    }
+                ]
+            );
+        }
+
+        const updateCartMessageFields = () =>
+        {
+            groupToggleSelect(
+                '#ppcp-message_cart_layout',
+                [
+                    {
+                        value:'text',
+                        selector:'#field-message_cart_logo'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_cart_position'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_cart_color'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_cart_flex_ratio'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_cart_flex_color'
                     }
                 ]
             );
@@ -254,33 +288,10 @@ document.addEventListener(
                     }
                 ]
             );
-            groupToggleSelect(
-                '#ppcp-message_cart_layout',
-                [
-                    {
-                        value:'text',
-                        selector:'#field-message_cart_logo'
-                    },
-                    {
-                        value:'text',
-                        selector:'#field-message_cart_position'
-                    },
-                    {
-                        value:'text',
-                        selector:'#field-message_cart_color'
-                    },
-                    {
-                        value:'flex',
-                        selector:'#field-message_cart_flex_ratio'
-                    },
-                    {
-                        value:'flex',
-                        selector:'#field-message_cart_flex_color'
-                    }
-                ]
-            );
+
             updateCheckoutMessageFields();
             updateProductMessageFields();
+            updateCartMessageFields();
         })();
     }
 )

--- a/modules/ppcp-onboarding/assets/js/settings.js
+++ b/modules/ppcp-onboarding/assets/js/settings.js
@@ -280,6 +280,7 @@ document.addEventListener(
                 ]
             );
             updateCheckoutMessageFields();
+            updateProductMessageFields();
         })();
     }
 )

--- a/modules/ppcp-onboarding/assets/js/settings.js
+++ b/modules/ppcp-onboarding/assets/js/settings.js
@@ -25,6 +25,11 @@ document.addEventListener(
                     group.forEach( (elementToShow) => {
                         document.querySelector(elementToShow).style.display = 'table-row';
                     })
+
+                    if('ppcp-message_enabled' === event.target.getAttribute('id')){
+                        updateCheckoutMessageFields();
+                    }
+
                 }
             );
         };
@@ -62,6 +67,34 @@ document.addEventListener(
                 }
             );
         };
+
+        const updateCheckoutMessageFields = () => {
+            groupToggleSelect(
+                '#ppcp-message_layout',
+                [
+                    {
+                        value:'text',
+                        selector:'#field-message_logo'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_position'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_color'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_flex_ratio'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_flex_color'
+                    }
+                ]
+            );
+        }
 
         const disableOptions = (sourceSelector, targetSelector) => {
 
@@ -237,31 +270,7 @@ document.addEventListener(
                     }
                 ]
             );
-            groupToggleSelect(
-                '#ppcp-message_layout',
-                [
-                    {
-                        value:'text',
-                        selector:'#field-message_logo'
-                    },
-                    {
-                        value:'text',
-                        selector:'#field-message_position'
-                    },
-                    {
-                        value:'text',
-                        selector:'#field-message_color'
-                    },
-                    {
-                        value:'flex',
-                        selector:'#field-message_flex_ratio'
-                    },
-                    {
-                        value:'flex',
-                        selector:'#field-message_flex_color'
-                    }
-                ]
-            );
+            updateCheckoutMessageFields();
         })();
     }
 )

--- a/modules/ppcp-onboarding/assets/js/settings.js
+++ b/modules/ppcp-onboarding/assets/js/settings.js
@@ -28,6 +28,7 @@ document.addEventListener(
 
                     if('ppcp-message_enabled' === event.target.getAttribute('id')){
                         updateCheckoutMessageFields();
+                        return;
                     }
 
                     if('ppcp-message_product_enabled' === event.target.getAttribute('id')){

--- a/modules/ppcp-onboarding/assets/js/settings.js
+++ b/modules/ppcp-onboarding/assets/js/settings.js
@@ -30,6 +30,10 @@ document.addEventListener(
                         updateCheckoutMessageFields();
                     }
 
+                    if('ppcp-message_product_enabled' === event.target.getAttribute('id')){
+                        updateProductMessageFields();
+                    }
+
                 }
             );
         };
@@ -91,6 +95,34 @@ document.addEventListener(
                     {
                         value:'flex',
                         selector:'#field-message_flex_color'
+                    }
+                ]
+            );
+        }
+
+        const updateProductMessageFields = () => {
+            groupToggleSelect(
+                '#ppcp-message_product_layout',
+                [
+                    {
+                        value:'text',
+                        selector:'#field-message_product_logo'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_product_position'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_product_color'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_product_flex_ratio'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_product_flex_color'
                     }
                 ]
             );
@@ -211,31 +243,7 @@ document.addEventListener(
                 ]
             );
 
-            groupToggleSelect(
-                '#ppcp-message_product_layout',
-                [
-                    {
-                        value:'text',
-                        selector:'#field-message_product_logo'
-                    },
-                    {
-                        value:'text',
-                        selector:'#field-message_product_position'
-                    },
-                    {
-                        value:'text',
-                        selector:'#field-message_product_color'
-                    },
-                    {
-                        value:'flex',
-                        selector:'#field-message_product_flex_ratio'
-                    },
-                    {
-                        value:'flex',
-                        selector:'#field-message_product_flex_color'
-                    }
-                ]
-            );
+
             groupToggleSelect(
                 '#ppcp-intent',
                 [

--- a/modules/ppcp-onboarding/assets/js/settings.js
+++ b/modules/ppcp-onboarding/assets/js/settings.js
@@ -1,262 +1,267 @@
-const groupToggle = (selector, group) => {
-    const toggleElement = document.querySelector(selector);
-    if (! toggleElement) {
-        return;
-    }
-    if (! toggleElement.checked) {
-        group.forEach( (elementToHide) => {
-            document.querySelector(elementToHide).style.display = 'none';
-        })
-    }
-    toggleElement.addEventListener(
-        'change',
-        (event) => {
-
-            if (! event.target.checked) {
-                group.forEach( (elementToHide) => {
-                    document.querySelector(elementToHide).style.display = 'none';
-                });
+document.addEventListener(
+    'DOMContentLoaded',
+    () => {
+        const groupToggle = (selector, group) => {
+            const toggleElement = document.querySelector(selector);
+            if (! toggleElement) {
                 return;
             }
+            if (! toggleElement.checked) {
+                group.forEach( (elementToHide) => {
+                    document.querySelector(elementToHide).style.display = 'none';
+                })
+            }
+            toggleElement.addEventListener(
+                'change',
+                (event) => {
 
-            group.forEach( (elementToShow) => {
-                document.querySelector(elementToShow).style.display = 'table-row';
-            })
-        }
-    );
-};
+                    if (! event.target.checked) {
+                        group.forEach( (elementToHide) => {
+                            document.querySelector(elementToHide).style.display = 'none';
+                        });
+                        return;
+                    }
 
-const groupToggleSelect = (selector, group) => {
-    const toggleElement = document.querySelector(selector);
-    if (! toggleElement) {
-        return;
-    }
-    const value = toggleElement.value;
-    group.forEach( (elementToToggle) => {
-        const domElement = document.querySelector(elementToToggle.selector);
-        if (! domElement) {
-            return;
-        }
-        if (value === elementToToggle.value && domElement.style.display !== 'none') {
-            domElement.style.display = 'table-row';
-            return;
-        }
-        domElement.style.display = 'none';
-    });
+                    group.forEach( (elementToShow) => {
+                        document.querySelector(elementToShow).style.display = 'table-row';
+                    })
+                }
+            );
+        };
 
-    // We need to use jQuery here as the select might be a select2 element, which doesn't use native events.
-    jQuery(toggleElement).on(
-        'change',
-        (event) => {
-            const value = event.target.value;
+        const groupToggleSelect = (selector, group) => {
+            const toggleElement = document.querySelector(selector);
+            if (! toggleElement) {
+                return;
+            }
+            const value = toggleElement.value;
             group.forEach( (elementToToggle) => {
-                if (value === elementToToggle.value) {
-                    document.querySelector(elementToToggle.selector).style.display = 'table-row';
+                const domElement = document.querySelector(elementToToggle.selector);
+                if (! domElement) {
                     return;
                 }
-                document.querySelector(elementToToggle.selector).style.display = 'none';
-            })
-        }
-    );
-};
+                if (value === elementToToggle.value && domElement.style.display !== 'none') {
+                    domElement.style.display = 'table-row';
+                    return;
+                }
+                domElement.style.display = 'none';
+            });
 
-const disableOptions = (sourceSelector, targetSelector) => {
+            // We need to use jQuery here as the select might be a select2 element, which doesn't use native events.
+            jQuery(toggleElement).on(
+                'change',
+                (event) => {
+                    const value = event.target.value;
+                    group.forEach( (elementToToggle) => {
+                        if (value === elementToToggle.value) {
+                            document.querySelector(elementToToggle.selector).style.display = 'table-row';
+                            return;
+                        }
+                        document.querySelector(elementToToggle.selector).style.display = 'none';
+                    })
+                }
+            );
+        };
 
-    const source = jQuery(sourceSelector);
-    const target = document.querySelector(targetSelector);
-    if (! target) {
-        return;
+        const disableOptions = (sourceSelector, targetSelector) => {
+
+            const source = jQuery(sourceSelector);
+            const target = document.querySelector(targetSelector);
+            if (! target) {
+                return;
+            }
+            const allOptions = Array.from(document.querySelectorAll('select[name="ppcp[disable_cards][]"] option'));
+            const replace = () => {
+                const validOptions = allOptions.filter(
+                    (option) => {
+
+                        return ! option.selected
+                    }
+                );
+                const selectedValidOptions = validOptions.map(
+                    (option) => {
+                        option = option.cloneNode(true);
+                        option.selected = target.querySelector('option[value="' + option.value + '"]') && target.querySelector('option[value="' + option.value + '"]').selected;
+                        return option;
+                    }
+                );
+                target.innerHTML = '';
+                selectedValidOptions.forEach(
+                    (option) => {
+                        target.append(option);
+                    }
+                );
+            };
+
+            source.on('change',replace);
+            replace();
+        };
+
+        (() => {
+            disableOptions('select[name="ppcp[disable_cards][]"]', 'select[name="ppcp[card_icons][]"]');
+            groupToggle(
+                '#ppcp-button_enabled',
+                [
+                    '#field-button_layout',
+                    '#field-button_tagline',
+                    '#field-button_label',
+                    '#field-button_color',
+                    '#field-button_shape',
+                ]
+            );
+
+            groupToggle(
+                '#ppcp-message_enabled',
+                [
+                    '#field-message_layout',
+                    '#field-message_logo',
+                    '#field-message_position',
+                    '#field-message_color',
+                    '#field-message_flex_color',
+                    '#field-message_flex_ratio',
+                ]
+            );
+
+            groupToggle(
+                '#ppcp-button_product_enabled',
+                [
+                    '#field-button_product_layout',
+                    '#field-button_product_tagline',
+                    '#field-button_product_label',
+                    '#field-button_product_color',
+                    '#field-button_product_shape',
+                ]
+            );
+
+            groupToggle(
+                '#ppcp-message_product_enabled',
+                [
+                    '#field-message_product_layout',
+                    '#field-message_product_logo',
+                    '#field-message_product_position',
+                    '#field-message_product_color',
+                    '#field-message_product_flex_color',
+                    '#field-message_product_flex_ratio',
+                ]
+            );
+
+            groupToggle(
+                '#ppcp-button_mini-cart_enabled',
+                [
+                    '#field-button_mini-cart_layout',
+                    '#field-button_mini-cart_tagline',
+                    '#field-button_mini-cart_label',
+                    '#field-button_mini-cart_color',
+                    '#field-button_mini-cart_shape',
+                ]
+            );
+
+            groupToggle(
+                '#ppcp-button_cart_enabled',
+                [
+                    '#field-button_cart_layout',
+                    '#field-button_cart_tagline',
+                    '#field-button_cart_label',
+                    '#field-button_cart_color',
+                    '#field-button_cart_shape',
+                ]
+            );
+            groupToggle(
+                '#ppcp-message_cart_enabled',
+                [
+                    '#field-message_cart_layout',
+                    '#field-message_cart_logo',
+                    '#field-message_cart_position',
+                    '#field-message_cart_color',
+                    '#field-message_cart_flex_color',
+                    '#field-message_cart_flex_ratio',
+                ]
+            );
+
+            groupToggleSelect(
+                '#ppcp-message_product_layout',
+                [
+                    {
+                        value:'text',
+                        selector:'#field-message_product_logo'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_product_position'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_product_color'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_product_flex_ratio'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_product_flex_color'
+                    }
+                ]
+            );
+            groupToggleSelect(
+                '#ppcp-intent',
+                [
+                    {
+                        value:'authorize',
+                        selector:'#field-capture_for_virtual_only'
+                    }
+                ]
+            );
+            groupToggleSelect(
+                '#ppcp-message_cart_layout',
+                [
+                    {
+                        value:'text',
+                        selector:'#field-message_cart_logo'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_cart_position'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_cart_color'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_cart_flex_ratio'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_cart_flex_color'
+                    }
+                ]
+            );
+            groupToggleSelect(
+                '#ppcp-message_layout',
+                [
+                    {
+                        value:'text',
+                        selector:'#field-message_logo'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_position'
+                    },
+                    {
+                        value:'text',
+                        selector:'#field-message_color'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_flex_ratio'
+                    },
+                    {
+                        value:'flex',
+                        selector:'#field-message_flex_color'
+                    }
+                ]
+            );
+        })();
     }
-    const allOptions = Array.from(document.querySelectorAll('select[name="ppcp[disable_cards][]"] option'));
-    const replace = () => {
-        const validOptions = allOptions.filter(
-            (option) => {
-
-                return ! option.selected
-            }
-        );
-        const selectedValidOptions = validOptions.map(
-            (option) => {
-                option = option.cloneNode(true);
-                option.selected = target.querySelector('option[value="' + option.value + '"]') && target.querySelector('option[value="' + option.value + '"]').selected;
-                return option;
-            }
-        );
-        target.innerHTML = '';
-        selectedValidOptions.forEach(
-            (option) => {
-                target.append(option);
-            }
-        );
-    };
-
-    source.on('change',replace);
-    replace();
-};
-
-(() => {
-    disableOptions('select[name="ppcp[disable_cards][]"]', 'select[name="ppcp[card_icons][]"]');
-    groupToggle(
-        '#ppcp-button_enabled',
-        [
-            '#field-button_layout',
-            '#field-button_tagline',
-            '#field-button_label',
-            '#field-button_color',
-            '#field-button_shape',
-        ]
-    );
-
-    groupToggle(
-        '#ppcp-message_enabled',
-        [
-            '#field-message_layout',
-            '#field-message_logo',
-            '#field-message_position',
-            '#field-message_color',
-            '#field-message_flex_color',
-            '#field-message_flex_ratio',
-        ]
-    );
-
-    groupToggle(
-        '#ppcp-button_product_enabled',
-        [
-            '#field-button_product_layout',
-            '#field-button_product_tagline',
-            '#field-button_product_label',
-            '#field-button_product_color',
-            '#field-button_product_shape',
-        ]
-    );
-
-    groupToggle(
-        '#ppcp-message_product_enabled',
-        [
-            '#field-message_product_layout',
-            '#field-message_product_logo',
-            '#field-message_product_position',
-            '#field-message_product_color',
-            '#field-message_product_flex_color',
-            '#field-message_product_flex_ratio',
-        ]
-    );
-
-    groupToggle(
-        '#ppcp-button_mini-cart_enabled',
-        [
-            '#field-button_mini-cart_layout',
-            '#field-button_mini-cart_tagline',
-            '#field-button_mini-cart_label',
-            '#field-button_mini-cart_color',
-            '#field-button_mini-cart_shape',
-        ]
-    );
-
-    groupToggle(
-        '#ppcp-button_cart_enabled',
-        [
-            '#field-button_cart_layout',
-            '#field-button_cart_tagline',
-            '#field-button_cart_label',
-            '#field-button_cart_color',
-            '#field-button_cart_shape',
-        ]
-    );
-    groupToggle(
-        '#ppcp-message_cart_enabled',
-        [
-            '#field-message_cart_layout',
-            '#field-message_cart_logo',
-            '#field-message_cart_position',
-            '#field-message_cart_color',
-            '#field-message_cart_flex_color',
-            '#field-message_cart_flex_ratio',
-        ]
-    );
-
-    groupToggleSelect(
-        '#ppcp-message_product_layout',
-        [
-            {
-                value:'text',
-                selector:'#field-message_product_logo'
-            },
-            {
-                value:'text',
-                selector:'#field-message_product_position'
-            },
-            {
-                value:'text',
-                selector:'#field-message_product_color'
-            },
-            {
-                value:'flex',
-                selector:'#field-message_product_flex_ratio'
-            },
-            {
-                value:'flex',
-                selector:'#field-message_product_flex_color'
-            }
-        ]
-    );
-    groupToggleSelect(
-        '#ppcp-intent',
-        [
-            {
-                value:'authorize',
-                selector:'#field-capture_for_virtual_only'
-            }
-        ]
-    );
-    groupToggleSelect(
-        '#ppcp-message_cart_layout',
-        [
-            {
-                value:'text',
-                selector:'#field-message_cart_logo'
-            },
-            {
-                value:'text',
-                selector:'#field-message_cart_position'
-            },
-            {
-                value:'text',
-                selector:'#field-message_cart_color'
-            },
-            {
-                value:'flex',
-                selector:'#field-message_cart_flex_ratio'
-            },
-            {
-                value:'flex',
-                selector:'#field-message_cart_flex_color'
-            }
-        ]
-    );
-    groupToggleSelect(
-        '#ppcp-message_layout',
-        [
-            {
-                value:'text',
-                selector:'#field-message_logo'
-            },
-            {
-                value:'text',
-                selector:'#field-message_position'
-            },
-            {
-                value:'text',
-                selector:'#field-message_color'
-            },
-            {
-                value:'flex',
-                selector:'#field-message_flex_ratio'
-            },
-            {
-                value:'flex',
-                selector:'#field-message_flex_color'
-            }
-        ]
-    );
-})();
+)


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: [PCP-113](https://inpsyde.atlassian.net/browse/PCP-113).

---

### Description
Pay Later messaging settings are contained fields related to two types of layout: text and flex. At any moment only one type of field should be displayed, depending on what selected, text or flex.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Log into WP admin.
2. Go to the plugin settings.
3. Enable Pay Later messaging (if not enabled).
4. Check what type of layout is selected.
5. Make sure that only respective options are displayed below the layout select field. For `Text`: logo, logo position, text color. For `Flex`: color and ratio. Also, WC help tips next to each field contain info on what type of layout this setting relates to.
6. Try to check/uncheck PayLater messages and save. Make sure the proper fields are displayed each time and no fields displayed if PayLater messaging is disabled.
7. Try to switch layout and save. Make sure you can see proper fields.

_Note:_ There are three sets of settings fields related to Pay Later messages: for checkout, for cart, and for product page. They have the same fields and the same appearance logic described above.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Fix - Pay Later settings appearance based on selected layout type.

Closes #138.
