### PR TITLE
Remove extra slash in the assets URL

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -396,7 +396,7 @@ class SmartButton implements SmartButtonInterface {
 		if ( in_array( $this->context(), array( 'pay-now', 'checkout' ), true ) && $this->can_render_dcc() ) {
 			wp_enqueue_style(
 				'ppcp-hosted-fields',
-				$this->module_url . '/assets/css/hosted-fields.css',
+				$this->module_url . 'assets/css/hosted-fields.css',
 				array(),
 				1
 			);
@@ -404,7 +404,7 @@ class SmartButton implements SmartButtonInterface {
 		if ( $load_script ) {
 			wp_enqueue_script(
 				'ppcp-smart-button',
-				$this->module_url . '/assets/js/button.js',
+				$this->module_url . 'assets/js/button.js',
 				array( 'jquery' ),
 				'1.3.2',
 				true


### PR DESCRIPTION
**Issue**: #189 

---

### Description
Remove the slash at the beginning of the strings appended to the plugin's URL. The URL already has a trailing slash so the one at the beginning of the appended string would only make it double.

### Steps to test:

1. Go to WooCommerce -> Settings -> Payments and enable PayPal and PayPal Card Processing
2. Go to the store, add some product to the card, and go to the checkout page
3. Open the inspector and search `assets/css/hosted-fields`
4. Confirm that the href property has a single slash before `assets`
5. Now search `assets/js/button`
6. Confirm that the href property has a single slash before `assets`

### Documentation
- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog entry
> Fix the assets URL containing double slashes.

Closes #189 
