### PR TITLE
Cannot enable Apple Pay when API credentials were manually created (2626)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/SellerStatus.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatus.php
@@ -22,18 +22,36 @@ class SellerStatus {
 	private $products;
 
 	/**
+	 * The capabilities.
+	 *
+	 * @var SellerStatusCapability[]
+	 */
+	private $capabilities;
+
+	/**
 	 * SellerStatus constructor.
 	 *
-	 * @param SellerStatusProduct[] $products The products.
+	 * @param SellerStatusProduct[]    $products The products.
+	 * @param SellerStatusCapability[] $capabilities The capabilities.
+	 *
+	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
-	public function __construct( array $products ) {
+	public function __construct( array $products, array $capabilities ) {
 		foreach ( $products as $key => $product ) {
 			if ( is_a( $product, SellerStatusProduct::class ) ) {
 				continue;
 			}
 			unset( $products[ $key ] );
 		}
-		$this->products = $products;
+		foreach ( $capabilities as $key => $capability ) {
+			if ( is_a( $capability, SellerStatusCapability::class ) ) {
+				continue;
+			}
+			unset( $capabilities[ $key ] );
+		}
+
+		$this->products     = $products;
+		$this->capabilities = $capabilities;
 	}
 
 	/**
@@ -43,6 +61,15 @@ class SellerStatus {
 	 */
 	public function products() : array {
 		return $this->products;
+	}
+
+	/**
+	 * Returns the capabilities.
+	 *
+	 * @return SellerStatusCapability[]
+	 */
+	public function capabilities() : array {
+		return $this->capabilities;
 	}
 
 	/**
@@ -58,8 +85,16 @@ class SellerStatus {
 			$this->products()
 		);
 
+		$capabilities = array_map(
+			function( SellerStatusCapability $capability ) : array {
+				return $capability->to_array();
+			},
+			$this->capabilities()
+		);
+
 		return array(
-			'products' => $products,
+			'products'     => $products,
+			'capabilities' => $capabilities,
 		);
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/SellerStatusCapability.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatusCapability.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * The capabilities of a seller status.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Entity
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
+
+/**
+ * Class SellerStatusCapability
+ */
+class SellerStatusCapability {
+
+	const STATUS_ACTIVE = 'ACTIVE';
+
+	/**
+	 * The name of the product.
+	 *
+	 * @var string
+	 */
+	private $name;
+
+	/**
+	 * The status of the capability.
+	 *
+	 * @var string
+	 */
+	private $status;
+
+	/**
+	 * SellerStatusCapability constructor.
+	 *
+	 * @param string $name   The name of the product.
+	 * @param string $status The status of the capability.
+	 */
+	public function __construct(
+		string $name,
+		string $status
+	) {
+		$this->name   = $name;
+		$this->status = $status;
+	}
+
+	/**
+	 * Returns the name of the product.
+	 *
+	 * @return string
+	 */
+	public function name() : string {
+		return $this->name;
+	}
+
+	/**
+	 * Returns the status for this capability.
+	 *
+	 * @return string
+	 */
+	public function status() : string {
+		return $this->status;
+	}
+
+	/**
+	 * Returns the entity as array.
+	 *
+	 * @return array
+	 */
+	public function to_array() : array {
+		return array(
+			'name'   => $this->name(),
+			'status' => $this->status(),
+		);
+	}
+
+}

--- a/modules/ppcp-api-client/src/Factory/SellerStatusFactory.php
+++ b/modules/ppcp-api-client/src/Factory/SellerStatusFactory.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusProduct;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusCapability;
 
 /**
  * Class SellerStatusFactory
@@ -37,6 +38,17 @@ class SellerStatusFactory {
 			isset( $json->products ) ? (array) $json->products : array()
 		);
 
-		return new SellerStatus( $products );
+		$capabilities = array_map(
+			function( $json ) : SellerStatusCapability {
+				$capability = new SellerStatusCapability(
+					isset( $json->name ) ? (string) $json->name : '',
+					isset( $json->status ) ? (string) $json->status : ''
+				);
+				return $capability;
+			},
+			isset( $json->capabilities ) ? (array) $json->capabilities : array()
+		);
+
+		return new SellerStatus( $products, $capabilities );
 	}
 }

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\Applepay\Assets\BlocksPaymentMethod;
 use WooCommerce\PayPalCommerce\Applepay\Assets\PropertiesDictionary;
 use WooCommerce\PayPalCommerce\Applepay\Helper\ApmApplies;
 use WooCommerce\PayPalCommerce\Applepay\Helper\AvailabilityNotice;
+use WooCommerce\PayPalCommerce\Common\Pattern\SingletonDecorator;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -72,14 +73,16 @@ return array(
 		return $settings->has( 'applepay_validated' ) ? $settings->get( 'applepay_validated' ) === true : false;
 	},
 
-	'applepay.apple-product-status'              => static function( ContainerInterface $container ): AppleProductStatus {
-		return new AppleProductStatus(
-			$container->get( 'wcgateway.settings' ),
-			$container->get( 'api.endpoint.partners' ),
-			$container->get( 'onboarding.state' ),
-			$container->get( 'api.helper.failure-registry' )
-		);
-	},
+	'applepay.apple-product-status'              => SingletonDecorator::make(
+		static function( ContainerInterface $container ): AppleProductStatus {
+			return new AppleProductStatus(
+				$container->get( 'wcgateway.settings' ),
+				$container->get( 'api.endpoint.partners' ),
+				$container->get( 'onboarding.state' ),
+				$container->get( 'api.helper.failure-registry' )
+			);
+		}
+	),
 	'applepay.available'                         => static function ( ContainerInterface $container ): bool {
 		if ( apply_filters( 'woocommerce_paypal_payments_applepay_validate_product_status', true ) ) {
 			$status = $container->get( 'applepay.apple-product-status' );

--- a/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
+++ b/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
@@ -100,6 +100,11 @@ class AppleProductStatus {
 			return false;
 		}
 
+		$status_override = apply_filters( 'woocommerce_paypal_payments_apple_pay_product_status', null );
+		if ( null !== $status_override ) {
+			return $status_override;
+		}
+
 		// If status was already checked on this request return the same result.
 		if ( null !== $this->current_status ) {
 			return $this->current_status;

--- a/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
+++ b/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Applepay\Assets;
 
 use Throwable;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusCapability;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
@@ -133,19 +134,30 @@ class AppleProductStatus {
 		}
 
 		// Check the seller status for the intended capability.
+		$has_capability = false;
 		foreach ( $seller_status->products() as $product ) {
 			if ( $product->name() !== 'PAYMENT_METHODS' ) {
 				continue;
 			}
 
 			if ( in_array( self::CAPABILITY_NAME, $product->capabilities(), true ) ) {
-				// Capability found, persist status and return true.
-				$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-				$this->settings->persist();
-
-				$this->current_status = true;
-				return $this->current_status;
+				$has_capability = true;
 			}
+		}
+
+		foreach ( $seller_status->capabilities() as $capability ) {
+			if ( $capability->name() === self::CAPABILITY_NAME && $capability->status() === SellerStatusCapability::STATUS_ACTIVE ) {
+				$has_capability = true;
+			}
+		}
+
+		if ( $has_capability ) {
+			// Capability found, persist status and return true.
+			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
+			$this->settings->persist();
+
+			$this->current_status = true;
+			return $this->current_status;
 		}
 
 		// Capability not found, persist status and return false.

--- a/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
@@ -100,6 +100,11 @@ class ApmProductStatus {
 			return false;
 		}
 
+		$status_override = apply_filters( 'woocommerce_paypal_payments_google_pay_product_status', null );
+		if ( null !== $status_override ) {
+			return $status_override;
+		}
+
 		// If status was already checked on this request return the same result.
 		if ( null !== $this->current_status ) {
 			return $this->current_status;

--- a/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Googlepay\Helper;
 
 use Throwable;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusCapability;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
@@ -133,19 +134,30 @@ class ApmProductStatus {
 		}
 
 		// Check the seller status for the intended capability.
+		$has_capability = false;
 		foreach ( $seller_status->products() as $product ) {
 			if ( $product->name() !== 'PAYMENT_METHODS' ) {
 				continue;
 			}
 
 			if ( in_array( self::CAPABILITY_NAME, $product->capabilities(), true ) ) {
-				// Capability found, persist status and return true.
-				$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-				$this->settings->persist();
-
-				$this->current_status = true;
-				return $this->current_status;
+				$has_capability = true;
 			}
+		}
+
+		foreach ( $seller_status->capabilities() as $capability ) {
+			if ( $capability->name() === self::CAPABILITY_NAME && $capability->status() === SellerStatusCapability::STATUS_ACTIVE ) {
+				$has_capability = true;
+			}
+		}
+
+		if ( $has_capability ) {
+			// Capability found, persist status and return true.
+			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
+			$this->settings->persist();
+
+			$this->current_status = true;
+			return $this->current_status;
 		}
 
 		// Capability not found, persist status and return false.

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -346,9 +346,10 @@ class SettingsListener {
 	/**
 	 * Prevent enabling both Pay Later messaging and PayPal vaulting
 	 *
+	 * @return void
 	 * @throws RuntimeException When API request fails.
 	 */
-	public function listen_for_vaulting_enabled() {
+	public function listen_for_vaulting_enabled(): void {
 		if ( ! $this->is_valid_site_request() || State::STATE_ONBOARDED !== $this->state->current_state() ) {
 			return;
 		}


### PR DESCRIPTION
# PR Description
This PR fixes an issue where multiple instances of `AppleProductStatus` could cause inconsistent states. It also introduces a filter to override the product status (for Apple Pay & Google Pay)

# Issue Description
- Apple Pay cannot be enabled when the merchant-integrations call fails (e.g. due to manually created API credentials)
- live merchant who is enabled for Apple Pay but for some reason cannot enable it
   - can either disconnect and connect manually created credentials
   - or apply a filter to override the product status

