### PR TITLE
Free trial subscription products using PayPal Vaulting when PayPal Subscriptions configured as Subscriptions Mode (2084)

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -137,7 +137,7 @@ const bootstrap = () => {
         }
 
         const isFreeTrial = PayPalCommerceGateway.is_free_trial_cart;
-        if (isFreeTrial && data.fundingSource !== 'card') {
+        if (isFreeTrial && data.fundingSource !== 'card' && ! PayPalCommerceGateway.subscription_plan_id) {
             freeTrialHandler.handle();
             return actions.reject();
         }
@@ -240,6 +240,7 @@ document.addEventListener(
     () => {
         if (!typeof (PayPalCommerceGateway)) {
             console.error('PayPal button could not be configured.');
+            return;
             return;
         }
 

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -498,7 +498,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 			$wc_order->save();
 		}
 
-		if ( 'card' !== $funding_source && $this->is_free_trial_order( $wc_order ) ) {
+		if ( 'card' !== $funding_source && $this->is_free_trial_order( $wc_order ) && ! $this->subscription_helper->paypal_subscription_id() ) {
 			$user_id = (int) $wc_order->get_customer_id();
 			$tokens  = $this->payment_token_repository->all_for_user_id( $user_id );
 			if ( ! array_filter(


### PR DESCRIPTION
When setting the Subscriptions Mode setting to PayPal Subscriptions and buying a free-trial subscription product, the payment will be handled using the Vaulting flow for free trials: [WooCommerce PayPal Payments Documentation - WooCommerce](https://woocommerce.com/document/woocommerce-paypal-payments/#free-trials) 

This PR ensures that subscriptions connected to PayPal Subscription API are excluded from free trial flow.

### Steps To Reproduce
- set the Subscriptions Mode setting to PayPal Subscriptions
- set up free trial subscription product & connect it with PayPal
- buy free trial product 
- observe the buyer is forwarded to PayPal website to save the payment method

### Expected behaviour
Instead of forwarding buyer to the PayPal website, the PayPal popup window should open and complete the payment via PayPal Subscriptions.