### PR TITLE
Multiple PHP warnings (PHP8)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/PaymentToken.php
+++ b/modules/ppcp-api-client/src/Entity/PaymentToken.php
@@ -43,9 +43,9 @@ class PaymentToken {
 	/**
 	 * PaymentToken constructor.
 	 *
-	 * @param string    $id The Id.
-	 * @param string    $type The type.
-	 * @param \stdClass $source The source.
+	 * @param string   $id The Id.
+	 * @param stdClass $source The source.
+	 * @param string   $type The type.
 	 * @throws RuntimeException When the type is not valid.
 	 */
 	public function __construct( string $id, stdClass $source, string $type = self::TYPE_PAYMENT_METHOD_TOKEN ) {

--- a/modules/ppcp-api-client/src/Entity/PaymentToken.php
+++ b/modules/ppcp-api-client/src/Entity/PaymentToken.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
 
+use stdClass;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
 /**
@@ -47,7 +48,7 @@ class PaymentToken {
 	 * @param \stdClass $source The source.
 	 * @throws RuntimeException When the type is not valid.
 	 */
-	public function __construct( string $id, string $type = self::TYPE_PAYMENT_METHOD_TOKEN, \stdClass $source ) {
+	public function __construct( string $id, stdClass $source, string $type = self::TYPE_PAYMENT_METHOD_TOKEN ) {
 		if ( ! in_array( $type, self::get_valid_types(), true ) ) {
 			throw new RuntimeException(
 				__( 'Not a valid payment source type.', 'woocommerce-paypal-payments' )

--- a/modules/ppcp-api-client/src/Factory/PaymentTokenFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PaymentTokenFactory.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
+use stdClass;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
@@ -25,7 +26,7 @@ class PaymentTokenFactory {
 	 * @return PaymentToken
 	 * @throws RuntimeException When JSON object is malformed.
 	 */
-	public function from_paypal_response( \stdClass $data ): PaymentToken {
+	public function from_paypal_response( stdClass $data ): PaymentToken {
 		if ( ! isset( $data->id ) ) {
 			throw new RuntimeException(
 				__( 'No id for payment token given', 'woocommerce-paypal-payments' )
@@ -34,8 +35,8 @@ class PaymentTokenFactory {
 
 		return new PaymentToken(
 			$data->id,
-			( isset( $data->type ) ) ? $data->type : PaymentToken::TYPE_PAYMENT_METHOD_TOKEN,
-			$data->source
+			$data->source,
+			( isset( $data->type ) ) ? $data->type : PaymentToken::TYPE_PAYMENT_METHOD_TOKEN
 		);
 	}
 

--- a/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
+++ b/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat\PPEC;
 
+use stdClass;
 use WooCommerce\PayPalCommerce\Subscription\RenewalHandler;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
 
@@ -125,7 +126,7 @@ class SubscriptionsHandler {
 			$billing_agreement_id = $order->get_meta( '_ppec_billing_agreement_id', true );
 
 			if ( $billing_agreement_id ) {
-				$token = new PaymentToken( $billing_agreement_id, 'BILLING_AGREEMENT', new \stdClass() );
+				$token = new PaymentToken( $billing_agreement_id, new stdClass(), 'BILLING_AGREEMENT' );
 			}
 		}
 

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -251,16 +251,24 @@ class PayUponInvoice {
 
 					$order = $this->pui_order_endpoint->order( $order_id );
 
-					$payment_instructions = array(
-						$order->payment_source->pay_upon_invoice->payment_reference,
-						$order->payment_source->pay_upon_invoice->deposit_bank_details,
-					);
-					$wc_order->update_meta_data(
-						'ppcp_ratepay_payment_instructions_payment_reference',
-						$payment_instructions
-					);
-					$wc_order->save_meta_data();
-					$this->logger->info( "Ratepay payment instructions added to order #{$wc_order->get_id()}." );
+					if (
+						property_exists( $order, 'payment_source' )
+						&& property_exists( $order->payment_source, 'pay_upon_invoice' )
+						&& property_exists( $order->payment_source->pay_upon_invoice, 'payment_reference' )
+						&& property_exists( $order->payment_source->pay_upon_invoice, 'deposit_bank_details' )
+					) {
+
+						$payment_instructions = array(
+							$order->payment_source->pay_upon_invoice->payment_reference,
+							$order->payment_source->pay_upon_invoice->deposit_bank_details,
+						);
+						$wc_order->update_meta_data(
+							'ppcp_ratepay_payment_instructions_payment_reference',
+							$payment_instructions
+						);
+						$wc_order->save_meta_data();
+						$this->logger->info( "Ratepay payment instructions added to order #{$wc_order->get_id()}." );
+					}
 
 					$capture   = $this->capture_factory->from_paypal_response( $order->purchase_units[0]->payments->captures[0] );
 					$breakdown = $capture->seller_receivable_breakdown();

--- a/tests/PHPUnit/Vaulting/PaymentTokenRepositoryTest.php
+++ b/tests/PHPUnit/Vaulting/PaymentTokenRepositoryTest.php
@@ -52,7 +52,7 @@ class PaymentTokenRepositoryTest extends TestCase
     {
         $id = 1;
         $source = new \stdClass();
-        $paymentToken = new PaymentToken('foo', 'PAYMENT_METHOD_TOKEN', $source);
+        $paymentToken = new PaymentToken('foo', $source, 'PAYMENT_METHOD_TOKEN');
 
         when('get_user_meta')->justReturn([]);
         $this->endpoint->shouldReceive('for_user')


### PR DESCRIPTION
PHP warnings found in debug log relating to Pay upon Invoice:
```
[18-Oct-2022 08:53:48 UTC] PHP Warning Undefined property: stdClass::$pay_upon_invoice in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php on line 234
[18-Oct-2022 08:53:48 UTC] PHP Warning Attempt to read property "payment_reference" on null in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php on line 234
[18-Oct-2022 08:53:48 UTC] PHP Warning Undefined property: stdClass::$pay_upon_invoice in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php on line 235
[18-Oct-2022 08:53:48 UTC] PHP Warning Attempt to read property "deposit_bank_details" on null in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php on line 235
[18-Oct-2022 08:53:48 UTC] PHP Warning Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php:234) in /var/www/html/wp-includes/rest-api/class-wp-rest-server.php on line 1717
[18-Oct-2022 19:30:52 UTC] PHP Deprecated: Required parameter $source follows optional parameter $type in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-api-client/src/Entity/PaymentToken.php on line 50
```