### PR TITLE
PayPal logo flashes when switching between tabs (1669)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
@@ -60,7 +60,7 @@ class HeaderRenderer {
 
 		return '
 			<div class="ppcp-settings-page-header">
-				<img alt="PayPal" src="' . esc_url( $this->module_url ) . 'assets/images/paypal.png"/>
+				<img alt="PayPal" src="' . esc_url( $this->module_url ) . 'assets/images/paypal.png" style="max-height: 30px" />
 				<h4> <span class="ppcp-inline-only">-</span> ' . __( 'The all-in-one checkout solution for WooCommerce', 'woocommerce-paypal-payments' ) . '</h4>
 				<a class="button" target="_blank" href="https://woocommerce.com/document/woocommerce-paypal-payments/">'
 					. __( 'Documentation', 'woocommerce-paypal-payments' ) .


### PR DESCRIPTION
# PR Description

When the rendering of the `IMG` DOM element is done before `onboarding.scss` is loaded, then the logo is shown with unrestricted size. When `onboarding.scss` finishes loading then the size is corrected.

To fix it an inline `CSS` was added.

# Issue Description

## Describe the Bug

The PayPal logo from the header of the plugin settings sometimes flashes when switching between tabs, after the user is onboarded with their account.

This is not consistently reproducible, but sometimes a full-size PayPal image appears for a brief moment until the page was loaded.

The image in question is this one: `/woocommerce-paypal-payments/modules/ppcp-wc-gateway/assets/images/paypal.png`

## To Reproduce

1. Connect PayPal Payments to your PayPal account
2. Switch between the PayPal Payments tabs, at `{your site}/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection`. Like the "Standard Payments" and "Pay Later" tabs
3. Notice that the PayPal logo shows up for less than a second each time you switch between tabs

## Expected Behavior

The image must not show up on the page unless the current page is the onboarding screen.

## Actual Behavior

The image shows up for a fraction of a second and it's hidden afterwards.

## Proposed solution

It is unclear what is causing the image to appear in its native resolution briefly.

Option 1: Understand which behavior causes the image to sometimes be briefly displayed in full resolution and fix it with code.

Option 2: Scale down the image to a more reasonable size (while keeping high-resolution screens in mind).

Option 3:  Display a scaled-down version of the image with a different name on the settings pages while keeping the original resolution file in the plugin but unused (e.g. in case someone used the path as a gateway icon)