### PR TITLE
PayPal Vaulting Subscriptions mode setting visible when merchant not enabled for Reference Transactions (2069)

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\SavePaymentMethods;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
@@ -57,6 +58,16 @@ class SavePaymentMethodsModule implements ModuleInterface {
 
 		$settings = $c->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
+
+		$billing_agreements_endpoint = $c->get( 'api.endpoint.billing-agreements' );
+		assert( $billing_agreements_endpoint instanceof BillingAgreementsEndpoint );
+
+		$reference_transaction_enabled = $billing_agreements_endpoint->reference_transaction_enabled();
+		if ( $reference_transaction_enabled !== true ) {
+			$settings->set( 'vault_enabled', false );
+			$settings->persist();
+		}
+
 		if (
 			( ! $settings->has( 'vault_enabled' ) || ! $settings->get( 'vault_enabled' ) )
 			&& ( ! $settings->has( 'vault_enabled_dcc' ) || ! $settings->get( 'vault_enabled_dcc' ) )

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -62,11 +62,13 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		$billing_agreements_endpoint = $c->get( 'api.endpoint.billing-agreements' );
 		assert( $billing_agreements_endpoint instanceof BillingAgreementsEndpoint );
 
-		$reference_transaction_enabled = $billing_agreements_endpoint->reference_transaction_enabled();
-		if ( $reference_transaction_enabled !== true ) {
-			$settings->set( 'vault_enabled', false );
-			$settings->persist();
-		}
+		add_action( 'woocommerce_paypal_payments_gateway_migrate_on_update', function() use($settings, $billing_agreements_endpoint) {
+			$reference_transaction_enabled = $billing_agreements_endpoint->reference_transaction_enabled();
+			if ( $reference_transaction_enabled !== true ) {
+				$settings->set( 'vault_enabled', false );
+				$settings->persist();
+			}
+		});
 
 		if (
 			( ! $settings->has( 'vault_enabled' ) || ! $settings->get( 'vault_enabled' ) )

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -62,13 +62,16 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		$billing_agreements_endpoint = $c->get( 'api.endpoint.billing-agreements' );
 		assert( $billing_agreements_endpoint instanceof BillingAgreementsEndpoint );
 
-		add_action( 'woocommerce_paypal_payments_gateway_migrate_on_update', function() use($settings, $billing_agreements_endpoint) {
-			$reference_transaction_enabled = $billing_agreements_endpoint->reference_transaction_enabled();
-			if ( $reference_transaction_enabled !== true ) {
-				$settings->set( 'vault_enabled', false );
-				$settings->persist();
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate_on_update',
+			function() use ( $settings, $billing_agreements_endpoint ) {
+				$reference_transaction_enabled = $billing_agreements_endpoint->reference_transaction_enabled();
+				if ( $reference_transaction_enabled !== true ) {
+					$settings->set( 'vault_enabled', false );
+					$settings->persist();
+				}
 			}
-		});
+		);
 
 		if (
 			( ! $settings->has( 'vault_enabled' ) || ! $settings->get( 'vault_enabled' ) )

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -421,6 +421,18 @@ return array(
 	},
 
 	'wcgateway.settings.fields.subscriptions_mode'         => static function ( ContainerInterface $container ): array {
+		$subscription_mode_options = array(
+			'vaulting_api'                 => __( 'PayPal Vaulting', 'woocommerce-paypal-payments' ),
+			'subscriptions_api'            => __( 'PayPal Subscriptions', 'woocommerce-paypal-payments' ),
+			'disable_paypal_subscriptions' => __( 'Disable PayPal for subscriptions', 'woocommerce-paypal-payments' ),
+		);
+
+		$billing_agreements_endpoint = $container->get( 'api.endpoint.billing-agreements' );
+		$reference_transaction_enabled = $billing_agreements_endpoint->reference_transaction_enabled();
+		if ( $reference_transaction_enabled !== true ) {
+			unset( $subscription_mode_options['vaulting_api'] );
+		}
+
 		return array(
 			'title'        => __( 'Subscriptions Mode', 'woocommerce-paypal-payments' ),
 			'type'         => 'select',
@@ -429,11 +441,7 @@ return array(
 			'desc_tip'     => true,
 			'description'  => __( 'Utilize PayPal Vaulting for flexible subscription processing with saved payment methods, create “PayPal Subscriptions” to bill customers at regular intervals, or disable PayPal for subscription-type products.', 'woocommerce-paypal-payments' ),
 			'default'      => 'vaulting_api',
-			'options'      => array(
-				'vaulting_api'                 => __( 'PayPal Vaulting', 'woocommerce-paypal-payments' ),
-				'subscriptions_api'            => __( 'PayPal Subscriptions', 'woocommerce-paypal-payments' ),
-				'disable_paypal_subscriptions' => __( 'Disable PayPal for subscriptions', 'woocommerce-paypal-payments' ),
-			),
+			'options'      => $subscription_mode_options,
 			'screens'      => array(
 				State::STATE_ONBOARDED,
 			),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -333,6 +333,7 @@ return array(
 			$container->get( 'http.redirector' ),
 			$container->get( 'api.partner_merchant_id-production' ),
 			$container->get( 'api.partner_merchant_id-sandbox' ),
+			$container->get( 'api.endpoint.billing-agreements' ),
 			$logger
 		);
 	},

--- a/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
+++ b/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
@@ -2,8 +2,10 @@
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
+use Psr\Log\LoggerInterface;
 use Requests_Utility_CaseInsensitiveDictionary;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\Helper\RedirectorStub;
 use WooCommerce\PayPalCommerce\Helper\StubRedirectionException;
@@ -12,7 +14,6 @@ use WooCommerce\PayPalCommerce\Onboarding\State;
 use Mockery;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
-use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
 class SettingsListenerTest extends ModularTestCase
@@ -40,6 +41,8 @@ class SettingsListenerTest extends ModularTestCase
 		$signup_link_ids = array();
         $pui_status_cache = Mockery::mock(Cache::class);
         $dcc_status_cache = Mockery::mock(Cache::class);
+		$billing_agreement_endpoint = Mockery::mock(BillingAgreementsEndpoint::class);
+		$logger = Mockery::mock(LoggerInterface::class);
 
 		$testee = new SettingsListener(
 			$settings,
@@ -55,7 +58,9 @@ class SettingsListenerTest extends ModularTestCase
             $dcc_status_cache,
 			new RedirectorStub(),
 			'',
-			''
+			'',
+			$billing_agreement_endpoint,
+			$logger
 		);
 
 		$_GET['section'] = PayPalGateway::ID;


### PR DESCRIPTION
When the connected merchant is not enabled for Reference Transactions, the PayPal Vaulting option is visible and the default selection. It should be hidden from the Subscriptions Mode dropdown when Reference Transactions are not available.

![image-20230922-163933](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/da4351ad-6c49-4bc3-81dd-3d970cd255c9)

### Steps To Reproduce
- enable WooCommerce Subscriptions plugin
- disconnect all connected accounts
- connect a PayPal account without Reference Transactions
- Subscriptions Mode setting defaults to PayPal Vaulting

### Expected behaviour
The PayPal Vaulting option should not be available in the Subscriptions Mode dropdown when the merchant is not enabled for Reference Transactions (or when the Vaulting checkbox is hidden).