### PR TITLE
Remove `merchant-id` query parameter in JSSDK

### DIFF
--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -59,7 +59,6 @@ return array(
 		if ( $paypal_disabled ) {
 			return new DisabledSmartButton();
 		}
-		$payee_repository = $container->get( 'api.repository.payee' );
 		$payer_factory    = $container->get( 'api.factory.payer' );
 		$request_data     = $container->get( 'button.request-data' );
 
@@ -73,7 +72,6 @@ return array(
 			$container->get( 'button.url' ),
 			$container->get( 'session.handler' ),
 			$settings,
-			$payee_repository,
 			$payer_factory,
 			$client_id,
 			$request_data,

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -11,7 +11,6 @@ namespace WooCommerce\PayPalCommerce\Button\Assets;
 
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
-use WooCommerce\PayPalCommerce\ApiClient\Repository\PayeeRepository;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ChangeCartEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\CreateOrderEndpoint;
@@ -50,13 +49,6 @@ class SmartButton implements SmartButtonInterface {
 	 * @var Settings
 	 */
 	private $settings;
-
-	/**
-	 * The Payee Repository.
-	 *
-	 * @var PayeeRepository
-	 */
-	private $payee_repository;
 
 	/**
 	 * The Payer Factory.
@@ -120,7 +112,6 @@ class SmartButton implements SmartButtonInterface {
 	 * @param string                 $module_url The URL to the module.
 	 * @param SessionHandler         $session_handler The Session Handler.
 	 * @param Settings               $settings The Settings.
-	 * @param PayeeRepository        $payee_repository The Payee Repository.
 	 * @param PayerFactory           $payer_factory The Payer factory.
 	 * @param string                 $client_id The client ID.
 	 * @param RequestData            $request_data The Request Data helper.
@@ -134,7 +125,6 @@ class SmartButton implements SmartButtonInterface {
 		string $module_url,
 		SessionHandler $session_handler,
 		Settings $settings,
-		PayeeRepository $payee_repository,
 		PayerFactory $payer_factory,
 		string $client_id,
 		RequestData $request_data,
@@ -148,7 +138,6 @@ class SmartButton implements SmartButtonInterface {
 		$this->module_url               = $module_url;
 		$this->session_handler          = $session_handler;
 		$this->settings                 = $settings;
-		$this->payee_repository         = $payee_repository;
 		$this->payer_factory            = $payer_factory;
 		$this->client_id                = $client_id;
 		$this->request_data             = $request_data;

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -740,10 +740,6 @@ class SmartButton implements SmartButtonInterface {
 		) {
 			$params['buyer-country'] = WC()->customer->get_billing_country();
 		}
-		$payee = $this->payee_repository->payee();
-		if ( $payee->merchant_id() ) {
-			$params['merchant-id'] = $payee->merchant_id();
-		}
 		$disable_funding = $this->settings->has( 'disable_funding' ) ?
 			$this->settings->get( 'disable_funding' ) : array();
 		if ( ! is_checkout() ) {


### PR DESCRIPTION
The `merchant-id` query parameter in the JSSDK is designed for doing third party calls. This parameter is extraneous for first-party calls when the Client ID is owned by the merchant. This has caused some issues previously, so should be removed.