### PR TITLE
Improve address retrieval in block

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -39,12 +39,17 @@ const PayPalComponent = ({
         if (!config.scriptData.continuation || !config.scriptData.continuation.order || window.ppcpContinuationFilled) {
             return;
         }
-        const paypalAddresses = paypalOrderToWcAddresses(config.scriptData.continuation.order);
-        const wcAddresses = wp.data.select('wc/store/cart').getCustomerData();
-        const addresses = mergeWcAddress(wcAddresses, paypalAddresses);
-        wp.data.dispatch('wc/store/cart').setBillingAddress(addresses.billingAddress);
-        if (shippingData.needsShipping) {
-            wp.data.dispatch('wc/store/cart').setShippingAddress(addresses.shippingAddress);
+        try {
+            const paypalAddresses = paypalOrderToWcAddresses(config.scriptData.continuation.order);
+            const wcAddresses = wp.data.select('wc/store/cart').getCustomerData();
+            const addresses = mergeWcAddress(wcAddresses, paypalAddresses);
+            wp.data.dispatch('wc/store/cart').setBillingAddress(addresses.billingAddress);
+            if (shippingData.needsShipping) {
+                wp.data.dispatch('wc/store/cart').setShippingAddress(addresses.shippingAddress);
+            }
+        } catch (err) {
+            // sometimes the PayPal address is missing, skip in this case.
+            console.log(err);
         }
         // this useEffect should run only once, but adding this in case of some kind of full re-rendering
         window.ppcpContinuationFilled = true;


### PR DESCRIPTION
Improved fallback to shipping address when billing address is missing. It was not handling cases where the `payer` object or `payer.name` are missing.

Also now ignoring the error when failed to retrieve address for filling the form in continuation mode, so at least the checkout can be completed after filling it manually.