### PR TITLE
PUI-relevant webhook not subscribed to (666)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -3,8 +3,8 @@ type: php
 docroot: .ddev/wordpress
 php_version: "7.1"
 webserver_type: apache-fpm
-router_http_port: "8080"
-router_https_port: "8443"
+router_http_port: "80"
+router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: ['wc-pp']
 additional_fqdns: []

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -3,8 +3,8 @@ type: php
 docroot: .ddev/wordpress
 php_version: "7.1"
 webserver_type: apache-fpm
-router_http_port: "80"
-router_https_port: "443"
+router_http_port: "8080"
+router_https_port: "8443"
 xdebug_enabled: false
 additional_hostnames: ['wc-pp']
 additional_fqdns: []

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -76,7 +76,7 @@ return array(
 		return array(
 			new CheckoutOrderApproved( $logger, $prefix, $order_endpoint ),
 			new CheckoutOrderCompleted( $logger, $prefix ),
-			new CheckoutPaymentApprovalReversed($logger),
+			new CheckoutPaymentApprovalReversed( $logger ),
 			new PaymentCaptureRefunded( $logger, $prefix ),
 			new PaymentCaptureReversed( $logger, $prefix ),
 			new PaymentCaptureCompleted( $logger, $prefix, $order_endpoint ),

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\Webhooks\Endpoint\SimulateEndpoint;
 use WooCommerce\PayPalCommerce\Webhooks\Endpoint\SimulationStateEndpoint;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\CheckoutOrderApproved;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\CheckoutOrderCompleted;
+use WooCommerce\PayPalCommerce\Webhooks\Handler\CheckoutPaymentApprovalReversed;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCaptureCompleted;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCaptureDenied;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCapturePending;
@@ -75,6 +76,7 @@ return array(
 		return array(
 			new CheckoutOrderApproved( $logger, $prefix, $order_endpoint ),
 			new CheckoutOrderCompleted( $logger, $prefix ),
+			new CheckoutPaymentApprovalReversed($logger),
 			new PaymentCaptureRefunded( $logger, $prefix ),
 			new PaymentCaptureReversed( $logger, $prefix ),
 			new PaymentCaptureCompleted( $logger, $prefix, $order_endpoint ),

--- a/modules/ppcp-webhooks/src/Handler/CheckoutPaymentApprovalReversed.php
+++ b/modules/ppcp-webhooks/src/Handler/CheckoutPaymentApprovalReversed.php
@@ -78,22 +78,20 @@ class CheckoutPaymentApprovalReversed implements RequestHandler {
 			return $this->no_wc_orders_from_custom_ids( $request, $response );
 		}
 
-		if ( is_array( $wc_orders ) ) {
-			foreach ( $wc_orders as $wc_order ) {
-				if ( in_array( $wc_order->get_status(), array( 'pending', 'on-hold' ), true ) ) {
-					$error_message = sprintf(
-					// translators: %1$s is the order id.
-						__(
-							'Failed to capture order %1$s through PayPal.',
-							'woocommerce-paypal-payments'
-						),
-						(string) $wc_order->get_id()
-					);
+		foreach ( $wc_orders as $wc_order ) {
+			if ( in_array( $wc_order->get_status(), array( 'pending', 'on-hold' ), true ) ) {
+				$error_message = sprintf(
+				// translators: %1$s is the order id.
+					__(
+						'Failed to capture order %1$s through PayPal.',
+						'woocommerce-paypal-payments'
+					),
+					(string) $wc_order->get_id()
+				);
 
-					$this->logger->warning( 'CHECKOUT.PAYMENT-APPROVAL.REVERSED received. ' . $error_message );
+				$this->logger->warning( 'CHECKOUT.PAYMENT-APPROVAL.REVERSED received. ' . $error_message );
 
-					$wc_order->update_status( 'failed', $error_message );
-				}
+				$wc_order->update_status( 'failed', $error_message );
 			}
 		}
 

--- a/modules/ppcp-webhooks/src/Handler/CheckoutPaymentApprovalReversed.php
+++ b/modules/ppcp-webhooks/src/Handler/CheckoutPaymentApprovalReversed.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Handles the Webhook CHECKOUT.ORDER.COMPLETED
+ * Handles CHECKOUT.PAYMENT-APPROVAL.REVERSED Webhook.
  *
  * @package WooCommerce\PayPalCommerce\Webhooks\Handler
  */
@@ -10,33 +10,30 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Webhooks\Handler;
 
 use Psr\Log\LoggerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WP_REST_Request;
 use WP_REST_Response;
 
 /**
- * Class CheckoutOrderCompleted
+ * Class CheckoutPaymentApprovalReversed
  */
-class CheckoutOrderCompleted implements RequestHandler {
+class CheckoutPaymentApprovalReversed implements RequestHandler {
 
-	use PrefixTrait, RequestHandlerTrait;
+	use RequestHandlerTrait;
 
 	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
 	 */
-	private $logger;
+	protected $logger;
 
 	/**
-	 * CheckoutOrderCompleted constructor.
+	 * CheckoutPaymentApprovalReversed constructor.
 	 *
 	 * @param LoggerInterface $logger The logger.
-	 * @param string          $prefix The prefix.
 	 */
-	public function __construct( LoggerInterface $logger, string $prefix ) {
+	public function __construct( LoggerInterface $logger ) {
 		$this->logger = $logger;
-		$this->prefix = $prefix;
 	}
 
 	/**
@@ -46,7 +43,7 @@ class CheckoutOrderCompleted implements RequestHandler {
 	 */
 	public function event_types(): array {
 		return array(
-			'CHECKOUT.ORDER.COMPLETED',
+			'CHECKOUT.PAYMENT-APPROVAL.REVERSED',
 		);
 	}
 
@@ -81,26 +78,23 @@ class CheckoutOrderCompleted implements RequestHandler {
 			return $this->no_wc_orders_from_custom_ids( $request, $response );
 		}
 
-		foreach ( $wc_orders as $wc_order ) {
-			if ( PayUponInvoiceGateway::ID === $wc_order->get_payment_method() ) {
-				continue;
-			}
-			if ( ! in_array( $wc_order->get_status(), array( 'pending', 'on-hold' ), true ) ) {
-				continue;
-			}
+		if ( is_array( $wc_orders ) ) {
+			foreach ( $wc_orders as $wc_order ) {
+				if ( in_array( $wc_order->get_status(), array( 'pending', 'on-hold' ), true ) ) {
+					$error_message = sprintf(
+					// translators: %1$s is the order id.
+						__(
+							'Failed to capture order %1$s through PayPal.',
+							'woocommerce-paypal-payments'
+						),
+						(string) $wc_order->get_id()
+					);
 
-			$wc_order->payment_complete();
+					$this->logger->warning( 'CHECKOUT.PAYMENT-APPROVAL.REVERSED received. ' . $error_message );
 
-			$this->logger->info(
-				sprintf(
-					// translators: %s is the order ID.
-					__(
-						'Order %s has been updated through PayPal',
-						'woocommerce-paypal-payments'
-					),
-					(string) $wc_order->get_id()
-				)
-			);
+					$wc_order->update_status( 'failed', $error_message );
+				}
+			}
 		}
 
 		$response['success'] = true;

--- a/modules/ppcp-webhooks/src/Handler/CheckoutPaymentApprovalReversed.php
+++ b/modules/ppcp-webhooks/src/Handler/CheckoutPaymentApprovalReversed.php
@@ -18,7 +18,7 @@ use WP_REST_Response;
  */
 class CheckoutPaymentApprovalReversed implements RequestHandler {
 
-	use RequestHandlerTrait;
+	use RequestHandlerTrait, PrefixTrait;
 
 	/**
 	 * The logger.

--- a/modules/ppcp-webhooks/src/Handler/RequestHandlerTrait.php
+++ b/modules/ppcp-webhooks/src/Handler/RequestHandlerTrait.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Trait which helps to handle the request.
+ *
+ * @package WooCommerce\PayPalCommerce\Webhooks\Handler
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks\Handler;
+
+use stdClass;
+use WC_Order;
+use WP_REST_Request;
+use WP_REST_Response;
+
+trait RequestHandlerTrait {
+
+	/**
+	 * Get available custom ids from the given request
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 * @return array
+	 */
+	protected function get_custom_ids_from_request( WP_REST_Request $request ): array {
+		return array_filter(
+			array_map(
+				static function ( array $purchase_unit ): string {
+					return isset( $purchase_unit['custom_id'] ) ?
+						(string) $purchase_unit['custom_id'] : '';
+				},
+				isset( $request['resource'] ) && isset( $request['resource']['purchase_units'] ) ?
+					(array) $request['resource']['purchase_units'] : array()
+			),
+			static function ( string $order_id ): bool {
+				return ! empty( $order_id );
+			}
+		);
+	}
+
+	/**
+	 * Get WC orders from the given custom ids.
+	 *
+	 * @param array $custom_ids The custom ids.
+	 * @return stdClass|WC_Order[]
+	 */
+	protected function get_wc_orders_from_custom_ids( array $custom_ids ) {
+		$order_ids = array_map(
+			array(
+				$this,
+				'sanitize_custom_id',
+			),
+			$custom_ids
+		);
+		$args      = array(
+			'post__in' => $order_ids,
+			'limit'    => -1,
+		);
+
+		return wc_get_orders( $args );
+	}
+
+	/**
+	 * Return and log response for no custom ids found in request.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @param array           $response The response.
+	 * @return WP_REST_Response
+	 */
+	protected function no_custom_ids_from_request( WP_REST_Request $request, array $response ): WP_REST_Response {
+		$message = sprintf(
+		// translators: %s is the PayPal webhook Id.
+			__( 'No order for webhook event %s was found.', 'woocommerce-paypal-payments' ),
+			isset( $request['id'] ) ? $request['id'] : ''
+		);
+
+		return $this->log_and_return_response( $message, $response );
+	}
+
+	/**
+	 * Return and log response for no WC orders found in response.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 * @param array           $response The response.
+	 * @return WP_REST_Response
+	 */
+	protected function no_wc_orders_from_custom_ids( WP_REST_Request $request, array $response ): WP_REST_Response {
+		$message = sprintf(
+		// translators: %s is the PayPal order Id.
+			__( 'WC order for PayPal order %s not found.', 'woocommerce-paypal-payments' ),
+			isset( $request['resource']['id'] ) ? $request['resource']['id'] : ''
+		);
+
+		return $this->log_and_return_response( $message, $response );
+	}
+
+	/**
+	 * Return and log response with the given message.
+	 *
+	 * @param string $message The message.
+	 * @param array  $response The response.
+	 * @return WP_REST_Response
+	 */
+	private function log_and_return_response( string $message, array $response ): WP_REST_Response {
+		$this->logger->warning( $message );
+		$response['message'] = $message;
+
+		return new WP_REST_Response( $response );
+	}
+}

--- a/modules/ppcp-webhooks/src/Handler/RequestHandlerTrait.php
+++ b/modules/ppcp-webhooks/src/Handler/RequestHandlerTrait.php
@@ -42,9 +42,9 @@ trait RequestHandlerTrait {
 	 * Get WC orders from the given custom ids.
 	 *
 	 * @param array $custom_ids The custom ids.
-	 * @return stdClass|WC_Order[]
+	 * @return WC_Order[]
 	 */
-	protected function get_wc_orders_from_custom_ids( array $custom_ids ) {
+	protected function get_wc_orders_from_custom_ids( array $custom_ids ): array {
 		$order_ids = array_map(
 			array(
 				$this,
@@ -57,7 +57,8 @@ trait RequestHandlerTrait {
 			'limit'    => -1,
 		);
 
-		return wc_get_orders( $args );
+		$orders = wc_get_orders( $args );
+		return is_array( $orders ) ? $orders : array();
 	}
 
 	/**

--- a/modules/ppcp-webhooks/src/Handler/RequestHandlerTrait.php
+++ b/modules/ppcp-webhooks/src/Handler/RequestHandlerTrait.php
@@ -29,7 +29,7 @@ trait RequestHandlerTrait {
 					return isset( $purchase_unit['custom_id'] ) ?
 						(string) $purchase_unit['custom_id'] : '';
 				},
-				isset( $request['resource'] ) && isset( $request['resource']['purchase_units'] ) ?
+				$request['resource'] !== null && isset( $request['resource']['purchase_units'] ) ?
 					(array) $request['resource']['purchase_units'] : array()
 			),
 			static function ( string $order_id ): bool {
@@ -71,7 +71,7 @@ trait RequestHandlerTrait {
 		$message = sprintf(
 		// translators: %s is the PayPal webhook Id.
 			__( 'No order for webhook event %s was found.', 'woocommerce-paypal-payments' ),
-			isset( $request['id'] ) ? $request['id'] : ''
+			$request['id'] !== null && isset( $request['id'] ) ? $request['id'] : ''
 		);
 
 		return $this->log_and_return_response( $message, $response );
@@ -88,7 +88,7 @@ trait RequestHandlerTrait {
 		$message = sprintf(
 		// translators: %s is the PayPal order Id.
 			__( 'WC order for PayPal order %s not found.', 'woocommerce-paypal-payments' ),
-			isset( $request['resource']['id'] ) ? $request['resource']['id'] : ''
+			$request['resource'] !== null && isset( $request['resource']['id'] ) ? $request['resource']['id'] : ''
 		);
 
 		return $this->log_and_return_response( $message, $response );


### PR DESCRIPTION
According to PayPal docs we should listen to: CHECKOUT.PAYMENT-APPROVAL.REVERSED

https://developer.paypal.com/docs/checkout/apm/pay-upon-invoice/integrate-pui-merchant/#link-listentowebhooks

But this webhook is not subscribed currently.