### PR TITLE
Isolate container and modularity deps

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,14 +5,14 @@
  * @package WooCommerce\PayPalCommerce
  */
 
-use Dhii\Container\CachingContainer;
-use Dhii\Container\CompositeCachingServiceProvider;
-use Dhii\Container\CompositeContainer;
-use Dhii\Container\DelegatingContainer;
-use Dhii\Container\ProxyContainer;
-use Dhii\Modular\Module\ModuleInterface;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\CachingContainer;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\CompositeCachingServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\CompositeContainer;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\DelegatingContainer;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ProxyContainer;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return function (
 	string $root_dir,

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,6 @@
     "require": {
         "php": "^7.1 | ^8.0",
         "ext-json": "*",
-        "dhii/module-interface": "^0.2 || ^0.3",
-        "container-interop/service-provider": "^0.4.0",
-        "dhii/containers": "^0.1.0-alpha1",
         "psr/log": "^1.1",
         "ralouphie/getallheaders": "^3.0",
         "wikimedia/composer-merge-plugin": "^1.4",
@@ -18,6 +15,9 @@
     },
     "require-dev": {
         "psr/container": "^1.0",
+        "dhii/module-interface": "^0.2 || ^0.3",
+        "container-interop/service-provider": "^0.4.0",
+        "dhii/containers": "^0.1.0-alpha1",
         "woocommerce/woocommerce-sniffs": "^0.1.0",
         "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
         "brain/monkey": "^2.4",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "php": "^7.1 | ^8.0",
         "ext-json": "*",
         "dhii/module-interface": "^0.2 || ^0.3",
-        "psr/container": "^1.0",
         "container-interop/service-provider": "^0.4.0",
         "dhii/containers": "^0.1.0-alpha1",
         "psr/log": "^1.1",
@@ -18,6 +17,7 @@
         "symfony/polyfill-php80": "^1.19"
     },
     "require-dev": {
+        "psr/container": "^1.0",
         "woocommerce/woocommerce-sniffs": "^0.1.0",
         "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
         "brain/monkey": "^2.4",
@@ -28,7 +28,8 @@
     },
     "autoload": {
         "psr-4": {
-            "WooCommerce\\PayPalCommerce\\": "src"
+            "WooCommerce\\PayPalCommerce\\": "src",
+            "WooCommerce\\PayPalCommerce\\Vendor\\": "lib/packages/"
         }
     },
     "autoload-dev": {
@@ -63,6 +64,18 @@
             "pre-commit": [
                 "vendor/bin/phpcbf"
             ]
+        },
+        "mozart": {
+            "dep_namespace": "WooCommerce\\PayPalCommerce\\Vendor\\",
+            "dep_directory": "/lib/packages/",
+            "classmap_directory": "/lib/classes/",
+            "classmap_prefix": "PCPP_",
+            "packages": [
+                "psr/container",
+                "dhii/containers",
+                "dhii/module-interface"
+            ],
+            "delete_vendor_directories": true
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -809,12 +809,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Amp\\ByteStream\\": "lib"
-                },
                 "files": [
                     "lib/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Amp\\ByteStream\\": "lib"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b16b39502bcfa86aaf9a9a53d78b187",
+    "content-hash": "7cab7228653731c826171dbf4956da77",
     "packages": [
         {
             "name": "container-interop/service-provider",
@@ -36,113 +36,6 @@
             "description": "Promoting container interoperability through standard service providers",
             "homepage": "https://github.com/container-interop/service-provider",
             "time": "2017-09-20T14:13:36+00:00"
-        },
-        {
-            "name": "dhii/collections-interface",
-            "version": "v0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Dhii/collections-interface.git",
-                "reference": "74464a969b340d16889eacd9eadc9817f7e7f47a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/collections-interface/zipball/74464a969b340d16889eacd9eadc9817f7e7f47a",
-                "reference": "74464a969b340d16889eacd9eadc9817f7e7f47a",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 | ^8.0",
-                "psr/container": "^1.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
-                "slevomat/coding-standard": "^6.0",
-                "vimeo/psalm": "^4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-develop": "0.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Dhii\\Collection\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dhii Team",
-                    "email": "development@dhii.co"
-                },
-                {
-                    "name": "Anton Ukhanev",
-                    "email": "xedin.unknown@gmail.com"
-                }
-            ],
-            "description": "A highly ISP-compliant collection of interfaces that represent maps and lists.",
-            "time": "2021-10-06T10:56:09+00:00"
-        },
-        {
-            "name": "dhii/containers",
-            "version": "v0.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Dhii/containers.git",
-                "reference": "42ab24683183fa0dc155f26c6a470ef697bbdc9a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/containers/zipball/42ab24683183fa0dc155f26c6a470ef697bbdc9a",
-                "reference": "42ab24683183fa0dc155f26c6a470ef697bbdc9a",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/service-provider": "^0.4",
-                "dhii/collections-interface": "^0.3.0-alpha4",
-                "php": "^7.1 | ^8.0"
-            },
-            "require-dev": {
-                "gmazzap/andrew": "^1.1",
-                "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
-                "psr/container": "^1.0",
-                "psr/simple-cache": "^1.0",
-                "slevomat/coding-standard": "^6.0",
-                "vimeo/psalm": "^4.0",
-                "wildwolf/psr-memory-cache": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-develop": "0.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Dhii\\Container\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dhii Team",
-                    "email": "development@dhii.co"
-                }
-            ],
-            "description": "A selection of PSR-11 containers for utility, simplicity, and ease.",
-            "keywords": [
-                "PSR-11",
-                "container"
-            ],
-            "time": "2021-10-06T11:13:51+00:00"
         },
         {
             "name": "dhii/human-readable-interface",
@@ -1301,6 +1194,113 @@
                 "tests"
             ],
             "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "dhii/collections-interface",
+            "version": "v0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/collections-interface.git",
+                "reference": "74464a969b340d16889eacd9eadc9817f7e7f47a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/collections-interface/zipball/74464a969b340d16889eacd9eadc9817f7e7f47a",
+                "reference": "74464a969b340d16889eacd9eadc9817f7e7f47a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 | ^8.0",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
+                "slevomat/coding-standard": "^6.0",
+                "vimeo/psalm": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "0.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Collection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                },
+                {
+                    "name": "Anton Ukhanev",
+                    "email": "xedin.unknown@gmail.com"
+                }
+            ],
+            "description": "A highly ISP-compliant collection of interfaces that represent maps and lists.",
+            "time": "2021-10-06T10:56:09+00:00"
+        },
+        {
+            "name": "dhii/containers",
+            "version": "v0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/containers.git",
+                "reference": "42ab24683183fa0dc155f26c6a470ef697bbdc9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/containers/zipball/42ab24683183fa0dc155f26c6a470ef697bbdc9a",
+                "reference": "42ab24683183fa0dc155f26c6a470ef697bbdc9a",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/service-provider": "^0.4",
+                "dhii/collections-interface": "^0.3.0-alpha4",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "gmazzap/andrew": "^1.1",
+                "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
+                "psr/container": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "slevomat/coding-standard": "^6.0",
+                "vimeo/psalm": "^4.0",
+                "wildwolf/psr-memory-cache": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-develop": "0.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "A selection of PSR-11 containers for utility, simplicity, and ease.",
+            "keywords": [
+                "PSR-11",
+                "container"
+            ],
+            "time": "2021-10-06T11:13:51+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c556381af92720a1f7c3cd0795c2653a",
+    "content-hash": "2b16b39502bcfa86aaf9a9a53d78b187",
     "packages": [
         {
             "name": "container-interop/service-provider",
@@ -1601,16 +1601,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "472fa8ca4e55483d55ee1e73c963718c4393791d"
+                "reference": "dc206df4fa314a50bbb81cf72239a305c5bbd5c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/472fa8ca4e55483d55ee1e73c963718c4393791d",
-                "reference": "472fa8ca4e55483d55ee1e73c963718c4393791d",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/dc206df4fa314a50bbb81cf72239a305c5bbd5c0",
+                "reference": "dc206df4fa314a50bbb81cf72239a305c5bbd5c0",
                 "shasum": ""
             },
             "require": {
@@ -1662,7 +1662,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2021-09-13T15:33:03+00:00"
+            "time": "2022-09-07T15:05:49+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1767,16 +1767,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.14.0",
+            "version": "v4.15.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1"
+                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/34bea19b6e03d8153165d8f30bba4c3be86184c1",
-                "reference": "34bea19b6e03d8153165d8f30bba4c3be86184c1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
+                "reference": "0ef6c55a3f47f89d7a374e6f835197a0b5fcf900",
                 "shasum": ""
             },
             "require": {
@@ -1815,7 +1815,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2022-05-31T20:59:12+00:00"
+            "time": "2022-09-04T07:30:47+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -2010,16 +2010,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.9.3",
+            "version": "v5.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "18d56875e5078a50b8ea4bc4b20b735ca61edeee"
+                "reference": "3e481f4c8195fb3ca9e3e4e52e5305bf59c74cdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/18d56875e5078a50b8ea4bc4b20b735ca61edeee",
-                "reference": "18d56875e5078a50b8ea4bc4b20b735ca61edeee",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/3e481f4c8195fb3ca9e3e4e52e5305bf59c74cdb",
+                "reference": "3e481f4c8195fb3ca9e3e4e52e5305bf59c74cdb",
                 "shasum": ""
             },
             "replace": {
@@ -2049,7 +2049,7 @@
                 "static analysis",
                 "wordpress"
             ],
-            "time": "2022-04-06T15:33:59+00:00"
+            "time": "2022-09-30T17:45:35+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -2111,16 +2111,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
                 "shasum": ""
             },
             "require": {
@@ -2157,22 +2157,23 @@
                 "paragonie",
                 "phpcs",
                 "polyfill",
-                "standards"
+                "standards",
+                "static analysis"
             ],
-            "time": "2021-02-15T10:24:51+00:00"
+            "time": "2022-10-25T01:46:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308"
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/d55de55f88697b9cdb94bccf04f14eb3b11cf308",
-                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
                 "shasum": ""
             },
             "require": {
@@ -2207,9 +2208,10 @@
                 "compatibility",
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
-            "time": "2021-12-30T16:37:40+00:00"
+            "time": "2022-10-24T09:00:36+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2696,6 +2698,12 @@
             "keywords": [
                 "timer"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-11-30T08:20:02+00:00"
         },
         {
@@ -2744,6 +2752,12 @@
             "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
             "keywords": [
                 "tokenizer"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
             ],
             "abandoned": true,
             "time": "2021-07-26T12:15:06+00:00"
@@ -2875,20 +2889,26 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-11-30T08:15:22+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "3.0.3",
+            "version": "3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
-                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
+                "reference": "1dc7ceb4a24aede938c7af2a9ed1de09609ca770",
                 "shasum": ""
             },
             "require": {
@@ -2939,7 +2959,13 @@
                 "compare",
                 "equality"
             ],
-            "time": "2020-11-30T08:04:30+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-09-14T12:31:48+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -2995,6 +3021,12 @@
                 "unidiff",
                 "unified diff"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-11-30T07:59:04+00:00"
         },
         {
@@ -3048,20 +3080,26 @@
                 "environment",
                 "hhvm"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-11-30T07:53:42+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.4",
+            "version": "3.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db"
+                "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
-                "reference": "0c32ea2e40dbf59de29f3b49bf375176ce7dd8db",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/73a9676f2833b9a7c36968f9d882589cd75511e6",
+                "reference": "73a9676f2833b9a7c36968f9d882589cd75511e6",
                 "shasum": ""
             },
             "require": {
@@ -3121,7 +3159,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-11T13:51:24+00:00"
+            "time": "2022-09-14T06:00:17+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -3219,6 +3257,12 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-11-30T07:40:27+00:00"
         },
         {
@@ -3264,6 +3308,12 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-11-30T07:37:18+00:00"
         },
         {
@@ -3317,6 +3367,12 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-11-30T07:34:24+00:00"
         },
         {
@@ -3359,6 +3415,12 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-11-30T07:30:19+00:00"
         },
         {
@@ -3406,16 +3468,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
-                "reference": "a2cd51b45bcaef9c1f2a4bda48f2dd2fa2b95563",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -3453,20 +3515,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2022-06-13T06:31:38+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v4.4.42",
+            "version": "v4.4.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cce7a9f99e22937a71a16b23afa762558808d587"
+                "reference": "8e70c1cab07ac641b885ce80385b9824a293c623"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cce7a9f99e22937a71a16b23afa762558808d587",
-                "reference": "cce7a9f99e22937a71a16b23afa762558808d587",
+                "url": "https://api.github.com/repos/symfony/console/zipball/8e70c1cab07ac641b885ce80385b9824a293c623",
+                "reference": "8e70c1cab07ac641b885ce80385b9824a293c623",
                 "shasum": ""
             },
             "require": {
@@ -3540,7 +3602,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-14T12:35:33+00:00"
+            "time": "2022-10-26T16:02:45+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3779,16 +3841,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v1.1.12",
+            "version": "v1.1.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "eedb374f02031714a48848758a27812f3eca317a"
+                "reference": "afa00c500c2d6aea6e3b2f4862355f507bc5ebb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/eedb374f02031714a48848758a27812f3eca317a",
-                "reference": "eedb374f02031714a48848758a27812f3eca317a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/afa00c500c2d6aea6e3b2f4862355f507bc5ebb4",
+                "reference": "afa00c500c2d6aea6e3b2f4862355f507bc5ebb4",
                 "shasum": ""
             },
             "require": {
@@ -3851,7 +3913,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-09T13:39:03+00:00"
+            "time": "2022-05-27T14:01:05+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -3895,16 +3957,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "4.23.0",
+            "version": "4.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88"
+                "reference": "d0bc6e25d89f649e4f36a534f330f8bb4643dd69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/f1fe6ff483bf325c803df9f510d09a03fd796f88",
-                "reference": "f1fe6ff483bf325c803df9f510d09a03fd796f88",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d0bc6e25d89f649e4f36a534f330f8bb4643dd69",
+                "reference": "d0bc6e25d89f649e4f36a534f330f8bb4643dd69",
                 "shasum": ""
             },
             "require": {
@@ -3943,6 +4005,7 @@
                 "phpdocumentor/reflection-docblock": "^5",
                 "phpmyadmin/sql-parser": "5.1.0||dev-master",
                 "phpspec/prophecy": ">=1.9.0",
+                "phpstan/phpdoc-parser": "1.2.* || 1.6.4",
                 "phpunit/phpunit": "^9.0",
                 "psalm/plugin-phpunit": "^0.16",
                 "slevomat/coding-standard": "^7.0",
@@ -3994,20 +4057,20 @@
                 "inspection",
                 "php"
             ],
