### PR TITLE
High volume of traffic from `merchant-integrations` endpoint

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - PPEC compatibility layer does not take over subscriptions #1193
 * Fix - Checkout conflict with "All products for subscriptions" plugin #629
 * Fix - Pay Later on order pay page #1214
+* Fix - High volume of traffic from merchant-integrations endpoint #1241
 * Enhancement - Save checkout form before free trial redirect #1135
 * Enhancement - Add filter for controlling the ditching of items/breakdown #1146
 * Enhancement - Add patch order data filter #1147

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -939,7 +939,8 @@ return array(
 			$settings,
 			$partner_endpoint,
 			$container->get( 'dcc.status-cache' ),
-			$container->get( 'api.helpers.dccapplies' )
+			$container->get( 'api.helpers.dccapplies' ),
+			$container->get( 'onboarding.state' )
 		);
 	},
 
@@ -1007,7 +1008,8 @@ return array(
 		return new PayUponInvoiceProductStatus(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'api.endpoint.partners' ),
-			$container->get( 'pui.status-cache' )
+			$container->get( 'pui.status-cache' ),
+			$container->get( 'onboarding.state' )
 		);
 	},
 	'wcgateway.pay-upon-invoice'                           => static function ( ContainerInterface $container ): PayUponInvoice {

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusProduct;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
+use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
@@ -58,23 +59,33 @@ class DCCProductStatus {
 	protected $dcc_applies;
 
 	/**
+	 * The onboarding state.
+	 *
+	 * @var State
+	 */
+	private $onboarding_state;
+
+	/**
 	 * DccProductStatus constructor.
 	 *
 	 * @param Settings         $settings The Settings.
 	 * @param PartnersEndpoint $partners_endpoint The Partner Endpoint.
 	 * @param Cache            $cache The cache.
 	 * @param DccApplies       $dcc_applies The dcc applies helper.
+	 * @param State            $onboarding_state The onboarding state.
 	 */
 	public function __construct(
 		Settings $settings,
 		PartnersEndpoint $partners_endpoint,
 		Cache $cache,
-		DccApplies $dcc_applies
+		DccApplies $dcc_applies,
+		State $onboarding_state
 	) {
 		$this->settings          = $settings;
 		$this->partners_endpoint = $partners_endpoint;
 		$this->cache             = $cache;
 		$this->dcc_applies       = $dcc_applies;
+		$this->onboarding_state  = $onboarding_state;
 	}
 
 	/**
@@ -83,6 +94,10 @@ class DCCProductStatus {
 	 * @return bool
 	 */
 	public function dcc_is_active() : bool {
+		if ( $this->onboarding_state->current_state() < State::STATE_ONBOARDED ) {
+			return false;
+		}
+
 		if ( $this->cache->has( self::DCC_STATUS_CACHE_KEY ) ) {
 			return (bool) $this->cache->get( self::DCC_STATUS_CACHE_KEY );
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -13,6 +13,7 @@ use Throwable;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusProduct;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
@@ -50,20 +51,30 @@ class PayUponInvoiceProductStatus {
 	private $partners_endpoint;
 
 	/**
+	 * The onboarding status
+	 *
+	 * @var State
+	 */
+	private $onboarding_state;
+
+	/**
 	 * PayUponInvoiceProductStatus constructor.
 	 *
 	 * @param Settings         $settings The Settings.
 	 * @param PartnersEndpoint $partners_endpoint The Partner Endpoint.
 	 * @param Cache            $cache The cache.
+	 * @param State            $onboarding_state The onboarding state.
 	 */
 	public function __construct(
 		Settings $settings,
 		PartnersEndpoint $partners_endpoint,
-		Cache $cache
+		Cache $cache,
+		State $onboarding_state
 	) {
 		$this->settings          = $settings;
 		$this->partners_endpoint = $partners_endpoint;
 		$this->cache             = $cache;
+		$this->onboarding_state  = $onboarding_state;
 	}
 
 	/**
@@ -72,6 +83,10 @@ class PayUponInvoiceProductStatus {
 	 * @return bool
 	 */
 	public function pui_is_active() : bool {
+		if ( $this->onboarding_state->current_state() < State::STATE_ONBOARDED ) {
+			return false;
+		}
+
 		if ( $this->cache->has( self::PUI_STATUS_CACHE_KEY ) ) {
 			return (bool) $this->cache->get( self::PUI_STATUS_CACHE_KEY );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - PPEC compatibility layer does not take over subscriptions #1193
 * Fix - Checkout conflict with "All products for subscriptions" plugin #629
 * Fix - Pay Later on order pay page #1214
+* Fix - High volume of traffic from merchant-integrations endpoint #1241
 * Enhancement - Save checkout form before free trial redirect #1135
 * Enhancement - Add filter for controlling the ditching of items/breakdown #1146
 * Enhancement - Add patch order data filter #1147


### PR DESCRIPTION
High volume traffic from `/v1/customer/partners/{partner-id}/merchant-integrations/{merchant-id}`.
This endpoint is used for checking ACDC and PUI availability on PayPal.

### Possible cause
One possible cause could be that when not onboarded the endpoint is called multiple times because no cache logic executed at this point.

### Suggested solution
To reduce the number of calls we could check if merchant is onboarded before calling the endpoint.