### PR TITLE
Prevent throwing an exception during woocommerce_gzd_shipment_after_save hook

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -176,7 +176,6 @@ class CompatModule implements ModuleInterface {
 					! $tracking_information ? $endpoint->add_tracking_information( $tracking_data, $wc_order->get_id() ) : $endpoint->update_tracking_information( $tracking_data, $wc_order->get_id() );
 				} catch ( Exception $exception ) {
 					$logger->error( "Couldn't sync tracking information: " . $exception->getMessage() );
-					$shipment->add_note( "Couldn't sync tracking information: " . $exception->getMessage() );
 				}
 			}
 		);

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -169,7 +169,7 @@ class CompatModule implements ModuleInterface {
 
 					$tracking_data['tracking_number'] = $tracking_information['tracking_number'] ?? '';
 
-					if ( $shipment->has_tracking() ) {
+					if ( $shipment->get_tracking_id() ) {
 						$tracking_data['tracking_number'] = $shipment->get_tracking_id();
 					}
 
@@ -177,7 +177,6 @@ class CompatModule implements ModuleInterface {
 				} catch ( Exception $exception ) {
 					$logger->error( "Couldn't sync tracking information: " . $exception->getMessage() );
 					$shipment->add_note( "Couldn't sync tracking information: " . $exception->getMessage() );
-					throw $exception;
 				}
 			}
 		);


### PR DESCRIPTION
**Issue**: #1020 

---

### Description

Prevent throwing an exception during `woocommerce_gzd_shipment_after_save` hook as it prevents status transitions from happening in case updating tracking information in PayPal fails while saving a shipment. Check for `tracking_id` availability only as the `has_tracking()` method might perform additional tracking checks.

### Steps to Test

1. Make sure Germanized for WooCommerce is installed
2. Create a new order with PayPal as payment method
3. Create a shipment to the order containing tracking information (tracking id and/or label) and DHL as shipping provider
4. Make sure updating tracking information fails and the [exception](https://github.com/woocommerce/woocommerce-paypal-payments/blob/f6802dd9770c4bdb46ac0fd93072f840820a1c4a/modules/ppcp-compat/src/CompatModule.php#L180) is thrown
5. See how updating the shipment status when saving the shipment fails

### Changelog Entry

Fixes a bug while updating tracking information based on shipment data in Germanized for WooCommerce.
