### PR TITLE
Plus sign in PayPal account email address gets converted to space #771 (874)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/Item.php
+++ b/modules/ppcp-api-client/src/Entity/Item.php
@@ -249,8 +249,11 @@ class Item {
 			'sku'         => $this->sku(),
 			'category'    => $this->category(),
 			'url'         => $this->url(),
-			'image_url'   => $this->image_url(),
 		);
+
+		if ( $this->image_url() ) {
+			$item['image_url'] = $this->image_url();
+		}
 
 		if ( $this->tax() ) {
 			$item['tax'] = $this->tax()->to_array();

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -211,7 +211,7 @@ class SettingsListener {
 		}
 
 		$merchant_id      = sanitize_text_field( wp_unslash( $_GET['merchantIdInPayPal'] ) );
-		$merchant_email   = sanitize_text_field( wp_unslash( $_GET['merchantId'] ) );
+		$merchant_email   = $this->sanitize_onboarding_email( sanitize_text_field( wp_unslash( $_GET['merchantId'] ) ) );
 		$onboarding_token = sanitize_text_field( wp_unslash( $_GET['ppcpToken'] ) );
 		$retry_count      = isset( $_GET['ppcpRetry'] ) ? ( (int) sanitize_text_field( wp_unslash( $_GET['ppcpRetry'] ) ) ) : 0;
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
@@ -276,6 +276,16 @@ class SettingsListener {
 		}
 
 		$this->onboarding_redirect();
+	}
+
+	/**
+	 * Sanitizes the onboarding email.
+	 *
+	 * @param string $email The onboarding email.
+	 * @return string
+	 */
+	private function sanitize_onboarding_email( string $email ): string {
+		return str_replace( ' ', '+', $email );
 	}
 
 	/**


### PR DESCRIPTION
# PR Description
This issue sanitizes the merchant email received from PayPal redirect URL on the onboarding process.

It also fixes another unrelated issue resulting on failed PayPal orders API calls when `image_url` is empty.

# Issue Description

If you connect a PayPal account with an email address that contains a plus sign (`+`), the plus sign appears to get converted into a space character somewhere in the process.

## Steps To Reproduce
1. Go to Settings → Payments → PayPal
2. Click the "Test payments with PayPal sandbox" button. (Note: I only tested this using a sandbox account - I'm not sure if it happens for the live version.)
3. Go through the usual onboarding process, using a sandbox account with a plus sign in the email address.
4. The process will appear to complete successfully; however, when you are returned to your WooCommerce site and view your API credentials, in the "Sandbox Email address" field, the plus sign will have been transformed into a space character.

I used a sandbox account with the email address `test+woocommerce@....` This is what the "Sandbox Email address" field looked like after connecting the account:
email-address

## Expected Behavior
The plus sign is commonly used in email addresses, so this should work correctly.

## Actual Behavior
The plus sign gets converted into a space.

## Additional Details

Note that there have been some similar issues in the past ([#56](https://github.com/woocommerce/woocommerce-paypal-payments/issues/56) and [#523](https://github.com/woocommerce/woocommerce-paypal-payments/issues/523)). However, those issues are referring to a customer email address used at checkout, while I'm talking about the merchant's PayPal account email address that the plugin is configured with.
