### PR TITLE
 Missing PUI refund functionality from WC order (736)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1994,7 +1994,9 @@ return array(
 			$container->get( 'wcgateway.transaction-url-provider' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'wcgateway.pay-upon-invoice-helper' ),
-			$container->get( 'wcgateway.checkout-helper' )
+			$container->get( 'wcgateway.checkout-helper' ),
+			$container->get( 'onboarding.state' ),
+			$container->get( 'wcgateway.processor.refunds' )
 		);
 	},
 	'wcgateway.pay-upon-invoice-fraudnet-session-id'       => static function ( ContainerInterface $container ): FraudNetSessionId {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -17,10 +17,12 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PayUponInvoiceOrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CheckoutHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderMetaTrait;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
 /**
  * Class PayUponInvoiceGateway.
@@ -88,6 +90,20 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	protected $checkout_helper;
 
 	/**
+	 * The onboarding state.
+	 *
+	 * @var State
+	 */
+	protected $state;
+
+	/**
+	 * The refund processor.
+	 *
+	 * @var RefundProcessor
+	 */
+	protected $refund_processor;
+
+	/**
 	 * PayUponInvoiceGateway constructor.
 	 *
 	 * @param PayUponInvoiceOrderEndpoint $order_endpoint The order endpoint.
@@ -98,6 +114,8 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	 * @param LoggerInterface             $logger The logger.
 	 * @param PayUponInvoiceHelper        $pui_helper The PUI helper.
 	 * @param CheckoutHelper              $checkout_helper The checkout helper.
+	 * @param State                       $state The onboarding state.
+	 * @param RefundProcessor             $refund_processor The refund processor.
 	 */
 	public function __construct(
 		PayUponInvoiceOrderEndpoint $order_endpoint,
@@ -107,7 +125,9 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 		TransactionUrlProvider $transaction_url_provider,
 		LoggerInterface $logger,
 		PayUponInvoiceHelper $pui_helper,
-		CheckoutHelper $checkout_helper
+		CheckoutHelper $checkout_helper,
+		State $state,
+		RefundProcessor $refund_processor
 	) {
 		$this->id = self::ID;
 
@@ -137,6 +157,12 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 		$this->transaction_url_provider = $transaction_url_provider;
 		$this->pui_helper               = $pui_helper;
 		$this->checkout_helper          = $checkout_helper;
+
+		$this->state = $state;
+		if ( $state->current_state() === State::STATE_ONBOARDED ) {
+			$this->supports = array( 'refunds' );
+		}
+		$this->refund_processor = $refund_processor;
 	}
 
 	/**
@@ -272,6 +298,22 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 				'redirect' => wc_get_checkout_url(),
 			);
 		}
+	}
+
+	/**
+	 * Process refund.
+	 *
+	 * @param  int    $order_id Order ID.
+	 * @param  float  $amount Refund amount.
+	 * @param  string $reason Refund reason.
+	 * @return boolean True or false based on success, or a WP_Error object.
+	 */
+	public function process_refund( $order_id, $amount = null, $reason = '' ) {
+		$order = wc_get_order( $order_id );
+		if ( ! is_a( $order, \WC_Order::class ) ) {
+			return false;
+		}
+		return $this->refund_processor->process( $order, (float) $amount, (string) $reason );
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Gateway/PayUponInvoice/PayUponInvoiceGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/PayUponInvoice/PayUponInvoiceGatewayTest.php
@@ -11,10 +11,12 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CheckoutHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceHelper;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 use function Brain\Monkey\Functions\when;
 
 class PayUponInvoiceGatewayTest extends TestCase
@@ -28,6 +30,8 @@ class PayUponInvoiceGatewayTest extends TestCase
 	private $testee;
 	private $pui_helper;
 	private $checkout_helper;
+	private $state;
+	private $refund_processor;
 
 	public function setUp(): void
 	{
@@ -42,6 +46,11 @@ class PayUponInvoiceGatewayTest extends TestCase
 		$this->pui_helper = Mockery::mock(PayUponInvoiceHelper::class);
 		$this->checkout_helper = Mockery::mock(CheckoutHelper::class);
 
+		$this->state = Mockery::mock(State::class);
+		$this->state->shouldReceive('current_state')->andReturn(State::STATE_ONBOARDED);
+
+		$this->refund_processor = Mockery::mock(RefundProcessor::class);
+
 		$this->setInitStubs();
 
 		$this->testee = new PayUponInvoiceGateway(
@@ -52,7 +61,9 @@ class PayUponInvoiceGatewayTest extends TestCase
 			$this->transaction_url_provider,
 			$this->logger,
 			$this->pui_helper,
-			$this->checkout_helper
+			$this->checkout_helper,
+			$this->state,
+			$this->refund_processor
 		);
 	}
 


### PR DESCRIPTION
If merchant want’s to perform a PUI refund from WC, he is not able to do so due to missing functionality.

### Steps To Reproduce
- Navigate to order details for Successful PUI purchase
- Click on refund button

Observe, there is no PUI refund functionality.