### PR TITLE
Webhook simulation

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -35,6 +35,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\PaymentTokenFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\SellerStatusFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookEventFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
@@ -114,6 +115,7 @@ return array(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$container->get( 'api.factory.webhook' ),
+			$container->get( 'api.factory.webhook-event' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
@@ -213,6 +215,9 @@ return array(
 	},
 	'api.factory.webhook'                   => static function ( $container ): WebhookFactory {
 		return new WebhookFactory();
+	},
+	'api.factory.webhook-event'             => static function ( $container ): WebhookEventFactory {
+		return new WebhookEventFactory();
 	},
 	'api.factory.capture'                   => static function ( $container ): CaptureFactory {
 

--- a/modules/ppcp-api-client/src/Entity/class-webhookevent.php
+++ b/modules/ppcp-api-client/src/Entity/class-webhookevent.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * The Webhook event notification object.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Entity
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
+
+use DateTime;
+use stdClass;
+
+/**
+ * Class WebhookEvent
+ */
+class WebhookEvent {
+
+	/**
+	 * The ID of the event notification.
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * The date and time when the event notification was created.
+	 *
+	 * @var DateTime|null
+	 */
+	private $create_time;
+
+	/**
+	 * The name of the resource related to the webhook notification event, such as 'checkout-order'.
+	 *
+	 * @var string
+	 */
+	private $resource_type;
+
+	/**
+	 * The event version in the webhook notification, such as '1.0'.
+	 *
+	 * @var string
+	 */
+	private $event_version;
+
+	/**
+	 * The event that triggered the webhook event notification, such as 'CHECKOUT.ORDER.APPROVED'.
+	 *
+	 * @var string
+	 */
+	private $event_type;
+
+	/**
+	 * A summary description for the event notification.
+	 *
+	 * @var string
+	 */
+	private $summary;
+
+	/**
+	 * The resource version in the webhook notification, such as '1.0'.
+	 *
+	 * @var string
+	 */
+	private $resource_version;
+
+	/**
+	 * The resource that triggered the webhook event notification.
+	 *
+	 * @var stdClass
+	 */
+	private $resource;
+
+	/**
+	 * WebhookEvent constructor.
+	 *
+	 * @param string        $id The ID of the event notification.
+	 * @param DateTime|null $create_time The date and time when the event notification was created.
+	 * @param string        $resource_type The name of the resource related to the webhook notification event, such as 'checkout-order'.
+	 * @param string        $event_version The event version in the webhook notification, such as '1.0'.
+	 * @param string        $event_type The event that triggered the webhook event notification, such as 'CHECKOUT.ORDER.APPROVED'.
+	 * @param string        $summary A summary description for the event notification.
+	 * @param string        $resource_version The resource version in the webhook notification, such as '1.0'.
+	 * @param stdClass      $resource The resource that triggered the webhook event notification.
+	 */
+	public function __construct( string $id, ?DateTime $create_time, string $resource_type, string $event_version, string $event_type, string $summary, string $resource_version, stdClass $resource ) {
+		$this->id               = $id;
+		$this->create_time      = $create_time;
+		$this->resource_type    = $resource_type;
+		$this->event_version    = $event_version;
+		$this->event_type       = $event_type;
+		$this->summary          = $summary;
+		$this->resource_version = $resource_version;
+		$this->resource         = $resource;
+	}
+
+	/**
+	 * The ID of the event notification.
+	 *
+	 * @return string
+	 */
+	public function id(): string {
+		return $this->id;
+	}
+
+	/**
+	 * The date and time when the event notification was created.
+	 *
+	 * @return DateTime|null
+	 */
+	public function create_time(): ?DateTime {
+		return $this->create_time;
+	}
+
+	/**
+	 * The name of the resource related to the webhook notification event, such as 'checkout-order'.
+	 *
+	 * @return string
+	 */
+	public function resource_type(): string {
+		return $this->resource_type;
+	}
+
+	/**
+	 * The event version in the webhook notification, such as '1.0'.
+	 *
+	 * @return string
+	 */
+	public function event_version(): string {
+		return $this->event_version;
+	}
+
+	/**
+	 * The event that triggered the webhook event notification, such as 'CHECKOUT.ORDER.APPROVED'.
+	 *
+	 * @return string
+	 */
+	public function event_type(): string {
+		return $this->event_type;
+	}
+
+	/**
+	 * A summary description for the event notification.
+	 *
+	 * @return string
+	 */
+	public function summary(): string {
+		return $this->summary;
+	}
+
+	/**
+	 * The resource version in the webhook notification, such as '1.0'.
+	 *
+	 * @return string
+	 */
+	public function resource_version(): string {
+		return $this->resource_version;
+	}
+
+	/**
+	 * The resource that triggered the webhook event notification.
+	 *
+	 * @return stdClass
+	 */
+	public function resource(): stdClass {
+		return $this->resource;
+	}
+}

--- a/modules/ppcp-api-client/src/Factory/class-webhookeventfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-webhookeventfactory.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Creates WebhookEvent.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Factory
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
+
+use DateTime;
+use stdClass;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\WebhookEvent;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+
+/**
+ * Class WebhookEventFactory
+ */
+class WebhookEventFactory {
+
+	/**
+	 * Returns a webhook from a given data array.
+	 *
+	 * @param array $data The data array.
+	 *
+	 * @return WebhookEvent
+	 */
+	public function from_array( array $data ): WebhookEvent {
+		return $this->from_paypal_response( (object) $data );
+	}
+
+	/**
+	 * Returns a Webhook based of a PayPal JSON response.
+	 *
+	 * @param stdClass $data The JSON object.
+	 *
+	 * @return WebhookEvent
+	 * @throws RuntimeException When JSON object is malformed.
+	 */
+	public function from_paypal_response( stdClass $data ): WebhookEvent {
+		if ( ! isset( $data->id ) ) {
+			throw new RuntimeException(
+				__( 'ID for webhook event not found.', 'woocommerce-paypal-payments' )
+			);
+		}
+		if ( ! isset( $data->event_type ) ) {
+			throw new RuntimeException(
+				__( 'Event type for webhook event not found.', 'woocommerce-paypal-payments' )
+			);
+		}
+
+		$create_time = ( isset( $data->create_time ) ) ?
+			DateTime::createFromFormat( 'Y-m-d\TH:i:sO', $data->create_time )
+			: null;
+
+		// Sometimes the time may be in weird format 2018-12-19T22:20:32.000Z (at least in simulation),
+		// we do not care much about time, so just ignore on failure.
+		if ( false === $create_time ) {
+			$create_time = null;
+		}
+
+		return new WebhookEvent(
+			(string) $data->id,
+			$create_time,
+			(string) $data->resource_type ?? '',
+			(string) $data->event_version ?? '',
+			(string) $data->event_type,
+			(string) $data->summary ?? '',
+			(string) $data->resource_version ?? '',
+			(object) $data->resource ?? ( new stdClass() )
+		);
+	}
+}

--- a/modules/ppcp-webhooks/extensions.php
+++ b/modules/ppcp-webhooks/extensions.php
@@ -43,6 +43,27 @@ return array(
 			),
 		);
 
+		$is_registered = $container->get( 'webhook.is-registered' );
+		if ( $is_registered ) {
+			$status_page_fields = array_merge(
+				$status_page_fields,
+				array(
+					'webhooks_simulate' => array(
+						'title'        => __( 'Webhook simulation', 'woocommerce-paypal-payments' ),
+						'type'         => 'ppcp-text',
+						'text'         => '<button type="button" class="button ppcp-webhooks-simulate">' . esc_html__( 'Simulate', 'woocommerce-paypal-payments' ) . '</button>',
+						'screens'      => array(
+							State::STATE_PROGRESSIVE,
+							State::STATE_ONBOARDED,
+						),
+						'requirements' => array(),
+						'gateway'      => WebhooksStatusPage::ID,
+						'description'  => __( 'Click to request a sample webhook payload from PayPal, allowing to check that your server can successfully receive webhooks.', 'woocommerce-paypal-payments' ),
+					),
+				)
+			);
+		}
+
 		return array_merge( $fields, $status_page_fields );
 	},
 );

