### PR TITLE
Do not save customer id in meta if vault v3 enabled

### DIFF
--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -54,7 +54,11 @@ class VaultingModule implements ModuleInterface {
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 		add_action(
 			'woocommerce_created_customer',
-			function( int $customer_id ) use ( $subscription_helper ) {
+			function( int $customer_id ) use ( $subscription_helper, $container ) {
+				if ( $container->has( 'save-payment-methods.eligible' ) && $container->get( 'save-payment-methods.eligible' ) ) {
+					return;
+				}
+
 				$session = WC()->session;
 				if ( ! $session ) {
 					return;


### PR DESCRIPTION
When Vault v3 is enabled saving customer id  payment is not needed  as the id is generated by PayPal in the response. This PR ensures no id is saved when  guest customer purchases subscription.