### PR TITLE
Release 1.3.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,16 @@
 *** Changelog ***
 
+= 1.3.1 - TBD =
+* Fix - Improve Subscription plugin support. #161
+* Fix - Disable vault setting if vaulting feature is not available. #150
+* Fix - Cast item get_quantity into int. #168
+* Fix - Fix Credit Card form fields placeholder and label. #146
+* Fix - Filter PayPal-supported language codes. #154
+* Fix - Wrong order status for orders with contain only products which are both virtual and downloadable. #145
+* Fix - Use order_number instead of internal id when creating invoice Id. #163
+* Fix - Fix pay later messaging options. #141
+* Fix - UI/UX for vaulting settings. #166
+
 = 1.3.1 - 2021-04-30 =
 * Fix - Fix Credit Card fields for non logged-in users. #152
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.7
 Requires PHP: 7.1
-Stable tag: 1.3.1
+Stable tag: 1.3.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -57,6 +57,17 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.3.1 =
+* Fix - Improve Subscription plugin support. #161
+* Fix - Disable vault setting if vaulting feature is not available. #150
+* Fix - Cast item get_quantity into int. #168
+* Fix - Fix Credit Card form fields placeholder and label. #146
+* Fix - Filter PayPal-supported language codes. #154
+* Fix - Wrong order status for orders with contain only products which are both virtual and downloadable. #145
+* Fix - Use order_number instead of internal id when creating invoice Id. #163
+* Fix - Fix pay later messaging options. #141
+* Fix - UI/UX for vaulting settings. #166
 
 = 1.3.1 =
 * Fix - Fix Credit Card fields for non logged-in users. #152

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.3.1
+ * Version:     1.3.2
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0


### PR DESCRIPTION
- Fix - Improve Subscription plugin support. #161
- Fix - Disable vault setting if vaulting feature is not available. #150
- Fix - Cast item get_quantity into int. #168
- Fix - Fix Credit Card form fields placeholder and label. #146
- Fix - Filter PayPal-supported language codes. #154
- Fix - Wrong order status for orders with contain only products which are both virtual and downloadable. #145
- Fix - Use order_number instead of internal id when creating invoice Id. #163
- Fix - Fix pay later messaging options. #141
- Fix - UI/UX for vaulting settings. #166