### PR TITLE
Display Pay Later messages before the payment methods on the Pay for Order page (2128)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -705,7 +705,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 	/**
 	 * Renders the HTML for the credit messaging.
 	 */
-	public function message_renderer() {
+	public function message_renderer(): void {
 
 		$product = wc_get_product();
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -402,7 +402,7 @@ class SmartButton implements SmartButtonInterface {
 				case 'cart':
 					return $this->messages_renderer_hook( $location, $this->proceed_to_checkout_button_renderer_hook(), 19 );
 				case 'pay-now':
-					return $this->messages_renderer_hook( 'pay_order', 'woocommerce_pay_order_before_submit', 10 );
+					return $this->messages_renderer_hook( $location, $default_pay_order_hook, 10 );
 				case 'product':
 					return $this->messages_renderer_hook( $location, $this->single_product_renderer_hook(), 30 );
 				case 'shop':
@@ -1399,18 +1399,20 @@ class SmartButton implements SmartButtonInterface {
 	 * @return array An array with 'name' and 'priority' keys.
 	 */
 	private function messages_renderer_hook( string $location, string $default_hook, int $default_priority ): array {
+		$location_hook = $this->location_to_hook( $location );
+
 		/**
 		 * The filter returning the action name that will be used for rendering Pay Later messages.
 		 */
 		$hook = (string) apply_filters(
-			"woocommerce_paypal_payments_${location}_messages_renderer_hook",
+			"woocommerce_paypal_payments_${location_hook}_messages_renderer_hook",
 			$default_hook
 		);
 		/**
 		 * The filter returning the action priority that will be used for rendering Pay Later messages.
 		 */
 		$priority = (int) apply_filters(
-			"woocommerce_paypal_payments_${location}_messages_renderer_priority",
+			"woocommerce_paypal_payments_${location_hook}_messages_renderer_priority",
 			$default_priority
 		);
 		return array(
@@ -1724,4 +1726,18 @@ class SmartButton implements SmartButtonInterface {
 
 	}
 
+	/**
+	 * Converts the location name into the name used in hooks.
+	 *
+	 * @param string $location The location.
+	 * @return string
+	 */
+	private function location_to_hook( string $location ): string {
+		switch ( $location ) {
+			case 'pay-now':
+				return 'pay_order';
+			default:
+				return $location;
+		}
+	}
 }

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -685,7 +685,8 @@ class SmartButton implements SmartButtonInterface {
 
 		$product = wc_get_product();
 
-		$location = $this->location();
+		$location      = $this->location();
+		$location_hook = $this->location_to_hook( $location );
 
 		if (
 			$location === 'product' && is_a( $product, WC_Product::class )
@@ -697,7 +698,17 @@ class SmartButton implements SmartButtonInterface {
 			return;
 		}
 
+		/**
+		 * A hook executed before rendering of the PCP Pay Later messages wrapper.
+		 */
+		do_action( "ppcp_before_{$location_hook}_message_wrapper" );
+
 		echo '<div id="ppcp-messages" data-partner-attribution-id="Woo_PPCP"></div>';
+
+		/**
+		 * A hook executed after rendering of the PCP Pay Later messages wrapper.
+		 */
+		do_action( "ppcp_after_{$location_hook}_message_wrapper" );
 	}
 
 	/**


### PR DESCRIPTION
Earlier in #1770 we moved the checkout Pay Later messages so that they are always visible, but on the pay for order page they were still remaining inside the payment method together with the buttons.

Looks like there are no hooks like `woocommerce_review_order_before_payment` on the pay for order page, so moving it using JS. It is done only if using the default hook (`woocommerce_pay_order_before_submit`) and `woocommerce_paypal_payments_put_pay_order_messages_before_payment_methods` filter is not changed to return `false`.

Also there is now `ppcp_after_{$location}_message_wrapper` hook which merchants can use for implementing similar things in other locations.