### PR TITLE
Apple Pay recurring payments (2521)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/FraudProcessorResponseFactory.php
+++ b/modules/ppcp-api-client/src/Factory/FraudProcessorResponseFactory.php
@@ -25,8 +25,8 @@ class FraudProcessorResponseFactory {
 	 * @return FraudProcessorResponse
 	 */
 	public function from_paypal_response( stdClass $data ): FraudProcessorResponse {
-		$avs_code = ($data->avs_code ?? null) ?: null;
-		$cvv_code = ($data->cvv_code ?? null) ?: null;
+		$avs_code = ( $data->avs_code ?? null ) ?: null;
+		$cvv_code = ( $data->cvv_code ?? null ) ?: null;
 
 		return new FraudProcessorResponse( $avs_code, $cvv_code );
 	}

--- a/modules/ppcp-api-client/src/Factory/FraudProcessorResponseFactory.php
+++ b/modules/ppcp-api-client/src/Factory/FraudProcessorResponseFactory.php
@@ -25,8 +25,8 @@ class FraudProcessorResponseFactory {
 	 * @return FraudProcessorResponse
 	 */
 	public function from_paypal_response( stdClass $data ): FraudProcessorResponse {
-		$avs_code = $data->avs_code ?: null;
-		$cvv_code = $data->cvv_code ?: null;
+		$avs_code = ($data->avs_code ?? null) ?: null;
+		$cvv_code = ($data->cvv_code ?? null) ?: null;
 
 		return new FraudProcessorResponse( $avs_code, $cvv_code );
 	}

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -70,10 +70,6 @@ class ApplepayButton {
 
         if (this.isEligible) {
             this.fetchTransactionInfo().then(() => {
-                const isSubscriptionProduct = this.ppcpConfig?.data_client_id?.has_subscriptions === true;
-                if (isSubscriptionProduct) {
-                    return;
-                }
                 this.addButton();
                 const id_minicart = "#apple-" + this.buttonConfig.button.mini_cart_wrapper;
                 const id = "#apple-" + this.buttonConfig.button.wrapper;

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -210,8 +210,6 @@ class ApplepayButton {
      * Show Apple Pay payment sheet when Apple Pay payment button is clicked
      */
     async onButtonClick(data, actions) {
-        console.log('data, actions', data, actions);
-
         this.log('onButtonClick', this.context);
 
         const paymentRequest = this.paymentRequest();

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -209,7 +209,7 @@ class ApplepayButton {
     /**
      * Show Apple Pay payment sheet when Apple Pay payment button is clicked
      */
-    async onButtonClick(data, actions) {
+    async onButtonClick() {
         this.log('onButtonClick', this.context);
 
         const paymentRequest = this.paymentRequest();

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -209,10 +209,14 @@ class ApplepayButton {
     /**
      * Show Apple Pay payment sheet when Apple Pay payment button is clicked
      */
-    async onButtonClick() {
+    async onButtonClick(data, actions) {
+        console.log('data, actions', data, actions);
+
         this.log('onButtonClick', this.context);
 
         const paymentRequest = this.paymentRequest();
+
+        window.ppcpFundingSource = 'apple_pay'; // Do this on another place like on create order endpoint handler.
 
         // Trigger woocommerce validation if we are in the checkout page.
         if (this.context === 'checkout') {

--- a/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
@@ -1,6 +1,7 @@
 import ErrorHandler from "../../../../ppcp-button/resources/js/modules/ErrorHandler";
 import CartActionHandler
     from "../../../../ppcp-button/resources/js/modules/ActionHandler/CartActionHandler";
+import {isPayPalSubscription} from "../../../../ppcp-blocks/resources/js/Helper/Subscription";
 
 class BaseHandler {
 
@@ -11,7 +12,8 @@ class BaseHandler {
 
     isVaultV3Mode() {
         return this.ppcpConfig?.save_payment_methods?.id_token // vault v3
-            && ! this.ppcpConfig.data_client_id.paypal_subscriptions_enabled; // not PayPal Subscriptions mode
+            && ! this.ppcpConfig?.data_client_id?.paypal_subscriptions_enabled // not PayPal Subscriptions mode
+            && this.ppcpConfig?.ppcpConfig.can_save_vault_token; // vault is enabled
     }
 
     validateContext() {

--- a/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
@@ -13,7 +13,7 @@ class BaseHandler {
     isVaultV3Mode() {
         return this.ppcpConfig?.save_payment_methods?.id_token // vault v3
             && ! this.ppcpConfig?.data_client_id?.paypal_subscriptions_enabled // not PayPal Subscriptions mode
-            && this.ppcpConfig?.ppcpConfig.can_save_vault_token; // vault is enabled
+            && this.ppcpConfig?.can_save_vault_token; // vault is enabled
     }
 
     validateContext() {

--- a/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
@@ -9,9 +9,14 @@ class BaseHandler {
         this.ppcpConfig = ppcpConfig;
     }
 
+    isVaultV3Mode() {
+        return this.ppcpConfig?.save_payment_methods?.id_token // vault v3
+            && ! this.ppcpConfig.data_client_id.paypal_subscriptions_enabled; // not PayPal Subscriptions mode
+    }
+
     validateContext() {
         if ( this.ppcpConfig?.locations_with_subscription_product?.cart ) {
-            return false;
+            return this.isVaultV3Mode();
         }
         return true;
     }

--- a/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
@@ -7,7 +7,7 @@ class PayNowHandler extends BaseHandler {
 
     validateContext() {
         if ( this.ppcpConfig?.locations_with_subscription_product?.payorder ) {
-            return false;
+            return this.isVaultV3Mode();
         }
         return true;
     }

--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
@@ -9,7 +9,7 @@ class SingleProductHandler extends BaseHandler {
 
     validateContext() {
         if ( this.ppcpConfig?.locations_with_subscription_product?.product ) {
-            return false;
+            return this.isVaultV3Mode();
         }
         return true;
     }

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -1,6 +1,7 @@
 import {useEffect, useState} from '@wordpress/element';
 import {registerExpressPaymentMethod, registerPaymentMethod} from '@woocommerce/blocks-registry';
 import {loadPaypalScript} from '../../../ppcp-button/resources/js/modules/Helper/ScriptLoading'
+import {cartHasSubscriptionProducts} from '../../../ppcp-blocks/resources/js/Helper/Subscription'
 import ApplepayManager from "./ApplepayManager";
 import {loadCustomScript} from "@paypal/paypal-js";
 
@@ -49,6 +50,10 @@ const ApplePayComponent = () => {
 }
 
 const features = ['products'];
+
+if (cartHasSubscriptionProducts(ppcpConfig)) {
+    features.push('subscriptions');
+}
 
 registerExpressPaymentMethod({
     name: buttonData.id,

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -1,7 +1,10 @@
 import {useEffect, useState} from '@wordpress/element';
 import {registerExpressPaymentMethod, registerPaymentMethod} from '@woocommerce/blocks-registry';
 import {loadPaypalScript} from '../../../ppcp-button/resources/js/modules/Helper/ScriptLoading'
-import {cartHasSubscriptionProducts} from '../../../ppcp-blocks/resources/js/Helper/Subscription'
+import {
+    cartHasSubscriptionProducts,
+    isPayPalSubscription
+} from '../../../ppcp-blocks/resources/js/Helper/Subscription'
 import ApplepayManager from "./ApplepayManager";
 import {loadCustomScript} from "@paypal/paypal-js";
 
@@ -51,7 +54,10 @@ const ApplePayComponent = () => {
 
 const features = ['products'];
 
-if (cartHasSubscriptionProducts(ppcpConfig)) {
+if (cartHasSubscriptionProducts(ppcpConfig)
+    && ! isPayPalSubscription(ppcpConfig)
+    && ppcpConfig.can_save_vault_token
+) {
     features.push('subscriptions');
 }
 

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -1,12 +1,10 @@
 import {useEffect, useState} from '@wordpress/element';
-import {registerExpressPaymentMethod, registerPaymentMethod} from '@woocommerce/blocks-registry';
+import {registerExpressPaymentMethod} from '@woocommerce/blocks-registry';
 import {loadPaypalScript} from '../../../ppcp-button/resources/js/modules/Helper/ScriptLoading'
-import {
-    cartHasSubscriptionProducts,
-    isPayPalSubscription
-} from '../../../ppcp-blocks/resources/js/Helper/Subscription'
+import {cartHasSubscriptionProducts} from '../../../ppcp-blocks/resources/js/Helper/Subscription'
 import ApplepayManager from "./ApplepayManager";
 import {loadCustomScript} from "@paypal/paypal-js";
+import CheckoutHandler from "./Context/CheckoutHandler";
 
 const ppcpData = wc.wcSettings.getSetting('ppcp-gateway_data');
 const ppcpConfig = ppcpData.scriptData;
@@ -54,9 +52,9 @@ const ApplePayComponent = () => {
 
 const features = ['products'];
 
-if (cartHasSubscriptionProducts(ppcpConfig)
-    && ! isPayPalSubscription(ppcpConfig)
-    && ppcpConfig.can_save_vault_token
+if (
+    cartHasSubscriptionProducts(ppcpConfig)
+    && (new CheckoutHandler(buttonConfig, ppcpConfig)).isVaultV3Mode()
 ) {
     features.push('subscriptions');
 }

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -77,7 +77,7 @@ const PayPalComponent = ({
         window.ppcpContinuationFilled = true;
     }, [])
 
-    const createOrder = async () => {
+    const createOrder = async (data, actions) => {
         try {
             const res = await fetch(config.scriptData.ajax.create_order.endpoint, {
                 method: 'POST',
@@ -87,6 +87,7 @@ const PayPalComponent = ({
                     bn_code: '',
                     context: config.scriptData.context,
                     payment_method: 'ppcp-gateway',
+                    funding_source: data.paymentSource,
                     createaccount: false
                 }),
             });

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -77,7 +77,7 @@ const PayPalComponent = ({
         window.ppcpContinuationFilled = true;
     }, [])
 
-    const createOrder = async (data, actions) => {
+    const createOrder = async () => {
         try {
             const res = await fetch(config.scriptData.ajax.create_order.endpoint, {
                 method: 'POST',

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -477,6 +477,14 @@ if(cartHasSubscriptionProducts(config.scriptData)) {
         block_enabled = false;
     }
 
+    // Don't render if vaulting disabled and is in vault subscription mode
+    if(
+        ! isPayPalSubscription(config.scriptData)
+        && ! config.scriptData.can_save_vault_token
+    ) {
+        block_enabled = false;
+    }
+
     // Don't render buttons if in subscription mode and product not associated with a PayPal subscription
     if(
         isPayPalSubscription(config.scriptData)

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -87,7 +87,7 @@ const PayPalComponent = ({
                     bn_code: '',
                     context: config.scriptData.context,
                     payment_method: 'ppcp-gateway',
-                    funding_source: data.paymentSource,
+                    funding_source: window.ppcpFundingSource ?? 'paypal',
                     createaccount: false
                 }),
             });

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -326,8 +326,6 @@ const PayPalComponent = ({
         };
 
         handleSubscriptionShippingChange = async (data, actions) => {
-            console.log('--- handleSubscriptionShippingChange', data, actions);
-
             try {
                 const shippingOptionId = data.selected_shipping_option?.id;
                 if (shippingOptionId) {

--- a/modules/ppcp-button/resources/js/modules/ButtonModuleWatcher.js
+++ b/modules/ppcp-button/resources/js/modules/ButtonModuleWatcher.js
@@ -7,7 +7,6 @@ class ButtonModuleWatcher {
     }
 
     watchContextBootstrap(callable) {
-        console.log('ButtonModuleWatcher.js: watchContextBootstrap', this.contextBootstrapRegistry)
         this.contextBootstrapWatchers.push(callable);
         Object.values(this.contextBootstrapRegistry).forEach(callable);
     }

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -119,14 +119,14 @@ class SavePaymentMethodsModule implements ModuleInterface {
 								),
 							),
 						);
-					} else if ( $funding_source === 'apple_pay' ) {
+					} elseif ( $funding_source && $funding_source === 'apple_pay' ) {
 						$data['payment_source'] = array(
 							'apple_pay' => array(
 								'stored_credential' => array(
 									'payment_initiator' => 'CUSTOMER',
 									'payment_type'      => 'RECURRING',
 								),
-								'attributes' => array(
+								'attributes'        => array(
 									'vault' => array(
 										'store_in_vault' => 'ON_SUCCESS',
 									),
@@ -191,7 +191,8 @@ class SavePaymentMethodsModule implements ModuleInterface {
 						$wc_payment_tokens->create_payment_token_paypal(
 							$wc_order->get_customer_id(),
 							$token_id,
-							$payment_source->properties()->email_address ?? ''
+							$payment_source->properties()->email_address ?? '',
+							$payment_source->name()
 						);
 					}
 				}

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -113,8 +113,9 @@ class SavePaymentMethodsModule implements ModuleInterface {
 							'venmo' => array(
 								'attributes' => array(
 									'vault' => array(
-										'store_in_vault' => 'ON_SUCCESS',
-										'usage_type'     => 'MERCHANT',
+										'store_in_vault'                 => 'ON_SUCCESS',
+										'usage_type'                     => 'MERCHANT',
+										'permit_multiple_payment_tokens' => true,
 									),
 								),
 							),
@@ -138,8 +139,9 @@ class SavePaymentMethodsModule implements ModuleInterface {
 							'paypal' => array(
 								'attributes' => array(
 									'vault' => array(
-										'store_in_vault' => 'ON_SUCCESS',
-										'usage_type'     => 'MERCHANT',
+										'store_in_vault'                 => 'ON_SUCCESS',
+										'usage_type'                     => 'MERCHANT',
+										'permit_multiple_payment_tokens' => true,
 									),
 								),
 							),

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -188,12 +188,29 @@ class SavePaymentMethodsModule implements ModuleInterface {
 					}
 
 					if ( $wc_order->get_payment_method() === PayPalGateway::ID ) {
-						$wc_payment_tokens->create_payment_token_paypal(
-							$wc_order->get_customer_id(),
-							$token_id,
-							$payment_source->properties()->email_address ?? '',
-							$payment_source->name()
-						);
+						switch ( $payment_source->name() ) {
+							case 'venmo':
+								$wc_payment_tokens->create_payment_token_venmo(
+									$wc_order->get_customer_id(),
+									$token_id,
+									$payment_source->properties()->email_address ?? ''
+								);
+								break;
+							case 'apple_pay':
+								$wc_payment_tokens->create_payment_token_applepay(
+									$wc_order->get_customer_id(),
+									$token_id
+								);
+								break;
+							case 'paypal':
+							default:
+								$wc_payment_tokens->create_payment_token_paypal(
+									$wc_order->get_customer_id(),
+									$token_id,
+									$payment_source->properties()->email_address ?? ''
+								);
+								break;
+						}
 					}
 				}
 			},

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -113,8 +113,8 @@ class SavePaymentMethodsModule implements ModuleInterface {
 							'venmo' => array(
 								'attributes' => array(
 									'vault' => array(
-										'store_in_vault'                 => 'ON_SUCCESS',
-										'usage_type'                     => 'MERCHANT',
+										'store_in_vault' => 'ON_SUCCESS',
+										'usage_type'     => 'MERCHANT',
 										'permit_multiple_payment_tokens' => true,
 									),
 								),
@@ -139,8 +139,8 @@ class SavePaymentMethodsModule implements ModuleInterface {
 							'paypal' => array(
 								'attributes' => array(
 									'vault' => array(
-										'store_in_vault'                 => 'ON_SUCCESS',
-										'usage_type'                     => 'MERCHANT',
+										'store_in_vault' => 'ON_SUCCESS',
+										'usage_type'     => 'MERCHANT',
 										'permit_multiple_payment_tokens' => true,
 									),
 								),

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -106,14 +106,29 @@ class SavePaymentMethodsModule implements ModuleInterface {
 				}
 
 				if ( $payment_method === PayPalGateway::ID ) {
+					$funding_source = $request_data['funding_source'] ?? null;
 
-					if ( $request_data['funding_source'] === 'venmo' ) {
+					if ( $funding_source === 'venmo' ) {
 						$data['payment_source'] = array(
 							'venmo' => array(
 								'attributes' => array(
 									'vault' => array(
 										'store_in_vault' => 'ON_SUCCESS',
 										'usage_type'     => 'MERCHANT',
+									),
+								),
+							),
+						);
+					} else if ( $funding_source === 'apple_pay' ) {
+						$data['payment_source'] = array(
+							'apple_pay' => array(
+								'stored_credential' => array(
+									'payment_initiator' => 'CUSTOMER',
+									'payment_type'      => 'RECURRING',
+								),
+								'attributes' => array(
+									'vault' => array(
+										'store_in_vault' => 'ON_SUCCESS',
 									),
 								),
 							),

--- a/modules/ppcp-save-payment-methods/src/WooCommercePaymentTokens.php
+++ b/modules/ppcp-save-payment-methods/src/WooCommercePaymentTokens.php
@@ -85,7 +85,13 @@ class WooCommercePaymentTokens {
 			return 0;
 		}
 
-		$payment_token_paypal = $this->payment_token_factory->create( 'paypal' );
+		// Try to update existing token of type before creating a new one.
+		$payment_token_paypal = $this->payment_token_helper->first_token_of_type( $wc_tokens, PaymentTokenPayPal::class );
+
+		if ( ! $payment_token_paypal ) {
+			$payment_token_paypal = $this->payment_token_factory->create( 'paypal' );
+		}
+
 		assert( $payment_token_paypal instanceof PaymentTokenPayPal );
 
 		$payment_token_paypal->set_token( $token );
@@ -127,7 +133,13 @@ class WooCommercePaymentTokens {
 			return 0;
 		}
 
-		$payment_token_venmo = $this->payment_token_factory->create( 'venmo' );
+		// Try to update existing token of type before creating a new one.
+		$payment_token_venmo = $this->payment_token_helper->first_token_of_type( $wc_tokens, PaymentTokenVenmo::class );
+
+		if ( ! $payment_token_venmo ) {
+			$payment_token_venmo = $this->payment_token_factory->create( 'venmo' );
+		}
+
 		assert( $payment_token_venmo instanceof PaymentTokenVenmo );
 
 		$payment_token_venmo->set_token( $token );
@@ -167,7 +179,13 @@ class WooCommercePaymentTokens {
 			return 0;
 		}
 
-		$payment_token_applepay = $this->payment_token_factory->create( 'apple_pay' );
+		// Try to update existing token of type before creating a new one.
+		$payment_token_applepay = $this->payment_token_helper->first_token_of_type( $wc_tokens, PaymentTokenApplePay::class );
+
+		if ( ! $payment_token_applepay ) {
+			$payment_token_applepay = $this->payment_token_factory->create( 'apple_pay' );
+		}
+
 		assert( $payment_token_applepay instanceof PaymentTokenApplePay );
 
 		$payment_token_applepay->set_token( $token );

--- a/modules/ppcp-save-payment-methods/src/WooCommercePaymentTokens.php
+++ b/modules/ppcp-save-payment-methods/src/WooCommercePaymentTokens.php
@@ -66,16 +66,18 @@ class WooCommercePaymentTokens {
 	/**
 	 * Creates a WC Payment Token for PayPal payment.
 	 *
-	 * @param int    $customer_id The WC customer ID.
-	 * @param string $token The PayPal payment token.
-	 * @param string $email The PayPal customer email.
+	 * @param int     $customer_id    The WC customer ID.
+	 * @param string  $token          The PayPal payment token.
+	 * @param string  $email          The PayPal customer email.
+	 * @param string $payment_source The funding source.
 	 *
 	 * @return int
 	 */
 	public function create_payment_token_paypal(
 		int $customer_id,
 		string $token,
-		string $email
+		string $email,
+		string $payment_source = ''
 	): int {
 
 		$wc_tokens = WC_Payment_Tokens::get_customer_tokens( $customer_id, PayPalGateway::ID );
@@ -92,6 +94,10 @@ class WooCommercePaymentTokens {
 
 		if ( $email && is_email( $email ) ) {
 			$payment_token_paypal->set_email( $email );
+		}
+
+		if ( $payment_source ) {
+			$payment_token_paypal->set_payment_source( $payment_source );
 		}
 
 		try {

--- a/modules/ppcp-save-payment-methods/src/WooCommercePaymentTokens.php
+++ b/modules/ppcp-save-payment-methods/src/WooCommercePaymentTokens.php
@@ -66,9 +66,9 @@ class WooCommercePaymentTokens {
 	/**
 	 * Creates a WC Payment Token for PayPal payment.
 	 *
-	 * @param int     $customer_id    The WC customer ID.
-	 * @param string  $token          The PayPal payment token.
-	 * @param string  $email          The PayPal customer email.
+	 * @param int    $customer_id    The WC customer ID.
+	 * @param string $token          The PayPal payment token.
+	 * @param string $email          The PayPal customer email.
 	 * @param string $payment_source The funding source.
 	 *
 	 * @return int

--- a/modules/ppcp-vaulting/src/PaymentTokenApplePay.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenApplePay.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * WooCommerce Payment token for ApplePay.
+ *
+ * @package WooCommerce\PayPalCommerce\Vaulting
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Vaulting;
+
+use WC_Payment_Token;
+
+/**
+ * Class PaymentTokenApplePay
+ */
+class PaymentTokenApplePay extends WC_Payment_Token {
+	/**
+	 * Token Type String.
+	 *
+	 * @var string
+	 */
+	protected $type = 'ApplePay';
+
+	/**
+	 * Extra data.
+	 *
+	 * @var string[]
+	 */
+	protected $extra_data = array();
+}

--- a/modules/ppcp-vaulting/src/PaymentTokenFactory.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenFactory.php
@@ -19,12 +19,16 @@ class PaymentTokenFactory {
 	 *
 	 * @param string $type The type of WC payment token.
 	 *
-	 * @return void|PaymentTokenPayPal
+	 * @return void|PaymentTokenPayPal|PaymentTokenVenmo|PaymentTokenApplePay
 	 */
 	public function create( string $type ) {
 		switch ( $type ) {
 			case 'paypal':
 				return new PaymentTokenPayPal();
+			case 'venmo':
+				return new PaymentTokenVenmo();
+			case 'apple_pay':
+				return new PaymentTokenApplePay();
 		}
 	}
 }

--- a/modules/ppcp-vaulting/src/PaymentTokenHelper.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenHelper.php
@@ -21,12 +21,19 @@ class PaymentTokenHelper {
 	 *
 	 * @param WC_Payment_Token[] $wc_tokens WC Payment Tokens.
 	 * @param string             $token_id Payment Token ID.
+	 * @param ?string            $class_name Class name of the token.
 	 * @return bool
 	 */
-	public function token_exist( array $wc_tokens, string $token_id ): bool {
+	public function token_exist( array $wc_tokens, string $token_id, string $class_name = null ): bool {
 		foreach ( $wc_tokens as $wc_token ) {
 			if ( $wc_token->get_token() === $token_id ) {
-				return true;
+				if ( null !== $class_name ) {
+					if ( $wc_token instanceof $class_name ) {
+						return true;
+					}
+				} else {
+					return true;
+				}
 			}
 		}
 

--- a/modules/ppcp-vaulting/src/PaymentTokenHelper.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenHelper.php
@@ -39,4 +39,21 @@ class PaymentTokenHelper {
 
 		return false;
 	}
+
+	/**
+	 * Checks if given token exist as WC Payment Token.
+	 *
+	 * @param array  $wc_tokens WC Payment Tokens.
+	 * @param string $class_name Class name of the token.
+	 * @return null|WC_Payment_Token
+	 */
+	public function first_token_of_type( array $wc_tokens, string $class_name ) {
+		foreach ( $wc_tokens as $wc_token ) {
+			if ( $wc_token instanceof $class_name ) {
+				return $wc_token;
+			}
+		}
+
+		return null;
+	}
 }

--- a/modules/ppcp-vaulting/src/PaymentTokenPayPal.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenPayPal.php
@@ -28,7 +28,8 @@ class PaymentTokenPayPal extends WC_Payment_Token {
 	 * @var string[]
 	 */
 	protected $extra_data = array(
-		'email' => '',
+		'email'          => '',
+		'payment_source' => '',
 	);
 
 	/**
@@ -47,5 +48,23 @@ class PaymentTokenPayPal extends WC_Payment_Token {
 	 */
 	public function set_email( $email ) {
 		$this->add_meta_data( 'email', $email, true );
+	}
+
+	/**
+	 * Get the payment source.
+	 *
+	 * @return string The payment source.
+	 */
+	public function get_payment_source() {
+		return $this->get_meta( 'payment_source' );
+	}
+
+	/**
+	 * Set the payment source.
+	 *
+	 * @param string $payment_source The payment source.
+	 */
+	public function set_payment_source( string $payment_source ) {
+		$this->add_meta_data( 'payment_source', $payment_source, true );
 	}
 }

--- a/modules/ppcp-vaulting/src/PaymentTokenVenmo.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenVenmo.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce Payment token for PayPal.
+ * WooCommerce Payment token for Venmo.
  *
  * @package WooCommerce\PayPalCommerce\Vaulting
  */
@@ -12,15 +12,15 @@ namespace WooCommerce\PayPalCommerce\Vaulting;
 use WC_Payment_Token;
 
 /**
- * Class PaymentTokenPayPal
+ * Class PaymentTokenVenmo
  */
-class PaymentTokenPayPal extends WC_Payment_Token {
+class PaymentTokenVenmo extends WC_Payment_Token {
 	/**
 	 * Token Type String.
 	 *
 	 * @var string
 	 */
-	protected $type = 'PayPal';
+	protected $type = 'Venmo';
 
 	/**
 	 * Extra data.

--- a/modules/ppcp-vaulting/src/PaymentTokensMigration.php
+++ b/modules/ppcp-vaulting/src/PaymentTokensMigration.php
@@ -107,7 +107,7 @@ class PaymentTokensMigration {
 				}
 			} elseif ( $token->source()->paypal ) {
 				$wc_tokens = WC_Payment_Tokens::get_customer_tokens( $id, PayPalGateway::ID );
-				if ( $this->payment_token_helper->token_exist( $wc_tokens, $token->id() ) ) {
+				if ( $this->payment_token_helper->token_exist( $wc_tokens, $token->id(), PaymentTokenPayPal::class ) ) {
 					$this->logger->info( 'Token already exist for user ' . (string) $id );
 					continue;
 				}

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -81,6 +81,12 @@ class VaultingModule implements ModuleInterface {
 				if ( $type === 'WC_Payment_Token_PayPal' ) {
 					return PaymentTokenPayPal::class;
 				}
+				if ( $type === 'WC_Payment_Token_Venmo' ) {
+					return PaymentTokenVenmo::class;
+				}
+				if ( $type === 'WC_Payment_Token_ApplePay' ) {
+					return PaymentTokenApplePay::class;
+				}
 
 				return $type;
 			}
@@ -102,10 +108,7 @@ class VaultingModule implements ModuleInterface {
 				// Exclude ApplePay tokens from payment pages.
 				if ( is_checkout() || is_cart() || is_product() ) {
 					foreach ( $tokens as $index => $token ) {
-						if (
-							$token instanceof PaymentTokenPayPal
-							&& $token->get_payment_source() === 'apple_pay'
-						) {
+						if ( $token instanceof PaymentTokenApplePay ) {
 							unset( $tokens[ $index ] );
 						}
 					}
@@ -129,24 +132,18 @@ class VaultingModule implements ModuleInterface {
 					return $item;
 				}
 
-				if ( strtolower( $payment_token->get_type() ) === 'paypal' ) {
-					assert( $payment_token instanceof PaymentTokenPayPal );
+				if ( $payment_token instanceof PaymentTokenPayPal ) {
+					$item['method']['brand'] = 'PayPal / ' . $payment_token->get_email();
+					return $item;
+				}
 
-					$email          = $payment_token->get_email();
-					$payment_source = $payment_token->get_payment_source();
-					$brand_parts    = array();
+				if ( $payment_token instanceof PaymentTokenVenmo ) {
+					$item['method']['brand'] = 'Venmo / ' . $payment_token->get_email();
+					return $item;
+				}
 
-					if ( $payment_source !== 'paypal' ) {
-						$brand_parts[] = ucwords( $payment_source );
-					}
-
-					if ( $email ) {
-						$brand_parts[] = $email;
-					} else {
-						$brand_parts[] = '#' . ( (string) $payment_token->get_id() );
-					}
-
-					$item['method']['brand'] = implode( ' / ', array_filter( $brand_parts ) );
+				if ( $payment_token instanceof PaymentTokenApplePay ) {
+					$item['method']['brand'] = 'ApplePay #' . ( (string) $payment_token->get_id() );
 					return $item;
 				}
 

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -105,8 +105,13 @@ class VaultingModule implements ModuleInterface {
 					return $tokens;
 				}
 
+				$is_post = isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST';
+
 				// Exclude ApplePay tokens from payment pages.
-				if ( is_checkout() || is_cart() || is_product() ) {
+				if (
+					( is_checkout() || is_cart() || is_product() )
+					&& ! $is_post // Don't check on POST so we have all payment methods on form submissions.
+				) {
 					foreach ( $tokens as $index => $token ) {
 						if ( $token instanceof PaymentTokenApplePay ) {
 							unset( $tokens[ $index ] );

--- a/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
+++ b/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
@@ -56,6 +56,8 @@ class FundingSourceRenderer {
 	 * @param string $id The ID of the funding source, such as 'venmo'.
 	 */
 	public function render_name( string $id ): string {
+		$id = $this->sanitize_id( $id );
+
 		if ( array_key_exists( $id, $this->funding_sources ) ) {
 			if ( in_array( $id, $this->own_funding_sources, true ) ) {
 				return $this->funding_sources[ $id ];
@@ -78,6 +80,8 @@ class FundingSourceRenderer {
 	 * @param string $id The ID of the funding source, such as 'venmo'.
 	 */
 	public function render_description( string $id ): string {
+		$id = $this->sanitize_id( $id );
+
 		if ( array_key_exists( $id, $this->funding_sources ) ) {
 			return sprintf(
 				/* translators: %s - Sofort, BLIK, iDeal, Mercado Pago, etc. */
@@ -89,5 +93,15 @@ class FundingSourceRenderer {
 		return $this->settings->has( 'description' ) ?
 			$this->settings->get( 'description' )
 			: __( 'Pay via PayPal.', 'woocommerce-paypal-payments' );
+	}
+
+	/**
+	 * Sanitizes the id to a standard format.
+	 *
+	 * @param string $id The funding source id.
+	 * @return string
+	 */
+	private function sanitize_id( string $id ): string {
+		return str_replace( '_', '', strtolower( $id ) );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -346,9 +346,10 @@ class SettingsListener {
 	/**
 	 * Prevent enabling both Pay Later messaging and PayPal vaulting
 	 *
+	 * @return void
 	 * @throws RuntimeException When API request fails.
 	 */
-	public function listen_for_vaulting_enabled() {
+	public function listen_for_vaulting_enabled(): void {
 		if ( ! $this->is_valid_site_request() || State::STATE_ONBOARDED !== $this->state->current_state() ) {
 			return;
 		}

--- a/modules/ppcp-wc-subscriptions/services.php
+++ b/modules/ppcp-wc-subscriptions/services.php
@@ -27,6 +27,7 @@ return array(
 		$environment           = $container->get( 'onboarding.environment' );
 		$settings                      = $container->get( 'wcgateway.settings' );
 		$authorized_payments_processor = $container->get( 'wcgateway.processor.authorized-payments' );
+		$funding_source_renderer       = $container->get( 'wcgateway.funding-source.renderer' );
 		return new RenewalHandler(
 			$logger,
 			$repository,
@@ -36,7 +37,8 @@ return array(
 			$payer_factory,
 			$environment,
 			$settings,
-			$authorized_payments_processor
+			$authorized_payments_processor,
+			$funding_source_renderer
 		);
 	},
 	'wc-subscriptions.repository.payment-token' => static function ( ContainerInterface $container ): PaymentTokenRepository {

--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -203,7 +203,7 @@ class RenewalHandler {
 		if ( $wc_order->get_payment_method() === PayPalGateway::ID ) {
 			$wc_tokens = WC_Payment_Tokens::get_customer_tokens( $wc_order->get_customer_id(), PayPalGateway::ID );
 			foreach ( $wc_tokens as $token ) {
-				$name = 'paypal';
+				$name       = 'paypal';
 				$properties = array(
 					'vault_id' => $token->get_token(),
 				);
@@ -215,7 +215,7 @@ class RenewalHandler {
 						$name = $payment_source_name;
 					}
 
-					// Add required stored_credentials for apple_pay
+					// Add required stored_credentials for apple_pay.
 					if ( $payment_source_name === 'apple_pay' ) {
 						$properties['stored_credential'] = array(
 							'payment_initiator' => 'MERCHANT',

--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -483,8 +483,8 @@ class RenewalHandler {
 	/**
 	 * Updates the payment source name to the one really used for the payment.
 	 *
-	 * @param PaymentSource $payment_source
-	 * @param \WC_Order $wc_order
+	 * @param PaymentSource $payment_source The Payment Source.
+	 * @param \WC_Order     $wc_order WC order.
 	 * @return void
 	 */
 	private function update_payment_source( PaymentSource $payment_source, \WC_Order $wc_order ): void {

--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -22,9 +22,11 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingPreferenceFactory;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenApplePay;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenPayPal;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenVenmo;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -209,20 +211,20 @@ class RenewalHandler {
 				);
 
 				if ( $token instanceof PaymentTokenPayPal ) {
-					$payment_source_name = $token->get_payment_source();
+					$name = 'paypal';
+				}
 
-					if ( $payment_source_name ) {
-						$name = $payment_source_name;
-					}
+				if ( $token instanceof PaymentTokenVenmo ) {
+					$name = 'venmo';
+				}
 
-					// Add required stored_credentials for apple_pay.
-					if ( $payment_source_name === 'apple_pay' ) {
-						$properties['stored_credential'] = array(
-							'payment_initiator' => 'MERCHANT',
-							'payment_type'      => 'RECURRING',
-							'usage'             => 'SUBSEQUENT',
-						);
-					}
+				if ( $token instanceof PaymentTokenApplePay ) {
+					$name                            = 'apple_pay';
+					$properties['stored_credential'] = array(
+						'payment_initiator' => 'MERCHANT',
+						'payment_type'      => 'RECURRING',
+						'usage'             => 'SUBSEQUENT',
+					);
 				}
 
 				$payment_source = new PaymentSource(

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -301,7 +301,7 @@ class WcSubscriptionsModule implements ModuleInterface {
 			foreach ( $tokens as $token ) {
 				$output     .= '<li>';
 					$output .= sprintf( '<input name="saved_paypal_payment" type="radio" value="%s" style="width:auto;" checked="checked">', $token->get_id() );
-					$output .= sprintf( '<label for="saved_paypal_payment">%s</label>', $token->get_meta( 'email' ) ?? '' );
+					$output .= sprintf( '<label for="saved_paypal_payment">%s / %s</label>', $token->get_type(), $token->get_meta( 'email' ) ?? '' );
 				$output     .= '</li>';
 			}
 			$output .= '</ul>';

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -111,6 +111,17 @@ class WcSubscriptionsModule implements ModuleInterface {
 							$subscription->update_meta_data( 'ppcp_previous_transaction_reference', $transaction_id );
 							$subscription->save();
 						}
+
+						// Update the initial payment method title if not the same as the first order.
+						$payment_method_title = $parent_order->get_payment_method_title();
+						if (
+							$payment_method_title
+							&& $subscription instanceof \WC_Subscription
+							&& $subscription->get_payment_method_title() !== $payment_method_title
+						) {
+							$subscription->set_payment_method_title( $payment_method_title );
+							$subscription->save();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
# PR Description
This PR adds support for `ApplePay` vaulting.

It ensures that `ApplePay` vaulted tokens, as per Apple policies, cannot be used to pay orders of returning users and only to renew subscriptions.

The PR refactors `ApplePay` and `Venmo` use their own dedicated payment token classes: `PaymentTokenVenmo`, PaymentTokenApplePay. This allows for better code interpretation and isolation.

`PayPal` and `Venmo` vaulting generate by default the same `vault.id`, which causes an issue where the token is only valid for the first payment_source that does a merchant initiated payment, and will fail if we try with the other `payment_source` (error: `MISMATCHED_VAULT_ID_TO_PAYMENT_SOURCE`).
To resolve this PayPal suggests setting the `permit_multiple_payment_tokens`=`true`.
This PR implements this suggestion so now a different `vault.id` is generated per vaulting request.
https://developer.paypal.com/docs/checkout/save-payment-methods/during-purchase/js-sdk/venmo/

# Issue Description
Add support for saving Apple Pay payment methods (when using Vault v3).

https://developer.paypal.com/docs/checkout/save-payment-methods/during-purchase/js-sdk/applepay/

Note: Apple Pay can't be used as a payment method for returning buyers, according to Apple guidelines.

This means saved Apple Pay payments will only be available as a payment method for subscription renewal payments, not for return-buyer checkouts.

We should ensure that buyers are not able to use a saved Apple Pay payment method for a return purchase on the Block Checkout, while still bing able to switch the payment method on existing subscriptions to the saved Apple Pay payment method.

Acceptance

**Given** a subscription product is in the cart (or on single product)
**When** using Apple Pay as a payment method
**Then** Apple Pay payment method gets saved 
**And** can be used only for subscription renewal payments