### PR TITLE
Revert PCP-590

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,6 @@
 * Fix - Hide smart buttons for free products and zero-sum carts #499
 * Fix - Unprocessable Entity when paying with AMEX card #516
 * Fix - Multisite path doubled in ajax URLs #528
-* Fix - Incorrect TAX details on PayPal order overview #541
 * Fix - "Place order" button looking unstyled in the Twenty Twenty-Two theme #478
 * Fix - PayPal options available on minicart when adding subscription to the cart from shop page without vaulting enabled #518
 * Fix - Buttons not visible on products page #551

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -76,12 +76,12 @@ class AmountFactory {
 		$item_total = $cart->get_cart_contents_total() + $cart->get_discount_total() + $total_fees_amount;
 		$item_total = new Money( (float) $item_total, $this->currency );
 		$shipping   = new Money(
-			(float) $cart->get_shipping_total(),
+			(float) $cart->get_shipping_total() + $cart->get_shipping_tax(),
 			$this->currency
 		);
 
 		$taxes = new Money(
-			$cart->get_subtotal_tax() + $cart->get_shipping_tax(),
+			$cart->get_subtotal_tax(),
 			$this->currency
 		);
 
@@ -131,7 +131,7 @@ class AmountFactory {
 			$currency
 		);
 		$shipping   = new Money(
-			(float) $order->get_shipping_total(),
+			(float) $order->get_shipping_total() + (float) $order->get_shipping_tax(),
 			$currency
 		);
 		$taxes      = new Money(

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -42,9 +42,8 @@ class ItemFactory {
 	 * @return Item[]
 	 */
 	public function from_wc_cart( \WC_Cart $cart ): array {
-		$shipping_tax = round( $cart->get_shipping_tax(), 2 );
-		$items        = array_map(
-			function ( array $item ) use ( $shipping_tax ): Item {
+		$items = array_map(
+			function ( array $item ): Item {
 				$product = $item['data'];
 
 				/**
@@ -58,7 +57,7 @@ class ItemFactory {
 				$price_without_tax         = (float) wc_get_price_excluding_tax( $product );
 				$price_without_tax_rounded = round( $price_without_tax, 2 );
 				$tax                       = round( $price - $price_without_tax_rounded, 2 );
-				$tax                       = new Money( $tax + $shipping_tax, $this->currency );
+				$tax                       = new Money( $tax, $this->currency );
 				return new Item(
 					mb_substr( $product->get_name(), 0, 127 ),
 					new Money( $price_without_tax_rounded, $this->currency ),
@@ -132,13 +131,12 @@ class ItemFactory {
 		 */
 		$product                   = $item->get_product();
 		$currency                  = $order->get_currency();
-		$shipping_tax              = round( (float) $order->get_shipping_tax(), 2 );
 		$quantity                  = (int) $item->get_quantity();
 		$price                     = (float) $order->get_item_subtotal( $item, true );
 		$price_without_tax         = (float) $order->get_item_subtotal( $item, false );
 		$price_without_tax_rounded = round( $price_without_tax, 2 );
 		$tax                       = round( $price - $price_without_tax_rounded, 2 );
-		$tax                       = new Money( $tax + $shipping_tax, $currency );
+		$tax                       = new Money( $tax, $currency );
 
 		return new Item(
 			mb_substr( $product->get_name(), 0, 127 ),

--- a/readme.txt
+++ b/readme.txt
@@ -85,7 +85,6 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - Hide smart buttons for free products and zero-sum carts #499
 * Fix - Unprocessable Entity when paying with AMEX card #516
 * Fix - Multisite path doubled in ajax URLs #528
-* Fix - Incorrect TAX details on PayPal order overview #541
 * Fix - "Place order" button looking unstyled in the Twenty Twenty-Two theme #478
 * Fix - PayPal options available on minicart when adding subscription to the cart from shop page without vaulting enabled #518
 * Fix - Buttons not visible on products page #551

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -68,11 +68,11 @@ class AmountFactoryTest extends TestCase
         $this->assertEquals((float) 1, $result->value());
         $this->assertEquals((float) 10, $result->breakdown()->discount()->value());
         $this->assertEquals($this->currency, $result->breakdown()->discount()->currency_code());
-        $this->assertEquals((float) 4, $result->breakdown()->shipping()->value());
+        $this->assertEquals((float) 9, $result->breakdown()->shipping()->value());
         $this->assertEquals($this->currency, $result->breakdown()->shipping()->currency_code());
         $this->assertEquals((float) 5, $result->breakdown()->item_total()->value());
         $this->assertEquals($this->currency, $result->breakdown()->item_total()->currency_code());
-        $this->assertEquals((float) 13, $result->breakdown()->tax_total()->value());
+        $this->assertEquals((float) 8, $result->breakdown()->tax_total()->value());
         $this->assertEquals($this->currency, $result->breakdown()->tax_total()->currency_code());
     }
 
@@ -161,7 +161,7 @@ class AmountFactoryTest extends TestCase
         $result = $this->testee->from_wc_order($order);
         $this->assertEquals((float) 3, $result->breakdown()->discount()->value());
         $this->assertEquals((float) 6, $result->breakdown()->item_total()->value());
-        $this->assertEquals((float) 1, $result->breakdown()->shipping()->value());
+        $this->assertEquals((float) 1.5, $result->breakdown()->shipping()->value());
         $this->assertEquals((float) 100, $result->value());
         $this->assertEquals((float) 2, $result->breakdown()->tax_total()->value());
         $this->assertEquals($this->currency, $result->breakdown()->discount()->currency_code());

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -41,7 +41,6 @@ class ItemFactoryTest extends TestCase
         $cart
             ->expects('get_cart_contents')
             ->andReturn($items);
-        $cart->expects('get_shipping_tax')->andReturn(1);
 
         expect('wc_get_price_including_tax')
             ->with($product)
@@ -73,7 +72,7 @@ class ItemFactoryTest extends TestCase
         $this->assertEquals('name', $item->name());
         $this->assertEquals('sku', $item->sku());
         $this->assertEquals(1, $item->unit_amount()->value());
-        $this->assertEquals(3, $item->tax()->value());
+        $this->assertEquals(2, $item->tax()->value());
     }
 
     public function testFromCartDigitalGood()
@@ -103,7 +102,6 @@ class ItemFactoryTest extends TestCase
         $cart
             ->expects('get_cart_contents')
             ->andReturn($items);
-        $cart->expects('get_shipping_tax')->andReturn(1);
 
         expect('wc_get_price_including_tax')
             ->with($product)
@@ -174,7 +172,6 @@ class ItemFactoryTest extends TestCase
         $order
             ->expects('get_fees')
             ->andReturn([]);
-        $order->expects('get_shipping_tax')->andReturn(1);
 
         $result = $testee->from_wc_order($order);
         $this->assertCount(1, $result);
@@ -188,7 +185,7 @@ class ItemFactoryTest extends TestCase
         $this->assertEquals(1, $item->quantity());
         $this->assertEquals(Item::PHYSICAL_GOODS, $item->category());
         $this->assertEquals(1, $item->unit_amount()->value());
-        $this->assertEquals(3, $item->tax()->value());
+        $this->assertEquals(2, $item->tax()->value());
     }
 
     public function testFromWcOrderDigitalGood()
@@ -238,7 +235,6 @@ class ItemFactoryTest extends TestCase
         $order
             ->expects('get_fees')
             ->andReturn([]);
-		$order->expects('get_shipping_tax')->andReturn(1);
 
         $result = $testee->from_wc_order($order);
         $item = current($result);
@@ -297,7 +293,6 @@ class ItemFactoryTest extends TestCase
         $order
             ->expects('get_fees')
             ->andReturn([]);
-		$order->expects('get_shipping_tax')->andReturn(1);
 
         $result = $testee->from_wc_order($order);
         $item = current($result);


### PR DESCRIPTION
#542 fixes the issue about adding shipping tax as shipping cost instead of adding it to taxes, however as this logic is also used in other parts of the code it is currently introducing issues in other parts where this same logic is used.

#541 needs to be reopened to handle all cases where the above logic is used.