### PR TITLE
Don't send `image_url` when it is empty (1983)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/Item.php
+++ b/modules/ppcp-api-client/src/Entity/Item.php
@@ -249,8 +249,11 @@ class Item {
 			'sku'         => $this->sku(),
 			'category'    => $this->category(),
 			'url'         => $this->url(),
-			'image_url'   => $this->image_url(),
 		);
+
+		if ( $this->image_url() ) {
+			$item['image_url'] = $this->image_url();
+		}
 
 		if ( $this->tax() ) {
 			$item['tax'] = $this->tax()->to_array();


### PR DESCRIPTION
# PR Description
Don't send `image_url` when it is empty during the `create_order` call to PayPal

# Issue Description

Payments currently may fail when a product in the Cart has no image, as the plugin would send an empty string as `item_url`, but PayPal requires between 1 and 2048 characters.

## Steps To Reproduce
* Create a new product
* Don’t add an image
* Add this product to Cart
* Initiate payment via PayPal
* Payment should be successful
