### PR TITLE
[Legacy] Add compatibility module `ppcp-compat`

### DIFF
--- a/modules/ppcp-compat/extensions.php
+++ b/modules/ppcp-compat/extensions.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * The compatibility module extensions.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+return array();

--- a/modules/ppcp-compat/module.php
+++ b/modules/ppcp-compat/module.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The compatibility module.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+use Dhii\Modular\Module\ModuleInterface;
+
+return static function (): ModuleInterface {
+	return new CompatModule();
+};

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * The compatibility module services.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+return array();

--- a/modules/ppcp-compat/src/class-compatmodule.php
+++ b/modules/ppcp-compat/src/class-compatmodule.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * The compatibility module.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+use Dhii\Container\ServiceProvider;
+use Dhii\Modular\Module\ModuleInterface;
+use Interop\Container\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Class CompatModule
+ */
+class CompatModule implements ModuleInterface {
+
+	/**
+	 * Setup the compatibility module.
+	 *
+	 * @return ServiceProviderInterface
+	 */
+	public function setup(): ServiceProviderInterface {
+		return new ServiceProvider(
+			require __DIR__ . '/../services.php',
+			require __DIR__ . '/../extensions.php'
+		);
+	}
+
+	/**
+	 * Run the compatibility module.
+	 *
+	 * @param ContainerInterface|null $container The Container.
+	 */
+	public function run( ContainerInterface $container ) {
+	}
+
+	/**
+	 * Returns the key for the module.
+	 *
+	 * @return string|void
+	 */
+	public function getKey() {
+	}
+}


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
The changes we're working on to make it easier to migrate from PayPal Checkout/Standard to PayPal Payments, will mostly live inside a compatibility module (`ppcp-compat`).

In order to make it easier to review and eventually merge those PRs into `trunk`, it makes sense to separate the module skeleton from the other PRs, which is what this particular PR does.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. --> 
Given the module does nothing as is, there's no need for testing.
