### PR TITLE
Add validation on the Plan Name field to not accept a blank value (2087)

### DIFF
--- a/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-subscription/src/SubscriptionsApiHandler.php
@@ -137,7 +137,7 @@ class SubscriptionsApiHandler {
 	public function create_plan( string $plan_name, WC_Product $product ): void {
 		try {
 			$subscription_plan = $this->billing_plans_endpoint->create(
-				$plan_name,
+				$plan_name ?: $product->get_title(),
 				$product->get_meta( 'ppcp_subscription_product' )['id'] ?? '',
 				$this->billing_cycles( $product ),
 				$this->payment_preferences_factory->from_wc_product( $product )->to_array()


### PR DESCRIPTION
Currently it's possible to call `POST /v1/billing/plans` with an empty `name` value resulting in `INVALID_STRING_MIN_LENGTH` response error.

This PR fixes the problem by using the WC product name when PayPal Plan Name is sent empty.

### Steps To Reproduce

- Enable WC Subscriptions plugin and PayPal Subscriptions mode in settings.
- Create a new subscription product with empty Plan Name.