### PR TITLE
update order with order note if payment failed after billing agreement canceled at PayPal (922)

### DIFF
--- a/modules/ppcp-api-client/src/Exception/PayPalApiException.php
+++ b/modules/ppcp-api-client/src/Exception/PayPalApiException.php
@@ -127,7 +127,7 @@ class PayPalApiException extends RuntimeException {
 	 * @return string
 	 */
 	public function get_details( string $error ): string {
-		if ( ! is_array( $this->details() ) || empty( $this->details() ) ) {
+		if ( empty( $this->details() ) ) {
 			return $error;
 		}
 

--- a/modules/ppcp-api-client/src/Exception/PayPalApiException.php
+++ b/modules/ppcp-api-client/src/Exception/PayPalApiException.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Exception;
 
-use stdClass;
-
 /**
  * Class PayPalApiException
  */

--- a/modules/ppcp-api-client/src/Exception/PayPalApiException.php
+++ b/modules/ppcp-api-client/src/Exception/PayPalApiException.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Exception;
 
+use stdClass;
+
 /**
  * Class PayPalApiException
  */
@@ -118,5 +120,27 @@ class PayPalApiException extends RuntimeException {
 	 */
 	public function status_code(): int {
 		return $this->status_code;
+	}
+
+	/**
+	 * Return exception details if exists.
+	 *
+	 * @param string $error The error to return in case no details found.
+	 * @return string
+	 */
+	public function get_details( string $error ): string {
+		if ( ! is_array( $this->details() ) || empty( $this->details() ) ) {
+			return $error;
+		}
+
+		$details = '';
+		foreach ( $this->details() as $detail ) {
+			$issue       = $detail->issue ?? '';
+			$field       = $detail->field ?? '';
+			$description = $detail->description ?? '';
+			$details    .= $issue . ' ' . $field . ' ' . $description . '<br>';
+		}
+
+		return $details;
 	}
 }

--- a/modules/ppcp-subscription/src/RenewalHandler.php
+++ b/modules/ppcp-subscription/src/RenewalHandler.php
@@ -150,7 +150,7 @@ class RenewalHandler {
 
 			$wc_order->update_status(
 				'failed',
-				$error
+					$error
 			);
 
 			$error_message = sprintf(

--- a/modules/ppcp-subscription/src/RenewalHandler.php
+++ b/modules/ppcp-subscription/src/RenewalHandler.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Subscription;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingPreferenceFactory;
@@ -142,16 +143,32 @@ class RenewalHandler {
 		try {
 			$this->process_order( $wc_order );
 		} catch ( \Exception $error ) {
-			$this->logger->error(
-				sprintf(
-					'An error occurred while trying to renew the subscription for order %1$d: %2$s',
-					$wc_order->get_id(),
-					$error->getMessage()
-				)
+			$error_details = $error->getMessage();
+			if ( is_a( $error, PayPalApiException::class ) ) {
+				$details = '';
+				foreach ( $error->details() as $detail ) {
+					$details .= $detail->issue . ' ' . $detail->description;
+				}
+				if ( $details ) {
+					$error_details = $details;
+				}
+			}
+
+			$error_message = sprintf(
+				'An error occurred while trying to renew the subscription for order %1$d: %2$s',
+				$wc_order->get_id(),
+				$error_details
 			);
+
+			$wc_order->update_status(
+				'failed',
+				$error_details
+			);
+			$this->logger->error( $error_message );
 
 			return;
 		}
+
 		$this->logger->info(
 			sprintf(
 				'Renewal for order %d is completed.',

--- a/modules/ppcp-subscription/src/RenewalHandler.php
+++ b/modules/ppcp-subscription/src/RenewalHandler.php
@@ -150,7 +150,7 @@ class RenewalHandler {
 
 			$wc_order->update_status(
 				'failed',
-					$error
+				$error
 			);
 
 			$error_message = sprintf(

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
@@ -167,17 +167,8 @@ class OXXOGateway extends WC_Payment_Gateway {
 			}
 		} catch ( RuntimeException $exception ) {
 			$error = $exception->getMessage();
-
-			if ( is_a( $exception, PayPalApiException::class ) && is_array( $exception->details() ) ) {
-				$details = '';
-				foreach ( $exception->details() as $detail ) {
-					$issue       = $detail->issue ?? '';
-					$field       = $detail->field ?? '';
-					$description = $detail->description ?? '';
-					$details    .= $issue . ' ' . $field . ' ' . $description . '<br>';
-				}
-
-				$error = $details;
+			if ( is_a( $exception, PayPalApiException::class ) ) {
+				$error = $exception->get_details( $error );
 			}
 
 			$this->logger->error( $error );

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -246,17 +246,8 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 			);
 		} catch ( RuntimeException $exception ) {
 			$error = $exception->getMessage();
-
-			if ( is_a( $exception, PayPalApiException::class ) && is_array( $exception->details() ) ) {
-				$details = '';
-				foreach ( $exception->details() as $detail ) {
-					$issue       = $detail->issue ?? '';
-					$field       = $detail->field ?? '';
-					$description = $detail->description ?? '';
-					$details    .= $issue . ' ' . $field . ' ' . $description . '<br>';
-				}
-
-				$error = $details;
+			if ( is_a( $exception, PayPalApiException::class ) ) {
+				$error = $exception->get_details( $error );
 			}
 
 			$this->logger->error( $error );


### PR DESCRIPTION
To reproduce:
- create a subscription with the PPEC plugin
- disable PPEC plugin
- enable PCP
- cancel the billing agreement at PayPal
- renew the subscripotion

Renewal order is created but remains “Pending payment” status and no order note is created and WooCommerce Subscriptions retry rules do not kick in.