### PR TITLE
Validate new user creation

### DIFF
--- a/modules/ppcp-button/src/Validation/CheckoutFormValidator.php
+++ b/modules/ppcp-button/src/Validation/CheckoutFormValidator.php
@@ -39,6 +39,45 @@ class CheckoutFormValidator extends WC_Checkout {
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		@$this->validate_checkout( $data, $errors );
 
+		if (
+			apply_filters( 'woocommerce_paypal_payments_early_wc_checkout_account_creation_validation_enabled', true ) &&
+			! is_user_logged_in() && ( $this->is_registration_required() || ! empty( $data['createaccount'] ) )
+		) {
+			$username = ! empty( $data['account_username'] ) ? $data['account_username'] : '';
+			$email    = $data['billing_email'] ?? '';
+
+			if ( email_exists( $email ) ) {
+				$errors->add(
+					'registration-error-email-exists',
+					apply_filters(
+						'woocommerce_registration_error_email_exists',
+						// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+						__( 'An account is already registered with your email address. <a href="#" class="showlogin">Please log in.</a>', 'woocommerce' ),
+						$email
+					)
+				);
+			}
+
+			if ( $username ) { // Empty username is already checked in validate_checkout, and it can be generated.
+				$username = sanitize_user( $username );
+				if ( empty( $username ) || ! validate_username( $username ) ) {
+					$errors->add(
+						'registration-error-invalid-username',
+						// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+						__( 'Please enter a valid account username.', 'woocommerce' )
+					);
+				}
+
+				if ( username_exists( $username ) ) {
+					$errors->add(
+						'registration-error-username-exists',
+						// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch
+						__( 'An account is already registered with that username. Please choose another.', 'woocommerce' )
+					);
+				}
+			}
+		}
+
 		if ( $errors->has_errors() ) {
 			throw new ValidationException( $errors->get_error_messages() );
 		}


### PR DESCRIPTION
The checks for new user creation were missing and the errors were shown only after the payment.

WC performs these checks only in `wc_create_new_customer` called during the checkout processing after validation. So the only way to fix it seems to be copying these checks for username/email into our validation.

Added `woocommerce_paypal_payments_early_wc_checkout_account_creation_validation_enabled` filter in case it causes some issues and needs to be disabled.