### PR TITLE
Hosted card fields payment not possible when Vaulting is active and user does not have a saved payment method (2466)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
@@ -91,8 +91,8 @@ class CardFieldsRenderer {
             this.spinner.block();
             this.errorHandler.clear();
 
-            const paymentToken = document.querySelector('input[name="wc-ppcp-credit-card-gateway-payment-token"]:checked').value
-            if(paymentToken !== 'new') {
+            const paymentToken = document.querySelector('input[name="wc-ppcp-credit-card-gateway-payment-token"]:checked')?.value
+            if(paymentToken && paymentToken !== 'new') {
                 fetch(this.defaultConfig.ajax.capture_card_payment.endpoint, {
                     method: 'POST',
                     credentials: 'same-origin',


### PR DESCRIPTION
Hosted card fields payments currently require the buyer to have a saved payment method. Without a saved payment method, the payment will not possible.

Upon clicking “Place order”, this console error appears and the payment is not processed:
![image-20231218-102050](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/96beabce-ac0d-410c-90a3-dd8bebee95d1)

### Steps To Reproduce
- Set up a new buyer without saved payment 
- Enable card fields
- Enable ACDC Vaulting
- Attempt ACDC payment

Observe payment fails.