### PR TITLE
Fix basic validation

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -37,7 +37,7 @@ const bootstrap = () => {
         requiredFields.each((i, input) => {
             jQuery(input).trigger('validate');
         });
-        if (jQuery('form.woocommerce-checkout .woocommerce-invalid').length) {
+        if (jQuery('form.woocommerce-checkout .woocommerce-invalid:visible').length) {
             errorHandler.clear();
             errorHandler.message(PayPalCommerceGateway.labels.error.js_validation);
 


### PR DESCRIPTION
Use `:visible` in both selectors, otherwise it may result in an unwanted error if something triggered  validation for hidden fields.