### PR TITLE
Do not render messages when buttons are not rendered.

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -14,6 +14,7 @@ class SingleProductBootstap {
         if (!this.shouldRender()) {
             this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
             this.renderer.hideButtons(this.gateway.button.wrapper);
+            this.messages.hideMessages();
             return;
         }
 
@@ -26,6 +27,7 @@ class SingleProductBootstap {
 
         if (!this.shouldRender()) {
             this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
+            this.messages.hideMessages();
             return;
         }
 

--- a/modules/ppcp-button/resources/js/modules/Renderer/MessageRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/MessageRenderer.js
@@ -53,5 +53,14 @@ class MessageRenderer {
         }
         return true;
     }
+
+    hideMessages() {
+        const domElement = document.querySelector(this.config.wrapper);
+        if (! domElement ) {
+            return false;
+        }
+        domElement.style.display = 'none';
+        return true;
+    }
 }
 export default MessageRenderer;


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #667

---

### Description

When the Pay Later messaging is enabled on the Single Product page, it will be displayed for variable products even when no variation has been selected or when the variation is out of stock.

The PR will fix this, the message will not be displayed if the button are not visible.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Create variable product (Variable Product or Variable Subscription).
2. Enable Pay Later messaging on Single Product page.
3. Visit variable product.
4. Pay Later messaging will display without having a variation selected.

---

Closes #667 .
