### PR TITLE
Add filter to allow modifying of order creation request body data

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -235,6 +235,11 @@ class OrderEndpoint {
 		if ( $payment_method ) {
 			$data['payment_method'] = $payment_method->to_array();
 		}
+
+		/**
+		 * The filter can be used to modify the request data.
+		 */
+		$data = apply_filters( 'ppcp_create_order_request_body_data', $data );
 		$url  = trailingslashit( $this->host ) . 'v2/checkout/orders';
 		$args = array(
 			'method'  => 'POST',

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -237,7 +237,7 @@ class OrderEndpoint {
 		}
 
 		/**
-		 * The filter can be used to modify the request data.
+		 * The filter can be used to modify the order creation request body data.
 		 */
 		$data = apply_filters( 'ppcp_create_order_request_body_data', $data );
 		$url  = trailingslashit( $this->host ) . 'v2/checkout/orders';


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #486

---

### Description

The PR will add the filter which will allow customers to modify the order creation request body data.
More info can be found on [WIKI page](https://github.com/woocommerce/woocommerce-paypal-payments/wiki/Actions-and-Filters#modify-the-order-creation-request-body-data)

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

Use the [WIKI page](https://github.com/woocommerce/woocommerce-paypal-payments/wiki/Actions-and-Filters#modify-the-order-creation-request-body-data) example to test

---

Closes #486.
