### PR TITLE
Fix unnecessary redirect

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -193,7 +193,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 */
 	public function needs_setup(): bool {
 
-		return true;
+		return ! $this->onboarded;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -381,4 +381,20 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 		return parent::get_transaction_url( $order );
 	}
+
+	/**
+	 * Updates WooCommerce gateway option.
+	 *
+	 * @param string $key The option key.
+	 * @param string $value The option value.
+	 * @return bool|void
+	 */
+	public function update_option( $key, $value = '' ) {
+		parent::update_option( $key, $value );
+
+		if ( 'enabled' === $key ) {
+			$this->config->set( 'enabled', 'yes' === $value );
+			$this->config->persist();
+		}
+	}
 }

--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -95,14 +95,14 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @var RefundProcessor
 	 */
 	private $refund_processor;
-	
+
 	/**
 	 * Whether the plugin is in onboarded state.
 	 *
 	 * @var bool
 	 */
 	private $onboarded;
-	
+
 	/**
 	 * PayPalGateway constructor.
 	 *

--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -95,7 +95,14 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @var RefundProcessor
 	 */
 	private $refund_processor;
-
+	
+	/**
+	 * Whether the plugin is in onboarded state.
+	 *
+	 * @var bool
+	 */
+	private $onboarded;
+	
 	/**
 	 * PayPalGateway constructor.
 	 *
@@ -132,8 +139,9 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->session_handler          = $session_handler;
 		$this->refund_processor         = $refund_processor;
 		$this->transaction_url_provider = $transaction_url_provider;
+		$this->onboarded                = $state->current_state() === State::STATE_ONBOARDED;
 
-		if ( $state->current_state() === State::STATE_ONBOARDED ) {
+		if ( $this->onboarded ) {
 			$this->supports = array( 'refunds' );
 		}
 		if (


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
When enabling gateway don't redirect to it's settings if plugin already is in onboarded state.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->

1. Complete onboarding or fill out all the relevant API details.
2. Go to WooCommerce > Settings > Payments.
3. Scroll down to "PayPal" and make sure the toggle is in the disabled state.
4. Click the toggle and make sure there is no redirection to the gateway settings page and the gateway is enabled.

5. Go to the gateway settings and disconnect to return to the not onboarded state.
6. Return  to WooCommerce > Settings > Payments.
7. Disable the PayPal gateway and try to enable it again.
8. Make sure this time you were redirected to the gateway settings.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
Fix unneeded redirection when enabling payment gateway and setup is already done.

Closes #190.
