### PR TITLE
Wrong PayPal subscription id on vaulted subscriptions (2016)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -543,7 +543,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 				}
 
 				$wc_order->payment_complete();
-				WC()->session->set( 'ppcp_subscription_id', '' );
 
 				return $this->handle_payment_success( $wc_order );
 			}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -543,6 +543,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 				}
 
 				$wc_order->payment_complete();
+				WC()->session->set( 'ppcp_subscription_id', '' );
+
 				return $this->handle_payment_success( $wc_order );
 			}
 

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -77,6 +77,7 @@ trait ProcessPaymentTrait {
 		}
 
 		$this->session_handler->destroy_session_data();
+		WC()->session->set( 'ppcp_subscription_id', '' );
 
 		wc_add_notice( $error->getMessage(), 'error' );
 
@@ -100,6 +101,7 @@ trait ProcessPaymentTrait {
 		}
 
 		$this->session_handler->destroy_session_data();
+		WC()->session->set( 'ppcp_subscription_id', '' );
 
 		return array(
 			'result'   => 'success',

--- a/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
@@ -78,6 +78,12 @@ class CreditCardGatewayTest extends TestCase
 		$wc_order = Mockery::mock(WC_Order::class);
 		when('wc_get_order')->justReturn($wc_order);
 
+		$woocommerce = Mockery::mock(\WooCommerce::class);
+		$session = Mockery::mock(\WC_Session::class);
+		when('WC')->justReturn($woocommerce);
+		$woocommerce->session = $session;
+		$session->shouldReceive('set')->andReturn([]);
+
 		$this->orderProcessor->shouldReceive('process')
 			->with($wc_order)
 			->andReturn(true);
@@ -94,6 +100,12 @@ class CreditCardGatewayTest extends TestCase
 		$wc_order = Mockery::mock(WC_Order::class);
 		$wc_order->shouldReceive('get_customer_id')->andReturn(1);
 		when('wc_get_order')->justReturn($wc_order);
+
+		$woocommerce = Mockery::mock(\WooCommerce::class);
+		$session = Mockery::mock(\WC_Session::class);
+		when('WC')->justReturn($woocommerce);
+		$woocommerce->session = $session;
+		$session->shouldReceive('set')->andReturn([]);
 
 		$savedCreditCard = 'abc123';
 		$_POST['saved_credit_card'] = $savedCreditCard;

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -147,9 +147,11 @@ class WcGatewayTest extends TestCase
 		when('WC')->justReturn($woocommerce);
 		$woocommerce->cart = $cart;
 		$cart->shouldReceive('empty_cart');
+
 		$session = Mockery::mock(\WC_Session::class);
 		$woocommerce->session = $session;
 		$session->shouldReceive('get');
+		$session->shouldReceive('set');
 
         $result = $testee->process_payment($orderId);
 
@@ -163,6 +165,12 @@ class WcGatewayTest extends TestCase
         $orderId = 1;
 
 	    $testee = $this->createGateway();
+
+		$woocommerce = Mockery::mock(\WooCommerce::class);
+		$session = Mockery::mock(\WC_Session::class);
+		when('WC')->justReturn($woocommerce);
+		$woocommerce->session = $session;
+		$session->shouldReceive('set')->andReturn([]);
 
         expect('wc_get_order')
             ->with($orderId)
@@ -227,6 +235,7 @@ class WcGatewayTest extends TestCase
 		$session = Mockery::mock(\WC_Session::class);
 		$woocommerce->session = $session;
 		$session->shouldReceive('get');
+		$session->shouldReceive('set');
 
 		$result = $testee->process_payment($orderId);
 


### PR DESCRIPTION
This PR fixes the issue when using same user session purchasing both PayPal Subscriptions API and Vaulted subscriptions products.

### Description
Subscriptions purchased with Vaulting mode shows PayPal connected metabox when using the same WC session.

### Steps To Reproduce
- Login as admin 
- Set “PayPal Subscriptions“ as Subscriptions Mode, uncheck Vaulting checkbox.
- As admin purchase a Subscriptions API connected product
- Set “PayPal Vaulting“ as Subscriptions Mode, check Vaulting checkbox.
- As admin purchase a non Subscriptions API connected product
- Check purchased subscription

### Expected behaviour
Purchased vaulted subscription should not display “PayPal Subscription“ metabox with the PayPal subscription ID. 

### Possible cause
We are not cleaning up session PayPal subscription id value when purchasing a PayPal Subscriptions connected product, so next purchase with the same user session will use the previous PayPal subscription id.

### Suggested solution
Clear PayPal subscription id from session when payment is complete. 