### PR TITLE
"Must pass createSubscription with intent=subscription" error with PayPal Subscriptions mode (2169)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -948,7 +948,10 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 	 * @return bool
 	 */
 	private function has_subscriptions(): bool {
-		if ( ! $this->subscription_helper->accept_only_automatic_payment_gateways() ) {
+		if (
+			! $this->subscription_helper->accept_only_automatic_payment_gateways()
+			&& $this->paypal_subscriptions_enabled() !== true
+		) {
 			return false;
 		}
 		if ( is_product() ) {


### PR DESCRIPTION
When trying to complete a subscription the PayPal button on the checkout page continually loads without proceeding further. This issue affects simple and variable subscriptions that are linked with PayPal Subscriptions.

This PR ensure PayPal subscriptions products are exclude from only automatic payments conditional.

### Steps To Reproduce
- Navigate to WooCommerce > Settings  > Subscriptions
- Enable “Accept Manual Renewals” checkbox
- Create linked PayPal Subscription product
- Add the subscription product to the cart
- Proceed to the checkout page

