### PR TITLE
Update release date for 1.6.5

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 1.6.5 - TBD =
+= 1.6.5 - 2022-01-22 =
 * Fix - Allow guest users to purchase subscription products #422
 * Fix - Transaction ID missing for renewal order #424
 * Fix - Save your credit card checkbox should be removed in pay for order for subscriptions #420


### PR DESCRIPTION
Update the release date for 1.6.5. 

The rest of the details required for the release were updated in https://github.com/woocommerce/woocommerce-paypal-payments/pull/444