### PR TITLE
Ensure PayPal Vaulting is not selected as Subscriptions Mode when Reference Transactions are disabled (2671)

### DIFF
--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -78,6 +78,8 @@ class StatusReportModule implements ModuleInterface {
 
 				$had_ppec_plugin = PPECHelper::is_plugin_configured();
 
+				$subscription_mode_options = $c->get( 'wcgateway.settings.fields.subscriptions_mode_options' );
+
 				$items = array(
 					array(
 						'label'          => esc_html__( 'Onboarded', 'woocommerce-paypal-payments' ),
@@ -169,7 +171,7 @@ class StatusReportModule implements ModuleInterface {
 						'description'    => esc_html__( 'Whether subscriptions are active and their mode.', 'woocommerce-paypal-payments' ),
 						'value'          => $this->subscriptions_mode_text(
 							$subscription_helper->plugin_is_active(),
-							$settings->has( 'subscriptions_mode' ) ? (string) $settings->get( 'subscriptions_mode' ) : '',
+							$settings->has( 'subscriptions_mode' ) ? (string) $subscription_mode_options[ $settings->get( 'subscriptions_mode' ) ] : '',
 							$subscriptions_mode_settings
 						),
 					),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -404,7 +404,6 @@ return array(
 	'wcgateway.admin.fees-renderer'                        => static function ( ContainerInterface $container ): FeesRenderer {
 		return new FeesRenderer();
 	},
-
 	'wcgateway.settings.should-render-settings'            => static function ( ContainerInterface $container ): bool {
 
 		$sections = array(
@@ -419,13 +418,15 @@ return array(
 
 		return array_key_exists( $current_page_id, $sections );
 	},
-
-	'wcgateway.settings.fields.subscriptions_mode'         => static function ( ContainerInterface $container ): array {
-		$subscription_mode_options = array(
+	'wcgateway.settings.fields.subscriptions_mode_options' => static function ( ContainerInterface $container ): array {
+		return array(
 			'vaulting_api'                 => __( 'PayPal Vaulting', 'woocommerce-paypal-payments' ),
 			'subscriptions_api'            => __( 'PayPal Subscriptions', 'woocommerce-paypal-payments' ),
 			'disable_paypal_subscriptions' => __( 'Disable PayPal for subscriptions', 'woocommerce-paypal-payments' ),
 		);
+	},
+	'wcgateway.settings.fields.subscriptions_mode'         => static function ( ContainerInterface $container ): array {
+		$subscription_mode_options = $container->get( 'wcgateway.settings.fields.subscriptions_mode_options' );
 
 		$billing_agreements_endpoint = $container->get( 'api.endpoint.billing-agreements' );
 		$reference_transaction_enabled = $billing_agreements_endpoint->reference_transaction_enabled();
@@ -440,7 +441,7 @@ return array(
 			'input_class'  => array( 'wc-enhanced-select' ),
 			'desc_tip'     => true,
 			'description'  => __( 'Utilize PayPal Vaulting for flexible subscription processing with saved payment methods, create “PayPal Subscriptions” to bill customers at regular intervals, or disable PayPal for subscription-type products.', 'woocommerce-paypal-payments' ),
-			'default'      => 'vaulting_api',
+			'default'      => array_key_first( $subscription_mode_options ),
 			'options'      => $subscription_mode_options,
 			'screens'      => array(
 				State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -383,6 +383,7 @@ class SettingsListener {
 
 		if ( $reference_transaction_enabled !== true ) {
 			$this->settings->set( 'vault_enabled', false );
+			$this->settings->set( 'subscriptions_mode', 'subscriptions_api' );
 			$this->settings->persist();
 		}
 


### PR DESCRIPTION
This PR ensures that subscription mode is setup as PayPal Subscriptions (`subscriptions_api`) when reference transactions is not available.

### Steps to reproduce
- connect live account without Reference Transactions (e.g. your developer account)
- connect sandbox account and set it active
- set Subscriptions Mode to PayPal Vaulting and save
- in system report, you can now see Subscriptions Mode - PayPal Vaulting
- switch to the live account in Connection tab
- in system report, you can now see Subscriptions Mode - vaulting_api
- when viewing Standard Payments tab, Subscriptions Mode appears to be set to PayPal Subscriptions
- but the option to connect a subscription product to PayPal only appears after the user once saved the settings
- because the settings are still saved with PayPal Vaulting despite the setting being hidden and disabled programmatically