### PR TITLE
Implement early WC validation for Hosted Card Fields (2487)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -48,7 +48,7 @@ class CheckoutActionHandler {
 
     configuration() {
         const spinner = this.spinner;
-        const createOrder = async (data, actions) => {
+        const createOrder = (data, actions) => {
             const payer = payerData();
             const bnCode = typeof this.config.bn_codes[this.config.context] !== 'undefined' ?
                 this.config.bn_codes[this.config.context] : '';
@@ -136,7 +136,7 @@ class CheckoutActionHandler {
                 console.error(err);
                 spinner.unblock();
 
-                if (err && (err.type === 'create-order-error')) {
+                if (err && err.type === 'create-order-error') {
                     return;
                 }
 

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -18,7 +18,7 @@ class CheckoutActionHandler {
                 try {
                     await validateCheckoutForm(this.config);
                 } catch (error) {
-                    throw {type: 'form-validation-error'};
+                    throw { type: 'form-validation-error' };
                 }
 
                 return actions.subscription.create({
@@ -48,7 +48,13 @@ class CheckoutActionHandler {
 
     configuration() {
         const spinner = this.spinner;
-        const createOrder = (data, actions) => {
+        const createOrder = async (data, actions) => {
+            try {
+                await validateCheckoutForm(this.config);
+            } catch (error) {
+                throw { type: 'form-validation-error' };
+            }
+
             const payer = payerData();
             const bnCode = typeof this.config.bn_codes[this.config.context] !== 'undefined' ?
                 this.config.bn_codes[this.config.context] : '';
@@ -136,7 +142,7 @@ class CheckoutActionHandler {
                 console.error(err);
                 spinner.unblock();
 
-                if (err && err.type === 'create-order-error') {
+                if (err && (err.type === 'create-order-error' || err.type === 'form-validation-error')) {
                     return;
                 }
 

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -18,7 +18,7 @@ class CheckoutActionHandler {
                 try {
                     await validateCheckoutForm(this.config);
                 } catch (error) {
-                    throw { type: 'form-validation-error' };
+                    throw {type: 'form-validation-error'};
                 }
 
                 return actions.subscription.create({
@@ -49,12 +49,6 @@ class CheckoutActionHandler {
     configuration() {
         const spinner = this.spinner;
         const createOrder = async (data, actions) => {
-            try {
-                await validateCheckoutForm(this.config);
-            } catch (error) {
-                throw { type: 'form-validation-error' };
-            }
-
             const payer = payerData();
             const bnCode = typeof this.config.bn_codes[this.config.context] !== 'undefined' ?
                 this.config.bn_codes[this.config.context] : '';
@@ -142,7 +136,7 @@ class CheckoutActionHandler {
                 console.error(err);
                 spinner.unblock();
 
-                if (err && (err.type === 'create-order-error' || err.type === 'form-validation-error')) {
+                if (err && (err.type === 'create-order-error')) {
                     return;
                 }
 

--- a/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
@@ -3,7 +3,7 @@ import {cardFieldStyles} from "../Helper/CardFieldsHelper";
 
 class CardFieldsRenderer {
 
-    constructor(defaultConfig, errorHandler, spinner) {
+    constructor(defaultConfig, errorHandler, spinner, onCardFieldsBeforeSubmit) {
         this.defaultConfig = defaultConfig;
         this.errorHandler = errorHandler;
         this.spinner = spinner;
@@ -11,6 +11,7 @@ class CardFieldsRenderer {
         this.formValid = false;
         this.emptyFields = new Set(['number', 'cvv', 'expirationDate']);
         this.currentHostedFieldsInstance = null;
+        this.onCardFieldsBeforeSubmit = onCardFieldsBeforeSubmit;
     }
 
     render(wrapper, contextConfig) {
@@ -110,10 +111,20 @@ class CardFieldsRenderer {
                 return;
             }
 
+            if (typeof this.onCardFieldsBeforeSubmit === 'function' && !this.onCardFieldsBeforeSubmit()) {
+                this.spinner.unblock();
+                return;
+            }
+
             cardField.submit()
                 .catch((error) => {
                     this.spinner.unblock();
                     console.error(error)
+
+                    if (error.type === 'form-validation-error') {
+                        return;
+                    }
+
                     this.errorHandler.message(this.defaultConfig.hosted_fields.labels.fields_not_valid);
                 });
         });

--- a/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
@@ -120,11 +120,6 @@ class CardFieldsRenderer {
                 .catch((error) => {
                     this.spinner.unblock();
                     console.error(error)
-
-                    if (error.type === 'form-validation-error') {
-                        return;
-                    }
-
                     this.errorHandler.message(this.defaultConfig.hosted_fields.labels.fields_not_valid);
                 });
         });

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -294,7 +294,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 			if ( $this->early_validation_enabled
 				&& $this->form
 				&& 'checkout' === $data['context']
-				&& in_array( $payment_method, array( PayPalGateway::ID, CardButtonGateway::ID ), true )
+				&& in_array( $payment_method, array( PayPalGateway::ID, CardButtonGateway::ID, CreditCardGateway::ID ), true )
 			) {
 				$this->validate_form( $this->form );
 			}


### PR DESCRIPTION
# PR Description
The PR adds support for both `Basic Checkout Validation` and `Early Checkout Validation` to the `card fields`.
It tries to maximize the reuse of existing validation logic.

A side effect is the `Early Checkout Validation` will be done even earlier also for the standard PayPal buttons.

# Issue Description
The new hosted card field implementation should trigger the early WC validation when clicking the “Place order” button.

Ideally, it should also be compatible with the basic validation (which is disabled by default).

## Acceptance Criteria
Given the new card fields are active
When filling card fields while leaving the WC form fields empty
Then the missing forms fields are immediately validated
And the 3D Secure popup does not trigger
