### PR TITLE
Venmo Vaulting integration (2522)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1253,6 +1253,16 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			'commit'           => in_array( $context, $this->pay_now_contexts, true ) ? 'true' : 'false',
 			'intent'           => $intent,
 		);
+
+		if (
+			$this->settings->has( 'subscriptions_mode' )
+			&& $this->settings->get( 'subscriptions_mode' ) === 'vaulting_api'
+			&& apply_filters( 'woocommerce_paypal_payments_save_payment_methods_eligible', false )
+		) {
+			// Remove vault parameter to allow for Venmo with Save Payment Methods (Vault V3).
+			unset( $params['vault'] );
+		}
+
 		if (
 			$this->environment->current_environment_is( Environment::SANDBOX )
 			&& defined( 'WP_DEBUG' ) && \WP_DEBUG

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -329,6 +329,13 @@ class SavePaymentMethodsModule implements ModuleInterface {
 				$endpoint->handle_request();
 			}
 		);
+
+		add_filter(
+			'woocommerce_paypal_payments_save_payment_methods_eligible',
+			function() {
+				return true;
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -106,16 +106,30 @@ class SavePaymentMethodsModule implements ModuleInterface {
 				}
 
 				if ( $payment_method === PayPalGateway::ID ) {
-					$data['payment_source'] = array(
-						'paypal' => array(
-							'attributes' => array(
-								'vault' => array(
-									'store_in_vault' => 'ON_SUCCESS',
-									'usage_type'     => 'MERCHANT',
+
+					if ( $request_data['funding_source'] === 'venmo' ) {
+						$data['payment_source'] = array(
+							'venmo' => array(
+								'attributes' => array(
+									'vault' => array(
+										'store_in_vault' => 'ON_SUCCESS',
+										'usage_type'     => 'MERCHANT',
+									),
 								),
 							),
-						),
-					);
+						);
+					} else {
+						$data['payment_source'] = array(
+							'paypal' => array(
+								'attributes' => array(
+									'vault' => array(
+										'store_in_vault' => 'ON_SUCCESS',
+										'usage_type'     => 'MERCHANT',
+									),
+								),
+							),
+						);
+					}
 				}
 
 				return $data;

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -177,6 +177,16 @@ class WcSubscriptionsModule implements ModuleInterface {
 
 		add_filter(
 			'woocommerce_subscription_payment_method_to_display',
+			/**
+			 * Corrects the payment method name for subscriptions.
+			 *
+			 * @param string $payment_method_to_display The payment method string.
+			 * @param \WC_Subscription $subscription The subscription instance.
+			 * @param string $context The context, ex: view.
+			 * @return string
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
 			function ( $payment_method_to_display, $subscription, $context ) {
 				$payment_gateway = wc_get_payment_gateway_by_order( $subscription );
 

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -190,11 +190,7 @@ class WcSubscriptionsModule implements ModuleInterface {
 			function ( $payment_method_to_display, $subscription, $context ) {
 				$payment_gateway = wc_get_payment_gateway_by_order( $subscription );
 
-				if (
-					$subscription instanceof \WC_Subscription
-					&& $payment_gateway
-					&& $payment_gateway->id === PayPalGateway::ID
-				) {
+				if ( $payment_gateway && $payment_gateway->id === PayPalGateway::ID ) {
 					return $subscription->get_payment_method_title( $context );
 				}
 

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -175,19 +175,24 @@ class WcSubscriptionsModule implements ModuleInterface {
 			}
 		);
 
-		add_filter( 'woocommerce_subscription_payment_method_to_display', function ( $payment_method_to_display, $subscription, $context ) {
-			$payment_gateway = wc_get_payment_gateway_by_order( $subscription );
+		add_filter(
+			'woocommerce_subscription_payment_method_to_display',
+			function ( $payment_method_to_display, $subscription, $context ) {
+				$payment_gateway = wc_get_payment_gateway_by_order( $subscription );
 
-			if (
-				$subscription instanceof \WC_Subscription
-				&& $payment_gateway
-				&& $payment_gateway->id === PayPalGateway::ID
-			) {
-				return $subscription->get_payment_method_title( $context ); //data['payment_method_title'] ?? '';
-			}
+				if (
+					$subscription instanceof \WC_Subscription
+					&& $payment_gateway
+					&& $payment_gateway->id === PayPalGateway::ID
+				) {
+					return $subscription->get_payment_method_title( $context );
+				}
 
-			return $payment_method_to_display;
-		}, 10, 3 );
+				return $payment_method_to_display;
+			},
+			10,
+			3
+		);
 
 		add_action(
 			'wc_ajax_' . SubscriptionChangePaymentMethod::ENDPOINT,

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -175,6 +175,20 @@ class WcSubscriptionsModule implements ModuleInterface {
 			}
 		);
 
+		add_filter( 'woocommerce_subscription_payment_method_to_display', function ( $payment_method_to_display, $subscription, $context ) {
+			$payment_gateway = wc_get_payment_gateway_by_order( $subscription );
+
+			if (
+				$subscription instanceof \WC_Subscription
+				&& $payment_gateway
+				&& $payment_gateway->id === PayPalGateway::ID
+			) {
+				return $subscription->get_payment_method_title( $context ); //data['payment_method_title'] ?? '';
+			}
+
+			return $payment_method_to_display;
+		}, 10, 3 );
+
 		add_action(
 			'wc_ajax_' . SubscriptionChangePaymentMethod::ENDPOINT,
 			static function () use ( $c ) {

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -190,7 +190,7 @@ class WcSubscriptionsModule implements ModuleInterface {
 			function ( $payment_method_to_display, $subscription, $context ) {
 				$payment_gateway = wc_get_payment_gateway_by_order( $subscription );
 
-				if ( $payment_gateway && $payment_gateway->id === PayPalGateway::ID ) {
+				if ( $payment_gateway instanceof \WC_Payment_Gateway && $payment_gateway->id === PayPalGateway::ID ) {
 					return $subscription->get_payment_method_title( $context );
 				}
 


### PR DESCRIPTION
# PR Description
This PR adds support for Venmo with Save Payment Methods (Vault V3).

# Issue Description
Add support for saving Venmo payment methods (when using Vault v3).

https://developer.paypal.com/docs/checkout/save-payment-methods/during-purchase/js-sdk/venmo/

- must clarify if Venmo Vaulting supports return-buyer experience 

## Acceptance
**Given** a subscription product is in the cart (or on single product)
**And** PayPal Vaulting is the selected subscriptions mode
**When** using Venmo as a payment method
**Then** Venmo payment method gets saved 
**And** can be used for subscription renewal payments