### PR TITLE
Display funding source on the admin order page

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -272,6 +272,27 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	}
 
 	/**
+	 * Return the gateway's title.
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		if ( is_admin() ) {
+			// $theorder and other things for retrieving the order or post info are not available
+			// in the constructor, so must do it here.
+			global $theorder;
+			if ( $theorder instanceof WC_Order ) {
+				$payment_method_title = $theorder->get_payment_method_title();
+				if ( $payment_method_title ) {
+					$this->title = $payment_method_title;
+				}
+			}
+		}
+
+		return parent::get_title();
+	}
+
+	/**
 	 * Whether the Gateway needs to be setup.
 	 *
 	 * @return bool


### PR DESCRIPTION
Now the payment method title on the admin order editing page includes the funding source instead of just "PayPal", the same as in the order list.