### PR TITLE
Fix the order status for virtual & downloadable products

### DIFF
--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -204,7 +204,7 @@ class OrderProcessor {
 				__( 'Payment successfully captured.', 'woocommerce-paypal-payments' )
 			);
 			$wc_order->update_meta_data( AuthorizedPaymentsProcessor::CAPTURED_META_KEY, 'true' );
-			$wc_order->update_status( 'processing' );
+			$wc_order->update_status( 'completed' );
 		}
 		$this->last_error = '';
 		return true;


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #665

---

### Description

When the intent is set to Authorize and Capture Virtual-Only Orders is checked, then virtual+downloadable products orders are not automatically Completed but instead move to the status Processing instead.

The PR will fix this problem.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Set the intent to Authorize.
2. Check Capture Virtual-Only Orders.
3. Pay for a virtual+downloadable product.
4. → payment is captured but order movies to Processing status instead of Completed

---

Closes #665 .
