### PR TITLE
Fix the description counting when emoji is used

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -61,7 +61,7 @@ class ItemFactory {
 					mb_substr( $product->get_name(), 0, 127 ),
 					new Money( $price_without_tax_rounded, $this->currency ),
 					$quantity,
-					mb_substr( wp_strip_all_tags( $product->get_description() ), 0, 127 ),
+					substr( wp_strip_all_tags( $product->get_description() ), 0, 127 ),
 					$tax,
 					$product->get_sku(),
 					( $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -61,7 +61,7 @@ class ItemFactory {
 					mb_substr( $product->get_name(), 0, 127 ),
 					new Money( $price_without_tax_rounded, $this->currency ),
 					$quantity,
-					substr( wp_strip_all_tags( $product->get_description() ), 0, 127 ),
+					substr( wp_strip_all_tags( $product->get_description() ), 0, 127 ) ?: '',
 					$tax,
 					$product->get_sku(),
 					( $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #491

---

### Description

When the product description contains text and an emoji like this 😉 in the first 127 characters that are sent to PayPal,  then the API responds with `INVALID_STRING_LENGTH` because the emoji would make the string longer than the maximum.

The PR will fix the problem by changing the `mb_substr` function to `substr` function

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Create a product with an emoji in the description (has to be in the part that’s sent to PayPal 😉)
2. Buy product from any page: single product page, cart, checkout
3. Payment fails

---

Closes #491 .
