### PR TITLE
Add support for HPOS for tracking module (1972)

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -83,7 +83,8 @@ return array(
 			$container->get( 'compat.module.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'compat.gzd.is_supported_plugin_version_active' ),
-			$container->get( 'compat.wc_shipment_tracking.is_supported_plugin_version_active' )
+			$container->get( 'compat.wc_shipment_tracking.is_supported_plugin_version_active' ),
+			$container->get( 'api.bearer' )
 		);
 	},
 );

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -82,7 +82,6 @@ return array(
 		return new CompatAssets(
 			$container->get( 'compat.module.url' ),
 			$container->get( 'ppcp.asset-version' ),
-			$container->get( 'order-tracking.is-module-enabled' ),
 			$container->get( 'compat.gzd.is_supported_plugin_version_active' ),
 			$container->get( 'compat.wc_shipment_tracking.is_supported_plugin_version_active' )
 		);

--- a/modules/ppcp-compat/src/Assets/CompatAssets.php
+++ b/modules/ppcp-compat/src/Assets/CompatAssets.php
@@ -28,13 +28,6 @@ class CompatAssets {
 	private $version;
 
 	/**
-	 * Whether tracking compat scripts should be loaded.
-	 *
-	 * @var bool
-	 */
-	protected $should_enqueue_tracking_scripts;
-
-	/**
 	 * Whether Germanized plugin is active.
 	 *
 	 * @var bool
@@ -53,23 +46,20 @@ class CompatAssets {
 	 *
 	 * @param string $module_url The URL to the module.
 	 * @param string $version The assets version.
-	 * @param bool   $should_enqueue_tracking_scripts Whether Germanized synchronization scripts should be loaded.
 	 * @param bool   $is_gzd_active Whether Germanized plugin is active.
 	 * @param bool   $is_wc_shipment_active Whether WC Shipments plugin is active.
 	 */
 	public function __construct(
 		string $module_url,
 		string $version,
-		bool $should_enqueue_tracking_scripts,
 		bool $is_gzd_active,
 		bool $is_wc_shipment_active
 	) {
 
-		$this->module_url                      = $module_url;
-		$this->version                         = $version;
-		$this->should_enqueue_tracking_scripts = $should_enqueue_tracking_scripts;
-		$this->is_gzd_active                   = $is_gzd_active;
-		$this->is_wc_shipment_active           = $is_wc_shipment_active;
+		$this->module_url            = $module_url;
+		$this->version               = $version;
+		$this->is_gzd_active         = $is_gzd_active;
+		$this->is_wc_shipment_active = $is_wc_shipment_active;
 	}
 
 	/**
@@ -78,24 +68,22 @@ class CompatAssets {
 	 * @return void
 	 */
 	public function register(): void {
-		if ( $this->should_enqueue_tracking_scripts ) {
-			wp_register_script(
-				'ppcp-tracking-compat',
-				untrailingslashit( $this->module_url ) . '/assets/js/tracking-compat.js',
-				array( 'jquery' ),
-				$this->version,
-				true
-			);
+		wp_register_script(
+			'ppcp-tracking-compat',
+			untrailingslashit( $this->module_url ) . '/assets/js/tracking-compat.js',
+			array( 'jquery' ),
+			$this->version,
+			true
+		);
 
-			wp_localize_script(
-				'ppcp-tracking-compat',
-				'PayPalCommerceGatewayOrderTrackingCompat',
-				array(
-					'gzd_sync_enabled'         => apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) && $this->is_gzd_active,
-					'wc_shipment_sync_enabled' => apply_filters( 'woocommerce_paypal_payments_sync_wc_shipment_tracking', true ) && $this->is_wc_shipment_active,
-				)
-			);
-		}
+		wp_localize_script(
+			'ppcp-tracking-compat',
+			'PayPalCommerceGatewayOrderTrackingCompat',
+			array(
+				'gzd_sync_enabled'         => apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) && $this->is_gzd_active,
+				'wc_shipment_sync_enabled' => apply_filters( 'woocommerce_paypal_payments_sync_wc_shipment_tracking', true ) && $this->is_wc_shipment_active,
+			)
+		);
 	}
 
 	/**
@@ -104,8 +92,6 @@ class CompatAssets {
 	 * @return void
 	 */
 	public function enqueue(): void {
-		if ( $this->should_enqueue_tracking_scripts ) {
-			wp_enqueue_script( 'ppcp-tracking-compat' );
-		}
+		wp_enqueue_script( 'ppcp-tracking-compat' );
 	}
 }

