### PR TITLE
Billing schedule fields not greyed out when PayPal Subscriptions product is connected (2086)

### DIFF
--- a/.psalm/wcs.php
+++ b/.psalm/wcs.php
@@ -2107,3 +2107,16 @@ function wc_get_page_screen_id( $for ) {}
  *
  */
 class WC_Product_Subscription_Variation extends WC_Product_Variation {}
+
+/**
+ * Variable Subscription Product Class
+ *
+ * This class extends the WC Variable product class to create variable products with recurring payments.
+ *
+ * @class WC_Product_Variable_Subscription
+ * @package WooCommerce Subscriptions
+ * @category Class
+ * @since 1.0.0 - Migrated from WooCommerce Subscriptions v1.3
+ *
+ */
+class WC_Product_Variable_Subscription extends WC_Product_Variable {}

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -204,7 +204,7 @@ class SubscriptionModule implements ModuleInterface {
 
 				if (
 					! $subscriptions_helper->plugin_is_active()
-					|| ! ( is_a( $product, WC_Product_Subscription::class ) || is_a( $product, WC_Product_Subscription_Variation::class ) )
+					|| ! ( is_a( $product, WC_Product_Subscription::class ) || is_a( $product, WC_Product_Variable_Subscription::class ) || is_a( $product, WC_Product_Subscription_Variation::class ) )
 					|| ! WC_Subscriptions_Product::is_subscription( $product )
 				) {
 					return;

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -204,7 +204,11 @@ class SubscriptionModule implements ModuleInterface {
 
 				if (
 					! $subscriptions_helper->plugin_is_active()
-					|| ! ( is_a( $product, WC_Product_Subscription::class ) || is_a( $product, WC_Product_Variable_Subscription::class ) || is_a( $product, WC_Product_Subscription_Variation::class ) )
+					|| ! (
+						is_a( $product, WC_Product_Subscription::class )
+						|| is_a( $product, WC_Product_Variable_Subscription::class )
+						|| is_a( $product, WC_Product_Subscription_Variation::class )
+					)
 					|| ! WC_Subscriptions_Product::is_subscription( $product )
 				) {
 					return;

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Subscription;
 use ActionScheduler_Store;
 use Exception;
 use WC_Product;
+use WC_Product_Subscription;
 use WC_Product_Subscription_Variation;
 use WC_Product_Variable;
 use WC_Product_Variable_Subscription;
@@ -203,7 +204,7 @@ class SubscriptionModule implements ModuleInterface {
 
 				if (
 					! $subscriptions_helper->plugin_is_active()
-					|| ! is_a( $product, WC_Product_Subscription_Variation::class )
+					|| ! ( is_a( $product, WC_Product_Subscription::class ) || is_a( $product, WC_Product_Subscription_Variation::class ) )
 					|| ! WC_Subscriptions_Product::is_subscription( $product )
 				) {
 					return;


### PR DESCRIPTION
When successfully connecting a subscription product, the billing cycle configuration (and all other settings that can’t be changed) fields are not greyed out/inactive:

![image-20230927-144309](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/04939c4f-a37b-4022-860c-8c01cd562f6c)

This PR fixes the problem by adding a check for `WC_Product_Subscription` class along with existing check for `WC_Product_Subscription_Variation`.

### Steps To Reproduce

- install 2.3.0+
- set up PayPal Subscriptions product connection
- observe billing cycle fields are not greyed out while product is connected with PayPal subscription

### Expected behaviour

Certain settings fields on the subscription are greyed out as long as the product is connected to PayPal.