### PR TITLE
GooglePay and ApplePay buttons disappear from the minicart when adding a product to the cart on the shop page (PCP-2472)

### DIFF
--- a/modules/ppcp-applepay/resources/js/boot.js
+++ b/modules/ppcp-applepay/resources/js/boot.js
@@ -21,6 +21,15 @@ import ApplepayManager from "./ApplepayManager";
         }
     });
 
+    // Use set timeout as it's unnecessary to refresh upon Minicart initial render.
+    setTimeout(() => {
+        jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', () => {
+            if (manager) {
+                manager.reinit();
+            }
+        });
+    }, 1000);
+
     document.addEventListener(
         'DOMContentLoaded',
         () => {

--- a/modules/ppcp-googlepay/resources/js/boot.js
+++ b/modules/ppcp-googlepay/resources/js/boot.js
@@ -21,6 +21,15 @@ import GooglepayManager from "./GooglepayManager";
         }
     });
 
+    // Use set timeout as it's unnecessary to refresh upon Minicart initial render.
+    setTimeout(() => {
+        jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', () => {
+            if (manager) {
+                manager.reinit();
+            }
+        });
+    }, 1000);
+
     document.addEventListener(
         'DOMContentLoaded',
         () => {


### PR DESCRIPTION
# PR Description

This PR handles rerendering of `ApplePay` and `GooglePay` buttons on `wc_fragments_loaded wc_fragments_refreshed` event.

# Issue Description

When adding a product to the Minicart on the shop page the GooglePay and ApplePay buttons disappear.

**Before adding to cart:**
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/c85aa897-e0ce-400b-bdb5-085283912b05)

**After adding to cart:**
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/8a654d2b-ce8c-4464-8ffe-6edf8f04d6ae)

## Steps To Reproduce
* Enable GooglePay and ApplePay.
* Have the Storefront theme active.
* Go to the shop page.
* See the GooglePay and ApplePay (when applicable) buttons on the minicart.
* Add a product to cart.
* See the GooglePay and ApplePay buttons missing on the minicart.

## Expected behaviour
After adding a product to cart on the shop page the minicart still has the GooglePay and ApplePay buttons visible.

## Possible cause
This is probably due to the minicart dom element being rerendered and but the GooglePay and ApplePay buttons not handling this event.

## Suggested solution
GooglePay and ApplePay buttons should handle the Minicart rerendering event.
