### PR TITLE
Subscriptions API buttons not loading when Vaulting is disabled (1701)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -988,12 +988,13 @@ class SmartButton implements SmartButtonInterface {
 			$intent = 'capture';
 		}
 
-		$params = array(
+		$subscription_mode = $this->settings->has( 'subscriptions_mode' ) ? $this->settings->get( 'subscriptions_mode' ) : '';
+		$params            = array(
 			'client-id'        => $this->client_id,
 			'currency'         => $this->currency,
 			'integration-date' => PAYPAL_INTEGRATION_DATE,
 			'components'       => implode( ',', $this->components() ),
-			'vault'            => $this->can_save_vault_token() ? 'true' : 'false',
+			'vault'            => ( $this->can_save_vault_token() || $this->subscription_helper->need_subscription_intent( $subscription_mode ) ) ? 'true' : 'false',
 			'commit'           => in_array( $context, $this->pay_now_contexts, true ) ? 'true' : 'false',
 			'intent'           => $intent,
 		);


### PR DESCRIPTION
In update 2.0.5, the Vaulting feature must be enabled to be able to use the PayPal Subscriptions functionality.

When Vaulting is disabled, this error prevents the smart button from loading:
```
throw new Error("SDK Validation error: 'Must pass vault=true for intent=subscription'" );
```

### Steps To Reproduce
- install 2.0.5-rc1
- enable PayPal Subscriptions functionality
- set Subscription Mode to PayPal Subscriptions 
- disable Vaulting
- visit subscription product with linked PayPal Subscriptions

PayPal button won’t load.