### PR TITLE
Improve blocks

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -16,6 +16,7 @@ const PayPalComponent = ({
                              emitResponse,
                              activePaymentMethod,
                              shippingData,
+                             isEditing,
 }) => {
     const {onPaymentSetup, onCheckoutAfterProcessingWithError} = eventRegistration;
     const {responseTypes} = emitResponse;
@@ -125,6 +126,10 @@ const PayPalComponent = ({
     };
 
     const handleClick = (data, actions) => {
+        if (isEditing) {
+            return actions.reject();
+        }
+
         window.ppcpFundingSource = data.fundingSource;
 
         onClick();
@@ -259,8 +264,8 @@ if (config.scriptData.continuation) {
 registerMethod({
     name: config.id,
     label: <div dangerouslySetInnerHTML={{__html: config.title}}/>,
-    content: <PayPalComponent/>,
-    edit: <b>TODO: editing</b>,
+    content: <PayPalComponent isEditing={false}/>,
+    edit: <PayPalComponent isEditing={true}/>,
     ariaLabel: config.title,
     canMakePayment: () => config.enabled,
     supports: {

--- a/modules/ppcp-session/src/Cancellation/CancelView.php
+++ b/modules/ppcp-session/src/Cancellation/CancelView.php
@@ -63,13 +63,13 @@ class CancelView {
 			printf(
 					// translators: %3$ is funding source like "PayPal" or "Venmo", other placeholders are html tags for a link.
 				esc_html__(
-					'You are currently paying with %3$s. If you want to cancel
-                            this process, please click %1$shere%2$s.',
+					'You are currently paying with %3$s. %4$s%1$sChoose another payment method%2$s.',
 					'woocommerce-paypal-payments'
 				),
 				'<a href="' . esc_url( $url ) . '">',
 				'</a>',
-				esc_html( $name )
+				esc_html( $name ),
+				'<br/>'
 			);
 			?>
 		</p>


### PR DESCRIPTION
Added rendering of PayPal buttons when editing a post with checkout block. The same as when not editing, just stopping the popup on click.
Also improved the continuation mode text. Not just for blocks, but I think it makes sense everywhere.