### PR TITLE
Remove redirect after vaulting settings check

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -441,18 +441,9 @@ class SettingsListener {
 	 */
 	private function is_valid_site_request() : bool {
 
-		/**
-		 * No nonce needed at this point.
-		 *
-		 * phpcs:disable WordPress.Security.NonceVerification.Missing
-		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
-		 */
 		if ( empty( $this->page_id ) ) {
 			return false;
 		}
-
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			return false;

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -208,10 +208,6 @@ class SettingsListener {
 		$this->settings->set( 'message_product_enabled', false );
 		$this->settings->set( 'message_cart_enabled', false );
 		$this->settings->persist();
-
-		$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' );
-		wp_safe_redirect( $redirect_url, 302 );
-		exit;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -167,7 +167,7 @@ class SettingsListener {
 	 * Prevent enabling both Pay Later messaging and PayPal vaulting
 	 */
 	public function listen_for_vaulting_enabled() {
-		if ( ! $this->is_valid_site_request() ) {
+		if ( ! $this->is_valid_site_request() || State::STATE_ONBOARDED !== $this->state->current_state() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #392 

The redirect does not seem to affect anything, so it is simply removed. Unclear why it was added in 38d1b1ad9d4f4514cd85fa2163a941618cedd763, maybe copy-paste of the previous listening function?

Also skipping these check when not onboarded, otherwise vaulting is disabled on disconnect which may cause confusion (may not notice that it is changed after the next onboarding).