### PR TITLE
Fix/refactor rounding check

### DIFF
--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -303,10 +303,13 @@ class PurchaseUnit {
 	 * @return bool
 	 */
 	private function ditch_items_when_mismatch( Amount $amount, Item ...$items ): bool {
-		$fee_items_total = ( $amount->breakdown() && $amount->breakdown()->item_total() ) ?
-			$amount->breakdown()->item_total()->value() : null;
-		$fee_tax_total   = ( $amount->breakdown() && $amount->breakdown()->tax_total() ) ?
-			$amount->breakdown()->tax_total()->value() : null;
+		$breakdown = $amount->breakdown();
+		if ( ! $breakdown ) {
+			return false;
+		}
+
+		$fee_items_total = $breakdown->item_total() ? $breakdown->item_total()->value() : null;
+		$fee_tax_total   = $breakdown->tax_total() ? $breakdown->tax_total()->value() : null;
 
 		foreach ( $items as $item ) {
 			if ( null !== $fee_items_total ) {
@@ -324,10 +327,6 @@ class PurchaseUnit {
 			return true;
 		}
 
-		$breakdown = $this->amount()->breakdown();
-		if ( ! $breakdown ) {
-			return false;
-		}
 		$amount_total = 0;
 		if ( $breakdown->shipping() ) {
 			$amount_total += $breakdown->shipping()->value();
@@ -351,7 +350,7 @@ class PurchaseUnit {
 			$amount_total += $breakdown->insurance()->value();
 		}
 
-		$amount_value   = $this->amount()->value();
+		$amount_value   = $amount->value();
 		$needs_to_ditch = (string) $amount_total !== (string) $amount_value;
 		return $needs_to_ditch;
 	}

--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -308,15 +308,20 @@ class PurchaseUnit {
 			return false;
 		}
 
-		$fee_items_total = $breakdown->item_total() ? $breakdown->item_total()->value() : null;
-		$fee_tax_total   = $breakdown->tax_total() ? $breakdown->tax_total()->value() : null;
+		$item_total = $breakdown->item_total();
+		$tax_total  = $breakdown->tax_total();
+
+		$fee_items_total = $item_total ? $item_total->value() : null;
+		$fee_tax_total   = $tax_total ? $tax_total->value() : null;
 
 		foreach ( $items as $item ) {
 			if ( null !== $fee_items_total ) {
-				$fee_items_total -= $item->unit_amount()->value() * $item->quantity();
+				$fee_items_total -= $item->unit_amount()->value() * (float) $item->quantity();
 			}
-			if ( null !== $fee_tax_total ) {
-				$fee_tax_total -= $item->tax()->value() * $item->quantity();
+
+			$tax = $item->tax();
+			if ( $tax && null !== $fee_tax_total ) {
+				$fee_tax_total -= $tax->value() * (float) $item->quantity();
 			}
 		}
 
@@ -327,27 +332,33 @@ class PurchaseUnit {
 			return true;
 		}
 
-		$amount_total = 0;
-		if ( $breakdown->shipping() ) {
-			$amount_total += $breakdown->shipping()->value();
+		$shipping          = $breakdown->shipping();
+		$discount          = $breakdown->discount();
+		$shipping_discount = $breakdown->shipping_discount();
+		$handling          = $breakdown->handling();
+		$insurance         = $breakdown->insurance();
+
+		$amount_total = 0.0;
+		if ( $shipping ) {
+			$amount_total += $shipping->value();
 		}
-		if ( $breakdown->item_total() ) {
-			$amount_total += $breakdown->item_total()->value();
+		if ( $item_total ) {
+			$amount_total += $item_total->value();
 		}
-		if ( $breakdown->discount() ) {
-			$amount_total -= $breakdown->discount()->value();
+		if ( $discount ) {
+			$amount_total -= $discount->value();
 		}
-		if ( $breakdown->tax_total() ) {
-			$amount_total += $breakdown->tax_total()->value();
+		if ( $tax_total ) {
+			$amount_total += $tax_total->value();
 		}
-		if ( $breakdown->shipping_discount() ) {
-			$amount_total -= $breakdown->shipping_discount()->value();
+		if ( $shipping_discount ) {
+			$amount_total -= $shipping_discount->value();
 		}
-		if ( $breakdown->handling() ) {
-			$amount_total += $breakdown->handling()->value();
+		if ( $handling ) {
+			$amount_total += $handling->value();
 		}
-		if ( $breakdown->insurance() ) {
-			$amount_total += $breakdown->insurance()->value();
+		if ( $insurance ) {
+			$amount_total += $insurance->value();
 		}
 
 		$amount_value   = $amount->value();

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -159,35 +159,10 @@
     </PossiblyNullReference>
   </file>
   <file src="modules/ppcp-api-client/src/Entity/PurchaseUnit.php">
-    <InvalidOperand occurrences="9">
-      <code>$amount_total += $breakdown-&gt;handling()-&gt;value()</code>
-      <code>$amount_total += $breakdown-&gt;insurance()-&gt;value()</code>
-      <code>$amount_total += $breakdown-&gt;item_total()-&gt;value()</code>
-      <code>$amount_total += $breakdown-&gt;shipping()-&gt;value()</code>
-      <code>$amount_total += $breakdown-&gt;tax_total()-&gt;value()</code>
-      <code>$amount_total -= $breakdown-&gt;discount()-&gt;value()</code>
-      <code>$amount_total -= $breakdown-&gt;shipping_discount()-&gt;value()</code>
-      <code>$item-&gt;tax()-&gt;value() * $item-&gt;quantity()</code>
-      <code>$item-&gt;unit_amount()-&gt;value() * $item-&gt;quantity()</code>
-    </InvalidOperand>
-    <PossiblyNullReference occurrences="17">
-      <code>item_total</code>
-      <code>item_total</code>
-      <code>tax_total</code>
-      <code>tax_total</code>
+    <PossiblyNullReference occurrences="3">
       <code>to_array</code>
       <code>to_array</code>
       <code>to_array</code>
-      <code>value</code>
-      <code>value</code>
-      <code>value</code>
-      <code>value</code>
-      <code>value</code>
-      <code>value</code>
-      <code>value</code>
-      <code>value</code>
-      <code>value</code>
-      <code>value</code>
     </PossiblyNullReference>
   </file>
   <file src="modules/ppcp-api-client/src/Entity/Refund.php">
@@ -768,9 +743,6 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php">
-    <MissingReturnType occurrences="1">
-      <code>set_order_transaction_id</code>
-    </MissingReturnType>
     <PossiblyNullReference occurrences="1">
       <code>card</code>
     </PossiblyNullReference>
@@ -926,25 +898,6 @@
     <PossiblyNullArrayAccess occurrences="2">
       <code>$request['resource']['id']</code>
       <code>$request['resource']['purchase_units']</code>
-    </PossiblyNullArrayAccess>
-  </file>
-  <file src="modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php">
-    <InvalidReturnStatement occurrences="4">
-      <code>rest_ensure_response( $response )</code>
-      <code>rest_ensure_response( $response )</code>
-      <code>rest_ensure_response( $response )</code>
-      <code>rest_ensure_response( $response )</code>
-    </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>\WP_REST_Response</code>
-    </InvalidReturnType>
-    <PossiblyNullArgument occurrences="3">
-      <code>$request['resource']['custom_id']</code>
-      <code>isset( $request['id'] ) ? $request['id'] : ''</code>
-      <code>isset( $request['id'] ) ? $request['id'] : ''</code>
-    </PossiblyNullArgument>
-    <PossiblyNullArrayAccess occurrences="1">
-      <code>$request['resource']['custom_id']</code>
     </PossiblyNullArrayAccess>
   </file>
   <file src="modules/ppcp-webhooks/src/Handler/PaymentCaptureRefunded.php">


### PR DESCRIPTION
Fixes #344 

Actually looks like it was already fixed in February https://github.com/strangerkir/woocommerce-paypal-payments/commit/aa5a6eb6399b1c6833cf21faf54fd6f2cc87a580 but it was in the PSR-4 PRs which were merged only after the last release.

I looked a bit into this code to figure out what it actually does and whether the fix is correct. As I understand it tries to check that the totals in WC and PayPal will match after float numbers rounding errors and taking into account the 2 decimal points limit in PayPal. I am not sure if it is done correctly and works in all cases, but I guess it cannot harm.

Fixed psalm errors and refactored the a bit confusing float cast of null.