### PR TITLE
Fatal error `get_cart_contents() on null` on 2.0.5-rc1

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1397,7 +1397,11 @@ class SmartButton implements SmartButtonInterface {
 			}
 		}
 
-		$items = WC()->cart->get_cart_contents();
+		$cart = WC()->cart ?? null;
+		if ( ! $cart || $cart->is_empty() ) {
+			return '';
+		}
+		$items = $cart->get_cart_contents();
 		foreach ( $items as $item ) {
 			$product = wc_get_product( $item['product_id'] );
 			assert( $product instanceof WC_Product );


### PR DESCRIPTION
Fixes `Uncaught Error: Call to a member function get_cart_contents() on null`.