### PR TITLE
Boolean false type sent as empty value when setting cache (PCP-1599)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -99,7 +99,7 @@ class DCCProductStatus {
 		}
 
 		if ( $this->cache->has( self::DCC_STATUS_CACHE_KEY ) ) {
-			return (bool) $this->cache->get( self::DCC_STATUS_CACHE_KEY );
+			return $this->cache->get( self::DCC_STATUS_CACHE_KEY ) === 'true';
 		}
 
 		if ( $this->current_status_cache === true ) {
@@ -135,7 +135,7 @@ class DCCProductStatus {
 				$this->settings->set( 'products_dcc_enabled', true );
 				$this->settings->persist();
 				$this->current_status_cache = true;
-				$this->cache->set( self::DCC_STATUS_CACHE_KEY, true, 3 * MONTH_IN_SECONDS );
+				$this->cache->set( self::DCC_STATUS_CACHE_KEY, 'true', 3 * MONTH_IN_SECONDS );
 				return true;
 			}
 		}
@@ -144,7 +144,7 @@ class DCCProductStatus {
 		if ( $this->dcc_applies->for_country_currency() ) {
 			$expiration = 3 * HOUR_IN_SECONDS;
 		}
-		$this->cache->set( self::DCC_STATUS_CACHE_KEY, false, $expiration );
+		$this->cache->set( self::DCC_STATUS_CACHE_KEY, 'false', $expiration );
 
 		$this->current_status_cache = false;
 		return false;

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -88,7 +88,7 @@ class PayUponInvoiceProductStatus {
 		}
 
 		if ( $this->cache->has( self::PUI_STATUS_CACHE_KEY ) ) {
-			return (bool) $this->cache->get( self::PUI_STATUS_CACHE_KEY );
+			return $this->cache->get( self::PUI_STATUS_CACHE_KEY ) === 'true';
 		}
 
 		if ( $this->current_status_cache === true ) {
@@ -127,11 +127,11 @@ class PayUponInvoiceProductStatus {
 				$this->settings->set( 'products_pui_enabled', true );
 				$this->settings->persist();
 				$this->current_status_cache = true;
-				$this->cache->set( self::PUI_STATUS_CACHE_KEY, true, 3 * MONTH_IN_SECONDS );
+				$this->cache->set( self::PUI_STATUS_CACHE_KEY, 'true', 3 * MONTH_IN_SECONDS );
 				return true;
 			}
 		}
-		$this->cache->set( self::PUI_STATUS_CACHE_KEY, false, 3 * MONTH_IN_SECONDS );
+		$this->cache->set( self::PUI_STATUS_CACHE_KEY, 'false', 3 * MONTH_IN_SECONDS );
 
 		$this->current_status_cache = false;
 		return false;


### PR DESCRIPTION
Related to #1273, we have detected that in some environments the boolean `false $value` is not received here: [woocommerce-paypal-payments/Cache.php at trunk · woocommerce/woocommerce-paypal-payments](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-api-client/src/Helper/Cache.php#L74) and therefore transient is not created.

In order to avoid this situation we could pass the value as string and then validate against this value in the cache logic.