### PR TITLE
Make the blocks integration (partial) available without feature flag

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -27,7 +27,6 @@ web_environment:
   - ADMIN_PASS=admin
   - ADMIN_EMAIL=admin@example.com
   - WC_VERSION=7.7.2
-  - PCP_BLOCKS_ENABLED=1
 
 # Key features of ddev's config.yaml:
 

--- a/modules.php
+++ b/modules.php
@@ -26,14 +26,8 @@ return function ( string $root_dir ): iterable {
 		( require "$modules_dir/ppcp-vaulting/module.php" )(),
 		( require "$modules_dir/ppcp-order-tracking/module.php" )(),
 		( require "$modules_dir/ppcp-uninstall/module.php" )(),
+		( require "$modules_dir/ppcp-blocks/module.php" )(),
 	);
-
-	if ( apply_filters(
-		'woocommerce_paypal_payments_blocks_enabled',
-		getenv( 'PCP_BLOCKS_ENABLED' ) === '1'
-	) ) {
-		$modules[] = ( require "$modules_dir/ppcp-blocks/module.php" )();
-	}
 
 	return $modules;
 };


### PR DESCRIPTION
The `woocommerce_paypal_payments_blocks_enabled` filter or `PCP_BLOCKS_ENABLED` env var are not used anymore, the blocks can be enabled in the settings without activating this feature flag first.
