### PR TITLE
"Proceed to PayPal" button displayed for Free trial PayPal Subscription products when payment token is saved (2641)

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/FreeTrialHandlerTrait.php
+++ b/modules/ppcp-wc-subscriptions/src/FreeTrialHandlerTrait.php
@@ -36,7 +36,11 @@ trait FreeTrialHandlerTrait {
 
 		foreach ( $cart->get_cart() as $item ) {
 			$product = $item['data'] ?? null;
-			if ( $product && WC_Subscriptions_Product::is_subscription( $product ) ) {
+			if (
+				$product
+				&& WC_Subscriptions_Product::is_subscription( $product )
+				&& ! $product->get_meta( 'ppcp_subscription_plan' )
+			) {
 				return true;
 			}
 		}


### PR DESCRIPTION
This PR ensures free trial flow is not executed when cart includes PayPal Subscriptions products.

### Steps To Reproduce
- Set Subscription  mode to PayPal subscription and enable Vaulting
- Set up free trial subscription product & connect it with PayPal
- Navigate to shop and add this free trial subscription to cart
- Navigate to checkout page
- Select PayPal gateway

Observe Proceed to PayPal button: 
![Screenshot 2024-02-05 at 16 33 47](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/9e137715-8244-416c-a51d-b115503f9c21)

![Screenshot 2024-02-05 at 16 31 09](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/6c571b10-5f0d-4e8b-bccd-97aa6c58ca84)



