### PR TITLE
Add button to reload feature eligibility status from Connection tab (2426)

### DIFF
--- a/modules/ppcp-applepay/src/Helper/ApmApplies.php
+++ b/modules/ppcp-applepay/src/Helper/ApmApplies.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * ApmApplies helper.
+ * Checks if ApplePay is available for a given country and currency.
  *
  * @package WooCommerce\PayPalCommerce\ApplePay\Helper
  */
@@ -15,7 +16,7 @@ namespace WooCommerce\PayPalCommerce\Applepay\Helper;
 class ApmApplies {
 
 	/**
-	 * The matrix which countries and currency combinations can be used for DCC.
+	 * The matrix which countries and currency combinations can be used for ApplePay.
 	 *
 	 * @var array
 	 */
@@ -38,7 +39,7 @@ class ApmApplies {
 	/**
 	 * ApmApplies constructor.
 	 *
-	 * @param array  $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for DCC.
+	 * @param array  $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for ApplePay.
 	 * @param string $currency 3-letter currency code of the shop.
 	 * @param string $country 2-letter country code of the shop.
 	 */

--- a/modules/ppcp-googlepay/src/Helper/ApmApplies.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmApplies.php
@@ -1,6 +1,7 @@
 <?php
 /**
- * Properties of the GooglePay module.
+ * ApmApplies helper.
+ * Checks if GooglePay is available for a given country and currency.
  *
  * @package WooCommerce\PayPalCommerce\Googlepay\Helper
  */
@@ -15,7 +16,7 @@ namespace WooCommerce\PayPalCommerce\Googlepay\Helper;
 class ApmApplies {
 
 	/**
-	 * The matrix which countries and currency combinations can be used for DCC.
+	 * The matrix which countries and currency combinations can be used for GooglePay.
 	 *
 	 * @var array
 	 */
@@ -38,7 +39,7 @@ class ApmApplies {
 	/**
 	 * DccApplies constructor.
 	 *
-	 * @param array  $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for DCC.
+	 * @param array  $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for GooglePay.
 	 * @param string $currency 3-letter currency code of the shop.
 	 * @param string $country 2-letter country code of the shop.
 	 */

--- a/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
+++ b/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
@@ -354,9 +354,8 @@ document.addEventListener(
             });
         }
 
-
-        (() => {
-            const props = PayPalCommerceGatewaySettings.ajax.refresh_feature_status;
+        // Logic to handle the "Check available features" button.
+        ((props) => {
             const $btn = jQuery(props.button);
 
             $btn.click(async () => {
@@ -388,7 +387,7 @@ document.addEventListener(
                 }
             });
 
-        })();
+        })(PayPalCommerceGatewaySettings.ajax.refresh_feature_status);
 
     }
 );

--- a/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
+++ b/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
@@ -353,5 +353,42 @@ document.addEventListener(
                 }, 'card'));
             });
         }
+
+
+        (() => {
+            const props = PayPalCommerceGatewaySettings.ajax.refresh_feature_status;
+            const $btn = jQuery(props.button);
+
+            $btn.click(async () => {
+                $btn.prop('disabled', true);
+
+                const response = await fetch(
+                    props.endpoint,
+                    {
+                        method: 'POST',
+                        credentials: 'same-origin',
+                        headers: {
+                            'content-type': 'application/json'
+                        },
+                        body: JSON.stringify(
+                            {
+                                nonce: props.nonce,
+                            }
+                        )
+                    }
+                );
+
+                const responseData = await response.json();
+
+                if (!responseData.success) {
+                    alert(responseData.data.message);
+                    $btn.prop('disabled', false);
+                } else {
+                    window.location.reload();
+                }
+            });
+
+        })();
+
     }
 );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\Common\Pattern\SingletonDecorator;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\FeesRenderer;
