### PR TITLE
Fix subscription module hooks

### DIFF
--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -656,7 +656,7 @@ class SubscriptionModule implements ModuleInterface {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function( $actions, $subscription ): array {
-				if ( ! is_a( $subscription, WC_Subscription::class ) ) {
+				if ( ! is_array( $actions ) || ! is_a( $subscription, WC_Subscription::class ) ) {
 					return $actions;
 				}
 

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -592,55 +592,60 @@ class SubscriptionModule implements ModuleInterface {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $id, $subscription ) use ( $c ) {
+			function( $id, $post ) use ( $c ) {
+				$subscription = wcs_get_subscription( $id );
+				if ( ! is_a( $subscription, WC_Subscription::class ) ) {
+					return;
+				}
 				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
-				if ( $subscription_id ) {
-					$subscriptions_endpoint = $c->get( 'api.endpoint.billing-subscriptions' );
-					assert( $subscriptions_endpoint instanceof BillingSubscriptions );
+				if ( ! $subscription_id ) {
+					return;
+				}
+				$subscriptions_endpoint = $c->get( 'api.endpoint.billing-subscriptions' );
+				assert( $subscriptions_endpoint instanceof BillingSubscriptions );
 
-					if ( $subscription->get_status() === 'cancelled' ) {
-						try {
-							$subscriptions_endpoint->cancel( $subscription_id );
-						} catch ( RuntimeException $exception ) {
-							$error = $exception->getMessage();
-							if ( is_a( $exception, PayPalApiException::class ) ) {
-								$error = $exception->get_details( $error );
-							}
-
-							$logger = $c->get( 'woocommerce.logger.woocommerce' );
-							$logger->error( 'Could not cancel subscription product on PayPal. ' . $error );
+				if ( $subscription->get_status() === 'cancelled' ) {
+					try {
+						$subscriptions_endpoint->cancel( $subscription_id );
+					} catch ( RuntimeException $exception ) {
+						$error = $exception->getMessage();
+						if ( is_a( $exception, PayPalApiException::class ) ) {
+							$error = $exception->get_details( $error );
 						}
+
+						$logger = $c->get( 'woocommerce.logger.woocommerce' );
+						$logger->error( 'Could not cancel subscription product on PayPal. ' . $error );
 					}
+				}
 
-					if ( $subscription->get_status() === 'pending-cancel' ) {
-						try {
-							$subscriptions_endpoint->suspend( $subscription_id );
-						} catch ( RuntimeException $exception ) {
-							$error = $exception->getMessage();
-							if ( is_a( $exception, PayPalApiException::class ) ) {
-								$error = $exception->get_details( $error );
-							}
-
-							$logger = $c->get( 'woocommerce.logger.woocommerce' );
-							$logger->error( 'Could not suspend subscription product on PayPal. ' . $error );
+				if ( $subscription->get_status() === 'pending-cancel' ) {
+					try {
+						$subscriptions_endpoint->suspend( $subscription_id );
+					} catch ( RuntimeException $exception ) {
+						$error = $exception->getMessage();
+						if ( is_a( $exception, PayPalApiException::class ) ) {
+							$error = $exception->get_details( $error );
 						}
+
+						$logger = $c->get( 'woocommerce.logger.woocommerce' );
+						$logger->error( 'Could not suspend subscription product on PayPal. ' . $error );
 					}
+				}
 
-					if ( $subscription->get_status() === 'active' ) {
-						try {
-							$current_subscription = $subscriptions_endpoint->subscription( $subscription_id );
-							if ( $current_subscription->status === 'SUSPENDED' ) {
-								$subscriptions_endpoint->activate( $subscription_id );
-							}
-						} catch ( RuntimeException $exception ) {
-							$error = $exception->getMessage();
-							if ( is_a( $exception, PayPalApiException::class ) ) {
-								$error = $exception->get_details( $error );
-							}
-
-							$logger = $c->get( 'woocommerce.logger.woocommerce' );
-							$logger->error( 'Could not reactivate subscription product on PayPal. ' . $error );
+				if ( $subscription->get_status() === 'active' ) {
+					try {
+						$current_subscription = $subscriptions_endpoint->subscription( $subscription_id );
+						if ( $current_subscription->status === 'SUSPENDED' ) {
+							$subscriptions_endpoint->activate( $subscription_id );
 						}
+					} catch ( RuntimeException $exception ) {
+						$error = $exception->getMessage();
+						if ( is_a( $exception, PayPalApiException::class ) ) {
+							$error = $exception->get_details( $error );
+						}
+
+						$logger = $c->get( 'woocommerce.logger.woocommerce' );
+						$logger->error( 'Could not reactivate subscription product on PayPal. ' . $error );
 					}
 				}
 			},


### PR DESCRIPTION
- Added type check in the `woocommerce_order_actions` handler because `$actions` can become `null` sometimes (probably because of third-party plugins).
- Added a `wcs_get_subscription` call in the `woocommerce_process_shop_subscription_meta` handler. It seems like this code was never actually working? This hook always receives a post, not a subscription. It was causing an  error when updating a sub in WC → Subscription, such as executing the renewal action.