### PR TITLE
Param types removed to avoid third-party issues (1063)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
@@ -81,12 +81,12 @@ class OXXO {
 		add_filter(
 			'woocommerce_thankyou_order_received_text',
 			/**
-			 * Order can be null.
+			 * Param types removed to avoid third-party issues.
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( string $message, $order ) {
-				if ( ! $order instanceof WC_Order ) {
+			function( $message, $order ) {
+				if ( ! is_string( $message ) || ! $order instanceof WC_Order ) {
 					return $message;
 				}
 


### PR DESCRIPTION
A fatal error is thrown when passing `null` on filter `woocommerce_thankyou_order_received_text`:
```
PHP Fatal error: Uncaught TypeError: Argument 1 passed to WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO::WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\{closure}() must be of the type string, null given
```