### PR TITLE
Improve the messaging configurator styles (2692)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -872,6 +872,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 		$text_color    = $this->settings->has( "{$setting_name_prefix}_color" ) ? $this->settings->get( "{$setting_name_prefix}_color" ) : 'black';
 		$style_color   = $this->settings->has( "{$setting_name_prefix}_flex_color" ) ? $this->settings->get( "{$setting_name_prefix}_flex_color" ) : 'blue';
 		$ratio         = $this->settings->has( "{$setting_name_prefix}_flex_ratio" ) ? $this->settings->get( "{$setting_name_prefix}_flex_ratio" ) : '1x1';
+		$text_size     = $this->settings->has( "{$setting_name_prefix}_text_size" ) ? $this->settings->get( "{$setting_name_prefix}_text_size" ) : '12';
 
 		return array(
 			'wrapper'   => '#ppcp-messages',
@@ -889,6 +890,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 				),
 				'text'   => array(
 					'color' => $text_color,
+					'size'  => $text_size,
 				),
 				'color'  => $style_color,
 				'ratio'  => $ratio,

--- a/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
+++ b/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
@@ -26,5 +26,17 @@
 		line-height: 1.5;
 		color: #3c434a;
 		font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+
+		a {
+			font-size: 14px;
+		}
+	}
+
+	.css-dpyjrq-text_body, .css-dpyjrq-text_body a {
+		font-size: 14px;
+	}
+
+	button.css-104jwuk {
+		background: none;
 	}
 }

--- a/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
+++ b/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
@@ -39,6 +39,10 @@
 	button.css-104jwuk {
 		background: none;
 	}
+
+	.css-1yo2lxy-text_body_strong, span.css-16jt5za-text_body, span.css-1yo2lxy-text_body_strong, span {
+		font-size: 14px;
+	}
 }
 
 #field-pay_later_messaging_heading h3{

--- a/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
+++ b/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
@@ -40,3 +40,7 @@
 		background: none;
 	}
 }
