### PR TITLE
introduce woocommerce_paypal_payments_product_supports_prb filter

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -420,11 +420,10 @@ class SmartButton implements SmartButtonInterface {
 	 */
 	public function button_renderer() {
 		$product = wc_get_product();
+
 		if (
 			! is_checkout() && is_a( $product, \WC_Product::class )
-			&& (
-				$product->is_type( array( 'external', 'grouped' ) )
-				|| ! $product->is_in_stock()
+			&& ( ! apply_filters( 'woocommerce_paypal_payments_product_supports_prb', ! $product->is_type( array( 'external', 'grouped' ) ) && $product->is_in_stock(), $product )
 			)
 		) {
 			return;
@@ -437,6 +436,15 @@ class SmartButton implements SmartButtonInterface {
 	 * Renders the HTML for the credit messaging.
 	 */
 	public function message_renderer() {
+		$product = wc_get_product();
+
+		if (
+			! is_checkout() && is_a( $product, \WC_Product::class )
+			&& ( ! apply_filters( 'woocommerce_paypal_payments_product_supports_prb', ! $product->is_type( array( 'external', 'grouped' ) ) && $product->is_in_stock(), $product )
+			)
+		) {
+			return;
+		}
 
 		echo '<div id="ppcp-messages" data-partner-attribution-id="Woo_PPCP"></div>';
 	}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -423,7 +423,7 @@ class SmartButton implements SmartButtonInterface {
 
 		if (
 			! is_checkout() && is_a( $product, \WC_Product::class )
-			&& ( ! apply_filters( 'woocommerce_paypal_payments_product_supports_prb', ! $product->is_type( array( 'external', 'grouped' ) ) && $product->is_in_stock(), $product )
+			&& ( ! apply_filters( 'woocommerce_paypal_payments_product_supports_payment_request_button', ! $product->is_type( array( 'external', 'grouped' ) ) && $product->is_in_stock(), $product )
 			)
 		) {
 			return;
@@ -440,7 +440,7 @@ class SmartButton implements SmartButtonInterface {
 
 		if (
 			! is_checkout() && is_a( $product, \WC_Product::class )
-			&& ( ! apply_filters( 'woocommerce_paypal_payments_product_supports_prb', ! $product->is_type( array( 'external', 'grouped' ) ) && $product->is_in_stock(), $product )
+			&& ( ! apply_filters( 'woocommerce_paypal_payments_product_supports_payment_request_button', ! $product->is_type( array( 'external', 'grouped' ) ) && $product->is_in_stock(), $product )
 			)
 		) {
 			return;


### PR DESCRIPTION
### Description

Add a filter that will allow other plugins to conditionally disable the payment request buttons for single products that cannot support them.

### Steps to test:

```
add_filter( 'woocommerce_paypal_payments_product_supports_prb', '__return_false' );
```

Should turn off payment request buttons on _all_ single products even if they are enabled in the admin.

Because the `$product` object is passed, can also disable conditionally, for example, in the case of Mix and Match products

```
/**
 * Disable support for payment request buttons
 * 
 * @param bool $supports_prb
 * @param WC_Product $product
 * @return bool
 */
function kia_test_buttons( $supports_prb, $product ){
    if ( $product->is_type( 'mix-and-match' ) ) {
        $supports_prb = false;
    }
    return $supports_prb;
    
}
add_action( 'woocommerce_paypal_payments_product_supports_prb', 'kia_test_buttons', 10, 2 );
```


### Changelog entry

Add `woocommerce_paypal_payments_product_supports_prb` filter

Closes #234.

cc @jimjasson
