### PR TITLE
Show tabs only after onboarding

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -211,7 +211,8 @@ return array(
 	'wcgateway.settings.sections-renderer'                 => static function ( ContainerInterface $container ): SectionsRenderer {
 		return new SectionsRenderer(
 			$container->get( 'wcgateway.current-ppcp-settings-page-id' ),
-			$container->get( 'wcgateway.settings.sections' )
+			$container->get( 'wcgateway.settings.sections' ),
+			$container->get( 'onboarding.state' )
 		);
 	},
 	'wcgateway.settings.sections'                          => static function ( ContainerInterface $container ): array {

--- a/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
+use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhooksStatusPage;
 
@@ -34,14 +35,23 @@ class SectionsRenderer {
 	protected $sections;
 
 	/**
+	 * The onboarding state.
+	 *
+	 * @var State
+	 */
+	private $state;
+
+	/**
 	 * SectionsRenderer constructor.
 	 *
 	 * @param string                $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
 	 * @param array<string, string> $sections Key - page/gateway ID, value - displayed text.
+	 * @param State                 $state The onboarding state.
 	 */
-	public function __construct( string $page_id, array $sections ) {
+	public function __construct( string $page_id, array $sections, State $state ) {
 		$this->page_id  = $page_id;
 		$this->sections = $sections;
+		$this->state    = $state;
 	}
 
 	/**
@@ -50,7 +60,9 @@ class SectionsRenderer {
 	 * @return bool
 	 */
 	public function should_render() : bool {
-		return ! empty( $this->page_id );
+		return ! empty( $this->page_id ) &&
+			( $this->state->production_state() === State::STATE_ONBOARDED ||
+			$this->state->sandbox_state() === State::STATE_ONBOARDED );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #788 

Renders tabs if either sandbox or live is onboarded. Currently it is possible to click the sandbox checkbox after onboarding and the tabs will still appear even if the current env is not onboarded, but fixing that probably not worth it, as I understand the main goal is to avoid confusion on initial setup.
![image](https://user-images.githubusercontent.com/70433191/185463293-949dd81b-9f1e-49db-ac37-8b2c558cc9d7.png)
