### PR TITLE
Use wp_loaded for fraudnet loading to avoid warnings

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -252,7 +252,7 @@ class WCGatewayModule implements ModuleInterface {
 		);
 
 		add_action(
-			'init',
+			'wp_loaded',
 			function () use ( $c ) {
 				if ( 'DE' === $c->get( 'api.shop.country' ) ) {
 					( $c->get( 'wcgateway.pay-upon-invoice' ) )->init();


### PR DESCRIPTION
It needs `wcgateway.enabled-ppcp-gateways` which calls `WC()->payment_gateways->get_available_payment_gateways()`, and the hooks inside it can be used by other plugins resulting in warnings about calling functions like `get_cart` too early.

One way to fix it is simply to use the `wp_loaded` hook instead of `init`, I think it supposed to be a more correct choice if interaction with other plugins (WC) is needed, because it is fired when "WP, all plugins, and the theme are fully loaded and instantiated"

