### PR TITLE
Disable Pay Later block by default

### DIFF
--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -28,7 +28,7 @@ class PayLaterBlockModule implements ModuleInterface {
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_block_enabled',
-			getenv( 'PCP_PAYLATER_BLOCK' ) !== '0'
+			getenv( 'PCP_PAYLATER_BLOCK' ) === '1'
 		);
 	}
 


### PR DESCRIPTION
This PR disables Pay Later block by default, to enable it please use the following filter:
```
add_filter('woocommerce.feature-flags.woocommerce_paypal_payments.paylater_block_enabled', '__return_true');
```