-            "time": "2022-04-28T17:35:49+00:00"
+            "time": "2022-11-06T20:37:08+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.4.1",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "264dce589e7ce37a7ba99cb901eed8249fbec92f"
+                "reference": "1a7ea2afc49c3ee6d87061f5a233e3a035d0eae7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/264dce589e7ce37a7ba99cb901eed8249fbec92f",
-                "reference": "264dce589e7ce37a7ba99cb901eed8249fbec92f",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/1a7ea2afc49c3ee6d87061f5a233e3a035d0eae7",
+                "reference": "1a7ea2afc49c3ee6d87061f5a233e3a035d0eae7",
                 "shasum": ""
             },
             "require": {
@@ -4022,15 +4085,19 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-filter": "*",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.21 || ^9.5.10"
+                "phpunit/phpunit": "^7.5.20 || ^8.5.30 || ^9.5.25"
             },
             "suggest": {
                 "ext-filter": "Required to use the boolean validator."
             },
             "type": "library",
             "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": true
+                },
                 "branch-alias": {
-                    "dev-master": "5.4-dev"
+                    "dev-master": "5.5-dev"
                 }
             },
             "autoload": {
@@ -4070,7 +4137,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-12T23:22:04+00:00"
+            "time": "2022-10-16T01:01:54+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,5 @@
+The packages that are likely to cause conflicts with other plugins (by loading multiple incompatible versions).
+Their namespaces are isolated by [Mozart](https://github.com/coenjacobs/mozart).
+
+Currently, the packages are simply added in the repo to avoid making the build process more complex (Mozart has different PHP requirements).
+We need to isolate only PSR-11 containers and Dhii modularity packages, which are not supposed to change often.

--- a/lib/packages/Dhii/Collection/ClearableContainerInterface.php
+++ b/lib/packages/Dhii/Collection/ClearableContainerInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerExceptionInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+
+interface ClearableContainerInterface extends PsrContainerInterface
+{
+    /**
+     * Removes all members from this container.
+     *
+     * @psalm-suppress InvalidThrow In PSR-11, this interface does not extend `Throwable`.
+     * @throws ContainerExceptionInterface If problem removing.
+     */
+    public function clear(): void;
+}

--- a/lib/packages/Dhii/Collection/ContainerFactoryInterface.php
+++ b/lib/packages/Dhii/Collection/ContainerFactoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use Exception;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Creates containers based on data maps.
+ */
+interface ContainerFactoryInterface
+{
+    /**
+     * Creates a container based on data.
+     *
+     * @param array<string, mixed> $data The data for the container.
+     *
+     * @return ContainerInterface The new container.
+     *
+     * @throws Exception If problem creating.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function createContainerFromArray(array $data): ContainerInterface;
+}

--- a/lib/packages/Dhii/Collection/ContainerInterface.php
+++ b/lib/packages/Dhii/Collection/ContainerInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as BaseContainerInterface;
+
+/**
+ * Something that can retrieve and determine the existence of a value by key.
+ */
+interface ContainerInterface extends
+    HasCapableInterface,
+    BaseContainerInterface
+{
+}

--- a/lib/packages/Dhii/Collection/CountableListInterface.php
+++ b/lib/packages/Dhii/Collection/CountableListInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use Traversable;
+use Countable;
+
+/**
+ * A list that can be counted.
+ *
+ * @since 0.2
+ */
+interface CountableListInterface extends
+    /* @since 0.2 */
+    Traversable,
+    /* @since 0.2 */
+    Countable
+{
+}

--- a/lib/packages/Dhii/Collection/CountableMapInterface.php
+++ b/lib/packages/Dhii/Collection/CountableMapInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+/**
+ * A countable map.
+ *
+ * @since 0.2
+ *
+ * @psalm-suppress UnusedClass
+ */
+interface CountableMapInterface extends
+    /* @since 0.2 */
+    CountableListInterface,
+    /* @since 0.2 */
+    MapInterface
+{
+
+}

--- a/lib/packages/Dhii/Collection/CountableSetInterface.php
+++ b/lib/packages/Dhii/Collection/CountableSetInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+/**
+ * A countable list that can be checked for a key.
+ *
+ * @since 0.2
+ *
+ * @psalm-suppress UnusedClass
+ */
+interface CountableSetInterface extends
+    /* @since 0.2 */
+    CountableListInterface,
+    /* @since 0.2 */
+    SetInterface
+{
+
+}

--- a/lib/packages/Dhii/Collection/HasCapableInterface.php
+++ b/lib/packages/Dhii/Collection/HasCapableInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerExceptionInterface;
+
+/**
+ * Something that can determine the existence of a key.
+ */
+interface HasCapableInterface
+{
+    /**
+     * Determines whether this instance has the specified key.
+     *
+     * @param string $key The key to check for.
+     *
+     * @return bool True if the key exists; false otherwise.
+     *
+     * @throws ContainerExceptionInterface If problem determining.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     * @psalm-suppress InvalidThrow
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    public function has($key);
+}

--- a/lib/packages/Dhii/Collection/HasItemCapableInterface.php
+++ b/lib/packages/Dhii/Collection/HasItemCapableInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use RuntimeException;
+
+/**
+ * Something that can check for the existence of an item.
+ *
+ * @since 0.2
+ */
+interface HasItemCapableInterface
+{
+    /**
+     * Checks whether this instance has the given item.
+     *
+     * @since 0.2
+     *
+     * @param mixed $item The item to check for.
+     *
+     * @return bool True if the item exists; false otherwise.
+     *
+     * @throws RuntimeException If the existence of the item could not be verified.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function hasItem($item): bool;
+}

--- a/lib/packages/Dhii/Collection/MapFactoryInterface.php
+++ b/lib/packages/Dhii/Collection/MapFactoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use Exception;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as BaseContainerInterface;
+
+/**
+ * A factory that can create maps.
+ *
+ * @since 0.2
+ */
+interface MapFactoryInterface extends ContainerFactoryInterface
+{
+    /**
+     * Creates a map based on data in an array.
+     *
+     * @param array<string, mixed> $data The data to base the map on.
+     *
+     * @return MapInterface The new map.
+     *
+     * @throws Exception If problem creating.
+     */
+    public function createContainerFromArray(array $data): BaseContainerInterface;
+}

--- a/lib/packages/Dhii/Collection/MapInterface.php
+++ b/lib/packages/Dhii/Collection/MapInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use Traversable;
+
+/**
+ * A traversable container.
+ *
+ * @since 0.2
+ */
+interface MapInterface extends
+    /* @since 0.2 */
+    Traversable,
+    /* @since 0.2 */
+    ContainerInterface
+{
+
+}

--- a/lib/packages/Dhii/Collection/MutableContainerInterface.php
+++ b/lib/packages/Dhii/Collection/MutableContainerInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerExceptionInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * A container that can have mappings added and removed.
+ *
+ * @psalm-suppress UnusedClass
+ */
+interface MutableContainerInterface extends ContainerInterface
+{
+    /**
+     * Maps the given value to the specified key.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $key   The key to map the value to.
+     * @param mixed  $value The value to map to the key.
+     *
+     * @throws ContainerExceptionInterface If problem mapping.
+     * @psalm-suppress InvalidThrow
+     */
+    public function set(string $key, $value): void;
+
+    /**
+     * Unmaps the value from the specified key.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $key The key to unmap the value from.
+     *
+     * @throws NotFoundExceptionInterface  If key not found.
+     * @throws ContainerExceptionInterface If problem unmapping.
+     * @psalm-suppress InvalidThrow
+     */
+    public function unset(string $key): void;
+}

--- a/lib/packages/Dhii/Collection/SetFactoryInterface.php
+++ b/lib/packages/Dhii/Collection/SetFactoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use Exception;
+
+/**
+ * A factory that can create sets.
+ *
+ * @since [*next-version*]
+ */
+interface SetFactoryInterface
+{
+    /**
+     * Creates a set based on data in a list.
+     *
+     * @since [*next-version*]
+     *
+     * @param array<mixed> $list The list to base the set on.
+     *
+     * @return SetInterface The new set.
+     *
+     * @throws Exception If problem creating.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function createSetFromList(array $list): SetInterface;
+}

--- a/lib/packages/Dhii/Collection/SetInterface.php
+++ b/lib/packages/Dhii/Collection/SetInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use Traversable;
+
+/**
+ * A list that can be checked for a key.
+ *
+ * @since 0.2
+ */
+interface SetInterface extends
+    /* @since 0.2 */
+    Traversable,
+    /* @since 0.2 */
+    HasItemCapableInterface
+{
+
+}

--- a/lib/packages/Dhii/Collection/WritableContainerFactoryInterface.php
+++ b/lib/packages/Dhii/Collection/WritableContainerFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * A map that can create a writable container.
+ */
+interface WritableContainerFactoryInterface extends ContainerFactoryInterface
+{
+    /**
+     * @inheritDoc
+     *
+     * @return WritableContainerInterface The new container.
+     */
+    public function createContainerFromArray(array $data): ContainerInterface;
+}

--- a/lib/packages/Dhii/Collection/WritableContainerInterface.php
+++ b/lib/packages/Dhii/Collection/WritableContainerInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use Exception;
+
+/**
+ * A container that can be written to.
+ */
+interface WritableContainerInterface extends ContainerInterface
+{
+    /**
+     * Creates a new instance with the specified mappings.
+     *
+     * @since [*next-version*]
+     *
+     * @param array<string, mixed> $mappings A map of keys to values.
+     *
+     * @return static A new instance of this class with only the specified key-value mappings.
+     *
+     * @throws Exception If problem creating.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function withMappings(array $mappings): WritableContainerInterface;
+
+    /**
+     * Creates a new instance with the specified mappings added to existing ones.
+     *
+     * @since [*next-version*]
+     *
+     * @param array<string, mixed> $mappings A map of keys to values.
+     *
+     * @return static A new instance of this class with the specified key-value mappings added to existing ones.
+     *
+     * @throws Exception If problem creating.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function withAddedMappings(array $mappings): WritableContainerInterface;
+
+    /**
+     * Creates a new instance with the specified keys not present.
+     *
+     * @since [*next-version*]
+     *
+     * @param array<string> $keys The keys to exclude.
+     *
+     * @return static A new instance of this class which does not contain the specified keys.
+     *
+     * @throws Exception If problem instantiating.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function withoutKeys(array $keys): WritableContainerInterface;
+}

--- a/lib/packages/Dhii/Collection/WritableMapFactoryInterface.php
+++ b/lib/packages/Dhii/Collection/WritableMapFactoryInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as BaseContainerInterface;
+
+/**
+ * Creates writable maps.
+ *
+ * @psalm-suppress UnusedClass
+ */
+interface WritableMapFactoryInterface extends WritableContainerFactoryInterface, MapFactoryInterface
+{
+    /**
+     * @inheritDoc
+     *
+     * @return WritableMapInterface The new map.
+     */
+    public function createContainerFromArray(array $data): BaseContainerInterface;
+}

--- a/lib/packages/Dhii/Collection/WritableMapInterface.php
+++ b/lib/packages/Dhii/Collection/WritableMapInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+/**
+ * A map that can have a value set for a key.
+ *
+ * @since [*next-version*]
+ */
+interface WritableMapInterface extends MapInterface, WritableContainerInterface
+{
+
+}

--- a/lib/packages/Dhii/Collection/WritableSetFactoryInterface.php
+++ b/lib/packages/Dhii/Collection/WritableSetFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+/**
+ * Creates writable sets.
+ *
+ * @psalm-suppress UnusedClass
+ */
+interface WritableSetFactoryInterface extends SetFactoryInterface
+{
+    /**
+     * @inheritDoc
+     *
+     * @return WritableSetInterface The new writable set.
+     */
+    public function createSetFromList(array $list): SetInterface;
+}

--- a/lib/packages/Dhii/Collection/WritableSetInterface.php
+++ b/lib/packages/Dhii/Collection/WritableSetInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Collection;
+
+use Exception;
+
+/**
+ * A set that can have items added.
+ *
+ * @psalm-suppress UnusedClass
+ */
+interface WritableSetInterface extends SetInterface
+{
+    /**
+     * Creates a new instance with the given items only.
+     *
+     * @param array|mixed[] $items A list of items for the set.
+     *
+     * @return static A new instance of this class with only the given items.
+     *
+     * @throws Exception If problem creating.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function withItems(array $items);
+
+    /**
+     * Creates a new instance with the given items added to existing ones.
+     *
+     * @param array|mixed[] $items A list of items to add.
+     *
+     * @return static A new instance of this class with the given items added to existing ones.
+     *
+     * @throws Exception If problem creating.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function withAddedItems(array $items): WritableSetInterface;
+
+    /**
+     * Creates a new instance with the given items not present.
+     *
+     * @param array|mixed[] $items A list of items to exclude.
+     *
+     * @return static An instance of this class without the given items.
+     *
+     * @throws Exception If problem creating.
+     *
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function withoutItems(array $items): WritableSetInterface;
+}

--- a/lib/packages/Dhii/Container/AliasingContainer.php
+++ b/lib/packages/Dhii/Container/AliasingContainer.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util\StringTranslatingTrait;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+
+use function array_key_exists;
+
+/**
+ * A container implementation that wraps around an inner container to alias its keys, so consumers can use the aliases
+ * to fetch data from the inner container.
+ */
+class AliasingContainer implements ContainerInterface
+{
+    /* @since [*next-version*] */
+    use StringTranslatingTrait;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var PsrContainerInterface
+     */
+    protected $inner;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var array<array-key, string>
+     */
+    protected $aliases;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param PsrContainerInterface    $inner   The container whose keys to alias.
+     * @param array<array-key, string> $aliases A mapping of aliases to their original container key counterparts.
+     */
+    public function __construct(PsrContainerInterface $inner, array $aliases)
+    {
+        $this->inner = $inner;
+        $this->aliases = $aliases;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function get($key)
+    {
+        return $this->inner->get($this->getInnerKey($key));
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function has($key)
+    {
+        return $this->inner->has($this->getInnerKey($key));
+    }
+
+    /**
+     * Retrieves the key to use for the inner container.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $key The outer key.
+     *
+     * @return string The inner key.
+     */
+    protected function getInnerKey(string $key): string
+    {
+        if (array_key_exists($key, $this->aliases)) {
+            return $this->aliases[$key];
+        }
+
+        return $key;
+    }
+}

--- a/lib/packages/Dhii/Container/CachingContainer.php
+++ b/lib/packages/Dhii/Container/CachingContainer.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\ContainerException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util\StringTranslatingTrait;
+use Exception;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * Caches entries from an internal container.
+ *
+ * @package Dhii\Container1
+ */
+class CachingContainer implements ContainerInterface
+{
+    use StringTranslatingTrait;
+
+    /** @var array<array-key, mixed> */
+    protected $cache;
+
+    /** @var PsrContainerInterface */
+    protected $container;
+
+    /**
+     * @param PsrContainerInterface $container The container to cache entries from.
+     */
+    public function __construct(PsrContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->cache = [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($key)
+    {
+        /** @psalm-suppress RedundantCastGivenDocblockType
+         * @psalm-suppress RedundantCast
+         * Will remove when switching to PHP 7.2 and new PSR-11 interfaces
+         */
+        $key = (string) $key;
+
+        /**
+         * @psalm-suppress InvalidCatch
+         * The base interface does not extend Throwable, but in fact everything that is possible
+         * in theory to catch will be Throwable, and PSR-11 exceptions will implement this interface
+         */
+        try {
+            /**
+             * @psalm-suppress MissingClosureReturnType
+             * Unable to specify mixed before PHP 8.
+             */
+            $value = $this->getCached($key, function () use ($key) {
+                return $this->container->get($key);
+            });
+        } catch (NotFoundExceptionInterface $e) {
+            throw new NotFoundException($this->__('Key "%1$s" not found in inner container', [$key]), 0, $e);
+        } catch (Exception $e) {
+            throw new ContainerException(
+                $this->__('Could not retrieve value for key "%1$s from inner container', [$key]),
+                0,
+                $e
+            );
+        }
+
+        return $value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function has($key)
+    {
+        /** @psalm-suppress RedundantCastGivenDocblockType
+         * Will remove when switching to PHP 7.2 and new PSR-11 interfaces
+         */
+        $key = (string) $key;
+
+        /**
+         * @psalm-suppress InvalidCatch
+         * The base interface does not extend Throwable, but in fact everything that is possible
+         * in theory to catch will be Throwable, and PSR-11 exceptions will implement this interface
+         */
+        try {
+            if ($this->hasCached($key)) {
+                return true;
+            }
+        } catch (Exception $e) {
+            throw new ContainerException($this->__('Could not check cache for key "%1$s"', [$key]), 0, $e);
+        }
+
+        try {
+            if ($this->container->has($key)) {
+                return true;
+            }
+        } catch (Exception $e) {
+            throw new ContainerException(
+                $this->__('Could not check inner container for key "%1$s"', [$key]),
+                0,
+                $e
+            );
+        }
+
+        return false;
+    }
+
+    /**
+     * Retrieves a value by key from cache, creating it if it does not exist.
+     *
+     * @param string $key The key to get.
+     * @param callable $generator Creates the value.
+     *
+     * @return mixed The cached value.
+     *
+     * @throws Exception If problem caching.
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    protected function getCached(string $key, callable $generator)
+    {
+        if (!array_key_exists($key, $this->cache)) {
+            $value = $this->invokeGenerator($generator);
+            $this->cache[$key] = $value;
+        }
+
+        return $this->cache[$key];
+    }
+
+    /**
+     * Checks the cache for the specified key.
+     *
+     * @param string $key The key to check for.
+     *
+     * @return bool True if cache contains the value; false otherwise.
+     *
+     * @throws Exception If problem checking.
+     */
+    protected function hasCached(string $key): bool
+    {
+        return array_key_exists($key, $this->cache);
+    }
+
+    /**
+     * Generates a value by invoking the generator.
+     *
+     * @param callable $generator Generates a value.
+     *
+     * @return mixed The generated result.
+     *
+     * @throws Exception If problem generating.
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    protected function invokeGenerator(callable $generator)
+    {
+        $result = $generator();
+        return $result;
+    }
+}

--- a/lib/packages/Dhii/Container/CompositeCachingServiceProvider.php
+++ b/lib/packages/Dhii/Container/CompositeCachingServiceProvider.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+
+/**
+ * A service provider that aggregates service definitions from other providers.
+ */
+class CompositeCachingServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * @var iterable<ServiceProviderInterface>
+     */
+    protected $providers;
+
+    /**
+     * @var ?iterable<callable>
+     */
+    protected $factories;
+
+    /**
+     * @var ?iterable<callable>
+     */
+    protected $extensions;
+
+    /**
+     * @param iterable<ServiceProviderInterface> $providers
+     */
+    public function __construct(iterable $providers)
+    {
+        $this->providers = $providers;
+        $this->factories = null;
+        $this->extensions = null;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @psalm-suppress InvalidNullableReturnType
+     * It isn't actually going to return null ever, because $factories will be filled during indexing.
+     */
+    public function getFactories()
+    {
+        if (!is_array($this->factories)) {
+            $this->indexProviderDefinitions($this->providers);
+        }
+
+        /**
+         * @psalm-suppress NullableReturnStatement
+         * Not going to be null because will be populated by indexing
+         */
+        return $this->factories;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @psalm-suppress InvalidNullableReturnType
+     * It isn't actually going to return null ever, because $factories will be filled during indexing.
+     */
+    public function getExtensions()
+    {
+        if (!is_array($this->extensions)) {
+            $this->indexProviderDefinitions($this->providers);
+        }
+
+        /**
+         * @psalm-suppress NullableReturnStatement
+         * Not going to be null because will be populated by indexing
+         */
+        return $this->extensions;
+    }
+
+    /**
+     * Indexes definitions in the specified service providers.
+     *
+     * Caches them internally.
+     *
+     * @param iterable|ServiceProviderInterface[] $providers The providers to index.
+     */
+    protected function indexProviderDefinitions(iterable $providers): void
+    {
+        $factories = [];
+        $extensions = [];
+
+        foreach ($providers as $provider) {
+            $factories = $this->mergeFactories($factories, $provider->getFactories());
+            $extensions = $this->mergeExtensions($extensions, $provider->getExtensions());
+        }
+
+        $this->factories = $factories;
+        $this->extensions = $extensions;
+    }
+
+    /**
+     * Merges two maps of factories.
+     *
+     * @param callable[] $defaults The factory map to merge into.
+     * @param callable[] $definitions The factory map to merge. Values from here will override defaults.
+     *
+     * @return callable[] The merged factories.
+     */
+    protected function mergeFactories(array $defaults, array $definitions): array
+    {
+        return array_merge($defaults, $definitions);
+    }
+
+    /**
+     * Merged service extensions.
+     *
+     * @param callable[] $defaults
+     * @param iterable<callable> $extensions
+     *
+     * @return callable[] The merged extensions.
+     */
+    protected function mergeExtensions(array $defaults, iterable $extensions): array
+    {
+        $merged = [];
+
+        foreach ($extensions as $key => $extension) {
+            if (isset($defaults[$key])) {
+                $default = $defaults[$key];
+                /**
+                 * @psalm-suppress MissingClosureReturnType
+                 * @psalm-suppress MissingClosureParamType
+                 * Unable to specify mixed before PHP 8.
+                 */
+                $merged[$key] = function (PsrContainerInterface $c, $previous = null) use ($default, $extension) {
+                    $result = $default($c, $previous);
+                    $result = $extension($c, $result);
+
+                    return $result;
+                };
+
+                unset($defaults[$key]);
+            } else {
+                $merged[$key] = $extension;
+            }
+        }
+
+        $merged = $this->mergeFactories($defaults, $merged);
+
+        return $merged;
+    }
+}

--- a/lib/packages/Dhii/Container/CompositeContainer.php
+++ b/lib/packages/Dhii/Container/CompositeContainer.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\ContainerException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util\StringTranslatingTrait;
+use Exception;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
+use Traversable;
+use UnexpectedValueException;
+
+class CompositeContainer implements ContainerInterface
+{
+    use StringTranslatingTrait;
+
+    /**
+     * @var iterable<PsrContainerInterface>
+     */
+    protected $containers;
+
+    /**
+     * @param iterable<PsrContainerInterface> $containers The list of containers.
+     */
+    public function __construct(iterable $containers)
+    {
+        $this->containers = $containers;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($key)
+    {
+        /** @psalm-suppress RedundantCastGivenDocblockType
+         * @psalm-suppress RedundantCast
+         * Will remove when switching to PHP 7.2 and new PSR-11 interfaces
+         */
+        $key = (string) $key;
+
+        foreach ($this->containers as $index => $container) {
+            /**
+             * @psalm-suppress InvalidCatch
+             * The base interface does not extend Throwable, but in fact everything that is possible
+             * in theory to catch will be Throwable, and PSR-11 exceptions will implement this interface
+             */
+            try {
+                if ($container->has($key)) {
+                    return $container->get($key);
+                }
+            } catch (NotFoundExceptionInterface $e) {
+                throw new NotFoundException(
+                    $this->__('Failed to retrieve value for key "%1$s" from container at index "%2$s"', [$key, $index]),
+                    0,
+                    $e
+                );
+            } catch (Exception $e) {
+                throw new ContainerException(
+                    $this->__('Failed check for key "%1$s" on container at index "%2$s"', [$key, $index]),
+                    0,
+                    $e
+                );
+            }
+        }
+
+        throw new NotFoundException(
+            $this->__('Key "%1$s" not found in any of the containers', [$key]),
+            0,
+            null
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function has($key)
+    {
+        /** @psalm-suppress RedundantCastGivenDocblockType
+         * Will remove when switching to PHP 7.2 and new PSR-11 interfaces
+         */
+        $key = (string) $key;
+
+        foreach ($this->containers as $index => $container) {
+            try {
+                if ($container->has($key)) {
+                    return true;
+                }
+            } catch (Exception $e) {
+                throw new ContainerException(
+                    $this->__('Failed check for key "%1$s" on container at index "%2$s"', [$key, $index]),
+                    0,
+                    $e
+                );
+            }
+        }
+
+        return false;
+    }
+}

--- a/lib/packages/Dhii/Container/DataStructureBasedFactory.php
+++ b/lib/packages/Dhii/Container/DataStructureBasedFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\WritableMapFactoryInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * @inheritDoc
+ */
+class DataStructureBasedFactory implements DataStructureBasedFactoryInterface
+{
+    /**
+     * @var WritableMapFactoryInterface
+     */
+    protected $containerFactory;
+    public function __construct(WritableMapFactoryInterface $containerFactory)
+    {
+        $this->containerFactory = $containerFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function createContainerFromArray(array $structure): ContainerInterface
+    {
+        $map = [];
+        foreach ($structure as $key => $value) {
+            if (is_object($value)) {
+                $value = get_object_vars($value);
+            }
+
+            if (is_array($value)) {
+                $value = $this->createContainerFromArray($value);
+            }
+
+            $map[$key] = $value;
+        }
+
+        $container = $this->containerFactory->createContainerFromArray($map);
+        return $container;
+    }
+}

--- a/lib/packages/Dhii/Container/DataStructureBasedFactoryInterface.php
+++ b/lib/packages/Dhii/Container/DataStructureBasedFactoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\WritableMapFactoryInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\WritableMapInterface;
+use Exception;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as BaseContainerInterface;
+
+/**
+ * Creates a container hierarchy based on a traditional data structure.
+ */
+interface DataStructureBasedFactoryInterface extends WritableMapFactoryInterface
+{
+    /**
+     * Based on a traditional data structure, creates a container hierarchy.
+     *
+     * @param mixed[] $structure The traditional data structure representation.
+     *
+     * @return WritableMapInterface A hierarchy of writable maps that reflects the data structure.
+     *
+     * @throws Exception If problem creating.
+     */
+    public function createContainerFromArray(array $structure): BaseContainerInterface;
+}

--- a/lib/packages/Dhii/Container/DelegatingContainer.php
+++ b/lib/packages/Dhii/Container/DelegatingContainer.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\ContainerException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util\StringTranslatingTrait;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+use UnexpectedValueException;
+
+class DelegatingContainer implements ContainerInterface
+{
+    use StringTranslatingTrait;
+
+    /**
+     * @var ServiceProviderInterface
+     */
+    protected $provider;
+
+    /**
+     * @var PsrContainerInterface|null
+     */
+    protected $parent;
+
+    /**
+     */
+    public function __construct(ServiceProviderInterface $provider, PsrContainerInterface $parent = null)
+    {
+        $this->provider = $provider;
+        $this->parent = $parent;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($id)
+    {
+        $provider = $this->provider;
+        $services = $provider->getFactories();
+
+        if (!array_key_exists($id, $services)) {
+            throw new NotFoundException(
+                $this->__('Service not found for key "%1$s"', [$id]),
+                0,
+                null
+            );
+        }
+
+        $service = $services[$id];
+
+        try {
+            $service = $this->invokeFactory($service);
+        } catch (UnexpectedValueException $e) {
+            throw new ContainerException(
+                $this->__('Could not create service "%1$s"', [$id]),
+                0,
+                $e
+            );
+        }
+
+        $extensions = $provider->getExtensions();
+
+        if (!array_key_exists($id, $extensions)) {
+            return $service;
+        }
+
+        $extension = $extensions[$id];
+
+        try {
+            $service = $this->invokeExtension($extension, $service);
+        } catch (UnexpectedValueException $e) {
+            throw new ContainerException(
+                $this->__('Could not extend service "%1$s"', [$id]),
+                0,
+                $e
+            );
+        }
+
+        return $service;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function has($id)
+    {
+        $services = $this->provider->getFactories();
+
+        return array_key_exists($id, $services);
+    }
+
+    /**
+     * Retrieves a service by invoking its factory.
+     *
+     * @param callable $factory The factory to invoke.
+     *
+     * @return mixed The service created by the factory.
+     *
+     * @throws UnexpectedValueException If factory could not be invoked.
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    protected function invokeFactory(callable $factory)
+    {
+        if (!is_callable($factory)) {
+            throw new UnexpectedValueException(
+                $this->__('Factory could not be invoked'),
+                0,
+                null
+            );
+        }
+
+        $baseContainer = $this->getBaseContainer();
+        $service = $factory($baseContainer);
+
+        return $service;
+    }
+
+    /**
+     * Extends the service by invoking the extension with it.
+     *
+     * @param callable $extension The extension to invoke.
+     * @param mixed $service The service to extend.
+     *
+     * @return mixed The extended service.
+     *
+     * @throws UnexpectedValueException If extension cannot be invoked.
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
+     */
+    protected function invokeExtension(callable $extension, $service)
+    {
+        if (!is_callable($extension)) {
+            throw new UnexpectedValueException(
+                $this->__('Factory could not be invoked'),
+                0,
+                null
+            );
+        }
+
+        $baseContainer = $this->getBaseContainer();
+        $service = $extension($baseContainer, $service);
+
+        return $service;
+    }
+
+    /**
+     * Retrieves the container to be used for definitions and extensions.
+     *
+     * @return PsrContainerInterface The parent container, if set. Otherwise, this instance.
+     */
+    protected function getBaseContainer(): PsrContainerInterface
+    {
+        return $this->parent instanceof PsrContainerInterface
+            ? $this->parent
+            : $this;
+    }
+}

--- a/lib/packages/Dhii/Container/DeprefixingContainer.php
+++ b/lib/packages/Dhii/Container/DeprefixingContainer.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * A container implementation that wraps around an inner container to automatically add prefixes to keys during
+ * fetching and look up, allowing consumers to omit them.
+ *
+ * @since [*next-version*]
+ */
+class DeprefixingContainer implements ContainerInterface
+{
+    /**
+     * @since [*next-version*]
+     *
+     * @var PsrContainerInterface
+     */
+    protected $inner;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var string
+     */
+    protected $prefix;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var bool
+     */
+    protected $strict;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param PsrContainerInterface $container The container whose keys to deprefix.
+     * @param string                $prefix    The prefix to remove from the container's keys.
+     * @param bool                  $strict    Whether or not to fallback to prefixed keys if an un-prefixed key does
+     *                                         not exist in the inner container.
+     */
+    public function __construct(PsrContainerInterface $container, string $prefix, bool $strict = true)
+    {
+        $this->inner = $container;
+        $this->prefix = $prefix;
+        $this->strict = $strict;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function get($key)
+    {
+        /**
+         * @psalm-suppress InvalidCatch
+         * The base interface does not extend Throwable, but in fact everything that is possible
+         * in theory to catch will be Throwable, and PSR-11 exceptions will implement this interface
+         */
+        try {
+            return $this->inner->get($this->getInnerKey($key));
+        } catch (NotFoundExceptionInterface $nfException) {
+            if ($this->strict || !$this->inner->has($key)) {
+                throw $nfException;
+            }
+        }
+
+        return $this->inner->get($key);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function has($key)
+    {
+        return $this->inner->has($this->getInnerKey($key)) || (!$this->strict && $this->inner->has($key));
+    }
+
+    /**
+     * Retrieves the key to use for the inner container.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $key The outer key.
+     *
+     * @return string The inner key.
+     */
+    protected function getInnerKey(string $key): string
+    {
+        return $this->prefix . $key;
+    }
+}

--- a/lib/packages/Dhii/Container/Dictionary.php
+++ b/lib/packages/Dhii/Container/Dictionary.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use ArrayIterator;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\WritableContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\WritableMapInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util\StringTranslatingTrait;
+use IteratorAggregate;
+use RangeException;
+
+/**
+ * A simple mutable dictionary, i.e. an enumerable key-value map.
+ */
+class Dictionary implements
+    IteratorAggregate,
+    WritableMapInterface
+{
+    use StringTranslatingTrait;
+
+    /** @var array<array-key, mixed> */
+    protected $data;
+
+    /**
+     * @param array<array-key, mixed> $data The key-value map of data.
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function get($key)
+    {
+        if (!array_key_exists($key, $this->data)) {
+            throw new NotFoundException(
+                $this->__('Dictionary does not have key "%1$s"', [$key]),
+                0,
+                null
+            );
+        }
+
+        return $this->data[$key];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function has($key)
+    {
+        $isHas = array_key_exists($key, $this->data);
+
+        return $isHas;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->data);
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-suppress MoreSpecificReturnType
+     * Psalm complains that the declared return type is more specific than inferred.
+     * This is not true, as it promises to return the interface.
+     */
+    public function withMappings(array $mappings): WritableContainerInterface
+    {
+        $dictionary = $this->cloneMe();
+        $dictionary->data = $mappings;
+
+        /**
+         * @psalm-suppress LessSpecificReturnStatement
+         * Looks like this needs to be suppressed until able to hint return type `self`.
+         */
+        return $dictionary;
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-suppress MoreSpecificReturnType
+     * Psalm complains that the declared return type is more specific than inferred.
+     * This is not true, as it promises to return the interface.
+     */
+    public function withAddedMappings(array $mappings): WritableContainerInterface
+    {
+        $dictionary = $this->cloneMe();
+        $dictionary->data = $mappings + $this->data;
+
+        /**
+         * @psalm-suppress LessSpecificReturnStatement
+         * Looks like this needs to be suppressed until able to hint return type `self`.
+         */
+        return $dictionary;
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-suppress MoreSpecificReturnType
+     * Psalm complains that the declared return type is more specific than inferred.
+     * This is not true, as it promises to return the interface.
+     */
+    public function withoutKeys(array $keys): WritableContainerInterface
+    {
+        $dictionary = $this->cloneMe();
+
+        foreach ($keys as $i => $key) {
+            /** @psalm-suppress DocblockTypeContradiction Still want to enforce string */
+            if (!is_string($key)) {
+                throw new RangeException($this->__('Key at index %1$d is not a string', [$i]));
+            }
+            unset($dictionary->data[$key]);
+        }
+
+        /**
+         * @psalm-suppress LessSpecificReturnStatement
+         * Looks like this needs to be suppressed until able to hint return type `self`.
+         */
+        return $dictionary;
+    }
+
+    /**
+     * Creates a copy of this instance
+     *
+     * @return Dictionary The new instance
+     */
+    protected function cloneMe(): Dictionary
+    {
+        return clone $this;
+    }
+}

--- a/lib/packages/Dhii/Container/DictionaryFactory.php
+++ b/lib/packages/Dhii/Container/DictionaryFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\WritableMapFactoryInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * @inheritDoc
+ */
+class DictionaryFactory implements WritableMapFactoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function createContainerFromArray(array $data): ContainerInterface
+    {
+        return new Dictionary($data);
+    }
+}

--- a/lib/packages/Dhii/Container/Exception/ContainerException.php
+++ b/lib/packages/Dhii/Container/Exception/ContainerException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception;
+
+use Exception;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerExceptionInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use Throwable;
+
+/**
+ * Basic implementation of container exception.
+ *
+ * @package Dhii\Di
+ */
+class ContainerException extends Exception implements ContainerExceptionInterface
+{
+    /**
+     * @var ContainerInterface|null
+     */
+    protected $container;
+
+    /**
+     * @param string         $message  The exception message.
+     * @param int            $code     The exception code.
+     * @param Throwable|null $previous The inner exception, if any.
+     */
+    public function __construct(string $message = "", int $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/lib/packages/Dhii/Container/Exception/NotFoundException.php
+++ b/lib/packages/Dhii/Container/Exception/NotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception;
+
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
+use Throwable;
+
+class NotFoundException extends ContainerException implements NotFoundExceptionInterface
+{
+    /**
+     * @param string         $message  The error message.
+     * @param int            $code     The error code.
+     * @param Throwable|null $previous The inner error, if any.
+     */
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/lib/packages/Dhii/Container/FlashContainer.php
+++ b/lib/packages/Dhii/Container/FlashContainer.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ClearableContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\MutableContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerExceptionInterface;
+
+/**
+ * A container for data that is accessible once per init.
+ *
+ * The {@see init()} method copies data from the internal container into memory,
+ * then clears it. The data is still accessible from memory,
+ * but no longer from internal container.
+ *
+ * This is useful for flash data, i.e. data that should only be accessible
+ * once per request. If a session-specific persistent container is used
+ * as storage, this will become session-based flash data.
+ */
+class FlashContainer implements
+    MutableContainerInterface,
+    ClearableContainerInterface
+{
+    /** @var MutableContainerInterface */
+    protected $data;
+    /** @var string */
+    protected $dataKey;
+    /** @var array<array-key, scalar> */
+    protected $flashData = [];
+
+    /**
+     * @param MutableContainerInterface $data The storage.
+     * @param string $dataKey The key to be used to store data in the storage.
+     */
+    public function __construct(MutableContainerInterface $data, string $dataKey)
+    {
+        $this->data = $data;
+        $this->dataKey = $dataKey;
+    }
+
+    /**
+     * Prepare storage before use.
+     *
+     * Should be called once before accessing data through this class.
+     * Will clear the data for the configured key from the storage.
+     */
+    public function init(): void
+    {
+        $this->flashData = $this->data->has($this->dataKey)
+            ? $this->data->get($this->dataKey)
+            : [];
+
+        $this->purgePersistentData();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->flashData);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Retrieves the value for the specified key from memory.
+     */
+    public function get($key)
+    {
+        if (!array_key_exists($key, $this->flashData)) {
+            throw new NotFoundException(sprintf('Flash data not found for key "%1$s"', $key));
+        }
+
+        return $this->flashData[$key];
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Assigns the given value to the specified key in memory, and persists this change in storage.
+     */
+    public function set(string $key, $value): void
+    {
+        $this->flashData[$key] = $value;
+        $this->persist($this->flashData);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Removes the specified key from memory, and persists this change in storage.
+     */
+    public function unset(string $key): void
+    {
+        if (!array_key_exists($key, $this->flashData)) {
+            throw new NotFoundException(sprintf('Flash data not found for key "%1$s"', $key));
+        }
+
+        unset($this->flashData[$key]);
+        $this->persist($this->flashData);
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * Clears all of this instance's data from memory.
+     */
+    public function clear(): void
+    {
+        $this->flashData = [];
+        $this->persist($this->flashData);
+    }
+
+    /**
+     * Clear data from internal storage.
+     */
+    protected function purgePersistentData(): void
+    {
+        $this->data->set($this->dataKey, []);
+    }
+
+    /**
+     * Persist this instance's data from memory into storage.
+     *
+     * @param array<array-key, scalar> $data The data to persist.
+     */
+    protected function persist(array $data): void
+    {
+        $this->data->set($this->dataKey, $data);
+    }
+}

--- a/lib/packages/Dhii/Container/HierarchyContainer.php
+++ b/lib/packages/Dhii/Container/HierarchyContainer.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use stdClass;
+
+/**
+ * A container implementation that provides access to hierarchical data in the form a container tree.
+ *
+ * This implementation dynamically transforms hierarchical data into a tree of containers, on-demand. The transformation
+ * is performed "in-place", converting internal array and object values into containers without producing a copy or
+ * internal cache, making this implementation very memory-friendly.
+ *
+ * **Example usage:**
+ *
+ * ```php
+ * $data = [
+ *      'config' => [
+ *          'db' => [
+ *              'host' => 'localhost',
+ *              'port' => 3306,
+ *          ],
+ *      ]
+ * ];
+ *
+ * $container = new HierarchicalContainer($data);
+ * $container->get('config')->get('db')->get('host'); // "localhost"
+ * ```
+ *
+ * @since [*next-version*]
+ * @see   PathContainer For an implementation that compliments this one by allowing container trees to be accessed using
+ *                      path-like keys.
+ * @see   SegmentingContainer For an implementation that achieves a similar effect but for flat hierarchies.
+ */
+class HierarchyContainer implements ContainerInterface
+{
+    /**
+     * @since [*next-version*]
+     *
+     * @var mixed[]
+     */
+    protected $data;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param mixed[] $data The hierarchical data for which to create the container tree.
+     */
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @since [*next-version*]
+     */
+    public function get($key)
+    {
+        if (!array_key_exists($key, $this->data)) {
+            throw new NotFoundException("Key '{$key}' does not exist", 0, null);
+        }
+
+        $value = $this->data[$key];
+
+        if ($value instanceof stdClass) {
+            $value = get_object_vars($value);
+        }
+
+        if (is_array($value)) {
+            $value = $this->data[$key] = new self($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @since [*next-version*]
+     */
+    public function has($key)
+    {
+        return array_key_exists($key, $this->data);
+    }
+}

--- a/lib/packages/Dhii/Container/MappingContainer.php
+++ b/lib/packages/Dhii/Container/MappingContainer.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util\StringTranslatingTrait;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+
+/**
+ * A container implementation that can map results from another container using a callback.
+ *
+ * **Example usage**:
+ *
+ * ```php
+ * $container = new Container([
+ *      'first' => 'Paul',
+ *      'second' => 'JC',
+ *      'third' => 'Alex',
+ * ]);
+ *
+ * $mContainer = new MappingContainer($container, function ($name) {
+ *      return $name . ' Denton';
+ * });
+ *
+ * $mContainer->get('first');  // "Paul Denton"
+ * $mContainer->get('second'); // "JC Denton"
+ *
+ * // We don't talk about Alex
+ * ```
+ *
+ * @since [*next-version*]
+ */
+class MappingContainer implements ContainerInterface
+{
+    /* @since [*next-version*] */
+    use StringTranslatingTrait;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var callable
+     */
+    protected $callback;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var PsrContainerInterface
+     */
+    protected $inner;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param PsrContainerInterface $inner    The container instance to decorate.
+     * @param callable              $callback The callback to invoke on get. It will be passed 3 parameters:
+     *                                         * The inner container's value for the key being fetched.
+     *                                         * The key being fetched.
+     *                                         * A reference to this container instance.
+     */
+    public function __construct(PsrContainerInterface $inner, callable $callback)
+    {
+        $this->callback = $callback;
+        $this->inner = $inner;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function get($key)
+    {
+        return ($this->callback)($this->inner->get($key), $key, $this);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function has($key)
+    {
+        return $this->inner->has($key);
+    }
+}

--- a/lib/packages/Dhii/Container/MaskingContainer.php
+++ b/lib/packages/Dhii/Container/MaskingContainer.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util\StringTranslatingTrait;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+
+use function array_key_exists;
+
+/**
+ * An implementation of a container that wraps around another to selectively expose or mask certain keys.
+ *
+ * @since [*next-version*]
+ */
+class MaskingContainer implements ContainerInterface
+{
+    /* @since [*next-version*] */
+    use StringTranslatingTrait;
+
+    /**
+     * @var PsrContainerInterface
+     */
+    protected $inner;
+
+    /**
+     * @var bool[]
+     */
+    protected $mask;
+
+    /**
+     * @var bool
+     */
+    protected $defMask;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param PsrContainerInterface $inner       The container whose entries to mask.
+     * @param bool                  $defaultMask The default mask. If true, all inner keys are exposed. If false, all
+     *                                           inner keys are hidden. Any keys specified in the $mask parameter will
+     *                                           naturally override this setting.
+     * @param bool[]                $mask        A mapping of keys to booleans, such that `true` exposes the mapped key
+     *                                           and `false` hides the mapped key.
+     */
+    public function __construct(PsrContainerInterface $inner, bool $defaultMask, array $mask)
+    {
+        $this->inner = $inner;
+        $this->defMask = $defaultMask;
+        $this->mask = $mask;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function get($key)
+    {
+        if (!$this->isExposed($key)) {
+            throw new NotFoundException(
+                $this->__('Inner key "%1$s" is not exposed', [$key]),
+                0,
+                null
+            );
+        }
+
+        return $this->inner->get($key);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function has($key)
+    {
+        return $this->isExposed($key) && $this->inner->has($key);
+    }
+
+    /**
+     * Checks if a key is exposed through the mask.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $key The key to check.
+     *
+     * @return bool True if the key is exposed, false if the key is hidden.
+     */
+    protected function isExposed(string $key): bool
+    {
+        return array_key_exists($key, $this->mask)
+            ? $this->mask[$key] !== false
+            : $this->defMask;
+    }
+}

--- a/lib/packages/Dhii/Container/NoOpContainer.php
+++ b/lib/packages/Dhii/Container/NoOpContainer.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use ArrayIterator;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ClearableContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\MutableContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\WritableContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\WritableMapInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\ContainerException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use IteratorAggregate;
+
+/**
+ * A container that does nothing.
+ *
+ * This can be used if an actual implementation is not available,
+ * without extra checks or nullables - just as if it was a real one.
+ */
+class NoOpContainer implements
+    MutableContainerInterface,
+    IteratorAggregate,
+    WritableMapInterface,
+    ClearableContainerInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function get($id)
+    {
+        throw new NotFoundException('NoOp container cannot have values');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($id)
+    {
+        return false;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(string $key, $value): void
+    {
+        // Do nothing
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unset(string $key): void
+    {
+        throw new ContainerException('NoOp container cannot have values');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): void
+    {
+        // Do nothing
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withMappings(array $mappings): WritableContainerInterface
+    {
+        return clone $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withAddedMappings(array $mappings): WritableContainerInterface
+    {
+        return clone $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withoutKeys(array $keys): WritableContainerInterface
+    {
+        return clone $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator([]);
+    }
+}

--- a/lib/packages/Dhii/Container/PathContainer.php
+++ b/lib/packages/Dhii/Container/PathContainer.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\ContainerException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * A container implementation that decorates a hierarchy of {@link ContainerInterface} instances to allow path-like
+ * access to deep containers or data.
+ *
+ * **Example usage**
+ *
+ * Consider the below hierarchy of containers:
+ *
+ * ```php
+ * $container = new Container([
+ *      'config' => new Container([
+ *          'db' => new Container([
+ *              'host' => 'localhost',
+ *              'port' => 3306
+ *          ])
+ *      ])
+ * ]);
+ * ```
+ *
+ * A {@link PathContainer} can decorate the `$container` to substitute this:
+ *
+ * ```php
+ * $host = $container->get('config')->get('db')->get('port');
+ * ```
+ *
+ * With this:
+ *
+ * ```php
+ * $pContainer = new PathContainer($container, '.');
+ * $pContainer->get('config.db.port');
+ * ```
+ *
+ * Note that this implementation DOES NOT create containers for hierarchical _values_. Each segment in a given path
+ * must correspond to a child {@link ContainerInterface} instance.
+ *
+ * @since [*next-version*]
+ * @see   SegmentingContainer For an implementation that achieves the opposite effect.
+ */
+class PathContainer implements ContainerInterface
+{
+    /**
+     * @since [*next-version*]
+     *
+     * @var PsrContainerInterface
+     */
+    protected $inner;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var non-empty-string
+     */
+    protected $delimiter;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param PsrContainerInterface $inner     The container instance to decorate.
+     * @param non-empty-string      $delimiter The path delimiter to use.
+     */
+    public function __construct(PsrContainerInterface $inner, string $delimiter = '/')
+    {
+        $this->inner = $inner;
+        $this->delimiter = $delimiter;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @since [*next-version*]
+     */
+    public function get($key)
+    {
+        $tKey = (strpos($key, $this->delimiter) === 0)
+            ? substr($key, strlen($this->delimiter))
+            : $key;
+
+        $delimiter = $this->delimiter;
+        if (!strlen($delimiter)) {
+            throw new ContainerException('Cannot use empty delimiter');
+        }
+
+        /**
+         * @psalm-suppress PossiblyFalseArgument
+         * Result of explode() will never be false, because delimiter is never empty - see above.
+         */
+        $path = array_filter(explode($this->delimiter, $tKey));
+
+        if (empty($path)) {
+            throw new NotFoundException('The path is empty');
+        }
+
+        $current = $this->inner;
+        $head = $path[0];
+
+        while (!empty($path)) {
+            if (!($current instanceof PsrContainerInterface)) {
+                $tail = implode($this->delimiter, $path);
+                throw new NotFoundException(sprintf('Key "%1$s" does not exist at path "%2$s"', $head, $tail));
+            }
+
+            $head = array_shift($path);
+            $current = $current->get($head);
+        }
+
+        return $current;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @since [*next-version*]
+     */
+    public function has($key)
+    {
+        /**
+         * @psalm-suppress InvalidCatch
+         * The base interface does not extend Throwable, but in fact everything that is possible
+         * in theory to catch will be Throwable, and PSR-11 exceptions will implement this interface
+         */
+        try {
+            $this->get($key);
+
+            return true;
+        } catch (NotFoundExceptionInterface $exception) {
+            return false;
+        }
+    }
+}

--- a/lib/packages/Dhii/Container/PrefixingContainer.php
+++ b/lib/packages/Dhii/Container/PrefixingContainer.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
+
+/**
+ * A container implementation that wraps around an inner container and prefixes its keys, requiring consumers to
+ * include them when fetching or looking up data.
+ *
+ * @since [*next-version*]
+ */
+class PrefixingContainer implements ContainerInterface
+{
+    /**
+     * @since [*next-version*]
+     *
+     * @var PsrContainerInterface
+     */
+    protected $inner;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var string
+     */
+    protected $prefix;
+
+    /**
+     * @since [*next-version*]
+     *
+     * @var bool
+     */
+    protected $strict;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param PsrContainerInterface $container The container whose keys to prefix.
+     * @param string                $prefix    The prefix to apply to the container's keys.
+     * @param bool                  $strict    Whether or not to fallback to un-prefixed keys if a prefixed key does not
+     *                                         exist in the inner container.
+     */
+    public function __construct(PsrContainerInterface $container, string $prefix, bool $strict = true)
+    {
+        $this->inner = $container;
+        $this->prefix = $prefix;
+        $this->strict = $strict;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function get($key)
+    {
+        if (!$this->isPrefixed($key) && $this->strict) {
+            throw new NotFoundException(sprintf('Key "%s" does not exist', $key));
+        }
+
+        /**
+         * @psalm-suppress InvalidCatch
+         * The base interface does not extend Throwable, but in fact everything that is possible
+         * in theory to catch will be Throwable, and PSR-11 exceptions will implement this interface
+         */
+        try {
+            return $this->inner->get($this->unprefix($key));
+        } catch (NotFoundExceptionInterface $nfException) {
+            if ($this->strict) {
+                throw $nfException;
+            }
+        }
+
+        return $this->inner->get($key);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function has($key)
+    {
+        if (!$this->isPrefixed($key) && $this->strict) {
+            return false;
+        }
+
+        return $this->inner->has($this->unprefix($key)) || (!$this->strict && $this->inner->has($key));
+    }
+
+    /**
+     * Retrieves the key to use for the inner container.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $key The outer key.
+     *
+     * @return string The inner key.
+     */
+    protected function unprefix(string $key): string
+    {
+        return $this->isPrefixed($key)
+            ? substr($key, strlen($this->prefix))
+            : $key;
+    }
+
+    /**
+     * Checks if the key is prefixed.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $key The key to check.
+     *
+     * @return bool True if the key is prefixed, false if not.
+     */
+    protected function isPrefixed(string $key): bool
+    {
+        return strlen($this->prefix) > 0 && strpos($key, $this->prefix) === 0;
+    }
+}

--- a/lib/packages/Dhii/Container/ProxyContainer.php
+++ b/lib/packages/Dhii/Container/ProxyContainer.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\ContainerException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util\StringTranslatingTrait;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as BaseContainerInterface;
+
+/**
+ * A proxy for another container, and nothing more.
+ *
+ * The advantage is that its setter can be used at any point after construction,
+ * which solves the chicken-egg problem of two co-dependent containers.
+ */
+class ProxyContainer implements BaseContainerInterface
+{
+    use StringTranslatingTrait;
+
+    /**
+     * @var ?BaseContainerInterface
+     */
+    protected $innerContainer;
+
+    /**
+     * @param BaseContainerInterface|null $innerContainer The inner container, if any.
+     *                                                    May also be set later with {@see setInnerContainer()}.
+     */
+    public function __construct(BaseContainerInterface $innerContainer = null)
+    {
+        $this->innerContainer = $innerContainer;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($key)
+    {
+        if (!($this->innerContainer instanceof BaseContainerInterface)) {
+            throw new ContainerException($this->__('Inner container not set'));
+        }
+
+        return $this->innerContainer->get($key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($key)
+    {
+        if (!($this->innerContainer instanceof BaseContainerInterface)) {
+            /** @psalm-suppress MissingThrowsDocblock The exception class implements declared thrown interface */
+            throw new ContainerException($this->__('Inner container not set'));
+        }
+
+        return $this->innerContainer->has($key);
+    }
+
+    /**
+     * Assigns an inner container tot his proxy.
+     *
+     * Calls to `has()` and `get()` will be forwarded to this inner container.
+     *
+     * @param BaseContainerInterface $innerContainer The inner container to proxy.
+     */
+    public function setInnerContainer(BaseContainerInterface $innerContainer): void
+    {
+        $this->innerContainer = $innerContainer;
+    }
+}

--- a/lib/packages/Dhii/Container/SegmentingContainer.php
+++ b/lib/packages/Dhii/Container/SegmentingContainer.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface as PsrContainerInterface;
+
+use function array_filter;
+use function ltrim;
+
+/**
+ * This container implementation decorates another to provide nested container access even when the decorated
+ * container's internal data is flat.
+ *
+ * Segmenting containers are intended to be used with keys that contain segments, i.e. keys that use a delimiter to
+ * indicate hierarchy. For example: "some/test/key" or "some.deep.config.value". The delimiter can be configured during
+ * construction of a segmenting container.
+ *
+ * A segmenting container can yield 2 different kinds of results when {@link SegmentingContainer::get()} is called:
+ *
+ * **Values**
+ *
+ * If the inner container has a value for the given key, that value is returned.
+ *
+ * **Segments**
+ *
+ * If the inner container has no value for the given key, a new {@link SegmentingContainer} instance is returned. This
+ * segmenting container will be aware of the key that resulted in its creation, and will automatically prepend that key
+ * to parameter keys given in `get()`.
+ *
+ * **Example usage:**
+ *
+ * Consider the below data and a regular `$container` that provides access to it:
+ *
+ * ```php
+ * $data = [
+ *     'config.db.host' => 'localhost',
+ *     'config.db.post' => '3306',
+ * ];
+ * ```
+ *
+ * A segmenting container can be created that provides access to the "host" and "port":
+ *
+ * ```php
+ * $segmented = new SegmentingContainer($container, '.');
+ * $dbConfig = $config->get('config')->get('db');
+ * $dbConfig->get("host"); // "localhost"
+ * $dbConfig->get("port"); // 3306
+ * ```
+ *
+ * @since [*next-version*]
+ * @see   PathContainer For an implementation that achieves the opposite effect.
+ */
+class SegmentingContainer implements ContainerInterface
+{
+    /**
+     * @var PsrContainerInterface
+     */
+    protected $inner;
+
+    /**
+     * @var string
+     */
+    protected $root;
+
+    /**
+     * @var string
+     */
+    protected $delimiter;
+
+    /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param PsrContainerInterface $inner     The container to decorate.
+     * @param string                $delimiter The path delimiter.
+     */
+    public function __construct(PsrContainerInterface $inner, string $delimiter = '/')
+    {
+        $this->inner = $inner;
+        $this->root = '';
+        $this->delimiter = $delimiter;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function get($key)
+    {
+        $tKey = ltrim($key, $this->delimiter);
+        $tRoot = rtrim($this->root, $this->delimiter);
+        // Implode to glue together the key and root, and array_filter to ignore them if they're empty
+        $fullKey = implode($this->delimiter, array_filter([$tRoot, $tKey]));
+
+        if ($this->inner->has($fullKey)) {
+            return $this->inner->get($fullKey);
+        }
+
+        $instance = clone $this;
+        $instance->root = $fullKey;
+
+        return $instance;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @since [*next-version*]
+     */
+    public function has($key)
+    {
+        return $this->inner->has($key);
+    }
+}

--- a/lib/packages/Dhii/Container/ServiceProvider.php
+++ b/lib/packages/Dhii/Container/ServiceProvider.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+
+/**
+ * A value object capable of providing services.
+ *
+ * @package Dhii\Di
+ */
+class ServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * @var callable[]
+     */
+    protected $factories;
+    /**
+     * @var callable[]
+     */
+    protected $extensions;
+
+    /**
+     * @param callable[] $factories A map of service name to service factory.
+     * @param callable[] $extensions A map of service name to service extension.
+     */
+    public function __construct(array $factories, array $extensions)
+    {
+        $this->factories = $factories;
+        $this->extensions = $extensions;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getFactories()
+    {
+        return $this->factories;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getExtensions()
+    {
+        return $this->extensions;
+    }
+}

--- a/lib/packages/Dhii/Container/SimpleCacheContainer.php
+++ b/lib/packages/Dhii/Container/SimpleCacheContainer.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\ClearableContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Collection\MutableContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\ContainerException;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Exception\NotFoundException;
+use Exception;
+use Psr\SimpleCache\CacheInterface;
+
+class SimpleCacheContainer implements
+    MutableContainerInterface,
+    ClearableContainerInterface
+{
+    /**
+     * @var CacheInterface
+     */
+    protected $storage;
+    /**
+     * @var int
+     */
+    protected $ttl;
+
+    public function __construct(CacheInterface $storage, int $ttl)
+    {
+        $this->storage = $storage;
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get($id)
+    {
+        $storage = $this->storage;
+
+        try {
+            if (!$storage->has($id)) {
+                return new NotFoundException(sprintf('Key "%1$s" not found', $id));
+            }
+
+            $value = $storage->get($id);
+        } catch (Exception $e) {
+            throw new ContainerException(sprintf('Could not retrieve value for key "%1$s"', $id), 0, $e);
+        }
+
+        return $value;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function has($id)
+    {
+        $storage = $this->storage;
+
+        try {
+            $has = $storage->has($id);
+        } catch (Exception $e) {
+            throw new ContainerException(sprintf('Could not check for key "%1$s"', $id), 0, $e);
+        }
+
+        return $has;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function set(string $key, $value): void
+    {
+        $storage = $this->storage;
+        $ttl = $this->ttl;
+
+        try {
+            $storage->set($key, $value, $ttl);
+        } catch (Exception $e) {
+            throw new ContainerException(sprintf('Could not set key "%1$s" with value "%2$s"', $key, $value), 0, $e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function unset(string $key): void
+    {
+        $storage = $this->storage;
+
+        try {
+            $storage->delete($key);
+        } catch (Exception $e) {
+            throw new ContainerException(sprintf('Could not unset key "%1$s"', $key), 0, $e);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clear(): void
+    {
+        $storage = $this->storage;
+
+        try {
+            $storage->clear();
+        } catch (Exception $e) {
+            throw new ContainerException(sprintf('Could not clear container'), 0, $e);
+        }
+    }
+}

--- a/lib/packages/Dhii/Container/Util/StringTranslatingTrait.php
+++ b/lib/packages/Dhii/Container/Util/StringTranslatingTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Util;
+
+/**
+ * Methods for classes which can translate.
+ *
+ * @since [*next-version*]
+ */
+trait StringTranslatingTrait
+{
+    /**
+     * Translates a string, and replaces placeholders.
+     *
+     * The translation itself is delegated to another method.
+     *
+     * @see sprintf()
+     * @see _translate()
+     *
+     * @param string       $string  The format string to translate.
+     * @param list<scalar> $args    Placeholder values to replace in the string.
+     * @param mixed        $context The context for translation.
+     *
+     * @return string The translated string.
+     */
+    protected function __(string $string, array $args = array(), $context = null): string
+    {
+        $string = $this->_translate($string, $context);
+        array_unshift($args, $string);
+        return call_user_func_array('sprintf', $args);
+    }
+
+    /**
+     * Translates a string.
+     *
+     * A no-op implementation.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $string The string to translate.
+     * @param string $context The context to translate the string in.
+     *
+     * @return string The translated string.
+     * phpcs:disable PSR2.Methods.MethodDeclaration.Underscore
+     */
+    protected function _translate(string $string, string $context = null): string
+    {
+        return $string;
+    }
+}

--- a/lib/packages/Dhii/Modular/Module/Exception/ModuleExceptionInterface.php
+++ b/lib/packages/Dhii/Modular/Module/Exception/ModuleExceptionInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\Exception;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleAwareInterface;
+use Throwable;
+
+/**
+ * Represents an exception that is thrown in relation to a module.
+ *
+ * @since 0.2
+ */
+interface ModuleExceptionInterface extends
+    Throwable,
+    ModuleAwareInterface
+{
+}

--- a/lib/packages/Dhii/Modular/Module/ModuleAwareInterface.php
+++ b/lib/packages/Dhii/Modular/Module/ModuleAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module;
+
+/**
+ * Something that can have a module instance retrieved.
+ *
+ * @since 0.2
+ */
+interface ModuleAwareInterface
+{
+    /**
+     * Retrieves the module that is associated with this instance.
+     *
+     * @since 0.2
+     *
+     * @return ModuleInterface|null The module, if applicable; otherwise, null.
+     */
+    public function getModule(): ?ModuleInterface;
+}

--- a/lib/packages/Dhii/Modular/Module/ModuleInterface.php
+++ b/lib/packages/Dhii/Modular/Module/ModuleInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\Exception\ModuleExceptionInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Something that represents an application module.
+ *
+ * @since 0.2
+ */
+interface ModuleInterface
+{
+    /**
+     * Performs module-specific setup and provides a service provider.
+     *
+     * This method SHOULD be called at least once before {@link ModuleInterface::run()} may be invoked for a particular
+     * module instance. The returned service provider instance SHOULD be incorporated by the application into the
+     * container instance that is then given to this module's {@link ModuleInterface::run()} method.
+     *
+     * The application MAY also incorporate the service provider into the container instance given to other modules,
+     * but this is not required. As such, services factories in the returned service provider should not assume the
+     * existence of other module's services. Use proxy services together with {@link ContainerInterface::has()} for
+     * optionally integrating with other modules.
+     *
+     * @since 0.2
+     *
+     * @return ServiceProviderInterface A service provider instance for this module's services.
+     *
+     * @throws ModuleExceptionInterface If module setup failed and/or a service provider instance could not be returned.
+     */
+    public function setup(): ServiceProviderInterface;
+
+    /**
+     * Runs the module.
+     *
+     * This method MUST be called after the module has been set up using {@link ModuleInterface::setup()}. A services
+     * container MUST be given to this method, and MUST incorporate the services from the service provider returned
+     * by the same module's {@link ModuleInterface::setup()} method. This container instance is not guaranteed to be
+     * the same instance given to other modules. As such, it is strongly advised to assume it is not, and to avoid
+     * referencing services from other modules.
+     *
+     * @since 0.2
+     *
+     * @param ContainerInterface $c A services container instance.
+     *
+     * @throws ModuleExceptionInterface If the module failed to run.
+     */
+    public function run(ContainerInterface $c): void;
+}

--- a/lib/packages/Interop/Container/ServiceProviderInterface.php
+++ b/lib/packages/Interop/Container/ServiceProviderInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WooCommerce\PayPalCommerce\Vendor\Interop\Container;
+
+/**
+ * A service provider provides entries to a container.
+ */
+interface ServiceProviderInterface
+{
+    /**
+     * Returns a list of all container entries registered by this service provider.
+     *
+     * - the key is the entry name
+     * - the value is a callable that will return the entry, aka the **factory**
+     *
+     * Factories have the following signature:
+     *        function(\WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface $container)
+     *
+     * @return callable[]
+     */
+    public function getFactories();
+
+    /**
+     * Returns a list of all container entries extended by this service provider.
+     *
+     * - the key is the entry name
+     * - the value is a callable that will return the modified entry
+     *
+     * Callables have the following signature:
+     *        function(WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface $container, $previous)
+     *     or function(WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface $container, $previous = null)
+     *
+     * About factories parameters:
+     *
+     * - the container (instance of `WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface`)
+     * - the entry to be extended. If the entry to be extended does not exist and the parameter is nullable, `null` will be passed.
+     *
+     * @return callable[]
+     */
+    public function getExtensions();
+}

--- a/lib/packages/Psr/Container/ContainerExceptionInterface.php
+++ b/lib/packages/Psr/Container/ContainerExceptionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace WooCommerce\PayPalCommerce\Vendor\Psr\Container;
+
+use Throwable;
+
+/**
+ * Base interface representing a generic exception in a container.
+ */
+interface ContainerExceptionInterface extends Throwable
+{
+}

--- a/lib/packages/Psr/Container/ContainerExceptionInterface.php
+++ b/lib/packages/Psr/Container/ContainerExceptionInterface.php
@@ -1,12 +1,13 @@
 <?php
+/**
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
 
 namespace WooCommerce\PayPalCommerce\Vendor\Psr\Container;
-
-use Throwable;
 
 /**
  * Base interface representing a generic exception in a container.
  */
-interface ContainerExceptionInterface extends Throwable
+interface ContainerExceptionInterface
 {
 }

--- a/lib/packages/Psr/Container/ContainerInterface.php
+++ b/lib/packages/Psr/Container/ContainerInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vendor\Psr\Container;
+
+/**
+ * Describes the interface of a container that exposes methods to read its entries.
+ */
+interface ContainerInterface
+{
+    /**
+     * Finds an entry of the container by its identifier and returns it.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @throws NotFoundExceptionInterface  No entry was found for **this** identifier.
+     * @throws ContainerExceptionInterface Error while retrieving the entry.
+     *
+     * @return mixed Entry.
+     */
+    public function get(string $id);
+
+    /**
+     * Returns true if the container can return an entry for the given identifier.
+     * Returns false otherwise.
+     *
+     * `has($id)` returning true does not mean that `get($id)` will not throw an exception.
+     * It does however mean that `get($id)` will not throw a `NotFoundExceptionInterface`.
+     *
+     * @param string $id Identifier of the entry to look for.
+     *
+     * @return bool
+     */
+    public function has(string $id);
+}

--- a/lib/packages/Psr/Container/ContainerInterface.php
+++ b/lib/packages/Psr/Container/ContainerInterface.php
@@ -1,6 +1,7 @@
 <?php
-
-declare(strict_types=1);
+/**
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
 
 namespace WooCommerce\PayPalCommerce\Vendor\Psr\Container;
 
@@ -19,7 +20,7 @@ interface ContainerInterface
      *
      * @return mixed Entry.
      */
-    public function get(string $id);
+    public function get($id);
 
     /**
      * Returns true if the container can return an entry for the given identifier.
@@ -32,5 +33,5 @@ interface ContainerInterface
      *
      * @return bool
      */
-    public function has(string $id);
+    public function has($id);
 }

--- a/lib/packages/Psr/Container/NotFoundExceptionInterface.php
+++ b/lib/packages/Psr/Container/NotFoundExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace WooCommerce\PayPalCommerce\Vendor\Psr\Container;
+
+/**
+ * No entry was found in the container.
+ */
+interface NotFoundExceptionInterface extends ContainerExceptionInterface
+{
+}

--- a/lib/packages/Psr/Container/NotFoundExceptionInterface.php
+++ b/lib/packages/Psr/Container/NotFoundExceptionInterface.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @license http://www.opensource.org/licenses/mit-license.php MIT (see the LICENSE file)
+ */
 
 namespace WooCommerce\PayPalCommerce\Vendor\Psr\Container;
 

--- a/modules/ppcp-admin-notices/module.php
+++ b/modules/ppcp-admin-notices/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\AdminNotices;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new AdminNotices();

--- a/modules/ppcp-admin-notices/services.php
+++ b/modules/ppcp-admin-notices/services.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\AdminNotices;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\AdminNotices\Renderer\Renderer;
 use WooCommerce\PayPalCommerce\AdminNotices\Renderer\RendererInterface;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;

--- a/modules/ppcp-admin-notices/src/AdminNotices.php
+++ b/modules/ppcp-admin-notices/src/AdminNotices.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\AdminNotices;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class AdminNotices

--- a/modules/ppcp-api-client/module.php
+++ b/modules/ppcp-api-client/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return function (): ModuleInterface {
 	return new ApiModule();

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;

--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class ApiModule

--- a/modules/ppcp-api-client/src/Entity/Capture.php
+++ b/modules/ppcp-api-client/src/Entity/Capture.php
@@ -154,9 +154,9 @@ class Capture {
 	/**
 	 * Returns the seller protection object.
 	 *
-	 * @return \stdClass
+	 * @return object
 	 */
-	public function seller_protection() : \stdClass {
+	public function seller_protection() {
 		return (object) array( 'status' => $this->seller_protection );
 	}
 

--- a/modules/ppcp-api-client/src/Entity/Token.php
+++ b/modules/ppcp-api-client/src/Entity/Token.php
@@ -19,7 +19,7 @@ class Token {
 	/**
 	 * The Token data.
 	 *
-	 * @var \stdClass
+	 * @var object
 	 */
 	private $json;
 
@@ -33,10 +33,10 @@ class Token {
 	/**
 	 * Token constructor.
 	 *
-	 * @param \stdClass $json The JSON object.
+	 * @param object $json The JSON object.
 	 * @throws RuntimeException When The JSON object is not valid.
 	 */
-	public function __construct( \stdClass $json ) {
+	public function __construct( $json ) {
 		if ( ! isset( $json->created ) ) {
 			$json->created = time();
 		}
@@ -122,11 +122,11 @@ class Token {
 	/**
 	 * Validates whether a JSON object can be transformed to a Token object.
 	 *
-	 * @param \stdClass $json The JSON object.
+	 * @param object $json The JSON object.
 	 *
 	 * @return bool
 	 */
-	private function validate( \stdClass $json ): bool {
+	private function validate( $json ): bool {
 		$property_map = array(
 			'created'    => 'is_int',
 			'expires_in' => 'is_int',

--- a/modules/ppcp-api-client/src/Entity/Webhook.php
+++ b/modules/ppcp-api-client/src/Entity/Webhook.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
 
-use stdClass;
-
 /**
  * Class Webhook
  */
@@ -33,16 +31,16 @@ class Webhook {
 	/**
 	 * The event types.
 	 *
-	 * @var string[]
+	 * @var object[]
 	 */
 	private $event_types;
 
 	/**
 	 * Webhook constructor.
 	 *
-	 * @param string     $url The URL of the webhook.
-	 * @param stdClass[] $event_types The associated event types.
-	 * @param string     $id The id of the webhook.
+	 * @param string   $url The URL of the webhook.
+	 * @param object[] $event_types The associated event types.
+	 * @param string   $id The id of the webhook.
 	 */
 	public function __construct( string $url, array $event_types, string $id = '' ) {
 		$this->url         = $url;
@@ -73,7 +71,7 @@ class Webhook {
 	/**
 	 * Returns the event types.
 	 *
-	 * @return stdClass[]
+	 * @return object[]
 	 */
 	public function event_types(): array {
 

--- a/modules/ppcp-api-client/src/Entity/WebhookEvent.php
+++ b/modules/ppcp-api-client/src/Entity/WebhookEvent.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
 
 use DateTime;
-use stdClass;
 
 /**
  * Class WebhookEvent
@@ -69,7 +68,7 @@ class WebhookEvent {
 	/**
 	 * The resource that triggered the webhook event notification.
 	 *
-	 * @var stdClass
+	 * @var object
 	 */
 	private $resource;
 
@@ -83,9 +82,9 @@ class WebhookEvent {
 	 * @param string        $event_type The event that triggered the webhook event notification, such as 'CHECKOUT.ORDER.APPROVED'.
 	 * @param string        $summary A summary description for the event notification.
 	 * @param string        $resource_version The resource version in the webhook notification, such as '1.0'.
-	 * @param stdClass      $resource The resource that triggered the webhook event notification.
+	 * @param object        $resource The resource that triggered the webhook event notification.
 	 */
-	public function __construct( string $id, ?DateTime $create_time, string $resource_type, string $event_version, string $event_type, string $summary, string $resource_version, stdClass $resource ) {
+	public function __construct( string $id, ?DateTime $create_time, string $resource_type, string $event_version, string $event_type, string $summary, string $resource_version, $resource ) {
 		$this->id               = $id;
 		$this->create_time      = $create_time;
 		$this->resource_type    = $resource_type;
@@ -162,9 +161,9 @@ class WebhookEvent {
 	/**
 	 * The resource that triggered the webhook event notification.
 	 *
-	 * @return stdClass
+	 * @return object
 	 */
-	public function resource(): stdClass {
+	public function resource() {
 		return $this->resource;
 	}
 }

--- a/modules/ppcp-api-client/src/Exception/NotFoundException.php
+++ b/modules/ppcp-api-client/src/Exception/NotFoundException.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Exception;
 
-use Psr\Container\NotFoundExceptionInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
 use Exception;
 
 /**

--- a/modules/ppcp-api-client/src/Factory/PaymentTokenFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PaymentTokenFactory.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
-use stdClass;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
@@ -21,12 +20,12 @@ class PaymentTokenFactory {
 	/**
 	 * Returns a PaymentToken based off a PayPal Response object.
 	 *
-	 * @param \stdClass $data The JSON object.
+	 * @param object $data The JSON object.
 	 *
 	 * @return PaymentToken
 	 * @throws RuntimeException When JSON object is malformed.
 	 */
-	public function from_paypal_response( stdClass $data ): PaymentToken {
+	public function from_paypal_response( $data ): PaymentToken {
 		if ( ! isset( $data->id ) ) {
 			throw new RuntimeException(
 				__( 'No id for payment token given', 'woocommerce-paypal-payments' )

--- a/modules/ppcp-api-client/src/Factory/WebhookEventFactory.php
+++ b/modules/ppcp-api-client/src/Factory/WebhookEventFactory.php
@@ -33,12 +33,12 @@ class WebhookEventFactory {
 	/**
 	 * Returns a Webhook based of a PayPal JSON response.
 	 *
-	 * @param stdClass $data The JSON object.
+	 * @param object $data The JSON object.
 	 *
 	 * @return WebhookEvent
 	 * @throws RuntimeException When JSON object is malformed.
 	 */
-	public function from_paypal_response( stdClass $data ): WebhookEvent {
+	public function from_paypal_response( $data ): WebhookEvent {
 		if ( ! isset( $data->id ) ) {
 			throw new RuntimeException(
 				__( 'ID for webhook event not found.', 'woocommerce-paypal-payments' )

--- a/modules/ppcp-api-client/src/Factory/WebhookFactory.php
+++ b/modules/ppcp-api-client/src/Factory/WebhookFactory.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
-use stdClass;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
@@ -28,7 +27,7 @@ class WebhookFactory {
 	 */
 	public function for_url_and_events( string $url, array $event_types ): Webhook {
 		$event_types = array_map(
-			static function ( string $type ): stdClass {
+			static function ( string $type ) {
 				return (object) array( 'name' => $type );
 			},
 			$event_types
@@ -53,12 +52,12 @@ class WebhookFactory {
 	/**
 	 * Returns a Webhook based of a PayPal JSON response.
 	 *
-	 * @param stdClass $data The JSON object.
+	 * @param object $data The JSON object.
 	 *
 	 * @return Webhook
 	 * @throws RuntimeException When JSON object is malformed.
 	 */
-	public function from_paypal_response( stdClass $data ): Webhook {
+	public function from_paypal_response( $data ): Webhook {
 		if ( ! isset( $data->id ) ) {
 			throw new RuntimeException(
 				__( 'No id for webhook given.', 'woocommerce-paypal-payments' )

--- a/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
+++ b/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
@@ -11,7 +11,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Repository;
 
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class ApplicationContextRepository

--- a/modules/ppcp-button/module.php
+++ b/modules/ppcp-button/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new ButtonModule();

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\DisabledSmartButton;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButton;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;

--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ChangeCartEndpoint;
@@ -18,8 +18,8 @@ use WooCommerce\PayPalCommerce\Button\Endpoint\CreateOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\DataClientIdEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\StartPayPalVaultingEndpoint;
 use WooCommerce\PayPalCommerce\Button\Helper\EarlyOrderHandler;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class ButtonModule

--- a/modules/ppcp-compat/module.php
+++ b/modules/ppcp-compat/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new CompatModule();

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use Exception;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Vendidero\Germanized\Shipments\Shipment;
 use WC_Order;

--- a/modules/ppcp-onboarding/module.php
+++ b/modules/ppcp-onboarding/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Onboarding;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new OnboardingModule();

--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Onboarding;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\ConnectBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;

--- a/modules/ppcp-onboarding/src/Environment.php
+++ b/modules/ppcp-onboarding/src/Environment.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Onboarding;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class Environment

--- a/modules/ppcp-onboarding/src/OnboardingModule.php
+++ b/modules/ppcp-onboarding/src/OnboardingModule.php
@@ -9,14 +9,14 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Onboarding;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ChangeCartEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Assets\OnboardingAssets;
 use WooCommerce\PayPalCommerce\Onboarding\Endpoint\LoginSellerEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingRenderer;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class OnboardingModule

--- a/modules/ppcp-onboarding/src/OnboardingRESTController.php
+++ b/modules/ppcp-onboarding/src/OnboardingRESTController.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Onboarding;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 

--- a/modules/ppcp-onboarding/src/State.php
+++ b/modules/ppcp-onboarding/src/State.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Onboarding;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class State

--- a/modules/ppcp-order-tracking/carriers.php
+++ b/modules/ppcp-order-tracking/carriers.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 	return array(
 		'global' => array(

--- a/modules/ppcp-order-tracking/module.php
+++ b/modules/ppcp-order-tracking/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new OrderTrackingModule();

--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\OrderTracking\Assets\OrderEditPageAssets;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use Exception;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\OrderTracking\Assets\OrderEditPageAssets;

--- a/modules/ppcp-session/module.php
+++ b/modules/ppcp-session/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Session;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return function (): ModuleInterface {
 	return new SessionModule();

--- a/modules/ppcp-session/services.php
+++ b/modules/ppcp-session/services.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Session;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 

--- a/modules/ppcp-session/src/Cancellation/CancelView.php
+++ b/modules/ppcp-session/src/Cancellation/CancelView.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Session\Cancellation;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
 
 /**

--- a/modules/ppcp-session/src/SessionModule.php
+++ b/modules/ppcp-session/src/SessionModule.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Session;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class SessionModule

--- a/modules/ppcp-status-report/module.php
+++ b/modules/ppcp-status-report/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\StatusReport;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new StatusReportModule();

--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\StatusReport;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;

--- a/modules/ppcp-subscription/module.php
+++ b/modules/ppcp-subscription/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Subscription;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new SubscriptionModule();

--- a/modules/ppcp-subscription/services.php
+++ b/modules/ppcp-subscription/services.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Subscription;
 
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
 
 return array(

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Subscription;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 use WC_Subscription;
@@ -19,8 +19,8 @@ use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 

--- a/modules/ppcp-vaulting/module.php
+++ b/modules/ppcp-vaulting/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Vaulting;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new VaultingModule();

--- a/modules/ppcp-vaulting/services.php
+++ b/modules/ppcp-vaulting/services.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Vaulting;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Vaulting\Assets\MyAccountPaymentsAssets;
 use WooCommerce\PayPalCommerce\Vaulting\Endpoint\DeletePaymentTokenEndpoint;
 

--- a/modules/ppcp-vaulting/src/VaultedCreditCardHandler.php
+++ b/modules/ppcp-vaulting/src/VaultedCreditCardHandler.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Vaulting;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WC_Customer;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Vaulting;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;

--- a/modules/ppcp-wc-gateway/connection-tab-settings.php
+++ b/modules/ppcp-wc-gateway/connection-tab-settings.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;

--- a/modules/ppcp-wc-gateway/extensions.php
+++ b/modules/ppcp-wc-gateway/extensions.php
@@ -15,7 +15,7 @@ use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 use WooCommerce\WooCommerce\Logging\Logger\WooCommerceLogger;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 return array(

--- a/modules/ppcp-wc-gateway/module.php
+++ b/modules/ppcp-wc-gateway/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new WCGatewayModule();

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PayUponInvoiceOrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;

--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -13,7 +13,7 @@ use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class DisableGateways

--- a/modules/ppcp-wc-gateway/src/Exception/NotFoundException.php
+++ b/modules/ppcp-wc-gateway/src/Exception/NotFoundException.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Exception;
 
 use Exception;
-use Psr\Container\NotFoundExceptionInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
 
 /**
  * Class NotFoundException

--- a/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
+++ b/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\FundingSource;
 
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class FundingSourceRenderer

--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -23,7 +23,7 @@ use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\GatewayGenericException;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
 
 /**

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -25,7 +25,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Exception\GatewayGenericException;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class CreditCardGateway

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -28,7 +28,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class PayPalGateway

--- a/modules/ppcp-wc-gateway/src/Notice/ConnectAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/ConnectAdminNotice.php
@@ -12,7 +12,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Notice;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class ConnectAdminNotice

--- a/modules/ppcp-wc-gateway/src/Notice/GatewayWithoutPayPalAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/GatewayWithoutPayPalAdminNotice.php
@@ -12,7 +12,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Notice;
 use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\Onboarding\State;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Creates the admin message about the gateway being enabled without the PayPal gateway.

--- a/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 use Exception;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;

--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class Settings

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -14,7 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
@@ -39,8 +39,8 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\SectionsRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsListener;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class WcGatewayModule

--- a/modules/ppcp-webhooks/module.php
+++ b/modules/ppcp-webhooks/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Webhooks;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return static function (): ModuleInterface {
 	return new WebhookModule();

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -25,7 +25,7 @@ use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCaptureDenied;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCapturePending;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCaptureRefunded;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\PaymentCaptureReversed;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\VaultCreditCardCreated;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\VaultPaymentTokenCreated;
 use WooCommerce\PayPalCommerce\Webhooks\Status\Assets\WebhooksStatusPageAssets;

--- a/modules/ppcp-webhooks/src/WebhookModule.php
+++ b/modules/ppcp-webhooks/src/WebhookModule.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Webhooks;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use Exception;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\Webhooks\Endpoint\ResubscribeEndpoint;

--- a/modules/woocommerce-logging/module.php
+++ b/modules/woocommerce-logging/module.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\WooCommerce\Logging;
 
-use Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 
 return function (): ModuleInterface {
 	return new WooCommerceLoggingModule();

--- a/modules/woocommerce-logging/services.php
+++ b/modules/woocommerce-logging/services.php
@@ -11,7 +11,7 @@ namespace WooCommerce\WooCommerce\Logging;
 
 use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 use WooCommerce\WooCommerce\Logging\Logger\WooCommerceLogger;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 return array(

--- a/modules/woocommerce-logging/src/WooCommerceLoggingModule.php
+++ b/modules/woocommerce-logging/src/WooCommerceLoggingModule.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\WooCommerce\Logging;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class WooCommerceLoggingModule

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -152,6 +152,7 @@
 		<MixedStringOffsetAssignment errorLevel="info"/>
 		<ParamNameMismatch errorLevel="info"/>
 		<RedundantCastGivenDocblockType errorLevel="info"/>
+		<RiskyCast errorLevel="info"/>
 
 		<TooManyArguments>
 			<errorLevel type="suppress">

--- a/src/PluginModule.php
+++ b/src/PluginModule.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce;
 
-use Dhii\Container\ServiceProvider;
-use Dhii\Modular\Module\ModuleInterface;
-use Interop\Container\ServiceProviderInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class PluginModule

--- a/src/services.php
+++ b/src/services.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce;
 
 use Dhii\Versions\StringVersionFactory;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WpOop\WordPress\Plugin\PluginInterface;
 
 return array(

--- a/tests/PHPUnit/ModularTestCase.php
+++ b/tests/PHPUnit/ModularTestCase.php
@@ -3,11 +3,11 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce;
 
-use Dhii\Container\CompositeCachingServiceProvider;
-use Dhii\Container\DelegatingContainer;
-use Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\CompositeCachingServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\DelegatingContainer;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use function Brain\Monkey\Functions\when;
 
 class ModularTestCase extends TestCase

--- a/tests/PHPUnit/Subscription/RenewalHandlerTest.php
+++ b/tests/PHPUnit/Subscription/RenewalHandlerTest.php
@@ -3,7 +3,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Subscription;
 
-use Dhii\Container\Dictionary;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Dictionary;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;

--- a/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
+++ b/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
@@ -3,7 +3,7 @@
 namespace PHPUnit\Vaulting;
 
 use Mockery;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WC_Customer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;

--- a/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
 use Mockery;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -5,7 +5,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 
 use Mockery\MockInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 
-use Dhii\Container\Dictionary;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\Dictionary;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;

--- a/tests/PHPUnit/WcGateway/Repository/ApplicationContextRepositoryTest.php
+++ b/tests/PHPUnit/WcGateway/Repository/ApplicationContextRepositoryTest.php
@@ -9,7 +9,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\ApplicationContextRepository;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery\MockInterface;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use function Brain\Monkey\Functions\expect;
 
 class ApplicationContextRepositoryTest extends TestCase

--- a/tests/e2e/PHPUnit/TestCase.php
+++ b/tests/e2e/PHPUnit/TestCase.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Tests\E2e;
 
 use PPCP_E2E;
-use Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WC_Cart;
 use WC_Customer;
 use WC_Session;


### PR DESCRIPTION
Prefixed container and modularity deps using [Mozart](https://github.com/coenjacobs/mozart) to fix conflicts that seem to appear more frequently now in newer WC.

Currently, the packages are simply added in the repo (like in WC https://github.com/woocommerce/woocommerce/pull/33703) to avoid making the build process more complex (Mozart requires PHP 7.3).
We need to isolate only PSR-11 containers and Dhii modularity packages, which are not supposed to change often, so it should not be a problem.

This will break plugin extensions via modules like https://github.com/woocommerce/woocommerce-paypal-payments/issues/234#issuecomment-946783583
But there are not many such users (if any?), and it can be easily fixed by adding the namespace prefix (`WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface`, `WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface`).