### PR TITLE
Disable Package Tracking for order if transaction ID doesn't exist (2024)

### DIFF
--- a/modules/ppcp-compat/src/AdminContextTrait.php
+++ b/modules/ppcp-compat/src/AdminContextTrait.php
@@ -30,7 +30,7 @@ trait AdminContextTrait {
 			return false;
 		}
 
-		if ( ! $order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) ) {
+		if ( ! $order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) || empty( $order->get_transaction_id() ) ) {
 			return false;
 		}
 

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -136,7 +136,6 @@ class OrderTrackingEndpoint {
 			$order_id = (int) $data['order_id'];
 			$action   = $data['action'] ?? '';
 
-			$this->validate_tracking_info( $data );
 			$shipment = $this->create_shipment( $order_id, $data );
 
 			$action === 'update'
@@ -382,16 +381,21 @@ class OrderTrackingEndpoint {
 		$carrier = $data['carrier'] ?? '';
 
 		$tracking_info = array(
-			'transaction_id'     => $data['transaction_id'] ?? '',
-			'status'             => $data['status'] ?? '',
-			'tracking_number'    => $data['tracking_number'] ?? '',
-			'carrier'            => $carrier,
-			'carrier_name_other' => $data['carrier_name_other'] ?? '',
+			'transaction_id'  => $data['transaction_id'] ?? '',
+			'status'          => $data['status'] ?? '',
+			'tracking_number' => $data['tracking_number'] ?? '',
+			'carrier'         => $carrier,
 		);
 
 		if ( ! empty( $data['items'] ) ) {
 			$tracking_info['items'] = array_map( 'intval', $data['items'] );
 		}
+
+		if ( $carrier === 'OTHER' ) {
+			$tracking_info['carrier_name_other'] = $data['carrier_name_other'] ?? '';
+		}
+
+		$this->validate_tracking_info( $tracking_info );
 
 		return $this->shipment_factory->create_shipment(
 			$wc_order_id,
@@ -399,36 +403,23 @@ class OrderTrackingEndpoint {
 			$tracking_info['tracking_number'],
 			$tracking_info['status'],
 			$tracking_info['carrier'],
-			$tracking_info['carrier_name_other'],
+			$tracking_info['carrier_name_other'] ?? '',
 			$tracking_info['items'] ?? array()
 		);
 	}
 
 	/**
-	 * Validates tracking info for given request values.
+	 * Validates the requested tracking info.
 	 *
-	 * @param array<string, mixed> $request_values A map of request keys to values.
+	 * @param array<string, mixed> $tracking_info A map of tracking information keys to values.
 	 * @return void
 	 * @throws RuntimeException If validation failed.
 	 */
-	protected function validate_tracking_info( array $request_values ): void {
+	protected function validate_tracking_info( array $tracking_info ): void {
 		$error_message = __( 'Missing required information: ', 'woocommerce-paypal-payments' );
 		$empty_keys    = array();
 
-		$carrier = $request_values['carrier'] ?? '';
-
-		$data_to_check = array(
-			'transaction_id'  => $request_values['transaction_id'] ?? '',
-			'status'          => $request_values['status'] ?? '',
-			'tracking_number' => $request_values['tracking_number'] ?? '',
-			'carrier'         => $carrier,
-		);
-
-		if ( $carrier === 'OTHER' ) {
-			$data_to_check['carrier_name_other'] = $request_values['carrier_name_other'] ?? '';
-		}
-
-		foreach ( $data_to_check as $key => $value ) {
+		foreach ( $tracking_info as $key => $value ) {
 			if ( ! empty( $value ) ) {
 				continue;
 			}


### PR DESCRIPTION
# PR Description
The PR will disable the tracking functionality when the transaction ID is empty.

# Issue Description

In version 2.3.0-rc1, when the webhook for a PayPal order is not correctly handled and therefore PayPal meta such as transaction ID is not added, the Package Tracking integration attempts to call the PayPal API without a transaction ID which will result in an error.

## Steps To Reproduce
* Check the order edit page when the webhook for a PayPal order is not correctly handled.
