### PR TITLE
Fix Apple Pay CSS

### DIFF
--- a/modules/ppcp-applepay/resources/css/styles.scss
+++ b/modules/ppcp-applepay/resources/css/styles.scss
@@ -18,7 +18,7 @@
 
 .woocommerce-checkout {
 	#applepay-container, .ppcp-button-applepay {
-		margin-top: 0.5em;
+		margin-top: 0;
 		--apple-pay-button-border-radius: 4px;
 		--apple-pay-button-height: 45px;
 		&.ppcp-button-pill {
@@ -31,6 +31,7 @@
 
 	.wp-block-woocommerce-checkout {
 		#applepay-container, .ppcp-button-applepay {
+			margin: 0;
 			--apple-pay-button-margin: 0;
 			--apple-pay-button-height: 48px;
 			&.ppcp-button-pill {
@@ -41,6 +42,7 @@
 
 	.wp-block-woocommerce-cart {
 		#applepay-container, .ppcp-button-applepay {
+			margin: 0;
 			--apple-pay-button-margin: 0;
 			--apple-pay-button-height: 48px;
 		}

--- a/modules/ppcp-applepay/resources/css/styles.scss
+++ b/modules/ppcp-applepay/resources/css/styles.scss
@@ -46,13 +46,6 @@
 			--apple-pay-button-margin: 0;
 			--apple-pay-button-height: 48px;
 		}
-		/* Workaround for blocks grid */
-		.wc-block-components-express-payment__event-buttons {
-			--apple-pay-button-display: block;
-			li[id*="express-payment-method-ppcp-"] {
-				--apple-pay-button-padding-bottom: 0;
-			}
-		}
 	}
 }
 

--- a/modules/ppcp-googlepay/resources/css/styles.scss
+++ b/modules/ppcp-googlepay/resources/css/styles.scss
@@ -34,13 +34,6 @@
 			margin: 0;
 			height: 48px;
 		}
-		/* Workaround for blocks grid */
-		.wc-block-components-express-payment__event-buttons {
-			display: block;
-			li[id*="express-payment-method-ppcp-"] {
-				padding-bottom: 0;
-			}
-		}
 	}
 
 }


### PR DESCRIPTION
Updated the Apple Pay CSS to match Google Pay, removed the spacing workaround in block which should not be needed after #1858