### PR TITLE
 Missing PayPal fee in WC order details for PUI purchase (735)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PayUponInvoiceOrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PayUponInvoiceOrderEndpoint.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
 
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use stdClass;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
@@ -162,14 +163,14 @@ class PayUponInvoiceOrderEndpoint {
 	}
 
 	/**
-	 * Get Ratepay payment instructions from PayPal order.
+	 * Get PayPal order as object.
 	 *
 	 * @param string $id The PayPal order ID.
-	 * @return array
+	 * @return stdClass
 	 * @throws RuntimeException When there is a problem getting the order.
 	 * @throws PayPalApiException When there is a problem getting the order.
 	 */
-	public function order_payment_instructions( string $id ): array {
+	public function order( string $id ): stdClass {
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $id;
 		$args   = array(
@@ -191,10 +192,7 @@ class PayUponInvoiceOrderEndpoint {
 			throw new PayPalApiException( $json, $status_code );
 		}
 
-		return array(
-			$json->payment_source->pay_upon_invoice->payment_reference,
-			$json->payment_source->pay_upon_invoice->deposit_bank_details,
-		);
+		return $json;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2214,7 +2214,8 @@ return array(
 			$container->get( 'wcgateway.is-ppcp-settings-page' ),
 			$container->get( 'wcgateway.current-ppcp-settings-page-id' ),
 			$container->get( 'wcgateway.pay-upon-invoice-product-status' ),
-			$container->get( 'wcgateway.pay-upon-invoice-helper' )
+			$container->get( 'wcgateway.pay-upon-invoice-helper' ),
+			$container->get( 'api.factory.capture' )
 		);
 	},
 	'wcgateway.logging.is-enabled'                      => function ( ContainerInterface $container ) : bool {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -235,7 +235,7 @@ class PayUponInvoice {
 					$wc_order->save_meta_data();
 					$this->logger->info( "Ratepay payment instructions added to order #{$wc_order->get_id()}." );
 
-					$capture   = $this->capture_factory->from_paypal_response( $order );
+					$capture   = $this->capture_factory->from_paypal_response( $order->purchase_units[0]->payments->captures[0] );
 					$breakdown = $capture->seller_receivable_breakdown();
 					if ( $breakdown ) {
 						$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -17,8 +17,10 @@ use WC_Product;
 use WC_Product_Variable;
 use WC_Product_Variation;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PayUponInvoiceOrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\CaptureFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceHelper;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
@@ -119,6 +121,13 @@ class PayUponInvoice {
 	protected $pui_product_status;
 
 	/**
+	 * The capture factory.
+	 *
+	 * @var CaptureFactory
+	 */
+	protected $capture_factory;
+
+	/**
 	 * PayUponInvoice constructor.
 	 *
 	 * @param string                      $module_url The module URL.
@@ -133,6 +142,7 @@ class PayUponInvoice {
 	 * @param string                      $current_ppcp_settings_page_id Current PayPal settings page id.
 	 * @param PayUponInvoiceProductStatus $pui_product_status The PUI product status.
 	 * @param PayUponInvoiceHelper        $pui_helper The PUI helper.
+	 * @param CaptureFactory              $capture_factory The capture factory.
 	 */
 	public function __construct(
 		string $module_url,
@@ -146,7 +156,8 @@ class PayUponInvoice {
 		bool $is_ppcp_settings_page,
 		string $current_ppcp_settings_page_id,
 		PayUponInvoiceProductStatus $pui_product_status,
-		PayUponInvoiceHelper $pui_helper
+		PayUponInvoiceHelper $pui_helper,
+		CaptureFactory $capture_factory
 	) {
 		$this->module_url                    = $module_url;
 		$this->fraud_net                     = $fraud_net;
@@ -160,6 +171,7 @@ class PayUponInvoice {
 		$this->current_ppcp_settings_page_id = $current_ppcp_settings_page_id;
 		$this->pui_product_status            = $pui_product_status;
 		$this->pui_helper                    = $pui_helper;
+		$this->capture_factory               = $capture_factory;
 	}
 
 	/**
@@ -210,7 +222,12 @@ class PayUponInvoice {
 			'ppcp_payment_capture_completed_webhook_handler',
 			function ( WC_Order $wc_order, string $order_id ) {
 				try {
-					$payment_instructions = $this->pui_order_endpoint->order_payment_instructions( $order_id );
+					$order = $this->pui_order_endpoint->order( $order_id );
+
+					$payment_instructions = array(
+						$order->payment_source->pay_upon_invoice->payment_reference,
+						$order->payment_source->pay_upon_invoice->deposit_bank_details,
+					);
 					$wc_order->update_meta_data(
 						'ppcp_ratepay_payment_instructions_payment_reference',
 						$payment_instructions
@@ -218,6 +235,12 @@ class PayUponInvoice {
 					$wc_order->save_meta_data();
 					$this->logger->info( "Ratepay payment instructions added to order #{$wc_order->get_id()}." );
 
+					$capture   = $this->capture_factory->from_paypal_response( $order );
+					$breakdown = $capture->seller_receivable_breakdown();
+					if ( $breakdown ) {
+						$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
+						$wc_order->save_meta_data();
+					}
 				} catch ( RuntimeException $exception ) {
 					$this->logger->error( $exception->getMessage() );
 				}


### PR DESCRIPTION
When PUI order is received, in WC order detail PayPal fee is not displayed.

### Steps to reproduce

1. Successfully perform a PUI purchase
2. Navigate to order detail page

Observe, PayPal fee is no displayed in WC order details.