### PR TITLE
Add gateway fee metadata to WC order

### DIFF
--- a/modules/ppcp-api-client/src/Entity/Capture.php
+++ b/modules/ppcp-api-client/src/Entity/Capture.php
@@ -52,6 +52,13 @@ class Capture {
 	private $seller_protection;
 
 	/**
+	 * The detailed breakdown of the capture activity.
+	 *
+	 * @var \stdClass
+	 */
+	private $seller_receivable_breakdown;
+
+	/**
 	 * The invoice id.
 	 *
 	 * @var string
@@ -73,6 +80,7 @@ class Capture {
 	 * @param Amount        $amount The amount.
 	 * @param bool          $final_capture The final capture.
 	 * @param string        $seller_protection The seller protection.
+	 * @param \stdClass     $seller_receivable_breakdown The detailed breakdown of the capture activity.
 	 * @param string        $invoice_id The invoice id.
 	 * @param string        $custom_id The custom id.
 	 */
@@ -82,17 +90,19 @@ class Capture {
 		Amount $amount,
 		bool $final_capture,
 		string $seller_protection,
+		\stdClass $seller_receivable_breakdown,
 		string $invoice_id,
 		string $custom_id
 	) {
 
-		$this->id                = $id;
-		$this->status            = $status;
-		$this->amount            = $amount;
-		$this->final_capture     = $final_capture;
-		$this->seller_protection = $seller_protection;
-		$this->invoice_id        = $invoice_id;
-		$this->custom_id         = $custom_id;
+		$this->id                          = $id;
+		$this->status                      = $status;
+		$this->amount                      = $amount;
+		$this->final_capture               = $final_capture;
+		$this->seller_protection           = $seller_protection;
+		$this->seller_receivable_breakdown = $seller_receivable_breakdown;
+		$this->invoice_id                  = $invoice_id;
+		$this->custom_id                   = $custom_id;
 	}
 
 	/**
@@ -141,6 +151,15 @@ class Capture {
 	}
 
 	/**
+	 * Returns the seller receivable breakdown object.
+	 *
+	 * @return \stdClass
+	 */
+	public function seller_receivable_breakdown() : \stdClass {
+		return $this->seller_receivable_breakdown;
+	}
+
+	/**
 	 * Returns the invoice id.
 	 *
 	 * @return string
@@ -165,13 +184,14 @@ class Capture {
 	 */
 	public function to_array() : array {
 		$data    = array(
-			'id'                => $this->id(),
-			'status'            => $this->status()->name(),
-			'amount'            => $this->amount()->to_array(),
-			'final_capture'     => $this->final_capture(),
-			'seller_protection' => (array) $this->seller_protection(),
-			'invoice_id'        => $this->invoice_id(),
-			'custom_id'         => $this->custom_id(),
+			'id'                          => $this->id(),
+			'status'                      => $this->status()->name(),
+			'amount'                      => $this->amount()->to_array(),
+			'final_capture'               => $this->final_capture(),
+			'seller_protection'           => (array) $this->seller_protection(),
+			'seller_receivable_breakdown' => $this->seller_receivable_breakdown(),
+			'invoice_id'                  => $this->invoice_id(),
+			'custom_id'                   => $this->custom_id(),
 		);
 		$details = $this->status()->details();
 		if ( $details ) {

--- a/modules/ppcp-api-client/src/Factory/CaptureFactory.php
+++ b/modules/ppcp-api-client/src/Factory/CaptureFactory.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatusDetails;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 
 /**
  * Class CaptureFactory
@@ -46,6 +47,20 @@ class CaptureFactory {
 
 		$reason = $data->status_details->reason ?? null;
 
+		$seller_receivable_breakdown = new \stdClass();
+
+		$seller_receivable_breakdown->gross_amount = ( isset( $data->seller_receivable_breakdown->gross_amount ) ) ?
+			new Money( (float) $data->seller_receivable_breakdown->gross_amount->value, $data->seller_receivable_breakdown->gross_amount->currency_code )
+		: null;
+
+		$seller_receivable_breakdown->paypal_fee = ( isset( $data->seller_receivable_breakdown->paypal_fee ) ) ?
+			new Money( (float) $data->seller_receivable_breakdown->paypal_fee->value, $data->seller_receivable_breakdown->paypal_fee->currency_code )
+			: null;
+
+		$seller_receivable_breakdown->net_amount = ( isset( $data->seller_receivable_breakdown->net_amount ) ) ?
+			new Money( (float) $data->seller_receivable_breakdown->net_amount->value, $data->seller_receivable_breakdown->net_amount->currency_code )
+			: null;
+
 		return new Capture(
 			(string) $data->id,
 			new CaptureStatus(
@@ -55,6 +70,7 @@ class CaptureFactory {
 			$this->amount_factory->from_paypal_response( $data->amount ),
 			(bool) $data->final_capture,
 			(string) $data->seller_protection->status,
+			$seller_receivable_breakdown,
 			(string) $data->invoice_id,
 			(string) $data->custom_id
 		);

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -37,6 +37,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	const INTENT_META_KEY             = '_ppcp_paypal_intent';
 	const ORDER_ID_META_KEY           = '_ppcp_paypal_order_id';
 	const ORDER_PAYMENT_MODE_META_KEY = '_ppcp_paypal_payment_mode';
+	const FEE_META_KEY                = '_ppcp_paypal_fee';
 
 	/**
 	 * The Settings Renderer.

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -167,6 +167,8 @@ class OrderProcessor {
 
 		if ( $order->intent() === 'CAPTURE' ) {
 			$order = $this->order_endpoint->capture( $order );
+
+			$wc_order->update_meta_data( PayPalGateway::FEE_META_KEY, $order->purchase_units()[0]->payments()->captures()[0]->seller_receivable_breakdown()->paypal_fee->value() );
 		}
 
 		if ( $order->intent() === 'AUTHORIZE' ) {


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #467 

---

### Description

Adds seller receivable breakdown from PayPal API response to Capture object, so we can read the gateway fee and add it to the WC order metadata once the transaction is captured.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Complete a woocommerce order using PayPal payments
2. Verify the `_ppcp_paypal_fee` metadata is set correctly

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Closes #467. Add gateway fee metadata to WC order.
