### PR TITLE
Ensure pay for order exist in request

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -459,7 +459,8 @@ class PayUponInvoice {
 				if (
 					! $this->pui_product_status->pui_is_active()
 					|| ! $this->pui_helper->is_checkout_ready_for_pui()
-					|| ! $this->pui_helper->is_pay_for_order_ready_for_pui()
+					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					|| ( isset( $_GET['pay_for_order'] ) && $_GET['pay_for_order'] === 'true' && ! $this->pui_helper->is_pay_for_order_ready_for_pui() )
 				) {
 					unset( $methods[ PayUponInvoiceGateway::ID ] );
 				}


### PR DESCRIPTION
Ensure `pay_for_order` exist in the request before using it for unsetting PUI gateway.