### PR TITLE
Apple Pay validation notice improvements (2131)

### DIFF
--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -24,7 +24,7 @@ return array(
 			return $fields;
 		}
 
-		$is_available = $container->get( 'applepay.enabled' );
+		$is_available = $container->get( 'applepay.available' );
 		$is_referral  = $container->get( 'applepay.is_referral' );
 
 		$insert_after = function ( array $array, string $key, array $new ): array {

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -422,7 +422,7 @@ class ApplePayButton implements ButtonInterface {
 		}
 		$applepay_request_data_object->order_data( $context );
 		$this->update_posted_data( $applepay_request_data_object );
-		if ( $context == 'product' ) {
+		if ( $context === 'product' ) {
 			$cart_item_key = $this->prepare_cart( $applepay_request_data_object );
 			$cart          = WC()->cart;
 			$address       = $applepay_request_data_object->shipping_address();
@@ -902,15 +902,19 @@ class ApplePayButton implements ButtonInterface {
 	 * Renders the Apple Pay button on the page
 	 *
 	 * @return bool
+	 *
+	 * @psalm-suppress RedundantCondition
 	 */
 	public function render(): bool {
-		$is_applepay_button_enabled = $this->settings->has( 'applepay_button_enabled' ) ? $this->settings->get( 'applepay_button_enabled' ) : false;
+		if ( ! $this->is_enabled() ) {
+			return true;
+		}
 
-		$button_enabled_product  = $is_applepay_button_enabled && $this->settings_status->is_smart_button_enabled_for_location( 'product' );
-		$button_enabled_cart     = $is_applepay_button_enabled && $this->settings_status->is_smart_button_enabled_for_location( 'cart' );
-		$button_enabled_checkout = $is_applepay_button_enabled;
-		$button_enabled_payorder = $is_applepay_button_enabled;
-		$button_enabled_minicart = $is_applepay_button_enabled && $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' );
+		$button_enabled_product  = $this->settings_status->is_smart_button_enabled_for_location( 'product' );
+		$button_enabled_cart     = $this->settings_status->is_smart_button_enabled_for_location( 'cart' );
+		$button_enabled_checkout = true;
+		$button_enabled_payorder = true;
+		$button_enabled_minicart = $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' );
 
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
@@ -1054,7 +1058,6 @@ class ApplePayButton implements ButtonInterface {
 	 */
 	public function is_enabled(): bool {
 		try {
-			// todo add also onboarded apple and enabled buttons.
 			return $this->settings->has( 'applepay_button_enabled' ) && $this->settings->get( 'applepay_button_enabled' );
 		} catch ( Exception $e ) {
 			return false;

--- a/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
+++ b/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
@@ -1,41 +1,37 @@
 <?php
 /**
- * Manage the Seller status.
+ * Status of the ApplePay merchant connection.
  *
- * @package WooCommerce\PayPalCommerce\WcGateway\Helper
+ * @package WooCommerce\PayPalCommerce\Applepay\Assets
  */
 
-declare( strict_types=1 );
+declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Applepay\Assets;
 
 use Throwable;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
- * Class PayUponInvoiceProductStatus
+ * Class AppleProductStatus
  */
 class AppleProductStatus {
+	const CAPABILITY_NAME = 'APPLE_PAY';
+	const SETTINGS_KEY    = 'products_apple_enabled';
 
-	const APPLE_STATUS_CACHE_KEY = 'apple_status_cache';
-
-	/**
-	 * The Cache.
-	 *
-	 * @var Cache
-	 */
-	protected $cache;
+	const SETTINGS_VALUE_ENABLED   = 'yes';
+	const SETTINGS_VALUE_DISABLED  = 'no';
+	const SETTINGS_VALUE_UNDEFINED = '';
 
 	/**
-	 * Caches the status for the current load.
+	 * The current status stored in memory.
 	 *
 	 * @var bool|null
 	 */
-	private $current_status_cache;
+	private $current_status = null;
 
 	/**
 	 * If there was a request failure.
@@ -73,24 +69,21 @@ class AppleProductStatus {
 	private $api_failure_registry;
 
 	/**
-	 * PayUponInvoiceProductStatus constructor.
+	 * AppleProductStatus constructor.
 	 *
 	 * @param Settings         $settings The Settings.
 	 * @param PartnersEndpoint $partners_endpoint The Partner Endpoint.
-	 * @param Cache            $cache The cache.
 	 * @param State            $onboarding_state The onboarding state.
 	 * @param FailureRegistry  $api_failure_registry The API failure registry.
 	 */
 	public function __construct(
 		Settings $settings,
 		PartnersEndpoint $partners_endpoint,
-		Cache $cache,
 		State $onboarding_state,
 		FailureRegistry $api_failure_registry
 	) {
 		$this->settings             = $settings;
 		$this->partners_endpoint    = $partners_endpoint;
-		$this->cache                = $cache;
 		$this->onboarding_state     = $onboarding_state;
 		$this->api_failure_registry = $api_failure_registry;
 	}
@@ -100,55 +93,71 @@ class AppleProductStatus {
 	 *
 	 * @return bool
 	 */
-	public function apple_is_active() : bool {
-		if ( $this->onboarding_state->current_state() < State::STATE_ONBOARDED ) {
+	public function is_active() : bool {
+
+		// If not onboarded then makes no sense to check status.
+		if ( ! $this->is_onboarded() ) {
 			return false;
 		}
 
-		if ( $this->cache->has( self::APPLE_STATUS_CACHE_KEY ) ) {
-			return $this->cache->get( self::APPLE_STATUS_CACHE_KEY ) === 'true';
+		// If status was already checked on this request return the same result.
+		if ( null !== $this->current_status ) {
+			return $this->current_status;
 		}
 
-		if ( $this->current_status_cache === true ) {
-			return $this->current_status_cache;
-		}
-		if ( $this->settings->has( 'products_apple_enabled' ) && $this->settings->get( 'products_apple_enabled' ) === true ) {
-			$this->current_status_cache = true;
-			return true;
+		// Check if status was checked on previous requests.
+		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
+			$this->current_status = wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
+			return $this->current_status;
 		}
 
 		// Check API failure registry to prevent multiple failed API requests.
 		if ( $this->api_failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, HOUR_IN_SECONDS ) ) {
-			$this->has_request_failure  = true;
-			$this->current_status_cache = false;
-			return $this->current_status_cache;
+			$this->has_request_failure = true;
+			$this->current_status      = false;
+			return $this->current_status;
 		}
 
+		// Request seller status via PayPal API.
 		try {
 			$seller_status = $this->partners_endpoint->seller_status();
 		} catch ( Throwable $error ) {
-			$this->has_request_failure  = true;
-			$this->current_status_cache = false;
-			return false;
+			$this->has_request_failure = true;
+			$this->current_status      = false;
+			return $this->current_status;
 		}
 
+		// Check the seller status for the intended capability.
 		foreach ( $seller_status->products() as $product ) {
 			if ( $product->name() !== 'PAYMENT_METHODS' ) {
 				continue;
 			}
 
-			if ( in_array( 'APPLE_PAY', $product->capabilities(), true ) ) {
-				$this->settings->set( 'products_apple_enabled', true );
+			if ( in_array( self::CAPABILITY_NAME, $product->capabilities(), true ) ) {
+				// Capability found, persist status and return true.
+				$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
 				$this->settings->persist();
-				$this->current_status_cache = true;
-				$this->cache->set( self::APPLE_STATUS_CACHE_KEY, 'true', 3 * MONTH_IN_SECONDS );
-				return true;
+
+				$this->current_status = true;
+				return $this->current_status;
 			}
 		}
-		$this->cache->set( self::APPLE_STATUS_CACHE_KEY, 'false', 3 * MONTH_IN_SECONDS );
 
-		$this->current_status_cache = false;
-		return false;
+		// Capability not found, persist status and return false.
+		$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_DISABLED );
+		$this->settings->persist();
+
+		$this->current_status = false;
+		return $this->current_status;
+	}
+
+	/**
+	 * Returns if the seller is onboarded.
+	 *
+	 * @return bool
+	 */
+	public function is_onboarded(): bool {
+		return $this->onboarding_state->current_state() >= State::STATE_ONBOARDED;
 	}
 
 	/**
@@ -158,6 +167,26 @@ class AppleProductStatus {
 	 */
 	public function has_request_failure(): bool {
 		return $this->has_request_failure;
+	}
+
+	/**
+	 * Clears the persisted result to force a recheck.
+	 *
+	 * @param Settings|null $settings The settings object.
+	 * We accept a Settings object to don't override other sequential settings that are being updated elsewhere.
+	 * @return void
+	 */
+	public function clear( Settings $settings = null ): void {
+		if ( null === $settings ) {
+			$settings = $this->settings;
+		}
+
+		$this->current_status = null;
+
+		if ( $settings->has( self::SETTINGS_KEY ) ) {
+			$settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_UNDEFINED );
+			$settings->persist();
+		}
 	}
 
 }

--- a/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
+++ b/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Adds availability notice if applicable.
+ *
+ * @package WooCommerce\PayPalCommerce\Applepay\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Applepay\Helper;
+
+use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
+use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
+use WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton;
+use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
+
+/**
+ * Class AvailabilityNotice
+ */
+class AvailabilityNotice {
+
+	/**
+	 * The product status handler.
+	 *
+	 * @var AppleProductStatus
+	 */
+	private $product_status;
+
+	/**
+	 * Indicates if we're on the WooCommerce gateways list page.
+	 *
+	 * @var bool
+	 */
+	private $is_wc_gateways_list_page;
+
+	/**
+	 * Indicates if we're on a PPCP Settings page.
+	 *
+	 * @var bool
+	 */
+	private $is_ppcp_settings_page;
+
+	/**
+	 * Indicates if ApplePay is available to be enabled.
+	 *
+	 * @var bool
+	 */
+	private $is_available;
+
+	/**
+	 * Indicates if this server is supported for ApplePay.
+	 *
+	 * @var bool
+	 */
+	private $is_server_supported;
+
+	/**
+	 * Indicates if the merchant is validated for ApplePay.
+	 *
+	 * @var bool
+	 */
+	private $is_merchant_validated;
+
+	/**
+	 * The button.
+	 *
+	 * @var ApplePayButton
+	 */
+	private $button;
+
+	/**
+	 * Class ApmProductStatus constructor.
+	 *
+	 * @param AppleProductStatus $product_status The product status handler.
+	 * @param bool               $is_wc_gateways_list_page Indicates if we're on the WooCommerce gateways list page.
+	 * @param bool               $is_ppcp_settings_page Indicates if we're on a PPCP Settings page.
+	 * @param bool               $is_available Indicates if ApplePay is available to be enabled.
+	 * @param bool               $is_server_supported Indicates if this server is supported for ApplePay.
+	 * @param bool               $is_merchant_validated Indicates if the merchant is validated for ApplePay.
+	 * @param ApplePayButton     $button The button.
+	 */
+	public function __construct(
+		AppleProductStatus $product_status,
+		bool $is_wc_gateways_list_page,
+		bool $is_ppcp_settings_page,
+		bool $is_available,
+		bool $is_server_supported,
+		bool $is_merchant_validated,
+		ApplePayButton $button
+	) {
+		$this->product_status           = $product_status;
+		$this->is_wc_gateways_list_page = $is_wc_gateways_list_page;
+		$this->is_ppcp_settings_page    = $is_ppcp_settings_page;
+		$this->is_available             = $is_available;
+		$this->is_server_supported      = $is_server_supported;
+		$this->is_merchant_validated    = $is_merchant_validated;
+		$this->button                   = $button;
+	}
+
+	/**
+	 * Adds availability notice if applicable.
+	 *
+	 * @return void
+	 */
+	public function execute(): void {
+		if ( ! $this->should_display() ) {
+			return;
+		}
+
+		// We need to check is active before checking failure requests, otherwise failure status won't be set.
+		$is_active = $this->product_status->is_active();
+
+		if ( $this->product_status->has_request_failure() ) {
+			$this->add_seller_status_failure_notice();
+		} elseif ( ! $is_active ) {
+			$this->add_not_available_notice();
+		}
+
+		if ( ! $this->is_available ) {
+			return;
+		}
+
+		if ( ! $this->is_server_supported ) {
+			$this->add_server_not_supported_notice();
+		}
+
+		if ( ! $this->button->is_enabled() ) {
+			return;
+		}
+
+		if ( ! $this->is_merchant_validated ) {
+			$this->add_merchant_not_validated_notice();
+		}
+
+	}
+
+	/**
+	 * Whether the message should display.
+	 *
+	 * @return bool
+	 */
+	protected function should_display(): bool {
+		if ( ! $this->product_status->is_onboarded() ) {
+			return false;
+		}
+		if ( ! $this->is_wc_gateways_list_page && ! $this->is_ppcp_settings_page ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Adds seller status failure notice.
+	 *
+	 * @return void
+	 */
+	private function add_seller_status_failure_notice(): void {
+		add_filter(
+			Repository::NOTICES_FILTER,
+			/**
+			 * Adds seller status notice.
+			 *
+			 * @param array $notices The notices.
+			 * @return array
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			static function ( $notices ): array {
+				$message = sprintf(
+					// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
+					__(
+						'<p>Notice: We could not determine your PayPal seller status to list your available features. Disconnect and reconnect your PayPal account through our %1$sonboarding process%2$s to resolve this.</p><p>Don\'t worry if you cannot use the %1$sonboarding process%2$s; most functionalities available to your account should work.</p>',
+						'woocommerce-paypal-payments'
+					),
+					'<a href="https://woocommerce.com/document/woocommerce-paypal-payments/#connect-paypal-account" target="_blank">',
+					'</a>'
+				);
+
+				// Name the key so it can be overridden in other modules.
+				$notices['error_product_status'] = new Message( $message, 'warning', true, 'ppcp-notice-wrapper' );
+				return $notices;
+			}
+		);
+	}
+
+	/**
+	 * Adds not available notice.
+	 *
+	 * @return void
+	 */
+	private function add_not_available_notice(): void {
+		add_filter(
+			Repository::NOTICES_FILTER,
+			/**
+			 * Adds ApplePay not available notice.
+			 *
+			 * @param array $notices The notices.
+			 * @return array
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			static function ( $notices ): array {
+				$message = sprintf(
+					__(
+						'Apple Pay is not available on your PayPal seller account.',
+						'woocommerce-paypal-payments'
+					)
+				);
+
+				$notices[] = new Message( $message, 'warning', true, 'ppcp-notice-wrapper' );
+				return $notices;
+			}
+		);
+	}
+
+	/**
+	 * Adds ApplePay server not supported notice.
+	 *
+	 * @return void
+	 */
+	private function add_server_not_supported_notice(): void {
+		add_filter(
+			Repository::NOTICES_FILTER,
+			/**
+			 * Adds ApplePay server not supported notice.
+			 *
+			 * @param array $notices The notices.
+			 * @return array
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			static function ( $notices ): array {
+				$message = sprintf(
+					__(
+						'Apple Pay is not supported on this server. Please contact your hosting provider to enable it.',
+						'woocommerce-paypal-payments'
+					)
+				);
+
+				$notices[] = new Message( $message, 'error', true, 'ppcp-notice-wrapper' );
+				return $notices;
+			}
+		);
+	}
+
+	/**
+	 * Adds ApplePay merchant not validated notice.
+	 *
+	 * @return void
+	 */
+	private function add_merchant_not_validated_notice(): void {
+		add_filter(
+			Repository::NOTICES_FILTER,
+			/**
+			 * Adds ApplePay merchant not validated notice.
+			 *
+			 * @param array $notices The notices.
+			 * @return array
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			static function ( $notices ): array {
+				$message = sprintf(
+					// translators: %1$s and %2$s are the opening and closing of HTML <a> tag for the well-known file, %3$s and %4$s are the opening and closing of HTML <a> tag for the help document.
+					__(
+						'Apple Pay Validation Error. Please ensure the presentment of the correct %1$sdomain association file%2$s for Apple to validate your domain. %3$sLearn more%4$s about the Apple Pay requirements',
+						'woocommerce-paypal-payments'
+					),
+					'<a href="/.well-known/apple-developer-merchantid-domain-association" target="_blank">',
+					'</a>',
+					'<a href="https://woocommerce.com/document/woocommerce-paypal-payments/#apple-pay" target="_blank">',
+					'</a>'
+				);
+
+				$notices[] = new Message( $message, 'error', true, 'ppcp-notice-wrapper' );
+				return $notices;
+			}
+		);
+	}
+
+}

--- a/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
+++ b/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
@@ -124,7 +124,17 @@ class AvailabilityNotice {
 			$this->add_server_not_supported_notice();
 		}
 
-		if ( ! $this->button->is_enabled() ) {
+		$button_enabled = $this->button->is_enabled();
+
+		// We do this check on $_POST because this is called before settings are saved.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( isset( $_POST['ppcp'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$post_data      = wc_clean( (array) wp_unslash( $_POST['ppcp'] ) );
+			$button_enabled = wc_string_to_bool( $post_data['applepay_button_enabled'] ?? false );
+		}
+
+		if ( ! $button_enabled ) {
 			return;
 		}
 

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -45,7 +45,6 @@ class GooglepayModule implements ModuleInterface {
 			function( Settings $settings = null ) use ( $c ): void {
 				$apm_status = $c->get( 'googlepay.helpers.apm-product-status' );
 				assert( $apm_status instanceof ApmProductStatus );
-
 				$apm_status->clear( $settings );
 			}
 		);

--- a/modules/ppcp-googlepay/src/Helper/AvailabilityNotice.php
+++ b/modules/ppcp-googlepay/src/Helper/AvailabilityNotice.php
@@ -107,7 +107,6 @@ class AvailabilityNotice {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			static function ( $notices ): array {
-
 				$message = sprintf(
 					// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
 					__(
@@ -142,7 +141,6 @@ class AvailabilityNotice {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			static function ( $notices ): array {
-
 				$message = sprintf(
 					__(
 						'Google Pay is not available on your PayPal seller account.',


### PR DESCRIPTION
# PR Description

This issue:
* Refactors the Apple Pay notices (handling, placement and text).
* Refactors the `AppleProductStatus` to align it with `GooglePay` `ProductStatus`
* Also adds small changes to uniformize with Google Pay module.

# Issue Description

![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/501d1534-d0b0-474e-a1eb-97dd3e6e254f)

* Validation notice should only be displayed in our new notice location within our settings and not globally on admin pages
* Notice should also not be shown when Apple Pay feature is disabled.
* The notice text should be updated: Apple Pay Validation Error. Please ensure the presentment of the correct [domain association file]({SiteURL}/.well-known/apple-developer-merchantid-domain-association) for Apple to validate your domain. [Learn more](https://woocommerce.com/document/woocommerce-paypal-payments/#apple-pay) about the Apple Pay requirements