### PR TITLE
Release 1.6.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,19 @@
 *** Changelog ***
 
+= 1.6.2 - TBD =
+* Fix - Order of WooCommerce checkout actions causing incompatibility with AvaTax address validation #335
+* Fix - Can't checkout to certain countries with optional postcode #330
+* FIx - Prevent subscription from being purchased when saving payment fails #308
+* FIx - Guest users must checkout twice for subscriptions, no smart buttons loaded #342
+* FIx - Failed PayPal API request causing strange error #347
+* FIx - PayPal payments page empty after switching packages #350
+* FIx - Could Not Validate Nonce Error #239
+* FIx - Refund via PayPal dashboard does not set the WooCommerce order to "Refunded" #241
+* FIx - Uncaught TypeError: round() #344
+* FIx - Broken multi-level (nested) associative array values after getting submitted from checkout page #307
+* FIx - Transaction id missing in some cases #328
+* FIx - Payment not possible in pay for order form because of terms checkbox missing #294
+
 = 1.6.1 - 2021-10-12 =
 * Fix - Handle authorization capture failures #312
 * Fix - Handle denied payment authorization #302

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.6.1
+Stable tag: 1.6.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,20 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.6.2 =
+* Fix - Order of WooCommerce checkout actions causing incompatibility with AvaTax address validation #335
+* Fix - Can't checkout to certain countries with optional postcode #330
+* FIx - Prevent subscription from being purchased when saving payment fails #308
+* FIx - Guest users must checkout twice for subscriptions, no smart buttons loaded #342
+* FIx - Failed PayPal API request causing strange error #347
+* FIx - PayPal payments page empty after switching packages #350
+* FIx - Could Not Validate Nonce Error #239
+* FIx - Refund via PayPal dashboard does not set the WooCommerce order to "Refunded" #241
+* FIx - Uncaught TypeError: round() #344
+* FIx - Broken multi-level (nested) associative array values after getting submitted from checkout page #307
+* FIx - Transaction id missing in some cases #328
+* FIx - Payment not possible in pay for order form because of terms checkbox missing #294
 
 = 1.6.1 =
 * Fix - Handle authorization capture failures #312

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,13 +3,13 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.6.1
+ * Version:     1.6.2
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 5.7
+ * WC tested up to: 5.9
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce


### PR DESCRIPTION
* Fix - Order of WooCommerce checkout actions causing incompatibility with AvaTax address validation #335
* Fix - Can't checkout to certain countries with optional postcode #330
* FIx - Prevent subscription from being purchased when saving payment fails #308
* FIx - Guest users must checkout twice for subscriptions, no smart buttons loaded #342
* FIx - Failed PayPal API request causing strange error #347
* FIx - PayPal payments page empty after switching packages #350
* FIx - Could Not Validate Nonce Error #239
* FIx - Refund via PayPal dashboard does not set the WooCommerce order to "Refunded" #241
* FIx - Uncaught TypeError: round() #344
* FIx - Broken multi-level (nested) associative array values after getting submitted from checkout page #307
* FIx - Transaction id missing in some cases #328
* FIx - Payment not possible in pay for order form because of terms checkbox missing #294