### PR TITLE
Release 1.6.5

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,19 @@
 *** Changelog ***
 
+= 1.6.5 - TBD =
+* Fix - Allow guest users to purchase subscription products #422
+* Fix - Transaction ID missing for renewal order #424
+* Fix - Save your credit card checkbox should be removed in pay for order for subscriptions #420
+* Fix - Null currency error when the Aelia currency switcher plugin is active #426
+* Fix - Hide Reference Transactions check from logs #428
+* Fix - Doubled plugin module URL path causing failure #438
+* Fix - is_ajax deprecated #441
+* Fix - Place order button from PayPal Card Processing does not get translated #290
+* Fix - AMEX missing from supported cards for DCC Australia #432
+* Fix - "Save your Credit Card" text not clickable to change checkbox state #430
+* Fix - Improve DCC error notice when not available #435
+* Enhancement - Add View Logs link #416
+
 = 1.6.4 - 2021-12-27 =
 * Fix - Non admin user cannot save changes to the plugin settings #278
 * Fix - Empty space in invoice prefix causes smart buttons to not load #390

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.8
 Requires PHP: 7.1
-Stable tag: 1.6.4
+Stable tag: 1.6.5
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,20 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.6.5 =
+* Fix - Allow guest users to purchase subscription products #422
+* Fix - Transaction ID missing for renewal order #424
+* Fix - Save your credit card checkbox should be removed in pay for order for subscriptions #420
+* Fix - Null currency error when the Aelia currency switcher plugin is active #426
+* Fix - Hide Reference Transactions check from logs #428
+* Fix - Doubled plugin module URL path causing failure #438
+* Fix - is_ajax deprecated #441
+* Fix - Place order button from PayPal Card Processing does not get translated #290
+* Fix - AMEX missing from supported cards for DCC Australia #432
+* Fix - "Save your Credit Card" text not clickable to change checkbox state #430
+* Fix - Improve DCC error notice when not available #435
+* Enhancement - Add View Logs link #416
 
 = 1.6.4 =
 * Fix - Non admin user cannot save changes to the plugin settings #278

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,13 +3,13 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.6.4
+ * Version:     1.6.5
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 6.0
+ * WC tested up to: 6.1
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce


### PR DESCRIPTION
* Fix - Allow guest users to purchase subscription products from checkout page #422
* Fix - Transaction ID missing for renewal order #424
* Fix - Save your credit card checkbox should be removed in pay for order for subscriptions #420
* Fix - Null currency error when the Aelia currency switcher plugin is active #426
* Fix - Hide Reference Transactions check from logs #428
* Fix - Doubled plugin module URL path causing failure #438
* Fix - is_ajax deprecated #441
* Fix - Place order button from PayPal Card Processing does not get translated #290
* Fix - AMEX missing from supported cards for DCC Australia #432
* Fix - "Save your Credit Card" text not clickable to change checkbox state #430
* Fix - Improve DCC error notice when not available #435
* Enhancement - Add View Logs link #416