### PR TITLE
Fix the tracking status label filter.

### DIFF
--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -48,7 +48,12 @@ return array(
 		);
 	},
 	'order-tracking.allowed-shipping-statuses' => static function ( ContainerInterface $container ): array {
-		return array( 'SHIPPED', 'ON_HOLD', 'DELIVERED', 'CANCELLED' );
+		return array(
+			'SHIPPED'   => 'SHIPPED',
+			'ON_HOLD'   => 'ON_HOLD',
+			'DELIVERED' => 'DELIVERED',
+			'CANCELLED' => 'CANCELLED',
+		);
 	},
 	'order-tracking.allowed-carriers'          => static function ( ContainerInterface $container ): array {
 		return require __DIR__ . '/carriers.php';

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -100,8 +100,8 @@ class MetaBoxRenderer {
 		<p>
 			<label for="<?php echo esc_attr( self::NAME_PREFIX ); ?>-status"><?php echo esc_html__( 'Status', 'woocommerce-paypal-payments' ); ?></label>
 			<select class="<?php echo esc_attr( self::NAME_PREFIX ); ?>-status" id="<?php echo esc_attr( self::NAME_PREFIX ); ?>-status" name="<?php echo esc_attr( self::NAME_PREFIX ); ?>[status]">
-				<?php foreach ( $statuses as $status ) : ?>
-					<option value="<?php echo esc_attr( $status ); ?>" <?php selected( $status_value, $status ); ?>><?php echo esc_html( $status ); ?></option>
+				<?php foreach ( $statuses as $key => $status ) : ?>
+					<option value="<?php echo esc_attr( $key ); ?>" <?php selected( $status_value, $key ); ?>><?php echo esc_html( $status ); ?></option>
 				<?php endforeach; ?>
 			</select>
 		</p>


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #970

---

### Description

This filter does not work as expected:
```
add_filter('woocommerce_paypal_payments_tracking_statuses', static function(array $statuses): array {
    $statuses['SHIPPED'] = 'TEST';
    return $statuses;
});
```
The label in the tracking metabox should be `TEST` and the value that is sent to PayPal should be `SHIPPED`.

But the plugin would send `TEST` instead of `SHIPPED` which results in an API error because PayPal does not accept the value.

The PR will fix this so that the status labels can be filtered correctly.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Add the filter.
2. Add tracking info to order with custom status.
3. Creating/updating tracking works correctly.

---

Closes #970 .
