### PR TITLE
Fix links after adding connection tab

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -169,6 +169,13 @@ return array(
 		$section = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : '';
 		$ppcp_tab = isset( $_GET[ SectionsRenderer::KEY ] ) ? sanitize_text_field( wp_unslash( $_GET[ SectionsRenderer::KEY ] ) ) : '';
 
+		$state = $container->get( 'onboarding.state' );
+		assert( $state instanceof State );
+
+		if ( ! $ppcp_tab && PayPalGateway::ID === $section && $state->current_state() !== State::STATE_ONBOARDED ) {
+			return Settings::CONNECTION_TAB_ID;
+		}
+
 		return $ppcp_tab ? $ppcp_tab : $section;
 	},
 

--- a/modules/ppcp-wc-gateway/src/Notice/ConnectAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/ConnectAdminNotice.php
@@ -60,7 +60,7 @@ class ConnectAdminNotice {
 				'PayPal Payments is almost ready. To get started, <a href="%1$s">connect your account</a>.',
 				'woocommerce-paypal-payments'
 			),
-			admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' )
+			admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=' . Settings::CONNECTION_TAB_ID )
 		);
 		return new Message( $message, 'warning' );
 	}

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -196,7 +196,7 @@ class SettingsListener {
 		/**
 		 * The URL opened at the end of onboarding after saving the merchant ID/email.
 		 */
-		$redirect_url = apply_filters( 'woocommerce_paypal_payments_onboarding_redirect_url', admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection' ) );
+		$redirect_url = apply_filters( 'woocommerce_paypal_payments_onboarding_redirect_url', admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=' . Settings::CONNECTION_TAB_ID ) );
 		if ( ! $this->settings->has( 'client_id' ) || ! $this->settings->get( 'client_id' ) ) {
 			$redirect_url = add_query_arg( 'ppcp-onboarding-error', '1', $redirect_url );
 		}

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -19,6 +19,8 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce;
 
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
 define( 'PAYPAL_API_URL', 'https://api.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api.sandbox.paypal.com' );
 define( 'PAYPAL_INTEGRATION_DATE', '2022-04-13' );
@@ -134,7 +136,7 @@ define( 'PPCP_FLAG_SEPARATE_APM_BUTTONS', apply_filters( 'woocommerce_paypal_pay
 				$links,
 				sprintf(
 					'<a href="%1$s">%2$s</a>',
-					admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+					admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=' . Settings::CONNECTION_TAB_ID ),
 					__( 'Settings', 'woocommerce-paypal-payments' )
 				)
 			);


### PR DESCRIPTION
Updates some links after the #801 PRs, so that users would not end up on the 2nd tab (without any way to switch) when not onboarded.

Also now using the connection tab instead of PayPal settings tab (the 2nd tab) when the tab is not specified and not onboarded. This is needed for:

- If we missed some link.
- If a merchant updated the plugin and refreshed the old page.
- To make the link on the payments page point to the connection tab only if not onboarded.