### PR TITLE
Do not remove card funding source for free trials if card button enabled

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -984,7 +984,7 @@ class SmartButton implements SmartButtonInterface {
 
 		if ( $this->is_free_trial_cart() ) {
 			$all_sources = array_keys( $this->all_funding_sources );
-			if ( $is_dcc_enabled ) {
+			if ( $is_dcc_enabled || $is_separate_card_enabled ) {
 				$all_sources = array_diff( $all_sources, array( 'card' ) );
 			}
 			$disable_funding = $all_sources;


### PR DESCRIPTION
We were removing all sources for free trials to leave only the PayPal button, but we were not removing `card` if DCC is enabled (because it requires it), now we also need to keep `card` if the card button gateway is enabled.