### PR TITLE
`DEVICE_DATA_NOT_AVAILABLE` error message when FraudNet is enabled (1429)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\Button\Endpoint\DataClientIdEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
 use WooCommerce\PayPalCommerce\Button\Endpoint\SaveCheckoutFormEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\StartPayPalVaultingEndpoint;
+use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -41,7 +42,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  */
 class SmartButton implements SmartButtonInterface {
 
-	use FreeTrialHandlerTrait;
+	use FreeTrialHandlerTrait, ContextTrait;
 
 	/**
 	 * The Settings status helper.
@@ -1065,48 +1066,6 @@ class SmartButton implements SmartButtonInterface {
 			default:
 				return $smart_button_enabled_for_mini_cart;
 		}
-	}
-
-	/**
-	 * The current context.
-	 *
-	 * @return string
-	 */
-	private function context(): string {
-		$context = 'mini-cart';
-		if ( is_product() || wc_post_content_has_shortcode( 'product_page' ) ) {
-			$context = 'product';
-		}
-		if ( is_cart() ) {
-			$context = 'cart';
-		}
-		if ( is_checkout() && ! $this->is_paypal_continuation() ) {
-			$context = 'checkout';
-		}
-		if ( is_checkout_pay_page() ) {
-			$context = 'pay-now';
-		}
-		return $context;
-	}
-
-	/**
-	 * Checks if PayPal payment was already initiated (on the product or cart pages).
-	 *
-	 * @return bool
-	 */
-	private function is_paypal_continuation(): bool {
-		$order = $this->session_handler->order();
-		if ( ! $order ) {
-			return false;
-		}
-		$source = $order->payment_source();
-		if ( $source && $source->card() ) {
-			return false; // Ignore for DCC.
-		}
-		if ( 'card' === $this->session_handler->funding_source() ) {
-			return false; // Ignore for card buttons.
-		}
-		return true;
 	}
 
 	/**

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Helper trait for context.
+ *
+ * @package WooCommerce\PayPalCommerce\Button\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Helper;
+
+trait ContextTrait {
+
+	/**
+	 * The current context.
+	 *
+	 * @return string
+	 */
+	protected function context(): string {
+		$context = 'mini-cart';
+		if ( is_product() || wc_post_content_has_shortcode( 'product_page' ) ) {
+			$context = 'product';
+		}
+
+		if ( is_cart() ) {
+			$context = 'cart';
+		}
+
+		if ( is_checkout() && ! $this->is_paypal_continuation() ) {
+			$context = 'checkout';
+		}
+
+		if ( is_checkout_pay_page() ) {
+			$context = 'pay-now';
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Checks if PayPal payment was already initiated (on the product or cart pages).
+	 *
+	 * @return bool
+	 */
+	private function is_paypal_continuation(): bool {
+		$order = $this->session_handler->order();
+		if ( ! $order ) {
+			return false;
+		}
+
+		$source = $order->payment_source();
+		if ( $source && $source->card() ) {
+			return false; // Ignore for DCC.
+		}
+
+		if ( 'card' === $this->session_handler->funding_source() ) {
+			return false; // Ignore for card buttons.
+		}
+
+		return true;
+	}
+}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1333,39 +1333,6 @@ return array(
 
 		return $enabled_ppcp_gateways;
 	},
-	'wcgateway.is-paypal-continuation'                     => static function ( ContainerInterface $container ): bool {
-		$session_handler              = $container->get( 'session.handler' );
-		assert( $session_handler instanceof SessionHandler );
-
-		$order = $session_handler->order();
-		if ( ! $order ) {
-			return false;
-		}
-		$source = $order->payment_source();
-		if ( $source && $source->card() ) {
-			return false; // Ignore for DCC.
-		}
-		if ( 'card' === $session_handler->funding_source() ) {
-			return false; // Ignore for card buttons.
-		}
-		return true;
-	},
-	'wcgateway.current-context'                            => static function ( ContainerInterface $container ): string {
-		$context = 'mini-cart';
-		if ( is_product() || wc_post_content_has_shortcode( 'product_page' ) ) {
-			$context = 'product';
-		}
-		if ( is_cart() ) {
-			$context = 'cart';
-		}
-		if ( is_checkout() && ! $container->get( 'wcgateway.is-paypal-continuation' ) ) {
-			$context = 'checkout';
-		}
-		if ( is_checkout_pay_page() ) {
-			$context = 'pay-now';
-		}
-		return $context;
-	},
 	'wcgateway.is-fraudnet-enabled'                        => static function ( ContainerInterface $container ): bool {
 		$settings      = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
@@ -1380,7 +1347,7 @@ return array(
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'wcgateway.enabled-ppcp-gateways' ),
-			$container->get( 'wcgateway.current-context' ),
+			$container->get( 'session.handler' ),
 			$container->get( 'wcgateway.is-fraudnet-enabled' )
 		);
 	},

--- a/modules/ppcp-wc-gateway/src/Assets/FraudNetAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/FraudNetAssets.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\FraudNet\FraudNet;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
@@ -63,11 +65,11 @@ class FraudNetAssets {
 	protected $enabled_ppcp_gateways;
 
 	/**
-	 * The current context.
+	 * The session handler
 	 *
-	 * @var string
+	 * @var SessionHandler
 	 */
-	protected $context;
+	protected $session_handler;
 
 	/**
 	 * True if FraudNet support is enabled in settings, otherwise false.
@@ -79,14 +81,14 @@ class FraudNetAssets {
 	/**
 	 * Assets constructor.
 	 *
-	 * @param string      $module_url The url of this module.
-	 * @param string      $version The assets version.
-	 * @param FraudNet    $fraud_net The FraudNet entity.
-	 * @param Environment $environment The environment.
-	 * @param Settings    $settings The Settings.
-	 * @param string[]    $enabled_ppcp_gateways The list of enabled PayPal gateways.
-	 * @param string      $context The current context.
-	 * @param bool        $is_fraudnet_enabled true if FraudNet support is enabled in settings, otherwise false.
+	 * @param string         $module_url The url of this module.
+	 * @param string         $version The assets version.
+	 * @param FraudNet       $fraud_net The FraudNet entity.
+	 * @param Environment    $environment The environment.
+	 * @param Settings       $settings The Settings.
+	 * @param string[]       $enabled_ppcp_gateways The list of enabled PayPal gateways.
+	 * @param SessionHandler $session_handler The session handler.
+	 * @param bool           $is_fraudnet_enabled true if FraudNet support is enabled in settings, otherwise false.
 	 */
 	public function __construct(
 		string $module_url,
@@ -95,7 +97,7 @@ class FraudNetAssets {
 		Environment $environment,
 		Settings $settings,
 		array $enabled_ppcp_gateways,
-		string $context,
+		SessionHandler $session_handler,
 		bool $is_fraudnet_enabled
 	) {
 		$this->module_url            = $module_url;
@@ -104,7 +106,7 @@ class FraudNetAssets {
 		$this->environment           = $environment;
 		$this->settings              = $settings;
 		$this->enabled_ppcp_gateways = $enabled_ppcp_gateways;
-		$this->context               = $context;
+		$this->session_handler       = $session_handler;
 		$this->is_fraudnet_enabled   = $is_fraudnet_enabled;
 	}
 
@@ -151,7 +153,7 @@ class FraudNetAssets {
 		$is_pui_gateway_enabled           = in_array( PayUponInvoiceGateway::ID, $this->enabled_ppcp_gateways, true );
 		$is_only_standard_gateway_enabled = $this->enabled_ppcp_gateways === array( PayPalGateway::ID );
 
-		if ( $this->context !== 'checkout' || $is_only_standard_gateway_enabled ) {
+		if ( $this->context() !== 'checkout' || $is_only_standard_gateway_enabled ) {
 			return $this->is_fraudnet_enabled && $this->are_buttons_enabled_for_context();
 		}
 
@@ -168,19 +170,64 @@ class FraudNetAssets {
 		if ( ! in_array( PayPalGateway::ID, $this->enabled_ppcp_gateways, true ) ) {
 			return false;
 		}
-
-		$location_prefix             = $this->context === 'checkout' ? '' : "{$this->context}_";
-		$setting_name                = "button_{$location_prefix}enabled";
-		$buttons_enabled_for_context = $this->settings->has( $setting_name ) && $this->settings->get( $setting_name );
-
-		if ( $this->context === 'product' ) {
-			return $buttons_enabled_for_context || $this->settings->has( 'mini-cart' ) && $this->settings->get( 'mini-cart' );
+		try {
+			$button_locations = $this->settings->get( 'smart_button_locations' );
+		} catch ( NotFoundException $exception ) {
+			return false;
 		}
 
-		if ( $this->context === 'pay-now' ) {
+		if ( $this->context() === 'pay-now' ) {
 			return true;
 		}
 
-		return $buttons_enabled_for_context;
+		if ( $this->context() === 'product' ) {
+			return in_array( 'product', $button_locations, true ) || in_array( 'mini-cart', $button_locations, true );
+		}
+
+		return in_array( $this->context(), $button_locations, true );
+	}
+
+	/**
+	 * Get context.
+	 *
+	 * @return string
+	 */
+	protected function context(): string {
+		$context = 'mini-cart';
+		if ( is_product() || wc_post_content_has_shortcode( 'product_page' ) ) {
+			$context = 'product';
+		}
+		if ( is_cart() ) {
+			$context = 'cart';
+		}
+		if ( is_checkout() && ! $this->is_paypal_continuation() ) {
+			$context = 'checkout';
+		}
+		if ( is_checkout_pay_page() ) {
+			$context = 'pay-now';
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Whether is PayPal continuation or not.
+	 *
+	 * @return bool
+	 */
+	protected function is_paypal_continuation(): bool {
+		$order = $this->session_handler->order();
+		if ( ! $order ) {
+			return false;
+		}
+			$source = $order->payment_source();
+		if ( $source && $source->card() ) {
+			return false; // Ignore for DCC.
+		}
+		if ( 'card' === $this->session_handler->funding_source() ) {
+			return false; // Ignore for card buttons.
+		}
+
+		return true;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Assets/FraudNetAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/FraudNetAssets.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 
+use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
@@ -21,6 +22,8 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  * Class FraudNetAssets
  */
 class FraudNetAssets {
+
+	use ContextTrait;
 
 	/**
 	 * The URL of this module.
@@ -158,7 +161,6 @@ class FraudNetAssets {
 		}
 
 		return $is_pui_gateway_enabled ? true : $this->is_fraudnet_enabled;
-
 	}
 
 	/**
@@ -185,49 +187,5 @@ class FraudNetAssets {
 		}
 
 		return in_array( $this->context(), $button_locations, true );
-	}
-
-	/**
-	 * Get context.
-	 *
-	 * @return string
-	 */
-	protected function context(): string {
-		$context = 'mini-cart';
-		if ( is_product() || wc_post_content_has_shortcode( 'product_page' ) ) {
-			$context = 'product';
-		}
-		if ( is_cart() ) {
-			$context = 'cart';
-		}
-		if ( is_checkout() && ! $this->is_paypal_continuation() ) {
-			$context = 'checkout';
-		}
-		if ( is_checkout_pay_page() ) {
-			$context = 'pay-now';
-		}
-
-		return $context;
-	}
-
-	/**
-	 * Whether is PayPal continuation or not.
-	 *
-	 * @return bool
-	 */
-	protected function is_paypal_continuation(): bool {
-		$order = $this->session_handler->order();
-		if ( ! $order ) {
-			return false;
-		}
-			$source = $order->payment_source();
-		if ( $source && $source->card() ) {
-			return false; // Ignore for DCC.
-		}
-		if ( 'card' === $this->session_handler->funding_source() ) {
-			return false; // Ignore for card buttons.
-		}
-
-		return true;
 	}
 }


### PR DESCRIPTION
When FraundNet setting is enabled and not configured correctly is displays `DEVICE_DATA_NOT_AVAILABLE` error message when trying to create the PayPal order.

We've found that `fraudnet.js` script was not loaded due to a bug, this PR fixes that and loads it correctly.

Please note that Fraudnet `fncls` script is currently rendered twice, the one we are implementing have the following format: 
```
<script type="application/json" fncls="fnparams-dede7cc5-15fd-4c75-a9f4-36c430ee3a99">
      {
          "f":"<32_character_GUID>",
          "s":"<merchant_id>_<page_id>",
          "sandbox":false
      }
  </script>
```
The other is added by PayPal automatically with the following format: 
```
... "s":"SMART_PAYMENT_BUTTONS","u":"example.com","cb1":"fnCallback"...
```

### Steps to reproduce
- Disable all payments except PayPal payment.
- Enable FraudNet setting.
- Ensure Checkout exist in Smart Button Locations, otherwise add it*.
- Add product to Cart and go to Checkout page.
- Search in page source code for `fnparams-`

Check for one** of the `fnparams-` scripts that contains `s` param with the following format `<merchant_id>_<page_id>` 

*The same applies for Single Product, Cart and Mini-Cart locations.
**Currently `fnparams` is rendered twice with different values, one from the plugin code (fraudnet.js) and the other added by PayPal automatically.