### PR TITLE
Incorrect API credentials cause fatal error

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -29,9 +29,6 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-suggest
 
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
-
     - name: Run test suite
       run: ./vendor/bin/phpunit
     - name: Run Woocommerce coding standards

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,10 +11,19 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-versions: ['7.1']
+
     steps:
     - uses: actions/checkout@v2
 
-    - name: Validate composer.json and composer.lock
+    - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+
+      - name: Validate composer.json and composer.lock
       run: composer validate
 
     - name: Install dependencies

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
 
-      - name: Validate composer.json and composer.lock
+    - name: Validate composer.json and composer.lock
       run: composer validate
 
     - name: Install dependencies

--- a/modules/ppcp-api-client/src/Authentication/class-paypalbearer.php
+++ b/modules/ppcp-api-client/src/Authentication/class-paypalbearer.php
@@ -120,7 +120,11 @@ class PayPalBearer implements Bearer {
 
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
 			$error = new RuntimeException(
-				__( 'Could not create token.', 'woocommerce-paypal-payments' )
+				sprintf(
+					// translators: %s is the error description.
+					__( 'Could not create token. %s', 'woocommerce-paypal-payments' ),
+					isset( json_decode( $response['body'] )->error_description ) ? json_decode( $response['body'] )->error_description : ''
+				)
 			);
 			$this->logger->log(
 				'warning',

--- a/modules/ppcp-wc-gateway/src/Assets/class-settingspageassets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/class-settingspageassets.php
@@ -122,7 +122,7 @@ class SettingsPageAssets {
 				)
 			);
 		} catch ( RuntimeException $exception ) {
-			// Already displaying an admin message in SettingsListener.
+			return;
 		}
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Assets/class-settingspageassets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/class-settingspageassets.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
 /**
  * Class SettingsPageAssets
@@ -111,13 +112,17 @@ class SettingsPageAssets {
 			true
 		);
 
-		$token = $bearer->bearer();
-		wp_localize_script(
-			'ppcp-gateway-settings',
-			'PayPalCommerceGatewaySettings',
-			array(
-				'vaulting_features_available' => $token->vaulting_available(),
-			)
-		);
+		try {
+			$token = $bearer->bearer();
+			wp_localize_script(
+				'ppcp-gateway-settings',
+				'PayPalCommerceGatewaySettings',
+				array(
+					'vaulting_features_available' => $token->vaulting_available(),
+				)
+			);
+		} catch ( RuntimeException $exception ) {
+			// Already displaying an admin message in SettingsListener.
+		}
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -160,7 +160,6 @@ class SettingsListener {
 				'admin_notices',
 				function () use ( $exception ) {
 					printf(
-						// translators: %s is the error message.
 						'<div class="notice notice-error"><p>%s</p></div>',
 						$exception->getMessage()
 					);

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -161,7 +161,7 @@ class SettingsListener {
 				function () use ( $exception ) {
 					printf(
 						'<div class="notice notice-error"><p>%s</p></div>',
-						$exception->getMessage()
+						esc_attr( $exception->getMessage() )
 					);
 				}
 			);

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
@@ -147,11 +148,24 @@ class SettingsListener {
 			return;
 		}
 
-		$token = $this->bearer->bearer();
-		if ( ! $token->vaulting_available() ) {
-			$this->settings->set( 'vault_enabled', false );
-			$this->settings->persist();
-			return;
+		try {
+			$token = $this->bearer->bearer();
+			if ( ! $token->vaulting_available() ) {
+				$this->settings->set( 'vault_enabled', false );
+				$this->settings->persist();
+				return;
+			}
+		} catch ( RuntimeException $exception ) {
+			add_action(
+				'admin_notices',
+				function () use ( $exception ) {
+					printf(
+						// translators: %s is the error message.
+						'<div class="notice notice-error"><p>%s</p></div>',
+						$exception->getMessage()
+					);
+				}
+			);
 		}
 
 		/**

--- a/modules/ppcp-wc-gateway/src/class-wcgatewaymodule.php
+++ b/modules/ppcp-wc-gateway/src/class-wcgatewaymodule.php
@@ -11,7 +11,6 @@ namespace WooCommerce\PayPalCommerce\WcGateway;
 
 use Dhii\Container\ServiceProvider;
 use Dhii\Modular\Module\ModuleInterface;
-use http\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\PayPalRequestIdRepository;

--- a/modules/ppcp-wc-gateway/src/class-wcgatewaymodule.php
+++ b/modules/ppcp-wc-gateway/src/class-wcgatewaymodule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway;
 
 use Dhii\Container\ServiceProvider;
 use Dhii\Modular\Module\ModuleInterface;
+use http\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\PayPalRequestIdRepository;


### PR DESCRIPTION
### Description
Manually entering incorrect API information in the settings leads to a fatal error:
![image-20210630-095926](https://user-images.githubusercontent.com/456223/124261956-b87cd000-db31-11eb-9ac6-098c5f6f1c44.png)

### Steps to test:
1. Enter any credentials for manual connection for email, merchant ID, client ID & secret (random letters are ok)
2. Save settings
3. Fatal error will prevent opening the plugin settings