+
+#field-pay_later_messaging_heading h3{
+	margin-bottom: 0px;
+}

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -1,10 +1,18 @@
 document.addEventListener( 'DOMContentLoaded', () => {
     const form = document.querySelector('#mainform');
     const table = form.querySelector('.form-table');
+    const headingRow = table.querySelector('#field-pay_later_messaging_heading');
     const saveChangesButton = form.querySelector('.woocommerce-save-button');
     const publishButtonClassName = PcpPayLaterConfigurator.publishButtonClassName;
 
-    table.insertAdjacentHTML('afterend', '<div id="messaging-configurator"></div>');
+    const tempContainer = document.createElement('div');
+    tempContainer.innerHTML = `<div id='messaging-configurator'></div>`;
+
+    // Get the new row element from the container
+    const newRow = tempContainer.firstChild;
+
+    // Insert the new row after the headingRow
+    headingRow.parentNode.insertBefore(newRow, headingRow.nextSibling);
 
 
     saveChangesButton.addEventListener('click', () => {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -396,13 +396,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		}
 
 		if ( $this->is_pay_later_tab() ) {
-			return sprintf(
-			// translators: %1$s is </ br> HTML tag and %2$s, %3$s are the opening and closing of HTML <i> tag.
-				__( 'Let customers pay over time while you get paid up front — at no additional cost.%1$sPayPal’s pay later options are boosting merchant conversion rates and increasing cart sizes by 39%%. %2$s(PayPal Q2 Earnings-2021.)%3$s', 'woocommerce-paypal-payments' ),
-				'</ br>',
-				'<i>',
-				'</ i>'
-			);
+			return '';
 		}
 
 		if ( is_admin() ) {

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/pay-later-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/pay-later-tab-fields.php
@@ -51,13 +51,6 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'screens'      => array( State::STATE_ONBOARDED ),
 			'requirements' => array( 'messages' ),
 			'gateway'      => Settings::PAY_LATER_TAB_ID,
-			'description'  => sprintf(
-			// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
-				__( 'When enabled, %1$sPayPal Pay Later messaging%2$s is displayed for eligible customers.%3$sCustomers automatically see the most relevant Pay Later offering.', 'woocommerce-paypal-payments' ),
-				'<a href="https://woocommerce.com/document/woocommerce-paypal-payments/#pay-later-messaging" target="_blank">',
-				'</a>',
-				'</ br>'
-			),
 		),
 		'pay_later_messaging_enabled'                     => array(
 			'title'        => __( 'Enable/Disable', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/pay-later-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/pay-later-tab-fields.php
@@ -44,51 +44,6 @@ return function ( ContainerInterface $container, array $fields ): array {
 	};
 
 	$pay_later_fields = array(
-		'pay_later_button_heading'                        => array(
-			'heading'      => __( 'Pay Later Button', 'woocommerce-paypal-payments' ),
-			'type'         => 'ppcp-heading',
-			'screens'      => array( State::STATE_ONBOARDED ),
-			'requirements' => array( 'messages' ),
-			'gateway'      => Settings::PAY_LATER_TAB_ID,
-			'description'  => sprintf(
-			// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
-				__( 'When enabled, a %1$sPay Later button%2$s is displayed for eligible customers.%3$sPayPal buttons must be enabled to display the Pay Later button.', 'woocommerce-paypal-payments' ),
-				'<a href="https://woocommerce.com/document/woocommerce-paypal-payments/#pay-later-buttons" target="_blank">',
-				'</a>',
-				'</ br>'
-			),
-		),
-		'pay_later_button_enabled'                        => array(
-			'title'        => __( 'Enable/Disable', 'woocommerce-paypal-payments' ),
-			'type'         => 'checkbox',
-			'label'        => esc_html( $pay_later_messaging_enabled_label ),
-			'default'      => true,
-			'screens'      => array( State::STATE_ONBOARDED ),
-			'requirements' => array( 'messages' ),
-			'gateway'      => Settings::PAY_LATER_TAB_ID,
-			'input_class'  => $vault_enabled ? array( 'ppcp-disabled-checkbox' ) : array(),
-		),
-		'pay_later_button_locations'                      => array(
-			'title'        => __( 'Pay Later Button Locations', 'woocommerce-paypal-payments' ),
-			'type'         => 'ppcp-multiselect',
-			'class'        => array(),
-			'input_class'  => array( 'wc-enhanced-select' ),
-			'default'      => $container->get( 'wcgateway.settings.pay-later.default-button-locations' ),
-			'desc_tip'     => false,
-			'description'  => __( 'Select where the Pay Later button should be displayed.', 'woocommerce-paypal-payments' ),
-			'options'      => $container->get( 'wcgateway.settings.pay-later.button-locations' ),
-			'screens'      => array( State::STATE_ONBOARDED ),
-			'requirements' => array( 'messages' ),
-			'gateway'      => Settings::PAY_LATER_TAB_ID,
-		),
-		'pay_later_button_preview'                        => array(
-			'type'         => 'ppcp-text',
-			'text'         => $render_preview_element( 'ppcpPayLaterButtonPreview', 'button', $button_message ),
-			'screens'      => array( State::STATE_ONBOARDED ),
-			'requirements' => array( 'messages' ),
-			'gateway'      => Settings::PAY_LATER_TAB_ID,
-		),
-
 		// Messaging.
 		'pay_later_messaging_heading'                     => array(
 			'heading'      => __( 'Pay Later Messaging', 'woocommerce-paypal-payments' ),
@@ -867,6 +822,50 @@ return function ( ContainerInterface $container, array $fields ): array {
 		'pay_later_home_message_preview'                  => array(
 			'type'         => 'ppcp-text',
 			'text'         => $render_preview_element( 'ppcpHomeMessagePreview', 'message', $messaging_message ),
+			'screens'      => array( State::STATE_ONBOARDED ),
+			'requirements' => array( 'messages' ),
+			'gateway'      => Settings::PAY_LATER_TAB_ID,
+		),
+		'pay_later_button_heading'                        => array(
+			'heading'      => __( 'Pay Later Button', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-heading',
+			'screens'      => array( State::STATE_ONBOARDED ),
+			'requirements' => array( 'messages' ),
+			'gateway'      => Settings::PAY_LATER_TAB_ID,
+			'description'  => sprintf(
+			// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
+				__( 'When enabled, a %1$sPay Later button%2$s is displayed for eligible customers.%3$sPayPal buttons must be enabled to display the Pay Later button.', 'woocommerce-paypal-payments' ),
+				'<a href="https://woocommerce.com/document/woocommerce-paypal-payments/#pay-later-buttons" target="_blank">',
+				'</a>',
+				'</ br>'
+			),
+		),
+		'pay_later_button_enabled'                        => array(
+			'title'        => __( 'Enable/Disable', 'woocommerce-paypal-payments' ),
+			'type'         => 'checkbox',
+			'label'        => esc_html( $pay_later_messaging_enabled_label ),
+			'default'      => true,
+			'screens'      => array( State::STATE_ONBOARDED ),
+			'requirements' => array( 'messages' ),
+			'gateway'      => Settings::PAY_LATER_TAB_ID,
+			'input_class'  => $vault_enabled ? array( 'ppcp-disabled-checkbox' ) : array(),
+		),
+		'pay_later_button_locations'                      => array(
+			'title'        => __( 'Pay Later Button Locations', 'woocommerce-paypal-payments' ),
+			'type'         => 'ppcp-multiselect',
+			'class'        => array(),
+			'input_class'  => array( 'wc-enhanced-select' ),
+			'default'      => $container->get( 'wcgateway.settings.pay-later.default-button-locations' ),
+			'desc_tip'     => false,
+			'description'  => __( 'Select where the Pay Later button should be displayed.', 'woocommerce-paypal-payments' ),
+			'options'      => $container->get( 'wcgateway.settings.pay-later.button-locations' ),
+			'screens'      => array( State::STATE_ONBOARDED ),
+			'requirements' => array( 'messages' ),
+			'gateway'      => Settings::PAY_LATER_TAB_ID,
+		),
+		'pay_later_button_preview'                        => array(
+			'type'         => 'ppcp-text',
+			'text'         => $render_preview_element( 'ppcpPayLaterButtonPreview', 'button', $button_message ),
 			'screens'      => array( State::STATE_ONBOARDED ),
 			'requirements' => array( 'messages' ),
 			'gateway'      => Settings::PAY_LATER_TAB_ID,


### PR DESCRIPTION
# PR Description
The PR will add the following changes:

- Standardize font sizes, including placement names and inputs
- Remove suggested text messages
- Improve styles as suggested, including moving the configurator on top of the page
- Add support for the "Text Size" config.

# Issue Description

Based on PayPal feedback we have to do the following changes

1. **Standardize font sizes** in the configurator- seems like there is some css impacting font size- e.g., ‘[More about Pay Later](https://www.paypal.com/us/business/accept-payments/checkout/installments)’ link seems large, same with ‘Need more help? [Go to the developer docs](https://developer.paypal.com/docs/checkout/pay-later/us/commerce-platforms/)’ and the page placement names (see integration doc for desired ux)
2. Please **remove the preexisting “Pay Later Messaging…When enabled…relevant Pay Later offering.” header and subheader**- replace this header by displaying the one from the configurator (will be localized and future proof)
3. **Remove highlight/background color** from “Reset to our recommendations” link
4. **Move the Pay Later messaging section/configurator to top of the page**, above the button section. This way, value prop/description from the configurator and page header will be at the top and apply to the whole page
So the order of items will be:
- Heading: **PayPal Pay Later**
   - Subheading: original text removed
- Heading: **Pay Later Messaging**
   - Subheading: original text removed
   - Messaging Configurator
- Heading: **Pay Later Button**
   - Pay Later Button config

5.  We must add support for the Text Size setting as this was previously not provided.