### PR TITLE
Auto-disabled ACDC vaulting after updating to 2.1.0 (1842)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -864,7 +864,6 @@ return array(
 		$billing_agreements_endpoint = $container->get( 'api.endpoint.billing-agreements' );
 		if ( ! $billing_agreements_endpoint->reference_transaction_enabled() ) {
 			unset( $fields['vault_enabled'] );
-			unset( $fields['vault_enabled_dcc'] );
 		}
 
 		/**

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -241,6 +241,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 					'subscription_payment_method_change_admin',
 					'multiple_subscriptions'
 				);
+			} elseif ( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) ) {
+				$this->supports[] = 'tokenization';
 			}
 		}
 

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -225,6 +225,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 			if (
 				( $this->config->has( 'vault_enabled' ) && $this->config->get( 'vault_enabled' ) )
+				|| ( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) )
 				|| ( $this->config->has( 'subscriptions_mode' ) && $this->config->get( 'subscriptions_mode' ) === 'subscriptions_api' )
 			) {
 				array_push(
@@ -241,8 +242,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 					'subscription_payment_method_change_admin',
 					'multiple_subscriptions'
 				);
-			} elseif ( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) ) {
-				$this->supports[] = 'tokenization';
 			}
 		}
 


### PR DESCRIPTION
## The problem

After the recent update to WooCommerce PayPal Payments Plugin 2.1.0, we have noticed an issue that impacts the Advanced Card Processing Vaulting feature. Specifically, the checkbox that enables on-site card saving has disappeared if the connected merchant is not enabled for Reference Transactions. This essentially means the card vaulting feature is now disabled.

Previously, the ACDC vaulting feature was enabled in the settings and functioned properly. However, post-update, there's no longer an option to enable this feature.

Sandbox accounts have Reference Transactions enabled by default, making the case non-reproducible in a regular sandbox environment.

Actual Result:

When RT is disabled, ACDC vaulting gets disabled after the update, and there's no option to enable it again.

## Steps To Reproduce

The problem can only be reproduced when the connected merchant is enabled for ACDC, but not for Reference Transactions.

## Expected behaviour

When RT is disabled, and ACDC vaulting was previously enabled, the vaulting should remain enabled post-update. 

## Suggested solution

The only possible solution now is to downgrade to the previous build.