### PR TITLE
Add GH Action for building packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ trim_trailing_whitespace = false
 
 [*.{js,json,yml}]
 indent_style = space
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,41 @@
+name: Build package
+
+on:
+  workflow_dispatch:
+    inputs:
+      packageVersion:
+        description: 'Package Version'
+        required: false
+        type: string
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+
+    name: Build package
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 7.1
+        tools: composer:v1
+
+    - name: Set plugin version header
+      env:
+        PACKAGE_VERSION: ${{ github.event.inputs.packageVersion }}
+      run: 'sed -Ei "s/Version: .*/Version:     ${PACKAGE_VERSION}/g" woocommerce-paypal-payments.php'
+      if: github.event.inputs.packageVersion
+
+    - name: Build
+      run: yarn build
+
+    - name: Unzip # GH currently always zips, so if we upload a zip we get a zip inside a zip
+      run: unzip woocommerce-paypal-payments.zip -d dist
+
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: woocommerce-paypal-payments
+        path: dist/


### PR DESCRIPTION
Added a manual GH Action for creating a package and uploading it to GH Actions artifacts. It makes the package creation easier and helps to avoid human errors like "forgot to pull before running the script" or using wrong PHP version.

It cannot be fully tested until it is merged, because it is not shown until the workflow with this name is present in the default branch, can only trigger via `push` hook or [gh cli](https://stackoverflow.com/a/67840292/964478). But it seems to work well so far, tested with `push` and in another repo. 

It supposed to show this menu with the version input and branch selection when you click the button after opening the `Build package` workflow in the left column of the Action page. The version can be empty to keep the current one.

![image](https://user-images.githubusercontent.com/5680466/182086978-e5baf7f1-1669-4bfa-a0b7-6cadcac067a6.png)

And then when opening the run summary (e.g. clicking in the list) it will have the package zip at the bottom. https://github.com/woocommerce/woocommerce-paypal-payments/actions/runs/2761087985

![image](https://user-images.githubusercontent.com/5680466/182087003-de229857-df32-4157-b390-a2714efc26b8.png)

More about GH Actions storage: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts 

There are limits [for private repos](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions), but for public [it supposed to be free](https://github.com/orgs/community/discussions/26438#discussioncomment-3251931) (and unlimited?). Either way the limits should be fine if we just trigger manually. The files are deleted after 90 days.