### PR TITLE
Add invoice prefix input validation

### DIFF
--- a/modules/ppcp-onboarding/assets/css/onboarding.css
+++ b/modules/ppcp-onboarding/assets/css/onboarding.css
@@ -88,3 +88,7 @@
 .woocommerce_page_wc-settings h3.ppcp-subheading {
 	font-size: 1.1em;
 }
+
+.input-text[pattern]:invalid {
+	border: red solid 2px;
+}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -741,6 +741,7 @@ return array(
 				'type'         => 'text',
 				'desc_tip'     => true,
 				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please do not use numbers in your prefix.', 'woocommerce-paypal-payments' ),
+				'maxlength'    => 15,
 				'default'      => ( static function (): string {
 					$site_url = get_site_url( get_current_blog_id() );
 					$hash = md5( $site_url );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -737,23 +737,26 @@ return array(
 				'gateway'      => 'paypal',
 			),
 			'prefix'                         => array(
-				'title'        => __( 'Invoice prefix', 'woocommerce-paypal-payments' ),
-				'type'         => 'text',
-				'desc_tip'     => true,
-				'description'  => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please do not use numbers in your prefix.', 'woocommerce-paypal-payments' ),
-				'maxlength'    => 15,
-				'default'      => ( static function (): string {
+				'title'             => __( 'Invoice prefix', 'woocommerce-paypal-payments' ),
+				'type'              => 'text',
+				'desc_tip'          => true,
+				'description'       => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please use only English letters and "-", "_" characters.', 'woocommerce-paypal-payments' ),
+				'maxlength'         => 15,
+				'custom_attributes' => array(
+					'pattern' => '[a-zA-Z_-]+',
+				),
+				'default'           => ( static function (): string {
 					$site_url = get_site_url( get_current_blog_id() );
 					$hash = md5( $site_url );
 					$letters = preg_replace( '~\d~', '', $hash );
 					return substr( $letters, 0, 6 ) . '-';
 				} )(),
-				'screens'      => array(
+				'screens'           => array(
 					State::STATE_PROGRESSIVE,
 					State::STATE_ONBOARDED,
 				),
-				'requirements' => array(),
-				'gateway'      => 'paypal',
+				'requirements'      => array(),
+				'gateway'           => 'paypal',
 			),
 
 			// General button styles.


### PR DESCRIPTION
Fixes #390

Limited max length to 15 and added `pattern` attribute with regex to allow only latin letters and `-`, `_`.

When contains not allowed characters, the red border appears:

![image](https://user-images.githubusercontent.com/5680466/144849613-360d3adc-405b-4cfb-ad6c-070a3abd7942.png)

There are some issues such as that when saving via the button and the prefix is invalid, the page will scroll to it, but not enough, and it will be hidden under the page header.

![image](https://user-images.githubusercontent.com/5680466/144850573-89ebd342-9b1b-4d3c-8ace-a55496fa618c.png)

But during input the red border appears immediately, so it should be good enough for this admin setting.

At first I was thinking to simply delete/replace the not allowed characters during saving on the server side, but it could result in confusion and bad prefixes (not unique across the merchant instances), because the merchant would not notice it after saving + afaik currently there is no good way to show a noticeable error message after saving, and we do not validate anything else like this.
