### PR TITLE
Incorrect margins when PayPal buttons are rendered as separate gateways. [v2] (2468)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -140,17 +140,16 @@ class ApplepayButton {
         const wrapper_id = '#' + wrapper;
 
         const syncButtonVisibility = () => {
+            if (!this.isEligible) {
+                return;
+            }
+
             const $ppcpButtonWrapper = jQuery(ppcpButtonWrapper);
             setVisible(wrapper_id, $ppcpButtonWrapper.is(':visible'));
             setEnabled(wrapper_id, !$ppcpButtonWrapper.hasClass('ppcp-disabled'));
         }
 
         jQuery(document).on('ppcp-shown ppcp-hidden ppcp-enabled ppcp-disabled', (ev, data) => {
-            if (!this.isEligible) {
-                setVisible(wrapper_id, false);
-                return;
-            }
-
             if (jQuery(data.selector).is(ppcpButtonWrapper)) {
                 syncButtonVisibility();
             }

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -34,6 +34,9 @@ class ApplepayButton {
         // Stores initialization data sent to the button.
         this.initialPaymentRequest = null;
 
+        // Default eligibility status.
+        this.isEligible = true;
+
         this.log = function() {
             if ( this.buttonConfig.is_debug ) {
                 console.log('[ApplePayButton]', ...arguments);
@@ -63,9 +66,9 @@ class ApplepayButton {
         this.initEventHandlers();
         this.isInitialized = true;
         this.applePayConfig = config;
-        const isEligible = (this.applePayConfig.isEligible && window.ApplePaySession) || this.buttonConfig.is_admin;
+        this.isEligible = (this.applePayConfig.isEligible && window.ApplePaySession) || this.buttonConfig.is_admin;
 
-        if (isEligible) {
+        if (this.isEligible) {
             this.fetchTransactionInfo().then(() => {
                 const isSubscriptionProduct = this.ppcpConfig?.data_client_id?.has_subscriptions === true;
                 if (isSubscriptionProduct) {
@@ -143,6 +146,11 @@ class ApplepayButton {
         }
 
         jQuery(document).on('ppcp-shown ppcp-hidden ppcp-enabled ppcp-disabled', (ev, data) => {
+            if (!this.isEligible) {
+                setVisible(wrapper_id, false);
+                return;
+            }
+
             if (jQuery(data.selector).is(ppcpButtonWrapper)) {
                 syncButtonVisibility();
             }

--- a/modules/ppcp-button/resources/js/modules/Helper/ApmButtons.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ApmButtons.js
@@ -40,6 +40,11 @@ export class ApmButtons {
             this.refresh();
         });
 
+        jQuery(document).on('ppcp-shown ppcp-hidden ppcp-enabled ppcp-disabled', (ev, data) => {
+            this.refresh();
+            setTimeout(this.refresh.bind(this), 200);
+        });
+
         // Observes for new buttons.
         (new MutationObserver(this.observeElementsCallback.bind(this)))
             .observe(document.body, { childList: true, subtree: true });

--- a/modules/ppcp-button/resources/js/modules/Helper/ApmButtons.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ApmButtons.js
@@ -104,8 +104,10 @@ export class ApmButtons {
                     return true;
                 }
 
+                const minMargin = 11; // Minimum margin.
                 const height = $el.height();
-                $el.css('margin-top', `${Math.round(height * 0.3)}px`);
+                const margin = Math.max(minMargin, Math.round(height * 0.3));
+                $el.css('margin-top', `${margin}px`);
             });
 
         }


### PR DESCRIPTION
# PR Description
This PR fixes a scenario where the ApplePay buttons are made visible by the visibility synchronization mechanism with the PayPal Buttons but should be hidden due to ApplePay eligibility.

# Issue Description

When the PayPal buttons are rendered as separate gateways there is no margin between the buttons.

## Steps To Reproduce
- Enable Create gateway for Standard Card Button option.
- Add a product to the cart.
- Go to classic checkout page.
- The PayPal buttons have no spacing between them.

**_[V2]_**

On the checkout page when switching between payment methods the ApplePay button spacing is visible even when it should be hidden due to ineligibility.

![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/85f3ebff-a13b-4987-b838-8f3e1d40f0d3)


