### PR TITLE
Use order ID instead of "number" for PayPal custom field

### DIFF
--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -119,9 +119,8 @@ class PurchaseUnitFactory {
 		$reference_id    = 'default';
 		$description     = '';
 		$payee           = $this->payee_repository->payee();
-		$wc_order_id     = $order->get_order_number();
-		$custom_id       = $this->prefix . $wc_order_id;
-		$invoice_id      = $this->prefix . $wc_order_id;
+		$custom_id       = $this->prefix . (string) $order->get_id();
+		$invoice_id      = $this->prefix . $order->get_order_number();
 		$soft_descriptor = '';
 		$purchase_unit   = new PurchaseUnit(
 			$amount,

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -119,7 +119,7 @@ class PurchaseUnitFactory {
 		$reference_id    = 'default';
 		$description     = '';
 		$payee           = $this->payee_repository->payee();
-		$custom_id       = $this->prefix . (string) $order->get_id();
+		$custom_id       = (string) $order->get_id();
 		$invoice_id      = $this->prefix . $order->get_order_number();
 		$soft_descriptor = '';
 		$purchase_unit   = new PurchaseUnit(

--- a/modules/ppcp-webhooks/src/Handler/PrefixTrait.php
+++ b/modules/ppcp-webhooks/src/Handler/PrefixTrait.php
@@ -31,7 +31,10 @@ trait PrefixTrait {
 	 */
 	private function sanitize_custom_id( string $custom_id ): int {
 
-		$id = str_replace( $this->prefix, '', $custom_id );
+		$id = $custom_id;
+		if ( strlen( $this->prefix ) > 0 && 0 === strpos( $id, $this->prefix ) ) {
+			$id = substr( $id, strlen( $this->prefix ) );
+		}
 		return (int) $id;
 	}
 }

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -18,13 +18,14 @@ use function Brain\Monkey\Functions\expect;
 
 class PurchaseUnitFactoryTest extends TestCase
 {
+	private $wcOrderId = 1;
+	private $wcOrderNumber = '100000';
 
     public function testWcOrderDefault()
     {
-        $wcOrderId = 1;
         $wcOrder = Mockery::mock(\WC_Order::class);
-        $wcOrder
-            ->expects('get_order_number')->andReturn($wcOrderId);
+        $wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
+        $wcOrder->expects('get_id')->andReturn($this->wcOrderId);
         $amount = Mockery::mock(Amount::class);
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amountFactory
@@ -76,9 +77,9 @@ class PurchaseUnitFactoryTest extends TestCase
         $this->assertEquals($payee, $unit->payee());
         $this->assertEquals('', $unit->description());
         $this->assertEquals('default', $unit->reference_id());
-        $this->assertEquals('WC-' . $wcOrderId, $unit->custom_id());
+        $this->assertEquals('WC-' . $this->wcOrderId, $unit->custom_id());
         $this->assertEquals('', $unit->soft_descriptor());
-        $this->assertEquals('WC-' . $wcOrderId, $unit->invoice_id());
+        $this->assertEquals('WC-' . $this->wcOrderNumber, $unit->invoice_id());
         $this->assertEquals([$item], $unit->items());
         $this->assertEquals($amount, $unit->amount());
         $this->assertEquals($shipping, $unit->shipping());
@@ -87,8 +88,8 @@ class PurchaseUnitFactoryTest extends TestCase
     public function testWcOrderShippingGetsDroppedWhenNoPostalCode()
     {
         $wcOrder = Mockery::mock(\WC_Order::class);
-        $wcOrder
-            ->expects('get_order_number')->andReturn(1);
+        $wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
+        $wcOrder->expects('get_id')->andReturn($this->wcOrderId);
         $amount = Mockery::mock(Amount::class);
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amountFactory
@@ -142,8 +143,8 @@ class PurchaseUnitFactoryTest extends TestCase
     public function testWcOrderShippingGetsDroppedWhenNoCountryCode()
     {
         $wcOrder = Mockery::mock(\WC_Order::class);
-        $wcOrder
-            ->expects('get_order_number')->andReturn(1);
+        $wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
+        $wcOrder->expects('get_id')->andReturn($this->wcOrderId);
         $amount = Mockery::mock(Amount::class);
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amountFactory

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -77,7 +77,7 @@ class PurchaseUnitFactoryTest extends TestCase
         $this->assertEquals($payee, $unit->payee());
         $this->assertEquals('', $unit->description());
         $this->assertEquals('default', $unit->reference_id());
-        $this->assertEquals('WC-' . $this->wcOrderId, $unit->custom_id());
+        $this->assertEquals($this->wcOrderId, $unit->custom_id());
         $this->assertEquals('', $unit->soft_descriptor());
         $this->assertEquals('WC-' . $this->wcOrderNumber, $unit->invoice_id());
         $this->assertEquals([$item], $unit->items());


### PR DESCRIPTION
Fixes #354 

There are 2 fields: invoice ID and custom. It seems like we can just put the real ID into the second one.

![image](https://user-images.githubusercontent.com/5680466/141964838-89b17558-c59f-4228-9f55-6a799e510297.png)
