### PR TITLE
Fix shipping address validation

### DIFF
--- a/modules/ppcp-button/src/Validation/CheckoutFormValidator.php
+++ b/modules/ppcp-button/src/Validation/CheckoutFormValidator.php
@@ -32,6 +32,8 @@ class CheckoutFormValidator extends WC_Checkout {
 		foreach ( $data as $key => $value ) {
 			$_POST[ $key ] = $value;
 		}
+		// And we must call get_posted_data because it handles the shipping address.
+		$data = $this->get_posted_data();
 
 		// It throws some notices when checking fields etc., also from other plugins via hooks.
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged


### PR DESCRIPTION
`WC_Checkout::get_posted_data` fills the shipping fields when needed, otherwise they can be missing in some cases, resulting in an unexpected validation error.

So now just calling it too, since we already had to set `$_POST`.