### PR TITLE
Apply Capture On Status Change only when order contains PayPal payment method (1906)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,9 +12,6 @@ jobs:
 
     name: PHP ${{ matrix.php-versions }} WC ${{ matrix.wc-versions }}
     steps:
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-
     - uses: ddev/github-action-setup-ddev@v1
       with:
         autostart: false

--- a/modules/ppcp-subscription/src/RenewalHandler.php
+++ b/modules/ppcp-subscription/src/RenewalHandler.php
@@ -226,7 +226,7 @@ class RenewalHandler {
 	 * @param \WC_Customer $customer The customer.
 	 * @param \WC_Order    $wc_order The current WooCommerce order we want to process.
 	 *
-	 * @return PaymentToken|null
+	 * @return PaymentToken|null|false
 	 */
 	private function get_token_for_customer( \WC_Customer $customer, \WC_Order $wc_order ) {
 		/**

--- a/modules/ppcp-wc-gateway/src/Gateway/GatewayRepository.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/GatewayRepository.php
@@ -44,4 +44,14 @@ class GatewayRepository {
 			}
 		);
 	}
+
+	/**
+	 * Indicates if a given gateway ID is registered.
+	 *
+	 * @param string $gateway_id The gateway ID.
+	 * @return bool
+	 */
+	public function exists( string $gateway_id ): bool {
+		return in_array( $gateway_id, $this->ppcp_gateway_ids, true );
+	}
 }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -33,6 +33,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Checkout\DisableGateways;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\GatewayRepository;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
@@ -352,6 +353,14 @@ class WCGatewayModule implements ModuleInterface {
 				assert( $settings instanceof ContainerInterface );
 
 				if ( ! $settings->has( 'capture_on_status_change' ) || ! $settings->get( 'capture_on_status_change' ) ) {
+					return;
+				}
+
+				$gateway_repository = $c->get( 'wcgateway.gateway-repository' );
+				assert( $gateway_repository instanceof GatewayRepository );
+
+				// Only allow to proceed if the payment method is one of our Gateways.
+				if ( ! $gateway_repository->exists( $wc_order->get_payment_method() ) ) {
 					return;
 				}
 


### PR DESCRIPTION
# Issue Description
Only allow to proceed with `woocommerce_order_status_changed` filter, if the payment gateway for the WC Order is one of our Gateways.

# PR Description
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/80bb2f80-f532-4e40-a540-79d12d297257)

* Should only trigger when changing an order status and PCP is the active payment method of this order

## The problem
* payment via PayPal failed
* customer came back and tried to pay for the same order with another payment provider
* this payment was successful
* but the WooCommerce order remains in status Failed
* order status cannot be manually changed