### PR TITLE
Version 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ PayPal's latest complete payments processing solution. Accept PayPal, Pay Later,
 
 ## Requirements
 
-* PHP >= 7.0
+* PHP >= 7.1
 * WordPress >=5.3
 * WooCommerce >=4.5
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 1.5.1 - TBD =
+= 1.5.1 - 2021-08-19 =
 * Fix - Set 3DS contingencies to "SCA_WHEN_REQUIRED". #178
 * Fix - Plugin conflict blocking line item details. #221
 * Fix - WooCommerce orders left in "Pending Payment" after a decline. #222

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 *** Changelog ***
 
+= 1.5.1 - TBD =
+* Fix - Set 3DS contingencies to "SCA_WHEN_REQUIRED". #178
+* Fix - Plugin conflict blocking line item details. #221
+* Fix - WooCommerce orders left in "Pending Payment" after a decline. #222
+* Fix - Do not send decimals when currency does not support them. #202
+* Fix - Gateway can be activated without a connected PayPal account. #205
+
 = 1.5.0 - 2021-08-09 =
 * Add - Filter to modify plugin modules list. #203
 * Add - Filters to move PayPal buttons and Pay Later messages. #203

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.5.0
+Stable tag: 1.5.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,13 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.5.1 =
+* Fix - Set 3DS contingencies to "SCA_WHEN_REQUIRED". #178
+* Fix - Plugin conflict blocking line item details. #221
+* Fix - WooCommerce orders left in "Pending Payment" after a decline. #222
+* Fix - Do not send decimals when currency does not support them. #202
+* Fix - Gateway can be activated without a connected PayPal account. #205
 
 = 1.5.0 =
 * Add - Filter to modify plugin modules list. #203

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -9,7 +9,7 @@
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 5.5
+ * WC tested up to: 5.6
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.5.0
+ * Version:     1.5.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0


### PR DESCRIPTION
* Fix - Set 3DS contingencies to "SCA_WHEN_REQUIRED". #178
* Fix - Plugin conflict blocking line item details. #221
* Fix - WooCommerce orders left in "Pending Payment" after a decline. #222
* Fix - Do not send decimals when currency does not support them. #202
* Fix - Gateway can be activated without a connected PayPal account. #205