### PR TITLE
Prepare the SKU for sending to PayPal (2666)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -66,7 +66,7 @@ class ItemFactory {
 					$quantity,
 					$this->prepare_description( $product->get_description() ),
 					null,
-					$product->get_sku(),
+					$this->prepare_sku( $product->get_sku() ),
 					( $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
 					$product->get_permalink(),
 					$image[0] ?? '',
@@ -143,7 +143,7 @@ class ItemFactory {
 			$quantity,
 			$product instanceof WC_Product ? $this->prepare_description( $product->get_description() ) : '',
 			null,
-			$product instanceof WC_Product ? $product->get_sku() : '',
+			$product instanceof WC_Product ? $this->prepare_sku( $product->get_sku() ) : '',
 			( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
 			$product instanceof WC_Product ? $product->get_permalink() : '',
 			$image[0] ?? ''

--- a/modules/ppcp-api-client/src/Helper/ItemTrait.php
+++ b/modules/ppcp-api-client/src/Helper/ItemTrait.php
@@ -21,4 +21,14 @@ trait ItemTrait {
 		$description = strip_shortcodes( wp_strip_all_tags( $description ) );
 		return substr( $description, 0, 127 ) ?: '';
 	}
+
+	/**
+	 * Prepares the sku for sending to PayPal.
+	 *
+	 * @param string $sku Item sku.
+	 * @return string
+	 */
+	protected function prepare_sku( string $sku ): string {
+		return substr( wp_strip_all_tags( $sku ), 0, 127 ) ?: '';
+	}
 }

--- a/modules/ppcp-order-tracking/src/Shipment/Shipment.php
+++ b/modules/ppcp-order-tracking/src/Shipment/Shipment.php
@@ -14,12 +14,15 @@ use WC_Order_Item_Product;
 use WC_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ItemTrait;
 use WooCommerce\PayPalCommerce\OrderTracking\OrderTrackingModule;
 
 /**
  * Class Shipment
  */
 class Shipment implements ShipmentInterface {
+
+	use ItemTrait;
 
 	/**
 	 * The WC order ID.
@@ -171,7 +174,7 @@ class Shipment implements ShipmentInterface {
 				$quantity,
 				$this->prepare_description( $product->get_description() ),
 				null,
-				$product->get_sku(),
+				$this->prepare_sku( $product->get_sku() ),
 				$product->is_virtual() ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
 				$product->get_permalink(),
 				$image[0] ?? ''
@@ -237,17 +240,6 @@ class Shipment implements ShipmentInterface {
 		}
 
 		return $shipment;
-	}
-
-	/**
-	 * Cleanups the description and prepares it for sending to PayPal.
-	 *
-	 * @param string $description Item description.
-	 * @return string
-	 */
-	protected function prepare_description( string $description ): string {
-		$description = strip_shortcodes( wp_strip_all_tags( $description ) );
-		return substr( $description, 0, 127 ) ?: '';
 	}
 
 	/**


### PR DESCRIPTION
# PR Description
This PR fixes an issue when the product SKU exceeds the 127 characters.
The fix is applied also for the shipments.

# Issue Description
The SKU cannot exceed 127 characters. When sending a longer SKU, it results in an `INVALID_STRING_LENGTH` error.

