### PR TITLE
make all hosted card fields strings translatable (2488)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
@@ -55,28 +55,52 @@ class CardFieldsRenderer {
             const nameField = document.getElementById('ppcp-credit-card-gateway-card-name');
             if (nameField) {
                 let styles = cardFieldStyles(nameField);
-                cardField.NameField({style: {'input': styles}}).render(nameField.parentNode);
+                let fieldOptions = {
+                    style: { 'input': styles }
+                }
+                if (nameField.getAttribute('placeholder')) {
+                    fieldOptions.placeholder = nameField.getAttribute('placeholder');
+                }
+                cardField.NameField(fieldOptions).render(nameField.parentNode);
                 nameField.remove();
             }
 
             const numberField = document.getElementById('ppcp-credit-card-gateway-card-number');
             if (numberField) {
                 let styles = cardFieldStyles(numberField);
-                cardField.NumberField({style: {'input': styles}}).render(numberField.parentNode);
+                let fieldOptions = {
+                    style: { 'input': styles }
+                }
+                if (numberField.getAttribute('placeholder')) {
+                    fieldOptions.placeholder = numberField.getAttribute('placeholder');
+                }
+                cardField.NumberField(fieldOptions).render(numberField.parentNode);
                 numberField.remove();
             }
 
             const expiryField = document.getElementById('ppcp-credit-card-gateway-card-expiry');
             if (expiryField) {
                 let styles = cardFieldStyles(expiryField);
-                cardField.ExpiryField({style: {'input': styles}}).render(expiryField.parentNode);
+                let fieldOptions = {
+                    style: { 'input': styles }
+                }
+                if (expiryField.getAttribute('placeholder')) {
+                    fieldOptions.placeholder = expiryField.getAttribute('placeholder');
+                }
+                cardField.ExpiryField(fieldOptions).render(expiryField.parentNode);
                 expiryField.remove();
             }
 
             const cvvField = document.getElementById('ppcp-credit-card-gateway-card-cvc');
             if (cvvField) {
                 let styles = cardFieldStyles(cvvField);
-                cardField.CVVField({style: {'input': styles}}).render(cvvField.parentNode);
+                let fieldOptions = {
+                    style: { 'input': styles }
+                }
+                if (cvvField.getAttribute('placeholder')) {
+                    fieldOptions.placeholder = cvvField.getAttribute('placeholder');
+                }
+                cardField.CVVField(fieldOptions).render(cvvField.parentNode);
                 cvvField.remove();
             }
 

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -80,6 +80,17 @@ class CardFieldsModule implements ModuleInterface {
 					array_unshift( $default_fields, $new_field );
 				}
 
+				if ( apply_filters( 'woocommerce_paypal_payments_card_fields_translate_card_number', true ) ) {
+					if ( isset( $default_fields['card-number-field'] ) ) {
+						// Replaces the default card number placeholder with a translatable one.
+						$default_fields['card-number-field'] = str_replace(
+							'&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull;',
+							esc_attr__( 'Card number', 'woocommerce-paypal-payments' ),
+							$default_fields['card-number-field']
+						);
+					}
+				}
+
 				return $default_fields;
 			},
 			10,


### PR DESCRIPTION
# PR Description

- Some of the `Card Fields` texts are already translatable via WooCommerce native translations. https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/gateways/class-wc-payment-gateway-cc.php#L60-L74
- For the `placeholders` of the `Card Fields` to be translated the `placeholder` Javascript configuration attribute needs to be passed to each field.
- The native WooCommerce `Card Number` field `placeholder` isn't translatable, this PR also adds the possibility of translating it, and applies the `woocommerce_paypal_payments_card_fields_translate_card_number` filter in case we want to disable this translation.

# Issue Description
Currently, only the Cardholder Name field can be translated with WordPress translation files.

The Card number, Expiry, and CVV fields currently are provided by the PayPal SDK but they should also be translatable with WordPress translation files.