### PR TITLE
Fix Pay Later on order pay page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,8 @@
 * Fix - After Updating to 2.0.2, Site Health reports REST API error #1195
 * Fix - Do not send buyer-country for previews in live mode to avoid error #1186
 * Fix - PPEC compatibility layer does not take over subscriptions #1193
+* Fix - Checkout conflict with "All products for subscriptions" plugin #629
+* Fix - Pay Later on order pay page #1214
 * Enhancement - Save checkout form before free trial redirect #1135
 * Enhancement - Add filter for controlling the ditching of items/breakdown #1146
 * Enhancement - Add patch order data filter #1147

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1074,11 +1074,10 @@ class SmartButton implements SmartButtonInterface {
 		switch ( $this->context() ) {
 			case 'checkout':
 			case 'cart':
+			case 'pay-now':
 				return $smart_button_enabled_for_current_location || $messaging_enabled_for_current_location;
 			case 'product':
 				return $smart_button_enabled_for_current_location || $messaging_enabled_for_current_location || $smart_button_enabled_for_mini_cart;
-			case 'pay-now':
-				return true;
 			default:
 				return $smart_button_enabled_for_mini_cart;
 		}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -972,7 +972,7 @@ class SmartButton implements SmartButtonInterface {
 			$disable_funding = $all_sources;
 		}
 
-		if ( ! $this->settings_status->is_pay_later_button_enabled_for_context( $this->context() ) ) {
+		if ( ! $this->settings_status->is_pay_later_button_enabled_for_location( $this->context() ) ) {
 			$disable_funding[] = 'credit';
 		}
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -972,17 +972,18 @@ class SmartButton implements SmartButtonInterface {
 			$disable_funding = $all_sources;
 		}
 
-		if ( ! $this->settings_status->is_pay_later_button_enabled_for_location( $this->context() ) ) {
-			$disable_funding[] = 'credit';
+		$enable_funding = array( 'venmo' );
+
+		if ( $this->settings_status->is_pay_later_button_enabled_for_location( $this->context() ) ||
+			$this->settings_status->is_pay_later_messaging_enabled_for_location( $this->context() )
+		) {
+			$enable_funding[] = 'paylater';
+		} else {
+			$disable_funding[] = 'paylater';
 		}
 
 		if ( count( $disable_funding ) > 0 ) {
 			$params['disable-funding'] = implode( ',', array_unique( $disable_funding ) );
-		}
-
-		$enable_funding = array( 'venmo' );
-		if ( $this->settings_status->is_pay_later_messaging_enabled_for_location( $this->context() ) || ! in_array( 'credit', $disable_funding, true ) ) {
-			$enable_funding[] = 'paylater';
 		}
 
 		if ( $this->is_free_trial_cart() ) {

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -405,7 +405,7 @@ class SmartButton implements SmartButtonInterface {
 			add_action(
 				$this->pay_order_renderer_hook(),
 				array( $this, 'message_renderer' ),
-				11
+				15
 			);
 		}
 		return true;
@@ -478,7 +478,8 @@ class SmartButton implements SmartButtonInterface {
 				function (): void {
 					$this->button_renderer( PayPalGateway::ID );
 					$this->button_renderer( CardButtonGateway::ID );
-				}
+				},
+				20
 			);
 			add_action(
 				$this->checkout_button_renderer_hook(),

--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -37,7 +37,6 @@ class SettingsStatus {
 	 * Check whether Pay Later message is enabled either for checkout, cart or product page.
 	 *
 	 * @return bool true if is enabled, otherwise false.
-	 * @throws NotFoundException When a setting was not found.
 	 */
 	public function is_pay_later_messaging_enabled(): bool {
 		$messaging_enabled  = $this->settings->has( 'pay_later_messaging_enabled' ) && $this->settings->get( 'pay_later_messaging_enabled' );
@@ -51,7 +50,6 @@ class SettingsStatus {
 	 *
 	 * @param string $location The location setting name.
 	 * @return bool true if is enabled, otherwise false.
-	 * @throws NotFoundException When a setting was not found.
 	 */
 	public function is_pay_later_messaging_enabled_for_location( string $location ): bool {
 		$location = $this->normalize_location( $location );
@@ -87,7 +85,6 @@ class SettingsStatus {
 	 *
 	 * @param string $location The location.
 	 * @return bool true if is enabled, otherwise false.
-	 * @throws NotFoundException When a setting was not found.
 	 */
 	public function is_pay_later_button_enabled_for_location( string $location ): bool {
 		$location = $this->normalize_location( $location );

--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -52,26 +52,13 @@ class SettingsStatus {
 	 * @return bool true if is enabled, otherwise false.
 	 */
 	public function is_pay_later_messaging_enabled_for_location( string $location ): bool {
-		$location = $this->normalize_location( $location );
-
-		if ( ! $this->is_pay_later_messaging_enabled() ) {
-			return false;
-		}
-
-		$selected_locations = $this->settings->has( 'pay_later_messaging_locations' ) ? $this->settings->get( 'pay_later_messaging_locations' ) : array();
-
-		if ( empty( $selected_locations ) ) {
-			return false;
-		}
-
-		return in_array( $location, $selected_locations, true );
+		return $this->is_pay_later_messaging_enabled() && $this->is_enabled_for_location( 'pay_later_messaging_locations', $location );
 	}
 
 	/**
 	 * Check whether Pay Later button is enabled either for checkout, cart or product page.
 	 *
 	 * @return bool true if is enabled, otherwise false.
-	 * @throws NotFoundException When a setting was not found.
 	 */
 	public function is_pay_later_button_enabled(): bool {
 		$pay_later_button_enabled = $this->settings->has( 'pay_later_button_enabled' ) && $this->settings->get( 'pay_later_button_enabled' );
@@ -87,19 +74,7 @@ class SettingsStatus {
 	 * @return bool true if is enabled, otherwise false.
 	 */
 	public function is_pay_later_button_enabled_for_location( string $location ): bool {
-		$location = $this->normalize_location( $location );
-
-		if ( ! $this->is_pay_later_button_enabled() ) {
-			return false;
-		}
-
-		$selected_locations = $this->settings->has( 'pay_later_button_locations' ) ? $this->settings->get( 'pay_later_button_locations' ) : array();
-
-		if ( empty( $selected_locations ) ) {
-			return false;
-		}
-
-		return in_array( $location, $selected_locations, true );
+		return $this->is_pay_later_button_enabled() && $this->is_enabled_for_location( 'pay_later_button_locations', $location );
 	}
 
 	/**
@@ -109,15 +84,7 @@ class SettingsStatus {
 	 * @return bool true if is enabled, otherwise false.
 	 */
 	public function is_smart_button_enabled_for_location( string $location ): bool {
-		$location = $this->normalize_location( $location );
-
-		$selected_locations = $this->settings->has( 'smart_button_locations' ) ? $this->settings->get( 'smart_button_locations' ) : array();
-
-		if ( empty( $selected_locations ) ) {
-			return false;
-		}
-
-		return in_array( $location, $selected_locations, true );
+		return $this->is_enabled_for_location( 'smart_button_locations', $location );
 	}
 
 	/**
@@ -131,5 +98,24 @@ class SettingsStatus {
 			$location = 'checkout';
 		}
 		return $location;
+	}
+
+	/**
+	 * Checks whether the locations field in the settings includes the given location.
+	 *
+	 * @param string $setting_name The name of the enabled locations field in the settings.
+	 * @param string $location The location.
+	 * @return bool
+	 */
+	protected function is_enabled_for_location( string $setting_name, string $location ): bool {
+		$location = $this->normalize_location( $location );
+
+		$selected_locations = $this->settings->has( $setting_name ) ? $this->settings->get( $setting_name ) : array();
+
+		if ( empty( $selected_locations ) ) {
+			return false;
+		}
+
+		return in_array( $location, $selected_locations, true );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -54,6 +54,8 @@ class SettingsStatus {
 	 * @throws NotFoundException When a setting was not found.
 	 */
 	public function is_pay_later_messaging_enabled_for_location( string $location ): bool {
+		$location = $this->normalize_location( $location );
+
 		if ( ! $this->is_pay_later_messaging_enabled() ) {
 			return false;
 		}
@@ -88,6 +90,8 @@ class SettingsStatus {
 	 * @throws NotFoundException When a setting was not found.
 	 */
 	public function is_pay_later_button_enabled_for_location( string $location ): bool {
+		$location = $this->normalize_location( $location );
+
 		if ( ! $this->is_pay_later_button_enabled() ) {
 			return false;
 		}
@@ -133,6 +137,8 @@ class SettingsStatus {
 	 * @return bool true if is enabled, otherwise false.
 	 */
 	public function is_smart_button_enabled_for_location( string $location ): bool {
+		$location = $this->normalize_location( $location );
+
 		$selected_locations = $this->settings->has( 'smart_button_locations' ) ? $this->settings->get( 'smart_button_locations' ) : array();
 
 		if ( empty( $selected_locations ) ) {
@@ -140,5 +146,18 @@ class SettingsStatus {
 		}
 
 		return in_array( $location, $selected_locations, true );
+	}
+
+	/**
+	 * Adapts the context value to match the location settings.
+	 *
+	 * @param string $location The location/context.
+	 * @return string
+	 */
+	protected function normalize_location( string $location ): string {
+		if ( 'pay-now' === $location ) {
+			$location = 'checkout';
+		}
+		return $location;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -106,31 +106,6 @@ class SettingsStatus {
 	}
 
 	/**
-	 * Check whether Pay Later button is enabled for a given context.
-	 *
-	 * @param string $context The context.
-	 * @return bool true if is enabled, otherwise false.
-	 * @throws NotFoundException When a setting was not found.
-	 */
-	public function is_pay_later_button_enabled_for_context( string $context ): bool {
-		if ( ! $this->is_pay_later_button_enabled() ) {
-			return false;
-		}
-
-		$selected_locations = $this->settings->has( 'pay_later_button_locations' ) ? $this->settings->get( 'pay_later_button_locations' ) : array();
-
-		if ( empty( $selected_locations ) ) {
-			return false;
-		}
-
-		$enabled_for_current_location = $this->is_pay_later_button_enabled_for_location( $context );
-		$enabled_for_product          = $this->is_pay_later_button_enabled_for_location( 'product' );
-		$enabled_for_mini_cart        = $this->is_pay_later_button_enabled_for_location( 'mini-cart' );
-
-		return $context === 'product' ? $enabled_for_product || $enabled_for_mini_cart : $enabled_for_current_location;
-	}
-
-	/**
 	 * Checks whether smart buttons are enabled for a given location.
 	 *
 	 * @param string $location The location.

--- a/readme.txt
+++ b/readme.txt
@@ -90,6 +90,8 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - After Updating to 2.0.2, Site Health reports REST API error #1195
 * Fix - Do not send buyer-country for previews in live mode to avoid error #1186
 * Fix - PPEC compatibility layer does not take over subscriptions #1193
+* Fix - Checkout conflict with "All products for subscriptions" plugin #629
+* Fix - Pay Later on order pay page #1214
 * Enhancement - Save checkout form before free trial redirect #1135
 * Enhancement - Add filter for controlling the ditching of items/breakdown #1146
 * Enhancement - Add patch order data filter #1147


### PR DESCRIPTION
Fixed missing Pay Later on order pay page.

Also some refactoring, and Pay Later is now shown only if enabled on the Pay Later tab (earlier it was supposed to be always shown unless excluded via funding source settings).