### PR TITLE
Do not send decimals when currency does not support them

### DIFF
--- a/modules/ppcp-api-client/src/Entity/class-amount.php
+++ b/modules/ppcp-api-client/src/Entity/class-amount.php
@@ -29,6 +29,13 @@ class Amount {
 	private $breakdown;
 
 	/**
+	 * Currencies that does not support decimals.
+	 *
+	 * @var array
+	 */
+	private $currencies_without_decimals = array( 'HUF', 'JPY', 'TWD' );
+
+	/**
 	 * Amount constructor.
 	 *
 	 * @param Money                $money The money.
@@ -74,7 +81,9 @@ class Amount {
 	public function to_array(): array {
 		$amount = array(
 			'currency_code' => $this->currency_code(),
-			'value'         => number_format( $this->value(), 2, '.', '' ),
+			'value'         => in_array( $this->currency_code(), $this->currencies_without_decimals, true )
+				? round( $this->value(), 0 )
+				: number_format( $this->value(), 2, '.', '' ),
 		);
 		if ( $this->breakdown() && count( $this->breakdown()->to_array() ) ) {
 			$amount['breakdown'] = $this->breakdown()->to_array();

--- a/modules/ppcp-api-client/src/Entity/class-money.php
+++ b/modules/ppcp-api-client/src/Entity/class-money.php
@@ -29,6 +29,13 @@ class Money {
 	private $value;
 
 	/**
+	 * Currencies that does not support decimals.
+	 *
+	 * @var array
+	 */
+	private $currencies_without_decimals = array( 'HUF', 'JPY', 'TWD' );
+
+	/**
 	 * Money constructor.
 	 *
 	 * @param float  $value The value.
@@ -65,7 +72,9 @@ class Money {
 	public function to_array(): array {
 		return array(
 			'currency_code' => $this->currency_code(),
-			'value'         => number_format( $this->value(), 2, '.', '' ),
+			'value'         => in_array( $this->currency_code(), $this->currencies_without_decimals, true )
+				? round( $this->value(), 0 )
+				: number_format( $this->value(), 2, '.', '' ),
 		);
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingsrenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingsrenderer.php
@@ -131,6 +131,16 @@ class SettingsRenderer {
 			$messages[] = new Message( $pay_later_messages_or_vaulting_text, 'warning' );
 		}
 
+		if ( ! $this->currency_supports_decimals() && $this->is_paypal_checkout_screen() ) {
+			$messages[] = new Message(
+				sprintf(
+					esc_html__( 'Currency %s does not support decimals, total amount will be sent rounded without decimals to PayPal.', 'woocommerce-paypal-payments' ),
+					get_woocommerce_currency()
+				),
+				'warning'
+			);
+		}
+
         //phpcs:disable WordPress.Security.NonceVerification.Recommended
         //phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( ! isset( $_GET['ppcp-onboarding-error'] ) || ! empty( $_POST ) ) {
@@ -550,4 +560,9 @@ class SettingsRenderer {
 		return $this->is_paypal_checkout_screen() && $this->paypal_vaulting_is_enabled()
 			|| $this->is_paypal_checkout_screen() && $this->settings_status->pay_later_messaging_is_enabled();
 	}
+
+	private function currency_supports_decimals() {
+		return ! in_array( get_woocommerce_currency(), array( 'HUF', 'JPY', 'TWD' ), true );
+	}
 }
+

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingsrenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingsrenderer.php
@@ -131,16 +131,6 @@ class SettingsRenderer {
 			$messages[] = new Message( $pay_later_messages_or_vaulting_text, 'warning' );
 		}
 
-		if ( ! $this->currency_supports_decimals() && $this->is_paypal_checkout_screen() ) {
-			$messages[] = new Message(
-				sprintf(
-					esc_html__( 'Currency %s does not support decimals, total amount will be sent rounded without decimals to PayPal.', 'woocommerce-paypal-payments' ),
-					get_woocommerce_currency()
-				),
-				'warning'
-			);
-		}
-
         //phpcs:disable WordPress.Security.NonceVerification.Recommended
         //phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( ! isset( $_GET['ppcp-onboarding-error'] ) || ! empty( $_POST ) ) {
@@ -559,10 +549,6 @@ class SettingsRenderer {
 
 		return $this->is_paypal_checkout_screen() && $this->paypal_vaulting_is_enabled()
 			|| $this->is_paypal_checkout_screen() && $this->settings_status->pay_later_messaging_is_enabled();
-	}
-
-	private function currency_supports_decimals() {
-		return ! in_array( get_woocommerce_currency(), array( 'HUF', 'JPY', 'TWD' ), true );
 	}
 }
 


### PR DESCRIPTION
### Description
Currency Japananese Yen/JPY is not functional in PPP because it does not support decimals, see https://developer.paypal.com/docs/reports/reference/paypal-supported-currencies/

This PR ensures sending rounded values without decimals for currencies that does not allow decimals.

### Steps to test:
- Set webstore to JPY (Japanese Yen)
- Purchase item and try to pay at any step
- Getting the errors:
Something went wrong. Please try again or choose another payment source. (on basked PP payment)[UNPROCESSABLE_ENTITY] The requested action could not be performed, semantically incorrect, or failed business validation. https://developer.paypal.com/docs/api/orders/v2/#error-DECIMALS_NOT_SUPPORTED (on checkout PP payment)
