### PR TITLE
Connection tab improvements

### DIFF
--- a/modules/ppcp-onboarding/assets/js/onboarding.js
+++ b/modules/ppcp-onboarding/assets/js/onboarding.js
@@ -247,6 +247,12 @@ function ppcp_onboarding_productionCallback(...args) {
             }
         );
 
+        if (sandboxSwitchElement.checked) {
+            sandboxSwitchElement.checked = false;
+        } else {
+            sandboxSwitchElement.checked = true;
+        }
+
         isDisconnecting = true;
 
         document.querySelector('.woocommerce-save-button').click();

--- a/modules/ppcp-onboarding/assets/js/onboarding.js
+++ b/modules/ppcp-onboarding/assets/js/onboarding.js
@@ -247,11 +247,7 @@ function ppcp_onboarding_productionCallback(...args) {
             }
         );
 
-        if (sandboxSwitchElement.checked) {
-            sandboxSwitchElement.checked = false;
-        } else {
-            sandboxSwitchElement.checked = true;
-        }
+        sandboxSwitchElement.checked = ! sandboxSwitchElement.checked;
 
         isDisconnecting = true;
 

--- a/modules/ppcp-onboarding/src/Assets/OnboardingAssets.php
+++ b/modules/ppcp-onboarding/src/Assets/OnboardingAssets.php
@@ -13,6 +13,7 @@ use WooCommerce\PayPalCommerce\Onboarding\Endpoint\LoginSellerEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class OnboardingAssets
@@ -172,6 +173,6 @@ class OnboardingAssets {
 	 * @return bool
 	 */
 	private function should_render_onboarding_script(): bool {
-		return PayPalGateway::ID === $this->page_id;
+		return PayPalGateway::ID === $this->page_id || Settings::CONNECTION_TAB_ID === $this->page_id;
 	}
 }

