### PR TITLE
Type check error with German Market plugin (961)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -291,6 +291,11 @@ class PayUponInvoice {
 
 		add_action(
 			'woocommerce_email_before_order_table',
+			/**
+			 * WC_Email type removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
 			function( WC_Order $order, bool $sent_to_admin, bool $plain_text, $email ) {
 				if (
 					! $sent_to_admin

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -291,12 +291,12 @@ class PayUponInvoice {
 
 		add_action(
 			'woocommerce_email_before_order_table',
-			function( WC_Order $order, bool $sent_to_admin, bool $plain_text, WC_Email $email ) {
+			function( WC_Order $order, bool $sent_to_admin, bool $plain_text, $email ) {
 				if (
 					! $sent_to_admin
 					&& PayUponInvoiceGateway::ID === $order->get_payment_method()
 					&& $order->has_status( 'processing' )
-					&& $email->id === 'customer_processing_order'
+					&& is_a( $email, WC_Email::class ) && $email->id === 'customer_processing_order'
 				) {
 					$this->logger->info( "Adding Ratepay payment instructions to email for order #{$order->get_id()}." );
 


### PR DESCRIPTION
User reported this error occuring while Pay upon Invoice is disabled and when attempting to check out with a 0€ product. So no payment gateway is involved, but the checkout still fails due to this error.
```
CRITICAL Uncaught TypeError: Argument 4 passed to WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoice::WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\{closure}() must be an instance of WC_Email, bool given
```