### PR TITLE
Fatal Error in WooCommerce PayPal Payments Plugin After 2.5.0 Update (2597)

### DIFF
--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -195,8 +195,18 @@ class VaultingModule implements ModuleInterface {
 
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function( array $methods ): array {
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function( $methods ) {
 				global $wp;
+
+				if ( ! is_array( $methods ) ) {
+					return $methods;
+				}
+
 				if (
 					isset( $wp->query_vars['add-payment-method'] )
 					&& apply_filters( 'woocommerce_paypal_payments_disable_add_payment_method', true )

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -158,7 +158,16 @@ class WcSubscriptionsModule implements ModuleInterface {
 
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			function( array $methods ) use ( $c ) : array {
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function( $methods ) use ( $c ) {
+				if ( ! is_array( $methods ) ) {
+					return $methods;
+				}
+
 				if ( ! is_wc_endpoint_url( 'order-pay' ) ) {
 					return $methods;
 				}


### PR DESCRIPTION
# PR Description
This PR removes the type the `woocommerce_available_payment_gateways` hooks so they are resilient to third-party plugins changing the `$methods` argument to a different type than `array`.

# Issue Description

Following the recent update of the WooCommerce PayPal Payments plugin, users are experiencing a fatal error leading to site crashes. The error is a TypeError in the WcSubscriptionsModule. The issue seems to occur in combination with the core WooCommerce plugin.

## Steps To Reproduce
1. Update the WooCommerce PayPal Payments plugin to the latest version.
2. Observe the site's behavior and note any errors or crashes.

Fatal error causing the website to crash, specifically a TypeError in the WcSubscriptionsModule of the WooCommerce PayPal Payments plugin.

## Expected behaviour
The plugin update should not cause any crashes or errors.