### PR TITLE
Handle payment errors in blocks

### DIFF
--- a/modules/ppcp-session/services.php
+++ b/modules/ppcp-session/services.php
@@ -15,17 +15,7 @@ use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 
 return array(
 	'session.handler'                 => function ( ContainerInterface $container ) : SessionHandler {
-
-		if ( is_null( WC()->session ) ) {
-			return new SessionHandler();
-		}
-		$result = WC()->session->get( SessionHandler::ID );
-		if ( is_a( $result, SessionHandler::class ) ) {
-			return $result;
-		}
-		$session_handler = new SessionHandler();
-		WC()->session->set( SessionHandler::ID, $session_handler );
-		return $session_handler;
+		return new SessionHandler();
 	},
 	'session.cancellation.view'       => function ( ContainerInterface $container ) : CancelView {
 		return new CancelView(

--- a/modules/ppcp-session/src/SessionHandler.php
+++ b/modules/ppcp-session/src/SessionHandler.php
@@ -16,7 +16,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
  */
 class SessionHandler {
 
-	const ID = 'ppcp';
+	private const SESSION_KEY = 'ppcp';
 
 	/**
 	 * The Order.
@@ -33,7 +33,7 @@ class SessionHandler {
 	private $bn_code = '';
 
 	/**
-	 * If PayPal respondes with INSTRUMENT_DECLINED, we only
+	 * If PayPal responds with INSTRUMENT_DECLINED, we only
 	 * want to go max. three times through the process of trying again.
 	 *
 	 * @var int
@@ -53,6 +53,8 @@ class SessionHandler {
 	 * @return Order|null
 	 */
 	public function order() {
+		$this->load_session();
+
 		return $this->order;
 	}
 
@@ -60,13 +62,13 @@ class SessionHandler {
 	 * Replaces the current order.
 	 *
 	 * @param Order $order The new order.
-	 *
-	 * @return SessionHandler
 	 */
-	public function replace_order( Order $order ) : SessionHandler {
+	public function replace_order( Order $order ): void {
+		$this->load_session();
+
 		$this->order = $order;
+
 		$this->store_session();
-		return $this;
 	}
 
 	/**
@@ -75,6 +77,8 @@ class SessionHandler {
 	 * @return string
 	 */
 	public function bn_code() : string {
+		$this->load_session();
+
 		return $this->bn_code;
 	}
 
@@ -82,13 +86,13 @@ class SessionHandler {
 	 * Replaces the BN Code.
 	 *
 	 * @param string $bn_code The new BN Code.
-	 *
-	 * @return SessionHandler
 	 */
-	public function replace_bn_code( string $bn_code ) : SessionHandler {
+	public function replace_bn_code( string $bn_code ) : void {
+		$this->load_session();
+
 		$this->bn_code = $bn_code;
+
 		$this->store_session();
-		return $this;
 	}
 
 	/**
@@ -97,6 +101,8 @@ class SessionHandler {
 	 * @return string|null
 	 */
 	public function funding_source(): ?string {
+		$this->load_session();
+
 		return $this->funding_source;
 	}
 
@@ -104,13 +110,13 @@ class SessionHandler {
 	 * Replaces the funding source of the current checkout.
 	 *
 	 * @param string|null $funding_source The funding source.
-	 *
-	 * @return SessionHandler
 	 */
-	public function replace_funding_source( ?string $funding_source ): SessionHandler {
+	public function replace_funding_source( ?string $funding_source ): void {
+		$this->load_session();
+
 		$this->funding_source = $funding_source;
+
 		$this->store_session();
-		return $this;
 	}
 
 	/**
@@ -119,18 +125,20 @@ class SessionHandler {
 	 * @return int
 	 */
 	public function insufficient_funding_tries() : int {
+		$this->load_session();
+
 		return $this->insufficient_funding_tries;
 	}
 
 	/**
 	 * Increments the number of tries, the customer has done in this session.
-	 *
-	 * @return SessionHandler
 	 */
-	public function increment_insufficient_funding_tries() : SessionHandler {
+	public function increment_insufficient_funding_tries(): void {
+		$this->load_session();
+
 		$this->insufficient_funding_tries++;
+
 		$this->store_session();
-		return $this;
 	}
 
 	/**
@@ -148,9 +156,52 @@ class SessionHandler {
 	}
 
 	/**
-	 * Stores the session.
+	 * Stores the data into the WC session.
 	 */
-	private function store_session() {
-		WC()->session->set( self::ID, $this );
+	private function store_session(): void {
+		WC()->session->set( self::SESSION_KEY, self::make_array( $this ) );
+	}
+
+	/**
+	 * Loads the data from the session.
+	 */
+	private function load_session(): void {
+		if ( isset( WC()->session ) ) {
+			$data = WC()->session->get( self::SESSION_KEY );
+		} else {
+			$data = array();
+		}
+
+		if ( $data instanceof SessionHandler ) {
+			$data = self::make_array( $data );
+		} elseif ( ! is_array( $data ) ) {
+			$data = array();
+		}
+
+		$this->order = $data['order'] ?? null;
+		if ( ! $this->order instanceof Order ) {
+			$this->order = null;
+		}
+		$this->bn_code                    = (string) ( $data['bn_code'] ?? '' );
+		$this->insufficient_funding_tries = (int) ( $data['insufficient_funding_tries'] ?? '' );
+		$this->funding_source             = $data['funding_source'] ?? null;
+		if ( ! is_string( $this->funding_source ) ) {
+			$this->funding_source = null;
+		}
+	}
+
+	/**
+	 * Converts given SessionHandler object into an array.
+	 *
+	 * @param SessionHandler $obj The object to convert.
+	 * @return array
+	 */
+	private static function make_array( SessionHandler $obj ): array {
+		return array(
+			'order'                      => $obj->order,
+			'bn_code'                    => $obj->bn_code,
+			'insufficient_funding_tries' => $obj->insufficient_funding_tries,
+			'funding_source'             => $obj->funding_source,
+		);
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Checkout/CheckoutPayPalAddressPreset.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/CheckoutPayPalAddressPreset.php
@@ -137,7 +137,7 @@ class CheckoutPayPalAddressPreset {
 		}
 
 		$shipping = null;
-		foreach ( $this->session_handler->order()->purchase_units() as $unit ) {
+		foreach ( $order->purchase_units() as $unit ) {
 			$shipping = $unit->shipping();
 			if ( $shipping ) {
 				break;

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -81,8 +81,9 @@ trait ProcessPaymentTrait {
 		wc_add_notice( $error->getMessage(), 'error' );
 
 		return array(
-			'result'   => 'failure',
-			'redirect' => wc_get_checkout_url(),
+			'result'       => 'failure',
+			'redirect'     => wc_get_checkout_url(),
+			'errorMessage' => $error->getMessage(),
 		);
 	}
 

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -171,12 +171,17 @@ class WcGatewayTest extends TestCase
 
         expect('wc_add_notice');
 
+		$result = $testee->process_payment($orderId);
+
+		$this->assertArrayHasKey('errorMessage', $result);
+		unset($result['errorMessage']);
+
         $this->assertEquals(
         	[
         		'result' => 'failure',
-				'redirect' => $redirectUrl
+				'redirect' => $redirectUrl,
 			],
-			$testee->process_payment($orderId)
+			$result
 		);
     }
 
@@ -217,10 +222,14 @@ class WcGatewayTest extends TestCase
 		$session->shouldReceive('get');
 
 		$result = $testee->process_payment($orderId);
-        $this->assertEquals(
-        	[
-        		'result' => 'failure',
-				'redirect' => $redirectUrl
+
+		$this->assertArrayHasKey('errorMessage', $result);
+		unset($result['errorMessage']);
+
+		$this->assertEquals(
+			[
+				'result' => 'failure',
+				'redirect' => $redirectUrl,
 			],
 			$result
 		);


### PR DESCRIPTION
Fixed handling of payment processing errors in express blocks, now the UI does not get stuck and shows the message.

Also fixed redirect for instrument decline errors. It was failing to get the order from WC session because our `SessionHandler` object was created too early when registering the blocks. I refactored it, now it always retrieves the current data from the session, allowing it to be created at any time. And now the data is stored as array instead of object, to make things simpler, and because according to WC PHPDoc type the value can be either a string or array (currently it just calls `serialize` and supports objects too, but I think we are not supposed to rely on that). To avoid breaking any sessions on upgrade, for now it also handles the previous way when loading the data.