### PR TITLE
Trigger WC checkout_error event

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -102,6 +102,9 @@ class CheckoutActionHandler {
                         } else {
                             errorHandler.message(data.data.message);
                         }
+
+                        // fire WC event for other plugins
+                        jQuery( document.body ).trigger( 'checkout_error' , [ errorHandler.currentHtml() ] );
                     }
 
                     throw {type: 'create-order-error', data: data.data};

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/FreeTrialHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/FreeTrialHandler.js
@@ -40,6 +40,10 @@ class FreeTrialHandler {
                     if (errors.length > 0) {
                         this.spinner.unblock();
                         this.errorHandler.messages(errors);
+
+                        // fire WC event for other plugins
+                        jQuery( document.body ).trigger( 'checkout_error' , [ this.errorHandler.currentHtml() ] );
+
                         return;
                     }
                 } catch (error) {

--- a/modules/ppcp-button/resources/js/modules/ErrorHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ErrorHandler.js
@@ -41,6 +41,15 @@ class ErrorHandler {
     }
 
     /**
+     * @returns {String}
+     */
+    currentHtml()
+    {
+        const messageContainer = this._getMessageContainer();
+        return messageContainer.outerHTML;
+    }
+
+    /**
      * @private
      * @param {String} text
      */


### PR DESCRIPTION
Triggering WC `checkout_error` event for our validation, similarly to [the WC submit ajax handler](https://github.com/woocommerce/woocommerce/blob/eebd3ed2851274e5c9a4d78d8bfdd63fc64e21a1/plugins/woocommerce/client/legacy/js/frontend/checkout.js#L580).

Other plugins/themes can use it in the same way as the WC event:

```
jQuery(document).on('checkout_error', (e, errors) => {
    console.log(errors)
});
```