### PR TITLE
Add setup URL for reference transactions.

### DIFF
--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -71,7 +71,7 @@ return array(
 		// Connection tab fields.
 		$fields = $insert_after(
 			$fields,
-			'ppcp_dcc_status',
+			'ppcp_reference_transactions_status',
 			array(
 				'applepay_status' => array(
 					'title'        => __( 'Apple Pay Payments', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-googlepay/extensions.php
+++ b/modules/ppcp-googlepay/extensions.php
@@ -42,7 +42,7 @@ return array(
 		// Connection tab fields.
 		$fields = $insert_after(
 			$fields,
-			'ppcp_dcc_status',
+			'ppcp_reference_transactions_status',
 			array(
 				'googlepay_status' => array(
 					'title'        => __( 'Google Pay Payments', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway;
 
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PayUponInvoiceOrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
@@ -1315,6 +1316,12 @@ return array(
 	'wcgateway.enable-pui-url-live'                        => static function ( ContainerInterface $container ): string {
 		return 'https://www.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE';
 	},
+	'wcgateway.enable-reference-transactions-url-sandbox'  => static function ( ContainerInterface $container ): string {
+		return 'https://www.sandbox.paypal.com/bizsignup/entry?product=ADVANCED_VAULTING';
+	},
+	'wcgateway.enable-reference-transactions-url-live'     => static function ( ContainerInterface $container ): string {
+		return 'https://www.paypal.com/bizsignup/entry?product=ADVANCED_VAULTING';
+	},
 	'wcgateway.settings.connection.dcc-status-text'        => static function ( ContainerInterface $container ): string {
 		$state = $container->get( 'onboarding.state' );
 		if ( $state->current_state() < State::STATE_ONBOARDED ) {
@@ -1351,6 +1358,39 @@ return array(
 			$dcc_enabled ? '_self' : '_blank',
 			esc_url( $dcc_button_url ),
 			esc_html( $dcc_button_text )
+		);
+	},
+	'wcgateway.settings.connection.reference-transactions-status-text' => static function ( ContainerInterface $container ): string {
+		$environment = $container->get( 'onboarding.environment' );
+		assert( $environment instanceof Environment );
+
+		$billing_agreements_endpoint = $container->get( 'api.endpoint.billing-agreements' );
+		assert( $billing_agreements_endpoint instanceof BillingAgreementsEndpoint );
+
+		$enabled = $billing_agreements_endpoint->reference_transaction_enabled();
+
+		$enabled_status_text  = esc_html__( 'Status: Available', 'woocommerce-paypal-payments' );
+		$disabled_status_text = esc_html__( 'Status: Not yet enabled', 'woocommerce-paypal-payments' );
+
+		$button_text = $enabled
+			? esc_html__( 'Settings', 'woocommerce-paypal-payments' )
+			: esc_html__( 'Enable Advanced PayPal Wallet', 'woocommerce-paypal-payments' );
+
+		$enable_url = $environment->current_environment_is( Environment::PRODUCTION )
+			? $container->get( 'wcgateway.enable-reference-transactions-url-live' )
+			: $container->get( 'wcgateway.enable-reference-transactions-url-sandbox' );
+
+		$button_url = $enabled
+			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' )
+			: $enable_url;
+
+		return sprintf(
+			'<p>%1$s %2$s</p><p><a target="%3$s" href="%4$s" class="button">%5$s</a></p>',
+			$enabled ? $enabled_status_text : $disabled_status_text,
+			$enabled ? '<span class="dashicons dashicons-yes"></span>' : '<span class="dashicons dashicons-no"></span>',
+			$enabled ? '_self' : '_blank',
+			esc_url( $button_url ),
+			esc_html( $button_text )
 		);
 	},
 	'wcgateway.settings.connection.pui-status-text'        => static function ( ContainerInterface $container ): string {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1381,7 +1381,7 @@ return array(
 			: $container->get( 'wcgateway.enable-reference-transactions-url-sandbox' );
 
 		$button_url = $enabled
-			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' )
+			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway#field-paypal_saved_payments' )
 			: $enable_url;
 
 		return sprintf(

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -410,6 +410,16 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array( 'dcc' ),
 			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
+		'ppcp_reference_transactions_status'            => array(
+			'title'        => __( 'Advanced PayPal Wallet', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-text',
+			'text'         => $container->get( 'wcgateway.settings.connection.reference-transactions-status-text' ),
+			'screens'      => array(
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array( 'dcc' ),
+			'gateway'      => Settings::CONNECTION_TAB_ID,
+		),
 		'ppcp_pui_status'                               => array(
 			'title'        => __( 'Pay upon Invoice', 'woocommerce-paypal-payments' ),
 			'type'         => 'ppcp-text',

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -435,15 +435,21 @@ class WCGatewayModule implements ModuleInterface {
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
 			function( Settings $settings = null ) use ( $c ): void {
+
+				// Clear DCC Product status.
 				$dcc_product_status = $c->get( 'wcgateway.helper.dcc-product-status' );
 				if ( $dcc_product_status instanceof DCCProductStatus ) {
 					$dcc_product_status->clear( $settings );
 				}
 
+				// Clear Pay Upon Invoice status.
 				$pui_product_status = $c->get( 'wcgateway.pay-upon-invoice-product-status' );
 				if ( $pui_product_status instanceof PayUponInvoiceProductStatus ) {
 					$pui_product_status->clear( $settings );
 				}
+
+				// Clear Reference Transaction status.
+				delete_transient( 'ppcp_reference_transaction_enabled' );
 			}
 		);
 	}


### PR DESCRIPTION
# PR Description
This PR adds support for Reference Transaction status refresh.

# Issue Description
In the Connection tab, we need a button for users to sign up for the Advanced Wallet (Reference Transactions) when they are not yet enabled.

The plugin already checks all 30 days for the availability of Reference Transactions which is equal to having access to the PayPal Advanced Wallet.

The result of this check currently is displayed in the system report for the support to know, but there is no UI for the user to see the status and/or sign up for it.

So we need a new button in the Connection tab:
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/45217709/09b1c16a-78bd-4232-978a-af07b12219de)

Clicking “Refresh feature availability” should also delete the transient for the Reference Transactions check.