### PR TITLE
Display Package Tracking metabox below Order actions when HPOS is active (2282)

### DIFF
--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -102,7 +102,8 @@ class OrderTrackingModule implements ModuleInterface {
 					__( 'PayPal Package Tracking', 'woocommerce-paypal-payments' ),
 					array( $meta_box_renderer, 'render' ),
 					$screen,
-					'side'
+					'side',
+					'high'
 				);
 			},
 			10,


### PR DESCRIPTION
# PR Description

The PR will add priority "high" for tracking metabox registration

# Issue Description

PayPal Package tracking goes under order notes instead order data when HPOS is active

# Steps To Reproduce

- Activate HPOS
- Navigate to shop 
- Add product to cart
- Navigate to checkout and do payment with PayPal
- Navigate to WC->Orders
- Click on recently made order
- Observe PayPal Package tracking under Order notes