### PR TITLE
Fix form decoding and email handling

### DIFF
--- a/modules/ppcp-api-client/src/Factory/PayerFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PayerFactory.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\PayerName;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PayerTaxInfo;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Phone;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PhoneWithType;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
 /**
  * Class PayerFactory
@@ -158,6 +159,7 @@ class PayerFactory {
 	 *
 	 * @param array $form_fields The checkout form fields.
 	 * @return Payer
+	 * @throws RuntimeException When invalid data.
 	 */
 	public function from_checkout_form( array $form_fields ): Payer {
 
@@ -187,6 +189,14 @@ class PayerFactory {
 					);
 				}
 			}
+		}
+
+		if ( ! is_email( $billing_email ) ) {
+			/*
+			phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+			translators: %s: email address
+			*/
+			throw new RuntimeException( sprintf( __( '%s is not a valid email address.', 'woocommerce' ), esc_html( $billing_email ) ) );
 		}
 
 		return new Payer(

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -20,7 +20,9 @@ class CheckoutActionHandler {
             const errorHandler = this.errorHandler;
 
             const formSelector = this.config.context === 'checkout' ? 'form.checkout' : 'form#order_review';
-            const formValues = jQuery(formSelector).serialize();
+            const formData = new FormData(document.querySelector(formSelector));
+            // will not handle fields with multiple values (checkboxes, <select multiple>), but we do not care about this here
+            const formJsonObj = Object.fromEntries(formData);
 
             const createaccount = jQuery('#createaccount').is(":checked") ? true : false;
 
@@ -34,7 +36,7 @@ class CheckoutActionHandler {
                     order_id:this.config.order_id,
                     payment_method: getCurrentPaymentMethod(),
                     funding_source: window.ppcpFundingSource,
-                    form:formValues,
+                    form: formJsonObj,
                     createaccount: createaccount
                 })
             }).then(function (res) {

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -61,7 +61,7 @@ class CheckoutActionHandler {
                         }
                     }
 
-                    return;
+                    throw new Error(data.data.message);
                 }
                 const input = document.createElement('input');
                 input.setAttribute('type', 'hidden');

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -403,9 +403,9 @@ class CreateOrderEndpoint implements EndpointInterface {
 		}
 
 		if ( ! $payer && isset( $data['form'] ) ) {
-			parse_str( $data['form'], $form_fields );
+			$form_fields = $data['form'];
 
-			if ( isset( $form_fields['billing_email'] ) && '' !== $form_fields['billing_email'] ) {
+			if ( is_array( $form_fields ) && isset( $form_fields['billing_email'] ) && '' !== $form_fields['billing_email'] ) {
 				return $this->payer_factory->from_checkout_form( $form_fields );
 			}
 		}

--- a/modules/ppcp-button/src/Endpoint/RequestData.php
+++ b/modules/ppcp-button/src/Endpoint/RequestData.php
@@ -81,15 +81,9 @@ class RequestData {
 		$data = array();
 		foreach ( (array) $assoc_array as $raw_key => $raw_value ) {
 			if ( ! is_array( $raw_value ) ) {
-				/**
-				 * The 'form' key is preserved for url encoded data and needs different
-				 * sanitization.
-				 */
-				if ( 'form' !== $raw_key ) {
-					$data[ sanitize_text_field( (string) $raw_key ) ] = sanitize_text_field( (string) $raw_value );
-				} else {
-					$data[ sanitize_text_field( (string) $raw_key ) ] = sanitize_text_field( urldecode( (string) $raw_value ) );
-				}
+				// Not sure if it is a good idea to sanitize everything at this level,
+				// but should be fine for now since we do not send any HTML or multi-line texts via ajax.
+				$data[ sanitize_text_field( (string) $raw_key ) ] = sanitize_text_field( (string) $raw_value );
 				continue;
 			}
 			$data[ sanitize_text_field( (string) $raw_key ) ] = $this->sanitize( $raw_value );


### PR DESCRIPTION
Fixes #523 

It was happening because we were sending form data as an url-encoded string and it was decoded twice, in `RequestData` and by `parse_str`. So now simply sending it as an object to avoid this additional handling.

Also kind of related to #513, added email validation [like in WC](https://github.com/woocommerce/woocommerce/blob/2a4de35e24a19d1346370e08aaccce4b1f442b4b/plugins/woocommerce/includes/class-wc-checkout.php#L804-L809) to fix confusing error message (other fields somehow do not cause it).

And added `throw` in `CheckoutActionHandler` when `createOrder` fails (like in other handlers) because otherwise PayPal tries to continue and adds an unfriendly message about missing ID.