### PR TITLE
Do not check type in filter callback signature (994)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
@@ -63,7 +63,15 @@ class OXXO {
 
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function ( array $methods ): array {
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function ( $methods ) {
+				if ( ! is_array( $methods ) ) {
+					return $methods;
+				}
 
 				if ( ! $this->checkout_allowed_for_oxxo() ) {
 					unset( $methods[ OXXOGateway::ID ] );


### PR DESCRIPTION
Fixes type check error in callback signature:
```
An error of type E_ERROR was caused in line 66 of the file [...]/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php. Error message: Uncaught TypeError: Argument 1 passed to WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO::WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\{closure}() must be of the type array, null given, called in [...