### PR TITLE
"Send checkout billing and shipping data to Apple Pay" displayed when Apple Pay is disabled (2386)

### DIFF
--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -157,6 +157,7 @@ return array(
 									->action_visible( 'applepay_button_color' )
 									->action_visible( 'applepay_button_type' )
 									->action_visible( 'applepay_button_language' )
+									->action_visible( 'applepay_checkout_data_mode' )
 									->to_array(),
 							)
 						),


### PR DESCRIPTION
# PR Description
Added `applepay_checkout_data_mode` to the `applepay_button_enabled` rules.

# Issue Description
The in 2.4.2 introduced setting Send checkout billing and shipping data to Apple Pay is visible even when Apple Pay is not enabled:

## Steps To Reproduce
- Navigate to Standard Payments tab
- Disable Apple Pay
- Observe setting is visible

## Expected behaviour

Setting is not shown when Apple Pay is disabled.