### PR TITLE
One-page checkout causes mini cart not showing the PP button on certain pages (1871)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 
-    - uses: jonaseberle/github-action-setup-ddev@v1
+    - uses: ddev/github-action-setup-ddev@v1
       with:
         autostart: false
 

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -137,16 +137,15 @@ const bootstrap = () => {
     };
     const renderer = new Renderer(creditCardRenderer, PayPalCommerceGateway, onSmartButtonClick, onSmartButtonsInit);
     const messageRenderer = new MessageRenderer(PayPalCommerceGateway.messages);
-    if (context === 'mini-cart' || context === 'product') {
-        if (PayPalCommerceGateway.mini_cart_buttons_enabled === '1') {
-            const miniCartBootstrap = new MiniCartBootstap(
-                PayPalCommerceGateway,
-                renderer,
-                errorHandler,
-            );
 
-            miniCartBootstrap.init();
-        }
+    if (PayPalCommerceGateway.mini_cart_buttons_enabled === '1') {
+        const miniCartBootstrap = new MiniCartBootstap(
+            PayPalCommerceGateway,
+            renderer,
+            errorHandler,
+        );
+
+        miniCartBootstrap.init();
     }
 
     if (context === 'product' && PayPalCommerceGateway.single_product_buttons_enabled === '1') {

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1532,17 +1532,25 @@ class SmartButton implements SmartButtonInterface {
 	 */
 	private function sanitize_woocommerce_filters(): void {
 
-		// Sometimes external plugins like "woocommerce-one-page-checkout" set the $value to null.
-		// Here we also disable the mini-cart on cart-block and checkout-block pages where our buttons aren't supported yet.
-		add_filter( 'woocommerce_widget_cart_is_hidden', function ($value) {
-			if (null === $value) {
-				if ( is_product() ) {
-					return false;
+		add_filter(
+			'woocommerce_widget_cart_is_hidden',
+			/**
+			 * Sometimes external plugins like "woocommerce-one-page-checkout" set the $value to null, handle that case here.
+			 * Here we also disable the mini-cart on cart-block and checkout-block pages where our buttons aren't supported yet.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function ( $value ) {
+				if ( null === $value ) {
+					if ( is_product() ) {
+						return false;
+					}
+					return in_array( $this->context(), array( 'cart', 'checkout', 'cart-block', 'checkout-block' ), true );
 				}
-				return in_array($this->context(), array('cart', 'checkout', 'cart-block', 'checkout-block'));
-			}
-			return in_array($this->context(), array('cart-block', 'checkout-block')) ? true : $value;
-		}, 11);
+				return in_array( $this->context(), array( 'cart-block', 'checkout-block' ), true ) ? true : $value;
+			},
+			11
+		);
 
 	}
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -372,6 +372,8 @@ class SmartButton implements SmartButtonInterface {
 			);
 		}
 
+		$this->sanitize_woocommerce_filters();
+
 		return true;
 	}
 
@@ -1522,4 +1524,26 @@ class SmartButton implements SmartButtonInterface {
 
 		return absint( $wp->query_vars['order-pay'] );
 	}
+
+	/**
+	 * Sanitize woocommerce filter on unexpected states.
+	 *
+	 * @return void
+	 */
+	private function sanitize_woocommerce_filters(): void {
+
+		// Sometimes external plugins like "woocommerce-one-page-checkout" set the $value to null.
+		// Here we also disable the mini-cart on cart-block and checkout-block pages where our buttons aren't supported yet.
+		add_filter( 'woocommerce_widget_cart_is_hidden', function ($value) {
+			if (null === $value) {
+				if ( is_product() ) {
+					return false;
+				}
+				return in_array($this->context(), array('cart', 'checkout', 'cart-block', 'checkout-block'));
+			}
+			return in_array($this->context(), array('cart-block', 'checkout-block')) ? true : $value;
+		}, 11);
+
+	}
+
 }


### PR DESCRIPTION
# PR Description

This issue handles two inconsistencies:
* The PayPal buttons on the mini-cart can be supported on the cart and checkout pages (also on the product page with single page checkout enabled) but were being disabled by an hardcoded condition. This PR removes that condition since it seems unnecessary as the Mini-cart Bootstrap only renders if the mini-cart element is present in the DOM.
* The Single Page Checkout plugin under some conditions leaves the filter "woocommerce_widget_cart_is_hidden" in a null state which causes the mini-cart to show on the cart and checkout pages, we handle that case while also disabling the mini-cart in the cart-block and checkout-block contexts as our buttons aren't supported on the mini-cart of those pages.

# Issue Description

While the one-page-checkout plugin is activated, the mini-cart PayPal button does not show up on the pages:
* Shop
* Cart
* Checkout
* Cart Blocks
* Checkout Blocks

The button does show up in the mini cart on the pages:
* product
* my account
* Sample page

There was a situation that it did show up, but we are currently uncertain what setting caused this change.