### PR TITLE
Cast item `get_quantity` into `int`

### DIFF
--- a/modules/ppcp-api-client/src/Factory/class-itemfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-itemfactory.php
@@ -91,7 +91,7 @@ class ItemFactory {
 		 *
 		 * @var \WC_Product $product
 		 */
-		$quantity = $item->get_quantity();
+		$quantity = (int) $item->get_quantity();
 
 		$price                     = (float) $order->get_item_subtotal( $item, true );
 		$price_without_tax         = (float) $order->get_item_subtotal( $item, false );


### PR DESCRIPTION
Customers are having issue with quantity amounts, as you are aware when checking out amounts can be seen as 1.00 instead of 1, this is causing issues as decimals are rejected by PayPal if added into the request for quantity values. 

This PR casts the vaule of item `get_quantity` into integer.