### PR TITLE
Remove "no shipment" message after adding tracking (1980)

### DIFF
--- a/modules/ppcp-order-tracking/resources/js/order-edit-page.js
+++ b/modules/ppcp-order-tracking/resources/js/order-edit-page.js
@@ -73,6 +73,7 @@ document.addEventListener(
                 const status = document.querySelector('.ppcp-tracking-status');
                 const submitButton = document.querySelector('.submit_tracking_info');
                 const items = document.querySelector('.ppcp-tracking-items');
+                const noShipemntsContainer = document.querySelector('.ppcp-tracking-no-shipments');
 
                 let checkedItems = includeAllItemsCheckbox?.checked || !items ? 0 : Array.from(items.selectedOptions).map(option => option.value)
 
@@ -109,6 +110,9 @@ document.addEventListener(
                     jQuery( "<span class='success tracking-info-message'>" + data.data.message + "</span>" ).insertAfter(submitButton);
                     setTimeout(()=> jQuery('.tracking-info-message').remove(),3000);
                     jQuery(data.data.shipment).appendTo(shipmentsWrapper);
+                    if (noShipemntsContainer) {
+                        noShipemntsContainer.parentNode.removeChild(noShipemntsContainer);
+                    }
                 });
             })
         }

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -165,7 +165,7 @@ class MetaBoxRenderer {
 				}
 				?>
 				<?php if ( empty( $shipments ) ) : ?>
-					<p><?php echo esc_html__( 'No PayPal Shipment Tracking added to this order yet. Add new Shipment Tracking or reload the page to refresh', 'woocommerce-paypal-payments' ); ?></p>
+					<p class="ppcp-tracking-no-shipments"><?php echo esc_html__( 'No PayPal Shipment Tracking added to this order yet. Add new Shipment Tracking or reload the page to refresh', 'woocommerce-paypal-payments' ); ?></p>
 				<?php endif; ?>
 			</div>
 			<div class="blockUI blockOverlay ppcp-tracking-loader"></div>


### PR DESCRIPTION
# PR Description
The “No PayPal Shipment Tracking added to this order yet. Add new Shipment Tracking or reload the page to refresh“ message is removed after tracking is added without page refresh.

# Issue Description

Place holder text “No PayPal Shipment Tracking added to this order yet. Add new Shipment Tracking or reload the page to refresh“ is visible even when shipment is added. This happens when the tracking is added via `AJAX` call, without page refresh

## Steps To Reproduce
* Go to shop
* Add product to cart
* Go to checkout page
* Make a purchase
* Go to WC->Orders
* Click on recently made one
* Scroll  to PayPal Shipment Tracking box
* Add tracking number 
* Click on button Add Shipment
* Observe message is still visible
