### PR TITLE
Handle undefined array key warnings on PHP 8.1 (2104)

### DIFF
--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -48,8 +48,8 @@ class ApiModule implements ModuleInterface {
 			'ppcp_create_order_request_body_data',
 			function( array $data ) use ( $c ) {
 
-				foreach ( $data['purchase_units'] as $purchase_unit_index => $purchase_unit ) {
-					foreach ( $purchase_unit['items'] as $item_index => $item ) {
+				foreach ( ( $data['purchase_units'] ?? array() ) as $purchase_unit_index => $purchase_unit ) {
+					foreach ( ( $purchase_unit['items'] ?? array() ) as $item_index => $item ) {
 						$data['purchase_units'][ $purchase_unit_index ]['items'][ $item_index ]['name'] =
 							apply_filters( 'woocommerce_paypal_payments_cart_line_item_name', $item['name'], $item['cart_item_key'] ?? null );
 					}

--- a/modules/ppcp-api-client/src/Helper/OrderTransient.php
+++ b/modules/ppcp-api-client/src/Helper/OrderTransient.php
@@ -102,7 +102,7 @@ class OrderTransient {
 			$transient = array();
 		}
 
-		if ( ! is_array( $transient['notes'] ) ) {
+		if ( ! is_array( $transient['notes'] ?? null ) ) {
 			$transient['notes'] = array();
 		}
 


### PR DESCRIPTION
# PR Description

This PR prevents the warnings from showing.


# Issue Description

A user reported these warnings:

```
2023/09/30 12:16:06 [error] 934922#934922: *41688 FastCGI sent in stderr: "
PHP message: PHP Warning: Undefined array key "items" in /home/wp/disk/wordpress/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-api-client/src/ApiModule.php on line 51
PHP message: PHP Warning: foreach() argument must be of type array|object, null given in /home/wp/disk/wordpress/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-api-client/src/ApiModule.php on line 51
PHP message: PHP Warning: Undefined array key "notes" in /home/wp/disk/wordpress/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-api-client/src/Helper/OrderTransient.php on line 105" 
while reading response header from upstream, client: xx.xx.xx.xx, server: www.produkte-vom-schaf.de,, request: "POST /?wc-ajax=ppc-create-order HTTP/1.1", upstream: "fastcgi://unix:/var/run/wordpress.php-fpm.sock:", host: "www.produkte-vom-schaf.de", referrer: "https://www.produkte-vom-schaf.de/zur-kasse/"
```