### PR TITLE
Set payment method title for order edit page only if our gateway

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -290,9 +290,11 @@ class PayPalGateway extends \WC_Payment_Gateway {
 			// in the constructor, so must do it here.
 			global $theorder;
 			if ( $theorder instanceof WC_Order ) {
-				$payment_method_title = $theorder->get_payment_method_title();
-				if ( $payment_method_title ) {
-					$this->title = $payment_method_title;
+				if ( $theorder->get_payment_method() === self::ID ) {
+					$payment_method_title = $theorder->get_payment_method_title();
+					if ( $payment_method_title ) {
+						$this->title = $payment_method_title;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Since #1450 we were setting the payment method title on the admin order editing page to show funding sources (Venmo, Sofort etc.) but we were not checking if the order was done by the PCP gateway, resulting in wrong title for PCP gateway in the method selection dropdown in such cases.

Now fixed this by checking the order payment method ID first.