### PR TITLE
Add "Type" attribute to checkout button

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -589,7 +589,7 @@ class SmartButton implements SmartButtonInterface {
 
 		printf(
 			'<div id="%1$s" style="display:none;">
-                        <button class="button alt ppcp-dcc-order-button">%2$s</button>
+                        <button type="submit" class="button alt ppcp-dcc-order-button">%2$s</button>
                     </div><div id="payments-sdk__contingency-lightbox"></div><style id="ppcp-hide-dcc">.payment_method_ppcp-credit-card-gateway {display:none;}</style>',
 			esc_attr( $id ),
 			esc_html( $label )


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #478

---

### Description

The "Place Order" button on the Checkout page is looking unstyled when Card Processing is enabled.
![152812705-b203b863-b7c7-4e76-a6bb-6c67cfa361c9](https://user-images.githubusercontent.com/11319597/158395084-68ec9107-3b06-4302-8e59-d9243d2a3852.png)

The PR will fix that by adding the `type="submit"` attribute which is used by for styling 

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Make sure you have WP 5.9 and the twenty twenty-two theme active
2. Enable credit card processing
3. Add a product to your cart and proceed to checkout
4. Select “Credit card” as the payment method
5. Notice that the “Place order” button is looking off

---

Closes #478
