### PR TITLE
Pay upon invoice doesn't show on checkout page (1514)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -435,7 +435,13 @@ class PayUponInvoice {
 				if (
 					! $this->pui_product_status->pui_is_active()
 					|| ! $this->pui_helper->is_checkout_ready_for_pui()
-					|| ! $this->pui_helper->is_pay_for_order_ready_for_pui()
+				) {
+					unset( $methods[ PayUponInvoiceGateway::ID ] );
+				}
+
+				if (
+					isset( $_GET['pay_for_order'] ) && $_GET['pay_for_order'] === 'true'
+					&& ! $this->pui_helper->is_pay_for_order_ready_for_pui()
 				) {
 					unset( $methods[ PayUponInvoiceGateway::ID ] );
 				}


### PR DESCRIPTION
Pay upon invoice doesn't show on checkout page (release package 2.0.4-rc1, in earlier package pay upon invoice is ok)

### Steps To Reproduce

- (Store Germany, currency euro, merchant from Germany)
- Go to WC->Settings->Payments->Pay upon invoice
- Enable Pay upon invoice
- Fill mandatory fields 
- Scroll to button Save changes and click on it
- Go to store
- Add product to cart
- Go to checkout
- Fill billing info (Germany)
- Observe pay upon invoice doesn’t showing