### PR TITLE
Ensure PayPal Subscriptions API products description is 1-127 characters (2089)

### DIFF
--- a/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
@@ -114,7 +114,7 @@ class SubscriptionsApiHandler {
 	 */
 	public function create_product( WC_Product $product ) {
 		try {
-			$subscription_product = $this->products_endpoint->create( $product->get_title(), $this->prepare_description($product->get_description()) );
+			$subscription_product = $this->products_endpoint->create( $product->get_title(), $this->prepare_description( $product->get_description() ) );
 			$product->update_meta_data( 'ppcp_subscription_product', $subscription_product->to_array() );
 			$product->save();
 		} catch ( RuntimeException $exception ) {
@@ -169,9 +169,9 @@ class SubscriptionsApiHandler {
 				$catalog_product_name        = $catalog_product->name() ?: '';
 				$catalog_product_description = $catalog_product->description() ?: '';
 
-				$wc_product_description = $this->prepare_description($product->get_description()) ?: $product->get_title();
+				$wc_product_description = $this->prepare_description( $product->get_description() ) ?: $product->get_title();
 
-				if ( $catalog_product_name !== $product->get_title() || $catalog_product_description !== $wc_product_description) {
+				if ( $catalog_product_name !== $product->get_title() || $catalog_product_description !== $wc_product_description ) {
 					$data = array();
 					if ( $catalog_product_name !== $product->get_title() ) {
 						$data[] = (object) array(
@@ -180,7 +180,7 @@ class SubscriptionsApiHandler {
 							'value' => $product->get_title(),
 						);
 					}
-					if ( $catalog_product_description !== $wc_product_description) {
+					if ( $catalog_product_description !== $wc_product_description ) {
 						$data[] = (object) array(
 							'op'    => 'replace',
 							'path'  => '/description',

--- a/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
@@ -114,7 +114,7 @@ class SubscriptionsApiHandler {
 	 */
 	public function create_product( WC_Product $product ) {
 		try {
-			$subscription_product = $this->products_endpoint->create( $product->get_title(), $product->get_description() );
+			$subscription_product = $this->products_endpoint->create( $product->get_title(), $this->prepare_description($product->get_description()) );
 			$product->update_meta_data( 'ppcp_subscription_product', $subscription_product->to_array() );
 			$product->save();
 		} catch ( RuntimeException $exception ) {
@@ -168,7 +168,10 @@ class SubscriptionsApiHandler {
 				$catalog_product             = $this->products_endpoint->product( $catalog_product_id );
 				$catalog_product_name        = $catalog_product->name() ?: '';
 				$catalog_product_description = $catalog_product->description() ?: '';
-				if ( $catalog_product_name !== $product->get_title() || $catalog_product_description !== $product->get_description() ) {
+
+				$wc_product_description = $this->prepare_description($product->get_description()) ?: $product->get_title();
+
+				if ( $catalog_product_name !== $product->get_title() || $catalog_product_description !== $wc_product_description) {
 					$data = array();
 					if ( $catalog_product_name !== $product->get_title() ) {
 						$data[] = (object) array(
@@ -177,11 +180,11 @@ class SubscriptionsApiHandler {
 							'value' => $product->get_title(),
 						);
 					}
-					if ( $catalog_product_description !== $product->get_description() ) {
+					if ( $catalog_product_description !== $wc_product_description) {
 						$data[] = (object) array(
 							'op'    => 'replace',
 							'path'  => '/description',
-							'value' => $this->prepare_description( $product->get_description() ) ?: '',
+							'value' => $wc_product_description,
 						);
 					}
 

--- a/tests/Playwright/tests/subscriptions-api.spec.js
+++ b/tests/Playwright/tests/subscriptions-api.spec.js
@@ -11,6 +11,16 @@ const {
     CART_URL,
 } = process.env;
 
+const longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ultricies integer quis auctor elit sed vulputate mi. Aliquam sem et tortor consequat id porta nibh venenatis cras. Massa enim nec dui nunc. Nulla porttitor massa id neque aliquam vestibulum morbi blandit cursus. Eu lobortis elementum nibh tellus molestie nunc. Euismod nisi porta lorem mollis aliquam ut porttitor. Ultrices tincidunt arcu non sodales neque sodales ut etiam. Urna cursus eget nunc scelerisque. Pulvinar sapien et ligula ullamcorper malesuada proin libero. Convallis a cras semper auctor neque vitae tempus quam pellentesque. Phasellus egestas tellus rutrum tellus pellentesque eu tincidunt tortor aliquam. Cras tincidunt lobortis feugiat vivamus. Nec ultrices dui sapien eget mi proin sed libero enim. Neque gravida in fermentum et sollicitudin ac orci phasellus egestas. Aliquam faucibus purus in massa. Viverra accumsan in nisl nisi scelerisque eu ultrices vitae. At augue eget arcu dictum varius duis. Commodo ullamcorper a lacus vestibulum sed arcu non odio.\n' +
+    '\n' +
+    'Id cursus metus aliquam eleifend mi in nulla. A diam sollicitudin tempor id eu nisl. Faucibus purus in massa tempor. Lacus luctus accumsan tortor posuere ac ut consequat. Mauris augue neque gravida in fermentum et sollicitudin ac. Venenatis tellus in metus vulputate. Consectetur libero id faucibus nisl tincidunt eget. Pellentesque eu tincidunt tortor aliquam nulla facilisi cras fermentum odio. Dolor sed viverra ipsum nunc aliquet bibendum. Turpis in eu mi bibendum neque. Ac tincidunt vitae semper quis lectus nulla at volutpat. Felis imperdiet proin fermentum leo vel orci porta. Sed sed risus pretium quam vulputate dignissim.\n' +
+    '\n' +
+    'Urna et pharetra pharetra massa massa ultricies mi quis. Egestas purus viverra accumsan in nisl nisi. Elit sed vulputate mi sit amet mauris commodo. Cras fermentum odio eu feugiat pretium nibh ipsum consequat. Justo laoreet sit amet cursus sit amet dictum. Nunc id cursus metus aliquam. Tortor at auctor urna nunc id. Quis lectus nulla at volutpat diam ut. Lorem ipsum dolor sit amet consectetur adipiscing elit pellentesque. Tincidunt lobortis feugiat vivamus at augue eget arcu dictum varius.\n' +
+    '\n' +
+    'Mattis nunc sed blandit libero. Vitae ultricies leo integer malesuada nunc vel risus. Dapibus ultrices in iaculis nunc. Interdum varius sit amet mattis. Tortor vitae purus faucibus ornare. Netus et malesuada fames ac turpis. Elit duis tristique sollicitudin nibh sit amet. Lacus suspendisse faucibus interdum posuere lorem. In pellentesque massa placerat duis. Fusce ut placerat orci nulla pellentesque dignissim. Dictum fusce ut placerat orci nulla pellentesque dignissim enim. Nibh sit amet commodo nulla facilisi. Maecenas sed enim ut sem. Non consectetur a erat nam at lectus urna duis convallis. Diam phasellus vestibulum lorem sed risus ultricies tristique nulla. Nunc congue nisi vitae suscipit. Tortor condimentum lacinia quis vel eros donec ac. Eleifend mi in nulla posuere.\n' +
+    '\n' +
+    'Vestibulum lectus mauris ultrices eros. Massa sed elementum tempus egestas sed sed risus. Ut placerat orci nulla pellentesque dignissim enim sit. Duis ut diam quam nulla porttitor. Morbi tincidunt ornare massa eget egestas purus. Commodo sed egestas egestas fringilla phasellus faucibus scelerisque eleifend donec. Arcu odio ut sem nulla pharetra diam sit. Risus sed vulputate odio ut enim. Faucibus et molestie ac feugiat. A scelerisque purus semper eget. Odio facilisis mauris sit amet massa vitae tortor. Condimentum vitae sapien pellentesque habitant morbi tristique senectus. Nec feugiat in fermentum posuere urna. Volutpat est velit egestas dui id ornare arcu odio ut. Ullamcorper malesuada proin libero nunc consequat interdum. Suspendisse in est ante in nibh mauris cursus mattis molestie. Vel eros donec ac odio tempor orci dapibus. Et tortor at risus viverra adipiscing at in tellus. Metus aliquam eleifend mi in.'
+
 async function purchaseSubscriptionFromCart(page) {
     await loginAsCustomer(page);
     await page.goto(SUBSCRIPTION_URL);
@@ -98,6 +108,7 @@ test.describe.serial('Subscriptions Merchant', () => {
 
         await page.fill('#title', `Updated ${productTitle}`);
         await page.fill('#_subscription_price', '20');
+        await page.fill('#content', longText)
 
         await Promise.all([
             page.waitForNavigation(),


### PR DESCRIPTION
This PR ensures subscription product description is 1-127 characters.

### Steps To Reproduce

Enable WC Subscriptions plugin and PayPal Subscriptions mode in settings.

#### Update Product description longer than 127 characters
- Create and connect a new subscription product with empty description, 
- Save and ensure product is connected to PayPal
- Add a description longer than 127 characters and update product
- Ensure description is updated on PayPal

#### Create Product description longer than 127 characters and clear afterwards
- Create and connect a new subscription product with description longer than 127 characters, 
- Save and ensure product is connected to PayPal
- Remove product description completely and update product
- Ensure description is the same as product title 