### PR TITLE
Gateway can be activated without a connected PayPal account

### DIFF
--- a/modules/ppcp-api-client/src/Authentication/class-paypalbearer.php
+++ b/modules/ppcp-api-client/src/Authentication/class-paypalbearer.php
@@ -134,11 +134,7 @@ class PayPalBearer implements Bearer {
 
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
 			$error = new RuntimeException(
-				sprintf(
-					// translators: %s is the error description.
-					__( 'Could not create token. %s', 'woocommerce-paypal-payments' ),
-					isset( json_decode( $response['body'] )->error_description ) ? json_decode( $response['body'] )->error_description : ''
-				)
+				__( 'Could not create token.', 'woocommerce-paypal-payments' )
 			);
 			$this->logger->log(
 				'warning',

--- a/modules/ppcp-api-client/src/Authentication/class-paypalbearer.php
+++ b/modules/ppcp-api-client/src/Authentication/class-paypalbearer.php
@@ -24,12 +24,15 @@ class PayPalBearer implements Bearer {
 	use RequestTrait;
 
 	const CACHE_KEY = 'ppcp-bearer';
-    /**
-     * @var Settings
-     */
-    protected $settings;
 
-    /**
+	/**
+	 * The settings.
+	 *
+	 * @var Settings
+	 */
+	protected $settings;
+
+	/**
 	 * The cache.
 	 *
 	 * @var Cache
@@ -72,6 +75,7 @@ class PayPalBearer implements Bearer {
 	 * @param string          $key The key.
 	 * @param string          $secret The secret.
 	 * @param LoggerInterface $logger The logger.
+	 * @param Settings        $settings The settings.
 	 */
 	public function __construct(
 		Cache $cache,
@@ -79,16 +83,16 @@ class PayPalBearer implements Bearer {
 		string $key,
 		string $secret,
 		LoggerInterface $logger,
-        Settings $settings
+		Settings $settings
 	) {
 
-		$this->cache  = $cache;
-		$this->host   = $host;
-		$this->key    = $key;
-		$this->secret = $secret;
-		$this->logger = $logger;
-        $this->settings = $settings;
-    }
+		$this->cache    = $cache;
+		$this->host     = $host;
+		$this->key      = $key;
+		$this->secret   = $secret;
+		$this->logger   = $logger;
+		$this->settings = $settings;
+	}
 
 	/**
 	 * Returns a bearer token.
@@ -112,15 +116,15 @@ class PayPalBearer implements Bearer {
 	 * @throws RuntimeException When request fails.
 	 */
 	private function newBearer(): Token {
-        $key = $this->settings->has('client_id') && $this->settings->get('client_id') ? $this->settings->get('client_id') : $this->key;
-        $secret = $this->settings->has('client_secret') && $this->settings->get('client_secret') ? $this->settings->get('client_secret') : $this->secret;
-		$url      = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials';
+		$key    = $this->settings->has( 'client_id' ) && $this->settings->get( 'client_id' ) ? $this->settings->get( 'client_id' ) : $this->key;
+		$secret = $this->settings->has( 'client_secret' ) && $this->settings->get( 'client_secret' ) ? $this->settings->get( 'client_secret' ) : $this->secret;
+		$url    = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials';
 
-        $args     = array(
+		$args     = array(
 			'method'  => 'POST',
 			'headers' => array(
 				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
-				'Authorization' => 'Basic ' . base64_encode( $key . ':' . $secret),
+				'Authorization' => 'Basic ' . base64_encode( $key . ':' . $secret ),
 			),
 		);
 		$response = $this->request(

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -51,7 +51,7 @@ return array(
 		 *
 		 * @var State $state
 		 */
-		if ( $state->current_state() < State::STATE_PROGRESSIVE ) {
+		if ( $state->current_state() <= State::STATE_PROGRESSIVE ) {
 			return new DisabledSmartButton();
 		}
 		$settings           = $container->get( 'wcgateway.settings' );

--- a/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php
@@ -174,7 +174,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 			$this->set_bn_code( $data );
 
 			if ( 'checkout' === $data['context'] ) {
-				if ( '1' === $data['createaccount'] ) {
+				if ( isset( $data['createaccount'] ) && '1' === $data['createaccount'] ) {
 					$this->process_checkout_form_when_creating_account( $data['form'], $wc_order );
 				}
 

--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -103,15 +103,16 @@ return array(
 		$cache  = new Cache( 'ppcp-paypal-bearer' );
 		$key    = $container->get( 'api.key' );
 		$secret = $container->get( 'api.secret' );
-
 		$host   = $container->get( 'api.host' );
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
+		$settings = $container->get('wcgateway.settings');
 		return new PayPalBearer(
 			$cache,
 			$host,
 			$key,
 			$secret,
-			$logger
+			$logger,
+            $settings
 		);
 	},
 	'onboarding.state'                          => function( $container ) : State {

--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -105,14 +105,14 @@ return array(
 		$secret = $container->get( 'api.secret' );
 		$host   = $container->get( 'api.host' );
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
-		$settings = $container->get('wcgateway.settings');
+		$settings = $container->get( 'wcgateway.settings' );
 		return new PayPalBearer(
 			$cache,
 			$host,
 			$key,
 			$secret,
 			$logger,
-            $settings
+			$settings
 		);
 	},
 	'onboarding.state'                          => function( $container ) : State {

--- a/modules/ppcp-status-report/extensions.php
+++ b/modules/ppcp-status-report/extensions.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * The status report module extensions.
+ *
+ * @package WooCommerce\PayPalCommerce\StatusReport
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\StatusReport;
+
+return array();

--- a/modules/ppcp-status-report/module.php
+++ b/modules/ppcp-status-report/module.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The status report module.
+ *
+ * @package WooCommerce\PayPalCommerce\StatusReport
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\StatusReport;
+
+use Dhii\Modular\Module\ModuleInterface;
+
+return static function (): ModuleInterface {
+	return new StatusReportModule();
+};

--- a/modules/ppcp-status-report/services.php
+++ b/modules/ppcp-status-report/services.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * The status report module services.
+ *
+ * @package WooCommerce\PayPalCommerce\StatusReport
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\StatusReport;
+
+return array();

--- a/modules/ppcp-status-report/services.php
+++ b/modules/ppcp-status-report/services.php
@@ -9,4 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\StatusReport;
 
-return array();
+return array(
+	'status-report.renderer' => static function ( $container ): Renderer {
+		return new Renderer();
+	},
+);

--- a/modules/ppcp-status-report/src/class-renderer.php
+++ b/modules/ppcp-status-report/src/class-renderer.php
@@ -38,6 +38,7 @@ class Renderer {
 				?>
 				<tr>
 					<td data-export-label="<?php echo esc_attr( $item['label'] ); ?>"><?php echo esc_attr( $item['label'] ); ?></td>
+					<td class="help"><?php echo wc_help_tip( $item['description'] ); ?></td>
 					<td><?php echo esc_attr( $item['value'] ); ?></td>
 				</tr>
 				<?php

--- a/modules/ppcp-status-report/src/class-renderer.php
+++ b/modules/ppcp-status-report/src/class-renderer.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * The status report renderer.
+ *
+ * @package WooCommerce\PayPalCommerce\StatusReport
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\StatusReport;
+
+/**
+ * Class Renderer
+ */
+class Renderer {
+
+	/**
+	 * It renders the status report content.
+	 *
+	 * @param string $title The title.
+	 * @param array  $items The items.
+	 * @return false|string
+	 */
+	public function render( string $title, array $items ) {
+		ob_start();
+		?>
+		<table class="wc_status_table widefat" id="status">
+			<thead>
+			<tr>
+				<th colspan="3" data-export-label="<?php echo esc_attr( $title ); ?>">
+					<h2><?php echo esc_attr( $title ); ?></h2>
+				</th>
+			</tr>
+			</thead>
+			<tbody>
+			<?php
+			foreach ( $items as $item ) {
+				?>
+				<tr>
+					<td data-export-label="<?php echo esc_attr( $item['label'] ); ?>"><?php echo esc_attr( $item['label'] ); ?></td>
+					<td><?php echo esc_attr( $item['value'] ); ?></td>
+				</tr>
+				<?php
+			}
+			?>
+			</tbody>
+		</table>
+		<?php
+		return ob_get_clean();
+	}
+}

--- a/modules/ppcp-status-report/src/class-statusreportmodule.php
+++ b/modules/ppcp-status-report/src/class-statusreportmodule.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * The status report module.
+ *
+ * @package WooCommerce\PayPalCommerce\StatusReport
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\StatusReport;
+
+use Dhii\Container\ServiceProvider;
+use Dhii\Modular\Module\ModuleInterface;
+use Interop\Container\ServiceProviderInterface;
+use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
+use WooCommerce\PayPalCommerce\Onboarding\State;
+
+/**
+ * Class StatusReportModule
+ */
+class StatusReportModule implements ModuleInterface {
+
+	/**
+	 * Setup the compatibility module.
+	 *
+	 * @return ServiceProviderInterface
+	 */
+	public function setup(): ServiceProviderInterface {
+		return new ServiceProvider(
+			require __DIR__ . '/../services.php',
+			require __DIR__ . '/../extensions.php'
+		);
+	}
+
+	/**
+	 * Run the compatibility module.
+	 *
+	 * @param ContainerInterface|null $container The Container.
+	 */
+	public function run( ContainerInterface $container ): void {
+		/* @var State $state The state */
+		$state = $container->get( 'onboarding.state' );
+
+		/* @var Bearer $bearer The bearer */
+		$bearer = $container->get( 'api.bearer' );
+
+		/* @var DccApplies $dcc_applies The ddc applies */
+		$dcc_applies = $container->get( 'api.helpers.dccapplies' );
+
+		/* @var MessagesApply $messages_apply The messages apply */
+		$messages_apply = $container->get( 'button.helper.messages-apply' );
+
+		add_action(
+			'woocommerce_system_status_report',
+			function() use ( $state, $bearer, $dcc_applies, $messages_apply ) { ?>
+			<table class="wc_status_table widefat" id="status">
+				<thead>
+					<tr>
+						<th colspan="3" data-export-label="WooCommerce PayPal Payments">
+							<h2><?php esc_html_e( 'WooCommerce PayPal Payments', 'woocommerce-paypal-payments' ); ?></h2>
+						</th>
+					</tr>
+				</thead>
+
+				<tbody>
+					<tr>
+						<td data-export-label="Onboarding state"><?php esc_html_e( 'Onboarding state', 'woocommerce-paypal-payments' ); ?></td>
+						<td>
+						<?php
+							$current_state = $state->current_state();
+						switch ( $current_state ) {
+							case $state::STATE_START:
+								echo esc_html__( 'Start', 'woocommerce-paypal-payments' );
+								break;
+							case $state::STATE_PROGRESSIVE:
+								echo esc_html__( 'Progressive', 'woocommerce-paypal-payments' );
+								break;
+							case $state::STATE_ONBOARDED:
+								echo esc_html__( 'Onboarded', 'woocommerce-paypal-payments' );
+								break;
+							default:
+								echo esc_html__( 'Unknown', 'woocommerce-paypal-payments' );
+						}
+						?>
+							</td>
+					</tr>
+					<tr>
+						<td data-export-label="Shop country code"><?php esc_html_e( 'Shop country code', 'woocommerce-paypal-payments' ); ?></td>
+						<td>
+						<?php
+							$region = wc_get_base_location();
+							echo esc_attr( $region['country'] );
+						?>
+							</td>
+					</tr>
+					<tr>
+						<td data-export-label="PayPal card processing"><?php esc_html_e( 'PayPal card processing', 'woocommerce-paypal-payments' ); ?></td>
+						<td>
+						<?php
+							echo esc_attr( $dcc_applies->for_country_currency() ? esc_html__( 'Yes', 'woocommerce-paypal-payments' ) : esc_html__( 'No', 'woocommerce-paypal-payments' ) );
+						?>
+						</td>
+					</tr>
+					<tr>
+						<td data-export-label="Messaging apply"><?php esc_html_e( 'Messaging apply', 'woocommerce-paypal-payments' ); ?></td>
+						<td><?php echo esc_attr( $messages_apply->for_country() ? esc_html__( 'Yes', 'woocommerce-paypal-payments' ) : esc_html__( 'No', 'woocommerce-paypal-payments' ) ); ?>
+						</td>
+					</tr>
+					<tr>
+						<td data-export-label="Vault enabled"><?php esc_html_e( 'Vault enabled', 'woocommerce-paypal-payments' ); ?></td>
+						<td>
+						<?php
+						try {
+							$token = $bearer->bearer();
+							echo esc_attr( $token->vaulting_available() ? esc_html__( 'Yes', 'woocommerce-paypal-payments' ) : esc_html__( 'No', 'woocommerce-paypal-payments' ) );
+						} catch ( RuntimeException $exception ) {
+							echo esc_html__( 'No', 'woocommerce-paypal-payments' );
+						}
+						?>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+				<?php
+			}
+		);
+	}
+
+	/**
+	 * Returns the key for the module.
+	 *
+	 * @return string|void
+	 */
+	public function getKey() {
+	}
+}

--- a/modules/ppcp-status-report/src/class-statusreportmodule.php
+++ b/modules/ppcp-status-report/src/class-statusreportmodule.php
@@ -87,7 +87,7 @@ class StatusReportModule implements ModuleInterface {
 					),
 					array(
 						'label'       => esc_html__( 'Vault enabled', 'woocommerce-paypal-payments' ),
-						'description' => esc_html__( 'Whether vaulting is enabled for the PayPal account or not.', 'woocommerce-paypal-payments' ),
+						'description' => esc_html__( 'Whether vaulting is enabled on PayPal account or not.', 'woocommerce-paypal-payments' ),
 						'value'       => $this->vault_enabled( $bearer ),
 					),
 				);

--- a/modules/ppcp-status-report/src/class-statusreportmodule.php
+++ b/modules/ppcp-status-report/src/class-statusreportmodule.php
@@ -25,9 +25,7 @@ use WooCommerce\PayPalCommerce\Onboarding\State;
 class StatusReportModule implements ModuleInterface {
 
 	/**
-	 * Setup the compatibility module.
-	 *
-	 * @return ServiceProviderInterface
+     * @inheritDoc
 	 */
 	public function setup(): ServiceProviderInterface {
 		return new ServiceProvider(
@@ -37,9 +35,7 @@ class StatusReportModule implements ModuleInterface {
 	}
 
 	/**
-	 * Run the compatibility module.
-	 *
-	 * @param ContainerInterface|null $container The Container.
+	 * @inheritDoc
 	 */
 	public function run( ContainerInterface $container ): void {
 		/* @var State $state The state */
@@ -131,9 +127,7 @@ class StatusReportModule implements ModuleInterface {
 	}
 
 	/**
-	 * Returns the key for the module.
-	 *
-	 * @return string|void
+	 * @inheritDoc
 	 */
 	public function getKey() {
 	}

--- a/modules/ppcp-status-report/src/class-statusreportmodule.php
+++ b/modules/ppcp-status-report/src/class-statusreportmodule.php
@@ -87,7 +87,7 @@ class StatusReportModule implements ModuleInterface {
 					),
 					array(
 						'label'       => esc_html__( 'Vault enabled', 'woocommerce-paypal-payments' ),
-						'description' => esc_html__( 'Whether vaulting is enabled or not.', 'woocommerce-paypal-payments' ),
+						'description' => esc_html__( 'Whether vaulting is enabled for the PayPal account or not.', 'woocommerce-paypal-payments' ),
 						'value'       => $this->vault_enabled( $bearer ),
 					),
 				);

--- a/modules/ppcp-status-report/src/class-statusreportmodule.php
+++ b/modules/ppcp-status-report/src/class-statusreportmodule.php
@@ -25,7 +25,7 @@ use WooCommerce\PayPalCommerce\Onboarding\State;
 class StatusReportModule implements ModuleInterface {
 
 	/**
-     * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public function setup(): ServiceProviderInterface {
 		return new ServiceProvider(
@@ -35,19 +35,21 @@ class StatusReportModule implements ModuleInterface {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
+	 *
+	 * @param ContainerInterface $container A services container instance.
 	 */
 	public function run( ContainerInterface $container ): void {
-		/* @var State $state The state */
+		/* @var State $state The state. */
 		$state = $container->get( 'onboarding.state' );
 
-		/* @var Bearer $bearer The bearer */
+		/* @var Bearer $bearer The bearer. */
 		$bearer = $container->get( 'api.bearer' );
 
-		/* @var DccApplies $dcc_applies The ddc applies */
+		/* @var DccApplies $dcc_applies The ddc applies. */
 		$dcc_applies = $container->get( 'api.helpers.dccapplies' );
 
-		/* @var MessagesApply $messages_apply The messages apply */
+		/* @var MessagesApply $messages_apply The messages apply. */
 		$messages_apply = $container->get( 'button.helper.messages-apply' );
 
 		add_action(
@@ -102,7 +104,7 @@ class StatusReportModule implements ModuleInterface {
 						</td>
 					</tr>
 					<tr>
-						<td data-export-label="Messaging apply"><?php esc_html_e( 'Messaging apply', 'woocommerce-paypal-payments' ); ?></td>
+						<td data-export-label="Pay Later messaging"><?php esc_html_e( 'Pay Later messaging', 'woocommerce-paypal-payments' ); ?></td>
 						<td><?php echo esc_attr( $messages_apply->for_country() ? esc_html__( 'Yes', 'woocommerce-paypal-payments' ) : esc_html__( 'No', 'woocommerce-paypal-payments' ) ); ?>
 						</td>
 					</tr>
@@ -127,7 +129,7 @@ class StatusReportModule implements ModuleInterface {
 	}
 
 	/**
-	 * @inheritDoc
+	 * {@inheritDoc}
 	 */
 	public function getKey() {
 	}

--- a/modules/ppcp-status-report/src/class-statusreportmodule.php
+++ b/modules/ppcp-status-report/src/class-statusreportmodule.php
@@ -43,7 +43,7 @@ class StatusReportModule implements ModuleInterface {
 	public function run( ContainerInterface $container ): void {
 		add_action(
 			'woocommerce_system_status_report',
-			function () use ($container) {
+			function () use ( $container ) {
 
 				/* @var State $state The state. */
 				$state = $container->get( 'onboarding.state' );
@@ -106,22 +106,22 @@ class StatusReportModule implements ModuleInterface {
 	 * It returns the current onboarding status.
 	 *
 	 * @param Bearer $bearer The bearer.
-	 * @param State $state The state.
+	 * @param State  $state The state.
 	 * @return string
 	 */
-	private function onboarded( $bearer, $state): string {
+	private function onboarded( $bearer, $state ): string {
 		try {
 			$token = $bearer->bearer();
 		} catch ( RuntimeException $exception ) {
-			return esc_html__('No', 'woocommerce-paypal-payments');
+			return esc_html__( 'No', 'woocommerce-paypal-payments' );
 		}
 
 		$current_state = $state->current_state();
-		if($token->is_valid() && $current_state === $state::STATE_ONBOARDED) {
-			return esc_html__('Yes', 'woocommerce-paypal-payments');
+		if ( $token->is_valid() && $current_state === $state::STATE_ONBOARDED ) {
+			return esc_html__( 'Yes', 'woocommerce-paypal-payments' );
 		}
 
-		return esc_html__('No', 'woocommerce-paypal-payments');
+		return esc_html__( 'No', 'woocommerce-paypal-payments' );
 	}
 
 	/**

--- a/modules/ppcp-status-report/src/class-statusreportmodule.php
+++ b/modules/ppcp-status-report/src/class-statusreportmodule.php
@@ -14,6 +14,7 @@ use Dhii\Modular\Module\ModuleInterface;
 use Interop\Container\ServiceProviderInterface;
 use Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
@@ -40,52 +41,52 @@ class StatusReportModule implements ModuleInterface {
 	 * @param ContainerInterface $container A services container instance.
 	 */
 	public function run( ContainerInterface $container ): void {
-		/* @var State $state The state. */
-		$state = $container->get( 'onboarding.state' );
-
-		/* @var Bearer $bearer The bearer. */
-		$bearer = $container->get( 'api.bearer' );
-
-		/* @var DccApplies $dcc_applies The ddc applies. */
-		$dcc_applies = $container->get( 'api.helpers.dccapplies' );
-
-		/* @var MessagesApply $messages_apply The messages apply. */
-		$messages_apply = $container->get( 'button.helper.messages-apply' );
-
-		/* @var Renderer $renderer The renderer. */
-		$renderer = $container->get( 'status-report.renderer' );
-
-		$items = array(
-			array(
-				'label' => esc_html__( 'Onboarding state', 'woocommerce-paypal-payments' ),
-				'value' => $this->onboarding_state( $state ),
-			),
-			array(
-				'label' => esc_html__( 'Shop country code', 'woocommerce-paypal-payments' ),
-				'value' => wc_get_base_location()['country'],
-			),
-			array(
-				'label' => esc_html__( 'PayPal card processing', 'woocommerce-paypal-payments' ),
-				'value' => $dcc_applies->for_country_currency()
-					? esc_html__( 'Yes', 'woocommerce-paypal-payments' )
-					: esc_html__( 'No', 'woocommerce-paypal-payments' ),
-			),
-			array(
-				'label' => esc_html__( 'Pay Later messaging', 'woocommerce-paypal-payments' ),
-				'value' => $messages_apply->for_country()
-					? esc_html__( 'Yes', 'woocommerce-paypal-payments' )
-					: esc_html__( 'No', 'woocommerce-paypal-payments' ),
-			),
-			array(
-				'label' => esc_html__( 'Vault enabled', 'woocommerce-paypal-payments' ),
-				'value' => $this->vault_enabled( $bearer ),
-			),
-		);
-
 		add_action(
 			'woocommerce_system_status_report',
-			function () use ( $renderer, $items ) { ?>
-				<?php
+			function () use ($container) {
+
+				/* @var State $state The state. */
+				$state = $container->get( 'onboarding.state' );
+
+				/* @var Bearer $bearer The bearer. */
+				$bearer = $container->get( 'api.bearer' );
+
+				/* @var DccApplies $dcc_applies The ddc applies. */
+				$dcc_applies = $container->get( 'api.helpers.dccapplies' );
+
+				/* @var MessagesApply $messages_apply The messages apply. */
+				$messages_apply = $container->get( 'button.helper.messages-apply' );
+
+				/* @var Renderer $renderer The renderer. */
+				$renderer = $container->get( 'status-report.renderer' );
+
+				$items = array(
+					array(
+						'label' => esc_html__( 'Onboarded', 'woocommerce-paypal-payments' ),
+						'value' => $this->onboarded( $bearer, $state ),
+					),
+					array(
+						'label' => esc_html__( 'Shop country code', 'woocommerce-paypal-payments' ),
+						'value' => wc_get_base_location()['country'],
+					),
+					array(
+						'label' => esc_html__( 'PayPal card processing available in country', 'woocommerce-paypal-payments' ),
+						'value' => $dcc_applies->for_country_currency()
+							? esc_html__( 'Yes', 'woocommerce-paypal-payments' )
+							: esc_html__( 'No', 'woocommerce-paypal-payments' ),
+					),
+					array(
+						'label' => esc_html__( 'Pay Later messaging available in country', 'woocommerce-paypal-payments' ),
+						'value' => $messages_apply->for_country()
+							? esc_html__( 'Yes', 'woocommerce-paypal-payments' )
+							: esc_html__( 'No', 'woocommerce-paypal-payments' ),
+					),
+					array(
+						'label' => esc_html__( 'Vault enabled', 'woocommerce-paypal-payments' ),
+						'value' => $this->vault_enabled( $bearer ),
+					),
+				);
+
 				echo wp_kses_post(
 					$renderer->render(
 						esc_html__( 'WooCommerce PayPal Payments', 'woocommerce-paypal-payments' ),
@@ -102,23 +103,25 @@ class StatusReportModule implements ModuleInterface {
 	public function getKey() {  }
 
 	/**
-	 * It returns the current onboarding state.
+	 * It returns the current onboarding status.
 	 *
+	 * @param Bearer $bearer The bearer.
 	 * @param State $state The state.
 	 * @return string
 	 */
-	private function onboarding_state( $state ): string {
-		$current_state = $state->current_state();
-		switch ( $current_state ) {
-			case $state::STATE_START:
-				return esc_html__( 'Start', 'woocommerce-paypal-payments' );
-			case $state::STATE_PROGRESSIVE:
-				return esc_html__( 'Progressive', 'woocommerce-paypal-payments' );
-			case $state::STATE_ONBOARDED:
-				return esc_html__( 'Onboarded', 'woocommerce-paypal-payments' );
-			default:
-				return esc_html__( 'Unknown', 'woocommerce-paypal-payments' );
+	private function onboarded( $bearer, $state): string {
+		try {
+			$token = $bearer->bearer();
+		} catch ( RuntimeException $exception ) {
+			return esc_html__('No', 'woocommerce-paypal-payments');
 		}
+
+		$current_state = $state->current_state();
+		if($token->is_valid() && $current_state === $state::STATE_ONBOARDED) {
+			return esc_html__('Yes', 'woocommerce-paypal-payments');
+		}
+
+		return esc_html__('No', 'woocommerce-paypal-payments');
 	}
 
 	/**

--- a/modules/ppcp-status-report/src/class-statusreportmodule.php
+++ b/modules/ppcp-status-report/src/class-statusreportmodule.php
@@ -62,28 +62,33 @@ class StatusReportModule implements ModuleInterface {
 
 				$items = array(
 					array(
-						'label' => esc_html__( 'Onboarded', 'woocommerce-paypal-payments' ),
-						'value' => $this->onboarded( $bearer, $state ),
+						'label'       => esc_html__( 'Onboarded', 'woocommerce-paypal-payments' ),
+						'description' => esc_html__( 'Whether PayPal account is correctly configured or not.', 'woocommerce-paypal-payments' ),
+						'value'       => $this->onboarded( $bearer, $state ),
 					),
 					array(
-						'label' => esc_html__( 'Shop country code', 'woocommerce-paypal-payments' ),
-						'value' => wc_get_base_location()['country'],
+						'label'       => esc_html__( 'Shop country code', 'woocommerce-paypal-payments' ),
+						'description' => esc_html__( 'Country / State value on Settings / General / Store Address.', 'woocommerce-paypal-payments' ),
+						'value'       => wc_get_base_location()['country'],
 					),
 					array(
-						'label' => esc_html__( 'PayPal card processing available in country', 'woocommerce-paypal-payments' ),
-						'value' => $dcc_applies->for_country_currency()
+						'label'       => esc_html__( 'PayPal card processing available in country', 'woocommerce-paypal-payments' ),
+						'description' => esc_html__( 'Whether PayPal card processing is available in country or not.', 'woocommerce-paypal-payments' ),
+						'value'       => $dcc_applies->for_country_currency()
 							? esc_html__( 'Yes', 'woocommerce-paypal-payments' )
 							: esc_html__( 'No', 'woocommerce-paypal-payments' ),
 					),
 					array(
-						'label' => esc_html__( 'Pay Later messaging available in country', 'woocommerce-paypal-payments' ),
-						'value' => $messages_apply->for_country()
+						'label'       => esc_html__( 'Pay Later messaging available in country', 'woocommerce-paypal-payments' ),
+						'description' => esc_html__( 'Whether Pay Later is available in country or not.', 'woocommerce-paypal-payments' ),
+						'value'       => $messages_apply->for_country()
 							? esc_html__( 'Yes', 'woocommerce-paypal-payments' )
 							: esc_html__( 'No', 'woocommerce-paypal-payments' ),
 					),
 					array(
-						'label' => esc_html__( 'Vault enabled', 'woocommerce-paypal-payments' ),
-						'value' => $this->vault_enabled( $bearer ),
+						'label'       => esc_html__( 'Vault enabled', 'woocommerce-paypal-payments' ),
+						'description' => esc_html__( 'Whether vaulting is enabled or not.', 'woocommerce-paypal-payments' ),
+						'value'       => $this->vault_enabled( $bearer ),
 					),
 				);
 

--- a/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
+++ b/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
@@ -25,7 +25,7 @@
             atLeastOneChecked(payLaterMessagingCheckboxes) ? disableAll(vaultingCheckboxes) : enableAll(vaultingCheckboxes)
             atLeastOneChecked(vaultingCheckboxes) ? disableAll(payLaterMessagingCheckboxes) : enableAll(payLaterMessagingCheckboxes)
 
-            if(PayPalCommerceGatewaySettings.vaulting_features_available !== '1' ) {
+            if(typeof PayPalCommerceGatewaySettings === 'undefined' || PayPalCommerceGatewaySettings.vaulting_features_available !== '1' ) {
                 disableAll(vaultingCheckboxes)
             }
         }

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -156,6 +156,9 @@ class SettingsListener {
 				return;
 			}
 		} catch ( RuntimeException $exception ) {
+			$this->settings->set( 'vault_enabled', false );
+			$this->settings->persist();
+
 			add_action(
 				'admin_notices',
 				function () use ( $exception ) {

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -165,7 +165,7 @@ class SettingsListener {
 					printf(
 						'<div class="notice notice-error"><p>%1$s</p><p>%2$s</p></div>',
 						esc_html__( 'Authentication with PayPal failed: ', 'woocommerce-paypal-payments' ) . esc_attr( $exception->getMessage() ),
-						wp_kses_post( __( 'Please verify your API Credentials and try again to connect your PayPal merchant account. Visit the <a href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/" target="_blank">plugin documentation</a> for more information about the setup.', 'woocommerce-paypal-payments' ) )
+						wp_kses_post( __( 'Please verify your API Credentials and try again to connect your PayPal business account. Visit the <a href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/" target="_blank">plugin documentation</a> for more information about the setup.', 'woocommerce-paypal-payments' ) )
 					);
 				}
 			);

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingslistener.php
@@ -163,8 +163,9 @@ class SettingsListener {
 				'admin_notices',
 				function () use ( $exception ) {
 					printf(
-						'<div class="notice notice-error"><p>%s</p></div>',
-						esc_attr( $exception->getMessage() )
+						'<div class="notice notice-error"><p>%1$s</p><p>%2$s</p></div>',
+						esc_html__( 'Authentication with PayPal failed: ', 'woocommerce-paypal-payments' ) . esc_attr( $exception->getMessage() ),
+						wp_kses_post( __( 'Please verify your API Credentials and try again to connect your PayPal merchant account. Visit the <a href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/" target="_blank">plugin documentation</a> for more information about the setup.', 'woocommerce-paypal-payments' ) )
 					);
 				}
 			);

--- a/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
@@ -8,6 +8,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\TestCase;
 use Psr\Log\LoggerInterface;
 use Mockery;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use function Brain\Monkey\Functions\expect;
 
 class PayPalBearerTest extends TestCase
@@ -28,8 +29,11 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('log');
+        $settings = Mockery::mock(Settings::class);
+        $settings->shouldReceive('has')->andReturn(true);
+        $settings->shouldReceive('get')->andReturn('');
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
 
         expect('trailingslashit')
             ->with($host)
@@ -77,8 +81,11 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('log');
+        $settings = Mockery::mock(Settings::class);
+        $settings->shouldReceive('has')->andReturn(true);
+        $settings->shouldReceive('get')->andReturn('');
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
 
         expect('trailingslashit')
             ->with($host)
@@ -123,8 +130,11 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('log');
+        $settings = Mockery::mock(Settings::class);
+        $settings->shouldReceive('has')->andReturn(true);
+        $settings->shouldReceive('get')->andReturn('');
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
 
         $token = $bearer->bearer();
         $this->assertEquals("abc", $token->token());
@@ -143,8 +153,11 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('log');
+        $settings = Mockery::mock(Settings::class);
+        $settings->shouldReceive('has')->andReturn(true);
+        $settings->shouldReceive('get')->andReturn('');
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
 
         expect('trailingslashit')
             ->with($host)
@@ -186,8 +199,11 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('log');
+        $settings = Mockery::mock(Settings::class);
+        $settings->shouldReceive('has')->andReturn(true);
+        $settings->shouldReceive('get')->andReturn('');
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
 
         expect('trailingslashit')
             ->with($host)

--- a/tests/PHPUnit/StatusReport/RendererTest.php
+++ b/tests/PHPUnit/StatusReport/RendererTest.php
@@ -13,17 +13,20 @@ class RendererTest extends TestCase
         $items = [
             [
                 'label' => 'Foo',
-                'value' => 'Bar'
+                'description' => 'Bar',
+                'value' => 'Baz'
             ],
         ];
 
         when('esc_attr')->returnArg();
+        when('wc_help_tip')->returnArg();
 
         $testee = new Renderer();
         $result = $testee->render('Some title here', $items);
 
         self::assertStringContainsString('<h2>Some title here</h2>', $result);
         self::assertStringContainsString('<td data-export-label="Foo">Foo</td>', $result);
-        self::assertStringContainsString('<td>Bar</td>', $result);
+        self::assertStringContainsString('<td class="help">Bar</td>', $result);
+        self::assertStringContainsString('<td>Baz</td>', $result);
     }
 }

--- a/tests/PHPUnit/StatusReport/RendererTest.php
+++ b/tests/PHPUnit/StatusReport/RendererTest.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\StatusReport;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+class RendererTest extends TestCase
+{
+    public function testRender()
+    {
+        $items = [
+            [
+                'label' => 'Foo',
+                'value' => 'Bar'
+            ],
+        ];
+
+        when('esc_attr')->returnArg();
+
+        $testee = new Renderer();
+        $result = $testee->render('Some title here', $items);
+
+        self::assertStringContainsString('<h2>Some title here</h2>', $result);
+        self::assertStringContainsString('<td data-export-label="Foo">Foo</td>', $result);
+        self::assertStringContainsString('<td>Bar</td>', $result);
+    }
+}


### PR DESCRIPTION
This PR prevents activating the gateway when merchant account is not connected correctly to PayPal.
It also displays PayPal onboarding information into WooCommerce system status page:

![paypal-system-status](https://user-images.githubusercontent.com/456223/127133288-445ca974-ff51-4dd9-b0dc-b6aed08a5ef1.png)

It also adds onboarding related improvements like not displaying PayPal buttons when the merchant is not onboarded correctly and displaying an admin error message when access token is not generated correctly:

![access-token-error-message](https://user-images.githubusercontent.com/456223/127466420-121912e2-49cd-4f65-a067-c94103d51900.png)