### PR TITLE
Log endpoint errors

### DIFF
--- a/modules/ppcp-button/src/Endpoint/class-approveorderendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-approveorderendpoint.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
@@ -195,7 +196,9 @@ class ApproveOrderEndpoint implements EndpointInterface {
 			$this->session_handler->replace_order( $order );
 			wp_send_json_success( $order );
 			return true;
-		} catch ( \RuntimeException $error ) {
+		} catch ( Exception $error ) {
+			$this->logger->error( 'Order approve failed: ' . $error->getMessage() );
+
 			wp_send_json_error(
 				array(
 					'name'    => is_a( $error, PayPalApiException::class ) ? $error->name() : '',

--- a/modules/ppcp-button/src/Endpoint/class-dataclientidendpoint.php
+++ b/modules/ppcp-button/src/Endpoint/class-dataclientidendpoint.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
+use Exception;
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\IdentityToken;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
@@ -36,18 +38,28 @@ class DataClientIdEndpoint implements EndpointInterface {
 	private $identity_token;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	protected $logger;
+
+	/**
 	 * DataClientIdEndpoint constructor.
 	 *
-	 * @param RequestData   $request_data The Request Data Helper.
-	 * @param IdentityToken $identity_token The Identity Token.
+	 * @param RequestData     $request_data The Request Data Helper.
+	 * @param IdentityToken   $identity_token The Identity Token.
+	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
 		RequestData $request_data,
-		IdentityToken $identity_token
+		IdentityToken $identity_token,
+		LoggerInterface $logger
 	) {
 
 		$this->request_data   = $request_data;
 		$this->identity_token = $identity_token;
+		$this->logger         = $logger;
 	}
 
 	/**
@@ -77,7 +89,9 @@ class DataClientIdEndpoint implements EndpointInterface {
 				)
 			);
 			return true;
-		} catch ( RuntimeException $error ) {
+		} catch ( Exception $error ) {
+			$this->logger->error( 'Client ID retrieval failed: ' . $error->getMessage() );
+
 			wp_send_json_error(
 				array(
 					'name'    => is_a( $error, PayPalApiException::class ) ? $error->name() : '',

--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -169,6 +169,7 @@ return array(
 		$login_seller_sandbox    = $container->get( 'api.endpoint.login-seller-sandbox' );
 		$partner_referrals_data  = $container->get( 'api.repository.partner-referrals-data' );
 		$settings                = $container->get( 'wcgateway.settings' );
+		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 
 		$cache = new Cache( 'ppcp-paypal-bearer' );
 		return new LoginSellerEndpoint(
@@ -177,7 +178,8 @@ return array(
 			$login_seller_sandbox,
 			$partner_referrals_data,
 			$settings,
-			$cache
+			$cache,
+			$logger
 		);
 	},
 	'api.endpoint.partner-referrals-sandbox'    => static function ( $container ) : PartnerReferrals {

--- a/modules/ppcp-onboarding/src/Endpoint/class-loginsellerendpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/class-loginsellerendpoint.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Onboarding\Endpoint;
 
+use Exception;
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\LoginSeller;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
@@ -68,6 +70,13 @@ class LoginSellerEndpoint implements EndpointInterface {
 	private $cache;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	protected $logger;
+
+	/**
 	 * LoginSellerEndpoint constructor.
 	 *
 	 * @param RequestData          $request_data The Request Data.
@@ -76,6 +85,7 @@ class LoginSellerEndpoint implements EndpointInterface {
 	 * @param PartnerReferralsData $partner_referrals_data The Partner Referrals Data.
 	 * @param Settings             $settings The Settings.
 	 * @param Cache                $cache The Cache.
+	 * @param LoggerInterface      $logger The logger.
 	 */
 	public function __construct(
 		RequestData $request_data,
@@ -83,7 +93,8 @@ class LoginSellerEndpoint implements EndpointInterface {
 		LoginSeller $login_seller_sandbox,
 		PartnerReferralsData $partner_referrals_data,
 		Settings $settings,
-		Cache $cache
+		Cache $cache,
+		LoggerInterface $logger
 	) {
 
 		$this->request_data            = $request_data;
@@ -92,6 +103,7 @@ class LoginSellerEndpoint implements EndpointInterface {
 		$this->partner_referrals_data  = $partner_referrals_data;
 		$this->settings                = $settings;
 		$this->cache                   = $cache;
+		$this->logger                  = $logger;
 	}
 
 	/**
@@ -141,7 +153,8 @@ class LoginSellerEndpoint implements EndpointInterface {
 			);
 			wp_send_json_success();
 			return true;
-		} catch ( \RuntimeException $error ) {
+		} catch ( Exception $error ) {
+			$this->logger->error( 'Onboarding completion handling error: ' . $error->getMessage() );
 			wp_send_json_error( $error->getMessage() );
 			return false;
 		}

--- a/tests/PHPUnit/Button/Endpoint/ChangeCartEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/ChangeCartEndpointTest.php
@@ -8,6 +8,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\CartRepository;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
+use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 use function Brain\Monkey\Functions\expect;
 
 class ChangeCartEndpointTest extends TestCase
@@ -68,7 +69,8 @@ class ChangeCartEndpointTest extends TestCase
             $shipping,
             $requestData,
             $cartRepository,
-            $dataStore
+            $dataStore,
+			new NullLogger()
         );
 
         expect('wp_send_json_success')

--- a/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
+use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 use function Brain\Monkey\Functions\expect;
 
 class CreateOrderEndpointTest extends TestCase
@@ -160,7 +161,8 @@ class CreateOrderEndpointTest extends TestCase
             $payer_factory,
             $session_handler,
             $settings,
-            $early_order_handler
+            $early_order_handler,
+			new NullLogger()
         );
         return array($payer_factory, $testee);
     }

--- a/tests/PHPUnit/Button/Endpoint/DataClientIdEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/DataClientIdEndpointTest.php
@@ -8,6 +8,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
+use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 use function Brain\Monkey\Functions\when;
 use function Brain\Monkey\Functions\expect;
 
@@ -22,7 +23,7 @@ class DataClientIdEndpointTest extends TestCase
         parent::setUp();
         $this->requestData = Mockery::mock(RequestData::class);
         $this->identityToken = Mockery::mock(IdentityToken::class);
-        $this->sut = new DataClientIdEndpoint($this->requestData, $this->identityToken);
+        $this->sut = new DataClientIdEndpoint($this->requestData, $this->identityToken, new NullLogger());
     }
 
     public function testHandleRequestSuccess()


### PR DESCRIPTION
Currently some errors are not logged and not displayed anywhere (except the body of ajax responses) making debugging very difficult.

Quick fixed it by logging errors in ajax handlers on the server.