### PR TITLE
Fix SiteGround Optimizer plugin compatibility

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -38,4 +38,16 @@ return array(
 		return new PPEC\SettingsImporter( $settings );
 	},
 
+	'compat.plugin-script-names'        => static function( $container ) : array {
+		return array(
+			'ppcp-smart-button',
+			'ppcp-oxxo',
+			'ppcp-pay-upon-invoice',
+			'ppcp-vaulting-myaccount-payments',
+			'ppcp-gateway-settings',
+			'ppcp-webhooks-status-page',
+			'ppcp-tracking',
+		);
+	},
+
 );

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -32,13 +32,13 @@ return array(
 		return new PPEC\SubscriptionsHandler( $ppcp_renewal_handler, $gateway );
 	},
 
-	'compat.ppec.settings_importer'     => static function( $container ) : PPEC\SettingsImporter {
+	'compat.ppec.settings_importer'     => static function( ContainerInterface $container ) : PPEC\SettingsImporter {
 		$settings = $container->get( 'wcgateway.settings' );
 
 		return new PPEC\SettingsImporter( $settings );
 	},
 
-	'compat.plugin-script-names'        => static function( $container ) : array {
+	'compat.plugin-script-names'        => static function( ContainerInterface $container ) : array {
 		return array(
 			'ppcp-smart-button',
 			'ppcp-oxxo',

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -39,6 +39,7 @@ class CompatModule implements ModuleInterface {
 	 */
 	public function run( ContainerInterface $c ): void {
 		$this->initialize_ppec_compat_layer( $c );
+		$this->fix_site_ground_optimizer_compatibility( $c );
 	}
 
 	/**
@@ -76,4 +77,20 @@ class CompatModule implements ModuleInterface {
 
 	}
 
+	/**
+	 * Fixes the compatibility issue for <a href="https://wordpress.org/plugins/sg-cachepress/">SiteGround Optimizer plugin</a>.
+	 *
+	 * @link https://wordpress.org/plugins/sg-cachepress/
+	 *
+	 * @param ContainerInterface $c The Container.
+	 */
+	protected function fix_site_ground_optimizer_compatibility( ContainerInterface $c ): void {
+		$ppcp_script_names = $c->get( 'compat.plugin-script-names' );
+		add_filter(
+			'sgo_js_minify_exclude',
+			function ( array $scripts ) use ( $ppcp_script_names ) {
+				return array_merge( $scripts, $ppcp_script_names );
+			}
+		);
+	}
 }

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -33,9 +33,7 @@ class CompatModule implements ModuleInterface {
 	}
 
 	/**
-	 * Run the compatibility module.
-	 *
-	 * @param ContainerInterface|null $c The Container.
+	 * {@inheritDoc}
 	 */
 	public function run( ContainerInterface $c ): void {
 		$this->initialize_ppec_compat_layer( $c );
@@ -53,10 +51,10 @@ class CompatModule implements ModuleInterface {
 	/**
 	 * Sets up the PayPal Express Checkout compatibility layer.
 	 *
-	 * @param ContainerInterface|null $container The Container.
+	 * @param ContainerInterface $container The Container.
 	 * @return void
 	 */
-	private function initialize_ppec_compat_layer( ?ContainerInterface $container ): void {
+	private function initialize_ppec_compat_layer( ContainerInterface $container ): void {
 		// Process PPEC subscription renewals through PayPal Payments.
 		$handler = $container->get( 'compat.ppec.subscriptions-handler' );
 		$handler->maybe_hook();

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -56,7 +56,7 @@ class CompatModule implements ModuleInterface {
 	 * @param ContainerInterface|null $container The Container.
 	 * @return void
 	 */
-	private function initialize_ppec_compat_layer( $container ): void {
+	private function initialize_ppec_compat_layer( ?ContainerInterface $container ): void {
 		// Process PPEC subscription renewals through PayPal Payments.
 		$handler = $container->get( 'compat.ppec.subscriptions-handler' );
 		$handler->maybe_hook();


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #797

---

### Description

The PR will add a filter (`sgo_js_minify_exclude`) to automatically prevent the [Siteground Optimizer plugin ](https://wordpress.org/plugins/sg-cachepress/) from minifying or caching PayPal Payments scripts.

### Steps to Test

We cannot reproduce the problem ourselves because it only occurs on SiteGround-hosted sites.

---

Closes #797 .
