### PR TITLE
Fix payment method change detection

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -58,7 +58,7 @@ trait ProcessPaymentTrait {
 		 * If customer has chosen a saved credit card payment.
 		 */
 		$saved_credit_card = filter_input( INPUT_POST, 'saved_credit_card', FILTER_SANITIZE_STRING );
-		$change_payment    = filter_input( INPUT_GET, 'woocommerce_change_payment', FILTER_SANITIZE_STRING );
+		$change_payment    = filter_input( INPUT_POST, 'woocommerce_change_payment', FILTER_SANITIZE_STRING );
 		if ( $saved_credit_card && ! isset( $change_payment ) ) {
 
 			$user_id  = (int) $wc_order->get_customer_id();


### PR DESCRIPTION
was broken after https://github.com/woocommerce/woocommerce-paypal-payments/pull/361/commits/1f8b449e38722fafc180ab1bf2076a8e89a02d70

Not sure why I didn't catch it during testing of that PR, but it seems like the problem is that this field is in body, not URL.