### PR TITLE
Hide Apple Pay & Google Pay for subscription type products (2217)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -42,6 +42,10 @@ class ApplepayButton {
             return;
         }
 
+        if (!this.contextHandler.validateContext()) {
+            return;
+        }
+
         this.log('Init', this.context);
         this.initEventHandlers();
         this.isInitialized = true;
@@ -263,7 +267,7 @@ class ApplepayButton {
         switch (this.context) {
             case 'product':
                 // Refresh product data that makes the price change.
-                this.productQuantity = document.querySelector('input.qty').value;
+                this.productQuantity = document.querySelector('input.qty')?.value;
                 this.products = this.contextHandler.products();
                 this.log('Products updated', this.products);
                 break;

--- a/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
@@ -9,6 +9,13 @@ class BaseHandler {
         this.ppcpConfig = ppcpConfig;
     }
 
+    validateContext() {
+        if ( this.ppcpConfig?.locations_with_subscription_product?.cart ) {
+            return false;
+        }
+        return true;
+    }
+
     shippingAllowed() {
         return true;
     }

--- a/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
@@ -5,6 +5,13 @@ import CheckoutActionHandler
 
 class PayNowHandler extends BaseHandler {
 
+    validateContext() {
+        if ( this.ppcpConfig?.locations_with_subscription_product?.payorder ) {
+            return false;
+        }
+        return true;
+    }
+
     shippingAllowed() {
         return false;
     }

--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
@@ -7,6 +7,13 @@ import BaseHandler from "./BaseHandler";
 
 class SingleProductHandler extends BaseHandler {
 
+    validateContext() {
+        if ( this.ppcpConfig?.locations_with_subscription_product?.product ) {
+            return false;
+        }
+        return true;
+    }
+
     transactionInfo() {
         const errorHandler = new ErrorHandler(
             this.ppcpConfig.labels.error.generic,

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -973,6 +973,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			'subscription_plan_id'                    => $this->subscription_helper->paypal_subscription_id(),
 			'variable_paypal_subscription_variations' => $this->subscription_helper->variable_paypal_subscription_variations(),
 			'subscription_product_allowed'            => $this->subscription_helper->checkout_subscription_product_allowed(),
+			'locations_with_subscription_product'     => $this->subscription_helper->locations_with_subscription_product(),
 			'enforce_vault'                           => $this->has_subscriptions(),
 			'can_save_vault_token'                    => $this->can_save_vault_token(),
 			'is_free_trial_cart'                      => $is_free_trial_cart,

--- a/modules/ppcp-googlepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/BaseHandler.js
@@ -10,6 +10,13 @@ class BaseHandler {
         this.externalHandler = externalHandler;
     }
 
+    validateContext() {
+        if ( this.ppcpConfig?.locations_with_subscription_product?.cart ) {
+            return false;
+        }
+        return true;
+    }
+
     shippingAllowed() {
         return true;
     }

--- a/modules/ppcp-googlepay/resources/js/Context/PayNowHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/PayNowHandler.js
@@ -5,6 +5,13 @@ import CheckoutActionHandler
 
 class PayNowHandler extends BaseHandler {
 
+    validateContext() {
+        if ( this.ppcpConfig?.locations_with_subscription_product?.payorder ) {
+            return false;
+        }
+        return true;
+    }
+
     shippingAllowed() {
         return false;
     }

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
@@ -7,6 +7,13 @@ import BaseHandler from "./BaseHandler";
 
 class SingleProductHandler extends BaseHandler {
 
+    validateContext() {
+        if ( this.ppcpConfig?.locations_with_subscription_product?.product ) {
+            return false;
+        }
+        return true;
+    }
+
     transactionInfo() {
         const errorHandler = new ErrorHandler(
             this.ppcpConfig.labels.error.generic,

--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -40,6 +40,10 @@ class GooglepayButton {
             return;
         }
 
+        if (!this.contextHandler.validateContext()) {
+            return;
+        }
+
         this.googlePayConfig = config;
         this.allowedPaymentMethods = config.allowedPaymentMethods;
         this.baseCardPaymentMethod = this.allowedPaymentMethods[0];

--- a/modules/ppcp-subscription/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-subscription/src/Helper/SubscriptionHelper.php
@@ -271,4 +271,17 @@ class SubscriptionHelper {
 
 		return true;
 	}
+
+	/**
+	 * Returns the locations on the page which have subscription products.
+	 *
+	 * @return array
+	 */
+	public function locations_with_subscription_product(): array {
+		return array(
+			'product'  => is_product() && $this->current_product_is_subscription(),
+			'payorder' => is_wc_endpoint_url( 'order-pay' ) && $this->order_pay_contains_subscription(),
+			'cart'     => $this->cart_contains_subscription(),
+		);
+	}
 }


### PR DESCRIPTION
# PR Description
Added a validation step in GooglePay and ApplePay modules to check for the existence of subscription products in the respective context.

Decided to do the validations client side because of HTML caching as is the case of mini-cart.

# Issue Description
Currently the Apple Pay & Google Pay buttons may appear on subscription type products, but these payment methods currently don’t support subscription payments.

So they should be hidden when on a product page for a subscription or when one is in the cart.