### PR TITLE
[PUI] handle webhook failures

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -180,6 +180,14 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 			$order = $this->order_endpoint->create( array( $purchase_unit ), $payment_source );
 			$this->add_paypal_meta( $wc_order, $order, $this->environment );
 
+			as_schedule_single_action(
+				time() + ( 5 * MINUTE_IN_SECONDS ),
+				'woocommerce_paypal_payments_check_pui_payment_captured',
+				array(
+					'order_id' => $order_id,
+				)
+			);
+
 			WC()->cart->empty_cart();
 
 			return array(

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -194,6 +194,22 @@ class WCGatewayModule implements ModuleInterface {
 				}
 			}
 		);
+
+		add_action(
+			'woocommerce_paypal_payments_check_pui_payment_captured',
+			function ( int $order_id ) {
+				$wc_order = wc_get_order( $order_id );
+				if ( ! is_a( $wc_order, WC_Order::class ) || $wc_order->get_status() !== 'on-hold' ) {
+					return;
+				}
+
+				$message = __(
+					'Could not process order because PAYMENT.CAPTURE.COMPLETED webhook not received.',
+					'woocommerce-paypal-payments'
+				);
+				$wc_order->update_status( 'failed', $message );
+			}
+		);
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Gateway/PayUponInvoice/PayUponInvoiceGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/PayUponInvoice/PayUponInvoiceGatewayTest.php
@@ -53,6 +53,9 @@ class PayUponInvoiceGatewayTest extends TestCase
 			$payment_source
 		)->andReturn($order);
 
+		define( 'MINUTE_IN_SECONDS', 60 );
+		when('as_schedule_single_action')->justReturn();
+
 		$result = $this->testee->process_payment(1);
 		$this->assertEquals('success', $result['result']);
 	}


### PR DESCRIPTION
### Description
When the user is not subscribed to webhooks, but a PUI order is attempted, the order will remain “On-hold” indefinitely and will never update or send out payment instructions as the webhook would not arrive.

### Steps to Test
1. remove webhooks in PayPal or untrack “payment_capture_complet”
2. create PUI order
3. order will remain “On-hold” indefintely

### Expected behaviour
- The order should fail after a certain time when no webhook was received.
- An order note should be added that no webhook was received from PayPal, causing the failure.
