### PR TITLE
Fatal error when saving product while WooCommerce Subscriptions plugin is not active (2079)

### DIFF
--- a/modules/ppcp-subscription/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-subscription/src/Helper/SubscriptionHelper.php
@@ -121,7 +121,7 @@ class SubscriptionHelper {
 	 */
 	public function plugin_is_active(): bool {
 
-		return class_exists( WC_Subscriptions::class ) && class_exists(WC_Subscriptions_Product::class);
+		return class_exists( WC_Subscriptions::class ) && class_exists( WC_Subscriptions_Product::class );
 	}
 
 	/**

--- a/modules/ppcp-subscription/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-subscription/src/Helper/SubscriptionHelper.php
@@ -13,6 +13,7 @@ namespace WooCommerce\PayPalCommerce\Subscription\Helper;
 
 use WC_Product;
 use WC_Product_Subscription_Variation;
+use WC_Subscriptions;
 use WC_Subscriptions_Product;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
@@ -120,7 +121,7 @@ class SubscriptionHelper {
 	 */
 	public function plugin_is_active(): bool {
 
-		return class_exists( \WC_Subscriptions::class );
+		return class_exists( WC_Subscriptions::class ) && class_exists(WC_Subscriptions_Product::class);
 	}
 
 	/**

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -194,7 +194,18 @@ class SubscriptionModule implements ModuleInterface {
 				//phpcs:disable WordPress.Security.NonceVerification.Recommended
 				$post_id = wc_clean( wp_unslash( $_GET['post'] ?? '' ) );
 				$product = wc_get_product( $post_id );
-				if ( ! ( is_a( $product, WC_Product::class ) || is_a( $product, WC_Product_Subscription_Variation::class ) ) || ! WC_Subscriptions_Product::is_subscription( $product ) ) {
+				if ( ! ( is_a( $product, WC_Product::class ) )) {
+					return;
+				}
+
+				$subscriptions_helper = $c->get('subscription.helper');
+				assert($subscriptions_helper instanceof SubscriptionHelper);
+
+				if(
+					!$subscriptions_helper->plugin_is_active()
+					|| ! is_a( $product, WC_Product_Subscription_Variation::class )
+					|| ! WC_Subscriptions_Product::is_subscription( $product )
+				) {
 					return;
 				}
 

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -558,8 +558,13 @@ class SubscriptionModule implements ModuleInterface {
 			 */
 			function( $variation_id ) use ( $c ) {
 				$wcsnonce_save_variations = wc_clean( wp_unslash( $_POST['_wcsnonce_save_variations'] ?? '' ) );
+
+				$subscriptions_helper = $c->get('subscription.helper');
+				assert($subscriptions_helper instanceof SubscriptionHelper);
+
 				if (
-					! WC_Subscriptions_Product::is_subscription( $variation_id )
+					!$subscriptions_helper->plugin_is_active()
+					|| ! WC_Subscriptions_Product::is_subscription( $variation_id )
 					|| ! is_string( $wcsnonce_save_variations )
 					|| ! wp_verify_nonce( $wcsnonce_save_variations, 'wcs_subscription_variations' )
 				) {

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -221,6 +221,13 @@ class SubscriptionModule implements ModuleInterface {
 				$products = array( $this->set_product_config( $product ) );
 				if ( $product->get_type() === 'variable-subscription' ) {
 					$products = array();
+
+					/**
+					 * @psalm-suppress TypeDoesNotContainType
+					 *
+					 * WC_Product_Variable_Subscription extends WC_Product_Variable.
+					 */
+					assert( $product instanceof WC_Product_Variable );
 					$available_variations = $product->get_available_variations();
 					foreach ( $available_variations as $variation ) {
 						/**

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -194,15 +194,15 @@ class SubscriptionModule implements ModuleInterface {
 				//phpcs:disable WordPress.Security.NonceVerification.Recommended
 				$post_id = wc_clean( wp_unslash( $_GET['post'] ?? '' ) );
 				$product = wc_get_product( $post_id );
-				if ( ! ( is_a( $product, WC_Product::class ) )) {
+				if ( ! ( is_a( $product, WC_Product::class ) ) ) {
 					return;
 				}
 
-				$subscriptions_helper = $c->get('subscription.helper');
-				assert($subscriptions_helper instanceof SubscriptionHelper);
+				$subscriptions_helper = $c->get( 'subscription.helper' );
+				assert( $subscriptions_helper instanceof SubscriptionHelper );
 
-				if(
-					!$subscriptions_helper->plugin_is_active()
+				if (
+					! $subscriptions_helper->plugin_is_active()
 					|| ! is_a( $product, WC_Product_Subscription_Variation::class )
 					|| ! WC_Subscriptions_Product::is_subscription( $product )
 				) {
@@ -223,6 +223,8 @@ class SubscriptionModule implements ModuleInterface {
 					$products = array();
 
 					/**
+					 * Suppress pslam.
+					 *
 					 * @psalm-suppress TypeDoesNotContainType
 					 *
 					 * WC_Product_Variable_Subscription extends WC_Product_Variable.
@@ -559,11 +561,11 @@ class SubscriptionModule implements ModuleInterface {
 			function( $variation_id ) use ( $c ) {
 				$wcsnonce_save_variations = wc_clean( wp_unslash( $_POST['_wcsnonce_save_variations'] ?? '' ) );
 
-				$subscriptions_helper = $c->get('subscription.helper');
-				assert($subscriptions_helper instanceof SubscriptionHelper);
+				$subscriptions_helper = $c->get( 'subscription.helper' );
+				assert( $subscriptions_helper instanceof SubscriptionHelper );
 
 				if (
-					!$subscriptions_helper->plugin_is_active()
+					! $subscriptions_helper->plugin_is_active()
 					|| ! WC_Subscriptions_Product::is_subscription( $variation_id )
 					|| ! is_string( $wcsnonce_save_variations )
 					|| ! wp_verify_nonce( $wcsnonce_save_variations, 'wcs_subscription_variations' )

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -221,7 +221,6 @@ class SubscriptionModule implements ModuleInterface {
 				$products = array( $this->set_product_config( $product ) );
 				if ( $product->get_type() === 'variable-subscription' ) {
 					$products = array();
-					assert( $product instanceof WC_Product_Variable );
 					$available_variations = $product->get_available_variations();
 					foreach ( $available_variations as $variation ) {
 						/**


### PR DESCRIPTION
In 2.3.0, products cannot be edited while the WooCommerce Subscriptions plugin is not active:
```
Fatal error: Uncaught Error: Class "WC_Subscriptions_Product" not found
in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-subscription/src/SubscriptionModule.php on line 197
```

### Steps To Reproduce
- Install 2.3.0
- ensure WooCommerce Subscriptions plugin is not active
- edit an existing product
- observe fatal error
