### PR TITLE
Check if the `$wpdb->wc_orders` exists before query (1976) 

### DIFF
--- a/modules/ppcp-compat/src/PPEC/PPECHelper.php
+++ b/modules/ppcp-compat/src/PPEC/PPECHelper.php
@@ -75,7 +75,7 @@ class PPECHelper {
 		}
 
 		global $wpdb;
-		if ( class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled() && isset( $wpdb->wc_orders ) ) {
 			$result = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT 1 FROM {$wpdb->wc_orders} WHERE payment_method = %s",


### PR DESCRIPTION
# Issue Description
There have been a few reports about the PPEC Subscription migration-related warning after 2.2.2 update.
```
[Thu Aug 31 15:15:41.170453 2023] [proxy_fcgi:error] [pid 18742:tid 140601475438336] [client 157.55.39.215:0] AH01071: Got error ‘
PHP message: PHP Warning:  Undefined property: wpdb::$wc_orders in public_html/wp-includes/class-wpdb.php on line 789
PHP message: WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ‘WHERE payment_method = ‘ppec_paypal” at line 1 for query SELECT 1 FROM  WHERE payment_method = ‘ppec_paypal’
made by require(‘wp-blog-header.php’), require_once(‘wp-load.php’), require_once(‘wp-config.php’), require_once(‘wp-settings.php’), do_action(‘plugins_loaded’), WP_Hook->do_action, WP_Hook->apply_filters, WooCommerce\\PayPalCommerce\\{closure}, WooCommerce\\PayPalCommerce\\init, {closure}, WooCommerce\\PayPalCommerce\\Compat\\CompatModule->run, WooCommerce\\PayPalCommerce\\Compat\\CompatModule->initialize_ppec_compat_layer, WooCommerce\\PayPalCommerce\\Compat\\PPEC\\SubscriptionsHandler->maybe_hook, WooCommerce\\PayPalCommerce\\Compat\\PPEC\\PPECHelper::use_ppec_compat_layer_for_subscriptions, WooCommerce\\PayPalCommerce\\Compat\\PPEC\\PPECHelper::site_has_ppec_subscriptions’
```
Was able to reproduce on fresh install, when activating the plugin for the first time.

### Here is why it happens

1. When installing the plugin for the first time [this value](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L72) returns `(bool) false `
2. This `if` [statement](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L73) is `false` so the code continues.
3. The `$wpdb->wc_orders` property doesn’t exist (I guess because is empty) so the warning is thrown
4. The query becomes `SELECT 1 FROM  WHERE payment_method = ‘ppec_paypal’ `→ the message about syntax error in query is thrown
5. Code reaches to [this](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L98) line where the `$result`  is `null`
6. We set the `'ppcp_has_ppec_subscriptions'` transient to `(string) 'false'` and return `false` as a result of `site_has_ppec_subscriptions` method 

### Why does this happen only once?

Because during the first time we we set the `'ppcp_has_ppec_subscriptions'` transient to `(string) 'false' `, therefore when we refresh the page again:

1. [this value](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L72) returns `(string) 'false'`
2. This `if` [statement](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L73) is `true` ( `if ( 'false' !== false ) { `) so the code enter into the body of it.
3. Then it just return `false` as a result of `site_has_ppec_subscriptions` method and exit [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L74) ( `return 'false' === 'true';` ).

### Why does this happen only when activating the plugin for the first time?

Because during the first time we we set the `‘ppcp_has_ppec_subscriptions'` transient to `(string) 'false'`and we don’t remove this transient during the plugin uninstall, therefore when we install the page again:

1. [this value](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L72) returns `(string) 'false'`
2. This `if` [statement](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L73) is `true` ( `if ( 'false' !== false ) { `) so the code enter into the body of it.
3. Then it just return `false` as a result of `site_has_ppec_subscriptions` method and exit [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L74) ( `return 'false' === 'true';` ).

# PR Description

The solution of the problem is to add the `isset($wpdb->wc_orders)` to [this](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a477770256004f90253931c13f48f391b333708b/modules/ppcp-compat/src/PPEC/PPECHelper.php#L78) `if`