### PR TITLE
Double "Place Order" button

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -75,7 +75,7 @@ class CheckoutBootstap {
         else {
             setTimeout(() => {
                 jQuery('#place_order').hide();
-            }, 300)
+            }, 1000)
 
             if (currentPaymentMethod === 'ppcp-gateway') {
                 this.renderer.showButtons(this.gateway.button.wrapper);

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -73,7 +73,10 @@ class CheckoutBootstap {
             jQuery('#place_order').show();
         }
         else {
-            jQuery('#place_order').hide();
+            setTimeout(() => {
+                jQuery('#place_order').hide();
+            }, 300)
+
             if (currentPaymentMethod === 'ppcp-gateway') {
                 this.renderer.showButtons(this.gateway.button.wrapper);
                 this.renderer.showButtons(this.gateway.messages.wrapper);


### PR DESCRIPTION
### Description
Default WooCommerce place order button is conditionally hidden and displayed depending on the selected payment gateway, the plugin hides it and displays an identical place order button to start the advanced credit card flow. It could happen that other plugins are also hiding and displaying the place order button and that could end in both buttons displayed at the same time.

This PR adds a delay when hiding the default WooCommerce place order button when PayPal or advanced credit card payments are selected on the checkout page.

### Steps to test:
Method A:
1. Install and activate https://wordpress.org/plugins/woocommerce-gateway-paypal-express-checkout/ 
2. Do not active **WooCommerce PayPal Checkout Payment Gateway** as a gateway in WooCommerce
3. Add product and go to the Checkout page
4. Select Credit card payment
![01](https://user-images.githubusercontent.com/456223/121869498-669b1400-cd02-11eb-9aac-02412d0c6e3f.png)

Method B:
- install Sabino theme: Sabino 
- visit checkout
- Double buttons appear

Method C:
This plugin adds conditional fields to the checkout and they are loaded after the button was hidden, which causes the button to reappear. The conditional needs to be applied to a product in your cart to trigger the behavior.
PLUGIN: https://woocommerce.com/products/conditional-checkout-fields-for-woocommerce/
The PR linked in this issue apparently fixed the issue for this particular method, but not for the others.
