### PR TITLE
Cross Site Request Forgery (CSRF) can invalidate merchant credentials (1600)

### DIFF
--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -84,7 +84,7 @@ class PartnerReferralsData {
 					 */
 					'return_url'             => apply_filters(
 						'woocommerce_paypal_payments_partner_config_override_return_url',
-						admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' )
+						add_query_arg( 'ppcp-return-url-nonce', wp_create_nonce( 'ppcp-return-url' ), admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ) )
 					),
 					/**
 					 * Returns the description of the URL which will be opened at the end of onboarding.

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -84,7 +84,7 @@ class PartnerReferralsData {
 					 */
 					'return_url'             => apply_filters(
 						'woocommerce_paypal_payments_partner_config_override_return_url',
-						add_query_arg( 'ppcp-return-url-nonce', wp_create_nonce( 'ppcp-return-url' ), admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ) )
+						admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' )
 					),
 					/**
 					 * Returns the description of the URL which will be opened at the end of onboarding.

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -172,11 +172,6 @@ class SettingsListener {
 			return;
 		}
 
-		$nonce = wc_clean( wp_unslash( $_GET['ppcp-return-url-nonce'] ?? '' ) );
-		if ( ! $nonce || ! is_string($nonce) || ! wp_verify_nonce( $nonce, 'ppcp-return-url' ) ) {
-			return;
-		}
-
 		if ( ! isset( $_GET['merchantIdInPayPal'] ) || ! isset( $_GET['merchantId'] ) ) {
 			return;
 		}

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -172,11 +172,18 @@ class SettingsListener {
 			return;
 		}
 
+		/**
+		 * No nonce provided.
+		 * phpcs:disable WordPress.Security.NonceVerification.Missing
+		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
+		 */
 		if ( ! isset( $_GET['merchantIdInPayPal'] ) || ! isset( $_GET['merchantId'] ) ) {
 			return;
 		}
 		$merchant_id    = sanitize_text_field( wp_unslash( $_GET['merchantIdInPayPal'] ) );
 		$merchant_email = sanitize_text_field( wp_unslash( $_GET['merchantId'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$this->settings->set( 'merchant_id', $merchant_id );
 		$this->settings->set( 'merchant_email', $merchant_email );

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -173,7 +173,7 @@ class SettingsListener {
 		}
 
 		$nonce = wc_clean( wp_unslash( $_GET['ppcp-return-url-nonce'] ?? '' ) );
-		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'ppcp-return-url' ) ) {
+		if ( ! $nonce || ! is_string($nonce) || ! wp_verify_nonce( $nonce, 'ppcp-return-url' ) ) {
 			return;
 		}
 

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -168,23 +168,20 @@ class SettingsListener {
 	 * Listens if the merchant ID should be updated.
 	 */
 	public function listen_for_merchant_id() {
-
 		if ( ! $this->is_valid_site_request() ) {
 			return;
 		}
 
-		/**
-		 * No nonce provided.
-		 * phpcs:disable WordPress.Security.NonceVerification.Missing
-		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
-		 */
+		$nonce = wc_clean( wp_unslash( $_GET['ppcp-return-url-nonce'] ?? '' ) );
+		if ( ! $nonce || ! wp_verify_nonce( $nonce, 'ppcp-return-url' ) ) {
+			return;
+		}
+
 		if ( ! isset( $_GET['merchantIdInPayPal'] ) || ! isset( $_GET['merchantId'] ) ) {
 			return;
 		}
 		$merchant_id    = sanitize_text_field( wp_unslash( $_GET['merchantIdInPayPal'] ) );
 		$merchant_email = sanitize_text_field( wp_unslash( $_GET['merchantId'] ) );
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$this->settings->set( 'merchant_id', $merchant_id );
 		$this->settings->set( 'merchant_email', $merchant_email );

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -168,7 +168,7 @@ class SettingsListener {
 	 * Listens if the merchant ID should be updated.
 	 */
 	public function listen_for_merchant_id() {
-		if ( ! $this->is_valid_site_request() ) {
+		if ( ! $this->is_valid_site_request() || $this->state->current_state() === State::STATE_ONBOARDED ) {
 			return;
 		}
 


### PR DESCRIPTION
### Steps To Reproduce

1. Log in as an Admin in your store, with PayPal Payments installed but not yet connected to your PayPal account
2. Visit the following URL, crafted by a malicious user: http://localhost/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&merchantIdInPayPal=CSRF&merchantId=CSRF
3. Visit PayPal Payments’ settings page , click the “Toggle to manual credential input” and confirm that the email address and merchant id have been updated to “CSRF” (Settings page URL http://localhost/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway)

### Impact
The worst case we can foresee is a merchant saving the wrong credentials and getting their store disconnected from PayPal.