### PR TITLE
Fix duplicated partial refunds

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PaymentsEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentsEndpoint.php
@@ -198,11 +198,11 @@ class PaymentsEndpoint {
 	 *
 	 * @param Refund $refund The refund to be processed.
 	 *
-	 * @return void
+	 * @return string Refund ID.
 	 * @throws RuntimeException If the request fails.
 	 * @throws PayPalApiException If the request fails.
 	 */
-	public function refund( Refund $refund ) : void {
+	public function refund( Refund $refund ) : string {
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/payments/captures/' . $refund->for_capture()->id() . '/refund';
 		$args   = array(
@@ -223,12 +223,15 @@ class PaymentsEndpoint {
 		}
 
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
-		if ( 201 !== $status_code ) {
+		$json        = json_decode( $response['body'] );
+		if ( 201 !== $status_code || ! is_object( $json ) ) {
 			throw new PayPalApiException(
 				$json,
 				$status_code
 			);
 		}
+
+		return $json->id;
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Endpoint/PaymentsEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentsEndpoint.php
@@ -216,7 +216,6 @@ class PaymentsEndpoint {
 		);
 
 		$response = $this->request( $url, $args );
-		$json     = json_decode( $response['body'] );
 
 		if ( is_wp_error( $response ) ) {
 			throw new RuntimeException( 'Could not refund payment.' );

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -127,7 +127,7 @@ class AmountFactory {
 		$total_value = (float) $order->get_total();
 		if ( (
 			CreditCardGateway::ID === $order->get_payment_method()
-				|| ( PayPalGateway::ID === $order->get_payment_method() && 'card' === $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE ) )
+				|| ( PayPalGateway::ID === $order->get_payment_method() && 'card' === $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) )
 			)
 			&& $this->is_free_trial_order( $order )
 		) {

--- a/modules/ppcp-vaulting/src/PaymentTokenChecker.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenChecker.php
@@ -119,7 +119,7 @@ class PaymentTokenChecker {
 			try {
 				if ( $this->is_free_trial_order( $wc_order ) ) {
 					if ( CreditCardGateway::ID === $wc_order->get_payment_method()
-						|| ( PayPalGateway::ID === $wc_order->get_payment_method() && 'card' === $wc_order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE ) )
+						|| ( PayPalGateway::ID === $wc_order->get_payment_method() && 'card' === $wc_order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) )
 					) {
 						$order = $this->order_repository->for_wc_order( $wc_order );
 						$this->authorized_payments_processor->void_authorizations( $order );

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -39,6 +39,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	const ORDER_PAYMENT_MODE_META_KEY   = '_ppcp_paypal_payment_mode';
 	const ORDER_PAYMENT_SOURCE_META_KEY = '_ppcp_paypal_payment_source';
 	const FEES_META_KEY                 = '_ppcp_paypal_fees';
+	const REFUNDS_META_KEY              = '_ppcp_refunds';
 
 	/**
 	 * The Settings Renderer.

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -33,12 +33,12 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 	use ProcessPaymentTrait;
 
-	const ID                          = 'ppcp-gateway';
-	const INTENT_META_KEY             = '_ppcp_paypal_intent';
-	const ORDER_ID_META_KEY           = '_ppcp_paypal_order_id';
-	const ORDER_PAYMENT_MODE_META_KEY = '_ppcp_paypal_payment_mode';
-	const ORDER_PAYMENT_SOURCE        = '_ppcp_paypal_payment_source';
-	const FEES_META_KEY               = '_ppcp_paypal_fees';
+	const ID                            = 'ppcp-gateway';
+	const INTENT_META_KEY               = '_ppcp_paypal_intent';
+	const ORDER_ID_META_KEY             = '_ppcp_paypal_order_id';
+	const ORDER_PAYMENT_MODE_META_KEY   = '_ppcp_paypal_payment_mode';
+	const ORDER_PAYMENT_SOURCE_META_KEY = '_ppcp_paypal_payment_source';
+	const FEES_META_KEY                 = '_ppcp_paypal_fees';
 
 	/**
 	 * The Settings Renderer.

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -39,7 +39,7 @@ trait OrderMetaTrait {
 		);
 		$payment_source = $this->get_payment_source( $order );
 		if ( $payment_source ) {
-			$wc_order->update_meta_data( PayPalGateway::ORDER_PAYMENT_SOURCE, $payment_source );
+			$wc_order->update_meta_data( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY, $payment_source );
 		}
 	}
 

--- a/modules/ppcp-wc-gateway/src/Processor/RefundMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundMetaTrait.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Operations with refund metadata.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Processor
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+/**
+ * Trait RefundMetaTrait.
+ */
+trait RefundMetaTrait {
+
+	/**
+	 * Adds a refund ID to the order metadata.
+	 *
+	 * @param WC_Order $wc_order The WC order to which metadata will be added.
+	 * @param string   $refund_id The refund ID to be added.
+	 */
+	protected function add_refund_to_meta( WC_Order $wc_order, string $refund_id ): void {
+		$refunds   = $this->get_refunds_meta( $wc_order );
+		$refunds[] = $refund_id;
+		$wc_order->update_meta_data( PayPalGateway::REFUNDS_META_KEY, $refunds );
+		$wc_order->save();
+	}
+
+	/**
+	 * Returns refund IDs from the order metadata.
+	 *
+	 * @param WC_Order $wc_order The WC order.
+	 *
+	 * @return string[]
+	 */
+	protected function get_refunds_meta( WC_Order $wc_order ): array {
+		$refunds = $wc_order->get_meta( PayPalGateway::REFUNDS_META_KEY );
+		if ( ! is_array( $refunds ) ) {
+			$refunds = array();
+		}
+		return $refunds;
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
@@ -26,6 +26,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
  * Class RefundProcessor
  */
 class RefundProcessor {
+	use RefundMetaTrait;
 
 	private const REFUND_MODE_REFUND  = 'refund';
 	private const REFUND_MODE_VOID    = 'void';
@@ -113,8 +114,8 @@ class RefundProcessor {
 						throw new RuntimeException( 'No capture.' );
 					}
 
-					$capture = $captures[0];
-					$refund  = new Refund(
+					$capture   = $captures[0];
+					$refund    = new Refund(
 						$capture,
 						$capture->invoice_id(),
 						$reason,
@@ -122,7 +123,10 @@ class RefundProcessor {
 							new Money( $amount, $wc_order->get_currency() )
 						)
 					);
-					$this->payments_endpoint->refund( $refund );
+					$refund_id = $this->payments_endpoint->refund( $refund );
+
+					$this->add_refund_to_meta( $wc_order, $refund_id );
+
 					break;
 				case self::REFUND_MODE_VOID:
 					$voidable_authorizations = array_filter(

--- a/modules/ppcp-webhooks/src/Handler/PaymentCaptureRefunded.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentCaptureRefunded.php
@@ -12,6 +12,8 @@ namespace WooCommerce\PayPalCommerce\Webhooks\Handler;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundMetaTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
+use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * Class PaymentCaptureRefunded
@@ -50,24 +52,24 @@ class PaymentCaptureRefunded implements RequestHandler {
 	/**
 	 * Whether a handler is responsible for a given request or not.
 	 *
-	 * @param \WP_REST_Request $request The request.
+	 * @param WP_REST_Request $request The request.
 	 *
 	 * @return bool
 	 */
-	public function responsible_for_request( \WP_REST_Request $request ): bool {
+	public function responsible_for_request( WP_REST_Request $request ): bool {
 		return in_array( $request['event_type'], $this->event_types(), true );
 	}
 
 	/**
 	 * Responsible for handling the request.
 	 *
-	 * @param \WP_REST_Request $request The request.
+	 * @param WP_REST_Request $request The request.
 	 *
-	 * @return \WP_REST_Response
+	 * @return WP_REST_Response
 	 */
-	public function handle_request( \WP_REST_Request $request ): \WP_REST_Response {
-		$response = array( 'success' => false );
-		$order_id = isset( $request['resource']['custom_id'] ) ?
+	public function handle_request( WP_REST_Request $request ): WP_REST_Response {
+		$response  = array( 'success' => false );
+		$order_id  = isset( $request['resource']['custom_id'] ) ?
 			$this->sanitize_custom_id( $request['resource']['custom_id'] ) : 0;
 		$refund_id = (string) ( $request['resource']['id'] ?? '' );
 		if ( ! $order_id ) {
@@ -87,7 +89,7 @@ class PaymentCaptureRefunded implements RequestHandler {
 				)
 			);
 			$response['message'] = $message;
-			return rest_ensure_response( $response );
+			return new WP_REST_Response( $response );
 		}
 
 		$wc_order = wc_get_order( $order_id );
@@ -105,7 +107,7 @@ class PaymentCaptureRefunded implements RequestHandler {
 				)
 			);
 			$response['message'] = $message;
-			return rest_ensure_response( $response );
+			return new WP_REST_Response( $response );
 		}
 
 		$already_added_refunds = $this->get_refunds_meta( $wc_order );
@@ -140,7 +142,7 @@ class PaymentCaptureRefunded implements RequestHandler {
 			);
 
 			$response['message'] = $refund->get_error_message();
-			return rest_ensure_response( $response );
+			return new WP_REST_Response( $response );
 		}
 
 		$this->logger->log(
@@ -166,6 +168,6 @@ class PaymentCaptureRefunded implements RequestHandler {
 		}
 
 		$response['success'] = true;
-		return rest_ensure_response( $response );
+		return new WP_REST_Response( $response );
 	}
 }


### PR DESCRIPTION
Fixes #522 

It may not be a perfect solution because theoretically we may get a race condition if we get webhook immediately after sending the refund to PayPal before the refund ID is saved. But it seems like currently the webhooks are sent a bit later, not during the `v2/payments/captures/.../refund` API request, so hopefully it's ok.