### PR TITLE
ACDC payments with new credit card may fail when debugging is enabled (JSON malformed by warning) (2466)

### DIFF
--- a/modules/ppcp-button/src/Helper/ThreeDSecure.php
+++ b/modules/ppcp-button/src/Helper/ThreeDSecure.php
@@ -67,10 +67,10 @@ class ThreeDSecure {
 			return self::NO_DECISION;
 		}
 
-		if ( ! $payment_source->properties()->brand ?? '' ) {
+		if ( ! ( $payment_source->properties()->brand ?? '' ) ) {
 			return self::NO_DECISION;
 		}
-		if ( ! $payment_source->properties()->authentication_result ?? '' ) {
+		if ( ! ( $payment_source->properties()->authentication_result ?? '' ) ) {
 			return self::NO_DECISION;
 		}
 


### PR DESCRIPTION
# PR Description
This PR fixes a potential warning in ThreeDSecure on PHP8+

# Issue Description
Steps To Reproduce
1. Enable debugging
2. Navigate to shop
3. Add product to cart
4. Navigate to checkout page
5. Select acdc gateway
6. Enter credit card details (do not use saved payment)
7. Click on button Place order