### PR TITLE
High volume of traffic from merchant integrations endpoint (1491)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -231,8 +231,11 @@ return array(
 	'wcgateway.settings.sections-renderer'                 => static function ( ContainerInterface $container ): SectionsRenderer {
 		return new SectionsRenderer(
 			$container->get( 'wcgateway.current-ppcp-settings-page-id' ),
-			$container->get( 'wcgateway.settings.sections' ),
-			$container->get( 'onboarding.state' )
+			$container->get( 'onboarding.state' ),
+			$container->get( 'wcgateway.helper.dcc-product-status' ),
+			$container->get( 'api.helpers.dccapplies' ),
+			$container->get( 'button.helper.messages-apply' ),
+			$container->get( 'wcgateway.pay-upon-invoice-product-status' )
 		);
 	},
 	'wcgateway.settings.header-renderer'                   => static function ( ContainerInterface $container ): HeaderRenderer {
@@ -240,52 +243,6 @@ return array(
 			$container->get( 'wcgateway.current-ppcp-settings-page-id' ),
 			$container->get( 'wcgateway.url' )
 		);
-	},
-	'wcgateway.settings.sections'                          => static function ( ContainerInterface $container ): array {
-		$sections = array(
-			Settings::CONNECTION_TAB_ID => __( 'Connection', 'woocommerce-paypal-payments' ),
-			PayPalGateway::ID           => __( 'Standard Payments', 'woocommerce-paypal-payments' ),
-			Settings::PAY_LATER_TAB_ID  => __( 'Pay Later', 'woocommerce-paypal-payments' ),
-			CreditCardGateway::ID       => __( 'Advanced Card Processing', 'woocommerce-paypal-payments' ),
-			CardButtonGateway::ID       => __( 'Standard Card Button', 'woocommerce-paypal-payments' ),
-			OXXOGateway::ID             => __( 'OXXO', 'woocommerce-paypal-payments' ),
-			PayUponInvoiceGateway::ID   => __( 'Pay upon Invoice', 'woocommerce-paypal-payments' ),
-		);
-
-		// Remove for all not registered in WC gateways that cannot render anything in this case.
-		$gateways = WC()->payment_gateways->payment_gateways();
-		foreach ( array_diff(
-			array_keys( $sections ),
-			array( Settings::CONNECTION_TAB_ID, PayPalGateway::ID, CreditCardGateway::ID, Settings::PAY_LATER_TAB_ID )
-		) as $id ) {
-			if ( ! isset( $gateways[ $id ] ) ) {
-				unset( $sections[ $id ] );
-			}
-		}
-
-		$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
-		assert( $dcc_product_status instanceof DCCProductStatus );
-		$dcc_applies = $container->get( 'api.helpers.dccapplies' );
-		assert( $dcc_applies instanceof DccApplies );
-		if ( ! $dcc_product_status->dcc_is_active() || ! $dcc_applies->for_country_currency() ) {
-			unset( $sections['ppcp-credit-card-gateway'] );
-		}
-
-		$messages_apply = $container->get( 'button.helper.messages-apply' );
-		assert( $messages_apply instanceof MessagesApply );
-
-		if ( ! $messages_apply->for_country() ) {
-			unset( $sections[ Settings::PAY_LATER_TAB_ID ] );
-		}
-
-		$pui_product_status = $container->get( 'wcgateway.pay-upon-invoice-product-status' );
-		assert( $pui_product_status instanceof PayUponInvoiceProductStatus );
-
-		if ( ! $pui_product_status->pui_is_active() ) {
-			unset( $sections[ PayUponInvoiceGateway::ID ] );
-		}
-
-		return $sections;
 	},
 	'wcgateway.settings.status'                            => static function ( ContainerInterface $container ): SettingsStatus {
 		$settings      = $container->get( 'wcgateway.settings' );

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -423,45 +423,24 @@ class PayUponInvoice {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function ( $methods ) {
-				if ( ! is_array( $methods ) || State::STATE_ONBOARDED !== $this->state->current_state() ) {
+				if (
+					! is_array( $methods )
+					|| State::STATE_ONBOARDED !== $this->state->current_state()
+					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					|| ! ( is_checkout() || isset( $_GET['pay_for_order'] ) && $_GET['pay_for_order'] === 'true' )
+				) {
 					return $methods;
 				}
 
 				if (
 					! $this->pui_product_status->pui_is_active()
 					|| ! $this->pui_helper->is_checkout_ready_for_pui()
-					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					|| ( isset( $_GET['pay_for_order'] ) && $_GET['pay_for_order'] === 'true' && ! $this->pui_helper->is_pay_for_order_ready_for_pui() )
+					|| ! $this->pui_helper->is_pay_for_order_ready_for_pui()
 				) {
 					unset( $methods[ PayUponInvoiceGateway::ID ] );
 				}
 
 				return $methods;
-			}
-		);
-
-		add_action(
-			'woocommerce_settings_checkout',
-			function () {
-				if (
-					PayUponInvoiceGateway::ID === $this->current_ppcp_settings_page_id
-					&& ! $this->pui_product_status->pui_is_active()
-				) {
-					$gateway_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
-					$gateway_enabled  = $gateway_settings['enabled'] ?? '';
-					if ( 'yes' === $gateway_enabled ) {
-						$gateway_settings['enabled'] = 'no';
-						update_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings', $gateway_settings );
-						$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-pay-upon-invoice-gateway' );
-						wp_safe_redirect( $redirect_url );
-						exit;
-					}
-
-					printf(
-						'<div class="notice notice-error"><p>%1$s</p></div>',
-						esc_html__( 'Could not enable gateway because the connected PayPal account is not activated for Pay upon Invoice. Reconnect your account while Onboard with Pay upon Invoice is selected to try again.', 'woocommerce-paypal-payments' )
-					);
-				}
 			}
 		);
 
@@ -509,6 +488,19 @@ class PayUponInvoice {
 						</div>
 						<?php
 					}
+				} elseif ( PayUponInvoiceGateway::ID === $this->current_ppcp_settings_page_id ) {
+					$pui_gateway = WC()->payment_gateways->payment_gateways()[ PayUponInvoiceGateway::ID ];
+					if ( 'yes' === $pui_gateway->get_option( 'enabled' ) ) {
+						$pui_gateway->update_option( 'enabled', 'no' );
+						$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-pay-upon-invoice-gateway' );
+						wp_safe_redirect( $redirect_url );
+						exit;
+					}
+
+					printf(
+						'<div class="notice notice-error"><p>%1$s</p></div>',
+						esc_html__( 'Could not enable gateway because the connected PayPal account is not activated for Pay upon Invoice. Reconnect your account while Onboard with Pay upon Invoice is selected to try again.', 'woocommerce-paypal-payments' )
+					);
 				}
 			}
 		);

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -102,11 +102,11 @@ class DCCProductStatus {
 			return (bool) $this->cache->get( self::DCC_STATUS_CACHE_KEY );
 		}
 
