### PR TITLE
Check if price total is not zero before showing buttons

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -9,21 +9,51 @@ class SingleProductBootstap {
         this.messages = messages;
     }
 
-    init() {
+
+    handleChange() {
         if (!this.shouldRender()) {
-           this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
+            this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
+            this.renderer.hideButtons(this.gateway.button.wrapper);
             return;
         }
 
         this.render();
     }
 
-    shouldRender() {
-        if (document.querySelector('form.cart') === null) {
-            return false;
+    init() {
+
+        document.querySelector('form.cart').addEventListener('change', this.handleChange.bind(this))
+
+        if (!this.shouldRender()) {
+            this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
+            return;
         }
 
-        return true;
+        this.render();
+
+    }
+
+    shouldRender() {
+
+        return document.querySelector('form.cart') !== null && !this.priceAmountIsZero();
+
+    }
+
+    priceAmountIsZero() {
+
+        let priceText = "0";
+        if (document.querySelector('form.cart ins .woocommerce-Price-amount')) {
+            priceText = document.querySelector('form.cart ins .woocommerce-Price-amount').innerText;
+        }
+        else if (document.querySelector('form.cart .woocommerce-Price-amount')) {
+            priceText = document.querySelector('form.cart .woocommerce-Price-amount').innerText;
+        }
+        else if (document.querySelector('.woocommerce-Price-amount')) {
+            priceText = document.querySelector('.woocommerce-Price-amount').innerText;
+        }
+        const amount = parseFloat(priceText.replace(/([^\d,\.\s]*)/g, ''));
+        return amount === 0;
+
     }
 
     render() {

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -331,7 +331,6 @@ class SmartButton implements SmartButtonInterface {
 		if (
 			( is_product() || wc_post_content_has_shortcode( 'product_page' ) )
 			&& ! $not_enabled_on_product_page
-			&& ! $this->is_product_price_total_zero()
 		) {
 			add_action(
 				$this->single_product_renderer_hook(),
@@ -1085,21 +1084,5 @@ class SmartButton implements SmartButtonInterface {
 	protected function is_cart_price_total_zero(): bool {
         // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
 		return WC()->cart->get_cart_contents_total() == 0;
-	}
-
-	/**
-	 * Check if current product price total is 0.
-	 *
-	 * @return bool true if is 0, otherwise false.
-	 */
-	protected function is_product_price_total_zero(): bool {
-		if ( ! is_product() ) {
-			return false;
-		}
-
-		$product = wc_get_product();
-
-        // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-		return $product && $product->get_price() == 0;
 	}
 }

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1081,8 +1081,8 @@ class SmartButton implements SmartButtonInterface {
 	 * @return bool true if is 0, otherwise false.
 	 */
 	protected function is_cart_price_total_zero(): bool {
-		$cart_total = WC()->cart->get_cart_contents_total();
-		return ! ( $cart_total > 0 );
+        // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+		return WC()->cart->get_cart_contents_total() == 0;
 	}
 
 	/**
@@ -1095,9 +1095,9 @@ class SmartButton implements SmartButtonInterface {
 			return false;
 		}
 
-		$product       = wc_get_product();
-		$product_price = $product ? $product->get_price() : 0;
+		$product = wc_get_product();
 
-		return ! ( (float) $product_price > 0 );
+        // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+		return $product && $product->get_price() == 0;
 	}
 }

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -326,23 +326,6 @@ class SmartButton implements SmartButtonInterface {
 	 */
 	private function render_button_wrapper_registrar(): bool {
 
-		$not_enabled_on_cart = $this->settings->has( 'button_cart_enabled' ) &&
-			! $this->settings->get( 'button_cart_enabled' );
-		if (
-			is_cart()
-			&& ! $not_enabled_on_cart
-			&& ! $this->is_cart_price_total_zero()
-		) {
-			add_action(
-				$this->proceed_to_checkout_button_renderer_hook(),
-				array(
-					$this,
-					'button_renderer',
-				),
-				20
-			);
-		}
-
 		$not_enabled_on_product_page = $this->settings->has( 'button_single_product_enabled' ) &&
 			! $this->settings->get( 'button_single_product_enabled' );
 		if (
@@ -360,11 +343,30 @@ class SmartButton implements SmartButtonInterface {
 			);
 		}
 
+		if ( $this->is_cart_price_total_zero() ) {
+			return false;
+		}
+
+		$not_enabled_on_cart = $this->settings->has( 'button_cart_enabled' ) &&
+			! $this->settings->get( 'button_cart_enabled' );
+		if (
+			is_cart()
+			&& ! $not_enabled_on_cart
+		) {
+			add_action(
+				$this->proceed_to_checkout_button_renderer_hook(),
+				array(
+					$this,
+					'button_renderer',
+				),
+				20
+			);
+		}
+
 		$not_enabled_on_minicart = $this->settings->has( 'button_mini_cart_enabled' ) &&
 			! $this->settings->get( 'button_mini_cart_enabled' );
 		if (
 			! $not_enabled_on_minicart
-			&& ! $this->is_cart_price_total_zero()
 		) {
 			add_action(
 				$this->mini_cart_button_renderer_hook(),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -331,6 +331,7 @@ class SmartButton implements SmartButtonInterface {
 		if (
 			is_cart()
 			&& ! $not_enabled_on_cart
+			&& ! $this->is_cart_price_total_zero()
 		) {
 			add_action(
 				$this->proceed_to_checkout_button_renderer_hook(),
@@ -347,6 +348,7 @@ class SmartButton implements SmartButtonInterface {
 		if (
 			( is_product() || wc_post_content_has_shortcode( 'product_page' ) )
 			&& ! $not_enabled_on_product_page
+			&& ! $this->is_product_price_total_zero()
 		) {
 			add_action(
 				$this->single_product_renderer_hook(),
@@ -362,6 +364,7 @@ class SmartButton implements SmartButtonInterface {
 			! $this->settings->get( 'button_mini_cart_enabled' );
 		if (
 			! $not_enabled_on_minicart
+			&& ! $this->is_cart_price_total_zero()
 		) {
 			add_action(
 				$this->mini_cart_button_renderer_hook(),
@@ -439,6 +442,7 @@ class SmartButton implements SmartButtonInterface {
 				|| ! $product->is_in_stock()
 			)
 		) {
+
 			return;
 		}
 
@@ -568,7 +572,7 @@ class SmartButton implements SmartButtonInterface {
 			return;
 		}
 
-		// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+        // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
 		$label = 'checkout' === $this->context() ? apply_filters( 'woocommerce_order_button_text', __( 'Place order', 'woocommerce' ) ) : __( 'Pay for order', 'woocommerce' );
 
 		printf(
@@ -1069,5 +1073,31 @@ class SmartButton implements SmartButtonInterface {
 	 */
 	private function single_product_renderer_hook(): string {
 		return (string) apply_filters( 'woocommerce_paypal_payments_single_product_renderer_hook', 'woocommerce_single_product_summary' );
+	}
+
+	/**
+	 * Check if cart product price total is 0.
+	 *
+	 * @return bool true if is 0, otherwise false.
+	 */
+	protected function is_cart_price_total_zero(): bool {
+		$cart_total = WC()->cart->get_cart_contents_total();
+		return ! ( $cart_total > 0 );
+	}
+
+	/**
+	 * Check if current product price total is 0.
+	 *
+	 * @return bool true if is 0, otherwise false.
+	 */
+	protected function is_product_price_total_zero(): bool {
+		if ( ! is_product() ) {
+			return false;
+		}
+
+		$product       = wc_get_product();
+		$product_price = $product ? $product->get_price() : 0;
+
+		return ! ( (float) $product_price > 0 );
 	}
 }


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #499

---

### Description

Paypal doesn't not support zero-sum payments(when they are $0) so the buttons should be hidden in the cart/checkout when user adds a **$0** item to their order.
The PR will add a check to see if the product price amount is not zero before showing the buttons.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. create product with $0 price
2. smart button on single product page & cart will load
3. checkout will not work as PayPal does not support zero-sum payments

