### PR TITLE
Pay by link - Germany - PayPal buttons are not visible on Pay for order page (2588, 2591)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -346,9 +346,10 @@ class SettingsListener {
 	/**
 	 * Prevent enabling both Pay Later messaging and PayPal vaulting
 	 *
+	 * @return void
 	 * @throws RuntimeException When API request fails.
 	 */
-	public function listen_for_vaulting_enabled() {
+	public function listen_for_vaulting_enabled(): void {
 		if ( ! $this->is_valid_site_request() || State::STATE_ONBOARDED !== $this->state->current_state() ) {
 			return;
 		}

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -168,7 +168,8 @@ class WcSubscriptionsModule implements ModuleInterface {
 					return $methods;
 				}
 
-				if ( ! is_wc_endpoint_url( 'order-pay' ) ) {
+				//phpcs:disable WordPress.Security.NonceVerification.Recommended
+				if ( ! ( isset( $_GET['change_payment_method'] ) && is_wc_endpoint_url( 'order-pay' ) ) ) {
 					return $methods;
 				}
 


### PR DESCRIPTION
# PR Descriptions
This PR addresses both (2588 and 2591) issues.

A condition was added to the `WcSubscriptions` Module to only unset available gateways on the `change_payment_method` (which was the original intent) and not on every `order-pay` page.

# Issue Description

## Pay by link - Germany - PayPal buttons are not visible on Pay for order page (2588)
PayPal buttons are not displayed on Pay for order page (Customer payment page) neither for registered customer nor for guest

**Steps To Reproduce**

1. Login as admin and connect German merchant
2. Create order for a registered customer
3. On frontend, login to the shop as a registered customer
4. Navigate to Customer payment page

**Expected behaviour**

PayPal gateway buttons should be visible on Customer payment page for both registered customer and guest

- PayPal buttons are visible on other pages
- The behavior was correct in previous PCP version 2.4.3
- WP Debugging plugin is ON - should eliminate localization issues

## Pay by link - ACDC - Germany - Debit & Credit Cards tab is not displayed (2591)

Debit & Credit Cards tab is not displayed on Pay for order page (Customer payment page) neither for registered customer nor for guest

**Steps To Reproduce**

1. Login as admin and connect German merchant
2. Enable Advanced Card Processing
3. Create order for a guest or registered customer
4. On frontend, login to the shop as a guest or registered customer
5. Navigate to Customer payment page

**Expected behaviour**

Debit & Credit Cards tab should be displayed on Pay for order page (Customer payment page) for both registered customer and guest

- Debit & Credit Cards tab is visible on other pages
- The behavior was correct in previous PCP version 2.4.3
- WP Debugging plugin is ON - should eliminate localization issues