### PR TITLE
Error when product description linked with a PayPal subscription exceeds 127 characters (1797)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/CatalogProducts.php
+++ b/modules/ppcp-api-client/src/Endpoint/CatalogProducts.php
@@ -83,12 +83,9 @@ class CatalogProducts {
 	 */
 	public function create( string $name, string $description ): Product {
 		$data = array(
-			'name' => $name,
+			'name'        => $name,
+			'description' => $description ?: $name,
 		);
-
-		if ( $description ) {
-			$data['description'] = $description;
-		}
 
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v1/catalogs/products';

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -13,11 +13,15 @@ use WC_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ItemTrait;
 
 /**
  * Class ItemFactory
  */
 class ItemFactory {
+
+	use ItemTrait;
+
 	/**
 	 * 3-letter currency code of the shop.
 	 *
@@ -210,16 +214,5 @@ class ItemFactory {
 			$url,
 			$image_url
 		);
-	}
-
-	/**
-	 * Cleanups the description and prepares it for sending to PayPal.
-	 *
-	 * @param string $description Item description.
-	 * @return string
-	 */
-	protected function prepare_description( string $description ): string {
-		$description = strip_shortcodes( wp_strip_all_tags( $description ) );
-		return substr( $description, 0, 127 ) ?: '';
 	}
 }

--- a/modules/ppcp-api-client/src/Helper/ItemTrait.php
+++ b/modules/ppcp-api-client/src/Helper/ItemTrait.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * PayPal item helper.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+trait ItemTrait {
+
+	/**
+	 * Cleanups the description and prepares it for sending to PayPal.
+	 *
+	 * @param string $description Item description.
+	 * @return string
+	 */
+	protected function prepare_description( string $description ): string {
+		$description = strip_shortcodes( wp_strip_all_tags( $description ) );
+		return substr( $description, 0, 127 ) ?: '';
+	}
+}

--- a/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
@@ -178,7 +178,15 @@ class SubscriptionsApiHandler {
 						$data[] = (object) array(
 							'op'    => 'replace',
 							'path'  => '/description',
-							'value' => $product->get_description(),
+							'value' => substr(
+								strip_shortcodes(
+									wp_strip_all_tags(
+										$product->get_description()
+									)
+								),
+								0,
+								127
+							) ?: '',
 						);
 					}
 

--- a/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
@@ -19,11 +19,14 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\BillingCycleFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PaymentPreferencesFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ProductFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ItemTrait;
 
 /**
  * Class SubscriptionsApiHandler
  */
 class SubscriptionsApiHandler {
+
+	use ItemTrait;
 
 	/**
 	 * Catalog products.
@@ -178,15 +181,7 @@ class SubscriptionsApiHandler {
 						$data[] = (object) array(
 							'op'    => 'replace',
 							'path'  => '/description',
-							'value' => substr(
-								strip_shortcodes(
-									wp_strip_all_tags(
-										$product->get_description()
-									)
-								),
-								0,
-								127
-							) ?: '',
+							'value' => $this->prepare_description( $product->get_description() ),
 						);
 					}
 

--- a/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
@@ -211,7 +211,7 @@ class SubscriptionsApiHandler {
 				$subscription_plan = $this->billing_plans_endpoint->plan( $subscription_plan_id );
 
 				$price = $subscription_plan->billing_cycles()[0]->pricing_scheme()['fixed_price']['value'] ?? '';
-				if ( $price && round( $price, 2 ) !== round( (float) $product->get_price(), 2 ) ) {
+				if ( $price && round( (float) $price, 2 ) !== round( (float) $product->get_price(), 2 ) ) {
 					$this->billing_plans_endpoint->update_pricing(
 						$subscription_plan_id,
 						$this->billing_cycle_factory->from_wc_product( $product )

--- a/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
@@ -181,7 +181,7 @@ class SubscriptionsApiHandler {
 						$data[] = (object) array(
 							'op'    => 'replace',
 							'path'  => '/description',
-							'value' => $this->prepare_description( $product->get_description() ),
+							'value' => $this->prepare_description( $product->get_description() ) ?: '',
 						);
 					}
 


### PR DESCRIPTION
This PR fixes the error when product description exceeds 127 characters, also ensures description field is sent on creation otherwise it's not possible to update it afterwards.

### Description
The issue occurs when attempting to edit the description of a WooCommerce product that is already linked with a PayPal subscription. If the description length exceeds 127 characters, a critical error is encountered.

```
Fatal error: Uncaught TypeError: round(): Argument #1 ($num) must be of type int|float, string given in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-subscription/src/SubscriptionsApiHandler.php:211 Stack trace: #0 /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-subscription/src/SubscriptionsApiHandler.php(211): round('10.0', 2) #1 /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-subscription/src/SubscriptionModule.php(375): WooCommerce\PayPalCommerce\Subscription\SubscriptionsApiHandler->update_plan(Object(WC_Product_Subscription)) #2 /var/www/html/wp-includes/class-wp-hook.php(310): WooCommerce\PayPalCommerce\Subscription\SubscriptionModule->WooCommerce\PayPalCommerce\Subscription\{closure}(68) #3 /var/www/html/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters(NULL, Array) #4 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #5 /var/www/html/wp-includes/post.php(4715): do_action('save_post', 68, Object(WP_Post), true) #6 /var/www/html/wp-includes/post.php(4817): wp_insert_post(Array, false, true) #7 /var/www/html/wp-admin/includes/post.php(439): wp_update_post(Array) #8 /var/www/html/wp-admin/post.php(227): edit_post() #9 {main} thrown in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-subscription/src/SubscriptionsApiHandler.php on line 211
```

### Steps To Reproduce
- Ensure Subscriptions Mode is set to PayPal Subscriptions
- Edit a WooCommerce product that is already linked with a PayPal subscription.
- Change the product description to exceed 127 characters. 
- Update the product.

### Expected behaviour
With the description edited to be over 127 characters, the product should be successfully updated without any critical error.