### PR TITLE
Change the onboarding message

### DIFF
--- a/modules/ppcp-wc-gateway/src/Notice/ConnectAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/ConnectAdminNotice.php
@@ -57,7 +57,7 @@ class ConnectAdminNotice {
 		$message = sprintf(
 			/* translators: %1$s the gateway name. */
 			__(
-				'PayPal Checkout is almost ready. To get started, <a href="%1$s">connect your account</a>.',
+				'PayPal Payments is almost ready. To get started, <a href="%1$s">connect your account</a>.',
 				'woocommerce-paypal-payments'
 			),
 			admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' )


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #465

---

### Description

Change the onboarding message from 

> PayPal Checkout is almost ready.

to

> PayPal Payments is almost ready.


### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Install the plugin
2. See the notice in dashboard.
