### PR TITLE
Use `get_icon` to display credit card gateway icons

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
@@ -253,7 +253,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			function ( string $type ) use ( $title_options ): string {
 				return '<img
                  title="' . esc_attr( $title_options[ $type ] ) . '"
-                 src="' . esc_url( $this->module_url ) . '/assets/images/' . esc_attr( $type ) . '.svg"
+                 src="' . esc_url( $this->module_url ) . 'assets/images/' . esc_attr( $type ) . '.svg"
                  class="ppcp-card-icon"
                 > ';
 			},

--- a/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
@@ -236,21 +236,16 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Returns the title of the gateway.
+	 * Returns the icons of the gateway.
 	 *
 	 * @return string
 	 */
-	public function get_title() {
+	public function get_icon() {
+		$icon = parent::get_icon();
 
-		//phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! is_checkout() || ( is_ajax() && isset( $_GET['wc-ajax'] ) && 'update_order_review' !== $_GET['wc-ajax'] ) ) {
-			return parent::get_title();
-		}
-		//phpcs:enable WordPress.Security.NonceVerification.Recommended
-		$title = parent::get_title();
 		$icons = $this->config->has( 'card_icons' ) ? (array) $this->config->get( 'card_icons' ) : array();
 		if ( empty( $icons ) ) {
-			return $title;
+			return $icon;
 		}
 
 		$title_options = $this->card_labels();
@@ -264,7 +259,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			},
 			$icons
 		);
-		return $title . implode( '', $images );
+
+		return implode( '', $images );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #186.