### PR TITLE
Enable Vault v3 and Card Fields by default for US merchants

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -55,14 +55,14 @@ return function ( string $root_dir ): iterable {
 
 	if ( apply_filters(
 		'woocommerce.feature-flags.woocommerce_paypal_payments.card_fields_enabled',
-		getenv( 'PCP_CARD_FIELDS_ENABLED' ) === '1'
+		getenv( 'PCP_CARD_FIELDS_ENABLED' ) !== '0'
 	) ) {
 		$modules[] = ( require "$modules_dir/ppcp-card-fields/module.php" )();
 	}
 
 	if ( apply_filters(
 		'woocommerce.feature-flags.woocommerce_paypal_payments.save_payment_methods_enabled',
-		getenv( 'PCP_SAVE_PAYMENT_METHODS' ) === '1'
+		getenv( 'PCP_SAVE_PAYMENT_METHODS' ) !== '0'
 	) ) {
 		$modules[] = ( require "$modules_dir/ppcp-save-payment-methods/module.php" )();
 	}


### PR DESCRIPTION
This PR enables [Vault v3](https://developer.paypal.com/docs/multiparty/checkout/save-payment-methods/) and  [Card Fields](https://developer.paypal.com/docs/checkout/advanced/) by default for US merchants. To disable it please use these filters:
```

add_filter('woocommerce.feature-flags.woocommerce_paypal_payments.save_payment_methods_enabled', '__return_false');
add_filter('woocommerce.feature-flags.woocommerce_paypal_payments.card_fields_enabled', '__return_false');
```