### PR TITLE
Fatal error when API credentials invalid (1697)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
 
+use Exception;
 use stdClass;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
@@ -138,7 +139,7 @@ class BillingAgreementsEndpoint {
 			}
 
 			return true;
-		} catch ( PayPalApiException $exception ) {
+		} catch ( Exception $exception ) {
 			delete_transient( 'ppcp_reference_transaction_enabled' );
 			return false;
 		}


### PR DESCRIPTION
`Fatal error: Uncaught WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException: Could not create token. in ...` 

### Steps To Reproduce
- disconnect PayPal account
- manually connect invalid API credentials (e.g.  X, X, X, X )

→ fatal error when visiting settings page.