### PR TITLE
PUI gateway is displayed with unsupported store currency (733)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -284,7 +284,7 @@ class WCGatewayModule implements ModuleInterface {
 					$methods[] = $container->get( 'wcgateway.credit-card-gateway' );
 				}
 
-				if ( 'DE' === $container->get( 'api.shop.country' ) ) {
+				if ( 'DE' === $container->get( 'api.shop.country' ) && 'EUR' === get_woocommerce_currency() ) {
 					$methods[] = $container->get( 'wcgateway.pay-upon-invoice-gateway' );
 				}
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -228,7 +228,7 @@ class WCGatewayModule implements ModuleInterface {
 		add_action(
 			'init',
 			function () use ( $c ) {
-				if ( 'DE' === $c->get( 'api.shop.country' ) && 'EUR' === get_woocommerce_currency() ) {
+				if ( 'DE' === $c->get( 'api.shop.country' ) && 'EUR' === $c->get( 'api.shop.currency' ) ) {
 					( $c->get( 'wcgateway.pay-upon-invoice' ) )->init();
 				}
 			}
@@ -284,7 +284,7 @@ class WCGatewayModule implements ModuleInterface {
 					$methods[] = $container->get( 'wcgateway.credit-card-gateway' );
 				}
 
-				if ( 'DE' === $container->get( 'api.shop.country' ) && 'EUR' === get_woocommerce_currency() ) {
+				if ( 'DE' === $container->get( 'api.shop.country' ) && 'EUR' === $container->get( 'api.shop.currency' ) ) {
 					$methods[] = $container->get( 'wcgateway.pay-upon-invoice-gateway' );
 				}
 


### PR DESCRIPTION
When merchant set store currency different than Euro then PUI gateway will be displayed regardless.

### Steps to Test

1. Install plugin
2. Set store currency to any currency different then Euro.
3. Enable PUI gateway
4. Navigate to checkout with a supported product type.
5. Set billing country to Germany

Observe PUI gateway is displayed while it should not.