### PR TITLE
Display Shop location Pay Later messaging on product category pages

### DIFF
--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -86,7 +86,7 @@ trait ContextTrait {
 			return $context;
 		}
 
-		if ( is_shop() ) {
+		if ( is_shop() || is_product_category() ) {
 			return 'shop';
 		}
 


### PR DESCRIPTION
Now the check for the Shop location includes `is_product_category()` to cover the product category pages.

Looks like the `woocommerce_archive_description` hook works there too.