### PR TITLE
Fix mismatch checking (776)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/Amount.php
+++ b/modules/ppcp-api-client/src/Entity/Amount.php
@@ -65,6 +65,15 @@ class Amount {
 	}
 
 	/**
+	 * The value formatted as string for API requests.
+	 *
+	 * @return string
+	 */
+	public function value_str(): string {
+		return $this->money->value_str();
+	}
+
+	/**
 	 * Returns the breakdown.
 	 *
 	 * @return AmountBreakdown|null
@@ -79,12 +88,7 @@ class Amount {
 	 * @return array
 	 */
 	public function to_array(): array {
-		$amount = array(
-			'currency_code' => $this->currency_code(),
-			'value'         => in_array( $this->currency_code(), $this->currencies_without_decimals, true )
-				? round( $this->value(), 0 )
-				: number_format( $this->value(), 2, '.', '' ),
-		);
+		$amount = $this->money->to_array();
 		if ( $this->breakdown() && count( $this->breakdown()->to_array() ) ) {
 			$amount['breakdown'] = $this->breakdown()->to_array();
 		}

--- a/modules/ppcp-api-client/src/Entity/Money.php
+++ b/modules/ppcp-api-client/src/Entity/Money.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
 
+use WooCommerce\PayPalCommerce\ApiClient\Helper\MoneyFormatter;
+
 /**
  * Class Money
  */
@@ -29,11 +31,11 @@ class Money {
 	private $value;
 
 	/**
-	 * Currencies that does not support decimals.
+	 * The MoneyFormatter.
 	 *
-	 * @var array
+	 * @var MoneyFormatter
 	 */
-	private $currencies_without_decimals = array( 'HUF', 'JPY', 'TWD' );
+	private $money_formatter;
 
 	/**
 	 * Money constructor.
@@ -44,6 +46,8 @@ class Money {
 	public function __construct( float $value, string $currency_code ) {
 		$this->value         = $value;
 		$this->currency_code = $currency_code;
+
+		$this->money_formatter = new MoneyFormatter();
 	}
 
 	/**
@@ -53,6 +57,15 @@ class Money {
 	 */
 	public function value(): float {
 		return $this->value;
+	}
+
+	/**
+	 * The value formatted as string for API requests.
+	 *
+	 * @return string
+	 */
+	public function value_str(): string {
+		return $this->money_formatter->format( $this->value, $this->currency_code );
 	}
 
 	/**
@@ -72,9 +85,7 @@ class Money {
 	public function to_array(): array {
 		return array(
 			'currency_code' => $this->currency_code(),
-			'value'         => in_array( $this->currency_code(), $this->currencies_without_decimals, true )
-				? round( $this->value(), 0 )
-				: number_format( $this->value(), 2, '.', '' ),
+			'value'         => $this->value_str(),
 		);
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -331,9 +331,9 @@ class PurchaseUnit {
 			$remaining_item_total = array_reduce(
 				$items,
 				function ( float $total, Item $item ): float {
-					return $total - $item->unit_amount()->value() * (float) $item->quantity();
+					return $total - (float) $item->unit_amount()->value_str() * (float) $item->quantity();
 				},
-				$item_total->value()
+				(float) $item_total->value_str()
 			);
 
 			$remaining_item_total = round( $remaining_item_total, 2 );
@@ -356,11 +356,11 @@ class PurchaseUnit {
 				function ( float $total, Item $item ): float {
 					$tax = $item->tax();
 					if ( $tax ) {
-						$total -= $tax->value() * (float) $item->quantity();
+						$total -= (float) $tax->value_str() * (float) $item->quantity();
 					}
 					return $total;
 				},
-				$tax_total->value()
+				(float) $tax_total->value_str()
 			);
 
 			$remaining_tax_total = round( $remaining_tax_total, 2 );
@@ -378,29 +378,29 @@ class PurchaseUnit {
 
 		$amount_total = 0.0;
 		if ( $shipping ) {
-			$amount_total += $shipping->value();
+			$amount_total += (float) $shipping->value_str();
 		}
 		if ( $item_total ) {
-			$amount_total += $item_total->value();
+			$amount_total += (float) $item_total->value_str();
 		}
 		if ( $discount ) {
-			$amount_total -= $discount->value();
+			$amount_total -= (float) $discount->value_str();
 		}
 		if ( $tax_total ) {
-			$amount_total += $tax_total->value();
+			$amount_total += (float) $tax_total->value_str();
 		}
 		if ( $shipping_discount ) {
-			$amount_total -= $shipping_discount->value();
+			$amount_total -= (float) $shipping_discount->value_str();
 		}
 		if ( $handling ) {
-			$amount_total += $handling->value();
+			$amount_total += (float) $handling->value_str();
 		}
 		if ( $insurance ) {
-			$amount_total += $insurance->value();
+			$amount_total += (float) $insurance->value_str();
 		}
 
-		$amount_str       = (string) $amount->to_array()['value'];
-		$amount_total_str = (string) ( new Money( $amount_total, $amount->currency_code() ) )->to_array()['value'];
+		$amount_str       = $amount->value_str();
+		$amount_total_str = ( new Money( $amount_total, $amount->currency_code() ) )->value_str();
 		$needs_to_ditch   = $amount_str !== $amount_total_str;
 		return $needs_to_ditch;
 	}

--- a/modules/ppcp-api-client/src/Helper/MoneyFormatter.php
+++ b/modules/ppcp-api-client/src/Helper/MoneyFormatter.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Class MoneyFormatter.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Entity
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+/**
+ * Class MoneyFormatter
+ */
+class MoneyFormatter {
+	/**
+	 * Currencies that does not support decimals.
+	 *
+	 * @var array
+	 */
+	private $currencies_without_decimals = array( 'HUF', 'JPY', 'TWD' );
+
+	/**
+	 * Returns the value formatted as string for API requests.
+	 *
+	 * @param float  $value The value.
+	 * @param string $currency The 3-letter currency code.
+	 *
+	 * @return string
+	 */
+	public function format( float $value, string $currency ): string {
+		return in_array( $currency, $this->currencies_without_decimals, true )
+			? (string) round( $value, 0 )
+			: number_format( $value, 2, '.', '' );
+	}
+}

--- a/tests/PHPUnit/ApiClient/Entity/AmountTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/AmountTest.php
@@ -22,9 +22,7 @@ class AmountTest extends TestCase
 
     public function testBreakdownIsNull()
     {
-        $money = Mockery::mock(Money::class);
-        $money->shouldReceive('currency_code')->andReturn('currencyCode');
-        $money->shouldReceive('value')->andReturn(1.10);
+        $money = new Money(1.10, 'currencyCode');
         $testee = new Amount($money);
 
         $this->assertNull($testee->breakdown());
@@ -38,9 +36,7 @@ class AmountTest extends TestCase
 
     public function testBreakdown()
     {
-        $money = Mockery::mock(Money::class);
-        $money->shouldReceive('currency_code')->andReturn('currencyCode');
-        $money->shouldReceive('value')->andReturn(1.10);
+		$money = new Money(1.10, 'currencyCode');
         $breakdown = Mockery::mock(AmountBreakdown::class);
         $breakdown->shouldReceive('to_array')->andReturn([1]);
         $testee = new Amount($money, $breakdown);

--- a/tests/PHPUnit/ApiClient/Entity/PurchaseUnitTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/PurchaseUnitTest.php
@@ -412,10 +412,8 @@ class PurchaseUnitTest extends TestCase
         foreach ($data as $testKey => $test) {
             $items = [];
             foreach ($test['items'] as $key => $item) {
-                $unitAmount = Mockery::mock(Money::class);
-                $unitAmount->shouldReceive('value')->andReturn($item['value']);
-                $tax = Mockery::mock(Money::class);
-                $tax->shouldReceive('value')->andReturn($item['tax']);
+                $unitAmount = new Money($item['value'], 'EUR');
+                $tax = new Money($item['tax'], 'EUR');
                 $items[$key] = Mockery::mock(
                     Item::class,
                     [
@@ -436,15 +434,14 @@ class PurchaseUnitTest extends TestCase
                             return null;
                         }
 
-                        $money = Mockery::mock(Money::class);
-                        $money->shouldReceive('value')->andReturn($value);
+                        $money = new Money($value, 'EUR');
                         return $money;
                     });
                 }
             }
             $amount = Mockery::mock(Amount::class);
             $amount->shouldReceive('to_array')->andReturn(['value' => number_format( $test['amount'], 2, '.', '' ), 'breakdown' => []]);
-            $amount->shouldReceive('value')->andReturn($test['amount']);
+            $amount->shouldReceive('value_str')->andReturn(number_format( $test['amount'], 2, '.', '' ));
             $amount->shouldReceive('currency_code')->andReturn('EUR');
             $amount->shouldReceive('breakdown')->andReturn($breakdown);
 

--- a/tests/e2e/PHPUnit/Order/PurchaseUnitTest.php
+++ b/tests/e2e/PHPUnit/Order/PurchaseUnitTest.php
@@ -68,8 +68,6 @@ class PurchaseUnitTest extends TestCase
 		$pu = $this->puFactory->from_wc_order($wcOrder);
 		$puData = $pu->to_array();
 
-		self::assertTrue(isset($puData['amount']['breakdown']));
-
 		self::assertEquals($expectedAmount, $puData['amount']);
     }
 
@@ -82,8 +80,6 @@ class PurchaseUnitTest extends TestCase
 
 		$pu = $this->puFactory->from_wc_cart($this->cart);
 		$puData = $pu->to_array();
-
-		self::assertTrue(isset($puData['amount']['breakdown']));
 
 		self::assertEquals($expectedAmount, $puData['amount']);
     }
@@ -353,6 +349,18 @@ class PurchaseUnitTest extends TestCase
 				],
 			], 'JPY'),
 		];
