### PR TITLE
PayPal Package Tracking string improvements

### DIFF
--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -109,14 +109,14 @@ class MetaBoxRenderer {
 					<p>
 						<label for="include-all-items"><?php echo esc_html__( 'Include All Products', 'woocommerce-paypal-payments' ); ?></label>
 						<input type="checkbox" id="include-all-items" checked>
-						<div id="items-select-container">
-							<label for="ppcp-tracking-items"><?php echo esc_html__( 'Select items for this shipment', 'woocommerce-paypal-payments' ); ?></label>
-							<select multiple class="wc-enhanced-select ppcp-tracking-items" id="ppcp-tracking-items" name="ppcp-tracking[items]">
-								<?php foreach ( $order_items as $item ) : ?>
-									<option value="<?php echo intval( $item->get_id() ); ?>"><?php echo esc_html( $item->get_name() ); ?></option>
-								<?php endforeach; ?>
-							</select>
-						</div>
+					<div id="items-select-container">
+						<label for="ppcp-tracking-items"><?php echo esc_html__( 'Select items for this shipment', 'woocommerce-paypal-payments' ); ?></label>
+						<select multiple class="wc-enhanced-select ppcp-tracking-items" id="ppcp-tracking-items" name="ppcp-tracking[items]">
+							<?php foreach ( $order_items as $item ) : ?>
+								<option value="<?php echo intval( $item->get_id() ); ?>"><?php echo esc_html( $item->get_name() ); ?></option>
+							<?php endforeach; ?>
+						</select>
+					</div>
 					</p>
 				<?php endif; ?>
 				<p>
@@ -163,28 +163,33 @@ class MetaBoxRenderer {
 				foreach ( $shipments as $shipment ) {
 					$shipment->render( $this->allowed_statuses );
 				}
-				?>
-				<?php if ( empty( $shipments ) ) : ?>
-					<?php
+				if ( empty( $shipments ) ) :
 					$documentation_url = 'https://woocommerce.com/document/woocommerce-paypal-payments/#package-tracking';
 					$message1 = esc_html__( 'Package Tracking data has not been shared with PayPal on this order.', 'woocommerce-paypal-payments' );
 					$message2 = esc_html__( 'Add tracking details on this order to qualify for PayPal Seller Protection, faster holds release and automated dispute resolution.', 'woocommerce-paypal-payments' );
 					$message3 = sprintf(
-					/* translators: %1$s: the documentation URL opening HTML tag, %2$s: the link ending HTML tag. */
+					/* translators: %1$s: opening anchor tag with URL, %2$s: closing anchor tag */
 						esc_html__( '%1$sDiscover full benefits of PayPal Package Tracking here.%2$s', 'woocommerce-paypal-payments' ),
-						'<strong><a href="' . esc_url( $documentation_url ) . '">',
+						'<strong><a target="_blank" href="' . esc_url( $documentation_url ) . '">',
 						'</a></strong>'
 					);
-					$allowed_html = array(
-						'a' => array(
-							'href' => array(),
-						),
-						'strong' => array(),
-						'br' => array(),
-					);
+					$allowed_html = [
+						'a'      => [
+							'href' => [],
+							'target' => [],
+						],
+						'strong' => [],
+						'br'     => [],
+					];
 					?>
 					<p class="ppcp-tracking-no-shipments">
-						<?php echo wp_kses( $message1 . '<br>' . $message2 . '<br><br>' . $message3, $allowed_html ); ?>
+						<?php
+						echo esc_html( $message1 );
+						echo '<br>';
+						echo esc_html( $message2 );
+						echo '<br><br>';
+						echo wp_kses( $message3, $allowed_html );
+						?>
 					</p>
 				<?php endif; ?>
 			</div>

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -100,7 +100,7 @@ class MetaBoxRenderer {
 		?>
 		<div class="ppcp-tracking-columns-wrapper">
 			<div class="ppcp-tracking-column">
-				<h3><?php echo esc_html__( 'Add New Shipment Tracking to PayPal order', 'woocommerce-paypal-payments' ); ?></h3>
+				<h3><?php echo esc_html__( 'Send Package Tracking Data to PayPal', 'woocommerce-paypal-payments' ); ?></h3>
 				<p>
 					<label for="ppcp-tracking-transaction_id"><?php echo esc_html__( 'Transaction ID', 'woocommerce-paypal-payments' ); ?></label>
 					<input type="text" disabled class="ppcp-tracking-transaction_id disabled" id="ppcp-tracking-transaction_id" name="ppcp-tracking[transaction_id]" value="<?php echo esc_attr( $transaction_id ); ?>" />
@@ -155,18 +155,28 @@ class MetaBoxRenderer {
 					<input type="text" class="ppcp-tracking-carrier_name_other" id="ppcp-tracking-carrier_name_other" name="ppcp-tracking[carrier_name_other]" />
 				</p>
 				<input type="hidden" class="ppcp-tracking-order_id" name="ppcp-tracking[order_id]" value="<?php echo (int) $wc_order->get_id(); ?>"/>
-				<p><button type="button" class="button submit_tracking_info"><?php echo esc_html__( 'Add Shipment', 'woocommerce-paypal-payments' ); ?></button></p>
+				<p><button type="button" class="button submit_tracking_info"><?php echo esc_html__( 'Add Package Tracking', 'woocommerce-paypal-payments' ); ?></button></p>
 			</div>
 			<div class="ppcp-tracking-column shipments">
-				<h3><?php echo esc_html__( 'Shipments', 'woocommerce-paypal-payments' ); ?></h3>
+				<h3><?php echo esc_html__( 'Package Tracking', 'woocommerce-paypal-payments' ); ?></h3>
 				<?php
 				foreach ( $shipments as $shipment ) {
 					$shipment->render( $this->allowed_statuses );
 				}
 				?>
 				<?php if ( empty( $shipments ) ) : ?>
-					<p class="ppcp-tracking-no-shipments"><?php echo esc_html__( 'No PayPal Shipment Tracking added to this order yet. Add new Shipment Tracking or reload the page to refresh', 'woocommerce-paypal-payments' ); ?></p>
+					<?php
+					$documentation_url = 'https://woocommerce.com/document/woocommerce-paypal-payments/#package-tracking';
+					$message = sprintf(
+					/* translators: %1$s: the documentation URL opening HTML tag, %2$s: the link ending HTML tag. */
+						esc_html__( 'No PayPal Package Tracking added to this order yet. Add new Package Tracking or reload the page to refresh. %1$sLearn more%2$s about the benefits of sharing package tracking data with PayPal.', 'woocommerce-paypal-payments' ),
+						'<a href="' . esc_url( $documentation_url ) . '">',
+						'</a>'
+					);
+					?>
+					<p class="ppcp-tracking-no-shipments"><?php echo $message; ?></p>
 				<?php endif; ?>
+
 			</div>
 			<div class="blockUI blockOverlay ppcp-tracking-loader"></div>
 		</div>

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -176,11 +176,10 @@ class MetaBoxRenderer {
 							'<a href="' . esc_url( $documentation_url ) . '">',
 							'</a>'
 						)
-    );
+					);
 					?>
-					<p class="ppcp-tracking-no-shipments"><?php echo $message; ?></p>
+					<p class="ppcp-tracking-no-shipments"><?php echo esc_html( $message ); ?></p>
 				<?php endif; ?>
-
 			</div>
 			<div class="blockUI blockOverlay ppcp-tracking-loader"></div>
 		</div>

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -158,7 +158,7 @@ class MetaBoxRenderer {
 				<p><button type="button" class="button submit_tracking_info"><?php echo esc_html__( 'Add Package Tracking', 'woocommerce-paypal-payments' ); ?></button></p>
 			</div>
 			<div class="ppcp-tracking-column shipments">
-				<h3><?php echo esc_html__( 'Shared Package Tracking Data', 'woocommerce-paypal-payments' ); ?></h3>
+				<h3><?php echo esc_html__( 'PayPal Package Tracking Status', 'woocommerce-paypal-payments' ); ?></h3>
 				<?php
 				foreach ( $shipments as $shipment ) {
 					$shipment->render( $this->allowed_statuses );
@@ -167,18 +167,25 @@ class MetaBoxRenderer {
 				<?php if ( empty( $shipments ) ) : ?>
 					<?php
 					$documentation_url = 'https://woocommerce.com/document/woocommerce-paypal-payments/#package-tracking';
-					$message = sprintf(
+					$message1 = esc_html__( 'Package Tracking data has not been shared with PayPal on this order.', 'woocommerce-paypal-payments' );
+					$message2 = esc_html__( 'Add tracking details on this order to qualify for PayPal Seller Protection, faster holds release and automated dispute resolution.', 'woocommerce-paypal-payments' );
+					$message3 = sprintf(
 					/* translators: %1$s: the documentation URL opening HTML tag, %2$s: the link ending HTML tag. */
-						esc_html__( 'No PayPal Package Tracking added to this order yet. Share new Package Tracking data with PayPal or reload the page to refresh.', 'woocommerce-paypal-payments' ) . '<br>' .
-						sprintf(
-						/* translators: %1$s: the documentation URL opening HTML tag, %2$s: the link ending HTML tag. */
-							esc_html__( '%1$sDiscover the benefits of PayPal Package Tracking%2$s to elevate your post-purchase experiences.', 'woocommerce-paypal-payments' ),
-							'<a href="' . esc_url( $documentation_url ) . '">',
-							'</a>'
-						)
+						esc_html__( '%1$sDiscover full benefits of PayPal Package Tracking here.%2$s', 'woocommerce-paypal-payments' ),
+						'<strong><a href="' . esc_url( $documentation_url ) . '">',
+						'</a></strong>'
+					);
+					$allowed_html = array(
+						'a' => array(
+							'href' => array(),
+						),
+						'strong' => array(),
+						'br' => array(),
 					);
 					?>
-					<p class="ppcp-tracking-no-shipments"><?php echo esc_html( $message ); ?></p>
+					<p class="ppcp-tracking-no-shipments">
+						<?php echo wp_kses( $message1 . '<br>' . $message2 . '<br><br>' . $message3, $allowed_html ); ?>
+					</p>
 				<?php endif; ?>
 			</div>
 			<div class="blockUI blockOverlay ppcp-tracking-loader"></div>

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -100,7 +100,7 @@ class MetaBoxRenderer {
 		?>
 		<div class="ppcp-tracking-columns-wrapper">
 			<div class="ppcp-tracking-column">
-				<h3><?php echo esc_html__( 'Send Package Tracking Data to PayPal', 'woocommerce-paypal-payments' ); ?></h3>
+				<h3><?php echo esc_html__( 'Share Package Tracking Data with PayPal', 'woocommerce-paypal-payments' ); ?></h3>
 				<p>
 					<label for="ppcp-tracking-transaction_id"><?php echo esc_html__( 'Transaction ID', 'woocommerce-paypal-payments' ); ?></label>
 					<input type="text" disabled class="ppcp-tracking-transaction_id disabled" id="ppcp-tracking-transaction_id" name="ppcp-tracking[transaction_id]" value="<?php echo esc_attr( $transaction_id ); ?>" />
@@ -158,7 +158,7 @@ class MetaBoxRenderer {
 				<p><button type="button" class="button submit_tracking_info"><?php echo esc_html__( 'Add Package Tracking', 'woocommerce-paypal-payments' ); ?></button></p>
 			</div>
 			<div class="ppcp-tracking-column shipments">
-				<h3><?php echo esc_html__( 'Package Tracking', 'woocommerce-paypal-payments' ); ?></h3>
+				<h3><?php echo esc_html__( 'Shared Package Tracking Data', 'woocommerce-paypal-payments' ); ?></h3>
 				<?php
 				foreach ( $shipments as $shipment ) {
 					$shipment->render( $this->allowed_statuses );
@@ -169,10 +169,14 @@ class MetaBoxRenderer {
 					$documentation_url = 'https://woocommerce.com/document/woocommerce-paypal-payments/#package-tracking';
 					$message = sprintf(
 					/* translators: %1$s: the documentation URL opening HTML tag, %2$s: the link ending HTML tag. */
-						esc_html__( 'No PayPal Package Tracking added to this order yet. Add new Package Tracking or reload the page to refresh. %1$sLearn more%2$s about the benefits of sharing package tracking data with PayPal.', 'woocommerce-paypal-payments' ),
-						'<a href="' . esc_url( $documentation_url ) . '">',
-						'</a>'
-					);
+						esc_html__( 'No PayPal Package Tracking added to this order yet. Share new Package Tracking data with PayPal or reload the page to refresh.', 'woocommerce-paypal-payments' ) . '<br>' .
+						sprintf(
+						/* translators: %1$s: the documentation URL opening HTML tag, %2$s: the link ending HTML tag. */
+							esc_html__( '%1$sDiscover the benefits of PayPal Package Tracking%2$s to elevate your post-purchase experiences.', 'woocommerce-paypal-payments' ),
+							'<a href="' . esc_url( $documentation_url ) . '">',
+							'</a>'
+						)
+    );
 					?>
 					<p class="ppcp-tracking-no-shipments"><?php echo $message; ?></p>
 				<?php endif; ?>

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -99,7 +99,7 @@ class OrderTrackingModule implements ModuleInterface {
 
 				add_meta_box(
 					'ppcp_order-tracking',
-					__( 'PayPal Shipment Tracking', 'woocommerce-paypal-payments' ),
+					__( 'PayPal Package Tracking', 'woocommerce-paypal-payments' ),
 					array( $meta_box_renderer, 'render' ),
 					$screen,
 					'normal'


### PR DESCRIPTION
### Description of the Problem:

<!-- A concise description of the problem. E.g., "Currently, we don't handle XYZ, leading to ABC issues.  -->
`PayPal Shipment Tracking` should be referred to as `PayPal Package Tracking`.

### Changes proposed:

<!-- Describe the changes made to this Pull Request and the reason for such changes. E.g. "This PR fixes the problem by <doing these things/steps>. Additionally, refactored <...> for better performance." -->

1. Updated strings to remain consistent with PayPal/docs
2. Split one description string into three strings for better presentation and to make the text better translatable

### Testing Instructions:

<!-- Please provide as much detail as possible. Using the WooCommerce Testing Instructions Guide can help: https://github.com/woocommerce/woocommerce/wiki/Writing-high-quality-testing-instructions -->

1. Navigate to a WooCommerce order paid via PayPal
2. View PayPal Package Tracking metabox
3. Description is displayed correctly

### Visual Proof (Screenshots/Videos):

<!-- Attach relevant screenshots or videos that support the testing instructions or show the issue (if applicable). This helps in visual verification. -->
Default layout:
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/70433191/76e989a0-8bcd-43ed-ba09-ee3696fac0b7)
Sidebar layout:
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/70433191/f65d04e4-e473-48ed-9b15-45aee1247127)



