### PR TITLE
Do not send payee email

### DIFF
--- a/modules/ppcp-api-client/src/Entity/class-payee.php
+++ b/modules/ppcp-api-client/src/Entity/class-payee.php
@@ -68,11 +68,11 @@ class Payee {
 	 * @return array
 	 */
 	public function to_array(): array {
-		$data = array(
-			'email_address' => $this->email(),
-		);
+		$data = array();
 		if ( $this->merchant_id ) {
 			$data['merchant_id'] = $this->merchant_id();
+		} else {
+			$data['email_address'] = $this->email();
 		}
 		return $data;
 	}

--- a/modules/ppcp-api-client/src/Factory/class-payeefactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-payeefactory.php
@@ -26,13 +26,8 @@ class PayeeFactory {
 	 * @throws RuntimeException When JSON object is malformed.
 	 */
 	public function from_paypal_response( \stdClass $data ) {
-		if ( ! isset( $data->email_address ) ) {
-			throw new RuntimeException(
-				__( 'No email for payee given.', 'woocommerce-paypal-payments' )
-			);
-		}
-
+		$email       = ( isset( $data->email_address ) ) ? $data->email_address : '';
 		$merchant_id = ( isset( $data->merchant_id ) ) ? $data->merchant_id : '';
-		return new Payee( $data->email_address, $merchant_id );
+		return new Payee( $email, $merchant_id );
 	}
 }


### PR DESCRIPTION
### Description

Do not include the merchant email in the `payee`  object when sending API requests. It seems to be not needed since we already send ID, and email causes validation issues in some cases.

I did that by modifying `Payee::to_array` to not include email when we have ID (is it possible to not have ID?), not sure if that's the best approach, I guess ideally we would want to decouple this serialization logic somehow (e.g. in case we want to have email for some cases).

### Steps to test:
1. Perform a checkout.
2. It seems like we cannot see the body of the request in the sandbox history... So besides adding some debug logging, the best thing we can do is probably just check the response of ajax `ppc-create-order` request in DevTools, inside `payee` it should have only id without email. Or ideally we could try finding out what was causing the original issue and check that it cannot be reproduced with this fix.

### Changelog entry

- Do not send the merchant email in API requests if we send the merchant ID.
