### PR TITLE
Improve Apple Pay compatibility with variable products on single product page (2156)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -25,7 +25,7 @@ class ApplepayButton {
 
         this.updated_contact_info = []
         this.selectedShippingMethod = []
-        this.nonce = document.getElementById('woocommerce-process-checkout-nonce').value
+        this.nonce = document.getElementById('woocommerce-process-checkout-nonce')?.value
 
         this.log = function() {
             if ( this.buttonConfig.is_debug ) {

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -23,9 +23,6 @@ class ApplepayButton {
             this.ppcpConfig
         );
 
-        //PRODUCT DETAIL PAGE
-        this.refreshContextData();
-
         this.updated_contact_info = []
         this.selectedShippingMethod = []
         this.nonce = document.getElementById('woocommerce-process-checkout-nonce').value
@@ -34,6 +31,21 @@ class ApplepayButton {
             if ( this.buttonConfig.is_debug ) {
                 console.log('[ApplePayButton]', ...arguments);
             }
+        }
+
+        //PRODUCT DETAIL PAGE
+        this.refreshContextData();
+
+        if (this.context === 'product') {
+            jQuery(document).on('appleclick', () => {
+                (this.onshippingcontactselected())({
+                    shippingContact: {
+                        locality: 'New York',
+                        postalCode: '10001',
+                        countryCode: 'US'
+                    }
+                });
+            });
         }
     }
 
@@ -260,6 +272,8 @@ class ApplepayButton {
             case 'product':
                 // Refresh product data that makes the price change.
                 this.productQuantity = document.querySelector('input.qty').value;
+                this.products = this.contextHandler.products();
+                this.log('Products updated', this.products);
                 break;
         }
     }
@@ -389,6 +403,7 @@ class ApplepayButton {
                 return {
                     action: 'ppcp_update_shipping_contact',
                     product_id: product_id,
+                    products: JSON.stringify(this.products),
                     caller_page: 'productDetail',
                     product_quantity: this.productQuantity,
                     simplified_contact: event.shippingContact,
@@ -419,6 +434,7 @@ class ApplepayButton {
                 action: 'ppcp_update_shipping_method',
                 shipping_method: event.shippingMethod,
                 product_id: product_id,
+                products: JSON.stringify(this.products),
                 caller_page: 'productDetail',
                 product_quantity: this.productQuantity,
                 simplified_contact: this.updated_contact_info,
@@ -456,6 +472,7 @@ class ApplepayButton {
                             action: 'ppcp_create_order',
                             'caller_page': this.context,
                             'product_id': this.buttonConfig.product.id ?? null,
+                            'products': JSON.stringify(this.products),
                             'product_quantity': this.productQuantity ?? null,
                             'shipping_contact': shippingContact,
                             'billing_contact': billingContact,

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -33,20 +33,7 @@ class ApplepayButton {
             }
         }
 
-        //PRODUCT DETAIL PAGE
         this.refreshContextData();
-
-        if (this.context === 'product') {
-            jQuery(document).on('appleclick', () => {
-                (this.onshippingcontactselected())({
-                    shippingContact: {
-                        locality: 'New York',
-                        postalCode: '10001',
-                        countryCode: 'US'
-                    }
-                });
-            });
-        }
     }
 
     init(config) {

--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
@@ -49,12 +49,20 @@ class SingleProductHandler extends BaseHandler {
     }
 
     createOrder() {
+        return this.actionHandler().configuration().createOrder();
+    }
+
+    products() {
+        return this.actionHandler().getProducts();
+    }
+
+    actionHandler() {
         const errorHandler = new ErrorHandler(
             this.ppcpConfig.labels.error.generic,
             document.querySelector('.woocommerce-notices-wrapper')
         );
 
-        const actionHandler = new SingleProductActionHandler(
+        return new SingleProductActionHandler(
             this.ppcpConfig,
             new UpdateCart(
                 this.ppcpConfig.ajax.change_cart.endpoint,
@@ -63,8 +71,6 @@ class SingleProductHandler extends BaseHandler {
             document.querySelector('form.cart'),
             errorHandler,
         );
-
-        return actionHandler.configuration().createOrder();
     }
 
 }

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -109,7 +109,7 @@ return array(
 			$container->get( 'applepay.data_to_scripts' ),
 			$container->get( 'wcgateway.settings.status' ),
 			$container->get( 'button.helper.cart-products' )
-	);
+		);
 	},
 	'applepay.blocks-payment-method'             => static function ( ContainerInterface $container ): PaymentMethodTypeInterface {
 		return new BlocksPaymentMethod(

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -100,7 +100,6 @@ return array(
 		return new DataToAppleButtonScripts( $container->get( 'applepay.sdk_script_url' ), $container->get( 'wcgateway.settings' ) );
 	},
 	'applepay.button'                            => static function ( ContainerInterface $container ): ApplePayButton {
-
 		return new ApplePayButton(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
@@ -108,8 +107,9 @@ return array(
 			$container->get( 'applepay.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'applepay.data_to_scripts' ),
-			$container->get( 'wcgateway.settings.status' )
-		);
+			$container->get( 'wcgateway.settings.status' ),
+			$container->get( 'button.helper.cart-products' )
+	);
 	},
 	'applepay.blocks-payment-method'             => static function ( ContainerInterface $container ): PaymentMethodTypeInterface {
 		return new BlocksPaymentMethod(

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Applepay;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
+use WooCommerce\PayPalCommerce\Applepay\Assets\PropertiesDictionary;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Applepay\Helper\AvailabilityNotice;
@@ -89,6 +90,27 @@ class ApplepayModule implements ModuleInterface {
 
 				$apple_payment_method->bootstrap_ajax_request();
 			}
+		);
+
+		add_filter(
+			'nonce_user_logged_out',
+			/**
+			 * Prevents nonce from being changed for non logged in users.
+			 *
+			 * @param int $uid The uid.
+			 * @param string|int $action The action.
+			 * @return int
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function ( $uid, $action ) {
+				if ( $action === PropertiesDictionary::NONCE_ACTION ) {
+					return 0;
+				}
+				return $uid;
+			},
+			100,
+			2
 		);
 	}
 

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -40,6 +40,7 @@ class ApplepayModule implements ModuleInterface {
 	 * {@inheritDoc}
 	 */
 	public function run( ContainerInterface $c ): void {
+		$module = $this;
 
 		// Clears product status when appropriate.
 		add_action(
@@ -51,38 +52,44 @@ class ApplepayModule implements ModuleInterface {
 			}
 		);
 
-		// Check if the module is applicable, correct country, currency, ... etc.
-		if ( ! $c->get( 'applepay.eligible' ) ) {
-			return;
-		}
+		add_action(
+			'init',
+			static function () use ( $c, $module ) {
 
-		// Load the button handler.
-		$apple_payment_method = $c->get( 'applepay.button' );
-		// add onboarding and referrals hooks.
-		assert( $apple_payment_method instanceof ApplepayButton );
-		$apple_payment_method->initialize();
+				// Check if the module is applicable, correct country, currency, ... etc.
+				if ( ! $c->get( 'applepay.eligible' ) ) {
+					return;
+				}
 
-		// Show notice if there are product availability issues.
-		$availability_notice = $c->get( 'applepay.availability_notice' );
-		assert( $availability_notice instanceof AvailabilityNotice );
-		$availability_notice->execute();
+				// Load the button handler.
+				$apple_payment_method = $c->get( 'applepay.button' );
+				// add onboarding and referrals hooks.
+				assert( $apple_payment_method instanceof ApplepayButton );
+				$apple_payment_method->initialize();
 
-		// Return if server not supported.
-		if ( ! $c->get( 'applepay.server_supported' ) ) {
-			return;
-		}
+				// Show notice if there are product availability issues.
+				$availability_notice = $c->get( 'applepay.availability_notice' );
+				assert( $availability_notice instanceof AvailabilityNotice );
+				$availability_notice->execute();
 
-		// Check if this merchant can activate / use the buttons.
-		// We allow non referral merchants as they can potentially still use ApplePay, we just have no way of checking the capability.
-		if ( ( ! $c->get( 'applepay.available' ) ) && $c->get( 'applepay.is_referral' ) ) {
-			return;
-		}
+				// Return if server not supported.
+				if ( ! $c->get( 'applepay.server_supported' ) ) {
+					return;
+				}
 
-		$this->load_assets( $c, $apple_payment_method );
-		$this->handle_validation_file( $c );
-		$this->render_buttons( $c, $apple_payment_method );
+				// Check if this merchant can activate / use the buttons.
+				// We allow non referral merchants as they can potentially still use ApplePay, we just have no way of checking the capability.
+				if ( ( ! $c->get( 'applepay.available' ) ) && $c->get( 'applepay.is_referral' ) ) {
+					return;
+				}
 
-		$apple_payment_method->bootstrap_ajax_request();
+				$module->load_assets( $c, $apple_payment_method );
+				$module->handle_validation_file( $c );
+				$module->render_buttons( $c, $apple_payment_method );
+
+				$apple_payment_method->bootstrap_ajax_request();
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
@@ -62,21 +62,21 @@ class ApplePayDataObjectHttp {
 	/**
 	 * The product variations.
 	 *
-	 * @var string
+	 * @var array
 	 */
 	protected $product_variations = array();
 
 	/**
 	 * The product extra.
 	 *
-	 * @var string
+	 * @var array
 	 */
 	protected $product_extra = array();
 
 	/**
 	 * The product booking.
 	 *
-	 * @var string
+	 * @var array
 	 */
 	protected $product_booking = array();
 
@@ -295,7 +295,7 @@ class ApplePayDataObjectHttp {
 	/**
 	 * Pre-processes request data to transform it to a standard format.
 	 *
-	 * @param array $data
+	 * @param array $data The data.
 	 * @return array
 	 */
 	protected function preprocess_request_data( array $data ): array {
@@ -602,7 +602,7 @@ class ApplePayDataObjectHttp {
 	/**
 	 * Returns the product variations.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function product_variations(): array {
 		return $this->product_variations;
@@ -611,7 +611,7 @@ class ApplePayDataObjectHttp {
 	/**
 	 * Returns the product extra.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function product_extra(): array {
 		return $this->product_extra;
@@ -620,7 +620,7 @@ class ApplePayDataObjectHttp {
 	/**
 	 * Returns the product booking.
 	 *
-	 * @return string
+	 * @return array
 	 */
 	public function product_booking(): array {
 		return $this->product_booking;
@@ -697,6 +697,10 @@ class ApplePayDataObjectHttp {
 				),
 			)
 		);
+
+		if ( ! $data ) {
+			return false;
+		}
 
 		return $this->append_products_to_data( $data, $_POST );
 	}

--- a/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
@@ -254,6 +254,7 @@ class ApplePayDataObjectHttp {
 			return;
 		}
 
+		$data = $this->append_products_to_data( $data, $_POST );
 		$data = $this->preprocess_request_data( $data );
 
 		$data[ PropertiesDictionary::CALLER_PAGE ] = $caller_page;
@@ -697,7 +698,18 @@ class ApplePayDataObjectHttp {
 			)
 		);
 
-		$products = json_decode( wp_unslash( $_POST[ PropertiesDictionary::PRODUCTS ] ?? '' ), true );
+		return $this->append_products_to_data( $data, $_POST );
+	}
+
+	/**
+	 * Appends product to a data array.
+	 *
+	 * @param array $data The data.
+	 * @param array $request_data The request data.
+	 * @return array
+	 */
+	public function append_products_to_data( array $data, array $request_data ): array {
+		$products = json_decode( wp_unslash( $request_data[ PropertiesDictionary::PRODUCTS ] ?? '' ), true );
 
 		if ( $products ) {
 			$data[ PropertiesDictionary::PRODUCTS ] = $products;

--- a/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php
+++ b/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php
@@ -199,7 +199,7 @@ class DataToAppleButtonScripts {
 				'totalLabel'   => $total_label,
 			),
 			'ajax_url'     => admin_url( 'admin-ajax.php' ),
-			'buttonMarkup' => $button_markup,
+			'buttonMarkup' => $button_markup, // Is this being used?
 		);
 	}
 }

--- a/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php
+++ b/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php
@@ -169,37 +169,32 @@ class DataToAppleButtonScripts {
 		if ( ! $cart ) {
 			return array();
 		}
-		$nonce         = wp_nonce_field( 'woocommerce-process_checkout', 'woocommerce-process-checkout-nonce' );
-		$button_markup =
-			'<div id="applepay-container">'
-			. $nonce
-			. '</div>';
-		$type          = $this->settings->has( 'applepay_button_type' ) ? $this->settings->get( 'applepay_button_type' ) : '';
-		$color         = $this->settings->has( 'applepay_button_color' ) ? $this->settings->get( 'applepay_button_color' ) : '';
-		$lang          = $this->settings->has( 'applepay_button_language' ) ? $this->settings->get( 'applepay_button_language' ) : '';
-		$lang          = apply_filters( 'woocommerce_paypal_payments_applepay_button_language', $lang );
+
+		$type  = $this->settings->has( 'applepay_button_type' ) ? $this->settings->get( 'applepay_button_type' ) : '';
+		$color = $this->settings->has( 'applepay_button_color' ) ? $this->settings->get( 'applepay_button_color' ) : '';
+		$lang  = $this->settings->has( 'applepay_button_language' ) ? $this->settings->get( 'applepay_button_language' ) : '';
+		$lang  = apply_filters( 'woocommerce_paypal_payments_applepay_button_language', $lang );
 
 		return array(
-			'sdk_url'      => $this->sdk_url,
-			'is_debug'     => defined( 'WP_DEBUG' ) && WP_DEBUG ? true : false,
-			'button'       => array(
+			'sdk_url'  => $this->sdk_url,
+			'is_debug' => defined( 'WP_DEBUG' ) && WP_DEBUG ? true : false,
+			'button'   => array(
 				'wrapper'           => 'applepay-container',
 				'mini_cart_wrapper' => 'applepay-container-minicart',
 				'type'              => $type,
 				'color'             => $color,
 				'lang'              => $lang,
 			),
-			'product'      => array(
+			'product'  => array(
 				'needShipping' => $cart->needs_shipping(),
 				'subtotal'     => $cart->get_subtotal(),
 			),
-			'shop'         => array(
+			'shop'     => array(
 				'countryCode'  => $shop_country_code,
 				'currencyCode' => $currency_code,
 				'totalLabel'   => $total_label,
 			),
-			'ajax_url'     => admin_url( 'admin-ajax.php' ),
-			'buttonMarkup' => $button_markup, // Is this being used?
+			'ajax_url' => admin_url( 'admin-ajax.php' ),
 		);
 	}
 }

--- a/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
+++ b/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
@@ -74,8 +74,9 @@ class PropertiesDictionary {
 	public const SHIPPING_CONTACT_INVALID = 'shipping Contact Invalid';
 	public const BILLING_CONTACT          = 'billing_contact';
 
-	public const NONCE   = 'nonce';
-	public const WCNONCE = 'woocommerce-process-checkout-nonce';
+	public const NONCE        = 'nonce';
+	public const NONCE_ACTION = 'woocommerce-process_checkout';
+	public const WCNONCE      = 'woocommerce-process-checkout-nonce';
 
 	public const CREATE_ORDER_CART_REQUIRED_FIELDS =
 		array(

--- a/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
+++ b/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
@@ -14,7 +14,6 @@ namespace WooCommerce\PayPalCommerce\Applepay\Assets;
  */
 class PropertiesDictionary {
 
-
 	public const BILLING_CONTACT_INVALID = 'billing Contact Invalid';
 
 	public const CREATE_ORDER_SINGLE_PROD_REQUIRED_FIELDS =
@@ -62,18 +61,20 @@ class PropertiesDictionary {
 			self::SIMPLIFIED_CONTACT,
 		);
 
-	public const PRODUCT_ID = 'product_id';
+	public const PRODUCTS           = 'products';
+	public const PRODUCT_ID         = 'product_id';
+	public const PRODUCT_QUANTITY   = 'product_quantity';
+	public const PRODUCT_VARIATIONS = 'product_variations';
+	public const PRODUCT_EXTRA      = 'product_extra';
+	public const PRODUCT_BOOKING    = 'product_booking';
 
-	public const SIMPLIFIED_CONTACT = 'simplified_contact';
-
-	public const SHIPPING_METHOD = 'shipping_method';
-
-	public const SHIPPING_CONTACT = 'shipping_contact';
-
+	public const SIMPLIFIED_CONTACT       = 'simplified_contact';
+	public const SHIPPING_METHOD          = 'shipping_method';
+	public const SHIPPING_CONTACT         = 'shipping_contact';
 	public const SHIPPING_CONTACT_INVALID = 'shipping Contact Invalid';
+	public const BILLING_CONTACT          = 'billing_contact';
 
-	public const NONCE = 'nonce';
-
+	public const NONCE   = 'nonce';
 	public const WCNONCE = 'woocommerce-process-checkout-nonce';
 
 	public const CREATE_ORDER_CART_REQUIRED_FIELDS =
@@ -83,25 +84,16 @@ class PropertiesDictionary {
 			self::SHIPPING_CONTACT,
 		);
 
-	public const PRODUCT_QUANTITY = 'product_quantity';
-
 	public const CALLER_PAGE = 'caller_page';
-
-	public const BILLING_CONTACT = 'billing_contact';
 
 	public const NEED_SHIPPING = 'need_shipping';
 
 	public const UPDATE_SHIPPING_CONTACT = 'ppcp_update_shipping_contact';
-
-	public const UPDATE_SHIPPING_METHOD = 'ppcp_update_shipping_method';
-
-	public const CREATE_ORDER = 'ppcp_create_order';
-
-	public const CREATE_ORDER_CART = 'ppcp_create_order_cart';
-
-	public const REDIRECT = 'ppcp_redirect';
-
-	public const VALIDATE = 'ppcp_validate';
+	public const UPDATE_SHIPPING_METHOD  = 'ppcp_update_shipping_method';
+	public const CREATE_ORDER            = 'ppcp_create_order';
+	public const CREATE_ORDER_CART       = 'ppcp_create_order_cart';
+	public const REDIRECT                = 'ppcp_redirect';
+	public const VALIDATE                = 'ppcp_validate';
 
 	/**
 	 * Returns the possible list of button colors.

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -254,7 +254,7 @@ return array(
 	},
 
 	'button.helper.cart-products'                 => static function ( ContainerInterface $container ): CartProductsHelper {
-		$data_store   = \WC_Data_Store::load( 'product' );
+		$data_store = \WC_Data_Store::load( 'product' );
 		return new CartProductsHelper( $data_store );
 	},
 

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Button;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveSubscriptionEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\CartScriptParamsEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\SimulateCartEndpoint;
+use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 use WooCommerce\PayPalCommerce\Button\Helper\CheckoutFormSaver;
 use WooCommerce\PayPalCommerce\Button\Endpoint\SaveCheckoutFormEndpoint;
 use WooCommerce\PayPalCommerce\Button\Validation\CheckoutFormValidator;
@@ -128,24 +129,24 @@ return array(
 		if ( ! \WC()->cart ) {
 			throw new RuntimeException( 'cant initialize endpoint at this moment' );
 		}
-		$smart_button = $container->get( 'button.smart-button' );
-		$cart         = WC()->cart;
-		$request_data = $container->get( 'button.request-data' );
-		$data_store   = \WC_Data_Store::load( 'product' );
-		$logger       = $container->get( 'woocommerce.logger.woocommerce' );
-		return new SimulateCartEndpoint( $smart_button, $cart, $request_data, $data_store, $logger );
+		$smart_button  = $container->get( 'button.smart-button' );
+		$cart          = WC()->cart;
+		$request_data  = $container->get( 'button.request-data' );
+		$cart_products = $container->get( 'button.helper.cart-products' );
+		$logger        = $container->get( 'woocommerce.logger.woocommerce' );
+		return new SimulateCartEndpoint( $smart_button, $cart, $request_data, $cart_products, $logger );
 	},
 	'button.endpoint.change-cart'                 => static function ( ContainerInterface $container ): ChangeCartEndpoint {
 		if ( ! \WC()->cart ) {
 			throw new RuntimeException( 'cant initialize endpoint at this moment' );
 		}
-		$cart        = WC()->cart;
-		$shipping    = WC()->shipping();
-		$request_data = $container->get( 'button.request-data' );
+		$cart                  = WC()->cart;
+		$shipping              = WC()->shipping();
+		$request_data          = $container->get( 'button.request-data' );
 		$purchase_unit_factory = $container->get( 'api.factory.purchase-unit' );
-		$data_store   = \WC_Data_Store::load( 'product' );
-		$logger                        = $container->get( 'woocommerce.logger.woocommerce' );
-		return new ChangeCartEndpoint( $cart, $shipping, $request_data, $purchase_unit_factory, $data_store, $logger );
+		$cart_products         = $container->get( 'button.helper.cart-products' );
+		$logger                = $container->get( 'woocommerce.logger.woocommerce' );
+		return new ChangeCartEndpoint( $cart, $shipping, $request_data, $purchase_unit_factory, $cart_products, $logger );
 	},
 	'button.endpoint.create-order'                => static function ( ContainerInterface $container ): CreateOrderEndpoint {
 		$request_data          = $container->get( 'button.request-data' );
@@ -251,6 +252,12 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
+
+	'button.helper.cart-products'                 => static function ( ContainerInterface $container ): CartProductsHelper {
+		$data_store   = \WC_Data_Store::load( 'product' );
+		return new CartProductsHelper( $data_store );
+	},
+
 	'button.helper.three-d-secure'                => static function ( ContainerInterface $container ): ThreeDSecure {
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 		return new ThreeDSecure( $logger );

--- a/modules/ppcp-button/src/Endpoint/AbstractCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/AbstractCartEndpoint.php
@@ -10,6 +10,7 @@ namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 
 /**
  * Abstract Class AbstractCartEndpoint
@@ -26,11 +27,11 @@ abstract class AbstractCartEndpoint implements EndpointInterface {
 	protected $cart;
 
 	/**
-	 * The product data store.
+	 * The cart products helper.
 	 *
-	 * @var \WC_Data_Store
+	 * @var CartProductsHelper
 	 */
-	protected $product_data_store;
+	protected $cart_products;
 
 	/**
 	 * The request data helper.
@@ -52,13 +53,6 @@ abstract class AbstractCartEndpoint implements EndpointInterface {
 	 * @var string
 	 */
 	protected $logger_tag = '';
-
-	/**
-	 * The added cart item IDs
-	 *
-	 * @var array
-	 */
-	private $cart_item_keys = array();
 
 	/**
 	 * The nonce.
@@ -110,44 +104,13 @@ abstract class AbstractCartEndpoint implements EndpointInterface {
 	protected function add_products( array $products ): bool {
 		$this->cart->empty_cart( false );
 
-		$success = true;
-		foreach ( $products as $product ) {
-
-			// Add extras to POST, they are usually added by custom plugins.
-			if ( $product['extra'] && is_array( $product['extra'] ) ) {
-				// Handle cases like field[].
-				$query = http_build_query( $product['extra'] );
-				parse_str( $query, $extra );
-
-				foreach ( $extra as $key => $value ) {
-					$_POST[ $key ] = $value;
-				}
-			}
-
-			if ( $product['product']->is_type( 'booking' ) ) {
-				$success = $success && $this->add_booking_product(
-					$product['product'],
-					$product['booking']
-				);
-			} elseif ( $product['product']->is_type( 'variable' ) ) {
-				$success = $success && $this->add_variable_product(
-					$product['product'],
-					$product['quantity'],
-					$product['variations']
-				);
-			} else {
-				$success = $success && $this->add_product(
-					$product['product'],
-					$product['quantity']
-				);
-			}
-		}
-
-		if ( ! $success ) {
+		try {
+			$this->cart_products->add_products( $products );
+		} catch ( Exception $e ) {
 			$this->handle_error();
 		}
 
-		return $success;
+		return true;
 	}
 
 	/**
@@ -193,7 +156,7 @@ abstract class AbstractCartEndpoint implements EndpointInterface {
 	 */
 	protected function products_from_request() {
 		$data     = $this->request_data->read_request( $this->nonce() );
-		$products = $this->products_from_data( $data );
+		$products = $this->cart_products->products_from_data( $data );
 		if ( ! $products ) {
 			wp_send_json_error(
 				array(
@@ -213,140 +176,11 @@ abstract class AbstractCartEndpoint implements EndpointInterface {
 	}
 
 	/**
-	 * Returns product information from a data array.
-	 *
-	 * @param array $data The data array.
-	 *
-	 * @return array|null
-	 */
-	protected function products_from_data( array $data ): ?array {
-
-		$products = array();
-
-		if (
-			! isset( $data['products'] )
-			|| ! is_array( $data['products'] )
-		) {
-			return null;
-		}
-		foreach ( $data['products'] as $product ) {
-			if ( ! isset( $product['quantity'] ) || ! isset( $product['id'] ) ) {
-				return null;
-			}
-
-			$wc_product = wc_get_product( (int) $product['id'] );
-
-			if ( ! $wc_product ) {
-				return null;
-			}
-			$products[] = array(
-				'product'    => $wc_product,
-				'quantity'   => (int) $product['quantity'],
-				'variations' => $product['variations'] ?? null,
-				'booking'    => $product['booking'] ?? null,
-				'extra'      => $product['extra'] ?? null,
-			);
-		}
-		return $products;
-	}
-
-	/**
-	 * Adds a product to the cart.
-	 *
-	 * @param \WC_Product $product The Product.
-	 * @param int         $quantity The Quantity.
-	 *
-	 * @return bool
-	 * @throws Exception When product could not be added.
-	 */
-	private function add_product( \WC_Product $product, int $quantity ): bool {
-		$cart_item_key = $this->cart->add_to_cart( $product->get_id(), $quantity );
-
-		if ( $cart_item_key ) {
-			$this->cart_item_keys[] = $cart_item_key;
-		}
-		return false !== $cart_item_key;
-	}
-
-	/**
-	 * Adds variations to the cart.
-	 *
-	 * @param \WC_Product $product The Product.
-	 * @param int         $quantity The Quantity.
-	 * @param array       $post_variations The variations.
-	 *
-	 * @return bool
-	 * @throws Exception When product could not be added.
-	 */
-	private function add_variable_product(
-		\WC_Product $product,
-		int $quantity,
-		array $post_variations
-	): bool {
-
-		$variations = array();
-		foreach ( $post_variations as $key => $value ) {
-			$variations[ $value['name'] ] = $value['value'];
-		}
-
-		$variation_id = $this->product_data_store->find_matching_product_variation( $product, $variations );
-
-		// ToDo: Check stock status for variation.
-		$cart_item_key = $this->cart->add_to_cart(
-			$product->get_id(),
-			$quantity,
-			$variation_id,
-			$variations
-		);
-
-		if ( $cart_item_key ) {
-			$this->cart_item_keys[] = $cart_item_key;
-		}
-		return false !== $cart_item_key;
-	}
-
-	/**
-	 * Adds booking to the cart.
-	 *
-	 * @param \WC_Product $product The Product.
-	 * @param array       $data Data used by the booking plugin.
-	 *
-	 * @return bool
-	 * @throws Exception When product could not be added.
-	 */
-	private function add_booking_product(
-		\WC_Product $product,
-		array $data
-	): bool {
-
-		if ( ! is_callable( 'wc_bookings_get_posted_data' ) ) {
-			return false;
-		}
-
-		$cart_item_data = array(
-			'booking' => wc_bookings_get_posted_data( $data, $product ),
-		);
-
-		$cart_item_key = $this->cart->add_to_cart( $product->get_id(), 1, 0, array(), $cart_item_data );
-
-		if ( $cart_item_key ) {
-			$this->cart_item_keys[] = $cart_item_key;
-		}
-		return false !== $cart_item_key;
-	}
-
-	/**
 	 * Removes stored cart items from WooCommerce cart.
 	 *
 	 * @return void
 	 */
 	protected function remove_cart_items(): void {
-		foreach ( $this->cart_item_keys as $cart_item_key ) {
-			if ( ! $cart_item_key ) {
-				continue;
-			}
-			$this->cart->remove_cart_item( $cart_item_key );
-		}
+		$this->cart_products->remove_cart_items();
 	}
-
 }

--- a/modules/ppcp-button/src/Endpoint/ChangeCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ChangeCartEndpoint.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 
 /**
  * Class ChangeCartEndpoint
@@ -41,7 +42,7 @@ class ChangeCartEndpoint extends AbstractCartEndpoint {
 	 * @param \WC_Shipping        $shipping The current WC shipping object.
 	 * @param RequestData         $request_data The request data helper.
 	 * @param PurchaseUnitFactory $purchase_unit_factory The PurchaseUnit factory.
-	 * @param \WC_Data_Store      $product_data_store The data store for products.
+	 * @param CartProductsHelper  $cart_products The cart products helper.
 	 * @param LoggerInterface     $logger The logger.
 	 */
 	public function __construct(
@@ -49,7 +50,7 @@ class ChangeCartEndpoint extends AbstractCartEndpoint {
 		\WC_Shipping $shipping,
 		RequestData $request_data,
 		PurchaseUnitFactory $purchase_unit_factory,
-		\WC_Data_Store $product_data_store,
+		CartProductsHelper $cart_products,
 		LoggerInterface $logger
 	) {
 
@@ -57,7 +58,7 @@ class ChangeCartEndpoint extends AbstractCartEndpoint {
 		$this->shipping              = $shipping;
 		$this->request_data          = $request_data;
 		$this->purchase_unit_factory = $purchase_unit_factory;
-		$this->product_data_store    = $product_data_store;
+		$this->cart_products         = $cart_products;
 		$this->logger                = $logger;
 
 		$this->logger_tag = 'updating';
@@ -70,6 +71,8 @@ class ChangeCartEndpoint extends AbstractCartEndpoint {
 	 * @throws Exception On error.
 	 */
 	protected function handle_data(): bool {
+		$this->cart_products->set_cart( $this->cart );
+
 		$products = $this->products_from_request();
 
 		if ( ! $products ) {

--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -52,11 +52,11 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 		CartProductsHelper $cart_products,
 		LoggerInterface $logger
 	) {
-		$this->smart_button       = $smart_button;
-		$this->cart               = clone $cart;
-		$this->request_data       = $request_data;
-		$this->cart_products      = $cart_products;
-		$this->logger             = $logger;
+		$this->smart_button  = $smart_button;
+		$this->cart          = clone $cart;
+		$this->request_data  = $request_data;
+		$this->cart_products = $cart_products;
+		$this->logger        = $logger;
 
 		$this->logger_tag = 'simulation';
 	}

--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -13,6 +13,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButton;
+use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 
 /**
  * Class SimulateCartEndpoint
@@ -38,23 +39,23 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 	/**
 	 * ChangeCartEndpoint constructor.
 	 *
-	 * @param SmartButton     $smart_button The SmartButton.
-	 * @param \WC_Cart        $cart The current WC cart object.
-	 * @param RequestData     $request_data The request data helper.
-	 * @param \WC_Data_Store  $product_data_store The data store for products.
-	 * @param LoggerInterface $logger The logger.
+	 * @param SmartButton        $smart_button The SmartButton.
+	 * @param \WC_Cart           $cart The current WC cart object.
+	 * @param RequestData        $request_data The request data helper.
+	 * @param CartProductsHelper $cart_products The cart products helper.
+	 * @param LoggerInterface    $logger The logger.
 	 */
 	public function __construct(
 		SmartButton $smart_button,
 		\WC_Cart $cart,
 		RequestData $request_data,
-		\WC_Data_Store $product_data_store,
+		CartProductsHelper $cart_products,
 		LoggerInterface $logger
 	) {
 		$this->smart_button       = $smart_button;
 		$this->cart               = clone $cart;
 		$this->request_data       = $request_data;
-		$this->product_data_store = $product_data_store;
+		$this->cart_products      = $cart_products;
 		$this->logger             = $logger;
 
 		$this->logger_tag = 'simulation';
@@ -147,6 +148,7 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 		// Store a reference to the real cart.
 		$this->real_cart = WC()->cart;
 		WC()->cart       = $this->cart;
+		$this->cart_products->set_cart( $this->cart );
 	}
 
 	/**

--- a/modules/ppcp-button/src/Helper/CartProductsHelper.php
+++ b/modules/ppcp-button/src/Helper/CartProductsHelper.php
@@ -53,7 +53,7 @@ class CartProductsHelper {
 	/**
 	 * Sets a new cart instance.
 	 *
-	 * @param WC_Cart $cart
+	 * @param WC_Cart $cart The cart.
 	 * @return void
 	 */
 	public function set_cart( WC_Cart $cart ): void {
@@ -89,7 +89,7 @@ class CartProductsHelper {
 	/**
 	 * Returns product information from a data array.
 	 *
-	 * @param array $product
+	 * @param array $product The product data array, usually provided by the product page form.
 	 * @return array|null
 	 */
 	public function product_from_data( array $product ): ?array {
@@ -135,20 +135,20 @@ class CartProductsHelper {
 
 			if ( $product['product']->is_type( 'booking' ) ) {
 				$success = $success && $this->add_booking_product(
-						$product['product'],
-						$product['booking']
-					);
+					$product['product'],
+					$product['booking']
+				);
 			} elseif ( $product['product']->is_type( 'variable' ) ) {
 				$success = $success && $this->add_variable_product(
-						$product['product'],
-						$product['quantity'],
-						$product['variations']
-					);
+					$product['product'],
+					$product['quantity'],
+					$product['variations']
+				);
 			} else {
 				$success = $success && $this->add_product(
-						$product['product'],
-						$product['quantity']
-					);
+					$product['product'],
+					$product['quantity']
+				);
 			}
 		}
 
@@ -169,7 +169,9 @@ class CartProductsHelper {
 	 * @throws Exception When product could not be added.
 	 */
 	public function add_product( \WC_Product $product, int $quantity ): bool {
-		$this->validate_cart();
+		if ( ! $this->cart ) {
+			throw new Exception( 'Cart not set.' );
+		}
 
 		$cart_item_key = $this->cart->add_to_cart( $product->get_id(), $quantity );
 
@@ -194,7 +196,9 @@ class CartProductsHelper {
 		int $quantity,
 		array $post_variations
 	): bool {
-		$this->validate_cart();
+		if ( ! $this->cart ) {
+			throw new Exception( 'Cart not set.' );
+		}
 
 		$variations = array();
 		foreach ( $post_variations as $key => $value ) {
@@ -230,7 +234,9 @@ class CartProductsHelper {
 		\WC_Product $product,
 		array $data
 	): bool {
-		$this->validate_cart();
+		if ( ! $this->cart ) {
+			throw new Exception( 'Cart not set.' );
+		}
 
 		if ( ! is_callable( 'wc_bookings_get_posted_data' ) ) {
 			return false;
@@ -252,10 +258,12 @@ class CartProductsHelper {
 	 * Removes stored cart items from WooCommerce cart.
 	 *
 	 * @return void
-	 * @throws Exception
+	 * @throws Exception Throws if there's a failure removing the cart items.
 	 */
 	public function remove_cart_items(): void {
-		$this->validate_cart();
+		if ( ! $this->cart ) {
+			throw new Exception( 'Cart not set.' );
+		}
 
 		foreach ( $this->cart_item_keys as $cart_item_key ) {
 			if ( ! $cart_item_key ) {
@@ -266,21 +274,12 @@ class CartProductsHelper {
 	}
 
 	/**
+	 * Returns the cart item keys of the items added to cart.
+	 *
 	 * @return array
 	 */
 	public function cart_item_keys(): array {
 		return $this->cart_item_keys;
 	}
 
-	/**
-	 * Throws the cart not set exception.
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	private function validate_cart(): void {
-		if ( ! $this->cart ) {
-			throw new Exception( 'Cart not set.' );
-		}
-	}
 }

--- a/modules/ppcp-button/src/Helper/CartProductsHelper.php
+++ b/modules/ppcp-button/src/Helper/CartProductsHelper.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Handles the adding of products to WooCommerce cart.
+ *
+ * @package WooCommerce\PayPalCommerce\Button\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Helper;
+
+use Exception;
+use WC_Cart;
+use WC_Data_Store;
+
+/**
+ * Class CartProductsHelper
+ */
+class CartProductsHelper {
+
+	/**
+	 * The cart
+	 *
+	 * @var ?WC_Cart
+	 */
+	private $cart;
+
+	/**
+	 * The product data store.
+	 *
+	 * @var WC_Data_Store
+	 */
+	protected $product_data_store;
+
+	/**
+	 * The added cart item IDs
+	 *
+	 * @var array
+	 */
+	private $cart_item_keys = array();
+
+	/**
+	 * CheckoutFormSaver constructor.
+	 *
+	 * @param WC_Data_Store $product_data_store The data store for products.
+	 */
+	public function __construct(
+		WC_Data_Store $product_data_store
+	) {
+		$this->product_data_store = $product_data_store;
+	}
+
+	/**
+	 * Sets a new cart instance.
+	 *
+	 * @param WC_Cart $cart
+	 * @return void
+	 */
+	public function set_cart( WC_Cart $cart ): void {
+		$this->cart = $cart;
+	}
+
+	/**
+	 * Returns products information from a data array.
+	 *
+	 * @param array $data The data array.
+	 *
+	 * @return array|null
+	 */
+	public function products_from_data( array $data ): ?array {
+
+		$products = array();
+
+		if (
+			! isset( $data['products'] )
+			|| ! is_array( $data['products'] )
+		) {
+			return null;
+		}
+		foreach ( $data['products'] as $product ) {
+			$product = $this->products_from_data( $product );
+			if ( $product ) {
+				$products[] = $product;
+			}
+		}
+		return $products;
+	}
+
+	/**
+	 * Returns product information from a data array.
+	 *
+	 * @param array $product
+	 * @return array|null
+	 */
+	public function product_from_data( array $product ): ?array {
+		if ( ! isset( $product['quantity'] ) || ! isset( $product['id'] ) ) {
+			return null;
+		}
+
+		$wc_product = wc_get_product( (int) $product['id'] );
+
+		if ( ! $wc_product ) {
+			return null;
+		}
+		return array(
+			'product'    => $wc_product,
+			'quantity'   => (int) $product['quantity'],
+			'variations' => $product['variations'] ?? null,
+			'booking'    => $product['booking'] ?? null,
+			'extra'      => $product['extra'] ?? null,
+		);
+	}
+
+	/**
+	 * Adds products to cart.
+	 *
+	 * @param array $products Array of products to be added to cart.
+	 * @return bool
+	 * @throws Exception Add to cart methods throw an exception on fail.
+	 */
+	public function add_products( array $products ): bool {
+		$success = true;
+		foreach ( $products as $product ) {
+
+			// Add extras to POST, they are usually added by custom plugins.
+			if ( $product['extra'] && is_array( $product['extra'] ) ) {
+				// Handle cases like field[].
+				$query = http_build_query( $product['extra'] );
+				parse_str( $query, $extra );
+
+				foreach ( $extra as $key => $value ) {
+					$_POST[ $key ] = $value;
+				}
+			}
+
+			if ( $product['product']->is_type( 'booking' ) ) {
+				$success = $success && $this->add_booking_product(
+						$product['product'],
+						$product['booking']
+					);
+			} elseif ( $product['product']->is_type( 'variable' ) ) {
+				$success = $success && $this->add_variable_product(
+						$product['product'],
+						$product['quantity'],
+						$product['variations']
+					);
+			} else {
+				$success = $success && $this->add_product(
+						$product['product'],
+						$product['quantity']
+					);
+			}
+		}
+
+		if ( ! $success ) {
+			throw new Exception( 'Error adding products to cart.' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Adds a product to the cart.
+	 *
+	 * @param \WC_Product $product The Product.
+	 * @param int         $quantity The Quantity.
+	 *
+	 * @return bool
+	 * @throws Exception When product could not be added.
+	 */
+	public function add_product( \WC_Product $product, int $quantity ): bool {
+		$this->validate_cart();
+
+		$cart_item_key = $this->cart->add_to_cart( $product->get_id(), $quantity );
+
+		if ( $cart_item_key ) {
+			$this->cart_item_keys[] = $cart_item_key;
+		}
+		return false !== $cart_item_key;
+	}
+
+	/**
+	 * Adds variations to the cart.
+	 *
+	 * @param \WC_Product $product The Product.
+	 * @param int         $quantity The Quantity.
+	 * @param array       $post_variations The variations.
+	 *
+	 * @return bool
+	 * @throws Exception When product could not be added.
+	 */
+	public function add_variable_product(
+		\WC_Product $product,
+		int $quantity,
+		array $post_variations
+	): bool {
+		$this->validate_cart();
+
+		$variations = array();
+		foreach ( $post_variations as $key => $value ) {
+			$variations[ $value['name'] ] = $value['value'];
+		}
+
+		$variation_id = $this->product_data_store->find_matching_product_variation( $product, $variations );
+
+		// ToDo: Check stock status for variation.
+		$cart_item_key = $this->cart->add_to_cart(
+			$product->get_id(),
+			$quantity,
+			$variation_id,
+			$variations
+		);
+
+		if ( $cart_item_key ) {
+			$this->cart_item_keys[] = $cart_item_key;
+		}
+		return false !== $cart_item_key;
+	}
+
+	/**
+	 * Adds booking to the cart.
+	 *
+	 * @param \WC_Product $product The Product.
+	 * @param array       $data Data used by the booking plugin.
+	 *
+	 * @return bool
+	 * @throws Exception When product could not be added.
+	 */
+	public function add_booking_product(
+		\WC_Product $product,
+		array $data
+	): bool {
+		$this->validate_cart();
+
+		if ( ! is_callable( 'wc_bookings_get_posted_data' ) ) {
+			return false;
+		}
+
+		$cart_item_data = array(
+			'booking' => wc_bookings_get_posted_data( $data, $product ),
+		);
+
+		$cart_item_key = $this->cart->add_to_cart( $product->get_id(), 1, 0, array(), $cart_item_data );
+
+		if ( $cart_item_key ) {
+			$this->cart_item_keys[] = $cart_item_key;
+		}
+		return false !== $cart_item_key;
+	}
+
+	/**
+	 * Removes stored cart items from WooCommerce cart.
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function remove_cart_items(): void {
+		$this->validate_cart();
+
+		foreach ( $this->cart_item_keys as $cart_item_key ) {
+			if ( ! $cart_item_key ) {
+				continue;
+			}
+			$this->cart->remove_cart_item( $cart_item_key );
+		}
+	}
+
+	/**
+	 * @return array
+	 */
+	public function cart_item_keys(): array {
+		return $this->cart_item_keys;
+	}
+
+	/**
+	 * Throws the cart not set exception.
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	private function validate_cart(): void {
+		if ( ! $this->cart ) {
+			throw new Exception( 'Cart not set.' );
+		}
+	}
+}

--- a/modules/ppcp-button/src/Helper/CartProductsHelper.php
+++ b/modules/ppcp-button/src/Helper/CartProductsHelper.php
@@ -78,7 +78,7 @@ class CartProductsHelper {
 			return null;
 		}
 		foreach ( $data['products'] as $product ) {
-			$product = $this->products_from_data( $product );
+			$product = $this->product_from_data( $product );
 			if ( $product ) {
 				$products[] = $product;
 			}

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -50,103 +50,105 @@ class GooglepayModule implements ModuleInterface {
 			}
 		);
 
-		// Check if the module is applicable, correct country, currency, ... etc.
-		if ( ! $c->get( 'googlepay.eligible' ) ) {
-			return;
-		}
-
-		// Load the button handler.
-		$button = $c->get( 'googlepay.button' );
-		assert( $button instanceof ButtonInterface );
-		$button->initialize();
-
-		// Show notice if there are product availability issues.
-		$availability_notice = $c->get( 'googlepay.availability_notice' );
-		assert( $availability_notice instanceof AvailabilityNotice );
-		$availability_notice->execute();
-
-		// Check if this merchant can activate / use the buttons.
-		// We allow non referral merchants as they can potentially still use GooglePay, we just have no way of checking the capability.
-		if ( ( ! $c->get( 'googlepay.available' ) ) && $c->get( 'googlepay.is_referral' ) ) {
-			return;
-		}
-
-		// Initializes button rendering.
 		add_action(
-			'wp',
-			static function () use ( $c, $button ) {
-				if ( is_admin() ) {
-					return;
-				}
-				$button->render();
-			}
-		);
-
-		// Enqueue frontend scripts.
-		add_action(
-			'wp_enqueue_scripts',
-			static function () use ( $c, $button ) {
-				$smart_button = $c->get( 'button.smart-button' );
-				assert( $smart_button instanceof SmartButtonInterface );
-				if ( $smart_button->should_load_ppcp_script() ) {
-					$button->enqueue();
-				}
-
-				if ( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) {
-					/**
-					 * Should add this to the ButtonInterface.
-					 *
-					 * @psalm-suppress UndefinedInterfaceMethod
-					 */
-					$button->enqueue_styles();
-				}
-			}
-		);
-
-		// Enqueue backend scripts.
-		add_action(
-			'admin_enqueue_scripts',
-			static function () use ( $c, $button ) {
-				if ( ! is_admin() ) {
-					return;
-				}
-				/**
-				 * Should add this to the ButtonInterface.
-				 *
-				 * @psalm-suppress UndefinedInterfaceMethod
-				 */
-				$button->enqueue_admin();
-			}
-		);
-
-		// Registers buttons on blocks pages.
-		add_action(
-			'woocommerce_blocks_payment_method_type_registration',
-			function( PaymentMethodRegistry $payment_method_registry ) use ( $c, $button ): void {
-				if ( $button->is_enabled() ) {
-					$payment_method_registry->register( $c->get( 'googlepay.blocks-payment-method' ) );
-				}
-			}
-		);
-
-		// Adds GooglePay component to the backend button preview settings.
-		add_action(
-			'woocommerce_paypal_payments_admin_gateway_settings',
-			function( array $settings ) use ( $c, $button ): array {
-				if ( is_array( $settings['components'] ) ) {
-					$settings['components'][] = 'googlepay';
-				}
-				return $settings;
-			}
-		);
-
-		// Initialize AJAX endpoints.
-		add_action(
-			'wc_ajax_' . UpdatePaymentDataEndpoint::ENDPOINT,
+			'init',
 			static function () use ( $c ) {
-				$endpoint = $c->get( 'googlepay.endpoint.update-payment-data' );
-				assert( $endpoint instanceof UpdatePaymentDataEndpoint );
-				$endpoint->handle_request();
+
+				// Check if the module is applicable, correct country, currency, ... etc.
+				if ( ! $c->get( 'googlepay.eligible' ) ) {
+					return;
+				}
+
+				// Load the button handler.
+				$button = $c->get( 'googlepay.button' );
+				assert( $button instanceof ButtonInterface );
+				$button->initialize();
+
+				// Show notice if there are product availability issues.
+				$availability_notice = $c->get( 'googlepay.availability_notice' );
+				assert( $availability_notice instanceof AvailabilityNotice );
+				$availability_notice->execute();
+
+				// Check if this merchant can activate / use the buttons.
+				// We allow non referral merchants as they can potentially still use GooglePay, we just have no way of checking the capability.
+				if ( ( ! $c->get( 'googlepay.available' ) ) && $c->get( 'googlepay.is_referral' ) ) {
+					return;
+				}
+
+				// Initializes button rendering.
+				if ( ! is_admin() ) {
+					$button->render();
+				}
+
+				// Enqueue frontend scripts.
+				add_action(
+					'wp_enqueue_scripts',
+					static function () use ( $c, $button ) {
+						$smart_button = $c->get( 'button.smart-button' );
+						assert( $smart_button instanceof SmartButtonInterface );
+						if ( $smart_button->should_load_ppcp_script() ) {
+							$button->enqueue();
+						}
+
+						if ( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) {
+							/**
+							 * Should add this to the ButtonInterface.
+							 *
+							 * @psalm-suppress UndefinedInterfaceMethod
+							 */
+							$button->enqueue_styles();
+						}
+					}
+				);
+
+				// Enqueue backend scripts.
+				add_action(
+					'admin_enqueue_scripts',
+					static function () use ( $c, $button ) {
+						if ( ! is_admin() ) {
+							return;
+						}
+
+						/**
+						 * Should add this to the ButtonInterface.
+						 *
+						 * @psalm-suppress UndefinedInterfaceMethod
+						 */
+						$button->enqueue_admin();
+					}
+				);
+
+				// Registers buttons on blocks pages.
+				add_action(
+					'woocommerce_blocks_payment_method_type_registration',
+					function( PaymentMethodRegistry $payment_method_registry ) use ( $c, $button ): void {
+						if ( $button->is_enabled() ) {
+							$payment_method_registry->register( $c->get( 'googlepay.blocks-payment-method' ) );
+						}
+					}
+				);
+
+				// Adds GooglePay component to the backend button preview settings.
+				add_action(
+					'woocommerce_paypal_payments_admin_gateway_settings',
+					function( array $settings ) use ( $c ): array {
+						if ( is_array( $settings['components'] ) ) {
+							$settings['components'][] = 'googlepay';
+						}
+						return $settings;
+					}
+				);
+
+				// Initialize AJAX endpoints.
+				add_action(
+					'wc_ajax_' . UpdatePaymentDataEndpoint::ENDPOINT,
+					static function () use ( $c ) {
+						$endpoint = $c->get( 'googlepay.endpoint.update-payment-data' );
+						assert( $endpoint instanceof UpdatePaymentDataEndpoint );
+						$endpoint->handle_request();
+					}
+				);
+
 			}
 		);
 	}

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -76,9 +76,15 @@ class GooglepayModule implements ModuleInterface {
 				}
 
 				// Initializes button rendering.
-				if ( ! is_admin() ) {
-					$button->render();
-				}
+				add_action(
+					'wp',
+					static function () use ( $c, $button ) {
+						if ( is_admin() ) {
+							return;
+						}
+						$button->render();
+					}
+				);
 
 				// Enqueue frontend scripts.
 				add_action(

--- a/tests/PHPUnit/Button/Endpoint/ChangeCartEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/ChangeCartEndpointTest.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
 use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
@@ -91,12 +92,16 @@ class ChangeCartEndpointTest extends TestCase
             ->expects('from_wc_cart')
             ->andReturn($pu);
 
+		$productsHelper = new CartProductsHelper(
+			$dataStore
+		);
+
         $testee = new ChangeCartEndpoint(
             $cart,
             $shipping,
             $requestData,
             $purchase_unit_factory,
-            $dataStore,
+			$productsHelper,
 			new NullLogger()
         );
 


### PR DESCRIPTION
# PR Description

In this PR:
- Adds support for product variations, also support extra data and booking data.
- Refactors `SimulateCartEndpoint` and `ChangeCartEndpoint` to share logic with `ApplePay` as it also manipulates the cart based on the single product page. 
- Now `ApplePay` and `GooglePay` are booted on `init` action to guarantee all resources are available. There was a case where `WC_Data_Store` wasn't available for `ApplePay` on it's initialization.
- Applied a fix to nonce of non logged in users.
- Some reordering of code was done to help with readability.

Issues identified and still pending resolution (maybe on separate issues):
- On the single product page the cost shown on ApplePay modal is only updated (according to the selected options) upon the update of addresses or payment method callback.
- This code is a candidate for additional refactoring namely have a specific data structure / object for product(s) on ApplePay.

# Issue Description
On a variable product detail page ApplePay price isn’t updating it’s price according to the selected variant.

## Steps To Reproduce

1. Enter a variable product page
2. Select a variant
3. Click the ApplePay buttons
4. See if the ApplePay modal price reflects the variant price
5. Close the ApplePay modal
6. Select another variant with a different price
7. See if the ApplePay modal price reflects the variant price

## Expected behaviour

ApplePay should reflect the selected variant price.