### PR TITLE
Create wordpress directory during ddev start

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -14,6 +14,9 @@ nfs_mount_enabled: false
 mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: "1"
+hooks:
+  pre-start:
+    - exec-host: "mkdir -p .ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}"
 web_environment:
   - WP_VERSION=5.9.3
   - WP_LOCALE=en_US


### PR DESCRIPTION
Otherwise it will be created automatically with wrong permissions.