### PR TITLE
Add compat layer for Yith tracking (1952)

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -14,7 +14,7 @@ use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
 
 return array(
 
-	'compat.ppec.mock-gateway'                      => static function( $container ) {
+	'compat.ppec.mock-gateway'                       => static function( $container ) {
 		$settings = $container->get( 'wcgateway.settings' );
 		$title    = $settings->has( 'title' ) ? $settings->get( 'title' ) : __( 'PayPal', 'woocommerce-paypal-payments' );
 		$title    = sprintf(
@@ -26,20 +26,20 @@ return array(
 		return new PPEC\MockGateway( $title );
 	},
 
-	'compat.ppec.subscriptions-handler'             => static function ( ContainerInterface $container ) {
+	'compat.ppec.subscriptions-handler'              => static function ( ContainerInterface $container ) {
 		$ppcp_renewal_handler = $container->get( 'subscription.renewal-handler' );
 		$gateway              = $container->get( 'compat.ppec.mock-gateway' );
 
 		return new PPEC\SubscriptionsHandler( $ppcp_renewal_handler, $gateway );
 	},
 
-	'compat.ppec.settings_importer'                 => static function( ContainerInterface $container ) : PPEC\SettingsImporter {
+	'compat.ppec.settings_importer'                  => static function( ContainerInterface $container ) : PPEC\SettingsImporter {
 		$settings = $container->get( 'wcgateway.settings' );
 
 		return new PPEC\SettingsImporter( $settings );
 	},
 
-	'compat.plugin-script-names'                    => static function( ContainerInterface $container ) : array {
+	'compat.plugin-script-names'                     => static function( ContainerInterface $container ) : array {
 		return array(
 			'ppcp-smart-button',
 			'ppcp-oxxo',
@@ -54,7 +54,7 @@ return array(
 		);
 	},
 
-	'compat.gzd.is_supported_plugin_version_active' => function (): bool {
+	'compat.gzd.is_supported_plugin_version_active'  => function (): bool {
 		return function_exists( 'wc_gzd_get_shipments_by_order' ); // 3.0+
 	},
 
@@ -62,7 +62,11 @@ return array(
 		return class_exists( 'WC_Shipment_Tracking' );
 	},
 
-	'compat.module.url'                             => static function ( ContainerInterface $container ): string {
+	'compat.ywot.is_supported_plugin_version_active' => function (): bool {
+		return function_exists( 'yith_ywot_init' );
+	},
+
+	'compat.module.url'                              => static function ( ContainerInterface $container ): string {
 		/**
 		 * The path cannot be false.
 		 *
@@ -74,7 +78,7 @@ return array(
 		);
 	},
 
-	'compat.assets'                                 => function( ContainerInterface $container ) : CompatAssets {
+	'compat.assets'                                  => function( ContainerInterface $container ) : CompatAssets {
 		return new CompatAssets(
 			$container->get( 'compat.module.url' ),
 			$container->get( 'ppcp.asset-version' ),

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -285,9 +285,11 @@ class CompatModule implements ModuleInterface {
 					return;
 				}
 
-				$transaction_id  = $wc_order->get_transaction_id();
+				$transaction_id = $wc_order->get_transaction_id();
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing
 				$tracking_number = wc_clean( wp_unslash( $_POST['ywot_tracking_code'] ?? '' ) );
-				$carrier         = wc_clean( wp_unslash( $_POST['ywot_carrier_name'] ?? '' ) );
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing
+				$carrier = wc_clean( wp_unslash( $_POST['ywot_carrier_name'] ?? '' ) );
 
 				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $transaction_id ) {
 					return;


### PR DESCRIPTION
# PR Description
Adds compatibility layer for [YITH WooCommerce Order & Shipment Tracking](https://wordpress.org/plugins/yith-woocommerce-order-tracking/) plugin with tracking integration.

# Issue Description

Compatibility layer for [YITH WooCommerce Order & Shipment Tracking](https://wordpress.org/plugins/yith-woocommerce-order-tracking/) plugin with tracking integration.

## Steps To Reproduce
* Install the [YITH WooCommerce Order & Shipment Tracking](https://wordpress.org/plugins/yith-woocommerce-order-tracking/) plugin.
* In order edit screen add tracking with Yith plugin.
* The tracking is also added for PayPal payments
