### PR TITLE
When Brand Name field is left empty, PUI purchase fails (742)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -509,13 +509,18 @@ class PayUponInvoice {
 				) {
 					$error_messages = array();
 					$pui_gateway    = WC()->payment_gateways->payment_gateways()[ PayUponInvoiceGateway::ID ];
+					if ( $pui_gateway->get_option( 'brand_name' ) === '' ) {
+						$error_messages[] = esc_html__( 'Could not enable gateway because "Brand name" field is empty.', 'woocommerce-paypal-payments' );
+					}
 					if ( $pui_gateway->get_option( 'logo_url' ) === '' ) {
 						$error_messages[] = esc_html__( 'Could not enable gateway because "Logo URL" field is empty.', 'woocommerce-paypal-payments' );
 					}
 					if ( $pui_gateway->get_option( 'customer_service_instructions' ) === '' ) {
 						$error_messages[] = esc_html__( 'Could not enable gateway because "Customer service instructions" field is empty.', 'woocommerce-paypal-payments' );
 					}
-					if ( count( $error_messages ) > 0 ) { ?>
+					if ( count( $error_messages ) > 0 ) {
+						$pui_gateway->update_option( 'enabled', 'no' );
+						?>
 						<div class="notice notice-error">
 							<?php
 							array_map(


### PR DESCRIPTION
If merchant leaves Brand Name field empty, then checkout with PUI will fail. 

### Steps to reproduce
- Enable PUI gateway
- Remove all text from Brand Name field (leave it empty)
- Save
- Navigate to checkout page with a supported product
- Fill in all mandatory billing details
- Click on PUI gateway and fill in valid birth date
- Attempt to place the order

Observe, order failed with error message
> INVALID_STRING_LENGTH /payment_source/pay_upon_invoice/pay_upon_invoice_experience_context/brand_name The value of a field is either too short or too long.