### PR TITLE
Release 1.7.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,16 @@
 *** Changelog ***
 
+= 1.7.1 - TBD =
+* Fix - Hide smart buttons for free products and zero-sum carts #499
+* Fix - Unprocessable Entity when paying with AMEX card #516
+* Fix - Multisite path doubled in ajax URLs #528
+* Fix - Incorrect TAX details on PayPal order overview #541
+* Fix - "Place order" button looking unstyled in the Twenty Twenty-Two theme #478
+* Fix - PayPal options available on minicart when adding subscription to the cart from shop page without vaulting enabled #518
+* Enhancement - PayPal buttons loading time #533
+* Enhancement - Improve payment token checking for subscriptions #525
+* Enhancement - Add Spain and Italy to messaging #497
+
 = 1.7.0 - 2022-02-28 =
 * Fix - DCC orders randomly failing #503
 * Fix - Multi-currency broke #481

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.9
 Requires PHP: 7.1
-Stable tag: 1.7.0
+Stable tag: 1.7.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,17 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.7.1 =
+* Fix - Hide smart buttons for free products and zero-sum carts #499
+* Fix - Unprocessable Entity when paying with AMEX card #516
+* Fix - Multisite path doubled in ajax URLs #528
+* Fix - Incorrect TAX details on PayPal order overview #541
+* Fix - "Place order" button looking unstyled in the Twenty Twenty-Two theme #478
+* Fix - PayPal options available on minicart when adding subscription to the cart from shop page without vaulting enabled #518
+* Enhancement - PayPal buttons loading time #533
+* Enhancement - Improve payment token checking for subscriptions #525
+* Enhancement - Add Spain and Italy to messaging #497
 
 = 1.7.0 =
 * Fix - DCC orders randomly failing #503

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,13 +3,13 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.7.0
+ * Version:     1.7.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 6.2
+ * WC tested up to: 6.3
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce


### PR DESCRIPTION
* Fix - Hide smart buttons for free products and zero-sum carts #499
* Fix - Unprocessable Entity when paying with AMEX card #516
* Fix - Multisite path doubled in ajax URLs #528
* Fix - Incorrect TAX details on PayPal order overview #541
* Fix - "Place order" button looking unstyled in the Twenty Twenty-Two theme #478
* Fix - PayPal options available on minicart when adding subscription to the cart from shop page without vaulting enabled #518
* Enhancement - PayPal buttons loading time #533
* Enhancement - Improve payment token checking for subscriptions #525
* Enhancement - Add Spain and Italy to messaging #497