### PR TITLE
Download the specified WP version in DDEV

### DIFF
--- a/.ddev/commands/web/orchestrate.d/00_download_wordpress.sh
+++ b/.ddev/commands/web/orchestrate.d/00_download_wordpress.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if ! wp core download; then
+if ! wp core download --version="${WP_VERSION:-latest}"; then
  echo 'WordPress is already installed.'
  exit
 fi


### PR DESCRIPTION
This parameter was not passed to `wp core download`