### PR TITLE
Order page is broken when WC Subscriptions is deactivated (1947)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,9 +12,6 @@ jobs:
 
     name: PHP ${{ matrix.php-versions }} WC ${{ matrix.wc-versions }}
     steps:
-    - uses: satackey/action-docker-layer-caching@v0.0.11
-      continue-on-error: true
-
     - uses: ddev/github-action-setup-ddev@v1
       with:
         autostart: false

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -233,6 +233,10 @@ class SubscriptionModule implements ModuleInterface {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function( string $post_type, $post_or_order_object ) use ( $c ) {
+				if ( ! function_exists( 'wcs_get_subscription' ) ) {
+					return;
+				}
+
 				$order = ( $post_or_order_object instanceof WP_Post )
 					? wc_get_order( $post_or_order_object->ID )
 					: $post_or_order_object;

--- a/modules/ppcp-vaulting/src/PaymentTokenChecker.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenChecker.php
@@ -215,11 +215,11 @@ class PaymentTokenChecker {
 		$wc_order->update_status( 'failed', $error_message );
 
 		/**
-		 * Function already exist in Subscription plugin
+		 * Function already exist in WC Subscriptions plugin.
 		 *
 		 * @psalm-suppress UndefinedFunction
 		 */
-		$subscriptions = wcs_get_subscriptions_for_order( $wc_order->get_id() );
+		$subscriptions = function_exists( 'wcs_get_subscriptions_for_order' ) ? wcs_get_subscriptions_for_order( $wc_order->get_id() ) : array();
 		foreach ( $subscriptions as $key => $subscription ) {
 			if ( $subscription->get_parent_id() === $wc_order->get_id() ) {
 				try {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -525,7 +525,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 				$order = $this->session_handler->order();
 				$this->add_paypal_meta( $wc_order, $order, $this->environment );
 
-				$subscriptions = wcs_get_subscriptions_for_order( $order_id );
+				$subscriptions = function_exists( 'wcs_get_subscriptions_for_order' ) ? wcs_get_subscriptions_for_order( $order_id ) : array();
 				foreach ( $subscriptions as $subscription ) {
 					$subscription->update_meta_data( 'ppcp_subscription', $paypal_subscription_id );
 					$subscription->save();

--- a/modules/ppcp-webhooks/src/Handler/BillingSubscriptionCancelled.php
+++ b/modules/ppcp-webhooks/src/Handler/BillingSubscriptionCancelled.php
@@ -81,7 +81,7 @@ class BillingSubscriptionCancelled implements RequestHandler {
 					),
 				),
 			);
-			$subscriptions = wcs_get_subscriptions( $args );
+			$subscriptions = function_exists( 'wcs_get_subscriptions' ) ? wcs_get_subscriptions( $args ) : array();
 			foreach ( $subscriptions as $subscription ) {
 				$subscription->update_status( 'cancelled' );
 			}

--- a/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
@@ -71,10 +71,13 @@ class PaymentSaleCompleted implements RequestHandler {
 			return $this->failure_response();
 		}
 
+		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
+			return $this->failure_response( 'WooCommerce Subscriptions plugin is not active.' );
+		}
+
 		$billing_agreement_id = wc_clean( wp_unslash( $request['resource']['billing_agreement_id'] ?? '' ) );
 		if ( ! $billing_agreement_id ) {
-			$message = 'Could not retrieve billing agreement id for subscription.';
-			return $this->failure_response( $message );
+			return $this->failure_response( 'Could not retrieve billing agreement id for subscription.' );
 		}
 
 		$args          = array(


### PR DESCRIPTION
When merchant visit Order page for the order created during payment, critical error is displayed.

### Steps to reproduce

- Disable WC Subscriptions plugin
- Make an order with any payment method
- Visit the order page for the order created after payment