### PR TITLE
Cast gateway description to string

### DIFF
--- a/modules/ppcp-subscription/src/class-subscriptionmodule.php
+++ b/modules/ppcp-subscription/src/class-subscriptionmodule.php
@@ -80,7 +80,7 @@ class SubscriptionModule implements ModuleInterface {
 				$settings                 = $container->get( 'wcgateway.settings' );
 				$subscription_helper      = $container->get( 'subscription.helper' );
 
-				return $this->display_saved_paypal_payments( $settings, $id, $payment_token_repository, (string) $description, $subscription_helper );
+				return $this->display_saved_paypal_payments( $settings, (string) $id, $payment_token_repository, (string) $description, $subscription_helper );
 			},
 			10,
 			2

--- a/modules/ppcp-subscription/src/class-subscriptionmodule.php
+++ b/modules/ppcp-subscription/src/class-subscriptionmodule.php
@@ -80,7 +80,7 @@ class SubscriptionModule implements ModuleInterface {
 				$settings                 = $container->get( 'wcgateway.settings' );
 				$subscription_helper      = $container->get( 'subscription.helper' );
 
-				return $this->display_saved_paypal_payments( $settings, $id, $payment_token_repository, $description, $subscription_helper );
+				return $this->display_saved_paypal_payments( $settings, $id, $payment_token_repository, (string) $description, $subscription_helper );
 			},
 			10,
 			2


### PR DESCRIPTION
When `woocommerce_gateway_description` filter receives `$description` as `null` it throws an error because private method `display_saved_paypal_payments` expects a string, this PR fixes this problem by casting `$description` as string when is passed along to the private method.
