### PR TITLE
Enhance merchant credential validation & remove PAYEE object (2144)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -309,8 +309,6 @@ return array(
 	'api.factory.purchase-unit'                 => static function ( ContainerInterface $container ): PurchaseUnitFactory {
 
 		$amount_factory   = $container->get( 'api.factory.amount' );
-		$payee_repository = $container->get( 'api.repository.payee' );
-		$payee_factory    = $container->get( 'api.factory.payee' );
 		$item_factory     = $container->get( 'api.factory.item' );
 		$shipping_factory = $container->get( 'api.factory.shipping' );
 		$payments_factory = $container->get( 'api.factory.payments' );
@@ -320,8 +318,6 @@ return array(
 
 		return new PurchaseUnitFactory(
 			$amount_factory,
-			$payee_repository,
-			$payee_factory,
 			$item_factory,
 			$shipping_factory,
 			$payments_factory,

--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -52,13 +52,6 @@ class PurchaseUnit {
 	private $description;
 
 	/**
-	 * The Payee.
-	 *
-	 * @var Payee|null
-	 */
-	private $payee;
-
-	/**
 	 * The custom id.
 	 *
 	 * @var string
@@ -108,7 +101,6 @@ class PurchaseUnit {
 	 * @param Shipping|null $shipping The Shipping.
 	 * @param string        $reference_id The reference ID.
 	 * @param string        $description The description.
-	 * @param Payee|null    $payee The Payee.
 	 * @param string        $custom_id The custom ID.
 	 * @param string        $invoice_id The invoice ID.
 	 * @param string        $soft_descriptor The soft descriptor.
@@ -120,7 +112,6 @@ class PurchaseUnit {
 		Shipping $shipping = null,
 		string $reference_id = 'default',
 		string $description = '',
-		Payee $payee = null,
 		string $custom_id = '',
 		string $invoice_id = '',
 		string $soft_descriptor = '',
@@ -150,7 +141,6 @@ class PurchaseUnit {
 				}
 			)
 		);
-		$this->payee           = $payee;
 		$this->custom_id       = $custom_id;
 		$this->invoice_id      = $invoice_id;
 		$this->soft_descriptor = $soft_descriptor;
@@ -258,15 +248,6 @@ class PurchaseUnit {
 	}
 
 	/**
-	 * Returns the Payee.
-	 *
-	 * @return Payee|null
-	 */
-	public function payee() {
-		return $this->payee;
-	}
-
-	/**
 	 * Returns the Payments.
 	 *
 	 * @return Payments|null
@@ -313,10 +294,6 @@ class PurchaseUnit {
 				$this->items()
 			),
 		);
-
-		if ( $this->payee() ) {
-			$purchase_unit['payee'] = $this->payee()->to_array();
-		}
 
 		if ( $this->payments() ) {
 			$purchase_unit['payments'] = $this->payments()->to_array();

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -14,7 +14,6 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PurchaseUnitSanitizer;
-use WooCommerce\PayPalCommerce\ApiClient\Repository\PayeeRepository;
 use WooCommerce\PayPalCommerce\Webhooks\CustomIds;
 
 /**
@@ -28,20 +27,6 @@ class PurchaseUnitFactory {
 	 * @var AmountFactory
 	 */
 	private $amount_factory;
-
-	/**
-	 * The payee repository.
-	 *
-	 * @var PayeeRepository
-	 */
-	private $payee_repository;
-
-	/**
-	 * The payee factory.
-	 *
-	 * @var PayeeFactory
-	 */
-	private $payee_factory;
 
 	/**
 	 * The item factory.
@@ -89,8 +74,6 @@ class PurchaseUnitFactory {
 	 * PurchaseUnitFactory constructor.
 	 *
 	 * @param AmountFactory          $amount_factory The amount factory.
-	 * @param PayeeRepository        $payee_repository The Payee repository.
-	 * @param PayeeFactory           $payee_factory The Payee factory.
 	 * @param ItemFactory            $item_factory The item factory.
 	 * @param ShippingFactory        $shipping_factory The shipping factory.
 	 * @param PaymentsFactory        $payments_factory The payments factory.
@@ -100,8 +83,6 @@ class PurchaseUnitFactory {
 	 */
 	public function __construct(
 		AmountFactory $amount_factory,
-		PayeeRepository $payee_repository,
-		PayeeFactory $payee_factory,
 		ItemFactory $item_factory,
 		ShippingFactory $shipping_factory,
 		PaymentsFactory $payments_factory,
@@ -111,8 +92,6 @@ class PurchaseUnitFactory {
 	) {
 
 		$this->amount_factory   = $amount_factory;
-		$this->payee_repository = $payee_repository;
-		$this->payee_factory    = $payee_factory;
 		$this->item_factory     = $item_factory;
 		$this->shipping_factory = $shipping_factory;
 		$this->payments_factory = $payments_factory;
@@ -146,7 +125,6 @@ class PurchaseUnitFactory {
 		}
 		$reference_id    = 'default';
 		$description     = '';
-		$payee           = $this->payee_repository->payee();
 		$custom_id       = (string) $order->get_id();
 		$invoice_id      = $this->prefix . $order->get_order_number();
 		$soft_descriptor = $this->soft_descriptor;
@@ -157,7 +135,6 @@ class PurchaseUnitFactory {
 			$shipping,
 			$reference_id,
 			$description,
-			$payee,
 			$custom_id,
 			$invoice_id,
 			$soft_descriptor
@@ -211,8 +188,6 @@ class PurchaseUnitFactory {
 		$reference_id = 'default';
 		$description  = '';
 
-		$payee = $this->payee_repository->payee();
-
 		$custom_id = '';
 		$session   = WC()->session;
 		if ( $session instanceof WC_Session_Handler ) {
@@ -229,7 +204,6 @@ class PurchaseUnitFactory {
 			$shipping,
 			$reference_id,
 			$description,
-			$payee,
 			$custom_id,
 			$invoice_id,
 			$soft_descriptor
@@ -269,7 +243,6 @@ class PurchaseUnitFactory {
 				$data->items
 			);
 		}
-		$payee    = isset( $data->payee ) ? $this->payee_factory->from_paypal_response( $data->payee ) : null;
 		$shipping = null;
 		try {
 			if ( isset( $data->shipping ) ) {
@@ -293,7 +266,6 @@ class PurchaseUnitFactory {
 			$shipping,
 			$data->reference_id,
 			$description,
-			$payee,
 			$custom_id,
 			$invoice_id,
 			$soft_descriptor,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -318,6 +318,8 @@ return array(
 			$pui_status_cache,
 			$dcc_status_cache,
 			$container->get( 'http.redirector' ),
+			$container->get( 'api.partner_merchant_id-production' ),
+			$container->get( 'api.partner_merchant_id-sandbox' ),
 			$logger
 		);
 	},

--- a/tests/PHPUnit/ApiClient/Entity/PurchaseUnitTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/PurchaseUnitTest.php
@@ -45,7 +45,6 @@ class PurchaseUnitTest extends TestCase
             $shipping,
             'referenceId',
             'description',
-            null,
             'customId',
             'invoiceId',
             'softDescriptor'
@@ -54,7 +53,6 @@ class PurchaseUnitTest extends TestCase
         $this->assertEquals($amount, $testee->amount());
         $this->assertEquals('referenceId', $testee->reference_id());
         $this->assertEquals('description', $testee->description());
-        $this->assertNull($testee->payee());
         $this->assertEquals('customId', $testee->custom_id());
         $this->assertEquals('invoiceId', $testee->invoice_id());
         $this->assertEquals('softDescriptor', $testee->soft_descriptor());
@@ -808,46 +806,4 @@ class PurchaseUnitTest extends TestCase
 
 		return $values;
 	}
-
-    public function testPayee()
-    {
-        $amount = Mockery::mock(Amount::class);
-        $amount->shouldReceive('breakdown')->andReturnNull();
-        $amount->shouldReceive('to_array')->andReturn(['amount']);
-        $item1 = Mockery::mock(Item::class);
-        $item1->shouldReceive('to_array')->andReturn(['item1']);
-        $item2 = Mockery::mock(Item::class);
-        $item2->shouldReceive('to_array')->andReturn(['item2']);
-        $shipping = Mockery::mock(Shipping::class);
-        $shipping->shouldReceive('to_array')->andReturn(['shipping']);
-        $payee = Mockery::mock(Payee::class);
-        $payee->shouldReceive('to_array')->andReturn(['payee']);
-        $testee = new PurchaseUnit(
-            $amount,
-            [],
-            $shipping,
-            'referenceId',
-            'description',
-            $payee,
-            'customId',
-            'invoiceId',
-            'softDescriptor'
-        );
-
-        $this->assertEquals($payee, $testee->payee());
-
-        $expected = [
-            'reference_id' => 'referenceId',
-            'amount' => ['amount'],
-            'description' => 'description',
-            'items' => [],
-            'shipping' => ['shipping'],
-            'custom_id' => 'customId',
-            'invoice_id' => 'invoiceId',
-            'soft_descriptor' => 'softDescriptor',
-            'payee' => ['payee'],
-        ];
-
-        $this->assertEquals($expected, $testee->to_array());
-    }
 }

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -75,8 +75,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -139,8 +137,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -194,8 +190,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -243,8 +237,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -299,8 +291,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -346,8 +336,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -395,8 +383,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -427,8 +413,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -478,8 +462,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -518,8 +500,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -550,8 +530,6 @@ class PurchaseUnitFactoryTest extends TestCase
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory
@@ -600,8 +578,6 @@ class PurchaseUnitFactoryTest extends TestCase
 
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFactory
@@ -650,8 +626,6 @@ class PurchaseUnitFactoryTest extends TestCase
 
         $testee = new PurchaseUnitFactory(
             $amountFactory,
-            $payeeRepository,
-            $payeeFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFactory

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -7,11 +7,9 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Address;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\Payee;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
-use WooCommerce\PayPalCommerce\ApiClient\Repository\PayeeRepository;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
 
@@ -45,11 +43,6 @@ class PurchaseUnitFactoryTest extends TestCase
             ->shouldReceive('from_wc_order')
             ->with($wcOrder)
             ->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeRepository
-            ->shouldReceive('payee')->andReturn($payee);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $itemFactory
             ->shouldReceive('from_wc_order')
@@ -82,7 +75,6 @@ class PurchaseUnitFactoryTest extends TestCase
 
         $unit = $testee->from_wc_order($wcOrder);
         $this->assertTrue(is_a($unit, PurchaseUnit::class));
-        $this->assertEquals($payee, $unit->payee());
         $this->assertEquals('', $unit->description());
         $this->assertEquals('default', $unit->reference_id());
         $this->assertEquals($this->wcOrderId, $unit->custom_id());
@@ -104,11 +96,6 @@ class PurchaseUnitFactoryTest extends TestCase
             ->shouldReceive('from_wc_order')
             ->with($wcOrder)
             ->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeRepository
-            ->shouldReceive('payee')->andReturn($payee);
 
 		$fee = Mockery::mock(Item::class, [
 			'category' => Item::DIGITAL_GOODS,
@@ -158,11 +145,6 @@ class PurchaseUnitFactoryTest extends TestCase
             ->expects('from_wc_order')
             ->with($wcOrder)
             ->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeRepository
-            ->expects('payee')->andReturn($payee);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $itemFactory
             ->expects('from_wc_order')
@@ -210,11 +192,6 @@ class PurchaseUnitFactoryTest extends TestCase
             ->expects('from_wc_order')
             ->with($wcOrder)
             ->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeRepository
-            ->expects('payee')->andReturn($payee);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $itemFactory
             ->expects('from_wc_order')
@@ -259,11 +236,6 @@ class PurchaseUnitFactoryTest extends TestCase
             ->expects('from_wc_cart')
             ->with($wcCart)
             ->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeRepository
-            ->expects('payee')->andReturn($payee);
 
         $itemFactory = Mockery::mock(ItemFactory::class);
         $itemFactory
@@ -298,7 +270,6 @@ class PurchaseUnitFactoryTest extends TestCase
 
         $unit = $testee->from_wc_cart($wcCart);
         $this->assertTrue(is_a($unit, PurchaseUnit::class));
-        $this->assertEquals($payee, $unit->payee());
         $this->assertEquals('', $unit->description());
         $this->assertEquals('default', $unit->reference_id());
         $this->assertEquals('', $unit->custom_id());
@@ -321,11 +292,6 @@ class PurchaseUnitFactoryTest extends TestCase
             ->expects('from_wc_cart')
             ->with($wcCart)
             ->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeRepository
-            ->expects('payee')->andReturn($payee);
 
         $itemFactory = Mockery::mock(ItemFactory::class);
         $itemFactory
@@ -357,11 +323,6 @@ class PurchaseUnitFactoryTest extends TestCase
             ->expects('from_wc_cart')
             ->with($wcCart)
             ->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeRepository
-            ->expects('payee')->andReturn($payee);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $itemFactory
             ->expects('from_wc_cart')
@@ -396,15 +357,10 @@ class PurchaseUnitFactoryTest extends TestCase
     {
         $rawItem = (object) ['items' => 1];
         $rawAmount =  (object) ['amount' => 1];
-        $rawPayee =  (object) ['payee' => 1];
         $rawShipping = (object) ['shipping' => 1];
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amount = Mockery::mock(Amount::class);
         $amountFactory->expects('from_paypal_response')->with($rawAmount)->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeFactory->expects('from_paypal_response')->with($rawPayee)->andReturn($payee);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $itemFactory->expects('from_paypal_response')->with($rawItem)->andReturn($this->item);
         $shippingFactory = Mockery::mock(ShippingFactory::class);
@@ -426,13 +382,11 @@ class PurchaseUnitFactoryTest extends TestCase
             'soft_descriptor' => 'softDescriptor',
             'amount' => $rawAmount,
             'items' => [$rawItem],
-            'payee' => $rawPayee,
             'shipping' => $rawShipping,
         ];
 
         $unit = $testee->from_paypal_response($response);
         $this->assertTrue(is_a($unit, PurchaseUnit::class));
-        $this->assertEquals($payee, $unit->payee());
         $this->assertEquals('description', $unit->description());
         $this->assertEquals('default', $unit->reference_id());
         $this->assertEquals('customId', $unit->custom_id());
@@ -443,57 +397,13 @@ class PurchaseUnitFactoryTest extends TestCase
         $this->assertEquals($shipping, $unit->shipping());
     }
 
-    public function testFromPayPalResponsePayeeIsNull()
-    {
-        $rawItem = (object) ['items' => 1];
-        $rawAmount =  (object) ['amount' => 1];
-        $rawPayee =  (object) ['payee' => 1];
-        $rawShipping = (object) ['shipping' => 1];
-        $amountFactory = Mockery::mock(AmountFactory::class);
-        $amount = Mockery::mock(Amount::class);
-        $amountFactory->expects('from_paypal_response')->with($rawAmount)->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
-        $itemFactory = Mockery::mock(ItemFactory::class);
-        $itemFactory->expects('from_paypal_response')->with($rawItem)->andReturn($this->item);
-        $shippingFactory = Mockery::mock(ShippingFactory::class);
-        $shipping = Mockery::mock(Shipping::class);
-        $shippingFactory->expects('from_paypal_response')->with($rawShipping)->andReturn($shipping);
-        $paymentsFacory = Mockery::mock(PaymentsFactory::class);
-        $testee = new PurchaseUnitFactory(
-            $amountFactory,
-            $itemFactory,
-            $shippingFactory,
-            $paymentsFacory
-        );
-
-        $response = (object) [
-            'reference_id' => 'default',
-            'description' => 'description',
-            'customId' => 'customId',
-            'invoiceId' => 'invoiceId',
-            'softDescriptor' => 'softDescriptor',
-            'amount' => $rawAmount,
-            'items' => [$rawItem],
-            'shipping' => $rawShipping,
-        ];
-
-        $unit = $testee->from_paypal_response($response);
-        $this->assertNull($unit->payee());
-    }
-
     public function testFromPayPalResponseShippingIsNull()
     {
         $rawItem = (object) ['items' => 1];
         $rawAmount =  (object) ['amount' => 1];
-        $rawPayee =  (object) ['payee' => 1];
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amount = Mockery::mock(Amount::class);
         $amountFactory->expects('from_paypal_response')->with($rawAmount)->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeFactory->expects('from_paypal_response')->with($rawPayee)->andReturn($payee);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $itemFactory->expects('from_paypal_response')->with($rawItem)->andReturn($this->item);
         $shippingFactory = Mockery::mock(ShippingFactory::class);
@@ -513,7 +423,6 @@ class PurchaseUnitFactoryTest extends TestCase
             'softDescriptor' => 'softDescriptor',
             'amount' => $rawAmount,
             'items' => [$rawItem],
-            'payee' => $rawPayee,
         ];
 
         $unit = $testee->from_paypal_response($response);
@@ -523,8 +432,6 @@ class PurchaseUnitFactoryTest extends TestCase
     public function testFromPayPalResponseNeedsReferenceId()
     {
         $amountFactory = Mockery::mock(AmountFactory::class);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $shippingFactory = Mockery::mock(ShippingFactory::class);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
@@ -542,7 +449,6 @@ class PurchaseUnitFactoryTest extends TestCase
             'softDescriptor' => 'softDescriptor',
             'amount' => '',
             'items' => [],
-            'payee' => '',
             'shipping' => '',
         ];
 
@@ -554,17 +460,12 @@ class PurchaseUnitFactoryTest extends TestCase
     {
         $rawItem = (object)['items' => 1];
         $rawAmount = (object)['amount' => 1];
-        $rawPayee = (object)['payee' => 1];
         $rawShipping = (object)['shipping' => 1];
         $rawPayments = (object)['payments' => 1];
 
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amount = Mockery::mock(Amount::class);
         $amountFactory->expects('from_paypal_response')->with($rawAmount)->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeFactory->expects('from_paypal_response')->with($rawPayee)->andReturn($payee);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $item = Mockery::mock(Item::class, ['category' => Item::PHYSICAL_GOODS]);
         $itemFactory->expects('from_paypal_response')->with($rawItem)->andReturn($item);
@@ -591,7 +492,6 @@ class PurchaseUnitFactoryTest extends TestCase
             'softDescriptor' => 'softDescriptor',
             'amount' => $rawAmount,
             'items' => [$rawItem],
-            'payee' => $rawPayee,
             'shipping' => $rawShipping,
             'payments' => $rawPayments,
         ];
@@ -604,17 +504,12 @@ class PurchaseUnitFactoryTest extends TestCase
     {
         $rawItem = (object)['items' => 1];
         $rawAmount = (object)['amount' => 1];
-        $rawPayee = (object)['payee' => 1];
         $rawShipping = (object)['shipping' => 1];
         $rawPayments = (object)['payments' => 1];
 
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amount = Mockery::mock(Amount::class);
         $amountFactory->expects('from_paypal_response')->with($rawAmount)->andReturn($amount);
-        $payeeFactory = Mockery::mock(PayeeFactory::class);
-        $payee = Mockery::mock(Payee::class);
-        $payeeFactory->expects('from_paypal_response')->with($rawPayee)->andReturn($payee);
-        $payeeRepository = Mockery::mock(PayeeRepository::class);
         $itemFactory = Mockery::mock(ItemFactory::class);
         $item = Mockery::mock(Item::class, ['category' => Item::PHYSICAL_GOODS]);
         $itemFactory->expects('from_paypal_response')->with($rawItem)->andReturn($item);
@@ -639,7 +534,6 @@ class PurchaseUnitFactoryTest extends TestCase
             'softDescriptor' => 'softDescriptor',
             'amount' => $rawAmount,
             'items' => [$rawItem],
-            'payee' => $rawPayee,
             'shipping' => $rawShipping,
         ];
 

--- a/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
+++ b/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
@@ -53,7 +53,9 @@ class SettingsListenerTest extends ModularTestCase
 			$signup_link_ids,
             $pui_status_cache,
             $dcc_status_cache,
-			new RedirectorStub()
+			new RedirectorStub(),
+			'',
+			''
 		);
 
 		$_GET['section'] = PayPalGateway::ID;


### PR DESCRIPTION
To maintain the integrity of the payment process and ensure data security, we're making two enhancements:

We're removing the PAYEE object from our API requests, ensuring that all payments are directed toward the API caller.

We're enhancing our credential validation process to prevent any potential data misuse. This validation ensures that certain IDs don't match specific internal references.