### PR TITLE
[Legacy] Upgrade inbox notes

### DIFF
--- a/modules/ppcp-compat/src/PPEC/class-deactivatenote.php
+++ b/modules/ppcp-compat/src/PPEC/class-deactivatenote.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Deactivate PayPal Express Checkout inbox note.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat\PPEC
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat\PPEC;
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+
+/**
+ * Inbox note for PayPal Express Checkout deactivation.
+ */
+class DeactivateNote {
+
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'ppcp-disable-ppxo-note';
+
+	/**
+	 * Note initialization.
+	 */
+	public static function init() {
+		if ( ! PPECHelper::is_plugin_active() ) {
+			self::maybe_mark_note_as_actioned();
+			return;
+		}
+
+		self::possibly_add_note();
+	}
+
+	/**
+	 * Get the note.
+	 *
+	 * @return Automatic\WooCommerce\Admin\Notes\Note
+	 */
+	public static function get_note() {
+		if ( PPECHelper::site_has_ppec_subscriptions() ) {
+			$msg = __(
+				'As of 1 Sept 2021, PayPal Checkout will be officially retired from WooCommerce.com, and support for this product will end as of 1 March 2022. PayPal Payments can now handle all your subscription renewals even if they were first created using PayPal Checkout. To fully switch over, all you need to do is deactivate and/or remove the PayPal Checkout plugin from your store.',
+				'woocommerce-paypal-payments'
+			);
+		} else {
+			$msg = __(
+				'As of 1 Sept 2021, PayPal Checkout will be officially retired from WooCommerce.com, and support for this product will end as of 1 March 2022. To fully switch over, all you need to do is deactivate and/or remove the PayPal Checkout plugin from your store.',
+				'woocommerce-paypal-payments'
+			);
+		}
+
+		$note = new Note();
+		$note->set_name( self::NOTE_NAME );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_source( 'woocommerce-paypal-payments' );
+		$note->set_title(
+			__( 'Action Required: Deactivate PayPal Checkout', 'woocommerce-paypal-payments' )
+		);
+		$note->set_content( $msg );
+		$note->add_action(
+			'deactivate-paypal-checkout-plugin',
+			__( 'Deactivate PayPal Checkout', 'woocommerce-paypal-payments' ),
+			admin_url( 'plugins.php?action=deactivate&plugin=' . rawurlencode( PPECHelper::PPEC_PLUGIN_FILE ) . '&plugin_status=all&paged=1&_wpnonce=' . wp_create_nonce( 'deactivate-plugin_' . PPECHelper::PPEC_PLUGIN_FILE ) ),
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
+			true
+		);
+		$note->add_action(
+			'learn-more',
+			__( 'Learn More', 'woocommerce-paypal-payments' ),
+			'https://docs.woocommerce.com/document/woocommerce-paypal-payments/paypal-payments-upgrade-guide/',
+			Note::E_WC_ADMIN_NOTE_UNACTIONED
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Marks the inbox note as actioned so that it doesn't re-appear.
+	 */
+	private static function maybe_mark_note_as_actioned() {
+		try {
+			$data_store = \WC_Data_Store::load( 'admin-note' );
+		} catch ( \Exception $e ) {
+			$data_store = null;
+		}
+
+		if ( ! $data_store ) {
+			return;
+		}
+
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+
+		if ( empty( $note_ids ) ) {
+			return;
+		}
+
+		$note = Notes::get_note( $note_ids[0] );
+
+		if ( Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
+			$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
+			$note->save();
+		}
+	}
+
+}

--- a/modules/ppcp-compat/src/class-compatmodule.php
+++ b/modules/ppcp-compat/src/class-compatmodule.php
@@ -63,6 +63,17 @@ class CompatModule implements ModuleInterface {
 		// Settings.
 		$ppec_import = $container->get( 'compat.ppec.settings_importer' );
 		$ppec_import->maybe_hook();
+
+		// Inbox note inviting merchant to disable PayPal Express Checkout.
+		add_action(
+			'woocommerce_init',
+			function() {
+				if ( is_callable( array( WC(), 'is_wc_admin_active' ) ) && WC()->is_wc_admin_active() ) {
+					PPEC\DeactivateNote::init();
+				}
+			}
+		);
+
 	}
 
 }


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
This PR adds an inbox note with upgrade messaging.

### Steps to test:

#### No Subscriptions messaging
1. Check out this branch.
1. Install and enable PayPal Express Checkout (if necessary).
1. Make sure there aren't any subscriptions on the site running via PayPal Express Checkout.
1. An inbox note inviting you to deactivate PayPal Express Checkout should appear (on WC > Orders > Inbox, for example).
1. Follow the link to deactivate PayPal Express Checkout (or do it via Plugins).
1. The inbox note should no longer appear.

#### Subscriptions messaging
1. Disable PayPal Payments (to prevent the "no subscriptions" note from re-appearing).
1. Clear note information from the database. SQL query: `DELETE FROM wp_wc_admin_notes WHERE name='ppcp-disable-ppxo-note'`.
1. Re-enable PayPal Express Checkout.
1. Either purchase a subscription using PayPal Express Checkout or create a manual subscription and set its payment method to PayPal Express Checkout.
1. Re-enable PayPal Payments.
1. You should see an inbox note inviting you to deactivate PayPal Express Checkout, but with a specific mention of subscriptions support.
1. Follow the link to deactivate PayPal Express Checkout (or do it via Plugins).
1. The inbox note should no longer appear.

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Add messaging for PayPal Express Checkout users.
