### PR TITLE
Improve Disable Funding setting label and desc

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -671,15 +671,20 @@ return array(
 				'gateway'      => 'paypal',
 			),
 			'disable_funding'                => array(
-				'title'        => __( 'Disable funding sources', 'woocommerce-paypal-payments' ),
+				'title'        => __( 'Hide Funding Source(s)', 'woocommerce-paypal-payments' ),
 				'type'         => 'ppcp-multiselect',
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
 				'default'      => array(),
-				'desc_tip'     => true,
-				'description'  => __(
-					'By default all possible funding sources will be shown. You can disable some sources, if you wish.',
-					'woocommerce-paypal-payments'
+				'desc_tip'     => false,
+				'description'  => sprintf(
+					// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
+					__( 'By default, all possible funding sources will be shown. This setting can disable funding sources such as Credit Cards, Pay Later, Venmo, or other %1$sAlternative Payment Methods%2$s.', 'woocommerce-paypal-payments' ),
+					'<a
+						href="https://developer.paypal.com/docs/checkout/apm/"
+						target="_blank"
+					>',
+					'</a>'
 				),
 				'options'      => array(
 					'card'        => _x( 'Credit or debit cards', 'Name of payment method', 'woocommerce-paypal-payments' ),
@@ -1919,7 +1924,7 @@ return array(
 				'options'      => array(
 					'NO_3D_SECURE'      => __( 'No 3D Secure (transaction will be denied if 3D Secure is required)', 'woocommerce-paypal-payments' ),
 					'SCA_WHEN_REQUIRED' => __( '3D Secure when required', 'woocommerce-paypal-payments' ),
-					'SCA_ALWAYS'         => __( 'Always trigger 3D Secure', 'woocommerce-paypal-payments' ),
+					'SCA_ALWAYS'        => __( 'Always trigger 3D Secure', 'woocommerce-paypal-payments' ),
 				),
 				'screens'      => array(
 					State::STATE_ONBOARDED,


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #475 

---

### Description

Too many customers are asking how to disable [Alternative Payment Methods](https://developer.paypal.com/docs/checkout/integration-features/alternative-payment-methods/#availability) because they oversee the Disable funding sources setting.
In other PayPal integrations, this feature is usually called Hide Funding Source(s) instead. This makes it clear that the setting is too difficult to see/understand because of inconsistent working compacted to PayPal Checkout.

The PR will Improve the label for the "Disable Funds" setting to be

> Hide Funding Source(s)

And also will put more detailed description about this field right below the field

### Steps to Test

1. Install and activate the plugin.
2. Complete the onboarding.
3. In the settings find the one called "Disable funding sources"