### PR TITLE
Bump WC version to 6.6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,10 @@
 * Fix - Free trial period causing incorrerct disable-funding parameters with DCC disabled #661 
 * Fix - Smart button not visible on single product page when product price is below 1 and decimal is "," #654 
 * Fix - Checkout using an email address containing a + symbol results in a "[INVALID_REQUEST]" error #523
+* Fix - Order details are sometimes empty in PayPal dashboard #689
+* Fix - Incorrect TAX details on PayPal order overview #541
+* Fix - Fatal error: Uncaught Error: Call to a member function get_name() on bool #622
+* Fix - DCC causes checkout continuation state after checkout validation error #695
 * Enhancement - Improve checkout validation & order creation #513
 
 = 1.8.1 - 2022-05-31 =

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,10 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - Free trial period causing incorrerct disable-funding parameters with DCC disabled #661 
 * Fix - Smart button not visible on single product page when product price is below 1 and decimal is "," #654 
 * Fix - Checkout using an email address containing a + symbol results in a "[INVALID_REQUEST]" error #523
+* Fix - Order details are sometimes empty in PayPal dashboard #689
+* Fix - Incorrect TAX details on PayPal order overview #541
+* Fix - Fatal error: Uncaught Error: Call to a member function get_name() on bool #622
+* Fix - DCC causes checkout continuation state after checkout validation error #695
 * Enhancement - Improve checkout validation & order creation #513
 
 = 1.8.1 =

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -9,7 +9,7 @@
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 6.5
+ * WC tested up to: 6.6
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce


### PR DESCRIPTION
* Fix - Order details are sometimes empty in PayPal dashboard #689
* Fix - Incorrect TAX details on PayPal order overview #541
* Fix - Fatal error: Uncaught Error: Call to a member function get_name() on bool #622
* Fix - DCC causes checkout continuation state after checkout validation error #695