### PR TITLE
Improve Apple Pay compatibility on Pay for Order page (2157)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -25,7 +25,7 @@ class ApplepayButton {
 
         this.updated_contact_info = []
         this.selectedShippingMethod = []
-        this.nonce = document.getElementById('woocommerce-process-checkout-nonce')?.value
+        this.nonce = document.getElementById('woocommerce-process-checkout-nonce')?.value || buttonConfig.nonce
 
         this.log = function() {
             if ( this.buttonConfig.is_debug ) {

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -244,6 +244,11 @@ class ApplepayButton {
             requiredShippingContactFields: ["postalAddress", "email", "phone"],
             requiredBillingContactFields: ["postalAddress", "email", "phone"],
         }
+
+        if (!this.contextHandler.shippingAllowed()) {
+            baseRequest.requiredShippingContactFields = [];
+        }
+
         const paymentDataRequest = Object.assign({}, baseRequest);
         paymentDataRequest.currencyCode = buttonConfig.shop.currencyCode;
         paymentDataRequest.total = {
@@ -508,18 +513,53 @@ class ApplepayButton {
                 if (confirmOrderResponse && confirmOrderResponse.approveApplePayPayment) {
                     if (confirmOrderResponse.approveApplePayPayment.status === "APPROVED") {
                         try {
-                            let data = {
-                                billing_contact: event.payment.billingContact,
-                                shipping_contact: event.payment.shippingContact,
-                                paypal_order_id: id,
-                            };
-                            let authorizationResult = await processInWooAndCapture(data);
-                            if (authorizationResult.result === "success") {
-                                session.completePayment(ApplePaySession.STATUS_SUCCESS)
-                                window.location.href = authorizationResult.redirect
+
+                            if (!this.contextHandler.shippingAllowed()) {
+                                // No shipping, expect immediate capture, ex: PayNow.
+
+                                let approveFailed = false;
+                                await this.contextHandler.approveOrder({
+                                    orderID: id
+                                }, { // actions mock object.
+                                    restart: () => new Promise((resolve, reject) => {
+                                        approveFailed = true;
+                                        resolve();
+                                    }),
+                                    order: {
+                                        get: () => new Promise((resolve, reject) => {
+                                            resolve(null);
+                                        })
+                                    }
+                                });
+
+                                if (!approveFailed) {
+                                    this.log('onpaymentauthorized approveOrder OK');
+                                    session.completePayment(ApplePaySession.STATUS_SUCCESS);
+                                } else {
+                                    this.log('onpaymentauthorized approveOrder FAIL');
+                                    session.completePayment(ApplePaySession.STATUS_FAILURE);
+                                    session.abort()
+                                    console.error(error);
+                                }
+
                             } else {
-                                session.completePayment(ApplePaySession.STATUS_FAILURE)
+                                // Default payment.
+
+                                let data = {
+                                    billing_contact: event.payment.billingContact,
+                                    shipping_contact: event.payment.shippingContact,
+                                    paypal_order_id: id,
+                                };
+                                let authorizationResult = await processInWooAndCapture(data);
+                                if (authorizationResult.result === "success") {
+                                    session.completePayment(ApplePaySession.STATUS_SUCCESS)
+                                    window.location.href = authorizationResult.redirect
+                                } else {
+                                    session.completePayment(ApplePaySession.STATUS_FAILURE)
+                                }
+
                             }
+
                         } catch (error) {
                             session.completePayment(ApplePaySession.STATUS_FAILURE);
                             session.abort()

--- a/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
@@ -1,14 +1,16 @@
 import ErrorHandler from "../../../../ppcp-button/resources/js/modules/ErrorHandler";
 import CartActionHandler
     from "../../../../ppcp-button/resources/js/modules/ActionHandler/CartActionHandler";
-import onApprove
-    from "../../../../ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue";
 
 class BaseHandler {
 
     constructor(buttonConfig, ppcpConfig) {
         this.buttonConfig = buttonConfig;
         this.ppcpConfig = ppcpConfig;
+    }
+
+    shippingAllowed() {
+        return true;
     }
 
     transactionInfo() {
@@ -42,30 +44,25 @@ class BaseHandler {
     }
 
     createOrder() {
-        const errorHandler = new ErrorHandler(
-            this.ppcpConfig.labels.error.generic,
-            document.querySelector('.woocommerce-notices-wrapper')
-        );
-
-        const actionHandler = new CartActionHandler(
-            this.ppcpConfig,
-            errorHandler,
-        );
-
-        return actionHandler.configuration().createOrder(null, null);
+        return this.actionHandler().configuration().createOrder(null, null);
     }
 
-    approveOrderForContinue(data, actions) {
-        const errorHandler = new ErrorHandler(
+    approveOrder(data, actions) {
+        return this.actionHandler().configuration().onApprove(data, actions);
+    }
+
+    actionHandler() {
+        return new CartActionHandler(
+            this.ppcpConfig,
+            this.errorHandler(),
+        );
+    }
+
+    errorHandler() {
+        return new ErrorHandler(
             this.ppcpConfig.labels.error.generic,
             document.querySelector('.woocommerce-notices-wrapper')
         );
-
-        let onApproveHandler = onApprove({
-            config: this.ppcpConfig
-        }, errorHandler);
-
-        return onApproveHandler(data, actions);
     }
 
 }

--- a/modules/ppcp-applepay/resources/js/Context/ContextHandlerFactory.js
+++ b/modules/ppcp-applepay/resources/js/Context/ContextHandlerFactory.js
@@ -4,6 +4,7 @@ import CheckoutHandler from "./CheckoutHandler";
 import CartBlockHandler from "./CartBlockHandler";
 import CheckoutBlockHandler from "./CheckoutBlockHandler";
 import MiniCartHandler from "./MiniCartHandler";
+import PayNowHandler from "./PayNowHandler";
 
 class ContextHandlerFactory {
 
@@ -14,8 +15,9 @@ class ContextHandlerFactory {
             case 'cart':
                 return new CartHandler(buttonConfig, ppcpConfig);
             case 'checkout':
-            case 'pay-now': // same as checkout
                 return new CheckoutHandler(buttonConfig, ppcpConfig);
+            case 'pay-now':
+                return new PayNowHandler(buttonConfig, ppcpConfig);
             case 'mini-cart':
                 return new MiniCartHandler(buttonConfig, ppcpConfig);
             case 'cart-block':

--- a/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
@@ -1,0 +1,35 @@
+import Spinner from "../../../../ppcp-button/resources/js/modules/Helper/Spinner";
+import BaseHandler from "./BaseHandler";
+import CheckoutActionHandler
+    from "../../../../ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler";
+
+class PayNowHandler extends BaseHandler {
+
+    shippingAllowed() {
+        return false;
+    }
+
+    transactionInfo() {
+        return new Promise(async (resolve, reject) => {
+            const data = this.ppcpConfig['pay_now'];
+
+            resolve({
+                countryCode: data.country_code,
+                currencyCode: data.currency_code,
+                totalPriceStatus: 'FINAL',
+                totalPrice: data.total_str
+            });
+        });
+    }
+
+    actionHandler() {
+        return new CheckoutActionHandler(
+            this.ppcpConfig,
+            this.errorHandler(),
+            new Spinner()
+        );
+    }
+
+}
+
+export default PayNowHandler;

--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
@@ -48,23 +48,16 @@ class SingleProductHandler extends BaseHandler {
         });
     }
 
-    createOrder() {
-        const errorHandler = new ErrorHandler(
-            this.ppcpConfig.labels.error.generic,
-            document.querySelector('.woocommerce-notices-wrapper')
-        );
-
-        const actionHandler = new SingleProductActionHandler(
+    actionHandler() {
+        return new SingleProductActionHandler(
             this.ppcpConfig,
             new UpdateCart(
                 this.ppcpConfig.ajax.change_cart.endpoint,
                 this.ppcpConfig.ajax.change_cart.nonce,
             ),
             document.querySelector('form.cart'),
-            errorHandler,
+            this.errorHandler(),
         );
-
-        return actionHandler.configuration().createOrder();
     }
 
 }

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -89,7 +89,8 @@ class ApplepayModule implements ModuleInterface {
 				$module->render_buttons( $c, $apple_payment_method );
 
 				$apple_payment_method->bootstrap_ajax_request();
-			}
+			},
+			1
 		);
 
 		add_filter(

--- a/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php
+++ b/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php
@@ -148,6 +148,7 @@ class DataToAppleButtonScripts {
 				'totalLabel'   => $total_label,
 			),
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
+			'nonce'    => wp_create_nonce( 'woocommerce-process_checkout' ),
 		);
 	}
 
@@ -195,6 +196,7 @@ class DataToAppleButtonScripts {
 				'totalLabel'   => $total_label,
 			),
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
+			'nonce'    => wp_create_nonce( 'woocommerce-process_checkout' ),
 		);
 	}
 }

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -155,7 +155,8 @@ class GooglepayModule implements ModuleInterface {
 					}
 				);
 
-			}
+			},
+			1
 		);
 	}
 


### PR DESCRIPTION
# PR Description
This issue:
- Adds ApplePay support for the PayNow page.
- Fixes ApplePay and GooglePay not showing on block pages.
- Fixes an ApplePay nonce issue on the block pages.

# Issue Description
ApplePay should support for the PayNow page of a given order. 
- Isn’t reflecting the order price.
- Isn’t paying for the order.