### PR TITLE
When creating `Address` do not throw but set empty string when no country code is received (681)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AddressFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AddressFactory.php
@@ -69,13 +69,8 @@ class AddressFactory {
 	 * @throws RuntimeException When JSON object is malformed.
 	 */
 	public function from_paypal_response( \stdClass $data ): Address {
-		if ( ! isset( $data->country_code ) ) {
-			throw new RuntimeException(
-				__( 'No country given for address.', 'woocommerce-paypal-payments' )
-			);
-		}
 		return new Address(
-			$data->country_code,
+			( isset( $data->country_code ) ) ? $data->country_code : '',
 			( isset( $data->address_line_1 ) ) ? $data->address_line_1 : '',
 			( isset( $data->address_line_2 ) ) ? $data->address_line_2 : '',
 			( isset( $data->admin_area_1 ) ) ? $data->admin_area_1 : '',

--- a/tests/PHPUnit/ApiClient/Factory/AddressFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AddressFactoryTest.php
@@ -127,21 +127,6 @@ class AddressFactoryTest extends TestCase
         $this->assertEquals($expectedPostalCode, $result->postal_code());
     }
 
-    public function testFromPayPalRequestThrowsError()
-    {
-        $testee = new AddressFactory();
-
-        $data = (object) [
-            'address_line_1' => 'shipping_address_1',
-            'address_line_2' => 'shipping_address_2',
-            'admin_area_1' => 'shipping_admin_area_1',
-            'admin_area_2' => 'shipping_admin_area_2',
-            'postal_code' => 'shipping_postcode',
-        ];
-        $this->expectException(RuntimeException::class);
-        $testee->from_paypal_response($data);
-    }
-
     public function dataFromPayPalRequest() : array
     {
         return [


### PR DESCRIPTION
Fixes #639.