### PR TITLE
Check if the line item is associated with a valid product.

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -99,20 +99,26 @@ class ItemFactory {
 	 */
 	public function from_wc_order( \WC_Order $order ): array {
 		$items = array_map(
-			function ( \WC_Order_Item_Product $item ) use ( $order ): Item {
+			function ( \WC_Order_Item_Product $item ) use ( $order ): ?Item {
+				if ( ! $item->get_product() ) {
+					return null;
+				}
 				return $this->from_wc_order_line_item( $item, $order );
 			},
 			$order->get_items( 'line_item' )
 		);
 
 		$fees = array_map(
-			function ( \WC_Order_Item_Fee $item ) use ( $order ): Item {
+			function ( \WC_Order_Item_Fee $item ) use ( $order ): ?Item {
+				if ( ! $item ) {
+					return null;
+				}
 				return $this->from_wc_order_fee( $item, $order );
 			},
 			$order->get_fees()
 		);
 
-		return array_merge( $items, $fees );
+		return array_merge( array_filter( $items ), array_filter( $fees ) );
 	}
 
 	/**

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -149,6 +149,7 @@ class ItemFactoryTest extends TestCase
         $item = Mockery::mock(\WC_Order_Item_Product::class);
         $item
             ->expects('get_product')
+            ->twice()
             ->andReturn($product);
         $item
             ->expects('get_quantity')
@@ -212,6 +213,7 @@ class ItemFactoryTest extends TestCase
         $item = Mockery::mock(\WC_Order_Item_Product::class);
         $item
             ->expects('get_product')
+            ->twice()
             ->andReturn($product);
         $item
             ->expects('get_quantity')
@@ -270,6 +272,7 @@ class ItemFactoryTest extends TestCase
         $item = Mockery::mock(\WC_Order_Item_Product::class);
         $item
             ->expects('get_product')
+            ->twice()
             ->andReturn($product);
         $item
             ->expects('get_quantity')


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #622

---

### Description

Although we were not able to reproduce the problem but there were several reports about this.
`Fatal error: Uncaught Error: Call to a member function get_name() on bool (368)`
Error likely caused by a plugin conflict.

After some investigation I have found that in this particular example the error means that the `WC_Order_Item_Product`  type `$item->get_product()` is `false` , which in other words means that the line item is not associated with a valid product.

[Here in array_map](https://github.com/woocommerce/woocommerce-paypal-payments/blob/6ebd88230b51a73cc43348f0eaf0994ca434274b/modules/ppcp-api-client/src/Factory/ItemFactory.php#L101) each `WC_Order_Item_Product` `$item` is passed to [from_wc_order_line_item](https://github.com/woocommerce/woocommerce-paypal-payments/blob/6ebd88230b51a73cc43348f0eaf0994ca434274b/modules/ppcp-api-client/src/Factory/ItemFactory.php#L126) method where the `$item->get_product()` is `false` [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/6ebd88230b51a73cc43348f0eaf0994ca434274b/modules/ppcp-api-client/src/Factory/ItemFactory.php#L132). Then we try to use `$product` to get several values like `$product->get_name()`  or `$product->get_description()` which causes the fatal error.

Since the [“line item“ problem](https://inpsyde.atlassian.net/browse/PCP-253) is not reproducible either then I would propose the following solution, although it is not the correct way to fix this problem to my mind, because the correct way to solve this problem would be to check and fix why there is an invalid product associated with the line item.

- So [Here in array_map](https://github.com/woocommerce/woocommerce-paypal-payments/blob/6ebd88230b51a73cc43348f0eaf0994ca434274b/modules/ppcp-api-client/src/Factory/ItemFactory.php#L101) the callback returns `Item` type. I would change to return either `Item` type or null (`?Item`)
- Then inside callback body I will check if `$item->get_product()` is `false` then I will return `null` so it will not enter the [from_wc_order_line_item](https://github.com/woocommerce/woocommerce-paypal-payments/blob/6ebd88230b51a73cc43348f0eaf0994ca434274b/modules/ppcp-api-client/src/Factory/ItemFactory.php#L126) method and will not cause the error

- The same way I will filter the `$fees` [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/6ebd88230b51a73cc43348f0eaf0994ca434274b/modules/ppcp-api-client/src/Factory/ItemFactory.php#L108)

- Finally to avoid the same problem by consumers of [this method](https://github.com/woocommerce/woocommerce-paypal-payments/blob/6ebd88230b51a73cc43348f0eaf0994ca434274b/modules/ppcp-api-client/src/Factory/ItemFactory.php#L100) instead of [returning](https://github.com/woocommerce/woocommerce-paypal-payments/blob/6ebd88230b51a73cc43348f0eaf0994ca434274b/modules/ppcp-api-client/src/Factory/ItemFactory.php#L115) `array_merge( $items, $fees );` I will return `array_merge( array_filter($items), array_filter($fees) )` where `array_filter` will remove all “null“ items and will keep only the ones which contain a valid product.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

Since we were not able to reproduce it the decision was made to create a PR with a potential workaround and when we have any new customer reports about this, we can create a new package with the potential fix.

If the proposed fix works and causes no issues, we can merge it.

---

Closes #622 .
