### PR TITLE
Fix DCC with free trial

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Subscription\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 /**
  * Class AmountFactory
@@ -124,7 +125,12 @@ class AmountFactory {
 		$items    = $this->item_factory->from_wc_order( $order );
 
 		$total_value = (float) $order->get_total();
-		if ( CreditCardGateway::ID === $order->get_payment_method() && $this->is_free_trial_order( $order ) ) {
+		if ( (
+			CreditCardGateway::ID === $order->get_payment_method()
+				|| ( PayPalGateway::ID === $order->get_payment_method() && 'card' === $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE ) )
+			)
+			&& $this->is_free_trial_order( $order )
+		) {
 			$total_value = 1.0;
 		}
 		$total = new Money( $total_value, $currency );

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -31,8 +31,17 @@ const bootstrap = () => {
     const onSmartButtonClick = (data, actions) => {
         window.ppcpFundingSource = data.fundingSource;
 
+        const form = document.querySelector('form.woocommerce-checkout');
+        if (form) {
+            jQuery('#ppcp-funding-source-form-input').remove();
+            form.insertAdjacentHTML(
+                'beforeend',
+                `<input type="hidden" name="ppcp-funding-source" value="${data.fundingSource}" id="ppcp-funding-source-form-input">`
+            )
+        }
+
         const isFreeTrial = PayPalCommerceGateway.is_free_trial_cart;
-        if (isFreeTrial) {
+        if (isFreeTrial && data.fundingSource !== 'card') {
             freeTrialHandler.handle();
             return actions.reject();
         }

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
@@ -20,6 +20,7 @@ class CartActionHandler {
                     nonce: this.config.ajax.create_order.nonce,
                     purchase_units: [],
                     payment_method: PaymentMethods.PAYPAL,
+                    funding_source: window.ppcpFundingSource,
                     bn_code:bnCode,
                     payer,
                     context:this.config.context

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -33,6 +33,7 @@ class CheckoutActionHandler {
                     context:this.config.context,
                     order_id:this.config.order_id,
                     payment_method: getCurrentPaymentMethod(),
+                    funding_source: window.ppcpFundingSource,
                     form:formValues,
                     createaccount: createaccount
                 })

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
@@ -86,6 +86,7 @@ class SingleProductActionHandler {
                         payer,
                         bn_code:bnCode,
                         payment_method: PaymentMethods.PAYPAL,
+                        funding_source: window.ppcpFundingSource,
                         context:this.config.context
                     })
                 }).then(function (res) {

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -898,7 +898,10 @@ class SmartButton implements SmartButtonInterface {
 		if ( ! is_checkout() ) {
 			$disable_funding[] = 'card';
 		}
-		if ( is_checkout() && $this->settings->has( 'dcc_enabled' ) && $this->settings->get( 'dcc_enabled' ) ) {
+
+		$is_dcc_enabled = $this->settings->has( 'dcc_enabled' ) && $this->settings->get( 'dcc_enabled' );
+
+		if ( is_checkout() && $is_dcc_enabled ) {
 			$key = array_search( 'card', $disable_funding, true );
 			if ( false !== $key ) {
 				unset( $disable_funding[ $key ] );
@@ -906,7 +909,11 @@ class SmartButton implements SmartButtonInterface {
 		}
 
 		if ( $this->is_free_trial_cart() ) {
-			$disable_funding = array_keys( $this->all_funding_sources );
+			$all_sources = $this->all_funding_sources;
+			if ( $is_dcc_enabled ) {
+				$all_sources = array_keys( array_diff_key( $all_sources, array( 'card' => '' ) ) );
+			}
+			$disable_funding = $all_sources;
 		}
 
 		if ( count( $disable_funding ) > 0 ) {

--- a/modules/ppcp-vaulting/src/PaymentTokenChecker.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenChecker.php
@@ -17,6 +17,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\OrderRepository;
 use WooCommerce\PayPalCommerce\Subscription\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
@@ -117,7 +118,9 @@ class PaymentTokenChecker {
 		if ( $tokens ) {
 			try {
 				if ( $this->is_free_trial_order( $wc_order ) ) {
-					if ( CreditCardGateway::ID === $wc_order->get_payment_method() ) {
+					if ( CreditCardGateway::ID === $wc_order->get_payment_method()
+						|| ( PayPalGateway::ID === $wc_order->get_payment_method() && 'card' === $wc_order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE ) )
+					) {
 						$order = $this->order_repository->for_wc_order( $wc_order );
 						$this->authorized_payments_processor->void_authorizations( $order );
 						$wc_order->payment_complete();

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -37,6 +37,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	const INTENT_META_KEY             = '_ppcp_paypal_intent';
 	const ORDER_ID_META_KEY           = '_ppcp_paypal_order_id';
 	const ORDER_PAYMENT_MODE_META_KEY = '_ppcp_paypal_payment_mode';
+	const ORDER_PAYMENT_SOURCE        = '_ppcp_paypal_payment_source';
 	const FEES_META_KEY               = '_ppcp_paypal_fees';
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -55,6 +55,7 @@ trait ProcessPaymentTrait {
 		}
 
 		$payment_method = filter_input( INPUT_POST, 'payment_method', FILTER_SANITIZE_STRING );
+		$funding_source = filter_input( INPUT_POST, 'ppcp-funding-source', FILTER_SANITIZE_STRING );
 
 		/**
 		 * If customer has chosen a saved credit card payment.
@@ -135,7 +136,7 @@ trait ProcessPaymentTrait {
 			}
 		}
 
-		if ( PayPalGateway::ID === $payment_method && $this->is_free_trial_order( $wc_order ) ) {
+		if ( PayPalGateway::ID === $payment_method && 'card' !== $funding_source && $this->is_free_trial_order( $wc_order ) ) {
 			$user_id = (int) $wc_order->get_customer_id();
 			$tokens  = $this->payment_token_repository->all_for_user_id( $user_id );
 			if ( ! array_filter(

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -37,5 +37,29 @@ trait OrderMetaTrait {
 			PayPalGateway::ORDER_PAYMENT_MODE_META_KEY,
 			$environment->current_environment_is( Environment::SANDBOX ) ? 'sandbox' : 'live'
 		);
+		$payment_source = $this->get_payment_source( $order );
+		if ( $payment_source ) {
+			$wc_order->update_meta_data( PayPalGateway::ORDER_PAYMENT_SOURCE, $payment_source );
+		}
+	}
+
+	/**
+	 * Returns the payment source type or null,
+	 *
+	 * @param Order $order The PayPal order.
+	 * @return string|null
+	 */
+	private function get_payment_source( Order $order ): ?string {
+		$source = $order->payment_source();
+		if ( $source ) {
+			if ( $source->card() ) {
+				return 'card';
+			}
+			if ( $source->wallet() ) {
+				return 'wallet';
+			}
+		}
+
+		return null;
 	}
 }

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -162,6 +162,9 @@ class AmountFactoryTest extends TestCase
             ->shouldReceive('get_total_discount')
             ->with(false)
             ->andReturn(3);
