### PR TITLE
Integrate pay later messaging block with the messaging configurator (2691)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -68,7 +68,7 @@ return function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-save-payment-methods/module.php" )();
 	}
 
-	if ( PayLaterBlockModule::is_enabled() ) {
+	if ( PayLaterBlockModule::is_module_loading_required() ) {
 		$modules[] = ( require "$modules_dir/ppcp-paylater-block/module.php" )();
 	}
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -631,7 +631,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 
 		$messaging_enabled_for_current_location = $this->settings_status->is_pay_later_messaging_enabled_for_location( $location );
 
-		$has_paylater_block = has_block( 'woocommerce-paypal-payments/paylater-messages' ) && PayLaterBlockModule::is_enabled();
+		$has_paylater_block = has_block( 'woocommerce-paypal-payments/paylater-messages' ) && PayLaterBlockModule::is_block_enabled( $this->settings_status );
 
 		switch ( $location ) {
 			case 'checkout':
@@ -878,7 +878,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			'wrapper'   => '#ppcp-messages',
 			'is_hidden' => ! $this->is_pay_later_filter_enabled_for_location( $this->context() ),
 			'block'     => array(
-				'enabled' => PayLaterBlockModule::is_enabled(),
+				'enabled' => PayLaterBlockModule::is_block_enabled( $this->settings_status ),
 			),
 			'amount'    => $amount,
 			'placement' => $placement,

--- a/modules/ppcp-paylater-block/resources/js/edit.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.js
@@ -34,7 +34,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
     };
 
     let classes = ['ppcp-paylater-block-preview', 'ppcp-overlay-parent'];
-    if (PcpPayLaterBlock.vaultingEnabled) {
+    if (PcpPayLaterBlock.vaultingEnabled || !PcpPayLaterBlock.placementEnabled) {
         classes = ['ppcp-paylater-block-preview', 'ppcp-paylater-unavailable', 'block-editor-warning'];
     }
     const props = useBlockProps({className: classes});
@@ -55,6 +55,27 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
                 <div className={'class="block-editor-warning__actions"'}>
                     <span className={'block-editor-warning__action'}>
                         <a href={PcpPayLaterBlock.settingsUrl} className={'components-button is-primary'}>
+                            {__('PayPal Payments Settings', 'woocommerce-paypal-payments')}
+                        </a>
+                    </span>
+                    <span className={'block-editor-warning__action'}>
+                        <button onClick={() => wp.data.dispatch( 'core/block-editor' ).removeBlock(clientId)} type={'button'} className={'components-button is-secondary'}>
+                            {__('Remove Block', 'woocommerce-paypal-payments')}
+                        </button>
+                    </span>
+                </div>
+            </div>
+        </div>
+    }
+
+    if (!PcpPayLaterBlock.placementEnabled) {
+        return <div {...props}>
+            <div className={'block-editor-warning__contents'}>
+                <h3>{__('PayPal Pay Later Messaging', 'woocommerce-paypal-payments')}</h3>
+                <p className={'block-editor-warning__message'}>{__('Pay Later Messaging cannot be used while the “WooCommerce Block” messaging placement is disabled. Enable the placement in the PayPal Payments Pay Later settings to reactivate this block.', 'woocommerce-paypal-payments')}</p>
+                <div className={'class="block-editor-warning__actions"'}>
+                    <span className={'block-editor-warning__action'}>
+                        <a href={PcpPayLaterBlock.payLaterSettingsUrl} className={'components-button is-primary'}>
                             {__('PayPal Payments Settings', 'woocommerce-paypal-payments')}
                         </a>
                     </span>

--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -40,7 +40,7 @@ class PayLaterBlockModule implements ModuleInterface {
 	 * @return bool true if the block is enabled, otherwise false.
 	 */
 	public static function is_block_enabled( SettingsStatus $settings_status ): bool {
-		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'product_preview' );
+		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'woocommerceBlock' );
 	}
 
 	/**

--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -40,7 +40,7 @@ class PayLaterBlockModule implements ModuleInterface {
 	 * @return bool true if the block is enabled, otherwise false.
 	 */
 	public static function is_block_enabled( SettingsStatus $settings_status ): bool {
-		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'woocommerceBlock' );
+		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'product_preview' );
 	}
 
 	/**

--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
@@ -22,14 +23,24 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  */
 class PayLaterBlockModule implements ModuleInterface {
 	/**
-	 * Returns whether the block should be loaded.
+	 * Returns whether the block module should be loaded.
 	 */
-	public static function is_enabled(): bool {
+	public static function is_module_loading_required(): bool {
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_block_enabled',
-			getenv( 'PCP_PAYLATER_BLOCK' ) === '1'
+			getenv( 'PCP_PAYLATER_BLOCK' ) !== '0'
 		);
+	}
+
+	/**
+	 * Returns whether the block is enabled.
+	 *
+	 * @param SettingsStatus $settings_status The Settings status helper.
+	 * @return bool true if the block is enabled, otherwise false.
+	 */
+	public static function is_block_enabled( SettingsStatus $settings_status ): bool {
+		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'product_preview' );
 	}
 
 	/**

--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -82,13 +82,15 @@ class PayLaterBlockModule implements ModuleInterface {
 					$script_handle,
 					'PcpPayLaterBlock',
 					array(
-						'ajax'            => array(
+						'ajax'                => array(
 							'cart_script_params' => array(
 								'endpoint' => \WC_AJAX::get_endpoint( CartScriptParamsEndpoint::ENDPOINT ),
 							),
 						),
-						'settingsUrl'     => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'vaultingEnabled' => $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' ),
+						'settingsUrl'         => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+						'vaultingEnabled'     => $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' ),
+						'placementEnabled'    => self::is_block_enabled( $c->get( 'wcgateway.settings.status' ) ),
+						'payLaterSettingsUrl' => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' ),
 					)
 				);
 

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -30,7 +30,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
         partnerClientId: PcpPayLaterConfigurator.partnerClientId,
         partnerName: 'WooCommerce',
         bnCode: 'Woo_PPCP',
-        placements: ['cart', 'checkout', 'product', 'category', 'homepage', 'product_preview'],
+        placements: ['cart', 'checkout', 'product', 'shop', 'home', 'product_preview'],
         styleOverrides: {
             button: publishButtonClassName,
             header: PcpPayLaterConfigurator.headerClassName,

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -30,7 +30,10 @@ document.addEventListener( 'DOMContentLoaded', () => {
         partnerClientId: PcpPayLaterConfigurator.partnerClientId,
         partnerName: 'WooCommerce',
         bnCode: 'Woo_PPCP',
-        placements: ['cart', 'checkout', 'product', 'shop', 'home', 'product_preview'],
+        placements: ['cart', 'checkout', 'product', 'shop', 'home'],
+        custom_placement:[{
+            message_reference: 'woocommerceBlock',
+        }],
         styleOverrides: {
             button: publishButtonClassName,
             header: PcpPayLaterConfigurator.headerClassName,

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -30,10 +30,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
         partnerClientId: PcpPayLaterConfigurator.partnerClientId,
         partnerName: 'WooCommerce',
         bnCode: 'Woo_PPCP',
-        placements: ['cart', 'checkout', 'product', 'shop', 'home'],
-        custom_placement:[{
-            message_reference: 'woocommerceBlock',
-        }],
+        placements: ['cart', 'checkout', 'product', 'shop', 'home', 'product_preview'],
         styleOverrides: {
             button: publishButtonClassName,
             header: PcpPayLaterConfigurator.headerClassName,

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -30,7 +30,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
         partnerClientId: PcpPayLaterConfigurator.partnerClientId,
         partnerName: 'WooCommerce',
         bnCode: 'Woo_PPCP',
-        placements: ['cart', 'checkout', 'product', 'category', 'homepage', 'custom_placement'],
+        placements: ['cart', 'checkout', 'product', 'category', 'homepage', 'product_preview'],
         styleOverrides: {
             button: publishButtonClassName,
             header: PcpPayLaterConfigurator.headerClassName,

--- a/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
+++ b/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
@@ -156,6 +156,7 @@ class SaveConfig {
 			case 'cart':
 			case 'checkout':
 			case 'product':
+			case 'product_preview':
 				return $placement;
 			case 'category':
 				return 'shop';

--- a/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
+++ b/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
@@ -101,12 +101,10 @@ class SaveConfig {
 		$enabled_locations = array();
 
 		foreach ( $config as $placement => $data ) {
-			$location = $this->configurator_placement_to_location( $placement );
-
-			$this->save_config_for_location( $data, $location );
+			$this->save_config_for_location( $data, $placement );
 
 			if ( $data['status'] === 'enabled' ) {
-				$enabled_locations[] = $location;
+				$enabled_locations[] = $placement;
 			}
 		}
 
@@ -143,27 +141,6 @@ class SaveConfig {
 	private function set_value_if_present( array $config, string $key, string $settings_key ): void {
 		if ( isset( $config[ $key ] ) ) {
 			$this->settings->set( $settings_key, $config[ $key ] );
-		}
-	}
-
-	/**
-	 * Converts the configurator placement into location in the old settings.
-	 *
-	 * @param string $placement The configurator placement.
-	 */
-	private function configurator_placement_to_location( string $placement ): string {
-		switch ( $placement ) {
-			case 'cart':
-			case 'checkout':
-			case 'product':
-			case 'product_preview':
-				return $placement;
-			case 'category':
-				return 'shop';
-			case 'homepage':
-				return 'home';
-			default:
-				return '';
 		}
 	}
 }

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -22,12 +22,12 @@ class ConfigFactory {
 	 */
 	public function from_settings( Settings $settings ): array {
 		return array(
-			$this->location_to_configurator_placement( 'cart' ) => $this->for_location( $settings, 'cart' ),
-			$this->location_to_configurator_placement( 'checkout' ) => $this->for_location( $settings, 'checkout' ),
-			$this->location_to_configurator_placement( 'product' ) => $this->for_location( $settings, 'product' ),
-			$this->location_to_configurator_placement( 'shop' ) => $this->for_location( $settings, 'shop' ),
-			$this->location_to_configurator_placement( 'home' ) => $this->for_location( $settings, 'home' ),
-			$this->location_to_configurator_placement( 'product_preview' ) => $this->for_location( $settings, 'product_preview' ),
+			'cart'            => $this->for_location( $settings, 'cart' ),
+			'checkout'        => $this->for_location( $settings, 'checkout' ),
+			'product'         => $this->for_location( $settings, 'product' ),
+			'shop'            => $this->for_location( $settings, 'shop' ),
+			'home'            => $this->for_location( $settings, 'home' ),
+			'product_preview' => $this->for_location( $settings, 'product_preview' ),
 		);
 	}
 
@@ -40,8 +40,7 @@ class ConfigFactory {
 	private function for_location( Settings $settings, string $location ): array {
 		$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
 
-		$placement = $this->location_to_configurator_placement( $location );
-		if ( in_array( $placement, array( 'category', 'homepage' ), true ) ) {
+		if ( in_array( $location, array( 'shop', 'home' ), true ) ) {
 			$config = array(
 				'layout' => 'flex',
 				'color'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black', array( 'black', 'blue', 'white', 'white-no-border' ) ),
@@ -61,31 +60,10 @@ class ConfigFactory {
 		return array_merge(
 			array(
 				'status'    => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
-				'placement' => $placement,
+				'placement' => $location,
 			),
 			$config
 		);
-	}
-
-	/**
-	 * Converts the location name from the old settings into the configurator placement.
-	 *
-	 * @param string $location The location name in the old settings.
-	 */
-	private function location_to_configurator_placement( string $location ): string {
-		switch ( $location ) {
-			case 'cart':
-			case 'checkout':
-			case 'product':
-			case 'product_preview':
-				return $location;
-			case 'shop':
-				return 'category';
-			case 'home':
-				return 'homepage';
-			default:
-				return '';
-		}
 	}
 
 	/**

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -22,12 +22,12 @@ class ConfigFactory {
 	 */
 	public function from_settings( Settings $settings ): array {
 		return array(
-			'cart'             => $this->for_location( $settings, 'cart' ),
-			'checkout'         => $this->for_location( $settings, 'checkout' ),
-			'product'          => $this->for_location( $settings, 'product' ),
-			'shop'             => $this->for_location( $settings, 'shop' ),
-			'home'             => $this->for_location( $settings, 'home' ),
-			'woocommerceBlock' => $this->for_location( $settings, 'woocommerceBlock' ),
+			'cart'            => $this->for_location( $settings, 'cart' ),
+			'checkout'        => $this->for_location( $settings, 'checkout' ),
+			'product'         => $this->for_location( $settings, 'product' ),
+			'shop'            => $this->for_location( $settings, 'shop' ),
+			'home'            => $this->for_location( $settings, 'home' ),
+			'product_preview' => $this->for_location( $settings, 'product_preview' ),
 		);
 	}
 

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -27,6 +27,7 @@ class ConfigFactory {
 			$this->location_to_configurator_placement( 'product' ) => $this->for_location( $settings, 'product' ),
 			$this->location_to_configurator_placement( 'shop' ) => $this->for_location( $settings, 'shop' ),
 			$this->location_to_configurator_placement( 'home' ) => $this->for_location( $settings, 'home' ),
+			$this->location_to_configurator_placement( 'product_preview' ) => $this->for_location( $settings, 'product_preview' ),
 		);
 	}
 
@@ -76,6 +77,7 @@ class ConfigFactory {
 			case 'cart':
 			case 'checkout':
 			case 'product':
+			case 'product_preview':
 				return $location;
 			case 'shop':
 				return 'category';

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -22,12 +22,12 @@ class ConfigFactory {
 	 */
 	public function from_settings( Settings $settings ): array {
 		return array(
-			'cart'            => $this->for_location( $settings, 'cart' ),
-			'checkout'        => $this->for_location( $settings, 'checkout' ),
-			'product'         => $this->for_location( $settings, 'product' ),
-			'shop'            => $this->for_location( $settings, 'shop' ),
-			'home'            => $this->for_location( $settings, 'home' ),
-			'product_preview' => $this->for_location( $settings, 'product_preview' ),
+			'cart'             => $this->for_location( $settings, 'cart' ),
+			'checkout'         => $this->for_location( $settings, 'checkout' ),
+			'product'          => $this->for_location( $settings, 'product' ),
+			'shop'             => $this->for_location( $settings, 'shop' ),
+			'home'             => $this->for_location( $settings, 'home' ),
+			'woocommerceBlock' => $this->for_location( $settings, 'woocommerceBlock' ),
 		);
 	}
 

--- a/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
+++ b/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
@@ -29,7 +29,7 @@ class PayLaterConfiguratorModule implements ModuleInterface {
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_configurator_enabled',
-			getenv( 'PCP_PAYLATER_CONFIGURATOR' ) === '1'
+			getenv( 'PCP_PAYLATER_CONFIGURATOR' ) !== '0'
 		);
 	}
 

--- a/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
+++ b/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
@@ -79,7 +79,7 @@ class PayLaterConfiguratorModule implements ModuleInterface {
 			static function () use ( $c, $settings ) {
 				wp_enqueue_script(
 					'ppcp-paylater-configurator-lib',
-					'https://www.paypalobjects.com/merchant-library/preview/merchant-configurator.js',
+					'https://www.paypalobjects.com/merchant-library/merchant-configurator.js',
 					array(),
 					$c->get( 'ppcp.asset-version' ),
 					true


### PR DESCRIPTION
# PR Description
This PR will use the custom placement to enable disable the messaging block

# Issue Description
PayPal will provide additional placements (including a custom one) for us to wire up the Pay Later messaging block.
We also:
- Must switch back from the preview script to the production script (remove /preview)
- Have to enable feature flags for both messaging configurator and the block modules