### PR TITLE
Hide PayPal Card Processing tab is not available in country or for merchant (886)

### DIFF
--- a/.psalm/stubs.php
+++ b/.psalm/stubs.php
@@ -5,3 +5,6 @@ if (!defined('EP_PAGES')) {
 if (!defined('MONTH_IN_SECONDS')) {
 	define('MONTH_IN_SECONDS', 30 * DAY_IN_SECONDS);
 }
+if (!defined('HOUR_IN_SECONDS')) {
+	define('HOUR_IN_SECONDS', 60 * MINUTE_IN_SECONDS);
+}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -245,7 +245,9 @@ return array(
 
 		$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
 		assert( $dcc_product_status instanceof DCCProductStatus );
-		if ( ! $dcc_product_status->dcc_is_active() ) {
+		$dcc_applies = $container->get( 'api.helpers.dccapplies' );
+		assert( $dcc_applies instanceof DccApplies );
+		if ( ! $dcc_product_status->dcc_is_active() || ! $dcc_applies->for_country_currency() ) {
 			unset( $sections['ppcp-credit-card-gateway'] );
 		}
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1929,7 +1929,12 @@ return array(
 
 		$settings         = $container->get( 'wcgateway.settings' );
 		$partner_endpoint = $container->get( 'api.endpoint.partners' );
-		return new DCCProductStatus( $settings, $partner_endpoint, $container->get( 'dcc.status-cache' ) );
+		return new DCCProductStatus(
+			$settings,
+			$partner_endpoint,
+			$container->get( 'dcc.status-cache' ),
+			$container->get( 'api.helpers.dccapplies' )
+		);
 	},
 
 	'button.helper.messages-disclaimers'                   => static function ( ContainerInterface $container ): MessagesDisclaimers {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -243,6 +243,12 @@ return array(
 			}
 		}
 
+		$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
+		assert( $dcc_product_status instanceof DCCProductStatus );
+		if ( ! $dcc_product_status->dcc_is_active() ) {
+			unset( $sections['ppcp-credit-card-gateway'] );
+		}
+
 		return $sections;
 	},
 	'wcgateway.settings.status'                            => static function ( ContainerInterface $container ): SettingsStatus {


### PR DESCRIPTION
When the PayPal merchant account is not enabled for advanced card payments, the PayPal Card Processing tab should be hidden entirely:
![image-20220818-185938](https://user-images.githubusercontent.com/456223/192776789-d998943a-36cc-49cd-9e5d-cea04444e21c.png)
