### PR TITLE
Apple Pay domain registration & browser eligibility check (2132)

### DIFF
--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -38,7 +38,7 @@ return array(
 		$display_manager = $container->get( 'wcgateway.display-manager' );
 		assert( $display_manager instanceof DisplayManager );
 
-		// Domain registration
+		// Domain registration.
 		$env = $container->get( 'onboarding.environment' );
 		assert( $env instanceof Environment );
 
@@ -47,13 +47,13 @@ return array(
 			$domain_registration_url = 'https://www.sandbox.paypal.com/uccservicing/apm/applepay';
 		}
 
-		// Domain validation
+		// Domain validation.
 		$domain_validation_text = __( 'Status: Domain validation failed ❌', 'woocommerce-paypal-payments' );
 		if ( $container->get( 'applepay.is_validated' ) ) {
 			$domain_validation_text = __( 'Status: Domain successfully validated ✔️', 'woocommerce-paypal-payments' );
 		}
 
-		// Device eligibility
+		// Device eligibility.
 		$device_eligibility_text = __( 'Your current browser/device does not seem to support Apple Pay ❌.', 'woocommerce-paypal-payments' );
 		$device_eligibility_notes = sprintf(
 		// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
@@ -129,7 +129,7 @@ return array(
 			$fields,
 			'allow_card_button_gateway',
 			array(
-				'applepay_button_enabled'  => array(
+				'applepay_button_enabled'             => array(
 					'title'             => __( 'Apple Pay Button', 'woocommerce-paypal-payments' ),
 					'type'              => 'checkbox',
 					'label'             => __( 'Enable Apple Pay button', 'woocommerce-paypal-payments' )
@@ -162,10 +162,10 @@ return array(
 						),
 					),
 				),
-				'applepay_button_domain_registration'     => array(
+				'applepay_button_domain_registration' => array(
 					'title'        => str_repeat( '&nbsp;', 6 ) . __( 'Domain Registration', 'woocommerce-paypal-payments' ),
 					'type'         => 'ppcp-text',
-					'text'             =>
+					'text'         =>
 						'<a href="' . $domain_registration_url . '" class="button" target="_blank">'
 						. __( 'Manage Domain Registration', 'woocommerce-paypal-payments' )
 						. '</a>'
@@ -182,7 +182,7 @@ return array(
 					'gateway'      => 'paypal',
 					'requirements' => array(),
 				),
-				'applepay_button_domain_validation'     => array(
+				'applepay_button_domain_validation'   => array(
 					'title'        => str_repeat( '&nbsp;', 6 ) . __( 'Domain Validation', 'woocommerce-paypal-payments' ),
 					'type'         => 'ppcp-text',
 					'text'         => $domain_validation_text
@@ -204,7 +204,7 @@ return array(
 					'gateway'      => 'paypal',
 					'requirements' => array(),
 				),
-				'applepay_button_device_eligibility'     => array(
+				'applepay_button_device_eligibility'  => array(
 					'title'        => str_repeat( '&nbsp;', 6 ) . __( 'Device Eligibility', 'woocommerce-paypal-payments' ),
 					'type'         => 'ppcp-text',
 					'text'         => $device_eligibility_text
@@ -221,12 +221,7 @@ return array(
 					'gateway'      => 'paypal',
 					'requirements' => array(),
 				),
-
-
-
-
-
-				'applepay_button_type'     => array(
+				'applepay_button_type'                => array(
 					'title'        => str_repeat( '&nbsp;', 6 ) . __( 'Button Label', 'woocommerce-paypal-payments' ),
 					'type'         => 'select',
 					'desc_tip'     => true,
@@ -242,7 +237,7 @@ return array(
 					'gateway'      => 'paypal',
 					'requirements' => array(),
 				),
-				'applepay_button_color'    => array(
+				'applepay_button_color'               => array(
 					'title'        => str_repeat( '&nbsp;', 6 ) . __( 'Button Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'select',
 					'desc_tip'     => true,
@@ -259,7 +254,7 @@ return array(
 					'gateway'      => 'paypal',
 					'requirements' => array(),
 				),
-				'applepay_button_language' => array(
+				'applepay_button_language'            => array(
 					'title'        => str_repeat( '&nbsp;', 6 ) . __( 'Button Language', 'woocommerce-paypal-payments' ),
 					'type'         => 'select',
 					'desc_tip'     => true,

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -90,10 +90,13 @@ return array(
 		return ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off';
 	},
 	'applepay.is_browser_supported'              => static function ( ContainerInterface $container ): bool {
-		$user_agent = $_SERVER['HTTP_USER_AGENT'] ?? '';
-		foreach ( PropertiesDictionary::ALLOWED_USER_AGENTS as $allowed_agent ) {
-			if (strpos($user_agent, $allowed_agent) !== false) {
-				return true;
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' );
+		if ( $user_agent ) {
+			foreach ( PropertiesDictionary::ALLOWED_USER_AGENTS as $allowed_agent ) {
+				if ( strpos( $user_agent, $allowed_agent ) !== false ) {
+					return true;
+				}
 			}
 		}
 		return false;

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Applepay\Assets\DataToAppleButtonScripts;
 use WooCommerce\PayPalCommerce\Applepay\Assets\BlocksPaymentMethod;
+use WooCommerce\PayPalCommerce\Applepay\Assets\PropertiesDictionary;
 use WooCommerce\PayPalCommerce\Applepay\Helper\ApmApplies;
 use WooCommerce\PayPalCommerce\Applepay\Helper\AvailabilityNotice;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
@@ -56,9 +57,14 @@ return array(
 			$container->get( 'wcgateway.is-ppcp-settings-page' ),
 			$container->get( 'applepay.available' ) || ( ! $container->get( 'applepay.is_referral' ) ),
 			$container->get( 'applepay.server_supported' ),
-			$settings->has( 'applepay_validated' ) ? $settings->get( 'applepay_validated' ) === true : false,
+			$container->get( 'applepay.is_validated' ),
 			$container->get( 'applepay.button' )
 		);
+	},
+
+	'applepay.is_validated'                      => static function ( ContainerInterface $container ): bool {
+		$settings = $container->get( 'wcgateway.settings' );
+		return $settings->has( 'applepay_validated' ) ? $settings->get( 'applepay_validated' ) === true : false;
 	},
 
 	'applepay.apple-product-status'              => static function( ContainerInterface $container ): AppleProductStatus {
@@ -82,6 +88,15 @@ return array(
 	},
 	'applepay.server_supported'                  => static function ( ContainerInterface $container ): bool {
 		return ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off';
+	},
+	'applepay.is_browser_supported'              => static function ( ContainerInterface $container ): bool {
+		$user_agent = $_SERVER['HTTP_USER_AGENT'] ?? '';
+		foreach ( PropertiesDictionary::ALLOWED_USER_AGENTS as $allowed_agent ) {
+			if (strpos($user_agent, $allowed_agent) !== false) {
+				return true;
+			}
+		}
+		return false;
 	},
 	'applepay.url'                               => static function ( ContainerInterface $container ): string {
 		$path = realpath( __FILE__ );

--- a/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
+++ b/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
@@ -13,6 +13,7 @@ namespace WooCommerce\PayPalCommerce\Applepay\Assets;
  * Class PropertiesDictionary
  */
 class PropertiesDictionary {
+	public const ALLOWED_USER_AGENTS = array( 'Safari', 'Macintosh', 'iPhone', 'iPad', 'iPod' );
 
 	public const BILLING_CONTACT_INVALID = 'billing Contact Invalid';
 

--- a/modules/ppcp-compat/src/Assets/CompatAssets.php
+++ b/modules/ppcp-compat/src/Assets/CompatAssets.php
@@ -107,8 +107,8 @@ class CompatAssets {
 				'ppcp-tracking-compat',
 				'PayPalCommerceGatewayOrderTrackingCompat',
 				array(
-					'gzd_sync_enabled'         => apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) && $this->is_gzd_active,
-					'wc_shipment_sync_enabled' => apply_filters( 'woocommerce_paypal_payments_sync_wc_shipment_tracking', true ) && $this->is_wc_shipment_active,
+					'gzd_sync_enabled'             => apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) && $this->is_gzd_active,
+					'wc_shipment_sync_enabled'     => apply_filters( 'woocommerce_paypal_payments_sync_wc_shipment_tracking', true ) && $this->is_wc_shipment_active,
 					'wc_shipping_tax_sync_enabled' => apply_filters( 'woocommerce_paypal_payments_sync_wc_shipping_tax', true ) && $this->is_wc_shipping_tax_active,
 				)
 			);


### PR DESCRIPTION
# PR Description
This PR improves ApplePay configuration instructions in admin settings.

# Issue Description

## 1. Displaying the Domain Registration Button

When the "Enable Apple Pay" button is activated:

- **Setting Name:** `Domain Registration`
- **Type:** Button
- **Button Label:** `Manage Domain Registration`
- **Button Link:** [Sandbox Link](https://www.sandbox.paypal.com/uccservicing/apm/applepay) & [Live Link](https://www.paypal.com/uccservicing/apm/applepay)
- **Button Description:** `Any (sub)domain names showing an Apple Pay button must be registered on the PayPal website. If the domain displaying the Apple Pay button isn't registered, the payment method won't work.`
- **Hover Bubble Text:** `Registering the website domain on the PayPal site is mandated by Apple. Payments will fail if the Apple Pay button is used on an unregistered domain.`

## 2. Displaying the Domain Validation Status
- **Setting Name:** `Domain Validation`
- **Type:** Text (derived from previous transaction status)
- **Setting Label Options:**
  - Status: `Domain successfully validated ✔️`
  - Status: `Domain validation failed ❌`
- **Setting Description (slightly greyed out):**
- **Note:** PayPal Payments automatically presents the [domain association file](https://chat.openai.com/%7BSiteURL%7D/.well-known/apple-developer-merchantid-domain-association) for Apple to validate your registered domain.
- **Hover Bubble Text:** `Apple requires the website domain to be registered and validated. PayPal Payments automatically presents your domain association file for Apple to validate the manually registered domain.`

## 3. Information on Browser Eligibility
- **Setting Name:** `Device Eligibility`
- **Type:** Text (should be simple & based on current browser header - preferably no [API call](https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_js_api/checking_for_apple_pay_availability))
- **Setting Label Options:**
  - `Your current browser/device does not seem to support Apple Pay ❌.`
     `Though the button may display in previews, it won't appear in the shop. For details, refer to the [Apple Pay requirements](https://woocommerce.com/document/woocommerce-paypal-payments/#apple-pay).`
  - `Your browser/device supports Apple Pay ✔️. `
     `The Apple Pay button will be visible both in previews and below the PayPal buttons in the shop.`
- **Hover Bubble Text:** `Apple Pay demands certain Apple devices for secure payment execution. This helps determine if your current device is compliant.`