### PR TITLE
Disable the tracking if payment is not captured (2134)

### DIFF
--- a/modules/ppcp-order-tracking/src/TrackingAvailabilityTrait.php
+++ b/modules/ppcp-order-tracking/src/TrackingAvailabilityTrait.php
@@ -9,25 +9,40 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
-use WooCommerce\PayPalCommerce\Compat\AdminContextTrait;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 
 trait TrackingAvailabilityTrait {
 
-	use AdminContextTrait;
-
 	/**
-	 * Checks if tracking is enabled.
+	 * Checks if tracking should be enabled for current post.
 	 *
 	 * @param Bearer $bearer The Bearer.
 	 * @return bool
 	 */
 	protected function is_tracking_enabled( Bearer $bearer ): bool {
+		$post_id = (int) wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! $post_id ) {
+			return false;
+		}
+
+		$order = wc_get_order( $post_id );
+		if ( ! is_a( $order, WC_Order::class ) ) {
+			return false;
+		}
+
+		$captured                  = $order->get_meta( AuthorizedPaymentsProcessor::CAPTURED_META_KEY );
+		$is_captured               = empty( $captured ) || wc_string_to_bool( $captured );
+		$is_paypal_order_edit_page = $order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) && ! empty( $order->get_transaction_id() );
+
 		try {
 			$token = $bearer->bearer();
-			return $token->is_tracking_available()
-				&& $this->is_paypal_order_edit_page()
+			return $is_paypal_order_edit_page
+				&& $is_captured
+				&& $token->is_tracking_available()
 				&& apply_filters( 'woocommerce_paypal_payments_shipment_tracking_enabled', true );
 		} catch ( RuntimeException $exception ) {
 			return false;


### PR DESCRIPTION
# PR Description
When the order payment is not captured we don't need to show the tracking metabox at all.
The PR will add a check to disable the tracking functionality for orders which are not captured.

# Issue Description

We are seeing Orders V2 tracking calls fail for some merchants. Based on our engineering assessment, it looks like these errors happen when order is not captured. The merchant is authorizing the order & sending authorization ID as capture ID while creating a tracker. This is resulting in validation error in Orders where we verify if the capture ID being passed belongs to the order ID when track endpoint is called.

## Steps To Reproduce
* Configure an authorize intent.
* Create order and authorize the payment.
* Visit WooCommerce order
* Observe API call with authorization ID
