### PR TITLE
When onboarding loading the return_url too fast may cause the onboarding to fail (1925)

### DIFF
--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -229,13 +229,15 @@ return array(
 		$partner_referrals_sandbox = $container->get( 'api.endpoint.partner-referrals-sandbox' );
 		$partner_referrals_data    = $container->get( 'api.repository.partner-referrals-data' );
 		$settings                  = $container->get( 'wcgateway.settings' );
-		$signup_link_cache  = $container->get( 'onboarding.signup-link-cache' );
+		$signup_link_cache         = $container->get( 'onboarding.signup-link-cache' );
+		$logger                    = $container->get( 'woocommerce.logger.woocommerce' );
 		return new OnboardingRenderer(
 			$settings,
 			$partner_referrals,
 			$partner_referrals_sandbox,
 			$partner_referrals_data,
-			$signup_link_cache
+			$signup_link_cache,
+			$logger
 		);
 	},
 	'onboarding.render-options'                 => static function ( ContainerInterface $container ) : OnboardingOptionsRenderer {

--- a/modules/ppcp-onboarding/src/Render/OnboardingRenderer.php
+++ b/modules/ppcp-onboarding/src/Render/OnboardingRenderer.php
@@ -9,12 +9,14 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Onboarding\Render;
 
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnerReferrals;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\PartnerReferralsData;
 use WooCommerce\PayPalCommerce\Onboarding\Helper\OnboardingUrl;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 
 /**
  * Class OnboardingRenderer
@@ -57,6 +59,13 @@ class OnboardingRenderer {
 	protected $cache;
 
 	/**
+	 * The logger
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
 	 * OnboardingRenderer constructor.
 	 *
 	 * @param Settings             $settings The settings.
@@ -64,19 +73,22 @@ class OnboardingRenderer {
 	 * @param PartnerReferrals     $sandbox_partner_referrals The PartnerReferrals for sandbox.
 	 * @param PartnerReferralsData $partner_referrals_data The default partner referrals data.
 	 * @param Cache                $cache The cache.
+	 * @param ?LoggerInterface     $logger The logger.
 	 */
 	public function __construct(
 		Settings $settings,
 		PartnerReferrals $production_partner_referrals,
 		PartnerReferrals $sandbox_partner_referrals,
 		PartnerReferralsData $partner_referrals_data,
-		Cache $cache
+		Cache $cache,
+		LoggerInterface $logger = null
 	) {
 		$this->settings                     = $settings;
 		$this->production_partner_referrals = $production_partner_referrals;
 		$this->sandbox_partner_referrals    = $sandbox_partner_referrals;
 		$this->partner_referrals_data       = $partner_referrals_data;
 		$this->cache                        = $cache;
+		$this->logger                       = $logger ?: new NullLogger();
 	}
 
 	/**
@@ -102,8 +114,11 @@ class OnboardingRenderer {
 		$onboarding_url = new OnboardingUrl( $this->cache, $cache_key, get_current_user_id() );
 
 		if ( $onboarding_url->load() ) {
+			$this->logger->debug( 'Loaded onbording URL from cache: ' . $cache_key );
 			return $onboarding_url->get() ?: '';
 		}
+
+		$this->logger->info( 'Generating onboarding URL for: ' . $cache_key );
 
 		$onboarding_url->init();
 
@@ -115,6 +130,8 @@ class OnboardingRenderer {
 
 		$onboarding_url->set( $url );
 		$onboarding_url->persist();
+
+		$this->logger->info( 'Persisted onboarding URL for: ' . $cache_key );
 
 		return $url;
 	}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -292,6 +292,7 @@ return array(
 		$signup_link_ids = $container->get( 'onboarding.signup-link-ids' );
 		$pui_status_cache = $container->get( 'pui.status-cache' );
 		$dcc_status_cache = $container->get( 'dcc.status-cache' );
+		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 		return new SettingsListener(
 			$settings,
 			$fields,
@@ -304,7 +305,8 @@ return array(
 			$signup_link_ids,
 			$pui_status_cache,
 			$dcc_status_cache,
-			$container->get( 'http.redirector' )
+			$container->get( 'http.redirector' ),
+			$logger
 		);
 	},
 	'wcgateway.order-processor'                            => static function ( ContainerInterface $container ): OrderProcessor {

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -136,7 +136,7 @@ class SettingsListener {
 	 *
 	 * @var int
 	 */
-	private $onboarding_max_retries = 3;
+	private $onboarding_max_retries = 5;
 
 	/**
 	 * Delay between onboarding URL retries.
@@ -238,7 +238,7 @@ class SettingsListener {
 		}
 
 		// Process token validation.
-		$onboarding_token_sample = ( (string) substr( $onboarding_token, 0, 4 ) ) . '...' . ( (string) substr( $onboarding_token, -4 ) );
+		$onboarding_token_sample = ( (string) substr( $onboarding_token, 0, 2 ) ) . '...' . ( (string) substr( $onboarding_token, -6 ) );
 		$this->logger->debug( 'Validating onboarding ppcpToken: ' . $onboarding_token_sample );
 
 		if ( ! OnboardingUrl::validate_token_and_delete( $this->signup_link_cache, $onboarding_token, get_current_user_id() ) ) {

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
@@ -23,6 +24,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 
 /**
  * Class SettingsListener
@@ -123,6 +125,27 @@ class SettingsListener {
 	protected $redirector;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
+	 * Max onboarding URL retries.
+	 *
+	 * @var int
+	 */
+	private $onboarding_max_retries = 3;
+
+	/**
+	 * Delay between onboarding URL retries.
+	 *
+	 * @var int
+	 */
+	private $onboarding_retry_delay = 2;
+
+	/**
 	 * SettingsListener constructor.
 	 *
 	 * @param Settings            $settings The settings.
@@ -137,6 +160,7 @@ class SettingsListener {
 	 * @param Cache               $pui_status_cache The PUI status cache.
 	 * @param Cache               $dcc_status_cache The DCC status cache.
 	 * @param RedirectorInterface $redirector The HTTP redirector.
+	 * @param ?LoggerInterface    $logger The logger.
 	 */
 	public function __construct(
 		Settings $settings,
@@ -150,7 +174,8 @@ class SettingsListener {
 		array $signup_link_ids,
 		Cache $pui_status_cache,
 		Cache $dcc_status_cache,
-		RedirectorInterface $redirector
+		RedirectorInterface $redirector,
+		LoggerInterface $logger = null
 	) {
 
 		$this->settings          = $settings;
@@ -165,6 +190,7 @@ class SettingsListener {
 		$this->pui_status_cache  = $pui_status_cache;
 		$this->dcc_status_cache  = $dcc_status_cache;
 		$this->redirector        = $redirector;
+		$this->logger            = $logger ?: new NullLogger();
 	}
 
 	/**
@@ -187,16 +213,48 @@ class SettingsListener {
 		$merchant_id      = sanitize_text_field( wp_unslash( $_GET['merchantIdInPayPal'] ) );
 		$merchant_email   = sanitize_text_field( wp_unslash( $_GET['merchantId'] ) );
 		$onboarding_token = sanitize_text_field( wp_unslash( $_GET['ppcpToken'] ) );
+		$retry_count      = isset( $_GET['ppcpRetry'] ) ? ( (int) sanitize_text_field( wp_unslash( $_GET['ppcpRetry'] ) ) ) : 0;
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		$this->settings->set( 'merchant_id', $merchant_id );
 		$this->settings->set( 'merchant_email', $merchant_email );
 
-		if ( ! OnboardingUrl::validate_token_and_delete( $this->signup_link_cache, $onboarding_token, get_current_user_id() ) ) {
-			$this->onboarding_redirect( false );
+		// If no client_id is present we will try to wait for PayPal to invoke LoginSellerEndpoint.
+		if ( ! $this->settings->has( 'client_id' ) || ! $this->settings->get( 'client_id' ) ) {
+
+			// Try at most {onboarding_max_retries} times ({onboarding_retry_delay} seconds delay). Then give up and just fill the merchant fields like before.
+			if ( $retry_count < $this->onboarding_max_retries ) {
+
+				if ( $this->onboarding_retry_delay > 0 ) {
+					sleep( $this->onboarding_retry_delay );
+				}
+
+				$retry_count++;
+				$this->logger->info( 'Retrying onboarding return URL, retry nr: ' . ( (string) $retry_count ) );
+				$redirect_url = add_query_arg( 'ppcpRetry', $retry_count );
+				$this->redirector->redirect( $redirect_url );
+			}
 		}
 
+		// Process token validation.
+		$onboarding_token_sample = ( (string) substr( $onboarding_token, 0, 4 ) ) . '...' . ( (string) substr( $onboarding_token, -4 ) );
+		$this->logger->debug( 'Validating onboarding ppcpToken: ' . $onboarding_token_sample );
+
+		if ( ! OnboardingUrl::validate_token_and_delete( $this->signup_link_cache, $onboarding_token, get_current_user_id() ) ) {
+			if ( OnboardingUrl::validate_previous_token( $this->signup_link_cache, $onboarding_token, get_current_user_id() ) ) {
+				// It's a valid token used previously, don't do anything but silently redirect.
+				$this->logger->info( 'Validated previous token, silently redirecting: ' . $onboarding_token_sample );
+				$this->onboarding_redirect();
+			} else {
+				$this->logger->error( 'Failed to validate onboarding ppcpToken: ' . $onboarding_token_sample );
+				$this->onboarding_redirect( false );
+			}
+		}
+
+		$this->logger->info( 'Validated onboarding ppcpToken: ' . $onboarding_token_sample );
+
+		// Save the merchant data.
 		$is_sandbox = $this->settings->has( 'sandbox_on' ) && $this->settings->get( 'sandbox_on' );
 		if ( $is_sandbox ) {
 			$this->settings->set( 'merchant_id_sandbox', $merchant_id );
@@ -212,6 +270,7 @@ class SettingsListener {
 		 */
 		do_action( 'woocommerce_paypal_payments_onboarding_before_redirect' );
 
+		// If after all the retry redirects there still isn't a valid client_id then just send an error.
 		if ( ! $this->settings->has( 'client_id' ) || ! $this->settings->get( 'client_id' ) ) {
 			$this->onboarding_redirect( false );
 		}
@@ -230,6 +289,10 @@ class SettingsListener {
 
 		if ( ! $success ) {
 			$redirect_url = add_query_arg( 'ppcp-onboarding-error', '1', $redirect_url );
+			$this->logger->info( 'Redirect ERROR: ' . $redirect_url );
+		} else {
+			$redirect_url = remove_query_arg( 'ppcp-onboarding-error', $redirect_url );
+			$this->logger->info( 'Redirect OK: ' . $redirect_url );
 		}
 
 		$this->redirector->redirect( $redirect_url );

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -685,10 +685,11 @@
       <code>listen_for_merchant_id</code>
       <code>listen_for_vaulting_enabled</code>
     </MissingReturnType>
-    <PossiblyInvalidArgument occurrences="4">
+    <PossiblyInvalidArgument occurrences="5">
       <code>wp_unslash( $_GET['merchantId'] )</code>
       <code>wp_unslash( $_GET['merchantIdInPayPal'] )</code>
       <code>wp_unslash( $_GET['ppcpToken'] )</code>
+      <code>wp_unslash( $_GET['ppcpRetry'] )</code>
       <code>wp_unslash( $_POST['ppcp-nonce'] )</code>
     </PossiblyInvalidArgument>
   </file>

--- a/tests/PHPUnit/Onboarding/Helper/OnboardingUrlTest.php
+++ b/tests/PHPUnit/Onboarding/Helper/OnboardingUrlTest.php
@@ -58,6 +58,7 @@ class OnboardingUrlTest extends TestCase
 		// Expectations
 		$this->cache->shouldReceive('has')->once()->andReturn(true);
 		$this->cache->shouldReceive('get')->once()->andReturn($cacheData);
+		$this->cache->shouldReceive('set')->once();
 		$this->cache->shouldReceive('delete')->once();
 
 		$this->assertTrue(


### PR DESCRIPTION
# PR Description

This PR tries to resolve two issues:
1. When onboarding if the user clicks too fast on the return to the website URL may cause a race condition with the endpoint that saves user credentials `client_id` and `secret`.
To prevent this race condition a retry mechanism was implemented to the return URL to wait for `client_id` and `secret` to be filled first.

2. The onboarding return_url is sometimes invoked multiple times by the PayPal popup. The return_url token was designed to be used only once, so multiple validations with the same valid token would result in error messages.
To prevent this and keep the single usage security guarantees the first time the token is validated we assume all relevant processes are executed. Subsequent same token validations allow to detect that the token is no longer valid but was valid within a certain timeout. This allows us to do redirects without sending error messages.

# Issue Description

## The problem

When in the onboarding process if the user clicks the PayPal buttons on the PayPal popup too fast when he returns to the website sometimes the onboarding will fail.

## Steps To Reproduce

1. In Settings > Connection tab click `Disconnect Account`
4. Start a new onboarding process clicking the PayPal popup buttons as fast as possible.
5. When returning to the website there is a change the onboaring will fail.
6. note: sometime an error message will be shown but the onboarding will succeed (check if four connection fields are filled).

## Expected behaviour

Onboarding quickly wont cause errors nor errors messages are incorrectly shown.

## Possible cause

There are two factors involved in this behaviour:

1. The onboarding fails due to a race condition between `\WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsListener::listen_for_merchant_id` and `\WooCommerce\PayPalCommerce\Onboarding\Endpoint\LoginSellerEndpoint::handle_request`
3. The incorrect error message is shown due to multiple calls (redirects) of PayPal to `\WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsListener::listen_for_merchant_id` with the same token, which until now should be used once.

```
1st call
2023-07-31T13:30:05+00:00 DEBUG Validating onboarding ppcpToken: eyJrIjo...
2023-07-31T13:30:05+00:00 INFO Validated onboarding ppcpToken: eyJrIjo...

2nd call
2023-07-31T13:30:06+00:00 DEBUG Validating onboarding ppcpToken: eyJrIjo...
2023-07-31T13:30:06+00:00 ERROR Failed to validate onboarding ppcpToken: eyJrIjo...
```

## Suggested solution

1. Retry `\WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsListener::listen_for_merchant_id` if `client_id` or `secret` not present.
4. Allow the onboarding token to be used more than once. Or at least don’t give errors.

## Workaround
For now wait a few seconds (ex: 5 seconds) before clicking the return to merchant website link on PayPal popup.