### PR TITLE
Add 3d secure contingency settings

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -104,7 +104,7 @@ class CreditCardRenderer {
                     const vault = document.getElementById('ppcp-credit-card-vault') ?
                       document.getElementById('ppcp-credit-card-vault').checked : save_card;
                     hostedFields.submit({
-                        contingencies: ['SCA_WHEN_REQUIRED'],
+                        contingencies: [this.defaultConfig.hosted_fields.contingency],
                         vault: vault
                     }).then((payload) => {
                         payload.orderID = payload.orderId;

--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -103,10 +103,14 @@ class CreditCardRenderer {
                     const save_card = this.defaultConfig.save_card ? true : false;
                     const vault = document.getElementById('ppcp-credit-card-vault') ?
                       document.getElementById('ppcp-credit-card-vault').checked : save_card;
-                    hostedFields.submit({
-                        contingencies: [this.defaultConfig.hosted_fields.contingency],
+                    const contingency = this.defaultConfig.hosted_fields.contingency;
+                    const hostedFieldsData = {
                         vault: vault
-                    }).then((payload) => {
+                    };
+                    if (contingency !== 'NO_3D_SECURE') {
+                        hostedFieldsData.contingencies = [contingency];
+                    }
+                    hostedFields.submit(hostedFieldsData).then((payload) => {
                         payload.orderID = payload.orderId;
                         this.spinner.unblock();
                         return contextConfig.onApprove(payload);

--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -602,6 +602,19 @@ class SmartButton implements SmartButtonInterface {
 	}
 
 	/**
+	 * Retrieves the 3D Secure contingency settings.
+	 *
+	 * @return string
+	 */
+	private function get_3ds_contingency(): string {
+		if ( $this->settings->has( '3d_secure_contingency' ) ) {
+			return $this->settings->get( '3d_secure_contingency' );
+		}
+
+		return 'SCA_WHEN_REQUIRED';
+	}
+
+	/**
 	 * The localized data for the smart button.
 	 *
 	 * @return array
@@ -677,6 +690,7 @@ class SmartButton implements SmartButtonInterface {
 					),
 				),
 				'valid_cards'       => $this->dcc_applies->valid_cards(),
+				'contingency'       => $this->get_3ds_contingency(),
 			),
 			'messages'                       => $this->message_values(),
 			'labels'                         => array(

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1840,8 +1840,9 @@ return array(
 				'default'      => 'SCA_WHEN_REQUIRED',
 				'desc_tip'     => false,
 				'options'      => array(
-					'SCA_WHEN_REQUIRED' => __( 'When required', 'woocommerce-paypal-payments' ),
-					'3D_SECURE'         => __( 'Always', 'woocommerce-paypal-payments' ),
+					'NO_3D_SECURE'      => __( 'No 3D Secure (transaction will be denied if 3D Secure is required)', 'woocommerce-paypal-payments' ),
+					'SCA_WHEN_REQUIRED' => __( '3D Secure when required', 'woocommerce-paypal-payments' ),
+					'3D_SECURE'         => __( 'Always trigger 3D Secure', 'woocommerce-paypal-payments' ),
 				),
 				'screens'      => array(
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1835,10 +1835,18 @@ return array(
 			'3d_secure_contingency'          => array(
 				'title'        => __( 'Contingency for 3D Secure', 'woocommerce-paypal-payments' ),
 				'type'         => 'select',
+				'description'  => sprintf(
+				// translators: %1$s and %2$s opening and closing ul tag, %3$s and %4$s opening and closing li tag.
+					__( '%1$s%3$sNo 3D Secure will cause transactions to be denied if 3D Secure is required by the bank of the cardholder.%4$s%3$sSCA_WHEN_REQUIRED returns a 3D Secure contingency when it is a mandate in the region where you operate.%4$s%3$sSCA_ALWAYS triggers 3D Secure for every transaction, regardless of SCA requirements.%4$s%2$s', 'woocommerce-paypal-payments' ),
+					'<ul>',
+					'</ul>',
+					'<li>',
+					'</li>'
+				),
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
 				'default'      => 'SCA_WHEN_REQUIRED',
-				'desc_tip'     => false,
+				'desc_tip'     => true,
 				'options'      => array(
 					'NO_3D_SECURE'      => __( 'No 3D Secure (transaction will be denied if 3D Secure is required)', 'woocommerce-paypal-payments' ),
 					'SCA_WHEN_REQUIRED' => __( '3D Secure when required', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1804,6 +1804,53 @@ return array(
 				),
 				'gateway'      => 'dcc',
 			),
+			'3d_secure_heading'              => array(
+				'heading'      => __( '3D Secure', 'woocommerce-paypal-payments' ),
+				'type'         => 'ppcp-heading',
+				'description'  => wp_kses_post(
+					sprintf(
+					// translators: %1$s and %2$s is a link tag.
+						__(
+							'3D Secure benefits cardholders and merchants by providing
+                                  an additional layer of verification using Verified by Visa,
+                                  MasterCard SecureCode and American Express SafeKey.
+                                  %1$sLearn more about 3D Secure.%2$s',
+							'woocommerce-paypal-payments'
+						),
+						'<a
+                            rel="noreferrer noopener"
+                            href="https://woocommerce.com/posts/introducing-strong-customer-authentication-sca/"
+                            >',
+						'</a>'
+					)
+				),
+				'screens'      => array(
+					State::STATE_ONBOARDED,
+				),
+				'requirements' => array(
+					'dcc',
+				),
+				'gateway'      => 'dcc',
+			),
+			'3d_secure_contingency'          => array(
+				'title'        => __( 'Contingency for 3D Secure', 'woocommerce-paypal-payments' ),
+				'type'         => 'select',
+				'class'        => array(),
+				'input_class'  => array( 'wc-enhanced-select' ),
+				'default'      => 'SCA_WHEN_REQUIRED',
+				'desc_tip'     => false,
+				'options'      => array(
+					'SCA_WHEN_REQUIRED' => __( 'When required', 'woocommerce-paypal-payments' ),
+					'3D_SECURE'         => __( 'Always', 'woocommerce-paypal-payments' ),
+				),
+				'screens'      => array(
+					State::STATE_ONBOARDED,
+				),
+				'requirements' => array(
+					'dcc',
+				),
+				'gateway'      => 'dcc',
+			),
 		);
 		if ( ! defined( 'PPCP_FLAG_SUBSCRIPTION' ) || ! PPCP_FLAG_SUBSCRIPTION ) {
 			unset( $fields['vault_enabled'] );

--- a/modules/ppcp-wc-gateway/src/Settings/class-settingsrenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/class-settingsrenderer.php
@@ -399,8 +399,6 @@ class SettingsRenderer {
 			if ( $this->dcc_applies->for_country_currency() ) {
 				if ( State::STATE_ONBOARDED > $this->state->current_state() ) {
 					$this->render_dcc_onboarding_info();
-				} elseif ( State::STATE_ONBOARDED === $this->state->current_state() && $this->dcc_product_status->dcc_is_active() ) {
-					$this->render_3d_secure_info();
 				} elseif ( ! $this->dcc_product_status->dcc_is_active() ) {
 					$this->render_dcc_not_active_yet();
 				}
@@ -447,45 +445,6 @@ class SettingsRenderer {
 				</p>
 			</td>
 		</tr>
-		<?php
-	}
-
-	/**
-	 * Renders the 3d secure info text.
-	 */
-	private function render_3d_secure_info() {
-		?>
-<tr>
-	<th><?php esc_html_e( '3D Secure', 'woocommerce-paypal-payments' ); ?></th>
-	<td>
-		<p>
-			<?php
-			/**
-			 * We still need to provide a docs link.
-			 *
-			 * @todo: Provide link to documentation.
-			 */
-			echo wp_kses_post(
-				sprintf(
-				// translators: %1$s and %2$s is a link tag.
-					__(
-						'3D Secure benefits cardholders and merchants by providing
-                                  an additional layer of verification using Verified by Visa,
-                                  MasterCard SecureCode and American Express SafeKey.
-                                  %1$sLearn more about 3D Secure.%2$s',
-						'woocommerce-paypal-payments'
-					),
-					'<a
-                            rel="noreferrer noopener"
-                            href="https://woocommerce.com/posts/introducing-strong-customer-authentication-sca/"
-                            >',
-					'</a>'
-				)
-			);
-			?>
-		</p>
-	</td>
-</tr>
 		<?php
 	}
 


### PR DESCRIPTION
### Description

![image](https://user-images.githubusercontent.com/5680466/130423089-b20f75cd-c092-439b-b541-f4d6793f2e4a.png)

### Steps to test:
1. Go to PayPal Card Processing and change Contingency for 3D Secure option.
2. Perform a checkout, check via DevTools --> Network that the selected 3D secure mode is in the POST request to `validate-payment-method`, such as `"verification":{"method":"SCA_WHEN_REQUIRED"}`, or no such verification object if `No 3D Secure` is chosen.

### Changelog entry

- Add 3D secure contingency settings.