### PR TITLE
Ensure all metaboxes are HPOS compatible (1942)

### DIFF
--- a/modules/ppcp-compat/src/AdminContextTrait.php
+++ b/modules/ppcp-compat/src/AdminContextTrait.php
@@ -20,7 +20,7 @@ trait AdminContextTrait {
 	 * @return bool
 	 */
 	private function is_paypal_order_edit_page(): bool {
-		$post_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) );
+		$post_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! $post_id ) {
 			return false;
 		}

--- a/modules/ppcp-compat/src/AdminContextTrait.php
+++ b/modules/ppcp-compat/src/AdminContextTrait.php
@@ -20,7 +20,7 @@ trait AdminContextTrait {
 	 * @return bool
 	 */
 	private function is_paypal_order_edit_page(): bool {
-		$post_id = isset( $_GET['post'] ) ? (int) $_GET['post'] : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$post_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) );
 		if ( ! $post_id ) {
 			return false;
 		}

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use WooCommerce\PayPalCommerce\Compat\AdminContextTrait;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
@@ -102,7 +103,16 @@ class OrderTrackingModule implements ModuleInterface {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function( $post_type ) use ( $c ) {
-				if ( $post_type !== 'shop_order' || ! $this->is_paypal_order_edit_page() ) {
+				/**
+				 * Class and function exist in WooCommerce.
+				 *
+				 * @psalm-suppress UndefinedClass
+				 * @psalm-suppress UndefinedFunction
+				 */
+				$screen = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+					? wc_get_page_screen_id( 'shop-order' )
+					: 'shop_order';
+				if ( $post_type !== $screen || ! $this->is_paypal_order_edit_page() ) {
 					return;
 				}
 
@@ -111,7 +121,7 @@ class OrderTrackingModule implements ModuleInterface {
 					'ppcp_order-tracking',
 					__( 'Tracking Information', 'woocommerce-paypal-payments' ),
 					array( $meta_box_renderer, 'render' ),
-					'shop_order',
+					$screen,
 					'side'
 				);
 			},

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -109,7 +109,7 @@ class OrderTrackingModule implements ModuleInterface {
 				 * @psalm-suppress UndefinedClass
 				 * @psalm-suppress UndefinedFunction
 				 */
-				$screen = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+				$screen = class_exists( CustomOrdersTableController::class ) && wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
 					? wc_get_page_screen_id( 'shop-order' )
 					: 'shop_order';
 				if ( $post_type !== $screen || ! $this->is_paypal_order_edit_page() ) {

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -227,12 +227,21 @@ class SubscriptionModule implements ModuleInterface {
 
 		add_action(
 			'add_meta_boxes',
-			function( string $post_type, WP_Post $post ) use ( $c ) {
-				if ( $post_type !== 'shop_subscription' ) {
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function( string $post_type, $post_or_order_object ) use ( $c ) {
+				$order = ( $post_or_order_object instanceof WP_Post )
+					? wc_get_order( $post_or_order_object->ID )
+					: $post_or_order_object;
+
+				if ( ! is_a( $order, WC_Order::class ) ) {
 					return;
 				}
 
-				$subscription = wcs_get_subscription( $post->ID );
+				$subscription = wcs_get_subscription( $order->get_id() );
 				if ( ! is_a( $subscription, WC_Subscription::class ) ) {
 					return;
 				}

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
@@ -161,7 +161,7 @@ class OXXO {
 				 * @psalm-suppress UndefinedClass
 				 * @psalm-suppress UndefinedFunction
 				 */
-				$screen = class_exists(CustomOrdersTableController::class) && wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+				$screen = class_exists( CustomOrdersTableController::class ) && wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
 					? wc_get_page_screen_id( 'shop-order' )
 					: 'shop_order';
 

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
@@ -161,7 +161,7 @@ class OXXO {
 				 * @psalm-suppress UndefinedClass
 				 * @psalm-suppress UndefinedFunction
 				 */
-				$screen = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+				$screen = class_exists(CustomOrdersTableController::class) && wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
 					? wc_get_page_screen_id( 'shop-order' )
 					: 'shop_order';
 

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -519,7 +519,7 @@ class PayUponInvoice {
 				 * @psalm-suppress UndefinedClass
 				 * @psalm-suppress UndefinedFunction
 				 */
-				$screen = wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
+				$screen = class_exists( CustomOrdersTableController::class ) && wc_get_container()->get( CustomOrdersTableController::class )->custom_orders_table_usage_is_enabled()
 					? wc_get_page_screen_id( 'shop-order' )
 					: 'shop_order';
 


### PR DESCRIPTION
In #1561 we added HPOS compatibility to some parts of the code, this PR ensures that all metaboxes have compatibility with [HPOS admin screens](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book#audit-for-order-administration-screen-functions).