### PR TITLE
Fix the "get Help" links

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
@@ -65,7 +65,7 @@ class HeaderRenderer {
 				<a class="button" href="https://woocommerce.com/document/woocommerce-paypal-payments/">'
 					. __( 'Documentation', 'woocommerce-paypal-payments' ) .
 				'</a>
-				<a class="button" href="https://woocommerce.com/my-account/create-a-ticket/">'
+				<a class="button" target="_blank" href="https://woocommerce.com/document/woocommerce-paypal-payments/#get-help">'
 					. __( 'Get Help', 'woocommerce-paypal-payments' ) .
 				'</a>
 				<span class="ppcp-right-align">

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -160,8 +160,8 @@ define( 'PPCP_FLAG_SEPARATE_APM_BUTTONS', apply_filters( 'woocommerce_paypal_pay
 						__( 'Documentation', 'woocommerce-paypal-payments' )
 					),
 					sprintf(
-						'<a href="%1$s">%2$s</a>',
-						'https://woocommerce.com/my-account/create-a-ticket/',
+						'<a target="_blank" href="%1$s">%2$s</a>',
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#get-help',
 						__( 'Get help', 'woocommerce-paypal-payments' )
 					),
 					sprintf(


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #804

---

### Description

The “Get help” links in the plugin go here:

[https://woocommerce.com/my-account/create-a-ticket/](https://woocommerce.com/my-account/create-a-ticket/)

but should go here instead:

[https://woocommerce.com/document/woocommerce-paypal-payments/#get-help](https://woocommerce.com/document/woocommerce-paypal-payments/#get-help)

![920f397b-0e0c-48e6-b779-3913cd98241e](https://user-images.githubusercontent.com/11319597/187183840-de3af0e5-1b4b-45c9-a3a6-735feed3ed1a.png)

![c7c4488a-bdcc-4684-ad0b-b339214761e2](https://user-images.githubusercontent.com/11319597/187183868-61eadafc-4442-46ff-924c-d090be422ec1.png)

The PR will fix both links and will add the `target="_blank"` attribute 

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Install the plugin.
2. Click the “Get help” links on plugins page and in the plugin settings.
3. Wrong URL.

---

Closes #804 .
