### PR TITLE
Add Spain and Italy to messaging (565)

### DIFF
--- a/modules/ppcp-button/src/Helper/MessagesApply.php
+++ b/modules/ppcp-button/src/Helper/MessagesApply.php
@@ -26,6 +26,8 @@ class MessagesApply {
 		'GB',
 		'FR',
 		'AU',
+		'IT',
+		'ES',
 	);
 
 	/**

--- a/modules/ppcp-button/src/Helper/MessagesDisclaimers.php
+++ b/modules/ppcp-button/src/Helper/MessagesDisclaimers.php
@@ -23,19 +23,25 @@ class MessagesDisclaimers {
 	 */
 	private $disclaimers = array(
 		'US' => array(
-			'link' => 'https://developer.paypal.com/docs/commerce-platforms/admin-panel/woocommerce/us/',
+			'link' => 'https://developer.paypal.com/docs/checkout/pay-later/us/commerce-platforms/woocommerce/',
 		),
 		'GB' => array(
-			'link' => 'https://developer.paypal.com/docs/commerce-platforms/admin-panel/woocommerce/uk/',
+			'link' => 'https://developer.paypal.com/docs/checkout/pay-later/gb/commerce-platforms/woocommerce/',
 		),
 		'DE' => array(
-			'link' => 'https://developer.paypal.com/docs/commerce-platforms/admin-panel/woocommerce/de/',
+			'link' => 'https://developer.paypal.com/docs/checkout/pay-later/de/commerce-platforms/woocommerce/',
 		),
 		'AU' => array(
-			'link' => 'https://developer.paypal.com/docs/commerce-platforms/admin-panel/woocommerce/au/',
+			'link' => 'https://developer.paypal.com/docs/checkout/pay-later/au/commerce-platforms/woocommerce/',
 		),
 		'FR' => array(
-			'link' => 'https://developer.paypal.com/docs/commerce-platforms/admin-panel/woocommerce/fr/',
+			'link' => 'https://developer.paypal.com/docs/checkout/pay-later/fr/commerce-platforms/woocommerce/',
+		),
+		'IT' => array(
+			'link' => 'https://developer.paypal.com/docs/checkout/pay-later/it/commerce-platforms/woocommerce/',
+		),
+		'ES' => array(
+			'link' => 'https://developer.paypal.com/docs/checkout/pay-later/es/commerce-platforms/woocommerce/',
 		),
 	);
 


### PR DESCRIPTION
Messaging and buttons will be available in late March.

Description
Add Italy and Spain to Pay Later messaging list.

Steps to Test
Change store country to Spain or Italy.
Go to Settings
Verify Pay Later messaging options appear in admin.
Input a IT or ES client ID.
Set currency to EUR
Go to a page where messaging should be displayed.
Documentation
Any documentation pages that list geographic regions for Pay Later messaging will need to add Italy and Spain.

Changelog Entry
Added Pay Later messaging options for Italy and Spain.