### PR TITLE
Introduce the WP hook proxy functionality.

### DIFF
--- a/modules/woocommerce-logging/src/Logger/WPHookProxyTrait.php
+++ b/modules/woocommerce-logging/src/Logger/WPHookProxyTrait.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * The WPHookProxyTrait is used as a proxy for WordPress defined callbacks.
+ *
+ * @package WooCommerce\WooCommerce\Logging\Logger
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\WooCommerce\Logging\Logger;
+
+use Exception;
+use TypeError;
+
+/**
+ * Trait for WordPress defined callbacks
+ */
+trait WPHookProxyTrait {
+
+	/**
+	 * Proxy for WordPress defined callbacks
+	 *
+	 * This function is used when we have to call one of our methods but the callback is hooked into
+	 * a WordPress filter or action.
+	 *
+	 * Since isn't possible to ensure third party plugins will pass the correct data declared
+	 * by WordPress we need a way to prevent fatal errors without introduce complexity.
+	 *
+	 * In this case, this function will allow us to maintain our type hints and in case something wrong
+	 * happen we rise a E_USER_NOTICE error so the issue get logged and also firing an action we allow
+	 * use or third party developer to be able to perform a more accurate debug.
+	 *
+	 * @param callable $callback The callback.
+	 * @return callable The callback.
+	 * @throws Exception|TypeError In case WP_DEBUG is active.
+	 *
+     * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration.NoArgumentType
+     * phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration.NoReturnType
+     * phpcs:disable Generic.Metrics.NestingLevel.TooHigh
+	 */
+	private function wp_hook_proxy( callable $callback ): callable {
+		/**
+		 * Remove checks.
+		 *
+		 * @psalm-suppress MissingClosureParamType
+         * phpcs:enable
+         * phpcs:disable Inpsyde.CodeQuality.ReturnTypeDeclaration.NoReturnType
+         * phpcs:disable Inpsyde.CodeQuality.ArgumentTypeDeclaration.NoArgumentType
+		 */
+		return static function ( ...$args ) use ( $callback ) {
+
+            // phpcs:enable
+
+			$returned_value = $args[0] ?? null;
+
+			try {
+				$returned_value = $callback( ...$args );
+			} catch ( TypeError $thr ) {
+				do_action( 'ppcp_wp_hook_proxy_log', 'error', $thr->getMessage(), compact( 'thr' ) );
+
+				if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+					throw $thr;
+				}
+			}
+
+			return $returned_value;
+		};
+	}
+}

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -19,6 +19,8 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce;
 
+use Psr\Log\LoggerInterface;
+
 define( 'PAYPAL_API_URL', 'https://api.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api.sandbox.paypal.com' );
 define( 'PAYPAL_INTEGRATION_DATE', '2022-04-13' );
@@ -77,6 +79,21 @@ define( 'PPCP_FLAG_SUBSCRIPTION', true );
 			 * The hook fired after the plugin bootstrap with the app services container as parameter.
 			 */
 			do_action( 'woocommerce_paypal_payments_built_container', $app_container );
+
+			/**
+			 * The logger.
+			 *
+			 * @var LoggerInterface $logger
+			 */
+			$logger = $app_container->get( 'woocommerce.logger.woocommerce' );
+			add_action(
+				'ppcp_wp_hook_proxy_log',
+				static function( string $type, string $message ) use ( $logger ) {
+					$logger->$type( $message );
+				},
+				10,
+				2
+			);
 		}
 	}
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #730

---

### Description

Recently we have received a report about the following error:

```
Fatal error: Uncaught TypeError: WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer::render_multiselect(): Return value must be of type string, null returned in /var/www/vhosts/stage.gaco.netz.rocks/htdocs/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php:178
```

This is because of a conflict with other plugin which is using the same `filter/action`
A decision was made to implement the WPHookProxyTrait to be used as a proxy for WordPress defined callbacks.
The error will not break the site (If WP_DEBUG is false), instead, the fields which are invalid will not be displayed and the error info will be added to logs.

The PR will add the `WPHookProxyTrait` described above.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Put the following filter in active theme’s functions.php file

```
add_filter(
    'woocommerce_form_field',
    static function ( $field, $key, $args, $value ) {
        //var_dump($args['type']);
        if ( 'text' === $args['type'] ) {
            return null;
        }
        return $field;
    },
    1,
    4
);
```
This will trigger the similar conflict described above

2. Check the settings page and see the error

---

Closes #730 .
