### PR TITLE
Incompatibility with WooCommerce One Page Checkout (or similar use cases) in Version 2.1.0 (1816)

### DIFF
--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -19,8 +19,9 @@ trait ContextTrait {
 	protected function context(): string {
 		if ( is_product() || wc_post_content_has_shortcode( 'product_page' ) ) {
 
-			// Detection if "woocommerce-one-page-checkout" is enabled for this product.
-			if ( is_callable( 'is_wcopc_checkout' ) && is_wcopc_checkout( get_the_ID() ) ) {
+			// Do this check here instead of reordering outside conditions.
+			// In order to have more control over the context.
+			if ( ( is_checkout() ) && ! $this->is_paypal_continuation() ) {
 				return 'checkout';
 			}
 

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -18,6 +18,12 @@ trait ContextTrait {
 	 */
 	protected function context(): string {
 		if ( is_product() || wc_post_content_has_shortcode( 'product_page' ) ) {
+
+			// Detection if "woocommerce-one-page-checkout" is enabled for this product.
+			if ( is_callable( 'is_wcopc_checkout' ) && is_wcopc_checkout( get_the_ID() ) ) {
+				return 'checkout';
+			}
+
 			return 'product';
 		}
 


### PR DESCRIPTION
## The problem
We have encountered an issue related to the WooCommerce One Page Checkout plugin compatibility with the update 2.1.0. The problems observed include:
1. The "Place Order" button, as well as the smart buttons, are being displayed in the PayPal gateway on the one-page checkout pages.
2. The Advanced Card Processing (ACDC) gateway fails to load on the one-page checkout pages.

## Steps To Reproduce
1. Enable the Advanced Card Processing feature.
2. Install the One Page Checkout plugin.
3. Create a new product and enable the "One Page Checkout" attribute (found next to the virtual/downloadable options).
4. Visit the product page that you just created.

## Observed Behavior:
* Both PayPal smart buttons and the "Place Order" button appear on the page.
* The Advanced Card Processing gateway does not load.

## Expected behaviour
* The "Place Order" button should not load for the PayPal gateway on this page.
* If enabled, the Advanced Card Processing gateway should appear on the page.