### PR TITLE
Payments with saved card tokens use Capture intent when Authorize is configured (2713)

### DIFF
--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -829,6 +829,7 @@ return array(
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'session.handler' ),
 			$container->get( 'wc-subscriptions.helpers.real-time-account-updater' ),
+			$container->get( 'wcgateway.settings' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -130,6 +130,7 @@ return array(
 			$payments_endpoint,
 			$vaulted_credit_card_handler,
 			$container->get( 'onboarding.environment' ),
+			$container->get( 'api.endpoint.order' ),
 			$logger
 		);
 	},

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -127,9 +127,10 @@ return array(
 			$state,
 			$transaction_url_provider,
 			$subscription_helper,
-			$logger,
 			$payments_endpoint,
-			$vaulted_credit_card_handler
+			$vaulted_credit_card_handler,
+			$container->get( 'onboarding.environment' ),
+			$logger
 		);
 	},
 	'wcgateway.card-button-gateway'                        => static function ( ContainerInterface $container ): CardButtonGateway {

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -13,12 +13,15 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 use WC_Payment_Tokens;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\PaymentsStatusHandlingTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
@@ -34,7 +37,7 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
  */
 class CreditCardGateway extends \WC_Payment_Gateway_CC {
 
-	use ProcessPaymentTrait, GatewaySettingsRendererTrait, TransactionIdHandlingTrait;
+	use ProcessPaymentTrait, GatewaySettingsRendererTrait, TransactionIdHandlingTrait, PaymentsStatusHandlingTrait;
 
 	const ID = 'ppcp-credit-card-gateway';
 
@@ -130,6 +133,13 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	private $environment;
 
 	/**
+	 * The order endpoint.
+	 *
+	 * @var OrderEndpoint
+	 */
+	private $order_endpoint;
+
+	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -151,6 +161,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 * @param PaymentsEndpoint         $payments_endpoint The payments endpoint.
 	 * @param VaultedCreditCardHandler $vaulted_credit_card_handler The vaulted credit card handler.
 	 * @param Environment              $environment The environment.
+	 * @param OrderEndpoint            $order_endpoint The order endpoint.
 	 * @param LoggerInterface          $logger The logger.
 	 */
 	public function __construct(
@@ -166,6 +177,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		PaymentsEndpoint $payments_endpoint,
 		VaultedCreditCardHandler $vaulted_credit_card_handler,
 		Environment $environment,
+		OrderEndpoint $order_endpoint,
 		LoggerInterface $logger
 	) {
 		$this->id                          = self::ID;
@@ -181,6 +193,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$this->payments_endpoint           = $payments_endpoint;
 		$this->vaulted_credit_card_handler = $vaulted_credit_card_handler;
 		$this->environment                 = $environment;
+		$this->order_endpoint              = $order_endpoint;
 		$this->logger                      = $logger;
 
 		if ( $state->current_state() === State::STATE_ONBOARDED ) {
@@ -387,12 +400,35 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 				);
 				$wc_order->save_meta_data();
 
-				$this->update_transaction_id( $saved_payment_card['order_id'], $wc_order );
-				$wc_order->payment_complete();
+				$order_id = $saved_payment_card['order_id'] ?? '';
+				if ( $order_id ) {
+					$order = $this->order_endpoint->order( $order_id );
+					$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
+
+					if ( $order->intent() === 'AUTHORIZE' ) {
+						$order = $this->order_endpoint->authorize( $order );
+
+						$wc_order->update_meta_data( AuthorizedPaymentsProcessor::CAPTURED_META_KEY, 'false' );
+
+						if ( $this->subscription_helper->has_subscription( $wc_order->get_id() ) ) {
+							$wc_order->update_meta_data( '_ppcp_captured_vault_webhook', 'false' );
+						}
+					}
+
+					$transaction_id = $this->get_paypal_order_transaction_id( $order );
+					if ( $transaction_id ) {
+						$this->update_transaction_id( $transaction_id, $wc_order );
+					}
+
+					$this->handle_new_order_status( $order, $wc_order );
+				}
+
 				WC()->session->set( 'ppcp_saved_payment_card', null );
 
 				return $this->handle_payment_success( $wc_order );
 			}
+
+			WC()->session->set( 'ppcp_saved_payment_card', null );
 		}
 
 		/**

--- a/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
 use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WC_Order;
@@ -32,6 +34,8 @@ class CreditCardGatewayTest extends TestCase
 	private $logger;
 	private $paymentsEndpoint;
 	private $vaultedCreditCardHandler;
+	private $environment;
+	private $orderEndpoint;
 	private $testee;
 
 	public function setUp(): void
@@ -50,6 +54,8 @@ class CreditCardGatewayTest extends TestCase
 		$this->logger = Mockery::mock(LoggerInterface::class);
 		$this->paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
 		$this->vaultedCreditCardHandler = Mockery::mock(VaultedCreditCardHandler::class);
+		$this->environment = Mockery::mock(Environment::class);
+		$this->orderEndpoint = Mockery::mock(OrderEndpoint::class);
 
 		$this->state->shouldReceive('current_state')->andReturn(State::STATE_ONBOARDED);
 		$this->config->shouldReceive('has')->andReturn(true);
@@ -67,9 +73,11 @@ class CreditCardGatewayTest extends TestCase
 			$this->state,
 			$this->transactionUrlProvider,
 			$this->subscriptionHelper,
-			$this->logger,
 			$this->paymentsEndpoint,
-			$this->vaultedCreditCardHandler
+			$this->vaultedCreditCardHandler,
+			$this->environment,
+			$this->orderEndpoint,
+			$this->logger
 		);
 	}
 


### PR DESCRIPTION
When using Vault v3 to process payments with a saved card, the transaction defaults to the "Capture" intent, despite the PayPal Payments plugin being configured to use "Authorize" intent. This behavior bypasses the intended authorization flow, leading to immediate fund capture without merchant review.

### Steps To Reproduce
- Configure PayPal Payments plugin to use "Authorize" intent for transactions
- Pay with a card using Vault v3 feature and save it
- Observe that the payment is processed with "Authorize" intent
- Attempt to make a payment with the saved card

Observe that the payment is processed with "Capture" intent instead of "Authorize".

### Expected behaviour
When a payment is made using a saved card with Vault v3, the transaction should follow the plugin configuration, using the "Authorize" intent if so configured. This should allow merchants to review transactions before capturing funds.