### PR TITLE
Allow Pay Later in mini-cart

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -16,9 +16,12 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return function (
 	string $root_dir,
-	ContainerInterface ...$additional_containers
+	array $additional_containers = array(),
+	array $additional_modules = array()
 ): ContainerInterface {
 	$modules = ( require "$root_dir/modules.php" )( $root_dir );
+
+	$modules = array_merge( $modules, $additional_modules );
 
 	/**
 	 * Use this filter to add custom module or remove some of existing ones.

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1338,24 +1338,10 @@ return array(
 		assert( $settings instanceof Settings );
 
 		$button_locations = $container->get( 'wcgateway.button.locations' );
-		unset( $button_locations['mini-cart'] );
 
 		$smart_button_selected_locations = $settings->has( 'smart_button_locations' ) ? $settings->get( 'smart_button_locations' ) : array();
-		$pay_later_button_locations = array();
 
-		if ( empty( $smart_button_selected_locations ) ) {
-			return $pay_later_button_locations;
-		}
-
-		foreach ( $button_locations as $location_key => $location ) {
-			if ( ! in_array( $location_key, $smart_button_selected_locations, true ) ) {
-				continue;
-			}
-
-			$pay_later_button_locations[ $location_key ] = $location;
-		}
-
-		return $pay_later_button_locations;
+		return array_intersect_key( $button_locations, array_flip( $smart_button_selected_locations ) );
 	},
 	'wcgateway.ppcp-gateways'                              => static function ( ContainerInterface $container ): array {
 		return array(

--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
-use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
@@ -74,7 +73,9 @@ class SettingsStatus {
 	 * @return bool true if is enabled, otherwise false.
 	 */
 	public function is_pay_later_button_enabled_for_location( string $location ): bool {
-		return $this->is_pay_later_button_enabled() && $this->is_enabled_for_location( 'pay_later_button_locations', $location );
+		return $this->is_pay_later_button_enabled() &&
+			( $this->is_enabled_for_location( 'pay_later_button_locations', $location ) ||
+				( 'product' === $location && $this->is_enabled_for_location( 'pay_later_button_locations', 'mini-cart' ) ) );
 	}
 
 	/**

--- a/tests/PHPUnit/Button/Endpoint/ValidateCheckoutEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/ValidateCheckoutEndpointTest.php
@@ -5,6 +5,7 @@ namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
 use Exception;
 use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\Button\Exception\ValidationException;
 use WooCommerce\PayPalCommerce\Button\Validation\CheckoutFormValidator;
@@ -13,6 +14,8 @@ use function Brain\Monkey\Functions\expect;
 
 class ValidateCheckoutEndpointTest extends TestCase
 {
+	use MockeryPHPUnitIntegration;
+
 	private $requestData;
 	private $formValidator;
 	private $logger;

--- a/tests/PHPUnit/Helper/SettingsStub.php
+++ b/tests/PHPUnit/Helper/SettingsStub.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Helper;
+
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+class SettingsStub extends Settings
+{
+	/**
+	 * @var array
+	 */
+	protected $data;
+
+	/**
+	 * @param array $data
+	 */
+	public function __construct(array $data) {
+		$this->data = $data;
+	}
+
+	public function get($id) {
+		if ( ! $this->has( $id ) ) {
+			throw new NotFoundException();
+		}
+
+		return $this->data[$id];
+	}
+
+	public function has($id) {
+		return array_key_exists( $id, $this->data );
+	}
+
+	public function set($id, $value) {
+		$this->data[$id] = $value;
+	}
+
+	public function persist() {
+	}
+}

--- a/tests/PHPUnit/ModularTestCase.php
+++ b/tests/PHPUnit/ModularTestCase.php
@@ -3,10 +3,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce;
 
-use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\CompositeCachingServiceProvider;
-use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\DelegatingContainer;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use function Brain\Monkey\Functions\when;
 
