### PR TITLE
Submit the form instead of refreshing the page to show the save notice (2709)

### DIFF
--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -15,14 +15,24 @@ document.addEventListener( 'DOMContentLoaded', () => {
     headingRow.parentNode.insertBefore(newRow, headingRow.nextSibling);
 
 
-    saveChangesButton.addEventListener('click', () => {
-        form.querySelector('.' + publishButtonClassName).click();
+    let isSaving = false; // Flag variable to track whether saving is in progress
 
-        // Delay the page refresh by a few milliseconds to ensure changes take effect
-        setTimeout(() => {
-            location.reload();
-        }, 1000);
+    saveChangesButton.addEventListener('click', () => {
+        // Check if saving is not already in progress
+        if (!isSaving) {
+            isSaving = true; // Set flag to indicate saving is in progress
+
+            // Trigger the click event on the publish button
+            form.querySelector('.' + publishButtonClassName).click();
+
+            // Trigger click event on saveChangesButton after a short delay
+            setTimeout(() => {
+                saveChangesButton.click(); // Trigger click event on saveChangesButton
+                isSaving = false; // Reset flag when saving is complete
+            }, 500); // Adjust the delay as needed
+        }
     });
+
 
     merchantConfigurators.Messaging({
         config: PcpPayLaterConfigurator.config,


### PR DESCRIPTION
# PR Description
This PR will solve the problem by submitting the form again instead of refreshing the page

# Issue Description
On Pay Later tab the "The settings have been saved." notice is not displayed after saving changes.
Although it’s not critical but many autotests depend on viewing this notice an expected result of Save Changes action

**Steps To Reproduce**

- Navigate to WooCommerce → Settings → Payments → PayPal
- Open Pay Later tab
- Change some settings
- Click on Save Changes button