### PR TITLE
Disable PayPal Vaulting setting instead of hiding it when Reference Transactions not available (2616)

### DIFF
--- a/modules/ppcp-onboarding/resources/js/settings.js
+++ b/modules/ppcp-onboarding/resources/js/settings.js
@@ -359,6 +359,20 @@ document.addEventListener(
             );
         }
 
+        const referenceTransactionsCheck = () => {
+            if (
+                typeof PayPalCommerceGatewaySettings !== 'undefined'
+                && PayPalCommerceGatewaySettings.reference_transaction_enabled !== '1'
+            ) {
+                document.getElementById('ppcp-vault_enabled')?.setAttribute('disabled', 'disabled');
+
+                const description = document.getElementById('field-vault_enabled')?.getElementsByClassName('description')[0];
+                if (description) {
+                    description.innerHTML = PayPalCommerceGatewaySettings.vaulting_must_enable_advance_wallet_message;
+                }
+            }
+        }
+
         (() => {
             removeDisabledCardIcons('select[name="ppcp[disable_cards][]"]', 'select[name="ppcp[card_icons][]"]');
 
@@ -408,6 +422,8 @@ document.addEventListener(
             );
 
             togglePayLaterMessageFields();
+
+            referenceTransactionsCheck()
         })();
     }
 )

--- a/modules/ppcp-onboarding/resources/js/settings.js
+++ b/modules/ppcp-onboarding/resources/js/settings.js
@@ -368,7 +368,7 @@ document.addEventListener(
 
                 const description = document.getElementById('field-vault_enabled')?.getElementsByClassName('description')[0];
                 if (description) {
-                    description.innerHTML = PayPalCommerceGatewaySettings.vaulting_must_enable_advance_wallet_message;
+                    description.innerHTML = PayPalCommerceGatewaySettings.vaulting_must_enable_advanced_wallet_message;
                 }
             }
         }

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -910,11 +910,6 @@ return array(
 			unset( $fields['subscriptions_mode'] );
 		}
 
