### PR TITLE
reauthorize authorized payments (2143)

### DIFF
--- a/modules/ppcp-admin-notices/src/AdminNotices.php
+++ b/modules/ppcp-admin-notices/src/AdminNotices.php
@@ -45,7 +45,19 @@ class AdminNotices implements ModuleInterface {
 
 		add_action(
 			Repository::NOTICES_FILTER,
+			/**
+			 * Adds persisted notices to the notices array.
+			 *
+			 * @param array $notices The notices.
+			 * @return array
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
 			function ( $notices ) use ( $c ) {
+				if ( ! is_array( $notices ) ) {
+					return $notices;
+				}
+
 				$admin_notices = $c->get( 'admin-notices.repository' );
 				assert( $admin_notices instanceof Repository );
 

--- a/modules/ppcp-admin-notices/src/AdminNotices.php
+++ b/modules/ppcp-admin-notices/src/AdminNotices.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\AdminNotices;
 
+use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
+use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
@@ -38,6 +40,22 @@ class AdminNotices implements ModuleInterface {
 			function() use ( $c ) {
 				$renderer = $c->get( 'admin-notices.renderer' );
 				$renderer->render();
+			}
+		);
+
+		add_action(
+			Repository::NOTICES_FILTER,
+			function ( $notices ) use ( $c ) {
+				$admin_notices = $c->get( 'admin-notices.repository' );
+				assert( $admin_notices instanceof Repository );
+
+				$persisted_notices = $admin_notices->get_persisted_and_clear();
+
+				if ( $persisted_notices ) {
+					$notices = array_merge( $notices, $persisted_notices );
+				}
+
+				return $notices;
 			}
 		);
 	}

--- a/modules/ppcp-admin-notices/src/Entity/Message.php
+++ b/modules/ppcp-admin-notices/src/Entity/Message.php
@@ -92,4 +92,18 @@ class Message {
 	public function wrapper(): string {
 		return $this->wrapper;
 	}
+
+	/**
+	 * Returns the object as array.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		return array(
+			'type'        => $this->type,
+			'message'     => $this->message,
+			'dismissable' => $this->dismissable,
+			'wrapper'     => $this->wrapper,
+		);
+	}
 }

--- a/modules/ppcp-admin-notices/src/Repository/Repository.php
+++ b/modules/ppcp-admin-notices/src/Repository/Repository.php
@@ -16,7 +16,8 @@ use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
  */
 class Repository implements RepositoryInterface {
 
-	const NOTICES_FILTER = 'ppcp.admin-notices.current-notices';
+	const NOTICES_FILTER           = 'ppcp.admin-notices.current-notices';
+	const PERSISTED_NOTICES_OPTION = 'woocommerce_ppcp-admin-notices';
 
 	/**
 	 * Returns the current messages.
@@ -36,5 +37,41 @@ class Repository implements RepositoryInterface {
 				return is_a( $element, Message::class );
 			}
 		);
+	}
+
+	/**
+	 * Adds a message to persist between page reloads.
+	 *
+	 * @param Message $message The message.
+	 * @return void
+	 */
+	public function persist( Message $message ): void {
+		$persisted_notices = get_option( self::PERSISTED_NOTICES_OPTION ) ?: array();
+
+		$persisted_notices[] = $message->to_array();
+
+		update_option( self::PERSISTED_NOTICES_OPTION, $persisted_notices );
+	}
+
+	/**
+	 * Adds a message to persist between page reloads.
+	 *
+	 * @return array|Message[]
+	 */
+	public function get_persisted_and_clear(): array {
+		$notices = array();
+
+		$persisted_data = get_option( self::PERSISTED_NOTICES_OPTION ) ?: array();
+		foreach ( $persisted_data as $notice_data ) {
+			$notices[] = new Message(
+				(string) ( $notice_data['message'] ?? '' ),
+				(string) ( $notice_data['type'] ?? '' ),
+				(bool) ( $notice_data['dismissable'] ?? true ),
+				(string) ( $notice_data['wrapper'] ?? '' )
+			);
+		}
+
+		update_option( self::PERSISTED_NOTICES_OPTION, array(), true );
+		return $notices;
 	}
 }

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -22,6 +22,7 @@ use WooCommerce\PayPalCommerce\Common\Pattern\SingletonDecorator;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\WcGateway\Admin\RenderReauthorizeAction;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -392,6 +393,10 @@ return array(
 	'wcgateway.admin.render-authorize-action'              => static function ( ContainerInterface $container ): RenderAuthorizeAction {
 		$column = $container->get( 'wcgateway.admin.orders-payment-status-column' );
 		return new RenderAuthorizeAction( $column );
+	},
+	'wcgateway.admin.render-reauthorize-action'            => static function ( ContainerInterface $container ): RenderReauthorizeAction {
+		$column = $container->get( 'wcgateway.admin.orders-payment-status-column' );
+		return new RenderReauthorizeAction( $column );
 	},
 	'wcgateway.admin.order-payment-status'                 => static function ( ContainerInterface $container ): PaymentStatusOrderDetail {
 		$column = $container->get( 'wcgateway.admin.orders-payment-status-column' );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -381,13 +381,15 @@ return array(
 		$notice              = $container->get( 'wcgateway.notice.authorize-order-action' );
 		$settings            = $container->get( 'wcgateway.settings' );
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
+		$amount_factory      = $container->get( 'api.factory.amount' );
 		return new AuthorizedPaymentsProcessor(
 			$order_endpoint,
 			$payments_endpoint,
 			$logger,
 			$notice,
 			$settings,
-			$subscription_helper
+			$subscription_helper,
+			$amount_factory
 		);
 	},
 	'wcgateway.admin.render-authorize-action'              => static function ( ContainerInterface $container ): RenderAuthorizeAction {

--- a/modules/ppcp-wc-gateway/src/Admin/RenderAuthorizeAction.php
+++ b/modules/ppcp-wc-gateway/src/Admin/RenderAuthorizeAction.php
@@ -9,9 +9,6 @@ declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Admin;
 
-use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
-
 /**
  * Class RenderAuthorizeAction
  */

--- a/modules/ppcp-wc-gateway/src/Admin/RenderReauthorizeAction.php
+++ b/modules/ppcp-wc-gateway/src/Admin/RenderReauthorizeAction.php
@@ -9,9 +9,6 @@ declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Admin;
 
-use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
-
 /**
  * Class RenderReauthorizeAction
  */
@@ -47,7 +44,7 @@ class RenderReauthorizeAction {
 		}
 
 		$order_actions['ppcp_reauthorize_order'] = esc_html__(
-			'Reauthorized PayPal payment',
+			'Reauthorize PayPal payment',
 			'woocommerce-paypal-payments'
 		);
 		return $order_actions;

--- a/modules/ppcp-wc-gateway/src/Admin/RenderReauthorizeAction.php
+++ b/modules/ppcp-wc-gateway/src/Admin/RenderReauthorizeAction.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Renders the order action "Reauthorize PayPal payment"
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Admin
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Admin;
+
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
+
+/**
+ * Class RenderReauthorizeAction
+ */
+class RenderReauthorizeAction {
+	/**
+	 * The capture info column.
+	 *
+	 * @var OrderTablePaymentStatusColumn
+	 */
+	private $column;
+
+	/**
+	 * PaymentStatusOrderDetail constructor.
+	 *
+	 * @param OrderTablePaymentStatusColumn $column The capture info column.
+	 */
+	public function __construct( OrderTablePaymentStatusColumn $column ) {
+		$this->column = $column;
+	}
+
+	/**
+	 * Renders the action into the $order_actions array based on the WooCommerce order.
+	 *
+	 * @param array     $order_actions The actions to render into.
+	 * @param \WC_Order $wc_order The order for which to render the action.
+	 *
+	 * @return array
+	 */
+	public function render( array $order_actions, \WC_Order $wc_order ) : array {
+
+		if ( ! $this->should_render_for_order( $wc_order ) ) {
+			return $order_actions;
+		}
+
+		$order_actions['ppcp_reauthorize_order'] = esc_html__(
+			'Reauthorized PayPal payment',
+			'woocommerce-paypal-payments'
+		);
+		return $order_actions;
+	}
+
+	/**
+	 * Whether the action should be rendered for a certain WooCommerce order.
+	 *
+	 * @param \WC_Order $order The Woocommerce order.
+	 *
+	 * @return bool
+	 */
+	private function should_render_for_order( \WC_Order $order ) : bool {
+		$status               = $order->get_status();
+		$not_allowed_statuses = array( 'refunded', 'cancelled', 'failed' );
+		return $this->column->should_render_for_order( $order ) &&
+			! $this->column->is_captured( $order ) &&
+			! in_array( $status, $not_allowed_statuses, true );
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 use Exception;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WC_Order;
@@ -92,6 +94,20 @@ class AuthorizedPaymentsProcessor {
 	private $subscription_helper;
 
 	/**
+	 * The amount factory.
+	 *
+	 * @var AmountFactory
+	 */
+	private $amount_factory;
+
+	/**
+	 * The reauthorization failure reason.
+	 *
+	 * @var string
+	 */
+	private $reauthorization_failure_reason;
+
+	/**
 	 * AuthorizedPaymentsProcessor constructor.
 	 *
 	 * @param OrderEndpoint              $order_endpoint The Order endpoint.
@@ -100,6 +116,7 @@ class AuthorizedPaymentsProcessor {
 	 * @param AuthorizeOrderActionNotice $notice The notice.
 	 * @param ContainerInterface         $config The settings.
 	 * @param SubscriptionHelper         $subscription_helper The subscription helper.
+	 * @param AmountFactory              $amount_factory The amount factory.
 	 */
 	public function __construct(
 		OrderEndpoint $order_endpoint,
@@ -107,7 +124,8 @@ class AuthorizedPaymentsProcessor {
 		LoggerInterface $logger,
 		AuthorizeOrderActionNotice $notice,
 		ContainerInterface $config,
-		SubscriptionHelper $subscription_helper
+		SubscriptionHelper $subscription_helper,
+		AmountFactory $amount_factory
 	) {
 
 		$this->order_endpoint      = $order_endpoint;
@@ -116,6 +134,7 @@ class AuthorizedPaymentsProcessor {
 		$this->notice              = $notice;
 		$this->config              = $config;
 		$this->subscription_helper = $subscription_helper;
+		$this->amount_factory      = $amount_factory;
 	}
 
 	/**
@@ -247,6 +266,67 @@ class AuthorizedPaymentsProcessor {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Reauthorizes an authorized payment for an WooCommerce order.
+	 *
+	 * @param WC_Order $wc_order The WooCommerce order.
+	 *
+	 * @return string The status or reauthorization id.
+	 */
+	public function reauthorize_payment( WC_Order $wc_order ): string {
+		$this->reauthorization_failure_reason = '';
+
+		try {
+			$order = $this->paypal_order_from_wc_order( $wc_order );
+		} catch ( Exception $exception ) {
+			$this->logger->error( 'Could not get PayPal order from WC order: ' . $exception->getMessage() );
+			if ( $exception->getCode() === 404 ) {
+				return self::NOT_FOUND;
+			}
+			return self::INACCESSIBLE;
+		}
+
+		$amount = $this->amount_factory->from_wc_order( $wc_order );
+
+		$authorizations            = $this->all_authorizations( $order );
+		$uncaptured_authorizations = $this->authorizations_to_capture( ...$authorizations );
+
+		if ( ! $uncaptured_authorizations ) {
+			if ( $this->captured_authorizations( ...$authorizations ) ) {
+				$this->logger->info( 'Authorizations already captured.' );
+				return self::ALREADY_CAPTURED;
+			}
+
+			$this->logger->info( 'Bad authorization.' );
+			return self::BAD_AUTHORIZATION;
+		}
+
+		$authorization = end( $uncaptured_authorizations );
+
+		try {
+			$this->payments_endpoint->reauthorize( $authorization->id(), new Money( $amount->value(), $amount->currency_code() ) );
+		} catch ( PayPalApiException $exception ) {
+			$this->reauthorization_failure_reason = $exception->details()[0]->description ?? null;
+			$this->logger->error( 'Reauthorization failed: ' . $exception->name() . ' | ' . $this->reauthorization_failure_reason );
+			return self::FAILED;
+
+		} catch ( Exception $exception ) {
+			$this->logger->error( 'Failed to capture authorization: ' . $exception->getMessage() );
+			return self::FAILED;
+		}
+
+		return self::SUCCESSFUL;
+	}
+
+	/**
+	 * The reason for a failed reauthorization.
+	 *
+	 * @return string
+	 */
+	public function reauthorization_failure_reason(): string {
+		return $this->reauthorization_failure_reason;
 	}
 
 	/**
@@ -392,4 +472,5 @@ class AuthorizedPaymentsProcessor {
 			}
 		);
 	}
+
 }

--- a/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
@@ -105,7 +105,7 @@ class AuthorizedPaymentsProcessor {
 	 *
 	 * @var string
 	 */
-	private $reauthorization_failure_reason;
+	private $reauthorization_failure_reason = '';
 
 	/**
 	 * AuthorizedPaymentsProcessor constructor.

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -614,13 +614,18 @@ class WCGatewayModule implements ModuleInterface {
 					return $order_actions;
 				}
 
-				$render = $container->get( 'wcgateway.admin.render-authorize-action' );
+				$render_reauthorize = $container->get( 'wcgateway.admin.render-reauthorize-action' );
+				$render_authorize   = $container->get( 'wcgateway.admin.render-authorize-action' );
+
 				/**
 				 * Renders the authorize action in the select field.
 				 *
 				 * @var RenderAuthorizeAction $render
 				 */
-				return $render->render( $order_actions, $theorder );
+				return $render_reauthorize->render(
+					$render_authorize->render( $order_actions, $theorder ),
+					$theorder
+				);
 			}
 		);
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -666,6 +666,10 @@ class WCGatewayModule implements ModuleInterface {
 					$admin_notices->persist( new Message( $message, 'error' ) );
 				} else {
 					$admin_notices->persist( new Message( 'Payment reauthorized.', 'info' ) );
+
+					$wc_order->add_order_note(
+						__( 'Payment reauthorized.', 'woocommerce-paypal-payments' )
+					);
 				}
 			}
 		);

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -642,6 +642,20 @@ class WCGatewayModule implements ModuleInterface {
 				$authorized_payments_processor->capture_authorized_payment( $wc_order );
 			}
 		);
+
+		add_action(
+			'woocommerce_order_action_ppcp_reauthorize_order',
+			static function ( WC_Order $wc_order ) use ( $container ) {
+
+				/**
+				 * The authorized payments processor.
+				 *
+				 * @var AuthorizedPaymentsProcessor $authorized_payments_processor
+				 */
+				$authorized_payments_processor = $container->get( 'wcgateway.processor.authorized-payments' );
+				$authorized_payments_processor->reauthorize_payment( $wc_order );
+			}
+		);
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -5,6 +5,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 
 use Mockery\MockInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 use WC_Order;
@@ -69,6 +70,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 
 		$this->config = Mockery::mock(ContainerInterface::class);
 		$this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
+		$this->amount_factory = Mockery::mock(AmountFactory::class);
 
 		$this->testee = new AuthorizedPaymentsProcessor(
 			$this->orderEndpoint,
@@ -76,7 +78,8 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 			new NullLogger(),
 			$this->notice,
 			$this->config,
-			$this->subscription_helper
+			$this->subscription_helper,
+			$this->amount_factory
 		);
 	}
 


### PR DESCRIPTION
# PR Description
This PR adds an option in the Order page to reauthorize an authorized PayPal payment.

It also adds the function `ppcp_reauthorize_order` to reauthorize an order programmatically.

Adds the `reauthorize_payment` method to send reauthorization requests to the PayPal API.

This PR also adds a mechanism to persist admin notices between page reloads.

# Issue Description
https://developer.paypal.com/docs/api/payments/v2/#authorizations_reauthorize

## Reauthorize authorized payment

**POST** /v2/payments/authorizations/{authorization_id}/reauthorize

Reauthorizes an authorized PayPal account payment, by ID. To ensure that funds are still available, reauthorize a payment after its initial three-day honor period expires. Within the 29-day authorization period, you can issue multiple re-authorizations after the honor period expires.

If 30 days have transpired since the date of the original authorization, you must create an authorized payment instead of reauthorizing the original authorized payment.

A reauthorized payment itself has a new honor period of three days.

You can reauthorize an authorized payment once for up to 115% of the original authorized amount, not to exceed an increase of $75 USD.

Supports only the `amount` request parameter.

**Note:** This request is currently not supported for Partner use cases.

Benefits

- authorizations only last 30 days
  - this can extend the timeframe
- capture amount cannot exceed authorized amount
  - this can allow merchants to increase order total after authorizing without having to create a new WooCommerce order

We currently provide an API to capture, void & refund.

We should add reauthorize to this API as well for merchants to trigger it programmatically.