### PR TITLE
Execute WC validation only for buttons in checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Fix PHP 8.1 deprecated error #1009
 * Fix - Wrong asset path Germanized compat #1051
 * Fix - Fix DCC error messages handling #1035
+* Fix - Execute WC validation only for smart buttons in checkout #1074
 * Enhancement - Param types removed in closure to avoid third-party issues #1046
 
 = 2.0.0 - 2022-11-21 =

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -248,7 +248,11 @@ class CreateOrderEndpoint implements EndpointInterface {
 
 			$form_fields = $data['form'] ?? null;
 
-			if ( $this->early_validation_enabled && is_array( $form_fields ) ) {
+			if ( $this->early_validation_enabled
+				&& is_array( $form_fields )
+				&& 'checkout' === $data['context']
+				&& in_array( $payment_method, array( PayPalGateway::ID, CardButtonGateway::ID ), true )
+			) {
 				$this->validate_form( $form_fields );
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - Fix PHP 8.1 deprecated error #1009
 * Fix - Wrong asset path Germanized compat #1051
 * Fix - Fix DCC error messages handling #1035
+* Fix - Execute WC validation only for smart buttons in checkout #1074
 * Enhancement - Param types removed in closure to avoid third-party issues #1046
 
 = 2.0.0 =


### PR DESCRIPTION
Using this validation on other pages (pay for order page) or other payment methods seems to cause issues, so now using it only for smart buttons in checkout.

Should partially fix #1011