### PR TITLE
Add 30 seconds timeout by default to all requests

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/class-requesttrait.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-requesttrait.php
@@ -24,6 +24,8 @@ trait RequestTrait {
 	 */
 	private function request( string $url, array $args ) {
 
+		$args['timeout'] = 30;
+
 		/**
 		 * This filter can be used to alter the request args.
 		 * For example, during testing, the PayPal-Mock-Response header could be


### PR DESCRIPTION
In order to prevent timeout errors due to default WordPress 5 seconds, this PR adds 30 seconds timeout by default to all its requests to PayPal. 