### PR TITLE
Fix credit card detection.

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Helper/DccInputFactory.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/DccInputFactory.js
@@ -1,9 +1,12 @@
 const dccInputFactory = (original) => {
     const styles = window.getComputedStyle(original);
     const newElement = document.createElement('span');
+
     newElement.setAttribute('id', original.id);
+    newElement.setAttribute('class', original.className);
+
     Object.values(styles).forEach( (prop) => {
-        if (! styles[prop] || ! isNaN(prop) ) {
+        if (! styles[prop] || ! isNaN(prop) || prop === 'background-image' ) {
             return;
         }
         newElement.style.setProperty(prop,'' + styles[prop]);

--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -1,5 +1,6 @@
 import dccInputFactory from "../Helper/DccInputFactory";
 import {show} from "../Helper/Hiding";
+import Product from "../Entity/Product";
 
 class CreditCardRenderer {
 
@@ -117,11 +118,23 @@ class CreditCardRenderer {
                 }
                 const validCards = this.defaultConfig.hosted_fields.valid_cards;
                 this.cardValid = validCards.indexOf(event.cards[0].type) !== -1;
+
+                const className = this._cardNumberFiledCLassNameByCardType(event.cards[0].type);
+                this._recreateElementClassAttribute(cardNumber, cardNumberField.className);
+                if (event.fields.number.isValid) {
+                    cardNumber.classList.add(className);
+                }
             })
             hostedFields.on('validityChange', (event) => {
                 const formValid = Object.keys(event.fields).every(function (key) {
                     return event.fields[key].isValid;
                 });
+
+                const className = this._cardNumberFiledCLassNameByCardType(event.cards[0].type);
+                event.fields.number.isValid
+                    ? cardNumber.classList.add(className)
+                    : this._recreateElementClassAttribute(cardNumber, cardNumberField.className);
+
                this.formValid = formValid;
 
             });
@@ -229,6 +242,15 @@ class CreditCardRenderer {
             const message = ! this.cardValid ? this.defaultConfig.hosted_fields.labels.card_not_supported : this.defaultConfig.hosted_fields.labels.fields_not_valid;
             this.errorHandler.message(message);
         }
+    }
+
+    _cardNumberFiledCLassNameByCardType(cardType) {
+        return cardType === 'american-express' ? 'amex' : cardType.replace('-', '');
+    }
+
+    _recreateElementClassAttribute(element, newClassName) {
+        element.removeAttribute('class')
+        element.setAttribute('class', newClassName);
     }
 }
 export default CreditCardRenderer;


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #685

---

### Description

The PayPal Card Processing is supposed to detect the card type depending on the card number and display the respective cc icon on the right side. With the Storefront theme, the icon placeholder is usually displayed in the top left corner and does not change according to the card number.

![42a8301c-da66-49a2-8824-23876cb3df00](https://user-images.githubusercontent.com/11319597/174310061-b2b83a9d-6860-449b-b4fb-39b3d03249d0.png)

The PR will fix card type detection problems and will add the appropriate placeholder texts.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Activate Storefront theme.
2. Visit checkout with PayPal Card Processing active.
3. Observe placeholder and icon.

---

Closes #685 .
