### PR TITLE
Allow WC Shop Managers to edit settings

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -448,7 +448,7 @@ class SettingsListener {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return false;
 		}
 		return true;


### PR DESCRIPTION
Fixes #278

https://woocommerce.com/document/roles-capabilities/