### PR TITLE
Fix err.details check, show message if no details

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -233,8 +233,12 @@ class CreditCardRenderer {
                 this.spinner.unblock();
                 this.errorHandler.clear();
 
-                if (err.details) {
+                if (err.details?.length) {
                     this.errorHandler.message(err.details.map(d => `${d.issue} ${d.description}`).join('<br/>'), true);
+                } else if (err.message) {
+                    this.errorHandler.message(err.message, true);
+                } else {
+                    this.errorHandler.genericError();
                 }
             });
         } else {


### PR DESCRIPTION
The array check was wrong, resulting in no message shown and an error about empty string. Also we should output `.message` if no `.details`, or at least a generic message if no `.message` too
