### PR TITLE
Void transaction

### DIFF
--- a/modules/ppcp-api-client/src/Exception/class-paypalapiexception.php
+++ b/modules/ppcp-api-client/src/Exception/class-paypalapiexception.php
@@ -39,9 +39,13 @@ class PayPalApiException extends RuntimeException {
 			$response = new \stdClass();
 		}
 		if ( ! isset( $response->message ) ) {
-			$response->message = __(
-				'Unknown error while connecting to PayPal.',
-				'woocommerce-paypal-payments'
+			$response->message = sprintf(
+				/* translators: %1$d - HTTP status code number (404, 500, ...) */
+				__(
+					'Unknown error while connecting to PayPal. Status code: %1$d.',
+					'woocommerce-paypal-payments'
+				),
+				$this->status_code
 			);
 		}
 		if ( ! isset( $response->name ) ) {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -229,7 +229,8 @@ return array(
 		return new RenderAuthorizeAction();
 	},
 	'wcgateway.admin.order-payment-status'         => static function ( $container ): PaymentStatusOrderDetail {
-		return new PaymentStatusOrderDetail();
+		$column = $container->get( 'wcgateway.admin.orders-payment-status-column' );
+		return new PaymentStatusOrderDetail( $column );
 	},
 	'wcgateway.admin.orders-payment-status-column' => static function ( $container ): OrderTablePaymentStatusColumn {
 		$settings = $container->get( 'wcgateway.settings' );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -215,7 +215,8 @@ return array(
 	'wcgateway.processor.refunds'                  => static function ( $container ): RefundProcessor {
 		$order_endpoint    = $container->get( 'api.endpoint.order' );
 		$payments_endpoint    = $container->get( 'api.endpoint.payments' );
-		return new RefundProcessor( $order_endpoint, $payments_endpoint );
+		$logger                        = $container->get( 'woocommerce.logger.woocommerce' );
+		return new RefundProcessor( $order_endpoint, $payments_endpoint, $logger );
 	},
 	'wcgateway.processor.authorized-payments'      => static function ( $container ): AuthorizedPaymentsProcessor {
 		$order_endpoint    = $container->get( 'api.endpoint.order' );

--- a/modules/ppcp-wc-gateway/src/Admin/class-ordertablepaymentstatuscolumn.php
+++ b/modules/ppcp-wc-gateway/src/Admin/class-ordertablepaymentstatuscolumn.php
@@ -101,10 +101,13 @@ class OrderTablePaymentStatusColumn {
 	 * @return bool
 	 */
 	public function should_render_for_order( \WC_Order $order ): bool {
-		$intent   = $order->get_meta( PayPalGateway::INTENT_META_KEY );
-		$captured = $order->get_meta( PayPalGateway::CAPTURED_META_KEY );
+		$intent               = $order->get_meta( PayPalGateway::INTENT_META_KEY );
+		$captured             = $order->get_meta( PayPalGateway::CAPTURED_META_KEY );
+		$status               = $order->get_status();
+		$not_allowed_statuses = array( 'refunded' );
 		return ! empty( $intent ) && strtoupper( self::INTENT ) === strtoupper( $intent ) &&
-			! empty( $captured );
+			! empty( $captured ) &&
+			! in_array( $status, $not_allowed_statuses, true );
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Admin/class-ordertablepaymentstatuscolumn.php
+++ b/modules/ppcp-wc-gateway/src/Admin/class-ordertablepaymentstatuscolumn.php
@@ -81,7 +81,7 @@ class OrderTablePaymentStatusColumn {
 
 		$wc_order = wc_get_order( $wc_order_id );
 
-		if ( ! is_a( $wc_order, \WC_Order::class ) || ! $this->render_for_order( $wc_order ) ) {
+		if ( ! is_a( $wc_order, \WC_Order::class ) || ! $this->should_render_for_order( $wc_order ) ) {
 			return;
 		}
 
@@ -100,8 +100,11 @@ class OrderTablePaymentStatusColumn {
 	 *
 	 * @return bool
 	 */
-	private function render_for_order( \WC_Order $order ): bool {
-		return ! empty( $order->get_meta( PayPalGateway::CAPTURED_META_KEY ) );
+	public function should_render_for_order( \WC_Order $order ): bool {
+		$intent   = $order->get_meta( PayPalGateway::INTENT_META_KEY );
+		$captured = $order->get_meta( PayPalGateway::CAPTURED_META_KEY );
+		return ! empty( $intent ) && strtoupper( self::INTENT ) === strtoupper( $intent ) &&
+			! empty( $captured );
 	}
 
 	/**
@@ -111,7 +114,7 @@ class OrderTablePaymentStatusColumn {
 	 *
 	 * @return bool
 	 */
-	private function is_captured( \WC_Order $wc_order ): bool {
+	public function is_captured( \WC_Order $wc_order ): bool {
 		$captured = $wc_order->get_meta( PayPalGateway::CAPTURED_META_KEY );
 		return wc_string_to_bool( $captured );
 	}

--- a/modules/ppcp-wc-gateway/src/Admin/class-paymentstatusorderdetail.php
+++ b/modules/ppcp-wc-gateway/src/Admin/class-paymentstatusorderdetail.php
@@ -17,20 +17,30 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 class PaymentStatusOrderDetail {
 
 	/**
+	 * The capture info column.
+	 *
+	 * @var OrderTablePaymentStatusColumn
+	 */
+	private $column;
+
+	/**
+	 * PaymentStatusOrderDetail constructor.
+	 *
+	 * @param OrderTablePaymentStatusColumn $column The capture info column.
+	 */
+	public function __construct( OrderTablePaymentStatusColumn $column ) {
+		$this->column = $column;
+	}
+
+	/**
 	 * Renders the not captured information.
 	 *
 	 * @param int $wc_order_id The WooCommerce order id.
 	 */
 	public function render( int $wc_order_id ) {
 		$wc_order = new \WC_Order( $wc_order_id );
-		$intent   = $wc_order->get_meta( PayPalGateway::INTENT_META_KEY );
-		$captured = $wc_order->get_meta( PayPalGateway::CAPTURED_META_KEY );
 
-		if ( strcasecmp( $intent, 'AUTHORIZE' ) !== 0 ) {
-			return;
-		}
-
-		if ( ! empty( $captured ) && wc_string_to_bool( $captured ) ) {
+		if ( ! $this->column->should_render_for_order( $wc_order ) || $this->column->is_captured( $wc_order ) ) {
 			return;
 		}
 

--- a/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
@@ -137,6 +137,9 @@ class RefundProcessor {
 						$this->payments_endpoint->void( $authorization );
 					}
 
+					$wc_order->set_status('refunded');
+					$wc_order->save();
+
 					break;
 				default:
 					throw new RuntimeException( 'Nothing to refund/void.' );

--- a/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
@@ -137,7 +137,7 @@ class RefundProcessor {
 						$this->payments_endpoint->void( $authorization );
 					}
 
-					$wc_order->set_status('refunded');
+					$wc_order->set_status( 'refunded' );
 					$wc_order->save();
 
 					break;

--- a/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
@@ -37,15 +38,24 @@ class RefundProcessor {
 	private $payments_endpoint;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
 	 * RefundProcessor constructor.
 	 *
 	 * @param OrderEndpoint    $order_endpoint The order endpoint.
 	 * @param PaymentsEndpoint $payments_endpoint The payments endpoint.
+	 * @param LoggerInterface  $logger The logger.
 	 */
-	public function __construct( OrderEndpoint $order_endpoint, PaymentsEndpoint $payments_endpoint ) {
+	public function __construct( OrderEndpoint $order_endpoint, PaymentsEndpoint $payments_endpoint, LoggerInterface $logger ) {
 
 		$this->order_endpoint    = $order_endpoint;
 		$this->payments_endpoint = $payments_endpoint;
+		$this->logger            = $logger;
 	}
 
 	/**
@@ -91,8 +101,10 @@ class RefundProcessor {
 					new Money( $amount, $wc_order->get_currency() )
 				)
 			);
-			return $this->payments_endpoint->refund( $refund );
+			$this->payments_endpoint->refund( $refund );
+			return true;
 		} catch ( RuntimeException $error ) {
+			$this->logger->error( 'Refund failed: ' . $error->getMessage() );
 			return false;
 		}
 	}


### PR DESCRIPTION
Void non-captured authorizations instead of refunding #293

It is done in the gateway refund handler, I am not sure if there is an easy way to add `Void` button and  hide `Refund`. I guess we would need to do that via JS + ajax, but also I think there are other ways to trigger refunds in WC, so using the refund handler should be more reliable. However, currently it is possible to "refund" (void) while not specifying the whole money amount (I think we cannot affect it from the handler) and order status will not change. Should we set the `Refunded` status in this case? Also maybe we should add an order note about voiding.