### PR TITLE
When PUI is enabled FraudNet should be also enabled (mandatory for PUI)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Enhancement - Add FraudNet to all payments #1040
 * Enhancement - Update "Standard Payments" tab settings #1065
 * Enhancement - Update PHP 7.2 requirement in all relevant files #1084
+* Enhancement - When PUI is enabled FraudNet should be also enabled #1129
 
 = 2.0.1 - 2022-12-13 =
 * Fix - Error while syncing tracking data to PayPal -> Sync GZD Tracking #1020

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1147,6 +1147,16 @@ return array(
 
 		return false;
 	},
+	'wcgateway.settings.should-disable-fraudnet-checkbox'  => static function( ContainerInterface $container ): bool {
+		$pui_helper = $container->get( 'wcgateway.pay-upon-invoice-helper' );
+		assert( $pui_helper instanceof PayUponInvoiceHelper );
+
+		if ( $pui_helper->is_pui_gateway_enabled() ) {
+			return true;
+		}
+
+		return false;
+	},
 	'wcgateway.settings.tracking-label'                    => static function ( ContainerInterface $container ): string {
 		$tracking_label = sprintf(
 		// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -139,6 +139,11 @@ class PayUponInvoice {
 	 * @throws NotFoundException When setting is not found.
 	 */
 	public function init(): void {
+		if ( $this->pui_helper->is_pui_gateway_enabled() ) {
+			$this->settings->set( 'fraudnet_enabled', true );
+			$this->settings->persist();
+		}
+
 		add_filter(
 			'ppcp_partner_referrals_data',
 			function ( array $data ): array {

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -411,6 +411,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			),
 			'requirements' => array(),
 			'gateway'      => Settings::CONNECTION_TAB_ID,
+			'input_class'  => $container->get( 'wcgateway.settings.should-disable-fraudnet-checkbox' ) ? array( 'ppcp-disabled-checkbox' ) : array(),
 		),
 
 		'credentials_integration_configuration_heading' => array(

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Enhancement - Add FraudNet to all payments #1040
 * Enhancement - Update "Standard Payments" tab settings #1065
 * Enhancement - Update PHP 7.2 requirement in all relevant files #1084
+* Enhancement - When PUI is enabled FraudNet should be also enabled #1129
 
 = 2.0.1 =
 * Fix - Error while syncing tracking data to PayPal -> Sync GZD Tracking #1020


### PR DESCRIPTION
When PUI is enabled FraudNet is optional but should be mandatory for it

### Steps To Reproduce

- Go to WC->Settings->Payments
- Scroll to Pay upon invoice and enabled it (fill all mandatory fields)
- Scroll to button Save changes and click
- Go to Connection tabScroll to FraudNet
- Observe FraudNet is optional to enabled/disabled
- Leave it unchecked
- Go to store
- Add product to cart
- Go to checkout page
- Fill billing informations
- Select Pay upon invoice
- Add birth date
- Click on button Place order
- See "DEVICE_DATA_NOT_AVAILABLE" error message 
