### PR TITLE
Remove WC logo during onboarding

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Enhancement - Hide PayPal Card Processing tab if not available in country or for merchant #870
 * Enhancement - Resubscribe webhooks on plugin upgrades #838
 * Enhancement - PUI-relevant webhook not subscribed to #842
+* Enhancement - Remove WC logo during onboarding #881
 
 = 1.9.3 - 2022-08-31 =
 * Add - Tracking API #792

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -79,7 +79,6 @@ class PartnerReferralsData {
 			'ppcp_partner_referrals_data',
 			array(
 				'partner_config_override' => array(
-					'partner_logo_url'       => 'https://connect.woocommerce.com/images/woocommerce_logo.png',
 					/**
 					 * Returns the URL which will be opened at the end of onboarding.
 					 */

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Enhancement - Hide PayPal Card Processing tab if not available in country or for merchant #870
 * Enhancement - Resubscribe webhooks on plugin upgrades #838
 * Enhancement - PUI-relevant webhook not subscribed to #842
+* Enhancement - Remove WC logo during onboarding #881
 
 = 1.9.3 =
 * Add - Tracking API #792


### PR DESCRIPTION
Removes the WC logo during onboarding as requested by WC.

Note that the onboarding URLs are cached in `ppcp-paypal-signup-link*` transients, so they need to be cleared for this to see the effect.