### PR TITLE
Get gateway enabled value from gateway object instead of plugin settings

### DIFF
--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -88,9 +88,12 @@ class DisableGateways {
 	 * @return bool
 	 */
 	private function disable_all_gateways() : bool {
-		if ( ! $this->settings->has( 'enabled' ) || ! $this->settings->get( 'enabled' ) ) {
-			return true;
+		foreach ( WC()->payment_gateways->payment_gateways() as $gateway ) {
+			if ( PayPalGateway::ID === $gateway->id && $gateway->enabled !== 'yes' ) {
+				return true;
+			}
 		}
+
 		if ( ! $this->settings->has( 'merchant_email' ) || ! is_email( $this->settings->get( 'merchant_email' ) ) ) {
 			return true;
 		}


### PR DESCRIPTION
This PR prevents getting incorrect gateway enabled value by getting the value from WC Gateway object instead of the plugin settings.