### PR TITLE
Refactor hosted fields for early card detection

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CreditCardRenderer.js
@@ -122,24 +122,17 @@ class CreditCardRenderer {
 
                 const className = this._cardNumberFiledCLassNameByCardType(event.cards[0].type);
                 this._recreateElementClassAttribute(cardNumber, cardNumberField.className);
-                if (event.fields.number.isValid) {
+                if (event.cards.length === 1) {
                     cardNumber.classList.add(className);
                 }
             })
             hostedFields.on('validityChange', (event) => {
-                const formValid = Object.keys(event.fields).every(function (key) {
+                this.formValid = Object.keys(event.fields).every(function (key) {
                     return event.fields[key].isValid;
                 });
-
-                const className = event.cards.length ? this._cardNumberFiledCLassNameByCardType(event.cards[0].type) : '';
-                event.fields.number.isValid
-                    ? cardNumber.classList.add(className)
-                    : this._recreateElementClassAttribute(cardNumber, cardNumberField.className);
-
-               this.formValid = formValid;
-
             });
             hostedFields.on('empty', (event) => {
+                this._recreateElementClassAttribute(cardNumber, cardNumberField.className);
                 this.emptyFields.add(event.emittedBy);
             });
             hostedFields.on('notEmpty', (event) => {


### PR DESCRIPTION
## PR Description

`event.cards.length` is an array with all possible card types for the written numbers, when it's equal to `1` it means we already know the card type.

## Issue Description

Currently, the card type detection for ACDC only triggers when the full card number has been entered.

The PayPal docs also contain examples that have the card type detected sooner (after the first two digits were entered):
https://developer.paypal.com/braintree/docs/guides/hosted-fields/examples/javascript/v3#example--animating-events

Some users requested the card type to be detected sooner and we should investigate if this is possible.