### PR TITLE
Introduce validation for mini cart button height setting

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1800,17 +1800,21 @@ return array(
 				'gateway'      => 'paypal',
 			),
 			'button_mini-cart_height'                => array(
-				'title'        => __( 'Button Height', 'woocommerce-paypal-payments' ),
-				'type'         => 'number',
-				'default'      => '35',
-				'desc_tip'     => true,
-				'description'  => __( 'Add a value from 25 to 55.', 'woocommerce-paypal-payments' ),
-				'screens'      => array(
+				'title'             => __( 'Button Height', 'woocommerce-paypal-payments' ),
+				'type'              => 'number',
+				'default'           => '35',
+				'custom_attributes' => array(
+					'min' => 25,
+					'max' => 55,
+				),
+				'desc_tip'          => true,
+				'description'       => __( 'Add a value from 25 to 55.', 'woocommerce-paypal-payments' ),
+				'screens'           => array(
 					State::STATE_START,
 					State::STATE_ONBOARDED,
 				),
-				'requirements' => array(),
-				'gateway'      => 'paypal',
+				'requirements'      => array(),
+				'gateway'           => 'paypal',
 			),
 			'button_mini-cart_preview'               => array(
 				'type'         => 'ppcp-text',


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #976

---

### Description

Merchant has option to select mini cart button height in range from 25 - 55, but manually he can input any number out of that range. Good thing is that those out of range numbers will not be applied to the mini cart button.

The PR will add the `min` and `max` attributes to height input so that customers will see a message if they put wrong value. 

### Steps to Test

<img width="724" alt="Screen Shot 2022-11-10 at 18 31 57" src="https://user-images.githubusercontent.com/11319597/201118799-5dae2423-30e1-402a-ad57-ffdadf9eb4ba.png">


---

Closes #976 .