--- a/modules/ppcp-compat/src/Assets/CompatAssets.php
+++ b/modules/ppcp-compat/src/Assets/CompatAssets.php
@@ -9,10 +9,16 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat\Assets;
 
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\OrderTracking\TrackingAvailabilityTrait;
+
 /**
  * Class OrderEditPageAssets
  */
 class CompatAssets {
+
+	use TrackingAvailabilityTrait;
+
 	/**
 	 * The URL to the module.
 	 *
@@ -42,24 +48,34 @@ class CompatAssets {
 	protected $is_wc_shipment_active;
 
 	/**
+	 * The bearer.
+	 *
+	 * @var Bearer
+	 */
+	protected $bearer;
+
+	/**
 	 * Compat module assets constructor.
 	 *
 	 * @param string $module_url The URL to the module.
 	 * @param string $version The assets version.
 	 * @param bool   $is_gzd_active Whether Germanized plugin is active.
 	 * @param bool   $is_wc_shipment_active Whether WC Shipments plugin is active.
+	 * @param Bearer $bearer The bearer.
 	 */
 	public function __construct(
 		string $module_url,
 		string $version,
 		bool $is_gzd_active,
-		bool $is_wc_shipment_active
+		bool $is_wc_shipment_active,
+		Bearer $bearer
 	) {
 
 		$this->module_url            = $module_url;
 		$this->version               = $version;
 		$this->is_gzd_active         = $is_gzd_active;
 		$this->is_wc_shipment_active = $is_wc_shipment_active;
+		$this->bearer                = $bearer;
 	}
 
 	/**
@@ -68,22 +84,24 @@ class CompatAssets {
 	 * @return void
 	 */
 	public function register(): void {
-		wp_register_script(
-			'ppcp-tracking-compat',
-			untrailingslashit( $this->module_url ) . '/assets/js/tracking-compat.js',
-			array( 'jquery' ),
-			$this->version,
-			true
-		);
+		if ( $this->is_tracking_enabled( $this->bearer ) ) {
+			wp_register_script(
+				'ppcp-tracking-compat',
+				untrailingslashit( $this->module_url ) . '/assets/js/tracking-compat.js',
+				array( 'jquery' ),
+				$this->version,
+				true
+			);
 
-		wp_localize_script(
-			'ppcp-tracking-compat',
-			'PayPalCommerceGatewayOrderTrackingCompat',
-			array(
-				'gzd_sync_enabled'         => apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) && $this->is_gzd_active,
-				'wc_shipment_sync_enabled' => apply_filters( 'woocommerce_paypal_payments_sync_wc_shipment_tracking', true ) && $this->is_wc_shipment_active,
-			)
-		);
+			wp_localize_script(
+				'ppcp-tracking-compat',
+				'PayPalCommerceGatewayOrderTrackingCompat',
+				array(
+					'gzd_sync_enabled'         => apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) && $this->is_gzd_active,
+					'wc_shipment_sync_enabled' => apply_filters( 'woocommerce_paypal_payments_sync_wc_shipment_tracking', true ) && $this->is_wc_shipment_active,
+				)
+			);
+		}
 	}
 
 	/**
@@ -92,6 +110,8 @@ class CompatAssets {
 	 * @return void
 	 */
 	public function enqueue(): void {
-		wp_enqueue_script( 'ppcp-tracking-compat' );
+		if ( $this->is_tracking_enabled( $this->bearer ) ) {
+			wp_enqueue_script( 'ppcp-tracking-compat' );
+		}
 	}
 }

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -11,7 +11,6 @@ namespace WooCommerce\PayPalCommerce\Compat;
 
 use Vendidero\Germanized\Shipments\ShipmentItem;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
