### PR TITLE
Improve single product page button placement with Block themes (1961)

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -273,7 +273,12 @@ class CompatModule implements ModuleInterface {
 		add_action(
 			'init',
 			function() {
-				if ( $this->is_elementor_pro_active() || $this->is_divi_theme_active() ) {
+				if (
+					$this->is_block_theme_active()
+					|| $this->is_elementor_pro_active()
+					|| $this->is_divi_theme_active()
+					|| $this->is_divi_child_theme_active()
+				) {
 					add_filter(
 						'woocommerce_paypal_payments_single_product_renderer_hook',
 						function(): string {
@@ -284,6 +289,15 @@ class CompatModule implements ModuleInterface {
 				}
 			}
 		);
+	}
+
+	/**
+	 * Checks whether the current theme is a blocks theme.
+	 *
+	 * @return bool
+	 */
+	protected function is_block_theme_active(): bool {
+		return function_exists( 'wp_is_block_theme' ) && wp_is_block_theme();
 	}
 
 	/**
@@ -303,5 +317,16 @@ class CompatModule implements ModuleInterface {
 	protected function is_divi_theme_active(): bool {
 		$theme = wp_get_theme();
 		return $theme->get( 'Name' ) === 'Divi';
+	}
+
+	/**
+	 * Checks whether a Divi child theme is currently used.
+	 *
+	 * @return bool
+	 */
+	protected function is_divi_child_theme_active(): bool {
+		$theme  = wp_get_theme();
+		$parent = $theme->parent();
+		return ( $parent && $parent->get( 'Name' ) === 'Divi' );
 	}
 }


### PR DESCRIPTION
# PR Description
This PR changes the rendering location of the single product page buttons to the `woocommerce_after_add_to_cart_form` hook in case the current theme is a block theme or is a Divi child theme.

As it seems this location is more reliable than the `woocommerce_single_product_summary` hook under those conditions.

# Issue Description

When using a Block theme like `Twenty Twenty Two`, `Twenty Twenty Three`, or `Twenty Twenty Four`, the PayPal buttons & Pay Later messaging on the single product page will be rendered at the top of the content.

## Steps To Reproduce

- Configure PayPal button & Pay Later messaging to be rendered on single product
- Activate a Block theme, e.g. `Twenty Twenty-Two` or `Twenty Twenty-Three` or `Twenty Twenty-Four`
- Visit single product page
- Observe PayPal button & Pay Later messaging at the top of the page

## Expected behaviour

PayPal button is rendered below “Add to Cart” button.

## Acceptance

**Given** the website uses a Block theme
**And** the plugin is configured for a Pay Later compatible region 
**And** the PayPal button and Pay Later messaging on the Single Product location are enabled
**When** visiting the Single Product page
**Then** the PayPal button and Pay Later messaging are displayed below the “Add to cart” button

## Suggested solution

There is already a function to work around such problems by changing the render hook: https://github.com/woocommerce/woocommerce-paypal-payments/blob/7571a1cea88492e97621241e29df6d56c2f20d25/modules/ppcp-compat/src/CompatModule.php#L351

But this doesn’t apply when using Divi with a child theme or when using a Block theme.

Suggestion: Improve detection of Divi child themes and Block themes.

## Workaround
```
add_filter('woocommerce_paypal_payments_single_product_renderer_hook', function() {
    return 'woocommerce_after_add_to_cart_form';
});

```