@@ -58,13 +58,22 @@ class ModularTestCase extends TestCase
      */
     protected function bootstrapModule(array $overriddenServices = []): ContainerInterface
     {
-        $overridingContainer = new DelegatingContainer(new CompositeCachingServiceProvider([
-            new ServiceProvider($overriddenServices, []),
-        ]));
+		$module = new class ($overriddenServices) implements ModuleInterface {
+			public function __construct(array $services) {
+				$this->services = $services;
+			}
+
+			public function setup(): ServiceProviderInterface{
+				return new ServiceProvider($this->services, []);
+			}
+
+			public function run(ContainerInterface $c): void {
+			}
+		};
 
         $rootDir = ROOT_DIR;
         $bootstrap = require ("$rootDir/bootstrap.php");
-        $appContainer = $bootstrap($rootDir, $overridingContainer);
+        $appContainer = $bootstrap($rootDir, [], [$module]);
 
         return $appContainer;
     }

--- a/tests/PHPUnit/WcGateway/Settings/LocationsTest.php
+++ b/tests/PHPUnit/WcGateway/Settings/LocationsTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
+
+use WooCommerce\PayPalCommerce\Helper\SettingsStub;
+use WooCommerce\PayPalCommerce\ModularTestCase;
+
+class LocationsTest extends ModularTestCase
+{
+	private $appContainer;
+
+	private $settings;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->settings = new SettingsStub([]);
+
+		$this->appContainer = $this->bootstrapModule([
+			'wcgateway.settings' => function () {
+				return $this->settings;
+			},
+		]);
+	}
+
+	/**
+	 * @dataProvider payLaterButtonLocationsData
+	 */
+	public function testPayLaterButtonLocations(array $selectedLocations, array $expectedResult) {
+		$this->settings->set('smart_button_locations', $selectedLocations);
+
+		$result = $this->appContainer->get('wcgateway.settings.pay-later.button-locations');
+
+		self::assertEquals($expectedResult, $result);
+	}
+
+	public function payLaterButtonLocationsData()
+	{
+		yield [
+			['product', 'cart', 'checkout', 'mini-cart'],
+			[
+				'product' => 'Single Product',
+				'cart' => 'Cart',
+				'checkout' => 'Checkout',
+				'mini-cart' => 'Mini Cart',
+			],
+		];
+		yield [
+			['cart', 'checkout'],
+			[
+				'cart' => 'Cart',
+				'checkout' => 'Checkout',
+			],
+		];
+		yield [
+			[],
+			[],
+		];
+	}
+}

--- a/tests/e2e/PHPUnit/Order/PurchaseUnitTest.php
+++ b/tests/e2e/PHPUnit/Order/PurchaseUnitTest.php
@@ -45,6 +45,10 @@ class PurchaseUnitTest extends TestCase
 
 		$this->puFactory = $this->container->get( 'api.factory.purchase-unit' );
 		assert($this->puFactory instanceof PurchaseUnitFactory);
+
+		add_filter('woocommerce_get_base_location', function () {
+			return 'AQ';
+		});
 	}
 
 	public function tearDown(): void
@@ -195,6 +199,7 @@ class PurchaseUnitTest extends TestCase
 		$product->set_regular_price((string) $data['price']);
 		$product->set_tax_status('taxable');
 		$product->set_tax_class('');
+		$product->set_virtual(true);
 
 		$product->save();
 

--- a/tests/e2e/PHPUnit/Validation/ValidationTest.php
+++ b/tests/e2e/PHPUnit/Validation/ValidationTest.php
@@ -43,6 +43,8 @@ class ValidationTest extends TestCase
 			'terms-field'=>'1',
 			'terms'=>'on',
 		]);
+
+		self::assertTrue(true); // no assertions warnings
     }
 
     public function testInvalid()


### PR DESCRIPTION
Restores the mini-cart location for Pay Later missing since 2.0.2.

Also some fixes/improvements in tests.