### PR TITLE
Fix button positioning for products with One Page Checkout Extension enabled

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -370,6 +370,7 @@ class SmartButton implements SmartButtonInterface {
 		if (
 			( is_product() || wc_post_content_has_shortcode( 'product_page' ) )
 			&& ! $not_enabled_on_product_page
+			&& ! is_checkout()
 		) {
 			add_action(
 				$this->single_product_renderer_hook(),
@@ -420,6 +421,7 @@ class SmartButton implements SmartButtonInterface {
 			// TODO: it seems like there is no easy way to properly handle vaulted PayPal free trial,
 			// so disable the buttons for now everywhere except checkout for free trial.
 			&& ! $this->is_free_trial_product()
+			&& ! is_checkout()
 		) {
 			add_action(
 				$this->single_product_renderer_hook(),


### PR DESCRIPTION
**Issue**: #356 

---

### Description

Check whether we're on a checkout page when deciding where to load the PayPal buttons, including on product pages. One Page Checkout ensures is_checkout() is true on pages containing the one-page checkout form.

### Steps to Test

1. Enable both One Page Checkout and PayPal
2. Enable One Page Checkout for a simple product
3. View the simple product, scroll down to the One Page Checkout Form, select PayPal payment method
4. Confirm that the payment buttons appear within the checkout, and not in the product description above

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Fix PayPal button positioning on single product pages when the One Page Checkout Extension is enabled.

Closes #356.
