### PR TITLE
Add woocommerce inbox variant

### DIFF
--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.3.1
+ * Version:     1.3.0
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
@@ -98,6 +98,7 @@ define( 'PPCP_FLAG_SUBSCRIPTION', true );
 		'plugins_loaded',
 		function () {
 			init();
+			add_woocommerce_inbox_variant();
 		}
 	);
 	register_activation_hook(
@@ -140,3 +141,19 @@ define( 'PPCP_FLAG_SUBSCRIPTION', true );
 	);
 
 } )();
+
+
+/**
+ * Add woocommerce_inbox_variant for the Remote Inbox Notification.
+ *
+ * P2 post can be found at https://wp.me/paJDYF-1uJ.
+ */
+if ( ! function_exists( 'add_woocommerce_inbox_variant' ) ) {
+	function add_woocommerce_inbox_variant() {
+		$config_name = 'woocommerce_inbox_variant';
+		if ( false === get_option( $config_name, false ) ) {
+			update_option( $config_name, wp_rand( 1, 5 ) );
+		}
+	}
+}
+register_activation_hook( __FILE__, 'add_woocommerce_inbox_variant' );


### PR DESCRIPTION
Add WooCommerce inbox variant option.

#Changes proposed in this Pull Request:

P2: paJDYF-1uJ-p2
Fixes https://github.com/Automattic/woocommerce.com/issues/10117

Description: This PR adds a new option `woocommerce_inbox_variant ` for the Remote Inbox Notification on plugin activation or upgrade.

* This PR does not clean up `woocommerce_inbox_variant ` option on uninstallation so that we don't create a different value in case user decides to install the plugin again.  

* I'm calling `add_woocommerce_inbox_variant` method in the `plugins_loaded` hook since I wasn't able to find a way to trigger a method when the plugin gets upgraded. It's not ideal, but performance should be ok since the option is autoloaded. 


# Testing instructions

**Testing Activation**
1. Ensure `woocommerce_inbox_variant ` option does not exist. If it does, delete it before testing.
2. Deactivate the plugin then activate it again
3. `woocommerce_inbox_variant` option should be created.
4. Repeat step 2 and ensure that the value of `woocommerce_inbox_variant` does not change.
