### PR TITLE
Add Canada to advanced credit and debit card

### DIFF
--- a/modules/ppcp-api-client/src/Helper/class-dccapplies.php
+++ b/modules/ppcp-api-client/src/Helper/class-dccapplies.php
@@ -118,6 +118,24 @@ class DccApplies {
 			'JPY',
 			'USD',
 		),
+		'CA' => array(
+			'AUD',
+			'CAD',
+			'CHF',
+			'CZK',
+			'DKK',
+			'EUR',
+			'GBP',
+			'HKD',
+			'HUF',
+			'JPY',
+			'NOK',
+			'NZD',
+			'PLN',
+			'SEK',
+			'SGD',
+			'USD',
+		),
 	);
 
 	/**
@@ -156,6 +174,12 @@ class DccApplies {
 			'visa'       => array(),
 			'amex'       => array( 'USD' ),
 			'discover'   => array( 'USD' ),
+		),
+		'CA' => array(
+			'mastercard' => array(),
+			'visa'       => array(),
+			'amex'       => array( 'CAD' ),
+			'jcb'        => array( 'CAD' ),
 		),
 	);
 


### PR DESCRIPTION
Canadian merchants are now approved to utilize ACDC.
<img width="774" alt="Bildschirmfoto 2021-05-07 um 15 42 29" src="https://user-images.githubusercontent.com/456223/122353549-727c1580-cf50-11eb-96e7-5406011fcf6f.png">
