### PR TITLE
Credit Card not displayed when Vaulting setting is disabled

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -647,7 +647,7 @@ class SmartButton implements SmartButtonInterface {
 		$localize = array(
 			'script_attributes'              => $this->attributes(),
 			'data_client_id'                 => array(
-				'set_attribute'     => $this->can_save_vault_token(),
+				'set_attribute'     => ( is_checkout() && $this->dcc_is_enabled() ) || $this->can_save_vault_token(),
 				'endpoint'          => home_url( \WC_AJAX::get_endpoint( DataClientIdEndpoint::ENDPOINT ) ),
 				'nonce'             => wp_create_nonce( DataClientIdEndpoint::nonce() ),
 				'user'              => get_current_user_id(),


### PR DESCRIPTION
During 1.6.5 pre-release testing we found that Credit Card gateway was not displayed when Vaulting setting is disabled. This PR reverts back the functionality as it was before.