### PR TITLE
Fix missing Pay Later messages in cart + refactoring

### DIFF
--- a/modules/ppcp-button/resources/css/gateway.scss
+++ b/modules/ppcp-button/resources/css/gateway.scss
@@ -1,3 +1,9 @@
 #place_order.ppcp-hidden {
 	display: none !important;
 }
+
+.ppcp-disabled {
+	cursor: not-allowed;
+	-webkit-filter: grayscale(100%);
+	filter: grayscale(100%);
+}

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -19,6 +19,7 @@ import FreeTrialHandler from "./modules/ActionHandler/FreeTrialHandler";
 import FormSaver from './modules/Helper/FormSaver';
 import FormValidator from "./modules/Helper/FormValidator";
 import {loadPaypalScript} from "./modules/Helper/ScriptLoading";
+import MessagesBootstrap from "./modules/ContextBootstrap/MessagesBootstap";
 
 // TODO: could be a good idea to have a separate spinner for each gateway,
 // but I think we care mainly about the script loading, so one spinner should be enough.
@@ -158,7 +159,6 @@ const bootstrap = () => {
         const singleProductBootstrap = new SingleProductBootstap(
             PayPalCommerceGateway,
             renderer,
-            messageRenderer,
             errorHandler,
         );
 
@@ -169,7 +169,6 @@ const bootstrap = () => {
         const cartBootstrap = new CartBootstrap(
             PayPalCommerceGateway,
             renderer,
-            messageRenderer,
             errorHandler,
         );
 
@@ -180,7 +179,6 @@ const bootstrap = () => {
         const checkoutBootstap = new CheckoutBootstap(
             PayPalCommerceGateway,
             renderer,
-            messageRenderer,
             spinner,
             errorHandler,
         );
@@ -199,6 +197,11 @@ const bootstrap = () => {
         payNowBootstrap.init();
     }
 
+    const messagesBootstrap = new MessagesBootstrap(
+        PayPalCommerceGateway,
+        messageRenderer,
+    );
+    messagesBootstrap.init();
 };
 
 const hasMessages = () => {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MessagesBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MessagesBootstap.js
@@ -1,0 +1,55 @@
+import {setVisible} from "../Helper/Hiding";
+
+class MessagesBootstrap {
+    constructor(gateway, messageRenderer) {
+        this.gateway = gateway;
+        this.renderer = messageRenderer;
+        this.lastAmount = this.gateway.messages.amount;
+    }
+
+    init() {
+        jQuery(document.body).on('ppcp_cart_rendered ppcp_checkout_rendered', () => {
+            this.render();
+        });
+        jQuery(document.body).on('ppcp_script_data_changed', (e, data) => {
+            this.gateway = data;
+
+            this.render();
+        });
+        jQuery(document.body).on('ppcp_cart_total_updated ppcp_checkout_total_updated ppcp_product_total_updated', (e, amount) => {
+            if (this.lastAmount !== amount) {
+                this.lastAmount = amount;
+
+                this.render();
+            }
+        });
+
+        this.render();
+    }
+
+    shouldShow() {
+        if (this.gateway.messages.is_hidden === true) {
+            return false;
+        }
+
+        const eventData = {result: true}
+        jQuery(document.body).trigger('ppcp_should_show_messages', [eventData]);
+        return eventData.result;
+    }
+
+    shouldRender() {
+        return this.shouldShow() && this.renderer.shouldRender();
+    }
+
+    render() {
+        setVisible(this.gateway.messages.wrapper, this.shouldShow());
+
+        if (!this.shouldRender()) {
+            return;
+        }
+
+        this.renderer.renderWithAmount(this.lastAmount);
+    }
+}
+
+export default MessagesBootstrap;

--- a/modules/ppcp-button/resources/js/modules/Helper/BootstrapHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/BootstrapHelper.js
@@ -1,4 +1,4 @@
-import {disable, enable} from "./ButtonDisabler";
+import {disable, enable, isDisabled} from "./ButtonDisabler";
 import {hide, show} from "./Hiding";
 
 /**
@@ -19,15 +19,18 @@ export default class BootstrapHelper {
             hide(options.messagesWrapper);
         }
 
+        const wasDisabled = isDisabled(options.wrapper);
+        const shouldEnable = bs.shouldEnable();
+
         // Handle enable / disable
-        if (bs.shouldEnable()) {
+        if (shouldEnable && wasDisabled) {
             bs.renderer.enableSmartButtons(options.wrapper);
             enable(options.wrapper);
 
             if (!options.skipMessages) {
                 enable(options.messagesWrapper);
             }
-        } else {
+        } else if (!shouldEnable && !wasDisabled) {
             bs.renderer.disableSmartButtons(options.wrapper);
             disable(options.wrapper, options.formSelector || null);
 

--- a/modules/ppcp-button/resources/js/modules/Helper/BootstrapHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/BootstrapHelper.js
@@ -1,5 +1,5 @@
 import {disable, enable, isDisabled} from "./ButtonDisabler";
-import {hide, show} from "./Hiding";
+import merge from "deepmerge";
 
 /**
  * Common Bootstrap methods to avoid code repetition.
@@ -9,15 +9,6 @@ export default class BootstrapHelper {
     static handleButtonStatus(bs, options) {
         options = options || {};
         options.wrapper = options.wrapper || bs.gateway.button.wrapper;
-        options.messagesWrapper = options.messagesWrapper || bs.gateway.messages.wrapper;
-        options.skipMessages = options.skipMessages || false;
-
-        // Handle messages hide / show
-        if (this.shouldShowMessages(bs, options)) {
-            show(options.messagesWrapper);
-        } else {
-            hide(options.messagesWrapper);
-        }
 
         const wasDisabled = isDisabled(options.wrapper);
         const shouldEnable = bs.shouldEnable();
@@ -26,17 +17,9 @@ export default class BootstrapHelper {
         if (shouldEnable && wasDisabled) {
             bs.renderer.enableSmartButtons(options.wrapper);
             enable(options.wrapper);
-
-            if (!options.skipMessages) {
-                enable(options.messagesWrapper);
-            }
         } else if (!shouldEnable && !wasDisabled) {
             bs.renderer.disableSmartButtons(options.wrapper);
             disable(options.wrapper, options.formSelector || null);
-
-            if (!options.skipMessages) {
-                disable(options.messagesWrapper);
-            }
         }
 
         if (wasDisabled !== !shouldEnable) {
@@ -54,12 +37,15 @@ export default class BootstrapHelper {
             && options.isDisabled !== true;
     }
 
-    static shouldShowMessages(bs, options) {
-        options = options || {};
-        if (typeof options.isMessagesHidden === 'undefined') {
-            options.isMessagesHidden = bs.gateway.messages.is_hidden;
-        }
+    static updateScriptData(bs, newData) {
+        const newObj = merge(bs.gateway, newData);
 
-        return options.isMessagesHidden !== true;
+        const isChanged = JSON.stringify(bs.gateway) !== JSON.stringify(newObj);
+
+        bs.gateway = newObj;
+
+        if (isChanged) {
+            jQuery(document.body).trigger('ppcp_script_data_changed', [newObj]);
+        }
     }
 }

--- a/modules/ppcp-button/resources/js/modules/Helper/BootstrapHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/BootstrapHelper.js
@@ -38,6 +38,10 @@ export default class BootstrapHelper {
                 disable(options.messagesWrapper);
             }
         }
+
+        if (wasDisabled !== !shouldEnable) {
+            jQuery(options.wrapper).trigger('ppcp_buttons_enabled_changed', [shouldEnable]);
+        }
     }
 
     static shouldEnable(bs, options) {

--- a/modules/ppcp-button/resources/js/modules/Helper/ButtonDisabler.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ButtonDisabler.js
@@ -47,6 +47,16 @@ export const setEnabled = (selectorOrElement, enable, form = null) => {
     }
 };
 
+export const isDisabled = (selectorOrElement) => {
+    const element = getElement(selectorOrElement);
+
+    if (!element) {
+        return false;
+    }
+
+    return jQuery(element).hasClass('ppcp-disabled');
+};
+
 export const disable = (selectorOrElement, form = null) => {
     setEnabled(selectorOrElement, false, form);
 };

--- a/modules/ppcp-button/resources/js/modules/Helper/ButtonDisabler.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ButtonDisabler.js
@@ -17,20 +17,14 @@ export const setEnabled = (selectorOrElement, enable, form = null) => {
     }
 
     if (enable) {
-        jQuery(element).css({
-                'cursor': '',
-                '-webkit-filter': '',
-                'filter': '',
-            } )
+        jQuery(element)
+            .removeClass('ppcp-disabled')
             .off('mouseup')
             .find('> *')
             .css('pointer-events', '');
     } else {
-        jQuery(element).css({
-                'cursor': 'not-allowed',
-                '-webkit-filter': 'grayscale(100%)',
-                'filter': 'grayscale(100%)',
-            })
+        jQuery(element)
+            .addClass('ppcp-disabled')
             .on('mouseup', function(event) {
                 event.stopImmediatePropagation();
 

--- a/modules/ppcp-button/resources/js/modules/Renderer/MessageRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/MessageRenderer.js
@@ -5,6 +5,7 @@ class MessageRenderer {
     constructor(config) {
         this.config = config;
         this.optionsFingerprint = null;
+        this.currentNumber = 0;
     }
 
     renderWithAmount(amount) {
@@ -18,12 +19,19 @@ class MessageRenderer {
             style: this.config.style
         };
 
+        // sometimes the element is destroyed while the options stay the same
+        if (document.querySelector(this.config.wrapper).getAttribute('data-render-number') !== this.currentNumber.toString()) {
+            this.optionsFingerprint = null;
+        }
+
         if (this.optionsEqual(options)) {
             return;
         }
 
         const newWrapper = document.createElement('div');
         newWrapper.setAttribute('id', this.config.wrapper.replace('#', ''));
+        this.currentNumber++;
+        newWrapper.setAttribute('data-render-number', this.currentNumber);
 
         const oldWrapper = document.querySelector(this.config.wrapper);
         const sibling = oldWrapper.nextSibling;

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -165,14 +165,22 @@ class Renderer {
         if (!this.buttonsOptions[wrapper]) {
             return;
         }
-        this.buttonsOptions[wrapper].actions.disable();
+        try {
+            this.buttonsOptions[wrapper].actions.disable();
+        } catch (err) {
+            console.log('Failed to disable buttons: ' + err);
+        }
     }
 
     enableSmartButtons(wrapper) {
         if (!this.buttonsOptions[wrapper]) {
             return;
         }
-        this.buttonsOptions[wrapper].actions.enable();
+        try {
+            this.buttonsOptions[wrapper].actions.enable();
+        } catch (err) {
+            console.log('Failed to enable buttons: ' + err);
+        }
     }
 }
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -591,14 +591,12 @@ class SmartButton implements SmartButtonInterface {
 			);
 		}
 
-		if ( in_array( $this->context(), array( 'pay-now', 'checkout' ), true ) ) {
-			wp_enqueue_style(
-				'gateway',
-				untrailingslashit( $this->module_url ) . '/assets/css/gateway.css',
-				array(),
-				$this->version
-			);
-		}
+		wp_enqueue_style(
+			'gateway',
+			untrailingslashit( $this->module_url ) . '/assets/css/gateway.css',
+			array(),
+			$this->version
+		);
 
 		wp_enqueue_script(
 			'ppcp-smart-button',


### PR DESCRIPTION
Fixes missing messages in cart

- when PayPal buttons disabled
- when triggering the totals area refresh by WC without actually changing the total (e.g. pressing Apply coupon with empty coupon field, also probably can be reproduced in checkout). It was happening because of the `optionsEqual` check before rendering, now added a `data-` attribute with a counter and checking it before the check.

Also fixed error when calling `actions.enable()` / `actions.disable()` on destroyed buttons. Now it is catched and ignored + not calling if there were no status changes. Unclear if we really need to call this at all, CSS may be enough already, but keeping for now.

Also I tried to refactor message rendering by making it more separate from checkout/cart/product, to simplify things and to allow rendering it in other places on the pages in future.

The difficulty here was that currently it still must depend on some cart/checkout events, also duplicating the same ajax request for messages and cart/product buttons for updating totals and other data is not good, so I added several JS events for solving these issues.