### PR TITLE
Billing agreements endpoint called too frequently for Reference Transactions check (1870)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
@@ -121,7 +121,7 @@ class BillingAgreementsEndpoint {
 	 */
 	public function reference_transaction_enabled(): bool {
 		try {
-			if ( get_transient( 'ppcp_reference_transaction_enabled' ) === true ) {
+			if ( get_transient( 'ppcp_reference_transaction_enabled' ) === '1' ) {
 				return true;
 			}
 

--- a/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
@@ -121,7 +121,7 @@ class BillingAgreementsEndpoint {
 	 */
 	public function reference_transaction_enabled(): bool {
 		try {
-			if ( get_transient( 'ppcp_reference_transaction_enabled' ) === '1' ) {
+			if ( wc_string_to_bool( get_transient( 'ppcp_reference_transaction_enabled' ) ) === true ) {
 				return true;
 			}
 


### PR DESCRIPTION
The call to the API that checks Reference Transactions availability should only happen once and then be cached for 3 months. But seemingly, this call happens more frequently, even without clearing the transient: `_transient_ppcp_reference_transaction_enabled`.

### Steps To Reproduce
- Set up PayPal Payments 2.2.0+
- Log into PayPal developer console
- Navigate WooCommerce for a while
- Observe API logs for the connected merchant account

### Possible cause
Checking transient `ppcp_reference_transaction_enabled` fails because expects a boolean `true` but receives a string `'1'`:
https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php#L124

### Suggested solution
As value is already saved as `'1'` for existing users, I suggest to just check for this value:
```
if ( get_transient( 'ppcp_reference_transaction_enabled' ) === '1' ) {
```