### PR TITLE
Fix disable-funding field access

### DIFF
--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -214,7 +214,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 			}
 		}
 
-		$disabled_funding_sources = explode( ',', $script_data['url_params']['disable-funding'] ) ?: array();
+		$disabled_funding_sources = explode( ',', $script_data['url_params']['disable-funding'] ?? '' ) ?: array();
 		$funding_sources          = array_values(
 			array_diff(
 				array_keys( $this->all_funding_sources ),


### PR DESCRIPTION
Fixed usage of the `disabled-funding` field usage because It can be missing, it is added only if there are disabled funding sources.
