### PR TITLE
Show basic validation error only for required fields

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -38,7 +38,7 @@ const bootstrap = () => {
             requiredFields.each((i, input) => {
                 jQuery(input).trigger('validate');
             });
-            if (jQuery('form.woocommerce-checkout .woocommerce-invalid:visible').length) {
+            if (jQuery('form.woocommerce-checkout .validate-required.woocommerce-invalid:visible').length) {
                 errorHandler.clear();
                 errorHandler.message(PayPalCommerceGateway.labels.error.js_validation);
 


### PR DESCRIPTION
Otherwise it may trigger on some sites when the field is no longer required but still marked as invalid, e.g. after switching to a country without required state.