### PR TITLE
Release 2.2.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,25 @@
 *** Changelog ***
 
+= 2.2.1 - xxxx-xx-xx =
+* Fix - One-page checkout causes mini cart not showing the PP button on certain pages #1536
+* Fix - When onboarding loading the return_url too fast may cause the onboarding to fail #1565
+* Fix - PayPal button doesn't work for variable products on product page after recent 2.2.0 release #1533
+* Fix - Send payee_preferred correctly for instant payments #1489
+* Fix - Auto-disabled ACDC vaulting after updating to 2.1.0 #1490
+* Fix - Paypal Payments serializing formData of array inputs #1501
+* Fix - Buttons not working on single product page for WooCommerce Bookings product #1478
+* Enhancement - PayPal Later message price amount doesn't update dynamically #1585
+* Enhancement - Improve WC order creation in webhook #1530
+* Enhancement - Refactor hosted fields for early card detection #1554
+* Enhancement - Pay Later button and message get hidden when product/cart/checkout value is outside of range #1511
+* Enhancement - Add link to manual credential docs #1430
+* Enhancement - Validate Merchant ID field format when saving settings #1509
+* Enhancement - Include soft descriptor for card's activity #1427
+* Enhancement - Update Pay Later amount on the cart page and checkout when total changes #1441
+* Enhancement - Log Subscription Mode configuration in system report #1507
+* Enhancement - HPOS compatibility issues #1555
+* Feature preview - PayPal Subscriptions API fixes and improvements #1443
+
 = 2.2.0 - 2023-07-17 =
 * Fix - Improve handling of APM payments when buyer did not return to Checkout #1233
 * Fix - Use order currency instead of shop currency on order-pay page #1363

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@
 * Fix - PayPal button doesn't work for variable products on product page after recent 2.2.0 release #1533
 * Fix - Send payee_preferred correctly for instant payments #1489
 * Fix - Auto-disabled ACDC vaulting after updating to 2.1.0 #1490
-* Fix - Paypal Payments serializing formData of array inputs #1501
+* Fix - PayPal Payments serializing formData of array inputs #1501
 * Fix - Buttons not working on single product page for WooCommerce Bookings product #1478
 * Enhancement - PayPal Later message price amount doesn't update dynamically #1585
 * Enhancement - Improve WC order creation in webhook #1530

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: woocommerce, automattic, inpsyde
 Tags: woocommerce, paypal, payments, ecommerce, e-commerce, store, sales, sell, shop, shopping, cart, checkout
 Requires at least: 5.3
-Tested up to: 6.2
+Tested up to: 6.3
 Requires PHP: 7.2
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -80,6 +80,26 @@ Follow the steps below to connect the plugin to your PayPal account:
 6. Main settings screen.
 
 == Changelog ==
+
+= 2.2.1 - xxxx-xx-xx =
+* Fix - One-page checkout causes mini cart not showing the PP button on certain pages #1536
+* Fix - When onboarding loading the return_url too fast may cause the onboarding to fail #1565
+* Fix - PayPal button doesn't work for variable products on product page after recent 2.2.0 release #1533
+* Fix - Send payee_preferred correctly for instant payments #1489
+* Fix - Auto-disabled ACDC vaulting after updating to 2.1.0 #1490
+* Fix - Paypal Payments serializing formData of array inputs #1501
+* Fix - Buttons not working on single product page for WooCommerce Bookings product #1478
+* Enhancement - PayPal Later message price amount doesn't update dynamically #1585
+* Enhancement - Improve WC order creation in webhook #1530
+* Enhancement - Refactor hosted fields for early card detection #1554
+* Enhancement - Pay Later button and message get hidden when product/cart/checkout value is outside of range #1511
+* Enhancement - Add link to manual credential docs #1430
+* Enhancement - Validate Merchant ID field format when saving settings #1509
+* Enhancement - Include soft descriptor for card's activity #1427
+* Enhancement - Update Pay Later amount on the cart page and checkout when total changes #1441
+* Enhancement - Log Subscription Mode configuration in system report #1507
+* Enhancement - HPOS compatibility issues #1555
+* Feature preview - PayPal Subscriptions API fixes and improvements #1443
 
 = 2.2.0 - 2023-07-17 =
 * Fix - Improve handling of APM payments when buyer did not return to Checkout #1233

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ Follow the steps below to connect the plugin to your PayPal account:
 * Fix - PayPal button doesn't work for variable products on product page after recent 2.2.0 release #1533
 * Fix - Send payee_preferred correctly for instant payments #1489
 * Fix - Auto-disabled ACDC vaulting after updating to 2.1.0 #1490
-* Fix - Paypal Payments serializing formData of array inputs #1501
+* Fix - PayPal Payments serializing formData of array inputs #1501
 * Fix - Buttons not working on single product page for WooCommerce Bookings product #1478
 * Enhancement - PayPal Later message price amount doesn't update dynamically #1585
 * Enhancement - Improve WC order creation in webhook #1530

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,13 +3,13 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     2.2.0
+ * Version:     2.2.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.2
  * WC requires at least: 3.9
- * WC tested up to: 7.8
+ * WC tested up to: 8.0
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce
@@ -23,7 +23,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 define( 'PAYPAL_API_URL', 'https://api.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2023-07-06' );
+define( 'PAYPAL_INTEGRATION_DATE', '2023-08-11' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );
 ! defined( 'CONNECT_WOO_SANDBOX_CLIENT_ID' ) && define( 'CONNECT_WOO_SANDBOX_CLIENT_ID', 'AYmOHbt1VHg-OZ_oihPdzKEVbU3qg0qXonBcAztuzniQRaKE0w1Hr762cSFwd4n8wxOl-TCWohEa0XM_' );


### PR DESCRIPTION
* Fix - One-page checkout causes mini cart not showing the PP button on certain pages #1536
* Fix - When onboarding loading the return_url too fast may cause the onboarding to fail #1565
* Fix - PayPal button doesn't work for variable products on product page after recent 2.2.0 release #1533
* Fix - Send payee_preferred correctly for instant payments #1489
* Fix - Auto-disabled ACDC vaulting after updating to 2.1.0 #1490
* Fix - PayPal Payments serializing formData of array inputs #1501
* Fix - Buttons not working on single product page for WooCommerce Bookings product #1478
* Enhancement - PayPal Later message price amount doesn't update dynamically #1585
* Enhancement - Improve WC order creation in webhook #1530
* Enhancement - Refactor hosted fields for early card detection #1554
* Enhancement - Pay Later button and message get hidden when product/cart/checkout value is outside of range #1511
* Enhancement - Add link to manual credential docs #1430
* Enhancement - Validate Merchant ID field format when saving settings #1509
* Enhancement - Include soft descriptor for card's activity #1427
* Enhancement - Update Pay Later amount on the cart page and checkout when total changes #1441
* Enhancement - Log Subscription Mode configuration in system report #1507
* Enhancement - HPOS compatibility issues #1555
* Feature preview - PayPal Subscriptions API fixes and improvements #1443