### PR TITLE
Handle complex form fields when submitting checkout form 

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -50,8 +50,6 @@ class CheckoutActionHandler {
 
             const formSelector = this.config.context === 'checkout' ? 'form.checkout' : 'form#order_review';
             const formData = new FormData(document.querySelector(formSelector));
-            // will not handle fields with multiple values (checkboxes, <select multiple>), but we do not care about this here
-            const formJsonObj = Object.fromEntries(formData.entries());
 
             const createaccount = jQuery('#createaccount').is(":checked") ? true : false;
 
@@ -72,7 +70,8 @@ class CheckoutActionHandler {
                     order_id:this.config.order_id,
                     payment_method: paymentMethod,
                     funding_source: fundingSource,
-                    form: formJsonObj,
+                    // send as urlencoded string to handle complex fields via PHP functions the same as normal form submit
+                    form_encoded: new URLSearchParams(formData).toString(),
                     createaccount: createaccount
                 })
             }).then(function (res) {

--- a/modules/ppcp-button/resources/js/modules/Helper/FormValidator.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/FormValidator.js
@@ -6,7 +6,6 @@ export default class FormValidator {
 
     async validate(form) {
         const formData = new FormData(form);
-        const formJsonObj = Object.fromEntries(formData.entries());
 
         const res = await fetch(this.url, {
             method: 'POST',
@@ -16,7 +15,7 @@ export default class FormValidator {
             credentials: 'same-origin',
             body: JSON.stringify({
                 nonce: this.nonce,
-                form: formJsonObj,
+                form_encoded: new URLSearchParams(formData).toString(),
             }),
         });
 

--- a/modules/ppcp-button/src/Endpoint/RequestData.php
+++ b/modules/ppcp-button/src/Endpoint/RequestData.php
@@ -53,6 +53,11 @@ class RequestData {
 		}
 		$this->dequeue_nonce_fix();
 
+		if ( isset( $json['form_encoded'] ) ) {
+			$json['form'] = array();
+			parse_str( $json['form_encoded'], $json['form'] );
+		}
+
 		$sanitized = $this->sanitize( $json );
 		return $sanitized;
 	}
@@ -80,6 +85,10 @@ class RequestData {
 	private function sanitize( array $assoc_array ): array {
 		$data = array();
 		foreach ( (array) $assoc_array as $raw_key => $raw_value ) {
+			if ( $raw_key === 'form_encoded' ) {
+				$data[ $raw_key ] = $raw_value;
+				continue;
+			}
 			if ( ! is_array( $raw_value ) ) {
 				// Not sure if it is a good idea to sanitize everything at this level,
 				// but should be fine for now since we do not send any HTML or multi-line texts via ajax.


### PR DESCRIPTION
Fixes #1501 

Our current way of handling the checkout form via ajax does not match the WC behavior which submits them in urlencoded request instead of JSON. When it is submitted as JSON object PHP does not parse it for `$_POST` etc., and we do not get its handling of arrays, breaking some plugins.
Now submitting the form as an urlencoded string inside JSON and parsing via `parse_str` which seems to handle it the same as `$_POST`.
The parsing is handled in `RequestData` (adding `'form'` to output when `'form_encoded'` is present) to avoid duplicating it in multiple places and to keep our weird sanitization here. Not sure if it's a good idea to sanitize so early, but for now keeping it like this to avoid major refactoring or introducing new vulnerabilities.

## Steps To Reproduce

- add this code snippet somewhere, e.g. in a plugin or theme file:

```
add_action(
	'woocommerce_after_order_notes',
	function ( $checkout ) {
		$cart_items = WC()->cart->get_cart_contents();
		$quantity   = 0;
		foreach ( $cart_items as $item ) {
			$quantity += $item['quantity'];
		}

		// If there are any products in the cart then add custom checkout field
		if ( $quantity > 0 ) {
			echo '<div id="custom_checkout_field"><h2>Ticket Information</h2>';

			for ( $i = 0; $i < $quantity; $i++ ) {
				woocommerce_form_field(
					'ticket[name][' . $i . ']',
					array(
						'type'     => 'text',
						'class'    => array( 'ticket-name form-row-wide' ),
						'label'    => __( 'Ticket Name ' . ( $i + 1 ) ),
						'required' => true,
					),
					$checkout->get_value( "ticket[name][$i]" )
				);
			}

			echo '</div>';
		}
	}
);

add_action(
	'woocommerce_after_checkout_validation',
	function ( $data, $errors ) {
		if ( isset( $_POST['ticket'] ) ) {
			$ticket_names = $_POST['ticket'];
			foreach ( $ticket_names as $name_arr ) {
				foreach ( $name_arr as $name ) {
					if ( empty( $name ) ) {
						$errors->add( 'validation', 'Please ensure all names are entered that will be attending the event. #1' );
						return;
					}
				}
			}
		} else {
			$errors->add( 'validation', 'Please ensure all names are entered that will be attending the event. #2' );
		}
	},
	10,
	2
);
```

- add products to the cart
- navigate to Checkout page
- fill in the name fields at the bottom of the form fields
- click PayPal button
- validation error will occur `Please ensure all names are entered that will be attending the event. #2` even though the names are entered