### PR TITLE
Add more checks to prevent "PayPal order ID not found" errors

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -196,7 +196,7 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $actions, $subscription ): array {
+			function( $actions, $subscription = null ): array {
 				if ( ! is_array( $actions ) || ! is_a( $subscription, WC_Subscription::class ) ) {
 					return $actions;
 				}

--- a/modules/ppcp-saved-payment-checker/src/PaymentTokenChecker.php
+++ b/modules/ppcp-saved-payment-checker/src/PaymentTokenChecker.php
@@ -126,6 +126,10 @@ class PaymentTokenChecker {
 			return;
 		}
 
+		if ( ! in_array( $wc_order->get_payment_method(), array( PayPalGateway::ID, CreditCardGateway::ID, CardButtonGateway::ID ), true ) ) {
+			return;
+		}
+
 		if ( $wc_order->get_status() === 'processing' || 'capture' !== $intent ) {
 			return;
 		}

--- a/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
@@ -22,6 +22,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\RefundCapture;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\RefundFeesUpdater;
 
@@ -107,6 +109,10 @@ class RefundProcessor {
 	 */
 	public function process( WC_Order $wc_order, float $amount = null, string $reason = '' ) : bool {
 		try {
+			if ( ! in_array( $wc_order->get_payment_method(), array( PayPalGateway::ID, CreditCardGateway::ID, CardButtonGateway::ID ), true ) ) {
+				return true;
+			}
+
 			$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
 			if ( ! $order_id ) {
 				throw new RuntimeException( 'PayPal order ID not found in meta.' );


### PR DESCRIPTION
The plugin logic should only run for our PayPal orders. We should probably add more safeguards here:
- https://github.com/woocommerce/woocommerce-paypal-payments/blob/53c2c96b8c32cd363814cf035f0a377002fbeb94/modules/ppcp-api-client/src/Repository/OrderRepository.php#L49
- https://github.com/woocommerce/woocommerce-paypal-payments/blob/53c2c96b8c32cd363814cf035f0a377002fbeb94/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php#L112

Also fix: https://wordpress.org/support/topic/fatal-error-when-used-with-automatewoo/