### PR TITLE
Add "PayPal Transaction Key" into order custom fields.

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -81,6 +81,10 @@ class WCGatewayModule implements ModuleInterface {
 				if ( $breakdown ) {
 					$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
 					$wc_order->save_meta_data();
+					$paypal_fee = $breakdown->paypal_fee();
+					if ( $paypal_fee ) {
+						update_post_meta( $wc_order->get_id(), 'PayPal Transaction Key', $paypal_fee->value() );
+					}
 				}
 			},
 			10,


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #591

---

### Description

In PayPal Standard you can export the sales with the PayPal fee as a separate column, like this:
![image](https://user-images.githubusercontent.com/78153894/163168170-7dcebd6c-4664-4647-ab30-8bd8bfaf48cc.png)

This is not possible in the current release.

The PR will store the value of PayPal fee into `PayPal Transaction Key` custom field as in screenshot
### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Make an order with PayPal.
2. Edit the order in admin area.
3. Check the `PayPal Transaction Key` custom field.

---

Closes #591 .
