### PR TITLE
Error "PayPal order ID not found in meta" prevents automations from triggering when buying subscription via third-party payment gateway (2184)

### DIFF
--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -29,6 +29,7 @@ use WC_Subscription;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
@@ -80,6 +81,14 @@ class SubscriptionModule implements ModuleInterface {
 		add_action(
 			'woocommerce_subscription_payment_complete',
 			function ( $subscription ) use ( $c ) {
+				if (
+					$subscription->get_payment_method() !== PayPalGateway::ID
+					|| $subscription->get_payment_method() !== CreditCardGateway::ID
+					|| $subscription->get_payment_method() !== CardButtonGateway::ID
+				) {
+					return;
+				}
+
 				$paypal_subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
 				if ( $paypal_subscription_id ) {
 					return;

--- a/modules/ppcp-subscription/src/SubscriptionModule.php
+++ b/modules/ppcp-subscription/src/SubscriptionModule.php
@@ -81,11 +81,7 @@ class SubscriptionModule implements ModuleInterface {
 		add_action(
 			'woocommerce_subscription_payment_complete',
 			function ( $subscription ) use ( $c ) {
-				if (
-					$subscription->get_payment_method() !== PayPalGateway::ID
-					|| $subscription->get_payment_method() !== CreditCardGateway::ID
-					|| $subscription->get_payment_method() !== CardButtonGateway::ID
-				) {
+				if ( ! in_array( $subscription->get_payment_method(), array( PayPalGateway::ID, CreditCardGateway::ID, CardButtonGateway::ID ), true ) ) {
 					return;
 				}
 


### PR DESCRIPTION
Some users are seeing this error on non-PayPal orders: **Error during status transition. PayPal order ID not found in meta.**
The merchant informed that when they have PP and ACDC active and selling a subscription via Visa, MC or Amex via Woo Payments an Exception is thrown stating:
```
Error during status transition. PayPal order ID not found in meta.
```
This PR checks if the payment method  is allowed before saving the payment token.