### PR TITLE
Release 1.9.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,16 @@
 *** Changelog ***
 
+= 1.9.4 - TBD =
+* Add - Create new connection tab #801
+* Add - Functionality to choose subscription failure behavior #728
+* Fix - Virtual-only orders always move order status to completed #868
+* Fix - PayPal order created twice when context is checkout #832
+* Enhancement - Handle unsupported browsers better #843
+* Enhancement - Combine the Webhooks Status page into a new Connection tab (891) #827
+* Enhancement - Hide PayPal Card Processing tab is not available in country or for merchant #870
+* Enhancement - Resubscribe webhooks on plugin upgrades #838
+* Enhancement - PUI-relevant webhook not subscribed to #842
+
 = 1.9.3 - 2022-08-31 =
 * Add - Tracking API #792
 * Fix - Improve compatibility with Siteground Optimizer plugin #797

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@
 * Fix - PayPal order created twice when context is checkout #832
 * Enhancement - Handle unsupported browsers better #843
 * Enhancement - Combine the Webhooks Status page into a new Connection tab (891) #827
-* Enhancement - Hide PayPal Card Processing tab is not available in country or for merchant #870
+* Enhancement - Hide PayPal Card Processing tab if not available in country or for merchant #870
 * Enhancement - Resubscribe webhooks on plugin upgrades #838
 * Enhancement - PUI-relevant webhook not subscribed to #842
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, 
 Requires at least: 5.3
 Tested up to: 6.0
 Requires PHP: 7.1
-Stable tag: 1.9.3
+Stable tag: 1.9.4
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,17 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 1.9.4 =
+* Add - Create new connection tab #801
+* Add - Functionality to choose subscription failure behavior #728
+* Fix - Virtual-only orders always move order status to completed #868
+* Fix - PayPal order created twice when context is checkout #832
+* Enhancement - Handle unsupported browsers better #843
+* Enhancement - Combine the Webhooks Status page into a new Connection tab (891) #827
+* Enhancement - Hide PayPal Card Processing tab is not available in country or for merchant #870
+* Enhancement - Resubscribe webhooks on plugin upgrades #838
+* Enhancement - PUI-relevant webhook not subscribed to #842
 
 = 1.9.3 =
 * Add - Tracking API #792

--- a/readme.txt
+++ b/readme.txt
@@ -88,7 +88,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - PayPal order created twice when context is checkout #832
 * Enhancement - Handle unsupported browsers better #843
 * Enhancement - Combine the Webhooks Status page into a new Connection tab (891) #827
-* Enhancement - Hide PayPal Card Processing tab is not available in country or for merchant #870
+* Enhancement - Hide PayPal Card Processing tab if not available in country or for merchant #870
 * Enhancement - Resubscribe webhooks on plugin upgrades #838
 * Enhancement - PUI-relevant webhook not subscribed to #842
 

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,13 +3,13 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     1.9.3
+ * Version:     1.9.4
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.1
  * WC requires at least: 3.9
- * WC tested up to: 6.8
+ * WC tested up to: 6.9
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce


### PR DESCRIPTION
* Add - Create new connection tab #801
* Add - Functionality to choose subscription failure behavior #728
* Fix - Virtual-only orders always move order status to completed #868
* Fix - PayPal order created twice when context is checkout #832
* Enhancement - Handle unsupported browsers better #843
* Enhancement - Combine the Webhooks Status page into a new Connection tab (891) #827
* Enhancement - Hide PayPal Card Processing tab is not available in country or for merchant #870
* Enhancement - Resubscribe webhooks on plugin upgrades #838
* Enhancement - PUI-relevant webhook not subscribed to #842