### PR TITLE
Do not declare subscription support for PayPal when only ACDC vaulting

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -227,7 +227,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 			if (
 				( $this->config->has( 'vault_enabled' ) && $this->config->get( 'vault_enabled' ) )
-				|| ( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) )
 				|| ( $this->config->has( 'subscriptions_mode' ) && $this->config->get( 'subscriptions_mode' ) === 'subscriptions_api' )
 			) {
 				array_push(
@@ -244,6 +243,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 					'subscription_payment_method_change_admin',
 					'multiple_subscriptions'
 				);
+			} elseif ( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) ) {
+				$this->supports[] = 'tokenization';
 			}
 		}
 


### PR DESCRIPTION
Reverted commit 01717e740a31b74e1128c1b6356efa002ca10496

We need to check `vault_enabled_dcc` in the PayPal gateway only for enabling `tokenization` support when only ACDC vaulting is enabled because otherwise the Payment methods page with saved cards will not appear. We don't need to add all these subscription flags in this case to the PayPal gateway.