### PR TITLE
Fix card button subscription support declaration

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -171,13 +171,17 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 		$this->payment_token_repository = $payment_token_repository;
 		$this->logger                   = $logger;
 
-		if ( $this->onboarded ) {
-			$this->supports = array( 'refunds' );
-		}
-		if ( $this->gateways_enabled() ) {
-			$this->supports = array(
-				'refunds',
-				'products',
+		$this->supports = array(
+			'refunds',
+			'products',
+		);
+
+		if (
+			( $this->config->has( 'vault_enabled' ) && $this->config->get( 'vault_enabled' ) )
+			|| ( $this->config->has( 'subscriptions_mode' ) && $this->config->get( 'subscriptions_mode' ) === 'subscriptions_api' )
+		) {
+			array_push(
+				$this->supports,
 				'subscriptions',
 				'subscription_cancellation',
 				'subscription_suspension',
@@ -187,7 +191,7 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 				'subscription_payment_method_change',
 				'subscription_payment_method_change_customer',
 				'subscription_payment_method_change_admin',
-				'multiple_subscriptions',
+				'multiple_subscriptions'
 			);
 		}
 

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -19,21 +19,6 @@ use WooCommerce\PayPalCommerce\WcGateway\Exception\GatewayGenericException;
  */
 trait ProcessPaymentTrait {
 	/**
-	 * Checks if PayPal or Credit Card gateways are enabled.
-	 *
-	 * @return bool Whether any of the gateways is enabled.
-	 */
-	protected function gateways_enabled(): bool {
-		if ( $this->config->has( 'enabled' ) && $this->config->get( 'enabled' ) ) {
-			return true;
-		}
-		if ( $this->config->has( 'dcc_enabled' ) && $this->config->get( 'dcc_enabled' ) ) {
-			return true;
-		}
-		return false;
-	}
-
-	/**
 	 * Handles the payment failure.
 	 *
 	 * @param WC_Order|null $wc_order The order.


### PR DESCRIPTION
The declaration of subscription support now added to the card button gateway only when vaulting or sub API is enabled, similarly to other gateways.

Also there was a strange condition about checking whether PayPal or DCC gateways enabled. Looks like it was added to the PayPal gateway in one of the sub API PRs long time ago and then copied here.

By the way there is a small problem that when the PayPal gateway is disabled we also remove the card button gateway, so it disappears on the order pages, making the payment method title weird and not showing the refund button. But there is probably no simple fix if we want to hide such gateways like that, and hopefully it is not actually causing issues for anyone, refunds can be always done from the PayPal dashboard.