### PR TITLE
Fix creating WC payment token when saving payment method

### DIFF
--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
@@ -100,8 +100,7 @@ class CreatePaymentToken implements EndpointInterface {
 			if ( is_user_logged_in() && isset( $result->customer->id ) ) {
 				update_user_meta( get_current_user_id(), '_ppcp_target_customer_id', $result->customer->id );
 
-				$payment_method = $data['payment_method'] ?? '';
-				if ( $payment_method === PayPalGateway::ID ) {
+				if ( isset($result->payment_source->paypal) ) {
 					$email = '';
 					if ( isset( $result->payment_source->paypal->email_address ) ) {
 						$email = $result->payment_source->paypal->email_address;
@@ -114,7 +113,7 @@ class CreatePaymentToken implements EndpointInterface {
 					);
 				}
 
-				if ( $payment_method === CreditCardGateway::ID ) {
+				if ( isset($result->payment_source->card) ) {
 					$token = new \WC_Payment_Token_CC();
 					$token->set_token( $result->id );
 					$token->set_user_id( get_current_user_id() );

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
@@ -100,7 +100,7 @@ class CreatePaymentToken implements EndpointInterface {
 			if ( is_user_logged_in() && isset( $result->customer->id ) ) {
 				update_user_meta( get_current_user_id(), '_ppcp_target_customer_id', $result->customer->id );
 
-				if ( isset($result->payment_source->paypal) ) {
+				if ( isset( $result->payment_source->paypal ) ) {
 					$email = '';
 					if ( isset( $result->payment_source->paypal->email_address ) ) {
 						$email = $result->payment_source->paypal->email_address;
@@ -113,7 +113,7 @@ class CreatePaymentToken implements EndpointInterface {
 					);
 				}
 
-				if ( isset($result->payment_source->card) ) {
+				if ( isset( $result->payment_source->card ) ) {
 					$token = new \WC_Payment_Token_CC();
 					$token->set_token( $result->id );
 					$token->set_user_id( get_current_user_id() );


### PR DESCRIPTION
This PR fixes an issue when creating WC payment token by checking payment source in the PayPal response.