### PR TITLE
NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE error for merchants without reference transactions

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -78,8 +78,15 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		// Adds attributes needed to save payment method.
 		add_filter(
 			'ppcp_create_order_request_body_data',
-			function( array $data, string $payment_method, array $request_data ): array {
+			function( array $data, string $payment_method, array $request_data ) use ( $c ): array {
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
 				if ( $payment_method === CreditCardGateway::ID ) {
+					if ( ! $settings->has( 'vault_enabled_dcc' ) || ! $settings->get( 'vault_enabled_dcc' ) ) {
+						return $data;
+					}
+
 					$save_payment_method = $request_data['save_payment_method'] ?? false;
 					if ( $save_payment_method ) {
 						$data['payment_source'] = array(
@@ -106,6 +113,10 @@ class SavePaymentMethodsModule implements ModuleInterface {
 				}
 
 				if ( $payment_method === PayPalGateway::ID ) {
+					if ( ! $settings->has( 'vault_enabled' ) || ! $settings->get( 'vault_enabled' ) ) {
+						return $data;
+					}
+
 					$funding_source = $request_data['funding_source'] ?? null;
 
 					if ( $funding_source && $funding_source === 'venmo' ) {

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -55,6 +55,15 @@ class SavePaymentMethodsModule implements ModuleInterface {
 			return;
 		}
 
+		$settings = $c->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+		if (
+			( ! $settings->has( 'vault_enabled' ) || ! $settings->get( 'vault_enabled' ) )
+			&& ( ! $settings->has( 'vault_enabled_dcc' ) || ! $settings->get( 'vault_enabled_dcc' ) )
+		) {
+			return;
+		}
+
 		add_filter(
 			'woocommerce_paypal_payments_localized_script_data',
 			function( array $localized_script_data ) use ( $c ) {
@@ -78,10 +87,7 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		// Adds attributes needed to save payment method.
 		add_filter(
 			'ppcp_create_order_request_body_data',
-			function( array $data, string $payment_method, array $request_data ) use ( $c ): array {
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
-
+			function( array $data, string $payment_method, array $request_data ) use ( $settings ): array {
 				if ( $payment_method === CreditCardGateway::ID ) {
 					if ( ! $settings->has( 'vault_enabled_dcc' ) || ! $settings->get( 'vault_enabled_dcc' ) ) {
 						return $data;


### PR DESCRIPTION
In 2.5.0 release which includes Vault v3 integration, merchants without Reference Transactions enabled are getting `NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE` error as the plugin is sending `vault` attribute despite it being disabled.

The plugin is sending the following vault attribute when Vaulting setting is disabled:
```
"paypal": {
            "attributes": {
                "vault": {
                    "store_in_vault": "xxxxxx",
                    "usage_type": "MERCHANT"
                }
            }
        }
```
This is causing merchants that do not have Reference Transactions enabled to have the order fail.

This PR ensures that `vault` property is not sent when Vaulting setting is disabled.

### Steps To Reproduce
Despite not being able to fully reproduce the error locally as Reference Transactions could not be disabled in Sandbox (at least we didn't found a way to do so at the moment), we need to ensure that the plugin does not send the `vault` attribute when creates the PayPal order if Vaulting setting is disabled.

- Disable Vaulting for both PayPal and Advanced Card payment payment methods.
- Enable Logging in Connection tab
- Purchase a product using one of the above payment methods
- Check log entries and ensure the `vault` attribute is not send:
```
  POST https://api-m.sandbox.paypal.com/v2/checkout/orders
  "payment_source": {
    "paypal": {
      "attributes": {
        "vault": {
          "store_in_vault": "ON_SUCCESS",
          "usage_type": "MERCHANT"
        }
```