### PR TITLE
Do not ignore disabled APMs list in blocks

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1271,9 +1271,12 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 		}
 
 		if ( in_array( $context, array( 'checkout-block', 'cart-block' ), true ) ) {
-			$disable_funding = array_diff(
-				array_keys( $this->all_funding_sources ),
-				array( 'venmo', 'paylater' )
+			$disable_funding = array_merge(
+				$disable_funding,
+				array_diff(
+					array_keys( $this->all_funding_sources ),
+					array( 'venmo', 'paylater' )
+				)
 			);
 		}
 


### PR DESCRIPTION
Looks like we were overwriting this value removing the previously added disabled APMs (could affect only Venmo currently). Now adding instead of overwriting everything (there is an `array_unique` call before outputting).
