### PR TITLE
Filter refunded status

### DIFF
--- a/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
@@ -143,7 +143,15 @@ class RefundProcessor {
 						$this->payments_endpoint->void( $authorization );
 					}
 
-					$wc_order->set_status( 'refunded' );
+					$wc_order->set_status(
+						apply_filter(
+							'woocommerce_order_fully_refunded_status',
+							'refunded',
+							$wc_order->get_id(),
+							null
+						)
+					);
+
 					$wc_order->save();
 
 					break;

--- a/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
@@ -144,7 +144,7 @@ class RefundProcessor {
 					}
 
 					$wc_order->set_status(
-						apply_filter(
+						apply_filters(
 							'woocommerce_order_fully_refunded_status',
 							'refunded',
 							$wc_order->get_id(),


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #590 

---

### Description

Apply the [woocommerce_order_fully_refunded_status](http://hookr.io/filters/woocommerce_order_fully_refunded_status/) filter to allow using `wc_refund_payment()` for voiding a transaction programmatically.  The only issue that I see with doing so currently is that the order status gets changed which, in my case, I do not want.

### Steps to Test

Create 2 orders both using the Paypal gateway in authorize mode .  Refund them by calling the following script:

```
<?php
require_once('wp-load.php');

$order_1 = wc_get_order(1234); // Replace 1234 with the post_ID of the first order
$order_2 = wc_get_order(1235); // Replace 1235 with the post_ID of the second order

wc_refund_payment($order_1);
add_filter('woocommerce_order_fully_refunded_status', '__return_false');
wc_refund_payment($order_2);
```

Observe that `$order_1` is now in the refunded status whereas $order_2 remained in the status it was at in the beginning, but both authorizations were voided in Paypal.

### Changelog Entry

> Allow filtering of refunded status on voids
