### PR TITLE
Sync GZD shipment only if status is changed to "shipped"

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -56,15 +56,6 @@ return array(
 		return function_exists( 'wc_gzd_get_shipments_by_order' ); // 3.0+
 	},
 
-	'compat.gzd.tracking_statuses_map'              => function ( ContainerInterface $container ): array {
-		return array(
-			'draft'      => 'ON_HOLD',
-			'processing' => 'SHIPPED',
-			'shipped'    => 'SHIPPED',
-			'delivered'  => 'DELIVERED',
-		);
-	},
-
 	'compat.module.url'                             => static function ( ContainerInterface $container ): string {
 		/**
 		 * The path cannot be false.

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -130,17 +130,10 @@ class CompatModule implements ModuleInterface {
 		$logger = $c->get( 'woocommerce.logger.woocommerce' );
 		assert( $logger instanceof LoggerInterface );
 
-		$status_map = $c->get( 'compat.gzd.tracking_statuses_map' );
-
 		add_action(
-			'woocommerce_gzd_shipment_after_save',
-			static function( Shipment $shipment ) use ( $endpoint, $logger, $status_map ) {
+			'woocommerce_gzd_shipment_status_shipped',
+			static function( int $shipment_id, Shipment $shipment ) use ( $endpoint, $logger ) {
 				if ( ! apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) ) {
-					return;
-				}
-
-				$gzd_shipment_status = $shipment->get_status();
-				if ( ! array_key_exists( $gzd_shipment_status, $status_map ) ) {
 					return;
 				}
 
@@ -156,7 +149,7 @@ class CompatModule implements ModuleInterface {
 
 				$tracking_data = array(
 					'transaction_id' => $transaction_id,
-					'status'         => (string) $status_map[ $gzd_shipment_status ],
+					'status'         => 'SHIPPED',
 				);
 
 				$provider = $shipment->get_shipping_provider();
@@ -177,7 +170,9 @@ class CompatModule implements ModuleInterface {
 				} catch ( Exception $exception ) {
 					$logger->error( "Couldn't sync tracking information: " . $exception->getMessage() );
 				}
-			}
+			},
+			500,
+			2
 		);
 	}
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #1020

---

### Description

Currently when changing the Germanized shipment we automatically send the tracking info to PayPal. Since there is a limitation on PayPal which doesn't allow to update the same tracking for more then certain number of times (about 15), the decision was made to sync the GZD shipment only when status is changed to "shipped" ( suggested by GZD ).

### Steps to Test

1. When the status is not "Shipped" the sync should not happen.
2. When the status is "Shipped" the sync not happens after saving the shipment.

---

Closes #1020 .
