### PR TITLE
Add Fraud Processor Response as an order note.

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -27,6 +27,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\ApplicationContextFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\AuthorizationFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\CaptureFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ExchangeRateFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\FraudProcessorResponseFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ItemFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\MoneyFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
@@ -257,7 +258,8 @@ return array(
 		$amount_factory   = $container->get( 'api.factory.amount' );
 		return new CaptureFactory(
 			$amount_factory,
-			$container->get( 'api.factory.seller-receivable-breakdown' )
+			$container->get( 'api.factory.seller-receivable-breakdown' ),
+			$container->get( 'api.factory.fraud-processor-response' )
 		);
 	},
 	'api.factory.purchase-unit'                 => static function ( ContainerInterface $container ): PurchaseUnitFactory {
@@ -353,6 +355,9 @@ return array(
 			$container->get( 'api.factory.exchange-rate' ),
 			$container->get( 'api.factory.platform-fee' )
 		);
+	},
+	'api.factory.fraud-processor-response'      => static function ( ContainerInterface $container ): FraudProcessorResponseFactory {
+		return new FraudProcessorResponseFactory();
 	},
 	'api.helpers.dccapplies'                    => static function ( ContainerInterface $container ) : DccApplies {
 		return new DccApplies(

--- a/modules/ppcp-api-client/src/Entity/Capture.php
+++ b/modules/ppcp-api-client/src/Entity/Capture.php
@@ -59,6 +59,13 @@ class Capture {
 	private $seller_receivable_breakdown;
 
 	/**
+	 * The fraud processor response (AVS, CVV ...).
+	 *
+	 * @var FraudProcessorResponse|null
+	 */
+	protected $fraud_processor_response;
+
+	/**
 	 * The invoice id.
 	 *
 	 * @var string
@@ -83,6 +90,7 @@ class Capture {
 	 * @param string                         $invoice_id The invoice id.
 	 * @param string                         $custom_id The custom id.
 	 * @param SellerReceivableBreakdown|null $seller_receivable_breakdown The detailed breakdown of the capture activity (fees, ...).
+	 * @param FraudProcessorResponse|null    $fraud_processor_response The fraud processor response (AVS, CVV ...).
 	 */
 	public function __construct(
 		string $id,
@@ -92,7 +100,8 @@ class Capture {
 		string $seller_protection,
 		string $invoice_id,
 		string $custom_id,
-		?SellerReceivableBreakdown $seller_receivable_breakdown
+		?SellerReceivableBreakdown $seller_receivable_breakdown,
+		?FraudProcessorResponse $fraud_processor_response
 	) {
 
 		$this->id                          = $id;
@@ -103,6 +112,7 @@ class Capture {
 		$this->invoice_id                  = $invoice_id;
 		$this->custom_id                   = $custom_id;
 		$this->seller_receivable_breakdown = $seller_receivable_breakdown;
+		$this->fraud_processor_response    = $fraud_processor_response;
 	}
 
 	/**
@@ -178,6 +188,15 @@ class Capture {
 	}
 
 	/**
+	 * Returns the fraud processor response (AVS, CVV ...).
+	 *
+	 * @return FraudProcessorResponse|null
+	 */
+	public function fraud_processor_response() : ?FraudProcessorResponse {
+		return $this->fraud_processor_response;
+	}
+
+	/**
 	 * Returns the entity as array.
 	 *
 	 * @return array
@@ -198,6 +217,9 @@ class Capture {
 		}
 		if ( $this->seller_receivable_breakdown ) {
 			$data['seller_receivable_breakdown'] = $this->seller_receivable_breakdown->to_array();
+		}
+		if ( $this->fraud_processor_response ) {
+			$data['fraud_processor_response'] = $this->fraud_processor_response->to_array();
 		}
 		return $data;
 	}

--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * The FraudProcessorResponse object.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Entity
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
+
+/**
+ * Class FraudProcessorResponse
+ */
+class FraudProcessorResponse {
+
+	/**
+	 * The AVS response code.
+	 *
+	 * @var string|null
+	 */
+	protected $avs_code;
+
+	/**
+	 * The CVV response code.
+	 *
+	 * @var string|null
+	 */
+	protected $cvv_code;
+
+	/**
+	 * FraudProcessorResponse constructor.
+	 *
+	 * @param string|null $avs_code The AVS response code.
+	 * @param string|null $cvv_code The CVV response code.
+	 */
+	public function __construct( ?string $avs_code, ?string $cvv_code ) {
+		$this->avs_code = $avs_code;
+		$this->cvv_code = $cvv_code;
+	}
+
+	/**
+	 * Returns the AVS response code.
+	 *
+	 * @return string|null
+	 */
+	public function avs_code(): ?string {
+		return $this->avs_code;
+	}
+
+	/**
+	 * Returns the CVV response code.
+	 *
+	 * @return string|null
+	 */
+	public function cvv_code(): ?string {
+		return $this->cvv_code;
+	}
+
+	/**
+	 * Returns the object as array.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return array(
+			'avs_code'      => $this->avs_code() ?: '',
+			'address_match' => $this->avs_code() === 'M' ? 'Y' : 'N',
+			'postal_match'  => $this->avs_code() === 'M' ? 'Y' : 'N',
+			'cvv_match'     => $this->cvv_code() === 'M' ? 'Y' : 'N',
+		);
+	}
+
+}

--- a/modules/ppcp-api-client/src/Factory/CaptureFactory.php
+++ b/modules/ppcp-api-client/src/Factory/CaptureFactory.php
@@ -33,18 +33,28 @@ class CaptureFactory {
 	private $seller_receivable_breakdown_factory;
 
 	/**
+	 * The FraudProcessorResponseFactory factory.
+	 *
+	 * @var FraudProcessorResponseFactory
+	 */
+	protected $fraud_processor_response_factory;
+
+	/**
 	 * CaptureFactory constructor.
 	 *
 	 * @param AmountFactory                    $amount_factory The amount factory.
 	 * @param SellerReceivableBreakdownFactory $seller_receivable_breakdown_factory The SellerReceivableBreakdown factory.
+	 * @param FraudProcessorResponseFactory    $fraud_processor_response_factory The FraudProcessorResponseFactory factory.
 	 */
 	public function __construct(
 		AmountFactory $amount_factory,
-		SellerReceivableBreakdownFactory $seller_receivable_breakdown_factory
+		SellerReceivableBreakdownFactory $seller_receivable_breakdown_factory,
+		FraudProcessorResponseFactory $fraud_processor_response_factory
 	) {
 
 		$this->amount_factory                      = $amount_factory;
 		$this->seller_receivable_breakdown_factory = $seller_receivable_breakdown_factory;
+		$this->fraud_processor_response_factory    = $fraud_processor_response_factory;
 	}
 
 	/**
@@ -55,10 +65,13 @@ class CaptureFactory {
 	 * @return Capture
 	 */
 	public function from_paypal_response( \stdClass $data ) : Capture {
-
 		$reason                      = $data->status_details->reason ?? null;
 		$seller_receivable_breakdown = isset( $data->seller_receivable_breakdown ) ?
 			$this->seller_receivable_breakdown_factory->from_paypal_response( $data->seller_receivable_breakdown )
+			: null;
+
+		$fraud_processor_response = isset( $data->processor_response ) ?
+			$this->fraud_processor_response_factory->from_paypal_response( $data->processor_response )
 			: null;
 
 		return new Capture(
@@ -72,7 +85,8 @@ class CaptureFactory {
 			(string) $data->seller_protection->status,
 			(string) $data->invoice_id,
 			(string) $data->custom_id,
-			$seller_receivable_breakdown
+			$seller_receivable_breakdown,
+			$fraud_processor_response
 		);
 	}
 }

--- a/modules/ppcp-api-client/src/Factory/FraudProcessorResponseFactory.php
+++ b/modules/ppcp-api-client/src/Factory/FraudProcessorResponseFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * The FraudProcessorResponseFactory Factory.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Factory
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
+
+use stdClass;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\FraudProcessorResponse;
+
+/**
+ * Class FraudProcessorResponseFactory
+ */
+class FraudProcessorResponseFactory {
+
+	/**
+	 * Returns a FraudProcessorResponse object based off a PayPal Response.
+	 *
+	 * @param stdClass $data The JSON object.
+	 *
+	 * @return FraudProcessorResponse
+	 */
+	public function from_paypal_response( stdClass $data ): FraudProcessorResponse {
+		$avs_code = $data->avs_code ?: null;
+		$cvv_code = $data->cvv_code ?: null;
+
+		return new FraudProcessorResponse( $avs_code, $cvv_code );
+	}
+}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -82,6 +82,44 @@ class WCGatewayModule implements ModuleInterface {
 					$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
 					$wc_order->save_meta_data();
 				}
+
+				$fraud = $capture->fraud_processor_response();
+				if ( $fraud ) {
+					$fraud_responses               = $fraud->to_array();
+					$avs_response_order_note_title = __( 'Address Verification Result', 'woocommerce-paypal-payments' );
+					/* translators: %1$s is AVS order note title, %2$s is AVS order note result markup */
+					$avs_response_order_note_format        = __( '%1$s %2$s', 'woocommerce-paypal-payments' );
+					$avs_response_order_note_result_format = '<ul class="ppcp_avs_result">
+                                                                <li>%1$s</li>
+                                                                <ul class="ppcp_avs_result_inner">
+                                                                    <li>%2$s</li>
+                                                                    <li>%3$s</li>
+                                                                </ul>
+                                                            </ul>';
+					$avs_response_order_note_result        = sprintf(
+						$avs_response_order_note_result_format,
+						/* translators: %s is fraud AVS code */
+						sprintf( __( 'AVS: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['avs_code'] ) ),
+						/* translators: %s is fraud AVS address match */
+						sprintf( __( 'Address Match: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['address_match'] ) ),
+						/* translators: %s is fraud AVS postal match */
+						sprintf( __( 'Postal Match: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['postal_match'] ) )
+					);
+					$avs_response_order_note = sprintf(
+						$avs_response_order_note_format,
+						esc_html( $avs_response_order_note_title ),
+						wp_kses_post( $avs_response_order_note_result )
+					);
+					$wc_order->add_order_note( $avs_response_order_note );
+
+					$cvv_response_order_note_format = '<ul class="ppcp_cvv_result"><li>%1$s</li></ul>';
+					$cvv_response_order_note        = sprintf(
+						$cvv_response_order_note_format,
+						/* translators: %s is fraud CVV match */
+						sprintf( __( 'CVV2 Match: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['cvv_match'] ) )
+					);
+					$wc_order->add_order_note( $cvv_response_order_note );
+				}
 			},
 			10,
 			2


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #616

---

### Description

The PR will add functionality for adding Fraud Processor Response in order notes when it exists.

- Address Verification Result
   - AVS
   - Address Match (Y/N)
   - Postal / Zip Code Match (Y/N)
  
- Card Security Code Result
   - CVV2 Match (Y/N)

![364d6c09-a87f-41a0-b048-d2f80732bf30](https://user-images.githubusercontent.com/11319597/165121500-c3b5f21c-7208-4ebe-865b-8b10a7bfd94b.png)

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Pay for order with credit card.
2. Check the order edit screen in admin area.

---

Closes #616 .
