### PR TITLE
Product page PP button keep loading popup - "wc_add_to_cart_params is not defined" error in WooCommerce (1971)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Helper/CartHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/CartHelper.js
@@ -2,8 +2,17 @@ class CartHelper {
 
     constructor(cartItemKeys = [])
     {
-        this.endpoint = wc_cart_fragments_params.wc_ajax_url.toString().replace('%%endpoint%%', 'remove_from_cart');
         this.cartItemKeys = cartItemKeys;
+    }
+
+    getEndpoint() {
+        let ajaxUrl = "/?wc-ajax=%%endpoint%%";
+
+        if ((typeof wc_cart_fragments_params !== 'undefined') && wc_cart_fragments_params.wc_ajax_url) {
+            ajaxUrl = wc_cart_fragments_params.wc_ajax_url;
+        }
+
+        return ajaxUrl.toString().replace('%%endpoint%%', 'remove_from_cart');
     }
 
     addFromPurchaseUnits(purchaseUnits) {
@@ -46,7 +55,7 @@ class CartHelper {
                     continue;
                 }
 
-                fetch(this.endpoint, {
+                fetch(this.getEndpoint(), {
                     method: 'POST',
                     credentials: 'same-origin',
                     body: params


### PR DESCRIPTION
# PR Description
To handle scenarios where `wc_cart_fragments_params` my be `undefined` now:
* The endpoint has a default value and checks if `wc_cart_fragments_params` is set.
* The endpoint is only resolved when needed.

# Issue Description
Since `2.2.1` there seems to be an error in place “"wc_add_to_cart_params is not defined" 

A quick workaround would be:

```php
if (typeof wc_cart_fragments_params === 'undefined') {
	wc_cart_fragments_params = { wc_ajax_url: "/?wc-ajax=%%endpoint%%" };
}
```
or reverting to `2.2.0`.