+        $order
+            ->shouldReceive('get_meta')
+            ->andReturn(null);
 
         $result = $this->testee->from_wc_order($order);
         $this->assertEquals((float) 3, $result->breakdown()->discount()->value());
@@ -222,6 +225,9 @@ class AmountFactoryTest extends TestCase
             ->shouldReceive('get_total_discount')
             ->with(false)
             ->andReturn(0);
+		$order
+			->shouldReceive('get_meta')
+			->andReturn(null);
 
         $result = $this->testee->from_wc_order($order);
         $this->assertNull($result->breakdown()->discount());

--- a/tests/PHPUnit/Subscription/RenewalHandlerTest.php
+++ b/tests/PHPUnit/Subscription/RenewalHandlerTest.php
@@ -98,6 +98,9 @@ class RenewalHandlerTest extends TestCase
 		$order
 			->shouldReceive('purchase_units')
 			->andReturn([$purchaseUnit]);
+		$order
+			->shouldReceive('payment_source')
+			->andReturn(null);
 
 		$wcOrder
 			->shouldReceive('get_id')

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -85,6 +85,9 @@ class OrderProcessorTest extends TestCase
             ->andReturn($orderStatus);
         $currentOrder->shouldReceive('purchase_units')
             ->andReturn([$purchaseUnit]);
+		$currentOrder
+			->shouldReceive('payment_source')
+			->andReturn(null);
 
         $sessionHandler = Mockery::mock(SessionHandler::class);
         $sessionHandler
@@ -202,6 +205,9 @@ class OrderProcessorTest extends TestCase
         $currentOrder
             ->shouldReceive('purchase_units')
             ->andReturn([$purchaseUnit]);
+		$currentOrder
+			->shouldReceive('payment_source')
+			->andReturn(null);
         $sessionHandler = Mockery::mock(SessionHandler::class);
         $sessionHandler
             ->expects('order')


### PR DESCRIPTION
Fixes #614

Now handling the card smart button for free trials similarly to DCC (1$ auth + void) because disabling this funding source also disables DCC, not just the button.