### PR TITLE
High rate of auth voids on vaulted subscriptions for guest users (1899)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PaymentTokenEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentTokenEndpoint.php
@@ -97,7 +97,7 @@ class PaymentTokenEndpoint {
 	}
 
 	/**
-	 * Returns the payment tokens for a user.
+	 * Returns the payment tokens for the given user id.
 	 *
 	 * @param int $id The user id.
 	 *
@@ -118,7 +118,67 @@ class PaymentTokenEndpoint {
 		$response = $this->request( $url, $args );
 		if ( is_wp_error( $response ) ) {
 			$error = new RuntimeException(
-				__( 'Could not fetch payment token.', 'woocommerce-paypal-payments' )
+				__( 'Could not fetch payment token for customer id.', 'woocommerce-paypal-payments' )
+			);
+			$this->logger->log(
+				'warning',
+				$error->getMessage(),
+				array(
+					'args'     => $args,
+					'response' => $response,
+				)
+			);
+			throw $error;
+		}
+		$json        = json_decode( $response['body'] );
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $status_code ) {
+			$error = new PayPalApiException(
+				$json,
+				$status_code
+			);
+			$this->logger->log(
+				'warning',
+				$error->getMessage(),
+				array(
+					'args'     => $args,
+					'response' => $response,
+				)
+			);
+			throw $error;
+		}
+
+		$tokens = array();
+		foreach ( $json->payment_tokens as $token_value ) {
+			$tokens[] = $this->factory->from_paypal_response( $token_value );
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Returns the payment tokens for the given guest customer id.
+	 *
+	 * @param string $customer_id The guest customer id.
+	 *
+	 * @return PaymentToken[]
+	 * @throws RuntimeException If the request fails.
+	 */
+	public function for_guest( string $customer_id ): array {
+		$bearer = $this->bearer->bearer();
+		$url    = trailingslashit( $this->host ) . 'v2/vault/payment-tokens/?customer_id=' . $customer_id;
+		$args   = array(
+			'method'  => 'GET',
+			'headers' => array(
+				'Authorization' => 'Bearer ' . $bearer->token(),
+				'Content-Type'  => 'application/json',
+			),
+		);
+
+		$response = $this->request( $url, $args );
+		if ( is_wp_error( $response ) ) {
+			$error = new RuntimeException(
+				__( 'Could not fetch payment token for guest customer id.', 'woocommerce-paypal-payments' )
 			);
 			$this->logger->log(
 				'warning',

--- a/modules/ppcp-api-client/src/Endpoint/PaymentTokenEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentTokenEndpoint.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\PaymentTokenActionLinksFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PaymentTokenFactory;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\CustomerRepository;
+use WP_Error;
 
 /**
  * Class PaymentTokenEndpoint
@@ -176,7 +177,7 @@ class PaymentTokenEndpoint {
 		);
 
 		$response = $this->request( $url, $args );
-		if ( is_wp_error( $response ) ) {
+		if ( $response instanceof WP_Error ) {
 			$error = new RuntimeException(
 				__( 'Could not fetch payment token for guest customer id.', 'woocommerce-paypal-payments' )
 			);

--- a/modules/ppcp-vaulting/services.php
+++ b/modules/ppcp-vaulting/services.php
@@ -30,6 +30,7 @@ return array(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'wcgateway.processor.authorized-payments' ),
 			$container->get( 'api.endpoint.payments' ),
+			$container->get( 'api.endpoint.payment-token' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-vaulting/src/PaymentTokenChecker.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenChecker.php
@@ -14,6 +14,8 @@ use Psr\Log\LoggerInterface;
 use RuntimeException;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokenEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\OrderRepository;
 use WooCommerce\PayPalCommerce\Subscription\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
@@ -68,6 +70,13 @@ class PaymentTokenChecker {
 	protected $payments_endpoint;
 
 	/**
+	 * The payment token endpoint.
+	 *
+	 * @var PaymentTokenEndpoint
+	 */
+	protected $payment_token_endpoint;
+
+	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -82,6 +91,7 @@ class PaymentTokenChecker {
 	 * @param Settings                    $settings The settings.
 	 * @param AuthorizedPaymentsProcessor $authorized_payments_processor The authorized payments processor.
 	 * @param PaymentsEndpoint            $payments_endpoint The payments endpoint.
+	 * @param PaymentTokenEndpoint        $payment_token_endpoint The payment token endpoint.
 	 * @param LoggerInterface             $logger The logger.
 	 */
 	public function __construct(
@@ -90,6 +100,7 @@ class PaymentTokenChecker {
 		Settings $settings,
 		AuthorizedPaymentsProcessor $authorized_payments_processor,
 		PaymentsEndpoint $payments_endpoint,
+		PaymentTokenEndpoint $payment_token_endpoint,
 		LoggerInterface $logger
 	) {
 		$this->payment_token_repository      = $payment_token_repository;
@@ -97,6 +108,7 @@ class PaymentTokenChecker {
 		$this->settings                      = $settings;
 		$this->authorized_payments_processor = $authorized_payments_processor;
 		$this->payments_endpoint             = $payments_endpoint;
+		$this->payment_token_endpoint        = $payment_token_endpoint;
 		$this->logger                        = $logger;
 	}
 
@@ -130,7 +142,7 @@ class PaymentTokenChecker {
 			return;
 		}
 
-		$tokens = $this->payment_token_repository->all_for_user_id( $customer_id );
+		$tokens = $this->tokens_for_user( $customer_id );
 		if ( $tokens ) {
 			try {
 				$this->capture_authorized_payment( $wc_order );
@@ -230,5 +242,33 @@ class PaymentTokenChecker {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Returns customer tokens either from guest or customer id.
+	 *
+	 * @param int $customer_id The customer id.
+	 * @return PaymentToken[]
+	 */
+	private function tokens_for_user( int $customer_id ): array {
+		$tokens = array();
+
+		$guest_customer_id = get_user_meta( $customer_id, 'ppcp_guest_customer_id', true );
+		if ( $guest_customer_id ) {
+			$tokens = $this->payment_token_endpoint->for_guest( $guest_customer_id );
+		}
+
+		if ( ! $tokens ) {
+			$guest_customer_id = get_user_meta( $customer_id, 'ppcp_customer_id', true );
+			if ( $guest_customer_id ) {
+				$tokens = $this->payment_token_endpoint->for_guest( $guest_customer_id );
+			}
+		}
+
+		if ( ! $tokens ) {
+			$tokens = $this->payment_token_repository->all_for_user_id( $customer_id );
+		}
+
+		return $tokens;
 	}
 }

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -72,6 +72,7 @@ class VaultingModule implements ModuleInterface {
 			'woocommerce_paypal_payments_check_saved_payment',
 			function ( int $order_id, int $customer_id, string $intent ) use ( $container ) {
 				$payment_token_checker = $container->get( 'vaulting.payment-token-checker' );
+				assert( $payment_token_checker instanceof PaymentTokenChecker );
 				$payment_token_checker->check_and_update( $order_id, $customer_id, $intent );
 			},
 			10,

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -40,7 +40,7 @@ trait ProcessPaymentTrait {
 	 * @param int $customer_id The customer ID.
 	 */
 	protected function schedule_saved_payment_check( int $wc_order_id, int $customer_id ): void {
-		$timestamp = 1 * MINUTE_IN_SECONDS;
+		$timestamp = 3 * MINUTE_IN_SECONDS;
 		if (
 			$this->config->has( 'subscription_behavior_when_vault_fails' )
 			&& $this->config->get( 'subscription_behavior_when_vault_fails' ) === 'capture_auth'

--- a/modules/ppcp-webhooks/src/Handler/VaultPaymentTokenCreated.php
+++ b/modules/ppcp-webhooks/src/Handler/VaultPaymentTokenCreated.php
@@ -107,12 +107,18 @@ class VaultPaymentTokenCreated implements RequestHandler {
 		$customer_id = null !== $request['resource'] && isset( $request['resource']['customer_id'] )
 			? $request['resource']['customer_id']
 			: '';
+
 		if ( ! $customer_id ) {
 			$message = 'No customer id was found.';
 			return $this->failure_response( $message );
 		}
 
-		$wc_customer_id = (int) str_replace( $this->prefix, '', $customer_id );
+		$wc_customer_id = $this->wc_customer_id_from( $customer_id );
+		if ( ! $wc_customer_id ) {
+			$message = "No WC customer id was found from PayPal customer id {$customer_id}";
+			return $this->failure_response( $message );
+		}
+
 		$this->authorized_payments_processor->capture_authorized_payments_for_customer( $wc_customer_id );
 
 		if ( ! is_null( $request['resource'] ) && isset( $request['resource']['id'] ) ) {
@@ -148,5 +154,30 @@ class VaultPaymentTokenCreated implements RequestHandler {
 		}
 
 		return $this->success_response();
+	}
+
+	/**
+	 * Returns WC customer id from PayPal customer id.
+	 *
+	 * @param string $customer_id The customer ID from PayPal.
+	 * @return int
+	 */
+	private function wc_customer_id_from( string $customer_id ): int {
+		$customers = get_users(
+			array(
+				'meta_key'   => 'ppcp_guest_customer_id',
+				'meta_value' => $customer_id,
+				'fields'     => 'ids',
+				'number'     => 1,
+			)
+		);
+
+		$wc_customer_id = $customers[0] ?? '';
+		if ( $wc_customer_id ) {
+			return (int) $wc_customer_id;
+		}
+
+		$id = str_replace( $this->prefix, '', $customer_id );
+		return is_numeric( $id ) ? (int) $id : 0;
 	}
 }

--- a/modules/ppcp-webhooks/src/Handler/VaultPaymentTokenCreated.php
+++ b/modules/ppcp-webhooks/src/Handler/VaultPaymentTokenCreated.php
@@ -165,8 +165,8 @@ class VaultPaymentTokenCreated implements RequestHandler {
 	private function wc_customer_id_from( string $customer_id ): int {
 		$customers = get_users(
 			array(
-				'meta_key'   => 'ppcp_guest_customer_id',
-				'meta_value' => $customer_id,
+				'meta_key'   => 'ppcp_guest_customer_id', //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $customer_id, //phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
 				'fields'     => 'ids',
 				'number'     => 1,
 			)


### PR DESCRIPTION
PayPal generated a PMT (Payment Token) with a customer ID of `someprefix-xyz456f`, and then sent a webhook (and was received), but the call to `v2/vault/payment-tokens` queried `someprefix-123` and then voided when it didn’t get any results.

When receiving `VAULT.PAYMENT-TOKEN.CREATED` webhook we generate the WC customer ID based on `$customer_id` value:
```
$wc_customer_id = (int)str_replace( $this->prefix, '', $customer_id );
```
It does work if `$customer_id` contains a valid user id after prefix (`someprefix-123`), but the customer id could also be generated as random alphanumeric string when the customer is not registered yet (ex: `someprefix-xyz456f`): 
https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-api-client/src/Repository/CustomerRepository.php#L47

This PR fixes that by first checking if a guest id (`ppcp_guest_customer_id`) value exists as user meta for a user and if so then use that user id. 

### Steps To Reproduce
- Create a brand new PayPal personal account
- As guest purchase a subscription using the new account
`VAULT.PAYMENT-TOKEN.CREATED` handler does not generate the correct WC customer ID from the received PayPal customer ID.