### PR TITLE
`PAYMENT_SOURCE_CANNOT_BE_USED` error for pay upon invoice when ship to a different address country different then Germany (942)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -59,6 +59,12 @@ class PayUponInvoiceHelper {
 			return false;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$shipping_country = wc_clean( wp_unslash( $_POST['s_country'] ?? '' ) );
+		if ( $shipping_country && 'DE' !== $shipping_country ) {
+			return false;
+		}
+
 		if ( ! $this->is_valid_currency() ) {
 			return false;
 		}


### PR DESCRIPTION
`PAYMENT_SOURCE_CANNOT_BE_USED` error for pay upon invoice when Ship to a different address country different then Germany

### Steps To Reproduce
- Go to WC->Settings->General
- Put for Store Address Country / State Germany
- Scroll to button Save changes and click
- Go to store
- Add one simple product to cart
- Go to Checkout page
- Add Billing details (country/state Germany)
- Scroll to Ship to a different address
- Add details and Country / State for example Italy
- Select Pay upon Invoice as payment method and add birth day date
- Click on button Place order


