### PR TITLE
Do not send customer email when order status is on hold

### DIFF
--- a/modules/ppcp-wc-gateway/src/class-wcgatewaymodule.php
+++ b/modules/ppcp-wc-gateway/src/class-wcgatewaymodule.php
@@ -135,6 +135,18 @@ class WcGatewayModule implements ModuleInterface {
 				$endpoint->handle_request();
 			}
 		);
+
+		add_filter(
+			'woocommerce_email_recipient_customer_on_hold_order',
+			function( $recipient, $order ) {
+				if ( $order->get_payment_method() === PayPalGateway::ID || $order->get_payment_method() === CreditCardGateway::ID ) {
+					$recipient = '';
+				}
+				return $recipient;
+			},
+			10,
+			2
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Description
After the order payment was processed, PayPal Payments orders are first set to **On-Hold** and then immediately to **Processing**. 

This triggers two emails from WooCommerce.

Customers first receive the email, that their order was received and is **Processing**. at the same moment, a second email is sent, saying that the order is **On-Hold** until the payment was received.
But this was already confirmed with the previous mail. They both arrive at virtually the same time, but first the **Processing** mail and then afterward the **On-Hold** mail.

### Solution
This PR disables sending emails to the customer when status is **On-Hold**.

