### PR TITLE
add the link to the vaulting documentation

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -634,7 +634,14 @@ return array(
 				'title'        => __( 'Vaulting', 'woocommerce-paypal-payments' ),
 				'type'         => 'checkbox',
 				'desc_tip'     => true,
-				'label'        => __( 'To use vaulting features, you must enable vaulting on your account.', 'woocommerce-paypal-payments' ),
+				'label' => sprintf(
+					__('To use vaulting features, you must %1$senable vaulting on your account%2$s.', 'woocommerce-paypal-payments'),
+			'<a 
+						href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/#enable-vaulting-on-your-live-account"
+						target="_blank"
+					>',
+					'</a>'
+				),
 				'description'  => __( 'Allow registered buyers to save PayPal and Credit Card accounts. Allow Subscription renewals.', 'woocommerce-paypal-payments' ),
 				'default'      => false,
 				'screens'      => array(

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -636,7 +636,7 @@ return array(
 				'desc_tip'     => true,
 				'label' => sprintf(
 					__('To use vaulting features, you must %1$senable vaulting on your account%2$s.', 'woocommerce-paypal-payments'),
-			'<a 
+					'<a 
 						href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/#enable-vaulting-on-your-live-account"
 						target="_blank"
 					>',


### PR DESCRIPTION
Added link to the vaulting documentation to the settings page.

Implement suggestion from the comment https://github.com/woocommerce/woocommerce-paypal-payments/pull/144#issuecomment-827706582