### PR TITLE
fix REFUND_CAPTURE_CURRENCY_MISMATCH on multicurrency sites

### DIFF
--- a/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
@@ -88,7 +88,7 @@ class RefundProcessor {
 				$capture->invoice_id(),
 				$reason,
 				new Amount(
-					new Money( $amount, get_woocommerce_currency() )
+					new Money( $amount, $wc_order->get_currency() )
 				)
 			);
 			return $this->payments_endpoint->refund( $refund );


### PR DESCRIPTION
### Description
Orders with a currency other than the shop base currency can't be refunded via PayPal. When you try to refund an order with a currency other than the shop base currency, the PayPal API returns the following error:

`WARNING [UNPROCESSABLE_ENTITY] The requested action could not be performed, semantically incorrect, or failed business validation. https://developer.paypal.com/docs/api/payments/v2/#error-REFUND_CAPTURE_CURRENCY_MISMATCH`

The above message is logged in the WooCommerce logs when the "Logging" option of "PayPal Payment" is enabled.

### Steps to test:
1. Install a multicurrency plugin like [https://woocommerce.com/products/multi-currency/](https://woocommerce.com/products/multi-currency/ )or [Price Based on Country for WooCommerce](https://wordpress.org/plugins/woocommerce-product-price-based-on-countries) and configure the plugin settings to allow customers to pay in a currency other than the store's base currency.
2. Place an order in a currency different from the shop base currency.
3. Go to the order edit page, and try to refund the order via PayPal. You get an error message.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Fixed: Error on refund process when the order's currency is other than the shop base currency.

