### PR TITLE
Fix messaging display when the buttons are disabled.

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -840,7 +840,7 @@ class SmartButton implements SmartButtonInterface {
 			'messages'                       => $this->message_values(),
 			'labels'                         => array(
 				'error' => array(
-					'generic' => __(
+					'generic'       => __(
 						'Something went wrong. Please try again or choose another payment source.',
 						'woocommerce-paypal-payments'
 					),
@@ -1037,6 +1037,7 @@ class SmartButton implements SmartButtonInterface {
 			$this->context() === 'product'
 			&& $this->settings->has( 'button_product_enabled' )
 			&& $this->settings->get( 'button_product_enabled' )
+			|| $this->settings->has( 'message_product_enabled' )
 		) {
 			$load_buttons = true;
 		}
@@ -1050,6 +1051,7 @@ class SmartButton implements SmartButtonInterface {
 			$this->context() === 'cart'
 			&& $this->settings->has( 'button_cart_enabled' )
 			&& $this->settings->get( 'button_cart_enabled' )
+			|| $this->settings->has( 'message_product_enabled' )
 		) {
 			$load_buttons = true;
 		}


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #283

---

### Description

The Pay Later messaging is only displayed on the product page/cart/checkout when the PayPal buttons are activated for the same page. When no button is loaded for the site, then the messaging is hidden.

The PR will fix the behavior.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

- enable Pay Later messaging on the single product page
- disable PayPal button on single product page
- 
- disable PayPal button on the mini cart
- → the Pay Later banner will not be displayed on the single product page
- enable PayPal button on the mini cart
- → the Pay Later banner will be displayed on the single product page


---

Closes #283 .
