### PR TITLE
Improve WC order creation in webhook

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 
-    - uses: jonaseberle/github-action-setup-ddev@v1
+    - uses: ddev/github-action-setup-ddev@v1
       with:
         autostart: false
 

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -123,7 +123,7 @@ const bootstrap = () => {
             return actions.reject();
         }
 
-        if (context === 'checkout' && !PayPalCommerceGateway.funding_sources_without_redirect.includes(data.fundingSource)) {
+        if (context === 'checkout') {
             try {
                 await formSaver.save(form);
             } catch (error) {

--- a/modules/ppcp-webhooks/src/Handler/CheckoutOrderApproved.php
+++ b/modules/ppcp-webhooks/src/Handler/CheckoutOrderApproved.php
@@ -145,6 +145,10 @@ class CheckoutOrderApproved implements RequestHandler {
 				return $this->success_response();
 			}
 
+			if ( ! (bool) apply_filters( 'woocommerce_paypal_payments_order_approved_webhook_can_create_wc_order', true ) ) {
+				return $this->success_response();
+			}
+
 			$wc_session = new WC_Session_Handler();
 
 			$session_data = $wc_session->get_session( $customer_id );

--- a/modules/ppcp-webhooks/src/Handler/CheckoutOrderApproved.php
+++ b/modules/ppcp-webhooks/src/Handler/CheckoutOrderApproved.php
@@ -159,6 +159,14 @@ class CheckoutOrderApproved implements RequestHandler {
 			WC()->cart->calculate_shipping();
 
 			$form = $this->session_handler->checkout_form();
+			if ( ! $form ) {
+				return $this->failure_response(
+					sprintf(
+						'Failed to create WC order in webhook event %s, checkout data not found.',
+						$request['id'] ?: ''
+					)
+				);
+			}
 
 			$checkout    = new WC_Checkout();
 			$wc_order_id = $checkout->create_order( $form );

--- a/modules/ppcp-webhooks/src/Handler/CheckoutOrderApproved.php
+++ b/modules/ppcp-webhooks/src/Handler/CheckoutOrderApproved.php
@@ -145,7 +145,7 @@ class CheckoutOrderApproved implements RequestHandler {
 				return $this->success_response();
 			}
 
-			if ( ! (bool) apply_filters( 'woocommerce_paypal_payments_order_approved_webhook_can_create_wc_order', true ) ) {
+			if ( ! (bool) apply_filters( 'woocommerce_paypal_payments_order_approved_webhook_can_create_wc_order', false ) ) {
 				return $this->success_response();
 			}
 


### PR DESCRIPTION
This PR should improve #1522 if it is caused by #1435. It may happen when for some reason WC checkout was not finished after completing the payment popup (e.g. validation by a third-party plugin not using `woocommerce_after_checkout_validation` filter was performed after the payment popup and failed) but `CHECKOUT.ORDER.APPROVED` webhook arrived later and attempted to create a WC order.

We should look for a better solution but for now these improvements may solve these issues for some users:

- Saving the form data into the session for all buttons (PayPal, Pay Later, ...) instead of only some APMs.
- Not creating WC order in the webhook when there is no form data.
- Added `woocommerce_paypal_payments_order_approved_webhook_can_create_wc_order` filter allowing to disable WC order in the webhook.