### PR TITLE
Refresh checkout totals after validation if needed (1572)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -62,6 +62,11 @@ class CheckoutActionHandler {
                         );
                     } else {
                         errorHandler.clear();
+
+                        if (data.data.refresh) {
+                            jQuery( document.body ).trigger( 'update_checkout' );
+                        }
+
                         if (data.data.errors?.length > 0) {
                             errorHandler.messages(data.data.errors);
                         } else if (data.data.details?.length > 0) {

--- a/modules/ppcp-button/resources/js/modules/Helper/FormValidator.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/FormValidator.js
@@ -23,6 +23,10 @@ export default class FormValidator {
         const data = await res.json();
 
         if (!data.success) {
+            if (data.data.refresh) {
+                jQuery( document.body ).trigger( 'update_checkout' );
+            }
+
             if (data.data.errors) {
                 return data.data.errors;
             }

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -288,12 +288,15 @@ class CreateOrderEndpoint implements EndpointInterface {
 			return true;
 
 		} catch ( ValidationException $error ) {
-			wp_send_json_error(
-				array(
-					'message' => $error->getMessage(),
-					'errors'  => $error->errors(),
-				)
+			$response = array(
+				'message' => $error->getMessage(),
+				'errors'  => $error->errors(),
+				'refresh' => isset( WC()->session->refresh_totals ),
 			);
+
+			unset( WC()->session->refresh_totals );
+
+			wp_send_json_error( $response );
 		} catch ( \RuntimeException $error ) {
 			$this->logger->error( 'Order creation failed: ' . $error->getMessage() );
 

--- a/modules/ppcp-button/src/Endpoint/ValidateCheckoutEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ValidateCheckoutEndpoint.php
@@ -86,12 +86,15 @@ class ValidateCheckoutEndpoint implements EndpointInterface {
 
 			return true;
 		} catch ( ValidationException $exception ) {
-			wp_send_json_error(
-				array(
-					'message' => $exception->getMessage(),
-					'errors'  => $exception->errors(),
-				)
+			$response = array(
+				'message' => $exception->getMessage(),
+				'errors'  => $exception->errors(),
+				'refresh' => isset( WC()->session->refresh_totals ),
 			);
+
+			unset( WC()->session->refresh_totals );
+
+			wp_send_json_error( $response );
 			return false;
 		} catch ( Throwable $error ) {
 			$this->logger->error( "Form validation execution failed. {$error->getMessage()} {$error->getFile()}:{$error->getLine()}" );

--- a/tests/PHPUnit/Button/Endpoint/ValidateCheckoutEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/ValidateCheckoutEndpointTest.php
@@ -11,6 +11,7 @@ use WooCommerce\PayPalCommerce\Button\Exception\ValidationException;
 use WooCommerce\PayPalCommerce\Button\Validation\CheckoutFormValidator;
 use WooCommerce\PayPalCommerce\TestCase;
 use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
 
 class ValidateCheckoutEndpointTest extends TestCase
 {
@@ -20,6 +21,8 @@ class ValidateCheckoutEndpointTest extends TestCase
 	private $formValidator;
 	private $logger;
 	private $sut;
+
+	private $session = [];
 
 	public function setUp(): void
 	{
@@ -36,6 +39,10 @@ class ValidateCheckoutEndpointTest extends TestCase
 		);
 
 		$this->requestData->expects('read_request')->andReturn(['form' => ['field1' => 'value']]);
+
+		when('WC')->alias(function () {
+			return (object) ['session' => (object) $this->session];
+		});
 	}
 
 	public function testValid()
@@ -54,7 +61,21 @@ class ValidateCheckoutEndpointTest extends TestCase
 			->andThrow($exception);
 
 		expect('wp_send_json_error')->once()
-			->with(['message' => $exception->getMessage(), 'errors' => ['Invalid value']]);
+			->with(['message' => $exception->getMessage(), 'errors' => ['Invalid value'], 'refresh' => false]);
+
+		$this->sut->handle_request();
+	}
+
+	public function testInvalidAndRefresh()
+	{
+		$exception = new ValidationException(['Invalid value']);
+		$this->formValidator->expects('validate')->once()
+			->andThrow($exception);
+
+		$this->session['refresh_totals'] = true;
+
+		expect('wp_send_json_error')->once()
+			->with(['message' => $exception->getMessage(), 'errors' => ['Invalid value'], 'refresh' => true]);
 
 		$this->sut->handle_request();
 	}


### PR DESCRIPTION
Refreshing the totals the same way as WC does this.

https://github.com/woocommerce/woocommerce/blob/21f7cea2b6ab1a268c137dcf761c4df721f1ec0b/plugins/woocommerce/legacy/js/frontend/checkout.js#L547-L549

https://github.com/woocommerce/woocommerce/blob/6b12a7c2303f1c6bb30f57d20bcd923212c01980/plugins/woocommerce/includes/class-wc-checkout.php#L1117-L1126