### PR TITLE
Do not complete non-checkout button orders via webhooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Incompatibility with WooCommerce One Page Checkout (or similar use cases) in Version 2.1.0 #1473
 * Fix - Prevent Repetitive Token Migration and Database Overload After 2.1.0 Update #1461
 * Fix - Onboarding from connection page with CSRF parameter manipulates email and merchant id fields #1502
+* Fix - Do not complete non-checkout button orders via webhooks #1513
 * Enhancement - Remove feature flag requirement for express cart/checkout block integration #1483
 * Enhancement - Add notice when shop currency is unsupported #1433
 * Enhancement - Improve ACDC error message when empty fields #1360

--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -212,6 +212,15 @@ class PurchaseUnit {
 	}
 
 	/**
+	 * Sets the custom ID.
+	 *
+	 * @param string $custom_id The value to set.
+	 */
+	public function set_custom_id( string $custom_id ): void {
+		$this->custom_id = $custom_id;
+	}
+
+	/**
 	 * Returns the invoice id.
 	 *
 	 * @return string

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -258,6 +258,12 @@ class CreateOrderEndpoint implements EndpointInterface {
 			} else {
 				$this->purchase_unit = $this->purchase_unit_factory->from_wc_cart( null, $this->handle_shipping_in_paypal );
 
+				// Do not allow completion by webhooks when started via non-checkout buttons,
+				// it is needed only for some APMs in checkout.
+				if ( in_array( $data['context'], array( 'product', 'cart', 'cart-block' ), true ) ) {
+					$this->purchase_unit->set_custom_id( '' );
+				}
+
 				// The cart does not have any info about payment method, so we must handle free trial here.
 				if ( (
 					in_array( $payment_method, array( CreditCardGateway::ID, CardButtonGateway::ID ), true )

--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - Incompatibility with WooCommerce One Page Checkout (or similar use cases) in Version 2.1.0 #1473
 * Fix - Prevent Repetitive Token Migration and Database Overload After 2.1.0 Update #1461
 * Fix - Onboarding from connection page with CSRF parameter manipulates email and merchant id fields #1502
+* Fix - Do not complete non-checkout button orders via webhooks #1513
 * Enhancement - Remove feature flag requirement for express cart/checkout block integration #1483
 * Enhancement - Add notice when shop currency is unsupported #1433
 * Enhancement - Improve ACDC error message when empty fields #1360


### PR DESCRIPTION
After #1435 we may complete approved orders in ` CHECKOUT.ORDER.APPROVED` webhooks, which can cause issues when starting from product or cart pages. This webhook is needed only for APMs in checkout, so we need to skip it in other cases.

To achieve this, now the `pcp_customer_...` custom ID is not sent when creating non-checkout orders to make it impossible for the webhook to complete the order, like before #1435. I think there is no cleaner way because there is no way to include other meta data in a PayPal order except the custom ID field.

## Steps to reproduce

1. Start payment from product or cart page.
2. After redirect to checkout, Wait until the `CHECKOUT.ORDER.APPROVED` webhook arrives.
3. Try to finish the checkout.