### PR TITLE
Apple Pay validation message improvements (2373)

### DIFF
--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -49,7 +49,9 @@ return array(
 
 		// Domain validation.
 		$domain_validation_text = __( 'Status: Domain validation failed ❌', 'woocommerce-paypal-payments' );
-		if ( $container->get( 'applepay.is_validated' ) ) {
+		if ( ! $container->get( 'applepay.has_validated' ) ) {
+			$domain_validation_text = __( 'The domain has not yet been validated. Use the Apple Pay button to validate the domain ❌', 'woocommerce-paypal-payments' );
+		} elseif ( $container->get( 'applepay.is_validated' ) ) {
 			$domain_validation_text = __( 'Status: Domain successfully validated ✔️', 'woocommerce-paypal-payments' );
 		}
 

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -62,6 +62,11 @@ return array(
 		);
 	},
 
+	'applepay.has_validated'                     => static function ( ContainerInterface $container ): bool {
+		$settings = $container->get( 'wcgateway.settings' );
+		return $settings->has( 'applepay_validated' );
+	},
+
 	'applepay.is_validated'                      => static function ( ContainerInterface $container ): bool {
 		$settings = $container->get( 'wcgateway.settings' );
 		return $settings->has( 'applepay_validated' ) ? $settings->get( 'applepay_validated' ) === true : false;


### PR DESCRIPTION
# PR Description
This PR adds a specific message in ApplePay admin for when the `applepay.is_validated` is not set, meaning no validation attempt was made.

# Issue Description
Users are confused by the wording in the Apple Pay validation notice after setting up the plugin.

The notice suggests that it failed and may not work.

But instead, it should clarify that the validation is only triggered by clicking the button in the frontend.

So on the initial setup, the notice should have a different wording until it was once attempted to validate it.

Something like “The domain has not yet been validated. Use the Apple Pay button to validate the domain”