### PR TITLE
Use subtotal_tax instead of adding taxes ourselves

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -64,7 +64,7 @@ class AmountFactory {
 		);
 
 		$taxes = new Money(
-			(float) $cart->get_cart_contents_tax() + (float) $cart->get_discount_tax(),
+			$cart->get_subtotal_tax(),
 			$currency
 		);
 

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -43,6 +43,9 @@ class AmountFactoryTest extends TestCase
         $cart
             ->shouldReceive('get_discount_tax')
             ->andReturn(7);
+        $cart
+            ->shouldReceive('get_subtotal_tax')
+            ->andReturn(8);
 
         expect('get_woocommerce_currency')->andReturn($expectedCurrency);
 
@@ -61,7 +64,7 @@ class AmountFactoryTest extends TestCase
         $this->assertEquals($expectedCurrency, $result->breakdown()->shipping()->currency_code());
         $this->assertEquals((float) 5, $result->breakdown()->item_total()->value());
         $this->assertEquals($expectedCurrency, $result->breakdown()->item_total()->currency_code());
-        $this->assertEquals((float) 13, $result->breakdown()->tax_total()->value());
+        $this->assertEquals((float) 8, $result->breakdown()->tax_total()->value());
         $this->assertEquals($expectedCurrency, $result->breakdown()->tax_total()->currency_code());
     }
 
@@ -95,6 +98,9 @@ class AmountFactoryTest extends TestCase
         $cart
             ->shouldReceive('get_discount_tax')
             ->andReturn(0);
+		$cart
+			->shouldReceive('get_subtotal_tax')
+			->andReturn(11);
 
         expect('get_woocommerce_currency')->andReturn($expectedCurrency);
 


### PR DESCRIPTION
Fixes #372 

It seems like when we add product and discount taxes ourselves, we get 5.16 + 1.375 = rounded to 6.54 (maybe we need to round differently? Like down instead of up)

`get_subtotal_tax` returns 6.53, not sure if it fixes the issue completely, but I guess using it is more correct anyway than calculating ourselves.

I also checked when shipping tax is present, looks like it is not included in `get_subtotal_tax`, so the same as it was before.

---

I tried looking into [the WC code about cart taxes/totals](https://github.com/woocommerce/woocommerce/blob/a50b9860fe075fce5e67f27438645651586831fd/plugins/woocommerce/includes/class-wc-cart-totals.php#L767) to figure out if we are doing something wrong in general, but not found anything useful so far. [For rounding](https://github.com/woocommerce/woocommerce/blob/a50b9860fe075fce5e67f27438645651586831fd/plugins/woocommerce/includes/traits/trait-wc-item-totals.php#L61) they seem to use the `up` mode too.