### PR TITLE
Release 2.5.2-rc3

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE error for merchants without reference transactions #1984
 * Fix - Fatal error in WooCommerce PayPal Payments plugin after 2.5.0 update #1985
 * Fix - Can not refund order purchased with Vault v3 Card payment #1997
+* Fix - PayPal Vaulting Subscriptions mode setting visible when merchant not enabled for Reference Transactions #1999
 * Enhancement - Add setup URL for reference transactions #1964
 * Enhancement - Improve PUI performance for variable products #1950
 

--- a/readme.txt
+++ b/readme.txt
@@ -183,6 +183,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE error for merchants without reference transactions #1984
 * Fix - Fatal error in WooCommerce PayPal Payments plugin after 2.5.0 update #1985
 * Fix - Can not refund order purchased with Vault v3 Card payment #1997
+* Fix - PayPal Vaulting Subscriptions mode setting visible when merchant not enabled for Reference Transactions #1999
 * Enhancement - Add setup URL for reference transactions #1964
 * Enhancement - Improve PUI performance for variable products #1950
 


### PR DESCRIPTION
[2.5.2-rc2](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.5.2-rc2) plus:
* Fix - PayPal Vaulting Subscriptions mode setting visible when merchant not enabled for Reference Transactions #1999