### PR TITLE
Fix DCC error messages handling

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -59,9 +59,9 @@ class CheckoutActionHandler {
                         );
                     } else {
                         errorHandler.clear();
-                        if (data.data.errors.length > 0) {
+                        if (data.data.errors?.length > 0) {
                             errorHandler.messages(data.data.errors);
-                        } else if (data.data.details.length > 0) {
+                        } else if (data.data.details?.length > 0) {
                             errorHandler.message(data.data.details.map(d => `${d.issue} ${d.description}`).join('<br/>'), true);
                         } else {
                             errorHandler.message(data.data.message, true);

--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -233,8 +233,14 @@ class CreditCardRenderer {
                 this.spinner.unblock();
                 this.errorHandler.clear();
 
-                if (err.details?.length) {
+                if (err.data?.details?.length) {
+                    this.errorHandler.message(err.data.details.map(d => `${d.issue} ${d.description}`).join('<br/>'), true);
+                } else if (err.details?.length) {
                     this.errorHandler.message(err.details.map(d => `${d.issue} ${d.description}`).join('<br/>'), true);
+                } else if (err.data?.errors?.length > 0) {
+                    this.errorHandler.messages(err.data.errors);
+                } else if (err.data?.message) {
+                    this.errorHandler.message(err.data.message, true);
                 } else if (err.message) {
                     this.errorHandler.message(err.message, true);
                 } else {


### PR DESCRIPTION
We were not handling the validation errors output here like in https://github.com/woocommerce/woocommerce-paypal-payments/blob/e5cced2008313d896350f518d4e032b3bed1bc0c/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js#L62-L63

Also `err` here may have `.data` object instead of having all info directly, depending on where it came from. For example, the validation errors from us are inside `.data`, but PayPal errors coming from SDK do not have `.data`.

Not sure about `.details`, so keeping both for now.

And also in the buttons checkout link above, we are missing null checks/`?`, so it will fail if e.g. not validation errors, fixed that too.