### PR TITLE
Release 1.8.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 = 1.8.1 - TBD =
 * Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530
 * Fix - "No PayPal order found in the current WooCommerce session" error for guests on Pay for Order page #605
-* Fix - WooCommerce PayPal Payments & Conditional Discounts By Orion #548
+* Fix - Error on order discount by third-party plugins #548
 * Fix - Empty payer data may cause CITY_REQUIRED error for certain checkout countries #632
 * Fix - Mini Cart smart buttons visible after adding subscription product to cart from "shop" page while Vaulting is disabled #624
 * Fix - Smart buttons not loading when free product is in cart but shipping costs are available #606

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,21 @@
 *** Changelog ***
 
+= 1.8.1 - TBD =
+* Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530
+* Fix - "No PayPal order found in the current WooCommerce session" error for guests on Pay for Order page #605
+* Fix - WooCommerce PayPal Payments & Conditional Discounts By Orion #548
+* Fix - Empty payer data may cause CITY_REQUIRED error for certain checkout countries #632
+* Fix - Mini Cart smart buttons visible after adding subscription product to cart from "shop" page while Vaulting is disabled #624
+* Fix - Smart buttons not loading when free product is in cart but shipping costs are available #606
+* Fix - Smart button & Pay Later messaging disappear on the cart page after changing shipping method #288
+* Fix - Disabling PayPal Checkout on the checkout page also removes the button from the Cart and Product Pages #577
+* Fix - Partial refunds via PayPal are created twice/double in WooCommerce order #522
+* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
+* Enhancement - Vaulting & Pay Later UI/UX #174
+* Enhancement - Redirect after updating settings for DCC sends you to PPCP settings screen #392
+* Enhancement - Add Fraud Processor Response as an order note #616
+* Enhancement - Add the Paypal Fee to the Meta Custom Field for export purposes #591
+
 = 1.8.0 - 2022-05-03 =
 * Add - Allow free trial subscriptions #580
 * Fix - The Card Processing does not appear as an available payment method when manually creating an order #562

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 5.9
 Requires PHP: 7.1
-Stable tag: 1.8.0
+Stable tag: 1.8.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,22 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.8.1 =
+* Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530
+* Fix - "No PayPal order found in the current WooCommerce session" error for guests on Pay for Order page #605
+* Fix - WooCommerce PayPal Payments & Conditional Discounts By Orion #548
+* Fix - Empty payer data may cause CITY_REQUIRED error for certain checkout countries #632
+* Fix - Mini Cart smart buttons visible after adding subscription product to cart from "shop" page while Vaulting is disabled #624
+* Fix - Smart buttons not loading when free product is in cart but shipping costs are available #606
+* Fix - Smart button & Pay Later messaging disappear on the cart page after changing shipping method #288
+* Fix - Disabling PayPal Checkout on the checkout page also removes the button from the Cart and Product Pages #577
+* Fix - Partial refunds via PayPal are created twice/double in WooCommerce order #522
+* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
+* Enhancement - Vaulting & Pay Later UI/UX #174
+* Enhancement - Redirect after updating settings for DCC sends you to PPCP settings screen #392
+* Enhancement - Add Fraud Processor Response as an order note #616
+* Enhancement - Add the Paypal Fee to the Meta Custom Field for export purposes #591
 
 = 1.8.0 =
 * Add - Allow free trial subscriptions #580

--- a/readme.txt
+++ b/readme.txt
@@ -84,7 +84,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 = 1.8.1 =
 * Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530
 * Fix - "No PayPal order found in the current WooCommerce session" error for guests on Pay for Order page #605
-* Fix - WooCommerce PayPal Payments & Conditional Discounts By Orion #548
+* Fix - Error on order discount by third-party plugins #548
 * Fix - Empty payer data may cause CITY_REQUIRED error for certain checkout countries #632
 * Fix - Mini Cart smart buttons visible after adding subscription product to cart from "shop" page while Vaulting is disabled #624
 * Fix - Smart buttons not loading when free product is in cart but shipping costs are available #606

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,13 +3,13 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.8.0
+ * Version:     1.8.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 6.4
+ * WC tested up to: 6.5
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce


### PR DESCRIPTION
* Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530
* Fix - "No PayPal order found in the current WooCommerce session" error for guests on Pay for Order page #605
* Fix - WooCommerce PayPal Payments & Conditional Discounts By Orion #548
* Fix - Empty payer data may cause CITY_REQUIRED error for certain checkout countries #632
* Fix - Mini Cart smart buttons visible after adding subscription product to cart from "shop" page while Vaulting is disabled #624
* Fix - Smart buttons not loading when free product is in cart but shipping costs are available #606
* Fix - Smart button & Pay Later messaging disappear on the cart page after changing shipping method #288
* Fix - Disabling PayPal Checkout on the checkout page also removes the button from the Cart and Product Pages #577
* Fix - Partial refunds via PayPal are created twice/double in WooCommerce order #522
* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
* Enhancement - Vaulting & Pay Later UI/UX #174
* Enhancement - Redirect after updating settings for DCC sends you to PPCP settings screen #392
* Enhancement - Add Fraud Processor Response as an order note #616
* Enhancement - Add the Paypal Fee to the Meta Custom Field for export purposes #591