### PR TITLE
Fix style merging

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,8 @@
 * Fix - PayPal scripts were loading on pages without smart buttons or Pay Later messaging. #750
 * Fix - Do not show links for unavailable gateways settings pages. #753
 * Fix - The smart buttons were not loaded on single product page if a subscription product exists in the cart. #703
-* Fix - DCC was causing other gateways to disappear after checkout validation error #757
+* Fix - DCC was causing other gateways to disappear after checkout validation error. #757
+* Fix - Buttons not loading on single product page with default settings when product is in cart. #777
 * Enhancement - Improve Checkout Field Validation Message. #739
 * Enhancement - Handle PAYER_ACTION_REQUIRED error. #759
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -912,10 +912,10 @@ class SmartButton implements SmartButtonInterface {
 		);
 
 		if ( $this->style_for_context( 'layout', 'mini-cart' ) !== 'horizontal' ) {
-			unset( $localize['button']['mini_cart_style']['tagline'] );
+			$localize['button']['mini_cart_style']['tagline'] = false;
 		}
 		if ( $this->style_for_context( 'layout', $this->context() ) !== 'horizontal' ) {
-			unset( $localize['button']['style']['tagline'] );
+			$localize['button']['style']['tagline'] = false;
 		}
 
 		$this->request_data->dequeue_nonce_fix();

--- a/readme.txt
+++ b/readme.txt
@@ -89,7 +89,8 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - PayPal scripts were loading on pages without smart buttons or Pay Later messaging. #750
 * Fix - Do not show links for unavailable gateways settings pages. #753
 * Fix - The smart buttons were not loaded on single product page if a subscription product exists in the cart. #703
-* Fix - DCC was causing other gateways to disappear after checkout validation error #757
+* Fix - DCC was causing other gateways to disappear after checkout validation error. #757
+* Fix - Buttons not loading on single product page with default settings when product is in cart. #777
 * Enhancement - Improve Checkout Field Validation Message. #739
 * Enhancement - Handle PAYER_ACTION_REQUIRED error. #759
 


### PR DESCRIPTION
Fixes style merging [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/c48fc6c87911a956090024fa7174862cf03f6d1b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js#L14). When unset, the previously existing property will remain, resulting in an error when e.g. `tagline = true` remains for vertical mini-cart. So for now simply setting to `false` instead of unsetting. This should fix the mini-cart issue, and in the future with the new settings we probably need to do styling differently anyway.