### PR TITLE
Mini-Cart bug causing wrong DOM-Structure on certain browsers (2094)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -482,7 +482,7 @@ class SmartButton implements SmartButtonInterface {
 					echo '<p class="woocommerce-mini-cart__buttons buttons">';
 					echo '<span id="ppc-button-minicart"></span>';
 					do_action( 'woocommerce_paypal_payments_minicart_button_render' );
-					echo '</div>';
+					echo '</p>';
 				},
 				30
 			);


### PR DESCRIPTION
Fixes #1735

# PR Description

The closing tag should be a `</p>`.


# Issue Description

The minicart may generate a broken header when PayPal button is present.

There is a closing `</div>` instead of a `</p>` at the and, which closes a parent element.

## Steps To Reproduce
In WooCommerce PayPal Payments (v2.3.1)
* Add the PayPal Button to the Minicart placement.
* Add an article to you cart to see the bug.

It’s hard to reproduce since most browsers autocorrect the HTML. And the Minicart HTML can’t be viewed by view page source.

## Expected behaviour
Correct DOM-Structure in mini-cart.

## Possible cause
Wrong DOM-Structure in mini-cart.

## Suggested solution
Fix the closing tag.