### PR TITLE
Work around possible wc-admin fatal error

### DIFF
--- a/modules/ppcp-compat/src/PPEC/class-deactivatenote.php
+++ b/modules/ppcp-compat/src/PPEC/class-deactivatenote.php
@@ -34,7 +34,11 @@ class DeactivateNote {
 			return;
 		}
 
-		self::possibly_add_note();
+		try {
+			self::possibly_add_note();
+		} catch ( \Exception $e ) {
+			return;
+		}
 	}
 
 	/**

--- a/modules/ppcp-compat/src/class-compatmodule.php
+++ b/modules/ppcp-compat/src/class-compatmodule.php
@@ -68,7 +68,7 @@ class CompatModule implements ModuleInterface {
 		add_action(
 			'woocommerce_init',
 			function() {
-				if ( is_callable( array( WC(), 'is_wc_admin_active' ) ) && WC()->is_wc_admin_active() ) {
+				if ( is_callable( array( WC(), 'is_wc_admin_active' ) ) && WC()->is_wc_admin_active() && class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 					PPEC\DeactivateNote::init();
 				}
 			}


### PR DESCRIPTION
### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Under strange circumstances, wc-admin might throw `NotesUnavailableException` when attempting to load the admin-note datastore. Given a lot of methods in `NoteTraits` silently rely on this datastore, this can result in a fatal error.

### Steps to test:
I wasn't able to replicate and the admin-note datastore not being available should generate errors outside of PayPal Payments, but given this was [reported on wp.org](https://wordpress.org/support/topic/fatal-site-error-with-1-5-0/) I think it'd be best to add a workaround.

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix - Address possible error in certain versions of wc-admin.
