### PR TITLE
wrong PUI locale sent causing error PAYMENT_SOURCE_CANNOT_BE_USED

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
 * Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
 * Fix - PUI gateway is displayed with unsupported store currency #711 
+* Fix - Wrong PUI locale sent causing error PAYMENT_SOURCE_CANNOT_BE_USED #741
 * Enhancement - Missing PayPal fee in WC order details for PUI purchase #714 
 * Enhancement - Skip loading of PUI js file on all pages where PUI gateway is not displayed #723
 * Enhancement - PUI feature capitalization not consistent #724

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PaymentSourceFactory.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PaymentSourceFactory.php
@@ -50,7 +50,7 @@ class PaymentSourceFactory {
 			$address['city'] ?? '',
 			$address['postcode'] ?? '',
 			$address['country'] ?? '',
-			'en-DE',
+			'de-DE',
 			$merchant_name,
 			$logo_url,
 			array( $customer_service_instructions )

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,8 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - Pay Later messaging only displayed when smart button is active on the same page #283
 * Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
 * Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
-* Fix - PUI gateway is displayed with unsupported store currency #711 
+* Fix - PUI gateway is displayed with unsupported store currency #711
+* Fix - Wrong PUI locale sent causing error PAYMENT_SOURCE_CANNOT_BE_USED #741 
 * Enhancement - Missing PayPal fee in WC order details for PUI purchase #714
 * Enhancement - Skip loading of PUI js file on all pages where PUI gateway is not displayed #723
 * Enhancement - PUI feature capitalization not consistent #724 


### PR DESCRIPTION
The plugin sends `en-DE` locale when it should be `de-DE`

