### PR TITLE
Update 3D Secure (521)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1914,12 +1914,12 @@ return array(
 				),
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => $container->get( 'api.shop.is-psd2-country' ) ? '3D_SECURE' : 'NO_3D_SECURE',
+				'default'      => $container->get( 'api.shop.is-psd2-country' ) ? 'SCA_ALWAYS' : 'NO_3D_SECURE',
 				'desc_tip'     => true,
 				'options'      => array(
 					'NO_3D_SECURE'      => __( 'No 3D Secure (transaction will be denied if 3D Secure is required)', 'woocommerce-paypal-payments' ),
 					'SCA_WHEN_REQUIRED' => __( '3D Secure when required', 'woocommerce-paypal-payments' ),
-					'3D_SECURE'         => __( 'Always trigger 3D Secure', 'woocommerce-paypal-payments' ),
+					'SCA_ALWAYS'         => __( 'Always trigger 3D Secure', 'woocommerce-paypal-payments' ),
 				),
 				'screens'      => array(
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1914,7 +1914,7 @@ return array(
 				),
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => $container->get( 'api.shop.is-psd2-country' ) ? 'SCA_ALWAYS' : 'NO_3D_SECURE',
+				'default'      => $container->get( 'api.shop.is-psd2-country' ) ? 'SCA_WHEN_REQUIRED' : 'NO_3D_SECURE',
 				'desc_tip'     => true,
 				'options'      => array(
 					'NO_3D_SECURE'      => __( 'No 3D Secure (transaction will be denied if 3D Secure is required)', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
Change the 3D SECURE contingency to SCA_ALWAYS

<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: The 3DS Contingency values have changed with introduction of 3DS v2.

**Ticket**:

**Slack Thread**:

---

### Description

Update 3D_SECURE contingency to SCA_ALWAYS


### Documentation

No documentation changes needed.

### Changelog Entry

Updates 3D Secure contingency,

Closes # .
