### PR TITLE
Fixed PHP Fatal error: Return value must be of type string, null returned.

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -172,7 +172,7 @@ class SettingsRenderer {
 	 *
 	 * @return string
 	 */
-	public function render_multiselect( $field, $key, $config, $value ): string {
+	public function render_multiselect( $field, $key, $config, $value ): ?string {
 
 		if ( 'ppcp-multiselect' !== $config['type'] ) {
 			return $field;
@@ -211,7 +211,7 @@ class SettingsRenderer {
 	 *
 	 * @return string
 	 */
-	public function render_password( $field, $key, $config, $value ): string {
+	public function render_password( $field, $key, $config, $value ): ?string {
 
 		if ( 'ppcp-password' !== $config['type'] ) {
 			return $field;
@@ -244,7 +244,7 @@ class SettingsRenderer {
 	 *
 	 * @return string
 	 */
-	public function render_text_input( $field, $key, $config, $value ): string {
+	public function render_text_input( $field, $key, $config, $value ): ?string {
 
 		if ( 'ppcp-text-input' !== $config['type'] ) {
 			return $field;
@@ -276,7 +276,7 @@ class SettingsRenderer {
 	 *
 	 * @return string
 	 */
-	public function render_heading( $field, $key, $config, $value ): string {
+	public function render_heading( $field, $key, $config, $value ): ?string {
 
 		if ( 'ppcp-heading' !== $config['type'] ) {
 			return $field;
@@ -298,7 +298,7 @@ class SettingsRenderer {
 	 * @param string $tag HTML tag ('td', 'th').
 	 * @return string
 	 */
-	public function render_table_row( array $data, string $tag = 'td' ): string {
+	public function render_table_row( array $data, string $tag = 'td' ): ?string {
 		$cells = array_map(
 			function ( $value ) use ( $tag ): string {
 				return "<$tag>" . (string) $value . "</$tag>";
@@ -318,7 +318,7 @@ class SettingsRenderer {
 	 *
 	 * @return string HTML.
 	 */
-	public function render_table( $field, $key, $config, $value ): string {
+	public function render_table( $field, $key, $config, $value ): ?string {
 		if ( 'ppcp-table' !== $config['type'] ) {
 			return $field;
 		}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-paypal-payments/issues/730

Replaces https://github.com/woocommerce/woocommerce-paypal-payments/pull/731

### Description

The following PHP Fatal Error appears when trying to set up the plugin:

```
Fatal error: Uncaught Error: WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer::render_multiselect():
Return value must be of type string, null returned
in wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php on line 178
```

Resolving this error subsequently exposes further fatal errors in the other render callbacks in the same class.

### Steps to Test

1. Download the plugin and activate it.
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway`

### Changelog Entry

> Fixed PHP Fatal error: Return value must be of type string, null returned.

Closes #730 
