### PR TITLE
Convert the "," separator into "." before checking the price amount.

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -51,6 +51,8 @@ class SingleProductBootstap {
         else if (document.querySelector('.product .woocommerce-Price-amount')) {
             priceText = document.querySelector('.product .woocommerce-Price-amount').innerText;
         }
+
+        priceText = priceText.replace(/,/g, '.');
         const amount = parseFloat(priceText.replace(/([^\d,\.\s]*)/g, ''));
         return amount === 0;
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #654

---

### Description

When a product costs less than 1 (€, $, etc.), then the smart buttons will not render on the single product page if the decimal separator is set to ",".
The PR will fix it by converting the separator into "." before checking price amount.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Create product with price 0,99€.
2. Enable button on single product page.
3. Visit product.
4. Button won’t load.
5. Increase product price to 1€ or change the decimal separator to ".".
6. Visit product.
7. Button will load.

---

Closes #654 .
