### PR TITLE
A solution to the "Call to undefined method WP_Post::get_meta()" issue that occurs when updating a subscription via WP-Admin.

### DIFF
--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -593,7 +593,10 @@ class SubscriptionModule implements ModuleInterface {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function( $id, $subscription ) use ( $c ) {
+				// Get the $subscription variable WC_Subscription again.
+				$subscription = wcs_get_subscription( $id );
 				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
+				// Since I don't know exactly what the "ppcp_subscription" meta value is, I'm not touching the code below. However, if the id "$subscription_id" is equal to the existing subscription id, only $id can be used instead of $subscription_id.
 				if ( $subscription_id ) {
 					$subscriptions_endpoint = $c->get( 'api.endpoint.billing-subscriptions' );
 					assert( $subscriptions_endpoint instanceof BillingSubscriptions );


### PR DESCRIPTION
**Issue**: #

"Call to undefined method WP_Post::get_meta()" error when updating a subscription via WP-Admin.

---

### Description

The $id parameter sent in the hook matches the current subscription id. However, the sent $subscription object, which is the secondary parameter, is derived from the WP_Post class and it gives an error because there is no get_meta() method in this class. I replaced the WP_Post class with the WC_Subscription class.

### Steps to Test

Since there is a get_meta() method in the WC_Subscription class, it no longer gives this error and moves forward.

### Documentation

No need

### Changelog Entry

The critical error "Call to undefined method WP_Post::get_meta()" that occurred during manual subscription update in WP-Admin has been fixed.

Closes # .
