### PR TITLE
Fix the Standard Card button gateway strings

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -196,7 +196,7 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 			);
 		}
 
-		$this->method_title       = __( 'Advanced Card Processing', 'woocommerce-paypal-payments' );
+		$this->method_title       = __( 'Standard Card Button', 'woocommerce-paypal-payments' );
 		$this->method_description = __( 'The separate payment gateway with the card button. If disabled, the button is included in the PayPal gateway.', 'woocommerce-paypal-payments' );
 		$this->title              = $this->get_option( 'title', __( 'Debit & Credit Cards', 'woocommerce-paypal-payments' ) );
 		$this->description        = $this->get_option( 'description', '' );
@@ -230,7 +230,7 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 			'enabled'     => array(
 				'title'       => __( 'Enable/Disable', 'woocommerce-paypal-payments' ),
 				'type'        => 'checkbox',
-				'label'       => __( 'Enable Advanced Card Processing', 'woocommerce-paypal-payments' ),
+				'label'       => __( 'Enable Standard Card Button gateway', 'woocommerce-paypal-payments' ),
 				'default'     => $this->default_enabled ? 'yes' : 'no',
 				'desc_tip'    => true,
 				'description' => __( 'Enable/Disable the separate payment gateway with the card button.', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #1002

---

### Description

<h3 data-renderer-start-pos="1" style="margin: 0px; padding: 0px; font-size: 1.14286em; line-height: 1.25; font-weight: 600; letter-spacing: -0.006em; font-style: normal; color: rgb(23, 43, 77); text-transform: none; font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-variant-ligatures: normal; font-variant-caps: normal; orphans: 2; text-align: start; text-indent: 0px; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(235, 236, 240); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Standard Card Button gateway settings</h3><div class="pm-table-container " data-layout="default" style="margin: 0px auto 16px; padding: 0px; position: relative; box-sizing: border-box; clear: both; z-index: 0; transition: all 0.1s linear 0s; display: flex; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(235, 236, 240); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; width: inherit;"><div class="pm-table-wrapper" style="margin: 0px; padding: 0px; overflow-x: auto;">

current string | new string
-- | --
Advanced Card Processing | Standard Card Button
Enable Advanced Card Processing | Enable Standard Card Button gateway

</div></div><div data-layout="align-start" data-width="50" data-node-type="mediaSingle" class="rich-media-item mediaSingleView-content-wrap image-align-start css-3lm7n7" style="margin: 24px auto 24px 0px; padding: 0px; width: 438px; max-width: 100%; float: none; transition: width 100ms ease-in 0s; clear: both; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(235, 236, 240); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="css-g3k3ku" style="margin: 0px; padding: 0px; position: relative;"><div data-context-id="95434" data-type="file" data-node-type="media" data-width="799" data-height="454" data-id="923a94c4-3d03-4f2e-a96b-3385e14e7d6c" data-collection="" data-file-name="image-20221116-121139.png" data-file-size="45844" data-file-mime-type="image/png" data-alt="" style="margin: 0px; padding: 0px; position: static !important; height: 0px; width: 438px;"><div id="newFileExperienceWrapper" class="new-file-experience-wrapper css-dxo65y" data-testid="media-card-view" style="margin: 0px; padding: 0px; transition: all 0.3s ease 0s; box-sizing: border-box; position: absolute; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; width: 899px; max-width: 100%; height: 248.875px; max-height: 100%; border-radius: 3px; cursor: pointer; font-size: 14px; line-height: 22px;"><div class="media-file-card-view css-1f0gn7q" data-testid="media-file-card-view" data-test-status="complete" data-test-media-name="image-20221116-121139.png" data-test-progress="1" style="margin: 0px; padding: 0px; display: flex; position: relative; max-width: 100%; width: 438px; height: 248.875px; max-height: 100%; overflow: hidden; border-radius: 3px; box-sizing: border-box;"><img data-testid="media-image" draggable="false" alt="" src="blob:https://inpsyde.atlassian.net/a36e91c9-1fff-4e62-afa5-8e58f04745f6#media-blob-url=true&amp;id=923a94c4-3d03-4f2e-a96b-3385e14e7d6c&amp;collection=&amp;contextId=95434&amp;mimeType=image%2Fpng&amp;name=image-20221116-121139.png&amp;size=45844&amp;height=454&amp;width=799&amp;alt=" style="margin: 0px; padding: 0px; border: 0px; box-sizing: border-box; position: absolute; left: 219px; top: 124.438px; object-fit: contain; image-orientation: none; transform: translate(-50%, -50%); width: 438px;"></div></div></div></div></div><div data-layout="align-start" data-width="50" data-node-type="mediaSingle" class="rich-media-item mediaSingleView-content-wrap image-align-start css-3lm7n7" style="margin: 24px auto 24px 0px; padding: 0px; width: 438px; max-width: 100%; float: none; transition: width 100ms ease-in 0s; clear: both; color: rgb(23, 43, 77); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: pre-wrap; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(235, 236, 240); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="css-1bpe9zv" style="margin: 0px; padding: 0px; position: relative;"><div data-context-id="95434" data-type="file" data-node-type="media" data-width="1282" data-height="114" data-id="f4b60af8-62d5-496e-b254-f405ccab7262" data-collection="" data-file-name="image-20221116-121846.png" data-file-size="15341" data-file-mime-type="image/png" data-alt="" style="margin: 0px; padding: 0px; position: static !important; height: 0px; width: 438px;"><div id="newFileExperienceWrapper" class="new-file-experience-wrapper css-12vve75" data-testid="media-card-view" style="margin: 0px; padding: 0px; transition: all 0.3s ease 0s; box-sizing: border-box; position: absolute; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, Oxygen, Ubuntu, &quot;Fira Sans&quot;, &quot;Droid Sans&quot;, &quot;Helvetica Neue&quot;, sans-serif; width: 899px; max-width: 100%; height: 38.9453px; max-height: 100%; border-radius: 3px; cursor: pointer; font-size: 14px; line-height: 22px;"><div class="media-file-card-view css-1f0gn7q" data-testid="media-file-card-view" data-test-status="complete" data-test-media-name="image-20221116-121846.png" data-test-progress="1" style="margin: 0px; padding: 0px; display: flex; position: relative; max-width: 100%; width: 438px; height: 38.9453px; max-height: 100%; overflow: hidden; border-radius: 3px; box-sizing: border-box;"><img data-testid="media-image" draggable="false" alt="" src="blob:https://inpsyde.atlassian.net/ffbfb2a5-bf04-4174-a948-ed317f0f632f#media-blob-url=true&amp;id=f4b60af8-62d5-496e-b254-f405ccab7262&amp;collection=&amp;contextId=95434&amp;mimeType=image%2Fpng&amp;name=image-20221116-121846.png&amp;size=15341&amp;height=114&amp;width=1282&amp;alt=" style="margin: 0px; padding: 0px; border: 0px; box-sizing: border-box; position: absolute; left: 219px; top: 19.4688px; object-fit: contain; image-orientation: none; transform: translate(-50%, -50%); width: 438px;"></div></div></div></div></div>

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Check the strings for Standard Card Button gateway.

---

Closes #1002 .
