### PR TITLE
Do not exclude free items

### DIFF
--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -110,7 +110,7 @@ class PurchaseUnitFactory {
 		$items    = array_filter(
 			$this->item_factory->from_wc_order( $order ),
 			function ( Item $item ): bool {
-				return $item->unit_amount()->value() > 0;
+				return $item->unit_amount()->value() >= 0;
 			}
 		);
 		$shipping = $this->shipping_factory->from_wc_order( $order );
@@ -166,7 +166,7 @@ class PurchaseUnitFactory {
 		$items  = array_filter(
 			$this->item_factory->from_wc_cart( $cart ),
 			function ( Item $item ): bool {
-				return $item->unit_amount()->value() > 0;
+				return $item->unit_amount()->value() >= 0;
 			}
 		);
 


### PR DESCRIPTION
[Some time ago](https://github.com/woocommerce/woocommerce-paypal-payments/commit/88220aa3c6e7ed044686be7b16176f1ceca98c73#diff-1d23573baaaa925a90211c9706425b31e4189a4b88a96eb2d03af3b82b47a519) I added filtering of items to send only items with positive price to PayPal and handle negative prices (discounts) separately. Seems like sending items with `0` price is ok and a valid use case (WC supports creating such products), so changing the condition to `>= 0` instead of `> 0`.