### PR TITLE
PUI gateway visible when checkout currency or order total are not supported

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -286,7 +286,7 @@ class PayUponInvoice {
 
 		$cart = WC()->cart ?? null;
 		if ( $cart ) {
-			$cart_total = (int) WC()->cart->get_totals()['total'];
+			$cart_total = (float) $cart->get_total( 'numeric' );
 			if ( $cart_total < 5 || $cart_total > 2500 ) {
 				return false;
 			}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -260,14 +260,39 @@ class PayUponInvoice {
 		add_filter(
 			'woocommerce_available_payment_gateways',
 			function( array $methods ): array {
-				$billing_country = filter_input( INPUT_POST, 'country', FILTER_SANITIZE_STRING ) ?? null;
-				if ( $billing_country && 'DE' !== $billing_country ) {
+				if ( ! $this->is_checkout_ready_for_pui() ) {
 					unset( $methods[ PayUponInvoiceGateway::ID ] );
 				}
 
 				return $methods;
 			}
 		);
+	}
+
+	/**
+	 * Checks whether checkout is ready for PUI.
+	 *
+	 * @return bool
+	 */
+	private function is_checkout_ready_for_pui(): bool {
+		$billing_country = filter_input( INPUT_POST, 'country', FILTER_SANITIZE_STRING ) ?? null;
+		if ( $billing_country && 'DE' !== $billing_country ) {
+			return false;
+		}
+
+		if ( 'EUR' !== get_woocommerce_currency() ) {
+			return false;
+		}
+
+		$cart = WC()->cart ?? null;
+		if ( $cart ) {
+			$cart_total = (int) WC()->cart->get_totals()['total'] ?? 0;
+			if ( $cart_total < 5 || $cart_total > 2500 ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -286,7 +286,7 @@ class PayUponInvoice {
 
 		$cart = WC()->cart ?? null;
 		if ( $cart ) {
-			$cart_total = (int) WC()->cart->get_totals()['total'] ?? 0;
+			$cart_total = (int) WC()->cart->get_totals()['total'];
 			if ( $cart_total < 5 || $cart_total > 2500 ) {
 				return false;
 			}


### PR DESCRIPTION
### Description

The PUI gateway is visible for every currency as long as the Checkout county is Germany.

Payments must be made in EUR and be between 5€ and 2500€.
We should prevent errors whenever possible so it makes more sense it hide the gateway if the currency or checkout total is not supported.

### Steps to Test

1. set up PUI
2. change WooCommerce currency to any non-EUR currency
3. gateway remains visible but every Checkout attempt will fail
4. change currency back to EUR and change order total to anything outside of 5€-2500€
5. gateway remains visible but every Checkout attempt will fail