### PR TITLE
Change default ACDC title

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -201,8 +201,10 @@ return array(
 	},
 
 	'wcgateway.settings'                                   => static function ( ContainerInterface $container ): Settings {
-		$default_button_locations = $container->get( 'wcgateway.button.default-locations' );
-		return new Settings( $default_button_locations );
+		return new Settings(
+			$container->get( 'wcgateway.button.default-locations' ),
+			$container->get( 'wcgateway.settings.dcc-gateway-title.default' )
+		);
 	},
 	'wcgateway.notice.connect'                             => static function ( ContainerInterface $container ): ConnectAdminNotice {
 		$state    = $container->get( 'onboarding.state' );
@@ -487,7 +489,7 @@ return array(
 					'This controls the title which the user sees during checkout.',
 					'woocommerce-paypal-payments'
 				),
-				'default'      => __( 'Debit & Credit Cards', 'woocommerce-paypal-payments' ),
+				'default'      => $container->get( 'wcgateway.settings.dcc-gateway-title.default' ),
 				'desc_tip'     => true,
 				'screens'      => array(
 					State::STATE_ONBOARDED,
@@ -1184,6 +1186,10 @@ return array(
 		$vaulting_label .= '</p>';
 
 		return $vaulting_label;
+	},
+
+	'wcgateway.settings.dcc-gateway-title.default'         => static function ( ContainerInterface $container ): string {
+		return __( 'Debit & Credit Cards', 'woocommerce-paypal-payments' );
 	},
 
 	'wcgateway.settings.card_billing_data_mode.default'    => static function ( ContainerInterface $container ): string {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -487,7 +487,7 @@ return array(
 					'This controls the title which the user sees during checkout.',
 					'woocommerce-paypal-payments'
 				),
-				'default'      => __( 'Credit Cards', 'woocommerce-paypal-payments' ),
+				'default'      => __( 'Debit & Credit Cards', 'woocommerce-paypal-payments' ),
 				'desc_tip'     => true,
 				'screens'      => array(
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -202,8 +202,10 @@ return array(
 
 	'wcgateway.settings'                                   => SingletonDecorator::make(
 		static function ( ContainerInterface $container ): Settings {
-			$default_button_locations = $container->get( 'wcgateway.button.default-locations' );
-			return new Settings( $default_button_locations );
+			return new Settings(
+				$container->get( 'wcgateway.button.default-locations' ),
+				$container->get( 'wcgateway.settings.dcc-gateway-title.default' )
+			);
 		}
 	),
 	'wcgateway.notice.connect'                             => static function ( ContainerInterface $container ): ConnectAdminNotice {

--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -36,12 +36,21 @@ class Settings implements ContainerInterface {
 	protected $default_button_locations;
 
 	/**
+	 * The default ACDC gateway title.
+	 *
+	 * @var string
+	 */
+	protected $default_dcc_gateway_title;
+
+	/**
 	 * Settings constructor.
 	 *
 	 * @param string[] $default_button_locations The list of selected default button locations.
+	 * @param string   $default_dcc_gateway_title The default ACDC gateway title.
 	 */
-	public function __construct( array $default_button_locations ) {
-		$this->default_button_locations = $default_button_locations;
+	public function __construct( array $default_button_locations, string $default_dcc_gateway_title ) {
+		$this->default_button_locations  = $default_button_locations;
+		$this->default_dcc_gateway_title = $default_dcc_gateway_title;
 	}
 
 	/**
@@ -116,7 +125,7 @@ class Settings implements ContainerInterface {
 			'pay_later_button_locations'               => $this->default_button_locations,
 			'pay_later_messaging_locations'            => $this->default_button_locations,
 			'brand_name'                               => get_bloginfo( 'name' ),
-			'dcc_gateway_title'                        => __( 'Debit & Credit Cards', 'woocommerce-paypal-payments' ),
+			'dcc_gateway_title'                        => $this->default_dcc_gateway_title,
 			'dcc_gateway_description'                  => __(
 				'Pay with your credit card.',
 				'woocommerce-paypal-payments'

--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -116,7 +116,7 @@ class Settings implements ContainerInterface {
 			'pay_later_button_locations'               => $this->default_button_locations,
 			'pay_later_messaging_locations'            => $this->default_button_locations,
 			'brand_name'                               => get_bloginfo( 'name' ),
-			'dcc_gateway_title'                        => __( 'Credit Cards', 'woocommerce-paypal-payments' ),
+			'dcc_gateway_title'                        => __( 'Debit & Credit Cards', 'woocommerce-paypal-payments' ),
 			'dcc_gateway_description'                  => __(
 				'Pay with your credit card.',
 				'woocommerce-paypal-payments'


### PR DESCRIPTION
The default title (for new installations or after clearing settings) is now "Debit & Credit Cards" instead of "Credit Cards".

It seems like the default title is set in two places: the `wcgateway.settings.fields` service and the `Settings` class. As I understand we need to have some defaults in the `Settings` class for cases when the settings are not saved yet because the `default` values from the `wcgateway.settings.fields` service only affect the initial content of the settings inputs. A cleaner way would be to use it in the `Settings` class too, but it may not be a good idea to execute this service in every request that needs to access the current settings because this service is executing many other things, especially while the caching of services is still not enabled. So for now just extracted this default value into a separate service.

Also the `Settings` class [sets default](https://github.com/woocommerce/woocommerce-paypal-payments/blob/e530382a7cc31651f236d9e33359311a6701baf6/modules/ppcp-wc-gateway/src/Settings/Settings.php#L120C1-L122) for `dcc_gateway_description` and it is used [in the gateway](https://github.com/woocommerce/woocommerce-paypal-payments/blob/e530382a7cc31651f236d9e33359311a6701baf6/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php#L210), but I think it is not displayed anywhere, and we do not have the settings field for that.