### PR TITLE
Subtotal mismatch line name shows on Account settings page when merchant is disconnected (2017)

### DIFF
--- a/modules/ppcp-wc-gateway/resources/js/SettingsHandler/SubElementsHandler.js
+++ b/modules/ppcp-wc-gateway/resources/js/SettingsHandler/SubElementsHandler.js
@@ -27,9 +27,9 @@ class SubElementsHandler {
         value = (value !== null ? value.toString() : value);
 
         if (this.values.indexOf(value) !== -1) {
-            $elements.show();
+            $elements.removeClass('hide');
         } else {
-            $elements.hide();
+            $elements.addClass('hide');
         }
     }
 


### PR DESCRIPTION
# PR Description

On Chrome the jQuery `show`/`hide` methods were having more "strength" than the CSS classes that hide the fields on onboarding process. In this PR it was changed to use and already existing `hide` CSS class.

# Issue Description

## The problem

Subtotal mismatch line name is showing on Account settings page 

## Steps To Reproduce

Go to WC->Settings->Payments->PayPal and connect merchant
Scroll to Subtotal mismatch behavior and select Add another line item
Scroll to label Subtotal mismatch line name and add some text in text field (or delete existing text)
Click on button Save changes
On same tab click on button to disconnect
Observe Subtotal mismatch line name on Account settings page

## Expected behaviour

`Subtotal mismatch line name` is not showing on Account Setup page when no PayPal account is connected and the subtotal mismatch line item setting is populated and visible (**Subtotal mismatch behavior** configured with `Add another line item`)

