### PR TITLE
Check if cart exists before calling a method

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1217,7 +1217,7 @@ class SmartButton implements SmartButtonInterface {
 	 */
 	protected function is_cart_price_total_zero(): bool {
         // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-		return WC()->cart->get_cart_contents_total() == 0;
+		return WC()->cart && WC()->cart->get_cart_contents_total() == 0;
 	}
 
 	/**

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1214,6 +1214,7 @@ class SmartButton implements SmartButtonInterface {
 	 * Check if cart product price total is 0.
 	 *
 	 * @return bool true if is 0, otherwise false.
+	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
 	protected function is_cart_price_total_zero(): bool {
         // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #603

---

### Description

There are multiple errors reported:

```
2022-04-07T09:18:27+00:00 CRITICAL Uncaught Error: Call to a member function get_cart_contents_total() on null in /chroot/home/a4084adf/wealthyhair.com/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-button/src/Assets/SmartButton.php:1127
Stack trace:
#0 /chroot/home/a4084adf/wealthyhair.com/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-button/src/Assets/SmartButton.php(378): WooCommerce\PayPalCommerce\Button\Assets\SmartButton->is_cart_price_total_zero()
#1 /chroot/home/a4084adf/wealthyhair.com/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-button/src/Assets/SmartButton.php(195): WooCommerce\PayPalCommerce\Button\Assets\SmartButton->render_button_wrapper_registrar()
#2 /chroot/home/a4084adf/wealthyhair.com/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-button/src/ButtonModule.php(56): WooCommerce\PayPalCommerce\Button\Assets\SmartButton->render_wrapper()
#3 /chroot/home/a4084adf/wealthyhair.com/html/wp-includes/class-wp-hook.php(307): WooCommerce\PayPalCommerce\Button\But in /chroot/home/a4084adf/wealthyhair.com/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-button/src/Assets/SmartButton.php on line 1127
```
The PR will fix the error by adding a check if `WC()->cart` exists.

### Steps to Test

not quite sure how to reproduce but there are multiple reports.

---

Closes #603 .
