### PR TITLE
Add option to hide funding resource Trustly

### DIFF
--- a/modules/ppcp-compat/src/PPEC/SettingsImporter.php
+++ b/modules/ppcp-compat/src/PPEC/SettingsImporter.php
@@ -142,7 +142,7 @@ class SettingsImporter {
 					$value = array_values(
 						array_intersect(
 							array_map( 'strtolower', is_array( $option_value ) ? $option_value : array() ),
-							array( 'card', 'sepa', 'bancontact', 'blik', 'eps', 'giropay', 'ideal', 'mercadopago', 'mybank', 'p24', 'sofort', 'venmo' )
+							array( 'card', 'sepa', 'bancontact', 'blik', 'eps', 'giropay', 'ideal', 'mercadopago', 'mybank', 'p24', 'sofort', 'venmo', 'trustly' )
 						)
 					);
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -862,6 +862,7 @@ return array(
 			'p24'         => _x( 'Przelewy24', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'sofort'      => _x( 'Sofort', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'venmo'       => _x( 'Venmo', 'Name of payment method', 'woocommerce-paypal-payments' ),
+			'trustly'     => _x( 'Trustly', 'Name of payment method', 'woocommerce-paypal-payments' ),
 		);
 	},
 


### PR DESCRIPTION
This PR adds the missing funding resource to the list so it can be hidden which it can not currently.

### Changelog Entry

Add an option to hide funding resource Trustly

Closes #1155

Similar to: #384

Cheers 👍🏽