### PR TITLE
Change default "Place Order" button text, add additional "Place Order" description in block

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -321,11 +321,19 @@ const PayPalComponent = ({
 const features = ['products'];
 
 if ((config.addPlaceOrderMethod || config.usePlaceOrder) && !config.scriptData.continuation) {
+    let descriptionElement = <div dangerouslySetInnerHTML={{__html: config.description}}></div>;
+    if (config.placeOrderButtonDescription) {
+        descriptionElement = <div>
+            <p dangerouslySetInnerHTML={{__html: config.description}}></p>
+            <p style={{textAlign: 'center'}} className={'ppcp-place-order-description'} dangerouslySetInnerHTML={{__html: config.placeOrderButtonDescription}}></p>
+        </div>;
+    }
+
     registerPaymentMethod({
         name: config.id,
         label: <div dangerouslySetInnerHTML={{__html: config.title}}/>,
-        content: <div dangerouslySetInnerHTML={{__html: config.description}}/>,
-        edit: <div dangerouslySetInnerHTML={{__html: config.description}}/>,
+        content: descriptionElement,
+        edit: descriptionElement,
         placeOrderButtonLabel: config.placeOrderButtonText,
         ariaLabel: config.title,
         canMakePayment: () => config.enabled,

--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -38,6 +38,7 @@ return array(
 			$container->get( 'blocks.add-place-order-method' ),
 			$container->get( 'wcgateway.use-place-order-button' ),
 			$container->get( 'wcgateway.place-order-button-text' ),
+			$container->get( 'wcgateway.place-order-button-description' ),
 			$container->get( 'wcgateway.all-funding-sources' )
 		);
 	},

--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -109,6 +109,13 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	protected $place_order_button_text;
 
 	/**
+	 * The text for additional "Place order" description.
+	 *
+	 * @var string
+	 */
+	protected $place_order_button_description;
+
+	/**
 	 * All existing funding sources for PayPal buttons.
 	 *
 	 * @var array
@@ -130,6 +137,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	 * @param bool                 $add_place_order_method Whether to create a non-express method with the standard "Place order" button.
 	 * @param bool                 $use_place_order Whether to use the standard "Place order" button instead of PayPal buttons.
 	 * @param string               $place_order_button_text The text for the standard "Place order" button.
+	 * @param string               $place_order_button_description The text for additional "Place order" description.
 	 * @param array                $all_funding_sources All existing funding sources for PayPal buttons.
 	 */
 	public function __construct(
@@ -145,22 +153,24 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		bool $add_place_order_method,
 		bool $use_place_order,
 		string $place_order_button_text,
+		string $place_order_button_description,
 		array $all_funding_sources
 	) {
-		$this->name                    = PayPalGateway::ID;
-		$this->module_url              = $module_url;
-		$this->version                 = $version;
-		$this->smart_button            = $smart_button;
-		$this->plugin_settings         = $plugin_settings;
-		$this->settings_status         = $settings_status;
-		$this->gateway                 = $gateway;
-		$this->final_review_enabled    = $final_review_enabled;
-		$this->cancellation_view       = $cancellation_view;
-		$this->session_handler         = $session_handler;
-		$this->add_place_order_method  = $add_place_order_method;
-		$this->use_place_order         = $use_place_order;
-		$this->place_order_button_text = $place_order_button_text;
-		$this->all_funding_sources     = $all_funding_sources;
+		$this->name                           = PayPalGateway::ID;
+		$this->module_url                     = $module_url;
+		$this->version                        = $version;
+		$this->smart_button                   = $smart_button;
+		$this->plugin_settings                = $plugin_settings;
+		$this->settings_status                = $settings_status;
+		$this->gateway                        = $gateway;
+		$this->final_review_enabled           = $final_review_enabled;
+		$this->cancellation_view              = $cancellation_view;
+		$this->session_handler                = $session_handler;
+		$this->add_place_order_method         = $add_place_order_method;
+		$this->use_place_order                = $use_place_order;
+		$this->place_order_button_text        = $place_order_button_text;
+		$this->place_order_button_description = $place_order_button_description;
+		$this->all_funding_sources            = $all_funding_sources;
 	}
 
 	/**
@@ -223,23 +233,24 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		);
 
 		return array(
-			'id'                    => $this->gateway->id,
-			'title'                 => $this->gateway->title,
-			'description'           => $this->gateway->description,
-			'enabled'               => $this->settings_status->is_smart_button_enabled_for_location( $script_data['context'] ),
-			'fundingSource'         => $this->session_handler->funding_source(),
-			'finalReviewEnabled'    => $this->final_review_enabled,
-			'addPlaceOrderMethod'   => $this->add_place_order_method,
-			'usePlaceOrder'         => $this->use_place_order,
-			'placeOrderButtonText'  => $this->place_order_button_text,
-			'enabledFundingSources' => $funding_sources,
-			'ajax'                  => array(
+			'id'                          => $this->gateway->id,
+			'title'                       => $this->gateway->title,
+			'description'                 => $this->gateway->description,
+			'enabled'                     => $this->settings_status->is_smart_button_enabled_for_location( $script_data['context'] ),
+			'fundingSource'               => $this->session_handler->funding_source(),
+			'finalReviewEnabled'          => $this->final_review_enabled,
+			'addPlaceOrderMethod'         => $this->add_place_order_method,
+			'usePlaceOrder'               => $this->use_place_order,
+			'placeOrderButtonText'        => $this->place_order_button_text,
+			'placeOrderButtonDescription' => $this->place_order_button_description,
+			'enabledFundingSources'       => $funding_sources,
+			'ajax'                        => array(
 				'update_shipping' => array(
 					'endpoint' => WC_AJAX::get_endpoint( UpdateShippingEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( UpdateShippingEndpoint::nonce() ),
 				),
 			),
-			'scriptData'            => $script_data,
+			'scriptData'                  => $script_data,
 		);
 	}
 }

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1189,7 +1189,7 @@ return array(
 		 */
 		return apply_filters(
 			'woocommerce_paypal_payments_place_order_button_description',
-			__( 'Clicking "Proceed to PayPal", will redirect you to PayPal to complete your purchase.', 'woocommerce-paypal-payments' )
+			__( 'Clicking "Proceed to PayPal" will redirect you to PayPal to complete your purchase.', 'woocommerce-paypal-payments' )
 		);
 	},
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1183,6 +1183,15 @@ return array(
 			__( 'Proceed to PayPal', 'woocommerce-paypal-payments' )
 		);
 	},
+	'wcgateway.place-order-button-description'             => function ( ContainerInterface $container ) : string {
+		/**
+		 * The text for additional description, when the "Place order" button mode is enabled.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_place_order_button_description',
+			__( 'Clicking "Proceed to PayPal", will redirect you to PayPal to complete your purchase.', 'woocommerce-paypal-payments' )
+		);
+	},
 
 	'wcgateway.helper.vaulting-scope'                      => static function ( ContainerInterface $container ): bool {
 		try {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1180,7 +1180,7 @@ return array(
 		 */
 		return apply_filters(
 			'woocommerce_paypal_payments_place_order_button_text',
-			__( 'Pay with PayPal', 'woocommerce-paypal-payments' )
+			__( 'Proceed to PayPal', 'woocommerce-paypal-payments' )
 		);
 	},
 


### PR DESCRIPTION
Changed the default "Place Order" button text, and added an additional description for this mode in blocks.

The description can be changed via the `woocommerce_paypal_payments_place_order_button_description` (returning an empty string removes it), also it can be styled via the `ppcp-place-order-description` CSS class.

![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/5680466/6bdda9cb-4450-4d8c-9258-2e53ac9f6d99)
