### PR TITLE
Wrong asset path Germanized compat (1033)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "install:modules:ppcp-vaulting": "cd modules/ppcp-vaulting && yarn install",
     "install:modules:ppcp-order-tracking": "cd modules/ppcp-order-tracking && yarn install",
     "install:modules:ppcp-onboarding": "cd modules/ppcp-onboarding && yarn install",
+    "install:modules:ppcp-compat": "cd modules/ppcp-compat && yarn install",
 
     "build:modules:ppcp-button": "cd modules/ppcp-button && yarn run build",
     "build:modules:ppcp-wc-gateway": "cd modules/ppcp-wc-gateway && yarn run build",
@@ -21,6 +22,7 @@
     "build:modules:ppcp-vaulting": "cd modules/ppcp-vaulting && yarn run build",
     "build:modules:ppcp-order-tracking": "cd modules/ppcp-order-tracking && yarn run build",
     "build:modules:ppcp-onboarding": "cd modules/ppcp-onboarding && yarn run build",
+    "build:modules:ppcp-compat": "cd modules/ppcp-compat && yarn run build",
     "build:modules": "run-p build:modules:*",
 
     "watch:modules:ppcp-button": "cd modules/ppcp-button && yarn run watch",
@@ -29,6 +31,7 @@
     "watch:modules:ppcp-vaulting": "cd modules/ppcp-vaulting && yarn run watch",
     "watch:modules:ppcp-order-tracking": "cd modules/ppcp-order-tracking && yarn run watch",
     "watch:modules:ppcp-onboarding": "cd modules/ppcp-onboarding && yarn run watch",
+    "watch:modules:ppcp-compat": "cd modules/ppcp-compat && yarn run watch",
     "watch:modules": "run-p watch:modules:*",
 
     "ddev:setup": "ddev start && ddev orchestrate",


### PR DESCRIPTION
Installation searches for file `modules/ppcp-compat/assets/js/gzd-compat.js` which is not currently in `assets` path.

This PR adds `ppcp-compat` to package.json scripts which creates `assets` compiled directories at build time.