### PR TITLE
WooCommerce orders left in “Pending Payment” after a decline

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
@@ -141,6 +141,11 @@ trait ProcessPaymentTrait {
 			}
 		} catch ( PayPalApiException $error ) {
 			if ( $error->has_detail( 'INSTRUMENT_DECLINED' ) ) {
+				$wc_order->update_status(
+					'failed',
+					__( 'Instrument declined.', 'woocommerce-paypal-payments' )
+				);
+
 				$this->session_handler->increment_insufficient_funding_tries();
 				$host = $this->config->has( 'sandbox_on' ) && $this->config->get( 'sandbox_on' ) ?
 					'https://www.sandbox.paypal.com/' : 'https://www.paypal.com/';

--- a/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
@@ -166,6 +166,10 @@ trait ProcessPaymentTrait {
 
 			$this->session_handler->destroy_session_data();
 		} catch ( RuntimeException $error ) {
+			$wc_order->update_status(
+				'failed',
+				__( 'Could not process order.', 'woocommerce-paypal-payments' )
+			);
 			$this->session_handler->destroy_session_data();
 			wc_add_notice( $error->getMessage(), 'error' );
 			return $failure_data;
@@ -174,6 +178,10 @@ trait ProcessPaymentTrait {
 		wc_add_notice(
 			$this->order_processor->last_error(),
 			'error'
+		);
+		$wc_order->update_status(
+			'failed',
+			__( 'Could not process order.', 'woocommerce-paypal-payments' )
 		);
 
 		return $failure_data;

--- a/tests/PHPUnit/ApiClient/Endpoint/IdentityTokenTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/IdentityTokenTest.php
@@ -94,7 +94,7 @@ class IdentityTokenTest extends TestCase
         $this->bearer
             ->expects('bearer')->andReturn($token);
 
-        expect('wp_remote_get')->andReturn();
+        expect('wp_remote_get')->andReturn(['body' => '',]);
         expect('is_wp_error')->andReturn(false);
         expect('wp_remote_retrieve_response_code')->andReturn(500);
         $this->logger->shouldReceive('log');

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -169,6 +169,7 @@ class WcGatewayTest extends TestCase
         $subscriptionHelper = Mockery::mock(SubscriptionHelper::class);
         $subscriptionHelper->shouldReceive('has_subscription')->with($orderId)->andReturn(true);
         $subscriptionHelper->shouldReceive('is_subscription_change_payment')->andReturn(true);
+        $wcOrder->shouldReceive('update_status')->andReturn(true);
 
         $testee = new PayPalGateway(
             $settingsRenderer,


### PR DESCRIPTION
### Description
WooCommerce orders left in “Pending Payment” after a decline.

### Steps to test:
Use this filter to return a `INSTRUMENT_DECLINED` error in the response. 
```
add_filter('ppcp_request_args', function ($args, $url){
    if (strpos($url,'capture') !== false) {
        $args['headers']['PayPal-Mock-Response'] = '{"mock_application_codes": "INSTRUMENT_DECLINED"}';
    }
    return $args;
}, 10, 2);
```

### Changelog entry
> WooCommerce orders left in “Pending Payment” after a decline. #222
