### PR TITLE
Unset the gateway only on checkout page

### DIFF
--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -69,7 +69,7 @@ class DisableGateways {
 			unset( $methods[ CreditCardGateway::ID ] );
 		}
 
-		if ( $this->settings->has( 'button_enabled' ) && ! $this->settings->get( 'button_enabled' ) && ! $this->session_handler->order() ) {
+		if ( $this->settings->has( 'button_enabled' ) && ! $this->settings->get( 'button_enabled' ) && ! $this->session_handler->order() && is_checkout() ) {
 			unset( $methods[ PayPalGateway::ID ] );
 		}
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #577

---

### Description

For merchants who do not want to show the PayPal button on the checkout page, but keep it on the Product and Cart page, disabling PayPal Checkout on the checkout page also removes the button from the Cart and Product Pages.

The problem happens because the gateway is unset when the buttons are not enabled for Checkout page.
The PR will solve the problem by adding a check to unset the gateway only on Checkout Page.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Check that the PayPal button displays on all pages, “Checkout, Cart and Product pages”.
2. From the PayPal Payment settings page, uncheck the “Enable on Checkout” option to disable PayPal Checkout on the checkout page.
3. Make sure the options to enable the button on the “Checkout and Cart” pages are checked.
4. Check if disabling the PayPal Checkout on the checkout page also removes the button from the Cart and Product Pages.

---

Closes #577 .
