### PR TITLE
Fix Duplicate Invoice Id error

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -223,8 +223,7 @@ class OrderEndpoint {
 			'body'    => wp_json_encode( $data ),
 		);
 
-		$paypal_request_id = '' === $paypal_request_id ? $this->generate_request_id() : $paypal_request_id;
-
+		$paypal_request_id                    = $paypal_request_id ?: $this->generate_request_id();
 		$args['headers']['PayPal-Request-Id'] = $paypal_request_id;
 		if ( $this->bn_code ) {
 			$args['headers']['PayPal-Partner-Attribution-Id'] = $this->bn_code;

--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -322,7 +322,10 @@ class OrderEndpoint {
 			}
 			$this->logger->log(
 				'warning',
-				$error->getMessage(),
+				sprintf(
+					'Failed to capture order. PayPal API response: %1$s',
+					$error->getMessage()
+				),
 				array(
 					'args'     => $args,
 					'response' => $response,

--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -223,7 +223,7 @@ class OrderEndpoint {
 			'body'    => wp_json_encode( $data ),
 		);
 
-		$paypal_request_id                    = $paypal_request_id ?: $this->generate_request_id();
+		$paypal_request_id                    = $paypal_request_id ? $paypal_request_id : uniqid( 'ppcp-', true );
 		$args['headers']['PayPal-Request-Id'] = $paypal_request_id;
 		if ( $this->bn_code ) {
 			$args['headers']['PayPal-Partner-Attribution-Id'] = $this->bn_code;
@@ -555,14 +555,5 @@ class OrderEndpoint {
 
 		$new_order = $this->order( $order_to_update->id() );
 		return $new_order;
-	}
-
-	/**
-	 * Generate a new invoice id.
-	 *
-	 * @return string
-	 */
-	private function generate_request_id(): string {
-		return uniqid( 'ppcp-', true );
 	}
 }

--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -223,7 +223,8 @@ class OrderEndpoint {
 			'body'    => wp_json_encode( $data ),
 		);
 
-		$paypal_request_id                    = $paypal_request_id ?: $this->generate_request_id();
+		$paypal_request_id                    = '' === $paypal_request_id ? $this->generate_request_id() : $paypal_request_id;
+
 		$args['headers']['PayPal-Request-Id'] = $paypal_request_id;
 		if ( $this->bn_code ) {
 			$args['headers']['PayPal-Partner-Attribution-Id'] = $this->bn_code;

--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -253,7 +253,10 @@ class OrderEndpoint {
 			);
 			$this->logger->log(
 				'warning',
-				$error->getMessage(),
+				sprintf(
+					'Failed to create order. PayPal API response: %1$s',
+					$error->getMessage()
+				),
 				array(
 					'args'     => $args,
 					'response' => $response,
@@ -398,7 +401,10 @@ class OrderEndpoint {
 			);
 			$this->logger->log(
 				'warning',
-				$error->getMessage(),
+				sprintf(
+					'Failed to authorize order. PayPal API response: %1$s',
+					$error->getMessage()
+				),
 				array(
 					'args'     => $args,
 					'response' => $response,

--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -223,7 +223,7 @@ class OrderEndpoint {
 			'body'    => wp_json_encode( $data ),
 		);
 
-		$paypal_request_id                    = '' === $paypal_request_id ? $this->generate_request_id() : $paypal_request_id;
+		$paypal_request_id = '' === $paypal_request_id ? $this->generate_request_id() : $paypal_request_id;
 
 		$args['headers']['PayPal-Request-Id'] = $paypal_request_id;
 		if ( $this->bn_code ) {
@@ -557,14 +557,13 @@ class OrderEndpoint {
 		$new_order = $this->order( $order_to_update->id() );
 		return $new_order;
 	}
-	
+
 	/**
 	 * Generate a new invoice id.
 	 *
 	 * @return string
 	 */
-	private function generate_request_id(): string
-	{
+	private function generate_request_id(): string {
 		return uniqid( 'ppcp-', true );
 	}
 }

--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -223,7 +223,7 @@ class OrderEndpoint {
 			'body'    => wp_json_encode( $data ),
 		);
 
-		$paypal_request_id                    = $paypal_request_id ? $paypal_request_id : uniqid( 'ppcp-', true );
+		$paypal_request_id                    = $paypal_request_id ?: $this->generate_request_id();
 		$args['headers']['PayPal-Request-Id'] = $paypal_request_id;
 		if ( $this->bn_code ) {
 			$args['headers']['PayPal-Partner-Attribution-Id'] = $this->bn_code;
@@ -546,5 +546,15 @@ class OrderEndpoint {
 
 		$new_order = $this->order( $order_to_update->id() );
 		return $new_order;
+	}
+	
+	/**
+	 * Generate a new invoice id.
+	 *
+	 * @return string
+	 */
+	private function generate_request_id(): string
+	{
+		return uniqid( 'ppcp-', true );
 	}
 }

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -711,7 +711,7 @@ return array(
 				'title'        => __( 'Invoice prefix', 'woocommerce-paypal-payments' ),
 				'type'         => 'text',
 				'desc_tip'     => true,
-				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to seperate those installations. Please do not use numbers in your prefix.', 'woocommerce-paypal-payments' ),
+				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please do not use numbers in your prefix.', 'woocommerce-paypal-payments' ),
 				'default'      => 'WC-',
 				'screens'      => array(
 					State::STATE_PROGRESSIVE,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -711,12 +711,12 @@ return array(
 				'type'         => 'text',
 				'desc_tip'     => true,
 				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please do not use numbers in your prefix.', 'woocommerce-paypal-payments' ),
-				'default' => (static function (array $allowedSymbols): string {
-					$default_prefix_chars = array_rand(array_flip($allowedSymbols), 4);
-					$random_prefix = implode('', $default_prefix_chars) . '-';
-					$site_domain = parse_url(get_site_url(get_current_blog_id()), PHP_URL_HOST);
+				'default'      => ( static function ( array $allowedSymbols ): string {
+					$default_prefix_chars = array_rand( array_flip( $allowedSymbols ), 4 );
+					$random_prefix = implode( '', $default_prefix_chars ) . '-';
+					$site_domain = parse_url( get_site_url( get_current_blog_id() ), PHP_URL_HOST );
 					return $random_prefix . $site_domain;
-				})(range('A', 'Z')),
+				} )( range( 'A', 'Z' ) ),
 				'screens'      => array(
 					State::STATE_PROGRESSIVE,
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -711,7 +711,10 @@ return array(
 				'type'         => 'text',
 				'desc_tip'     => true,
 				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please do not use numbers in your prefix.', 'woocommerce-paypal-payments' ),
-				'default'      => 'WC-',
+				'default' => (static function (array $allowedSymbols): string { //Generate random string from 4 letters and -.
+					$default_prefix_chars = array_rand(array_flip($allowedSymbols), 4);
+					return implode('', $default_prefix_chars) . '-';
+				})(range('A', 'Z')),
 				'screens'      => array(
 					State::STATE_PROGRESSIVE,
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -711,8 +711,8 @@ return array(
 				'type'         => 'text',
 				'desc_tip'     => true,
 				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please do not use numbers in your prefix.', 'woocommerce-paypal-payments' ),
-				'default'      => ( static function ( array $allowedSymbols ): string {
-					$default_prefix_chars = array_rand( array_flip( $allowedSymbols ), 4 );
+				'default'      => ( static function ( array $char_list ): string {
+					$default_prefix_chars = array_rand( array_flip( $char_list ), 4 );
 					$random_prefix = implode( '', $default_prefix_chars ) . '-';
 					$site_domain = parse_url( get_site_url( get_current_blog_id() ), PHP_URL_HOST );
 					return $random_prefix . $site_domain;

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -711,9 +711,11 @@ return array(
 				'type'         => 'text',
 				'desc_tip'     => true,
 				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please do not use numbers in your prefix.', 'woocommerce-paypal-payments' ),
-				'default' => (static function (array $allowedSymbols): string { //Generate random string from 4 letters and -.
+				'default' => (static function (array $allowedSymbols): string {
 					$default_prefix_chars = array_rand(array_flip($allowedSymbols), 4);
-					return implode('', $default_prefix_chars) . '-';
+					$random_prefix = implode('', $default_prefix_chars) . '-';
+					$site_domain = parse_url(get_site_url(get_current_blog_id()), PHP_URL_HOST);
+					return $random_prefix . $site_domain;
 				})(range('A', 'Z')),
 				'screens'      => array(
 					State::STATE_PROGRESSIVE,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway;
 
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: [PCP-118](https://inpsyde.atlassian.net/browse/PCP-118).

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

Generate random prefix for default value Invoice id option. This prevents creating PayPal orders with the same invoice id.

For example, I have `example.com` and `staging.example.com` sites and I'm using the same PayPal merchant on both. Before, the default invoice prefix was `WC-`, so it was possible `example.com` will try to create an order with the invoice ID `WC-123` and fail because the order with this invoice id already created by `staging.example.com`.

From now, a random 4-letters string is generated and combined with the site domain to be used as a prefix. So, invoice ids for new installations will be like `ABCD-staging.example.com-123` and `WXYZ-example.com-123`.

_Note_: the `uniqid()` function wasn't used because the Invoice ID field description [suggested](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-wc-gateway/services.php#L662) avoiding using numbers.

This will not affect existing installations.

Additionally, a few log messages will be more detailed now.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. If you are testing on the site where this plugin was installed before, then remove plugin settings in the DB first.
2. After plugin activation you should see something like `ABCD-yourdomain.com-` in the `Invoice prefix` field on the plugin settings page.
3. After saving settings, you should see that value wasn't changed.
4. After creating a new PayPal order, you should see the invoice id consisting from the prefix you saw at the previous step and the WC order number. There should be something like `ABCD-yourdomain.com-123`.

![PCP-118-finished](https://user-images.githubusercontent.com/13065667/113698940-a5e32e00-96dd-11eb-92cf-820d498f8698.png)


### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Fix - Minimize the chance of DUPLICATE_INVOICE_ID error for the clients using the same PayPal merchant on multiple sites.
