### PR TITLE
Store card processing gateway "enabled" config as a string.

### DIFF
--- a/modules/ppcp-onboarding/src/OnboardingRESTController.php
+++ b/modules/ppcp-onboarding/src/OnboardingRESTController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Onboarding;
 
 use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 /**
@@ -206,7 +207,7 @@ class OnboardingRESTController {
 		}
 
 		foreach ( WC()->payment_gateways->payment_gateways() as $gateway ) {
-			if ( PayPalGateway::ID === $gateway->id ) {
+			if ( PayPalGateway::ID === $gateway->id || CreditCardGateway::ID === $gateway->id ) {
 				$gateway->update_option( 'enabled', 'yes' );
 				break;
 			}

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -439,7 +439,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		parent::init_settings();
 
 		// looks like in some cases WC uses this field instead of get_option.
-		$this->enabled = $this->is_enabled();
+		$this->enabled = $this->is_enabled() ? 'yes' : '';
 	}
 
 	/**
@@ -468,7 +468,9 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$ret = parent::update_option( $key, $value );
 
 		if ( 'enabled' === $key ) {
+
 			$this->config->set( 'dcc_enabled', 'yes' === $value );
+			$this->config->set( 'enabled', 'yes' === $value );
 			$this->config->persist();
 
 			return true;


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #562

---

### Description

The PayPal Card Processing does not appear as an available payment method when manually creating a WooCommerce order.

The PR will fix this by string the "_enabled"_ config of the gateway as the string _"yes"_ | _""_ instead of _true_ | _false_

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Enable PayPal Card Processing.
2. Manually create order in WooCommerce admin.
3. Assign a payment method and click the dropdown.
4. PayPal Card Processing will not appear in the list despite being enabled as a gateway.

![image-20220322-170123](https://user-images.githubusercontent.com/11319597/160870837-4de48896-5683-4bd4-affc-bc5781b05cf9.png)

---

Closes #562 .
