### PR TITLE
Agreement already cancelled error improved message

### DIFF
--- a/modules/ppcp-api-client/src/Exception/PayPalApiException.php
+++ b/modules/ppcp-api-client/src/Exception/PayPalApiException.php
@@ -160,6 +160,7 @@ class PayPalApiException extends RuntimeException {
 			'DUPLICATE_INVOICE_ID'     => __( 'The transaction has been refused because the Invoice ID already exists. Please create a new order or reach out to the store owner.', 'woocommerce-paypal-payments' ),
 			'PAYER_CANNOT_PAY'         => __( 'There was a problem processing this transaction. Please reach out to the store owner.', 'woocommerce-paypal-payments' ),
 			'PAYEE_ACCOUNT_RESTRICTED' => __( 'There was a problem processing this transaction. Please reach out to the store owner.', 'woocommerce-paypal-payments' ),
+			'AGREEMENT_ALREADY_CANCELLED' => __( 'The requested agreement is already canceled. Please reach out to the PayPal support for more information.', 'woocommerce-paypal-payments' ),
 		);
 		$improved_errors        = array_filter(
 			array_keys( $improved_keys_messages ),


### PR DESCRIPTION
The PR adds a new error handling "AGREEMENT_ALREADY_CANCELLED" to the series of improved message error responses to the customer. 