### PR TITLE
Do not handle VAULT.PAYMENT-TOKEN.CREATED webhook for Vault v3 (2727)

### DIFF
--- a/modules/ppcp-webhooks/src/Handler/VaultPaymentTokenCreated.php
+++ b/modules/ppcp-webhooks/src/Handler/VaultPaymentTokenCreated.php
@@ -115,6 +115,11 @@ class VaultPaymentTokenCreated implements RequestHandler {
 	 * @return WP_REST_Response
 	 */
 	public function handle_request( WP_REST_Request $request ): WP_REST_Response {
+		$resource_version = $request['resource_version'] ?? '';
+		if ( $resource_version && $resource_version !== '2.0' ) {
+			return $this->success_response();
+		}
+
 		$customer_id = null !== $request['resource'] && isset( $request['resource']['customer_id'] )
 			? $request['resource']['customer_id']
 			: '';

--- a/modules/ppcp-webhooks/src/IncomingWebhookEndpoint.php
+++ b/modules/ppcp-webhooks/src/IncomingWebhookEndpoint.php
@@ -248,9 +248,14 @@ class IncomingWebhookEndpoint {
 			}
 		}
 
+		$event_type = $request['event_type'] ?: '';
+		if ( in_array( $event_type, array( 'BILLING_AGREEMENTS.AGREEMENT.CREATED' ), true ) ) {
+			return $this->success_response();
+		}
+
 		$message = sprintf(
 			'Could not find handler for request type %s',
-			$request['event_type'] ?: ''
+			$event_type
 		);
 		return $this->failure_response( $message );
 	}


### PR DESCRIPTION
In [Vault v3](https://developer.paypal.com/docs/multiparty/checkout/save-payment-methods/) (since version 2.5.0) there is no need to wait for and handle `VAULT.PAYMENT-TOKEN.CREATED` webhook as now the related info that needs to be stored (customer id, vault id…) is included in the response.

However the webhook is not handled correctly and a customer id not found error is thrown:
```
{
    "success": false,
    "message": "No customer id was found."
}
```

To fix the problem we could check for `resource_version` value and skip handling when version is not 2.0.