### PR TITLE
Include `url` & `image_url` in create order call (1912)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/Item.php
+++ b/modules/ppcp-api-client/src/Entity/Item.php
@@ -67,6 +67,20 @@ class Item {
 	private $category;
 
 	/**
+	 * The product url.
+	 *
+	 * @var string
+	 */
+	protected $url;
+
+	/**
+	 * The product image url.
+	 *
+	 * @var string
+	 */
+	protected $image_url;
+
+	/**
 	 * The tax rate.
 	 *
 	 * @var float
@@ -90,6 +104,8 @@ class Item {
 	 * @param Money|null $tax The tax.
 	 * @param string     $sku The SKU.
 	 * @param string     $category The category.
+	 * @param string     $url The product url.
+	 * @param string     $image_url The product image url.
 	 * @param float      $tax_rate The tax rate.
 	 * @param ?string    $cart_item_key The cart key for this item.
 	 */
@@ -101,6 +117,8 @@ class Item {
 		Money $tax = null,
 		string $sku = '',
 		string $category = 'PHYSICAL_GOODS',
+		string $url = '',
+		string $image_url = '',
 		float $tax_rate = 0,
 		string $cart_item_key = null
 	) {
@@ -111,8 +129,9 @@ class Item {
 		$this->description   = $description;
 		$this->tax           = $tax;
 		$this->sku           = $sku;
-		$this->category      = ( self::DIGITAL_GOODS === $category ) ? self::DIGITAL_GOODS : self::PHYSICAL_GOODS;
 		$this->category      = $category;
+		$this->url           = $url;
+		$this->image_url     = $image_url;
 		$this->tax_rate      = $tax_rate;
 		$this->cart_item_key = $cart_item_key;
 	}
@@ -181,6 +200,24 @@ class Item {
 	}
 
 	/**
+	 * Returns the url.
+	 *
+	 * @return string
+	 */
+	public function url():string {
+		return $this->url;
+	}
+
+	/**
+	 * Returns the image url.
+	 *
+	 * @return string
+	 */
+	public function image_url():string {
+		return $this->image_url;
+	}
+
+	/**
 	 * Returns the tax rate.
 	 *
 	 * @return float
@@ -211,6 +248,8 @@ class Item {
 			'description' => $this->description(),
 			'sku'         => $this->sku(),
 			'category'    => $this->category(),
+			'url'         => $this->url(),
+			'image_url'   => $this->image_url(),
 		);
 
 		if ( $this->tax() ) {

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -53,6 +53,7 @@ class ItemFactory {
 				 * @var \WC_Product $product
 				 */
 				$quantity = (int) $item['quantity'];
+				$image    = wp_get_attachment_image_src( $product->get_image_id(), 'full' );
 
 				$price = (float) $item['line_subtotal'] / (float) $item['quantity'];
 				return new Item(
@@ -63,6 +64,8 @@ class ItemFactory {
 					null,
 					$product->get_sku(),
 					( $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
+					$product->get_permalink(),
+					$image[0] ?? '',
 					0,
 					$cart_item_key
 				);
@@ -128,6 +131,7 @@ class ItemFactory {
 		$quantity                  = (int) $item->get_quantity();
 		$price_without_tax         = (float) $order->get_item_subtotal( $item, false );
 		$price_without_tax_rounded = round( $price_without_tax, 2 );
+		$image                     = wp_get_attachment_image_src( $product->get_image_id(), 'full' );
 
 		return new Item(
 			mb_substr( $item->get_name(), 0, 127 ),
@@ -136,7 +140,9 @@ class ItemFactory {
 			$product instanceof WC_Product ? $this->prepare_description( $product->get_description() ) : '',
 			null,
 			$product instanceof WC_Product ? $product->get_sku() : '',
-			( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS
+			( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
+			$product->get_permalink(),
+			$image[0] ?? ''
 		);
 	}
 
@@ -190,6 +196,8 @@ class ItemFactory {
 			: null;
 		$sku         = ( isset( $data->sku ) ) ? $data->sku : '';
 		$category    = ( isset( $data->category ) ) ? $data->category : 'PHYSICAL_GOODS';
+		$url         = ( isset( $data->url ) ) ? $data->url : '';
+		$image_url   = ( isset( $data->image_url ) ) ? $data->image_url : '';
 
 		return new Item(
 			$data->name,
@@ -198,7 +206,9 @@ class ItemFactory {
 			$description,
 			$tax,
 			$sku,
-			$category
+			$category,
+			$url,
+			$image_url
 		);
 	}
 

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -53,7 +53,7 @@ class ItemFactory {
 				 * @var \WC_Product $product
 				 */
 				$quantity = (int) $item['quantity'];
-				$image    = wp_get_attachment_image_src( $product->get_image_id(), 'full' );
+				$image    = wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' );
 
 				$price = (float) $item['line_subtotal'] / (float) $item['quantity'];
 				return new Item(
@@ -131,7 +131,7 @@ class ItemFactory {
 		$quantity                  = (int) $item->get_quantity();
 		$price_without_tax         = (float) $order->get_item_subtotal( $item, false );
 		$price_without_tax_rounded = round( $price_without_tax, 2 );
-		$image                     = wp_get_attachment_image_src( $product->get_image_id(), 'full' );
+		$image                     = $product instanceof WC_Product ? wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' ) : '';
 
 		return new Item(
 			mb_substr( $item->get_name(), 0, 127 ),
@@ -141,7 +141,7 @@ class ItemFactory {
 			null,
 			$product instanceof WC_Product ? $product->get_sku() : '',
 			( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
-			$product->get_permalink(),
+			$product instanceof WC_Product ? $product->get_permalink() : '',
 			$image[0] ?? ''
 		);
 	}

--- a/tests/PHPUnit/ApiClient/Entity/ItemTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/ItemTest.php
@@ -66,7 +66,9 @@ class ItemTest extends TestCase
             'description',
             $tax,
             'sku',
-            'PHYSICAL_GOODS'
+            'PHYSICAL_GOODS',
+			'url',
+			'image_url'
         );
 
         $expected = [
@@ -76,6 +78,8 @@ class ItemTest extends TestCase
             'description' => 'description',
             'sku' => 'sku',
             'category' => 'PHYSICAL_GOODS',
+            'url' => 'url',
+            'image_url' => 'image_url',
             'tax' => [2],
         ];
 

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -52,6 +52,14 @@ class ItemFactoryTest extends TestCase
         $woocommerce->session = $session;
         $session->shouldReceive('get')->andReturn([]);
 
+		when('wp_get_attachment_image_src')->justReturn('image_url');
+		$product
+			->expects('get_image_id')
+			->andReturn(1);
+		$product
+			->expects('get_permalink')
+			->andReturn('url');
+
         $result = $testee->from_wc_cart($cart);
 
         $this->assertCount(1, $result);
@@ -107,6 +115,13 @@ class ItemFactoryTest extends TestCase
         $woocommerce->session = $session;
         $session->shouldReceive('get')->andReturn([]);
 
+		when('wp_get_attachment_image_src')->justReturn('image_url');
+		$product
+			->expects('get_image_id')
+			->andReturn(1);
+		$product
+			->expects('get_permalink')
+			->andReturn('url');
 
         $result = $testee->from_wc_cart($cart);
 
@@ -131,6 +146,14 @@ class ItemFactoryTest extends TestCase
 
 		expect('wp_strip_all_tags')->andReturnFirstArg();
 		expect('strip_shortcodes')->andReturnFirstArg();
+
+		when('wp_get_attachment_image_src')->justReturn('image_url');
+		$product
+			->expects('get_image_id')
+			->andReturn(1);
+		$product
+			->expects('get_permalink')
+			->andReturn('url');
 
         $item = Mockery::mock(\WC_Order_Item_Product::class);
         $item
@@ -217,6 +240,14 @@ class ItemFactoryTest extends TestCase
             ->expects('get_fees')
             ->andReturn([]);
 
+		when('wp_get_attachment_image_src')->justReturn('image_url');
+		$product
+			->expects('get_image_id')
+			->andReturn(1);
+		$product
+			->expects('get_permalink')
+			->andReturn('url');
+
         $result = $testee->from_wc_order($order);
         $item = current($result);
         /**
@@ -270,6 +301,14 @@ class ItemFactoryTest extends TestCase
         $order
             ->expects('get_fees')
             ->andReturn([]);
+
+		when('wp_get_attachment_image_src')->justReturn('image_url');
+		$product
+			->expects('get_image_id')
+			->andReturn(1);
+		$product
+			->expects('get_permalink')
+			->andReturn('url');
 
         $result = $testee->from_wc_order($order);
         $item = current($result);


### PR DESCRIPTION
# PR Description
Added the `url` & `image_url` in `item`
Removed redundant `$this->category  = ( self::DIGITAL_GOODS === $category ) ? self::DIGITAL_GOODS : self::PHYSICAL_GOODS;`, cause [it was overridden](https://github.com/woocommerce/woocommerce-paypal-payments/blob/2571d31ad864622cb5649244b00fe2e8b2e51768/modules/ppcp-api-client/src/Entity/Item.php#L114-L115) on next line

# Issue Description

For the tracking v2 integration, we must include additional details in the create order call.

This additional (mandatory) information includes **Item URL** and **Image URL**. 

see [here](https://developer.paypal.com/beta/tracking/#link-createorderwithitemdetails)

## Steps To Reproduce
* Check the functionality for creating the order
