### PR TITLE
Add a note about the modularity namespaces breaking change

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,10 @@
 * Enhancement - Hide Pay upon Invoice tab if not available for merchant #978
 * Enhancement - Handle synced sub without upfront payment like free trial #936
 * Enhancement - Isolate container and modularity deps #972
+  **NOTE**: if you were extending/modifying the plugin using the modularity system, 
+  you will need to add the `WooCommerce\PayPalCommerce\Vendor\`  prefix for the container/modularity namespaces in your code,
+  that is `Psr\Container\ContainerInterface` becomes `WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface`,
+  and `Dhii\Modular\Module\ModuleInterface` becomes `WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface`.
 * Enhancement - PUI gateway displayed on pay for order page when mandatory billing fields are left empty or country is unsupported #966
 * Enhancement - When Brand Name field is left empty, PUI purchase fails #916
 * Enhancement - Improve styling when using separate buttons #996

--- a/readme.txt
+++ b/readme.txt
@@ -99,6 +99,10 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Enhancement - Hide Pay upon Invoice tab if not available for merchant #978
 * Enhancement - Handle synced sub without upfront payment like free trial #936
 * Enhancement - Isolate container and modularity deps #972
+  **NOTE**: if you were extending/modifying the plugin using the modularity system, 
+  you will need to add the `WooCommerce\PayPalCommerce\Vendor\`  prefix for the container/modularity namespaces in your code,
+  that is `Psr\Container\ContainerInterface` becomes `WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface`,
+  and `Dhii\Modular\Module\ModuleInterface` becomes `WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface`.
 * Enhancement - PUI gateway displayed on pay for order page when mandatory billing fields are left empty or country is unsupported #966
 * Enhancement - When Brand Name field is left empty, PUI purchase fails #916
 * Enhancement - Improve styling when using separate buttons #996

--- a/readme.txt
+++ b/readme.txt
@@ -107,7 +107,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Enhancement - When Brand Name field is left empty, PUI purchase fails #916
 * Enhancement - Improve styling when using separate buttons #996
 
-= 1.9.5
+= 1.9.5 =
 * Fix - Invalid tracking number in logs when adding tracking #903
 * Fix - Tracking on Connection tab always enabled #900
 * Fix - PUI payment instructions printed in the refund email #873


### PR DESCRIPTION
Added a note about changing the namespaces for container/modularity interfaces (#972) in the changelogs.

Also fixed the missing `=` in the changelog.