@@ -1000,6 +1001,13 @@ return array(
 			$gateway,
 			$endpoint,
 			$container->get( 'session.handler' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
+		);
+	},
+	'wcgateway.endpoint.refresh-feature-status'            => static function ( ContainerInterface $container ) : RefreshFeatureStatusEndpoint {
+		return new RefreshFeatureStatusEndpoint(
+			$container->get( 'wcgateway.settings' ),
+			new Cache( 'ppcp-timeout' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
@@ -10,9 +10,11 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\Webhooks\Endpoint\ResubscribeEndpoint;
 
 /**
  * Class SettingsPageAssets
@@ -237,6 +239,13 @@ class SettingsPageAssets {
 					'disabled_sources'               => $this->disabled_sources,
 					'all_funding_sources'            => $this->all_funding_sources,
 					'components'                     => array( 'buttons', 'funding-eligibility', 'messages' ),
+					'ajax'                           => array(
+						'refresh_feature_status' => array(
+							'endpoint' => \WC_AJAX::get_endpoint( RefreshFeatureStatusEndpoint::ENDPOINT ),
+							'nonce'    => wp_create_nonce( RefreshFeatureStatusEndpoint::nonce() ),
+							'button'   => '.ppcp-refresh-feature-status',
+						),
+					),
 				)
 			)
 		);

--- a/modules/ppcp-wc-gateway/src/Endpoint/RefreshFeatureStatusEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/RefreshFeatureStatusEndpoint.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Controls the endpoint for refreshing feature status.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Endpoint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
+
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Class RefreshFeatureStatusEndpoint
+ */
+class RefreshFeatureStatusEndpoint {
+
+	const ENDPOINT = 'ppc-refresh-feature-status';
+
+	const CACHE_KEY = 'refresh_feature_status_timeout';
+	const TIMEOUT   = 60;
+
+	/**
+	 * The settings.
+	 *
+	 * @var ContainerInterface
+	 */
+	protected $settings;
+
+	/**
+	 * The cache.
+	 *
+	 * @var Cache
+	 */
+	protected $cache;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	protected $logger;
+
+	/**
+	 * RefreshFeatureStatusEndpoint constructor.
+	 *
+	 * @param ContainerInterface $settings The settings.
+	 * @param Cache              $cache The cache.
+	 * @param LoggerInterface    $logger The logger.
+	 */
+	public function __construct(
+		ContainerInterface $settings,
+		Cache $cache,
+		LoggerInterface $logger
+	) {
+		$this->settings = $settings;
+		$this->cache    = $cache;
+		$this->logger   = $logger;
+	}
+
+	/**
+	 * Returns the nonce.
+	 *
+	 * @return string
+	 */
+	public static function nonce(): string {
+		return self::ENDPOINT;
+	}
+
+	/**
+	 * Handles the incoming request.
+	 */
+	public function handle_request(): void {
+		$now               = time();
+		$last_request_time = $this->cache->get( self::CACHE_KEY ) ?: 0;
+		$seconds_missing   = $last_request_time + self::TIMEOUT - $now;
+
+		if ( $seconds_missing > 0 ) {
+			$response = array(
+				'message' => sprintf(
+				// translators: %1$s is the number of seconds remaining.
+					__( 'Wait %1$s seconds before trying again.', 'woocommerce-paypal-payments' ),
+					$seconds_missing
+				),
+			);
+			wp_send_json_error( $response );
+		}
+
+		$this->cache->set( self::CACHE_KEY, $now, self::TIMEOUT );
+		do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $this->settings );
+		wp_send_json_success();
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Endpoint/RefreshFeatureStatusEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/RefreshFeatureStatusEndpoint.php
@@ -109,7 +109,7 @@ class RefreshFeatureStatusEndpoint {
 	 * @return bool
 	 */
 	private function verify_nonce(): bool {
-		$json = json_decode( file_get_contents( 'php://input' ), true );
-		return wp_verify_nonce( $json['nonce'] ?? null, self::nonce() ) !== false;
+		$json = json_decode( file_get_contents( 'php://input' ) ?: '', true );
+		return wp_verify_nonce( $json['nonce'] ?? '', self::nonce() ) !== false;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -390,6 +390,16 @@ return function ( ContainerInterface $container, array $fields ): array {
 				'</a>'
 			),
 		),
+		'refresh_feature_status'                        => array(
+			'title'        => __( 'Refresh feature availability status', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-text',
+			'text'         => '<button type="button" class="button ppcp-refresh-feature-status">' . esc_html__( 'Check available features', 'woocommerce-paypal-payments' ) . '</button>',
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => Settings::CONNECTION_TAB_ID,
+		),
 		'ppcp_dcc_status'                               => array(
 			'title'        => __( 'Advanced Credit and Debit Card Payments', 'woocommerce-paypal-payments' ),
 			'type'         => 'ppcp-text',

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
@@ -251,6 +252,16 @@ class WCGatewayModule implements ModuleInterface {
 				 *
 				 * @var ReturnUrlEndpoint $endpoint
 				 */
+				$endpoint->handle_request();
+			}
+		);
+
+		add_action(
+			'wc_ajax_' . RefreshFeatureStatusEndpoint::ENDPOINT,
+			static function () use ( $c ) {
+				$endpoint = $c->get( 'wcgateway.endpoint.refresh-feature-status' );
+				assert( $endpoint instanceof RefreshFeatureStatusEndpoint );
+
 				$endpoint->handle_request();
 			}
 		);


### PR DESCRIPTION
# PR Description
This PR implements the `RefreshFeatureStatusEndpoint` endpoint and respective frontend UI logic.
The product status is refreshed via a call to the `woocommerce_paypal_payments_clear_apm_product_status` action.
A cache was used to enforce a timeout of 60 seconds between refresh attempts.

# Issue Description

As a user with an already-connected PayPal account
I sign up for ACDC/Apple Pay/Google Pay/PUI after my account was connected
And expect that the plugin reflects the status of the new feature availability

To ensure a smooth setup for advanced features like Apple Pay, users need a way to update the feature eligibility status from the Connection tab without reconnecting their account.

Above the buttons for Advanced Card Processing, PUI, Google Pay, & Apple Pay, a new button should refresh the eligibility status by performing a `merchant-integrations` call.

![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/f1887516-ca8f-430a-b18e-b0eb459bd612)

After the call, the page should reload and display an updated status.
There should be a 1-minute timeout on this button before it can be clicked again.

## Acceptance
**Given** I connected a new PayPal merchant to the plugin
**And** signed up for ACDC, Apple Pay, Google Pay after already being connected
**When** clicking the button to refresh the feature availability status
**Then** a merchant-integrations call can be observed in the logs
**And** the page refreshes with an updated status for the available features
