### PR TITLE
card-fields parameter included in button script despite Advanced Card Processing disabled

### DIFF
--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -39,6 +39,12 @@ class CardFieldsModule implements ModuleInterface {
 			return;
 		}
 
+		$settings = $c->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+		if ( ! $settings->has( 'dcc_enabled' ) || ! $settings->get( 'dcc_enabled' ) ) {
+			return;
+		}
+
 		/**
 		 * Param types removed to avoid third-party issues.
 		 *


### PR DESCRIPTION
Following 2.5.2 update, US merchants no longer see the Standard Card Button in the PayPal gateway. It happens when the WC store location is set to US, the plugin always sends the `card-fields` parameter in the button script. The button does appear when it is split into a separate gateway.

This PR fixes the issue by ensuring  `card-fields` component is not added if Advanced Card payment is not enabled.

### Steps To Reproduce
- set store to US
- enable card button in PayPal gateway
- visit checkout
- observe standard card button not present
- observe card-fields parameter is present in button script
- change store location to non-US country
- observe standard card button is present
- observe card-fields parameter is not present in button script

### Expected behaviour
The card-fields parameter should only be sent when Advanced Card Processing gateway is enabled.