### PR TITLE
Revert Elementor Pro Checkout hook compatibility (1854)

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -339,14 +339,6 @@ class CompatModule implements ModuleInterface {
 				},
 				5
 			);
-
-			add_filter(
-				'woocommerce_paypal_payments_checkout_button_renderer_hook',
-				function(): string {
-					return 'woocommerce_review_order_after_submit';
-				},
-				5
-			);
 		}
 	}
 


### PR DESCRIPTION
## Description

The Elementor Po compatibility we added in 2.1.0 was causing more problems than it helped resolve. Specifically, the filter to change the Checkout render hook results in the PayPal buttons not rendering at all for certain themes.

So we should remove these lines of code again: 
https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-compat/src/CompatModule.php#L343C7-L349