--- a/modules/ppcp-webhooks/resources/css/status-page.scss
+++ b/modules/ppcp-webhooks/resources/css/status-page.scss
@@ -1,9 +1,16 @@
-.ppcp-webhooks-table {
+.ppcp-webhooks-table, .ppcp-webhooks-status-text {
 	.error {
 		color: red;
 		font-weight: bold;
 	}
 
+	.success {
+		color: green;
+		font-weight: bold;
+	}
+}
+
+.ppcp-webhooks-table {
 	table {
 		border-collapse: collapse;
 
@@ -20,4 +27,8 @@
 			width: 450px;
 		}
 	}
+}
+
+.ppcp-webhooks-status-text {
+	padding-top: 4px;
 }

--- a/modules/ppcp-webhooks/resources/js/status-page.js
+++ b/modules/ppcp-webhooks/resources/js/status-page.js
@@ -38,5 +38,111 @@ document.addEventListener(
 
             window.location.reload();
         });
+
+        function sleep(ms) {
+            return new Promise(resolve => setTimeout(resolve, ms));
+        }
+
+        const simulateBtn = jQuery(PayPalCommerceGatewayWebhooksStatus.simulation.start.button);
+        simulateBtn.click(async () => {
+            simulateBtn.prop('disabled', true);
+
+            try {
+                const response = await fetch(
+                    PayPalCommerceGatewayWebhooksStatus.simulation.start.endpoint,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'content-type': 'application/json'
+                        },
+                        body: JSON.stringify(
+                            {
+                                nonce: PayPalCommerceGatewayWebhooksStatus.simulation.start.nonce,
+                            }
+                        )
+                    }
+                );
+
+                const reportError = error => {
+                    const msg = PayPalCommerceGatewayWebhooksStatus.simulation.start.failureMessage + ' ' + error;
+                    alert(msg);
+                };
+
+                if (!response.ok) {
+                    try {
+                        const result = await response.json();
+                        reportError(result.data);
+                    } catch (exc) {
+                        console.error(exc);
+                        reportError(response.status);
+                    }
+
+                    return;
+                }
+
+                const showStatus = html => {
+                    let statusBlock = simulateBtn.siblings('.ppcp-webhooks-status-text');
+                    if (!statusBlock.length) {
+                        statusBlock = jQuery('<div class="ppcp-webhooks-status-text"></div>').insertAfter(simulateBtn);
+                    }
+                    statusBlock.html(html);
+                };
+
+                simulateBtn.siblings('.description').hide();
+
+                showStatus(
+                    PayPalCommerceGatewayWebhooksStatus.simulation.state.waitingMessage +
+                    '<span class="spinner is-active" style="float: none;"></span>'
+                );
+
+                const delay = 2000;
+                const retriesBeforeErrorMessage = 15;
+                const maxRetries = 30;
+
+                for (let i = 0; i < maxRetries; i++) {
+                    await sleep(delay);
+
+                    const stateResponse = await fetch(
+                        PayPalCommerceGatewayWebhooksStatus.simulation.state.endpoint,
+                        {
+                            method: 'GET',
+                        }
+                    );
+
+                    try {
+                        const result = await stateResponse.json();
+
+                        if (!stateResponse.ok || !result.success) {
+                            console.error('Simulation state query failed: ' + result.data);
+                            continue;
+                        }
+
+                        const state = result.data.state;
+                        if (state === PayPalCommerceGatewayWebhooksStatus.simulation.state.successState) {
+                            showStatus(
+                                '<span class="success">' +
+                                '✔️ ' +
+                                PayPalCommerceGatewayWebhooksStatus.simulation.state.successMessage +
+                                '</span>'
+                            );
+                            return;
+                        }
+                    } catch (exc) {
+                        console.error(exc);
+                    }
+
+                    if (i === retriesBeforeErrorMessage) {
+                        showStatus(
+                            '<span class="error">' +
+                            PayPalCommerceGatewayWebhooksStatus.simulation.state.tooLongDelayMessage +
+                            '</span>'
+                        );
+                    }
+                }
+
+            } finally {
+                simulateBtn.prop('disabled', false);
+            }
+        });
     }
 );

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -144,7 +144,8 @@ return array(
 		$webhook  = $container->get( 'webhook.current' );
 		return new WebhookSimulation(
 			$webhook_endpoint,
-			$webhook
+			$webhook,
+			'PAYMENT.AUTHORIZATION.CREATED'
 		);
 	},
 

