### PR TITLE
Fix the product price amount calculation (597)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -48,8 +48,8 @@ class SingleProductBootstap {
         else if (document.querySelector('form.cart .woocommerce-Price-amount')) {
             priceText = document.querySelector('form.cart .woocommerce-Price-amount').innerText;
         }
-        else if (document.querySelector('.woocommerce-Price-amount')) {
-            priceText = document.querySelector('.woocommerce-Price-amount').innerText;
+        else if (document.querySelector('.product .woocommerce-Price-amount')) {
+            priceText = document.querySelector('.product .woocommerce-Price-amount').innerText;
         }
         const amount = parseFloat(priceText.replace(/([^\d,\.\s]*)/g, ''));
         return amount === 0;


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #551

---

### Description

When user navigates to any product page, buttons are not displayed. Only when user click on “Add to cart” button then buttons appear.
This happens because of the wrong calculation check if the product's price amount is 0.
The PR will fix this calculation check.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Activate Storefront theme.
2. Onboard successfully, enable PayPal gateway and buttons on product page.
3. Make sure the Cart is empty.
4. Navigate to any product page.
5. Buttons won’t be visible.
6. Click on “Add to cart” button.
7. Buttons are now displayed.

---

Closes #551 .
