### PR TITLE
Google Pay scripts loading on unrelated admin pages (2274)

### DIFF
--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -164,6 +164,7 @@ class ApplepayModule implements ModuleInterface {
 				assert( $smart_button instanceof SmartButtonInterface );
 				if ( $smart_button->should_load_ppcp_script() ) {
 					$button->enqueue();
+					return;
 				}
 
 				if ( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) {
@@ -196,7 +197,7 @@ class ApplepayModule implements ModuleInterface {
 		add_action(
 			'admin_enqueue_scripts',
 			static function () use ( $c, $button ) {
-				if ( ! is_admin() ) {
+				if ( ! is_admin() || ! $c->get( 'wcgateway.is-ppcp-settings-standard-payments-page' ) ) {
 					return;
 				}
 

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -94,6 +94,7 @@ class GooglepayModule implements ModuleInterface {
 						assert( $smart_button instanceof SmartButtonInterface );
 						if ( $smart_button->should_load_ppcp_script() ) {
 							$button->enqueue();
+							return;
 						}
 
 						if ( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) ) {
@@ -111,7 +112,7 @@ class GooglepayModule implements ModuleInterface {
 				add_action(
 					'admin_enqueue_scripts',
 					static function () use ( $c, $button ) {
-						if ( ! is_admin() ) {
+						if ( ! is_admin() || ! $c->get( 'wcgateway.is-ppcp-settings-standard-payments-page' ) ) {
 							return;
 						}
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -182,6 +182,11 @@ return array(
 		);
 	},
 
+	'wcgateway.is-ppcp-settings-standard-payments-page'    => static function ( ContainerInterface $container ): bool {
+		return $container->get( 'wcgateway.is-ppcp-settings-page' )
+			&& $container->get( 'wcgateway.current-ppcp-settings-page-id' ) === PayPalGateway::ID;
+	},
+
 	'wcgateway.current-ppcp-settings-page-id'              => static function ( ContainerInterface $container ): string {
 		if ( ! $container->get( 'wcgateway.is-ppcp-settings-page' ) ) {
 			return '';


### PR DESCRIPTION
# PR Description
Adds a verification to both GooglePay and ApplePay admin scripts enqueuing, to check for the admin standards payment page.

# Issue Description
On admin pages that are not PayPal Payments-related, the Google Pay scripts are loading even when not enabled:

## Steps To Reproduce

- set WC store location to a Google Pay eligible country
- browse any admin page
- observe pay.js loading in the network tab

## Expected behaviour

Google scripts only loaded on the PayPal Payments settings pages and frontend pages where the button is displayed.

