### PR TITLE
Release 1.8.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,17 @@
 *** Changelog ***
 
+= 1.8.0 - TBD =
+* Add - Allow free trial subscriptions #580
+* Fix - The Card Processing does not appear as an available payment method when manually creating an order #562
+* Fix - Express buttons & Pay Later visible on variable Subscription products /w disabled vaulting #281 
+* Fix - Pay for order (guest) failing when no email address available #535 
+* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
+* Enhancement - Redirect after updating settings for DCC sends you to PPCP settings screen #392
+* Enhancement - Change cart total amount that is sent to PayPal gateway #486
+* Enhancement - Include dark Visa and Mastercard gateway icon list for PayPal Card Processing #566
+* Enhancement - Onboarding errors improvements #558
+* Enhancement - "Place order" button visible during gateway load time when DCC gateway is selected as the default #560
+
 = 1.7.1 - 2022-04-06 =
 * Fix - Hide smart buttons for free products and zero-sum carts #499
 * Fix - Unprocessable Entity when paying with AMEX card #516

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.9
 Requires PHP: 7.1
-Stable tag: 1.7.1
+Stable tag: 1.8.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,18 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.8.0
+* Add - Allow free trial subscriptions #580
+* Fix - The Card Processing does not appear as an available payment method when manually creating an order #562
+* Fix - Express buttons & Pay Later visible on variable Subscription products /w disabled vaulting #281 
+* Fix - Pay for order (guest) failing when no email address available #535 
+* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
+* Enhancement - Redirect after updating settings for DCC sends you to PPCP settings screen #392
+* Enhancement - Change cart total amount that is sent to PayPal gateway #486
+* Enhancement - Include dark Visa and Mastercard gateway icon list for PayPal Card Processing #566
+* Enhancement - Onboarding errors improvements #558
+* Enhancement - "Place order" button visible during gateway load time when DCC gateway is selected as the default #560
 
 = 1.7.1 =
 * Fix - Hide smart buttons for free products and zero-sum carts #499

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,13 +3,13 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.7.1
+ * Version:     1.8.0
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 6.3
+ * WC tested up to: 6.4
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce
@@ -21,7 +21,7 @@ namespace WooCommerce\PayPalCommerce;
 
 define( 'PAYPAL_API_URL', 'https://api.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2021-09-17' );
+define( 'PAYPAL_INTEGRATION_DATE', '2022-04-13' );
 
 define( 'PPCP_FLAG_SUBSCRIPTION', true );
 


### PR DESCRIPTION
* Add - Allow free trial subscriptions #580
* Fix - The Card Processing does not appear as an available payment method when manually creating an order #562
* Fix - Express buttons & Pay Later visible on variable Subscription products /w disabled vaulting #281 
* Fix - Pay for order (guest) failing when no email address available #535 
* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
* Enhancement - Redirect after updating settings for DCC sends you to PPCP settings screen #392
* Enhancement - Change cart total amount that is sent to PayPal gateway #486
* Enhancement - Include dark Visa and Mastercard gateway icon list for PayPal Card Processing #566
* Enhancement - Onboarding errors improvements #558
* Enhancement - "Place order" button visible during gateway load time when DCC gateway is selected as the default #560