### PR TITLE
Execute server-side WC validation when clicking button

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -100,7 +100,8 @@ const bootstrap = () => {
         if (PayPalCommerceGateway.mini_cart_buttons_enabled === '1') {
             const miniCartBootstrap = new MiniCartBootstap(
                 PayPalCommerceGateway,
-                renderer
+                renderer,
+                errorHandler,
             );
 
             miniCartBootstrap.init();
@@ -112,6 +113,7 @@ const bootstrap = () => {
             PayPalCommerceGateway,
             renderer,
             messageRenderer,
+            errorHandler,
         );
 
         singleProductBootstrap.init();
@@ -121,6 +123,7 @@ const bootstrap = () => {
         const cartBootstrap = new CartBootstrap(
             PayPalCommerceGateway,
             renderer,
+            errorHandler,
         );
 
         cartBootstrap.init();
@@ -131,7 +134,8 @@ const bootstrap = () => {
             PayPalCommerceGateway,
             renderer,
             messageRenderer,
-            spinner
+            spinner,
+            errorHandler,
         );
 
         checkoutBootstap.init();
@@ -142,7 +146,8 @@ const bootstrap = () => {
             PayPalCommerceGateway,
             renderer,
             messageRenderer,
-            spinner
+            spinner,
+            errorHandler,
         );
         payNowBootstrap.init();
     }

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -66,7 +66,7 @@ class CheckoutActionHandler {
                         }
                     }
 
-                    throw new Error(data.data.message);
+                    throw {type: 'create-order-error', data: data.data};
                 }
                 const input = document.createElement('input');
                 input.setAttribute('type', 'hidden');
