### PR TITLE
Fix psalm

### DIFF
--- a/modules/ppcp-api-client/src/Entity/AmountBreakdown.php
+++ b/modules/ppcp-api-client/src/Entity/AmountBreakdown.php
@@ -17,49 +17,49 @@ class AmountBreakdown {
 	/**
 	 * The item total.
 	 *
-	 * @var Money
+	 * @var Money|null
 	 */
 	private $item_total;
 
 	/**
 	 * The shipping.
 	 *
-	 * @var Money
+	 * @var Money|null
 	 */
 	private $shipping;
 
 	/**
 	 * The tax total.
 	 *
-	 * @var Money
+	 * @var Money|null
 	 */
 	private $tax_total;
 
 	/**
 	 * The handling.
 	 *
-	 * @var Money
+	 * @var Money|null
 	 */
 	private $handling;
 
 	/**
 	 * The insurance.
 	 *
-	 * @var Money
+	 * @var Money|null
 	 */
 	private $insurance;
 
 	/**
 	 * The shipping discount.
 	 *
-	 * @var Money
+	 * @var Money|null
 	 */
 	private $shipping_discount;
 
 	/**
 	 * The discount.
 	 *
-	 * @var Money
+	 * @var Money|null
 	 */
 	private $discount;
 
@@ -75,13 +75,13 @@ class AmountBreakdown {
 	 * @param Money|null $discount The discount.
 	 */
 	public function __construct(
-		Money $item_total = null,
-		Money $shipping = null,
-		Money $tax_total = null,
-		Money $handling = null,
-		Money $insurance = null,
-		Money $shipping_discount = null,
-		Money $discount = null
+		?Money $item_total = null,
+		?Money $shipping = null,
+		?Money $tax_total = null,
+		?Money $handling = null,
+		?Money $insurance = null,
+		?Money $shipping_discount = null,
+		?Money $discount = null
 	) {
 
 		$this->item_total        = $item_total;

--- a/modules/ppcp-api-client/src/Factory/PatchCollectionFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PatchCollectionFactory.php
@@ -52,14 +52,12 @@ class PatchCollectionFactory {
 				array_filter(
 					$from,
 					static function ( PurchaseUnit $unit ) use ( $purchase_unit_to ): bool {
-                        //phpcs:disable WordPress.PHP.StrictComparisons.LooseComparison
 						// Loose comparison needed to compare two objects.
+						// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 						return $unit == $purchase_unit_to;
-                        //phpcs:enable WordPress.PHP.StrictComparisons.LooseComparison
 					}
 				)
 			);
-			$needs_update = true;
 			if ( ! $needs_update ) {
 				continue;
 			}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -728,7 +728,7 @@ class SmartButton implements SmartButtonInterface {
 	private function payerData() {
 
 		$customer = WC()->customer;
-		if ( ! is_user_logged_in() || ! is_a( $customer, \WC_Customer::class ) ) {
+		if ( ! is_user_logged_in() || ! ( $customer instanceof \WC_Customer ) ) {
 			return null;
 		}
 		return $this->payer_factory->from_customer( $customer )->to_array();
@@ -757,7 +757,7 @@ class SmartButton implements SmartButtonInterface {
 		if (
 			$this->environment->current_environment_is( Environment::SANDBOX )
 			&& defined( 'WP_DEBUG' ) && \WP_DEBUG && is_user_logged_in()
-			&& WC()->customer && WC()->customer->get_billing_country()
+			&& WC()->customer instanceof \WC_Customer && WC()->customer->get_billing_country()
 			&& 2 === strlen( WC()->customer->get_billing_country() )
 		) {
 			$params['buyer-country'] = WC()->customer->get_billing_country();

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -121,7 +121,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 	 * Handles the request.
 	 *
 	 * @return bool
-	 * @throws RuntimeException When no order was found.
+	 * @throws RuntimeException When order not found or handling failed.
 	 */
 	public function handle_request(): bool {
 		try {
@@ -133,15 +133,6 @@ class ApproveOrderEndpoint implements EndpointInterface {
 			}
 
 			$order = $this->api_endpoint->order( $data['order_id'] );
-			if ( ! $order ) {
-				throw new RuntimeException(
-					sprintf(
-						// translators: %s is the id of the order.
-						__( 'Order %s not found.', 'woocommerce-paypal-payments' ),
-						$data['order_id']
-					)
-				);
-			}
 
 			if ( $order->payment_source() && $order->payment_source()->card() ) {
 				if ( $this->settings->has( 'disable_cards' ) ) {

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -285,7 +285,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 * @throws RuntimeException If create order request fails.
 	 */
 	private function create_paypal_order( \WC_Order $wc_order = null ): Order {
-		$needs_shipping          = WC()->cart && WC()->cart->needs_shipping();
+		$needs_shipping          = WC()->cart instanceof \WC_Cart && WC()->cart->needs_shipping();
 		$shipping_address_is_fix = $needs_shipping && 'checkout' === $this->parsed_request_data['context'];
 
 		return $this->api_endpoint->create(

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -112,7 +112,7 @@ class SubscriptionModule implements ModuleInterface {
 	 * @return void
 	 */
 	protected function renew( $order, $container ) {
-		if ( ! is_a( $order, \WC_Order::class ) ) {
+		if ( ! ( $order instanceof \WC_Order ) ) {
 			return;
 		}
 

--- a/modules/ppcp-wc-gateway/src/Checkout/CheckoutPayPalAddressPreset.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/CheckoutPayPalAddressPreset.php
@@ -114,7 +114,6 @@ class CheckoutPayPalAddressPreset {
 			array_key_exists( $field_id, $payer_phone_map )
 			&& $payer
 			&& $payer->phone()
-			&& $payer->phone()->phone()
 		) {
 			return $payer->phone()->phone()->{$payer_phone_map[ $field_id ]}() ? $payer->phone()->phone()->{$payer_phone_map[ $field_id ]}() : null;
 		}

--- a/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
@@ -61,9 +61,6 @@ class ReturnUrlEndpoint {
 		$token = sanitize_text_field( wp_unslash( $_GET['token'] ) );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		$order = $this->order_endpoint->order( $token );
-		if ( ! $order ) {
-			exit();
-		}
 
 		$wc_order_id = $this->sanitize_custom_id( $order->purchase_units()[0]->custom_id() );
 		if ( ! $wc_order_id ) {


### PR DESCRIPTION
Most of the issues were simple, like wrong phpdoc. 

But there was one strange issue in the patch factory. It seems like the idea was to not create a patch if the items are the same, which makes sense. But at the end this flag was always set to `true`, added in https://github.com/woocommerce/woocommerce-paypal-payments/commit/fa137d49b81f5ba90753074377c93a6bb7095370. Seems like it is just leftovers from some kind of debugging/testing, because it was not even formatted properly in this commit.