### PR TITLE
Check if registration is needed

### DIFF
--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -115,7 +115,8 @@ return array(
 		$session_handler       = $container->get( 'session.handler' );
 		$settings              = $container->get( 'wcgateway.settings' );
 		$early_order_handler   = $container->get( 'button.helper.early-order-handler' );
-		$logger                        = $container->get( 'woocommerce.logger.woocommerce' );
+		$registration_needed    = $container->get( 'button.current-user-must-register' );
+		$logger                = $container->get( 'woocommerce.logger.woocommerce' );
 		return new CreateOrderEndpoint(
 			$request_data,
 			$cart_repository,
@@ -125,6 +126,7 @@ return array(
 			$session_handler,
 			$settings,
 			$early_order_handler,
+			$registration_needed,
 			$logger
 		);
 	},
@@ -170,5 +172,16 @@ return array(
 	},
 	'button.helper.messages-apply'      => static function ( ContainerInterface $container ): MessagesApply {
 		return new MessagesApply();
+	},
+
+	'button.is-logged-in'               => static function ( ContainerInterface $container ): bool {
+		return is_user_logged_in();
+	},
+	'button.registration-required'      => static function ( ContainerInterface $container ): bool {
+		return WC()->checkout()->is_registration_required();
+	},
+	'button.current-user-must-register' => static function ( ContainerInterface $container ): bool {
+		return ! $container->get( 'button.is-logged-in' ) &&
+			$container->get( 'button.registration-required' );
 	},
 );

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -105,6 +105,13 @@ class CreateOrderEndpoint implements EndpointInterface {
 	private $purchase_units;
 
 	/**
+	 * Whether a new user must be registered during checkout.
+	 *
+	 * @var bool
+	 */
+	private $registration_needed;
+
+	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -122,6 +129,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * @param SessionHandler      $session_handler The SessionHandler object.
 	 * @param Settings            $settings The Settings object.
 	 * @param EarlyOrderHandler   $early_order_handler The EarlyOrderHandler object.
+	 * @param bool                $registration_needed  Whether a new user must be registered during checkout.
 	 * @param LoggerInterface     $logger The logger.
 	 */
 	public function __construct(
@@ -133,6 +141,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 		SessionHandler $session_handler,
 		Settings $settings,
 		EarlyOrderHandler $early_order_handler,
+		bool $registration_needed,
 		LoggerInterface $logger
 	) {
 
@@ -144,6 +153,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 		$this->session_handler       = $session_handler;
 		$this->settings              = $settings;
 		$this->early_order_handler   = $early_order_handler;
+		$this->registration_needed   = $registration_needed;
 		$this->logger                = $logger;
 	}
 
@@ -186,7 +196,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 			$this->set_bn_code( $data );
 
 			if ( 'checkout' === $data['context'] ) {
-				if ( isset( $data['createaccount'] ) && '1' === $data['createaccount'] ) {
+				if ( $this->registration_needed || ( isset( $data['createaccount'] ) && '1' === $data['createaccount'] ) ) {
 					$this->process_checkout_form_when_creating_account( $data['form'], $wc_order );
 				}
 

--- a/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
@@ -162,6 +162,7 @@ class CreateOrderEndpointTest extends TestCase
             $session_handler,
             $settings,
             $early_order_handler,
+			false,
 			new NullLogger()
         );
         return array($payer_factory, $testee);


### PR DESCRIPTION
Partially fixes #239 

The loop is fixed, but there is still a strange bug about randomly reloaded page at the end of ordering process, breaking checkout.

To fix this, we probably need to understand first what exactly is supposed to happen after finishing registration during checkout. Because it is possible that reloading is actually intended:
https://github.com/woocommerce/woocommerce/blob/3611d4643791bad87a0d3e6e73e031bb80447417/plugins/woocommerce/includes/class-wc-checkout.php#L1052-L1053