### PR TITLE
Fix complex form data during form saving

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Helper/FormSaver.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/FormSaver.js
@@ -6,7 +6,6 @@ export default class FormSaver {
 
     async save(form) {
         const formData = new FormData(form);
-        const formJsonObj = Object.fromEntries(formData.entries());
 
         const res = await fetch(this.url, {
             method: 'POST',
@@ -16,7 +15,7 @@ export default class FormSaver {
             credentials: 'same-origin',
             body: JSON.stringify({
                 nonce: this.nonce,
-                form: formJsonObj,
+                form_encoded: new URLSearchParams(formData).toString(),
             }),
         });
 


### PR DESCRIPTION
Similarly to #1510, sending encoded form and using `parse_str` for `FormSaver`, which was still using the old way.

Fixes #1652 (though for some purposes #1510 and 2.2.2 release should already fix it)