### PR TITLE
Update the plugin-install information tab with content from woo.com product page

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,29 @@ PayPal's latest payments processing solution. Accept PayPal, Pay Later, credit/d
 PayPal's latest, most complete payment processing solution. Accept PayPal exclusives, credit/debit cards and local payment methods. Turn on only PayPal options or process a full suite of payment methods. Enable global transactions with extensive currency and country coverage.
 Built and supported by [WooCommerce](https://woocommerce.com) and [PayPal](https://paypal.com).
 
+= Give your customers their preferred ways to pay with one checkout solution =
+
+Streamline your business with one simple, powerful solution.
+
+With the latest PayPal extension, your customers can pay with PayPal, Pay Later options, credit & debit cards, and country-specific, local payment methods on any device — all with one seamless checkout experience.
+
+= Reach more customers in 200+ markets worldwide =
+
+Expand your business by connecting with over 370+ million active PayPal accounts around the globe. With PayPal, you can:
+
+- Sell in 200+ markets and accept 100+ currencies
+- Identify customer locations and offer country-specific, local payment methods
+
+= Offer subscription payments to help drive repeat business =
+
+Create stable, predictable income by offering subscription plans.
+
+With the vaulting feature on PayPal, you can offer flexible plans with fixed or quantity pricing, set billing cycles for the time period you want, and offer subscriptions with discounted trial periods.
+
+It’s easy for shoppers, simple for you, and great for your business–with no monthly or setup fees.
+
+PayPal is also compatible with [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/).
+
 == Installation ==
 
 = Requirements =


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
P2: pb0GrA-1cH-p2

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

We're going to be sending some inbox notifications to prompt store managers to install PayPal Payments and the button on this notification will send the customer to:

`wp-admin/plugin-install.php?tab=plugin-information&plugin=woocommerce-paypal-payments`

![](https://d.pr/i/VuUo2R+)

This page was looking pretty bare so this PR fleshes out the content a bit (I just copied some of the sections from our [WooCommerce.com Product page](https://woocommerce.com/products/woocommerce-paypal-payments/))

Feel free to re-word or add more to it.
