### PR TITLE
Do not show broken card button gateway when no checkout location

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -223,7 +223,8 @@ return array(
 			$container->get( 'onboarding.state' ),
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'wcgateway.is-wc-payments-page' ),
-			$container->get( 'wcgateway.is-ppcp-settings-page' )
+			$container->get( 'wcgateway.is-ppcp-settings-page' ),
+			$container->get( 'wcgateway.settings.status' )
 		);
 	},
 	'wcgateway.notice.authorize-order-action'              =>

--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -82,8 +82,11 @@ class DisableGateways {
 			unset( $methods[ CreditCardGateway::ID ] );
 		}
 
-		if ( ! $this->settings_status->is_smart_button_enabled_for_location( 'checkout' ) && ! $this->session_handler->order() && is_checkout() ) {
-			unset( $methods[ PayPalGateway::ID ] );
+		if ( ! $this->settings_status->is_smart_button_enabled_for_location( 'checkout' ) ) {
+			unset( $methods[ CardButtonGateway::ID ] );
+			if ( ! $this->session_handler->order() && is_checkout() ) {
+				unset( $methods[ PayPalGateway::ID ] );
+			}
 		}
 
 		if ( ! $this->needs_to_disable_gateways() ) {


### PR DESCRIPTION
Removes the card button gateway together with the PayPal gateway when disabled in checkout (since it gets broken anyway). Also refactored the admin notice about disabled gateway to add a message about disabled location.