### PR TITLE
Handle denied authorization

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -141,12 +141,14 @@ return array(
 	},
 	'api.endpoint.payments'                 => static function ( $container ): PaymentsEndpoint {
 		$authorizations_factory = $container->get( 'api.factory.authorization' );
-		$logger                 = $container->get( 'woocommerce.logger.woocommerce' );
+		$capture_factory = $container->get( 'api.factory.capture' );
+		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 
 		return new PaymentsEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$authorizations_factory,
+			$capture_factory,
 			$logger
 		);
 	},

--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
@@ -339,8 +340,8 @@ class OrderEndpoint {
 
 		$order = $this->order_factory->from_paypal_response( $json );
 
-		$purchase_units_payments_captures_status = $order->purchase_units()[0]->payments()->captures()[0]->status() ?? '';
-		if ( $purchase_units_payments_captures_status && 'DECLINED' === $purchase_units_payments_captures_status ) {
+		$capture_status = $order->purchase_units()[0]->payments()->captures()[0]->status() ?? null;
+		if ( $capture_status && $capture_status->is( CaptureStatus::DECLINED ) ) {
 			throw new RuntimeException( __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' ) );
 		}
 

--- a/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-orderendpoint.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
 
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
@@ -412,6 +413,12 @@ class OrderEndpoint {
 			throw $error;
 		}
 		$order = $this->order_factory->from_paypal_response( $json );
+
+		$authorization_status = $order->purchase_units()[0]->payments()->authorizations()[0]->status() ?? null;
+		if ( $authorization_status && $authorization_status->is( AuthorizationStatus::DENIED ) ) {
+			throw new RuntimeException( __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' ) );
+		}
+
 		return $order;
 	}
 

--- a/modules/ppcp-api-client/src/Endpoint/class-paymentsendpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/class-paymentsendpoint.php
@@ -11,11 +11,13 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
 
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
+use Woocommerce\PayPalCommerce\ApiClient\Entity\Capture;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Refund;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\AuthorizationFactory;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\CaptureFactory;
 
 /**
  * Class PaymentsEndpoint
@@ -46,6 +48,13 @@ class PaymentsEndpoint {
 	private $authorizations_factory;
 
 	/**
+	 * The capture factory.
+	 *
+	 * @var CaptureFactory
+	 */
+	private $capture_factory;
+
+	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -58,18 +67,21 @@ class PaymentsEndpoint {
 	 * @param string               $host The host.
 	 * @param Bearer               $bearer The bearer.
 	 * @param AuthorizationFactory $authorization_factory The authorization factory.
+	 * @param CaptureFactory       $capture_factory The capture factory.
 	 * @param LoggerInterface      $logger The logger.
 	 */
 	public function __construct(
 		string $host,
 		Bearer $bearer,
 		AuthorizationFactory $authorization_factory,
+		CaptureFactory $capture_factory,
 		LoggerInterface $logger
 	) {
 
 		$this->host                   = $host;
 		$this->bearer                 = $bearer;
 		$this->authorizations_factory = $authorization_factory;
+		$this->capture_factory        = $capture_factory;
 		$this->logger                 = $logger;
 	}
 
@@ -136,11 +148,11 @@ class PaymentsEndpoint {
 	 *
 	 * @param string $authorization_id The id.
 	 *
-	 * @return Authorization
+	 * @return Capture
 	 * @throws RuntimeException If the request fails.
 	 * @throws PayPalApiException If the request fails.
 	 */
-	public function capture( string $authorization_id ): Authorization {
+	public function capture( string $authorization_id ): Capture {
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/payments/authorizations/' . $authorization_id . '/capture';
 		$args   = array(
@@ -167,7 +179,7 @@ class PaymentsEndpoint {
 			);
 		}
 
-		return $this->authorizations_factory->from_paypal_response( $json );
+		return $this->capture_factory->from_paypal_response( $json );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Entity/class-authorizationstatus.php
+++ b/modules/ppcp-api-client/src/Entity/class-authorizationstatus.php
@@ -45,12 +45,20 @@ class AuthorizationStatus {
 	private $status;
 
 	/**
+	 * The details.
+	 *
+	 * @var AuthorizationStatusDetails|null
+	 */
+	private $details;
+
+	/**
 	 * AuthorizationStatus constructor.
 	 *
-	 * @param string $status The status.
+	 * @param string                          $status The status.
+	 * @param AuthorizationStatusDetails|null $details The details.
 	 * @throws RuntimeException When the status is not valid.
 	 */
-	public function __construct( string $status ) {
+	public function __construct( string $status, ?AuthorizationStatusDetails $details = null ) {
 		if ( ! in_array( $status, self::VALID_STATUS, true ) ) {
 			throw new RuntimeException(
 				sprintf(
@@ -60,7 +68,8 @@ class AuthorizationStatus {
 				)
 			);
 		}
-		$this->status = $status;
+		$this->status  = $status;
+		$this->details = $details;
 	}
 
 	/**
@@ -90,5 +99,14 @@ class AuthorizationStatus {
 	 */
 	public function name(): string {
 		return $this->status;
+	}
+
+	/**
+	 * Returns the details.
+	 *
+	 * @return AuthorizationStatusDetails|null
+	 */
+	public function details(): ?AuthorizationStatusDetails {
+		return $this->details;
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/class-authorizationstatusdetails.php
+++ b/modules/ppcp-api-client/src/Entity/class-authorizationstatusdetails.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * The AuthorizationStatusDetails object.
+ *
+ * @see https://developer.paypal.com/docs/api/payments/v2/#definition-authorization_status_details
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Entity
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
+
+/**
+ * Class AuthorizationStatusDetails
+ */
+class AuthorizationStatusDetails {
+
+	const BUYER_COMPLAINT                             = 'BUYER_COMPLAINT';
+	const CHARGEBACK                                  = 'CHARGEBACK';
+	const ECHECK                                      = 'ECHECK';
+	const INTERNATIONAL_WITHDRAWAL                    = 'INTERNATIONAL_WITHDRAWAL';
+	const OTHER                                       = 'OTHER';
+	const PENDING_REVIEW                              = 'PENDING_REVIEW';
+	const RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION = 'RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION';
+	const REFUNDED                                    = 'REFUNDED';
+	const TRANSACTION_APPROVED_AWAITING_FUNDING       = 'TRANSACTION_APPROVED_AWAITING_FUNDING';
+	const UNILATERAL                                  = 'REFUNDED';
+	const VERIFICATION_REQUIRED                       = 'VERIFICATION_REQUIRED';
+
+	/**
+	 * The reason.
+	 *
+	 * @var string
+	 */
+	private $reason;
+
+	/**
+	 * AuthorizationStatusDetails constructor.
+	 *
+	 * @param string $reason The reason explaining authorization status.
+	 */
+	public function __construct( string $reason ) {
+		$this->reason = $reason;
+	}
+
+	/**
+	 * Compares the current reason with a given one.
+	 *
+	 * @param string $reason The reason to compare with.
+	 *
+	 * @return bool
+	 */
+	public function is( string $reason ): bool {
+		return $this->reason === $reason;
+	}
+
+	/**
+	 * Returns the reason explaining authorization status.
+	 *
+	 * @return string
+	 */
+	public function name(): string {
+		return $this->reason;
+	}
+}

--- a/modules/ppcp-api-client/src/Entity/class-authorizationstatusdetails.php
+++ b/modules/ppcp-api-client/src/Entity/class-authorizationstatusdetails.php
@@ -16,17 +16,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
  */
 class AuthorizationStatusDetails {
 
-	const BUYER_COMPLAINT                             = 'BUYER_COMPLAINT';
-	const CHARGEBACK                                  = 'CHARGEBACK';
-	const ECHECK                                      = 'ECHECK';
-	const INTERNATIONAL_WITHDRAWAL                    = 'INTERNATIONAL_WITHDRAWAL';
-	const OTHER                                       = 'OTHER';
-	const PENDING_REVIEW                              = 'PENDING_REVIEW';
-	const RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION = 'RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION';
-	const REFUNDED                                    = 'REFUNDED';
-	const TRANSACTION_APPROVED_AWAITING_FUNDING       = 'TRANSACTION_APPROVED_AWAITING_FUNDING';
-	const UNILATERAL                                  = 'REFUNDED';
-	const VERIFICATION_REQUIRED                       = 'VERIFICATION_REQUIRED';
+	const PENDING_REVIEW = 'PENDING_REVIEW';
 
 	/**
 	 * The reason.

--- a/modules/ppcp-api-client/src/Entity/class-authorizationstatusdetails.php
+++ b/modules/ppcp-api-client/src/Entity/class-authorizationstatusdetails.php
@@ -60,7 +60,7 @@ class AuthorizationStatusDetails {
 	 *
 	 * @return string
 	 */
-	public function name(): string {
+	public function reason(): string {
 		return $this->reason;
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/class-capture.php
+++ b/modules/ppcp-api-client/src/Entity/class-capture.php
@@ -26,16 +26,9 @@ class Capture {
 	/**
 	 * The status.
 	 *
-	 * @var string
+	 * @var CaptureStatus
 	 */
 	private $status;
-
-	/**
-	 * The status details.
-	 *
-	 * @var string
-	 */
-	private $status_details;
 
 	/**
 	 * The amount.
@@ -75,19 +68,17 @@ class Capture {
 	/**
 	 * Capture constructor.
 	 *
-	 * @param string $id The ID.
-	 * @param string $status The status.
-	 * @param string $status_details The status details.
-	 * @param Amount $amount The amount.
-	 * @param bool   $final_capture The final capture.
-	 * @param string $seller_protection The seller protection.
-	 * @param string $invoice_id The invoice id.
-	 * @param string $custom_id The custom id.
+	 * @param string        $id The ID.
+	 * @param CaptureStatus $status The status.
+	 * @param Amount        $amount The amount.
+	 * @param bool          $final_capture The final capture.
+	 * @param string        $seller_protection The seller protection.
+	 * @param string        $invoice_id The invoice id.
+	 * @param string        $custom_id The custom id.
 	 */
 	public function __construct(
 		string $id,
-		string $status,
-		string $status_details,
+		CaptureStatus $status,
 		Amount $amount,
 		bool $final_capture,
 		string $seller_protection,
@@ -97,7 +88,6 @@ class Capture {
 
 		$this->id                = $id;
 		$this->status            = $status;
-		$this->status_details    = $status_details;
 		$this->amount            = $amount;
 		$this->final_capture     = $final_capture;
 		$this->seller_protection = $seller_protection;
@@ -117,19 +107,10 @@ class Capture {
 	/**
 	 * Returns the status.
 	 *
-	 * @return string
+	 * @return CaptureStatus
 	 */
-	public function status() : string {
+	public function status() : CaptureStatus {
 		return $this->status;
-	}
-
-	/**
-	 * Returns the status details object.
-	 *
-	 * @return \stdClass
-	 */
-	public function status_details() : \stdClass {
-		return (object) array( 'reason' => $this->status_details );
 	}
 
 	/**
@@ -183,15 +164,18 @@ class Capture {
 	 * @return array
 	 */
 	public function to_array() : array {
-		return array(
+		$data = array(
 			'id'                => $this->id(),
-			'status'            => $this->status(),
-			'status_details'    => (array) $this->status_details(),
+			'status'            => $this->status()->name(),
 			'amount'            => $this->amount()->to_array(),
 			'final_capture'     => $this->final_capture(),
 			'seller_protection' => (array) $this->seller_protection(),
 			'invoice_id'        => $this->invoice_id(),
 			'custom_id'         => $this->custom_id(),
 		);
+		if ( $this->status()->details() ) {
+			$data['status_details'] = array( 'reason' => $this->status()->details()->reason() );
+		}
+		return $data;
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/class-capturestatus.php
+++ b/modules/ppcp-api-client/src/Entity/class-capturestatus.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * The CaptureStatus object.
+ *
+ * @see https://developer.paypal.com/docs/api/orders/v2/#definition-capture_status
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Entity
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
+
+/**
+ * Class CaptureStatus
+ */
+class CaptureStatus {
+
+	const COMPLETED          = 'COMPLETED';
+	const DECLINED           = 'DECLINED';
+	const PARTIALLY_REFUNDED = 'PARTIALLY_REFUNDED';
+	const REFUNDED           = 'REFUNDED';
+	const FAILED             = 'FAILED';
+	const PENDING            = 'PENDING';
+
+	/**
+	 * The status.
+	 *
+	 * @var string
+	 */
+	private $status;
+
+	/**
+	 * The details.
+	 *
+	 * @var CaptureStatusDetails|null
+	 */
+	private $details;
+
+	/**
+	 * CaptureStatus constructor.
+	 *
+	 * @param string                    $status The status.
+	 * @param CaptureStatusDetails|null $details The details.
+	 */
+	public function __construct( string $status, ?CaptureStatusDetails $details = null ) {
+		$this->status  = $status;
+		$this->details = $details;
+	}
+
+	/**
+	 * Compares the current status with a given one.
+	 *
+	 * @param string $status The status to compare with.
+	 *
+	 * @return bool
+	 */
+	public function is( string $status ): bool {
+		return $this->status === $status;
+	}
+
+	/**
+	 * Returns the status.
+	 *
+	 * @return string
+	 */
+	public function name(): string {
+		return $this->status;
+	}
+
+	/**
+	 * Returns the details.
+	 *
+	 * @return CaptureStatusDetails|null
+	 */
+	public function details(): ?CaptureStatusDetails {
+		return $this->details;
+	}
+}

--- a/modules/ppcp-api-client/src/Entity/class-capturestatusdetails.php
+++ b/modules/ppcp-api-client/src/Entity/class-capturestatusdetails.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * The CaptureStatusDetails object.
+ *
+ * @see https://developer.paypal.com/docs/api/payments/v2/#definition-capture_status_details
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Entity
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
+
+/**
+ * Class CaptureStatusDetails
+ */
+class CaptureStatusDetails {
+
+	const BUYER_COMPLAINT                             = 'BUYER_COMPLAINT';
+	const CHARGEBACK                                  = 'CHARGEBACK';
+	const ECHECK                                      = 'ECHECK';
+	const INTERNATIONAL_WITHDRAWAL                    = 'INTERNATIONAL_WITHDRAWAL';
+	const OTHER                                       = 'OTHER';
+	const PENDING_REVIEW                              = 'PENDING_REVIEW';
+	const RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION = 'RECEIVING_PREFERENCE_MANDATES_MANUAL_ACTION';
+	const REFUNDED                                    = 'REFUNDED';
+	const TRANSACTION_APPROVED_AWAITING_FUNDING       = 'TRANSACTION_APPROVED_AWAITING_FUNDING';
+	const UNILATERAL                                  = 'REFUNDED';
+	const VERIFICATION_REQUIRED                       = 'VERIFICATION_REQUIRED';
+
+	/**
+	 * The reason.
+	 *
+	 * @var string
+	 */
+	private $reason;
+
+	/**
+	 * CaptureStatusDetails constructor.
+	 *
+	 * @param string $reason The reason explaining capture status.
+	 */
+	public function __construct( string $reason ) {
+		$this->reason = $reason;
+	}
+
+	/**
+	 * Compares the current reason with a given one.
+	 *
+	 * @param string $reason The reason to compare with.
+	 *
+	 * @return bool
+	 */
+	public function is( string $reason ): bool {
+		return $this->reason === $reason;
+	}
+
+	/**
+	 * Returns the reason explaining capture status.
+	 *
+	 * @return string
+	 */
+	public function reason(): string {
+		return $this->reason;
+	}
+}

--- a/modules/ppcp-api-client/src/Factory/class-authorizationfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-authorizationfactory.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatusDetails;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
 /**
@@ -39,9 +40,14 @@ class AuthorizationFactory {
 			);
 		}
 
+		$reason = $data->status_details->reason ?? null;
+
 		return new Authorization(
 			$data->id,
-			new AuthorizationStatus( $data->status )
+			new AuthorizationStatus(
+				$data->status,
+				$reason ? new AuthorizationStatusDetails( $reason ) : null
+			)
 		);
 	}
 }

--- a/modules/ppcp-api-client/src/Factory/class-capturefactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-capturefactory.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
 use Woocommerce\PayPalCommerce\ApiClient\Entity\Capture;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatusDetails;
 
 /**
  * Class CaptureFactory
@@ -42,11 +44,14 @@ class CaptureFactory {
 	 */
 	public function from_paypal_response( \stdClass $data ) : Capture {
 
-		$reason = isset( $data->status_details->reason ) ? (string) $data->status_details->reason : '';
+		$reason = $data->status_details->reason ?? null;
+
 		return new Capture(
 			(string) $data->id,
-			(string) $data->status,
-			$reason,
+			new CaptureStatus(
+				(string) $data->status,
+				$reason ? new CaptureStatusDetails( $reason ) : null
+			),
 			$this->amount_factory->from_paypal_response( $data->amount ),
 			(bool) $data->final_capture,
 			(string) $data->seller_protection->status,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -53,6 +53,7 @@ return array(
 		$transaction_url_provider = $container->get( 'wcgateway.transaction-url-provider' );
 		$subscription_helper = $container->get( 'subscription.helper' );
 		$page_id             = $container->get( 'wcgateway.current-ppcp-settings-page-id' );
+		$environment         = $container->get( 'onboarding.environment' );
 		return new PayPalGateway(
 			$settings_renderer,
 			$order_processor,
@@ -64,7 +65,8 @@ return array(
 			$state,
 			$transaction_url_provider,
 			$subscription_helper,
-			$page_id
+			$page_id,
+			$environment
 		);
 	},
 	'wcgateway.credit-card-gateway'                => static function ( $container ): CreditCardGateway {
@@ -83,7 +85,8 @@ return array(
 		$payer_factory = $container->get( 'api.factory.payer' );
 		$order_endpoint = $container->get( 'api.endpoint.order' );
 		$subscription_helper = $container->get( 'subscription.helper' );
-		$logger                        = $container->get( 'woocommerce.logger.woocommerce' );
+		$logger = $container->get( 'woocommerce.logger.woocommerce' );
+		$environment = $container->get( 'onboarding.environment' );
 		return new CreditCardGateway(
 			$settings_renderer,
 			$order_processor,
@@ -100,7 +103,8 @@ return array(
 			$payer_factory,
 			$order_endpoint,
 			$subscription_helper,
-			$logger
+			$logger,
+			$environment
 		);
 	},
 	'wcgateway.disabler'                           => static function ( $container ): DisableGateways {
@@ -209,7 +213,7 @@ return array(
 			$authorized_payments_processor,
 			$settings,
 			$logger,
-			$environment->current_environment_is( Environment::SANDBOX )
+			$environment
 		);
 	},
 	'wcgateway.processor.refunds'                  => static function ( $container ): RefundProcessor {

--- a/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-creditcardgateway.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
@@ -97,6 +98,13 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	private $order_endpoint;
 
 	/**
+	 * The environment.
+	 *
+	 * @var Environment
+	 */
+	protected $environment;
+
+	/**
 	 * CreditCardGateway constructor.
 	 *
 	 * @param SettingsRenderer            $settings_renderer The Settings Renderer.
@@ -115,6 +123,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 * @param OrderEndpoint               $order_endpoint The order endpoint.
 	 * @param SubscriptionHelper          $subscription_helper The subscription helper.
 	 * @param LoggerInterface             $logger The logger.
+	 * @param Environment                 $environment The environment.
 	 */
 	public function __construct(
 		SettingsRenderer $settings_renderer,
@@ -132,7 +141,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		PayerFactory $payer_factory,
 		OrderEndpoint $order_endpoint,
 		SubscriptionHelper $subscription_helper,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		Environment $environment
 	) {
 
 		$this->id                  = self::ID;
@@ -143,6 +153,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$this->config              = $config;
 		$this->session_handler     = $session_handler;
 		$this->refund_processor    = $refund_processor;
+		$this->environment         = $environment;
 
 		if ( $state->current_state() === State::STATE_ONBOARDED ) {
 			$this->supports = array( 'refunds' );
@@ -423,5 +434,14 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 */
 	private function is_enabled(): bool {
 		return $this->config->has( 'dcc_enabled' ) && $this->config->get( 'dcc_enabled' );
+	}
+
+	/**
+	 * Returns the environment.
+	 *
+	 * @return Environment
+	 */
+	protected function environment(): Environment {
+		return $this->environment;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-paypalgateway.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
+use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
@@ -112,6 +113,13 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	protected $page_id;
 
 	/**
+	 * The environment.
+	 *
+	 * @var Environment
+	 */
+	protected $environment;
+
+	/**
 	 * PayPalGateway constructor.
 	 *
 	 * @param SettingsRenderer            $settings_renderer The Settings Renderer.
@@ -125,6 +133,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @param TransactionUrlProvider      $transaction_url_provider Service providing transaction view URL based on order.
 	 * @param SubscriptionHelper          $subscription_helper The subscription helper.
 	 * @param string                      $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
+	 * @param Environment                 $environment The environment.
 	 */
 	public function __construct(
 		SettingsRenderer $settings_renderer,
@@ -137,7 +146,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		State $state,
 		TransactionUrlProvider $transaction_url_provider,
 		SubscriptionHelper $subscription_helper,
-		string $page_id
+		string $page_id,
+		Environment $environment
 	) {
 
 		$this->id                       = self::ID;
@@ -150,6 +160,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->refund_processor         = $refund_processor;
 		$this->transaction_url_provider = $transaction_url_provider;
 		$this->page_id                  = $page_id;
+		$this->environment              = $environment;
 		$this->onboarded                = $state->current_state() === State::STATE_ONBOARDED;
 
 		if ( $this->onboarded ) {
@@ -429,5 +440,14 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		}
 
 		return $ret;
+	}
+
+	/**
+	 * Returns the environment.
+	 *
+	 * @return Environment
+	 */
+	protected function environment(): Environment {
+		return $this->environment;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
@@ -110,6 +110,8 @@ trait ProcessPaymentTrait {
 				}
 
 				$this->logger->warning( "Could neither capture nor authorize order {$order->id()} using a saved credit card:" . 'Status: ' . $order->status()->name() . ' Intent: ' . $order->intent() );
+
+				return null;
 			} catch ( RuntimeException $error ) {
 				$this->handle_failure( $wc_order, $error );
 				return null;

--- a/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/class-processpaymenttrait.php
@@ -82,10 +82,7 @@ trait ProcessPaymentTrait {
 				$this->add_paypal_meta( $wc_order, $order, $this->environment() );
 
 				if ( $order->status()->is( OrderStatus::COMPLETED ) && $order->intent() === 'CAPTURE' ) {
-					$wc_order->update_status(
-						'processing',
-						__( 'Payment received.', 'woocommerce-paypal-payments' )
-					);
+					$wc_order->payment_complete();
 
 					$this->session_handler->destroy_session_data();
 					return array(

--- a/modules/ppcp-wc-gateway/src/Processor/class-ordermetatrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-ordermetatrait.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Adds common metadata to the order.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Processor
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+/**
+ * Trait OrderMetaTrait.
+ */
+trait OrderMetaTrait {
+
+	/**
+	 * Adds common metadata to the order.
+	 *
+	 * @param WC_Order    $wc_order The WC order to which metadata will be added.
+	 * @param Order       $order The PayPal order.
+	 * @param Environment $environment The environment.
+	 */
+	protected function add_paypal_meta(
+		WC_Order $wc_order,
+		Order $order,
+		Environment $environment
+	): void {
+		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
+		$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
+		$wc_order->update_meta_data(
+			PayPalGateway::ORDER_PAYMENT_MODE_META_KEY,
+			$environment->current_environment_is( Environment::SANDBOX ) ? 'sandbox' : 'live'
+		);
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Processor/class-paymentstatushandlingtrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-paymentstatushandlingtrait.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Common operations performed after payment authorization/capture.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Processor
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
+use Woocommerce\PayPalCommerce\ApiClient\Entity\Capture;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+
+/**
+ * Trait PaymentsStatusHandlingTrait.
+ */
+trait PaymentsStatusHandlingTrait {
+
+	/**
+	 * Changes status of a newly created order, based on the capture/authorization.
+	 *
+	 * @param Order    $order The PayPal order.
+	 * @param WC_Order $wc_order The WC order.
+	 *
+	 * @throws RuntimeException If payment denied.
+	 */
+	protected function handle_new_order_status(
+		Order $order,
+		WC_Order $wc_order
+	): void {
+		if ( $order->intent() === 'CAPTURE' ) {
+			$this->handle_capture_status( $order->purchase_units()[0]->payments()->captures()[0], $wc_order );
+		} elseif ( $order->intent() === 'AUTHORIZE' ) {
+			$this->handle_authorization_status( $order->purchase_units()[0]->payments()->authorizations()[0], $wc_order );
+		}
+	}
+
+	/**
+	 * Changes the order status, based on the capture.
+	 *
+	 * @param Capture  $capture The capture.
+	 * @param WC_Order $wc_order The WC order.
+	 *
+	 * @throws RuntimeException If payment denied.
+	 */
+	protected function handle_capture_status(
+		Capture $capture,
+		WC_Order $wc_order
+	): void {
+		$status = $capture->status();
+
+		if ( $status->details() ) {
+			$this->add_status_details_note( $wc_order, $status->name(), $status->details()->reason() );
+		}
+
+		switch ( $status->name() ) {
+			case CaptureStatus::COMPLETED:
+				$wc_order->payment_complete();
+				break;
+			// It is checked in the capture endpoint already, but there are other ways to capture,
+			// such as when paid via saved card.
+			case CaptureStatus::DECLINED:
+				$wc_order->update_status(
+					'failed',
+					__( 'Could not capture the payment.', 'woocommerce-paypal-payments' )
+				);
+				throw new RuntimeException( __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' ) );
+			case CaptureStatus::PENDING:
+			case CaptureStatus::FAILED:
+				$wc_order->update_status(
+					'on-hold',
+					__( 'Awaiting payment.', 'woocommerce-paypal-payments' )
+				);
+				break;
+		}
+	}
+
+	/**
+	 * Changes the order status, based on the authorization.
+	 *
+	 * @param Authorization $authorization The authorization.
+	 * @param WC_Order      $wc_order The WC order.
+	 *
+	 * @throws RuntimeException If payment denied.
+	 */
+	protected function handle_authorization_status(
+		Authorization $authorization,
+		WC_Order $wc_order
+	): void {
+		$status = $authorization->status();
+
+		if ( $status->details() ) {
+			$this->add_status_details_note( $wc_order, $status->name(), $status->details()->reason() );
+		}
+
+		switch ( $status->name() ) {
+			case AuthorizationStatus::CREATED:
+			case AuthorizationStatus::PENDING:
+				$wc_order->update_status(
+					'on-hold',
+					__( 'Awaiting payment.', 'woocommerce-paypal-payments' )
+				);
+				break;
+			case AuthorizationStatus::DENIED:
+				$wc_order->update_status(
+					'failed',
+					__( 'Could not get the payment authorization.', 'woocommerce-paypal-payments' )
+				);
+				throw new RuntimeException( __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' ) );
+		}
+	}
+
+	/**
+	 * Adds the order note with status details.
+	 *
+	 * @param WC_Order $wc_order The WC order to which the note will be added.
+	 * @param string   $status The status name.
+	 * @param string   $reason The status reason.
+	 */
+	protected function add_status_details_note(
+		WC_Order $wc_order,
+		string $status,
+		string $reason
+	): void {
+		$wc_order->add_order_note(
+			sprintf(
+				/* translators: %1$s - PENDING, DENIED, ... %2$s - PENDING_REVIEW, ... */
+				__( 'PayPal order payment is set to %1$s status, details: %2$s.', 'woocommerce-paypal-payments' ),
+				$status,
+				$reason
+			)
+		);
+		$wc_order->save();
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/class-refundprocessor.php
@@ -183,6 +183,7 @@ class RefundProcessor {
 	 * @return bool
 	 */
 	private function is_voidable_authorization( Authorization $authorization ): bool {
-		return $authorization->status()->is( AuthorizationStatus::CREATED );
+		return $authorization->status()->is( AuthorizationStatus::CREATED ) ||
+			$authorization->status()->is( AuthorizationStatus::PENDING );
 	}
 }

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
@@ -8,6 +8,7 @@ use Requests_Utility_CaseInsensitiveDictionary;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
 use Woocommerce\PayPalCommerce\ApiClient\Entity\Capture;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PatchCollection;
@@ -278,7 +279,7 @@ class OrderEndpointTest extends TestCase
 	    $expectedOrder->shouldReceive('purchase_units')->once()->andReturn(['0'=>$purchaseUnit]);
 	    $purchaseUnit->shouldReceive('payments')->once()->andReturn($payment);
 	    $payment->shouldReceive('captures')->once()->andReturn(['0'=>$capture]);
-	    $capture->shouldReceive('status')->once()->andReturn('');
+	    $capture->shouldReceive('status')->once()->andReturn(new CaptureStatus(CaptureStatus::COMPLETED));
 
         $result = $testee->capture($orderToCapture);
         $this->assertEquals($expectedOrder, $result);

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -5,6 +5,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
 
 use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
@@ -21,8 +22,15 @@ use function Brain\Monkey\Functions\when;
 
 class WcGatewayTest extends TestCase
 {
+	private $environment;
 
-    public function testProcessPaymentSuccess() {
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->environment = Mockery::mock(Environment::class);
+	}
+
+	public function testProcessPaymentSuccess() {
 	    expect('is_admin')->andReturn(false);
 
         $orderId = 1;
@@ -69,7 +77,8 @@ class WcGatewayTest extends TestCase
 	        $state,
             $transactionUrlProvider,
             $subscriptionHelper,
-			PayPalGateway::ID
+			PayPalGateway::ID,
+			$this->environment
         );
 
         expect('wc_get_order')
@@ -118,7 +127,8 @@ class WcGatewayTest extends TestCase
 	        $state,
             $transactionUrlProvider,
             $subscriptionHelper,
-			PayPalGateway::ID
+			PayPalGateway::ID,
+			$this->environment
         );
 
         expect('wc_get_order')
@@ -184,7 +194,8 @@ class WcGatewayTest extends TestCase
 	        $state,
             $transactionUrlProvider,
             $subscriptionHelper,
-			PayPalGateway::ID
+			PayPalGateway::ID,
+			$this->environment
         );
 
         expect('wc_get_order')
@@ -255,7 +266,8 @@ class WcGatewayTest extends TestCase
 	        $state,
             $transactionUrlProvider,
             $subscriptionHelper,
-			PayPalGateway::ID
+			PayPalGateway::ID,
+			$this->environment
         );
 
         $this->assertTrue($testee->capture_authorized_payment($wcOrder));
@@ -310,7 +322,8 @@ class WcGatewayTest extends TestCase
 	        $state,
             $transactionUrlProvider,
             $subscriptionHelper,
-			PayPalGateway::ID
+			PayPalGateway::ID,
+			$this->environment
         );
 
         $this->assertTrue($testee->capture_authorized_payment($wcOrder));
@@ -359,7 +372,8 @@ class WcGatewayTest extends TestCase
 	        $state,
             $transactionUrlProvider,
             $subscriptionHelper,
-			PayPalGateway::ID
+			PayPalGateway::ID,
+			$this->environment
         );
 
         $this->assertFalse($testee->capture_authorized_payment($wcOrder));
@@ -399,7 +413,8 @@ class WcGatewayTest extends TestCase
 		    $onboardingState,
 		    $transactionUrlProvider,
 		    $subscriptionHelper,
-			PayPalGateway::ID
+			PayPalGateway::ID,
+			$this->environment
 	    );
 
     	$this->assertSame($needSetup, $testee->needs_setup());

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -5,6 +5,8 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
 
 use Psr\Container\ContainerInterface;
+use Woocommerce\PayPalCommerce\ApiClient\Entity\Capture;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -234,11 +236,18 @@ class WcGatewayTest extends TestCase
             ->expects('save');
         $settingsRenderer = Mockery::mock(SettingsRenderer::class);
         $orderProcessor = Mockery::mock(OrderProcessor::class);
+		$capture = Mockery::mock(Capture::class);
+		$capture
+			->shouldReceive('status')
+			->andReturn(new CaptureStatus(CaptureStatus::COMPLETED));
         $authorizedPaymentsProcessor = Mockery::mock(AuthorizedPaymentsProcessor::class);
         $authorizedPaymentsProcessor
             ->expects('process')
             ->with($wcOrder)
 			->andReturn(AuthorizedPaymentsProcessor::SUCCESSFUL);
+        $authorizedPaymentsProcessor
+            ->expects('captures')
+			->andReturn([$capture]);
         $authorizedOrderActionNotice = Mockery::mock(AuthorizeOrderActionNotice::class);
         $authorizedOrderActionNotice
             ->expects('display_message')
@@ -346,6 +355,9 @@ class WcGatewayTest extends TestCase
             ->expects('process')
             ->with($wcOrder)
 			->andReturn($lastStatus);
+		$authorizedPaymentsProcessor
+			->expects('captures')
+			->andReturn([]);
         $authorizedOrderActionNotice = Mockery::mock(AuthorizeOrderActionNotice::class);
         $authorizedOrderActionNotice
             ->expects('display_message')

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -10,6 +10,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
+use Woocommerce\PayPalCommerce\ApiClient\Entity\Capture;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
@@ -57,7 +59,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 		$this->paymentsEndpoint
 			->expects('capture')
 			->with($this->authorizationId)
-			->andReturn($this->createAuthorization($this->authorizationId, AuthorizationStatus::CAPTURED));
+			->andReturn($this->createCapture(CaptureStatus::COMPLETED));
 
         $this->assertEquals(AuthorizedPaymentsProcessor::SUCCESSFUL, $this->testee->process($this->wcOrder));
     }
@@ -78,7 +80,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 			$this->paymentsEndpoint
 				->expects('capture')
 				->with($authorization->id())
-				->andReturn($this->createAuthorization($authorization->id(), AuthorizationStatus::CAPTURED));
+				->andReturn($this->createCapture(CaptureStatus::COMPLETED));
 		}
 
 		$this->assertEquals(AuthorizedPaymentsProcessor::SUCCESSFUL, $this->testee->process($this->wcOrder));
@@ -141,6 +143,14 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 			->shouldReceive('status')
 			->andReturn(new AuthorizationStatus($status));
 		return $authorization;
+	}
+
+	private function createCapture(string $status): Capture {
+		$capture = Mockery::mock(Capture::class);
+		$capture
+			->shouldReceive('status')
+			->andReturn(new CaptureStatus($status));
+		return $capture;
 	}
 
 	private function createPaypalOrder(array $authorizations): Order {

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 
+use Dhii\Container\Dictionary;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use Woocommerce\PayPalCommerce\ApiClient\Entity\Capture;
@@ -13,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\Button\Helper\ThreeDSecure;
+use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -22,6 +24,13 @@ use function Brain\Monkey\Functions\when;
 
 class OrderProcessorTest extends TestCase
 {
+	private $environment;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->environment = new Environment(new Dictionary([]));
+	}
 
     public function testAuthorize() {
         $transactionId = 'ABC123';
@@ -112,7 +121,7 @@ class OrderProcessorTest extends TestCase
             $authorizedPaymentProcessor,
             $settings,
             $logger,
-            false
+            $this->environment
         );
 
         $cart = Mockery::mock(\WC_Cart::class);
@@ -240,7 +249,7 @@ class OrderProcessorTest extends TestCase
             $authorizedPaymentProcessor,
             $settings,
             $logger,
-            false
+            $this->environment
         );
 
         $cart = Mockery::mock(\WC_Cart::class);
@@ -340,7 +349,7 @@ class OrderProcessorTest extends TestCase
             $authorizedPaymentProcessor,
             $settings,
             $logger,
-            false
+            $this->environment
         );
 
         $wcOrder
@@ -355,7 +364,7 @@ class OrderProcessorTest extends TestCase
                 PayPalGateway::INTENT_META_KEY,
                 $orderIntent
             );
-        
+
         $this->assertFalse($testee->process($wcOrder));
         $this->assertNotEmpty($testee->last_error());
     }


### PR DESCRIPTION
Fixes #302 and #312. Also some other bugs like missing metadata on captured orders paid via saved card (making impossible to refund).

There was lots of mess in the payment handling, duplicated code in different places (sometimes missing some things), etc. I tried to improve it a bit by extracting some things to traits.

The [order state/messages](https://github.com/woocommerce/woocommerce-paypal-payments/blob/fb3c4f01012011457bfcefcdd6b5cf29ca5fda5a/modules/ppcp-wc-gateway/src/Processor/class-paymentstatushandlingtrait.php#L61) should now match the behavior suggested by @Chaithi.

The only thing that I am not sure is when we have `intent=CAPTURE` and get a capture with `FAILED` status, maybe we need to make order `failed` and show some error? I am not sure when such status can occur.

Also we now always add an order note with the status and status details when we get a capture/authorization with details. As I understand besides `PENDING` we may get details for declined payments.

For #312 it is more like a quick fix. 
As I mentioned it #305 

> The logic in this part is a bit complex because theoretically it is possible that there are multiple authorizations. I don't know if it is actually possible, but that's how it was handled before.

We should figure out if it is actually possible to have multiple authorizations here, and decide how we need to handle them, or (if only single authorization is possible) simplify this part.

For now the order state is decided using the capture of the last captureable authorization in the list.
