### PR TITLE
validate Merchant ID field format when saving settings (468)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -252,7 +252,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'description'       => __( 'The merchant id of your account. Should be exactly 13 alphanumeric uppercase letters.', 'woocommerce-paypal-payments' ),
 			'maxlength'         => 13,
 			'custom_attributes' => array(
-				'pattern' => '[A-Z0-9]{13}',
+				'pattern'      => '[A-Z0-9]{13}',
 				'autocomplete' => 'off',
 			),
 			'default'           => false,
@@ -264,21 +264,21 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'           => Settings::CONNECTION_TAB_ID,
 		),
 		'client_id_production'                          => array(
-			'title'        => __( 'Live Client Id', 'woocommerce-paypal-payments' ),
-			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'         => 'text',
-			'desc_tip'     => true,
-			'description'  => __( 'The client id of your api ', 'woocommerce-paypal-payments' ),
+			'title'             => __( 'Live Client Id', 'woocommerce-paypal-payments' ),
+			'classes'           => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'              => 'text',
+			'desc_tip'          => true,
+			'description'       => __( 'The client id of your api ', 'woocommerce-paypal-payments' ),
 			'custom_attributes' => array(
 				'autocomplete' => 'off',
 			),
-			'default'      => false,
-			'screens'      => array(
+			'default'           => false,
+			'screens'           => array(
 				State::STATE_START,
 				State::STATE_ONBOARDED,
 			),
-			'requirements' => array(),
-			'gateway'      => Settings::CONNECTION_TAB_ID,
+			'requirements'      => array(),
+			'gateway'           => Settings::CONNECTION_TAB_ID,
 		),
 		'client_secret_production'                      => array(
 			'title'        => __( 'Live Secret Key', 'woocommerce-paypal-payments' ),
@@ -318,8 +318,8 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'description'       => __( 'The merchant id of your account. Should be exactly 13 alphanumeric uppercase letters.', 'woocommerce-paypal-payments' ),
 			'maxlength'         => 13,
 			'custom_attributes' => array(
-				'pattern' => '[A-Z0-9]{13}',
-				'autocomplete' => 'off'
+				'pattern'      => '[A-Z0-9]{13}',
+				'autocomplete' => 'off',
 			),
 			'default'           => false,
 			'screens'           => array(
@@ -330,21 +330,21 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'           => Settings::CONNECTION_TAB_ID,
 		),
 		'client_id_sandbox'                             => array(
-			'title'        => __( 'Sandbox Client Id', 'woocommerce-paypal-payments' ),
-			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'         => 'text',
-			'desc_tip'     => true,
-			'description'  => __( 'The client id of your api ', 'woocommerce-paypal-payments' ),
+			'title'             => __( 'Sandbox Client Id', 'woocommerce-paypal-payments' ),
+			'classes'           => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'              => 'text',
+			'desc_tip'          => true,
+			'description'       => __( 'The client id of your api ', 'woocommerce-paypal-payments' ),
 			'custom_attributes' => array(
 				'autocomplete' => 'off',
 			),
-			'default'      => false,
-			'screens'      => array(
+			'default'           => false,
+			'screens'           => array(
 				State::STATE_START,
 				State::STATE_ONBOARDED,
 			),
-			'requirements' => array(),
-			'gateway'      => Settings::CONNECTION_TAB_ID,
+			'requirements'      => array(),
+			'gateway'           => Settings::CONNECTION_TAB_ID,
 		),
 		'client_secret_sandbox'                         => array(
 			'title'        => __( 'Sandbox Secret Key', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -245,18 +245,22 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'merchant_id_production'                        => array(
-			'title'        => __( 'Live Merchant Id', 'woocommerce-paypal-payments' ),
-			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'         => 'ppcp-text-input',
-			'desc_tip'     => true,
-			'description'  => __( 'The merchant id of your account ', 'woocommerce-paypal-payments' ),
-			'default'      => false,
-			'screens'      => array(
+			'title'             => __( 'Live Merchant Id', 'woocommerce-paypal-payments' ),
+			'classes'           => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'              => 'ppcp-text-input',
+			'desc_tip'          => true,
+			'description'       => __( 'The merchant id of your account. Should be exactly 13 alphanumeric uppercase letters.', 'woocommerce-paypal-payments' ),
+			'maxlength'         => 13,
+			'custom_attributes' => array(
+				'pattern' => '[A-Z0-9]{13}',
+			),
+			'default'           => false,
+			'screens'           => array(
 				State::STATE_START,
 				State::STATE_ONBOARDED,
 			),
-			'requirements' => array(),
-			'gateway'      => Settings::CONNECTION_TAB_ID,
+			'requirements'      => array(),
+			'gateway'           => Settings::CONNECTION_TAB_ID,
 		),
 		'client_id_production'                          => array(
 			'title'        => __( 'Live Client Id', 'woocommerce-paypal-payments' ),
@@ -303,18 +307,22 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'merchant_id_sandbox'                           => array(
-			'title'        => __( 'Sandbox Merchant Id', 'woocommerce-paypal-payments' ),
-			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'         => 'ppcp-text-input',
-			'desc_tip'     => true,
-			'description'  => __( 'The merchant id of your account ', 'woocommerce-paypal-payments' ),
-			'default'      => false,
-			'screens'      => array(
+			'title'             => __( 'Sandbox Merchant Id', 'woocommerce-paypal-payments' ),
+			'classes'           => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
+			'type'              => 'ppcp-text-input',
+			'desc_tip'          => true,
+			'description'       => __( 'The merchant id of your account. Should be exactly 13 alphanumeric uppercase letters.', 'woocommerce-paypal-payments' ),
+			'maxlength'         => 13,
+			'custom_attributes' => array(
+				'pattern' => '[A-Z0-9]{13}',
+			),
+			'default'           => false,
+			'screens'           => array(
 				State::STATE_START,
 				State::STATE_ONBOARDED,
 			),
-			'requirements' => array(),
-			'gateway'      => Settings::CONNECTION_TAB_ID,
+			'requirements'      => array(),
+			'gateway'           => Settings::CONNECTION_TAB_ID,
 		),
 		'client_id_sandbox'                             => array(
 			'title'        => __( 'Sandbox Client Id', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -247,12 +247,13 @@ return function ( ContainerInterface $container, array $fields ): array {
 		'merchant_id_production'                        => array(
 			'title'             => __( 'Live Merchant Id', 'woocommerce-paypal-payments' ),
 			'classes'           => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'              => 'ppcp-text-input',
+			'type'              => 'text',
 			'desc_tip'          => true,
 			'description'       => __( 'The merchant id of your account. Should be exactly 13 alphanumeric uppercase letters.', 'woocommerce-paypal-payments' ),
 			'maxlength'         => 13,
 			'custom_attributes' => array(
 				'pattern' => '[A-Z0-9]{13}',
+				'autocomplete' => 'off',
 			),
 			'default'           => false,
 			'screens'           => array(
@@ -265,9 +266,12 @@ return function ( ContainerInterface $container, array $fields ): array {
 		'client_id_production'                          => array(
 			'title'        => __( 'Live Client Id', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'         => 'ppcp-text-input',
+			'type'         => 'text',
 			'desc_tip'     => true,
 			'description'  => __( 'The client id of your api ', 'woocommerce-paypal-payments' ),
+			'custom_attributes' => array(
+				'autocomplete' => 'off',
+			),
 			'default'      => false,
 			'screens'      => array(
 				State::STATE_START,
@@ -309,12 +313,13 @@ return function ( ContainerInterface $container, array $fields ): array {
 		'merchant_id_sandbox'                           => array(
 			'title'             => __( 'Sandbox Merchant Id', 'woocommerce-paypal-payments' ),
 			'classes'           => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'              => 'ppcp-text-input',
+			'type'              => 'text',
 			'desc_tip'          => true,
 			'description'       => __( 'The merchant id of your account. Should be exactly 13 alphanumeric uppercase letters.', 'woocommerce-paypal-payments' ),
 			'maxlength'         => 13,
 			'custom_attributes' => array(
 				'pattern' => '[A-Z0-9]{13}',
+				'autocomplete' => 'off'
 			),
 			'default'           => false,
 			'screens'           => array(
@@ -327,9 +332,12 @@ return function ( ContainerInterface $container, array $fields ): array {
 		'client_id_sandbox'                             => array(
 			'title'        => __( 'Sandbox Client Id', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'         => 'ppcp-text-input',
+			'type'         => 'text',
 			'desc_tip'     => true,
 			'description'  => __( 'The client id of your api ', 'woocommerce-paypal-payments' ),
+			'custom_attributes' => array(
+				'autocomplete' => 'off',
+			),
 			'default'      => false,
 			'screens'      => array(
 				State::STATE_START,

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -454,7 +454,6 @@ class SettingsListener {
 					break;
 				case 'text':
 				case 'number':
-				case 'ppcp-text-input':
 					$settings[ $key ] = isset( $raw_data[ $key ] ) ? wp_kses_post( $raw_data[ $key ] ) : '';
 					break;
 				case 'ppcp-password':

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -260,17 +260,33 @@ class SettingsRenderer {
 			return $field;
 		}
 
+		// Custom attribute handling.
+		$custom_attributes           = array();
+		$config['custom_attributes'] = array_filter( (array) $config['custom_attributes'], 'strlen' );
+
+		if ( $config['maxlength'] ) {
+			$config['custom_attributes']['maxlength'] = absint( $config['maxlength'] );
+		}
+
+		if ( ! empty( $config['custom_attributes'] ) ) {
+			foreach ( $config['custom_attributes'] as $attribute => $attribute_value ) {
+				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
+			}
+		}
+
 		$html = sprintf(
 			'<input
                         type="text"
                         autocomplete="off"
-                        class="%s"
+                        class="input-text %s"
                         name="%s"
                         value="%s"
-                     >',
+                        %s
+            >',
 			esc_attr( implode( ' ', $config['class'] ) ),
 			esc_attr( $key ),
-			esc_attr( $value )
+			esc_attr( $value ),
+			implode( ' ', $custom_attributes )
 		);
 
 		return $html;

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -243,55 +243,6 @@ class SettingsRenderer {
 		return $html;
 	}
 
-
-	/**
-	 * Renders the text input field.
-	 *
-	 * @param string $field The current field HTML.
-	 * @param string $key   The current key.
-	 * @param array  $config The configuration array.
-	 * @param string $value The current value.
-	 *
-	 * @return string
-	 */
-	public function render_text_input( $field, $key, $config, $value ): string {
-
-		if ( 'ppcp-text-input' !== $config['type'] ) {
-			return $field;
-		}
-
-		// Custom attribute handling.
-		$custom_attributes           = array();
-		$config['custom_attributes'] = array_filter( (array) $config['custom_attributes'], 'strlen' );
-
-		if ( $config['maxlength'] ) {
-			$config['custom_attributes']['maxlength'] = absint( $config['maxlength'] );
-		}
-
-		if ( ! empty( $config['custom_attributes'] ) ) {
-			foreach ( $config['custom_attributes'] as $attribute => $attribute_value ) {
-				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
-			}
-		}
-
-		$html = sprintf(
-			'<input
-                        type="text"
-                        autocomplete="off"
-                        class="input-text %s"
-                        name="%s"
-                        value="%s"
-                        %s
-            >',
-			esc_attr( implode( ' ', $config['class'] ) ),
-			esc_attr( $key ),
-			esc_attr( $value ),
-			implode( ' ', $custom_attributes )
-		);
-
-		return $html;
-	}
-
 	/**
 	 * Renders the heading field.
 	 *

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -528,7 +528,6 @@ class WCGatewayModule implements ModuleInterface {
 				 */
 				$field = $renderer->render_multiselect( $field, $key, $args, $value );
 				$field = $renderer->render_password( $field, $key, $args, $value );
-				$field = $renderer->render_text_input( $field, $key, $args, $value );
 				$field = $renderer->render_heading( $field, $key, $args, $value );
 				$field = $renderer->render_table( $field, $key, $args, $value );
 				return $field;


### PR DESCRIPTION
# PR Description

In order to validate the Merchant ID the validation pattern `[A-Z0-9]{13}` was added to both Sandbox and Production Merchant ID fields. A maxlength of 13 was also provided.

These custom_attributes were not being applied to the field because it was of a custom type "ppcp-text-input" which doesn't implement most of the standard WooCommerce "text" field. Assuming the reason for adding this custom field type was to add the `autocomplete="off"`, it was decided to revert these inputs to type "text" and configure the standard text field also to have `autocomplete="off"`.

Related issue:
https://github.com/woocommerce/woocommerce-paypal-payments/commit/754913b6325f1310df4d46d4517d2ed05558eeb7

# Issue Description

## The Problem

Currently, when users provide invalid, attempt to modify their Merchant ID into an invalid string (for instance, `ExampleID` instead of `LKNM3TPOS8SBV`), our system does not prevent the change or notify the users of the error. The PayPal Smart Buttons remain visible on the site frontend, but the checkout process fails with an error.

Here is how to get the right Merchant ID: https://woocommerce.com/document/woocommerce-paypal-payments/#obtaining-the-merchant-id 

When saving the plugin settings we should make sure that the merchant ID field has the correct format.

## Proposed Solution

To prevent this problem, I propose to extend the existing validation process when saving plugin settings to ensure that the Merchant ID entered conforms to the correct format.

The correct Merchant ID should always be a 13-character alphanumeric string. Hence, we can employ a regular expression (regex) pattern like this: /^[A-Z0-9]{13}$/.

This pattern can help to validate the Merchant ID. If the entered ID doesn't fit this pattern, an error should be displayed notifying users of incorrect API credentials. This immediate feedback will ensure merchants are made aware of incorrect Merchant ID format during the configuration stage.

Please note that this solution will only validate the format of the Merchant ID. The Merchant ID could still be invalid if it doesn't correspond to a real Merchant ID on PayPal's system. However, validating this from the settings page is considerably more complex and might require a different solution.
