### PR TITLE
Warning prevents payments on Pay for Order page when debugging is enabled (2021)

### DIFF
--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -50,7 +50,7 @@ class ApiModule implements ModuleInterface {
 				foreach ( $data['purchase_units'] as $purchase_unit_index => $purchase_unit ) {
 					foreach ( $purchase_unit['items'] as $item_index => $item ) {
 						$data['purchase_units'][ $purchase_unit_index ]['items'][ $item_index ]['name'] =
-							apply_filters( 'woocommerce_paypal_payments_cart_line_item_name', $item['name'], $item['cart_item_key'] );
+							apply_filters( 'woocommerce_paypal_payments_cart_line_item_name', $item['name'], $item['cart_item_key'] ?? null );
 					}
 				}
 


### PR DESCRIPTION
# PR Description

This PR prevent a `notice`/`warning` from being displayed on order creation in contexts which don't make use of the `cart`.

# Issue Description

When attempting to pay for an order on the Pay for Order endpoint with version 2.3.0-rc1, a warning occurs, preventing the payment process from initiating when debugging is enabled.

The PayPal popup only briefly opens but auto closes. ACDC payments fail with an error.

Without debugging active, the payment will succeed.
`Warning: Undefined array key "cart_item_key" in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-api-client/src/ApiModule.php on line 53 {"success":true,"data":{"id":"7FT97046GH495204T","custom_id":"62"}}`

## Steps To Reproduce

1. install 2.3.0-rc1
2. enable `WP_DEBUG` & `WP_DEBUG_DISPLAY`
3. manually create an order
4. navigate to Pay for Order page for this order
5. attempt to pay via PayPal/ACDC
6. payment will not succeed
7. errors can be observed in browser console
8. `?wc-ajax=ppc-create-order` endpoint displays the warning in the Preview tab

`Warning: Undefined array key "cart_item_key" in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-api-client/src/ApiModule.php on line 53 {"success":true,"data":{"id":"7FT97046GH495204T","custom_id":"62"}}
`

## Expected behaviour

On the Pay for Order page, there is no warning when attempting to pay for an order.

If a warning occurs regardless, it should not impact the payment process.

## Possible cause

Likely related to this Google Pay commit: [https://github.com/woocommerce/woocommerce-paypal-payments/commit/b8eed0f324d77116c304d1b1c4085aafb5f17254](https://github.com/woocommerce/woocommerce-paypal-payments/commit/b8eed0f324d77116c304d1b1c4085aafb5f17254)
 
Commenting out this filter at the top of the PR resolves the issue.