### PR TITLE
Fix ajax URLs on multisite

### DIFF
--- a/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
+++ b/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
@@ -50,7 +50,7 @@ class ApplicationContextRepository {
 		$landingpage = $this->settings->has( 'landing_page' ) ?
 			$this->settings->get( 'landing_page' ) : ApplicationContext::LANDING_PAGE_NO_PREFERENCE;
 		$context     = new ApplicationContext(
-			\WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ),
+			network_home_url( \WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ) ),
 			(string) wc_get_checkout_url(),
 			(string) $brand_name,
 			$locale,

--- a/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
+++ b/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
@@ -50,7 +50,7 @@ class ApplicationContextRepository {
 		$landingpage = $this->settings->has( 'landing_page' ) ?
 			$this->settings->get( 'landing_page' ) : ApplicationContext::LANDING_PAGE_NO_PREFERENCE;
 		$context     = new ApplicationContext(
-			(string) home_url( \WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ) ),
+			\WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ),
 			(string) wc_get_checkout_url(),
 			(string) $brand_name,
 			$locale,

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -664,7 +664,7 @@ class SmartButton implements SmartButtonInterface {
 			'script_attributes'              => $this->attributes(),
 			'data_client_id'                 => array(
 				'set_attribute'     => ( is_checkout() && $this->dcc_is_enabled() ) || $this->can_save_vault_token(),
-				'endpoint'          => home_url( \WC_AJAX::get_endpoint( DataClientIdEndpoint::ENDPOINT ) ),
+				'endpoint'          => \WC_AJAX::get_endpoint( DataClientIdEndpoint::ENDPOINT ),
 				'nonce'             => wp_create_nonce( DataClientIdEndpoint::nonce() ),
 				'user'              => get_current_user_id(),
 				'has_subscriptions' => $this->has_subscriptions(),
@@ -673,15 +673,15 @@ class SmartButton implements SmartButtonInterface {
 			'context'                        => $this->context(),
 			'ajax'                           => array(
 				'change_cart'   => array(
-					'endpoint' => home_url( \WC_AJAX::get_endpoint( ChangeCartEndpoint::ENDPOINT ) ),
+					'endpoint' => \WC_AJAX::get_endpoint( ChangeCartEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ChangeCartEndpoint::nonce() ),
 				),
 				'create_order'  => array(
-					'endpoint' => home_url( \WC_AJAX::get_endpoint( CreateOrderEndpoint::ENDPOINT ) ),
+					'endpoint' => \WC_AJAX::get_endpoint( CreateOrderEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreateOrderEndpoint::nonce() ),
 				),
 				'approve_order' => array(
-					'endpoint' => home_url( \WC_AJAX::get_endpoint( ApproveOrderEndpoint::ENDPOINT ) ),
+					'endpoint' => \WC_AJAX::get_endpoint( ApproveOrderEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ApproveOrderEndpoint::nonce() ),
 				),
 			),

--- a/modules/ppcp-onboarding/src/Assets/OnboardingAssets.php
+++ b/modules/ppcp-onboarding/src/Assets/OnboardingAssets.php
@@ -135,7 +135,7 @@ class OnboardingAssets {
 	 */
 	public function get_script_data() {
 		return array(
-			'endpoint'         => home_url( \WC_AJAX::get_endpoint( LoginSellerEndpoint::ENDPOINT ) ),
+			'endpoint'         => \WC_AJAX::get_endpoint( LoginSellerEndpoint::ENDPOINT ),
 			'nonce'            => wp_create_nonce( $this->login_seller_endpoint::nonce() ),
 			'paypal_js_url'    => 'https://www.paypal.com/webapps/merchantboarding/js/lib/lightbox/partner.js',
 			'sandbox_state'    => State::get_state_name( $this->state->sandbox_state() ),

--- a/modules/ppcp-vaulting/src/Assets/MyAccountPaymentsAssets.php
+++ b/modules/ppcp-vaulting/src/Assets/MyAccountPaymentsAssets.php
@@ -68,7 +68,7 @@ class MyAccountPaymentsAssets {
 			'PayPalCommerceGatewayVaulting',
 			array(
 				'delete' => array(
-					'endpoint' => home_url( \WC_AJAX::get_endpoint( DeletePaymentTokenEndpoint::ENDPOINT ) ),
+					'endpoint' => \WC_AJAX::get_endpoint( DeletePaymentTokenEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( DeletePaymentTokenEndpoint::nonce() ),
 				),
 			)

--- a/modules/ppcp-webhooks/src/Status/Assets/WebhooksStatusPageAssets.php
+++ b/modules/ppcp-webhooks/src/Status/Assets/WebhooksStatusPageAssets.php
@@ -83,20 +83,20 @@ class WebhooksStatusPageAssets {
 	public function get_script_data() {
 		return array(
 			'resubscribe' => array(
-				'endpoint'       => home_url( \WC_AJAX::get_endpoint( ResubscribeEndpoint::ENDPOINT ) ),
+				'endpoint'       => \WC_AJAX::get_endpoint( ResubscribeEndpoint::ENDPOINT ),
 				'nonce'          => wp_create_nonce( ResubscribeEndpoint::nonce() ),
 				'button'         => '.ppcp-webhooks-resubscribe',
 				'failureMessage' => __( 'Operation failed. Check WooCommerce logs for more details.', 'woocommerce-paypal-payments' ),
 			),
 			'simulation'  => array(
 				'start' => array(
-					'endpoint'       => home_url( \WC_AJAX::get_endpoint( SimulateEndpoint::ENDPOINT ) ),
+					'endpoint'       => \WC_AJAX::get_endpoint( SimulateEndpoint::ENDPOINT ),
 					'nonce'          => wp_create_nonce( SimulateEndpoint::nonce() ),
 					'button'         => '.ppcp-webhooks-simulate',
 					'failureMessage' => __( 'Operation failed. Check WooCommerce logs for more details.', 'woocommerce-paypal-payments' ),
 				),
 				'state' => array(
-					'endpoint'            => home_url( \WC_AJAX::get_endpoint( SimulationStateEndpoint::ENDPOINT ) ),
+					'endpoint'            => \WC_AJAX::get_endpoint( SimulationStateEndpoint::ENDPOINT ),
 					'successState'        => WebhookSimulation::STATE_RECEIVED,
 					'waitingMessage'      => __( 'Waiting for the webhook to arrive...', 'woocommerce-paypal-payments' ),
 					'successMessage'      => __( 'The webhook was received successfully.', 'woocommerce-paypal-payments' ),

--- a/tests/PHPUnit/WcGateway/Repository/ApplicationContextRepositoryTest.php
+++ b/tests/PHPUnit/WcGateway/Repository/ApplicationContextRepositoryTest.php
@@ -36,7 +36,7 @@ class ApplicationContextRepositoryTest extends TestCase
                 ->andReturn($value);
         }
 
-	    expect('home_url')
+	    expect('network_home_url')
 		    ->andReturn('https://example.com/');
 	    expect('wc_get_checkout_url')
 		    ->andReturn('https://example.com/checkout/');


### PR DESCRIPTION
Fixes #528

I think `home_url()` is not needed here, `/......` should work fine since we use ajax URLs only for requests performed from our site. WC does not use it too (e.g. `wc-ajax=update_order_review`).