### PR TITLE
Do not call get_available_payment_gateways early

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -36,6 +36,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\GatewayRepository;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXOEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXOGateway;
@@ -1348,19 +1349,10 @@ return array(
 			OXXOGateway::ID,
 		);
 	},
-	'wcgateway.enabled-ppcp-gateways'                      => static function ( ContainerInterface $container ): array {
-		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
-		$ppcp_gateways = $container->get( 'wcgateway.ppcp-gateways' );
-		$enabled_ppcp_gateways = array();
-
-		foreach ( $ppcp_gateways as $gateway ) {
-			if ( ! isset( $available_gateways[ $gateway ] ) ) {
-				continue;
-			}
-			$enabled_ppcp_gateways[] = $gateway;
-		}
-
-		return $enabled_ppcp_gateways;
+	'wcgateway.gateway-repository'                         => static function ( ContainerInterface $container ): GatewayRepository {
+		return new GatewayRepository(
+			$container->get( 'wcgateway.ppcp-gateways' )
+		);
 	},
 	'wcgateway.is-fraudnet-enabled'                        => static function ( ContainerInterface $container ): bool {
 		$settings      = $container->get( 'wcgateway.settings' );
@@ -1375,7 +1367,7 @@ return array(
 			$container->get( 'wcgateway.fraudnet' ),
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'wcgateway.settings' ),
-			$container->get( 'wcgateway.enabled-ppcp-gateways' ),
+			$container->get( 'wcgateway.gateway-repository' ),
 			$container->get( 'session.handler' ),
 			$container->get( 'wcgateway.is-fraudnet-enabled' )
 		);

--- a/modules/ppcp-wc-gateway/src/Gateway/GatewayRepository.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/GatewayRepository.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Operations with the WC gateways.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Gateway
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
+
+/**
+ * Class GatewayRepository
+ */
+class GatewayRepository {
+	/**
+	 * IDs of our gateways.
+	 *
+	 * @var string[]
+	 */
+	protected $ppcp_gateway_ids;
+
+	/**
+	 * GatewayRepository constructor.
+	 *
+	 * @param string[] $ppcp_gateway_ids IDs of our gateways.
+	 */
+	public function __construct( array $ppcp_gateway_ids ) {
+		$this->ppcp_gateway_ids = $ppcp_gateway_ids;
+	}
+
+	/**
+	 * Returns IDs of the currently enabled PPCP gateways.
+	 *
+	 * @return array
+	 */
+	public function get_enabled_ppcp_gateway_ids(): array {
+		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+
+		return array_filter(
+			$this->ppcp_gateway_ids,
+			function ( string $id ) use ( $available_gateways ): bool {
+				return isset( $available_gateways[ $id ] );
+			}
+		);
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -422,7 +422,7 @@ class PayUponInvoice {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function ( $methods ): array {
+			function ( $methods ) {
 				if ( ! is_array( $methods ) || State::STATE_ONBOARDED !== $this->state->current_state() ) {
 					return $methods;
 				}


### PR DESCRIPTION
Fixes #1195

Calling it during object construction causes issues with third-party plugins/filters when it is executed too early or in irrelevant requests (WP ajax for saving posts, ...). Now this function call is moved into a separate class to make it more difficult to accidentally execute early or when not needed.
