### PR TITLE
Improve Apple Pay validation notice text (2490)

### DIFF
--- a/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
+++ b/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
@@ -273,7 +273,7 @@ class AvailabilityNotice {
 				$message = sprintf(
 					// translators: %1$s and %2$s are the opening and closing of HTML <a> tag for the well-known file, %3$s and %4$s are the opening and closing of HTML <a> tag for the help document.
 					__(
-						'Apple Pay Validation Error. Please ensure the presentment of the correct %1$sdomain association file%2$s for Apple to validate your domain. %3$sLearn more%4$s about the Apple Pay requirements',
+						'Apple Pay has not yet been validated. Use the Apple Pay button in your shop for Apple to validate your domain. If this message persists after using the button, please verify your website displays the correct %1$sdomain association file%2$s. More details about the Apple Pay setup can be found in the %3$sPayPal Payments documentation%4$s.',
 						'woocommerce-paypal-payments'
 					),
 					'<a href="/.well-known/apple-developer-merchantid-domain-association" target="_blank">',

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1447,8 +1447,8 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			$context = 'general';
 		}
 
-		return $this->get_style_value( "button_{$context}_${style}" )
-			?? $this->get_style_value( "button_${style}" )
+		return $this->get_style_value( "button_{$context}_{$style}" )
+			?? $this->get_style_value( "button_{$style}" )
 			?? ( $default ? $this->normalize_style_value( $default ) : null )
 			?? $this->normalize_style_value( $defaults[ $style ] ?? '' );
 	}
@@ -1463,7 +1463,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 	 * @return string|int
 	 */
 	private function style_for_apm( string $style, string $apm, $default = null ) {
-		return $this->get_style_value( "${apm}_button_${style}" )
+		return $this->get_style_value( "{$apm}_button_{$style}" )
 			?? ( $default ? $this->normalize_style_value( $default ) : null )
 			?? $this->style_for_context( $style, 'checkout' );
 	}
@@ -1584,14 +1584,14 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 		 * The filter returning the action name that will be used for rendering Pay Later messages.
 		 */
 		$hook = (string) apply_filters(
-			"woocommerce_paypal_payments_${location_hook}_messages_renderer_hook",
+			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_hook",
 			$default_hook
 		);
 		/**
 		 * The filter returning the action priority that will be used for rendering Pay Later messages.
 		 */
 		$priority = (int) apply_filters(
-			"woocommerce_paypal_payments_${location_hook}_messages_renderer_priority",
+			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_priority",
 			$default_priority
 		);
 		return array(
@@ -1615,14 +1615,14 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 		 * The filter returning the action name that will be used for rendering Pay Later messages.
 		 */
 		$block_name = (string) apply_filters(
-			"woocommerce_paypal_payments_${location_hook}_messages_renderer_block",
+			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_block",
 			$default_block
 		);
 		/**
 		 * The filter returning the action priority that will be used for rendering Pay Later messages.
 		 */
 		$priority = (int) apply_filters(
-			"woocommerce_paypal_payments_${location_hook}_messages_renderer_block_priority",
+			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_block_priority",
 			$default_priority
 		);
 		return array(

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1447,8 +1447,8 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			$context = 'general';
 		}
 
-		return $this->get_style_value( "button_{$context}_{$style}" )
-			?? $this->get_style_value( "button_{$style}" )
+		return $this->get_style_value( "button_{$context}_${style}" )
+			?? $this->get_style_value( "button_${style}" )
 			?? ( $default ? $this->normalize_style_value( $default ) : null )
 			?? $this->normalize_style_value( $defaults[ $style ] ?? '' );
 	}
@@ -1463,7 +1463,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 	 * @return string|int
 	 */
 	private function style_for_apm( string $style, string $apm, $default = null ) {
-		return $this->get_style_value( "{$apm}_button_{$style}" )
+		return $this->get_style_value( "${apm}_button_${style}" )
 			?? ( $default ? $this->normalize_style_value( $default ) : null )
 			?? $this->style_for_context( $style, 'checkout' );
 	}
@@ -1584,14 +1584,14 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 		 * The filter returning the action name that will be used for rendering Pay Later messages.
 		 */
 		$hook = (string) apply_filters(
-			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_hook",
+			"woocommerce_paypal_payments_${location_hook}_messages_renderer_hook",
 			$default_hook
 		);
 		/**
 		 * The filter returning the action priority that will be used for rendering Pay Later messages.
 		 */
 		$priority = (int) apply_filters(
-			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_priority",
+			"woocommerce_paypal_payments_${location_hook}_messages_renderer_priority",
 			$default_priority
 		);
 		return array(
@@ -1615,14 +1615,14 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 		 * The filter returning the action name that will be used for rendering Pay Later messages.
 		 */
 		$block_name = (string) apply_filters(
-			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_block",
+			"woocommerce_paypal_payments_${location_hook}_messages_renderer_block",
 			$default_block
 		);
 		/**
 		 * The filter returning the action priority that will be used for rendering Pay Later messages.
 		 */
 		$priority = (int) apply_filters(
-			"woocommerce_paypal_payments_{$location_hook}_messages_renderer_block_priority",
+			"woocommerce_paypal_payments_${location_hook}_messages_renderer_block_priority",
 			$default_priority
 		);
 		return array(


### PR DESCRIPTION
# PR Description
Updates the text mentioned in the issue.

# Issue Description
Change this text: https://github.com/woocommerce/woocommerce-paypal-payments/blob/425b7b4a31dc88a99c42da420511230d98e18c36/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php#L276

From:
```
'Apple Pay Validation Error. Please ensure the presentment of the correct %1$sdomain association file%2$s for Apple to validate your domain. %3$sLearn more%4$s about the Apple Pay requirements', 'woocommerce-paypal-payments'
```

To 
```
'Apple Pay has not yet been validated. Use the Apple Pay button in your shop for Apple to validate your domain. If this message persists after using the button, please verify your website displays the correct %1$sdomain association file%2$s . More details about the Apple Pay setup can be found in the  %3$sPayPal Payments documentation%4$s', 'woocommerce-paypal-payments'
```