### PR TITLE
Fix product price retrieval for variable product buttons

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -7,6 +7,7 @@ class SingleProductBootstap {
         this.renderer = renderer;
         this.messages = messages;
         this.errorHandler = errorHandler;
+        this.mutationObserver = new MutationObserver(this.handleChange.bind(this));
     }
 
 
@@ -23,7 +24,13 @@ class SingleProductBootstap {
 
     init() {
 
-        document.querySelector('form.cart').addEventListener('change', this.handleChange.bind(this))
+        const form = document.querySelector('form.cart');
+        if (!form) {
+            return;
+        }
+
+        form.addEventListener('change', this.handleChange.bind(this));
+        this.mutationObserver.observe(form, {childList: true, subtree: true});
 
         if (!this.shouldRender()) {
             this.renderer.hideButtons(this.gateway.hosted_fields.wrapper);

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -42,21 +42,24 @@ class SingleProductBootstap {
     }
 
     priceAmount() {
+        const priceText = [
+            () => document.querySelector('form.cart ins .woocommerce-Price-amount')?.innerText,
+            () => document.querySelector('form.cart .woocommerce-Price-amount')?.innerText,
+            () => {
+                const priceEl = document.querySelector('.product .woocommerce-Price-amount');
+                // variable products show price like 10.00 - 20.00 here
+                if (priceEl && priceEl.parentElement.querySelectorAll('.woocommerce-Price-amount').length === 1) {
+                    return priceEl.innerText;
+                }
+                return null;
+            },
+        ].map(f => f()).find(val => val);
 
-        let priceText = "0";
-        if (document.querySelector('form.cart ins .woocommerce-Price-amount')) {
-            priceText = document.querySelector('form.cart ins .woocommerce-Price-amount').innerText;
-        }
-        else if (document.querySelector('form.cart .woocommerce-Price-amount')) {
-            priceText = document.querySelector('form.cart .woocommerce-Price-amount').innerText;
-        }
-        else if (document.querySelector('.product .woocommerce-Price-amount')) {
-            priceText = document.querySelector('.product .woocommerce-Price-amount').innerText;
+        if (!priceText) {
+            return 0;
         }
 
-        priceText = priceText.replace(/,/g, '.');
-
-        return  parseFloat(priceText.replace(/([^\d,\.\s]*)/g, ''));
+        return parseFloat(priceText.replace(/,/g, '.').replace(/([^\d,\.\s]*)/g, ''));
     }
 
     priceAmountIsZero() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -60,7 +60,8 @@ class SingleProductBootstap {
     }
 
     priceAmountIsZero() {
-        return this.priceAmount() === 0;
+        const price = this.priceAmount();
+        return !price || price === 0;
     }
 
     render() {


### PR DESCRIPTION
Fixes the brief button appearance during product page loading for unselected variations. It was incorrectly retrieving the price from the always present "10.00$ - 20.00$" line until the form finishes loading. And added `MutationObserver` because `form` `change` does not seem to trigger after the initial price loading, only when changing selection.