### PR TITLE
Add plugin update hook & run PayLater migration if plugin is updated

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -200,7 +200,7 @@ class CompatModule implements ModuleInterface {
 		}
 
 		add_action(
-			'woocommerce_paypal_payments_gateway_migrate',
+			'woocommerce_paypal_payments_gateway_migrate_on_update',
 			function () use ( $c, $is_pay_later_settings_migrated_option_name ) {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -90,13 +90,21 @@ define( 'PPCP_FLAG_SUBSCRIPTION', true );
 			if ( ! function_exists( 'get_plugin_data' ) ) {
 				require_once ABSPATH . 'wp-admin/includes/plugin.php';
 			}
-			$plugin_data    = get_plugin_data( __DIR__ . '/woocommerce-paypal-payments.php' );
-			$plugin_version = $plugin_data['Version'] ?? null;
-			if ( get_option( 'woocommerce-ppcp-version' ) !== $plugin_version ) {
+			$plugin_data              = get_plugin_data( __DIR__ . '/woocommerce-paypal-payments.php' );
+			$plugin_version           = $plugin_data['Version'] ?? null;
+			$installed_plugin_version = get_option( 'woocommerce-ppcp-version' );
+			if ( $installed_plugin_version !== $plugin_version ) {
 				/**
 				 * The hook fired when the plugin is installed or updated.
 				 */
 				do_action( 'woocommerce_paypal_payments_gateway_migrate' );
+
+				if ( $installed_plugin_version ) {
+					/**
+					 * The hook fired when the plugin is updated.
+					 */
+					do_action( 'woocommerce_paypal_payments_gateway_migrate_on_update' );
+				}
 				update_option( 'woocommerce-ppcp-version', $plugin_version );
 			}
 		}


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #1006

---

### Description

Currently the migration hook is fired if the plugin is updated OR INSTALLED. So when the plugin is installed then Pay Later settings migration will be executed and the defaults will not be set correctly

The PR will add a new hook when the plugin is updated only: `woocommerce_paypal_payments_gateway_migrate_on_update`
And migration will hook to this.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Install the plugin and make sure migration of pay later settings haven't done.

---

Closes #1006 .