--- a/modules/ppcp-wc-gateway/connection-tab-settings.php
+++ b/modules/ppcp-wc-gateway/connection-tab-settings.php
@@ -157,7 +157,11 @@ return function ( ContainerInterface $container, array $fields ): array {
 		'ppcp_disconnect_production'                    => array(
 			'title'        => __( 'Disconnect from PayPal', 'woocommerce-paypal-payments' ),
 			'type'         => 'ppcp-text',
-			'text'         => '<button type="button" class="button ppcp-disconnect production">' . esc_html__( 'Disconnect', 'woocommerce-paypal-payments' ) . '</button>',
+			'text'         => sprintf(
+				'<p>%1$s <span class="dashicons dashicons-yes"></span></p><p><button type="button" class="button ppcp-disconnect production">%2$s</button></p>',
+				esc_html__( 'Status: Connected', 'woocommerce-paypal-payments' ),
+				esc_html__( 'Disconnect Account', 'woocommerce-paypal-payments' )
+			),
 			'screens'      => array(
 				State::STATE_ONBOARDED,
 			),
@@ -341,7 +345,6 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'screens'      => array(
 				State::STATE_ONBOARDED,
 			),
-			'state_from'   => Environment::SANDBOX,
 			'requirements' => array(),
 			'gateway'      => 'connection',
 			'description'  => __( 'See which features are available.', 'woocommerce-paypal-payments' ),
@@ -387,7 +390,6 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'screens'      => array(
 				State::STATE_ONBOARDED,
 			),
-			'state_from'   => Environment::SANDBOX,
 			'requirements' => array(),
 			'gateway'      => 'connection',
 			'description'  => __( 'See which features are available.', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/connection-tab-settings.php
+++ b/modules/ppcp-wc-gateway/connection-tab-settings.php
@@ -422,8 +422,9 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'default'           => ( static function (): string {
 				$site_url = get_site_url( get_current_blog_id() );
 				$hash = md5( $site_url );
-				$letters = preg_replace( '~\d~', '', $hash );
-				return $letters ? substr( $letters, 0, 6 ) . '-' : '';
+				$letters = preg_replace( '~\d~', '', $hash ) ?? '';
+				$prefix = substr( $letters, 0, 6 );
+				return $prefix ? $prefix . '-' : '';
 			} )(),
 			'screens'           => array(
 				State::STATE_START,

--- a/modules/ppcp-wc-gateway/connection-tab-settings.php
+++ b/modules/ppcp-wc-gateway/connection-tab-settings.php
@@ -16,7 +16,6 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Onboarding\State;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 return function ( ContainerInterface $container, array $fields ): array {
 
@@ -33,52 +32,8 @@ return function ( ContainerInterface $container, array $fields ): array {
 
 	$module_url = $container->get( 'wcgateway.url' );
 
-	$dash_icon_yes = '<span class="dashicons dashicons-yes"></span>';
-	$dash_icon_no  = '<span class="dashicons dashicons-no"></span>';
-
-	$connected_to_paypal_markup = sprintf(
-		'<p>%1$s %2$s</p><p><button type="button" class="button ppcp-disconnect sandbox">%3$s</button></p>',
-		esc_html__( 'Status: Connected', 'woocommerce-paypal-payments' ),
-		$dash_icon_yes,
-		esc_html__( 'Disconnect Account', 'woocommerce-paypal-payments' )
-	);
-
-	$settings = $container->get( 'wcgateway.settings' );
-	assert( $settings instanceof Settings );
-
-	$enabled_status_text  = esc_html__( 'Status: Enabled', 'woocommerce-paypal-payments' );
-	$disabled_status_text = esc_html__( 'Status: Not yet enabled', 'woocommerce-paypal-payments' );
-
-	$dcc_enabled = $settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' );
-
-	$dcc_button_text = $dcc_enabled
-		? esc_html__( 'Disable Advanced Card Payments', 'woocommerce-paypal-payments' )
-		: esc_html__( 'Enable Advanced Card Payments', 'woocommerce-paypal-payments' );
-
-	$dcc_status = sprintf(
-		'<p>%1$s %2$s</p><p><a href="%3$s" class="button">%4$s</a></p>',
-		$dcc_enabled ? $enabled_status_text : $disabled_status_text,
-		$dcc_enabled ? $dash_icon_yes : $dash_icon_no,
-		admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-credit-card-gateway' ),
-		esc_html( $dcc_button_text )
-	);
-
-	$pui_enabled = $settings->has( 'products_pui_enabled' ) && $settings->get( 'products_pui_enabled' );
-
-	$pui_button_text = $pui_enabled
-		? esc_html__( 'Disable Pay Upon Invoice', 'woocommerce-paypal-payments' )
-		: esc_html__( 'Enable Pay Upon Invoice', 'woocommerce-paypal-payments' );
-
-	$pui_status = sprintf(
-		'<p>%1$s %2$s</p><p><a href="%3$s" class="button">%4$s</a></p>',
-		$pui_enabled ? $enabled_status_text : $disabled_status_text,
-		$pui_enabled ? $dash_icon_yes : $dash_icon_no,
-		admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-pay-upon-invoice-gateway' ),
-		esc_html( $pui_button_text )
-	);
-
 	$connection_fields = array(
-		'ppcp_onboarading_header'            => array(
+		'ppcp_onboarading_header'                       => array(
 			'type'         => 'ppcp-text',
 			'classes'      => array( 'ppcp-onboarding-element' ),
 			'text'         => '
@@ -110,7 +65,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'credentials_production_heading'     => array(
+		'credentials_production_heading'                => array(
 			'heading'      => __( 'API Credentials', 'woocommerce-paypal-payments' ),
 			'type'         => 'ppcp-heading',
 			'screens'      => array(
@@ -120,7 +75,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'credentials_sandbox_heading'        => array(
+		'credentials_sandbox_heading'                   => array(
 			'heading'      => __( 'Sandbox API Credentials', 'woocommerce-paypal-payments' ),
 			'type'         => 'ppcp-heading',
 			'screens'      => array(
@@ -132,7 +87,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'description'  => __( 'Your account is connected to sandbox, no real charging takes place. To accept live payments, turn off sandbox mode and connect your live PayPal account.', 'woocommerce-paypal-payments' ),
 		),
 
-		'ppcp_onboarading_options'           => array(
+		'ppcp_onboarading_options'                      => array(
 			'type'         => 'ppcp-text',
 			'classes'      => array( 'ppcp-onboarding-element' ),
 			'text'         => $onboarding_options_renderer->render( $is_shop_supports_dcc ),
@@ -148,7 +103,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 		// We need to have a button for each option (ppcp, express)
 		// because currently the only documented way to use the PayPal onboarding JS library
 		// is to have the buttons before loading the script.
-		'ppcp_onboarding_production_ppcp'    => array(
+		'ppcp_onboarding_production_ppcp'               => array(
 			'type'         => 'ppcp_onboarding',
 			'classes'      => array( 'ppcp-onboarding-element' ),
 			'screens'      => array(
@@ -160,7 +115,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'ppcp_onboarding_production_express' => array(
+		'ppcp_onboarding_production_express'            => array(
 			'type'         => 'ppcp_onboarding',
 			'classes'      => array( 'ppcp-onboarding-element' ),
 			'screens'      => array(
@@ -172,7 +127,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'ppcp_onboarding_sandbox_ppcp'       => array(
+		'ppcp_onboarding_sandbox_ppcp'                  => array(
 			'type'         => 'ppcp_onboarding',
 			'classes'      => array( 'ppcp-onboarding-element' ),
 			'screens'      => array(
@@ -185,7 +140,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'      => 'connection',
 			'description'  => __( 'Prior to accepting live payments, you can test payments on your WooCommerce platform in a safe PayPal sandbox environment.', 'woocommerce-paypal-payments' ),
 		),
-		'ppcp_onboarding_sandbox_express'    => array(
+		'ppcp_onboarding_sandbox_express'               => array(
 			'type'         => 'ppcp_onboarding',
 			'classes'      => array( 'ppcp-onboarding-element' ),
 			'screens'      => array(
@@ -199,7 +154,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'description'  => __( 'Prior to accepting live payments, you can test payments on your WooCommerce platform in a safe PayPal sandbox environment.', 'woocommerce-paypal-payments' ),
 		),
 
-		'ppcp_disconnect_production'         => array(
+		'ppcp_disconnect_production'                    => array(
 			'title'        => __( 'Disconnect from PayPal', 'woocommerce-paypal-payments' ),
 			'type'         => 'ppcp-text',
 			'text'         => '<button type="button" class="button ppcp-disconnect production">' . esc_html__( 'Disconnect', 'woocommerce-paypal-payments' ) . '</button>',
@@ -212,10 +167,14 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'      => 'connection',
 			'description'  => __( 'Click to reset current credentials and use another account.', 'woocommerce-paypal-payments' ),
 		),
-		'ppcp_disconnect_sandbox'            => array(
+		'ppcp_disconnect_sandbox'                       => array(
 			'title'        => __( 'Disconnect from PayPal Sandbox', 'woocommerce-paypal-payments' ),
 			'type'         => 'ppcp-text',
-			'text'         => $connected_to_paypal_markup,
+			'text'         => sprintf(
+				'<p>%1$s <span class="dashicons dashicons-yes"></span></p><p><button type="button" class="button ppcp-disconnect sandbox">%2$s</button></p>',
+				esc_html__( 'Status: Connected', 'woocommerce-paypal-payments' ),
+				esc_html__( 'Disconnect Account', 'woocommerce-paypal-payments' )
+			),
 			'screens'      => array(
 				State::STATE_ONBOARDED,
 			),
@@ -225,7 +184,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'      => 'connection',
 			'description'  => __( 'Click to reset current credentials and use another account.', 'woocommerce-paypal-payments' ),
 		),
-		'toggle_manual_input'                => array(
+		'toggle_manual_input'                           => array(
 			'type'         => 'ppcp-text',
 			'text'         => '<button type="button" id="ppcp[toggle_manual_input]">' . __( 'Toggle to manual credential input', 'woocommerce-paypal-payments' ) . '</button>',
 			'classes'      => array( 'ppcp-onboarding-element' ),
@@ -236,27 +195,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'ppcp_dcc_status'                    => array(
-			'title'        => __( 'Advanced Credit & Debit Crad Payments', 'woocommerce-paypal-payments' ),
-			'type'         => 'ppcp-text',
-			'text'         => $dcc_status,
-			'screens'      => array(
-				State::STATE_ONBOARDED,
-			),
-			'requirements' => array(),
-			'gateway'      => 'connection',
-		),
-		'ppcp_pui_status'                    => array(
-			'title'        => __( 'Pay Upon Invoice', 'woocommerce-paypal-payments' ),
-			'type'         => 'ppcp-text',
-			'text'         => $pui_status,
-			'screens'      => array(
-				State::STATE_ONBOARDED,
-			),
-			'requirements' => array( 'pui_ready' ),
-			'gateway'      => 'connection',
-		),
-		'error_label'                        => array(
+		'error_label'                                   => array(
 			'type'         => 'ppcp-text',
 			'text'         => '<label class="error" id="ppcp-form-errors-label"></label>',
 			'classes'      => array( 'hide', 'ppcp-always-shown-element' ),
@@ -267,7 +206,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'sandbox_on'                         => array(
+		'sandbox_on'                                    => array(
 			'title'        => __( 'Sandbox', 'woocommerce-paypal-payments' ),
 			'classes'      => array( 'ppcp-onboarding-element', 'ppcp-always-shown-element' ),
 			'type'         => 'checkbox',
@@ -280,7 +219,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'merchant_email_production'          => array(
+		'merchant_email_production'                     => array(
 			'title'        => __( 'Live Email address', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
 			'type'         => 'text',
@@ -295,7 +234,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'merchant_id_production'             => array(
+		'merchant_id_production'                        => array(
 			'title'        => __( 'Live Merchant Id', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
 			'type'         => 'ppcp-text-input',
@@ -309,7 +248,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'client_id_production'               => array(
+		'client_id_production'                          => array(
 			'title'        => __( 'Live Client Id', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
 			'type'         => 'ppcp-text-input',
@@ -323,7 +262,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'client_secret_production'           => array(
+		'client_secret_production'                      => array(
 			'title'        => __( 'Live Secret Key', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
 			'type'         => 'ppcp-password',
@@ -338,7 +277,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'      => 'connection',
 		),
 
-		'merchant_email_sandbox'             => array(
+		'merchant_email_sandbox'                        => array(
 			'title'        => __( 'Sandbox Email address', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
 			'type'         => 'text',
@@ -353,7 +292,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'merchant_id_sandbox'                => array(
+		'merchant_id_sandbox'                           => array(
 			'title'        => __( 'Sandbox Merchant Id', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
 			'type'         => 'ppcp-text-input',
@@ -367,7 +306,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'client_id_sandbox'                  => array(
+		'client_id_sandbox'                             => array(
 			'title'        => __( 'Sandbox Client Id', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
 			'type'         => 'ppcp-text-input',
@@ -381,7 +320,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'client_secret_sandbox'              => array(
+		'client_secret_sandbox'                         => array(
 			'title'        => __( 'Sandbox Secret Key', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
 			'type'         => 'ppcp-password',
@@ -395,22 +334,65 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'logging_enabled'                    => array(
-			'title'        => __( 'Logging', 'woocommerce-paypal-payments' ),
-			'type'         => 'checkbox',
-			'desc_tip'     => true,
-			'label'        => __( 'Enable logging. ', 'woocommerce-paypal-payments' ) .
-				' <a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">' . __( 'View logs', 'woocommerce-paypal-payments' ) . '</a>',
-			'description'  => __( 'Enable logging of unexpected behavior. This can also log private data and should only be enabled in a development or stage environment.', 'woocommerce-paypal-payments' ),
-			'default'      => false,
+
+		'credentials_feature_onboarding_heading'        => array(
+			'heading'      => __( 'Feature Onboarding', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-heading',
 			'screens'      => array(
-				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'state_from'   => Environment::SANDBOX,
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'description'  => __( 'See which features are available.', 'woocommerce-paypal-payments' ),
+		),
+		'ppcp_dcc_status'                               => array(
+			'title'        => __( 'Advanced Credit and Debit Card Payments', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-text',
+			'text'         => $container->get( 'wcgateway.settings.connection.dcc-status-text' ),
+			'screens'      => array(
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
 			'gateway'      => 'connection',
 		),
-		'prefix'                             => array(
+		'ppcp_pui_status'                               => array(
+			'title'        => __( 'Pay Upon Invoice', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-text',
+			'text'         => $container->get( 'wcgateway.settings.connection.pui-status-text' ),
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array( 'pui_ready' ),
+			'gateway'      => 'connection',
+		),
+		'tracking_enabled'                              => array(
+			'title'        => __( 'Tracking', 'woocommerce-paypal-payments' ),
+			'type'         => 'checkbox',
+			'desc_tip'     => true,
+			'label'        => $container->get( 'wcgateway.settings.tracking-label' ),
+			'description'  => __( 'Allows to send shipment tracking numbers to PayPal for PayPal transactions.', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'input_class'  => $container->get( 'wcgateway.settings.should-disable-tracking-checkbox' ) ? array( 'ppcp-disabled-checkbox' ) : array(),
+		),
+
+		'credentials_integration_configuration_heading' => array(
+			'heading'      => __( 'Integration configuration', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-heading',
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'state_from'   => Environment::SANDBOX,
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'description'  => __( 'See which features are available.', 'woocommerce-paypal-payments' ),
+		),
+		'prefix'                                        => array(
 			'title'             => __( 'Invoice prefix', 'woocommerce-paypal-payments' ),
 			'type'              => 'text',
 			'desc_tip'          => true,
@@ -433,19 +415,20 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements'      => array(),
 			'gateway'           => 'connection',
 		),
-		'tracking_enabled'                   => array(
-			'title'        => __( 'Tracking', 'woocommerce-paypal-payments' ),
+		'logging_enabled'                               => array(
+			'title'        => __( 'Logging', 'woocommerce-paypal-payments' ),
 			'type'         => 'checkbox',
 			'desc_tip'     => true,
-			'label'        => $container->get( 'wcgateway.settings.tracking-label' ),
-			'description'  => __( 'Allows to send shipment tracking numbers to PayPal for PayPal transactions.', 'woocommerce-paypal-payments' ),
+			'label'        => __( 'Enable logging. ', 'woocommerce-paypal-payments' ) .
+				' <a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">' . __( 'View logs', 'woocommerce-paypal-payments' ) . '</a>',
+			'description'  => __( 'Enable logging of unexpected behavior. This can also log private data and should only be enabled in a development or stage environment.', 'woocommerce-paypal-payments' ),
 			'default'      => false,
 			'screens'      => array(
+				State::STATE_START,
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
 			'gateway'      => 'connection',
-			'input_class'  => $container->get( 'wcgateway.settings.should-disable-tracking-checkbox' ) ? array( 'ppcp-disabled-checkbox' ) : array(),
 		),
 	);
 

--- a/modules/ppcp-wc-gateway/connection-tab-settings.php
+++ b/modules/ppcp-wc-gateway/connection-tab-settings.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 return function ( ContainerInterface $container, array $fields ): array {
 
@@ -63,7 +64,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'credentials_production_heading'                => array(
 			'heading'      => __( 'API Credentials', 'woocommerce-paypal-payments' ),
@@ -73,7 +74,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			),
 			'state_from'   => Environment::PRODUCTION,
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'credentials_sandbox_heading'                   => array(
 			'heading'      => __( 'Sandbox API Credentials', 'woocommerce-paypal-payments' ),
@@ -83,7 +84,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			),
 			'state_from'   => Environment::SANDBOX,
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 			'description'  => __( 'Your account is connected to sandbox, no real charging takes place. To accept live payments, turn off sandbox mode and connect your live PayPal account.', 'woocommerce-paypal-payments' ),
 		),
 
@@ -97,7 +98,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 
 		// We need to have a button for each option (ppcp, express)
@@ -113,7 +114,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'env'          => Environment::PRODUCTION,
 			'products'     => array( 'PPCP' ),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'ppcp_onboarding_production_express'            => array(
 			'type'         => 'ppcp_onboarding',
@@ -125,7 +126,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'env'          => Environment::PRODUCTION,
 			'products'     => array( 'EXPRESS_CHECKOUT' ),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'ppcp_onboarding_sandbox_ppcp'                  => array(
 			'type'         => 'ppcp_onboarding',
@@ -137,7 +138,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'env'          => Environment::SANDBOX,
 			'products'     => array( 'PPCP' ),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 			'description'  => __( 'Prior to accepting live payments, you can test payments on your WooCommerce platform in a safe PayPal sandbox environment.', 'woocommerce-paypal-payments' ),
 		),
 		'ppcp_onboarding_sandbox_express'               => array(
@@ -150,7 +151,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'env'          => Environment::SANDBOX,
 			'products'     => array( 'EXPRESS_CHECKOUT' ),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 			'description'  => __( 'Prior to accepting live payments, you can test payments on your WooCommerce platform in a safe PayPal sandbox environment.', 'woocommerce-paypal-payments' ),
 		),
 
@@ -168,7 +169,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'state_from'   => Environment::PRODUCTION,
 			'env'          => Environment::PRODUCTION,
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 			'description'  => __( 'Click to reset current credentials and use another account.', 'woocommerce-paypal-payments' ),
 		),
 		'ppcp_disconnect_sandbox'                       => array(
@@ -185,7 +186,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'state_from'   => Environment::SANDBOX,
 			'env'          => Environment::SANDBOX,
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 			'description'  => __( 'Click to reset current credentials and use another account.', 'woocommerce-paypal-payments' ),
 		),
 		'toggle_manual_input'                           => array(
@@ -197,7 +198,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'error_label'                                   => array(
 			'type'         => 'ppcp-text',
@@ -208,7 +209,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'sandbox_on'                                    => array(
 			'title'        => __( 'Sandbox', 'woocommerce-paypal-payments' ),
@@ -221,7 +222,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'merchant_email_production'                     => array(
 			'title'        => __( 'Live Email address', 'woocommerce-paypal-payments' ),
@@ -236,7 +237,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'merchant_id_production'                        => array(
 			'title'        => __( 'Live Merchant Id', 'woocommerce-paypal-payments' ),
@@ -250,7 +251,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'client_id_production'                          => array(
 			'title'        => __( 'Live Client Id', 'woocommerce-paypal-payments' ),
@@ -264,7 +265,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'client_secret_production'                      => array(
 			'title'        => __( 'Live Secret Key', 'woocommerce-paypal-payments' ),
@@ -278,7 +279,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 
 		'merchant_email_sandbox'                        => array(
@@ -294,7 +295,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'merchant_id_sandbox'                           => array(
 			'title'        => __( 'Sandbox Merchant Id', 'woocommerce-paypal-payments' ),
@@ -308,7 +309,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'client_id_sandbox'                             => array(
 			'title'        => __( 'Sandbox Client Id', 'woocommerce-paypal-payments' ),
@@ -322,7 +323,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'client_secret_sandbox'                         => array(
 			'title'        => __( 'Sandbox Secret Key', 'woocommerce-paypal-payments' ),
@@ -336,7 +337,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 
 		'credentials_feature_onboarding_heading'        => array(
@@ -346,7 +347,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 			'description'  => __( 'See which features are available.', 'woocommerce-paypal-payments' ),
 		),
 		'ppcp_dcc_status'                               => array(
@@ -356,8 +357,8 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'screens'      => array(
 				State::STATE_ONBOARDED,
 			),
-			'requirements' => array(),
-			'gateway'      => 'connection',
+			'requirements' => array( 'dcc' ),
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'ppcp_pui_status'                               => array(
 			'title'        => __( 'Pay Upon Invoice', 'woocommerce-paypal-payments' ),
@@ -367,7 +368,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array( 'pui_ready' ),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'tracking_enabled'                              => array(
 			'title'        => __( 'Tracking', 'woocommerce-paypal-payments' ),
@@ -380,7 +381,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 			'input_class'  => $container->get( 'wcgateway.settings.should-disable-tracking-checkbox' ) ? array( 'ppcp-disabled-checkbox' ) : array(),
 		),
 
@@ -391,7 +392,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 			'description'  => __( 'See which features are available.', 'woocommerce-paypal-payments' ),
 		),
 		'prefix'                                        => array(
@@ -415,7 +416,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements'      => array(),
-			'gateway'           => 'connection',
+			'gateway'           => Settings::CONNECTION_TAB_ID,
 		),
 		'logging_enabled'                               => array(
 			'title'        => __( 'Logging', 'woocommerce-paypal-payments' ),
@@ -430,7 +431,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				State::STATE_ONBOARDED,
 			),
 			'requirements' => array(),
-			'gateway'      => 'connection',
+			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 	);
 

--- a/modules/ppcp-wc-gateway/connection-tab-settings.php
+++ b/modules/ppcp-wc-gateway/connection-tab-settings.php
@@ -1,0 +1,452 @@
+<?php
+/**
+ * The services of the Gateway module.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway
+ */
+
+// phpcs:disable WordPress.Security.NonceVerification.Recommended
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway;
+
+use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
+use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
+use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+return function ( ContainerInterface $container, array $fields ): array {
+
+	$state = $container->get( 'onboarding.state' );
+	assert( $state instanceof State );
+
+	$dcc_applies = $container->get( 'api.helpers.dccapplies' );
+	assert( $dcc_applies instanceof DccApplies );
+
+	$is_shop_supports_dcc = $dcc_applies->for_country_currency() || $dcc_applies->for_wc_payments();
+
+	$onboarding_options_renderer = $container->get( 'onboarding.render-options' );
+	assert( $onboarding_options_renderer instanceof OnboardingOptionsRenderer );
+
+	$module_url = $container->get( 'wcgateway.url' );
+
+	$dash_icon_yes = '<span class="dashicons dashicons-yes"></span>';
+	$dash_icon_no  = '<span class="dashicons dashicons-no"></span>';
+
+	$connected_to_paypal_markup = sprintf(
+		'<p>%1$s %2$s</p><p><button type="button" class="button ppcp-disconnect sandbox">%3$s</button></p>',
+		esc_html__( 'Status: Connected', 'woocommerce-paypal-payments' ),
+		$dash_icon_yes,
+		esc_html__( 'Disconnect Account', 'woocommerce-paypal-payments' )
+	);
+
+	$settings = $container->get( 'wcgateway.settings' );
+	assert( $settings instanceof Settings );
+
+	$enabled_status_text  = esc_html__( 'Status: Enabled', 'woocommerce-paypal-payments' );
+	$disabled_status_text = esc_html__( 'Status: Not yet enabled', 'woocommerce-paypal-payments' );
+
+	$dcc_enabled = $settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' );
+
+	$dcc_button_text = $dcc_enabled
+		? esc_html__( 'Disable Advanced Card Payments', 'woocommerce-paypal-payments' )
+		: esc_html__( 'Enable Advanced Card Payments', 'woocommerce-paypal-payments' );
+
+	$dcc_status = sprintf(
+		'<p>%1$s %2$s</p><p><a href="%3$s" class="button">%4$s</a></p>',
+		$dcc_enabled ? $enabled_status_text : $disabled_status_text,
+		$dcc_enabled ? $dash_icon_yes : $dash_icon_no,
+		admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-credit-card-gateway' ),
+		esc_html( $dcc_button_text )
+	);
+
+	$pui_enabled = $settings->has( 'products_pui_enabled' ) && $settings->get( 'products_pui_enabled' );
+
+	$pui_button_text = $pui_enabled
+		? esc_html__( 'Disable Pay Upon Invoice', 'woocommerce-paypal-payments' )
+		: esc_html__( 'Enable Pay Upon Invoice', 'woocommerce-paypal-payments' );
+
+	$pui_status = sprintf(
+		'<p>%1$s %2$s</p><p><a href="%3$s" class="button">%4$s</a></p>',
+		$pui_enabled ? $enabled_status_text : $disabled_status_text,
+		$pui_enabled ? $dash_icon_yes : $dash_icon_no,
+		admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-pay-upon-invoice-gateway' ),
+		esc_html( $pui_button_text )
+	);
+
+	$connection_fields = array(
+		'ppcp_onboarading_header'            => array(
+			'type'         => 'ppcp-text',
+			'classes'      => array( 'ppcp-onboarding-element' ),
+			'text'         => '
+<div class="ppcp-onboarding-header">
+	<div class="ppcp-onboarding-header-left">
+		<img alt="PayPal" src="' . esc_url( $module_url ) . 'assets/images/paypal.png"/>
+		<h2>The all-in-one checkout solution</h2>
+	</div>
+	<div class="ppcp-onboarding-header-right">
+		<div class="ppcp-onboarding-header-paypal-logos">
+			<img alt="PayPal" src="' . esc_url( $module_url ) . 'assets/images/paypal-button.svg"/>
+			<img alt="Venmo" src="' . esc_url( $module_url ) . 'assets/images/venmo.svg"/>
+			<img alt="Pay Later" src="' . esc_url( $module_url ) . 'assets/images/paylater.svg"/>
+		</div>
+		<div class="ppcp-onboarding-header-cards">
+			<img alt="Visa" src="' . esc_url( $module_url ) . 'assets/images/visa-dark.svg"/>
+			<img alt="Mastercard" src="' . esc_url( $module_url ) . 'assets/images/mastercard-dark.svg"/>
+			<img alt="American Express" src="' . esc_url( $module_url ) . 'assets/images/amex.svg"/>
+			<img alt="Discover" src="' . esc_url( $module_url ) . 'assets/images/discover.svg"/>
+			<img alt="iDEAL" src="' . esc_url( $module_url ) . 'assets/images/ideal-dark.svg"/>
+			<img alt="Sofort" src="' . esc_url( $module_url ) . 'assets/images/sofort.svg"/>
+		</div>
+	</div>
+</div>',
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'credentials_production_heading'     => array(
+			'heading'      => __( 'API Credentials', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-heading',
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'state_from'   => Environment::PRODUCTION,
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'credentials_sandbox_heading'        => array(
+			'heading'      => __( 'Sandbox API Credentials', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-heading',
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'state_from'   => Environment::SANDBOX,
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'description'  => __( 'Your account is connected to sandbox, no real charging takes place. To accept live payments, turn off sandbox mode and connect your live PayPal account.', 'woocommerce-paypal-payments' ),
+		),
+
+		'ppcp_onboarading_options'           => array(
+			'type'         => 'ppcp-text',
+			'classes'      => array( 'ppcp-onboarding-element' ),
+			'text'         => $onboarding_options_renderer->render( $is_shop_supports_dcc ),
+			'raw'          => true,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+
+		// We need to have a button for each option (ppcp, express)
+		// because currently the only documented way to use the PayPal onboarding JS library
+		// is to have the buttons before loading the script.
+		'ppcp_onboarding_production_ppcp'    => array(
+			'type'         => 'ppcp_onboarding',
+			'classes'      => array( 'ppcp-onboarding-element' ),
+			'screens'      => array(
+				State::STATE_START,
+			),
+			'state_from'   => Environment::PRODUCTION,
+			'env'          => Environment::PRODUCTION,
+			'products'     => array( 'PPCP' ),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'ppcp_onboarding_production_express' => array(
+			'type'         => 'ppcp_onboarding',
+			'classes'      => array( 'ppcp-onboarding-element' ),
+			'screens'      => array(
+				State::STATE_START,
+			),
+			'state_from'   => Environment::PRODUCTION,
+			'env'          => Environment::PRODUCTION,
+			'products'     => array( 'EXPRESS_CHECKOUT' ),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'ppcp_onboarding_sandbox_ppcp'       => array(
+			'type'         => 'ppcp_onboarding',
+			'classes'      => array( 'ppcp-onboarding-element' ),
+			'screens'      => array(
+				State::STATE_START,
+			),
+			'state_from'   => Environment::SANDBOX,
+			'env'          => Environment::SANDBOX,
+			'products'     => array( 'PPCP' ),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'description'  => __( 'Prior to accepting live payments, you can test payments on your WooCommerce platform in a safe PayPal sandbox environment.', 'woocommerce-paypal-payments' ),
+		),
+		'ppcp_onboarding_sandbox_express'    => array(
+			'type'         => 'ppcp_onboarding',
+			'classes'      => array( 'ppcp-onboarding-element' ),
+			'screens'      => array(
+				State::STATE_START,
+			),
+			'state_from'   => Environment::SANDBOX,
+			'env'          => Environment::SANDBOX,
+			'products'     => array( 'EXPRESS_CHECKOUT' ),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'description'  => __( 'Prior to accepting live payments, you can test payments on your WooCommerce platform in a safe PayPal sandbox environment.', 'woocommerce-paypal-payments' ),
+		),
+
+		'ppcp_disconnect_production'         => array(
+			'title'        => __( 'Disconnect from PayPal', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-text',
+			'text'         => '<button type="button" class="button ppcp-disconnect production">' . esc_html__( 'Disconnect', 'woocommerce-paypal-payments' ) . '</button>',
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'state_from'   => Environment::PRODUCTION,
+			'env'          => Environment::PRODUCTION,
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'description'  => __( 'Click to reset current credentials and use another account.', 'woocommerce-paypal-payments' ),
+		),
+		'ppcp_disconnect_sandbox'            => array(
+			'title'        => __( 'Disconnect from PayPal Sandbox', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-text',
+			'text'         => $connected_to_paypal_markup,
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'state_from'   => Environment::SANDBOX,
+			'env'          => Environment::SANDBOX,
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'description'  => __( 'Click to reset current credentials and use another account.', 'woocommerce-paypal-payments' ),
+		),
+		'toggle_manual_input'                => array(
+			'type'         => 'ppcp-text',
+			'text'         => '<button type="button" id="ppcp[toggle_manual_input]">' . __( 'Toggle to manual credential input', 'woocommerce-paypal-payments' ) . '</button>',
+			'classes'      => array( 'ppcp-onboarding-element' ),
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'ppcp_dcc_status'                    => array(
+			'title'        => __( 'Advanced Credit & Debit Crad Payments', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-text',
+			'text'         => $dcc_status,
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'ppcp_pui_status'                    => array(
+			'title'        => __( 'Pay Upon Invoice', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-text',
+			'text'         => $pui_status,
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array( 'pui_ready' ),
+			'gateway'      => 'connection',
+		),
+		'error_label'                        => array(
+			'type'         => 'ppcp-text',
+			'text'         => '<label class="error" id="ppcp-form-errors-label"></label>',
+			'classes'      => array( 'hide', 'ppcp-always-shown-element' ),
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'sandbox_on'                         => array(
+			'title'        => __( 'Sandbox', 'woocommerce-paypal-payments' ),
+			'classes'      => array( 'ppcp-onboarding-element', 'ppcp-always-shown-element' ),
+			'type'         => 'checkbox',
+			'label'        => __( 'To test your WooCommerce installation, you can use the sandbox mode.', 'woocommerce-paypal-payments' ),
+			'default'      => 0,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'merchant_email_production'          => array(
+			'title'        => __( 'Live Email address', 'woocommerce-paypal-payments' ),
+			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'         => 'text',
+			'required'     => true,
+			'desc_tip'     => true,
+			'description'  => __( 'The email address of your PayPal account.', 'woocommerce-paypal-payments' ),
+			'default'      => '',
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'merchant_id_production'             => array(
+			'title'        => __( 'Live Merchant Id', 'woocommerce-paypal-payments' ),
+			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'         => 'ppcp-text-input',
+			'desc_tip'     => true,
+			'description'  => __( 'The merchant id of your account ', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'client_id_production'               => array(
+			'title'        => __( 'Live Client Id', 'woocommerce-paypal-payments' ),
+			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'         => 'ppcp-text-input',
+			'desc_tip'     => true,
+			'description'  => __( 'The client id of your api ', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'client_secret_production'           => array(
+			'title'        => __( 'Live Secret Key', 'woocommerce-paypal-payments' ),
+			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'         => 'ppcp-password',
+			'desc_tip'     => true,
+			'description'  => __( 'The secret key of your api', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+
+		'merchant_email_sandbox'             => array(
+			'title'        => __( 'Sandbox Email address', 'woocommerce-paypal-payments' ),
+			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'         => 'text',
+			'required'     => true,
+			'desc_tip'     => true,
+			'description'  => __( 'The email address of your PayPal account.', 'woocommerce-paypal-payments' ),
+			'default'      => '',
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'merchant_id_sandbox'                => array(
+			'title'        => __( 'Sandbox Merchant Id', 'woocommerce-paypal-payments' ),
+			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'         => 'ppcp-text-input',
+			'desc_tip'     => true,
+			'description'  => __( 'The merchant id of your account ', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'client_id_sandbox'                  => array(
+			'title'        => __( 'Sandbox Client Id', 'woocommerce-paypal-payments' ),
+			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'         => 'ppcp-text-input',
+			'desc_tip'     => true,
+			'description'  => __( 'The client id of your api ', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'client_secret_sandbox'              => array(
+			'title'        => __( 'Sandbox Secret Key', 'woocommerce-paypal-payments' ),
+			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'         => 'ppcp-password',
+			'desc_tip'     => true,
+			'description'  => __( 'The secret key of your api', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'logging_enabled'                    => array(
+			'title'        => __( 'Logging', 'woocommerce-paypal-payments' ),
+			'type'         => 'checkbox',
+			'desc_tip'     => true,
+			'label'        => __( 'Enable logging. ', 'woocommerce-paypal-payments' ) .
+				' <a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">' . __( 'View logs', 'woocommerce-paypal-payments' ) . '</a>',
+			'description'  => __( 'Enable logging of unexpected behavior. This can also log private data and should only be enabled in a development or stage environment.', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+		),
+		'prefix'                             => array(
+			'title'             => __( 'Invoice prefix', 'woocommerce-paypal-payments' ),
+			'type'              => 'text',
+			'desc_tip'          => true,
+			'description'       => __( 'If you use your PayPal account with more than one installation, please use a distinct prefix to separate those installations. Please use only English letters and "-", "_" characters.', 'woocommerce-paypal-payments' ),
+			'maxlength'         => 15,
+			'custom_attributes' => array(
+				'pattern' => '[a-zA-Z_-]+',
+			),
+			'default'           => ( static function (): string {
+				$site_url = get_site_url( get_current_blog_id() );
+				$hash = md5( $site_url );
+				$letters = preg_replace( '~\d~', '', $hash );
+				return $letters ? substr( $letters, 0, 6 ) . '-' : '';
+			} )(),
+			'screens'           => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements'      => array(),
+			'gateway'           => 'connection',
+		),
+		'tracking_enabled'                   => array(
+			'title'        => __( 'Tracking', 'woocommerce-paypal-payments' ),
+			'type'         => 'checkbox',
+			'desc_tip'     => true,
+			'label'        => $container->get( 'wcgateway.settings.tracking-label' ),
+			'description'  => __( 'Allows to send shipment tracking numbers to PayPal for PayPal transactions.', 'woocommerce-paypal-payments' ),
+			'default'      => false,
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'connection',
+			'input_class'  => $container->get( 'wcgateway.settings.should-disable-tracking-checkbox' ) ? array( 'ppcp-disabled-checkbox' ) : array(),
+		),
+	);
+
+	return array_merge( $fields, $connection_fields );
+};

--- a/modules/ppcp-wc-gateway/extensions.php
+++ b/modules/ppcp-wc-gateway/extensions.php
@@ -98,4 +98,6 @@ return array(
 			$source
 		);
 	},
+
+	'wcgateway.settings.fields'      => require __DIR__ . '/connection-tab-settings.php',
 );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2170,9 +2170,10 @@ return array(
 			: $enable_dcc_url;
 
 		return sprintf(
-			'<p>%1$s %2$s</p><p><a target="_blank" href="%3$s" class="button">%4$s</a></p>',
+			'<p>%1$s %2$s</p><p><a target="%3$s" href="%4$s" class="button">%5$s</a></p>',
 			$dcc_enabled ? $enabled_status_text : $disabled_status_text,
 			$dcc_enabled ? '<span class="dashicons dashicons-yes"></span>' : '<span class="dashicons dashicons-no"></span>',
+			$dcc_enabled ? '_self' : '_blank',
 			esc_url( $dcc_button_url ),
 			esc_html( $dcc_button_text )
 		);
@@ -2204,9 +2205,10 @@ return array(
 			: esc_html__( 'Enable Pay Upon Invoice', 'woocommerce-paypal-payments' );
 
 		return sprintf(
-			'<p>%1$s %2$s</p><p><a target="_blank" href="%3$s" class="button">%4$s</a></p>',
+			'<p>%1$s %2$s</p><p><a target="%3$s" href="%4$s" class="button">%5$s</a></p>',
 			$pui_enabled ? $enabled_status_text : $disabled_status_text,
 			$pui_enabled ? '<span class="dashicons dashicons-yes"></span>' : '<span class="dashicons dashicons-no"></span>',
+			$pui_enabled ? '_self' : '_blank',
 			esc_url( $pui_button_url ),
 			esc_html( $pui_button_text )
 		);

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2146,13 +2146,13 @@ return array(
 		return 'https://www.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE';
 	},
 	'wcgateway.settings.connection.dcc-status-text'        => static function ( ContainerInterface $container ): string {
-		$dcc_applies = $container->get( 'api.helpers.dccapplies' );
-		assert( $dcc_applies instanceof DccApplies );
+        $dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
+        assert( $dcc_product_status instanceof DCCProductStatus );
 
 		$environment = $container->get( 'onboarding.environment' );
 		assert( $environment instanceof Environment );
 
-		$dcc_enabled = $dcc_applies->for_country_currency() || $dcc_applies->for_wc_payments();
+		$dcc_enabled = $dcc_product_status->dcc_is_active();
 
 		$enabled_status_text  = esc_html__( 'Status: Enabled', 'woocommerce-paypal-payments' );
 		$disabled_status_text = esc_html__( 'Status: Not yet enabled', 'woocommerce-paypal-payments' );
@@ -2185,9 +2185,7 @@ return array(
 		$environment = $container->get( 'onboarding.environment' );
 		assert( $environment instanceof Environment );
 
-		$shop_country = $container->get( 'api.shop.country' );
-
-		$pui_enabled = 'DE' === $shop_country && $pui_product_status->pui_is_active();
+		$pui_enabled = $pui_product_status->pui_is_active();
 
 		$enabled_status_text  = esc_html__( 'Status: Enabled', 'woocommerce-paypal-payments' );
 		$disabled_status_text = esc_html__( 'Status: Not yet enabled', 'woocommerce-paypal-payments' );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2146,8 +2146,8 @@ return array(
 		return 'https://www.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE';
 	},
 	'wcgateway.settings.connection.dcc-status-text'        => static function ( ContainerInterface $container ): string {
-        $dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
-        assert( $dcc_product_status instanceof DCCProductStatus );
+		$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
+		assert( $dcc_product_status instanceof DCCProductStatus );
 
 		$environment = $container->get( 'onboarding.environment' );
 		assert( $environment instanceof Environment );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2133,18 +2133,18 @@ return array(
 
 		return $tracking_label;
 	},
-    'wcgateway.enable-dcc-url-sandbox'                    => static function ( ContainerInterface $container ): string {
-        return 'https://www.sandbox.paypal.com/bizsignup/entry/product/ppcp';
-    },
-    'wcgateway.enable-dcc-url-live'                    => static function ( ContainerInterface $container ): string {
-        return 'https://www.paypal.com/bizsignup/entry/product/ppcp';
-    },
-    'wcgateway.enable-pui-url-sandbox'                    => static function ( ContainerInterface $container ): string {
-        return 'https://www.sandbox.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE';
-    },
-    'wcgateway.enable-pui-url-live'                    => static function ( ContainerInterface $container ): string {
-        return 'https://www.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE';
-    },
+	'wcgateway.enable-dcc-url-sandbox'                     => static function ( ContainerInterface $container ): string {
+		return 'https://www.sandbox.paypal.com/bizsignup/entry/product/ppcp';
+	},
+	'wcgateway.enable-dcc-url-live'                        => static function ( ContainerInterface $container ): string {
+		return 'https://www.paypal.com/bizsignup/entry/product/ppcp';
+	},
+	'wcgateway.enable-pui-url-sandbox'                     => static function ( ContainerInterface $container ): string {
+		return 'https://www.sandbox.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE';
+	},
+	'wcgateway.enable-pui-url-live'                        => static function ( ContainerInterface $container ): string {
+		return 'https://www.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE';
+	},
 	'wcgateway.settings.connection.dcc-status-text'        => static function ( ContainerInterface $container ): string {
 		$dcc_applies = $container->get( 'api.helpers.dccapplies' );
 		assert( $dcc_applies instanceof DccApplies );
@@ -2162,8 +2162,8 @@ return array(
 			: esc_html__( 'Enable Advanced Card Payments', 'woocommerce-paypal-payments' );
 
 		$enable_dcc_url = $environment->current_environment_is( Environment::PRODUCTION )
-			? $container->get('wcgateway.enable-dcc-url-live')
-			: $container->get('wcgateway.enable-dcc-url-sandbox');
+			? $container->get( 'wcgateway.enable-dcc-url-live' )
+			: $container->get( 'wcgateway.enable-dcc-url-sandbox' );
 
 		$dcc_button_url = $dcc_enabled
 			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-credit-card-gateway' )
@@ -2192,8 +2192,8 @@ return array(
 		$disabled_status_text = esc_html__( 'Status: Not yet enabled', 'woocommerce-paypal-payments' );
 
 		$enable_pui_url = $environment->current_environment_is( Environment::PRODUCTION )
-			? $container->get('wcgateway.enable-pui-url-live')
-			: $container->get('wcgateway.enable-pui-url-sandbox');
+			? $container->get( 'wcgateway.enable-pui-url-live' )
+			: $container->get( 'wcgateway.enable-pui-url-sandbox' );
 
 		$pui_button_url = $pui_enabled
 			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-pay-upon-invoice-gateway' )

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -26,6 +26,7 @@ use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
 use Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhooksStatusPage;
@@ -290,6 +291,9 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @return string
 	 */
 	private function define_method_title(): string {
+		if ( $this->is_connection_tab() ) {
+			return __( 'Account Setup', 'woocommerce-paypal-payments' );
+		}
 		if ( $this->is_credit_card_tab() ) {
 			return __( 'PayPal Card Processing', 'woocommerce-paypal-payments' );
 		}
@@ -312,6 +316,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @return string
 	 */
 	private function define_method_description(): string {
+		if ( $this->is_connection_tab() ) {
+			return '';
+		}
+
 		if ( $this->is_credit_card_tab() ) {
 			return __(
 				'Accept debit and credit cards, and local payment methods.',
@@ -372,6 +380,16 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	private function is_webhooks_tab() : bool {
 		return is_admin()
 			&& WebhooksStatusPage::ID === $this->page_id;
+	}
+
+	/**
+	 * Whether we are on the connection tab.
+	 *
+	 * @return bool true if is connection tab, otherwise false
+	 */
+	protected function is_connection_tab() : bool {
+		return is_admin()
+			&& Settings::CONNECTION_TAB_ID === $this->page_id;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -62,6 +62,7 @@ class DCCProductStatus {
 		if ( is_bool( $this->current_status_cache ) ) {
 			return $this->current_status_cache;
 		}
+		//var_dump($this->settings->has( 'products_dcc_enabled' ) && $this->settings->get( 'products_dcc_enabled' ));die;
 		if ( $this->settings->has( 'products_dcc_enabled' ) && $this->settings->get( 'products_dcc_enabled' ) ) {
 			$this->current_status_cache = true;
 			return true;

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -62,7 +62,7 @@ class DCCProductStatus {
 		if ( is_bool( $this->current_status_cache ) ) {
 			return $this->current_status_cache;
 		}
-		//var_dump($this->settings->has( 'products_dcc_enabled' ) && $this->settings->get( 'products_dcc_enabled' ));die;
+
 		if ( $this->settings->has( 'products_dcc_enabled' ) && $this->settings->get( 'products_dcc_enabled' ) ) {
 			$this->current_status_cache = true;
 			return true;

--- a/modules/ppcp-wc-gateway/src/Settings/PageMatcherTrait.php
+++ b/modules/ppcp-wc-gateway/src/Settings/PageMatcherTrait.php
@@ -33,10 +33,11 @@ trait PageMatcherTrait {
 		}
 
 		$gateway_page_id_map = array(
-			PayPalGateway::ID      => 'paypal',
-			CreditCardGateway::ID  => 'dcc', // TODO: consider using just the gateway ID for PayPal and DCC too.
-			CardButtonGateway::ID  => CardButtonGateway::ID,
-			WebhooksStatusPage::ID => WebhooksStatusPage::ID,
+			Settings::CONNECTION_TAB_ID => 'connection',
+			PayPalGateway::ID           => 'paypal',
+			CreditCardGateway::ID       => 'dcc', // TODO: consider using just the gateway ID for PayPal and DCC too.
+			CardButtonGateway::ID       => CardButtonGateway::ID,
+			WebhooksStatusPage::ID      => WebhooksStatusPage::ID,
 		);
 		return array_key_exists( $current_page_id, $gateway_page_id_map )
 			&& in_array( $gateway_page_id_map[ $current_page_id ], $allowed_gateways, true );

--- a/modules/ppcp-wc-gateway/src/Settings/PageMatcherTrait.php
+++ b/modules/ppcp-wc-gateway/src/Settings/PageMatcherTrait.php
@@ -33,7 +33,7 @@ trait PageMatcherTrait {
 		}
 
 		$gateway_page_id_map = array(
-			Settings::CONNECTION_TAB_ID => 'connection',
+			Settings::CONNECTION_TAB_ID => Settings::CONNECTION_TAB_ID,
 			PayPalGateway::ID           => 'paypal',
 			CreditCardGateway::ID       => 'dcc', // TODO: consider using just the gateway ID for PayPal and DCC too.
 			CardButtonGateway::ID       => CardButtonGateway::ID,

--- a/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
@@ -77,7 +77,7 @@ class SectionsRenderer {
 
 		foreach ( $this->sections as $id => $label ) {
 			$url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $id );
-			if ( in_array( $id, array( CreditCardGateway::ID, WebhooksStatusPage::ID ), true ) ) {
+			if ( in_array( $id, array( Settings::CONNECTION_TAB_ID, CreditCardGateway::ID, WebhooksStatusPage::ID ), true ) ) {
 				// We need section=ppcp-gateway for the webhooks page because it is not a gateway,
 				// and for DCC because otherwise it will not render the page if gateway is not available (country/currency).
 				// Other gateways render fields differently, and their pages are not expected to work when gateway is not available.

--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -17,7 +17,8 @@ use Psr\Container\ContainerInterface;
  */
 class Settings implements ContainerInterface {
 
-	const KEY = 'woocommerce-ppcp-settings';
+	const KEY               = 'woocommerce-ppcp-settings';
+	const CONNECTION_TAB_ID = 'ppcp-connection';
 
 	/**
 	 * The settings.

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -174,7 +174,7 @@ class SettingsListener {
 		/**
 		 * The URL opened at the end of onboarding after saving the merchant ID/email.
 		 */
-		$redirect_url = apply_filters( 'woocommerce_paypal_payments_onboarding_redirect_url', admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ) );
+		$redirect_url = apply_filters( 'woocommerce_paypal_payments_onboarding_redirect_url', admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection' ) );
 		if ( ! $this->settings->has( 'client_id' ) || ! $this->settings->get( 'client_id' ) ) {
 			$redirect_url = add_query_arg( 'ppcp-onboarding-error', '1', $redirect_url );
 		}

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -259,7 +259,7 @@ class SettingsListener {
 
 		$credentials_change_status = null; // Cannot detect on Card Processing page.
 
-		if ( PayPalGateway::ID === $this->page_id ) {
+		if ( PayPalGateway::ID === $this->page_id || Settings::CONNECTION_TAB_ID === $this->page_id ) {
 			$settings['enabled'] = isset( $_POST['woocommerce_ppcp-gateway_enabled'] )
 				&& 1 === absint( $_POST['woocommerce_ppcp-gateway_enabled'] );
 
@@ -267,7 +267,6 @@ class SettingsListener {
 		}
 		// phpcs:enable phpcs:disable WordPress.Security.NonceVerification.Missing
 		// phpcs:enable phpcs:disable WordPress.Security.NonceVerification.Missing
-
 		if ( $credentials_change_status ) {
 			if ( self::CREDENTIALS_UNCHANGED !== $credentials_change_status ) {
 				$this->settings->set( 'products_dcc_enabled', null );

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -34,6 +34,13 @@ class SettingsRenderer {
 	protected $settings_status;
 
 	/**
+	 * The api shop country.
+	 *
+	 * @var string
+	 */
+	protected $api_shop_country;
+
+	/**
 	 * The settings.
 	 *
 	 * @var ContainerInterface
@@ -93,6 +100,7 @@ class SettingsRenderer {
 	 * @param DCCProductStatus   $dcc_product_status The product status.
 	 * @param SettingsStatus     $settings_status The Settings status helper.
 	 * @param string             $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
+	 * @param string             $api_shop_country The api shop country.
 	 */
 	public function __construct(
 		ContainerInterface $settings,
@@ -102,7 +110,8 @@ class SettingsRenderer {
 		MessagesApply $messages_apply,
 		DCCProductStatus $dcc_product_status,
 		SettingsStatus $settings_status,
-		string $page_id
+		string $page_id,
+		string $api_shop_country
 	) {
 
 		$this->settings           = $settings;
@@ -113,6 +122,7 @@ class SettingsRenderer {
 		$this->dcc_product_status = $dcc_product_status;
 		$this->settings_status    = $settings_status;
 		$this->page_id            = $page_id;
+		$this->api_shop_country   = $api_shop_country;
 	}
 
 	/**
@@ -348,7 +358,7 @@ $data_rows_html
 	/**
 	 * Renders the settings.
 	 */
-	public function render() {
+	public function render(): void {
 
 		$is_dcc = CreditCardGateway::ID === $this->page_id;
 		//phpcs:enable WordPress.Security.NonceVerification.Recommended
@@ -389,6 +399,12 @@ $data_rows_html
 			if (
 				in_array( 'messages', $config['requirements'], true )
 				&& ! $this->messages_apply->for_country()
+			) {
+				continue;
+			}
+			if (
+				in_array( 'pui_ready', $config['requirements'], true )
+				&& $this->api_shop_country !== 'DE'
 			) {
 				continue;
 			}

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -391,12 +391,6 @@ $data_rows_html
 				continue;
 			}
 			if (
-				in_array( 'dcc', $config['requirements'], true )
-				&& ! $this->dcc_product_status->dcc_is_active()
-			) {
-				continue;
-			}
-			if (
 				in_array( 'messages', $config['requirements'], true )
 				&& ! $this->messages_apply->for_country()
 			) {


### PR DESCRIPTION
### Description

The PR will add the following improvements:

- After connecting a PayPal account, should redirect the user to the Connection tab and not the PayPal Checkout tab

- ACDC eligibility check incorrect; must check if enabled for PayPal account

- if country/currency in WC does not match ACDC eligibility, hide the ACDC feature onboarding section (same as with PUI)

- ACDC and PUI eligibility checks should be separate for Sandbox and Live accounts

- when Live & Sandbox accounts are connected, and one gets disconnected, automatically swap to the other account (e.g. auto uncheck Sandbox checkbox when disconnecting sandbox account).