### PR TITLE
Disable messaging configurator when vault is enabled (2672)

### DIFF
--- a/modules/ppcp-paylater-configurator/extensions.php
+++ b/modules/ppcp-paylater-configurator/extensions.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\PayLaterConfigurator;
 
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 return array(
 	'wcgateway.settings.fields' => function ( ContainerInterface $container, array $fields ): array {
@@ -63,8 +64,16 @@ return array(
 			'pay_later_home_message_flex_color',
 			'pay_later_home_message_flex_ratio',
 			'pay_later_home_message_preview',
-			'pay_later_messaging_enabled',
 		);
+
+		$settings = $container->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+		$vault_enabled = $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' );
+
+		if ( ! $vault_enabled ) {
+			$old_fields[] = 'pay_later_messaging_enabled';
+		}
+
 		foreach ( $old_fields as $old_field ) {
 			unset( $fields[ $old_field ] );
 		}

--- a/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
+++ b/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
@@ -50,7 +50,12 @@ class PayLaterConfiguratorModule implements ModuleInterface {
 		$messages_apply = $c->get( 'button.helper.messages-apply' );
 		assert( $messages_apply instanceof MessagesApply );
 
-		if ( ! $messages_apply->for_country() ) {
+		$settings = $c->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+
+		$vault_enabled = $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' );
+
+		if ( $vault_enabled || ! $messages_apply->for_country() ) {
 			return;
 		}
 
@@ -68,9 +73,6 @@ class PayLaterConfiguratorModule implements ModuleInterface {
 		if ( $current_page_id !== Settings::PAY_LATER_TAB_ID ) {
 			return;
 		}
-
-		$settings = $c->get( 'wcgateway.settings' );
-		assert( $settings instanceof Settings );
 
 		add_action(
 			'init',


### PR DESCRIPTION
# PR Description
This PR will disable the messaging configurator when the vaulting is enabled and will show the old "enable/disable" checkbox with "disabled" attribute and message.

# Issue Description
Right now the configurator still lets users configure messaging when PayPal Vaulting is active. We must prevent the configurator from loading and unset all messaging locations when PayPal Vaulting is active to ensure that messaging does not load while PayPal Vaulting is active.

