### PR TITLE
Revert removal of gateway status check

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -559,6 +559,12 @@ class SmartButton implements SmartButtonInterface {
 			return;
 		}
 
+		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+
+		if ( ! isset( $available_gateways[ $gateway_id ] ) ) {
+			return;
+		}
+
 		// The wrapper is needed for the loading spinner,
 		// otherwise jQuery block() prevents buttons rendering.
 		echo '<div class="ppc-button-wrapper"><div id="ppc-button-' . esc_attr( $gateway_id ) . '"></div></div>';


### PR DESCRIPTION
Looks like it was accidentally removed after #704 merge conflict.
Without it we always render the hidden area for separate card gateway, so the check in JS fails and we always render all standard buttons separately in checkout, which may result in wrong style and other issues.
