### PR TITLE
Improve messages and PUI check

### DIFF
--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -51,7 +51,7 @@ class OrderTrackingModule implements ModuleInterface {
 		$pui_helper = $c->get( 'wcgateway.pay-upon-invoice-helper' );
 		assert( $pui_helper instanceof PayUponInvoiceHelper );
 
-		if ( $pui_helper->is_pui_ready_in_admin() ) {
+		if ( $pui_helper->is_pui_enabled() ) {
 			$settings->set( 'tracking_enabled', true );
 			$settings->persist();
 		}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2303,8 +2303,7 @@ return array(
 	'wcgateway.pay-upon-invoice-helper'                    => static function( ContainerInterface $container ): PayUponInvoiceHelper {
 		return new PayUponInvoiceHelper(
 			$container->get( 'wcgateway.checkout-helper' ),
-			$container->get( 'api.shop.country' ),
-			$container->get( 'wcgateway.pay-upon-invoice-product-status' )
+			$container->get( 'wcgateway.settings' )
 		);
 	},
 	'wcgateway.pay-upon-invoice-product-status'            => static function( ContainerInterface $container ): PayUponInvoiceProductStatus {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -949,8 +949,8 @@ return array(
 				'title'        => __( 'Tracking', 'woocommerce-paypal-payments' ),
 				'type'         => 'checkbox',
 				'desc_tip'     => true,
-				'label'        => __( 'Enable tracking', 'woocommerce-paypal-payments' ),
-				'description'  => __( 'Enable tracking', 'woocommerce-paypal-payments' ),
+				'label'        => $container->get( 'wcgateway.settings.tracking-label' ),
+				'description'  => __( 'Allows to send shipment tracking numbers to PayPal for PayPal transactions.', 'woocommerce-paypal-payments' ),
 				'default'      => false,
 				'screens'      => array(
 					State::STATE_ONBOARDED,
@@ -2456,10 +2456,33 @@ return array(
 			return true;
 		}
 
-		if ( $pui_helper->is_pui_ready_in_admin() ) {
+		if ( $pui_helper->is_pui_enabled() ) {
 			return true;
 		}
 
 		return false;
+	},
+	'wcgateway.settings.tracking-label'                    => static function ( ContainerInterface $container ): string {
+		$tracking_label = __( 'Enable tracking information feature on your store.', 'woocommerce-paypal-payments' );
+		$is_tracking_available = $container->get( 'order-tracking.is-tracking-available' );
+
+		if ( $is_tracking_available ) {
+			return $tracking_label;
+		}
+
+		$tracking_label .= sprintf(
+		// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
+			__(
+				' To use tracking features, you must %1$senable tracking on your account%2$s.',
+				'woocommerce-paypal-payments'
+			),
+			'<a
+					href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/#enable-tracking-on-your-live-account"
+					target="_blank"
+				>',
+			'</a>'
+		);
+
+		return $tracking_label;
 	},
 );

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -107,10 +107,6 @@ class PayUponInvoiceHelper {
 	 * @throws NotFoundException If problem when checking the settings.
 	 */
 	public function is_pui_enabled(): bool {
-		if ( $this->settings->has( 'products_pui_enabled' ) && $this->settings->get( 'products_pui_enabled' ) ) {
-			return true;
-		}
-
-		return false;
+		return $this->settings->has( 'products_pui_enabled' ) && $this->settings->get( 'products_pui_enabled' );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -10,6 +10,8 @@ declare( strict_types=1 );
 namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
 use WC_Order;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class PayUponInvoiceHelper
@@ -31,24 +33,24 @@ class PayUponInvoiceHelper {
 	protected $shop_country;
 
 	/**
-	 * The PUI seller product status.
+	 * The settings.
 	 *
-	 * @var PayUponInvoiceProductStatus
+	 * @var Settings
 	 */
-	protected $pui_product_status;
+	protected $settings;
 
 	/**
 	 * PayUponInvoiceHelper constructor.
 	 *
-	 * @param CheckoutHelper              $checkout_helper The checkout helper.
-	 * @param string                      $shop_country The selected shop country.
-	 * @param PayUponInvoiceProductStatus $pui_product_status The PUI seller product status.
+	 * @param CheckoutHelper $checkout_helper The checkout helper.
+	 * @param string         $shop_country The selected shop country.
+	 * @param Settings       $settings The Settings.
 	 */
-	public function __construct( CheckoutHelper $checkout_helper, string $shop_country, PayUponInvoiceProductStatus $pui_product_status ) {
+	public function __construct( CheckoutHelper $checkout_helper, string $shop_country, Settings $settings ) {
 
-		$this->checkout_helper    = $checkout_helper;
-		$this->shop_country       = $shop_country;
-		$this->pui_product_status = $pui_product_status;
+		$this->checkout_helper = $checkout_helper;
+		$this->shop_country    = $shop_country;
+		$this->settings        = $settings;
 	}
 
 	/**
@@ -99,12 +101,13 @@ class PayUponInvoiceHelper {
 	}
 
 	/**
-	 * Checks whether PUI is ready in admin screen.
+	 * Checks whether PUI is enabled.
 	 *
-	 * @return bool
+	 * @return bool True if PUI is active, otherwise false.
+	 * @throws NotFoundException If problem when checking the settings.
 	 */
-	public function is_pui_ready_in_admin(): bool {
-		if ( $this->shop_country === 'DE' && $this->pui_product_status->pui_is_active() ) {
+	public function is_pui_enabled(): bool {
+		if ( $this->settings->has( 'products_pui_enabled' ) && $this->settings->get( 'products_pui_enabled' ) ) {
 			return true;
 		}
 

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -26,13 +26,6 @@ class PayUponInvoiceHelper {
 	protected $checkout_helper;
 
 	/**
-	 * The selected shop country.
-	 *
-	 * @var string
-	 */
-	protected $shop_country;
-
-	/**
 	 * The settings.
 	 *
 	 * @var Settings
@@ -43,13 +36,11 @@ class PayUponInvoiceHelper {
 	 * PayUponInvoiceHelper constructor.
 	 *
 	 * @param CheckoutHelper $checkout_helper The checkout helper.
-	 * @param string         $shop_country The selected shop country.
 	 * @param Settings       $settings The Settings.
 	 */
-	public function __construct( CheckoutHelper $checkout_helper, string $shop_country, Settings $settings ) {
+	public function __construct( CheckoutHelper $checkout_helper, Settings $settings ) {
 
 		$this->checkout_helper = $checkout_helper;
-		$this->shop_country    = $shop_country;
 		$this->settings        = $settings;
 	}
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #792

---

### Description

The PR will:

1. Approve setting descriptions for tracking

<img width="738" alt="Screen Shot 2022-08-19 at 14 09 20" src="https://user-images.githubusercontent.com/11319597/185618159-9c0cf0eb-92a1-48ec-bc53-a68ea748cfee.png">
<img width="1322" alt="Screen Shot 2022-08-19 at 14 11 37" src="https://user-images.githubusercontent.com/11319597/185618179-0a85a50d-cdef-481b-8743-162c922cc6da.png">

2. Change the way of checking if PUI active. Instead of checking if it is active on merchant account and doing additional API request we just need to check if PUI is activated in Woo settings, that is enough for tracking.

