### PR TITLE
Do not validate checkout form when creating PayPal order

### DIFF
--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -160,6 +160,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * Handles the request.
 	 *
 	 * @return bool
+	 * @throws Exception On Error.
 	 */
 	public function handle_request(): bool {
 		try {


### PR DESCRIPTION
Fixes #335.

### Possible cause
We are currently calling WC `process_checkout` twice, the first time it's called before creating the PayPal order to validate WC checkout form.

This is causing third party plugins not working because they are using `woocommerce_after_checkout_validation` for validating its own logic and after that cleaning session data on `woocommerce_checkout_order_processed`, when our plugin calls `process_checkout` the second time it calls again `woocommerce_after_checkout_validation` making it fail because there is no session stored available, it was already cleared on `woocommerce_checkout_order_processed`.

### Suggested solution
We can simply skip WC checkout form validation when creating the PayPal order, that's in fact how it works when we create the PayPal order from other pages like Product or Cart.

By not calling `process_checkout` when creating the PayPal order we are going to probably also fix some of those WC Failed orders because the WC order is going to be created only after PayPal order is created correctly and WC checkout form is validated.