### PR TITLE
Store order info in wc order meta to get if there is no session.

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -207,12 +207,6 @@ class CreditCardRenderer {
                 const firstName = document.getElementById('billing_first_name') ? document.getElementById('billing_first_name').value : '';
                 const lastName = document.getElementById('billing_last_name') ? document.getElementById('billing_last_name').value : '';
 
-                if (!firstName || !lastName) {
-                    this.spinner.unblock();
-                    this.errorHandler.message(this.defaultConfig.hosted_fields.labels.cardholder_name_required);
-                    return;
-                }
-
                 hostedFieldsData.cardholderName = firstName + ' ' + lastName;
             }
 

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -242,6 +242,13 @@ class CreateOrderEndpoint implements EndpointInterface {
 			}
 
 			$order = $this->create_paypal_order( $wc_order );
+
+			if ( 'pay-now' === $data['context'] && is_a( $wc_order, \WC_Order::class ) ) {
+				$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
+				$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
+				$wc_order->save_meta_data();
+			}
+
 			wp_send_json_success( $order->to_array() );
 			return true;
 

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -150,7 +150,8 @@ class OrderProcessor {
 	 * @return bool
 	 */
 	public function process( \WC_Order $wc_order ): bool {
-		$order = $this->session_handler->order();
+		$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
+		$order    = $this->session_handler->order() ?? $this->order_endpoint->order( $order_id );
 		if ( ! $order ) {
 			$this->last_error = __( 'No PayPal order found in the current WooCommerce session.', 'woocommerce-paypal-payments' );
 			return false;

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -89,6 +89,11 @@ class OrderProcessorTest extends TestCase
 			->shouldReceive('payment_source')
 			->andReturn(null);
 
+        $wcOrder
+            ->shouldReceive('get_meta')
+            ->with(PayPalGateway::ORDER_ID_META_KEY)
+            ->andReturn(1);
+
         $sessionHandler = Mockery::mock(SessionHandler::class);
         $sessionHandler
             ->expects('order')
@@ -208,6 +213,12 @@ class OrderProcessorTest extends TestCase
 		$currentOrder
 			->shouldReceive('payment_source')
 			->andReturn(null);
+
+        $wcOrder
+            ->shouldReceive('get_meta')
+            ->with(PayPalGateway::ORDER_ID_META_KEY)
+            ->andReturn(1);
+
         $sessionHandler = Mockery::mock(SessionHandler::class);
         $sessionHandler
             ->expects('order')
@@ -313,6 +324,12 @@ class OrderProcessorTest extends TestCase
         $currentOrder
             ->shouldReceive('purchase_units')
             ->andReturn([$purchaseUnit]);
+
+        $wcOrder
+            ->shouldReceive('get_meta')
+            ->with(PayPalGateway::ORDER_ID_META_KEY)
+            ->andReturn(1);
+
         $sessionHandler = Mockery::mock(SessionHandler::class);
         $sessionHandler
             ->expects('order')


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #530, #605 

---

### Description

When a manual order is created and the payment link is sent to the customer, there may be an error when attempting to complete the purchase with the PayPal Card Processing while the customer is not logged-in:
`Cardholder's first and last name are required, please fill the checkout form required fields.`

![image](https://user-images.githubusercontent.com/70433191/157862591-3a5ec0ed-ba5c-4a5b-abfd-4cf19cd2702f.png)

Even when the name and last name are there or if you pay with PayPal instead of cards, you will get the “No PayPal order found in the current WooCommerce session“ error.

The PR will fix the both of the errors by storing the PayPal order info also in WC order meta so it can be used when there isn't session available for Guest users.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. From the WooCommerce Orders page, manually add a new order.
2. Fill in the details for the new order and save it.
3. Open the payment link with the "pay for order" page as a guest (while not logged in as a user)
4. From the pay for order page, confirm you are not logged in and pay with Credit Card (PayPal Card Processing) or PayPal.
5. Error occurs.

---

Closes # . #530, #605 
