### PR TITLE
Replace ddev GH action setup library

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: satackey/action-docker-layer-caching@v0.0.11
       continue-on-error: true
 
-    - uses: jonaseberle/github-action-setup-ddev@v1
+    - uses: ddev/github-action-setup-ddev@v1
       with:
         autostart: false
 


### PR DESCRIPTION
e2e CI is failing (ex. https://github.com/woocommerce/woocommerce-paypal-payments/actions/runs/5666609182/job/15353695054)
```
Invalid configuration in /home/runner/.ddev/global_config.yaml: invalid omit_containers: dba,ddev-ssh-agent, must contain only ddev-router,ddev-ssh-agent
```
This PR replaces GH action https://github.com/jonaseberle/github-action-setup-ddev/blob/master/README.md (which is deprecated now) with https://github.com/ddev/github-action-setup-ddev