### PR TITLE
Cart simulation improvements (2066)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -217,7 +217,6 @@ class SingleProductBootstap {
     }
 
     simulateCart() {
-        // Check of cart simulation is enabled.
         if (!this.gateway.simulate_cart.enabled) {
             return;
         }

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -17,7 +17,7 @@ class SingleProductBootstap {
         this.formSelector = 'form.cart';
 
         // Prevent simulate cart being called too many times in a burst.
-        this.simulateCartThrottled = throttle(this.simulateCart, 5000);
+        this.simulateCartThrottled = throttle(this.simulateCart, this.gateway.simulate_cart.throttling || 5000);
 
         this.renderer.onButtonsInit(this.gateway.button.wrapper, () => {
             this.handleChange();
@@ -217,6 +217,11 @@ class SingleProductBootstap {
     }
 
     simulateCart() {
+        // Check of cart simulation is enabled.
+        if (!this.gateway.simulate_cart.enabled) {
+            return;
+        }
+
         const actionHandler = new SingleProductActionHandler(
             null,
             null,

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -963,6 +963,10 @@ class SmartButton implements SmartButtonInterface {
 				// phpcs:ignore WordPress.WP.I18n
 				'shipping_field' => _x( 'Shipping %s', 'checkout-validation', 'woocommerce' ),
 			),
+			'simulate_cart'                           => array(
+				'enabled'    => apply_filters( 'woocommerce_paypal_payments_simulate_cart_enabled', true ),
+				'throttling' => apply_filters( 'woocommerce_paypal_payments_simulate_cart_throttling', 5000 ),
+			),
 			'order_id'                                => 'pay-now' === $this->context() ? $this->get_order_pay_id() : 0,
 			'single_product_buttons_enabled'          => $this->settings_status->is_smart_button_enabled_for_location( 'product' ),
 			'mini_cart_buttons_enabled'               => $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' ),

--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -151,6 +151,7 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 
 	/**
 	 * Restores the real cart.
+	 * Currently, unsets the WC cart to prevent race conditions arising from it being persisted.
 	 *
 	 * @return void
 	 */
@@ -158,7 +159,7 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 		// Remove from cart because some plugins reserve resources internally when adding to cart.
 		$this->remove_cart_items();
 
-		// Restore cart and unset cart clone.
+		// Unset cart to prevent it being updated/persisted.
 		unset( WC()->cart );
 		unset( $this->cart );
 	}

--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -159,9 +159,7 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 		$this->remove_cart_items();
 
 		// Restore cart and unset cart clone.
-		if ( null !== $this->real_cart ) {
-			WC()->cart = $this->real_cart;
-		}
+		unset( WC()->cart );
 		unset( $this->cart );
 	}
 

--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -159,8 +159,17 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 		// Remove from cart because some plugins reserve resources internally when adding to cart.
 		$this->remove_cart_items();
 
-		// Unset cart to prevent it being updated/persisted.
-		unset( WC()->cart );
+		if ( apply_filters( 'woocommerce_paypal_payments_simulate_cart_prevent_updates', true ) ) {
+			// Removes shutdown actions to prevent persisting session, transients and save cookies.
+			remove_all_actions( 'shutdown' );
+			unset( WC()->cart );
+		} else {
+			// Restores cart, may lead to race conditions.
+			if ( null !== $this->real_cart ) {
+				WC()->cart = $this->real_cart;
+			}
+		}
+
 		unset( $this->cart );
 	}
 


### PR DESCRIPTION
# PR Description
* Now by default the cart is unset, instead of restoring it after simulation we prevent/stop the race conditions.
* Suppressing the shutdown hooks also prevent unwanted database, session or cookie updates.
* Filters were added to disable the simulate_cart or customize the throttling:
  * `apply_filters( 'woocommerce_paypal_payments_simulate_cart_enabled', true ),`
  * `apply_filters( 'woocommerce_paypal_payments_simulate_cart_throttling', 5000 ),`

# Issue Description
Brainstorming about ways to improve the cart simulation behavior