### PR TITLE
Add filter to fallback tracking_data['carrier']

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -159,7 +159,7 @@ class CompatModule implements ModuleInterface {
 					 * The filter allowing to change the default Germanized carrier for order tracking,
 					 * such as DHL_DEUTSCHE_POST, DPD_DE, ...
 					 */
-					$tracking_data['carrier'] = apply_filters( 'woocommerce_paypal_payments_default_gzd_carrier', 'DHL_DEUTSCHE_POST', $provider );
+					$tracking_data['carrier'] = (string) apply_filters( 'woocommerce_paypal_payments_default_gzd_carrier', 'DHL_DEUTSCHE_POST', $provider );
 				}
 
 				try {

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -155,7 +155,8 @@ class CompatModule implements ModuleInterface {
 
 				$provider = $shipment->get_shipping_provider();
 				if ( ! empty( $provider ) && $provider !== 'none' ) {
-					$tracking_data['carrier'] = 'DHL_DEUTSCHE_POST';
+					$fallback_carrier = 'DHL_DEUTSCHE_POST';
+					$tracking_data['carrier'] = apply_filters('filter_paypal_payments_tracking_data_carrier',$fallback_carrier,$provider);
 				}
 
 				try {

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -155,8 +155,11 @@ class CompatModule implements ModuleInterface {
 
 				$provider = $shipment->get_shipping_provider();
 				if ( ! empty( $provider ) && $provider !== 'none' ) {
-					$fallback_carrier = 'DHL_DEUTSCHE_POST';
-					$tracking_data['carrier'] = apply_filters('filter_paypal_payments_tracking_data_carrier',$fallback_carrier,$provider);
+					/**
+					 * The filter allowing to change the default Germanized carrier for order tracking,
+					 * such as DHL_DEUTSCHE_POST, DPD_DE, ...
+					 */
+					$tracking_data['carrier'] = apply_filters( 'woocommerce_paypal_payments_default_gzd_carrier', 'DHL_DEUTSCHE_POST', $provider );
 				}
 
 				try {


### PR DESCRIPTION
PayPal Payments always defaults to DHL_DEUTSCHE_POST.  As Germanized offers to create your own carriers we should be able to filter it, thus being able to return the correct  carrier for PayPal, which is e.g. DPD_DE, GLS_DE, OTHER