### PR TITLE
Hide ACDC footer frame via CSS to avoid empty space

### DIFF
--- a/modules/ppcp-button/resources/css/hosted-fields.scss
+++ b/modules/ppcp-button/resources/css/hosted-fields.scss
@@ -15,3 +15,7 @@
 .ppcp-dcc-order-button {
 	float: right;
 }
+
+iframe[id^="hosted-fields-tokenization-frame_"] {
+	display: none;
+}


### PR DESCRIPTION
It seems like this iframe (added when ACDC is enabled) can result in some empty space being shown because of some inherited `body` CSS about fonts/text. So hiding it via `display: none`, I think it will not cause any issues, because this iframe is not supposed to be visible anyway (`width`, `height` are set to `0`).
