### PR TITLE
Release 1.8.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,16 @@
 *** Changelog ***
 
+= 1.8.2 - TBD =
+* Fix - Order not approved: payment via vaulted PayPal account fails #677
+* Fix - Something went wrong error in Virtual products when using vaulted payment #673 
+* Fix - PayPal smart buttons are not displayed for product variations when parent product is set to out of stock #669
+* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667 
+* Fix - "Capture Virtual-Only Orders" intent sets virtual+downloadable product orders to "Processing" instead of "Completed" #665 
+* Fix - Free trial period causing incorrerct disable-funding parameters with DCC disabled #661 
+* Fix - Smart button not visible on single product page when product price is below 1 and decimal is "," #654 
+* Fix - Checkout using an email address containing a + symbol results in a "[INVALID_REQUEST]" error #523
+* Enhancement - Improve checkout validation & order creation #513
+
 = 1.8.1 - 2022-05-31 =
 * Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530
 * Fix - "No PayPal order found in the current WooCommerce session" error for guests on Pay for Order page #605

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WooCommerce PayPal Payments ===
-Contributors: woocommerce, automattic
+Contributors: woocommerce, automattic, inpsyde
 Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, shop, shopping, cart, checkout
 Requires at least: 5.3
 Tested up to: 6.0

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 6.0
 Requires PHP: 7.1
-Stable tag: 1.8.1
+Stable tag: 1.8.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,17 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.8.2 =
+* Fix - Order not approved: payment via vaulted PayPal account fails #677
+* Fix - Something went wrong error in Virtual products when using vaulted payment #673 
+* Fix - PayPal smart buttons are not displayed for product variations when parent product is set to out of stock #669
+* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667 
+* Fix - "Capture Virtual-Only Orders" intent sets virtual+downloadable product orders to "Processing" instead of "Completed" #665 
+* Fix - Free trial period causing incorrerct disable-funding parameters with DCC disabled #661 
+* Fix - Smart button not visible on single product page when product price is below 1 and decimal is "," #654 
+* Fix - Checkout using an email address containing a + symbol results in a "[INVALID_REQUEST]" error #523
+* Enhancement - Improve checkout validation & order creation #513
 
 = 1.8.1 =
 * Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.8.1
+ * Version:     1.8.2
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0


### PR DESCRIPTION
* Fix - Order not approved: payment via vaulted PayPal account fails #677
* Fix - Something went wrong error in Virtual products when using vaulted payment #673 
* Fix - PayPal smart buttons are not displayed for product variations when parent product is set to out of stock #669
* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667 
* Fix - "Capture Virtual-Only Orders" intent sets virtual+downloadable product orders to "Processing" instead of "Completed" #665 
* Fix - Free trial period causing incorrerct disable-funding parameters with DCC disabled #661 
* Fix - Smart button not visible on single product page when product price is below 1 and decimal is "," #654 
* Fix - Checkout using an email address containing a + symbol results in a "[INVALID_REQUEST]" error #523
* Enhancement - Improve checkout validation & order creation #513