### PR TITLE
Can not refund order purchased with Vault v3 Card payment (2610)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -368,8 +368,9 @@ return array(
 		$order_endpoint      = $container->get( 'api.endpoint.order' );
 		$payments_endpoint   = $container->get( 'api.endpoint.payments' );
 		$refund_fees_updater = $container->get( 'wcgateway.helper.refund-fees-updater' );
+		$prefix           = $container->get( 'api.prefix' );
 		$logger              = $container->get( 'woocommerce.logger.woocommerce' );
-		return new RefundProcessor( $order_endpoint, $payments_endpoint, $refund_fees_updater, $logger );
+		return new RefundProcessor( $order_endpoint, $payments_endpoint, $refund_fees_updater, $prefix, $logger );
 	},
 	'wcgateway.processor.authorized-payments'              => static function ( ContainerInterface $container ): AuthorizedPaymentsProcessor {
 		$order_endpoint    = $container->get( 'api.endpoint.order' );

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -369,6 +369,9 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$saved_payment_card = WC()->session->get( 'ppcp_saved_payment_card' );
 		if ( $saved_payment_card ) {
 			if ( $saved_payment_card['payment_source'] === 'card' && $saved_payment_card['status'] === 'COMPLETED' ) {
+				$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $saved_payment_card['order_id'] );
+				$wc_order->save_meta_data();
+
 				$this->update_transaction_id( $saved_payment_card['order_id'], $wc_order );
 				$wc_order->payment_complete();
 				WC()->session->set( 'ppcp_saved_payment_card', null );

--- a/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
@@ -57,6 +57,13 @@ class RefundProcessor {
 	private $logger;
 
 	/**
+	 * The prefix.
+	 *
+	 * @var string
+	 */
+	private $prefix;
+
+	/**
 	 * The refund fees updater.
 	 *
 	 * @var RefundFeesUpdater
@@ -69,13 +76,21 @@ class RefundProcessor {
 	 * @param OrderEndpoint     $order_endpoint The order endpoint.
 	 * @param PaymentsEndpoint  $payments_endpoint The payments endpoint.
 	 * @param RefundFeesUpdater $refund_fees_updater The refund fees updater.
+	 * @param string            $prefix The prefix.
 	 * @param LoggerInterface   $logger The logger.
 	 */
-	public function __construct( OrderEndpoint $order_endpoint, PaymentsEndpoint $payments_endpoint, RefundFeesUpdater $refund_fees_updater, LoggerInterface $logger ) {
+	public function __construct(
+		OrderEndpoint $order_endpoint,
+		PaymentsEndpoint $payments_endpoint,
+		RefundFeesUpdater $refund_fees_updater,
+		string $prefix,
+		LoggerInterface $logger
+	) {
 
 		$this->order_endpoint      = $order_endpoint;
 		$this->payments_endpoint   = $payments_endpoint;
 		$this->refund_fees_updater = $refund_fees_updater;
+		$this->prefix              = $prefix;
 		$this->logger              = $logger;
 	}
 
@@ -164,7 +179,7 @@ class RefundProcessor {
 		$capture = $captures[0];
 		$refund  = new RefundCapture(
 			$capture,
-			$capture->invoice_id(),
+			$capture->invoice_id() ?: $this->prefix . $wc_order->get_order_number(),
 			$reason,
 			new Amount(
 				new Money( $amount, $wc_order->get_currency() )


### PR DESCRIPTION
When using Advanced Card payment with Vault v3 we are creating the PayPal order before WC order is created and therefore there is no WC order id for updating `invoice_id` in the PayPal order before it's completed.

This PR ensures that `invoice_id` is sent when refunding orders created with Advanced Card payment. 

### Steps to reproduce
- Purchase a product with Advanced Card payment with Vault v3 enabled.
- Try to refund the order.

