### PR TITLE
Ensure `WC()->payment_gateways` is not null

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Do not call PayPal get order by ID if it does not exist #1029
 * Fix - Type check error conflict with German Market #1056 
 * Fix - Backend Storage for the PayPalRequestIdRepository does not scale #983
+* Fix - Ensure WC()->payment_gateways is not null #1128
 * Enhancement - Remove plugin data after uninstalling #1075
 * Enhancement - Add FraudNet to all payments #1040
 * Enhancement - Update "Standard Payments" tab settings #1065

--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -99,6 +99,10 @@ class DisableGateways {
 	 * @return bool
 	 */
 	private function disable_all_gateways() : bool {
+		if ( is_null( WC()->payment_gateways ) ) {
+			return false;
+		}
+
 		foreach ( WC()->payment_gateways->payment_gateways() as $gateway ) {
 			if ( PayPalGateway::ID === $gateway->id && $gateway->enabled !== 'yes' ) {
 				return true;

--- a/readme.txt
+++ b/readme.txt
@@ -85,6 +85,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - Do not call PayPal get order by ID if it does not exist #1029
 * Fix - Type check error conflict with German Market #1056 
 * Fix - Backend Storage for the PayPalRequestIdRepository does not scale #983
+* Fix - Ensure WC()->payment_gateways is not null #1128
 * Enhancement - Remove plugin data after uninstalling #1075
 * Enhancement - Add FraudNet to all payments #1040
 * Enhancement - Update "Standard Payments" tab settings #1065


### PR DESCRIPTION
```
An error of type E_ERROR was caused in line 102 of the file /woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php. 
Error message: Uncaught Error: Call to a member function payment_gateways() on null in /woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php:102
```