### PR TITLE
(Regression) Error "PayPal order ID not found in meta" occurs when checking out via other payment methods

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -20,6 +20,7 @@ use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
@@ -84,6 +85,10 @@ class WcSubscriptionsModule implements ModuleInterface {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function ( $subscription ) use ( $c ) {
+				if ( ! in_array( $subscription->get_payment_method(), array( PayPalGateway::ID, CreditCardGateway::ID, CardButtonGateway::ID ), true ) ) {
+					return;
+				}
+
 				$paypal_subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
 				if ( $paypal_subscription_id ) {
 					return;


### PR DESCRIPTION
`woocommerce_subscription_payment_complete` action is called on all registered payment methods, this PR ensure it executes only in payment methods registered by the plugin.

# Acceptance Criteria
- Enable PayPal Payments
- Set up Stripe plugin
- Buy subscription via Stripe

Observe order note: **Error during status transition. PayPal order ID not found in meta.**