### PR TITLE
Run CI for PHP 7.1-7.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.3']
+        php-versions: ['7.1', '7.2', '7.3', '7.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -27,7 +27,9 @@ jobs:
       run: composer validate
 
     - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest
+      uses: ramsey/composer-install@v1
+      with:
+        composer-options: "--prefer-dist"
 
     - name: Run test suite
       run: ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ PayPal's latest complete payments processing solution. Accept PayPal, Pay Later,
 4. `$ yarn run build:dev`
 5. Change the `PAYPAL_INTEGRATION_DATE` constant to `gmdate( 'Y-m-d' )` to run the latest PayPal JavaScript SDK
 
-Note: PHPUnit needs at least PHP 7.3.
-
 ### Unit tests and code style
 
 1. `$ composer install`

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "woocommerce/woocommerce-sniffs": "^0.1.0",
-        "phpunit/phpunit": "^9.1",
+        "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
         "brain/monkey": "^2.4"
     },
     "autoload": {

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderTest.php
@@ -14,6 +14,7 @@ use Mockery;
 
 class OrderTest extends TestCase
 {
+    private $dateFormat = 'Y-m-d\TH:i:sO'; // no DateTimeInterface::ISO8601 in 7.1
 
     public function testOrder()
     {
@@ -64,8 +65,8 @@ class OrderTest extends TestCase
             'purchase_units' => [
                 [1],
             ],
-            'create_time' => $createTime->format(\DateTimeInterface::ISO8601),
-            'update_time' => $updateTime->format(\DateTimeInterface::ISO8601),
+            'create_time' => $createTime->format($this->dateFormat),
+            'update_time' => $updateTime->format($this->dateFormat),
             'payer' => ['payer'],
             'application_context' => ['applicationContext'],
             'payment_source' => ['paymentSource']


### PR DESCRIPTION
Looks like we only needed to allow `phpunit` 7/8 for that, and remove one 7.2+ constant in a test.

For 8.0 there are more complex issues with deps: https://github.com/woocommerce/woocommerce-paypal-payments/runs/3361390659