### PR TITLE
Do not include full path in exception

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -118,7 +118,7 @@ trait ProcessPaymentTrait {
 	 * @return string
 	 */
 	protected function format_exception( Throwable $exception ): string {
-		$output = $exception->getMessage() . ' ' . $exception->getFile() . ':' . $exception->getLine();
+		$output = $exception->getMessage() . ' ' . basename( $exception->getFile() ) . ':' . $exception->getLine();
 		$prev   = $exception->getPrevious();
 		if ( ! $prev ) {
 			return $output;


### PR DESCRIPTION
Improves message similarly to #778 but keeps the file names and inner messages, only removes the dir paths.

![image](https://user-images.githubusercontent.com/5680466/183599624-623caa9d-2d44-4a50-ae16-c3a19da5bb0b.png)
