### PR TITLE
All tabs hidden on OXXO tab visit (996)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -168,7 +168,7 @@ return array(
 				CreditCardGateway::ID,
 				PayUponInvoiceGateway::ID,
 				CardButtonGateway::ID,
-				OXXOGateway::ID .
+				OXXOGateway::ID,
 				Settings::PAY_LATER_TAB_ID,
 			),
 			true


### PR DESCRIPTION
When  merchant visit OXXO settings, all tabs will be hidden,

### Steps To Reproduce
- Set store country to Mexico
- Onboard with Mexican business account 
- Visit OXXO settings tab

Observe, tab structure has disappeared