-		$billing_agreements_endpoint = $container->get( 'api.endpoint.billing-agreements' );
-		if ( ! $billing_agreements_endpoint->reference_transaction_enabled() ) {
-			unset( $fields['vault_enabled'] );
-		}
-
 		/**
 		 * Depending on your store location, some credit cards can't be used.
 		 * Here, we filter them out.

--- a/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
@@ -261,7 +261,7 @@ class SettingsPageAssets {
 						),
 					),
 					'reference_transaction_enabled'  => $this->billing_agreements_endpoint->reference_transaction_enabled(),
-					'vaulting_must_enable_advance_wallet_message' => sprintf(
+					'vaulting_must_enable_advanced_wallet_message' => sprintf(
 						// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
 						esc_html__( 'Your PayPal account must be enabled for the %1$sAdvanced PayPal Wallet%2$s to use PayPal Vaulting.', 'woocommerce-paypal-payments' ),
 						'<a href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#field-credentials_feature_onboarding_heading">',

--- a/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
@@ -9,12 +9,12 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use WooCommerce\PayPalCommerce\Webhooks\Endpoint\ResubscribeEndpoint;
 
 /**
  * Class SettingsPageAssets
@@ -106,20 +106,28 @@ class SettingsPageAssets {
 	private $is_acdc_enabled;
 
 	/**
+	 * Billing Agreements endpoint.
+	 *
+	 * @var BillingAgreementsEndpoint
+	 */
+	private $billing_agreements_endpoint;
+
+	/**
 	 * Assets constructor.
 	 *
-	 * @param string             $module_url The url of this module.
-	 * @param string             $version                            The assets version.
-	 * @param SubscriptionHelper $subscription_helper The subscription helper.
-	 * @param string             $client_id The PayPal SDK client ID.
-	 * @param string             $currency 3-letter currency code of the shop.
-	 * @param string             $country 2-letter country code of the shop.
-	 * @param Environment        $environment The environment object.
-	 * @param bool               $is_pay_later_button_enabled Whether Pay Later button is enabled either for checkout, cart or product page.
-	 * @param array              $disabled_sources The list of disabled funding sources.
-	 * @param array              $all_funding_sources The list of all existing funding sources.
-	 * @param bool               $is_settings_page Whether it's a settings page of this plugin.
-	 * @param bool               $is_acdc_enabled Whether the ACDC gateway is enabled.
+	 * @param string                    $module_url The url of this module.
+	 * @param string                    $version                            The assets version.
+	 * @param SubscriptionHelper        $subscription_helper The subscription helper.
+	 * @param string                    $client_id The PayPal SDK client ID.
+	 * @param string                    $currency 3-letter currency code of the shop.
+	 * @param string                    $country 2-letter country code of the shop.
+	 * @param Environment               $environment The environment object.
+	 * @param bool                      $is_pay_later_button_enabled Whether Pay Later button is enabled either for checkout, cart or product page.
+	 * @param array                     $disabled_sources The list of disabled funding sources.
+	 * @param array                     $all_funding_sources The list of all existing funding sources.
+	 * @param bool                      $is_settings_page Whether it's a settings page of this plugin.
+	 * @param bool                      $is_acdc_enabled Whether the ACDC gateway is enabled.
+	 * @param BillingAgreementsEndpoint $billing_agreements_endpoint Billing Agreements endpoint.
 	 */
 	public function __construct(
 		string $module_url,
@@ -133,7 +141,8 @@ class SettingsPageAssets {
 		array $disabled_sources,
 		array $all_funding_sources,
 		bool $is_settings_page,
-		bool $is_acdc_enabled
+		bool $is_acdc_enabled,
+		BillingAgreementsEndpoint $billing_agreements_endpoint
 	) {
 		$this->module_url                  = $module_url;
 		$this->version                     = $version;
@@ -147,6 +156,7 @@ class SettingsPageAssets {
 		$this->all_funding_sources         = $all_funding_sources;
 		$this->is_settings_page            = $is_settings_page;
 		$this->is_acdc_enabled             = $is_acdc_enabled;
+		$this->billing_agreements_endpoint = $billing_agreements_endpoint;
 	}
 
 	/**
@@ -249,6 +259,13 @@ class SettingsPageAssets {
 								'success' => __( 'Feature status refreshed.', 'woocommerce-paypal-payments' ),
 							),
 						),
+					),
+					'reference_transaction_enabled'  => $this->billing_agreements_endpoint->reference_transaction_enabled(),
+					'vaulting_must_enable_advance_wallet_message' => sprintf(
+						// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
+						esc_html__( 'Your PayPal account must be enabled for the %1$sAdvanced PayPal Wallet%2$s to use PayPal Vaulting.', 'woocommerce-paypal-payments' ),
+						'<a href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#field-credentials_feature_onboarding_heading">',
+						'</a>'
 					),
 				)
 			)

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -381,6 +381,11 @@ class SettingsListener {
 
 		$reference_transaction_enabled = $this->billing_agreements_endpoint->reference_transaction_enabled();
 
+		if ( $reference_transaction_enabled !== true ) {
+			$this->settings->set( 'vault_enabled', false );
+			$this->settings->persist();
+		}
+
 		if ( $subscription_mode === 'vaulting_api' && $vault_enabled !== '1' && $reference_transaction_enabled === true ) {
 			$this->settings->set( 'vault_enabled', true );
 			$this->settings->persist();

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -181,7 +181,8 @@ class WCGatewayModule implements ModuleInterface {
 				$settings->has( 'disable_funding' ) ? $settings->get( 'disable_funding' ) : array(),
 				$c->get( 'wcgateway.settings.funding-sources' ),
 				$c->get( 'wcgateway.is-ppcp-settings-page' ),
-				$settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' )
+				$settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' ),
+				$c->get( 'api.endpoint.billing-agreements' )
 			);
 			$assets->register_assets();
 		}

--- a/tests/PHPUnit/WcGateway/Assets/SettingsPagesAssetsTest.php
+++ b/tests/PHPUnit/WcGateway/Assets/SettingsPagesAssetsTest.php
@@ -3,6 +3,7 @@
 namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\TestCase;
@@ -16,6 +17,8 @@ class SettingsPagesAssetsTest extends TestCase
 		$moduleUrl = 'http://example.com/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway';
 		$modulePath = '/var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway';
 		$subscriptionsHelper = Mockery::mock(SubscriptionHelper::class);
+		$billingAgreementEndpoint = Mockery::mock(BillingAgreementsEndpoint::class);
+
 
 		$testee = new SettingsPageAssets(
 		    $moduleUrl,
@@ -29,7 +32,8 @@ class SettingsPagesAssetsTest extends TestCase
             array(),
             array(),
 			true,
-			false
+			false,
+			$billingAgreementEndpoint
 		);
 
 		when('is_admin')


### PR DESCRIPTION
Currently, when the connected merchant is not eligible for Reference Transactions, the PayPal Vaulting checkbox will simply be hidden in the Standard Payments tab.

This can lead to the following scenario:
- user connects sandbox account (with Reference Transactions)
- user enables PayPal Vaulting in Standard Payments tab
- user connects live account (without Reference Transactions)
- checkbox for PayPal Vaulting in Standard Payments tab is hidden but still active

live payments on the site fail with `NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE` error until PayPal Vaulting was disabled.

When a user saves the settings in the Standard Payments tab while the currently connected account is not enabled for Reference Transactions, we must ensure the PayPal Vaulting checkbox is unchecked and that the setting is visible, but greyed out.

This PR unchecks PayPal Vaulting setting when loading the page while the current marchant is not eligible for Reference Transactions. It also grey out the PayPal Vaulting setting with this text while not eligible for Reference Transactions:

> Your PayPal account must be enabled for the Advanced PayPal Wallet to use PayPal Vaulting.

"Advanced PayPal Wallet" links to `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#field-credentials_feature_onboarding_heading`