### PR TITLE
Do not use transient expiration longer than month to support memcached

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
@@ -135,7 +135,7 @@ class BillingAgreementsEndpoint {
 				);
 			} finally {
 				$this->is_request_logging_enabled = true;
-				set_transient( 'ppcp_reference_transaction_enabled', true, 3 * MONTH_IN_SECONDS );
+				set_transient( 'ppcp_reference_transaction_enabled', true, MONTH_IN_SECONDS );
 			}
 
 			return true;

--- a/modules/ppcp-compat/src/PPEC/PPECHelper.php
+++ b/modules/ppcp-compat/src/PPEC/PPECHelper.php
@@ -98,7 +98,7 @@ class PPECHelper {
 		set_transient(
 			'ppcp_has_ppec_subscriptions',
 			! empty( $result ) ? 'true' : 'false',
-			3 * MONTH_IN_SECONDS
+			MONTH_IN_SECONDS
 		);
 
 		return ! empty( $result );

--- a/modules/ppcp-onboarding/src/Helper/OnboardingUrl.php
+++ b/modules/ppcp-onboarding/src/Helper/OnboardingUrl.php
@@ -64,7 +64,7 @@ class OnboardingUrl {
 	 *
 	 * @var int
 	 */
-	private $cache_ttl = 3 * MONTH_IN_SECONDS;
+	private $cache_ttl = MONTH_IN_SECONDS;
 
 	/**
 	 * The TTL for the previous token cache.

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -135,12 +135,12 @@ class DCCProductStatus {
 				$this->settings->set( 'products_dcc_enabled', true );
 				$this->settings->persist();
 				$this->current_status_cache = true;
-				$this->cache->set( self::DCC_STATUS_CACHE_KEY, 'true', 3 * MONTH_IN_SECONDS );
+				$this->cache->set( self::DCC_STATUS_CACHE_KEY, 'true', MONTH_IN_SECONDS );
 				return true;
 			}
 		}
 
-		$expiration = 3 * MONTH_IN_SECONDS;
+		$expiration = MONTH_IN_SECONDS;
 		if ( $this->dcc_applies->for_country_currency() ) {
 			$expiration = 3 * HOUR_IN_SECONDS;
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -127,11 +127,11 @@ class PayUponInvoiceProductStatus {
 				$this->settings->set( 'products_pui_enabled', true );
 				$this->settings->persist();
 				$this->current_status_cache = true;
-				$this->cache->set( self::PUI_STATUS_CACHE_KEY, 'true', 3 * MONTH_IN_SECONDS );
+				$this->cache->set( self::PUI_STATUS_CACHE_KEY, 'true', MONTH_IN_SECONDS );
 				return true;
 			}
 		}
-		$this->cache->set( self::PUI_STATUS_CACHE_KEY, 'false', 3 * MONTH_IN_SECONDS );
+		$this->cache->set( self::PUI_STATUS_CACHE_KEY, 'false', MONTH_IN_SECONDS );
 
 		$this->current_status_cache = false;
 		return false;


### PR DESCRIPTION
Fixes #1448, memcached does not support expiration in seconds greater than 30 days (treats it as a unix timestamp), so now just using 1 month expiration time for transients since there was no reason to make it specifically 3 months.

A better solution could be to use some kind of permanent flags instead of transients here, since we actually do not need to re-check it even after several months, and also to provide an easy way to clear them (without the rest of the settings), but it is more complex and will take more time, so for now we can include this simple fix.