### PR TITLE
Fix warning undefined funding_source.

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -106,8 +106,9 @@ class SavePaymentMethodsModule implements ModuleInterface {
 				}
 
 				if ( $payment_method === PayPalGateway::ID ) {
+					$funding_source = $request_data['funding_source'] ?? null;
 
-					if ( $request_data['funding_source'] === 'venmo' ) {
+					if ( $funding_source === 'venmo' ) {
 						$data['payment_source'] = array(
 							'venmo' => array(
 								'attributes' => array(

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -108,7 +108,7 @@ class SavePaymentMethodsModule implements ModuleInterface {
 				if ( $payment_method === PayPalGateway::ID ) {
 					$funding_source = $request_data['funding_source'] ?? null;
 
-					if ( $funding_source === 'venmo' ) {
+					if ( $funding_source && $funding_source === 'venmo' ) {
 						$data['payment_source'] = array(
 							'venmo' => array(
 								'attributes' => array(


### PR DESCRIPTION
This PR fixes a scenario with debug enabled where if `funding_source` is not defined it causes a warning ruining the respective JSON response.