### PR TITLE
Add fields to the basic js validation error message

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -38,9 +38,22 @@ const bootstrap = () => {
             requiredFields.each((i, input) => {
                 jQuery(input).trigger('validate');
             });
-            if (jQuery('form.woocommerce-checkout .validate-required.woocommerce-invalid:visible').length) {
+            const invalidFields = Array.from(jQuery('form.woocommerce-checkout .validate-required.woocommerce-invalid:visible'));
+            if (invalidFields.length) {
+                const namesMap = PayPalCommerceGateway.labels.elements;
+                const labels = invalidFields.map(el => {
+                    const name = el.querySelector('[name]')?.getAttribute('name');
+                    if (name && name in namesMap) {
+                        return namesMap[name];
+                    }
+                    return el.querySelector('label').textContent
+                        .replaceAll('*', '')
+                        .trim();
+                }).filter(s => s.length > 2);
+
                 errorHandler.clear();
                 errorHandler.message(PayPalCommerceGateway.labels.error.js_validation);
+                labels.forEach(s => errorHandler.message(s)); // each message() call adds <li>
 
                 return actions.reject();
             }

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -40,20 +40,34 @@ const bootstrap = () => {
             });
             const invalidFields = Array.from(jQuery('form.woocommerce-checkout .validate-required.woocommerce-invalid:visible'));
             if (invalidFields.length) {
-                const namesMap = PayPalCommerceGateway.labels.elements;
-                const labels = invalidFields.map(el => {
+                const billingFieldsContainer = document.querySelector('.woocommerce-billing-fields');
+                const shippingFieldsContainer = document.querySelector('.woocommerce-shipping-fields');
+
+                const nameMessageMap = PayPalCommerceGateway.labels.error.required.elements;
+                const messages = invalidFields.map(el => {
                     const name = el.querySelector('[name]')?.getAttribute('name');
-                    if (name && name in namesMap) {
-                        return namesMap[name];
+                    if (name && name in nameMessageMap) {
+                        return nameMessageMap[name];
                     }
-                    return el.querySelector('label').textContent
+                    let label = el.querySelector('label').textContent
                         .replaceAll('*', '')
                         .trim();
+                    if (billingFieldsContainer?.contains(el)) {
+                        label = PayPalCommerceGateway.labels.billing_field.replace('%s', label);
+                    }
+                    if (shippingFieldsContainer?.contains(el)) {
+                        label = PayPalCommerceGateway.labels.shipping_field.replace('%s', label);
+                    }
+                    return PayPalCommerceGateway.labels.error.required.field
+                        .replace('%s', `<strong>${label}</strong>`)
                 }).filter(s => s.length > 2);
 
                 errorHandler.clear();
-                errorHandler.message(PayPalCommerceGateway.labels.error.js_validation);
-                labels.forEach(s => errorHandler.message(s)); // each message() call adds <li>
+                if (messages.length) {
+                    messages.forEach(s => errorHandler.message(s));
+                } else {
+                    errorHandler.message(PayPalCommerceGateway.labels.error.required.generic);
+                }
 
                 return actions.reject();
             }
@@ -96,7 +110,7 @@ const bootstrap = () => {
             PayPalCommerceGateway,
             renderer,
             messageRenderer,
-        );
+        );w
 
         singleProductBootstrap.init();
     }

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -852,22 +852,31 @@ class SmartButton implements SmartButtonInterface {
 			),
 			'messages'                          => $this->message_values(),
 			'labels'                            => array(
-				'error'    => array(
-					'generic'       => __(
+				'error'          => array(
+					'generic'  => __(
 						'Something went wrong. Please try again or choose another payment source.',
 						'woocommerce-paypal-payments'
 					),
-					'js_validation' => __(
-						'Required form fields are not filled or invalid.',
-						'woocommerce-paypal-payments'
+					'required' => array(
+						'generic'  => __(
+							'Required form fields are not filled.',
+							'woocommerce-paypal-payments'
+						),
+						// phpcs:ignore WordPress.WP.I18n
+						'field'    => __( '%s is a required field.', 'woocommerce' ),
+						'elements' => array(  // Map <form element name> => text for error messages.
+							'terms' => __(
+								'Please read and accept the terms and conditions to proceed with your order.',
+								// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+								'woocommerce'
+							),
+						),
 					),
 				),
-				'elements' => array( // Map <form element name> => text, used for error messages.
-					'terms' => __(
-						'Terms and conditions',
-						'woocommerce-paypal-payments'
-					),
-				),
+				// phpcs:ignore WordPress.WP.I18n
+				'billing_field'  => _x( 'Billing %s', 'checkout-validation', 'woocommerce' ),
+				// phpcs:ignore WordPress.WP.I18n
+				'shipping_field' => _x( 'Shipping %s', 'checkout-validation', 'woocommerce' ),
 			),
 			'order_id'                          => 'pay-now' === $this->context() ? absint( $wp->query_vars['order-pay'] ) : 0,
 			'single_product_buttons_enabled'    => $this->settings->has( 'button_product_enabled' ) && $this->settings->get( 'button_product_enabled' ),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -852,13 +852,19 @@ class SmartButton implements SmartButtonInterface {
 			),
 			'messages'                          => $this->message_values(),
 			'labels'                            => array(
-				'error' => array(
+				'error'    => array(
 					'generic'       => __(
 						'Something went wrong. Please try again or choose another payment source.',
 						'woocommerce-paypal-payments'
 					),
 					'js_validation' => __(
 						'Required form fields are not filled or invalid.',
+						'woocommerce-paypal-payments'
+					),
+				),
+				'elements' => array( // Map <form element name> => text, used for error messages.
+					'terms' => __(
+						'Terms and conditions',
 						'woocommerce-paypal-payments'
 					),
 				),


### PR DESCRIPTION
Fixes #739 

![image](https://user-images.githubusercontent.com/5680466/180152973-84f5b4c1-1111-4457-b3ab-e6cc429e251a.png)

Uses the text from `<label>`, and for the terms and conditions checkbox there is a map `name => text` because otherwise it would the checkbox text like "I have read and agree ...".