@@ -82,9 +82,15 @@ class CheckoutActionHandler {
             onCancel: () => {
                 spinner.unblock();
             },
-            onError: () => {
-                this.errorHandler.genericError();
+            onError: (err) => {
+                console.error(err);
                 spinner.unblock();
+
+                if (err && err.type === 'create-order-error') {
+                    return;
+                }
+
+                this.errorHandler.genericError();
             }
         }
     }

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -59,7 +59,9 @@ class CheckoutActionHandler {
                         );
                     } else {
                         errorHandler.clear();
-                        if (data.data.details.length > 0) {
+                        if (data.data.errors.length > 0) {
+                            errorHandler.messages(data.data.errors);
+                        } else if (data.data.details.length > 0) {
                             errorHandler.message(data.data.details.map(d => `${d.issue} ${d.description}`).join('<br/>'), true);
                         } else {
                             errorHandler.message(data.data.message, true);

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
@@ -1,5 +1,4 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
-import ErrorHandler from '../ErrorHandler';
 
 class CartBootstrap {
     constructor(gateway, renderer, errorHandler) {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
@@ -2,9 +2,10 @@ import CartActionHandler from '../ActionHandler/CartActionHandler';
 import ErrorHandler from '../ErrorHandler';
 
 class CartBootstrap {
-    constructor(gateway, renderer) {
+    constructor(gateway, renderer, errorHandler) {
         this.gateway = gateway;
         this.renderer = renderer;
+        this.errorHandler = errorHandler;
     }
 
     init() {
@@ -28,7 +29,7 @@ class CartBootstrap {
     render() {
         const actionHandler = new CartActionHandler(
             PayPalCommerceGateway,
-            new ErrorHandler(this.gateway.labels.error.generic),
+            this.errorHandler,
         );
 
         this.renderer.render(

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -1,4 +1,3 @@
-import ErrorHandler from '../ErrorHandler';
 import CheckoutActionHandler from '../ActionHandler/CheckoutActionHandler';
 import {setVisible, setVisibleByClass} from '../Helper/Hiding';
 import {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -8,11 +8,12 @@ import {
 } from "../Helper/CheckoutMethodState";
 
 class CheckoutBootstap {
-    constructor(gateway, renderer, messages, spinner) {
+    constructor(gateway, renderer, messages, spinner, errorHandler) {
         this.gateway = gateway;
         this.renderer = renderer;
         this.messages = messages;
         this.spinner = spinner;
+        this.errorHandler = errorHandler;
 
         this.standardOrderButtonSelector = ORDER_BUTTON_SELECTOR;
     }
@@ -60,7 +61,7 @@ class CheckoutBootstap {
         }
         const actionHandler = new CheckoutActionHandler(
             PayPalCommerceGateway,
-            new ErrorHandler(this.gateway.labels.error.generic),
+            this.errorHandler,
             this.spinner
         );
 

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
@@ -2,9 +2,10 @@ import ErrorHandler from '../ErrorHandler';
 import CartActionHandler from '../ActionHandler/CartActionHandler';
 
 class MiniCartBootstap {
-    constructor(gateway, renderer) {
+    constructor(gateway, renderer, errorHandler) {
         this.gateway = gateway;
         this.renderer = renderer;
+        this.errorHandler = errorHandler;
         this.actionHandler = null;
     }
 
@@ -12,7 +13,7 @@ class MiniCartBootstap {
 
         this.actionHandler = new CartActionHandler(
             PayPalCommerceGateway,
-            new ErrorHandler(this.gateway.labels.error.generic),
+            this.errorHandler,
         );
         this.render();
 

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
@@ -1,4 +1,3 @@
-import ErrorHandler from '../ErrorHandler';
 import CartActionHandler from '../ActionHandler/CartActionHandler';
 
 class MiniCartBootstap {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/PayNowBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/PayNowBootstrap.js
@@ -2,8 +2,8 @@ import CheckoutBootstap from './CheckoutBootstap'
 import {isChangePaymentPage} from "../Helper/Subscriptions";
 
 class PayNowBootstrap extends CheckoutBootstap {
-    constructor(gateway, renderer, messages, spinner) {
-        super(gateway, renderer, messages, spinner)
+    constructor(gateway, renderer, messages, spinner, errorHandler) {
+        super(gateway, renderer, messages, spinner, errorHandler)
     }
 
     updateUi() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -1,4 +1,3 @@
-import ErrorHandler from '../ErrorHandler';
 import UpdateCart from "../Helper/UpdateCart";
 import SingleProductActionHandler from "../ActionHandler/SingleProductActionHandler";
 

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -3,10 +3,11 @@ import UpdateCart from "../Helper/UpdateCart";
 import SingleProductActionHandler from "../ActionHandler/SingleProductActionHandler";
 
 class SingleProductBootstap {
-    constructor(gateway, renderer, messages) {
+    constructor(gateway, renderer, messages, errorHandler) {
         this.gateway = gateway;
         this.renderer = renderer;
         this.messages = messages;
+        this.errorHandler = errorHandler;
     }
 
 
@@ -81,7 +82,7 @@ class SingleProductBootstap {
                 this.messages.hideMessages();
             },
             document.querySelector('form.cart'),
-            new ErrorHandler(this.gateway.labels.error.generic),
+            this.errorHandler,
         );
 
         this.renderer.render(

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -27,7 +27,7 @@ use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 
 return array(
-	'button.client_id'                         => static function ( ContainerInterface $container ): string {
+	'button.client_id'                            => static function ( ContainerInterface $container ): string {
 
 		$settings = $container->get( 'wcgateway.settings' );
 		$client_id = $settings->has( 'client_id' ) ? $settings->get( 'client_id' ) : '';
@@ -45,7 +45,7 @@ return array(
 		return $env->current_environment_is( Environment::SANDBOX ) ?
 			CONNECT_WOO_SANDBOX_CLIENT_ID : CONNECT_WOO_CLIENT_ID;
 	},
-	'button.smart-button'                      => static function ( ContainerInterface $container ): SmartButtonInterface {
+	'button.smart-button'                         => static function ( ContainerInterface $container ): SmartButtonInterface {
 
 		$state = $container->get( 'onboarding.state' );
 		/**
@@ -92,16 +92,16 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'button.url'                               => static function ( ContainerInterface $container ): string {
+	'button.url'                                  => static function ( ContainerInterface $container ): string {
 		return plugins_url(
 			'/modules/ppcp-button/',
 			dirname( realpath( __FILE__ ), 3 ) . '/woocommerce-paypal-payments.php'
 		);
 	},
-	'button.request-data'                      => static function ( ContainerInterface $container ): RequestData {
+	'button.request-data'                         => static function ( ContainerInterface $container ): RequestData {
 		return new RequestData();
 	},
-	'button.endpoint.change-cart'              => static function ( ContainerInterface $container ): ChangeCartEndpoint {
+	'button.endpoint.change-cart'                 => static function ( ContainerInterface $container ): ChangeCartEndpoint {
 		if ( ! \WC()->cart ) {
 			throw new RuntimeException( 'cant initialize endpoint at this moment' );
 		}
@@ -113,7 +113,7 @@ return array(
 		$logger                        = $container->get( 'woocommerce.logger.woocommerce' );
 		return new ChangeCartEndpoint( $cart, $shipping, $request_data, $purchase_unit_factory, $data_store, $logger );
 	},
-	'button.endpoint.create-order'             => static function ( ContainerInterface $container ): CreateOrderEndpoint {
+	'button.endpoint.create-order'                => static function ( ContainerInterface $container ): CreateOrderEndpoint {
 		$request_data          = $container->get( 'button.request-data' );
 		$purchase_unit_factory = $container->get( 'api.factory.purchase-unit' );
 		$order_endpoint        = $container->get( 'api.endpoint.order' );
@@ -134,10 +134,11 @@ return array(
 			$early_order_handler,
 			$registration_needed,
 			$container->get( 'wcgateway.settings.card_billing_data_mode' ),
+			$container->get( 'button.early-wc-checkout-validation-enabled' ),
 			$logger
 		);
 	},
-	'button.helper.early-order-handler'        => static function ( ContainerInterface $container ) : EarlyOrderHandler {
+	'button.helper.early-order-handler'           => static function ( ContainerInterface $container ) : EarlyOrderHandler {
 
 		$state          = $container->get( 'onboarding.state' );
 		$order_processor = $container->get( 'wcgateway.order-processor' );
@@ -145,7 +146,7 @@ return array(
 		$prefix         = $container->get( 'api.prefix' );
 		return new EarlyOrderHandler( $state, $order_processor, $session_handler, $prefix );
 	},
-	'button.endpoint.approve-order'            => static function ( ContainerInterface $container ): ApproveOrderEndpoint {
+	'button.endpoint.approve-order'               => static function ( ContainerInterface $container ): ApproveOrderEndpoint {
 		$request_data    = $container->get( 'button.request-data' );
 		$order_endpoint  = $container->get( 'api.endpoint.order' );
 		$session_handler = $container->get( 'session.handler' );
@@ -165,7 +166,7 @@ return array(
 			$logger
 		);
 	},
-	'button.endpoint.data-client-id'           => static function( ContainerInterface $container ) : DataClientIdEndpoint {
+	'button.endpoint.data-client-id'              => static function( ContainerInterface $container ) : DataClientIdEndpoint {
 		$request_data   = $container->get( 'button.request-data' );
 		$identity_token = $container->get( 'api.endpoint.identity-token' );
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
@@ -175,39 +176,47 @@ return array(
 			$logger
 		);
 	},
-	'button.endpoint.vault-paypal'             => static function( ContainerInterface $container ) : StartPayPalVaultingEndpoint {
+	'button.endpoint.vault-paypal'                => static function( ContainerInterface $container ) : StartPayPalVaultingEndpoint {
 		return new StartPayPalVaultingEndpoint(
 			$container->get( 'button.request-data' ),
 			$container->get( 'api.endpoint.payment-token' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'button.helper.three-d-secure'             => static function ( ContainerInterface $container ): ThreeDSecure {
+	'button.helper.three-d-secure'                => static function ( ContainerInterface $container ): ThreeDSecure {
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 		return new ThreeDSecure( $logger );
 	},
-	'button.helper.messages-apply'             => static function ( ContainerInterface $container ): MessagesApply {
+	'button.helper.messages-apply'                => static function ( ContainerInterface $container ): MessagesApply {
 		return new MessagesApply(
 			$container->get( 'api.shop.country' )
 		);
 	},
 
-	'button.is-logged-in'                      => static function ( ContainerInterface $container ): bool {
+	'button.is-logged-in'                         => static function ( ContainerInterface $container ): bool {
 		return is_user_logged_in();
 	},
-	'button.registration-required'             => static function ( ContainerInterface $container ): bool {
+	'button.registration-required'                => static function ( ContainerInterface $container ): bool {
 		return WC()->checkout()->is_registration_required();
 	},
-	'button.current-user-must-register'        => static function ( ContainerInterface $container ): bool {
+	'button.current-user-must-register'           => static function ( ContainerInterface $container ): bool {
 		return ! $container->get( 'button.is-logged-in' ) &&
 			$container->get( 'button.registration-required' );
 	},
 
-	'button.basic-checkout-validation-enabled' => static function ( ContainerInterface $container ): bool {
+	'button.basic-checkout-validation-enabled'    => static function ( ContainerInterface $container ): bool {
 		/**
 		 * The filter allowing to disable the basic client-side validation of the checkout form
 		 * when the PayPal button is clicked.
 		 */
-		return (bool) apply_filters( 'woocommerce_paypal_payments_basic_checkout_validation_enabled', true );
+		return (bool) apply_filters( 'woocommerce_paypal_payments_basic_checkout_validation_enabled', false );
+	},
+	'button.early-wc-checkout-validation-enabled' => static function ( ContainerInterface $container ): bool {
+		/**
+		 * The filter allowing to disable the WC validation of the checkout form
+		 * when the PayPal button is clicked.
+		 * The validation is triggered in a non-standard way and may cause issues on some sites.
+		 */
+		return (bool) apply_filters( 'woocommerce_paypal_payments_early_wc_checkout_validation_enabled', true );
 	},
 );

--- a/modules/ppcp-button/src/Exception/ValidationException.php
+++ b/modules/ppcp-button/src/Exception/ValidationException.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * ValidationException.
+ *
+ * @package WooCommerce\PayPalCommerce\Button\Exception
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Exception;
+
+/**
+ * Class ValidationException
+ */
+class ValidationException extends RuntimeException {
+	/**
+	 * The error messages.
+	 *
+	 * @var string[]
+	 */
+	protected $errors;
+
+	/**
+	 * ValidationException constructor.
+	 *
+	 * @param string[] $errors The validation error messages.
+	 * @param string   $message The error message.
+	 */
+	public function __construct( array $errors, string $message = '' ) {
+		$this->errors = $errors;
+
+		if ( ! $message ) {
+			$message = implode( ' ', $errors );
+		}
+
+		parent::__construct( $message );
+	}
+
+	/**
+	 * The error messages.
+	 *
+	 * @return string[]
+	 */
+	public function errors(): array {
+		return $this->errors;
+	}
+}

--- a/modules/ppcp-button/src/Validation/CheckoutFormValidator.php
+++ b/modules/ppcp-button/src/Validation/CheckoutFormValidator.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Executes WC checkout validation.
+ *
+ * @package WooCommerce\PayPalCommerce\Button\Endpoint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Validation;
+
+use WC_Checkout;
+use WooCommerce\PayPalCommerce\Button\Exception\ValidationException;
+use WP_Error;
+
+/**
+ * Class FormValidator
+ */
+class CheckoutFormValidator extends WC_Checkout {
+	/**
+	 * Validates the form data.
+	 *
+	 * @param array $data The form data.
+	 * @return void
+	 * @throws ValidationException When validation fails.
+	 */
+	public function validate( array $data ) {
+		$errors = new WP_Error();
+
+		if ( isset( $data['terms-field'] ) ) {
+			// WC checks this field via $_POST https://github.com/woocommerce/woocommerce/issues/35328 .
+			$_POST['terms-field'] = $data['terms-field'];
+		}
+
+		// It throws some notices when checking fields etc., also from other plugins via hooks.
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		@$this->validate_checkout( $data, $errors );
+
+		if ( $errors->has_errors() ) {
+			throw new ValidationException( $errors->get_error_messages() );
+		}
+	}
+}

--- a/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/CreateOrderEndpointTest.php
@@ -166,6 +166,7 @@ class CreateOrderEndpointTest extends TestCase
             $early_order_handler,
 			false,
 			CardBillingMode::MINIMAL_INPUT,
+			false,
 			new NullLogger()
         );
         return array($payer_factory, $testee);


### PR DESCRIPTION
Added execution of WC [`validate_checkout`](https://github.com/woocommerce/woocommerce/blob/1e94d3fc180783fd17ae096e84b87dda21dfc5e4/plugins/woocommerce/includes/class-wc-checkout.php#L849) during order creation.

This should be better than the basic JS validation #513, but it is still done in a bit non-standard/hacky way, may break depending on other plugins using the hooks, WC version (the method is not the public API, though hopefully `protected` is close enough to that and unlikely to have breaking changes) etc. There is a filter for disabling it. Also we catch/log the (non-validation) errors during the validation execution, if this happens it will be skipped and continue like before #513. The JS validation also remains for now, but disabled by default. 

Also fixed `errorHandler`s in JS, there were multiple instances of these objects creating their own error lists on the page, which was resulting in outdated messages still being present in some cases.

And it seems like after bb86f1b8e the order creation errors were replaced by the generic message (though probably not just this commit because after simply reverting it the messages were still broken), so fixed this too.