### PR TITLE
Refresh DCC/PUI status caches on plugin update

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -278,6 +278,15 @@ class WCGatewayModule implements ModuleInterface {
 				$settings->set( 'products_dcc_enabled', false );
 				$settings->set( 'products_pui_enabled', false );
 				$settings->persist();
+
+				// Update caches.
+				$dcc_status = $c->get( 'wcgateway.helper.dcc-product-status' );
+				assert( $dcc_status instanceof DCCProductStatus );
+				$dcc_status->dcc_is_active();
+
+				$pui_status = $c->get( 'wcgateway.pay-upon-invoice-product-status' );
+				assert( $pui_status instanceof PayUponInvoiceProductStatus );
+				$pui_status->pui_is_active();
 			}
 		);
 


### PR DESCRIPTION
Fixes #1432

Since #1273 we started clearing these caches on plugin updates. But we are updating these caches only on some admin pages
https://github.com/woocommerce/woocommerce-paypal-payments/blob/583dea8d99f60f710f54f6d689c5f57694562180/modules/ppcp-wc-gateway/src/WCGatewayModule.php#L421-L428
to avoid the API calls on every request in some cases, so DCC may become hidden if not visited these pages after update. Maybe we can do it more frequently now after 92ae16f99. But for now simply refreshing the caches during plugin update.