### PR TITLE
Check that event handler is not null

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -81,7 +81,9 @@ class Renderer {
             ...contextConfig,
             onClick: this.onSmartButtonClick,
             onInit: (data, actions) => {
-                this.onSmartButtonsInit(data, actions);
+                if (this.onSmartButtonsInit) {
+                    this.onSmartButtonsInit(data, actions);
+                }
                 this.handleOnButtonsInit(wrapper, data, actions);
             },
         });


### PR DESCRIPTION
It is passed as null in https://github.com/woocommerce/woocommerce-paypal-payments/blob/5a0b0b41a9478a133df732f8d29f46b97cce54e2/modules/ppcp-wc-gateway/resources/js/gateway-settings.js#L85 when rendering previews, so we need to check that it is not null before using it.
