### PR TITLE
Add notice when shop currency is unsupported

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -57,6 +57,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\AuthorizeOrderActionNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\ConnectAdminNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\GatewayWithoutPayPalAdminNotice;
+use WooCommerce\PayPalCommerce\WcGateway\Notice\UnsupportedCurrencyAdminNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
@@ -207,6 +208,11 @@ return array(
 		$state    = $container->get( 'onboarding.state' );
 		$settings = $container->get( 'wcgateway.settings' );
 		return new ConnectAdminNotice( $state, $settings );
+	},
+	'wcgateway.notice.currency-unsupported' => static function (ContainerInterface $container): UnsupportedCurrencyAdminNotice {
+		$state = $container->get('onboarding.state');
+		$settings = $container->get('wcgateway.settings');
+		return new UnsupportedCurrencyAdminNotice($state, $settings);
 	},
 	'wcgateway.notice.dcc-without-paypal'                  => static function ( ContainerInterface $container ): GatewayWithoutPayPalAdminNotice {
 		return new GatewayWithoutPayPalAdminNotice(

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -209,10 +209,11 @@ return array(
 		$settings = $container->get( 'wcgateway.settings' );
 		return new ConnectAdminNotice( $state, $settings );
 	},
-	'wcgateway.notice.currency-unsupported' => static function (ContainerInterface $container): UnsupportedCurrencyAdminNotice {
-		$state = $container->get('onboarding.state');
-		$settings = $container->get('wcgateway.settings');
-		return new UnsupportedCurrencyAdminNotice($state, $settings);
+	'wcgateway.notice.currency-unsupported'                => static function ( ContainerInterface $container ): UnsupportedCurrencyAdminNotice {
+		$state = $container->get( 'onboarding.state' );
+		$settings = $container->get( 'wcgateway.settings' );
+		$supported_currencies = $container->get( 'api.supported-currencies' );
+		return new UnsupportedCurrencyAdminNotice( $state, $settings, $supported_currencies );
 	},
 	'wcgateway.notice.dcc-without-paypal'                  => static function ( ContainerInterface $container ): GatewayWithoutPayPalAdminNotice {
 		return new GatewayWithoutPayPalAdminNotice(

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -211,9 +211,9 @@ return array(
 	},
 	'wcgateway.notice.currency-unsupported'                => static function ( ContainerInterface $container ): UnsupportedCurrencyAdminNotice {
 		$state = $container->get( 'onboarding.state' );
-		$settings = $container->get( 'wcgateway.settings' );
+		$shop_currency = $container->get( 'api.shop.currency' );
 		$supported_currencies = $container->get( 'api.supported-currencies' );
-		return new UnsupportedCurrencyAdminNotice( $state, $settings, $supported_currencies );
+		return new UnsupportedCurrencyAdminNotice( $state, $shop_currency, $supported_currencies );
 	},
 	'wcgateway.notice.dcc-without-paypal'                  => static function ( ContainerInterface $container ): GatewayWithoutPayPalAdminNotice {
 		return new GatewayWithoutPayPalAdminNotice(

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -64,11 +64,12 @@ class UnsupportedCurrencyAdminNotice {
 		}
 
 		$message = sprintf(
-			/* translators: %1$s the gateway name. */
+			/* translators: %1$s the shop currency, 2$s the gateway name. */
 			__(
-				'Attention: Your current WooCommerce store currency is not supported by PayPal. Please update your store currency to one that is supported by PayPal to ensure smooth transactions. Visit the <a href="%1$s">PayPal currency support page</a> for more information on supported currencies.',
+				'Attention: Your current WooCommerce store currency (%1$s) is not supported by PayPal. Please update your store currency to one that is supported by PayPal to ensure smooth transactions. Visit the <a href="%2$s">PayPal currency support page</a> for more information on supported currencies.',
 				'woocommerce-paypal-payments'
 			),
+			$this->shop_currency,
 			'https://developer.paypal.com/api/rest/reference/currency-codes/'
 		);
 		return new Message( $message, 'warning' );

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Registers the admin message to "connect your account" if necessary.
+ * Registers the admin message about unsupported currency set in WC shop settings.
  *
  * @package WooCommerce\PayPalCommerce\WcGateway\Notice
  */
@@ -15,7 +15,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
- * Class ConnectAdminNotice
+ * Class UnsupportedCurrencyAdminNotice
  */
 class UnsupportedCurrencyAdminNotice {
 
@@ -41,7 +41,7 @@ class UnsupportedCurrencyAdminNotice {
 	private $shop_currency;
 
 	/**
-	 * ConnectAdminNotice constructor.
+	 * UnsupportedCurrencyAdminNotice constructor.
 	 *
 	 * @param State  $state The state.
 	 * @param string $shop_currency The shop currency.

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -32,16 +32,24 @@ class UnsupportedCurrencyAdminNotice {
 	 * @var ContainerInterface
 	 */
 	private $settings;
+	/**
+	 * The supported currencies.
+	 *
+	 * @var array
+	 */
+	private $supported_currencies;
 
 	/**
 	 * ConnectAdminNotice constructor.
 	 *
 	 * @param State              $state The state.
 	 * @param ContainerInterface $settings The settings.
+	 * @param array              $supported_currencies The supported currencies.
 	 */
-	public function __construct( State $state, ContainerInterface $settings ) {
-		$this->state    = $state;
-		$this->settings = $settings;
+	public function __construct( State $state, ContainerInterface $settings, array $supported_currencies ) {
+		$this->state                = $state;
+		$this->settings             = $settings;
+		$this->supported_currencies = $supported_currencies;
 	}
 
 	/**
@@ -60,7 +68,7 @@ class UnsupportedCurrencyAdminNotice {
 				'Attention: Your current WooCommerce store currency is not supported by PayPal. Please update your store currency to one that is supported by PayPal to ensure smooth transactions. Visit the <a href="%1$s">PayPal currency support page</a> for more information on supported currencies.',
 				'woocommerce-paypal-payments'
 			),
-			"https://developer.paypal.com/api/rest/reference/currency-codes/"
+			'https://developer.paypal.com/api/rest/reference/currency-codes/'
 		);
 		return new Message( $message, 'warning' );
 	}
@@ -74,8 +82,14 @@ class UnsupportedCurrencyAdminNotice {
 		return $this->state->current_state() === State::STATE_ONBOARDED && ! $this->currency_supported();
 	}
 
-	private function currency_supported()
-	{
-		//TODO - get the currency from the settings
+	/**
+	 * Whether the currency is supported by PayPal.
+	 *
+	 * @return bool
+	 */
+	private function currency_supported(): bool {
+		$currency             = get_woocommerce_currency();
+		$supported_currencies = $this->supported_currencies;
+		return in_array( $currency, $supported_currencies, true );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Registers the admin message to "connect your account" if necessary.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Notice
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Notice;
+
+use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
+use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Class ConnectAdminNotice
+ */
+class UnsupportedCurrencyAdminNotice {
+
+	/**
+	 * The state.
+	 *
+	 * @var State
+	 */
+	private $state;
+
+	/**
+	 * The settings.
+	 *
+	 * @var ContainerInterface
+	 */
+	private $settings;
+
+	/**
+	 * ConnectAdminNotice constructor.
+	 *
+	 * @param State              $state The state.
+	 * @param ContainerInterface $settings The settings.
+	 */
+	public function __construct( State $state, ContainerInterface $settings ) {
+		$this->state    = $state;
+		$this->settings = $settings;
+	}
+
+	/**
+	 * Returns the message.
+	 *
+	 * @return Message|null
+	 */
+	public function unsupported_currency_message() {
+		if ( ! $this->should_display() ) {
+			return null;
+		}
+
+		$message = sprintf(
+			/* translators: %1$s the gateway name. */
+			__(
+				'Attention: Your current WooCommerce store currency is not supported by PayPal. Please update your store currency to one that is supported by PayPal to ensure smooth transactions. Visit the <a href="%1$s">PayPal currency support page</a> for more information on supported currencies.',
+				'woocommerce-paypal-payments'
+			),
+			"https://developer.paypal.com/api/rest/reference/currency-codes/"
+		);
+		return new Message( $message, 'warning' );
+	}
+
+	/**
+	 * Whether the message should display.
+	 *
+	 * @return bool
+	 */
+	protected function should_display(): bool {
+		return $this->state->current_state() === State::STATE_ONBOARDED && ! $this->currency_supported();
+	}
+
+	private function currency_supported()
+	{
+		//TODO - get the currency from the settings
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -27,12 +27,6 @@ class UnsupportedCurrencyAdminNotice {
 	private $state;
 
 	/**
-	 * The settings.
-	 *
-	 * @var ContainerInterface
-	 */
-	private $settings;
-	/**
 	 * The supported currencies.
 	 *
 	 * @var array
@@ -40,15 +34,22 @@ class UnsupportedCurrencyAdminNotice {
 	private $supported_currencies;
 
 	/**
+	 * The shop currency.
+	 *
+	 * @var string
+	 */
+	private $shop_currency;
+
+	/**
 	 * ConnectAdminNotice constructor.
 	 *
-	 * @param State              $state The state.
-	 * @param ContainerInterface $settings The settings.
-	 * @param array              $supported_currencies The supported currencies.
+	 * @param State  $state The state.
+	 * @param string $shop_currency The shop currency.
+	 * @param array  $supported_currencies The supported currencies.
 	 */
-	public function __construct( State $state, ContainerInterface $settings, array $supported_currencies ) {
+	public function __construct( State $state, string $shop_currency, array $supported_currencies ) {
 		$this->state                = $state;
-		$this->settings             = $settings;
+		$this->shop_currency        = $shop_currency;
 		$this->supported_currencies = $supported_currencies;
 	}
 
@@ -88,7 +89,7 @@ class UnsupportedCurrencyAdminNotice {
 	 * @return bool
 	 */
 	private function currency_supported(): bool {
-		$currency             = get_woocommerce_currency();
+		$currency             = $this->shop_currency;
 		$supported_currencies = $this->supported_currencies;
 		return in_array( $currency, $supported_currencies, true );
 	}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -39,6 +39,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\ConnectAdminNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\GatewayWithoutPayPalAdminNotice;
+use WooCommerce\PayPalCommerce\WcGateway\Notice\UnsupportedCurrencyAdminNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\HeaderRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SectionsRenderer;
@@ -195,6 +196,13 @@ class WCGatewayModule implements ModuleInterface {
 				$connect_message = $notice->connect_message();
 				if ( $connect_message ) {
 					$notices[] = $connect_message;
+				}
+
+				$notice = $c->get( 'wcgateway.notice.currency-unsupported' );
+				assert( $notice instanceof UnsupportedCurrencyAdminNotice );
+				$unsupported_currency_message = $notice->unsupported_currency_message();
+				if ( $unsupported_currency_message ) {
+					$notices[] = $unsupported_currency_message;
 				}
 
 				foreach ( array(


### PR DESCRIPTION
This PR adds a notice when the currency declared in the shop is not supported by PayPal. 
The current behavior makes it a bit confusing for the merchants as in the checkout page, the PayPal button does not render and the “Place order” button is hidden. 