### PR TITLE
Improve error & success validation messages (1981)

### DIFF
--- a/modules/ppcp-order-tracking/resources/css/order-edit-page.scss
+++ b/modules/ppcp-order-tracking/resources/css/order-edit-page.scss
@@ -1,8 +1,4 @@
 #ppcp_order-tracking {
-	.tracking-info-message {
-		padding-left: 20px;
-	}
-
 	.error {
 		color: red;
 		font-weight: bold;

--- a/modules/ppcp-order-tracking/resources/js/order-edit-page.js
+++ b/modules/ppcp-order-tracking/resources/js/order-edit-page.js
@@ -99,14 +99,14 @@ document.addEventListener(
                     toggleLoaderVisibility()
 
                     if (!data.success || ! data.data.shipment) {
-                        jQuery( "<span class='error tracking-info-message'>" + data.data.message + "</span>" ).insertAfter(submitButton);
+                        jQuery( "<p class='error tracking-info-message'>" + data.data.message + "</p>" ).insertAfter(submitButton);
                         setTimeout(()=> jQuery('.tracking-info-message').remove(),3000);
                         submitButton.removeAttribute('disabled');
                         console.error(data);
                         throw Error(data.data.message);
                     }
 
-                    jQuery( "<span class='success tracking-info-message'>" + data.data.message + "</span>" ).insertAfter(submitButton);
+                    jQuery( "<p class='success tracking-info-message'>" + data.data.message + "</p>" ).insertAfter(submitButton);
                     setTimeout(()=> jQuery('.tracking-info-message').remove(),3000);
                     jQuery(data.data.shipment).appendTo(shipmentsWrapper);
                 });
@@ -145,13 +145,13 @@ document.addEventListener(
                     toggleLoaderVisibility()
 
                     if (!data.success) {
-                        jQuery( "<span class='error tracking-info-message'>" + data.data.message + "</span>" ).insertAfter(updateShipment);
+                        jQuery( "<p class='error tracking-info-message'>" + data.data.message + "</p>" ).insertAfter(updateShipment);
                         setTimeout(()=> jQuery('.tracking-info-message').remove(),3000);
                         console.error(data);
                         throw Error(data.data.message);
                     }
 
-                    jQuery( "<span class='success tracking-info-message'>" + data.data.message + "</span>" ).insertAfter(updateShipment);
+                    jQuery( "<p class='success tracking-info-message'>" + data.data.message + "</p>" ).insertAfter(updateShipment);
                     setTimeout(()=> jQuery('.tracking-info-message').remove(),3000);
                 });
             })

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -406,7 +406,7 @@ class OrderTrackingEndpoint {
 	 * @throws RuntimeException If validation failed.
 	 */
 	protected function validate_tracking_info( array $tracking_info ): void {
-		$error_message = __( 'Missing required information:', 'woocommerce-paypal-payments' );
+		$error_message = __( 'Missing required information: ', 'woocommerce-paypal-payments' );
 		$empty_keys    = array();
 
 		foreach ( $tracking_info as $key => $value ) {
@@ -414,7 +414,7 @@ class OrderTrackingEndpoint {
 				continue;
 			}
 
-			$empty_keys[] = $key;
+			$empty_keys[] = ucwords(str_replace('_', ' ', $key));;
 		}
 
 		if ( empty( $empty_keys ) ) {

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -414,7 +414,7 @@ class OrderTrackingEndpoint {
 				continue;
 			}
 
-			$empty_keys[] = ucwords(str_replace('_', ' ', $key));;
+			$empty_keys[] = ucwords( str_replace( '_', ' ', $key ) );
 		}
 
 		if ( empty( $empty_keys ) ) {

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -121,7 +121,7 @@ class MetaBoxRenderer {
 				<?php endif; ?>
 				<p>
 					<label for="ppcp-tracking-tracking_number"><?php echo esc_html__( 'Tracking Number*', 'woocommerce-paypal-payments' ); ?></label>
-					<input type="text" class="ppcp-tracking-tracking_number" id="ppcp-tracking-tracking_number" name="ppcp-tracking[tracking_number]" />
+					<input type="text" class="ppcp-tracking-tracking_number" id="ppcp-tracking-tracking_number" name="ppcp-tracking[tracking_number]" maxlength="64" />
 				</p>
 				<p>
 					<label for="ppcp-tracking-status"><?php echo esc_html__( 'Status', 'woocommerce-paypal-payments' ); ?></label>


### PR DESCRIPTION
# PR Description
Will improve the error and success validation messages for tracking form
Will add the `maxlength="64"` attribute to tracking number input

# Issue Description

The improved versions of the messages:

<img width="587" alt="Screenshot 2023-09-07 at 16 21 33" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/11319597/46cac35c-a4a6-4cc6-9bdf-6a9d54c847da">

<img width="516" alt="Screenshot 2023-09-07 at 16 21 19" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/11319597/8728b8e3-ae5a-4f47-a11e-a2c3ff1a9198">


## Steps To Reproduce
* Edit Order
* Scroll to PayPal Shipment Tracking box
* Leave a filed Shipment Tracking empty
* Click on button Add Shipment
* Observe the message.
