### PR TITLE
Include `item_url` & `image_url` to tracking call (2034)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/Item.php
+++ b/modules/ppcp-api-client/src/Entity/Item.php
@@ -214,7 +214,7 @@ class Item {
 	 * @return string
 	 */
 	public function image_url():string {
-		return $this->image_url;
+		return $this->validate_image_url() ? $this->image_url : '';
 	}
 
 	/**
@@ -268,5 +268,15 @@ class Item {
 		}
 
 		return $item;
+	}
+
+	/**
+	 * Validates the image url for PayPal request.
+	 *
+	 * @return bool true if valid, otherwise false.
+	 */
+	protected function validate_image_url(): bool {
+		$pattern = '/^(https:)([\/|\.|\w|\s|-])*\.(?:jpg|gif|png|jpeg|JPG|GIF|PNG|JPEG)$/';
+		return (bool) preg_match( $pattern, $this->image_url );
 	}
 }

--- a/modules/ppcp-order-tracking/src/Shipment/Shipment.php
+++ b/modules/ppcp-order-tracking/src/Shipment/Shipment.php
@@ -159,6 +159,7 @@ class Shipment implements ShipmentInterface {
 			$quantity                  = (int) $item->get_quantity();
 			$price_without_tax         = (float) $wc_order->get_item_subtotal( $item, false );
 			$price_without_tax_rounded = round( $price_without_tax, 2 );
+            $image                     = wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' );
 
 			$ppcp_order_item = new Item(
 				mb_substr( $item->get_name(), 0, 127 ),
@@ -167,7 +168,9 @@ class Shipment implements ShipmentInterface {
 				$product instanceof WC_Product ? $this->prepare_description( $product->get_description() ) : '',
 				null,
 				$product instanceof WC_Product ? $product->get_sku() : '',
-				( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS
+				( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
+                $product->get_permalink(),
+                $image[0] ?? ''
 			);
 
 			$tracking_items[ $item->get_id() ] = $ppcp_order_item->to_array();

--- a/modules/ppcp-order-tracking/src/Shipment/Shipment.php
+++ b/modules/ppcp-order-tracking/src/Shipment/Shipment.php
@@ -154,23 +154,27 @@ class Shipment implements ShipmentInterface {
 				continue;
 			}
 
-			$product                   = $item->get_product();
+			$product = $item->get_product();
+			if ( ! is_a( $product, WC_Product::class ) ) {
+				continue;
+			}
+
 			$currency                  = $wc_order->get_currency();
 			$quantity                  = (int) $item->get_quantity();
 			$price_without_tax         = (float) $wc_order->get_item_subtotal( $item, false );
 			$price_without_tax_rounded = round( $price_without_tax, 2 );
-            $image                     = wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' );
+			$image                     = wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' );
 
 			$ppcp_order_item = new Item(
 				mb_substr( $item->get_name(), 0, 127 ),
 				new Money( $price_without_tax_rounded, $currency ),
 				$quantity,
-				$product instanceof WC_Product ? $this->prepare_description( $product->get_description() ) : '',
+				$this->prepare_description( $product->get_description() ),
 				null,
-				$product instanceof WC_Product ? $product->get_sku() : '',
-				( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
-                $product->get_permalink(),
-                $image[0] ?? ''
+				$product->get_sku(),
+				$product->is_virtual() ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
+				$product->get_permalink(),
+				$image[0] ?? ''
 			);
 
 			$tracking_items[ $item->get_id() ] = $ppcp_order_item->to_array();

--- a/tests/PHPUnit/ApiClient/Entity/ItemTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/ItemTest.php
@@ -59,6 +59,9 @@ class ItemTest extends TestCase
         $tax
             ->expects('to_array')
             ->andReturn([2]);
+
+		$image_url = 'https://example.com/wp-content/uploads/2023/06/beanie-2.jpg';
+
         $testee = new Item(
             'name',
             $unitAmount,
@@ -68,7 +71,7 @@ class ItemTest extends TestCase
             'sku',
             'PHYSICAL_GOODS',
 			'url',
-			'image_url'
+			$image_url
         );
 
         $expected = [
@@ -79,7 +82,7 @@ class ItemTest extends TestCase
             'sku' => 'sku',
             'category' => 'PHYSICAL_GOODS',
             'url' => 'url',
-            'image_url' => 'image_url',
+            'image_url' => $image_url,
             'tax' => [2],
         ];
 


### PR DESCRIPTION
# PR Description
The PR will add the `item_url` & `image_url` to tracking call.
It will also add the validation for "Line Item URL" as it is described in PayPal docs

# Issue Description

We need to include the `item_url` & `image_url` to tracking call as it was also added fro the "create order" call

## Steps To Reproduce
* For US merchant
* Create order with PayPal
* Add tracking
