### PR TITLE
Fix duplicated auth error when credentials become wrong

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -204,6 +204,8 @@ class SettingsListener {
 
 	/**
 	 * Prevent enabling both Pay Later messaging and PayPal vaulting
+	 *
+	 * @throws RuntimeException When API request fails.
 	 */
 	public function listen_for_vaulting_enabled() {
 		if ( ! $this->is_valid_site_request() || State::STATE_ONBOARDED !== $this->state->current_state() ) {
@@ -221,16 +223,7 @@ class SettingsListener {
 			$this->settings->set( 'vault_enabled', false );
 			$this->settings->persist();
 
-			add_action(
-				'admin_notices',
-				function () use ( $exception ) {
-					printf(
-						'<div class="notice notice-error"><p>%1$s</p><p>%2$s</p></div>',
-						esc_html__( 'Authentication with PayPal failed: ', 'woocommerce-paypal-payments' ) . esc_attr( $exception->getMessage() ),
-						wp_kses_post( __( 'Please verify your API Credentials and try again to connect your PayPal business account. Visit the <a href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/" target="_blank">plugin documentation</a> for more information about the setup.', 'woocommerce-paypal-payments' ) )
-					);
-				}
-			);
+			throw $exception;
 		}
 
 		/**
@@ -532,6 +525,8 @@ class SettingsListener {
 
 	/**
 	 * Prevent enabling tracking if it is not enabled for merchant account.
+	 *
+	 * @throws RuntimeException When API request fails.
 	 */
 	public function listen_for_tracking_enabled(): void {
 		if ( State::STATE_ONBOARDED !== $this->state->current_state() ) {
@@ -549,16 +544,7 @@ class SettingsListener {
 			$this->settings->set( 'tracking_enabled', false );
 			$this->settings->persist();
 
-			add_action(
-				'admin_notices',
-				function () use ( $exception ) {
-					printf(
-						'<div class="notice notice-error"><p>%1$s</p><p>%2$s</p></div>',
-						esc_html__( 'Authentication with PayPal failed: ', 'woocommerce-paypal-payments' ) . esc_attr( $exception->getMessage() ),
-						wp_kses_post( __( 'Please verify your API Credentials and try again to connect your PayPal business account. Visit the <a href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/" target="_blank">plugin documentation</a> for more information about the setup.', 'woocommerce-paypal-payments' ) )
-					);
-				}
-			);
+			throw $exception;
 		}
 	}
 }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway;
 
 use Psr\Log\LoggerInterface;
 use Throwable;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WC_Order;
@@ -453,14 +454,30 @@ class WCGatewayModule implements ModuleInterface {
 			'admin_init',
 			static function () use ( $container ) {
 				$listener = $container->get( 'wcgateway.settings.listener' );
-				/**
-				 * The settings listener.
-				 *
-				 * @var SettingsListener $listener
-				 */
+				assert( $listener instanceof SettingsListener );
+
 				$listener->listen_for_merchant_id();
-				$listener->listen_for_vaulting_enabled();
-				$listener->listen_for_tracking_enabled();
+
+				try {
+					$listener->listen_for_vaulting_enabled();
+					$listener->listen_for_tracking_enabled();
+				} catch ( RuntimeException $exception ) {
+					add_action(
+						'admin_notices',
+						function () use ( $exception ) {
+							printf(
+								'<div class="notice notice-error"><p>%1$s</p><p>%2$s</p></div>',
+								esc_html__( 'Authentication with PayPal failed: ', 'woocommerce-paypal-payments' ) . esc_attr( $exception->getMessage() ),
+								wp_kses_post(
+									__(
+										'Please verify your API Credentials and try again to connect your PayPal business account. Visit the <a href="https://docs.woocommerce.com/document/woocommerce-paypal-payments/" target="_blank">plugin documentation</a> for more information about the setup.',
+										'woocommerce-paypal-payments'
+									)
+								)
+							);
+						}
+					);
+				}
 			}
 		);
 


### PR DESCRIPTION
Fixes the duplicated auth error notice (and repeating the same request) when changing to wrong credentials.

There was also a problem about webhooks not re-appearing after fixing the credentials, but I reproduced it only once, and it may be fixed by #1223, or it can be fixed by refreshing the page once more or clicking the Resubscribe button.