### PR TITLE
add woocommerce_paypal_payments_single_product_disable_render filter WIP

### DIFF
--- a/modules/ppcp-button/src/Assets/class-smartbutton.php
+++ b/modules/ppcp-button/src/Assets/class-smartbutton.php
@@ -423,7 +423,7 @@ class SmartButton implements SmartButtonInterface {
 		if (
 			! is_checkout() && is_a( $product, \WC_Product::class )
 			&& (
-				$product->is_type( array( 'external', 'grouped' ) )
+				apply_filters( 'woocommerce_paypal_payments_single_product_disable_render', $product->is_type( array( 'external', 'grouped' ) ), $product )
 				|| ! $product->is_in_stock()
 			)
 		) {


### PR DESCRIPTION
### Description
Add a filter that will allow other plugins to conditionally disable the payment request buttons for single products that cannot support them.

### Steps to test:
```add_filter( 'woocommerce_paypal_payments_single_product_disable_render', '__return_true' );```

Should turn off payment request buttons on single products even if they are enabled in the admin.

### Documentation
<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation -->

### Changelog entry
> Add woocommerce_paypal_payments_single_product_disable_render filter

Closes #234.