+
+		yield [
+			[
+				'items' => [
+					['price' => 5.345, 'quantity' => 2],
+				],
+				'billing' => ['city' => 'city0'],
+			],
+			self::adaptAmountFormat([
+				'value' => 10.69,
+			]),
+		];
 	}
 
 	public function cartData() {
@@ -407,6 +415,18 @@ class PurchaseUnitTest extends TestCase
 					'shipping' => 0.00,
 					'discount' => 4.83,
 				],
+			], get_woocommerce_currency()),
+		];
+
+		yield [
+			[
+				'products' => [
+					['price' => 5.345, 'quantity' => 2],
+				],
+				'billing' => ['city' => 'city0'],
+			],
+			self::adaptAmountFormat([
+				'value' => 10.69,
 			], get_woocommerce_currency()),
 		];
 	}

--- a/tests/e2e/PHPUnit/Order/PurchaseUnitTest.php
+++ b/tests/e2e/PHPUnit/Order/PurchaseUnitTest.php
@@ -334,6 +334,25 @@ class PurchaseUnitTest extends TestCase
 				],
 			]),
 		];
+
+		yield 'no decimals currency' => [
+			[
+				'currency' => 'JPY',
+				'items' => [
+					['price' => 18.0, 'quantity' => 2],
+				],
+				'shipping' => ['total' => 5.0],
+				'billing' => ['city' => 'city2'],
+			],
+			self::adaptAmountFormat([
+				'value' => 66,
+				'breakdown' => [
+					'item_total' => 36,
+					'tax_total' => 25, // 24.60
+					'shipping' => 5,
+				],
+			], 'JPY'),
+		];
 	}
 
 	public function cartData() {


### PR DESCRIPTION
Looks like we got a regression in 1.9.0. `ITEM_TOTAL_MISMATCH` when e.g. adding multiple of products with `2.345` price.

In 1.8.1 we had rounding of item price when creating the `Item` object. Later it was removed (possibly in #690), so now it is rounded only when sending data, which breaks `ditch_items_when_mismatch` checks in some cases because it checks the float values directly. That is in 1.8.1 these items/breakdowns were ditched, resulting in empty order details in PP dashboard, but not causing errors.

So to make these checks more robust, now we are using the string value that will be sent to PayPal.
