### PR TITLE
Check the cart total amount inside mini cart buttons renderer hook.

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -361,11 +361,11 @@ class SmartButton implements SmartButtonInterface {
 		) {
 			add_action(
 				$this->mini_cart_button_renderer_hook(),
-				static function () {
-                    // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-					if ( WC()->cart->get_cart_contents_total() == 0 ) {
+				function () {
+					if ( $this->is_cart_price_total_zero() ) {
 						return;
 					}
+
 					echo '<p
                                 id="ppc-button-minicart"
                                 class="woocommerce-mini-cart__buttons buttons"

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -354,6 +354,27 @@ class SmartButton implements SmartButtonInterface {
 
 		add_action( $this->pay_order_renderer_hook(), array( $this, 'button_renderer' ), 10 );
 
+		$not_enabled_on_minicart = $this->settings->has( 'button_mini_cart_enabled' ) &&
+			! $this->settings->get( 'button_mini_cart_enabled' );
+		if (
+		! $not_enabled_on_minicart
+		) {
+			add_action(
+				$this->mini_cart_button_renderer_hook(),
+				static function () {
+                    // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+					if ( WC()->cart->get_cart_contents_total() == 0 ) {
+						return;
+					}
+					echo '<p
+                                id="ppc-button-minicart"
+                                class="woocommerce-mini-cart__buttons buttons"
+                          ></p>';
+				},
+				30
+			);
+		}
+
 		if ( $this->is_cart_price_total_zero() ) {
 			return false;
 		}
@@ -371,23 +392,6 @@ class SmartButton implements SmartButtonInterface {
 					'button_renderer',
 				),
 				20
-			);
-		}
-
-		$not_enabled_on_minicart = $this->settings->has( 'button_mini_cart_enabled' ) &&
-			! $this->settings->get( 'button_mini_cart_enabled' );
-		if (
-			! $not_enabled_on_minicart
-		) {
-			add_action(
-				$this->mini_cart_button_renderer_hook(),
-				static function () {
-					echo '<p
-                                id="ppc-button-minicart"
-                                class="woocommerce-mini-cart__buttons buttons"
-                          ></p>';
-				},
-				30
 			);
 		}
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #573

---

### Description

PayPal buttons are not added in minicart. adding product to cart which is a first product in cart then the buttons will not be show, until you add another product into cart.

The PR will fix the problem by making a check about cart total amount inside the button renderer hook.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Go to Shop.
2. Add product to cart.
3. Check minicart.
4. Reload page and check minicart.

---

Closes #573 .
