### PR TITLE
Error message formatting in order notes contains file path (864)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -77,7 +77,7 @@ trait ProcessPaymentTrait {
 		if ( $wc_order ) {
 			$wc_order->update_status(
 				'failed',
-				$this->format_exception( $error )
+				$error->getMessage()
 			);
 		}
 


### PR DESCRIPTION
### Description

When certain API responses are triggered, like `PAYMENT_DENIED`, then the order notes may contain needed information.

### Steps to Test

mock `PAYMENT_DENIED` error with this filter:
```
add_filter('ppcp_request_args', function ($args, $url){
    if (strpos($url,'capture') !== false) {
        $args['headers']['PayPal-Mock-Response'] = '{"mock_application_codes": "PAYMENT_DENIED"}';
    }
    return $args;
}, 10, 2);
```
- Add product to cart, visit checkout
- Go through payment process
- Attempt will fail
- Failed order is created with the file path in the order notes

### Expected behaviour

Other note does not contain file path.