### PR TITLE
Filter to conditionally block the PayPal buttons (1788)

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -122,21 +122,10 @@ const bootstrap = () => {
         }
     };
 
-    let smartButtonsOptions = {
-        onInit: null,
-        init: function (actions) {
-            this.actions = actions;
-            if (typeof this.onInit === 'function') {
-                this.onInit();
-            }
-        }
-    };
-
-    const onSmartButtonsInit = (data, actions) => {
+    const onSmartButtonsInit = () => {
         buttonsSpinner.unblock();
-        smartButtonsOptions.init(actions);
     };
-    const renderer = new Renderer(creditCardRenderer, PayPalCommerceGateway, onSmartButtonClick, onSmartButtonsInit, smartButtonsOptions);
+    const renderer = new Renderer(creditCardRenderer, PayPalCommerceGateway, onSmartButtonClick, onSmartButtonsInit);
     const messageRenderer = new MessageRenderer(PayPalCommerceGateway.messages);
     const context = PayPalCommerceGateway.context;
     if (context === 'mini-cart' || context === 'product') {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
@@ -1,6 +1,6 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
+import BootstrapHelper from "../Helper/BootstrapHelper";
 import {setVisible} from "../Helper/Hiding";
-import {disable, enable} from "../Helper/ButtonDisabler";
 
 class CartBootstrap {
     constructor(gateway, renderer, errorHandler) {
@@ -48,15 +48,7 @@ class CartBootstrap {
     }
 
     handleButtonStatus() {
-        if (!this.shouldEnable()) {
-            this.renderer.disableSmartButtons(this.gateway.button.wrapper);
-            disable(this.gateway.button.wrapper);
-            disable(this.gateway.messages.wrapper);
-            return;
-        }
-        this.renderer.enableSmartButtons(this.gateway.button.wrapper);
-        enable(this.gateway.button.wrapper);
-        enable(this.gateway.messages.wrapper);
+        BootstrapHelper.handleButtonStatus(this);
     }
 
     shouldRender() {
@@ -64,8 +56,7 @@ class CartBootstrap {
     }
 
     shouldEnable() {
-        return this.shouldRender()
-            && this.gateway.button.is_disabled !== true;
+        return BootstrapHelper.shouldEnable(this);
     }
 
     render() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
@@ -1,12 +1,16 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
 import {setVisible} from "../Helper/Hiding";
-import {disable} from "../Helper/ButtonDisabler";
+import {disable, enable} from "../Helper/ButtonDisabler";
 
 class CartBootstrap {
     constructor(gateway, renderer, errorHandler) {
         this.gateway = gateway;
         this.renderer = renderer;
         this.errorHandler = errorHandler;
+
+        this.renderer.onButtonsInit(this.gateway.button.wrapper, () => {
+            this.handleButtonStatus();
+        }, true);
     }
 
     init() {
@@ -15,16 +19,11 @@ class CartBootstrap {
         }
 
         this.render();
-
-        if (!this.shouldEnable()) {
-            this.renderer.disableSmartButtons();
-            disable(this.gateway.button.wrapper);
-            disable(this.gateway.messages.wrapper);
-            return;
-        }
+        this.handleButtonStatus();
 
         jQuery(document.body).on('updated_cart_totals updated_checkout', () => {
             this.render();
+            this.handleButtonStatus();
 
             fetch(
                 this.gateway.ajax.cart_script_params.endpoint,
@@ -46,6 +45,18 @@ class CartBootstrap {
                 setVisible(this.gateway.button.wrapper, !reloadRequired)
             });
         });
+    }
+
+    handleButtonStatus() {
+        if (!this.shouldEnable()) {
+            this.renderer.disableSmartButtons(this.gateway.button.wrapper);
+            disable(this.gateway.button.wrapper);
+            disable(this.gateway.messages.wrapper);
+            return;
+        }
+        this.renderer.enableSmartButtons(this.gateway.button.wrapper);
+        enable(this.gateway.button.wrapper);
+        enable(this.gateway.messages.wrapper);
     }
 
     shouldRender() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
@@ -1,5 +1,6 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
 import {setVisible} from "../Helper/Hiding";
+import {disable} from "../Helper/ButtonDisabler";
 
 class CartBootstrap {
     constructor(gateway, renderer, errorHandler) {
@@ -14,6 +15,13 @@ class CartBootstrap {
         }
 
         this.render();
+
+        if (!this.shouldEnable()) {
+            this.renderer.disableSmartButtons();
+            disable(this.gateway.button.wrapper);
+            disable(this.gateway.messages.wrapper);
+            return;
+        }
 
         jQuery(document.body).on('updated_cart_totals updated_checkout', () => {
             this.render();
@@ -42,6 +50,11 @@ class CartBootstrap {
 
     shouldRender() {
         return document.querySelector(this.gateway.button.wrapper) !== null;
+    }
+
+    shouldEnable() {
+        return this.shouldRender()
+            && this.gateway.button.is_disabled !== true;
     }
 
     render() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -5,6 +5,7 @@ import {
     isSavedCardSelected, ORDER_BUTTON_SELECTOR,
     PaymentMethods
 } from "../Helper/CheckoutMethodState";
+import {disable} from "../Helper/ButtonDisabler";
 
 class CheckoutBootstap {
     constructor(gateway, renderer, messages, spinner, errorHandler) {
@@ -19,6 +20,13 @@ class CheckoutBootstap {
 
     init() {
         this.render();
+
+        if (!this.shouldEnable()) {
+            this.renderer.disableSmartButtons();
+            disable(this.gateway.button.wrapper);
+            disable(this.gateway.messages.wrapper);
+            return;
+        }
 
         // Unselect saved card.
         // WC saves form values, so with our current UI it would be a bit weird
@@ -49,6 +57,11 @@ class CheckoutBootstap {
         }
 
         return document.querySelector(this.gateway.button.wrapper) !== null || document.querySelector(this.gateway.hosted_fields.wrapper) !== null;
+    }
+
+    shouldEnable() {
+        return this.shouldRender()
+            && this.gateway.button.is_disabled !== true;
     }
 
     render() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -5,6 +5,7 @@ import {
     isSavedCardSelected, ORDER_BUTTON_SELECTOR,
     PaymentMethods
 } from "../Helper/CheckoutMethodState";
+import BootstrapHelper from "../Helper/BootstrapHelper";
 import {disable, enable} from "../Helper/ButtonDisabler";
 
 class CheckoutBootstap {
@@ -51,15 +52,7 @@ class CheckoutBootstap {
     }
 
     handleButtonStatus() {
-        if (!this.shouldEnable()) {
-            this.renderer.disableSmartButtons(this.gateway.button.wrapper);
-            disable(this.gateway.button.wrapper);
-            disable(this.gateway.messages.wrapper);
-            return;
-        }
-        this.renderer.enableSmartButtons(this.gateway.button.wrapper);
-        enable(this.gateway.button.wrapper);
-        enable(this.gateway.messages.wrapper);
+        BootstrapHelper.handleButtonStatus(this);
     }
 
     shouldRender() {
@@ -71,8 +64,7 @@ class CheckoutBootstap {
     }
 
     shouldEnable() {
-        return this.shouldRender()
-            && this.gateway.button.is_disabled !== true;
+        return BootstrapHelper.shouldEnable(this);
     }
 
     render() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -5,7 +5,7 @@ import {
     isSavedCardSelected, ORDER_BUTTON_SELECTOR,
     PaymentMethods
 } from "../Helper/CheckoutMethodState";
-import {disable} from "../Helper/ButtonDisabler";
+import {disable, enable} from "../Helper/ButtonDisabler";
 
 class CheckoutBootstap {
     constructor(gateway, renderer, messages, spinner, errorHandler) {
@@ -16,17 +16,15 @@ class CheckoutBootstap {
         this.errorHandler = errorHandler;
 
         this.standardOrderButtonSelector = ORDER_BUTTON_SELECTOR;
+
+        this.renderer.onButtonsInit(this.gateway.button.wrapper, () => {
+            this.handleButtonStatus();
+        }, true);
     }
 
     init() {
         this.render();
-
-        if (!this.shouldEnable()) {
-            this.renderer.disableSmartButtons();
-            disable(this.gateway.button.wrapper);
-            disable(this.gateway.messages.wrapper);
-            return;
-        }
+        this.handleButtonStatus();
 
         // Unselect saved card.
         // WC saves form values, so with our current UI it would be a bit weird
@@ -36,6 +34,7 @@ class CheckoutBootstap {
 
         jQuery(document.body).on('updated_checkout', () => {
             this.render()
+            this.handleButtonStatus();
         });
 
         jQuery(document.body).on('updated_checkout payment_method_selected', () => {
@@ -49,6 +48,18 @@ class CheckoutBootstap {
         });
 
         this.updateUi();
+    }
+
+    handleButtonStatus() {
+        if (!this.shouldEnable()) {
+            this.renderer.disableSmartButtons(this.gateway.button.wrapper);
+            disable(this.gateway.button.wrapper);
+            disable(this.gateway.messages.wrapper);
+            return;
+        }
+        this.renderer.enableSmartButtons(this.gateway.button.wrapper);
+        enable(this.gateway.button.wrapper);
+        enable(this.gateway.messages.wrapper);
     }
 
     shouldRender() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
@@ -1,4 +1,5 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
+import {disable} from "../Helper/ButtonDisabler";
 
 class MiniCartBootstap {
     constructor(gateway, renderer, errorHandler) {
@@ -16,6 +17,13 @@ class MiniCartBootstap {
         );
         this.render();
 
+        if (!this.shouldEnable()) {
+            this.renderer.disableSmartButtons();
+            disable(this.gateway.button.wrapper);
+            disable(this.gateway.messages.wrapper);
+            return;
+        }
+
         jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', () => {
             this.render();
         });
@@ -24,6 +32,11 @@ class MiniCartBootstap {
     shouldRender() {
         return document.querySelector(this.gateway.button.mini_cart_wrapper) !== null
             || document.querySelector(this.gateway.hosted_fields.mini_cart_wrapper) !== null;
+    }
+
+    shouldEnable() {
+        return this.shouldRender()
+            && this.gateway.button.is_disabled !== true;
     }
 
     render() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
@@ -1,5 +1,5 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
-import {disable} from "../Helper/ButtonDisabler";
+import {disable, enable} from "../Helper/ButtonDisabler";
 
 class MiniCartBootstap {
     constructor(gateway, renderer, errorHandler) {
@@ -16,17 +16,26 @@ class MiniCartBootstap {
             this.errorHandler,
         );
         this.render();
-
-        if (!this.shouldEnable()) {
-            this.renderer.disableSmartButtons();
-            disable(this.gateway.button.wrapper);
-            disable(this.gateway.messages.wrapper);
-            return;
-        }
+        this.handleButtonStatus();
 
         jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', () => {
             this.render();
+            this.handleButtonStatus();
         });
+
+        this.renderer.onButtonsInit(this.gateway.button.mini_cart_wrapper, () => {
+            this.handleButtonStatus();
+        }, true);
+    }
+
+    handleButtonStatus() {
+        if (!this.shouldEnable()) {
+            this.renderer.disableSmartButtons(this.gateway.button.mini_cart_wrapper);
+            disable(this.gateway.button.mini_cart_wrapper);
+            return;
+        }
+        this.renderer.enableSmartButtons(this.gateway.button.mini_cart_wrapper);
+        enable(this.gateway.button.mini_cart_wrapper);
     }
 
     shouldRender() {
@@ -36,7 +45,7 @@ class MiniCartBootstap {
 
     shouldEnable() {
         return this.shouldRender()
-            && this.gateway.button.is_disabled !== true;
+            && this.gateway.button.is_mini_cart_disabled !== true;
     }
 
     render() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstap.js
@@ -1,5 +1,5 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
-import {disable, enable} from "../Helper/ButtonDisabler";
+import BootstrapHelper from "../Helper/BootstrapHelper";
 
 class MiniCartBootstap {
     constructor(gateway, renderer, errorHandler) {
@@ -29,13 +29,10 @@ class MiniCartBootstap {
     }
 
     handleButtonStatus() {
-        if (!this.shouldEnable()) {
-            this.renderer.disableSmartButtons(this.gateway.button.mini_cart_wrapper);
-            disable(this.gateway.button.mini_cart_wrapper);
-            return;
-        }
-        this.renderer.enableSmartButtons(this.gateway.button.mini_cart_wrapper);
-        enable(this.gateway.button.mini_cart_wrapper);
+        BootstrapHelper.handleButtonStatus(this, {
+            wrapper: this.gateway.button.mini_cart_wrapper,
+            skipMessages: true
+        });
     }
 
     shouldRender() {
@@ -44,8 +41,9 @@ class MiniCartBootstap {
     }
 
     shouldEnable() {
-        return this.shouldRender()
-            && this.gateway.button.is_mini_cart_disabled !== true;
+        return BootstrapHelper.shouldEnable(this, {
+            isDisabled: !!this.gateway.button.is_mini_cart_disabled
+        });
     }
 
     render() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -1,7 +1,7 @@
 import UpdateCart from "../Helper/UpdateCart";
 import SingleProductActionHandler from "../ActionHandler/SingleProductActionHandler";
 import {hide, show} from "../Helper/Hiding";
-import {disable, enable} from "../Helper/ButtonDisabler";
+import BootstrapHelper from "../Helper/BootstrapHelper";
 
 class SingleProductBootstap {
     constructor(gateway, renderer, messages, errorHandler) {
@@ -39,15 +39,9 @@ class SingleProductBootstap {
     }
 
     handleButtonStatus() {
-        if (!this.shouldEnable()) {
-            this.renderer.disableSmartButtons(this.gateway.button.wrapper);
-            disable(this.gateway.button.wrapper, this.formSelector);
-            disable(this.gateway.messages.wrapper);
-            return;
-        }
-        this.renderer.enableSmartButtons(this.gateway.button.wrapper);
-        enable(this.gateway.button.wrapper);
-        enable(this.gateway.messages.wrapper);
+        BootstrapHelper.handleButtonStatus(this, {
+            formSelector: this.formSelector
+        });
     }
 
     init() {
@@ -92,10 +86,9 @@ class SingleProductBootstap {
         const form = this.form();
         const addToCartButton = form ? form.querySelector('.single_add_to_cart_button') : null;
 
-        return this.shouldRender()
+        return BootstrapHelper.shouldEnable(this)
             && !this.priceAmountIsZero()
-            && ((null === addToCartButton) || !addToCartButton.classList.contains('disabled'))
-            && this.gateway.button.is_disabled !== true;
+            && ((null === addToCartButton) || !addToCartButton.classList.contains('disabled'));
     }
 
     priceAmount() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -96,7 +96,8 @@ class SingleProductBootstap {
 
         return this.shouldRender()
             && !this.priceAmountIsZero()
-            && ((null === addToCartButton) || !addToCartButton.classList.contains('disabled'));
+            && ((null === addToCartButton) || !addToCartButton.classList.contains('disabled'))
+            && this.gateway.button.is_disabled !== true;
     }
 
     priceAmount() {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -12,11 +12,9 @@ class SingleProductBootstap {
         this.mutationObserver = new MutationObserver(this.handleChange.bind(this));
         this.formSelector = 'form.cart';
 
-        if (this.renderer && this.renderer.smartButtonsOptions) {
-            this.renderer.smartButtonsOptions.onInit = () => {
-                this.handleChange();
-            };
-        }
+        this.renderer.onButtonsInit(this.gateway.button.wrapper, () => {
+            this.handleChange();
+        }, true);
     }
 
     form() {
@@ -25,7 +23,7 @@ class SingleProductBootstap {
 
     handleChange() {
         if (!this.shouldRender()) {
-            this.renderer.disableSmartButtons();
+            this.renderer.disableSmartButtons(this.gateway.button.wrapper);
             hide(this.gateway.button.wrapper, this.formSelector);
             hide(this.gateway.messages.wrapper);
             return;
@@ -33,7 +31,7 @@ class SingleProductBootstap {
 
         this.render();
 
-        this.renderer.enableSmartButtons();
+        this.renderer.enableSmartButtons(this.gateway.button.wrapper);
         show(this.gateway.button.wrapper);
         show(this.gateway.messages.wrapper);
 
@@ -42,12 +40,12 @@ class SingleProductBootstap {
 
     handleButtonStatus() {
         if (!this.shouldEnable()) {
-            this.renderer.disableSmartButtons();
+            this.renderer.disableSmartButtons(this.gateway.button.wrapper);
             disable(this.gateway.button.wrapper, this.formSelector);
             disable(this.gateway.messages.wrapper);
             return;
         }
-        this.renderer.enableSmartButtons();
+        this.renderer.enableSmartButtons(this.gateway.button.wrapper);
         enable(this.gateway.button.wrapper);
         enable(this.gateway.messages.wrapper);
     }

--- a/modules/ppcp-button/resources/js/modules/Helper/BootstrapHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/BootstrapHelper.js
@@ -1,0 +1,40 @@
+import {disable, enable} from "./ButtonDisabler";
+
+/**
+ * Common Bootstrap methods to avoid code repetition.
+ */
+export default class BootstrapHelper {
+
+    static handleButtonStatus(bs, options) {
+        options = options || {};
+        options.wrapper = options.wrapper || bs.gateway.button.wrapper;
+        options.messagesWrapper = options.messagesWrapper || bs.gateway.messages.wrapper;
+        options.skipMessages = options.skipMessages || false;
+
+        if (!bs.shouldEnable()) {
+            bs.renderer.disableSmartButtons(options.wrapper);
+            disable(options.wrapper, options.formSelector || null);
+
+            if (!options.skipMessages) {
+                disable(options.messagesWrapper);
+            }
+            return;
+        }
+        bs.renderer.enableSmartButtons(options.wrapper);
+        enable(options.wrapper);
+
+        if (!options.skipMessages) {
+            enable(options.messagesWrapper);
+        }
+    }
+
+    static shouldEnable(bs, options) {
+        options = options || {};
+        if (typeof options.isDisabled === 'undefined') {
+            options.isDisabled = bs.gateway.button.is_disabled;
+        }
+
+        return bs.shouldRender()
+            && options.isDisabled !== true;
+    }
+}

--- a/modules/ppcp-button/resources/js/modules/Helper/ButtonDisabler.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ButtonDisabler.js
@@ -36,7 +36,10 @@ export const setEnabled = (selectorOrElement, enable, form = null) => {
 
                 if (form) {
                     // Trigger form submit to show the error message
-                    jQuery(form).find(':submit').trigger('click');
+                    let $form = jQuery(form);
+                    if ($form.find('.single_add_to_cart_button').hasClass('disabled')) {
+                        $form.find(':submit').trigger('click');
+                    }
                 }
             })
             .find('> *')

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -860,6 +860,7 @@ class SmartButton implements SmartButtonInterface {
 				'wrapper'           => '#ppc-button-' . PayPalGateway::ID,
 				'mini_cart_wrapper' => '#ppc-button-minicart',
 				'cancel_wrapper'    => '#ppcp-cancel',
+				'is_disabled'		=> $this->is_button_disabled(),
 				'mini_cart_style'   => array(
 					'layout'  => $this->style_for_context( 'layout', 'mini-cart' ),
 					'color'   => $this->style_for_context( 'color', 'mini-cart' ),
@@ -1346,6 +1347,23 @@ class SmartButton implements SmartButtonInterface {
 		return apply_filters(
 			'woocommerce_paypal_payments_product_supports_payment_request_button',
 			! $product->is_type( array( 'external', 'grouped' ) ) && $in_stock,
+			$product
+		);
+	}
+
+	protected function is_button_disabled(): bool {
+		if ( 'product' !== $this->context() ) {
+			return false;
+		}
+
+		$product = wc_get_product();
+
+		/**
+		 * Allows to decide if the button should be disabled for a given product
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_product_button_disabled',
+			false,
 			$product
 		);
 	}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -860,7 +860,7 @@ class SmartButton implements SmartButtonInterface {
 				'wrapper'           => '#ppc-button-' . PayPalGateway::ID,
 				'mini_cart_wrapper' => '#ppc-button-minicart',
 				'cancel_wrapper'    => '#ppcp-cancel',
-				'is_disabled'		=> $this->is_button_disabled(),
+				'is_disabled'       => $this->is_button_disabled(),
 				'mini_cart_style'   => array(
 					'layout'  => $this->style_for_context( 'layout', 'mini-cart' ),
 					'color'   => $this->style_for_context( 'color', 'mini-cart' ),
@@ -1351,6 +1351,11 @@ class SmartButton implements SmartButtonInterface {
 		);
 	}
 
+	/**
+	 * Checks if PayPal buttons/messages should be rendered for the current page.
+	 *
+	 * @return bool
+	 */
 	protected function is_button_disabled(): bool {
 		if ( 'product' !== $this->context() ) {
 			return false;

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1357,20 +1357,43 @@ class SmartButton implements SmartButtonInterface {
 	 * @return bool
 	 */
 	protected function is_button_disabled(): bool {
-		if ( 'product' !== $this->context() ) {
-			return false;
+		$context = $this->context();
+
+		if ( 'product' === $context ) {
+			$product = wc_get_product();
+
+			/**
+			 * Allows to decide if the button should be disabled for a given product
+			 */
+			if ( ( $isDisabled = apply_filters(
+				'woocommerce_paypal_payments_product_button_disabled',
+				null,
+				$product )
+			) !== null) {
+				return $isDisabled;
+			}
+		} else {
+			$filterName = 'woocommerce_paypal_payments_'
+				. str_replace('-', '_', $context)
+				. '_button_disabled';
+
+			/**
+			 * Allows to decide if the button should be disabled in a given context
+			 */
+			if ( ( $isDisabled = apply_filters( $filterName, null ) ) !== null ) {
+				return $isDisabled;
+			}
 		}
 
-		$product = wc_get_product();
+		if ( ( $isDisabled = apply_filters(
+			'woocommerce_paypal_payments_button_disabled',
+			null,
+			$context
+		) ) !== null ) {
+			return $isDisabled;
+		}
 
-		/**
-		 * Allows to decide if the button should be disabled for a given product
-		 */
-		return apply_filters(
-			'woocommerce_paypal_payments_product_button_disabled',
-			false,
-			$product
-		);
+		return false;
 	}
 
 	/**

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1371,7 +1371,7 @@ class SmartButton implements SmartButtonInterface {
 			 * Allows to decide if the button should be disabled for a given product
 			 */
 			$is_disabled = apply_filters(
-				'woocommerce_paypal_payments_product_button_disabled',
+				'woocommerce_paypal_payments_product_buttons_disabled',
 				null,
 				$product
 			);
@@ -1385,7 +1385,7 @@ class SmartButton implements SmartButtonInterface {
 		 * Allows to decide if the button should be disabled globally or on a given context
 		 */
 		$is_disabled = apply_filters(
-			'woocommerce_paypal_payments_button_disabled',
+			'woocommerce_paypal_payments_buttons_disabled',
 			null,
 			$context
 		);


### PR DESCRIPTION
## Description

It’s possible to grey out the PayPal buttons (as can be seen in #1469) 

It would be nice if we could expose some kind of function for merchants to conditionally block the buttons like this:

We often had support requests from merchants asking how they could disable the buttons in certain circumstances and such a feature could simplify this customization process.

In that case, merchants wouldn’t need to remove the buttons and instead could just block them.

To disable / enable the buttons the following filters can be used `woocommerce_paypal_payments_buttons_disabled` (for any context) and `woocommerce_paypal_payments_product_buttons_disabled` (specific for products). 
```
add_filter('woocommerce_paypal_payments_buttons_disabled', function (?bool $is_disabled, string $context): bool {
	return true;
}, 10, 2);

add_filter('woocommerce_paypal_payments_product_buttons_disabled', function (?bool $is_disabled, \WC_Product $product): bool {
	return true;
}, 10, 2);
```