### PR TITLE
Enable ACDC by default only in locations where WooCommerce Payments is not available

### DIFF
--- a/modules/ppcp-api-client/src/Helper/DccApplies.php
+++ b/modules/ppcp-api-client/src/Helper/DccApplies.php
@@ -78,6 +78,18 @@ class DccApplies {
 	}
 
 	/**
+	 * Returns whether WooCommerce Payments plugin is available for the store country.
+	 *
+	 * @return bool
+	 */
+	public function for_wc_payments(): bool {
+		$countries = array_keys( $this->allowed_country_currency_matrix );
+		array_push( $countries, 'AT', 'BE', 'HK', 'IE', 'NL', 'PL', 'PT', 'SG', 'CH' );
+
+		return in_array( $this->country, $countries, true );
+	}
+
+	/**
 	 * Returns credit cards, which can be used.
 	 *
 	 * @return array

--- a/modules/ppcp-onboarding/assets/css/onboarding.css
+++ b/modules/ppcp-onboarding/assets/css/onboarding.css
@@ -55,6 +55,7 @@ ul.ppcp-onboarding-options, ul.ppcp-onboarding-options-sublist {
 
 ul.ppcp-onboarding-options-sublist {
 	margin-left: 15px;
+	margin-top: 15px;
 }
 
 .ppcp-muted-text {

--- a/modules/ppcp-onboarding/assets/js/onboarding.js
+++ b/modules/ppcp-onboarding/assets/js/onboarding.js
@@ -158,6 +158,8 @@ function ppcp_onboarding_productionCallback(...args) {
             input.disabled = !cardsChk.checked;
         });
 
+        document.querySelector('.ppcp-onboarding-cards-options').style.display = !cardsChk.checked ? 'none' : '';
+
         const basicRb = document.querySelector('#ppcp-onboarding-dcc-basic');
 
         const isExpress = !cardsChk.checked || basicRb.checked;

--- a/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
+++ b/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
@@ -56,6 +56,7 @@ class OnboardingOptionsRenderer {
 	 * @param bool $is_shop_supports_dcc Whether the shop can use DCC (country, currency).
 	 */
 	public function render( bool $is_shop_supports_dcc ): string {
+		$checked = $is_shop_supports_dcc ? '' : 'checked';
 		return '
 <ul class="ppcp-onboarding-options">
 	<li>
@@ -64,7 +65,7 @@ class OnboardingOptionsRenderer {
 		</label>
 	</li>
 	<li>
-		<label><input type="checkbox" id="ppcp-onboarding-accept-cards" checked> ' .
+		<label><input type="checkbox" id="ppcp-onboarding-accept-cards" '. $checked .'> ' .
 			__( 'Securely accept all major credit & debit cards on the strength of the PayPal network', 'woocommerce-paypal-payments' ) . '
 		</label>
 	</li>

--- a/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
+++ b/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
@@ -103,6 +103,44 @@ class OnboardingOptionsRenderer {
 
 		$is_us_shop = 'US' === $this->country;
 
+		$basic_table_rows = array(
+			$this->render_table_row(
+				__( 'Credit & Debit Card form fields', 'woocommerce-paypal-payments' ),
+				__( 'Prebuilt user experience', 'woocommerce-paypal-payments' )
+			),
+			! $is_us_shop ? '' : $this->render_table_row(
+				__( 'Credit & Debit Card pricing', 'woocommerce-paypal-payments' ),
+				__( '3.49% + $0.49', 'woocommerce-paypal-payments' ),
+				'',
+				__( 'for US domestic transactions', 'woocommerce-paypal-payments' )
+			),
+			$this->render_table_row(
+				__( 'Seller Protection', 'woocommerce-paypal-payments' ),
+				__( 'Yes', 'woocommerce-paypal-payments' ),
+				__( 'No matter what you sell, Seller Protection can help you avoid chargebacks, reversals, and fees on eligible PayPal payment transactions — even when a customer has filed a dispute.', 'woocommerce-paypal-payments' ),
+				__( 'for eligible PayPal transactions', 'woocommerce-paypal-payments' )
+			),
+			$this->render_table_row(
+				__( 'Seller Account Type', 'woocommerce-paypal-payments' ),
+				__( 'Business or Casual', 'woocommerce-paypal-payments' ),
+				__( 'For Standard payments, Casual sellers may connect their Personal PayPal account in eligible countries to sell on WooCommerce. For Advanced payments, a Business PayPal account is required.', 'woocommerce-paypal-payments' )
+			),
+		);
+		$items[]          = '
+<li ' . ( ! $is_shop_supports_dcc ? 'style="display: none;"' : '' ) . '>
+	<label>
+		<input type="radio" id="ppcp-onboarding-dcc-basic" name="ppcp_onboarding_dcc" value="basic" ' .
+			( ! $is_shop_supports_dcc ? 'checked' : '' ) .
+			' data-screen-url="' . $this->get_screen_url( 'basic' ) . '"' .
+			'> ' .
+		__( 'Standard Card Processing', 'woocommerce-paypal-payments' ) . '
+	</label>
+	' . $this->render_tooltip( __( 'Card transactions are managed by PayPal, which simplifies compliance requirements for you.', 'woocommerce-paypal-payments' ) ) . '
+	<table>
+		' . implode( $basic_table_rows ) . '
+	</table>
+</li>';
+
 		if ( $is_shop_supports_dcc ) {
 			$dcc_table_rows = array(
 				$this->render_table_row(
@@ -148,7 +186,7 @@ class OnboardingOptionsRenderer {
 	<label>
 		<input type="radio" id="ppcp-onboarding-dcc-acdc" name="ppcp_onboarding_dcc" value="acdc" checked ' .
 				'data-screen-url="' . $this->get_screen_url( 'acdc' ) . '"> ' .
-			__( 'Advanced Card Processing', 'woocommerce-paypal-payments' ) . '
+				__( 'Advanced Card Processing', 'woocommerce-paypal-payments' ) . '
 	</label>
 	' . $this->render_tooltip( __( 'PayPal acts as the payment processor for card transactions. You can add optional features like Chargeback Protection for more security.', 'woocommerce-paypal-payments' ) ) . '
 	<table>
@@ -156,44 +194,6 @@ class OnboardingOptionsRenderer {
 	</table>
 </li>';
 		}
-
-		$basic_table_rows = array(
-			$this->render_table_row(
-				__( 'Credit & Debit Card form fields', 'woocommerce-paypal-payments' ),
-				__( 'Prebuilt user experience', 'woocommerce-paypal-payments' )
-			),
-			! $is_us_shop ? '' : $this->render_table_row(
-				__( 'Credit & Debit Card pricing', 'woocommerce-paypal-payments' ),
-				__( '3.49% + $0.49', 'woocommerce-paypal-payments' ),
-				'',
-				__( 'for US domestic transactions', 'woocommerce-paypal-payments' )
-			),
-			$this->render_table_row(
-				__( 'Seller Protection', 'woocommerce-paypal-payments' ),
-				__( 'Yes', 'woocommerce-paypal-payments' ),
-				__( 'No matter what you sell, Seller Protection can help you avoid chargebacks, reversals, and fees on eligible PayPal payment transactions — even when a customer has filed a dispute.', 'woocommerce-paypal-payments' ),
-				__( 'for eligible PayPal transactions', 'woocommerce-paypal-payments' )
-			),
-			$this->render_table_row(
-				__( 'Seller Account Type', 'woocommerce-paypal-payments' ),
-				__( 'Business or Casual', 'woocommerce-paypal-payments' ),
-				__( 'For Standard payments, Casual sellers may connect their Personal PayPal account in eligible countries to sell on WooCommerce. For Advanced payments, a Business PayPal account is required.', 'woocommerce-paypal-payments' )
-			),
-		);
-		$items[]          = '
-<li ' . ( ! $is_shop_supports_dcc ? 'style="display: none;"' : '' ) . '>
-	<label>
-		<input type="radio" id="ppcp-onboarding-dcc-basic" name="ppcp_onboarding_dcc" value="basic" ' .
-			( ! $is_shop_supports_dcc ? 'checked' : '' ) .
-			' data-screen-url="' . $this->get_screen_url( 'basic' ) . '"' .
-			'> ' .
-		__( 'Standard Card Processing', 'woocommerce-paypal-payments' ) . '
-	</label>
-	' . $this->render_tooltip( __( 'Card transactions are managed by PayPal, which simplifies compliance requirements for you.', 'woocommerce-paypal-payments' ) ) . '
-	<table>
-		' . implode( $basic_table_rows ) . '
-	</table>
-</li>';
 
 		return '
 <div class="ppcp-onboarding-cards-options">

--- a/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
+++ b/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
@@ -65,9 +65,7 @@ class OnboardingOptionsRenderer {
 		</label>
 	</li>
 	<li>
-		<label><input type="checkbox" id="ppcp-onboarding-accept-cards" '. $checked .'> ' .
-			__( 'Securely accept all major credit & debit cards on the strength of the PayPal network', 'woocommerce-paypal-payments' ) . '
-		</label>
+		<label><input type="checkbox" id="ppcp-onboarding-accept-cards" ' . $checked . '> ' . __( 'Securely accept all major credit & debit cards on the strength of the PayPal network', 'woocommerce-paypal-payments' ) . '</label>
 	</li>
 	<li>' . $this->render_dcc( $is_shop_supports_dcc ) . '</li>' .
 			$this->render_pui_option()

--- a/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
+++ b/modules/ppcp-onboarding/src/Render/OnboardingOptionsRenderer.php
@@ -127,9 +127,9 @@ class OnboardingOptionsRenderer {
 			),
 		);
 		$items[]          = '
-<li ' . ( ! $is_shop_supports_dcc ? 'style="display: none;"' : '' ) . '>
+<li>
 	<label>
-		<input type="radio" id="ppcp-onboarding-dcc-basic" name="ppcp_onboarding_dcc" value="basic" ' .
+		<input type="radio" id="ppcp-onboarding-dcc-basic" name="ppcp_onboarding_dcc" value="basic" checked ' .
 			( ! $is_shop_supports_dcc ? 'checked' : '' ) .
 			' data-screen-url="' . $this->get_screen_url( 'basic' ) . '"' .
 			'> ' .
@@ -184,7 +184,7 @@ class OnboardingOptionsRenderer {
 			$items[]        = '
 <li>
 	<label>
-		<input type="radio" id="ppcp-onboarding-dcc-acdc" name="ppcp_onboarding_dcc" value="acdc" checked ' .
+		<input type="radio" id="ppcp-onboarding-dcc-acdc" name="ppcp_onboarding_dcc" value="acdc" ' .
 				'data-screen-url="' . $this->get_screen_url( 'acdc' ) . '"> ' .
 				__( 'Advanced Card Processing', 'woocommerce-paypal-payments' ) . '
 	</label>
@@ -201,9 +201,7 @@ class OnboardingOptionsRenderer {
 			implode( '', $items ) .
 			'
 	</ul>
-	<div class="ppcp-onboarding-cards-screen">' .
-			( $is_shop_supports_dcc ? '<img id="ppcp-onboarding-cards-screen-img" />' : '' ) . '
-	</div>
+	<div class="ppcp-onboarding-cards-screen"><img id="ppcp-onboarding-cards-screen-img" /></div>
 </div>';
 	}
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -358,7 +358,7 @@ return array(
 		$dcc_applies = $container->get( 'api.helpers.dccapplies' );
 		assert( $dcc_applies instanceof DccApplies );
 
-		$is_shop_supports_dcc = $dcc_applies->for_country_currency();
+		$is_shop_supports_dcc = $dcc_applies->for_country_currency() || $dcc_applies->for_wc_payments();
 
 		$onboarding_options_renderer = $container->get( 'onboarding.render-options' );
 		assert( $onboarding_options_renderer instanceof OnboardingOptionsRenderer );


### PR DESCRIPTION
Do not onboard users for advanced card payments in regions where the [WooCommerce Payments](https://woocommerce.com/products/woocommerce-payments/) plugin is available.

### What must be changed?

- While Securely accept all major credit & debit cards on the strength of the PayPal network is unchecked, hide all additional details regarding Standard Card Processing & Advanced Card Processing
- In countries where WooCommerce Payments is available, by default, uncheck  Securely accept all major credit & debit cards on the strength of the PayPal network
- When Advanced Card Payments are available, and Securely accept all major credit & debit cards on the strength of the PayPal network has been checked manually by the user, default to the Standard Card Processing radio button
- Switch the position of Standard Card Processing and Advanced Card Processing radio buttons