### PR TITLE
Subscription support depending on Vaulting setting instead of subscription mode setting (2014)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -180,10 +180,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 				'products',
 			);
 
-			if (
-				( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) )
-				|| ( $this->config->has( 'subscriptions_mode' ) && $this->config->get( 'subscriptions_mode' ) === 'subscriptions_api' )
-			) {
+			if ( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) ) {
 				array_push(
 					$this->supports,
 					'subscriptions',

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -340,7 +340,20 @@ class SettingsListener {
 		 * phpcs:disable WordPress.Security.NonceVerification.Missing
 		 * phpcs:disable WordPress.Security.NonceVerification.Recommended
 		 */
-		if ( ! isset( $_POST['ppcp']['vault_enabled'] ) ) {
+		$vault_enabled     = wc_clean( wp_unslash( $_POST['ppcp']['vault_enabled'] ?? '' ) );
+		$subscription_mode = wc_clean( wp_unslash( $_POST['ppcp']['subscriptions_mode'] ?? '' ) );
+
+		if ( $subscription_mode === 'vaulting_api' && $vault_enabled !== '1' ) {
+			$this->settings->set( 'vault_enabled', true );
+			$this->settings->persist();
+		}
+
+		if ( $subscription_mode === 'disable_paypal_subscriptions' && $vault_enabled === '1' ) {
+			$this->settings->set( 'vault_enabled', false );
+			$this->settings->persist();
+		}
+
+		if ( $vault_enabled !== '1' ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR adds logic to enable/disable Vaulting setting based on Subscription mode value.

### Description
When Subscription Mode setting is set to PayPal Vaulting while the Vaulting setting is disabled, the plugin does not declare subscription compatibility:

![image-20230913-145144](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/7611a808-0ac8-44d6-a8c1-63093a8d1edb)

When it is configured with “Disable PayPal for Subscriptions" and Vaulting setting is enabled, the plugin declares compatibility with subscriptions:

![image-20230913-145257](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/ed9a739a-4d6d-447e-8220-2b787b34eb6c)

In 2.3.0 and later, the Vaulting setting should no longer control subscription compatibility for the PayPal gateway.

Only for the ACDC gateway, the subscription compatibility should continue to be linked to the ACDC Vaulting checkbox.

### Steps To Reproduce
- enable PayPal Payments 2.3.0
- enable WooCommerce Subscriptions plugin
- set Subscription Mode setting is set to PayPal Vaulting
- ensure Vaulting checkbox is disabled
- navigate to the Payments tab
- observe subscription compatibility is not declared
- set Subscription Mode setting is set to Disable PayPal for Subscriptions
- ensure Vaulting checkbox is enabled
- navigate to the Payments tab
- observe subscription compatibility is declared

### Expected behaviour
In 2.3.0 and newer, subscription compatibility should be determined by the Subscriptions Mode setting, not by the Vaulting checkbox.