### PR TITLE
Do not add `previous_transaction_reference` for PayPal payment method

### DIFF
--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -107,8 +107,19 @@ class SubscriptionModule implements ModuleInterface {
 			function( array $data ) use ( $c ) {
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing
 				$wc_order_action = wc_clean( wp_unslash( $_POST['wc_order_action'] ?? '' ) );
+
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing
+				$subscription_id = wc_clean( wp_unslash( $_POST['post_ID'] ?? '' ) );
+				if ( ! $subscription_id ) {
+					return $data;
+				}
+				$subscription = wc_get_order( $subscription_id );
+				if ( ! is_a( $subscription, WC_Subscription::class ) ) {
+					return $data;
+				}
+
 				if (
-					$wc_order_action === 'wcs_process_renewal'
+					$wc_order_action === 'wcs_process_renewal' && $subscription->get_payment_method() === CreditCardGateway::ID
 					&& isset( $data['payment_source']['token'] ) && $data['payment_source']['token']['type'] === 'PAYMENT_METHOD_TOKEN'
 					&& isset( $data['payment_source']['token']['source']->card )
 				) {


### PR DESCRIPTION
Fixes `INVALID_PREVIOUS_TRANSACTION_REFERENCE` error.

When there a multiple payments saved, subscription renewals created using PayPal as payment method does not work if latest saved payment is an ACDC payment. 

### Steps to reproduce
1. Enable Vaulting and save a couple of payments, first using PayPal and latest using ACDC.
2. Purchase a subscription using PayPal gateway.
3. As admin go to the subscription edit page and trigger a renewal.