### PR TITLE
log Subscription Mode configuration in system report (1846)

### DIFF
--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\StatusReport;
 
+use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
@@ -49,6 +50,8 @@ class StatusReportModule implements ModuleInterface {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof ContainerInterface );
 
+				$subscriptions_mode_settings = $c->get( 'wcgateway.settings.fields.subscriptions_mode' ) ?: array();
+
 				/* @var State $state The state. */
 				$state = $c->get( 'onboarding.state' );
 
@@ -60,6 +63,9 @@ class StatusReportModule implements ModuleInterface {
 
 				/* @var MessagesApply $messages_apply The messages apply. */
 				$messages_apply = $c->get( 'button.helper.messages-apply' );
+
+				/* @var SubscriptionHelper $subscription_helper The subscription helper class. */
+				$subscription_helper = $c->get( 'subscription.helper' );
 
 				$last_webhook_storage = $c->get( 'webhook.last-webhook-storage' );
 				assert( $last_webhook_storage instanceof WebhookEventStorage );
@@ -167,6 +173,20 @@ class StatusReportModule implements ModuleInterface {
 					),
 				);
 
+				// For now only show this status if PPCP_FLAG_SUBSCRIPTIONS_API is true.
+				if ( defined( 'PPCP_FLAG_SUBSCRIPTIONS_API' ) && PPCP_FLAG_SUBSCRIPTIONS_API ) {
+					$items[] = array(
+						'label'          => esc_html__( 'Subscriptions Mode', 'woocommerce-paypal-payments' ),
+						'exported_label' => 'Subscriptions Mode',
+						'description'    => esc_html__( 'Whether subscriptions are active and their mode.', 'woocommerce-paypal-payments' ),
+						'value'          => $this->subscriptions_mode_text(
+							$subscription_helper->plugin_is_active(),
+							$settings->has( 'subscriptions_mode' ) ? (string) $settings->get( 'subscriptions_mode' ) : '',
+							$subscriptions_mode_settings
+						),
+					);
+				}
+
 				echo wp_kses_post(
 					$renderer->render(
 						esc_html__( 'WooCommerce PayPal Payments', 'woocommerce-paypal-payments' ),
@@ -198,6 +218,27 @@ class StatusReportModule implements ModuleInterface {
 
 		$current_state = $state->current_state();
 		return $token->is_valid() && $current_state === $state::STATE_ONBOARDED;
+	}
+
+	/**
+	 * Returns the text associated with the subscriptions mode status.
+	 *
+	 * @param bool   $is_plugin_active     Indicates if the WooCommerce Subscriptions plugin is active.
+	 * @param string $subscriptions_mode   The subscriptions mode stored in settings.
+	 * @param array  $field_settings       The subscriptions mode field settings.
+	 * @return string
+	 */
+	private function subscriptions_mode_text( bool $is_plugin_active, string $subscriptions_mode, array $field_settings ): string {
+		if ( ! $is_plugin_active || ! $field_settings ) {
+			return 'Disabled';
+		}
+
+		if ( ! $subscriptions_mode ) {
+			$subscriptions_mode = $field_settings['default'] ?? '';
+		}
+
+		// Return the options value or if it's missing from options the settings value.
+		return $field_settings['options'][ $subscriptions_mode ] ?? $subscriptions_mode;
 	}
 
 	/**

--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -229,7 +229,7 @@ class StatusReportModule implements ModuleInterface {
 	 * @return string
 	 */
 	private function subscriptions_mode_text( bool $is_plugin_active, string $subscriptions_mode, array $field_settings ): string {
-		if ( ! $is_plugin_active || ! $field_settings ) {
+		if ( ! $is_plugin_active || ! $field_settings || $subscriptions_mode === 'disable_paypal_subscriptions' ) {
 			return 'Disabled';
 		}
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -385,6 +385,28 @@ return array(
 		return array_key_exists( $current_page_id, $sections );
 	},
 
+	'wcgateway.settings.fields.subscriptions_mode'         => static function ( ContainerInterface $container ): array {
+		return array(
+			'title'        => __( 'Subscriptions Mode', 'woocommerce-paypal-payments' ),
+			'type'         => 'select',
+			'class'        => array(),
+			'input_class'  => array( 'wc-enhanced-select' ),
+			'desc_tip'     => true,
+			'description'  => __( 'Utilize PayPal Vaulting for flexible subscription processing with saved payment methods, create “PayPal Subscriptions” to bill customers at regular intervals, or disable PayPal for subscription-type products.', 'woocommerce-paypal-payments' ),
+			'default'      => 'vaulting_api',
+			'options'      => array(
+				'vaulting_api'                 => __( 'PayPal Vaulting', 'woocommerce-paypal-payments' ),
+				'subscriptions_api'            => __( 'PayPal Subscriptions', 'woocommerce-paypal-payments' ),
+				'disable_paypal_subscriptions' => __( 'Disable PayPal for subscriptions', 'woocommerce-paypal-payments' ),
+			),
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => 'paypal',
+		);
+	},
+
 	'wcgateway.settings.fields'                            => static function ( ContainerInterface $container ): array {
 
 		$should_render_settings = $container->get( 'wcgateway.settings.should-render-settings' );
@@ -797,25 +819,7 @@ return array(
 				'requirements' => array(),
 				'gateway'      => 'paypal',
 			),
-			'subscriptions_mode'                     => array(
-				'title'        => __( 'Subscriptions Mode', 'woocommerce-paypal-payments' ),
-				'type'         => 'select',
-				'class'        => array(),
-				'input_class'  => array( 'wc-enhanced-select' ),
-				'desc_tip'     => true,
-				'description'  => __( 'Utilize PayPal Vaulting for flexible subscription processing with saved payment methods, create “PayPal Subscriptions” to bill customers at regular intervals, or disable PayPal for subscription-type products.', 'woocommerce-paypal-payments' ),
-				'default'      => 'vaulting_api',
-				'options'      => array(
-					'vaulting_api'                 => __( 'PayPal Vaulting', 'woocommerce-paypal-payments' ),
-					'subscriptions_api'            => __( 'PayPal Subscriptions', 'woocommerce-paypal-payments' ),
-					'disable_paypal_subscriptions' => __( 'Disable PayPal for subscriptions', 'woocommerce-paypal-payments' ),
-				),
-				'screens'      => array(
-					State::STATE_ONBOARDED,
-				),
-				'requirements' => array(),
-				'gateway'      => 'paypal',
-			),
+			'subscriptions_mode'                     => $container->get( 'wcgateway.settings.fields.subscriptions_mode' ),
 			'vault_enabled'                          => array(
 				'title'        => __( 'Vaulting', 'woocommerce-paypal-payments' ),
 				'type'         => 'checkbox',


### PR DESCRIPTION
# PR Description

This PR adds to WooCommerce status page the Subscriptions Mode report.

In order to don't duplicate definitions and reuse the subscription mode field options in the status page, the options had to be separated from `wcgateway.settings.fields` because the condition `$should_render_settings = $container->get( 'wcgateway.settings.should-render-settings' );` was disabling them on the status page.

In addition to the `subscriptions_mode` setting the status text has to take into consideration if the WooCommerce Subscriptions plugin is active or not.

Because subscriptions are still being finalized this report will only be visible if the corresponding option in `WooCommerce > Settings > Payments > PayPal > Standard Payments > Subscriptions Mode`  is visible so need we add `putenv( 'PPCP_FLAG_SUBSCRIPTIONS_API=1' );` to the wp-config.php file or enable them via using a plugin that adds the filter `add_filter( 'ppcp_flag_subscriptions_api', '__return_true' );`.

# Issue Description

The WooCommerce PayPal Payments plugin enriches the system report by appending additional data to facilitate support's understanding of specific configurations.:
```
### WooCommerce PayPal Payments ###
Onboarded: ✔
Shop country code: US
WooCommerce currency supported: ✔
Advanced Card Processing available in country: ✔
Pay Later messaging available in country: ✔
Webhook status: ✔
Vault enabled: ✔
Logging enabled: ✔
Reference Transactions: -
Used PayPal Checkout plugin: ✔
Tracking enabled: -
```

This story requests a new entry for Subscriptions Mode:

This entry should display one of the three options (all of which refer to possible configurations):

- `Subscriptions Mode: Disabled`
- `Subscriptions Mode: PayPal Vaulting`
- `Subscriptions Mode: PayPal Subscriptions`

When the WooCommerce Subscriptions plugin is not active, it should display this status regardless of the actual option value in the database:

- `Subscriptions Mode: Disabled`