### PR TITLE
Subscription support on Block Cart & Block Express Checkout (2287)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Helper/Address.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Address.js
@@ -63,7 +63,7 @@ export const paypalAddressToWc = (address) => {
  * @returns {Object}
  */
 export const paypalShippingToWc = (shipping) => {
-    const [firstName, lastName] = splitFullName(shipping.name.full_name);
+    const [firstName, lastName] = (shipping.name ? splitFullName(shipping.name.full_name) : ['','']);
     return {
         ...paypalAddressToWc(shipping.address),
         first_name: firstName,
@@ -84,6 +84,22 @@ export const paypalPayerToWc = (payer) => {
         first_name: firstName,
         last_name: lastName,
         email: payer.email_address,
+    }
+}
+
+/**
+ * @param {Object} subscriber
+ * @returns {Object}
+ */
+export const paypalSubscriberToWc = (subscriber) => {
+    const firstName = subscriber?.name?.given_name ?? '';
+    const lastName = subscriber?.name?.surname ?? '';
+    const address = subscriber.address ? paypalAddressToWc(subscriber.shipping_address.address) : {};
+    return {
+        ...address,
+        first_name: firstName,
+        last_name: lastName,
+        email: subscriber.email_address,
     }
 }
 
@@ -127,6 +143,17 @@ export const paypalOrderToWcAddresses = (order) => {
         }
     }
 
+    return {billingAddress, shippingAddress};
+}
+
+/**
+ *
+ * @param subscription
+ * @returns {{shippingAddress: Object, billingAddress: Object}}
+ */
+export const paypalSubscriptionToWcAddresses = (subscription) => {
+    const shippingAddress = paypalSubscriberToWc(subscription.subscriber);
+    let billingAddress = shippingAddress;
     return {billingAddress, shippingAddress};
 }
 

--- a/modules/ppcp-blocks/resources/js/Helper/Subscription.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Subscription.js
@@ -1,0 +1,16 @@
+/**
+ * @param {Object} scriptData
+ * @returns {Boolean}
+ */
+export const isPayPalSubscription = (scriptData) => {
+    return scriptData.data_client_id.has_subscriptions
+        && scriptData.data_client_id.paypal_subscriptions_enabled;
+}
+
+/**
+ * @param {Object} scriptData
+ * @returns {Boolean}
+ */
+export const cartHasSubscriptionProducts = (scriptData) => {
+    return !! scriptData?.locations_with_subscription_product?.cart;
+}

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -466,9 +466,10 @@ const features = ['products'];
 let block_enabled = true;
 
 if(cartHasSubscriptionProducts(config.scriptData)) {
-    // Don't show buttons on block cart page if using vault v2
+    // Don't show buttons on block cart page if using vault v2 and user is not logged in
     if (
-        config.scriptData.context === "cart-block"
+        ! config.scriptData.user.is_logged
+        && config.scriptData.context === "cart-block"
         && ! isPayPalSubscription(config.scriptData) // using vaulting
         && ! config.scriptData?.save_payment_methods?.id_token // not vault v3
     ) {

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -476,6 +476,14 @@ if(cartHasSubscriptionProducts(config.scriptData)) {
         block_enabled = false;
     }
 
+    // Don't render buttons if in subscription mode and product not associated with a PayPal subscription
+    if(
+        isPayPalSubscription(config.scriptData)
+        && !config.scriptData.subscription_product_allowed
+    ) {
+        block_enabled = false;
+    }
+
     features.push('subscriptions');
 }
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1170,6 +1170,9 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			'basic_checkout_validation_enabled'       => $this->basic_checkout_validation_enabled,
 			'early_checkout_validation_enabled'       => $this->early_validation_enabled,
 			'funding_sources_without_redirect'        => $this->funding_sources_without_redirect,
+			'user'                                    => array(
+				'is_logged' => is_user_logged_in(),
+			),
 		);
 
 		if ( 'pay-now' === $this->context() ) {


### PR DESCRIPTION
# PR Description
This PR adds support for PayPal buttons on block pages with Subscriptions. It supports both vaulting (V2 and V3) and PayPal subscriptions.

# Issue Description
We must ensure that PayPal Vaulting and PayPal Subscriptions are working correctly on the ck Cart & Block Express Checkout

**Given** the plugin is configured to buy subscriptions via PayPal Vaulting (v2)
**And** Block Express Checkout button locations is enabled
**And** the user is logged out
**And** a subscription product is in the cart
**When** visiting the Block Checkout
**Then** the PayPal buttons appear on Block Express Checkout and can be used

**Given** the plugin is configured to buy subscriptions via PayPal Vaulting (v2)
**And** Block Cart button locations is enabled
**And** the user is logged out
**And** a subscription product is in the cart
**When** visiting the Block Cart
**Then** the PayPal button does not appear on Block Cart 

**Given** the plugin is configured to buy subscriptions via PayPal Vaulting (v3)
**And** Block Cart & Block Express Checkout button locations are enabled
**And** the user is logged out
**And** a subscription product is in the cart
**When** visiting the Block Cart & Block Checkout
**Then** the PayPal buttons appear on Block Cart & Block Express Checkout and can be used

**Given** the plugin is configured to buy subscriptions via PayPal Vaulting (v3)
**And** Block Cart & Block Express Checkout button locations are enabled
**And** the user is logged in
**And** a subscription product is in the cart
**When** visiting the Block Cart & Block Checkout
**Then** the PayPal buttons appear on Block Cart & Block Express Checkout and can be used

**Given** the plugin is configured to buy subscriptions via PayPal Subscriptions
**And** Block Cart & Block Express Checkout button locations are enabled
**And** the user is logged in
**And** a subscription product (linked to PayPal) is in the cart
**When** visiting the Block Cart & Block Checkout
**Then** the PayPal buttons appear on Block Cart & Block Express Checkout and can be used

**Given** the plugin is configured to buy subscriptions via PayPal Subscriptions
**And** Block Cart & Block Express Checkout button locations are enabled
**And** the user is logged out
**And** a subscription product (linked to PayPal) is in the cart
**When** visiting the Block Cart & Block Checkout
**Then** the PayPal buttons appear on Block Cart & Block Express Checkout and can be used
