### PR TITLE
Bump 1.9.0 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
-= 1.8.2 - TBD =
+= 1.9.0 - TBD =
+* Add - New Feature - Pay Upon Invoice (Germany only) #608
 * Fix - Order not approved: payment via vaulted PayPal account fails #677
 * Fix - Cant' refund : "ERROR Refund failed: No country given for address." #639
 * Fix - Something went wrong error in Virtual products when using vaulted payment #673 

--- a/modules/ppcp-api-client/src/Endpoint/RequestTrait.php
+++ b/modules/ppcp-api-client/src/Endpoint/RequestTrait.php
@@ -90,6 +90,7 @@ trait RequestTrait {
 			if (
 				isset( $response['body'] )
 				&& isset( $response['response']['code'] )
+				&& ! in_array( $response['response']['code'], array( 200, 201, 202, 204 ), true )
 			) {
 				$output .= 'Response Body: ' . wc_print_r( $response['body'], true ) . "\n";
 			}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2218,7 +2218,15 @@ return array(
 		);
 	},
 	'wcgateway.logging.is-enabled'                      => function ( ContainerInterface $container ) : bool {
-		return true;
+		$settings = $container->get( 'wcgateway.settings' );
+
+		/**
+		 * Whether the logging of the plugin errors/events is enabled.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_is_logging_enabled',
+			$settings->has( 'logging_enabled' ) && $settings->get( 'logging_enabled' )
+		);
 	},
 
 	'wcgateway.helper.vaulting-scope'                   => static function ( ContainerInterface $container ): bool {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 6.0
 Requires PHP: 7.1
-Stable tag: 1.9.0-test5
+Stable tag: 1.9.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -81,7 +81,8 @@ Follow the steps below to connect the plugin to your PayPal account:
 
 == Changelog ==
 
-= 1.8.2 =
+= 1.9.0 =
+* Add - New Feature - Pay Upon Invoice (Germany only) #608
 * Fix - Order not approved: payment via vaulted PayPal account fails #677
 * Fix - Cant' refund : "ERROR Refund failed: No country given for address." #639
 * Fix - Something went wrong error in Virtual products when using vaulted payment #673 

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.9.0-test5
+ * Version:     1.9.0
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0


### PR DESCRIPTION
* Add - New Feature - Pay Upon Invoice (Germany only) #608
* Fix - Order not approved: payment via vaulted PayPal account fails #677
* Fix - Cant' refund : "ERROR Refund failed: No country given for address." #639
* Fix - Something went wrong error in Virtual products when using vaulted payment #673 
* Fix - PayPal smart buttons are not displayed for product variations when parent product is set to out of stock #669
* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667 
* Fix - "Capture Virtual-Only Orders" intent sets virtual+downloadable product orders to "Processing" instead of "Completed" #665 
* Fix - Free trial period causing incorrerct disable-funding parameters with DCC disabled #661 
* Fix - Smart button not visible on single product page when product price is below 1 and decimal is "," #654 
* Fix - Checkout using an email address containing a + symbol results in a "[INVALID_REQUEST]" error #523
* Fix - Order details are sometimes empty in PayPal dashboard #689
* Fix - Incorrect TAX details on PayPal order overview #541
* Fix - Fatal error: Uncaught Error: Call to a member function get_name() on bool #622
* Fix - DCC causes checkout continuation state after checkout validation error #695
* Enhancement - Improve checkout validation & order creation #513