### PR TITLE
Fix action callback arguments count in ShipStation tracking integration (2312)

### DIFF
--- a/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
@@ -111,7 +111,7 @@ class ShipStationIntegration implements Integration {
 				}
 			},
 			500,
-			1
+			2
 		);
 	}
 }


### PR DESCRIPTION
# PR Description

The PR will fix the problem below by fixing the action callback arguments count

# Issue Description

A customer reported about a fatal error when using the [ShipStation](https://woo.com/products/shipstation-integration/) plugin with PayPal Payments, because of our ShipStation tracking integration.

```
2023-11-14T18:01:01+00:00 CRITICAL Uncaught ArgumentCountError: Too few arguments to function WooCommerce\PayPalCommerce\OrderTracking\Integration\ShipStationIntegration::WooCommerce\PayPalCommerce\OrderTracking\Integration\{closure}(), 1 passed in /wordpress/core/6.4.1/wp-includes/class-wp-hook.php on line 326 and exactly 2 expected in /srv/htdocs/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php:74
Stack trace:
#0 /wordpress/core/6.4.1/wp-includes/class-wp-hook.php(326): WooCommerce\PayPalCommerce\OrderTracking\Integration\ShipStationIntegration->WooCommerce\PayPalCommerce\OrderTracking\Integration\{closure}(Object(Automattic\WooCommerce\Admin\Overrides\Order))
#1 /wordpress/core/6.4.1/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#2 /wordpress/core/6.4.1/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 /srv/htdocs/wp-content/plugins/woocommerce-shipstation-integration/includes/api-requests/class-wc-shipstation-api-shipnotify.php(334): do_action('woocommerce_shi...', Object(Automattic\WooCommerce\Admin\Overrides\Order), Array)
#4 /srv/htdocs/wp-content/plugins/woocommerce-shipstation-integration/includes/class-wc-shipstation-api.php(80): WC_Shipstation_API_Shipnotify->request()
#5 /srv/htdocs/wp-content/plugins/woocommerce-shipstation-integration/includes/class-wc-shipstation-api.php(37): WC_Shipstation_API->request()
#6 /srv/htdocs/wp-content/plugins/woocommerce-shipstation-integration/includes/class-wc-shipstation-api.php(89): WC_Shipstation_API->__construct()
#7 /srv/htdocs/wp-content/plugins/woocommerce-shipstation-integration/woocommerce-shipstation.php(81): include_once('/srv/htdocs/wp-...')
#8 /wordpress/core/6.4.1/wp-includes/class-wp-hook.php(324): woocommerce_shipstation_api('')
#9 /wordpress/core/6.4.1/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#10 /wordpress/core/6.4.1/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#11 /srv/htdocs/wp-content/plugins/woocommerce/includes/class-wc-api.php(161): do_action('woocommerce_api...')
#12 /wordpress/core/6.4.1/wp-includes/class-wp-hook.php(324): WC_API->handle_api_requests(Object(WP))
#13 /wordpress/core/6.4.1/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#14 /wordpress/core/6.4.1/wp-includes/plugin.php(565): WP_Hook->do_action(Array)
#15 /wordpress/core/6.4.1/wp-includes/class-wp.php(418): do_action_ref_array('parse_request', Array)
#16 /wordpress/core/6.4.1/wp-includes/class-wp.php(813): WP->parse_request('')
#17 /wordpress/core/6.4.1/wp-includes/functions.php(1336): WP->main('')
#18 /wordpress/core/6.4.1/wp-blog-header.php(16): wp()
#19 /wordpress/core/6.4.1/index.php(17): require('/wordpress/core...')
#20 {main}
  thrown in /srv/htdocs/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php on line 74
```
