### PR TITLE
Fix payer name properties access

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -196,7 +196,7 @@ class CreditCardRenderer {
             }
 
             if (this.defaultConfig.payer) {
-                hostedFieldsData.cardholderName = this.defaultConfig.payer.given_name + ' ' + this.defaultConfig.payer.surname;
+                hostedFieldsData.cardholderName = this.defaultConfig.payer.name.given_name + ' ' + this.defaultConfig.payer.name.surname;
             }
             if (!hostedFieldsData.cardholderName) {
                 const firstName = document.getElementById('billing_first_name') ? document.getElementById('billing_first_name').value : '';


### PR DESCRIPTION
Fixes #395

The name properties are inside `name` object, not `payer`.