### PR TITLE
Add docker:build-package command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ follow these steps:
 ```
 $ yarn run build
 ```
+or if using the Docker setup:
+
+```
+$ yarn run docker:build-package
+```
 
 ## Setup
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "docker:test": "docker-compose run --rm test vendor/bin/phpunit",
     "docker:lint": "docker-compose run --rm test sh -c 'vendor/bin/phpcs --parallel=8 -s && vendor/bin/psalm --show-info=false --threads=8 --diff'",
     "docker:fix-lint": "docker-compose run --rm test vendor/bin/phpcbf",
+    "docker:build-package": "docker-compose run --rm build yarn run build",
 
 
     "prebuild": "rm -rf ./vendor && find . -name 'node_modules' -type d -maxdepth 3 -exec rm -rf {} +",


### PR DESCRIPTION
This allows to build a package using the docker env, which should be more consistent and allows to easily use the needed PHP version (e.g. the min supported) instead of the system PHP.