### PR TITLE
Do not remove html for plugin settings text inputs

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -372,14 +372,11 @@ class SettingsListener {
 				case 'text':
 				case 'number':
 				case 'ppcp-text-input':
-				case 'ppcp-password':
 					$settings[ $key ] = isset( $raw_data[ $key ] ) ? wp_kses_post( $raw_data[ $key ] ) : '';
 					break;
+				case 'ppcp-password':
 				case 'password':
-					if ( empty( $raw_data[ $key ] ) ) {
-						break;
-					}
-					$settings[ $key ] = sanitize_text_field( $raw_data[ $key ] );
+					$settings[ $key ] = $raw_data[ $key ] ?? '';
 					break;
 				case 'ppcp-multiselect':
 					$values         = isset( $raw_data[ $key ] ) ? (array) $raw_data[ $key ] : array();

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -373,7 +373,7 @@ class SettingsListener {
 				case 'number':
 				case 'ppcp-text-input':
 				case 'ppcp-password':
-					$settings[ $key ] = isset( $raw_data[ $key ] ) ? sanitize_text_field( $raw_data[ $key ] ) : '';
+					$settings[ $key ] = isset( $raw_data[ $key ] ) ? wp_kses_post( $raw_data[ $key ] ) : '';
 					break;
 				case 'password':
 					if ( empty( $raw_data[ $key ] ) ) {


### PR DESCRIPTION
Fixes #407 

Replaced `sanitize_text_field` with `wp_kses_post`. These fields are edited only by admins, so it should be ok.

Also removed sanitization for password fields.