### PR TITLE
Handle denied authorization when capturing via order action

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -220,7 +220,8 @@ return array(
 	'wcgateway.processor.authorized-payments'      => static function ( $container ): AuthorizedPaymentsProcessor {
 		$order_endpoint    = $container->get( 'api.endpoint.order' );
 		$payments_endpoint = $container->get( 'api.endpoint.payments' );
-		return new AuthorizedPaymentsProcessor( $order_endpoint, $payments_endpoint );
+		$logger = $container->get( 'woocommerce.logger.woocommerce' );
+		return new AuthorizedPaymentsProcessor( $order_endpoint, $payments_endpoint, $logger );
 	},
 	'wcgateway.admin.render-authorize-action'      => static function ( $container ): RenderAuthorizeAction {
 

--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -239,10 +239,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @return bool
 	 */
 	public function capture_authorized_payment( \WC_Order $wc_order ): bool {
-		$is_processed = $this->authorized_payments->process( $wc_order );
-		$this->render_authorization_message_for_status( $this->authorized_payments->last_status() );
+		$result_status = $this->authorized_payments->process( $wc_order );
+		$this->render_authorization_message_for_status( $result_status );
 
-		if ( $is_processed ) {
+		if ( AuthorizedPaymentsProcessor::SUCCESSFUL === $result_status ) {
 			$wc_order->add_order_note(
 				__( 'Payment successfully captured.', 'woocommerce-paypal-payments' )
 			);
@@ -252,7 +252,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 			return true;
 		}
 
-		if ( $this->authorized_payments->last_status() === AuthorizedPaymentsProcessor::ALREADY_CAPTURED ) {
+		if ( AuthorizedPaymentsProcessor::ALREADY_CAPTURED === $result_status ) {
 			if ( $wc_order->get_status() === 'on-hold' ) {
 				$wc_order->add_order_note(
 					__( 'Payment successfully captured.', 'woocommerce-paypal-payments' )

--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -275,10 +275,11 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	private function render_authorization_message_for_status( string $status ) {
 
 		$message_mapping = array(
-			AuthorizedPaymentsProcessor::SUCCESSFUL       => AuthorizeOrderActionNotice::SUCCESS,
-			AuthorizedPaymentsProcessor::ALREADY_CAPTURED => AuthorizeOrderActionNotice::ALREADY_CAPTURED,
-			AuthorizedPaymentsProcessor::INACCESSIBLE     => AuthorizeOrderActionNotice::NO_INFO,
-			AuthorizedPaymentsProcessor::NOT_FOUND        => AuthorizeOrderActionNotice::NOT_FOUND,
+			AuthorizedPaymentsProcessor::SUCCESSFUL        => AuthorizeOrderActionNotice::SUCCESS,
+			AuthorizedPaymentsProcessor::ALREADY_CAPTURED  => AuthorizeOrderActionNotice::ALREADY_CAPTURED,
+			AuthorizedPaymentsProcessor::INACCESSIBLE      => AuthorizeOrderActionNotice::NO_INFO,
+			AuthorizedPaymentsProcessor::NOT_FOUND         => AuthorizeOrderActionNotice::NOT_FOUND,
+			AuthorizedPaymentsProcessor::BAD_AUTHORIZATION => AuthorizeOrderActionNotice::BAD_AUTHORIZATION,
 		);
 		$display_message = ( isset( $message_mapping[ $status ] ) ) ?
 			$message_mapping[ $status ]

--- a/modules/ppcp-wc-gateway/src/Notice/class-authorizeorderactionnotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/class-authorizeorderactionnotice.php
@@ -18,11 +18,12 @@ class AuthorizeOrderActionNotice {
 
 	const QUERY_PARAM = 'ppcp-authorized-message';
 
-	const NO_INFO          = 81;
-	const ALREADY_CAPTURED = 82;
-	const FAILED           = 83;
-	const SUCCESS          = 84;
-	const NOT_FOUND        = 85;
+	const NO_INFO           = 81;
+	const ALREADY_CAPTURED  = 82;
+	const FAILED            = 83;
+	const SUCCESS           = 84;
+	const NOT_FOUND         = 85;
+	const BAD_AUTHORIZATION = 86;
 
 	/**
 	 * Returns the current message if there is one.
@@ -45,35 +46,42 @@ class AuthorizeOrderActionNotice {
 	 * @return array
 	 */
 	private function current_message(): array {
-		$messages[ self::NO_INFO ]          = array(
+		$messages[ self::NO_INFO ]           = array(
 			'message' => __(
 				'Could not retrieve information. Try again later.',
 				'woocommerce-paypal-payments'
 			),
 			'type'    => 'error',
 		);
-		$messages[ self::ALREADY_CAPTURED ] = array(
+		$messages[ self::ALREADY_CAPTURED ]  = array(
 			'message' => __(
 				'Payment already captured.',
 				'woocommerce-paypal-payments'
 			),
 			'type'    => 'error',
 		);
-		$messages[ self::FAILED ]           = array(
+		$messages[ self::FAILED ]            = array(
 			'message' => __(
-				'Failed to capture. Try again later.',
+				'Failed to capture. Try again later or checks the logs.',
 				'woocommerce-paypal-payments'
 			),
 			'type'    => 'error',
 		);
-		$messages[ self::NOT_FOUND ]        = array(
+		$messages[ self::BAD_AUTHORIZATION ] = array(
+			'message' => __(
+				'Cannot capture, no valid payment authorization.',
+				'woocommerce-paypal-payments'
+			),
+			'type'    => 'error',
+		);
+		$messages[ self::NOT_FOUND ]         = array(
 			'message' => __(
 				'Could not find payment to process.',
 				'woocommerce-paypal-payments'
 			),
 			'type'    => 'error',
 		);
-		$messages[ self::SUCCESS ]          = array(
+		$messages[ self::SUCCESS ]           = array(
 			'message' => __(
 				'Payment successfully captured.',
 				'woocommerce-paypal-payments'

--- a/modules/ppcp-wc-gateway/src/Processor/class-authorizedpaymentsprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-authorizedpaymentsprocessor.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 use Exception;
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
@@ -43,18 +44,28 @@ class AuthorizedPaymentsProcessor {
 	private $payments_endpoint;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
 	 * AuthorizedPaymentsProcessor constructor.
 	 *
 	 * @param OrderEndpoint    $order_endpoint The Order endpoint.
 	 * @param PaymentsEndpoint $payments_endpoint The Payments endpoint.
+	 * @param LoggerInterface  $logger The logger.
 	 */
 	public function __construct(
 		OrderEndpoint $order_endpoint,
-		PaymentsEndpoint $payments_endpoint
+		PaymentsEndpoint $payments_endpoint,
+		LoggerInterface $logger
 	) {
 
 		$this->order_endpoint    = $order_endpoint;
 		$this->payments_endpoint = $payments_endpoint;
+		$this->logger            = $logger;
 	}
 
 	/**
@@ -83,6 +94,7 @@ class AuthorizedPaymentsProcessor {
 		try {
 			$this->capture_authorizations( ...$authorizations );
 		} catch ( Exception $exception ) {
+			$this->logger->error( 'Failed to capture authorization: ' . $exception->getMessage() );
 			return self::FAILED;
 		}
 

--- a/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-orderprocessor.php
@@ -188,7 +188,7 @@ class OrderProcessor {
 			$wc_order->payment_complete();
 		}
 
-		if ( $this->capture_authorized_downloads( $order ) && $this->authorized_payments_processor->process( $wc_order ) ) {
+		if ( $this->capture_authorized_downloads( $order ) && AuthorizedPaymentsProcessor::SUCCESSFUL === $this->authorized_payments_processor->process( $wc_order ) ) {
 			$wc_order->add_order_note(
 				__( 'Payment successfully captured.', 'woocommerce-paypal-payments' )
 			);

--- a/tests/PHPUnit/ApiClient/Endpoint/PaymentsEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/PaymentsEndpointTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
 
+use Psr\Log\NullLogger;
 use Requests_Utility_CaseInsensitiveDictionary;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
@@ -235,10 +236,6 @@ class PaymentsEndpointTest extends TestCase
 
         $authorizationFactory = Mockery::mock(AuthorizationFactory::class);
 
-        $logger = Mockery::mock(LoggerInterface::class);
-        $logger->expects('log');
-        $logger->expects('debug');
-
 		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
 		$headers->shouldReceive('getAll');
         $rawResponse = [
@@ -250,7 +247,7 @@ class PaymentsEndpointTest extends TestCase
             $host,
             $bearer,
             $authorizationFactory,
-            $logger
+            new NullLogger()
         );
 
         expect('wp_remote_get')->andReturn($rawResponse);
@@ -281,15 +278,11 @@ class PaymentsEndpointTest extends TestCase
 			'headers' => $headers,
 			];
 
-        $logger = Mockery::mock(LoggerInterface::class);
-        $logger->expects('log');
-        $logger->expects('debug');
-
         $testee = new PaymentsEndpoint(
             $host,
             $bearer,
             $authorizationFactory,
-            $logger
+            new NullLogger()
         );
 
         expect('wp_remote_get')->andReturn($rawResponse);

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -227,10 +227,7 @@ class WcGatewayTest extends TestCase
         $authorizedPaymentsProcessor
             ->expects('process')
             ->with($wcOrder)
-            ->andReturnTrue();
-        $authorizedPaymentsProcessor
-            ->expects('last_status')
-            ->andReturn(AuthorizedPaymentsProcessor::SUCCESSFUL);
+			->andReturn(AuthorizedPaymentsProcessor::SUCCESSFUL);
         $authorizedOrderActionNotice = Mockery::mock(AuthorizeOrderActionNotice::class);
         $authorizedOrderActionNotice
             ->expects('display_message')
@@ -286,10 +283,7 @@ class WcGatewayTest extends TestCase
         $authorizedPaymentsProcessor
             ->expects('process')
             ->with($wcOrder)
-            ->andReturnFalse();
-        $authorizedPaymentsProcessor
-            ->shouldReceive('last_status')
-            ->andReturn(AuthorizedPaymentsProcessor::ALREADY_CAPTURED);
+			->andReturn(AuthorizedPaymentsProcessor::ALREADY_CAPTURED);
         $authorizedOrderActionNotice = Mockery::mock(AuthorizeOrderActionNotice::class);
         $authorizedOrderActionNotice
             ->expects('display_message')
@@ -338,10 +332,7 @@ class WcGatewayTest extends TestCase
         $authorizedPaymentsProcessor
             ->expects('process')
             ->with($wcOrder)
-            ->andReturnFalse();
-        $authorizedPaymentsProcessor
-            ->shouldReceive('last_status')
-            ->andReturn($lastStatus);
+			->andReturn($lastStatus);
         $authorizedOrderActionNotice = Mockery::mock(AuthorizeOrderActionNotice::class);
         $authorizedOrderActionNotice
             ->expects('display_message')

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -55,8 +55,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 			->with($this->authorizationId)
 			->andReturn($this->createAuthorization($this->authorizationId, AuthorizationStatus::CAPTURED));
 
-        $this->assertTrue($testee->process($this->wcOrder));
-        $this->assertEquals(AuthorizedPaymentsProcessor::SUCCESSFUL, $testee->last_status());
+        $this->assertEquals(AuthorizedPaymentsProcessor::SUCCESSFUL, $testee->process($this->wcOrder));
     }
 
 	public function testCapturesAllCaptureable() {
@@ -80,8 +79,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 				->andReturn($this->createAuthorization($authorization->id(), AuthorizationStatus::CAPTURED));
 		}
 
-        $this->assertTrue($testee->process($this->wcOrder));
-        $this->assertEquals(AuthorizedPaymentsProcessor::SUCCESSFUL, $testee->last_status());
+		$this->assertEquals(AuthorizedPaymentsProcessor::SUCCESSFUL, $testee->process($this->wcOrder));
     }
 
     public function testInaccessible() {
@@ -93,8 +91,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 
         $testee = new AuthorizedPaymentsProcessor($orderEndpoint, $this->paymentsEndpoint);
 
-        $this->assertFalse($testee->process($this->wcOrder));
-        $this->assertEquals(AuthorizedPaymentsProcessor::INACCESSIBLE, $testee->last_status());
+		$this->assertEquals(AuthorizedPaymentsProcessor::INACCESSIBLE, $testee->process($this->wcOrder));
     }
 
     public function testNotFound() {
@@ -106,8 +103,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 
         $testee = new AuthorizedPaymentsProcessor($orderEndpoint, $this->paymentsEndpoint);
 
-        $this->assertFalse($testee->process($this->wcOrder));
-        $this->assertEquals(AuthorizedPaymentsProcessor::NOT_FOUND, $testee->last_status());
+		$this->assertEquals(AuthorizedPaymentsProcessor::NOT_FOUND, $testee->process($this->wcOrder));
     }
 
     public function testCaptureFails() {
@@ -118,8 +114,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
             ->with($this->authorizationId)
             ->andThrow(RuntimeException::class);
 
-        $this->assertFalse($testee->process($this->wcOrder));
-        $this->assertEquals(AuthorizedPaymentsProcessor::FAILED, $testee->last_status());
+		$this->assertEquals(AuthorizedPaymentsProcessor::FAILED, $testee->process($this->wcOrder));
     }
 
     public function testAlreadyCaptured() {
@@ -127,8 +122,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 
 		$this->paypalOrder = $this->createPaypalOrder([$this->createAuthorization($this->authorizationId, AuthorizationStatus::CAPTURED)]);
 
-        $this->assertFalse($testee->process($this->wcOrder));
-        $this->assertEquals(AuthorizedPaymentsProcessor::ALREADY_CAPTURED, $testee->last_status());
+		$this->assertEquals(AuthorizedPaymentsProcessor::ALREADY_CAPTURED, $testee->process($this->wcOrder));
     }
 
 	private function createWcOrder(string $paypalOrderId): WC_Order {

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -117,6 +117,12 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 		$this->assertEquals(AuthorizedPaymentsProcessor::ALREADY_CAPTURED, $this->testee->process($this->wcOrder));
     }
 
+    public function testBadAuthorization() {
+		$this->paypalOrder = $this->createPaypalOrder([$this->createAuthorization($this->authorizationId, AuthorizationStatus::DENIED)]);
+
+		$this->assertEquals(AuthorizedPaymentsProcessor::BAD_AUTHORIZATION, $this->testee->process($this->wcOrder));
+    }
+
 	private function createWcOrder(string $paypalOrderId): WC_Order {
 		$wcOrder = Mockery::mock(WC_Order::class);
 		$wcOrder


### PR DESCRIPTION
Fixes #303. Also some refactoring.

Now the user will see `Cannot capture, no valid payment authorization.` message in this case. I think the UX here is not great because this message is displayed in a small line on top of the order page, but that's how it was done before, so for now keeping it the same.

![image](https://user-images.githubusercontent.com/5680466/135979571-02a1ed57-80e4-49ff-839f-b43d99dcda3e.png)

The logic is a bit complex because theoretically it is possible that there are multiple authorizations. I don't know if it is actually possible, but that's how it was handled before.

So now the logic is

- If there are authorizations that can be captured, try to capture them.
- If no such authorizations:
  - If has captured authorizations --> the `already_captured` message.
  - Otherwise show the new error above.

