### PR TITLE
ACDC Unsuccessfully payment with new credit card when debugging is enabled (2466)

### DIFF
--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -88,9 +88,7 @@ class CardFieldsModule implements ModuleInterface {
 
 		add_filter(
 			'ppcp_create_order_request_body_data',
-			function( array $data ) use ( $c ): array {
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing
-				$payment_method = wc_clean( wp_unslash( $_POST['payment_method'] ?? '' ) );
+			function( array $data, string $payment_method ) use ( $c ): array {
 				if ( $payment_method !== CreditCardGateway::ID ) {
 					return $data;
 				}
@@ -115,7 +113,9 @@ class CardFieldsModule implements ModuleInterface {
 				}
 
 				return $data;
-			}
+			},
+			10,
+			2
 		);
 	}
 }


### PR DESCRIPTION
3DS was not triggered because payment method from the request was empty, this PR uses the value from the filter callback parameter instead.

### Steps To Reproduce
- Enable debugging 
- Navigate to shop
- Add product to cart
- Navigate to checkout page
- Select ACDC gateway
- Enter credit card details (do not use saved payment)
- Click on button Place order

![Screenshot 2023-12-15 at 16 02 11](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/847ca170-03c4-4a8c-8d80-ef921eeb0e1b)