### PR TITLE
Do not get tracking if tracking number meta doesn't exist

### DIFF
--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -185,8 +185,12 @@ class OrderTrackingEndpoint {
 			throw new RuntimeException( 'wrong order ID' );
 		}
 
+		if ( ! $wc_order->meta_exists( '_ppcp_paypal_tracking_number' ) ) {
+			return null;
+		}
+
 		$transaction_id  = $wc_order->get_transaction_id();
-		$tracking_number = get_post_meta( $wc_order_id, '_ppcp_paypal_tracking_number', true );
+		$tracking_number = $wc_order->get_meta( '_ppcp_paypal_tracking_number', true );
 		$url             = trailingslashit( $this->host ) . 'v1/shipping/trackers/' . $this->find_tracker_id( $transaction_id, $tracking_number );
 
 		$args = array(

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -80,8 +80,6 @@ class MetaBoxRenderer {
 
 		$tracking_info = $this->order_tracking_endpoint->get_tracking_information( $wc_order->get_id() );
 
-		$tracking_is_not_added = empty( $tracking_info );
-
 		$transaction_id  = $tracking_info['transaction_id'] ?? $wc_order->get_transaction_id() ?: '';
 		$tracking_number = $tracking_info['tracking_number'] ?? '';
 		$status_value    = $tracking_info['status'] ?? 'SHIPPED';
@@ -90,7 +88,7 @@ class MetaBoxRenderer {
 		$carriers = (array) apply_filters( 'ppcp_tracking_carriers', $this->carriers );
 		$statuses = (array) apply_filters( 'ppcp_tracking_statuses', $this->allowed_statuses );
 
-		$action = $tracking_is_not_added ? 'create' : 'update';
+		$action = ! $tracking_info ? 'create' : 'update';
 		?>
 		<p>
 			<label for="<?php echo esc_attr( self::NAME_PREFIX ); ?>-transaction_id"><?php echo esc_html__( 'Transaction ID', 'woocommerce-paypal-payments' ); ?></label>


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #903

---

### Description

When order is created and there is no tracking information yet added, the tracking metabox is still doing call to PayPal to check if tracking exists which causing the record added in log file.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Create order.
2. Enter the order edit page.
3. Check the logs

---

Closes #903 .