--- a/modules/ppcp-webhooks/src/Endpoint/class-simulateendpoint.php
+++ b/modules/ppcp-webhooks/src/Endpoint/class-simulateendpoint.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * The endpoint for starting webhooks simulation.
+ *
+ * @package WooCommerce\PayPalCommerce\Webhooks\Endpoint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks\Endpoint;
+
+use Exception;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
+
+/**
+ * Class SimulateEndpoint
+ */
+class SimulateEndpoint {
+
+	const ENDPOINT = 'ppc-webhooks-simulate';
+
+	/**
+	 * The simulation handler.
+	 *
+	 * @var WebhookSimulation
+	 */
+	private $simulation;
+
+	/**
+	 * The Request Data helper object.
+	 *
+	 * @var RequestData
+	 */
+	private $request_data;
+
+	/**
+	 * SimulateEndpoint constructor.
+	 *
+	 * @param WebhookSimulation $simulation The simulation handler.
+	 * @param RequestData       $request_data The Request Data helper object.
+	 */
+	public function __construct(
+		WebhookSimulation $simulation,
+		RequestData $request_data
+	) {
+		$this->simulation   = $simulation;
+		$this->request_data = $request_data;
+	}
+
+	/**
+	 * Returns the nonce for the endpoint.
+	 *
+	 * @return string
+	 */
+	public static function nonce(): string {
+		return self::ENDPOINT;
+	}
+
+	/**
+	 * Handles the incoming request.
+	 */
+	public function handle_request() {
+		try {
+			// Validate nonce.
+			$this->request_data->read_request( $this->nonce() );
+
+			$this->simulation->start();
+
+			wp_send_json_success();
+			return true;
+		} catch ( Exception $error ) {
+			wp_send_json_error( $error->getMessage(), 500 );
+			return false;
+		}
+	}
+}

