### PR TITLE
Plugin conflict blocking line item details

### DIFF
--- a/modules/ppcp-api-client/src/Factory/class-amountfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-amountfactory.php
@@ -49,8 +49,11 @@ class AmountFactory {
 		$total    = new Money( (float) $cart->get_total( 'numeric' ), $currency );
 
 		$total_fees_amount = 0;
-		foreach ( WC()->session->get( 'fees' ) as $fee ) {
-			$total_fees_amount += (float) $fee->amount;
+		$fees              = WC()->session->get( 'ppcp_fees' );
+		if ( $fees ) {
+			foreach ( WC()->session->get( 'ppcp_fees' ) as $fee ) {
+				$total_fees_amount += (float) $fee->amount;
+			}
 		}
 
 		$item_total = $cart->get_cart_contents_total() + $cart->get_discount_total() + $total_fees_amount;

--- a/modules/ppcp-api-client/src/Factory/class-amountfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-amountfactory.php
@@ -45,9 +45,15 @@ class AmountFactory {
 	 * @return Amount
 	 */
 	public function from_wc_cart( \WC_Cart $cart ): Amount {
-		$currency   = get_woocommerce_currency();
-		$total      = new Money( (float) $cart->get_total( 'numeric' ), $currency );
-		$item_total = $cart->get_cart_contents_total() + $cart->get_discount_total();
+		$currency = get_woocommerce_currency();
+		$total    = new Money( (float) $cart->get_total( 'numeric' ), $currency );
+
+		$total_fees_amount = 0;
+		foreach ( WC()->session->get( 'fees' ) as $fee ) {
+			$total_fees_amount += (float) $fee->amount;
+		}
+
+		$item_total = $cart->get_cart_contents_total() + $cart->get_discount_total() + $total_fees_amount;
 		$item_total = new Money( (float) $item_total, $currency );
 		$shipping   = new Money(
 			(float) $cart->get_shipping_total() + $cart->get_shipping_tax(),

--- a/modules/ppcp-api-client/src/Factory/class-itemfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-itemfactory.php
@@ -56,7 +56,21 @@ class ItemFactory {
 			},
 			$cart->get_cart_contents()
 		);
-		return $items;
+
+		$fees = array_map(
+			static function ( \stdClass $fee ) use ( $currency ): Item {
+				return new Item(
+					$fee->name,
+					new Money( (float) $fee->amount, $currency ),
+					1,
+					'',
+					new Money( (float) $fee->tax, $currency )
+				);
+			},
+			WC()->session->get( 'fees' )
+		);
+
+		return array_merge( $items, $fees );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Factory/class-itemfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-itemfactory.php
@@ -66,12 +66,21 @@ class ItemFactory {
 	 * @return Item[]
 	 */
 	public function from_wc_order( \WC_Order $order ): array {
-		return array_map(
+		$items = array_map(
 			function ( \WC_Order_Item_Product $item ) use ( $order ): Item {
 				return $this->from_wc_order_line_item( $item, $order );
 			},
 			$order->get_items( 'line_item' )
 		);
+
+		$fees = array_map(
+			function ( \WC_Order_Item_Fee $item ) use ( $order ): Item {
+				return $this->from_wc_order_fee( $item, $order );
+			},
+			$order->get_fees()
+		);
+
+		return array_merge( $items, $fees );
 	}
 
 	/**
@@ -106,6 +115,24 @@ class ItemFactory {
 			$tax,
 			$product->get_sku(),
 			( $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS
+		);
+	}
+
+	/**
+	 * Creates an Item based off a WooCommerce Fee Item.
+	 *
+	 * @param \WC_Order_Item_Fee $item The WooCommerce order item.
+	 * @param \WC_Order          $order The WooCommerce order.
+	 *
+	 * @return Item
+	 */
+	private function from_wc_order_fee( \WC_Order_Item_Fee $item, \WC_Order $order ): Item {
+		return new Item(
+			$item->get_name(),
+			new Money( (float) $item->get_amount(), $order->get_currency() ),
+			$item->get_quantity(),
+			'',
+			new Money( (float) $item->get_total_tax(), $order->get_currency() )
 		);
 	}
 

--- a/modules/ppcp-api-client/src/Factory/class-itemfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-itemfactory.php
@@ -57,18 +57,22 @@ class ItemFactory {
 			$cart->get_cart_contents()
 		);
 
-		$fees = array_map(
-			static function ( \stdClass $fee ) use ( $currency ): Item {
-				return new Item(
-					$fee->name,
-					new Money( (float) $fee->amount, $currency ),
-					1,
-					'',
-					new Money( (float) $fee->tax, $currency )
-				);
-			},
-			WC()->session->get( 'fees' )
-		);
+		$fees              = array();
+		$fees_from_session = WC()->session->get( 'ppcp_fees' );
+		if ( $fees_from_session ) {
+			$fees = array_map(
+				static function ( \stdClass $fee ) use ( $currency ): Item {
+					return new Item(
+						$fee->name,
+						new Money( (float) $fee->amount, $currency ),
+						1,
+						'',
+						new Money( (float) $fee->tax, $currency )
+					);
+				},
+				$fees_from_session
+			);
+		}
 
 		return array_merge( $items, $fees );
 	}

--- a/modules/ppcp-api-client/src/class-apimodule.php
+++ b/modules/ppcp-api-client/src/class-apimodule.php
@@ -38,6 +38,15 @@ class ApiModule implements ModuleInterface {
 	 * @param ContainerInterface $container The container.
 	 */
 	public function run( ContainerInterface $container ): void {
+		add_action(
+			'woocommerce_after_calculate_totals',
+			function ( \WC_Cart $cart ) {
+				$fees = $cart->fees_api()->get_fees();
+				if ( $fees ) {
+					WC()->session->set( 'fees', $fees );
+				}
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/class-apimodule.php
+++ b/modules/ppcp-api-client/src/class-apimodule.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
 use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\Exception\ModuleExceptionInterface;
 use Dhii\Modular\Module\ModuleInterface;
 use Interop\Container\ServiceProviderInterface;
 use Psr\Container\ContainerInterface;
@@ -43,7 +42,7 @@ class ApiModule implements ModuleInterface {
 			function ( \WC_Cart $cart ) {
 				$fees = $cart->fees_api()->get_fees();
 				if ( $fees ) {
-					WC()->session->set( 'fees', $fees );
+					WC()->session->set( 'ppcp_fees', $fees );
 				}
 			}
 		);

--- a/modules/ppcp-api-client/src/class-apimodule.php
+++ b/modules/ppcp-api-client/src/class-apimodule.php
@@ -41,9 +41,7 @@ class ApiModule implements ModuleInterface {
 			'woocommerce_after_calculate_totals',
 			function ( \WC_Cart $cart ) {
 				$fees = $cart->fees_api()->get_fees();
-				if ( $fees ) {
-					WC()->session->set( 'ppcp_fees', $fees );
-				}
+				WC()->session->set( 'ppcp_fees', $fees );
 			}
 		);
 	}

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -3,13 +3,13 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
-use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\TestCase;
 use Mockery;
 use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
 
 class AmountFactoryTest extends TestCase
 {
@@ -45,6 +45,13 @@ class AmountFactoryTest extends TestCase
             ->andReturn(7);
 
         expect('get_woocommerce_currency')->andReturn($expectedCurrency);
+
+        $woocommerce = Mockery::mock(\WooCommerce::class);
+        $session = Mockery::mock(\WC_Session::class);
+        when('WC')->justReturn($woocommerce);
+        $woocommerce->session = $session;
+        $session->shouldReceive('get')->andReturn([]);
+
         $result = $testee->from_wc_cart($cart);
         $this->assertEquals($expectedCurrency, $result->currency_code());
         $this->assertEquals((float) 1, $result->value());
@@ -90,6 +97,12 @@ class AmountFactoryTest extends TestCase
             ->andReturn(0);
 
         expect('get_woocommerce_currency')->andReturn($expectedCurrency);
+
+        $woocommerce = Mockery::mock(\WooCommerce::class);
+        $session = Mockery::mock(\WC_Session::class);
+        when('WC')->justReturn($woocommerce);
+        $woocommerce->session = $session;
+        $session->shouldReceive('get')->andReturn([]);
         $result = $testee->from_wc_cart($cart);
         $this->assertNull($result->breakdown()->discount());
     }

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -158,6 +158,9 @@ class ItemFactoryTest extends TestCase
             ->expects('get_item_subtotal')
             ->with($item, false)
             ->andReturn(1);
+        $order
+            ->expects('get_fees')
+            ->andReturn([]);
 
         $result = $testee->from_wc_order($order);
         $this->assertCount(1, $result);
@@ -218,6 +221,9 @@ class ItemFactoryTest extends TestCase
             ->expects('get_item_subtotal')
             ->with($item, false)
             ->andReturn(1);
+        $order
+            ->expects('get_fees')
+            ->andReturn([]);
 
         $result = $testee->from_wc_order($order);
         $item = current($result);
@@ -273,6 +279,9 @@ class ItemFactoryTest extends TestCase
             ->expects('get_item_subtotal')
             ->with($item, false)
             ->andReturn(1);
+        $order
+            ->expects('get_fees')
+            ->andReturn([]);
 
         $result = $testee->from_wc_order($order);
         $item = current($result);

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -7,6 +7,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\TestCase;
 use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
 use Mockery;
 
 class ItemFactoryTest extends TestCase
@@ -51,6 +52,13 @@ class ItemFactoryTest extends TestCase
 	    expect('wp_strip_all_tags')
 		    ->with('description')
 		    ->andReturn('description');
+
+        $woocommerce = Mockery::mock(\WooCommerce::class);
+        $session = Mockery::mock(\WC_Session::class);
+        when('WC')->justReturn($woocommerce);
+        $woocommerce->session = $session;
+        $session->shouldReceive('get')->andReturn([]);
+
         $result = $testee->from_wc_cart($cart);
 
         $this->assertCount(1, $result);
@@ -107,6 +115,12 @@ class ItemFactoryTest extends TestCase
 	    expect('wp_strip_all_tags')
 		    ->with('description')
 		    ->andReturn('description');
+
+        $woocommerce = Mockery::mock(\WooCommerce::class);
+        $session = Mockery::mock(\WC_Session::class);
+        when('WC')->justReturn($woocommerce);
+        $woocommerce->session = $session;
+        $session->shouldReceive('get')->andReturn([]);
 
         $result = $testee->from_wc_cart($cart);
 


### PR DESCRIPTION
### Description
Plugins like [Woo Custom Fee](https://wordpress.org/plugins/woo-custom-fee/) are adding fees through `WC()->cart->add_fee`, it causes line items not sent to PayPal, this PR fixes this problem by sending fees as line items to PayPal.

### Steps to test:
1. Activate Woo Custom Fee
2. Visit the plugin settings, enable it, and set a fee value
3. Activate PayPal button on product page/cart
4. Visit product page/cart
5. Click PayPal button
6. Popup window will not display line item details (product+price) via dropdown at the top

