### PR TITLE
Do not call PayPal get order by ID if it does not exist (951)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -443,14 +443,8 @@ class OrderEndpoint {
 			$error = new RuntimeException(
 				__( 'Could not retrieve order.', 'woocommerce-paypal-payments' )
 			);
-			$this->logger->log(
-				'warning',
-				$error->getMessage(),
-				array(
-					'args'     => $args,
-					'response' => $response,
-				)
-			);
+			$this->logger->warning($error->getMessage());
+
 			throw $error;
 		}
 		$json        = json_decode( $response['body'] );
@@ -485,8 +479,8 @@ class OrderEndpoint {
 			);
 			throw $error;
 		}
-		$order = $this->order_factory->from_paypal_response( $json );
-		return $order;
+
+		return $this->order_factory->from_paypal_response( $json );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -443,7 +443,7 @@ class OrderEndpoint {
 			$error = new RuntimeException(
 				__( 'Could not retrieve order.', 'woocommerce-paypal-payments' )
 			);
-			$this->logger->warning($error->getMessage());
+			$this->logger->warning( $error->getMessage() );
 
 			throw $error;
 		}

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -167,7 +167,12 @@ class OrderProcessor {
 		if ( ! $order ) {
 			$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
 			if ( ! $order_id ) {
-				$this->logger->warning( "No PayPal order ID found in order #{$wc_order->get_id()} meta." );
+				$this->logger->warning(
+					sprintf(
+						'No PayPal order ID found in order #%d meta.',
+						$wc_order->get_id()
+					)
+				);
 				$this->last_error = __( 'Could not retrieve order. This browser may not be supported. Please try again with a different browser.', 'woocommerce-paypal-payments' );
 				return false;
 			}

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -10,9 +10,11 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 use Psr\Log\LoggerInterface;
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderHelper;
 use WooCommerce\PayPalCommerce\Button\Helper\ThreeDSecure;
@@ -160,17 +162,21 @@ class OrderProcessor {
 	 *
 	 * @return bool
 	 */
-	public function process( \WC_Order $wc_order ): bool {
-		$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
-		if ( ! $order_id ) {
-			$this->last_error = __( 'No PayPal order ID found in the current WooCommerce session.', 'woocommerce-paypal-payments' );
-			return false;
-		}
-
-		$order = $this->session_handler->order() ?? $this->order_endpoint->order( $order_id );
+	public function process( WC_Order $wc_order ): bool {
+		$order = $this->session_handler->order();
 		if ( ! $order ) {
-			$this->last_error = __( 'No PayPal order found in the current WooCommerce session.', 'woocommerce-paypal-payments' );
-			return false;
+			$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
+			if ( ! $order_id ) {
+				$this->last_error = __( 'No PayPal order ID found in order meta.', 'woocommerce-paypal-payments' );
+				return false;
+			}
+
+			try {
+				$order = $this->order_endpoint->order( $order_id );
+			} catch ( RuntimeException $exception ) {
+				$this->last_error = __( 'Could not retrieve PayPal order.', 'woocommerce-paypal-payments' );
+				return false;
+			}
 		}
 
 		$this->add_paypal_meta( $wc_order, $order, $this->environment );

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -168,7 +168,7 @@ class OrderProcessor {
 			$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
 			if ( ! $order_id ) {
 				$this->logger->warning( "No PayPal order ID found in order #{$wc_order->get_id()} meta." );
-				$this->last_error = __( 'Could not retrieve PayPal order.', 'woocommerce-paypal-payments' );
+				$this->last_error = __( 'Could not retrieve order. This browser may not be supported. Please try again with a different browser.', 'woocommerce-paypal-payments' );
 				return false;
 			}
 

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -162,7 +162,12 @@ class OrderProcessor {
 	 */
 	public function process( \WC_Order $wc_order ): bool {
 		$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
-		$order    = $this->session_handler->order() ?? $this->order_endpoint->order( $order_id );
+		if ( ! $order_id ) {
+			$this->last_error = __( 'No PayPal order ID found in the current WooCommerce session.', 'woocommerce-paypal-payments' );
+			return false;
+		}
+
+		$order = $this->session_handler->order() ?? $this->order_endpoint->order( $order_id );
 		if ( ! $order ) {
 			$this->last_error = __( 'No PayPal order found in the current WooCommerce session.', 'woocommerce-paypal-payments' );
 			return false;

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -167,7 +167,8 @@ class OrderProcessor {
 		if ( ! $order ) {
 			$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
 			if ( ! $order_id ) {
-				$this->last_error = __( 'No PayPal order ID found in order meta.', 'woocommerce-paypal-payments' );
+				$this->logger->warning( "No PayPal order ID found in order #{$wc_order->get_id()} meta." );
+				$this->last_error = __( 'Could not retrieve PayPal order.', 'woocommerce-paypal-payments' );
 				return false;
 			}
 

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
@@ -125,7 +125,7 @@ class OrderEndpointTest extends TestCase
         $patchCollectionFactory = Mockery::mock(PatchCollectionFactory::class);
         $intent = 'CAPTURE';
         $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('log');
+        $logger->shouldReceive('warning');
         $logger->shouldReceive('debug');
         $applicationContextRepository = Mockery::mock(ApplicationContextRepository::class);
         $paypalRequestIdRepository = Mockery::mock(PayPalRequestIdRepository::class);


### PR DESCRIPTION
For some reason (probably caused by a JS error that does not load the PayPal buttons) WC order meta returns an empty string in `OrderProcessor::process` and then `OrderEndpoint::order(string $id): Order` is called using that empty string.

```
GET https://api.paypal.com/v2/checkout/orders/
Response: Array
(
    [code] => 404
    [message] => Not Found
)
```
The above request displays "**Could not retrieve order**" error as no PayPal order exist in the request.

This PR ensures get order is not called when there is no id, it also updates the error message.