### PR TITLE
Revert vault failed value

### DIFF
--- a/modules/ppcp-vaulting/src/PaymentTokenChecker.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenChecker.php
@@ -143,7 +143,7 @@ class PaymentTokenChecker {
 
 		try {
 			$subscription_behavior_when_fails = $this->settings->get( 'subscription_behavior_when_vault_fails' );
-			$wc_order->add_meta_data( self::VAULTING_FAILED_META_KEY, $subscription_behavior_when_fails );
+			$wc_order->update_meta_data( self::VAULTING_FAILED_META_KEY, $subscription_behavior_when_fails );
 		} catch ( NotFoundException $exception ) {
 			return;
 		}

--- a/modules/ppcp-vaulting/src/PaymentTokenChecker.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenChecker.php
@@ -143,6 +143,7 @@ class PaymentTokenChecker {
 
 		try {
 			$subscription_behavior_when_fails = $this->settings->get( 'subscription_behavior_when_vault_fails' );
+			$wc_order->add_meta_data( self::VAULTING_FAILED_META_KEY, $subscription_behavior_when_fails );
 		} catch ( NotFoundException $exception ) {
 			return;
 		}

--- a/modules/ppcp-vaulting/src/PaymentTokenChecker.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenChecker.php
@@ -144,6 +144,7 @@ class PaymentTokenChecker {
 		try {
 			$subscription_behavior_when_fails = $this->settings->get( 'subscription_behavior_when_vault_fails' );
 			$wc_order->update_meta_data( self::VAULTING_FAILED_META_KEY, $subscription_behavior_when_fails );
+			$wc_order->save_meta_data();
 		} catch ( NotFoundException $exception ) {
 			return;
 		}

--- a/modules/ppcp-vaulting/src/PaymentTokenChecker.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenChecker.php
@@ -143,11 +143,12 @@ class PaymentTokenChecker {
 
 		try {
 			$subscription_behavior_when_fails = $this->settings->get( 'subscription_behavior_when_vault_fails' );
-			$wc_order->update_meta_data( self::VAULTING_FAILED_META_KEY, $subscription_behavior_when_fails );
-			$wc_order->save_meta_data();
 		} catch ( NotFoundException $exception ) {
-			return;
+			$subscription_behavior_when_fails = 'void_auth';
 		}
+
+		$wc_order->update_meta_data( self::VAULTING_FAILED_META_KEY, $subscription_behavior_when_fails );
+		$wc_order->save_meta_data();
 
 		switch ( $subscription_behavior_when_fails ) {
 			case 'void_auth':

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -178,25 +178,15 @@ class VaultingModule implements ModuleInterface {
 				 */
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );
 
-				/**
-				 * The Gateway settings.
-				 *
-				 * @var Settings $settings
-				 */
-				$settings = $container->get( 'wcgateway.settings' );
-
-				$vault_failed = get_post_meta( $order->get_id(), PaymentTokenChecker::VAULTING_FAILED_META_KEY );
+				$vault_failed = $order->get_meta( PaymentTokenChecker::VAULTING_FAILED_META_KEY );
 				if ( $subscription_helper->has_subscription( $order->get_id() ) && ! empty( $vault_failed ) ) {
-					$subscription_behavior_when_vault_fails_setting_name = 'subscription_behavior_when_vault_fails';
-					$subscription_behavior_when_vault_fails              = $settings->get( $subscription_behavior_when_vault_fails_setting_name );
-
 					$logger->info( "Adding vaulting failure info to email for order #{$order->get_id()}." );
 
-					if ( $subscription_behavior_when_vault_fails === 'void_auth' ) {
+					if ( $vault_failed === 'void_auth' ) {
 						echo wp_kses_post( '<p>' . __( 'The subscription payment failed because the payment method could not be saved. Please try again with a different payment method.', 'woocommerce-paypal-payments' ) . '</p>' );
 					}
 
-					if ( $subscription_behavior_when_vault_fails === 'capture_auth' ) {
+					if ( $vault_failed === 'capture_auth' ) {
 						echo wp_kses_post( '<p>' . __( 'The subscription has been activated, but the payment method could not be saved. Please contact the merchant to save a payment method for automatic subscription renewal payments.', 'woocommerce-paypal-payments' ) . '</p>' );
 					}
 				}
@@ -220,21 +210,11 @@ class VaultingModule implements ModuleInterface {
 				 */
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );
 
-				/**
-				 * The Gateway settings.
-				 *
-				 * @var Settings $settings
-				 */
-				$settings = $container->get( 'wcgateway.settings' );
-
-				$vault_failed = get_post_meta( $order->get_id(), PaymentTokenChecker::VAULTING_FAILED_META_KEY );
+				$vault_failed = $order->get_meta( PaymentTokenChecker::VAULTING_FAILED_META_KEY );
 				if ( $subscription_helper->has_subscription( $order->get_id() ) && ! empty( $vault_failed ) ) {
-					$subscription_behavior_when_vault_fails_setting_name = 'subscription_behavior_when_vault_fails';
-					$subscription_behavior_when_vault_fails              = $settings->get( $subscription_behavior_when_vault_fails_setting_name );
-
 					$logger->info( "Changing subscription auto-renewal status for order #{$order->get_id()}." );
 
-					if ( $subscription_behavior_when_vault_fails === 'capture_auth' ) {
+					if ( $vault_failed === 'capture_auth' ) {
 						$subscriptions = function_exists( 'wcs_get_subscriptions_for_order' ) ? wcs_get_subscriptions_for_order( $order->get_id() ) : array();
 						foreach ( $subscriptions as $subscription ) {
 							$subscription->set_requires_manual_renewal( true );


### PR DESCRIPTION
While refactoring in #729 I accidentally removed the value of the subscription failing behaviour type, this PR reverts it back, also uses WC API for adding meta to the order instead of WP post meta API.