### PR TITLE
PUI gateway displayed on pay for order page when mandatory billing fields are left empty or country is unsupprted (739)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -459,6 +459,7 @@ class PayUponInvoice {
 				if (
 					! $this->pui_product_status->pui_is_active()
 					|| ! $this->pui_helper->is_checkout_ready_for_pui()
+					|| ! $this->pui_helper->is_pay_for_order_ready_for_pui()
 				) {
 					unset( $methods[ PayUponInvoiceGateway::ID ] );
 				}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -167,8 +167,9 @@ class PayUponInvoiceHelper {
 			'country',
 		);
 
-		foreach ( $address as $key => $value ) {
-			if ( in_array( $key, $required_fields, true ) && $value === '' ) {
+		foreach ( $required_fields as $key ) {
+			$value = $address[ $key ] ?? '';
+			if ( $value === '' ) {
 				return false;
 			}
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -78,6 +78,39 @@ class PayUponInvoiceHelper {
 	}
 
 	/**
+	 * Checks whether pay for order is ready for PUI.
+	 *
+	 * @return bool
+	 */
+	public function is_pay_for_order_ready_for_pui(): bool {
+		/**
+		 * Needed for WordPress `query_vars`.
+		 *
+		 * @psalm-suppress InvalidGlobal
+		 */
+		global $wp;
+
+		$order_id = isset( $wp->query_vars['order-pay'] ) ? (int) $wp->query_vars['order-pay'] : 0;
+		if ( $order_id === 0 ) {
+			return false;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! is_a( $order, WC_Order::class ) ) {
+			return false;
+		}
+
+		$address = $order->get_address();
+		foreach ( $address as $key => $value ) {
+			if ( $value === '' ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * Checks if currency is allowed for PUI.
 	 *
 	 * @return bool

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -155,9 +155,20 @@ class PayUponInvoiceHelper {
 			return false;
 		}
 
-		$address = $order->get_address();
+		$address         = $order->get_address();
+		$required_fields = array(
+			'first_name',
+			'last_name',
+			'email',
+			'phone',
+			'address_1',
+			'city',
+			'postcode',
+			'country',
+		);
+
 		foreach ( $address as $key => $value ) {
-			if ( $value === '' ) {
+			if ( in_array( $key, $required_fields, true ) && $value === '' ) {
 				return false;
 			}
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -145,7 +145,7 @@ class PayUponInvoiceHelper {
 		 */
 		global $wp;
 
-		$order_id = isset( $wp->query_vars['order-pay'] ) ? (int) $wp->query_vars['order-pay'] : 0;
+		$order_id = (int) ( $wp->query_vars['order-pay'] ?? 0 );
 		if ( $order_id === 0 ) {
 			return false;
 		}


### PR DESCRIPTION
If merchant sent an link to customer to pay for the order without all mandatory billing fields filled in or added unsupported one to billing details, customer will see PUI gateway and is able to place the order which will fail on the same page.

### Steps To Reproduce
- From WC orders click on Add order button
- Expand the billing section to see all the billing fields
- Fill in all mandatory billing fields except country / region. ( or leave all or some mandatory fields empty)
- Add an supported product to the order 
- Create the order
- Click on customer payment page link

Observe, PUI gateway is displayed.