### PR TITLE
Fix duplicated button and saved cards in Pay Now

### DIFF
--- a/modules/ppcp-button/resources/css/hosted-fields.scss
+++ b/modules/ppcp-button/resources/css/hosted-fields.scss
@@ -11,3 +11,7 @@
 .ppcp-credit-card-gateway-form-field-disabled {
 	opacity: .5 !important;
 }
+
+.ppcp-dcc-order-button {
+	float: right;
+}

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -1,5 +1,6 @@
 import ErrorHandler from '../ErrorHandler';
 import CheckoutActionHandler from '../ActionHandler/CheckoutActionHandler';
+import { setVisible } from '../Helper/Hiding';
 
 class CheckoutBootstap {
     constructor(gateway, renderer, messages, spinner) {
@@ -72,10 +73,10 @@ class CheckoutBootstap {
         const isSavedCard = isCard && this.isSavedCardSelected();
         const isNotOurGateway = !isPaypal && !isCard;
 
-        jQuery(this.standardOrderButtonSelector).toggle(isNotOurGateway || isSavedCard);
-        jQuery(this.gateway.button.wrapper).toggle(isPaypal);
-        jQuery(this.gateway.messages.wrapper).toggle(isPaypal);
-        jQuery(this.gateway.hosted_fields.wrapper).toggle(isCard && !isSavedCard);
+        setVisible(this.standardOrderButtonSelector, isNotOurGateway || isSavedCard, true);
+        setVisible(this.gateway.button.wrapper, isPaypal);
+        setVisible(this.gateway.messages.wrapper, isPaypal);
+        setVisible(this.gateway.hosted_fields.wrapper, isCard && !isSavedCard);
 
         if (isPaypal) {
             this.messages.render();

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -10,6 +10,10 @@ class CheckoutBootstap {
         this.spinner = spinner;
 
         this.standardOrderButtonSelector = '#place_order';
+
+        this.buttonChangeObserver = new MutationObserver((el) => {
+            this.updateUi();
+        });
     }
 
     init() {
@@ -63,6 +67,11 @@ class CheckoutBootstap {
             this.gateway.button.wrapper,
             this.gateway.hosted_fields.wrapper,
             actionHandler.configuration(),
+        );
+
+        this.buttonChangeObserver.observe(
+            document.querySelector(this.standardOrderButtonSelector),
+            {attributes: true}
         );
     }
 

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -67,8 +67,7 @@ class CheckoutBootstap {
     switchBetweenPayPalandOrderButton() {
         jQuery('#saved-credit-card').val(jQuery('#saved-credit-card option:first').val());
 
-        const currentPaymentMethod = jQuery(
-            'input[name="payment_method"]:checked').val();
+        const currentPaymentMethod = this.currentPaymentMethod();
 
         if (currentPaymentMethod !== 'ppcp-gateway' && currentPaymentMethod !== 'ppcp-credit-card-gateway') {
             this.renderer.hideButtons(this.gateway.button.wrapper);
@@ -93,8 +92,7 @@ class CheckoutBootstap {
     }
 
     displayPlaceOrderButtonForSavedCreditCards() {
-        const currentPaymentMethod = jQuery(
-          'input[name="payment_method"]:checked').val();
+        const currentPaymentMethod = this.currentPaymentMethod();
         if (currentPaymentMethod !== 'ppcp-credit-card-gateway') {
             return;
         }
@@ -138,6 +136,10 @@ class CheckoutBootstap {
         jQuery('#ppcp-credit-card-vault').removeClass('ppcp-credit-card-gateway-form-field-disabled')
         jQuery('#ppcp-credit-card-vault').attr("disabled", false)
         this.renderer.enableCreditCardFields()
+    }
+
+    currentPaymentMethod() {
+        return jQuery('input[name="payment_method"]:checked').val();
     }
 }
 

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -12,8 +12,13 @@ class CheckoutBootstap {
     }
 
     init() {
-
         this.render();
+
+        // Unselect saved card.
+        // WC saves form values, so with our current UI it would be a bit weird
+        // if the user paid with saved, then after some time tries to pay again,
+        // but wants to enter a new card, and to do that they have to choose “Select payment” in the list.
+        jQuery('#saved-credit-card').val(jQuery('#saved-credit-card option:first').val());
 
         jQuery(document.body).on('updated_checkout', () => {
             this.render()
@@ -65,8 +70,6 @@ class CheckoutBootstap {
     }
 
     switchBetweenPayPalandOrderButton() {
-        jQuery('#saved-credit-card').val(jQuery('#saved-credit-card option:first').val());
-
         const currentPaymentMethod = this.currentPaymentMethod();
 
         if (currentPaymentMethod !== 'ppcp-gateway' && currentPaymentMethod !== 'ppcp-credit-card-gateway') {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -7,6 +7,8 @@ class CheckoutBootstap {
         this.renderer = renderer;
         this.messages = messages;
         this.spinner = spinner;
+
+        this.standardOrderButtonSelector = '#place_order';
     }
 
     init() {
@@ -72,10 +74,10 @@ class CheckoutBootstap {
             this.renderer.hideButtons(this.gateway.button.wrapper);
             this.renderer.hideButtons(this.gateway.messages.wrapper);
             this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
-            jQuery('#place_order').show();
+            jQuery(this.standardOrderButtonSelector).show();
         }
         else {
-            jQuery('#place_order').hide();
+            jQuery(this.standardOrderButtonSelector).hide();
             if (currentPaymentMethod === 'ppcp-gateway') {
                 this.renderer.showButtons(this.gateway.button.wrapper);
                 this.renderer.showButtons(this.gateway.messages.wrapper);
@@ -101,10 +103,10 @@ class CheckoutBootstap {
             this.renderer.hideButtons(this.gateway.button.wrapper)
             this.renderer.hideButtons(this.gateway.messages.wrapper)
             this.renderer.hideButtons(this.gateway.hosted_fields.wrapper)
-            jQuery('#place_order').show()
+            jQuery(this.standardOrderButtonSelector).show()
             this.disableCreditCardFields()
         } else {
-            jQuery('#place_order').hide()
+            jQuery(this.standardOrderButtonSelector).hide()
             this.renderer.hideButtons(this.gateway.button.wrapper)
             this.renderer.hideButtons(this.gateway.messages.wrapper)
             this.renderer.showButtons(this.gateway.hosted_fields.wrapper)

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -97,7 +97,7 @@ class CheckoutBootstap {
             return;
         }
 
-        if (jQuery('#saved-credit-card').length && jQuery('#saved-credit-card').val() !== '') {
+        if (this.isSavedCardSelected()) {
             this.renderer.hideButtons(this.gateway.button.wrapper)
             this.renderer.hideButtons(this.gateway.messages.wrapper)
             this.renderer.hideButtons(this.gateway.hosted_fields.wrapper)
@@ -140,6 +140,11 @@ class CheckoutBootstap {
 
     currentPaymentMethod() {
         return jQuery('input[name="payment_method"]:checked').val();
+    }
+
+    isSavedCardSelected() {
+        const savedCardList = jQuery('#saved-credit-card');
+        return savedCardList.length && savedCardList.val() !== '';
     }
 }
 

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/PayNowBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/PayNowBootstrap.js
@@ -1,86 +1,17 @@
-import ErrorHandler from '../ErrorHandler';
-import CheckoutActionHandler from '../ActionHandler/CheckoutActionHandler';
+import CheckoutBootstap from './CheckoutBootstap'
 
-class PayNowBootstrap {
+class PayNowBootstrap extends CheckoutBootstap {
     constructor(gateway, renderer, messages, spinner) {
-        this.gateway = gateway;
-        this.renderer = renderer;
-        this.messages = messages;
-        this.spinner = spinner;
+        super(gateway, renderer, messages, spinner)
     }
 
-    init() {
-
-        this.render();
-
-        jQuery(document.body).on('updated_checkout', () => {
-            this.render();
-        });
-
-        jQuery(document.body).
-        on('updated_checkout payment_method_selected', () => {
-            this.switchBetweenPayPalandOrderButton();
-        });
-        this.switchBetweenPayPalandOrderButton();
-    }
-
-    shouldRender() {
-        if (document.querySelector(this.gateway.button.cancel_wrapper)) {
-            return false;
-        }
-
-        return document.querySelector(this.gateway.button.wrapper) !== null || document.querySelector(this.gateway.hosted_fields.wrapper) !== null;
-    }
-
-    render() {
-        if (!this.shouldRender()) {
-            return;
-        }
-        if (document.querySelector(this.gateway.hosted_fields.wrapper + '>div')) {
-            document.querySelector(this.gateway.hosted_fields.wrapper + '>div').setAttribute('style', '');
-        }
-        const actionHandler = new CheckoutActionHandler(
-            PayPalCommerceGateway,
-            new ErrorHandler(this.gateway.labels.error.generic),
-            this.spinner
-        );
-
-        this.renderer.render(
-            this.gateway.button.wrapper,
-            this.gateway.hosted_fields.wrapper,
-            actionHandler.configuration(),
-        );
-    }
-
-    switchBetweenPayPalandOrderButton() {
+    updateUi() {
         const urlParams = new URLSearchParams(window.location.search)
         if (urlParams.has('change_payment_method')) {
             return
         }
 
-        const currentPaymentMethod = jQuery(
-            'input[name="payment_method"]:checked').val();
-
-        if (currentPaymentMethod !== 'ppcp-gateway' && currentPaymentMethod !== 'ppcp-credit-card-gateway') {
-            this.renderer.hideButtons(this.gateway.button.wrapper);
-            this.renderer.hideButtons(this.gateway.messages.wrapper);
-            this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
-            jQuery('#place_order').show();
-        }
-        else {
-            jQuery('#place_order').hide();
-            if (currentPaymentMethod === 'ppcp-gateway') {
-                this.renderer.showButtons(this.gateway.button.wrapper);
-                this.renderer.showButtons(this.gateway.messages.wrapper);
-                this.messages.render();
-                this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
-            }
-            if (currentPaymentMethod === 'ppcp-credit-card-gateway') {
-                this.renderer.hideButtons(this.gateway.button.wrapper);
-                this.renderer.hideButtons(this.gateway.messages.wrapper);
-                this.renderer.showButtons(this.gateway.hosted_fields.wrapper);
-            }
-        }
+        super.updateUi();
     }
 }
 

--- a/modules/ppcp-button/resources/js/modules/Helper/Hiding.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/Hiding.js
@@ -1,0 +1,44 @@
+const getElement = (selectorOrElement) => {
+    if (typeof selectorOrElement === 'string') {
+        return document.querySelector(selectorOrElement);
+    }
+    return selectorOrElement;
+}
+
+export const isVisible = (element) => {
+    return !!(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+}
+
+export const setVisible = (selectorOrElement, show, important = false) => {
+    const element = getElement(selectorOrElement);
+    if (!element) {
+        return;
+    }
+
+    const currentValue = element.style.getPropertyValue('display');
+
+    if (!show) {
+        if (currentValue === 'none') {
+            return;
+        }
+
+        element.style.setProperty('display', 'none', important ? 'important' : '');
+    } else {
+        if (currentValue === 'none') {
+            element.style.removeProperty('display');
+        }
+
+        // still not visible (if something else added display: none in CSS)
+        if (!isVisible(element)) {
+            element.style.setProperty('display', 'block');
+        }
+    }
+};
+
+export const hide = (selectorOrElement, important = false) => {
+    setVisible(selectorOrElement, false, important);
+};
+
+export const show = (selectorOrElement) => {
+    setVisible(selectorOrElement, true);
+};

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -560,7 +560,7 @@ class SmartButton implements SmartButtonInterface {
 
 		printf(
 			'<div id="%1$s" style="display:none;">
-                        <button class="button alt">%2$s</button>
+                        <button class="button alt ppcp-dcc-order-button">%2$s</button>
                     </div><div id="payments-sdk__contingency-lightbox"></div><style id="ppcp-hide-dcc">.payment_method_ppcp-credit-card-gateway {display:none;}</style>',
 			esc_attr( $id ),
 			esc_html( $label )

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -58,8 +58,8 @@ trait ProcessPaymentTrait {
 		 * If customer has chosen a saved credit card payment.
 		 */
 		$saved_credit_card = filter_input( INPUT_POST, 'saved_credit_card', FILTER_SANITIZE_STRING );
-		$pay_for_order     = filter_input( INPUT_GET, 'pay_for_order', FILTER_SANITIZE_STRING );
-		if ( $saved_credit_card && ! isset( $pay_for_order ) ) {
+		$change_payment    = filter_input( INPUT_GET, 'woocommerce_change_payment', FILTER_SANITIZE_STRING );
+		if ( $saved_credit_card && ! isset( $change_payment ) ) {
 
 			$user_id  = (int) $wc_order->get_customer_id();
 			$customer = new \WC_Customer( $user_id );


### PR DESCRIPTION
Fixes #362 and #360

I added a `MutationObserver` to listen for the button `style` changes and update its' visibility.

This should make the button hiding more reliable, and fixes the issue with the old PayPal Checkout plugin (which was updating visibility on `click` instead of `change` + with some delay caused by animation) and Conditional Checkout Fields plugin (which was loading some data via ajax before hiding).

Also I did some refactoring there to remove unneeded changes like hidden -> show() -> hide() during some updates when using saved cards, and to make the code more clear.

For themes like Sabino and FreeStore the issue was that they were setting `display: inline-block !important` in CSS files, so to override this via `style` I re-implemented hiding using `setProperty` with `important` parameter instead of jQuery. Also there was a problem that our button appears on the left side, while the standard button is on the right side. It happens because [WC applies this style to `#place_order`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/assets/css/woocommerce-layout.scss#L450-L452). Adding `float: right` fixes it and hopefully will not break anything. 

For some themes (Twenty Twenty, ...) there is also a problem that they use `width: 100%` for `#place_order`, and our button without it remains small. Not sure if we can do anything about it, maybe looking into `getComputedStyle` of the button could help.

For #360 I inherited `PayNowBootstrap` from `CheckoutBootstap` because they are almost the same. And also changed the check during the payment processing to skip when changing subscription payment method but not when paying for normal orders.