### PR TITLE
Add ability to select dark versions of Visa and Mastercard icons.

### DIFF
--- a/modules/ppcp-onboarding/assets/js/settings.js
+++ b/modules/ppcp-onboarding/assets/js/settings.js
@@ -171,6 +171,16 @@ document.addEventListener(
                 return;
             }
             const allOptions = Array.from(document.querySelectorAll('select[name="ppcp[disable_cards][]"] option'));
+            const iconVersions = {
+                'visa': {
+                    'light': {'label': 'Visa (light)'},
+                    'dark' : {'label': 'Visa (dark)', 'value': 'visa-dark'}
+                },
+                'mastercard': {
+                    'light': {'label': 'Mastercard (light)'},
+                    'dark' : {'label': 'Mastercard (dark)', 'value': 'mastercard-dark'}
+                }
+            }
             const replace = () => {
                 const validOptions = allOptions.filter(
                     (option) => {
@@ -181,13 +191,35 @@ document.addEventListener(
                 const selectedValidOptions = validOptions.map(
                     (option) => {
                         option = option.cloneNode(true);
-                        option.selected = target.querySelector('option[value="' + option.value + '"]') && target.querySelector('option[value="' + option.value + '"]').selected;
+                        let value = option.value;
+                        option.selected = target.querySelector('option[value="' + value + '"]') && target.querySelector('option[value="' + value + '"]').selected;
+                        if(value === 'visa' || value === 'mastercard') {
+                            let darkOption = option.cloneNode(true);
+                            let currentVersion = iconVersions[value];
+                            let darkValue = iconVersions[value].dark.value;
+
+                            option.text = currentVersion.light.label;
+                            darkOption.text = currentVersion.dark.label;
+                            darkOption.value = darkValue;
+                            darkOption.selected = target.querySelector('option[value="' + darkValue + '"]') && target.querySelector('option[value="' + darkValue + '"]').selected;
+
+                            return [option, darkOption];
+                        }
                         return option;
                     }
                 );
+
                 target.innerHTML = '';
                 selectedValidOptions.forEach(
                     (option) => {
+                        if(Array.isArray(option)){
+                            option.forEach(
+                                (option) => {
+                                    target.append(option);
+                                }
+                            )
+                        }
+
                         target.append(option);
                     }
                 );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1959,13 +1959,15 @@ return array(
 					'woocommerce-paypal-payments'
 				),
 				'options'      => array(
-					'visa'       => _x( 'Visa', 'Name of credit card', 'woocommerce-paypal-payments' ),
-					'mastercard' => _x( 'Mastercard', 'Name of credit card', 'woocommerce-paypal-payments' ),
-					'amex'       => _x( 'American Express', 'Name of credit card', 'woocommerce-paypal-payments' ),
-					'discover'   => _x( 'Discover', 'Name of credit card', 'woocommerce-paypal-payments' ),
-					'jcb'        => _x( 'JCB', 'Name of credit card', 'woocommerce-paypal-payments' ),
-					'elo'        => _x( 'Elo', 'Name of credit card', 'woocommerce-paypal-payments' ),
-					'hiper'      => _x( 'Hiper', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'visa'            => _x( 'Visa (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'visa-dark'       => _x( 'Visa (dark)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'mastercard'      => _x( 'Mastercard (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'mastercard-dark' => _x( 'Mastercard (dark)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'amex'            => _x( 'American Express', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'discover'        => _x( 'Discover', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'jcb'             => _x( 'JCB', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'elo'             => _x( 'Elo', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'hiper'           => _x( 'Hiper', 'Name of credit card', 'woocommerce-paypal-payments' ),
 				),
 				'screens'      => array(
 					State::STATE_ONBOARDED,
@@ -2041,14 +2043,23 @@ return array(
 		 * Here, we filter them out.
 		 */
 		$card_options = $fields['disable_cards']['options'];
+		$card_icons = $fields['card_icons']['options'];
+		$dark_versions = array();
 		foreach ( $card_options as $card => $label ) {
 			if ( $dcc_applies->can_process_card( $card ) ) {
+				if ( 'visa' === $card || 'mastercard' === $card ) {
+					$dark_versions = array(
+						'visa-dark'       => $card_icons['visa-dark'],
+						'mastercard-dark' => $card_icons['mastercard-dark'],
+					);
+				}
 				continue;
 			}
 			unset( $card_options[ $card ] );
 		}
+
 		$fields['disable_cards']['options'] = $card_options;
-		$fields['card_icons']['options'] = $card_options;
+		$fields['card_icons']['options'] = array_merge( $dark_versions, $card_options );
 
 		/**
 		 * Display vault message on Pay Later label if vault is enabled.

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -331,8 +331,9 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$title_options = $this->card_labels();
 		$images        = array_map(
 			function ( string $type ) use ( $title_options ): string {
+				$striped_dark = str_replace( '-dark', '', $type );
 				return '<img
-                 title="' . esc_attr( $title_options[ $type ] ) . '"
+                 title="' . esc_attr( $title_options[ $striped_dark ] ) . '"
                  src="' . esc_url( $this->module_url ) . 'assets/images/' . esc_attr( $type ) . '.svg"
                  class="ppcp-card-icon"
                 > ';


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #566

---

### Description

Update 1.7.0 added a dark Visa and Mastercard icons:

These dark icons cannot be selected in the dropdown for the gateway icons. So as of now, they can only be used by renaming the files, changing plugin code, or adding the icons via filter instead of the plugin setting.

Since the files already exist, I propose adding the additional icon variants we added to the dropdown of the icon selector:

Mastercard (light)
Mastercard (dark)
Visa (light)
Visa (dark)

The PR will rename the current _Visa_ and _Mastercard_ icon names to _Visa (light)_ and _Mastercard (light)_ (The field name itself is not changed so it will still work for existing users) and will add 2 options to select: **Visa (dark)** and **Mastercard (dark)**

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Go to **PayPal Card Processing** settings.
2. Try to select the dark versions of Visa and Mastercard from **Show logo of the following credit cards** field.

---

Closes #566 .
