### PR TITLE
Release 1.6.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 *** Changelog ***
 
+= 1.6.4 - TBD =
+* Fix - Non admin user cannot save changes to the plugin settings #278
+* Fix - Empty space in invoice prefix causes smart buttons to not load #390
+* Fix - woocommerce_payment_complete action not triggered for payments completed via webhook #399
+* Fix - Paying with Venmo - Change funding source on checkout page and receipt to Venmo  #394
+* Fix - Internal server error on checkout when selected saved card but then switched to paypal #403 
+* Enhancement - Allow formatted text for the Description field #407
+* Enhancement - Remove filter to prevent On-Hold emails #411
+
 = 1.6.3 - 2021-12-14 =
 * Fix - Payments fail when using custom order numbers #354
 * Fix - Do not display saved payments on PayPal buttons if vault option is disabled #358

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.6.3
+Stable tag: 1.6.4
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,15 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.6.4 =
+* Fix - Non admin user cannot save changes to the plugin settings #278
+* Fix - Empty space in invoice prefix causes smart buttons to not load #390
+* Fix - woocommerce_payment_complete action not triggered for payments completed via webhook #399
+* Fix - Paying with Venmo - Change funding source on checkout page and receipt to Venmo  #394
+* Fix - Internal server error on checkout when selected saved card but then switched to paypal #403 
+* Enhancement - Allow formatted text for the Description field #407
+* Enhancement - Remove filter to prevent On-Hold emails #411
 
 = 1.6.3 =
 * Fix - Payments fail when using custom order numbers #354

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,13 +3,13 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.6.3
+ * Version:     1.6.4
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 5.9
+ * WC tested up to: 6.0
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce


### PR DESCRIPTION
* Fix - Non admin user cannot save changes to the plugin settings #278
* Fix - Empty space in invoice prefix causes smart buttons to not load #390
* Fix - woocommerce_payment_complete action not triggered for payments completed via webhook #399
* Fix - Paying with Venmo - Change funding source on checkout page and receipt to Venmo  #394
* Fix - Internal server error on checkout when selected saved card but then switched to paypal #403 
* Enhancement - Allow formatted text for the Description field #407
* Enhancement - Remove filter to prevent On-Hold emails #411