### PR TITLE
Prevent Enter key submit for our non-standard button gateways

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -30,6 +30,16 @@ const bootstrap = () => {
 
     const freeTrialHandler = new FreeTrialHandler(PayPalCommerceGateway, spinner, errorHandler);
 
+    jQuery('form.woocommerce-checkout input').on('keydown', e => {
+        if (e.key === 'Enter' && [
+            PaymentMethods.PAYPAL,
+            PaymentMethods.CARDS,
+            PaymentMethods.CARD_BUTTON,
+        ].includes(getCurrentPaymentMethod())) {
+            e.preventDefault();
+        }
+    });
+
     const onSmartButtonClick = (data, actions) => {
         window.ppcpFundingSource = data.fundingSource;
 


### PR DESCRIPTION
Otherwise pressing Enter triggers WC order process without e.g. completing payment via PayPal popup, and results in failure with confusing error message.

Ideally Enter should trigger our buttons, but I think PayPal JS SDK does not provide any way to trigger smart buttons programmatically.