--- a/modules/ppcp-webhooks/src/Endpoint/class-simulationstateendpoint.php
+++ b/modules/ppcp-webhooks/src/Endpoint/class-simulationstateendpoint.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * The endpoint for getting the current webhooks simulation state.
+ *
+ * @package WooCommerce\PayPalCommerce\Webhooks\Endpoint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks\Endpoint;
+
+use Exception;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
+
+/**
+ * Class SimulationStateEndpoint
+ */
+class SimulationStateEndpoint {
+
+	const ENDPOINT = 'ppc-webhooks-simulation-state';
+
+	/**
+	 * The simulation handler.
+	 *
+	 * @var WebhookSimulation
+	 */
+	private $simulation;
+
+	/**
+	 * SimulationStateEndpoint constructor.
+	 *
+	 * @param WebhookSimulation $simulation The simulation handler.
+	 */
+	public function __construct(
+		WebhookSimulation $simulation
+	) {
+		$this->simulation = $simulation;
+	}
+
+	/**
+	 * Returns the nonce for the endpoint.
+	 *
+	 * @return string
+	 */
+	public static function nonce(): string {
+		return self::ENDPOINT;
+	}
+
+	/**
+	 * Handles the incoming request.
+	 */
+	public function handle_request() {
+		try {
+			$state = $this->simulation->get_state();
+
+			wp_send_json_success(
+				array(
+					'state' => $state,
+				)
+			);
+			return true;
+		} catch ( Exception $error ) {
+			wp_send_json_error( $error->getMessage(), 500 );
+			return false;
+		}
+	}
+}

