### PR TITLE
Use filter_var for REQUEST_URI

### DIFF
--- a/modules/ppcp-vaulting/src/CustomerApprovalListener.php
+++ b/modules/ppcp-vaulting/src/CustomerApprovalListener.php
@@ -58,7 +58,8 @@ class CustomerApprovalListener {
 			return;
 		}
 
-		$url = (string) filter_input( INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_URL );
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$url = (string) filter_var( $_SERVER['REQUEST_URI'] ?? '', FILTER_SANITIZE_URL );
 
 		$query = wp_parse_url( $url, PHP_URL_QUERY );
 		if ( $query && str_contains( $query, 'ppcp_vault=cancel' ) ) {


### PR DESCRIPTION
In some cases `filter_input` returns `NULL` for server variables even though they are present.
Such as this bug https://bugs.php.net/bug.php?id=49184, though not only in CLI.
At least in our DDEV it happens here.