### PR TITLE
Wrong order status for orders with contain only products which are both virtual and downloadable

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -215,10 +215,9 @@ class PayPalGateway extends \WC_Payment_Gateway {
 			$wc_order->add_order_note(
 				__( 'Payment successfully captured.', 'woocommerce-paypal-payments' )
 			);
-
-			$wc_order->set_status( 'processing' );
 			$wc_order->update_meta_data( self::CAPTURED_META_KEY, 'true' );
 			$wc_order->save();
+			$wc_order->payment_complete();
 			return true;
 		}
 
@@ -227,11 +226,11 @@ class PayPalGateway extends \WC_Payment_Gateway {
 				$wc_order->add_order_note(
 					__( 'Payment successfully captured.', 'woocommerce-paypal-payments' )
 				);
-				$wc_order->set_status( 'processing' );
 			}
 
 			$wc_order->update_meta_data( self::CAPTURED_META_KEY, 'true' );
 			$wc_order->save();
+			$wc_order->payment_complete();
 			return true;
 		}
 		return false;

--- a/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
@@ -176,7 +176,7 @@ class OrderProcessor {
 			__( 'Awaiting payment.', 'woocommerce-paypal-payments' )
 		);
 		if ( $order->status()->is( OrderStatus::COMPLETED ) && $order->intent() === 'CAPTURE' ) {
-			
+
 			$wc_order->payment_complete();
 		}
 

--- a/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
@@ -176,10 +176,8 @@ class OrderProcessor {
 			__( 'Awaiting payment.', 'woocommerce-paypal-payments' )
 		);
 		if ( $order->status()->is( OrderStatus::COMPLETED ) && $order->intent() === 'CAPTURE' ) {
-			$wc_order->update_status(
-				'processing',
-				__( 'Payment received.', 'woocommerce-paypal-payments' )
-			);
+			
+			$wc_order->payment_complete();
 		}
 
 		if ( $this->capture_authorized_downloads( $order ) && $this->authorized_payments_processor->process( $wc_order ) ) {

--- a/modules/ppcp-webhooks/src/Handler/class-paymentcapturecompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/class-paymentcapturecompleted.php
@@ -117,7 +117,7 @@ class PaymentCaptureCompleted implements RequestHandler {
 			__( 'Payment successfully captured.', 'woocommerce-paypal-payments' )
 		);
 
-		$wc_order->set_status( 'processing' );
+		$wc_order->payment_complete();
 		$wc_order->update_meta_data( PayPalGateway::CAPTURED_META_KEY, 'true' );
 		$wc_order->save();
 		$this->logger->log(

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -192,11 +192,10 @@ class WcGatewayTest extends TestCase
         $wcOrder
             ->expects('add_order_note');
         $wcOrder
-            ->expects('set_status')
-            ->with('processing');
-        $wcOrder
             ->expects('update_meta_data')
             ->with(PayPalGateway::CAPTURED_META_KEY, 'true');
+        $wcOrder
+	        ->expects('payment_complete');
         $wcOrder
             ->expects('save');
         $settingsRenderer = Mockery::mock(SettingsRenderer::class);
@@ -248,11 +247,10 @@ class WcGatewayTest extends TestCase
         $wcOrder
             ->expects('add_order_note');
         $wcOrder
-            ->expects('set_status')
-            ->with('processing');
-        $wcOrder
             ->expects('update_meta_data')
             ->with(PayPalGateway::CAPTURED_META_KEY, 'true');
+        $wcOrder
+	        ->expects('payment_complete');
         $wcOrder
             ->expects('save');
         $settingsRenderer = Mockery::mock(SettingsRenderer::class);

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -272,8 +272,7 @@ class OrderProcessorTest extends TestCase
         $wcOrder->expects('set_transaction_id')
             ->with($transactionId);
         $wcOrder
-            ->expects('update_status')
-            ->with('processing', 'Payment received.');
+	        ->expects('payment_complete');
         $this->assertTrue($testee->process($wcOrder));
     }
 


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**:  [PCP-109](https://inpsyde.atlassian.net/browse/PCP-109).
---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

Order status after payment completed now decided by Woocommerce, like for most of the other gateways.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Purchase a product(s) that are both virtual and downloadable. And check the order status after the payment complete (order captured in PayPal terms). The order status should be `completed`.
2. Same as above for the products which are not both virtual and downloadable. The order status should be `processing` after the order captured.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Fix - Wrong order status after payment completed.
