### PR TITLE
Improve PUI performance for variable products

### DIFF
--- a/modules/ppcp-wc-gateway/src/Helper/CheckoutHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CheckoutHelper.php
@@ -91,22 +91,12 @@ class CheckoutHelper {
 	/**
 	 * Ensures product is neither downloadable nor virtual.
 	 *
-	 * @param WC_Product $product WC product.
+	 * @param WC_Product $product WC product (can be a variation).
 	 * @return bool
 	 */
-	public function is_physical_product( WC_Product $product ):bool {
+	public function is_physical_product( WC_Product $product ): bool {
 		if ( $product->is_downloadable() || $product->is_virtual() ) {
 			return false;
-		}
-
-		if ( is_a( $product, WC_Product_Variable::class ) ) {
-			foreach ( $product->get_available_variations( 'object' ) as $variation ) {
-				if ( is_a( $variation, WC_Product_Variation::class ) ) {
-					if ( true === $variation->is_downloadable() || true === $variation->is_virtual() ) {
-						return false;
-					}
-				}
-			}
 		}
 
 		return true;

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -98,7 +98,11 @@ class PayUponInvoiceHelper {
 		if ( $cart && ! is_checkout_pay_page() ) {
 			$items = $cart->get_cart_contents();
 			foreach ( $items as $item ) {
-				$product = wc_get_product( $item['product_id'] );
+				$product_id = $item['product_id'];
+				if ( isset( $item['variation_id'] ) && $item['variation_id'] ) {
+					$product_id = $item['variation_id'];
+				}
+				$product = wc_get_product( $product_id );
 				if ( $product && ! $this->checkout_helper->is_physical_product( $product ) ) {
 					return false;
 				}


### PR DESCRIPTION
Fixes #1396

Now using only the variation from the cart for this PUI check instead of querying all variations.

This function is also used for order-pay page, but it already retrieves only the variation.
