### PR TITLE
Fix the script loading check.

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1092,9 +1092,10 @@ class SmartButton implements SmartButtonInterface {
 		}
 		if (
 			$this->context() === 'product'
-			&& ( $this->settings->has( 'button_product_enabled' )
-			&& $this->settings->get( 'button_product_enabled' )
-			|| $this->settings->has( 'message_product_enabled' ) )
+			&& (
+				( $this->settings->has( 'button_product_enabled' ) && $this->settings->get( 'button_product_enabled' ) ) ||
+				( $this->settings->has( 'message_product_enabled' ) && $this->settings->get( 'message_product_enabled' ) )
+			)
 		) {
 			$load_buttons = true;
 		}
@@ -1104,14 +1105,17 @@ class SmartButton implements SmartButtonInterface {
 		) {
 			$load_buttons = true;
 		}
+
 		if (
 			$this->context() === 'cart'
-			&& ( $this->settings->has( 'button_cart_enabled' )
-			&& $this->settings->get( 'button_cart_enabled' )
-			|| $this->settings->has( 'message_product_enabled' ) )
+			&& (
+				( $this->settings->has( 'button_cart_enabled' ) && $this->settings->get( 'button_cart_enabled' ) ) ||
+				( $this->settings->has( 'message_cart_enabled' ) && $this->settings->get( 'message_cart_enabled' ) )
+			)
 		) {
 			$load_buttons = true;
 		}
+
 		if ( $this->context() === 'pay-now' ) {
 			$load_buttons = true;
 		}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1092,9 +1092,9 @@ class SmartButton implements SmartButtonInterface {
 		}
 		if (
 			$this->context() === 'product'
-			&& $this->settings->has( 'button_product_enabled' )
+			&& ( $this->settings->has( 'button_product_enabled' )
 			&& $this->settings->get( 'button_product_enabled' )
-			|| $this->settings->has( 'message_product_enabled' )
+			|| $this->settings->has( 'message_product_enabled' ) )
 		) {
 			$load_buttons = true;
 		}
@@ -1106,9 +1106,9 @@ class SmartButton implements SmartButtonInterface {
 		}
 		if (
 			$this->context() === 'cart'
-			&& $this->settings->has( 'button_cart_enabled' )
+			&& ( $this->settings->has( 'button_cart_enabled' )
 			&& $this->settings->get( 'button_cart_enabled' )
-			|| $this->settings->has( 'message_product_enabled' )
+			|| $this->settings->has( 'message_product_enabled' ) )
 		) {
 			$load_buttons = true;
 		}


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #750

---

### Description

With version 1.9.1, PayPal scripts are loaded on all pages even if all smart buttons and Pay Later messaging are disabled.
The PR will fix this problem by fixing the script loading check logic.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Install version 1.9.1.
2. Open browser network activity.
3. Load any page without an active PayPal button or Pay Later messaging.
4. Observe PayPal scripts loading anyway.

---

Closes #750 .
