### PR TITLE
Pay later messaging displayed when variation is not selected

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -41,7 +41,7 @@ class SingleProductBootstap {
 
     }
 
-    priceAmountIsZero() {
+    priceAmount() {
 
         let priceText = "0";
         if (document.querySelector('form.cart ins .woocommerce-Price-amount')) {
@@ -53,9 +53,12 @@ class SingleProductBootstap {
         else if (document.querySelector('.product .woocommerce-Price-amount')) {
             priceText = document.querySelector('.product .woocommerce-Price-amount').innerText;
         }
-        const amount = parseFloat(priceText.replace(/([^\d,\.\s]*)/g, ''));
-        return amount === 0;
 
+        return  parseFloat(priceText.replace(/([^\d,\.\s]*)/g, ''));
+    }
+
+    priceAmountIsZero() {
+        return this.priceAmount() === 0;
     }
 
     render() {
@@ -68,19 +71,12 @@ class SingleProductBootstap {
             () => {
                 this.renderer.showButtons(this.gateway.button.wrapper);
                 this.renderer.showButtons(this.gateway.hosted_fields.wrapper);
-                let priceText = "0";
-                if (document.querySelector('form.cart ins .woocommerce-Price-amount')) {
-                    priceText = document.querySelector('form.cart ins .woocommerce-Price-amount').innerText;
-                }
-                else if (document.querySelector('form.cart .woocommerce-Price-amount')) {
-                    priceText = document.querySelector('form.cart .woocommerce-Price-amount').innerText;
-                }
-                const amount = parseInt(priceText.replace(/([^\d,\.\s]*)/g, ''));
-                this.messages.renderWithAmount(amount)
+                this.messages.renderWithAmount(this.priceAmount())
             },
             () => {
                 this.renderer.hideButtons(this.gateway.button.wrapper);
                 this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);
+                this.messages.hideMessages();
             },
             document.querySelector('form.cart'),
             new ErrorHandler(this.gateway.labels.error.generic),


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #667

---

### Description

When the Pay Later messaging is enabled on the Single Product page, it will be displayed for variable products even when no variation has been selected or when the variation is out of stock.

The PR will fix this, the message will not be displayed if the button are not visible.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Create variable product (Variable Product or Variable Subscription).
2. Enable Pay Later messaging on Single Product page.
3. Visit variable product.
4. Pay Later messaging will display without having a variation selected.

---

Closes #667 .
