### PR TITLE
validate email address API credentials field (1943)

### DIFF
--- a/modules/ppcp-onboarding/resources/css/onboarding.scss
+++ b/modules/ppcp-onboarding/resources/css/onboarding.scss
@@ -49,6 +49,10 @@ label.error {
 	border: red solid 2px;
 }
 
+.input-text:invalid {
+	border: red solid 2px;
+}
+
 ul.ppcp-onboarding-options, ul.ppcp-onboarding-options-sublist {
 	list-style: none;
 }

--- a/modules/ppcp-onboarding/resources/css/onboarding.scss
+++ b/modules/ppcp-onboarding/resources/css/onboarding.scss
@@ -45,11 +45,7 @@ label.error {
 	font-size: 1.1em;
 }
 
-.input-text[pattern]:invalid {
-	border: red solid 2px;
-}
-
-.input-text:invalid {
+.input-text[pattern]:invalid, .input-text[type=email]:invalid {
 	border: red solid 2px;
 }
 

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -238,7 +238,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 		'merchant_email_production'                     => array(
 			'title'        => __( 'Live Email address', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->production_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'         => 'text',
+			'type'         => 'email',
 			'required'     => true,
 			'desc_tip'     => true,
 			'description'  => __( 'The email address of your PayPal account.', 'woocommerce-paypal-payments' ),
@@ -304,7 +304,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 		'merchant_email_sandbox'                        => array(
 			'title'        => __( 'Sandbox Email address', 'woocommerce-paypal-payments' ),
 			'classes'      => array( State::STATE_ONBOARDED === $state->sandbox_state() ? 'onboarded' : '', 'ppcp-always-shown-element' ),
-			'type'         => 'text',
+			'type'         => 'email',
 			'required'     => true,
 			'desc_tip'     => true,
 			'description'  => __( 'The email address of your PayPal account.', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -549,6 +549,7 @@ class SettingsListener {
 					break;
 				case 'text':
 				case 'number':
+				case 'email':
 					$settings[ $key ] = isset( $raw_data[ $key ] ) ? wp_kses_post( $raw_data[ $key ] ) : '';
 					break;
 				case 'ppcp-password':


### PR DESCRIPTION
# PR Description

This PR changes the merchant email address fields to type `email` so it has email validation.

An alternative was to use a pattern for validation but there is no consensual regular expression to handle email addresses.

# Issue Description

When providing an invalid email address (e.g. double `@` symbol, or an `_` instead of a `@`, the PayPal buttons won’t be displayed, and the PayPal gateway also will not load.

But there is no error messaging indicating the failure.

Ideally when the field content does not match a regular email address format, it should be outlined in red and the browser should prevent the settings from being saved, similar to the Merchant id field.
