### PR TITLE
Use payment_complete instead of updating status directly

### DIFF
--- a/modules/ppcp-webhooks/src/Handler/CheckoutOrderCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/CheckoutOrderCompleted.php
@@ -134,15 +134,7 @@ class CheckoutOrderCompleted implements RequestHandler {
 			if ( ! in_array( $wc_order->get_status(), array( 'pending', 'on-hold' ), true ) ) {
 				continue;
 			}
-			/**
-			 * The WooCommerce order.
-			 *
-			 * @var \WC_Order $wc_order
-			 */
-			$wc_order->update_status(
-				'processing',
-				__( 'Payment received.', 'woocommerce-paypal-payments' )
-			);
+			$wc_order->payment_complete();
 			$this->logger->log(
 				'info',
 				sprintf(


### PR DESCRIPTION
Fixes #399

I am not sure if these webhook handlers work correctly overall, maybe some further fixes and refactoring are needed, e.g. reusing `PaymentsStatusHandlingTrait`, but for now fixing just the missing action.