### PR TITLE
Use order_number instead of internal id when creating invoice Id

### DIFF
--- a/modules/ppcp-api-client/src/Factory/class-purchaseunitfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-purchaseunitfactory.php
@@ -135,7 +135,7 @@ class PurchaseUnitFactory {
 			$soft_descriptor
 		);
 		return apply_filters(
-			'woocommerce-paypal-payments.purchase-unit.from-wc-order',
+			'woocommerce_paypal_payments_purchase_unit_from_wc_order',
 			$purchase_unit,
 			$order
 		);

--- a/modules/ppcp-api-client/src/Factory/class-purchaseunitfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-purchaseunitfactory.php
@@ -119,7 +119,7 @@ class PurchaseUnitFactory {
 		$reference_id    = 'default';
 		$description     = '';
 		$payee           = $this->payee_repository->payee();
-		$wc_order_id     = $order->get_id();
+		$wc_order_id     = $order->get_order_number();
 		$custom_id       = $this->prefix . $wc_order_id;
 		$invoice_id      = $this->prefix . $wc_order_id;
 		$soft_descriptor = '';
@@ -134,7 +134,11 @@ class PurchaseUnitFactory {
 			$invoice_id,
 			$soft_descriptor
 		);
-		return $purchase_unit;
+		return apply_filters(
+			'woocommerce-paypal-payments.purchase-unit.from-wc-order',
+			$purchase_unit,
+			$order
+		);
 	}
 
 	/**


### PR DESCRIPTION
**Issue**: #162

---

### Description
Uses the order number instead of the internal post id when creating the invoice number

### Steps to test:
See #162

### Filter
This PR also includes a filter. Not sure if this is wanted and if so, about naming.

### Changelog entry
> Uses the public order number when creating the invoice ID.

Closes #162 .
