### PR TITLE
PUI payment instructions printed in the refund email (899)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -258,7 +258,13 @@ class PayUponInvoice {
 		add_action(
 			'woocommerce_email_before_order_table',
 			function( WC_Order $order, bool $sent_to_admin ) {
-				if ( ! $sent_to_admin && PayUponInvoiceGateway::ID === $order->get_payment_method() && $order->has_status( 'processing' ) ) {
+				$action = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING ) ?? '';
+				if (
+					! $sent_to_admin
+					&& PayUponInvoiceGateway::ID === $order->get_payment_method()
+					&& $order->has_status( 'processing' )
+					&& ( $action && $action !== 'woocommerce_refund_line_items' )
+				) {
 					$this->logger->info( "Adding Ratepay payment instructions to email for order #{$order->get_id()}." );
 
 					$instructions = $order->get_meta( 'ppcp_ratepay_payment_instructions_payment_reference' );

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice;
 
 use Psr\Log\LoggerInterface;
+use WC_Email;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PayUponInvoiceOrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\CaptureFactory;
@@ -257,13 +258,12 @@ class PayUponInvoice {
 
 		add_action(
 			'woocommerce_email_before_order_table',
-			function( WC_Order $order, bool $sent_to_admin ) {
-				$action = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING ) ?? '';
+			function( WC_Order $order, bool $sent_to_admin, bool $plain_text, WC_Email $email ) {
 				if (
 					! $sent_to_admin
 					&& PayUponInvoiceGateway::ID === $order->get_payment_method()
 					&& $order->has_status( 'processing' )
-					&& ( $action && $action !== 'woocommerce_refund_line_items' )
+					&& $email->id === 'customer_processing_order'
 				) {
 					$this->logger->info( "Adding Ratepay payment instructions to email for order #{$order->get_id()}." );
 
@@ -315,7 +315,7 @@ class PayUponInvoice {
 				}
 			},
 			10,
-			2
+			4
 		);
 
 		add_filter(


### PR DESCRIPTION
When refunding a Pay upon Invoice order, the Ratepay payment instructions are inserted into the refund email.