### PR TITLE
PayPal Subscription initiated without a WooCommerce order (2415)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -2,6 +2,7 @@ import 'formdata-polyfill';
 import onApprove from '../OnApproveHandler/onApproveForPayNow.js';
 import {payerData} from "../Helper/PayerData";
 import {getCurrentPaymentMethod} from "../Helper/CheckoutMethodState";
+import validateCheckoutForm from "../Helper/CheckoutFormValidation";
 
 class CheckoutActionHandler {
 
@@ -13,7 +14,13 @@ class CheckoutActionHandler {
 
     subscriptionsConfiguration() {
         return {
-            createSubscription: (data, actions) => {
+            createSubscription: async (data, actions) => {
+                try {
+                    await validateCheckoutForm(this.config);
+                } catch (error) {
+                    throw {type: 'form-validation-error'};
+                }
+
                 return actions.subscription.create({
                     'plan_id': this.config.subscription_plan_id
                 });

--- a/modules/ppcp-button/resources/js/modules/Helper/CheckoutFormValidation.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/CheckoutFormValidation.js
@@ -1,0 +1,48 @@
+import Spinner from "./Spinner";
+import FormValidator from "./FormValidator";
+import ErrorHandler from "../ErrorHandler";
+
+const validateCheckoutForm = function (config) {
+    return new Promise(async (resolve, reject) => {
+        try {
+            const spinner = new Spinner();
+            const errorHandler = new ErrorHandler(
+                config.labels.error.generic,
+                document.querySelector('.woocommerce-notices-wrapper')
+            );
+
+            const formSelector = config.context === 'checkout' ? 'form.checkout' : 'form#order_review';
+            const formValidator = config.early_checkout_validation_enabled ?
+                new FormValidator(
+                    config.ajax.validate_checkout.endpoint,
+                    config.ajax.validate_checkout.nonce,
+                ) : null;
+
+            if (!formValidator) {
+                resolve();
+                return;
+            }
+
+            formValidator.validate(document.querySelector(formSelector)).then((errors) => {
+                if (errors.length > 0) {
+                    spinner.unblock();
+                    errorHandler.clear();
+                    errorHandler.messages(errors);
+
+                    // fire WC event for other plugins
+                    jQuery( document.body ).trigger( 'checkout_error' , [ errorHandler.currentHtml() ] );
+
+                    reject();
+                } else {
+                    resolve();
+                }
+            });
+
+        } catch (error) {
+            console.error(error);
+            reject();
+        }
+    });
+}
+
+export default validateCheckoutForm;


### PR DESCRIPTION

# PR Description
This PR adds a reusable `validateCheckoutForm` function and uses in on subscription product order creation.

# Issue Description

User reported that one of their clients bought a subscription through PayPal subscriptions and a WC order ID was not created. The logs show that for PayPal subscriptions involve using the PayPal API at https://api-m.paypal.com/v2/checkout/orders/*ORDERID*. This action happens three times as seen in the logs.

## Steps To Reproduce
* set up subscription with connection to PayPal
* add it to cart & navigate to Checkout page
* leave out any required field, like the terms checkbox or name
* click the PayPal button
* observe no form field validation
* confirm PayPal payment in poup window
* observe WooCommerce error message about missing fields
* fill missing fields
* click PayPal button again to confirm order
* observe the user now has two active PayPal Subscriptions

## Expected behaviour
The checkout form fields are validated with the early wc validation when clicking the PayPal button.

## Possible cause
The early wc validation does not trigger when the buyer attempts the payment from the Checkout page.

## Suggested solution
Implement early WC validation when clicking the button for a PayPal Subscriptions from the Checkout page.