### PR TITLE
Hide PUI gateway when merchant account not being enabled for PUI (683)

### DIFF
--- a/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
@@ -127,6 +127,7 @@ class LoginSellerEndpoint implements EndpointInterface {
 			$is_sandbox = isset( $data['env'] ) && 'sandbox' === $data['env'];
 			$this->settings->set( 'sandbox_on', $is_sandbox );
 			$this->settings->set( 'products_dcc_enabled', null );
+			$this->settings->set( 'products_pui_enabled', null );
 			$this->settings->persist();
 
 			$endpoint    = $is_sandbox ? $this->login_seller_sandbox : $this->login_seller_production;

--- a/modules/ppcp-onboarding/src/OnboardingRESTController.php
+++ b/modules/ppcp-onboarding/src/OnboardingRESTController.php
@@ -236,6 +236,7 @@ class OnboardingRESTController {
 		}
 
 		$settings->set( 'products_dcc_enabled', null );
+		$settings->set( 'products_pui_enabled', null );
 
 		if ( ! $settings->persist() ) {
 			return new \WP_Error(

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2193,7 +2193,7 @@ return array(
 			(string) $source_website_id()
 		);
 	},
-	'wcgateway.pay-upon-invoice-product-status' => static function(ContainerInterface $container): PayUponInvoiceProductStatus {
+	'wcgateway.pay-upon-invoice-product-status'         => static function( ContainerInterface $container ): PayUponInvoiceProductStatus {
 		return new PayUponInvoiceProductStatus(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'api.endpoint.partners' )
@@ -2209,9 +2209,9 @@ return array(
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'onboarding.state' ),
-			$container->get('wcgateway.is-ppcp-settings-page'),
+			$container->get( 'wcgateway.is-ppcp-settings-page' ),
 			$container->get( 'wcgateway.current-ppcp-settings-page-id' ),
-			$container->get('wcgateway.pay-upon-invoice-product-status')
+			$container->get( 'wcgateway.pay-upon-invoice-product-status' )
 		);
 	},
 	'wcgateway.logging.is-enabled'                      => function ( ContainerInterface $container ) : bool {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -37,7 +37,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PaymentSourceFac
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoice;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\AuthorizeOrderActionNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\ConnectAdminNotice;
@@ -2138,11 +2138,11 @@ return array(
 		return new TransactionUrlProvider( $sandbox_url_base, $live_url_base );
 	},
 
-	'wcgateway.helper.dcc-product-status'               => static function ( ContainerInterface $container ) : DCCProductStatus {
+	'wcgateway.helper.dcc-product-status'               => static function ( ContainerInterface $container ) : PayUponInvoiceProductStatus {
 
 		$settings         = $container->get( 'wcgateway.settings' );
 		$partner_endpoint = $container->get( 'api.endpoint.partners' );
-		return new DCCProductStatus( $settings, $partner_endpoint );
+		return new PayUponInvoiceProductStatus( $settings, $partner_endpoint );
 	},
 
 	'button.helper.messages-disclaimers'                => static function ( ContainerInterface $container ): MessagesDisclaimers {
@@ -2192,6 +2192,12 @@ return array(
 			(string) $source_website_id()
 		);
 	},
+	'wcgateway.pay-upon-invoice-product-status' => static function(ContainerInterface $container): PayUponInvoiceProductStatus {
+		return new PayUponInvoiceProductStatus(
+			$container->get( 'wcgateway.settings' ),
+			$container->get( 'api.endpoint.partners' )
+		);
+	},
 	'wcgateway.pay-upon-invoice'                        => static function ( ContainerInterface $container ): PayUponInvoice {
 		return new PayUponInvoice(
 			$container->get( 'wcgateway.url' ),
@@ -2200,7 +2206,11 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'onboarding.environment' ),
-			$container->get( 'ppcp.asset-version' )
+			$container->get( 'ppcp.asset-version' ),
+			$container->get( 'onboarding.state' ),
+			$container->get('wcgateway.is-ppcp-settings-page'),
+			$container->get( 'wcgateway.current-ppcp-settings-page-id' ),
+			$container->get('wcgateway.pay-upon-invoice-product-status')
 		);
 	},
 	'wcgateway.logging.is-enabled'                      => function ( ContainerInterface $container ) : bool {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -37,6 +37,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PaymentSourceFac
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoice;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\AuthorizeOrderActionNotice;
@@ -2138,11 +2139,11 @@ return array(
 		return new TransactionUrlProvider( $sandbox_url_base, $live_url_base );
 	},
 
-	'wcgateway.helper.dcc-product-status'               => static function ( ContainerInterface $container ) : PayUponInvoiceProductStatus {
+	'wcgateway.helper.dcc-product-status'               => static function ( ContainerInterface $container ) : DCCProductStatus {
 
 		$settings         = $container->get( 'wcgateway.settings' );
 		$partner_endpoint = $container->get( 'api.endpoint.partners' );
-		return new PayUponInvoiceProductStatus( $settings, $partner_endpoint );
+		return new DCCProductStatus( $settings, $partner_endpoint );
 	},
 
 	'button.helper.messages-disclaimers'                => static function ( ContainerInterface $container ): MessagesDisclaimers {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -14,6 +14,8 @@ use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PayUponInvoiceOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
@@ -76,6 +78,34 @@ class PayUponInvoice {
 	protected $asset_version;
 
 	/**
+	 * The onboarding state.
+	 *
+	 * @var State
+	 */
+	protected $state;
+
+	/**
+	 * The is ppcp settings page.
+	 *
+	 * @var bool
+	 */
+	protected $is_ppcp_settings_page;
+
+	/**
+	 * Current PayPal settings page id.
+	 *
+	 * @var string
+	 */
+	protected $current_ppcp_settings_page_id;
+
+	/**
+	 * PUI seller product status.
+	 *
+	 * @var PayUponInvoiceProductStatus
+	 */
+	protected $pui_product_status;
+
+	/**
 	 * PayUponInvoice constructor.
 	 *
 	 * @param string                      $module_url The module URL.
@@ -85,6 +115,10 @@ class PayUponInvoice {
 	 * @param Settings                    $settings The settings.
 	 * @param Environment                 $environment The environment.
 	 * @param string                      $asset_version The asset version.
+	 * @param State                       $state The onboarding state.
+	 * @param bool $is_ppcp_settings_page The is ppcp settings page.
+	 * @param string $current_ppcp_settings_page_id Current PayPal settings page id.
+	 * @param PayUponInvoiceProductStatus $pui_product_status PUI seller product status.
 	 */
 	public function __construct(
 		string $module_url,
@@ -93,15 +127,23 @@ class PayUponInvoice {
 		LoggerInterface $logger,
 		Settings $settings,
 		Environment $environment,
-		string $asset_version
+		string $asset_version,
+		State $state,
+		bool $is_ppcp_settings_page,
+		string $current_ppcp_settings_page_id,
+		PayUponInvoiceProductStatus $pui_product_status
 	) {
-		$this->module_url         = $module_url;
-		$this->fraud_net          = $fraud_net;
-		$this->pui_order_endpoint = $pui_order_endpoint;
-		$this->logger             = $logger;
-		$this->settings           = $settings;
-		$this->environment        = $environment;
-		$this->asset_version      = $asset_version;
+		$this->module_url                    = $module_url;
+		$this->fraud_net                     = $fraud_net;
+		$this->pui_order_endpoint            = $pui_order_endpoint;
+		$this->logger                        = $logger;
+		$this->settings                      = $settings;
+		$this->environment                   = $environment;
+		$this->asset_version                 = $asset_version;
+		$this->state                         = $state;
+		$this->is_ppcp_settings_page         = $is_ppcp_settings_page;
+		$this->current_ppcp_settings_page_id = $current_ppcp_settings_page_id;
+		$this->pui_product_status = $pui_product_status;
 	}
 
 	/**
@@ -140,6 +182,7 @@ class PayUponInvoice {
 						'ppcp_ratepay_payment_instructions_payment_reference',
 						$payment_instructions
 					);
+					$wc_order->save_meta_data();
 					$this->logger->info( "Ratepay payment instructions added to order #{$wc_order->get_id()}." );
 
 				} catch ( RuntimeException $exception ) {
@@ -274,6 +317,28 @@ class PayUponInvoice {
 				return $methods;
 			}
 		);
+
+		add_action(
+			'woocommerce_settings_checkout',
+			function () {
+				if (
+					$this->current_ppcp_settings_page_id === PayUponInvoiceGateway::ID
+					&& ! $this->pui_product_status->pui_is_active()
+				) {
+					$gateway_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
+					$gateway_enabled = $gateway_settings['enabled'] ?? '';
+					if($gateway_enabled === 'yes') {
+						$gateway_settings['enabled'] = 'no';
+						update_option('woocommerce_ppcp-pay-upon-invoice-gateway_settings', $gateway_settings);
+						$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-pay-upon-invoice-gateway' );
+						wp_safe_redirect( $redirect_url);
+						exit;
+					}
+
+					echo '<div class="notice notice-error"><p>Could not enable gateway because Pay upon invoice is not active on PayPal.</p></div>';
+				}
+			}
+		);
 	}
 
 	/**
@@ -331,6 +396,4 @@ class PayUponInvoice {
 			)
 		);
 	}
-
-
 }

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -116,8 +116,8 @@ class PayUponInvoice {
 	 * @param Environment                 $environment The environment.
 	 * @param string                      $asset_version The asset version.
 	 * @param State                       $state The onboarding state.
-	 * @param bool $is_ppcp_settings_page The is ppcp settings page.
-	 * @param string $current_ppcp_settings_page_id Current PayPal settings page id.
+	 * @param bool                        $is_ppcp_settings_page The is ppcp settings page.
+	 * @param string                      $current_ppcp_settings_page_id Current PayPal settings page id.
 	 * @param PayUponInvoiceProductStatus $pui_product_status PUI seller product status.
 	 */
 	public function __construct(
@@ -143,7 +143,7 @@ class PayUponInvoice {
 		$this->state                         = $state;
 		$this->is_ppcp_settings_page         = $is_ppcp_settings_page;
 		$this->current_ppcp_settings_page_id = $current_ppcp_settings_page_id;
-		$this->pui_product_status = $pui_product_status;
+		$this->pui_product_status            = $pui_product_status;
 	}
 
 	/**
@@ -322,16 +322,16 @@ class PayUponInvoice {
 			'woocommerce_settings_checkout',
 			function () {
 				if (
-					$this->current_ppcp_settings_page_id === PayUponInvoiceGateway::ID
+					PayUponInvoiceGateway::ID === $this->current_ppcp_settings_page_id
 					&& ! $this->pui_product_status->pui_is_active()
 				) {
 					$gateway_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
-					$gateway_enabled = $gateway_settings['enabled'] ?? '';
-					if($gateway_enabled === 'yes') {
+					$gateway_enabled  = $gateway_settings['enabled'] ?? '';
+					if ( 'yes' === $gateway_enabled ) {
 						$gateway_settings['enabled'] = 'no';
-						update_option('woocommerce_ppcp-pay-upon-invoice-gateway_settings', $gateway_settings);
+						update_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings', $gateway_settings );
 						$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-pay-upon-invoice-gateway' );
-						wp_safe_redirect( $redirect_url);
+						wp_safe_redirect( $redirect_url );
 						exit;
 					}
 
@@ -347,6 +347,10 @@ class PayUponInvoice {
 	 * @return bool
 	 */
 	private function is_checkout_ready_for_pui(): bool {
+		if ( ! $this->pui_product_status->pui_is_active() ) {
+			return false;
+		}
+
 		$billing_country = filter_input( INPUT_POST, 'country', FILTER_SANITIZE_STRING ) ?? null;
 		if ( $billing_country && 'DE' !== $billing_country ) {
 			return false;

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -335,7 +335,10 @@ class PayUponInvoice {
 						exit;
 					}
 
-					echo '<div class="notice notice-error"><p>Could not enable gateway because Pay upon invoice is not active on PayPal.</p></div>';
+					printf(
+						'<div class="notice notice-error"><p>%1$s</p></div>',
+						esc_html__( 'Could not enable gateway because Pay upon invoice is not active on PayPal.', 'woocommerce-paypal-payments' )
+					);
 				}
 			}
 		);

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -85,7 +85,7 @@ class PayUponInvoice {
 	protected $state;
 
 	/**
-	 * The is ppcp settings page.
+	 * Whether the current page is the PPCP settings page.
 	 *
 	 * @var bool
 	 */

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -78,6 +78,7 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	 * @param PurchaseUnitFactory         $purchase_unit_factory The purchase unit factory.
 	 * @param PaymentSourceFactory        $payment_source_factory The payment source factory.
 	 * @param Environment                 $environment The environment.
+	 * @param TransactionUrlProvider      $transaction_url_provider The transaction url provider.
 	 * @param LoggerInterface             $logger The logger.
 	 */
 	public function __construct(

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -13,6 +13,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusProduct;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 
 /**
  * Class DccProductStatus
@@ -22,7 +23,7 @@ class PayUponInvoiceProductStatus {
 	/**
 	 * Caches the status for the current load.
 	 *
-	 * @var string|null
+	 * @var bool|null
 	 */
 	private $current_status_cache;
 	/**
@@ -57,7 +58,7 @@ class PayUponInvoiceProductStatus {
 	 * Whether the active/subscribed products support PUI.
 	 *
 	 * @return bool
-	 * @throws \WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException Should a setting not be found.
+	 * @throws NotFoundException Should a setting not be found.
 	 */
 	public function pui_is_active() : bool {
 		if ( is_bool( $this->current_status_cache ) ) {
@@ -76,7 +77,7 @@ class PayUponInvoiceProductStatus {
 		}
 
 		foreach ( $seller_status->products() as $product ) {
-			if($product->name() !== 'PAYMENT_METHODS') {
+			if ( $product->name() !== 'PAYMENT_METHODS' ) {
 				continue;
 			}
 

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -16,7 +16,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 
 /**
- * Class DccProductStatus
+ * Class PayUponInvoiceProductStatus
  */
 class PayUponInvoiceProductStatus {
 
@@ -41,7 +41,7 @@ class PayUponInvoiceProductStatus {
 	private $partners_endpoint;
 
 	/**
-	 * DccProductStatus constructor.
+	 * PayUponInvoiceProductStatus constructor.
 	 *
 	 * @param Settings         $settings The Settings.
 	 * @param PartnersEndpoint $partners_endpoint The Partner Endpoint.
@@ -58,7 +58,6 @@ class PayUponInvoiceProductStatus {
 	 * Whether the active/subscribed products support PUI.
 	 *
 	 * @return bool
-	 * @throws NotFoundException Should a setting not be found.
 	 */
 	public function pui_is_active() : bool {
 		if ( is_bool( $this->current_status_cache ) ) {

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Manage the Seller status.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Helper
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusProduct;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+/**
+ * Class DccProductStatus
+ */
+class PayUponInvoiceProductStatus {
+
+	/**
+	 * Caches the status for the current load.
+	 *
+	 * @var string|null
+	 */
+	private $current_status_cache;
+	/**
+	 * The settings.
+	 *
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
+	 * The partners endpoint.
+	 *
+	 * @var PartnersEndpoint
+	 */
+	private $partners_endpoint;
+
+	/**
+	 * DccProductStatus constructor.
+	 *
+	 * @param Settings         $settings The Settings.
+	 * @param PartnersEndpoint $partners_endpoint The Partner Endpoint.
+	 */
+	public function __construct(
+		Settings $settings,
+		PartnersEndpoint $partners_endpoint
+	) {
+		$this->settings          = $settings;
+		$this->partners_endpoint = $partners_endpoint;
+	}
+
+	/**
+	 * Whether the active/subscribed products support PUI.
+	 *
+	 * @return bool
+	 * @throws \WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException Should a setting not be found.
+	 */
+	public function pui_is_active() : bool {
+		if ( is_bool( $this->current_status_cache ) ) {
+			return $this->current_status_cache;
+		}
+		if ( $this->settings->has( 'products_pui_enabled' ) && $this->settings->get( 'products_pui_enabled' ) ) {
+			$this->current_status_cache = true;
+			return true;
+		}
+
+		try {
+			$seller_status = $this->partners_endpoint->seller_status();
+		} catch ( RuntimeException $error ) {
+			$this->current_status_cache = false;
+			return false;
+		}
+
+		foreach ( $seller_status->products() as $product ) {
+			if($product->name() !== 'PAYMENT_METHODS') {
+				continue;
+			}
+
+			if ( ! in_array(
+				$product->vetting_status(),
+				array(
+					SellerStatusProduct::VETTING_STATUS_APPROVED,
+					SellerStatusProduct::VETTING_STATUS_SUBSCRIBED,
+				),
+				true
+			)
+			) {
+				continue;
+			}
+
+			if ( in_array( 'PAY_UPON_INVOICE', $product->capabilities(), true ) ) {
+				$this->settings->set( 'products_pui_enabled', true );
+				$this->settings->persist();
+				$this->current_status_cache = true;
+				return true;
+			}
+		}
+
+		$this->current_status_cache = false;
+		return false;
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -255,6 +255,7 @@ class SettingsListener {
 		if ( $credentials_change_status ) {
 			if ( self::CREDENTIALS_UNCHANGED !== $credentials_change_status ) {
 				$this->settings->set( 'products_dcc_enabled', null );
+				$this->settings->set( 'products_pui_enabled', null );
 			}
 
 			if ( in_array(

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -15,7 +15,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use Psr\Container\ContainerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 
@@ -71,7 +71,7 @@ class SettingsRenderer {
 	/**
 	 * The DCC Product Status.
 	 *
-	 * @var PayUponInvoiceProductStatus
+	 * @var DCCProductStatus
 	 */
 	private $dcc_product_status;
 
@@ -90,7 +90,7 @@ class SettingsRenderer {
 	 * @param array              $fields The setting fields.
 	 * @param DccApplies         $dcc_applies Whether DCC gateway can be shown.
 	 * @param MessagesApply      $messages_apply Whether messages can be shown.
-	 * @param PayUponInvoiceProductStatus   $dcc_product_status The product status.
+	 * @param DCCProductStatus   $dcc_product_status The product status.
 	 * @param SettingsStatus     $settings_status The Settings status helper.
 	 * @param string             $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
 	 */
@@ -100,7 +100,7 @@ class SettingsRenderer {
 		array $fields,
 		DccApplies $dcc_applies,
 		MessagesApply $messages_apply,
-		PayUponInvoiceProductStatus $dcc_product_status,
+		DCCProductStatus $dcc_product_status,
 		SettingsStatus $settings_status,
 		string $page_id
 	) {

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -15,7 +15,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use Psr\Container\ContainerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 
@@ -71,7 +71,7 @@ class SettingsRenderer {
 	/**
 	 * The DCC Product Status.
 	 *
-	 * @var DCCProductStatus
+	 * @var PayUponInvoiceProductStatus
 	 */
 	private $dcc_product_status;
 
@@ -90,7 +90,7 @@ class SettingsRenderer {
 	 * @param array              $fields The setting fields.
 	 * @param DccApplies         $dcc_applies Whether DCC gateway can be shown.
 	 * @param MessagesApply      $messages_apply Whether messages can be shown.
-	 * @param DCCProductStatus   $dcc_product_status The product status.
+	 * @param PayUponInvoiceProductStatus   $dcc_product_status The product status.
 	 * @param SettingsStatus     $settings_status The Settings status helper.
 	 * @param string             $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
 	 */
@@ -100,7 +100,7 @@ class SettingsRenderer {
 		array $fields,
 		DccApplies $dcc_applies,
 		MessagesApply $messages_apply,
-		DCCProductStatus $dcc_product_status,
+		PayUponInvoiceProductStatus $dcc_product_status,
 		SettingsStatus $settings_status,
 		string $page_id
 	) {

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -186,7 +186,7 @@ class WCGatewayModule implements ModuleInterface {
 		add_action(
 			'init',
 			function () use ( $c ) {
-				if ('DE' === $c->get( 'api.shop.country' ) && 'EUR' === get_woocommerce_currency() ) {
+				if ( 'DE' === $c->get( 'api.shop.country' ) && 'EUR' === get_woocommerce_currency() ) {
 					( $c->get( 'wcgateway.pay-upon-invoice' ) )->init();
 				}
 			}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -186,10 +186,7 @@ class WCGatewayModule implements ModuleInterface {
 		add_action(
 			'init',
 			function () use ( $c ) {
-				$gateway_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
-				$gateway_enabled  = $gateway_settings['enabled'] ?? '';
-
-				if ( 'yes' === $gateway_enabled && 'DE' === $c->get( 'api.shop.country' ) ) {
+				if ('DE' === $c->get( 'api.shop.country' ) && 'EUR' === get_woocommerce_currency() ) {
 					( $c->get( 'wcgateway.pay-upon-invoice' ) )->init();
 				}
 			}


### PR DESCRIPTION
### Description
When merchant is onboarded but not elegible for PUI (using a merchant account that is not elegible https://developer.paypal.com/limited-release/orders-apms/pay-upon-invoice/#link-eligibility), the gateway should be hidden.

### Proposed solution
We could get the current seller status ([woocommerce-paypal-payments/PartnersEndpoint.php at trunk · woocommerce/woocommerce-paypal-payments](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php#L100) ) and then check if it contains PUI product. If it does not contain it then disable the PUI gateway.