### PR TITLE
Support for Classic Checkout Block (2387)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -272,6 +272,8 @@ class SmartButton implements SmartButtonInterface {
 	 * @return bool
 	 */
 	public function render_wrapper(): bool {
+		$this->init_context();
+
 		if ( $this->settings->has( 'enabled' ) && $this->settings->get( 'enabled' ) ) {
 			$this->render_button_wrapper_registrar();
 			$this->render_message_wrapper_registrar();

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -18,6 +18,9 @@ trait ContextTrait {
 	 * @return void
 	 */
 	protected function init_context(): void {
+		if ( ! apply_filters( 'woocommerce_paypal_payments_block_classic_compat', true ) ) {
+			return;
+		}
 
 		/**
 		 * Activate is_checkout() on woocommerce/classic-shortcode checkout blocks.

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -13,6 +13,36 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 
 trait ContextTrait {
 	/**
+	 * Initializes context preconditions like is_cart() and is_checkout().
+	 *
+	 * @return void
+	 */
+	protected function init_context(): void {
+
+		/**
+		 * Activate is_checkout() on woocommerce/classic-shortcode checkout blocks.
+		 *
+		 * @psalm-suppress MissingClosureParamType
+		 */
+		add_filter(
+			'woocommerce_is_checkout',
+			function ( $is_checkout ) {
+				if ( $is_checkout ) {
+					return $is_checkout;
+				}
+				return has_block( 'woocommerce/classic-shortcode {"shortcode":"checkout"}' );
+			}
+		);
+
+		// Activate is_cart() on woocommerce/classic-shortcode cart blocks.
+		if ( ! is_cart() && is_callable( 'wc_maybe_define_constant' ) ) {
+			if ( has_block( 'woocommerce/classic-shortcode' ) && ! has_block( 'woocommerce/classic-shortcode {"shortcode":"checkout"}' ) ) {
+				wc_maybe_define_constant( 'WOOCOMMERCE_CART', true );
+			}
+		}
+	}
+
+	/**
 	 * Checks WC is_checkout() + WC checkout ajax requests.
 	 */
 	private function is_checkout(): bool {


### PR DESCRIPTION
# PR Description

As the blocks classic checkout/cart aren't by default reflected on the `is_checkout()` and `is_cart()` methods this PR fixes it by:
* For the `is_checkout()` uses the filter `woocommerce_is_checkout` if the block classic checkout is present.
* For the `is_cart()` uses the constant `WOOCOMMERCE_CART` if the block classic cart is present, as there are no filters to change the value of `is_cart()`.

# Issue Description
WooCommerce introduced a “Classic Checkout” Block which renders the shortcode checkout:
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/4a8e5a8b-3b54-48a3-a099-a2d593f7a7e8)

When using a Block theme, the field styling is broken:
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/08afe436-a76b-46d1-a5e8-a40d58e10f1c)

Using [Storefront](https://wordpress.org/themes/storefront/), the fields are styled correctly, but the PayPal Payments scripts are not loading, so there are no PayPal buttons:
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/0d7590c0-0b4f-430a-b0b5-19a051d7c667)

Following the introduction of the redirect fallback, the PayPal payment is still possible though.

This Classic Checkout block should be fully supported though, just like the regular shortcode Checkout.