### PR TITLE
Release 1.9.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,14 @@
 *** Changelog ***
 
+= 1.9.1 - TBD =
+* Fix - ITEM_TOTAL_MISMATCH error when checking out with multiple products #721
+* Fix - Unable to purchase a product with Credit card button in pay for order page #718
+* Fix - Pay Later messaging only displayed when smart button is active on the same page #283
+* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
+* Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
+* Fix - PUI gateway is displayed with unsupported store currency #711 
+* Enhancement - Missing PayPal fee in WC order details for PUI purchase #714 
+
 = 1.9.0 - 2022-07-04 =
 * Add - New Feature - Pay Upon Invoice (Germany only) #608
 * Fix - Order not approved: payment via vaulted PayPal account fails #677

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 6.0
 Requires PHP: 7.1
-Stable tag: 1.9.0
+Stable tag: 1.9.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,15 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.9.1 =
+* Fix - ITEM_TOTAL_MISMATCH error when checking out with multiple products #721
+* Fix - Unable to purchase a product with Credit card button in pay for order page #718
+* Fix - Pay Later messaging only displayed when smart button is active on the same page #283
+* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
+* Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
+* Fix - PUI gateway is displayed with unsupported store currency #711 
+* Enhancement - Missing PayPal fee in WC order details for PUI purchase #714 
 
 = 1.9.0 =
 * Add - New Feature - Pay Upon Invoice (Germany only) #608

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.9.0
+ * Version:     1.9.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0


### PR DESCRIPTION
* Fix - ITEM_TOTAL_MISMATCH error when checking out with multiple products #721
* Fix - Unable to purchase a product with Credit card button in pay for order page #718
* Fix - Pay Later messaging only displayed when smart button is active on the same page #283
* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
* Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
* Fix - PUI gateway is displayed with unsupported store currency #711 
* Enhancement - Missing PayPal fee in WC order details for PUI purchase #714 