### PR TITLE
Add content type json to all fetch ajax endpoints (1450)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Duplicated auth error when credentials become wrong #1229
 * Fix - Webhook issues when switching sandbox, and delete all webhooks when unsubscribing #1239
 * Fix - High volume of traffic from merchant-integrations endpoint #1273
+* Fix - Add content type json to all fetch ajax endpoints #1275
 * Enhancement - Remove shortcodes from description #1226
 * Enhancement - Handle price suffix with price for product button check #1234
 * Enhancement - Show funding source as payment method #1220

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
@@ -16,6 +16,9 @@ class CartActionHandler {
                 this.config.bn_codes[this.config.context] : '';
             return fetch(this.config.ajax.create_order.endpoint, {
                 method: 'POST',
+                headers: {
+                    "Content-Type": "application/json",
+                },
                 credentials: 'same-origin',
                 body: JSON.stringify({
                     nonce: this.config.ajax.create_order.nonce,

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
@@ -17,7 +17,7 @@ class CartActionHandler {
             return fetch(this.config.ajax.create_order.endpoint, {
                 method: 'POST',
                 headers: {
-                    "Content-Type": "application/json",
+                    'Content-Type': 'application/json'
                 },
                 credentials: 'same-origin',
                 body: JSON.stringify({

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -33,7 +33,7 @@ class CheckoutActionHandler {
             return fetch(this.config.ajax.create_order.endpoint, {
                 method: 'POST',
                 headers: {
-                    "Content-Type": "application/json",
+                    'Content-Type': 'application/json'
                 },
                 credentials: 'same-origin',
                 body: JSON.stringify({

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -32,6 +32,9 @@ class CheckoutActionHandler {
 
             return fetch(this.config.ajax.create_order.endpoint, {
                 method: 'POST',
+                headers: {
+                    "Content-Type": "application/json",
+                },
                 credentials: 'same-origin',
                 body: JSON.stringify({
                     nonce: this.config.ajax.create_order.nonce,

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/FreeTrialHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/FreeTrialHandler.js
@@ -49,6 +49,9 @@ class FreeTrialHandler {
 
             const res = await fetch(this.config.ajax.vault_paypal.endpoint, {
                 method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
                 credentials: 'same-origin',
                 body: JSON.stringify({
                     nonce: this.config.ajax.vault_paypal.nonce,

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
@@ -67,7 +67,7 @@ class SingleProductActionHandler {
                 return fetch(this.config.ajax.create_order.endpoint, {
                     method: 'POST',
                     headers: {
-                        "Content-Type": "application/json",
+                        'Content-Type': 'application/json'
                     },
                     credentials: 'same-origin',
                     body: JSON.stringify({

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
@@ -66,6 +66,9 @@ class SingleProductActionHandler {
                     this.config.bn_codes[this.config.context] : '';
                 return fetch(this.config.ajax.create_order.endpoint, {
                     method: 'POST',
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
                     credentials: 'same-origin',
                     body: JSON.stringify({
                         nonce: this.config.ajax.create_order.nonce,

--- a/modules/ppcp-button/resources/js/modules/DataClientIdAttributeHandler.js
+++ b/modules/ppcp-button/resources/js/modules/DataClientIdAttributeHandler.js
@@ -27,6 +27,9 @@ const storeToken = (token) => {
 const dataClientIdAttributeHandler = (script, config) => {
     fetch(config.endpoint, {
         method: 'POST',
+        headers: {
+            'Content-Type': 'application/json'
+        },
         credentials: 'same-origin',
         body: JSON.stringify({
             nonce: config.nonce

--- a/modules/ppcp-button/resources/js/modules/Helper/FormSaver.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/FormSaver.js
@@ -10,6 +10,9 @@ export default class FormSaver {
 
         const res = await fetch(this.url, {
             method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
             credentials: 'same-origin',
             body: JSON.stringify({
                 nonce: this.nonce,

--- a/modules/ppcp-button/resources/js/modules/Helper/FormValidator.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/FormValidator.js
@@ -10,6 +10,9 @@ export default class FormValidator {
 
         const res = await fetch(this.url, {
             method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
             credentials: 'same-origin',
             body: JSON.stringify({
                 nonce: this.nonce,

--- a/modules/ppcp-button/resources/js/modules/Helper/UpdateCart.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/UpdateCart.js
@@ -20,6 +20,9 @@ class UpdateCart {
                 this.endpoint,
                 {
                     method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
                     credentials: 'same-origin',
                     body: JSON.stringify({
                         nonce: this.nonce,

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
@@ -2,6 +2,9 @@ const onApprove = (context, errorHandler) => {
     return (data, actions) => {
         return fetch(context.config.ajax.approve_order.endpoint, {
             method: 'POST',
+            headers: {
+                "Content-Type": "application/json",
+            },
             credentials: 'same-origin',
             body: JSON.stringify({
                 nonce: context.config.ajax.approve_order.nonce,

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
@@ -3,7 +3,7 @@ const onApprove = (context, errorHandler) => {
         return fetch(context.config.ajax.approve_order.endpoint, {
             method: 'POST',
             headers: {
-                "Content-Type": "application/json",
+                'Content-Type': 'application/json'
             },
             credentials: 'same-origin',
             body: JSON.stringify({

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
@@ -5,6 +5,9 @@ const onApprove = (context, errorHandler, spinner) => {
 
         return fetch(context.config.ajax.approve_order.endpoint, {
             method: 'POST',
+            headers: {
+                "Content-Type": "application/json",
+            },
             credentials: 'same-origin',
             body: JSON.stringify({
                 nonce: context.config.ajax.approve_order.nonce,

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
@@ -6,7 +6,7 @@ const onApprove = (context, errorHandler, spinner) => {
         return fetch(context.config.ajax.approve_order.endpoint, {
             method: 'POST',
             headers: {
-                "Content-Type": "application/json",
+                'Content-Type': 'application/json'
             },
             credentials: 'same-origin',
             body: JSON.stringify({

--- a/modules/ppcp-onboarding/resources/js/onboarding.js
+++ b/modules/ppcp-onboarding/resources/js/onboarding.js
@@ -84,6 +84,9 @@ const ppcp_onboarding = {
 
             fetch(PayPalCommerceGatewayOnboarding.pui_endpoint, {
                 method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
                 credentials: 'same-origin',
                 body: JSON.stringify({
                     nonce: PayPalCommerceGatewayOnboarding.pui_nonce,

--- a/modules/ppcp-order-tracking/resources/js/order-edit-page.js
+++ b/modules/ppcp-order-tracking/resources/js/order-edit-page.js
@@ -18,6 +18,9 @@ document.addEventListener(
             submitButton.setAttribute('disabled', 'disabled');
             fetch(config.ajax.tracking_info.endpoint, {
                 method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
                 credentials: 'same-origin',
                 body: JSON.stringify({
                     nonce: config.ajax.tracking_info.nonce,

--- a/readme.txt
+++ b/readme.txt
@@ -86,6 +86,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - Duplicated auth error when credentials become wrong #1229
 * Fix - Webhook issues when switching sandbox, and delete all webhooks when unsubscribing #1239
 * Fix - High volume of traffic from merchant-integrations endpoint #1273
+* Fix - Add content type json to all fetch ajax endpoints #1275
 * Enhancement - Remove shortcodes from description #1226
 * Enhancement - Handle price suffix with price for product button check #1234
 * Enhancement - Show funding source as payment method #1220


### PR DESCRIPTION
This PR adds json content type header to all fetch ajax endpoints to avoid error: 
```
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```