### PR TITLE
PayPal Transaction Key meta field not populated for PUI payments (904)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -248,7 +248,8 @@ class PayUponInvoice {
 						$wc_order->save_meta_data();
 						$paypal_fee = $breakdown->paypal_fee();
 						if ( $paypal_fee ) {
-							update_post_meta( $wc_order->get_id(), 'PayPal Transaction Key', $paypal_fee->value() );
+							$wc_order->update_meta_data( 'PayPal Transaction Key', $paypal_fee->value() );
+							$wc_order->save_meta_data();
 						}
 					}
 				} catch ( RuntimeException $exception ) {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -246,6 +246,10 @@ class PayUponInvoice {
 					if ( $breakdown ) {
 						$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
 						$wc_order->save_meta_data();
+						$paypal_fee = $breakdown->paypal_fee();
+						if ( $paypal_fee ) {
+							update_post_meta( $wc_order->get_id(), 'PayPal Transaction Key', $paypal_fee->value() );
+						}
 					}
 				} catch ( RuntimeException $exception ) {
 					$this->logger->error( $exception->getMessage() );

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -247,7 +247,7 @@ class PayUponInvoice {
 						$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
 						$paypal_fee = $breakdown->paypal_fee();
 						if ( $paypal_fee ) {
-							$wc_order->update_meta_data( 'PayPal Transaction Fee', $paypal_fee->value() );
+							$wc_order->update_meta_data( 'PayPal Transaction Fee', (string) $paypal_fee->value() );
 						}
 
 						$wc_order->save_meta_data();

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -245,12 +245,12 @@ class PayUponInvoice {
 					$breakdown = $capture->seller_receivable_breakdown();
 					if ( $breakdown ) {
 						$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
-						$wc_order->save_meta_data();
 						$paypal_fee = $breakdown->paypal_fee();
 						if ( $paypal_fee ) {
-							$wc_order->update_meta_data( 'PayPal Transaction Key', $paypal_fee->value() );
-							$wc_order->save_meta_data();
+							$wc_order->update_meta_data( 'PayPal Transaction Fee', $paypal_fee->value() );
 						}
+
+						$wc_order->save_meta_data();
 					}
 				} catch ( RuntimeException $exception ) {
 					$this->logger->error( $exception->getMessage() );

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -87,12 +87,12 @@ class WCGatewayModule implements ModuleInterface {
 				$breakdown = $capture->seller_receivable_breakdown();
 				if ( $breakdown ) {
 					$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
-					$wc_order->save_meta_data();
 					$paypal_fee = $breakdown->paypal_fee();
 					if ( $paypal_fee ) {
-						$wc_order->update_meta_data( 'PayPal Transaction Key', $paypal_fee->value() );
-						$wc_order->save_meta_data();
+						$wc_order->update_meta_data( 'PayPal Transaction Fee', $paypal_fee->value() );
 					}
+
+					$wc_order->save_meta_data();
 				}
 
 				$fraud = $capture->fraud_processor_response();

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -89,7 +89,7 @@ class WCGatewayModule implements ModuleInterface {
 					$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
 					$paypal_fee = $breakdown->paypal_fee();
 					if ( $paypal_fee ) {
-						$wc_order->update_meta_data( 'PayPal Transaction Fee', $paypal_fee->value() );
+						$wc_order->update_meta_data( 'PayPal Transaction Fee', (string) $paypal_fee->value() );
 					}
 
 					$wc_order->save_meta_data();

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -90,7 +90,8 @@ class WCGatewayModule implements ModuleInterface {
 					$wc_order->save_meta_data();
 					$paypal_fee = $breakdown->paypal_fee();
 					if ( $paypal_fee ) {
-						update_post_meta( $wc_order->get_id(), 'PayPal Transaction Key', $paypal_fee->value() );
+						$wc_order->update_meta_data( 'PayPal Transaction Key', $paypal_fee->value() );
+						$wc_order->save_meta_data();
 					}
 				}
 


### PR DESCRIPTION
The PayPal and PayPal Card Processing gateway store the PayPal fee in the PayPal Transaction Key meta field (for export purposes).

### Steps to reproduce
- create PUI order
- after webhook is retrieved, PayPal fee is patched into the WC order
- "PayPal Transaction Key" meta field does not exist

### Expected behaviour
PayPal Transaction Key meta field exists and is populated with the PayPal fee for every gateway that relates to PayPal Payments.

Possible cause

meta field must probably be created for each gateway 