### PR TITLE
Grayed Out (Inactive) PayPal Button for Variable subscriptions on Checkout and Cart page with PayPal Subscriptions mode (2457)

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -220,8 +220,8 @@ class SubscriptionHelper {
 				 */
 				$product_variations = $product->get_available_variations();
 				foreach ( $product_variations as $variation ) {
-					$variation_product = wc_get_product( $variation['variation_id'] );
-					if ( $variation_product !== null && $variation_product !== false && $variation_product->meta_exists( 'ppcp_subscription_plan' ) ) {
+					$variation_product = wc_get_product( $variation['variation_id'] ) ?? '';
+					if ( $variation_product && $variation_product->meta_exists( 'ppcp_subscription_plan' ) ) {
 						return $variation_product->get_meta( 'ppcp_subscription_plan' )['id'];
 					}
 				}

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -213,10 +213,15 @@ class SubscriptionHelper {
 			}
 
 			if ( $product->get_type() === 'variable-subscription' ) {
+				/**
+				 * The method is defined in WC_Product_Variable class.
+				 *
+				 * @psalm-suppress UndefinedMethod
+				 */
 				$product_variations = $product->get_available_variations();
 				foreach ( $product_variations as $variation ) {
 					$variation_product = wc_get_product( $variation['variation_id'] );
-					if ( $variation_product->meta_exists( 'ppcp_subscription_plan' ) ) {
+					if ( $variation_product !== null && $variation_product !== false && $variation_product->meta_exists( 'ppcp_subscription_plan' ) ) {
 						return $variation_product->get_meta( 'ppcp_subscription_plan' )['id'];
 					}
 				}

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -211,6 +211,16 @@ class SubscriptionHelper {
 			if ( $product->get_type() === 'subscription' && $product->meta_exists( 'ppcp_subscription_plan' ) ) {
 				return $product->get_meta( 'ppcp_subscription_plan' )['id'];
 			}
+
+			if ( $product->get_type() === 'variable-subscription' ) {
+				$product_variations = $product->get_available_variations();
+				foreach ( $product_variations as $variation ) {
+					$variation_product = wc_get_product( $variation['variation_id'] );
+					if ( $variation_product->meta_exists( 'ppcp_subscription_plan' ) ) {
+						return $variation_product->get_meta( 'ppcp_subscription_plan' )['id'];
+					}
+				}
+			}
 		}
 
 		return '';


### PR DESCRIPTION
When configuring variable subscription with PayPal subscriptions mode, users encounter an issue where the PayPal button is grayed out (inactive) on the checkout page. Although the button works on the product page, allowing users to place orders, it becomes unresponsive (grayed out) when navigating to the cart and checkout pages.

### Steps To Reproduce
- Create variable subscriptions in the product settings.
- Connect the product to PayPal for subscription payments.
- Navigate to the checkout page.
- Observe that the PayPal button appears inactive (grayed out).