### PR TITLE
Chrome browser detected as eligible for Apple Pay on settings page (2257)

### DIFF
--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -54,7 +54,7 @@ return array(
 		}
 
 		// Device eligibility.
-		$device_eligibility_text = __( 'Status: Your current browser/device does not seem to support Apple Pay ❌.', 'woocommerce-paypal-payments' );
+		$device_eligibility_text = __( 'Status: Your current browser/device does not seem to support Apple Pay ❌', 'woocommerce-paypal-payments' );
 		$device_eligibility_notes = sprintf(
 		// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
 			__( 'Though the button may display in previews, it won\'t appear in the shop. For details, refer to the %1$sApple Pay requirements%2$s.', 'woocommerce-paypal-payments' ),
@@ -62,7 +62,7 @@ return array(
 			'</a>'
 		);
 		if ( $container->get( 'applepay.is_browser_supported' ) ) {
-			$device_eligibility_text = __( 'Status: Your current browser/device seems to support Apple Pay ✔️.', 'woocommerce-paypal-payments' );
+			$device_eligibility_text = __( 'Status: Your current browser/device seems to support Apple Pay ✔️', 'woocommerce-paypal-payments' );
 			$device_eligibility_notes = __( 'The Apple Pay button will be visible both in previews and below the PayPal buttons in the shop.', 'woocommerce-paypal-payments' );
 		}
 

--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -54,7 +54,7 @@ return array(
 		}
 
 		// Device eligibility.
-		$device_eligibility_text = __( 'Your current browser/device does not seem to support Apple Pay ❌.', 'woocommerce-paypal-payments' );
+		$device_eligibility_text = __( 'Status: Your current browser/device does not seem to support Apple Pay ❌.', 'woocommerce-paypal-payments' );
 		$device_eligibility_notes = sprintf(
 		// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
 			__( 'Though the button may display in previews, it won\'t appear in the shop. For details, refer to the %1$sApple Pay requirements%2$s.', 'woocommerce-paypal-payments' ),
@@ -62,7 +62,7 @@ return array(
 			'</a>'
 		);
 		if ( $container->get( 'applepay.is_browser_supported' ) ) {
-			$device_eligibility_text = __( 'Your browser/device supports Apple Pay ✔️.', 'woocommerce-paypal-payments' );
+			$device_eligibility_text = __( 'Status: Your current browser/device seems to support Apple Pay ✔️.', 'woocommerce-paypal-payments' );
 			$device_eligibility_notes = __( 'The Apple Pay button will be visible both in previews and below the PayPal buttons in the shop.', 'woocommerce-paypal-payments' );
 		}
 

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -93,6 +93,11 @@ return array(
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$user_agent = wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' );
 		if ( $user_agent ) {
+			foreach ( PropertiesDictionary::DISALLOWED_USER_AGENTS as $disallowed_agent ) {
+				if ( strpos( $user_agent, $disallowed_agent ) !== false ) {
+					return false;
+				}
+			}
 			foreach ( PropertiesDictionary::ALLOWED_USER_AGENTS as $allowed_agent ) {
 				if ( strpos( $user_agent, $allowed_agent ) !== false ) {
 					return true;

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -98,11 +98,24 @@ return array(
 					return false;
 				}
 			}
-			foreach ( PropertiesDictionary::ALLOWED_USER_AGENTS as $allowed_agent ) {
-				if ( strpos( $user_agent, $allowed_agent ) !== false ) {
-					return true;
+
+			$browser_allowed = false;
+			foreach ( PropertiesDictionary::ALLOWED_USER_BROWSERS as $allowed_browser ) {
+				if ( strpos( $user_agent, $allowed_browser ) !== false ) {
+					$browser_allowed = true;
+					break;
 				}
 			}
+
+			$device_allowed = false;
+			foreach ( PropertiesDictionary::ALLOWED_USER_DEVICES as $allowed_devices ) {
+				if ( strpos( $user_agent, $allowed_devices ) !== false ) {
+					$device_allowed = true;
+					break;
+				}
+			}
+
+			return $browser_allowed && $device_allowed;
 		}
 		return false;
 	},

--- a/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
+++ b/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
@@ -13,7 +13,8 @@ namespace WooCommerce\PayPalCommerce\Applepay\Assets;
  * Class PropertiesDictionary
  */
 class PropertiesDictionary {
-	public const ALLOWED_USER_AGENTS = array( 'Safari', 'Macintosh', 'iPhone', 'iPad', 'iPod' );
+	public const DISALLOWED_USER_AGENTS = array( 'Chrome' );
+	public const ALLOWED_USER_AGENTS    = array( 'Safari', 'Macintosh', 'iPhone', 'iPad', 'iPod' );
 
 	public const BILLING_CONTACT_INVALID = 'billing Contact Invalid';
 

--- a/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
+++ b/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
@@ -13,8 +13,15 @@ namespace WooCommerce\PayPalCommerce\Applepay\Assets;
  * Class PropertiesDictionary
  */
 class PropertiesDictionary {
-	public const DISALLOWED_USER_AGENTS = array( 'Chrome' );
-	public const ALLOWED_USER_AGENTS    = array( 'Safari', 'Macintosh', 'iPhone', 'iPad', 'iPod' );
+	public const DISALLOWED_USER_AGENTS = array(
+		'Chrome/',
+		'CriOS/', // Chrome on iOS.
+		'Firefox/',
+		'OPR/', // Opera.
+		'Edg/', // Edge.
+	);
+	public const ALLOWED_USER_BROWSERS  = array( 'Safari' );
+	public const ALLOWED_USER_DEVICES   = array( 'Macintosh', 'iPhone', 'iPad', 'iPod' );
 
 	public const BILLING_CONTACT_INVALID = 'billing Contact Invalid';
 


### PR DESCRIPTION
# PR Description
Adds a rejection condition for ineligible user agents.

# Issue Description
As a user browsing the PayPal Payments settings

I noticed the `Device Eligibility` section in the Apple Pay settings

And using Firefox, the device eligibility correctly detects I’m not eligible:
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/338006f1-d75b-4d4a-affb-4ee8b058e474)

But using Chrome, it says I’m eligible for some reason:
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/f3ce2b5e-6cac-4e70-92e4-d1877a691db6)

I also propose updating the strings for more consistency:

```
OLD
'Your current browser/device does not seem to support Apple Pay ❌.'
'Your browser/device supports Apple Pay ✔️.'
NEW
'Status: Your current browser/device does not seem to support Apple Pay ❌'
'Status: Your current browser/device seems to support Apple Pay ✔️'
```