### PR TITLE
Add transaction url support for OXXO

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2143,6 +2143,7 @@ return array(
 			$container->get( 'api.factory.purchase-unit' ),
 			$container->get( 'api.factory.shipping-preference' ),
 			$container->get( 'wcgateway.url' ),
+			$container->get( 'wcgateway.transaction-url-provider' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
@@ -10,12 +10,14 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO;
 
 use Psr\Log\LoggerInterface;
+use WC_Order;
 use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingPreferenceFactory;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 
 /**
  * Class OXXOGateway.
@@ -52,6 +54,13 @@ class OXXOGateway extends WC_Payment_Gateway {
 	private $module_url;
 
 	/**
+	 * The transaction url provider.
+	 *
+	 * @var TransactionUrlProvider
+	 */
+	protected $transaction_url_provider;
+
+	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -65,6 +74,7 @@ class OXXOGateway extends WC_Payment_Gateway {
 	 * @param PurchaseUnitFactory       $purchase_unit_factory The purchase unit factory.
 	 * @param ShippingPreferenceFactory $shipping_preference_factory The shipping preference factory.
 	 * @param string                    $module_url The URL to the module.
+	 * @param TransactionUrlProvider    $transaction_url_provider The transaction url provider.
 	 * @param LoggerInterface           $logger The logger.
 	 */
 	public function __construct(
@@ -72,6 +82,7 @@ class OXXOGateway extends WC_Payment_Gateway {
 		PurchaseUnitFactory $purchase_unit_factory,
 		ShippingPreferenceFactory $shipping_preference_factory,
 		string $module_url,
+		TransactionUrlProvider $transaction_url_provider,
 		LoggerInterface $logger
 	) {
 		$this->id = self::ID;
@@ -99,7 +110,8 @@ class OXXOGateway extends WC_Payment_Gateway {
 		$this->module_url                  = $module_url;
 		$this->logger                      = $logger;
 
-		$this->icon = esc_url( $this->module_url ) . 'assets/images/oxxo.svg';
+		$this->icon                     = esc_url( $this->module_url ) . 'assets/images/oxxo.svg';
+		$this->transaction_url_provider = $transaction_url_provider;
 	}
 
 	/**
@@ -197,5 +209,18 @@ class OXXOGateway extends WC_Payment_Gateway {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Return transaction url for this gateway and given order.
+	 *
+	 * @param WC_Order $order WC order to get transaction url by.
+	 *
+	 * @return string
+	 */
+	public function get_transaction_url( $order ): string {
+		$this->view_transaction_url = $this->transaction_url_provider->get_transaction_url_base( $order );
+
+		return parent::get_transaction_url( $order );
 	}
 }

--- a/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
@@ -13,6 +13,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingPreferenceFactory;
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use function Brain\Monkey\Functions\when;
 
 class OXXOGatewayTest extends TestCase
@@ -22,6 +23,7 @@ private $purchaseUnitFactory;
 private $shippingPreferenceFactory;
 private $logger;
 private $wcOrder;
+private $transactionUrlProvider;
 private $testee;
 
 	public function setUp(): void
@@ -31,6 +33,7 @@ private $testee;
 		$this->orderEndpoint = Mockery::mock(OrderEndpoint::class);
 		$this->purchaseUnitFactory = Mockery::mock(PurchaseUnitFactory::class);
 		$this->shippingPreferenceFactory = Mockery::mock(ShippingPreferenceFactory::class);
+		$this->transactionUrlProvider = Mockery::mock(TransactionUrlProvider::class);
 		$this->logger = Mockery::mock(LoggerInterface::class);
 
 		$this->wcOrder = Mockery::mock(WC_Order::class);
@@ -45,6 +48,7 @@ private $testee;
 			$this->purchaseUnitFactory,
 			$this->shippingPreferenceFactory,
 			'oxxo.svg',
+			$this->transactionUrlProvider,
 			$this->logger
 		);
 	}


### PR DESCRIPTION
OXXO payment gateway is missing support for transaction URL, this PR adds `get_transaction_url` to the gateway. 