### PR TITLE
Order does not contain intent on 3DS ACDC renewal (2007)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PatchCollection;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
@@ -174,14 +175,15 @@ class OrderEndpoint {
 	/**
 	 * Creates an order.
 	 *
-	 * @param PurchaseUnit[]    $items The purchase unit items for the order.
-	 * @param string            $shipping_preference One of ApplicationContext::SHIPPING_PREFERENCE_ values.
-	 * @param Payer|null        $payer The payer off the order.
-	 * @param PaymentToken|null $payment_token The payment token.
-	 * @param string            $paypal_request_id The PayPal request id.
-	 * @param string            $user_action The user action.
-	 * @param string            $payment_method WC payment method.
-	 * @param array             $request_data Request data.
+	 * @param PurchaseUnit[]     $items The purchase unit items for the order.
+	 * @param string             $shipping_preference One of ApplicationContext::SHIPPING_PREFERENCE_ values.
+	 * @param Payer|null         $payer The payer off the order.
+	 * @param PaymentToken|null  $payment_token The payment token.
+	 * @param PaymentSource|null $payment_source The payment source.
+	 * @param string             $paypal_request_id The PayPal request id.
+	 * @param string             $user_action The user action.
+	 * @param string             $payment_method WC payment method.
+	 * @param array              $request_data Request data.
 	 *
 	 * @return Order
 	 * @throws RuntimeException If the request fails.
@@ -191,6 +193,7 @@ class OrderEndpoint {
 		string $shipping_preference,
 		Payer $payer = null,
 		PaymentToken $payment_token = null,
+		PaymentSource $payment_source = null,
 		string $paypal_request_id = '',
 		string $user_action = ApplicationContext::USER_ACTION_CONTINUE,
 		string $payment_method = '',
@@ -220,6 +223,11 @@ class OrderEndpoint {
 		}
 		if ( $payment_token ) {
 			$data['payment_source']['token'] = $payment_token->to_array();
+		}
+		if ( $payment_source ) {
+			$data['payment_source'] = array(
+				$payment_source->name() => $payment_source->properties(),
+			);
 		}
 
 		/**

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -179,11 +179,11 @@ class OrderEndpoint {
 	 * @param string             $shipping_preference One of ApplicationContext::SHIPPING_PREFERENCE_ values.
 	 * @param Payer|null         $payer The payer off the order.
 	 * @param PaymentToken|null  $payment_token The payment token.
-	 * @param PaymentSource|null $payment_source The payment source.
 	 * @param string             $paypal_request_id The PayPal request id.
 	 * @param string             $user_action The user action.
 	 * @param string             $payment_method WC payment method.
 	 * @param array              $request_data Request data.
+	 * @param PaymentSource|null $payment_source The payment source.
 	 *
 	 * @return Order
 	 * @throws RuntimeException If the request fails.
@@ -193,11 +193,11 @@ class OrderEndpoint {
 		string $shipping_preference,
 		Payer $payer = null,
 		PaymentToken $payment_token = null,
-		PaymentSource $payment_source = null,
 		string $paypal_request_id = '',
 		string $user_action = ApplicationContext::USER_ACTION_CONTINUE,
 		string $payment_method = '',
-		array $request_data = array()
+		array $request_data = array(),
+		PaymentSource $payment_source = null
 	): Order {
 		$bearer = $this->bearer->bearer();
 		$data   = array(

--- a/modules/ppcp-api-client/src/Entity/PaymentSource.php
+++ b/modules/ppcp-api-client/src/Entity/PaymentSource.php
@@ -33,10 +33,10 @@ class PaymentSource {
 	/**
 	 * PaymentSource constructor.
 	 *
-	 * @param string   $name Payment source name.
-	 * @param stdClass $properties Payment source properties.
+	 * @param string $name Payment source name.
+	 * @param object $properties Payment source properties.
 	 */
-	public function __construct( string $name, stdClass $properties ) {
+	public function __construct( string $name, object $properties ) {
 		$this->name       = $name;
 		$this->properties = $properties;
 	}
@@ -53,9 +53,9 @@ class PaymentSource {
 	/**
 	 * Payment source properties.
 	 *
-	 * @return stdClass
+	 * @return object
 	 */
-	public function properties(): stdClass {
+	public function properties(): object {
 		return $this->properties;
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/PaymentSource.php
+++ b/modules/ppcp-api-client/src/Entity/PaymentSource.php
@@ -26,7 +26,7 @@ class PaymentSource {
 	/**
 	 * Payment source properties.
 	 *
-	 * @var stdClass
+	 * @var object
 	 */
 	private $properties;
 

--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\WcSubscriptions;
 
 use WC_Subscription;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
@@ -224,6 +225,10 @@ class RenewalHandler {
 					$shipping_preference,
 					$payer,
 					null,
+					'',
+					ApplicationContext::USER_ACTION_CONTINUE,
+					'',
+					array(),
 					$payment_source
 				);
 

--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -212,11 +212,6 @@ class RenewalHandler {
 					}
 				}
 
-				/**
-				 * Suppress ArgumentTypeCoercion
-				 *
-				 * @psalm-suppress ArgumentTypeCoercion
-				 */
 				$payment_source = new PaymentSource(
 					'card',
 					(object) array(

--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -212,6 +212,11 @@ class RenewalHandler {
 					}
 				}
 
+				/**
+				 * Suppress ArgumentTypeCoercion
+				 *
+				 * @psalm-suppress ArgumentTypeCoercion
+				 */
 				$payment_source = new PaymentSource(
 					'card',
 					(object) array(

--- a/tests/PHPUnit/WcSubscriptions/RenewalHandlerTest.php
+++ b/tests/PHPUnit/WcSubscriptions/RenewalHandlerTest.php
@@ -117,6 +117,9 @@ class RenewalHandlerTest extends TestCase
 			->andReturn(null);
 
 		$wcOrder
+			->shouldReceive('get_payment_method')
+			->andReturn('');
+		$wcOrder
 			->shouldReceive('get_meta')
 			->andReturn('');
 		$wcOrder


### PR DESCRIPTION
This PR fixes #1506 which did not entirely fixed the problem as incorrect payment source is still sent when subscriptions are renewed via action scheduler.

It should now send the correct payment source for both manual and automatic subscription renewals like so:
```
"payment_source": {
    "card": {
      "vault_id": "abc123",
      "stored_credential": {
        "payment_initiator": "MERCHANT",
        "payment_type": "RECURRING",
        "usage": "SUBSEQUENT",
        "previous_transaction_reference": "XYZ456"
 ```