### PR TITLE
Pass the WC_Order ID instead of the WP_Post object ID

### DIFF
--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -78,7 +78,7 @@ class MetaBoxRenderer {
 			return;
 		}
 
-		$tracking_info = $this->order_tracking_endpoint->get_tracking_information( $post->ID );
+		$tracking_info = $this->order_tracking_endpoint->get_tracking_information( $wc_order->get_id() );
 
 		$tracking_is_not_added = empty( $tracking_info );
 


### PR DESCRIPTION
### Description

A customer reported about an error coming from tracking metabox.

```
2022-09-01T10:02:15+00:00 CRITICAL Uncaught TypeError: Argument 1 passed to WooCommercePayPalCommerceOrderTrackingEndpointOrderTrackingEndpoint::get_tracking_information() must be of the type integer, string given, called in /SERVERPFAD/http/web/app/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/MetaBoxRenderer.php on line 81 and defined in /SERVERPFAD/http/web/app/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php:182
Stack trace:
#0 /SERVERPFAD/http/web/app/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/MetaBoxRenderer.php(81): WooCommercePayPalCommerceOrderTrackingEndpointOrderTrackingEndpoint->get_tracking_information('6037')
#1 /SERVERPFAD/http/web/wp/wp-admin/includes/template.php(1389): WooCommercePayPalCommerceOrderTrackingMetaBoxRenderer->render(Object(WP_Post), Array)
#2 /SERVERPFAD/http/ in /SERVERPFAD/http/web/app/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php in Zeile 182

2022-09-01T10:02:57+00:00 CRITICAL Uncaught TypeError: Argument 1 passed to WooCommercePayPalCommerceOrderTrackingEndpointOrderTrackingEndpoint::get_tracking_information() must be of the type integer, string given, called in /SERVERPFAD/http/web/app/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/MetaBoxRenderer.php on line 81 and defined in /SERVERPFAD/http/web/app/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php:182
Stack trace:
#0 /SERVERPFAD/http/web/app/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/MetaBoxRenderer.php(81): WooCommercePayPalCommerceOrderTrackingEndpointOrderTrackingEndpoint->get_tracking_information('6036')
#1 /SERVERPFAD/http/web/wp/wp-admin/includes/template.php(1389): WooCommercePayPalCommerceOrderTrackingMetaBoxRenderer->render(Object(WP_Post), Array)
#2 /SERVERPFAD/http/ in /SERVERPFAD/http/web/app/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php in Zeile 182 
```

It is purposed to use the `WC_Order->get_id()` instead of `WP_Post $post->ID`, cause it returns the integer.    

### Steps to Test

Cannot be reproduced, can be a conflict with 3rd party plugin
