### PR TITLE
release 2.4.0_rc1 Place order button remains - Could not retrieve order (2139)

### DIFF
--- a/modules/ppcp-applepay/resources/js/boot.js
+++ b/modules/ppcp-applepay/resources/js/boot.js
@@ -20,7 +20,6 @@ import ApplepayManager from "./ApplepayManager";
                 (typeof (buttonConfig) === 'undefined') ||
                 (typeof (ppcpConfig) === 'undefined')
             ) {
-                console.error('PayPal button could not be configured.');
                 return;
             }
             const isMiniCart = ppcpConfig.mini_cart_buttons_enabled;

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -136,9 +136,17 @@ class ApplepayModule implements ModuleInterface {
 				assert( $button instanceof ApplePayButton );
 				$smart_button = $c->get( 'button.smart-button' );
 				assert( $smart_button instanceof SmartButtonInterface );
-				$page_has_block = has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' );
-				if ( $smart_button->should_load_ppcp_script() || $page_has_block ) {
+				if ( $smart_button->should_load_ppcp_script() ) {
 					$button->enqueue();
+				}
+
+				if ( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) {
+					/**
+					 * Should add this to the ButtonInterface.
+					 *
+					 * @psalm-suppress UndefinedInterfaceMethod
+					 */
+					$button->enqueue_styles();
 				}
 			}
 		);

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -422,7 +422,7 @@ class ApplePayButton implements ButtonInterface {
 		}
 		$applepay_request_data_object->order_data( $context );
 		$this->update_posted_data( $applepay_request_data_object );
-		if ( $context == 'product' ) {
+		if ( $context === 'product' ) {
 			$cart_item_key = $this->prepare_cart( $applepay_request_data_object );
 			$cart          = WC()->cart;
 			$address       = $applepay_request_data_object->shipping_address();

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -1017,13 +1017,7 @@ class ApplePayButton implements ButtonInterface {
 		);
 		wp_enqueue_script( 'wc-ppcp-applepay' );
 
-		wp_register_style(
-			'wc-ppcp-applepay',
-			untrailingslashit( $this->module_url ) . '/assets/css/styles.css',
-			array(),
-			$this->version
-		);
-		wp_enqueue_style( 'wc-ppcp-applepay' );
+		$this->enqueue_styles();
 
 		wp_localize_script(
 			'wc-ppcp-applepay',
@@ -1036,6 +1030,23 @@ class ApplePayButton implements ButtonInterface {
 				wp_enqueue_script( 'wc-ppcp-applepay' );
 			}
 		);
+	}
+
+	/**
+	 * Enqueues styles.
+	 */
+	public function enqueue_styles(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
+		wp_register_style(
+			'wc-ppcp-applepay',
+			untrailingslashit( $this->module_url ) . '/assets/css/styles.css',
+			array(),
+			$this->version
+		);
+		wp_enqueue_style( 'wc-ppcp-applepay' );
 	}
 
 	/**

--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -189,7 +189,6 @@ class GooglepayButton {
                 callback(el);
             } else if (timeElapsed > timeout) {
                 clearInterval(interval);
-                console.error('Waiting for wrapper timed out.', selector);
             }
         }, delay);
     }

--- a/modules/ppcp-googlepay/resources/js/boot.js
+++ b/modules/ppcp-googlepay/resources/js/boot.js
@@ -16,7 +16,9 @@ import GooglepayManager from "./GooglepayManager";
     };
 
     jQuery(document.body).on('updated_cart_totals updated_checkout', () => {
-        manager.reinit();
+        if (manager) {
+            manager.reinit();
+        }
     });
 
     document.addEventListener(

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -363,6 +363,23 @@ class Button implements ButtonInterface {
 		);
 		wp_enqueue_script( 'wc-ppcp-googlepay' );
 
+		$this->enqueue_styles();
+
+		wp_localize_script(
+			'wc-ppcp-googlepay',
+			'wc_ppcp_googlepay',
+			$this->script_data()
+		);
+	}
+
+	/**
+	 * Enqueues styles.
+	 */
+	public function enqueue_styles(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		wp_register_style(
 			'wc-ppcp-googlepay',
 			untrailingslashit( $this->module_url ) . '/assets/css/styles.css',
@@ -370,12 +387,6 @@ class Button implements ButtonInterface {
 			$this->version
 		);
 		wp_enqueue_style( 'wc-ppcp-googlepay' );
-
-		wp_localize_script(
-			'wc-ppcp-googlepay',
-			'wc_ppcp_googlepay',
-			$this->script_data()
-		);
 	}
 
 	/**

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -89,11 +89,18 @@ class GooglepayModule implements ModuleInterface {
 			static function () use ( $c, $button ) {
 				$smart_button = $c->get( 'button.smart-button' );
 				assert( $smart_button instanceof SmartButtonInterface );
-				$page_has_block = has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' );
-				if ( ! $smart_button->should_load_ppcp_script() && ! $page_has_block ) {
-					return;
+				if ( $smart_button->should_load_ppcp_script() ) {
+					$button->enqueue();
 				}
-				$button->enqueue();
+
+				if ( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) {
+					/**
+					 * Should add this to the ButtonInterface.
+					 *
+					 * @psalm-suppress UndefinedInterfaceMethod
+					 */
+					$button->enqueue_styles();
+				}
 			}
 		);
 

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Googlepay;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
+use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\AvailabilityNotice;
@@ -86,6 +87,12 @@ class GooglepayModule implements ModuleInterface {
 		add_action(
 			'wp_enqueue_scripts',
 			static function () use ( $c, $button ) {
+				$smart_button = $c->get( 'button.smart-button' );
+				assert( $smart_button instanceof SmartButtonInterface );
+				$page_has_block = has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' );
+				if ( ! $smart_button->should_load_ppcp_script() && ! $page_has_block ) {
+					return;
+				}
 				$button->enqueue();
 			}
 		);


### PR DESCRIPTION
# PR Description
Several improvements were made to only load scripts and styles on relevant pages.
Also some unnecessary console.logs were removed.

# Issue Description
While using the 2.4.0_rc1 package, the WooCommerce button does not get replaced with the PayPal button on my environment (most others don’t encounter this issue).