### PR TITLE
Ratepay payment instructions added to non Pay upon Invoice orders

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -228,6 +228,10 @@ class PayUponInvoice {
 			'ppcp_payment_capture_completed_webhook_handler',
 			function ( WC_Order $wc_order, string $order_id ) {
 				try {
+					if ( $wc_order->get_payment_method() !== PayUponInvoiceGateway::ID ) {
+						return;
+					}
+
 					$order = $this->pui_order_endpoint->order( $order_id );
 
 					$payment_instructions = array(


### PR DESCRIPTION
### Steps to reproduce
- enable Vaulting
- create payment via vautled PayPal account
- check logs

According to the logs, instructions are added to this order which is not true or correct:
Ratepay payment instructions added to order #123.