### PR TITLE
Update system report plugin status for Vaulting (1827)

### DIFF
--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -120,11 +120,19 @@ class StatusReportModule implements ModuleInterface {
 						'value'          => $this->bool_to_html( ! $last_webhook_storage->is_empty() ),
 					),
 					array(
-						'label'          => esc_html__( 'Vault enabled', 'woocommerce-paypal-payments' ),
-						'exported_label' => 'Vault enabled',
-						'description'    => esc_html__( 'Whether vaulting is enabled on PayPal account or not.', 'woocommerce-paypal-payments' ),
+						'label'          => esc_html__( 'PayPal Vault enabled', 'woocommerce-paypal-payments' ),
+						'exported_label' => 'PayPal Vault enabled',
+						'description'    => esc_html__( 'Whether vaulting option is enabled on Standard Payments settings or not.', 'woocommerce-paypal-payments' ),
 						'value'          => $this->bool_to_html(
-							$this->vault_enabled( $bearer )
+							$settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' )
+						),
+					),
+					array(
+						'label'          => esc_html__( 'ACDC Vault enabled', 'woocommerce-paypal-payments' ),
+						'exported_label' => 'ACDC Vault enabled',
+						'description'    => esc_html__( 'Whether vaulting option is enabled on Advanced Card Processing settings or not.', 'woocommerce-paypal-payments' ),
+						'value'          => $this->bool_to_html(
+							$settings->has( 'vault_enabled_dcc' ) && $settings->get( 'vault_enabled_dcc' )
 						),
 					),
 					array(
@@ -190,21 +198,6 @@ class StatusReportModule implements ModuleInterface {
 
 		$current_state = $state->current_state();
 		return $token->is_valid() && $current_state === $state::STATE_ONBOARDED;
-	}
-
-	/**
-	 * It returns whether vaulting is enabled or not.
-	 *
-	 * @param Bearer $bearer The bearer.
-	 * @return bool
-	 */
-	private function vault_enabled( Bearer $bearer ): bool {
-		try {
-			$token = $bearer->bearer();
-			return $token->vaulting_available();
-		} catch ( RuntimeException $exception ) {
-			return false;
-		}
 	}
 
 	/**


### PR DESCRIPTION
# Description
## Current status

The WooCommerce PayPal Payments plugin enriches the system report by appending additional data to facilitate support's understanding of specific configurations.:

```
### WooCommerce PayPal Payments ###
Onboarded: ✔
Shop country code: US
WooCommerce currency supported: ✔
Advanced Card Processing available in country: ✔
Pay Later messaging available in country: ✔
Webhook status: ✔
Vault enabled: ✔
Logging enabled: ✔
Reference Transactions: -
Used PayPal Checkout plugin: ✔
Tracking enabled: -
```


A specific entry, `Vault enabled: ✔`, which shows whether the connected REST Application possesses the Vault capability, may lead to confusion. This entry doesn't imply "Vault approval" or "Reference Transactions". Initially, the Vault capability was not automatically enabled for manually crafted REST Apps, it was enabled only when connecting through the onboarding wizard.

Post the 2.1.0 update, Vaulting can be independently enabled as PayPal Vaulting and ACDC Vaulting, which has made it more challenging to determine if Vaulting is enabled by examining the PayPal button script.

# Proposal:

We should revamp the current `Vault enabled: ✔` entry to better serve its purpose and improve clarity.

Remove `Vault enabled: ✔`

Introduce `PayPal Vault enabled: ✔` and `ACDC Vault enabled: ✔`

These new entries should mirror the enabled status of the Vaulting Checkbox in the Standard Payments and Advanced Card Processing tabs, respectively.

These enhancements not only provide support with more precise information about whether Vaulting is enabled, but also serve as an indirect indicator to understand if the merchant is enabled for Advanced Card Processing. Since ACDC Vaulting is typically only enabled when the ACDC gateway is visible, i.e., the merchant is approved for it.

# Acceptance Criteria:

`Vault enabled: ✔` should be removed from the WooCommerce PayPal Payments system report.

`PayPal Vault enabled: ✔` and `ACDC Vault enabled: ✔` should be added to the report, reflecting the status of the respective Vaulting options in the plugin settings.

If changes are implemented successfully, support should be able to quickly determine the status of PayPal Vaulting and ACDC Vaulting from the system report.