### PR TITLE
Load onboarding.js only in Connection tab

### DIFF
--- a/modules/ppcp-onboarding/src/Assets/OnboardingAssets.php
+++ b/modules/ppcp-onboarding/src/Assets/OnboardingAssets.php
@@ -12,7 +12,6 @@ namespace WooCommerce\PayPalCommerce\Onboarding\Assets;
 use WooCommerce\PayPalCommerce\Onboarding\Endpoint\LoginSellerEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
-use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
@@ -173,6 +172,6 @@ class OnboardingAssets {
 	 * @return bool
 	 */
 	private function should_render_onboarding_script(): bool {
-		return PayPalGateway::ID === $this->page_id || Settings::CONNECTION_TAB_ID === $this->page_id;
+		return Settings::CONNECTION_TAB_ID === $this->page_id;
 	}
 }


### PR DESCRIPTION
Looks like it is not needed anywhere else, and in other tabs we get an error because it fails to find the checkbox.