### PR TITLE
Allow to capture automatically on status change

### DIFF
--- a/modules/ppcp-onboarding/resources/js/settings.js
+++ b/modules/ppcp-onboarding/resources/js/settings.js
@@ -396,6 +396,10 @@ document.addEventListener(
                     {
                         value:'authorize',
                         selector:'#field-capture_for_virtual_only'
+                    },
+                    {
+                        value:'authorize',
+                        selector:'#field-capture_on_status_change'
                     }
                 ]
             );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -538,6 +538,23 @@ return array(
 				'requirements' => array(),
 				'gateway'      => 'paypal',
 			),
+			'capture_on_status_change'               => array(
+				'title'        => __( 'Capture On Status Change', 'woocommerce-paypal-payments' ),
+				'type'         => 'checkbox',
+				'default'      => false,
+				'desc_tip'     => true,
+				'description'  => __(
+					'The transaction will be captured automatically when the order status changes to Processing or Completed.',
+					'woocommerce-paypal-payments'
+				),
+				'label'        => __( 'Capture On Status Change', 'woocommerce-paypal-payments' ),
+				'screens'      => array(
+					State::STATE_START,
+					State::STATE_ONBOARDED,
+				),
+				'requirements' => array(),
+				'gateway'      => 'paypal',
+			),
 			'capture_for_virtual_only'               => array(
 				'title'        => __( 'Capture Virtual-Only Orders ', 'woocommerce-paypal-payments' ),
 				'type'         => 'checkbox',


### PR DESCRIPTION
Fixes #587

Adds an option in the settings enabling automatic capture of authorizes payments when WC order status changes to `processing` or `completed`.

There is also a filter allowing to change the list of such statuses, such as remove one of them.