### PR TITLE
Add MX and JP to ACDC (1755)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,11 @@
 *** Changelog ***
 
-= 2.0.6 - TBD =
+= 2.1.0 - TBD =
 * Fix - Performance issue #1182
 * Fix - Webhooks not registered when onboarding with manual credentials #1223
 * Fix - Cross Site Request Forgery (CSRF) can invalidate merchant credentials #1339
 * Fix - Boolean false type sent as empty value when setting cache #1313
+* Fix - Fix ajax vulnerabilities #1411
 * Enhancement - Save and display vaulted payment methods in WC Payment Token API #1059
 * Enhancement - Cache webhook verification results #1379
 * Enhancement - Refresh checkout totals after validation if needed #1294

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 2.0.5 - TBD =
+= 2.0.6 - TBD =
 * Fix - Performance issue #1182
 * Fix - Webhooks not registered when onboarding with manual credentials #1223
 * Fix - Cross Site Request Forgery (CSRF) can invalidate merchant credentials #1339
@@ -9,6 +9,7 @@
 * Enhancement - Cache webhook verification results #1379
 * Enhancement - Refresh checkout totals after validation if needed #1294
 * Enhancement - Improve Divi and Elementor Pro compatibility #1254
+* Enhancement - Add MX and JP to ACDC #1415
 * Feature preview - Add express cart/checkout block #1346
 * Feature preview - Integrate PayPal Subscriptions API #1217
 

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -685,6 +685,27 @@ return array(
 					'SGD',
 					'USD',
 				),
+				'MX' => array(
+					'MXN',
+				),
+				'JP' => array(
+					'AUD',
+					'CAD',
+					'CHF',
+					'CZK',
+					'DKK',
+					'EUR',
+					'GBP',
+					'HKD',
+					'HUF',
+					'JPY',
+					'NOK',
+					'NZD',
+					'PLN',
+					'SEK',
+					'SGD',
+					'USD',
+				),
 			)
 		);
 	},
@@ -740,6 +761,17 @@ return array(
 					'visa'       => array(),
 					'amex'       => array( 'CAD' ),
 					'jcb'        => array( 'CAD' ),
+				),
+				'MX' => array(
+					'mastercard' => array(),
+					'visa'       => array(),
+					'amex'       => array(),
+				),
+				'JP' => array(
+					'mastercard' => array(),
+					'visa'       => array(),
+					'amex'       => array( 'JPY' ),
+					'jcb'        => array( 'JPY' ),
 				),
 			)
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -81,7 +81,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 
 == Changelog ==
 
-= 2.0.5 - TBD =
+= 2.0.6 - TBD =
 * Fix - Performance issue #1182
 * Fix - Webhooks not registered when onboarding with manual credentials #1223
 * Fix - Cross Site Request Forgery (CSRF) can invalidate merchant credentials #1339
@@ -90,6 +90,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Enhancement - Cache webhook verification results #1379
 * Enhancement - Refresh checkout totals after validation if needed #1294
 * Enhancement - Improve Divi and Elementor Pro compatibility #1254
+* Enhancement - Add MX and JP to ACDC #1415
 * Feature preview - Add express cart/checkout block #1346
 * Feature preview - Integrate PayPal Subscriptions API #1217
 

--- a/readme.txt
+++ b/readme.txt
@@ -81,11 +81,12 @@ Follow the steps below to connect the plugin to your PayPal account:
 
 == Changelog ==
 
-= 2.0.6 - TBD =
+= 2.1.0 - TBD =
 * Fix - Performance issue #1182
 * Fix - Webhooks not registered when onboarding with manual credentials #1223
 * Fix - Cross Site Request Forgery (CSRF) can invalidate merchant credentials #1339
 * Fix - Boolean false type sent as empty value when setting cache #1313
+* Fix ajax vulnerabilities #1411
 * Enhancement - Save and display vaulted payment methods in WC Payment Token API #1059
 * Enhancement - Cache webhook verification results #1379
 * Enhancement - Refresh checkout totals after validation if needed #1294


### PR DESCRIPTION
[Eligibility for ACDC](https://developer.paypal.com/docs/multiparty/checkout/advanced/#link-eligibility) has been updated to allow Mexico and Japan merchants.