--- a/modules/ppcp-webhooks/src/Status/Assets/class-webhooksstatuspageassets.php
+++ b/modules/ppcp-webhooks/src/Status/Assets/class-webhooksstatuspageassets.php
@@ -12,6 +12,9 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Webhooks\Endpoint\ResubscribeEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\Endpoint\SimulateEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\Endpoint\SimulationStateEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 
 /**
  * Class WebhooksStatusPageAssets
@@ -76,6 +79,21 @@ class WebhooksStatusPageAssets {
 				'nonce'          => wp_create_nonce( ResubscribeEndpoint::nonce() ),
 				'button'         => '.ppcp-webhooks-resubscribe',
 				'failureMessage' => __( 'Operation failed. Check WooCommerce logs for more details.', 'woocommerce-paypal-payments' ),
+			),
+			'simulation'  => array(
+				'start' => array(
+					'endpoint'       => home_url( \WC_AJAX::get_endpoint( SimulateEndpoint::ENDPOINT ) ),
+					'nonce'          => wp_create_nonce( SimulateEndpoint::nonce() ),
+					'button'         => '.ppcp-webhooks-simulate',
+					'failureMessage' => __( 'Operation failed. Check WooCommerce logs for more details.', 'woocommerce-paypal-payments' ),
+				),
+				'state' => array(
+					'endpoint'            => home_url( \WC_AJAX::get_endpoint( SimulationStateEndpoint::ENDPOINT ) ),
+					'successState'        => WebhookSimulation::STATE_RECEIVED,
+					'waitingMessage'      => __( 'Waiting for the webhook to arrive...', 'woocommerce-paypal-payments' ),
+					'successMessage'      => __( 'The webhook was received successfully.', 'woocommerce-paypal-payments' ),
+					'tooLongDelayMessage' => __( 'Looks like the webhook cannot be received. Check that your website is accessible from the internet.', 'woocommerce-paypal-payments' ),
+				),
 			),
 		);
 	}

--- a/modules/ppcp-webhooks/src/Status/class-webhooksimulation.php
+++ b/modules/ppcp-webhooks/src/Status/class-webhooksimulation.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Handles the webhook simulation.
+ *
+ * @package WooCommerce\PayPalCommerce\Webhooks\Status
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks\Status;
+
+use Exception;
+use UnexpectedValueException;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\WebhookEvent;
+
+/**
+ * Class WebhookSimulation
+ */
+class WebhookSimulation {
+
+	public const STATE_WAITING  = 'waiting';
+	public const STATE_RECEIVED = 'received';
+
+	private const OPTION_ID = 'ppcp-webhook-simulation';
+
+	/**
+	 * The webhooks endpoint.
+	 *
+	 * @var WebhookEndpoint
+	 */
+	private $webhook_endpoint;
+
+	/**
+	 * Our registered webhook.
+	 *
+	 * @var Webhook|null
+	 */
+	private $webhook;
+
+	/**
+	 * WebhookSimulation constructor.
+	 *
+	 * @param WebhookEndpoint $webhook_endpoint The webhooks endpoint.
+	 * @param Webhook|null    $webhook Our registered webhook.
+	 */
+	public function __construct(
+		WebhookEndpoint $webhook_endpoint,
+		Webhook $webhook
+	) {
+		$this->webhook_endpoint = $webhook_endpoint;
+		$this->webhook          = $webhook;
+	}
+
+	/**
+	 * Starts the simulation by sending request to PayPal and saving the simulation data with STATE_WAITING.
+	 *
+	 * @throws Exception If failed to start simulation.
+	 */
+	public function start() {
+		if ( ! $this->webhook ) {
+			throw new Exception( 'Webhooks not registered' );
+		}
+
+		$event = $this->webhook_endpoint->simulate( $this->webhook, 'PAYMENT.AUTHORIZATION.CREATED' );
+
+		$this->save(
+			array(
+				'id'    => $event->id(),
+				'state' => self::STATE_WAITING,
+			)
+		);
+	}
+
+	/**
+	 * Returns true if the given event matches the expected simulation event.
+	 *
+	 * @param WebhookEvent $event The webhook event.
+	 * @return bool
+	 */
+	public function is_simulation_event( WebhookEvent $event ): bool {
+		try {
+			$data = $this->load();
+
+			return isset( $data['id'] ) && $event->id() === $data['id'];
+		} catch ( Exception $exception ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Sets the simulation state to STATE_RECEIVED if the given event matches the expected simulation event.
+	 *
+	 * @param WebhookEvent $event The webhook event.
+	 *
+	 * @return bool
+	 * @throws Exception If failed to save new state.
+	 */
+	public function receive( WebhookEvent $event ): bool {
+		if ( ! $this->is_simulation_event( $event ) ) {
+			return false;
+		}
+
+		$this->set_state( self::STATE_RECEIVED );
+
+		return true;
+	}
+
+	/**
+	 * Returns the current simulation state, one of the STATE_ constants.
+	 *
+	 * @return string
+	 * @throws Exception If failed to load state.
+	 */
+	public function get_state(): string {
+		$data = $this->load();
+
+		return $data['state'];
+	}
+
+	/**
+	 * Saves the new state.
+	 *
+	 * @param string $state One of the STATE_ constants.
+	 *
+	 * @throws Exception If failed to load state.
+	 */
+	private function set_state( string $state ): void {
+		$data = $this->load();
+
+		$data['state'] = $state;
+
+		$this->save( $data );
+	}
+
+	/**
+	 * Saves the simulation data.
+	 *
+	 * @param array $data The simulation data.
+	 */
+	private function save( array $data ): void {
+		update_option( self::OPTION_ID, $data );
+	}
+
+	/**
+	 * Returns the current simulation data.
+	 *
+	 * @return array
+	 * @throws UnexpectedValueException If failed to load.
+	 */
+	private function load(): array {
+		$data = get_option( self::OPTION_ID );
+		if ( ! $data ) {
+			throw new UnexpectedValueException( 'Webhook simulation data not found.' );
+		}
+
+		return $data;
+	}
+}

--- a/modules/ppcp-webhooks/src/Status/class-webhooksimulation.php
+++ b/modules/ppcp-webhooks/src/Status/class-webhooksimulation.php
@@ -40,17 +40,27 @@ class WebhookSimulation {
 	private $webhook;
 
 	/**
+	 * The event type that will be simulated, such as CHECKOUT.ORDER.APPROVED.
+	 *
+	 * @var string
+	 */
+	private $event_type;
+
+	/**
 	 * WebhookSimulation constructor.
 	 *
 	 * @param WebhookEndpoint $webhook_endpoint The webhooks endpoint.
 	 * @param Webhook|null    $webhook Our registered webhook.
+	 * @param string          $event_type The event type that will be simulated, such as CHECKOUT.ORDER.APPROVED.
 	 */
 	public function __construct(
 		WebhookEndpoint $webhook_endpoint,
-		Webhook $webhook
+		Webhook $webhook,
+		string $event_type
 	) {
 		$this->webhook_endpoint = $webhook_endpoint;
 		$this->webhook          = $webhook;
+		$this->event_type       = $event_type;
 	}
 
 	/**
@@ -63,7 +73,7 @@ class WebhookSimulation {
 			throw new Exception( 'Webhooks not registered' );
 		}
 
-		$event = $this->webhook_endpoint->simulate( $this->webhook, 'PAYMENT.AUTHORIZATION.CREATED' );
+		$event = $this->webhook_endpoint->simulate( $this->webhook, $this->event_type );
 
 		$this->save(
 			array(

--- a/modules/ppcp-webhooks/src/class-incomingwebhookendpoint.php
+++ b/modules/ppcp-webhooks/src/class-incomingwebhookendpoint.php
@@ -9,11 +9,15 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Webhooks;
 
+use phpDocumentor\Reflection\Types\This;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\WebhookEvent;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookEventFactory;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\RequestHandler;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 
 /**
  * Class IncomingWebhookEndpoint
@@ -59,27 +63,47 @@ class IncomingWebhookEndpoint {
 	private $verify_request;
 
 	/**
+	 * The webhook event factory.
+	 *
+	 * @var WebhookEventFactory
+	 */
+	private $webhook_event_factory;
+
+	/**
+	 * The simulation handler.
+	 *
+	 * @var WebhookSimulation
+	 */
+	private $simulation;
+
+	/**
 	 * IncomingWebhookEndpoint constructor.
 	 *
-	 * @param WebhookEndpoint $webhook_endpoint The webhook endpoint.
-	 * @param Webhook|null    $webhook Our registered webhook.
-	 * @param LoggerInterface $logger The logger.
-	 * @param bool            $verify_request Whether requests need to be verified or not.
-	 * @param RequestHandler  ...$handlers The handlers, which process a request in the end.
+	 * @param WebhookEndpoint     $webhook_endpoint The webhook endpoint.
+	 * @param Webhook|null        $webhook Our registered webhook.
+	 * @param LoggerInterface     $logger The logger.
+	 * @param bool                $verify_request Whether requests need to be verified or not.
+	 * @param WebhookEventFactory $webhook_event_factory The webhook event factory.
+	 * @param WebhookSimulation   $simulation The simulation handler.
+	 * @param RequestHandler      ...$handlers The handlers, which process a request in the end.
 	 */
 	public function __construct(
 		WebhookEndpoint $webhook_endpoint,
 		?Webhook $webhook,
 		LoggerInterface $logger,
 		bool $verify_request,
+		WebhookEventFactory $webhook_event_factory,
+		WebhookSimulation $simulation,
 		RequestHandler ...$handlers
 	) {
 
-		$this->webhook_endpoint = $webhook_endpoint;
-		$this->webhook          = $webhook;
-		$this->handlers         = $handlers;
-		$this->logger           = $logger;
-		$this->verify_request   = $verify_request;
+		$this->webhook_endpoint      = $webhook_endpoint;
+		$this->webhook               = $webhook;
+		$this->handlers              = $handlers;
+		$this->logger                = $logger;
+		$this->verify_request        = $verify_request;
+		$this->webhook_event_factory = $webhook_event_factory;
+		$this->simulation            = $simulation;
 	}
 
 	/**
@@ -110,9 +134,11 @@ class IncomingWebhookEndpoint {
 	/**
 	 * Verifies the current request.
 	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
 	 * @return bool
 	 */
-	public function verify_request(): bool {
+	public function verify_request( \WP_REST_Request $request ): bool {
 		if ( ! $this->verify_request ) {
 			return true;
 		}
@@ -123,6 +149,12 @@ class IncomingWebhookEndpoint {
 		}
 
 		try {
+			$event = $this->event_from_request( $request );
+
+			if ( $this->simulation->is_simulation_event( $event ) ) {
+				return true;
+			}
+
 			$result = $this->webhook_endpoint->verify_current_request_for_webhook( $this->webhook );
 			if ( ! $result ) {
 				$this->logger->error( 'Webhook verification failed.' );
@@ -142,6 +174,17 @@ class IncomingWebhookEndpoint {
 	 * @return \WP_REST_Response
 	 */
 	public function handle_request( \WP_REST_Request $request ): \WP_REST_Response {
+		$event = $this->event_from_request( $request );
+
+		if ( $this->simulation->is_simulation_event( $event ) ) {
+			$this->logger->info( 'Received simulated webhook.' );
+			$this->simulation->receive( $event );
+			return rest_ensure_response(
+				array(
+					'success' => true,
+				)
+			);
+		}
 
 		foreach ( $this->handlers as $handler ) {
 			if ( $handler->responsible_for_request( $request ) ) {
@@ -201,5 +244,17 @@ class IncomingWebhookEndpoint {
 			$event_types = array_merge( $event_types, $handler->event_types() );
 		}
 		return array_unique( $event_types );
+	}
+
+	/**
+	 * Creates WebhookEvent from request data.
+	 *
+	 * @param \WP_REST_Request $request The request with event data.
+	 *
+	 * @return WebhookEvent
+	 * @throws RuntimeException When failed to create.
+	 */
+	private function event_from_request( \WP_REST_Request $request ): WebhookEvent {
+		return $this->webhook_event_factory->from_array( $request->get_params() );
 	}
 }

--- a/modules/ppcp-webhooks/src/class-incomingwebhookendpoint.php
+++ b/modules/ppcp-webhooks/src/class-incomingwebhookendpoint.php
@@ -129,17 +129,7 @@ class IncomingWebhookEndpoint {
 			}
 			return $result;
 		} catch ( RuntimeException $exception ) {
-			$this->logger->log(
-				'error',
-				sprintf(
-					// translators: %s is the error message.
-					__(
-						'Illegit Webhook request detected: %s',
-						'woocommerce-paypal-payments'
-					),
-					$exception->getMessage()
-				)
-			);
+			$this->logger->error( 'Webhook verification failed: ' . $exception->getMessage() );
 			return false;
 		}
 	}

--- a/modules/ppcp-webhooks/src/class-webhookmodule.php
+++ b/modules/ppcp-webhooks/src/class-webhookmodule.php
@@ -17,6 +17,8 @@ use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Assets\WebhooksStatusPageAssets;
 use WooCommerce\PayPalCommerce\Webhooks\Endpoint\ResubscribeEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\Endpoint\SimulateEndpoint;
+use WooCommerce\PayPalCommerce\Webhooks\Endpoint\SimulationStateEndpoint;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhooksStatusPage;
 
 /**
@@ -89,6 +91,25 @@ class WebhookModule implements ModuleInterface {
 			static function () use ( $container ) {
 				$endpoint = $container->get( 'webhook.endpoint.resubscribe' );
 				assert( $endpoint instanceof ResubscribeEndpoint );
+
+				$endpoint->handle_request();
+			}
+		);
+
+		add_action(
+			'wc_ajax_' . SimulateEndpoint::ENDPOINT,
+			static function () use ( $container ) {
+				$endpoint = $container->get( 'webhook.endpoint.simulate' );
+				assert( $endpoint instanceof SimulateEndpoint );
+
+				$endpoint->handle_request();
+			}
+		);
+		add_action(
+			'wc_ajax_' . SimulationStateEndpoint::ENDPOINT,
+			static function () use ( $container ) {
+				$endpoint = $container->get( 'webhook.endpoint.simulation-state' );
+				assert( $endpoint instanceof SimulationStateEndpoint );
 
 				$endpoint->handle_request();
 			}

--- a/tests/PHPUnit/Webhooks/Status/WebhookSimulationTest.php
+++ b/tests/PHPUnit/Webhooks/Status/WebhookSimulationTest.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks\Status;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\WebhookEvent;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+class WebhookSimulationTest extends TestCase
+{
+	private $webhook_endpoint;
+
+	private $webhook;
+
+	private $event_type = 'CHECKOUT.ORDER.APPROVED';
+
+	private $sut;
+
+	private $storage;
+
+	private $event_id = '123';
+	private $event;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->webhook_endpoint = Mockery::mock(WebhookEndpoint::class);
+		$this->webhook = new Webhook('https://example.com', []);
+
+		$this->sut = new WebhookSimulation($this->webhook_endpoint, $this->webhook, $this->event_type);
+
+		when('update_option')->alias(function ($key, $value) {
+			$this->storage[$key] = $value;
+		});
+		when('get_option')->alias(function ($key, $default = false) {
+			return $this->storage[$key] ?? $default;
+		});
+
+		$this->event = $this->createEvent($this->event_id);
+	}
+
+    public function testSimulation()
+    {
+		$this->webhook_endpoint
+			->expects('simulate')
+			->with($this->webhook, $this->event_type)
+			->andReturn($this->event);
+
+		$this->sut->start();
+
+		self::assertTrue($this->sut->is_simulation_event($this->createEvent($this->event_id)));
+		self::assertFalse($this->sut->is_simulation_event($this->createEvent('456')));
+
+		self::assertFalse($this->sut->receive($this->createEvent('456')));
+
+		self::assertEquals(WebhookSimulation::STATE_WAITING, $this->sut->get_state());
+
+		self::assertTrue($this->sut->receive($this->createEvent($this->event_id)));
+		self::assertEquals(WebhookSimulation::STATE_RECEIVED, $this->sut->get_state());
+    }
+
+    public function testIsSimulationNeverThrows()
+    {
+		self::assertFalse($this->sut->is_simulation_event($this->createEvent($this->event_id)));
+    }
+
+	private function createEvent(string $id): WebhookEvent
+	{
+		return new WebhookEvent($id, null, '', '', $this->event_type, '', '', (object) []);
+	}
+}


### PR DESCRIPTION
Adds #260 

At first I was thinking to simply save the time of the last webhook and display it here, but then I figured out that we can detect the simulated webhook by the ID we get after the API request. So it is saved into options and checked in the webhook listener. This way we get a bit better UX and no confusing logs because of failed webhook verifications (simulated webhook cannot be verified).

The status is checked every 2 sec via ajax, after 30 sec it displays an error but still tries for the next 30 sec.

https://user-images.githubusercontent.com/5680466/134470344-cb0725fd-16e9-4e3a-a117-21f05408296c.mp4

If failed:
![image](https://user-images.githubusercontent.com/5680466/134470237-bf8d78f2-6b65-462d-9372-0429e8fd3f9c.png)
