### PR TITLE
Fix the disabled tracking checkbox condition

### DIFF
--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -51,7 +51,7 @@ class OrderTrackingModule implements ModuleInterface {
 		$pui_helper = $c->get( 'wcgateway.pay-upon-invoice-helper' );
 		assert( $pui_helper instanceof PayUponInvoiceHelper );
 
-		if ( $pui_helper->is_pui_enabled() ) {
+		if ( $pui_helper->is_pui_gateway_enabled() ) {
 			$settings->set( 'tracking_enabled', true );
 			$settings->persist();
 		}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2014,7 +2014,7 @@ return array(
 	'wcgateway.pay-upon-invoice-helper'                    => static function( ContainerInterface $container ): PayUponInvoiceHelper {
 		return new PayUponInvoiceHelper(
 			$container->get( 'wcgateway.checkout-helper' ),
-			$container->get( 'wcgateway.settings' )
+			$container->get( 'api.shop.country' )
 		);
 	},
 	'wcgateway.pay-upon-invoice-product-status'            => static function( ContainerInterface $container ): PayUponInvoiceProductStatus {
@@ -2175,6 +2175,7 @@ return array(
 			return false;
 		}
 	},
+
 	'wcgateway.settings.should-disable-tracking-checkbox'  => static function ( ContainerInterface $container ): bool {
 		$pui_helper = $container->get( 'wcgateway.pay-upon-invoice-helper' );
 		assert( $pui_helper instanceof PayUponInvoiceHelper );
@@ -2185,7 +2186,7 @@ return array(
 			return true;
 		}
 
-		if ( $pui_helper->is_pui_enabled() ) {
+		if ( $pui_helper->is_pui_gateway_enabled() ) {
 			return true;
 		}
 

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -26,22 +26,21 @@ class PayUponInvoiceHelper {
 	protected $checkout_helper;
 
 	/**
-	 * The settings.
+	 * The api shop country.
 	 *
-	 * @var Settings
+	 * @var string
 	 */
-	protected $settings;
+	protected $api_shop_country;
 
 	/**
 	 * PayUponInvoiceHelper constructor.
 	 *
 	 * @param CheckoutHelper $checkout_helper The checkout helper.
-	 * @param Settings       $settings The Settings.
+	 * @param string         $api_shop_country The api shop country.
 	 */
-	public function __construct( CheckoutHelper $checkout_helper, Settings $settings ) {
-
-		$this->checkout_helper = $checkout_helper;
-		$this->settings        = $settings;
+	public function __construct( CheckoutHelper $checkout_helper, string $api_shop_country ) {
+		$this->checkout_helper  = $checkout_helper;
+		$this->api_shop_country = $api_shop_country;
 	}
 
 	/**
@@ -92,12 +91,12 @@ class PayUponInvoiceHelper {
 	}
 
 	/**
-	 * Checks whether PUI is enabled.
+	 * Checks whether PUI gateway is enabled.
 	 *
-	 * @return bool True if PUI is active, otherwise false.
-	 * @throws NotFoundException If problem when checking the settings.
+	 * @return bool True if PUI gateway is enabled, otherwise false.
 	 */
-	public function is_pui_enabled(): bool {
-		return $this->settings->has( 'products_pui_enabled' ) && $this->settings->get( 'products_pui_enabled' );
+	public function is_pui_gateway_enabled(): bool {
+		$gateway_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
+		return isset( $gateway_settings['enabled'] ) && $gateway_settings['enabled'] === 'yes' && 'DE' === $this->api_shop_country;
 	}
 }


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #900

---

### Description

There is a bug with tracking checkbox disabled condition. It is always showing as enabled regardless of PUI and shop country settings.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Go to WC->Settings -> General and set country store something else to Germany (example:Spain)
2. Go to Connection tab -> Tracking is enabled
3. Disable tracking.
4. Move to PayPal checkout tab or somewhere else
5. Go back to Connection tab
6. checkbox Enable tracking information feature on your store is enabled -> but should be disabled

---

Closes #900 .
