### PR TITLE
improve invalid currency backend notice (1926)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,9 +12,6 @@ jobs:
 
     name: PHP ${{ matrix.php-versions }} WC ${{ matrix.wc-versions }}
     steps:
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-
     - uses: ddev/github-action-setup-ddev@v1
       with:
         autostart: false

--- a/modules/ppcp-admin-notices/src/Entity/Message.php
+++ b/modules/ppcp-admin-notices/src/Entity/Message.php
@@ -36,16 +36,25 @@ class Message {
 	private $dismissable;
 
 	/**
+	 * The wrapper selector that will contain the notice.
+	 *
+	 * @var string
+	 */
+	private $wrapper;
+
+	/**
 	 * Message constructor.
 	 *
 	 * @param string $message The message text.
 	 * @param string $type The message type.
 	 * @param bool   $dismissable Whether the message is dismissable.
+	 * @param string $wrapper The wrapper selector that will contain the notice.
 	 */
-	public function __construct( string $message, string $type, bool $dismissable = true ) {
+	public function __construct( string $message, string $type, bool $dismissable = true, string $wrapper = '' ) {
 		$this->type        = $type;
 		$this->message     = $message;
 		$this->dismissable = $dismissable;
+		$this->wrapper     = $wrapper;
 	}
 
 	/**
@@ -73,5 +82,14 @@ class Message {
 	 */
 	public function is_dismissable(): bool {
 		return $this->dismissable;
+	}
+
+	/**
+	 * Returns the wrapper selector that will contain the notice.
+	 *
+	 * @return string
+	 */
+	public function wrapper(): string {
+		return $this->wrapper;
 	}
 }

--- a/modules/ppcp-admin-notices/src/Renderer/Renderer.php
+++ b/modules/ppcp-admin-notices/src/Renderer/Renderer.php
@@ -44,7 +44,7 @@ class Renderer implements RendererInterface {
 				'<div class="notice notice-%s %s" %s><p>%s</p></div>',
 				$message->type(),
 				( $message->is_dismissable() ) ? 'is-dismissible' : '',
-				$message->wrapper() ? sprintf('data-ppcp-wrapper="%s"', $message->wrapper()) : '',
+				( $message->wrapper() ? sprintf( 'data-ppcp-wrapper="%s"', esc_attr( $message->wrapper() ) ) : '' ),
 				wp_kses_post( $message->message() )
 			);
 		}