-		if ( is_bool( $this->current_status_cache ) ) {
+		if ( $this->current_status_cache === true ) {
 			return $this->current_status_cache;
 		}
 
-		if ( $this->settings->has( 'products_dcc_enabled' ) && $this->settings->get( 'products_dcc_enabled' ) ) {
+		if ( $this->settings->has( 'products_dcc_enabled' ) && $this->settings->get( 'products_dcc_enabled' ) === true ) {
 			$this->current_status_cache = true;
 			return true;
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -91,10 +91,10 @@ class PayUponInvoiceProductStatus {
 			return (bool) $this->cache->get( self::PUI_STATUS_CACHE_KEY );
 		}
 
-		if ( is_bool( $this->current_status_cache ) ) {
+		if ( $this->current_status_cache === true ) {
 			return $this->current_status_cache;
 		}
-		if ( $this->settings->has( 'products_pui_enabled' ) && $this->settings->get( 'products_pui_enabled' ) ) {
+		if ( $this->settings->has( 'products_pui_enabled' ) && $this->settings->get( 'products_pui_enabled' ) === true ) {
 			$this->current_status_cache = true;
 			return true;
 		}

--- a/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
@@ -79,26 +79,26 @@ class SectionsRenderer {
 	/**
 	 * SectionsRenderer constructor.
 	 *
-	 * @param string $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
-	 * @param State $state The onboarding state.
-	 * @param DCCProductStatus $dcc_product_status The DCC product status.
-	 * @param DccApplies $dcc_applies The DCC applies.
-	 * @param MessagesApply $messages_apply The Messages apply
+	 * @param string                      $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
+	 * @param State                       $state The onboarding state.
+	 * @param DCCProductStatus            $dcc_product_status The DCC product status.
+	 * @param DccApplies                  $dcc_applies The DCC applies.
+	 * @param MessagesApply               $messages_apply The Messages apply.
 	 * @param PayUponInvoiceProductStatus $pui_product_status The PUI product status.
 	 */
 	public function __construct(
-		string                      $page_id,
-		State                       $state,
-		DCCProductStatus            $dcc_product_status,
-		DccApplies                  $dcc_applies,
-		MessagesApply               $messages_apply,
+		string $page_id,
+		State $state,
+		DCCProductStatus $dcc_product_status,
+		DccApplies $dcc_applies,
+		MessagesApply $messages_apply,
 		PayUponInvoiceProductStatus $pui_product_status
 	) {
-		$this->page_id  = $page_id;
-		$this->state    = $state;
+		$this->page_id            = $page_id;
+		$this->state              = $state;
 		$this->dcc_product_status = $dcc_product_status;
-		$this->dcc_applies = $dcc_applies;
-		$this->messages_apply = $messages_apply;
+		$this->dcc_applies        = $dcc_applies;
+		$this->messages_apply     = $messages_apply;
 		$this->pui_product_status = $pui_product_status;
 	}
 
@@ -126,7 +126,7 @@ class SectionsRenderer {
 		$html = '<nav class="nav-tab-wrapper woo-nav-tab-wrapper">';
 
 		foreach ( $this->sections() as $id => $label ) {
-			$url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $id );
+			$url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . (string) $id );
 			if ( in_array( $id, array( Settings::CONNECTION_TAB_ID, CreditCardGateway::ID, Settings::PAY_LATER_TAB_ID ), true ) ) {
 				// We need section=ppcp-gateway for the webhooks page because it is not a gateway,
 				// and for DCC because otherwise it will not render the page if gateway is not available (country/currency).
@@ -160,9 +160,9 @@ class SectionsRenderer {
 		// Remove for all not registered in WC gateways that cannot render anything in this case.
 		$gateways = WC()->payment_gateways->payment_gateways();
 		foreach ( array_diff(
-					  array_keys( $sections ),
-					  array( Settings::CONNECTION_TAB_ID, PayPalGateway::ID, CreditCardGateway::ID, Settings::PAY_LATER_TAB_ID )
-				  ) as $id ) {
+			array_keys( $sections ),
+			array( Settings::CONNECTION_TAB_ID, PayPalGateway::ID, CreditCardGateway::ID, Settings::PAY_LATER_TAB_ID )
+		) as $id ) {
 			if ( ! isset( $gateways[ $id ] ) ) {
 				unset( $sections[ $id ] );
 			}

--- a/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
@@ -9,8 +9,16 @@ declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
+use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXOGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 
 /**
  * Class SectionsRenderer
@@ -27,13 +35,6 @@ class SectionsRenderer {
 	protected $page_id;
 
 	/**
-	 * Key - page/gateway ID, value - displayed text.
-	 *
-	 * @var array<string, string>
-	 */
-	protected $sections;
-
-	/**
 	 * The onboarding state.
 	 *
 	 * @var State
@@ -41,16 +42,64 @@ class SectionsRenderer {
 	private $state;
 
 	/**
+	 * The DCC product status
+	 *
+	 * @var DCCProductStatus
+	 */
+	private $dcc_product_status;
+
+	/**
+	 * The DCC applies
+	 *
+	 * @var DccApplies
+	 */
+	private $dcc_applies;
+
+	/**
+	 * The messages apply.
+	 *
+	 * @var MessagesApply
+	 */
+	private $messages_apply;
+
+	/**
+	 * The PUI product status.
+	 *
+	 * @var PayUponInvoiceProductStatus
+	 */
+	private $pui_product_status;
+
+	/**
 	 * SectionsRenderer constructor.
 	 *
 	 * @param string                $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
-	 * @param array<string, string> $sections Key - page/gateway ID, value - displayed text.
 	 * @param State                 $state The onboarding state.
 	 */
-	public function __construct( string $page_id, array $sections, State $state ) {
+
+	/**
+	 * SectionsRenderer constructor.
+	 *
+	 * @param string $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
+	 * @param State $state The onboarding state.
+	 * @param DCCProductStatus $dcc_product_status The DCC product status.
+	 * @param DccApplies $dcc_applies The DCC applies.
+	 * @param MessagesApply $messages_apply The Messages apply
+	 * @param PayUponInvoiceProductStatus $pui_product_status The PUI product status.
+	 */
+	public function __construct(
+		string                      $page_id,
+		State                       $state,
+		DCCProductStatus            $dcc_product_status,
+		DccApplies                  $dcc_applies,
+		MessagesApply               $messages_apply,
+		PayUponInvoiceProductStatus $pui_product_status
+	) {
 		$this->page_id  = $page_id;
-		$this->sections = $sections;
 		$this->state    = $state;
+		$this->dcc_product_status = $dcc_product_status;
+		$this->dcc_applies = $dcc_applies;
+		$this->messages_apply = $messages_apply;
+		$this->pui_product_status = $pui_product_status;
 	}
 
 	/**
@@ -66,6 +115,8 @@ class SectionsRenderer {
 
 	/**
 	 * Renders the Sections tab.
+	 *
+	 * @return string
 	 */
 	public function render(): string {
 		if ( ! $this->should_render() ) {
@@ -74,7 +125,7 @@ class SectionsRenderer {
 
 		$html = '<nav class="nav-tab-wrapper woo-nav-tab-wrapper">';
 
-		foreach ( $this->sections as $id => $label ) {
+		foreach ( $this->sections() as $id => $label ) {
 			$url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $id );
 			if ( in_array( $id, array( Settings::CONNECTION_TAB_ID, CreditCardGateway::ID, Settings::PAY_LATER_TAB_ID ), true ) ) {
 				// We need section=ppcp-gateway for the webhooks page because it is not a gateway,
@@ -88,5 +139,47 @@ class SectionsRenderer {
 		$html .= '</nav>';
 
 		return $html;
+	}
+
+	/**
+	 * Returns sections as Key - page/gateway ID, value - displayed text.
+	 *
+	 * @return array
+	 */
+	private function sections(): array {
+		$sections = array(
+			Settings::CONNECTION_TAB_ID => __( 'Connection', 'woocommerce-paypal-payments' ),
+			PayPalGateway::ID           => __( 'Standard Payments', 'woocommerce-paypal-payments' ),
+			Settings::PAY_LATER_TAB_ID  => __( 'Pay Later', 'woocommerce-paypal-payments' ),
+			CreditCardGateway::ID       => __( 'Advanced Card Processing', 'woocommerce-paypal-payments' ),
+			CardButtonGateway::ID       => __( 'Standard Card Button', 'woocommerce-paypal-payments' ),
+			OXXOGateway::ID             => __( 'OXXO', 'woocommerce-paypal-payments' ),
+			PayUponInvoiceGateway::ID   => __( 'Pay upon Invoice', 'woocommerce-paypal-payments' ),
+		);
+
+		// Remove for all not registered in WC gateways that cannot render anything in this case.
+		$gateways = WC()->payment_gateways->payment_gateways();
+		foreach ( array_diff(
+					  array_keys( $sections ),
+					  array( Settings::CONNECTION_TAB_ID, PayPalGateway::ID, CreditCardGateway::ID, Settings::PAY_LATER_TAB_ID )
+				  ) as $id ) {
+			if ( ! isset( $gateways[ $id ] ) ) {
+				unset( $sections[ $id ] );
+			}
+		}
+
+		if ( ! $this->dcc_product_status->dcc_is_active() || ! $this->dcc_applies->for_country_currency() ) {
+			unset( $sections['ppcp-credit-card-gateway'] );
+		}
+
+		if ( ! $this->messages_apply->for_country() ) {
+			unset( $sections[ Settings::PAY_LATER_TAB_ID ] );
+		}
+
+		if ( ! $this->pui_product_status->pui_is_active() ) {
+			unset( $sections[ PayUponInvoiceGateway::ID ] );
+		}
+
+		return $sections;
 	}
 }


### PR DESCRIPTION
#1241 did not fix the issue, merchants still receiving high volume traffic with 200 OK responses.

This PR tries to reduce the number of calls by moving code from service definition to class and refactoring some logic. 

It also cleanups the caching data on plugin upgrade to prevent cases where data could have been corrupted for some reason.