### PR TITLE
Do not re-render DCC

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -36,9 +36,8 @@ class CreditCardRenderer {
         const buttonSelector = wrapper + ' button';
 
         if (this.currentHostedFieldsInstance) {
-            this.currentHostedFieldsInstance.teardown()
-                .catch(err => console.error(`Hosted fields teardown error: ${err}`));
-            this.currentHostedFieldsInstance = null;
+            // Already rendered.
+            return;
         }
 
         const gateWayBox = document.querySelector('.payment_box.payment_method_ppcp-credit-card-gateway');


### PR DESCRIPTION
It's unclear why we were re-rendering it, maybe accidentally. Removing it does not seem to break anything and the card fields are not erased on ajax reloads (address, shipping change, ...). Also may fix some of "already in progress" errors #1011
