### PR TITLE
Fix thankyou_order_received filter usage

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
@@ -80,7 +80,16 @@ class OXXO {
 
 		add_filter(
 			'woocommerce_thankyou_order_received_text',
-			function( string $message, WC_Order $order ) {
+			/**
+			 * Order can be null.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function( string $message, $order ) {
+				if ( ! $order instanceof WC_Order ) {
+					return $message;
+				}
+
 				$payer_action = $order->get_meta( 'ppcp_oxxo_payer_action' ) ?? '';
 
 				$button = '';


### PR DESCRIPTION
Some users get this error 

```
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to WooCommerce\\PayPalCommerce\\WcGateway\\Gateway\\OXXO\\OXXO::WooCommerce\\PayPalCommerce\\WcGateway\\Gateway\\OXXO\\{closure}()
must be an instance of WC_Order, null given, called in
...
.../woocommerce/templates/checkout/thankyou.php(84): 
.../ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php on line 83
```

I thought that it is like other issues when themes/plugins pass a bad value to filters, but actually looks like `null` is valid here (used by WC), so we probably should simply check the type and exit.