### PR TITLE
Ensure shipping info when patching order

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -502,6 +502,14 @@ class OrderEndpoint {
 			return $order_to_update;
 		}
 
+		$patches_array = $patches->to_array();
+		if ( ! isset( $patches_array[0]['value']['shipping'] ) ) {
+			$shipping = isset( $order_to_update->purchase_units()[0] ) && null !== $order_to_update->purchase_units()[0]->shipping() ? $order_to_update->purchase_units()[0]->shipping() : null;
+			if ( $shipping ) {
+				$patches_array[0]['value']['shipping'] = $shipping->to_array();
+			}
+		}
+
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $order_to_update->id();
 		$args   = array(
@@ -514,7 +522,7 @@ class OrderEndpoint {
 					$order_to_update
 				),
 			),
-			'body'    => wp_json_encode( $patches->to_array() ),
+			'body'    => wp_json_encode( $patches_array ),
 		);
 		if ( $this->bn_code ) {
 			$args['headers']['PayPal-Partner-Attribution-Id'] = $this->bn_code;


### PR DESCRIPTION
### Description
There is an `[UNPROCESSABLE_ENTITY] #MISSING_SHIPPING_ADDRESS` error when shipping information is not sent along when patching an order, this PR ensures that shipping information is sent to prevent the aforementioned  error.

### Steps to test:
1. Add `add_filter( 'woocommerce_cart_needs_shipping_address', '__return_false');` either on a plugin or in theme functions.php.
2. Add a product and go to Checkout page
3. Click PayPal button

### What should happen
PayPal modal should appear to continue with the purchase.

### What happened instead
An `[UNPROCESSABLE_ENTITY] #MISSING_SHIPPING_ADDRESS` error is displayed on the screen.
