### PR TITLE
Certain coupons with PUI causing AMOUNT_MISMATCH error (949)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 
-    - uses: jonaseberle/github-action-setup-ddev@v1
+    - uses: ddev/github-action-setup-ddev@v1
       with:
         autostart: false
 

--- a/modules/ppcp-api-client/src/Endpoint/PayUponInvoiceOrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PayUponInvoiceOrderEndpoint.php
@@ -233,9 +233,15 @@ class PayUponInvoiceOrderEndpoint {
 	 * @return array
 	 */
 	private function ensure_taxes( WC_Order $wc_order, array $data ): array {
-		$tax_total       = $data['purchase_units'][0]['amount']['breakdown']['tax_total']['value'];
-		$item_total      = $data['purchase_units'][0]['amount']['breakdown']['item_total']['value'];
-		$shipping        = $data['purchase_units'][0]['amount']['breakdown']['shipping']['value'];
+		$tax_total  = $data['purchase_units'][0]['amount']['breakdown']['tax_total']['value'];
+		$item_total = $data['purchase_units'][0]['amount']['breakdown']['item_total']['value'];
+		$shipping   = $data['purchase_units'][0]['amount']['breakdown']['shipping']['value'];
+
+		$handling          = isset( $data['purchase_units'][0]['amount']['breakdown']['handling'] ) ? $data['purchase_units'][0]['amount']['breakdown']['handling']['value'] : 0;
+		$insurance         = isset( $data['purchase_units'][0]['amount']['breakdown']['insurance'] ) ? $data['purchase_units'][0]['amount']['breakdown']['insurance']['value'] : 0;
+		$shipping_discount = isset( $data['purchase_units'][0]['amount']['breakdown']['shipping_discount'] ) ? $data['purchase_units'][0]['amount']['breakdown']['shipping_discount']['value'] : 0;
+		$discount          = isset( $data['purchase_units'][0]['amount']['breakdown']['discount'] ) ? $data['purchase_units'][0]['amount']['breakdown']['discount']['value'] : 0;
+
 		$order_tax_total = $wc_order->get_total_tax();
 		$tax_rate        = round( ( $order_tax_total / $item_total ) * 100, 1 );
 
@@ -263,7 +269,7 @@ class PayUponInvoiceOrderEndpoint {
 		);
 
 		$total_amount    = $data['purchase_units'][0]['amount']['value'];
-		$breakdown_total = $item_total + $tax_total + $shipping;
+		$breakdown_total = $item_total + $tax_total + $shipping + $handling + $insurance - $shipping_discount - $discount;
 		$diff            = round( $total_amount - $breakdown_total, 2 );
 		if ( $diff === -0.01 || $diff === 0.01 ) {
 			$data['purchase_units'][0]['amount']['value'] = number_format( $breakdown_total, 2, '.', '' );


### PR DESCRIPTION
# PR Description
The `$breakdown_total` should consider the `$discount` for rounding issue detection.
Also added support for `+ $handling + $insurance - $shipping_discount` in case they are considered in the future in: https://github.com/woocommerce/woocommerce-paypal-payments/blob/75316431ca3bc9c87572f9f7e7cd06d321e55d4b/modules/ppcp-api-client/src/Factory/AmountFactory.php#L162-L164

# Issue Description

## The problem

PUI orders may fail with this error under certain circumstances when a coupon code is used:
`AMOUNT_MISMATCH /purchase_units/@reference_id=='default'/amount/value Should equal item_total + tax_total + shipping + handling + insurance - shipping_discount - discount.`

## Steps To Reproduce
* enable taxes in WC
* set up a tax rate for Germany with 19% VAT
* create a coupon with 50% percentage discount (varying amount may apply)
* create product with price 200€
* add product to cart
* go to Checkout
* apply coupon code
* attempt PUI payment → error occurs

## Expected behaviour
No error when attempting PUI payment with a coupon code.