### PR TITLE
Block Checkout reloads when submitting order with empty fields (2389)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -31,7 +31,7 @@ const PayPalComponent = ({
     const {responseTypes} = emitResponse;
 
     const [paypalOrder, setPaypalOrder] = useState(null);
-    const [gotoContinuation, setGotoContinuation] = useState(false);
+    const [gotoContinuationOnError, setGotoContinuationOnError] = useState(false);
 
     const methodId = fundingSource ? `${config.id}-${fundingSource}` : config.id;
 
@@ -153,7 +153,7 @@ const PayPalComponent = ({
             if (config.finalReviewEnabled) {
                 location.href = getCheckoutRedirectUrl();
             } else {
-                setGotoContinuation(true);
+                setGotoContinuationOnError(true);
                 onSubmit();
             }
         } catch (err) {
@@ -172,7 +172,7 @@ const PayPalComponent = ({
             if (config.scriptData.continuation) {
                 return true;
             }
-            if (gotoContinuation && wp.data.select('wc/store/validation').hasValidationErrors()) {
+            if (gotoContinuationOnError && wp.data.select('wc/store/validation').hasValidationErrors()) {
                 location.href = getCheckoutRedirectUrl();
                 return { type: responseTypes.ERROR };
             }
@@ -180,7 +180,7 @@ const PayPalComponent = ({
             return true;
         });
         return unsubscribe;
-    }, [onCheckoutValidation, gotoContinuation] );
+    }, [onCheckoutValidation, gotoContinuationOnError] );
 
     const handleClick = (data, actions) => {
         if (isEditing) {

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -31,6 +31,7 @@ const PayPalComponent = ({
     const {responseTypes} = emitResponse;
 
     const [paypalOrder, setPaypalOrder] = useState(null);
+    const [gotoContinuation, setGotoContinuation] = useState(false);
 
     const methodId = fundingSource ? `${config.id}-${fundingSource}` : config.id;
 
@@ -152,6 +153,7 @@ const PayPalComponent = ({
             if (config.finalReviewEnabled) {
                 location.href = getCheckoutRedirectUrl();
             } else {
+                setGotoContinuation(true);
                 onSubmit();
             }
         } catch (err) {
@@ -170,7 +172,7 @@ const PayPalComponent = ({
             if (config.scriptData.continuation) {
                 return true;
             }
-            if (wp.data.select('wc/store/validation').hasValidationErrors()) {
+            if (gotoContinuation && wp.data.select('wc/store/validation').hasValidationErrors()) {
                 location.href = getCheckoutRedirectUrl();
                 return { type: responseTypes.ERROR };
             }
@@ -178,7 +180,7 @@ const PayPalComponent = ({
             return true;
         });
         return unsubscribe;
-    }, [onCheckoutValidation] );
+    }, [onCheckoutValidation, gotoContinuation] );
 
     const handleClick = (data, actions) => {
         if (isEditing) {


### PR DESCRIPTION
# PR Description
To prevent the checkout page from reloading the `gotoContinuation` status variable was added. It's dynamically set only on scenarios where we want to redirect.

# Issue Description

When submitting a payment on the Block Checkout page while some fields are empty, the field error messages will only briefly appear as the page reloads

## Steps To Reproduce
- add product to cart
- navigate to Block Checkout
- leave some required fields empty
- click “Proceed to PayPal” button
- observe required field error briefly shows
- then page reloads

## Expected behaviour
page does not reload when WC validation failed