### PR TITLE
Fix ACDC disappearing after plugin updates

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -200,10 +200,12 @@ return array(
 		return $ppcp_tab ? $ppcp_tab : $section;
 	},
 
-	'wcgateway.settings'                                   => static function ( ContainerInterface $container ): Settings {
-		$default_button_locations = $container->get( 'wcgateway.button.default-locations' );
-		return new Settings( $default_button_locations );
-	},
+	'wcgateway.settings'                                   => SingletonDecorator::make(
+		static function ( ContainerInterface $container ): Settings {
+			$default_button_locations = $container->get( 'wcgateway.button.default-locations' );
+			return new Settings( $default_button_locations );
+		}
+	),
 	'wcgateway.notice.connect'                             => static function ( ContainerInterface $container ): ConnectAdminNotice {
 		$state    = $container->get( 'onboarding.state' );
 		$settings = $container->get( 'wcgateway.settings' );


### PR DESCRIPTION
Fixes the bug about ACDC being missing in checkout after plugin updates until settings are saved.

It was happening because the ACDC status in the account was cached via the `Settings` object, and after #1468 we are updating this cached value, but then [another part of the code](https://github.com/woocommerce/woocommerce-paypal-payments/blob/e530382a7cc31651f236d9e33359311a6701baf6/modules/ppcp-vaulting/src/VaultingModule.php#L157) calls updates another `Settings` instance with old data, and the previous updates are lost.

The main problem here is that we have [incorrect setup](https://github.com/woocommerce/woocommerce-paypal-payments/blob/e530382a7cc31651f236d9e33359311a6701baf6/bootstrap.php#L46) of the caching container for services, but it may be risky to fix for all services now.

So for now making just the settings service a singleton, like suggested by @pedrosilva-pt who also noticed a similar issue with settings.