### PR TITLE
Add basic input validation before opening PayPal popup

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -31,6 +31,19 @@ const bootstrap = () => {
     const onSmartButtonClick = (data, actions) => {
         window.ppcpFundingSource = data.fundingSource;
 
+        // TODO: quick fix to get the error about empty form before attempting PayPal order
+        // it should solve #513 for most of the users, but proper solution should be implemented later.
+        const requiredFields = jQuery('form.woocommerce-checkout .validate-required:visible :input');
+        requiredFields.each((i, input) => {
+            jQuery(input).trigger('validate');
+        });
+        if (jQuery('form.woocommerce-checkout .woocommerce-invalid').length) {
+            errorHandler.clear();
+            errorHandler.message(PayPalCommerceGateway.labels.error.js_validation);
+
+            return actions.reject();
+        }
+
         const form = document.querySelector('form.woocommerce-checkout');
         if (form) {
             jQuery('#ppcp-funding-source-form-input').remove();

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -843,6 +843,10 @@ class SmartButton implements SmartButtonInterface {
 						'Something went wrong. Please try again or choose another payment source.',
 						'woocommerce-paypal-payments'
 					),
+					'js_validation' => __(
+						'Required form fields are not filled or invalid.',
+						'woocommerce-paypal-payments'
+					),
 				),
 			),
 			'order_id'                       => 'pay-now' === $this->context() ? absint( $wp->query_vars['order-pay'] ) : 0,


### PR DESCRIPTION
A quick fix for #513, since a proper solution is still not found. It should solve most of the cases of starting the PayPal payment flow before filling the WC form.

It fires the custom `validate` event which triggers `validate_field` in [checkout.js](https://github.com/woocommerce/woocommerce/blob/21f7cea2b6ab1a268c137dcf761c4df721f1ec0b/plugins/woocommerce/legacy/js/frontend/checkout.js#L201).