### PR TITLE
Extend plugin modification options

### DIFF
--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -318,7 +318,7 @@ class SmartButton implements SmartButtonInterface {
 			&& ! $not_enabled_on_cart
 		) {
 			add_action(
-				'woocommerce_proceed_to_checkout',
+				$this->proceed_to_checkout_button_renderer_hook(),
 				array(
 					$this,
 					'button_renderer',
@@ -965,12 +965,25 @@ class SmartButton implements SmartButtonInterface {
 	}
 	
 	/**
-	 * Return action name PayPal buttons will be rendered at.
+	 * Return action name PayPal buttons will be rendered at on checkout page.
 	 *
 	 * @return string Action name.
 	 */
 	private function checkout_button_renderer_hook(): string
 	{
 		return (string) apply_filters('woocommerce_paypal_payments_checkout_button_renderer_hook', 'woocommerce_review_order_after_payment');
+	}
+	
+	/**
+	 * Return action name PayPal will be rendered next to Proceed to checkout button (normally displayed in cart).
+	 *
+	 * @return string
+	 */
+	private function proceed_to_checkout_button_renderer_hook(): string
+	{
+		return (string) apply_filters(
+			'woocommerce_paypal_payments_to_checkout_button_renderer_hook',
+			'woocommerce_proceed_to_checkout'
+		);
 	}
 }

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -182,7 +182,7 @@ class SmartButton implements SmartButtonInterface {
 			&& ! $this->session_handler->order()
 		) {
 			add_action(
-				'woocommerce_review_order_after_submit',
+				$this->checkout_dcc_button_renderer_hook(),
 				array(
 					$this,
 					'dcc_renderer',
@@ -972,6 +972,16 @@ class SmartButton implements SmartButtonInterface {
 	private function checkout_button_renderer_hook(): string
 	{
 		return (string) apply_filters('woocommerce_paypal_payments_checkout_button_renderer_hook', 'woocommerce_review_order_after_payment');
+	}
+	
+	/**
+	 * Return action name PayPal DCC button will be rendered at on checkout page.
+	 *
+	 * @return string
+	 */
+	private function checkout_dcc_button_renderer_hook(): string
+	{
+		return (string) apply_filters('woocommerce_paypal_payments_checkout_dcc_renderer_hook', 'woocommerce_review_order_after_submit');
 	}
 	
 	/**

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -349,7 +349,7 @@ class SmartButton implements SmartButtonInterface {
 			! $not_enabled_on_minicart
 		) {
 			add_action(
-				'woocommerce_widget_shopping_cart_after_buttons',
+				$this->mini_cart_button_renderer_hook(),
 				static function () {
 					echo '<p
                                 id="ppc-button-minicart"
@@ -995,7 +995,7 @@ class SmartButton implements SmartButtonInterface {
 	}
 	
 	/**
-	 * Return action name PayPal will be rendered next to Proceed to checkout button (normally displayed in cart).
+	 * Return action name PayPal button will be rendered next to Proceed to checkout button (normally displayed in cart).
 	 *
 	 * @return string
 	 */
@@ -1004,6 +1004,19 @@ class SmartButton implements SmartButtonInterface {
 		return (string) apply_filters(
 			'woocommerce_paypal_payments_to_checkout_button_renderer_hook',
 			'woocommerce_proceed_to_checkout'
+		);
+	}
+	
+	/**
+	 * Return action name PayPal button will be rendered in the WC mini cart.
+	 *
+	 * @return string
+	 */
+	private function mini_cart_button_renderer_hook(): string
+	{
+		return (string) apply_filters(
+			'woocommerce_paypal_payments_mini_cart_button_renderer_hook',
+			'woocommerce_widget_shopping_cart_after_buttons'
 		);
 	}
 }

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -360,7 +360,7 @@ class SmartButton implements SmartButtonInterface {
 			);
 		}
 
-		add_action( 'woocommerce_review_order_after_payment', array( $this, 'button_renderer' ), 10 );
+		add_action( $this->checkout_button_renderer_hook(), array( $this, 'button_renderer' ), 10 );
 		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'button_renderer' ), 10 );
 
 		return true;
@@ -962,5 +962,15 @@ class SmartButton implements SmartButtonInterface {
 		}
 
 		return $height;
+	}
+	
+	/**
+	 * Return action name PayPal buttons will be rendered at.
+	 *
+	 * @return string Action name.
+	 */
+	private function checkout_button_renderer_hook(): string
+	{
+		return (string) apply_filters('woocommerce_paypal_payments_checkout_button_renderer_hook', 'woocommerce_review_order_after_payment');
 	}
 }

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -991,7 +991,7 @@ class SmartButton implements SmartButtonInterface {
 	 */
 	private function pay_order_renderer_hook(): string
 	{
-		return (string) apply_filters('woocommerce_paypal_payments-pay-order_dcc_renderer_hook', 'woocommerce_pay_order_after_submit');
+		return (string) apply_filters('woocommerce_paypal_payments_pay_order_dcc_renderer_hook', 'woocommerce_pay_order_after_submit');
 	}
 	
 	/**

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -271,7 +271,7 @@ class SmartButton implements SmartButtonInterface {
 			&& ! $not_enabled_on_product_page
 		) {
 			add_action(
-				'woocommerce_single_product_summary',
+				$this->single_product_renderer_hook(),
 				array(
 					$this,
 					'message_renderer',
@@ -334,7 +334,7 @@ class SmartButton implements SmartButtonInterface {
 			&& ! $not_enabled_on_product_page
 		) {
 			add_action(
-				'woocommerce_single_product_summary',
+				$this->single_product_renderer_hook(),
 				array(
 					$this,
 					'button_renderer',
@@ -1018,5 +1018,15 @@ class SmartButton implements SmartButtonInterface {
 			'woocommerce_paypal_payments_mini_cart_button_renderer_hook',
 			'woocommerce_widget_shopping_cart_after_buttons'
 		);
+	}
+	
+	/**
+	 * Return action name PayPal button and Pay Later message will be rendered at on the single product page.
+	 *
+	 * @return string
+	 */
+	private function single_product_renderer_hook(): string
+	{
+		return (string) apply_filters('woocommerce_paypal_payments_single_product_renderer_hook', 'woocommerce_single_product_summary');
 	}
 }

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -191,7 +191,7 @@ class SmartButton implements SmartButtonInterface {
 			);
 
 			add_action(
-				'woocommerce_pay_order_after_submit',
+				$this->pay_order_dcc_button_renderer_hook(),
 				array(
 					$this,
 					'dcc_renderer',
@@ -982,6 +982,16 @@ class SmartButton implements SmartButtonInterface {
 	private function checkout_dcc_button_renderer_hook(): string
 	{
 		return (string) apply_filters('woocommerce_paypal_payments_checkout_dcc_renderer_hook', 'woocommerce_review_order_after_submit');
+	}
+	
+	/**
+	 * Return action name PayPal DCC button will be rendered at on pay-order page.
+	 *
+	 * @return string
+	 */
+	private function pay_order_dcc_button_renderer_hook(): string
+	{
+		return (string) apply_filters('woocommerce_paypal_payments-pay-order_dcc_renderer_hook', 'woocommerce_pay_order_after_submit');
 	}
 	
 	/**

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -191,7 +191,7 @@ class SmartButton implements SmartButtonInterface {
 			);
 
 			add_action(
-				$this->pay_order_dcc_button_renderer_hook(),
+				$this->pay_order_renderer_hook(),
 				array(
 					$this,
 					'dcc_renderer',
@@ -292,7 +292,7 @@ class SmartButton implements SmartButtonInterface {
 				11
 			);
 			add_action(
-				$this->pay_order_dcc_button_renderer_hook(),
+				$this->pay_order_renderer_hook(),
 				array(
 					$this,
 					'message_renderer',
@@ -361,7 +361,7 @@ class SmartButton implements SmartButtonInterface {
 		}
 
 		add_action( $this->checkout_button_renderer_hook(), array( $this, 'button_renderer' ), 10 );
-		add_action( $this->pay_order_dcc_button_renderer_hook(), array( $this, 'button_renderer' ), 10 );
+		add_action( $this->pay_order_renderer_hook(), array( $this, 'button_renderer' ), 10 );
 
 		return true;
 	}
@@ -985,11 +985,11 @@ class SmartButton implements SmartButtonInterface {
 	}
 	
 	/**
-	 * Return action name PayPal DCC button will be rendered at on pay-order page.
+	 * Return action name PayPal button and Pay Later message will be rendered at on pay-order page.
 	 *
 	 * @return string
 	 */
-	private function pay_order_dcc_button_renderer_hook(): string
+	private function pay_order_renderer_hook(): string
 	{
 		return (string) apply_filters('woocommerce_paypal_payments-pay-order_dcc_renderer_hook', 'woocommerce_pay_order_after_submit');
 	}

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -963,70 +963,64 @@ class SmartButton implements SmartButtonInterface {
 
 		return $height;
 	}
-	
+
 	/**
 	 * Return action name PayPal buttons will be rendered at on checkout page.
 	 *
 	 * @return string Action name.
 	 */
-	private function checkout_button_renderer_hook(): string
-	{
-		return (string) apply_filters('woocommerce_paypal_payments_checkout_button_renderer_hook', 'woocommerce_review_order_after_payment');
+	private function checkout_button_renderer_hook(): string {
+		return (string) apply_filters( 'woocommerce_paypal_payments_checkout_button_renderer_hook', 'woocommerce_review_order_after_payment' );
 	}
-	
+
 	/**
 	 * Return action name PayPal DCC button will be rendered at on checkout page.
 	 *
 	 * @return string
 	 */
-	private function checkout_dcc_button_renderer_hook(): string
-	{
-		return (string) apply_filters('woocommerce_paypal_payments_checkout_dcc_renderer_hook', 'woocommerce_review_order_after_submit');
+	private function checkout_dcc_button_renderer_hook(): string {
+		return (string) apply_filters( 'woocommerce_paypal_payments_checkout_dcc_renderer_hook', 'woocommerce_review_order_after_submit' );
 	}
-	
+
 	/**
 	 * Return action name PayPal button and Pay Later message will be rendered at on pay-order page.
 	 *
 	 * @return string
 	 */
-	private function pay_order_renderer_hook(): string
-	{
-		return (string) apply_filters('woocommerce_paypal_payments_pay_order_dcc_renderer_hook', 'woocommerce_pay_order_after_submit');
+	private function pay_order_renderer_hook(): string {
+		return (string) apply_filters( 'woocommerce_paypal_payments_pay_order_dcc_renderer_hook', 'woocommerce_pay_order_after_submit' );
 	}
-	
+
 	/**
 	 * Return action name PayPal button will be rendered next to Proceed to checkout button (normally displayed in cart).
 	 *
 	 * @return string
 	 */
-	private function proceed_to_checkout_button_renderer_hook(): string
-	{
+	private function proceed_to_checkout_button_renderer_hook(): string {
 		return (string) apply_filters(
 			'woocommerce_paypal_payments_proceed_to_checkout_button_renderer_hook',
 			'woocommerce_proceed_to_checkout'
 		);
 	}
-	
+
 	/**
 	 * Return action name PayPal button will be rendered in the WC mini cart.
 	 *
 	 * @return string
 	 */
-	private function mini_cart_button_renderer_hook(): string
-	{
+	private function mini_cart_button_renderer_hook(): string {
 		return (string) apply_filters(
 			'woocommerce_paypal_payments_mini_cart_button_renderer_hook',
 			'woocommerce_widget_shopping_cart_after_buttons'
 		);
 	}
-	
+
 	/**
 	 * Return action name PayPal button and Pay Later message will be rendered at on the single product page.
 	 *
 	 * @return string
 	 */
-	private function single_product_renderer_hook(): string
-	{
-		return (string) apply_filters('woocommerce_paypal_payments_single_product_renderer_hook', 'woocommerce_single_product_summary');
+	private function single_product_renderer_hook(): string {
+		return (string) apply_filters( 'woocommerce_paypal_payments_single_product_renderer_hook', 'woocommerce_single_product_summary' );
 	}
 }

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -1002,7 +1002,7 @@ class SmartButton implements SmartButtonInterface {
 	private function proceed_to_checkout_button_renderer_hook(): string
 	{
 		return (string) apply_filters(
-			'woocommerce_paypal_payments_to_checkout_button_renderer_hook',
+			'woocommerce_paypal_payments_proceed_to_checkout_button_renderer_hook',
 			'woocommerce_proceed_to_checkout'
 		);
 	}

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -255,7 +255,7 @@ class SmartButton implements SmartButtonInterface {
 			&& ! $not_enabled_on_cart
 		) {
 			add_action(
-				'woocommerce_proceed_to_checkout',
+				$this->proceed_to_checkout_button_renderer_hook(),
 				array(
 					$this,
 					'message_renderer',
@@ -284,7 +284,7 @@ class SmartButton implements SmartButtonInterface {
 			! $this->settings->get( 'message_enabled' );
 		if ( ! $not_enabled_on_checkout ) {
 			add_action(
-				'woocommerce_review_order_after_submit',
+				$this->checkout_dcc_button_renderer_hook(),
 				array(
 					$this,
 					'message_renderer',
@@ -292,7 +292,7 @@ class SmartButton implements SmartButtonInterface {
 				11
 			);
 			add_action(
-				'woocommerce_pay_order_after_submit',
+				$this->pay_order_dcc_button_renderer_hook(),
 				array(
 					$this,
 					'message_renderer',
@@ -361,7 +361,7 @@ class SmartButton implements SmartButtonInterface {
 		}
 
 		add_action( $this->checkout_button_renderer_hook(), array( $this, 'button_renderer' ), 10 );
-		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'button_renderer' ), 10 );
+		add_action( $this->pay_order_dcc_button_renderer_hook(), array( $this, 'button_renderer' ), 10 );
 
 		return true;
 	}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -761,7 +761,7 @@ return array(
 				'type'         => 'select',
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => 'paypal',
+				'default'      => apply_filters( 'woocommerce_paypal_payments_button_label_default', 'paypal' ),
 				'desc_tip'     => true,
 				'description'  => __(
 					'This controls the label on the primary button.',
@@ -1063,7 +1063,7 @@ return array(
 				'type'         => 'select',
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => 'paypal',
+				'default'      => apply_filters( 'woocommerce_paypal_payments_button_product_label_default', 'paypal' ),
 				'desc_tip'     => true,
 				'description'  => __(
 					'This controls the label on the primary button.',
@@ -1366,7 +1366,7 @@ return array(
 				'type'         => 'select',
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => 'paypal',
+				'default'      => apply_filters( 'woocommerce_paypal_payments_button_cart_label_default', 'paypal' ),
 				'desc_tip'     => true,
 				'description'  => __(
 					'This controls the label on the primary button.',
@@ -1669,7 +1669,7 @@ return array(
 				'type'         => 'select',
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => 'paypal',
+				'default'      => apply_filters( 'woocommerce_paypal_payments_button_mini_cart_label_default', 'paypal' ),
 				'desc_tip'     => true,
 				'description'  => __(
 					'This controls the label on the primary button.',

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -73,7 +73,11 @@ define( 'PPCP_FLAG_SUBSCRIPTION', true );
 		static $initialized;
 		if ( ! $initialized ) {
 			$modules = array( new PluginModule() );
-			foreach ( glob( plugin_dir_path( __FILE__ ) . 'modules/*/module.php' ) as $module_file ) {
+			$module_files = glob( plugin_dir_path( __FILE__ ) . 'modules/*/module.php' );
+			
+			//Use this filter to add custom module or remove some of added ones.
+			$module_files = apply_filters('woocommerce_paypal_payments_module_files_list', $module_files);
+			foreach ( $module_files as $module_file ) {
 				$modules[] = ( require $module_file )();
 			}
 			$providers = array();

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -73,11 +73,7 @@ define( 'PPCP_FLAG_SUBSCRIPTION', true );
 		static $initialized;
 		if ( ! $initialized ) {
 			$modules = array( new PluginModule() );
-			$module_files = glob( plugin_dir_path( __FILE__ ) . 'modules/*/module.php' );
-			
-			//Use this filter to add custom module or remove some of added ones.
-			$module_files = apply_filters('woocommerce_paypal_payments_module_files_list', $module_files);
-			foreach ( $module_files as $module_file ) {
+			foreach ( glob( plugin_dir_path( __FILE__ ) . 'modules/*/module.php' ) as $module_file ) {
 				$modules[] = ( require $module_file )();
 			}
 			$providers = array();

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -77,11 +77,11 @@ define( 'PPCP_FLAG_SUBSCRIPTION', true );
 				$modules[] = ( require $module_file )();
 			}
 			$providers = array();
-			
-			//Use this filter to add custom module or remove some of existing ones.
-			//Modules able to access container, add services and modify existing ones.
-			$modules = apply_filters('woocommerce_paypal_payments_modules', $modules);
-			
+
+			// Use this filter to add custom module or remove some of existing ones.
+			// Modules able to access container, add services and modify existing ones.
+			$modules = apply_filters( 'woocommerce_paypal_payments_modules', $modules );
+
 			foreach ( $modules as $module ) {
 				/* @var $module ModuleInterface module */
 				$providers[] = $module->setup();

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -77,6 +77,11 @@ define( 'PPCP_FLAG_SUBSCRIPTION', true );
 				$modules[] = ( require $module_file )();
 			}
 			$providers = array();
+			
+			//Use this filter to add custom module or remove some of existing ones.
+			//Modules able to access container, add services and modify existing ones.
+			$modules = apply_filters('woocommerce_paypal_payments_modules', $modules);
+			
 			foreach ( $modules as $module ) {
 				/* @var $module ModuleInterface module */
 				$providers[] = $module->setup();


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
1. Add filters to change hook PayPal buttons and Pay Later messages will be rendered on.
2. Add filter to allow adding custom modules to the plugin or removing existing ones.

Added filters list for buttons and message position (for fixing the issue with the Germanized plugin these hooks should be enough): 
* `woocommerce_paypal_payments_checkout_button_renderer_hook`,
* `woocommerce_paypal_payments_checkout_dcc_renderer_hook`,
* `woocommerce_paypal_payments_pay_order_dcc_renderer_hook`,
* `woocommerce_paypal_payments_proceed_to_checkout_button_renderer_hook`,
* `woocommerce_paypal_payments_mini_cart_button_renderer_hook`,
* `woocommerce_paypal_payments_single_product_renderer_hook`.

Added filter for custom modules (for more advanced extending, adding custom features, etc.):
* `woocommerce_paypal_payments_modules`


### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Make sure buttons are rendered as they should.
2. Create the simplest possible plugin, and use a filter to render buttons or message at another WC hook.
3. In the test plugin add a custom module, try to extend (override) a service from the WooCommerce PayPal Payments plugin or just access the container.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
* Add - Filters to move PayPal buttons and Pay Later messages.
* Add - Filter to modify plugin modules list.

Closes #209 (see added filters section above, the filter to use is `woocommerce_paypal_payments_modules`). Also, see the section below.

### Adding modules and accessing the plugin container
To access the container from outside, add your module using a filter provided above. Inside your module, you will be able to access and extend/modify the container. This is a simplified example:

//composer.json
```json
{
  "name": "vendor_name/test-plugin",
  "description": "description",
  "minimum-stability": "stable",
  "require": {
    "dhii/module-interface": "0.3.x-dev"
  }
}
```
//your-plugin.php
```php
$module = new class implements Dhii\Modular\Module\ModuleInterface{
	public function setup(): ServiceProviderInterface
	{
		return new ServiceProvider(
			[], //place here your services you want to add to container,
                        [] // place here your extensions to replace existing container services (see links below for more details).
		);
	}
	
	public function run(ContainerInterface $c): void
	{
                //here you can get the container instance and do something with it.
		add_action('admin_notices', function() use ($c){
			$c->get('admin-notices.renderer')->render();
		});
	}
};

add_filter('woocommerce_paypal_payments_modules', function($modules) use ($module) {
	array_push($modules, $module);
	
	return $modules;
});
```
See https://github.com/container-interop/service-provider and  https://github.com/Dhii/module-interface for more details.
