### PR TITLE
Subscriptions API renewals (1936)

### DIFF
--- a/modules/ppcp-subscription/src/RenewalHandler.php
+++ b/modules/ppcp-subscription/src/RenewalHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Subscription;
 
+use WC_Subscription;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
@@ -139,8 +140,16 @@ class RenewalHandler {
 	 *
 	 * @param \WC_Order $wc_order The WooCommerce order.
 	 */
-	public function renew( \WC_Order $wc_order ) {
+	public function renew( \WC_Order $wc_order ): void {
 		try {
+			$subscription = wcs_get_subscription( $wc_order->get_id() );
+			if ( is_a( $subscription, WC_Subscription::class ) ) {
+				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
+				if ( $subscription_id ) {
+					return;
+				}
+			}
+
 			$this->process_order( $wc_order );
 		} catch ( \Exception $exception ) {
 			$error = $exception->getMessage();

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -74,6 +74,11 @@ class SubscriptionModule implements ModuleInterface {
 		add_action(
 			'woocommerce_subscription_payment_complete',
 			function ( $subscription ) use ( $c ) {
+				$paypal_subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
+				if ( $paypal_subscription_id ) {
+					return;
+				}
+
 				$payment_token_repository = $c->get( 'vaulting.repository.payment-token' );
 				$logger                   = $c->get( 'woocommerce.logger.woocommerce' );
 

--- a/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
@@ -94,9 +94,12 @@ class PaymentSaleCompleted implements RequestHandler {
 		foreach ( $subscriptions as $subscription ) {
 			$transaction_id = wc_clean( wp_unslash( $request['resource']['id'] ?? '' ) );
 			if ( $transaction_id && is_string( $transaction_id ) ) {
+				$this->logger->info( 'Creating renewal order from PAYMENT.SALE.COMPLETED webhook handler' );
 				$renewal_order = wcs_create_renewal_order( $subscription );
 				if ( is_a( $renewal_order, WC_Order::class ) ) {
+					$renewal_order->payment_complete();
 					$this->update_transaction_id( $transaction_id, $renewal_order, $this->logger );
+					$this->logger->info( 'Updating status completed and transaction id from PAYMENT.SALE.COMPLETED webhook handler' );
 				}
 			}
 		}

--- a/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
@@ -92,10 +92,24 @@ class PaymentSaleCompleted implements RequestHandler {
 		);
 		$subscriptions = wcs_get_subscriptions( $args );
 		foreach ( $subscriptions as $subscription ) {
-			$parent_order   = wc_get_order( $subscription->get_parent() );
 			$transaction_id = wc_clean( wp_unslash( $request['resource']['id'] ?? '' ) );
-			if ( $transaction_id && is_string( $transaction_id ) && is_a( $parent_order, WC_Order::class ) ) {
-				$this->update_transaction_id( $transaction_id, $parent_order, $this->logger );
+			if ( $transaction_id && is_string( $transaction_id ) ) {
+				$is_renewal = $subscription->get_meta( '_ppcp_is_subscription_renewal' ) ?? '';
+				if ( $is_renewal ) {
+					$renewal_order = wcs_create_renewal_order( $subscription );
+					if ( is_a( $renewal_order, WC_Order::class ) ) {
+						$renewal_order->payment_complete();
+						$this->update_transaction_id( $transaction_id, $renewal_order, $this->logger );
+						break;
+					}
+				}
+
+				$parent_order = wc_get_order( $subscription->get_parent() );
+				if ( is_a( $parent_order, WC_Order::class ) ) {
+					$subscription->update_meta_data( '_ppcp_is_subscription_renewal', 'true' );
+					$subscription->save_meta_data();
+					$this->update_transaction_id( $transaction_id, $parent_order, $this->logger );
+				}
 			}
 		}
 

--- a/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
@@ -92,15 +92,10 @@ class PaymentSaleCompleted implements RequestHandler {
 		);
 		$subscriptions = wcs_get_subscriptions( $args );
 		foreach ( $subscriptions as $subscription ) {
+			$parent_order   = wc_get_order( $subscription->get_parent() );
 			$transaction_id = wc_clean( wp_unslash( $request['resource']['id'] ?? '' ) );
-			if ( $transaction_id && is_string( $transaction_id ) ) {
-				$this->logger->info( 'Creating renewal order from PAYMENT.SALE.COMPLETED webhook handler' );
-				$renewal_order = wcs_create_renewal_order( $subscription );
-				if ( is_a( $renewal_order, WC_Order::class ) ) {
-					$renewal_order->payment_complete();
-					$this->update_transaction_id( $transaction_id, $renewal_order, $this->logger );
-					$this->logger->info( 'Updating status completed and transaction id from PAYMENT.SALE.COMPLETED webhook handler' );
-				}
+			if ( $transaction_id && is_string( $transaction_id ) && is_a( $parent_order, WC_Order::class ) ) {
+				$this->update_transaction_id( $transaction_id, $parent_order, $this->logger );
 			}
 		}
 

--- a/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
@@ -89,10 +89,12 @@ class PaymentSaleCompleted implements RequestHandler {
 		);
 		$subscriptions = wcs_get_subscriptions( $args );
 		foreach ( $subscriptions as $subscription ) {
-			$parent_order   = wc_get_order( $subscription->get_parent() );
 			$transaction_id = wc_clean( wp_unslash( $request['resource']['id'] ?? '' ) );
-			if ( $transaction_id && is_string( $transaction_id ) && is_a( $parent_order, WC_Order::class ) ) {
-				$this->update_transaction_id( $transaction_id, $parent_order, $this->logger );
+			if ( $transaction_id && is_string( $transaction_id ) ) {
+				$renewal_order = wcs_create_renewal_order( $subscription );
+				if ( is_a( $renewal_order, WC_Order::class ) ) {
+					$this->update_transaction_id( $transaction_id, $renewal_order, $this->logger );
+				}
 			}
 		}
 

--- a/tests/PHPUnit/Subscription/RenewalHandlerTest.php
+++ b/tests/PHPUnit/Subscription/RenewalHandlerTest.php
@@ -116,6 +116,9 @@ class RenewalHandlerTest extends TestCase
 			->andReturn(null);
 
 		$wcOrder
+			->shouldReceive('get_meta')
+			->andReturn('');
+		$wcOrder
 			->shouldReceive('get_id')
 			->andReturn(1);
 		$wcOrder

--- a/tests/PHPUnit/TestCase.php
+++ b/tests/PHPUnit/TestCase.php
@@ -38,6 +38,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
 		when('wc_clean')->returnArg();
 		when('get_transient')->returnArg();
 		when('delete_transient')->returnArg();
+		when('wcs_get_subscription')->returnArg();
 
 		setUp();
 	}


### PR DESCRIPTION
This PR handles WC Subscriptions renewals coming from PayPal `PAYMENT.SALE.COMPLETED` webhook. It prevents executing logic related to Vaulting like saving user payment or when automatic renewal is triggered from WC Subscriptions plugin.

### Acceptance Criteria
- Enable Subscriptions API feature.
- Select "Subscriptions Mode" in Standard Payments / Saved payments / Subscriptions Mode.
- Create a simple subscription product with one day billing cycle checking "Connect to PayPal" and adding a plan name.
- As customer purchase the subscription.
- After purchase a Parent Order should be created with the corresponding transaction ID. Please note that it could take some minutes until the webhook is received.
- After 24 hours the first Renewal order should be created.