### PR TITLE
Create missing address keys when needed so that PayPal won't fail on fresh accounts

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -750,7 +750,45 @@ class SmartButton implements SmartButtonInterface {
 		if ( ! is_user_logged_in() || ! ( $customer instanceof \WC_Customer ) ) {
 			return null;
 		}
-		return $this->payer_factory->from_customer( $customer )->to_array();
+		
+		$payer_data = $this->payer_factory->from_customer( $customer )->to_array();
+		
+		if (array_key_exists('address', $payer_data) === false)
+		{
+			$payer_data['address'] = [];
+		}
+		
+		if (array_key_exists('country_code', $payer_data['address']) === false)
+		{
+			$payer_data['address']['country_code'] = '';
+		}
+		
+		if (array_key_exists('address_line_1', $payer_data['address']) === false)
+		{
+			$payer_data['address']['address_line_1'] = '';
+		}
+		
+		if (array_key_exists('address_line_2', $payer_data['address']) === false)
+		{
+			$payer_data['address']['address_line_2'] = '';
+		}
+		
+		if (array_key_exists('admin_area_1', $payer_data['address']) === false)
+		{
+			$payer_data['address']['admin_area_1'] = '';
+		}
+		
+		if (array_key_exists('admin_area_2', $payer_data['address']) === false)
+		{
+			$payer_data['address']['admin_area_2'] = '';
+		}
+		
+		if (array_key_exists('postal_code', $payer_data['address']) === false)
+		{
+			$payer_data['address']['postal_code'] = '';
+		}
+		
+		return $payer_data;
 	}
 
 	/**


### PR DESCRIPTION
In a situation where certain address fields (state, billing_address_1, billing_address_2, billing_city, billing_postcode) had been unset via the woocommerce_checkout_fields hook and the customer's account had not yet attempted to make a purchase, their payer data was missing a crucial array key (address) and their first attempt to make a purchase with PayPal would fail with a "payer.address is undefined" in the console and a generic error ("Something went wrong.") at the top of the checkout page. Subsequent attempts would produce the same error until the checkout page was refreshed, at which point the error would no longer occur.

This change ensures that the address key and its subkeys will default to blank values if they don't exist.

Fixes #454