### PR TITLE
PayPal Later message price amount doesn't update dynamically. (1930)

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -148,7 +148,13 @@ const bootstrap = () => {
         miniCartBootstrap.init();
     }
 
-    if (context === 'product' && PayPalCommerceGateway.single_product_buttons_enabled === '1') {
+    if (
+        context === 'product'
+        && (
+            PayPalCommerceGateway.single_product_buttons_enabled === '1'
+            || hasMessages()
+        )
+    ) {
         const singleProductBootstrap = new SingleProductBootstap(
             PayPalCommerceGateway,
             renderer,
@@ -194,6 +200,12 @@ const bootstrap = () => {
     }
 
 };
+
+const hasMessages = () => {
+    return PayPalCommerceGateway.messages.is_hidden === false
+        && document.querySelector(PayPalCommerceGateway.messages.wrapper);
+}
+
 document.addEventListener(
     'DOMContentLoaded',
     () => {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -187,6 +187,10 @@ class SingleProductBootstap {
 
             this.messages.renderWithAmount(data.total);
 
+            if ( this.gateway.single_product_buttons_enabled !== '1' ) {
+                return;
+            }
+
             let enableFunding = this.gateway.url_params['enable-funding'];
             let disableFunding = this.gateway.url_params['disable-funding'];
 


### PR DESCRIPTION
# PR Description

The reloading of messages is handled by the different Button `ContextBootstrap`s.
This issue fixes the dynamic reloading of Messages when Messages are present on Single Product Page but without Buttons present.

# Issue Description

We've identified a problem where the amount displayed in PayPal messages does not automatically adjust when a different product variant is chosen by a user. This anomaly was reported in 2 tickets. Tested with the recent update. 

## Steps To Reproduce

To reproduce this issue, you can follow the steps below:

* Visit the website
* Select a dimension from the available options.
* Then choose another dimension from the available options.
* Observe the PayPal message.

Actual Result: The price in the PayPal Later Message does not update according to the selected dimensions.

## Expected behaviour

The price in the PayPal Later Message should dynamically change to reflect the cost based on the selected dimensions.
