### PR TITLE
Do not pass `customer_id` if vaulting is disabled

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -130,14 +130,15 @@ return array(
 		);
 	},
 	'api.endpoint.identity-token'           => static function ( ContainerInterface $container ) : IdentityToken {
-
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 		$prefix = $container->get( 'api.prefix' );
+		$settings = $container->get( 'wcgateway.settings' );
 		return new IdentityToken(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$logger,
-			$prefix
+			$prefix,
+			$settings
 		);
 	},
 	'api.endpoint.payments'                 => static function ( ContainerInterface $container ): PaymentsEndpoint {

--- a/modules/ppcp-api-client/src/Endpoint/IdentityToken.php
+++ b/modules/ppcp-api-client/src/Endpoint/IdentityToken.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class IdentityToken
@@ -51,18 +52,27 @@ class IdentityToken {
 	private $prefix;
 
 	/**
+	 * The settings
+	 *
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
 	 * IdentityToken constructor.
 	 *
 	 * @param string          $host The host.
 	 * @param Bearer          $bearer The bearer.
 	 * @param LoggerInterface $logger The logger.
 	 * @param string          $prefix The prefix.
+	 * @param Settings        $settings The settings.
 	 */
-	public function __construct( string $host, Bearer $bearer, LoggerInterface $logger, string $prefix ) {
-		$this->host   = $host;
-		$this->bearer = $bearer;
-		$this->logger = $logger;
-		$this->prefix = $prefix;
+	public function __construct( string $host, Bearer $bearer, LoggerInterface $logger, string $prefix, Settings $settings ) {
+		$this->host     = $host;
+		$this->bearer   = $bearer;
+		$this->logger   = $logger;
+		$this->prefix   = $prefix;
+		$this->settings = $settings;
 	}
 
 	/**
@@ -84,7 +94,9 @@ class IdentityToken {
 				'Content-Type'  => 'application/json',
 			),
 		);
-		if ( $customer_id && defined( 'PPCP_FLAG_SUBSCRIPTION' ) && PPCP_FLAG_SUBSCRIPTION ) {
+		if ( $customer_id
+			&& ( $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ) )
+			&& defined( 'PPCP_FLAG_SUBSCRIPTION' ) && PPCP_FLAG_SUBSCRIPTION ) {
 			$args['body'] = wp_json_encode( array( 'customer_id' => $this->prefix . $customer_id ) );
 		}
 

--- a/modules/ppcp-api-client/src/Endpoint/IdentityToken.php
+++ b/modules/ppcp-api-client/src/Endpoint/IdentityToken.php
@@ -94,9 +94,11 @@ class IdentityToken {
 				'Content-Type'  => 'application/json',
 			),
 		);
-		if ( $customer_id
+		if (
+			$customer_id
 			&& ( $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ) )
-			&& defined( 'PPCP_FLAG_SUBSCRIPTION' ) && PPCP_FLAG_SUBSCRIPTION ) {
+			&& defined( 'PPCP_FLAG_SUBSCRIPTION' ) && PPCP_FLAG_SUBSCRIPTION
+		) {
 			$args['body'] = wp_json_encode( array( 'customer_id' => $this->prefix . $customer_id ) );
 		}
 

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -38,6 +38,11 @@ class VaultingModule implements ModuleInterface {
 	 */
 	public function run( ContainerInterface $container ): void {
 
+		$settings = $container->get( 'wcgateway.settings' );
+		if ( ! $settings->has( 'vault_enabled' ) || ! $settings->get( 'vault_enabled' ) ) {
+			return;
+		}
+
 		add_filter(
 			'woocommerce_account_menu_items',
 			function( $menu_links ) {

--- a/tests/PHPUnit/ApiClient/Endpoint/IdentityTokenTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/IdentityTokenTest.php
@@ -11,6 +11,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\TestCase;
 use Mockery;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
@@ -20,6 +21,7 @@ class IdentityTokenTest extends TestCase
     private $bearer;
     private $logger;
     private $prefix;
+    private $settings;
     private $sut;
 
     public function setUp(): void
@@ -30,7 +32,9 @@ class IdentityTokenTest extends TestCase
         $this->bearer = Mockery::mock(Bearer::class);
         $this->logger = Mockery::mock(LoggerInterface::class);
         $this->prefix = 'prefix';
-        $this->sut = new IdentityToken($this->host, $this->bearer, $this->logger, $this->prefix);
+        $this->settings = Mockery::mock(Settings::class);
+
+        $this->sut = new IdentityToken($this->host, $this->bearer, $this->logger, $this->prefix, $this->settings);
     }
 
     public function testGenerateForCustomerReturnsToken()
@@ -46,6 +50,8 @@ class IdentityTokenTest extends TestCase
 		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
 		$headers->shouldReceive('getAll');
 		$this->logger->shouldReceive('debug');
+		$this->settings->shouldReceive('has')->andReturn(true);
+		$this->settings->shouldReceive('get')->andReturn(true);
 
 		$rawResponse = [
 			'body' => '{"client_token":"abc123", "expires_in":3600}',
@@ -96,6 +102,8 @@ class IdentityTokenTest extends TestCase
 		when('wc_print_r')->returnArg();
         $this->logger->shouldReceive('log');
         $this->logger->shouldReceive('debug');
+		$this->settings->shouldReceive('has')->andReturn(true);
+		$this->settings->shouldReceive('get')->andReturn(true);
 
         $this->expectException(RuntimeException::class);
         $this->sut->generate_for_customer(1);
@@ -120,6 +128,8 @@ class IdentityTokenTest extends TestCase
 		when('wc_print_r')->returnArg();
         $this->logger->shouldReceive('log');
         $this->logger->shouldReceive('debug');
+		$this->settings->shouldReceive('has')->andReturn(true);
+		$this->settings->shouldReceive('get')->andReturn(true);
 
         $this->expectException(PayPalApiException::class);
         $this->sut->generate_for_customer(1);


### PR DESCRIPTION
Fixes #358.