### PR TITLE
Fix/pcp 130 fix cc fields

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -87,7 +87,7 @@ class CreditCardRenderer {
                 },
                 expirationDate: {
                     selector: '#ppcp-credit-card-gateway-card-expiry',
-                    placeholder: this.defaultConfig.hosted_fields.labels.mm_yyyy,
+                    placeholder: this.defaultConfig.hosted_fields.labels.mm_yy,
                 }
             }
         }).then(hostedFields => {

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -683,7 +683,7 @@ class SmartButton implements SmartButtonInterface {
 				'labels'            => array(
 					'credit_card_number' => '',
 					'cvv'                => '',
-					'mm_yyyy'            => __( 'MM/YY', 'woocommerce-paypal-payments' ),
+					'mm_yy'            => __( 'MM/YY', 'woocommerce-paypal-payments' ),
 					'fields_not_valid'   => __(
 						'Unfortunatly, your credit card details are not valid.',
 						'woocommerce-paypal-payments'

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -683,7 +683,7 @@ class SmartButton implements SmartButtonInterface {
 				'labels'            => array(
 					'credit_card_number' => '',
 					'cvv'                => '',
-					'mm_yy'            => __( 'MM/YY', 'woocommerce-paypal-payments' ),
+					'mm_yy'              => __( 'MM/YY', 'woocommerce-paypal-payments' ),
 					'fields_not_valid'   => __(
 						'Unfortunatly, your credit card details are not valid.',
 						'woocommerce-paypal-payments'

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -683,7 +683,7 @@ class SmartButton implements SmartButtonInterface {
 				'labels'            => array(
 					'credit_card_number' => '',
 					'cvv'                => '',
-					'mm_yyyy'            => __( 'MM/YYYY', 'woocommerce-paypal-payments' ),
+					'mm_yyyy'            => __( 'MM/YY', 'woocommerce-paypal-payments' ),
 					'fields_not_valid'   => __(
 						'Unfortunatly, your credit card details are not valid.',
 						'woocommerce-paypal-payments'

--- a/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
@@ -200,13 +200,12 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	/**
 	 * Render the credit card fields.
 	 */
-	public function form()
-	{
-		add_action('gettext', array($this, 'replace_credit_card_cvv_label'), 10, 3);
+	public function form() {
+		add_action( 'gettext', array( $this, 'replace_credit_card_cvv_label' ), 10, 3 );
 		parent::form();
-		remove_action('gettext', 'replace_credit_card_cvv_label');
+		remove_action( 'gettext', 'replace_credit_card_cvv_label' );
 	}
-	
+
 	/**
 	 * Replace WooCommerce credit card field label.
 	 *
@@ -216,13 +215,12 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 *
 	 * @return string Translated field.
 	 */
-	public function replace_credit_card_cvv_label(string $translation, string $text, string $domain): string
-	{
-		if('woocommerce' !== $domain || 'Card code' !== $text) {
+	public function replace_credit_card_cvv_label( string $translation, string $text, string $domain ): string {
+		if ( 'woocommerce' !== $domain || 'Card code' !== $text ) {
 			return $translation;
 		}
-		
-		return __('CVV', 'woocommerce-paypal-payments');
+
+		return __( 'CVV', 'woocommerce-paypal-payments' );
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
@@ -209,9 +209,9 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	/**
 	 * Replace WooCommerce credit card field label.
 	 *
-	 * @param $translation string Translated text.
-	 * @param $text string Original text to translate.
-	 * @param $domain string Text domain.
+	 * @param string $translation Translated text.
+	 * @param string $text Original text to translate.
+	 * @param string $domain Text domain.
 	 *
 	 * @return string Translated field.
 	 */

--- a/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
@@ -198,6 +198,34 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Render the credit card fields.
+	 */
+	public function form()
+	{
+		add_action('gettext', array($this, 'replace_credit_card_cvv_label'), 10, 3);
+		parent::form();
+		remove_action('gettext', 'replace_credit_card_cvv_label');
+	}
+	
+	/**
+	 * Replace WooCommerce credit card field label.
+	 *
+	 * @param $translation string Translated text.
+	 * @param $text string Original text to translate.
+	 * @param $domain string Text domain.
+	 *
+	 * @return string Translated field.
+	 */
+	public function replace_credit_card_cvv_label(string $translation, string $text, string $domain): string
+	{
+		if('woocommerce' !== $domain || 'Card code' !== $text) {
+			return $translation;
+		}
+		
+		return __('CVV', 'woocommerce-paypal-payments');
+	}
+
+	/**
 	 * Returns the title of the gateway.
 	 *
 	 * @return string


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**:  [PCP-130](https://inpsyde.atlassian.net/browse/PCP-130).

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Fix Credit Card form fields placeholder and label.

`MM\YYYY` placeholder is replaced with the `MM\YY` to be the same as the label, and also as the Woocommerce and many other systems use by default.

The `Card code` label is replaced with the `CVV` to avoid customer confusion.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Go to the checkout page, select Credit Card as payment method.
2. Check the credit card fields, they should have labels and placeholders like these:

![PCP-130-done](https://user-images.githubusercontent.com/13065667/115409942-e2914800-a1fa-11eb-8dcf-456c3cb839f3.png)


### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Fix - Credit card fields placeholder and label.

### Related issues
Closes #158 