### PR TITLE
PUI conflict with Germanized plugin

### DIFF
--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -378,7 +378,12 @@ class PurchaseUnit {
 
 		$amount_total = 0.0;
 		if ( $shipping ) {
-			$amount_total += (float) $shipping->value_str();
+			$wc_order = wc_get_order($this->custom_id);
+			if(is_a($wc_order, \WC_Order::class) ) {
+				$amount_total += (float) bcdiv((string)$shipping->value(), '1', 2);
+			} else {
+				$amount_total += (float) $shipping->value_str();
+			}
 		}
 		if ( $item_total ) {
 			$amount_total += (float) $item_total->value_str();

--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
 
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
+
 /**
  * Class PurchaseUnit
  */
@@ -379,7 +381,7 @@ class PurchaseUnit {
 		$amount_total = 0.0;
 		if ( $shipping ) {
 			$wc_order = wc_get_order($this->custom_id);
-			if(is_a($wc_order, \WC_Order::class) ) {
+			if(is_a($wc_order, \WC_Order::class) && $wc_order->get_payment_method() === PayUponInvoiceGateway::ID) {
 				$amount_total += (float) bcdiv((string)$shipping->value(), '1', 2);
 			} else {
 				$amount_total += (float) $shipping->value_str();

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\Subscription\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 
 /**
  * Class AmountFactory
@@ -146,10 +147,18 @@ class AmountFactory {
 			(float) $order->get_subtotal() + (float) $order->get_total_fees(),
 			$currency
 		);
+
 		$shipping   = new Money(
 			(float) $order->get_shipping_total(),
 			$currency
 		);
+		if($order->get_payment_method() === PayUponInvoiceGateway::ID) {
+			$shipping = new Money(
+				(float) bcdiv((string)$shipping->value(), '1', 2),
+				$currency
+			);
+		}
+
 		$taxes      = new Money(
 			(float) $order->get_total_tax(),
 			$currency


### PR DESCRIPTION
### Description

Following the setup of the Germanized plugin, users will see an checkout error in certain conditions when product and shipping have 2 decimals in the amount while attempting the purchase with PUI.

### Steps to Test

1. Install WooCommerce
2. Set store country and currency to Germany and Euro
3. Install latest PayPal Payments for WooCommerce plugin
4. Onboard with PUI feature 
5. Enable PUI feature
6. Install Germanized plugin and finish the setup
7. Enable tax
8. Enable shipping 
9. Add shipping zone with 10.10 euro flat rate 
10. Create a taxable simple product with 549.12 euro price
11. Navigate to checkout page
12. Select PUI gateway
13. Input billing details and birth date
14. Place the order.

Observe, error is thrown:
```
REQUIRED_PARAMETER_FOR_PAYMENT_SOURCE /purchase_units/0/items The parameter is required for provided payment source.
```