--- a/modules/ppcp-admin-notices/src/Renderer/Renderer.php
+++ b/modules/ppcp-admin-notices/src/Renderer/Renderer.php
@@ -41,9 +41,10 @@ class Renderer implements RendererInterface {
 		$messages = $this->repository->current_message();
 		foreach ( $messages as $message ) {
 			printf(
-				'<div class="notice notice-%s %s"><p>%s</p></div>',
+				'<div class="notice notice-%s %s" %s><p>%s</p></div>',
 				$message->type(),
 				( $message->is_dismissable() ) ? 'is-dismissible' : '',
+				$message->wrapper() ? sprintf('data-ppcp-wrapper="%s"', $message->wrapper()) : '',
 				wp_kses_post( $message->message() )
 			);
 		}

--- a/modules/ppcp-wc-gateway/resources/js/common.js
+++ b/modules/ppcp-wc-gateway/resources/js/common.js
@@ -1,0 +1,10 @@
+import moveWrappedElements from "./common/wrapped-elements";
+document.addEventListener(
+    'DOMContentLoaded',
+    () => {
+        // Wait for current execution context to end.
+        setTimeout(function () {
+            moveWrappedElements();
+        }, 0);
+    }
+);

--- a/modules/ppcp-wc-gateway/resources/js/common/wrapped-elements.js
+++ b/modules/ppcp-wc-gateway/resources/js/common/wrapped-elements.js
@@ -1,0 +1,14 @@
+
+// This function is needed because WordPress moves our custom notices to the global placeholder.
+function moveWrappedElements() {
+    (($) => {
+        $('*[data-ppcp-wrapper]').each(function() {
+            let $wrapper = $('.' + $(this).data('ppcpWrapper'));
+            if ($wrapper.length) {
+                $wrapper.append(this);
+            }
+        });
+    })(jQuery)
+}
+
+export default moveWrappedElements;

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -211,10 +211,18 @@ return array(
 		return new ConnectAdminNotice( $state, $settings );
 	},
 	'wcgateway.notice.currency-unsupported'                => static function ( ContainerInterface $container ): UnsupportedCurrencyAdminNotice {
-		$state = $container->get( 'onboarding.state' );
-		$shop_currency = $container->get( 'api.shop.currency' );
-		$supported_currencies = $container->get( 'api.supported-currencies' );
-		return new UnsupportedCurrencyAdminNotice( $state, $shop_currency, $supported_currencies );
+		$state                    = $container->get( 'onboarding.state' );
+		$shop_currency            = $container->get( 'api.shop.currency' );
+		$supported_currencies     = $container->get( 'api.supported-currencies' );
+		$is_wc_gateways_list_page = $container->get( 'wcgateway.is-wc-gateways-list-page' );
+		$is_ppcp_settings_page    = $container->get( 'wcgateway.is-ppcp-settings-page' );
+		return new UnsupportedCurrencyAdminNotice(
+			$state,
+			$shop_currency,
+			$supported_currencies,
+			$is_wc_gateways_list_page,
+			$is_ppcp_settings_page
+		);
 	},
 	'wcgateway.notice.dcc-without-paypal'                  => static function ( ContainerInterface $container ): GatewayWithoutPayPalAdminNotice {
 		return new GatewayWithoutPayPalAdminNotice(

--- a/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
@@ -88,6 +88,13 @@ class SettingsPageAssets {
 	protected $all_funding_sources;
 
 	/**
+	 * Whether it's a settings page of this plugin.
+	 *
+	 * @var bool
+	 */
+	private $is_settings_page;
+
+	/**
 	 * Assets constructor.
 	 *
 	 * @param string             $module_url The url of this module.
@@ -100,6 +107,7 @@ class SettingsPageAssets {
 	 * @param bool               $is_pay_later_button_enabled Whether Pay Later button is enabled either for checkout, cart or product page.
 	 * @param array              $disabled_sources The list of disabled funding sources.
 	 * @param array              $all_funding_sources The list of all existing funding sources.
+	 * @param bool               $is_settings_page Whether it's a settings page of this plugin.
 	 */
 	public function __construct(
 		string $module_url,
@@ -111,7 +119,8 @@ class SettingsPageAssets {
 		Environment $environment,
 		bool $is_pay_later_button_enabled,
 		array $disabled_sources,
-		array $all_funding_sources
+		array $all_funding_sources,
+		bool $is_settings_page
 	) {
 		$this->module_url                  = $module_url;
 		$this->version                     = $version;
@@ -123,6 +132,7 @@ class SettingsPageAssets {
 		$this->is_pay_later_button_enabled = $is_pay_later_button_enabled;
 		$this->disabled_sources            = $disabled_sources;
 		$this->all_funding_sources         = $all_funding_sources;
+		$this->is_settings_page            = $is_settings_page;
 	}
 
 	/**
@@ -136,11 +146,13 @@ class SettingsPageAssets {
 					return;
 				}
 
-				if ( ! $this->is_paypal_payment_method_page() ) {
-					return;
+				if ( $this->is_settings_page ) {
+					$this->register_admin_assets();
 				}
 
-				$this->register_admin_assets();
+				if ( $this->is_paypal_payment_method_page() ) {
+					$this->register_paypal_admin_assets();
+				}
 			}
 		);
 
@@ -171,9 +183,9 @@ class SettingsPageAssets {
 	}
 
 	/**
-	 * Register assets for admin pages.
+	 * Register assets for PayPal admin pages.
 	 */
-	private function register_admin_assets(): void {
+	private function register_paypal_admin_assets(): void {
 		wp_enqueue_style(
 			'ppcp-gateway-settings',
 			trailingslashit( $this->module_url ) . 'assets/css/gateway-settings.css',
@@ -210,4 +222,18 @@ class SettingsPageAssets {
 			)
 		);
 	}
+
+	/**
+	 * Register assets for PayPal admin pages.
+	 */
+	private function register_admin_assets(): void {
+		wp_enqueue_script(
+			'ppcp-admin-common',
+			trailingslashit( $this->module_url ) . 'assets/js/common.js',
+			array(),
+			$this->version,
+			true
+		);
+	}
+
 }

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -60,6 +60,8 @@ class UnsupportedCurrencyAdminNotice {
 	 * @param State  $state The state.
 	 * @param string $shop_currency The shop currency.
 	 * @param array  $supported_currencies The supported currencies.
+	 * @param bool   $is_wc_gateways_list_page Indicates if we're on the WooCommerce gateways list page.
+	 * @param bool   $is_ppcp_settings_page Indicates if we're on a PPCP Settings page.
 	 */
 	public function __construct(
 		State $state,
@@ -109,7 +111,7 @@ class UnsupportedCurrencyAdminNotice {
 	protected function should_display(): bool {
 		return $this->state->current_state() === State::STATE_ONBOARDED
 			&& ! $this->currency_supported()
-			&& ($this->is_wc_gateways_list_page || $this->is_ppcp_settings_page);
+			&& ( $this->is_wc_gateways_list_page || $this->is_ppcp_settings_page );
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -41,16 +41,39 @@ class UnsupportedCurrencyAdminNotice {
 	private $shop_currency;
 
 	/**
+	 * Indicates if we're on the WooCommerce gateways list page.
+	 *
+	 * @var bool
+	 */
+	private $is_wc_gateways_list_page;
+
+	/**
+	 * Indicates if we're on a PPCP Settings page.
+	 *
+	 * @var bool
+	 */
+	private $is_ppcp_settings_page;
+
+	/**
 	 * UnsupportedCurrencyAdminNotice constructor.
 	 *
 	 * @param State  $state The state.
 	 * @param string $shop_currency The shop currency.
 	 * @param array  $supported_currencies The supported currencies.
 	 */
-	public function __construct( State $state, string $shop_currency, array $supported_currencies ) {
-		$this->state                = $state;
-		$this->shop_currency        = $shop_currency;
-		$this->supported_currencies = $supported_currencies;
+	public function __construct(
+		State $state,
+		string $shop_currency,
+		array $supported_currencies,
+		bool $is_wc_gateways_list_page,
+		bool $is_ppcp_settings_page
+	) {
+		$this->state                    = $state;
+		$this->shop_currency            = $shop_currency;
+		$this->supported_currencies     = $supported_currencies;
+		$this->is_wc_gateways_list_page = $is_wc_gateways_list_page;
+		$this->is_ppcp_settings_page    = $is_ppcp_settings_page;
+
 	}
 
 	/**
@@ -63,16 +86,19 @@ class UnsupportedCurrencyAdminNotice {
 			return null;
 		}
 
+		$paypal_currency_support_url = 'https://developer.paypal.com/api/rest/reference/currency-codes/';
+
 		$message = sprintf(
-			/* translators: %1$s the shop currency, 2$s the gateway name. */
+			/* translators: %1$s the shop currency, %2$s the PayPal currency support page link opening HTML tag, %3$s the link ending HTML tag. */
 			__(
-				'Attention: Your current WooCommerce store currency (%1$s) is not supported by PayPal. Please update your store currency to one that is supported by PayPal to ensure smooth transactions. Visit the <a href="%2$s">PayPal currency support page</a> for more information on supported currencies.',
+				'Attention: Your current WooCommerce store currency (%1$s) is not supported by PayPal. Please update your store currency to one that is supported by PayPal to ensure smooth transactions. Visit the %2$sPayPal currency support page%3$s for more information on supported currencies.',
 				'woocommerce-paypal-payments'
 			),
 			$this->shop_currency,
-			'https://developer.paypal.com/api/rest/reference/currency-codes/'
+			'<a href="' . esc_url( $paypal_currency_support_url ) . '">',
+			'</a>'
 		);
-		return new Message( $message, 'warning' );
+		return new Message( $message, 'warning', true, 'ppcp-notice-wrapper' );
 	}
 
 	/**
@@ -81,7 +107,9 @@ class UnsupportedCurrencyAdminNotice {
 	 * @return bool
 	 */
 	protected function should_display(): bool {
-		return $this->state->current_state() === State::STATE_ONBOARDED && ! $this->currency_supported();
+		return $this->state->current_state() === State::STATE_ONBOARDED
+			&& ! $this->currency_supported()
+			&& ($this->is_wc_gateways_list_page || $this->is_ppcp_settings_page);
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
@@ -77,6 +77,8 @@ class HeaderRenderer {
 					'</a>
 				</span>
 			</div>
+
+			<div class="ppcp-notice-wrapper"></div>
 		';
 	}
 }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -183,7 +183,8 @@ class WCGatewayModule implements ModuleInterface {
 				$c->get( 'onboarding.environment' ),
 				$settings_status->is_pay_later_button_enabled(),
 				$settings->has( 'disable_funding' ) ? $settings->get( 'disable_funding' ) : array(),
-				$c->get( 'wcgateway.settings.funding-sources' )
+				$c->get( 'wcgateway.settings.funding-sources' ),
+				$c->get( 'wcgateway.is-ppcp-settings-page' )
 			);
 			$assets->register_assets();
 		}

--- a/modules/ppcp-wc-gateway/webpack.config.js
+++ b/modules/ppcp-wc-gateway/webpack.config.js
@@ -6,6 +6,7 @@ module.exports = {
     mode: isProduction ? 'production' : 'development',
     target: 'web',
     entry: {
+        'common': path.resolve('./resources/js/common.js'),
         'gateway-settings': path.resolve('./resources/js/gateway-settings.js'),
         'fraudnet': path.resolve('./resources/js/fraudnet.js'),
         'oxxo': path.resolve('./resources/js/oxxo.js'),

--- a/tests/PHPUnit/WcGateway/Assets/SettingsPagesAssetsTest.php
+++ b/tests/PHPUnit/WcGateway/Assets/SettingsPagesAssetsTest.php
@@ -27,8 +27,9 @@ class SettingsPagesAssetsTest extends TestCase
 			Mockery::mock(Environment::class),
             true,
             array(),
-            array()
-        );
+            array(),
+			true
+		);
 
 		when('is_admin')
 			->justReturn(true);


### PR DESCRIPTION
# PR Description

This PR restrict the rendering of the unsupported currency notice to the WooCommerce payments gateway listing page and the PPCP settings pages.

Since we don't have a script that is included on every PPCP settings page, it introduces a `common.js` for that.

WordPress tries to move all notices to it's default location, the javascript in this PR tries to move the notice to a wrapper of our choosing, but if it fails the notice is still rendered correctly on the default location.

# Issue Description

When an unsupported currency is configured, we currently display an admin notice across the entire WP-Admin backend. This notice should be more specific and only appear on the WooCommerce Payments settings tab and the PayPal Payments settings pages.

Additionally, there are issues with the translator comment and the localization string:
* The translator comment states "2$s the gateway name," but this is incorrect as it refers to the link to the PayPal docs, not the gateway name.
* The localization string does not follow best practices as it includes HTML tags inside the string. This makes translating it more difficult.

## Steps to reproduce
1. Enable PayPal Payments
2. Navigate to WooCommerce > Settings and configure a PayPal that PayPal does not support. E.g. South African rand (ZAR)
3. Observe the presence of the aforementioned notice across all areas of the wp-admin backend.

## Expected Result
* The notice should only be displayed on the WooCommerce Payments settings tab and all PayPal Payments settings pages.
* The placement of the notice on the PayPal Payments settings pages should be between the PayPal logo and settings tabs as seen in the attachment.
* The translator comment should correctly describe the 2$s placeholder.
* The localization string should not include HTML tags to adhere to best practices.

## Suggested Solution
* Modify the code to limit the display of this notice only to the WooCommerce Payments settings tab and the PayPal Payments settings pages.
* Correct the translator comment to accurately reflect what 2$s is.
* Revise the localization string to remove HTML tags and follow best practices for easier translation.

## Additional Information
The desired placement of the notice is between the PayPal logo and our custom settings tabs.