### PR TITLE
Remove PUI tab when PUI is not active for PayPal account

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -252,6 +252,13 @@ return array(
 			unset( $sections['ppcp-credit-card-gateway'] );
 		}
 
+		$pui_product_status = $container->get( 'wcgateway.pay-upon-invoice-product-status' );
+		assert( $pui_product_status instanceof PayUponInvoiceProductStatus );
+
+		if ( ! $pui_product_status->pui_is_active() ) {
+			unset( $sections[ PayUponInvoiceGateway::ID ] );
+		}
+
 		return $sections;
 	},
 	'wcgateway.settings.status'                            => static function ( ContainerInterface $container ): SettingsStatus {


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #978

---

### Description

In our efforts to reduce error messages, the Pay upon Invoice tab should only appear when the merchant account is enabled for it.

The PR will solve the problem described above.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Onboard with German account but without PUI
2. Check if PUI tab is not shown.

---

Closes #978 .
