### PR TITLE
PayPal button doesn't work for variable products on product page after recent 2.2.0 release. (1898)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -51,7 +51,7 @@ class SingleProductBootstap {
             return;
         }
 
-        form.addEventListener('change', () => {
+        jQuery(document).on('change', this.formSelector, () => {
             this.handleChange();
 
             setTimeout(() => { // Wait for the DOM to be fully updated
@@ -91,7 +91,7 @@ class SingleProductBootstap {
             && ((null === addToCartButton) || !addToCartButton.classList.contains('disabled'));
     }
 
-    priceAmount() {
+    priceAmount(returnOnUndefined = 0) {
         const priceText = [
             () => document.querySelector('form.cart ins .woocommerce-Price-amount')?.innerText,
             () => document.querySelector('form.cart .woocommerce-Price-amount')?.innerText,
@@ -110,6 +110,10 @@ class SingleProductBootstap {
             },
         ].map(f => f()).find(val => val);
 
+        if (typeof priceText === 'undefined') {
+            return returnOnUndefined;
+        }
+
         if (!priceText) {
             return 0;
         }
@@ -118,7 +122,13 @@ class SingleProductBootstap {
     }
 
     priceAmountIsZero() {
-        const price = this.priceAmount();
+        const price = this.priceAmount(-1);
+
+        // if we can't find the price in the DOM we want to return true so the button is visible.
+        if (price === -1) {
+            return false;
+        }
+
         return !price || price === 0;
     }
 


### PR DESCRIPTION
## PR Description

Some websites in V2.2 had some problems in the rendering/reacting to changes of the PayPal button.

Two possible improvements were detected:
1. Two of them didn't trigger an event when using `form.addEventListener('change',` it was changed to `jQuery(document).on('change', this.formSelector,` which is more resilient and even persists if the form is rerendered in the DOM.
2. Two of them were disabling the button when the product price could not be found in the DOM. In these cases where the DOM is in an unexpected state I think it's best to just show the button.

## Issue Description
The button should only be inactive (grayed out) for variable products when no specific option is selected from the list. However, it currently remains inactive at all times, which is not intended.