### PR TITLE
Check that wc session exists before using it

### DIFF
--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -107,7 +107,11 @@ class VaultingModule implements ModuleInterface {
 		add_action(
 			'woocommerce_created_customer',
 			function( int $customer_id ) use ( $subscription_helper ) {
-				$guest_customer_id = WC()->session->get( 'ppcp_guest_customer_id' );
+				$session = WC()->session;
+				if ( ! $session ) {
+					return;
+				}
+				$guest_customer_id = $session->get( 'ppcp_guest_customer_id' );
 				if ( $guest_customer_id && $subscription_helper->cart_contains_subscription() ) {
 					update_user_meta( $customer_id, 'ppcp_guest_customer_id', $guest_customer_id );
 				}


### PR DESCRIPTION
Hopefully fixes #845

I was not able to reproduce it, but we probably simply need to check that WC session is not null.