### PR TITLE
Release 2.5.0-rc2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,8 @@
 * Enhancement - Improve feature availability check UX #1941
 * Enhancement - Make all hosted card fields strings translatable #1926
 * Enhancement - PHP 8.2 deprecations #1939
+* Enhancement - Subscription support on Block Cart & Block Express Checkout #1956
+* Enhancement - Venmo Vaulting integration #1958
 
 = 2.4.3 - 2024-01-04 =
 * Fix - PayPal Subscription initiated without a WooCommerce order #1907

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 2.5.0 - xxxx-xx-xx =
 * Fix - WC Subscriptions change subscription payment #1953
 * Fix - GooglePay and ApplePay buttons disappear from the minicart when adding a product to the cart on the shop page #1915
+* Enhancement - Enable Vault v3 and Card Fields by default for US merchants #1967
 * Enhancement - Vault v3 WC Subscriptions integration #1920
 * Enhancement - Add Pay Later Messaging block #1897
 * Enhancement - Implement early WC validation for Hosted Card Fields #1925

--- a/modules/ppcp-button/resources/js/modules/Helper/ApmButtons.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ApmButtons.js
@@ -77,7 +77,6 @@ export class ApmButtons {
                 this.containers.push(parent);
             }
         });
-        console.log('this.containers', this.containers);
     }
 
     refresh() {

--- a/readme.txt
+++ b/readme.txt
@@ -190,6 +190,8 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Enhancement - Improve feature availability check UX #1941
 * Enhancement - Make all hosted card fields strings translatable #1926
 * Enhancement - PHP 8.2 deprecations #1939
+* Enhancement - Subscription support on Block Cart & Block Express Checkout #1956
+* Enhancement - Venmo Vaulting integration #1958
 
 = 2.4.3 - 2024-01-04 =
 * Fix - PayPal Subscription initiated without a WooCommerce order #1907

--- a/readme.txt
+++ b/readme.txt
@@ -182,6 +182,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 = 2.5.0 - xxxx-xx-xx =
 * Fix - WC Subscriptions change subscription payment #1953
 * Fix - GooglePay and ApplePay buttons disappear from the minicart when adding a product to the cart on the shop page #1915
+* Enhancement - Enable Vault v3 and Card Fields by default for US merchants #1967
 * Enhancement - Vault v3 WC Subscriptions integration #1920
 * Enhancement - Add Pay Later Messaging block #1897
 * Enhancement - Implement early WC validation for Hosted Card Fields #1925


### PR DESCRIPTION
[2.5.0-rc1](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.5.0-rc1) plus:
* Enhancement - Enable Vault v3 and Card Fields by default for US merchants #1967
* Enhancement - Subscription support on Block Cart & Block Express Checkout #1956
* Enhancement - Venmo Vaulting integration #1958