### PR TITLE
[PUI] Feature capitalization not consistent (664)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,8 @@
 * Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
 * Fix - PUI gateway is displayed with unsupported store currency #711 
 * Enhancement - Missing PayPal fee in WC order details for PUI purchase #714 
+* Enhancement - Skip loading of PUI js file on all pages where PUI gateway is not displayed #723
+* Enhancement - PUI feature capitalization not consistent #724
 
 = 1.9.0 - 2022-07-04 =
 * Add - New Feature - Pay Upon Invoice (Germany only) #608

--- a/modules/ppcp-onboarding/src/Endpoint/PayUponInvoiceEndpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/PayUponInvoiceEndpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Handles the onboard with Pay Upon Invoice setting.
+ * Handles the onboard with Pay upon Invoice setting.
  *
  * @package WooCommerce\PayPalCommerce\Onboarding\Endpoint
  */

--- a/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
+++ b/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
@@ -86,7 +86,7 @@ class OnboardingOptionsRenderer {
 				$checked = '';
 			}
 			return '<li><label><input type="checkbox" id="ppcp-onboarding-pui" ' . $checked . '> ' .
-				__( 'Onboard with Pay Upon Invoice', 'woocommerce-paypal-payments' ) . '
+				__( 'Onboard with Pay upon Invoice', 'woocommerce-paypal-payments' ) . '
 		</label></li>';
 		}
 

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -364,7 +364,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 			return __( 'PayPal Checkout', 'woocommerce-paypal-payments' );
 		}
 		if ( $this->is_pui_tab() ) {
-			return __( 'Pay Upon Invoice', 'woocommerce-paypal-payments' );
+			return __( 'Pay upon Invoice', 'woocommerce-paypal-payments' );
 		}
 
 		return __( 'PayPal', 'woocommerce-paypal-payments' );

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -418,7 +418,7 @@ class PayUponInvoice {
 
 					printf(
 						'<div class="notice notice-error"><p>%1$s</p></div>',
-						esc_html__( 'Could not enable gateway because the connected PayPal account is not activated for Pay upon Invoice. Reconnect your account while Onboard with Pay Upon Invoice is selected to try again.', 'woocommerce-paypal-payments' )
+						esc_html__( 'Could not enable gateway because the connected PayPal account is not activated for Pay upon Invoice. Reconnect your account while Onboard with Pay upon Invoice is selected to try again.', 'woocommerce-paypal-payments' )
 					);
 				}
 			}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -103,7 +103,7 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	) {
 		$this->id = self::ID;
 
-		$this->method_title       = __( 'Pay Upon Invoice', 'woocommerce-paypal-payments' );
+		$this->method_title       = __( 'Pay upon Invoice', 'woocommerce-paypal-payments' );
 		$this->method_description = __( 'Pay upon Invoice is an invoice payment method in Germany. It is a local buy now, pay later payment method that allows the buyer to place an order, receive the goods, try them, verify they are in good order, and then pay the invoice within 30 days.', 'woocommerce-paypal-payments' );
 
 		$gateway_settings  = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
@@ -141,7 +141,7 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 				'label'       => __( 'Pay upon Invoice', 'woocommerce-paypal-payments' ),
 				'default'     => 'no',
 				'desc_tip'    => true,
-				'description' => __( 'Enable/Disable Pay Upon Invoice payment gateway.', 'woocommerce-paypal-payments' ),
+				'description' => __( 'Enable/Disable Pay upon Invoice payment gateway.', 'woocommerce-paypal-payments' ),
 			),
 			'title'                         => array(
 				'title'       => __( 'Title', 'woocommerce-paypal-payments' ),
@@ -206,7 +206,7 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 			}
 		}
 
-		$wc_order->update_status( 'on-hold', __( 'Awaiting Pay Upon Invoice payment.', 'woocommerce-paypal-payments' ) );
+		$wc_order->update_status( 'on-hold', __( 'Awaiting Pay upon Invoice payment.', 'woocommerce-paypal-payments' ) );
 		$purchase_unit  = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$payment_source = $this->payment_source_factory->from_wc_order( $wc_order, $birth_date );
 

--- a/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
@@ -66,7 +66,7 @@ class SectionsRenderer {
 		$sections = array(
 			PayPalGateway::ID         => __( 'PayPal Checkout', 'woocommerce-paypal-payments' ),
 			CreditCardGateway::ID     => __( 'PayPal Card Processing', 'woocommerce-paypal-payments' ),
-			PayUponInvoiceGateway::ID => __( 'Pay Upon Invoice', 'woocommerce-paypal-payments' ),
+			PayUponInvoiceGateway::ID => __( 'Pay upon Invoice', 'woocommerce-paypal-payments' ),
 			WebhooksStatusPage::ID    => __( 'Webhooks Status', 'woocommerce-paypal-payments' ),
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -88,7 +88,9 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
 * Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
 * Fix - PUI gateway is displayed with unsupported store currency #711 
-* Enhancement - Missing PayPal fee in WC order details for PUI purchase #714 
+* Enhancement - Missing PayPal fee in WC order details for PUI purchase #714
+* Enhancement - Skip loading of PUI js file on all pages where PUI gateway is not displayed #723
+* Enhancement - PUI feature capitalization not consistent #724 
 
 = 1.9.0 =
 * Add - New Feature - Pay Upon Invoice (Germany only) #608


### PR DESCRIPTION
In the plugin settings, the feature is sometimes called **Pay Upon Invoice**, but it should be **Pay upon Invoice** instead

![image-20220427-211535](https://user-images.githubusercontent.com/456223/177968687-99768de2-5395-48f1-b4ba-a22a031a6897.png)
.