### PR TITLE
Add white color option

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -593,7 +593,7 @@ return array(
 				'type'         => 'select',
 				'class'        => array(),
 				'input_class'  => array( 'wc-enhanced-select' ),
-				'default'      => 'gold',
+				'default'      => ApplicationContext::LANDING_PAGE_LOGIN,
 				'desc_tip'     => true,
 				'description'  => __(
 					'Type of PayPal page to display.',

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php
@@ -49,7 +49,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'description'  => sprintf(
 			// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
 				__(
-					'Customize the appearance of the PayPal smart buttons on the 
+					'Customize the appearance of the PayPal smart buttons on the
 					%1$sCheckout page%5$s, %2$sSingle Product Page%5$s, %3$sCart page%5$s or on %4$sMini Cart%5$s.',
 					'woocommerce-paypal-payments'
 				),
@@ -163,6 +163,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				'blue'   => __( 'Blue', 'woocommerce-paypal-payments' ),
 				'silver' => __( 'Silver', 'woocommerce-paypal-payments' ),
 				'black'  => __( 'Black', 'woocommerce-paypal-payments' ),
+				'white'  => __( 'White', 'woocommerce-paypal-payments' ),
 			),
 			'screens'      => array(
 				State::STATE_START,
@@ -308,6 +309,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				'blue'   => __( 'Blue', 'woocommerce-paypal-payments' ),
 				'silver' => __( 'Silver', 'woocommerce-paypal-payments' ),
 				'black'  => __( 'Black', 'woocommerce-paypal-payments' ),
+				'white'  => __( 'White', 'woocommerce-paypal-payments' ),
 			),
 			'screens'      => array(
 				State::STATE_START,
@@ -447,6 +449,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				'blue'   => __( 'Blue', 'woocommerce-paypal-payments' ),
 				'silver' => __( 'Silver', 'woocommerce-paypal-payments' ),
 				'black'  => __( 'Black', 'woocommerce-paypal-payments' ),
+				'white'  => __( 'White', 'woocommerce-paypal-payments' ),
 			),
 			'screens'      => array(
 				State::STATE_START,
@@ -586,6 +589,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				'blue'   => __( 'Blue', 'woocommerce-paypal-payments' ),
 				'silver' => __( 'Silver', 'woocommerce-paypal-payments' ),
 				'black'  => __( 'Black', 'woocommerce-paypal-payments' ),
+				'white'  => __( 'White', 'woocommerce-paypal-payments' ),
 			),
 			'screens'      => array(
 				State::STATE_START,
@@ -725,6 +729,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 				'blue'   => __( 'Blue', 'woocommerce-paypal-payments' ),
 				'silver' => __( 'Silver', 'woocommerce-paypal-payments' ),
 				'black'  => __( 'Black', 'woocommerce-paypal-payments' ),
+				'white'  => __( 'White', 'woocommerce-paypal-payments' ),
 			),
 			'screens'      => array(
 				State::STATE_START,


### PR DESCRIPTION
Adds the ability to choose the white color for buttons.

It seems like there is a styling issue in checkout with the Storefront theme, the right side is cut off. It is not just for white, but it is less noticeable with other colors.

![image](https://user-images.githubusercontent.com/5680466/216918781-8a977509-6d48-4545-b065-812c016da55f.png) ![image](https://user-images.githubusercontent.com/5680466/216918755-bc96fc35-a9e5-4379-af41-6923c90df363.png)

Also fixed the incorrect default value for landing page. I think it was not causing issues because it defaults to the first list element when the element with the default key is missing, but still it should be fixed.