### PR TITLE
Add BN Code to Pay Later Messaging

### DIFF
--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -69,6 +69,7 @@ return array(
 		$messages_apply      = $container->get( 'button.helper.messages-apply' );
 		$environment         = $container->get( 'onboarding.environment' );
 		$payment_token_repository = $container->get( 'subscription.repository.payment-token' );
+		$settings_status = $container->get( 'wcgateway.settings.status' );
 		return new SmartButton(
 			$container->get( 'button.url' ),
 			$container->get( 'session.handler' ),
@@ -81,7 +82,8 @@ return array(
 			$subscription_helper,
 			$messages_apply,
 			$environment,
-			$payment_token_repository
+			$payment_token_repository,
+			$settings_status
 		);
 	},
 	'button.url'                        => static function ( $container ): string {

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -773,6 +773,10 @@ class SmartButton implements SmartButtonInterface {
 			$params['enable-funding'] = implode( ',', array_unique( $enable_funding ) );
 		}
 
+		if ( $this->settings_status->pay_later_messaging_is_enabled() ) {
+			$params['data-partner-attribution-id'] = 'Woo_PPCP';
+		}
+
 		$smart_button_url = add_query_arg( $params, 'https://www.paypal.com/sdk/js' );
 		return $smart_button_url;
 	}

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -773,10 +773,6 @@ class SmartButton implements SmartButtonInterface {
 			$params['enable-funding'] = implode( ',', array_unique( $enable_funding ) );
 		}
 
-		if ( $this->settings_status->pay_later_messaging_is_enabled() ) {
-			$params['data-partner-attribution-id'] = 'Woo_PPCP';
-		}
-
 		$smart_button_url = add_query_arg( $params, 'https://www.paypal.com/sdk/js' );
 		return $smart_button_url;
 	}

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -449,7 +449,7 @@ class SmartButton implements SmartButtonInterface {
 	 */
 	public function message_renderer() {
 
-		echo '<div id="ppcp-messages"></div>';
+		echo '<div id="ppcp-messages" data-partner-attribution-id="Woo_PPCP"></div>';
 	}
 
 	/**

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -23,12 +23,20 @@ use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Subscription\Repository\PaymentTokenRepository;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use Woocommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class SmartButton
  */
 class SmartButton implements SmartButtonInterface {
+
+	/**
+	 * The Settings status helper.
+	 *
+	 * @var SettingsStatus
+	 */
+	protected $settings_status;
 
 	/**
 	 * The URL to the module.
@@ -129,6 +137,7 @@ class SmartButton implements SmartButtonInterface {
 	 * @param MessagesApply          $messages_apply The Messages apply helper.
 	 * @param Environment            $environment The environment object.
 	 * @param PaymentTokenRepository $payment_token_repository The payment token repository.
+	 * @param SettingsStatus         $settings_status The Settings status helper.
 	 */
 	public function __construct(
 		string $module_url,
@@ -142,7 +151,8 @@ class SmartButton implements SmartButtonInterface {
 		SubscriptionHelper $subscription_helper,
 		MessagesApply $messages_apply,
 		Environment $environment,
-		PaymentTokenRepository $payment_token_repository
+		PaymentTokenRepository $payment_token_repository,
+		SettingsStatus $settings_status
 	) {
 
 		$this->module_url               = $module_url;
@@ -157,6 +167,7 @@ class SmartButton implements SmartButtonInterface {
 		$this->messages_apply           = $messages_apply;
 		$this->environment              = $environment;
 		$this->payment_token_repository = $payment_token_repository;
+		$this->settings_status          = $settings_status;
 	}
 
 	/**
@@ -752,6 +763,14 @@ class SmartButton implements SmartButtonInterface {
 
 		if ( count( $disable_funding ) > 0 ) {
 			$params['disable-funding'] = implode( ',', array_unique( $disable_funding ) );
+		}
+
+		$enable_funding = array();
+		if ( $this->settings_status->pay_later_messaging_is_enabled() ) {
+			$enable_funding[] = 'paylater';
+		}
+		if ( count( $enable_funding ) > 0 ) {
+			$params['enable-funding'] = implode( ',', array_unique( $enable_funding ) );
 		}
 
 		$smart_button_url = add_query_arg( $params, 'https://www.paypal.com/sdk/js' );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -25,6 +25,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use Woocommerce\PayPalCommerce\WcGateway\Helper\DccProductStatus;
+use Woocommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\AuthorizeOrderActionNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\ConnectAdminNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
@@ -114,6 +115,10 @@ return array(
 	'wcgateway.settings.sections-renderer'         => static function ( $container ): SectionsRenderer {
 		return new SectionsRenderer();
 	},
+	'wcgateway.settings.status'                    => static function ( $container ): SettingsStatus {
+		$settings      = $container->get( 'wcgateway.settings' );
+		return new SettingsStatus( $settings );
+	},
 	'wcgateway.settings.render'                    => static function ( $container ): SettingsRenderer {
 		$settings      = $container->get( 'wcgateway.settings' );
 		$state         = $container->get( 'onboarding.state' );
@@ -121,13 +126,15 @@ return array(
 		$dcc_applies    = $container->get( 'api.helpers.dccapplies' );
 		$messages_apply = $container->get( 'button.helper.messages-apply' );
 		$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
+		$settings_status = $container->get( 'wcgateway.settings.status' );
 		return new SettingsRenderer(
 			$settings,
 			$state,
 			$fields,
 			$dcc_applies,
 			$messages_apply,
-			$dcc_product_status
+			$dcc_product_status,
+			$settings_status
 		);
 	},
 	'wcgateway.settings.listener'                  => static function ( $container ): SettingsListener {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -835,7 +835,7 @@ return array(
 				),
 				'requirements' => array( 'messages' ),
 				'gateway'      => 'paypal',
-				'description'  => str_replace( '<a>', '<a href="' . $messages_disclaimers->link_for_country() . '" target="_blank">', __( 'Displays Pay Later messaging for available offers. Restrictions apply. <a>Click here to learn more.</a>', 'woocommerce-paypal-payments' ) ),
+				'description'  => str_replace( '<a>', '<a href="' . $messages_disclaimers->link_for_country() . '" target="_blank">', __( 'Displays Pay Later messaging for available offers. Restrictions apply. <a>Click here to learn more</a>. Pay Later button will show for eligible buyers and PayPal determines eligibility.', 'woocommerce-paypal-payments' ) ),
 				'class'        => array( 'ppcp-subheading' ),
 			),
 			'message_enabled'                => array(
@@ -1138,7 +1138,7 @@ return array(
 				),
 				'requirements' => array( 'messages' ),
 				'gateway'      => 'paypal',
-				'description'  => str_replace( '<a>', '<a href="' . $messages_disclaimers->link_for_country() . '" target="_blank">', __( 'Displays Pay Later messaging for available offers. Restrictions apply. <a>Click here to learn more.</a>', 'woocommerce-paypal-payments' ) ),
+				'description'  => str_replace( '<a>', '<a href="' . $messages_disclaimers->link_for_country() . '" target="_blank">', __( 'Displays Pay Later messaging for available offers. Restrictions apply. <a>Click here to learn more</a>. Pay Later button will show for eligible buyers and PayPal determines eligibility.', 'woocommerce-paypal-payments' ) ),
 				'class'        => array( 'ppcp-subheading' ),
 			),
 			'message_product_enabled'        => array(
@@ -1441,7 +1441,7 @@ return array(
 				),
 				'requirements' => array( 'messages' ),
 				'gateway'      => 'paypal',
-				'description'  => str_replace( '<a>', '<a href="' . $messages_disclaimers->link_for_country() . '" target="_blank">', __( 'Displays Pay Later messaging for available offers. Restrictions apply. <a>Click here to learn more.</a>', 'woocommerce-paypal-payments' ) ),
+				'description'  => str_replace( '<a>', '<a href="' . $messages_disclaimers->link_for_country() . '" target="_blank">', __( 'Displays Pay Later messaging for available offers. Restrictions apply. <a>Click here to learn more</a>. Pay Later button will show for eligible buyers and PayPal determines eligibility.', 'woocommerce-paypal-payments' ) ),
 				'class'        => array( 'ppcp-subheading' ),
 			),
 			'message_cart_enabled'           => array(

--- a/modules/ppcp-wc-gateway/src/Helper/class-settingsstatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/class-settingsstatus.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Helper to get settings status.
+ *
+ * @package Woocommerce\PayPalCommerce\WcGateway\Helper
+ */
+
+declare(strict_types=1);
+
+namespace Woocommerce\PayPalCommerce\WcGateway\Helper;
+
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+/**
+ * Class SettingsStatus
+ */
+class SettingsStatus {
+
+	/**
+	 * The Settings.
+	 *
+	 * @var Settings
+	 */
+	protected $settings;
+
+	/**
+	 * SettingsStatus constructor.
+	 *
+	 * @param Settings $settings The Settings.
+	 */
+	public function __construct( Settings $settings ) {
+		$this->settings = $settings;
+	}
+
+	/**
+	 * Check whether Pay Later message is enabled either for checkout, cart or product page.
+	 *
+	 * @return bool
+	 * @throws \WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException When a setting was not found.
+	 */
+	public function pay_later_messaging_is_enabled(): bool {
+		$pay_later_message_enabled_for_checkout = $this->settings->has( 'message_enabled' )
+			&& (bool) $this->settings->get( 'message_enabled' );
+
+		$pay_later_message_enabled_for_cart = $this->settings->has( 'message_cart_enabled' )
+			&& (bool) $this->settings->get( 'message_cart_enabled' );
+
+		$pay_later_message_enabled_for_product = $this->settings->has( 'message_product_enabled' )
+			&& (bool) $this->settings->get( 'message_product_enabled' );
+
+		return $pay_later_message_enabled_for_checkout ||
+			$pay_later_message_enabled_for_cart ||
+			$pay_later_message_enabled_for_product;
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingsrenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingsrenderer.php
@@ -16,11 +16,19 @@ use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use Psr\Container\ContainerInterface;
 use Woocommerce\PayPalCommerce\WcGateway\Helper\DccProductStatus;
+use Woocommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 
 /**
  * Class SettingsRenderer
  */
 class SettingsRenderer {
+
+	/**
+	 * The Settings status helper.
+	 *
+	 * @var SettingsStatus
+	 */
+	protected $settings_status;
 
 	/**
 	 * The settings.
@@ -73,6 +81,7 @@ class SettingsRenderer {
 	 * @param DccApplies         $dcc_applies Whether DCC gateway can be shown.
 	 * @param MessagesApply      $messages_apply Whether messages can be shown.
 	 * @param DccProductStatus   $dcc_product_status The product status.
+	 * @param SettingsStatus     $settings_status The Settings status helper.
 	 */
 	public function __construct(
 		ContainerInterface $settings,
@@ -80,7 +89,8 @@ class SettingsRenderer {
 		array $fields,
 		DccApplies $dcc_applies,
 		MessagesApply $messages_apply,
-		DccProductStatus $dcc_product_status
+		DccProductStatus $dcc_product_status,
+		SettingsStatus $settings_status
 	) {
 
 		$this->settings           = $settings;
@@ -89,6 +99,7 @@ class SettingsRenderer {
 		$this->dcc_applies        = $dcc_applies;
 		$this->messages_apply     = $messages_apply;
 		$this->dcc_product_status = $dcc_product_status;
+		$this->settings_status    = $settings_status;
 	}
 
 	/**
@@ -106,7 +117,7 @@ class SettingsRenderer {
 			$pay_later_messages_title = __( 'Pay Later Messaging', 'woocommerce-paypal-payments' );
 
 			$enabled  = $this->paypal_vaulting_is_enabled() ? $vaulting_title : $pay_later_messages_title;
-			$disabled = $this->pay_later_messaging_is_enabled() ? $vaulting_title : $pay_later_messages_title;
+			$disabled = $this->settings_status->pay_later_messaging_is_enabled() ? $vaulting_title : $pay_later_messages_title;
 
 			$pay_later_messages_or_vaulting_text = sprintf(
 				// translators: %1$s and %2$s is translated PayPal vaulting and Pay Later Messaging strings.
@@ -147,26 +158,6 @@ class SettingsRenderer {
 	 */
 	private function paypal_vaulting_is_enabled(): bool {
 		return $this->settings->has( 'vault_enabled' ) && (bool) $this->settings->get( 'vault_enabled' );
-	}
-
-	/**
-	 * Check whether Pay Later message is enabled either for checkout, cart or product page.
-	 *
-	 * @return bool
-	 */
-	private function pay_later_messaging_is_enabled(): bool {
-		$pay_later_message_enabled_for_checkout = $this->settings->has( 'message_enabled' )
-			&& (bool) $this->settings->get( 'message_enabled' );
-
-		$pay_later_message_enabled_for_cart = $this->settings->has( 'message_cart_enabled' )
-			&& (bool) $this->settings->get( 'message_cart_enabled' );
-
-		$pay_later_message_enabled_for_product = $this->settings->has( 'message_product_enabled' )
-			&& (bool) $this->settings->get( 'message_product_enabled' );
-
-		return $pay_later_message_enabled_for_checkout ||
-			$pay_later_message_enabled_for_cart ||
-			$pay_later_message_enabled_for_product;
 	}
 
 	/**
@@ -557,6 +548,6 @@ class SettingsRenderer {
 		}
 
 		return $this->is_paypal_checkout_screen() && $this->paypal_vaulting_is_enabled()
-			|| $this->is_paypal_checkout_screen() && $this->pay_later_messaging_is_enabled();
+			|| $this->is_paypal_checkout_screen() && $this->settings_status->pay_later_messaging_is_enabled();
 	}
 }


### PR DESCRIPTION
This PR adds `data-partner-attribution-id="Woo_PPCP"` in the wrapper div containing Pay Later messaging