### PR TITLE
Fix the button render logic when free product is in cart.

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
@@ -15,6 +15,8 @@ class CartBootstrap {
         this.render();
 
         jQuery(document.body).on('updated_cart_totals updated_checkout', () => {
+
+            console.log(document.querySelector(this.gateway.button.wrapper), document.querySelector(this.gateway.hosted_fields.wrapper));
             this.render();
         });
     }

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
@@ -15,8 +15,6 @@ class CartBootstrap {
         this.render();
 
         jQuery(document.body).on('updated_cart_totals updated_checkout', () => {
-
-            console.log(document.querySelector(this.gateway.button.wrapper), document.querySelector(this.gateway.hosted_fields.wrapper));
             this.render();
         });
     }

--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -13,7 +13,6 @@ class CreditCardRenderer {
     }
 
     render(wrapper, contextConfig) {
-
         if (
             (
                 this.defaultConfig.context !== 'checkout'
@@ -42,6 +41,9 @@ class CreditCardRenderer {
         }
 
         const gateWayBox = document.querySelector('.payment_box.payment_method_ppcp-credit-card-gateway');
+        if(! gateWayBox) {
+            return
+        }
         const oldDisplayStyle = gateWayBox.style.display;
         gateWayBox.style.display = 'block';
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -445,28 +445,21 @@ class SmartButton implements SmartButtonInterface {
 			);
 		}
 
-		if ( $this->is_cart_price_total_zero() && ! $this->is_free_trial_cart() ) {
-			return false;
-		}
+		add_action( $this->checkout_button_renderer_hook(), array( $this, 'button_renderer' ), 10 );
 
 		$not_enabled_on_cart = $this->settings->has( 'button_cart_enabled' ) &&
 			! $this->settings->get( 'button_cart_enabled' );
-		if (
-			is_cart()
-			&& ! $not_enabled_on_cart
-			&& ! $this->is_free_trial_cart()
-		) {
-			add_action(
-				$this->proceed_to_checkout_button_renderer_hook(),
-				array(
-					$this,
-					'button_renderer',
-				),
-				20
-			);
-		}
+		add_action(
+			$this->proceed_to_checkout_button_renderer_hook(),
+			function() use ( $not_enabled_on_cart ) {
+				if ( ! is_cart() || $not_enabled_on_cart || $this->is_free_trial_cart() || $this->is_cart_price_total_zero() ) {
+					return;
+				}
 
-		add_action( $this->checkout_button_renderer_hook(), array( $this, 'button_renderer' ), 10 );
+				$this->button_renderer();
+			},
+			20
+		);
 
 		return true;
 	}
@@ -1214,10 +1207,11 @@ class SmartButton implements SmartButtonInterface {
 	 * Check if cart product price total is 0.
 	 *
 	 * @return bool true if is 0, otherwise false.
+	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
 	protected function is_cart_price_total_zero(): bool {
         // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-		return WC()->cart->get_cart_contents_total() == 0;
+		return WC()->cart && WC()->cart->get_total( 'numeric' ) == 0;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #606

---

### Description

Smart buttons are not loading when free product is in cart but shipping costs are available.

The PR will fix/improve the button render logic.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Add free product to the cart.
2. Visit checkout page.
3. If there are no shipping costs, PayPal Payments gateway will be hidden.
4. When there are shipping costs, the gateway appears but the smart button won’t load because of the free product in the cart

---

Closes #606 and #610.
