### PR TITLE
Google Pay for variable product greyed out but clickable (2141)

### DIFF
--- a/modules/ppcp-button/resources/css/gateway.scss
+++ b/modules/ppcp-button/resources/css/gateway.scss
@@ -6,6 +6,10 @@
 	cursor: not-allowed;
 	-webkit-filter: grayscale(100%);
 	filter: grayscale(100%);
+
+	* {
+		pointer-events: none;
+	}
 }
 
 .ppc-button-wrapper #ppcp-messages:first-child {


### PR DESCRIPTION
# PR Description
Adds the `pointer-events` condition to the CSS rule. This CSS was being added in Javascript and potentially not all nested elements were loaded when being applied.

# Issue Description
Google Pay for variable product greyed out but clickable and we can pay with it

## Steps To Reproduce
Go to shop and click on variable product
Observe Google pay is greyed out
Click on it and do a purchase
Checkout page is opened and pay for it, order received page is opened
On order overview page order has status processing

## Expected behaviour
Google pay should not be clickable