### PR TITLE
Add PAYMENT.AUTHORIZATION.VOIDED event to a refund handler

### DIFF
--- a/modules/ppcp-webhooks/src/Handler/PaymentCaptureRefunded.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentCaptureRefunded.php
@@ -46,7 +46,7 @@ class PaymentCaptureRefunded implements RequestHandler {
 	 * @return string[]
 	 */
 	public function event_types(): array {
-		return array( 'PAYMENT.CAPTURE.REFUNDED' );
+		return array( 'PAYMENT.CAPTURE.REFUNDED', 'PAYMENT.AUTHORIZATION.VOIDED' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #712

---

### Description

When an authorized payment is voided at PayPal (for example because the payment method can’t be saved), then the WooCommerce order will not update.
The “Not captured” badge remains, and the order action does as well

![a442a503-8500-4104-ba09-73dd2ec848a4](https://user-images.githubusercontent.com/11319597/176920309-a0c3bbc5-4c31-451d-9aa3-848b3ab66a43.png)

The problem is that the `PAYMENT.AUTHORIZATION.VOIDED` hook is not handled, so the PR will add it inside `PaymentCaptureRefunded` handler

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Set intent to Authorize.
2. Authorize payment.
3. Void authorization at PayPal.
4. WooCommerce order won’t update.

---

Closes #712 .
