### PR TITLE
Convert the special char "+" into the percent-encoded char

### DIFF
--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -341,7 +341,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 		}
 
 		if ( ! $payer && isset( $data['form'] ) ) {
-			parse_str( $data['form'], $form_fields );
+			parse_str( str_replace( '+', '%2B', $data['form'] ), $form_fields );
 
 			if ( isset( $form_fields['billing_email'] ) && '' !== $form_fields['billing_email'] ) {
 				return $this->payer_factory->from_checkout_form( $form_fields );


### PR DESCRIPTION
**Issue**: #523

---

### Description

Checking out as a guest with an email address that contains special characters results in an `INVALID_PARAMETER_SYNTAX` error.

The PR will fix the problem by converting "+" character into percent-encoded character "%2B"

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Log out to become a guest user.
2. Add a product to your cart.
3. Navigate to the checkout screen.
4. In the email address field, use an email address containing a + symbol, eg: [email+123@example.tld](mailto:email+123@example.tld).
5. Click any PayPal smart button to initiate checkout.
6. Error occurs.

---

Closes #523 .
