### PR TITLE
Show "Venmo" instead of "PayPal" when using its' button

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -14,7 +14,10 @@ const bootstrap = () => {
     const errorHandler = new ErrorHandler(PayPalCommerceGateway.labels.error.generic);
     const spinner = new Spinner();
     const creditCardRenderer = new CreditCardRenderer(PayPalCommerceGateway, errorHandler, spinner);
-    const renderer = new Renderer(creditCardRenderer, PayPalCommerceGateway);
+    const onSmartButtonClick = data => {
+        window.ppcpFundingSource = data.fundingSource;
+    };
+    const renderer = new Renderer(creditCardRenderer, PayPalCommerceGateway, onSmartButtonClick);
     const messageRenderer = new MessageRenderer(PayPalCommerceGateway.messages);
     const context = PayPalCommerceGateway.context;
     if (context === 'mini-cart' || context === 'product') {

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
@@ -4,7 +4,8 @@ const onApprove = (context, errorHandler) => {
             method: 'POST',
             body: JSON.stringify({
                 nonce: context.config.ajax.approve_order.nonce,
-                order_id:data.orderID
+                order_id:data.orderID,
+                funding_source: window.ppcpFundingSource,
             })
         }).then((res)=>{
             return res.json();
@@ -13,7 +14,7 @@ const onApprove = (context, errorHandler) => {
                 errorHandler.genericError();
                 return actions.restart().catch(err => {
                     errorHandler.genericError();
-                });;
+                });
             }
             location.href = context.config.redirect;
         });

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
@@ -5,7 +5,8 @@ const onApprove = (context, errorHandler, spinner) => {
             method: 'POST',
             body: JSON.stringify({
                 nonce: context.config.ajax.approve_order.nonce,
-                order_id:data.orderID
+                order_id:data.orderID,
+                funding_source: window.ppcpFundingSource,
             })
         }).then((res)=>{
             return res.json();

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -1,7 +1,8 @@
 class Renderer {
-    constructor(creditCardRenderer, defaultConfig) {
+    constructor(creditCardRenderer, defaultConfig, onSmartButtonClick) {
         this.defaultConfig = defaultConfig;
         this.creditCardRenderer = creditCardRenderer;
+        this.onSmartButtonClick = onSmartButtonClick;
     }
 
     render(wrapper, hostedFieldsWrapper, contextConfig) {
@@ -19,6 +20,7 @@ class Renderer {
         paypal.Buttons({
             style,
             ...contextConfig,
+            onClick: this.onSmartButtonClick,
         }).render(wrapper);
     }
 

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -184,6 +184,9 @@ class ApproveOrderEndpoint implements EndpointInterface {
 				throw new RuntimeException( $message );
 			}
 
+			$funding_source = $data['funding_source'] ?? null;
+			$this->session_handler->replace_funding_source( $funding_source );
+
 			$this->session_handler->replace_order( $order );
 			wp_send_json_success( $order );
 			return true;

--- a/modules/ppcp-session/services.php
+++ b/modules/ppcp-session/services.php
@@ -28,7 +28,10 @@ return array(
 		return $session_handler;
 	},
 	'session.cancellation.view'       => function ( ContainerInterface $container ) : CancelView {
-		return new CancelView();
+		return new CancelView(
+			$container->get( 'wcgateway.settings' ),
+			$container->get( 'wcgateway.funding-source.renderer' )
+		);
 	},
 	'session.cancellation.controller' => function ( ContainerInterface $container ) : CancelController {
 		return new CancelController(

--- a/modules/ppcp-session/src/Cancellation/CancelController.php
+++ b/modules/ppcp-session/src/Cancellation/CancelController.php
@@ -67,7 +67,7 @@ class CancelController {
 		add_action(
 			'woocommerce_review_order_after_submit',
 			function () use ( $url ) {
-				$this->view->render_session_cancellation( $url );
+				$this->view->render_session_cancellation( $url, $this->session_handler->funding_source() );
 			}
 		);
 	}

--- a/modules/ppcp-session/src/Cancellation/CancelView.php
+++ b/modules/ppcp-session/src/Cancellation/CancelView.php
@@ -9,31 +9,66 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Session\Cancellation;
 
+use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
+
 /**
  * Class CancelView
  */
 class CancelView {
+	/**
+	 * The settings.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $settings;
+
+	/**
+	 * The funding source renderer.
+	 *
+	 * @var FundingSourceRenderer
+	 */
+	protected $funding_source_renderer;
+
+	/**
+	 * CancelView constructor.
+	 *
+	 * @param ContainerInterface    $settings The settings.
+	 * @param FundingSourceRenderer $funding_source_renderer The funding source renderer.
+	 */
+	public function __construct(
+		ContainerInterface $settings,
+		FundingSourceRenderer $funding_source_renderer
+	) {
+		$this->settings                = $settings;
+		$this->funding_source_renderer = $funding_source_renderer;
+	}
 
 	/**
 	 * Renders the cancel link.
 	 *
-	 * @param string $url The URL.
+	 * @param string      $url The URL.
+	 * @param string|null $funding_source The ID of the funding source, such as 'venmo'.
 	 */
-	public function render_session_cancellation( string $url ) {
+	public function render_session_cancellation( string $url, ?string $funding_source ) {
 		?>
 		<p id="ppcp-cancel"
 			class="has-text-align-center ppcp-cancel"
 		>
 			<?php
+			$name = $funding_source ?
+				$this->funding_source_renderer->render_name( $funding_source )
+				: ( $this->settings->has( 'title' ) ? $this->settings->get( 'title' ) : __( 'PayPal', 'woocommerce-paypal-payments' ) );
 			printf(
-					// translators: the placeholders are html tags for a link.
+					// translators: %3$ is funding source like "PayPal" or "Venmo", other placeholders are html tags for a link.
 				esc_html__(
-					'You are currently paying with PayPal. If you want to cancel
+					'You are currently paying with %3$s. If you want to cancel
                             this process, please click %1$shere%2$s.',
 					'woocommerce-paypal-payments'
 				),
 				'<a href="' . esc_url( $url ) . '">',
-				'</a>'
+				'</a>',
+				esc_html( $name )
 			);
 			?>
 		</p>

--- a/modules/ppcp-session/src/SessionHandler.php
+++ b/modules/ppcp-session/src/SessionHandler.php
@@ -41,6 +41,13 @@ class SessionHandler {
 	private $insufficient_funding_tries = 0;
 
 	/**
+	 * The funding source of the current checkout (venmo, ...) or null.
+	 *
+	 * @var string|null
+	 */
+	private $funding_source = null;
+
+	/**
 	 * Returns the order.
 	 *
 	 * @return Order|null
@@ -85,6 +92,28 @@ class SessionHandler {
 	}
 
 	/**
+	 * Returns the funding source of the current checkout (venmo, ...) or null.
+	 *
+	 * @return string|null
+	 */
+	public function funding_source(): ?string {
+		return $this->funding_source;
+	}
+
+	/**
+	 * Replaces the funding source of the current checkout.
+	 *
+	 * @param string|null $funding_source The funding source.
+	 *
+	 * @return SessionHandler
+	 */
+	public function replace_funding_source( ?string $funding_source ): SessionHandler {
+		$this->funding_source = $funding_source;
+		$this->store_session();
+		return $this;
+	}
+
+	/**
 	 * Returns how many times the customer tried to use the PayPal Gateway in this session.
 	 *
 	 * @return int
@@ -113,6 +142,7 @@ class SessionHandler {
 		$this->order                      = null;
 		$this->bn_code                    = '';
 		$this->insufficient_funding_tries = 0;
+		$this->funding_source             = null;
 		$this->store_session();
 		return $this;
 	}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -24,6 +24,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Admin\RenderAuthorizeAction;
 use WooCommerce\PayPalCommerce\WcGateway\Checkout\CheckoutPayPalAddressPreset;
 use WooCommerce\PayPalCommerce\WcGateway\Checkout\DisableGateways;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
+use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
@@ -45,6 +46,7 @@ return array(
 	'wcgateway.paypal-gateway'                     => static function ( ContainerInterface $container ): PayPalGateway {
 		$order_processor     = $container->get( 'wcgateway.order-processor' );
 		$settings_renderer   = $container->get( 'wcgateway.settings.render' );
+		$funding_source_renderer   = $container->get( 'wcgateway.funding-source.renderer' );
 		$authorized_payments = $container->get( 'wcgateway.processor.authorized-payments' );
 		$settings            = $container->get( 'wcgateway.settings' );
 		$session_handler     = $container->get( 'session.handler' );
@@ -60,6 +62,7 @@ return array(
 		$logger              = $container->get( 'woocommerce.logger.woocommerce' );
 		return new PayPalGateway(
 			$settings_renderer,
+			$funding_source_renderer,
 			$order_processor,
 			$authorized_payments,
 			$settings,
@@ -2028,6 +2031,12 @@ return array(
 	'button.helper.messages-disclaimers'           => static function ( ContainerInterface $container ): MessagesDisclaimers {
 		return new MessagesDisclaimers(
 			$container->get( 'api.shop.country' )
+		);
+	},
+
+	'wcgateway.funding-source.renderer'            => function ( ContainerInterface $container ) : FundingSourceRenderer {
+		return new FundingSourceRenderer(
+			$container->get( 'wcgateway.settings' )
 		);
 	},
 );

--- a/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
+++ b/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Renders info about funding sources like Venmo.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\FundingSource
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\FundingSource;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Class FundingSourceRenderer
+ */
+class FundingSourceRenderer {
+	/**
+	 * The settings.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $settings;
+
+	/**
+	 * FundingSourceRenderer constructor.
+	 *
+	 * @param ContainerInterface $settings The settings.
+	 */
+	public function __construct( ContainerInterface $settings ) {
+		$this->settings = $settings;
+	}
+
+	/**
+	 * Returns name of the funding source (suitable for displaying to user).
+	 *
+	 * @param string $id The ID of the funding source, such as 'venmo'.
+	 */
+	public function render_name( string $id ): string {
+		if ( 'venmo' === $id ) {
+			return __( 'Venmo', 'woocommerce-paypal-payments' );
+		}
+		return $this->settings->has( 'title' ) ?
+			$this->settings->get( 'title' )
+			: __( 'PayPal', 'woocommerce-paypal-payments' );
+	}
+
+	/**
+	 * Returns description of the funding source (for checkout).
+	 *
+	 * @param string $id The ID of the funding source, such as 'venmo'.
+	 */
+	public function render_description( string $id ): string {
+		if ( 'venmo' === $id ) {
+			return __( 'Pay via Venmo.', 'woocommerce-paypal-payments' );
+		}
+		return $this->settings->has( 'description' ) ?
+			$this->settings->get( 'description' )
+			: __( 'Pay via PayPal.', 'woocommerce-paypal-payments' );
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -350,8 +350,15 @@ class PayPalGateway extends \WC_Payment_Gateway {
 			);
 		}
 
+		if ( is_admin() ) {
+			return __(
+				'Accept PayPal, Pay Later and alternative payment types.',
+				'woocommerce-paypal-payments'
+			);
+		}
+
 		return __(
-			'Accept PayPal, Pay Later and alternative payment types.',
+			'Pay via PayPal.',
 			'woocommerce-paypal-payments'
 		);
 	}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
+use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
@@ -43,6 +44,13 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @var SettingsRenderer
 	 */
 	protected $settings_renderer;
+
+	/**
+	 * The funding source renderer.
+	 *
+	 * @var FundingSourceRenderer
+	 */
+	protected $funding_source_renderer;
 
 	/**
 	 * The processor for orders.
@@ -153,6 +161,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * PayPalGateway constructor.
 	 *
 	 * @param SettingsRenderer            $settings_renderer The Settings Renderer.
+	 * @param FundingSourceRenderer       $funding_source_renderer The funding source renderer.
 	 * @param OrderProcessor              $order_processor The Order Processor.
 	 * @param AuthorizedPaymentsProcessor $authorized_payments_processor The Authorized Payments Processor.
 	 * @param ContainerInterface          $config The settings.
@@ -170,6 +179,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 */
 	public function __construct(
 		SettingsRenderer $settings_renderer,
+		FundingSourceRenderer $funding_source_renderer,
 		OrderProcessor $order_processor,
 		AuthorizedPaymentsProcessor $authorized_payments_processor,
 		ContainerInterface $config,
@@ -190,6 +200,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->order_processor               = $order_processor;
 		$this->authorized_payments_processor = $authorized_payments_processor;
 		$this->settings_renderer             = $settings_renderer;
+		$this->funding_source_renderer       = $funding_source_renderer;
 		$this->config                        = $config;
 		$this->session_handler               = $session_handler;
 		$this->refund_processor              = $refund_processor;
@@ -242,9 +253,9 @@ class PayPalGateway extends \WC_Payment_Gateway {
 			$this->config->get( 'description' ) : $this->method_description;
 
 		$funding_source = $this->session_handler->funding_source();
-		if ( 'venmo' === $funding_source ) {
-			$this->title       = 'Venmo';
-			$this->description = __( 'Pay via Venmo.', 'woocommerce-paypal-payments' );
+		if ( $funding_source ) {
+			$this->title       = $this->funding_source_renderer->render_name( $funding_source );
+			$this->description = $this->funding_source_renderer->render_description( $funding_source );
 		}
 
 		$this->init_form_fields();

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -241,6 +241,12 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->description        = $this->config->has( 'description' ) ?
 			$this->config->get( 'description' ) : $this->method_description;
 
+		$funding_source = $this->session_handler->funding_source();
+		if ( 'venmo' === $funding_source ) {
+			$this->title       = 'Venmo';
+			$this->description = __( 'Pay via Venmo.', 'woocommerce-paypal-payments' );
+		}
+
 		$this->init_form_fields();
 		$this->init_settings();
 

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -28,75 +28,104 @@ use function Brain\Monkey\Functions\when;
 
 class WcGatewayTest extends TestCase
 {
+	private $isAdmin = false;
+	private $sessionHandler;
+	private $fundingSource = null;
+
+	private $settingsRenderer;
+	private $orderProcessor;
+	private $authorizedOrdersProcessor;
+	private $settings;
+	private $refundProcessor;
+	private $onboardingState;
+	private $transactionUrlProvider;
+	private $subscriptionHelper;
 	private $environment;
+	private $paymentTokenRepository;
+	private $logger;
+	private $paymentsEndpoint;
+	private $orderEndpoint;
 
 	public function setUp(): void {
 		parent::setUp();
 
+		expect('is_admin')->andReturnUsing(function () {
+			return $this->isAdmin;
+		});
+
+		$this->settingsRenderer = Mockery::mock(SettingsRenderer::class);
+		$this->orderProcessor = Mockery::mock(OrderProcessor::class);
+		$this->authorizedOrdersProcessor = Mockery::mock(AuthorizedPaymentsProcessor::class);
+		$this->settings = Mockery::mock(Settings::class);
+		$this->sessionHandler = Mockery::mock(SessionHandler::class);
+		$this->refundProcessor = Mockery::mock(RefundProcessor::class);
+		$this->onboardingState = Mockery::mock(State::class);
+		$this->transactionUrlProvider = Mockery::mock(TransactionUrlProvider::class);
+		$this->subscriptionHelper = Mockery::mock(SubscriptionHelper::class);
 		$this->environment = Mockery::mock(Environment::class);
+		$this->paymentTokenRepository = Mockery::mock(PaymentTokenRepository::class);
+		$this->logger = Mockery::mock(LoggerInterface::class);
+		$this->paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
+		$this->orderEndpoint = Mockery::mock(OrderEndpoint::class);
+
+		$this->onboardingState->shouldReceive('current_state')->andReturn(State::STATE_ONBOARDED);
+
+		$this->sessionHandler
+			->shouldReceive('funding_source')
+			->andReturnUsing(function () {
+				return $this->fundingSource;
+			});
+
+		$this->settings->shouldReceive('has')->andReturnFalse();
+
+		$this->logger->shouldReceive('info');
+	}
+
+	private function createGateway()
+	{
+		return new PayPalGateway(
+			$this->settingsRenderer,
+			$this->orderProcessor,
+			$this->authorizedOrdersProcessor,
+			$this->settings,
+			$this->sessionHandler,
+			$this->refundProcessor,
+			$this->onboardingState,
+			$this->transactionUrlProvider,
+			$this->subscriptionHelper,
+			PayPalGateway::ID,
+			$this->environment,
+			$this->paymentTokenRepository,
+			$this->logger,
+			$this->paymentsEndpoint,
+			$this->orderEndpoint
+		);
 	}
 
 	public function testProcessPaymentSuccess() {
-	    expect('is_admin')->andReturn(false);
-
         $orderId = 1;
         $wcOrder = Mockery::mock(\WC_Order::class);
 		$wcOrder->shouldReceive('get_customer_id')->andReturn(1);
 		$wcOrder->shouldReceive('get_meta')->andReturn('');
-        $settingsRenderer = Mockery::mock(SettingsRenderer::class);
-        $orderProcessor = Mockery::mock(OrderProcessor::class);
-        $orderProcessor
+		$this->orderProcessor
             ->expects('process')
             ->andReturnUsing(
                 function(\WC_Order $order) use ($wcOrder) : bool {
                     return $order === $wcOrder;
                 }
             );
-        $authorizedPaymentsProcessor = Mockery::mock(AuthorizedPaymentsProcessor::class);
-        $settings = Mockery::mock(Settings::class);
-        $sessionHandler = Mockery::mock(SessionHandler::class);
-        $sessionHandler
+		$this->sessionHandler
 	        ->shouldReceive('destroy_session_data');
-        $settings
-            ->shouldReceive('has')->andReturnFalse();
-        $refundProcessor = Mockery::mock(RefundProcessor::class);
-        $transactionUrlProvider = Mockery::mock(TransactionUrlProvider::class);
-        $state = Mockery::mock(State::class);
-        $state
-	        ->shouldReceive('current_state')->andReturn(State::STATE_ONBOARDED);
-        $subscriptionHelper = Mockery::mock(SubscriptionHelper::class);
-        $subscriptionHelper
+		$this->subscriptionHelper
             ->shouldReceive('has_subscription')
             ->with($orderId)
             ->andReturn(true)
 			->andReturn(false);
-        $subscriptionHelper
+		$this->subscriptionHelper
             ->shouldReceive('is_subscription_change_payment')
             ->andReturn(true);
 
-        $paymentTokenRepository = Mockery::mock(PaymentTokenRepository::class);
-        $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('info');
-        $paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
-        $orderEndpoint = Mockery::mock(OrderEndpoint::class);
-
-        $testee = new PayPalGateway(
-            $settingsRenderer,
-            $orderProcessor,
-            $authorizedPaymentsProcessor,
-            $settings,
-            $sessionHandler,
-	        $refundProcessor,
-	        $state,
-            $transactionUrlProvider,
-            $subscriptionHelper,
-			PayPalGateway::ID,
-			$this->environment,
-			$paymentTokenRepository,
-			$logger,
-			$paymentsEndpoint,
-			$orderEndpoint
-		);
+        $testee = $this->createGateway();
 
         expect('wc_get_order')
             ->with($orderId)
@@ -121,45 +150,9 @@ class WcGatewayTest extends TestCase
     }
 
     public function testProcessPaymentOrderNotFound() {
-	    expect('is_admin')->andReturn(false);
-
         $orderId = 1;
-        $settingsRenderer = Mockery::mock(SettingsRenderer::class);
-        $orderProcessor = Mockery::mock(OrderProcessor::class);
-        $authorizedPaymentsProcessor = Mockery::mock(AuthorizedPaymentsProcessor::class);
-        $settings = Mockery::mock(Settings::class);
-        $settings
-            ->shouldReceive('has')->andReturnFalse();
-        $sessionHandler = Mockery::mock(SessionHandler::class);
-	    $refundProcessor = Mockery::mock(RefundProcessor::class);
-	    $state = Mockery::mock(State::class);
-        $transactionUrlProvider = Mockery::mock(TransactionUrlProvider::class);
-	    $state
-		    ->shouldReceive('current_state')->andReturn(State::STATE_ONBOARDED);
-        $subscriptionHelper = Mockery::mock(SubscriptionHelper::class);
 
-		$paymentTokenRepository = Mockery::mock(PaymentTokenRepository::class);
-		$logger = Mockery::mock(LoggerInterface::class);
-		$paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
-		$orderEndpoint = Mockery::mock(OrderEndpoint::class);
-
-	    $testee = new PayPalGateway(
-            $settingsRenderer,
-            $orderProcessor,
-            $authorizedPaymentsProcessor,
-            $settings,
-            $sessionHandler,
-	        $refundProcessor,
-	        $state,
-            $transactionUrlProvider,
-            $subscriptionHelper,
-			PayPalGateway::ID,
-			$this->environment,
-			$paymentTokenRepository,
-			$logger,
-			$paymentsEndpoint,
-			$orderEndpoint
-        );
+	    $testee = $this->createGateway();
 
         expect('wc_get_order')
             ->with($orderId)
@@ -184,56 +177,20 @@ class WcGatewayTest extends TestCase
 
 
     public function testProcessPaymentFails() {
-    	expect('is_admin')->andReturn(false);
-
         $orderId = 1;
         $wcOrder = Mockery::mock(\WC_Order::class);
         $lastError = 'some-error';
-        $settingsRenderer = Mockery::mock(SettingsRenderer::class);
-        $orderProcessor = Mockery::mock(OrderProcessor::class);
-        $orderProcessor
+		$this->orderProcessor
             ->expects('process')
             ->andReturnFalse();
-        $orderProcessor
+		$this->orderProcessor
             ->expects('last_error')
             ->andReturn($lastError);
-        $authorizedPaymentsProcessor = Mockery::mock(AuthorizedPaymentsProcessor::class);
-        $settings = Mockery::mock(Settings::class);
-        $settings
-            ->shouldReceive('has')->andReturnFalse();
-        $sessionHandler = Mockery::mock(SessionHandler::class);
-	    $refundProcessor = Mockery::mock(RefundProcessor::class);
-	    $state = Mockery::mock(State::class);
-        $transactionUrlProvider = Mockery::mock(TransactionUrlProvider::class);
-	    $state
-		    ->shouldReceive('current_state')->andReturn(State::STATE_ONBOARDED);
-        $subscriptionHelper = Mockery::mock(SubscriptionHelper::class);
-        $subscriptionHelper->shouldReceive('has_subscription')->with($orderId)->andReturn(true);
-        $subscriptionHelper->shouldReceive('is_subscription_change_payment')->andReturn(true);
+		$this->subscriptionHelper->shouldReceive('has_subscription')->with($orderId)->andReturn(true);
+		$this->subscriptionHelper->shouldReceive('is_subscription_change_payment')->andReturn(true);
         $wcOrder->shouldReceive('update_status')->andReturn(true);
 
-		$paymentTokenRepository = Mockery::mock(PaymentTokenRepository::class);
-		$logger = Mockery::mock(LoggerInterface::class);
-		$paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
-		$orderEndpoint = Mockery::mock(OrderEndpoint::class);
-
-        $testee = new PayPalGateway(
-            $settingsRenderer,
-            $orderProcessor,
-            $authorizedPaymentsProcessor,
-            $settings,
-            $sessionHandler,
-	        $refundProcessor,
-	        $state,
-            $transactionUrlProvider,
-            $subscriptionHelper,
-			PayPalGateway::ID,
-			$this->environment,
-			$paymentTokenRepository,
-			$logger,
-			$paymentsEndpoint,
-			$orderEndpoint
-        );
+        $testee = $this->createGateway();
 
         expect('wc_get_order')
             ->with($orderId)
@@ -261,47 +218,29 @@ class WcGatewayTest extends TestCase
      */
     public function testNeedsSetup($currentState, $needSetup)
     {
-    	expect('is_admin')->andReturn(true);
-    	$settingsRenderer = Mockery::mock(SettingsRenderer::class);
-    	$orderProcessor = Mockery::mock(OrderProcessor::class);
-    	$authorizedOrdersProcessor = Mockery::mock(AuthorizedPaymentsProcessor::class);
-    	$config = Mockery::mock(ContainerInterface::class);
-    	$config
-		    ->shouldReceive('has')
-		    ->andReturn(false);
-    	$sessionHandler = Mockery::mock(SessionHandler::class);
-    	$refundProcessor = Mockery::mock(RefundProcessor::class);
-    	$onboardingState = Mockery::mock(State::class);
-    	$onboardingState
+		$this->isAdmin = true;
+
+		$this->onboardingState = Mockery::mock(State::class);
+		$this->onboardingState
 		    ->expects('current_state')
 		    ->andReturn($currentState);
-    	$transactionUrlProvider = Mockery::mock(TransactionUrlProvider::class);
-    	$subscriptionHelper = Mockery::mock(SubscriptionHelper::class);
 
-		$paymentTokenRepository = Mockery::mock(PaymentTokenRepository::class);
-		$logger = Mockery::mock(LoggerInterface::class);
-		$paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
-		$orderEndpoint = Mockery::mock(OrderEndpoint::class);
-
-    	$testee = new PayPalGateway(
-    		$settingsRenderer,
-		    $orderProcessor,
-		    $authorizedOrdersProcessor,
-		    $config,
-		    $sessionHandler,
-		    $refundProcessor,
-		    $onboardingState,
-		    $transactionUrlProvider,
-		    $subscriptionHelper,
-			PayPalGateway::ID,
-			$this->environment,
-			$paymentTokenRepository,
-			$logger,
-			$paymentsEndpoint,
-			$orderEndpoint
-	    );
+    	$testee = $this->createGateway();
 
     	$this->assertSame($needSetup, $testee->needs_setup());
+    }
+
+    /**
+     * @dataProvider dataForFundingSource
+     */
+    public function testFundingSource($fundingSource, $title, $description)
+    {
+		$this->fundingSource = $fundingSource;
+
+    	$testee = $this->createGateway();
+
+		self::assertEquals($title, $testee->title);
+		self::assertEquals($description, $testee->description);
     }
 
     public function dataForTestCaptureAuthorizedPaymentNoActionableFailures() : array
@@ -328,6 +267,15 @@ class WcGatewayTest extends TestCase
     		[State::STATE_START, true],
 		    [State::STATE_PROGRESSIVE, true],
 		    [State::STATE_ONBOARDED, false]
+	    ];
+    }
+
+    public function dataForFundingSource(): array
+    {
+    	return [
+    		[null, 'PayPal', 'Pay via PayPal.'],
+    		['venmo', 'Venmo', 'Pay via Venmo.'],
+    		['qwerty', 'PayPal', 'Pay via PayPal.'],
 	    ];
     }
 }

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
+use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\AuthorizeOrderActionNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
@@ -33,6 +34,7 @@ class WcGatewayTest extends TestCase
 	private $fundingSource = null;
 
 	private $settingsRenderer;
+	private $funding_source_renderer;
 	private $orderProcessor;
 	private $authorizedOrdersProcessor;
 	private $settings;
@@ -67,6 +69,7 @@ class WcGatewayTest extends TestCase
 		$this->logger = Mockery::mock(LoggerInterface::class);
 		$this->paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
 		$this->orderEndpoint = Mockery::mock(OrderEndpoint::class);
+		$this->funding_source_renderer = new FundingSourceRenderer($this->settings);
 
 		$this->onboardingState->shouldReceive('current_state')->andReturn(State::STATE_ONBOARDED);
 
@@ -85,6 +88,7 @@ class WcGatewayTest extends TestCase
 	{
 		return new PayPalGateway(
 			$this->settingsRenderer,
+			$this->funding_source_renderer,
 			$this->orderProcessor,
 			$this->authorizedOrdersProcessor,
 			$this->settings,


### PR DESCRIPTION
Fixes #394 

When the button clicked, the funding source is saved to `window.ppcpFundingSource` global variable (I think there are no other easy ways to make it available in the approve handlers), and then it is added to the approve endpoint parameters, and saved to the WC session. When this property is set to `venmo`, the gateway changes the title and description, and the cancellation view ("You are currently paying with ...") is updated too. 

Changing the gateway title during checkout also affects the receipt after checkout and in My Account --> Orders, because it is saved to the order.