### PR TITLE
Add `PayPal-Request-Id` if payment source exist (1387)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Enhancement - Update "Standard Payments" tab settings #1065
 * Enhancement - Update PHP 7.2 requirement in all relevant files #1084
 * Enhancement - When PUI is enabled FraudNet should be also enabled #1129
+* Enhancement - Add PayPal-Request-Id if payment source exist #1132
 
 = 2.0.1 - 2022-12-13 =
 * Fix - Error while syncing tracking data to PayPal -> Sync GZD Tracking #1020

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -236,6 +236,10 @@ class OrderEndpoint {
 			$args['headers']['PayPal-Client-Metadata-Id'] = $this->fraudnet->session_id();
 		}
 
+		if ( isset( $data['payment_source'] ) ) {
+			$args['headers']['PayPal-Request-Id'] = uniqid( 'ppcp-', true );
+		}
+
 		$response = $this->request( $url, $args );
 		if ( is_wp_error( $response ) ) {
 			$error = new RuntimeException(

--- a/readme.txt
+++ b/readme.txt
@@ -91,6 +91,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Enhancement - Update "Standard Payments" tab settings #1065
 * Enhancement - Update PHP 7.2 requirement in all relevant files #1084
 * Enhancement - When PUI is enabled FraudNet should be also enabled #1129
+* Enhancement - Add PayPal-Request-Id if payment source exist #1132
 
 = 2.0.1 =
 * Fix - Error while syncing tracking data to PayPal -> Sync GZD Tracking #1020


### PR DESCRIPTION
We removed `PayPal-Request-Id` in #1085 but it's needed for `payment_source`:
```
{"name":"INVALID_REQUEST", "details":[{
"issue":"PAYPAL_REQUEST_ID_REQUIRED",
"description":"A PayPal-Request-Id is required if you are trying to process payment for an Order. 
Please specify a PayPal-Request-Id or Create the Order without a 'payment_source' specified."}]
```

This PR adds `PayPal-Request-Id` when request contains `payment_source`.