### PR TITLE
Fix duplicated orders

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -8,6 +8,7 @@ class CreditCardRenderer {
         this.spinner = spinner;
         this.cardValid = false;
         this.formValid = false;
+        this.currentHostedFieldsInstance = null;
     }
 
     render(wrapper, contextConfig) {
@@ -29,6 +30,12 @@ class CreditCardRenderer {
             const wrapperElement = document.querySelector(wrapper);
             wrapperElement.parentNode.removeChild(wrapperElement);
             return;
+        }
+
+        if (this.currentHostedFieldsInstance) {
+            this.currentHostedFieldsInstance.teardown()
+                .catch(err => console.error(`Hosted fields teardown error: ${err}`));
+            this.currentHostedFieldsInstance = null;
         }
 
         const gateWayBox = document.querySelector('.payment_box.payment_method_ppcp-credit-card-gateway');
@@ -92,6 +99,7 @@ class CreditCardRenderer {
                 }
             }
         }).then(hostedFields => {
+            this.currentHostedFieldsInstance = hostedFields;
             const submitEvent = (event) => {
                 this.spinner.block();
                 if (event) {


### PR DESCRIPTION
Fixes #244.

### Description

Fixes the possibility to generate duplicated orders. Looks like it was caused by duplicated form submission listeners added during re-rendering when changing form fields like country etc.

### Steps to test:
1. Go to checkout.
2. Enter customer info, change country multiple times.
3. Fill the card data and submit (try all ways to submit: clicking the button, pressing Enter, ...).
4. Check that there are no duplicated orders/payments and no duplicated requests to `...ppc-create-order` in DevTools.

### Changelog entry

- Fix the possibility to generate duplicated orders.