### PR TITLE
Check if PayPal Payments is available before renderering the buttons

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -442,6 +442,12 @@ class SmartButton implements SmartButtonInterface {
 			return;
 		}
 
+		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+
+		if ( ! isset( $available_gateways['ppcp-gateway'] ) ) {
+			return;
+		}
+
 		echo '<div id="ppc-button"></div>';
 	}
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #447 

---

### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
There's a bug present on stores that don't have the WC Subscriptions plugin active and have both PayPal Payments and WooCommerce Payments with the free Subscriptions feature enabled where the PayPal buttons are incorrectly being rendered on Product/Cart pages.

To fix this, this PR adds the following code to the `button_renderer()` function to check if PayPal Payments is in the list of available payment gateways before rendering the buttons on the cart and product page:

```
$available_gateways = WC()->payment_gateways->get_available_payment_gateways();

if ( ! isset( $available_gateways['ppcp-gateway'] ) ) {
	return;
}
```

With the following changes, when you view a subscription product page or navigate to the cart page with a subscription product in your cart and don't have the WC Subscriptions plugin installed the PayPal buttons don't load:

![image](https://user-images.githubusercontent.com/2275145/155079260-a8c8abad-163a-4d88-ae03-07d6351c67f7.png)

As seen in the image above, the mini-cart will still show the buttons if it only contains non-subscription products.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Make sure WC Subscriptions extension is not activated
1. Activate and setup/connect both PayPal Payments and WooCommerce Payments
1. Make sure your store is based in the US or you have the WC Payments Dev tools extension activated
1. Enable the free Subscriptions with WooCommerce Payments feature found under WP Admin > Payments > Settings > Advanced
1. View a Subscription product page
1. Notice the PayPal Buttons are showing on the page ❌
1. Add a subscription product to the cart and view the cart page
1. Notice the PayPal Buttons are showing on the cart page ❌
1. Navigate to the checkout with a subscription in the cart
1. Notice no PayPal buttons ✅

On this branch, the PayPal Buttons will no longer show on Subscription product pages (non-subscription products are unaffected) and on the cart page when the cart contains a subscription product and you don't have the subscriptions extension enabled.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Fix - Improves Subscriptions with WooCommerce Payments compatibility.

Closes #447 .
