### PR TITLE
Check if payer's Email and name are set before sending data

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -226,7 +226,7 @@ class OrderEndpoint {
 			'application_context' => $this->application_context_repository
 				->current_context( $shipping_preference )->to_array(),
 		);
-		if ( ! empty( $payer->email_address() ) && ! empty( $payer->name() ) ) {
+		if ( $payer && ! empty( $payer->email_address() ) && ! empty( $payer->name() ) ) {
 			$data['payer'] = $payer->to_array();
 		}
 		if ( $payment_token ) {

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -226,7 +226,7 @@ class OrderEndpoint {
 			'application_context' => $this->application_context_repository
 				->current_context( $shipping_preference )->to_array(),
 		);
-		if ( $payer ) {
+		if ( ! empty( $payer->email_address() ) && ! empty( $payer->name() ) ) {
 			$data['payer'] = $payer->to_array();
 		}
 		if ( $payment_token ) {

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PatchCollection;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PayerName;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
@@ -945,7 +946,13 @@ class OrderEndpointTest extends TestCase
             );
         expect('is_wp_error')->with($rawResponse)->andReturn(false);
         expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(201);
-        $result = $testee->create([$purchaseUnit]);
+
+        $payer = Mockery::mock(Payer::class);
+        $payer
+            ->expects('email_address')
+            ->andReturn('');
+
+        $result = $testee->create([$purchaseUnit], $payer);
         $this->assertEquals($expectedOrder, $result);
     }
 
@@ -1038,6 +1045,9 @@ class OrderEndpointTest extends TestCase
         expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(201);
 
         $payer = Mockery::mock(Payer::class);
+        $payer->expects('email_address')->andReturn('email@email.com');
+        $payerName = Mockery::mock(PayerName::class);
+        $payer->expects('name')->andReturn($payerName);
         $payer->expects('to_array')->andReturn(['payer']);
         $result = $testee->create([$purchaseUnit], $payer);
         $this->assertEquals($expectedOrder, $result);
@@ -1125,7 +1135,13 @@ class OrderEndpointTest extends TestCase
             );
         expect('is_wp_error')->with($rawResponse)->andReturn(true);
         $this->expectException(RuntimeException::class);
-        $testee->create([$purchaseUnit]);
+
+        $payer = Mockery::mock(Payer::class);
+        $payer->expects('email_address')->andReturn('email@email.com');
+        $payerName = Mockery::mock(PayerName::class);
+        $payer->expects('name')->andReturn($payerName);
+        $payer->expects('to_array')->andReturn(['payer']);
+        $testee->create([$purchaseUnit], $payer);
     }
 
     public function testCreateForPurchaseUnitsIsNot201()
@@ -1211,6 +1227,11 @@ class OrderEndpointTest extends TestCase
         expect('is_wp_error')->with($rawResponse)->andReturn(false);
         expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(500);
         $this->expectException(RuntimeException::class);
-        $testee->create([$purchaseUnit]);
+        $payer = Mockery::mock(Payer::class);
+        $payer->expects('email_address')->andReturn('email@email.com');
+        $payerName = Mockery::mock(PayerName::class);
+        $payer->expects('name')->andReturn($payerName);
+        $payer->expects('to_array')->andReturn(['payer']);
+        $testee->create([$purchaseUnit], $payer);
     }
 }


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #535

---

### Description

When manually creating orders in WooCommerce backend and sending the link to the buyer, the payment with PayPal Payments will fail unless there is an email entered in the billing address email field.

The PR will add a check, so that if the payer Email or Name aren't filled then it will not include it in outgoing data

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. With "Add order" in WC backend , create guest order with no email address.
2. Visit payment link, attempt to pay with PayPal Payments.
3. Payment will fail.
