### PR TITLE
Typo in SCA indicators for ACDC Vault transactions (2725)

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -489,7 +489,7 @@ class RenewalHandler {
 		if ( $subscription ) {
 			$transaction = $this->subscription_helper->previous_transaction( $subscription );
 			if ( $transaction ) {
-				$properties['stored_credentials'] = array(
+				$properties['stored_credential'] = array(
 					'payment_initiator'              => 'MERCHANT',
 					'payment_type'                   => 'RECURRING',
 					'usage'                          => 'SUBSEQUENT',


### PR DESCRIPTION
Fixes typo in `stored_credential` SCA indicator.