### PR TITLE
2.5.2-rc2 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 2.5.2 - xxxx-xx-xx =
 * Fix - NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE error for merchants without reference transactions #1984
 * Fix - Fatal error in WooCommerce PayPal Payments plugin after 2.5.0 update #1985
+* Fix - Can not refund order purchased with Vault v3 Card payment #1997
 * Enhancement - Add setup URL for reference transactions #1964
 * Enhancement - Improve PUI performance for variable products #1950
 

--- a/readme.txt
+++ b/readme.txt
@@ -182,6 +182,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 = 2.5.2 - xxxx-xx-xx =
 * Fix - NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE error for merchants without reference transactions #1984
 * Fix - Fatal error in WooCommerce PayPal Payments plugin after 2.5.0 update #1985
+* Fix - Can not refund order purchased with Vault v3 Card payment #1997
 * Enhancement - Add setup URL for reference transactions #1964
 * Enhancement - Improve PUI performance for variable products #1950
 


### PR DESCRIPTION
[2.5.2-r1](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.5.2-rc1) plus:
 * Fix - Can not refund order purchased with Vault v3 Card payment #1997