### PR TITLE
Store the customer id for vaulted payment method in usermeta

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/IdentityToken.php
+++ b/modules/ppcp-api-client/src/Endpoint/IdentityToken.php
@@ -106,7 +106,7 @@ class IdentityToken {
 			&& defined( 'PPCP_FLAG_SUBSCRIPTION' ) && PPCP_FLAG_SUBSCRIPTION
 		) {
 			$customer_id = $this->customer_repository->customer_id_for_user( ( $user_id ) );
-
+			update_user_meta( $user_id, 'ppcp_customer_id', $customer_id );
 			$args['body'] = wp_json_encode(
 				array(
 					'customer_id' => $customer_id,

--- a/modules/ppcp-api-client/src/Repository/CustomerRepository.php
+++ b/modules/ppcp-api-client/src/Repository/CustomerRepository.php
@@ -57,6 +57,6 @@ class CustomerRepository {
 			return $guest_customer_id;
 		}
 
-		return $this->prefix . (string) $user_id;
+		return get_user_meta( $user_id, 'ppcp_customer_id', true ) ?: $this->prefix . (string) $user_id;
 	}
 }

--- a/tests/PHPUnit/ApiClient/Endpoint/IdentityTokenTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/IdentityTokenTest.php
@@ -46,6 +46,7 @@ class IdentityTokenTest extends TestCase
 
     public function testGenerateForCustomerReturnsToken()
     {
+        $id = 1;
         define( 'PPCP_FLAG_SUBSCRIPTION', true );
         $token = Mockery::mock(Token::class);
         $token
@@ -60,6 +61,7 @@ class IdentityTokenTest extends TestCase
 		$this->settings->shouldReceive('has')->andReturn(true);
 		$this->settings->shouldReceive('get')->andReturn(true);
 		$this->customer_repository->shouldReceive('customer_id_for_user')->andReturn('prefix1');
+        expect('update_user_meta')->with($id, 'ppcp_customer_id', 'prefix1');
 
 		$rawResponse = [
 			'body' => '{"client_token":"abc123", "expires_in":3600}',
@@ -97,6 +99,7 @@ class IdentityTokenTest extends TestCase
 
     public function testGenerateForCustomerFailsBecauseWpError()
     {
+        $id = 1;
         $token = Mockery::mock(Token::class);
         $token
             ->expects('token')->andReturn('bearer');
@@ -111,7 +114,8 @@ class IdentityTokenTest extends TestCase
         $this->logger->shouldReceive('debug');
 		$this->settings->shouldReceive('has')->andReturn(true);
 		$this->settings->shouldReceive('get')->andReturn(true);
-		$this->customer_repository->shouldReceive('customer_id_for_user');
+        $this->customer_repository->shouldReceive('customer_id_for_user')->andReturn('prefix1');
+        expect('update_user_meta')->with($id, 'ppcp_customer_id', 'prefix1');
 
         $this->expectException(RuntimeException::class);
         $this->sut->generate_for_user(1);
@@ -119,6 +123,7 @@ class IdentityTokenTest extends TestCase
 
     public function testGenerateForCustomerFailsBecauseResponseCodeIsNot200()
     {
+        $id = 1;
         $token = Mockery::mock(Token::class);
         $token
             ->expects('token')->andReturn('bearer');
@@ -137,7 +142,8 @@ class IdentityTokenTest extends TestCase
         $this->logger->shouldReceive('debug');
 		$this->settings->shouldReceive('has')->andReturn(true);
 		$this->settings->shouldReceive('get')->andReturn(true);
-		$this->customer_repository->shouldReceive('customer_id_for_user');
+        $this->customer_repository->shouldReceive('customer_id_for_user')->andReturn('prefix1');
+        expect('update_user_meta')->with($id, 'ppcp_customer_id', 'prefix1');
 
         $this->expectException(PayPalApiException::class);
         $this->sut->generate_for_user(1);


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #698

---

### Description

The customer id is generated by using the invoice prefix and the user id.
In case a guest user vaults a payment method, the customer id is generated using the invoice prefix and a random string pattern which will be applied to the user after the registration.

Whenever the plugin attempts to get the vaulted payment methods for the user, the customer id is taken from the invoice prefix and user id.

If the store owner changes the invoice prefix, then all vaulted payment methods can no longer be used because the customer ids would no longer be associated with any vaulted payment methods.

The PR will fix this behavior by storing the customer id with the prefix in the usermeta, so that after changing the prefix the customer id will still be get from database.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Enable Vaulting.
2. Vault a payment method.
3. Visit a page with a button.
4. See the vaulted button.
5. Change the invoice prefix in the plugin settings.
6. Visit a page with a button.
7. See the “regular” PayPal button instead of the vaulted button.

---

Closes #698 .
