### PR TITLE
Removes screen check for payment gateway.

### DIFF
--- a/modules/ppcp-wc-gateway/src/class-wcgatewaymodule.php
+++ b/modules/ppcp-wc-gateway/src/class-wcgatewaymodule.php
@@ -206,16 +206,12 @@ class WcGatewayModule implements ModuleInterface {
 				$methods[]   = $container->get( 'wcgateway.paypal-gateway' );
 				$dcc_applies = $container->get( 'api.helpers.dccapplies' );
 
-				$screen = ! function_exists( 'get_current_screen' ) ? (object) array( 'id' => 'front' ) : get_current_screen();
-				if ( ! $screen ) {
-					$screen = (object) array( 'id' => 'front' );
-				}
 				/**
 				 * The DCC Applies object.
 				 *
 				 * @var DccApplies $dcc_applies
 				 */
-				if ( 'woocommerce_page_wc-settings' !== $screen->id && $dcc_applies->for_country_currency() ) {
+				if ( $dcc_applies->for_country_currency() ) {
 					$methods[] = $container->get( 'wcgateway.credit-card-gateway' );
 				}
 				return (array) $methods;


### PR DESCRIPTION
<!-- Reference the source of this Pull Request. -->
<!-- Remove any which are not applicable. -->
**Issue**: #87 

---

### Description
<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Removes the screen check for adding the credit card payment gateway, allowing it to be reordered for display to end users just like any other payment gateway.

**However,** the default action button generated by WooCommerce in this interface goes to a settings page that this plugin doesn't utilize. Instead, the credit card gateway settings are currently configured _within_ the PayPal gateway settings. To say nothing of the merits of this strategy.

Looking for input on how to handle this. Simplest solution seems to introduce a redirect from the done-for-you settings screen to the sub-setting screen within the main PayPal gateway settings. It's already configured with an error-level notice to send folks to the main PayPal gateway settings screen if they haven't yet connected to PayPal.

Alternate solution would be to move the credit card gateway settings to the done-for-you settings screen from WooCommerce for the gateway.

### Steps to test:
<!-- Describe the steps to replicate the issue and confirm the fix -->
<!-- Try to include as many details as possible. -->
1. Navigate to WooCommerce > Settings > Payments
2. See the PayPal Credit Card gateway is now in the list of available gateways

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Exposes the credit card payment gateway on the default WooCommerce payment settings screen.
