### PR TITLE
Open doc external links in new tab.

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
@@ -62,17 +62,17 @@ class HeaderRenderer {
 			<div class="ppcp-settings-page-header">
 				<img alt="PayPal" src="' . esc_url( $this->module_url ) . 'assets/images/paypal.png"/>
 				<h4> <span class="ppcp-inline-only">-</span> ' . __( 'The all-in-one checkout solution for WooCommerce', 'woocommerce-paypal-payments' ) . '</h4>
-				<a class="button" href="https://woocommerce.com/document/woocommerce-paypal-payments/">'
+				<a class="button" target="_blank" href="https://woocommerce.com/document/woocommerce-paypal-payments/">'
 					. __( 'Documentation', 'woocommerce-paypal-payments' ) .
 				'</a>
 				<a class="button" target="_blank" href="https://woocommerce.com/document/woocommerce-paypal-payments/#get-help">'
 					. __( 'Get Help', 'woocommerce-paypal-payments' ) .
 				'</a>
 				<span class="ppcp-right-align">
-					<a href="https://woocommerce.com/feature-requests/woocommerce-paypal-payments/">'
+					<a target="_blank" href="https://woocommerce.com/feature-requests/woocommerce-paypal-payments/">'
 						. __( 'Request a feature', 'woocommerce-paypal-payments' ) .
 					'</a>
-					<a href="https://github.com/woocommerce/woocommerce-paypal-payments/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md">'
+					<a target="_blank" href="https://github.com/woocommerce/woocommerce-paypal-payments/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md">'
 						. __( 'Submit a bug', 'woocommerce-paypal-payments' ) .
 					'</a>
 				</span>

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -155,7 +155,7 @@ define( 'PPCP_FLAG_SEPARATE_APM_BUTTONS', apply_filters( 'woocommerce_paypal_pay
 				$links,
 				array(
 					sprintf(
-						'<a href="%1$s">%2$s</a>',
+						'<a target="_blank" href="%1$s">%2$s</a>',
 						'https://woocommerce.com/document/woocommerce-paypal-payments/',
 						__( 'Documentation', 'woocommerce-paypal-payments' )
 					),
@@ -165,12 +165,12 @@ define( 'PPCP_FLAG_SEPARATE_APM_BUTTONS', apply_filters( 'woocommerce_paypal_pay
 						__( 'Get help', 'woocommerce-paypal-payments' )
 					),
 					sprintf(
-						'<a href="%1$s">%2$s</a>',
+						'<a target="_blank" href="%1$s">%2$s</a>',
 						'https://woocommerce.com/feature-requests/woocommerce-paypal-payments/',
 						__( 'Request a feature', 'woocommerce-paypal-payments' )
 					),
 					sprintf(
-						'<a href="%1$s">%2$s</a>',
+						'<a target="_blank" href="%1$s">%2$s</a>',
 						'https://github.com/woocommerce/woocommerce-paypal-payments/issues/new?assignees=&labels=type%3A+bug&template=bug_report.md',
 						__( 'Submit a bug', 'woocommerce-paypal-payments' )
 					),


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #806

---

### Description

The links to the documentation and external resources should open in a new tab when clicked.
The PR will fix this.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Install the plugin.
2. Check the  links on plugins page and in the plugin settings.
3. They open in same tab.

---

Closes #806 .
