### PR TITLE
Ensure 3ds contingency uses `SCA_ALWAYS` instead of `3D_SECURE` (521)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -627,6 +627,10 @@ class SmartButton implements SmartButtonInterface {
 		if ( $this->settings->has( '3d_secure_contingency' ) ) {
 			$value = $this->settings->get( '3d_secure_contingency' );
 			if ( $value ) {
+				if ( '3D_SECURE' === $value ) {
+					$value = 'SCA_ALWAYS';
+				}
+
 				return $value;
 			}
 		}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -627,10 +627,6 @@ class SmartButton implements SmartButtonInterface {
 		if ( $this->settings->has( '3d_secure_contingency' ) ) {
 			$value = $this->settings->get( '3d_secure_contingency' );
 			if ( $value ) {
-				if ( '3D_SECURE' === $value ) {
-					$value = 'SCA_ALWAYS';
-				}
-
 				return $value;
 			}
 		}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1914,12 +1914,12 @@ return array(
 				),
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => $container->get( 'api.shop.is-psd2-country' ) ? '3D_SECURE' : 'NO_3D_SECURE',
+				'default'      => $container->get( 'api.shop.is-psd2-country' ) ? 'SCA_ALWAYS' : 'NO_3D_SECURE',
 				'desc_tip'     => true,
 				'options'      => array(
 					'NO_3D_SECURE'      => __( 'No 3D Secure (transaction will be denied if 3D Secure is required)', 'woocommerce-paypal-payments' ),
 					'SCA_WHEN_REQUIRED' => __( '3D Secure when required', 'woocommerce-paypal-payments' ),
-					'3D_SECURE'         => __( 'Always trigger 3D Secure', 'woocommerce-paypal-payments' ),
+					'SCA_ALWAYS'         => __( 'Always trigger 3D Secure', 'woocommerce-paypal-payments' ),
 				),
 				'screens'      => array(
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1914,7 +1914,7 @@ return array(
 				),
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => $container->get( 'api.shop.is-psd2-country' ) ? 'SCA_ALWAYS' : 'NO_3D_SECURE',
+				'default'      => $container->get( 'api.shop.is-psd2-country' ) ? 'SCA_WHEN_REQUIRED' : 'NO_3D_SECURE',
 				'desc_tip'     => true,
 				'options'      => array(
 					'NO_3D_SECURE'      => __( 'No 3D Secure (transaction will be denied if 3D Secure is required)', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -209,25 +209,6 @@ class SettingsListener {
 	}
 
 	/**
-	 * Ensure 3DS contingency use `SCA_ALWAYS` instead of `3D_SECURE`.
-	 *
-	 * @return void
-	 * @throws NotFoundException When a setting was not found.
-	 */
-	public function listen_for_3d_secure_contingency(): void {
-		if ( ! $this->is_valid_site_request() || $this->settings->get( '3d_secure_contingency' ) !== '3D_SECURE' ) {
-			return;
-		}
-
-		$this->settings->set( '3d_secure_contingency', 'SCA_ALWAYS' );
-		$this->settings->persist();
-
-		$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' );
-		wp_safe_redirect( $redirect_url, 302 );
-		exit;
-	}
-
-	/**
 	 * Listens to the request.
 	 *
 	 * @throws \WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException When a setting was not found.

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -211,9 +211,10 @@ class SettingsListener {
 	/**
 	 * Ensure 3DS contingency use `SCA_ALWAYS` instead of `3D_SECURE`.
 	 *
+	 * @return void
 	 * @throws NotFoundException When a setting was not found.
 	 */
-	public function listen_for_3d_secure_contingency() {
+	public function listen_for_3d_secure_contingency(): void {
 		if ( ! $this->is_valid_site_request() || $this->settings->get( '3d_secure_contingency' ) !== '3D_SECURE' ) {
 			return;
 		}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -137,6 +137,8 @@ class WCGatewayModule implements ModuleInterface {
 			'woocommerce_paypal_payments_gateway_migrate',
 			static function () use ( $c ) {
 				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
 				if ( $settings->get( '3d_secure_contingency' ) === '3D_SECURE' ) {
 					$settings->set( '3d_secure_contingency', 'SCA_ALWAYS' );
 					$settings->persist();

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -183,6 +183,7 @@ class WCGatewayModule implements ModuleInterface {
 				 */
 				$listener->listen_for_merchant_id();
 				$listener->listen_for_vaulting_enabled();
+				$listener->listen_for_3d_secure_contingency();
 			}
 		);
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -132,6 +132,17 @@ class WCGatewayModule implements ModuleInterface {
 				$endpoint->handle_request();
 			}
 		);
+
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			static function () use ( $c ) {
+				$settings = $c->get( 'wcgateway.settings' );
+				if ( $settings->get( '3d_secure_contingency' ) === '3D_SECURE' ) {
+					$settings->set( '3d_secure_contingency', 'SCA_ALWAYS' );
+					$settings->persist();
+				}
+			}
+		);
 	}
 
 	/**
@@ -183,7 +194,6 @@ class WCGatewayModule implements ModuleInterface {
 				 */
 				$listener->listen_for_merchant_id();
 				$listener->listen_for_vaulting_enabled();
-				$listener->listen_for_3d_secure_contingency();
 			}
 		);
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Assets\SettingsPageAssets;
 use WooCommerce\PayPalCommerce\WcGateway\Checkout\CheckoutPayPalAddressPreset;
 use WooCommerce\PayPalCommerce\WcGateway\Checkout\DisableGateways;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\ConnectAdminNotice;
@@ -139,9 +140,13 @@ class WCGatewayModule implements ModuleInterface {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
-				if ( $settings->get( '3d_secure_contingency' ) === '3D_SECURE' ) {
-					$settings->set( '3d_secure_contingency', 'SCA_ALWAYS' );
-					$settings->persist();
+				try {
+					if ( $settings->get( '3d_secure_contingency' ) === '3D_SECURE' ) {
+						$settings->set( '3d_secure_contingency', 'SCA_ALWAYS' );
+						$settings->persist();
+					}
+				} catch ( NotFoundException $exception ) {
+					return;
 				}
 			}
 		);


### PR DESCRIPTION
Add improvements to #463.

This PR ensures that `SCA_ALWAYS` is used instead of `3D_SECURE` stored in the database: https://github.com/woocommerce/woocommerce-paypal-payments/pull/463/files#diff-01a2758cc519d8adb065af0350c9459edb64a45576b4a2e527e8d2059c7889cbL1922-R1922

### Testing package
[PCP-521-woocommerce-paypal-payments.zip](https://github.com/woocommerce/woocommerce-paypal-payments/files/8001383/PCP-521-woocommerce-paypal-payments.zip)

### Acceptance criteria
1. For new plugin users on PSD2 countries ([see list here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-api-client/services.php#L586-L613)) default 3DS contingency should be `SCA_WHEN_REQUIRED`.
2. For existing plugin users with `3D_SECURE` option saved, `SCA_ALWAYS` option value should be automatically updated*

*Note that only the value is updated, the option label is still the same (Always trigger 3D Secure).
Also note that in order to trigger the update the plugin needs to be upgraded, the provided package contains a higher plugin version which needs to be uploaded and installed from Plugins admin screen (replace existing with the new one).