### PR TITLE
Improve handling of server error when submitting block

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -19,7 +19,7 @@ const PayPalComponent = ({
                              shippingData,
                              isEditing,
 }) => {
-    const {onPaymentSetup, onCheckoutAfterProcessingWithError, onCheckoutValidation} = eventRegistration;
+    const {onPaymentSetup, onCheckoutFail, onCheckoutValidation} = eventRegistration;
     const {responseTypes} = emitResponse;
 
     const [paypalOrder, setPaypalOrder] = useState(null);
@@ -253,7 +253,7 @@ const PayPalComponent = ({
     }, [onPaymentSetup, paypalOrder, activePaymentMethod]);
 
     useEffect(() => {
-        const unsubscribe = onCheckoutAfterProcessingWithError(({ processingResponse }) => {
+        const unsubscribe = onCheckoutFail(({ processingResponse }) => {
             if (onClose) {
                 onClose();
             }
@@ -267,7 +267,7 @@ const PayPalComponent = ({
             return true;
         });
         return unsubscribe;
-    }, [onCheckoutAfterProcessingWithError, onClose]);
+    }, [onCheckoutFail, onClose]);
 
     if (config.scriptData.continuation) {
         return (

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -253,21 +253,24 @@ const PayPalComponent = ({
     }, [onPaymentSetup, paypalOrder, activePaymentMethod]);
 
     useEffect(() => {
+        if (activePaymentMethod !== config.id) {
+            return;
+        }
         const unsubscribe = onCheckoutFail(({ processingResponse }) => {
+            console.error(processingResponse)
             if (onClose) {
                 onClose();
             }
-            if (processingResponse?.paymentDetails?.errorMessage) {
-                return {
-                    type: emitResponse.responseTypes.ERROR,
-                    message: processingResponse.paymentDetails.errorMessage,
-                    messageContext: config.scriptData.continuation ? emitResponse.noticeContexts.PAYMENTS : emitResponse.noticeContexts.EXPRESS_PAYMENTS,
-                };
+            if (config.scriptData.continuation) {
+                return true;
+            }
+            if (!config.finalReviewEnabled) {
+                location.href = getCheckoutRedirectUrl();
             }
             return true;
         });
         return unsubscribe;
-    }, [onCheckoutFail, onClose]);
+    }, [onCheckoutFail, onClose, activePaymentMethod]);
 
     if (config.scriptData.continuation) {
         return (


### PR DESCRIPTION
Similarly to #1528, now refreshing the block checkout page (into the continuation mode) if server validation fails in the no-review mode, such as when creating an account with an already used email. Before this PR it was getting stuck on such errors without any way to continue.