-use WooCommerce\PayPalCommerce\OrderTracking\TrackingAvailabilityTrait;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use Exception;
@@ -31,9 +30,6 @@ use WP_REST_Response;
  * Class CompatModule
  */
 class CompatModule implements ModuleInterface {
-
-	use TrackingAvailabilityTrait;
-
 	/**
 	 * Setup the compatibility module.
 	 *
@@ -60,28 +56,8 @@ class CompatModule implements ModuleInterface {
 		$asset_loader = $c->get( 'compat.assets' );
 		assert( $asset_loader instanceof CompatAssets );
 
-		$bearer = $c->get( 'api.bearer' );
-
-		add_action(
-			'init',
-			function() use ( $asset_loader, $bearer ) {
-				if ( ! $this->is_tracking_enabled( $bearer ) ) {
-					return;
-				}
-
-				$asset_loader->register();
-			}
-		);
-		add_action(
-			'init',
-			function() use ( $asset_loader, $bearer ) {
-				if ( ! $this->is_tracking_enabled( $bearer ) ) {
-					return;
-				}
-
-				$asset_loader->enqueue();
-			}
-		);
+		add_action( 'init', array( $asset_loader, 'register' ) );
+		add_action( 'admin_enqueue_scripts', array( $asset_loader, 'enqueue' ) );
 
 		$this->migrate_pay_later_settings( $c );
 		$this->migrate_smart_button_settings( $c );

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Compat;
 
 use Vendidero\Germanized\Shipments\ShipmentItem;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
+use WooCommerce\PayPalCommerce\OrderTracking\TrackingAvailabilityTrait;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use Exception;
@@ -30,6 +31,8 @@ use WP_REST_Response;
  * Class CompatModule
  */
 class CompatModule implements ModuleInterface {
+
+	use TrackingAvailabilityTrait;
 
 	/**
 	 * Setup the compatibility module.
@@ -57,8 +60,28 @@ class CompatModule implements ModuleInterface {
 		$asset_loader = $c->get( 'compat.assets' );
 		assert( $asset_loader instanceof CompatAssets );
 
-		add_action( 'init', array( $asset_loader, 'register' ) );
-		add_action( 'admin_enqueue_scripts', array( $asset_loader, 'enqueue' ) );
+		$bearer = $c->get( 'api.bearer' );
+
+		add_action(
+			'init',
+			function() use ( $asset_loader, $bearer ) {
+				if ( ! $this->is_tracking_enabled( $bearer ) ) {
+					return;
+				}
+
+				$asset_loader->register();
+			}
+		);
+		add_action(
+			'init',
+			function() use ( $asset_loader, $bearer ) {
+				if ( ! $this->is_tracking_enabled( $bearer ) ) {
+					return;
+				}
+
+				$asset_loader->enqueue();
+			}
+		);
 
 		$this->migrate_pay_later_settings( $c );
 		$this->migrate_smart_button_settings( $c );

--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
@@ -88,35 +89,6 @@ return array(
 			),
 		);
 	},
-	'order-tracking.is-tracking-available'     => static function ( ContainerInterface $container ): bool {
-		try {
-			$bearer = $container->get( 'api.bearer' );
-			assert( $bearer instanceof Bearer );
-
-			$token = $bearer->bearer();
-			return $token->is_tracking_available();
-		} catch ( RuntimeException $exception ) {
-			return false;
-		}
-	},
-	'order-tracking.is-module-enabled'         => static function ( ContainerInterface $container ): bool {
-		$order_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-		if ( empty( $order_id ) ) {
-			return false;
-		}
-
-		$meta = get_post_meta( (int) $order_id, PayPalGateway::ORDER_ID_META_KEY, true );
-
-		if ( empty( $meta ) ) {
-			return false;
-		}
-
-		$is_tracking_available = $container->get( 'order-tracking.is-tracking-available' );
-
-		return $is_tracking_available && apply_filters( 'woocommerce_paypal_payments_shipment_tracking_enabled', true );
-	},
-
 	'order-tracking.is-merchant-country-us'    => static function ( ContainerInterface $container ): bool {
 		return $container->get( 'api.shop.country' ) === 'US';
 	},

--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -106,7 +106,7 @@ return array(
 			return false;
 		}
 
-		$meta = get_post_meta( $order_id, PayPalGateway::ORDER_ID_META_KEY, true );
+		$meta = get_post_meta( (int) $order_id, PayPalGateway::ORDER_ID_META_KEY, true );
 
 		if ( empty( $meta ) ) {
 			return false;

--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -100,7 +100,8 @@ return array(
 		}
 	},
 	'order-tracking.is-module-enabled'         => static function ( ContainerInterface $container ): bool {
-		$order_id = isset( $_GET['post'] ) ? (int) $_GET['post'] : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$order_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
 		if ( empty( $order_id ) ) {
 			return false;
 		}

--- a/modules/ppcp-order-tracking/src/TrackingAvailabilityTrait.php
+++ b/modules/ppcp-order-tracking/src/TrackingAvailabilityTrait.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * The order tracking module.
+ *
+ * @package WooCommerce\PayPalCommerce\OrderTracking
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\OrderTracking;
+
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\Compat\AdminContextTrait;
+
+trait TrackingAvailabilityTrait {
+
+	use AdminContextTrait;
+
+	/**
+	 * Checks if tracking is enabled.
+	 *
+	 * @param Bearer $bearer The Bearer.
+	 * @return bool
+	 */
+	protected function is_tracking_enabled( Bearer $bearer ): bool {
+		try {
+			$token = $bearer->bearer();
+			return $token->is_tracking_available()
+				&& $this->is_paypal_order_edit_page()
+				&& apply_filters( 'woocommerce_paypal_payments_shipment_tracking_enabled', true );
+		} catch ( RuntimeException $exception ) {
+			return false;
+		}
+	}
+}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1208,22 +1208,6 @@ return array(
 	'wcgateway.settings.has_enabled_separate_button_gateways' => static function ( ContainerInterface $container ): bool {
 		return (bool) $container->get( 'wcgateway.settings.allow_card_button_gateway' );
 	},
-	'wcgateway.settings.should-disable-tracking-checkbox'  => static function ( ContainerInterface $container ): bool {
-		$pui_helper = $container->get( 'wcgateway.pay-upon-invoice-helper' );
-		assert( $pui_helper instanceof PayUponInvoiceHelper );
-
-		$is_tracking_available = $container->get( 'order-tracking.is-module-enabled' );
-
-		if ( ! $is_tracking_available ) {
-			return true;
-		}
-
-		if ( $pui_helper->is_pui_gateway_enabled() ) {
-			return true;
-		}
-
-		return false;
-	},
 	'wcgateway.settings.should-disable-fraudnet-checkbox'  => static function( ContainerInterface $container ): bool {
 		$pui_helper = $container->get( 'wcgateway.pay-upon-invoice-helper' );
 		assert( $pui_helper instanceof PayUponInvoiceHelper );


### PR DESCRIPTION
# PR Description
Adds support for HPOS for tracking module.

# Issue Description

PayPal  Shipment Tracking box isn't visible when HPOS is activated

## Steps To Reproduce
* On order edit page find PayPal Shipment Tracking metabox
* Go to WC Settings->Advanced->Features 
* Enable High performance order storage
* Edit order again
* Observe there is no PayPal Shipment Tracking metabox
