### PR TITLE
[Fix] Avoid calling  get_available_payment_gateways in every request.

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -488,38 +488,47 @@ class SmartButton implements SmartButtonInterface {
 			);
 		}
 
-		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 
-		if ( isset( $available_gateways['ppcp-gateway'] ) ) {
-			add_action(
-				$this->pay_order_renderer_hook(),
-				function (): void {
+		add_action(
+			$this->pay_order_renderer_hook(),
+			function (): void {
+				$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+
+				if ( isset( $available_gateways['ppcp-gateway'] ) ) {
 					$this->button_renderer( PayPalGateway::ID, 'woocommerce_paypal_payments_payorder_button_render' );
 					$this->button_renderer( CardButtonGateway::ID );
-				},
-				20
-			);
-			add_action(
-				$this->checkout_button_renderer_hook(),
-				function (): void {
+				}
+			},
+			20
+		);
+		add_action(
+			$this->checkout_button_renderer_hook(),
+			function (): void {
+				$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+
+				if ( isset( $available_gateways['ppcp-gateway'] ) ) {
 					$this->button_renderer( PayPalGateway::ID, 'woocommerce_paypal_payments_checkout_button_render' );
 					$this->button_renderer( CardButtonGateway::ID );
 				}
-			);
+			}
+		);
 
-			$enabled_on_cart = $this->settings_status->is_smart_button_enabled_for_location( 'cart' );
-			add_action(
-				$this->proceed_to_checkout_button_renderer_hook(),
-				function() use ( $enabled_on_cart ) {
-					if ( ! is_cart() || ! $enabled_on_cart || $this->is_free_trial_cart() || $this->is_cart_price_total_zero() ) {
-						return;
-					}
+		$enabled_on_cart = $this->settings_status->is_smart_button_enabled_for_location( 'cart' );
+		add_action(
+			$this->proceed_to_checkout_button_renderer_hook(),
+			function() use ( $enabled_on_cart ) {
+				if ( ! is_cart() || ! $enabled_on_cart || $this->is_free_trial_cart() || $this->is_cart_price_total_zero() ) {
+					return;
+				}
 
+				$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+
+				if ( isset( $available_gateways['ppcp-gateway'] ) ) {
 					$this->button_renderer( PayPalGateway::ID, 'woocommerce_paypal_payments_cart_button_render' );
-				},
-				20
-			);
-		}
+				}
+			},
+			20
+		);
 
 		return true;
 	}


### PR DESCRIPTION
Right now every request is loading available_gateways which is very slow call around 86ms (screenshot bellow).

<img width="816" alt="Screenshot 2023-10-11 at 1 02 33 PM" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/12052390/bee83356-97fb-40fe-84e8-2d1cb1e73a38">


