### PR TITLE
Self redirect after updating DDC settings

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -209,7 +209,7 @@ class SettingsListener {
 		$this->settings->set( 'message_cart_enabled', false );
 		$this->settings->persist();
 
-		$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' );
+		$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-credit-card-gateway' );
 		wp_safe_redirect( $redirect_url, 302 );
 		exit;
 	}


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #392

---

### Description

After (possibly) making changes to the settings on the "PayPal Card Processing" screen, you're redirected to the "PayPal" settings screen instead.

The PR will fix this and after the redirect the "PayPal Card Processing"  will be still active.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Go to WC > Settings > Payments > PayPal Card Processing.
2. Make sure to enable vaulting if it was disabled.
3. Click "Save changes".
4. Confirm you're now on the "PayPal" settings tab instead.

---

Closes #392 .
