### PR TITLE
invoice_id not included in API call when creating payment with saved card (2766)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
@@ -127,19 +127,7 @@ class CardFieldsRenderer {
 
             const paymentToken = document.querySelector('input[name="wc-ppcp-credit-card-gateway-payment-token"]:checked')?.value
             if(paymentToken && paymentToken !== 'new') {
-                fetch(this.defaultConfig.ajax.capture_card_payment.endpoint, {
-                    method: 'POST',
-                    credentials: 'same-origin',
-                    body: JSON.stringify({
-                        nonce: this.defaultConfig.ajax.capture_card_payment.nonce,
-                        payment_token: paymentToken
-                    })
-                }).then((res) => {
-                    return res.json();
-                }).then((data) => {
-                    document.querySelector('#place_order').click();
-                });
-
+                document.querySelector('#place_order').click();
                 return;
             }
 

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -821,7 +821,6 @@ return array(
 	},
 	'save-payment-methods.endpoint.capture-card-payment' => static function( ContainerInterface $container ): CaptureCardPayment {
 		return new CaptureCardPayment(
-			$container->get( 'button.request-data' ),
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$container->get( 'api.factory.order' ),

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CaptureCardPayment.php
@@ -132,6 +132,8 @@ class CaptureCardPayment {
 	 * Creates PayPal order from the given card vault id.
 	 *
 	 * @param string $vault_id Vault id.
+	 * @param string $custom_id Custom id.
+	 * @param string $invoice_id Invoice id.
 	 * @return stdClass
 	 * @throws RuntimeException When request fails.
 	 */
@@ -157,8 +159,8 @@ class CaptureCardPayment {
 					),
 				),
 			),
-			'custom_id' => $custom_id,
-			'invoice_id' => $invoice_id,
+			'custom_id'      => $custom_id,
+			'invoice_id'     => $invoice_id,
 		);
 
 		$bearer = $this->bearer->bearer();

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CaptureCardPayment.php
@@ -12,15 +12,12 @@ namespace WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use stdClass;
-use WC_Payment_Tokens;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
-use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
-use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\RealTimeAccountUpdaterHelper;
@@ -29,18 +26,9 @@ use WP_Error;
 /**
  * Class CaptureCardPayment
  */
-class CaptureCardPayment implements EndpointInterface {
+class CaptureCardPayment {
 
 	use RequestTrait;
-
-	const ENDPOINT = 'ppc-capture-card-payment';
-
-	/**
-	 * The request data.
-	 *
-	 * @var RequestData
-	 */
-	private $request_data;
 
 	/**
 	 * The host.
@@ -108,7 +96,6 @@ class CaptureCardPayment implements EndpointInterface {
 	/**
 	 * CaptureCardPayment constructor.
 	 *
-	 * @param RequestData                  $request_data The request data.
 	 * @param string                       $host The host.
 	 * @param Bearer                       $bearer The bearer.
 	 * @param OrderFactory                 $order_factory The order factory.
@@ -120,7 +107,6 @@ class CaptureCardPayment implements EndpointInterface {
 	 * @param LoggerInterface              $logger The logger.
 	 */
 	public function __construct(
-		RequestData $request_data,
 		string $host,
 		Bearer $bearer,
 		OrderFactory $order_factory,
@@ -131,7 +117,6 @@ class CaptureCardPayment implements EndpointInterface {
 		Settings $settings,
 		LoggerInterface $logger
 	) {
-		$this->request_data                     = $request_data;
 		$this->host                             = $host;
 		$this->bearer                           = $bearer;
 		$this->order_factory                    = $order_factory;
@@ -139,66 +124,8 @@ class CaptureCardPayment implements EndpointInterface {
 		$this->order_endpoint                   = $order_endpoint;
 		$this->session_handler                  = $session_handler;
 		$this->real_time_account_updater_helper = $real_time_account_updater_helper;
-		$this->logger                           = $logger;
 		$this->settings                         = $settings;
-	}
-
-	/**
-	 * Returns the nonce.
-	 *
-	 * @return string
-	 */
-	public static function nonce(): string {
-		return self::ENDPOINT;
-	}
-
-	/**
-	 * Handles the request.
-	 *
-	 * @return bool
-	 */
-	public function handle_request(): bool {
-		$data = $this->request_data->read_request( $this->nonce() );
-
-		$tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id() );
-		foreach ( $tokens as $token ) {
-			if ( $token->get_id() === (int) $data['payment_token'] ) {
-				try {
-					$order = $this->create_order( $token->get_token() );
-
-					$id             = $order->id ?? '';
-					$status         = $order->status ?? '';
-					$payment_source = isset( $order->payment_source->card ) ? 'card' : '';
-					$expiry         = $order->payment_source->card->expiry ?? '';
-					$last_digits    = $order->payment_source->card->last_digits ?? '';
-					if ( $id && $status && $payment_source && $expiry && $last_digits ) {
-						$this->real_time_account_updater_helper->update_wc_card_token(
-							$expiry,
-							$last_digits,
-							$token
-						);
-
-						WC()->session->set(
-							'ppcp_saved_payment_card',
-							array(
-								'order_id'       => $id,
-								'status'         => $status,
-								'payment_source' => $payment_source,
-							)
-						);
-
-						wp_send_json_success();
-						return true;
-					}
-				} catch ( RuntimeException $exception ) {
-					wp_send_json_error();
-					return false;
-				}
-			}
-		}
-
-		wp_send_json_error();
-		return false;
+		$this->logger                           = $logger;
 	}
 
 	/**
@@ -208,7 +135,7 @@ class CaptureCardPayment implements EndpointInterface {
 	 * @return stdClass
 	 * @throws RuntimeException When request fails.
 	 */
-	private function create_order( string $vault_id ): stdClass {
+	public function create_order( string $vault_id, string $custom_id, string $invoice_id ): stdClass {
 		$intent = $this->settings->has( 'intent' ) && strtoupper( (string) $this->settings->get( 'intent' ) ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
 		$items  = array( $this->purchase_unit_factory->from_wc_cart() );
 
@@ -230,6 +157,8 @@ class CaptureCardPayment implements EndpointInterface {
 					),
 				),
 			),
+			'custom_id' => $custom_id,
+			'invoice_id' => $invoice_id,
 		);
 
 		$bearer = $this->bearer->bearer();

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -79,6 +79,18 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		) {
 			return;
 		}
+		add_filter(
+			'woocommerce_paypal_payments_localized_script_data',
+			function( array $localized_script_data ) use ( $c ) {
+				$api = $c->get( 'api.user-id-token' );
+				assert( $api instanceof UserIdToken );
+
+				$logger = $c->get( 'woocommerce.logger.woocommerce' );
+				assert( $logger instanceof LoggerInterface );
+
+				return $this->add_id_token_to_script_data( $api, $logger, $localized_script_data );
+			}
+		);
 
 		// Adds attributes needed to save payment method.
 		add_filter(
@@ -388,5 +400,46 @@ class SavePaymentMethodsModule implements ModuleInterface {
 				return true;
 			}
 		);
+	}
+
+	/**
+	 * Adds id token to localized script data.
+	 *
+	 * @param UserIdToken     $api User id token api.
+	 * @param LoggerInterface $logger The logger.
+	 * @param array           $localized_script_data The localized script data.
+	 * @return array
+	 */
+	private function add_id_token_to_script_data(
+		UserIdToken $api,
+		LoggerInterface $logger,
+		array $localized_script_data
+	): array {
+		try {
+			$target_customer_id = '';
+			if ( is_user_logged_in() ) {
+				$target_customer_id = get_user_meta( get_current_user_id(), '_ppcp_target_customer_id', true );
+				if ( ! $target_customer_id ) {
+					$target_customer_id = get_user_meta( get_current_user_id(), 'ppcp_customer_id', true );
+				}
+			}
+
+			$id_token                                      = $api->id_token( $target_customer_id );
+			$localized_script_data['save_payment_methods'] = array(
+				'id_token' => $id_token,
+			);
+
+			$localized_script_data['data_client_id']['set_attribute'] = false;
+
+		} catch ( RuntimeException $exception ) {
+			$error = $exception->getMessage();
+			if ( is_a( $exception, PayPalApiException::class ) ) {
+				$error = $exception->get_details( $error );
+			}
+
+			$logger->error( $error );
+		}
+
+		return $localized_script_data;
 	}
 }

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -80,26 +80,6 @@ class SavePaymentMethodsModule implements ModuleInterface {
 			return;
 		}
 
-		add_filter(
-			'woocommerce_paypal_payments_localized_script_data',
-			function( array $localized_script_data ) use ( $c ) {
-				$api = $c->get( 'api.user-id-token' );
-				assert( $api instanceof UserIdToken );
-
-				$logger = $c->get( 'woocommerce.logger.woocommerce' );
-				assert( $logger instanceof LoggerInterface );
-
-				$localized_script_data = $this->add_id_token_to_script_data( $api, $logger, $localized_script_data );
-
-				$localized_script_data['ajax']['capture_card_payment'] = array(
-					'endpoint' => \WC_AJAX::get_endpoint( CaptureCardPayment::ENDPOINT ),
-					'nonce'    => wp_create_nonce( CaptureCardPayment::nonce() ),
-				);
-
-				return $localized_script_data;
-			}
-		);
-
 		// Adds attributes needed to save payment method.
 		add_filter(
 			'ppcp_create_order_request_body_data',
@@ -399,16 +379,6 @@ class SavePaymentMethodsModule implements ModuleInterface {
 				}
 
 				return $supports;
-			}
-		);
-
-		add_action(
-			'wc_ajax_' . CaptureCardPayment::ENDPOINT,
-			static function () use ( $c ) {
-				$endpoint = $c->get( 'save-payment-methods.endpoint.capture-card-payment' );
-				assert( $endpoint instanceof CaptureCardPayment );
-
-				$endpoint->handle_request();
 			}
 		);
 

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -389,45 +389,4 @@ class SavePaymentMethodsModule implements ModuleInterface {
 			}
 		);
 	}
-
-	/**
-	 * Adds id token to localized script data.
-	 *
-	 * @param UserIdToken     $api User id token api.
-	 * @param LoggerInterface $logger The logger.
-	 * @param array           $localized_script_data The localized script data.
-	 * @return array
-	 */
-	private function add_id_token_to_script_data(
-		UserIdToken $api,
-		LoggerInterface $logger,
-		array $localized_script_data
-	): array {
-		try {
-			$target_customer_id = '';
-			if ( is_user_logged_in() ) {
-				$target_customer_id = get_user_meta( get_current_user_id(), '_ppcp_target_customer_id', true );
-				if ( ! $target_customer_id ) {
-					$target_customer_id = get_user_meta( get_current_user_id(), 'ppcp_customer_id', true );
-				}
-			}
-
-			$id_token                                      = $api->id_token( $target_customer_id );
-			$localized_script_data['save_payment_methods'] = array(
-				'id_token' => $id_token,
-			);
-
-			$localized_script_data['data_client_id']['set_attribute'] = false;
-
-		} catch ( RuntimeException $exception ) {
-			$error = $exception->getMessage();
-			if ( is_a( $exception, PayPalApiException::class ) ) {
-				$error = $exception->get_details( $error );
-			}
-
-			$logger->error( $error );
-		}
-
-		return $localized_script_data;
-	}
 }

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -79,6 +79,7 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		) {
 			return;
 		}
+
 		add_filter(
 			'woocommerce_paypal_payments_localized_script_data',
 			function( array $localized_script_data ) use ( $c ) {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -131,6 +131,8 @@ return array(
 			$vaulted_credit_card_handler,
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'api.endpoint.order' ),
+			$container->get('save-payment-methods.endpoint.capture-card-payment'),
+			$container->get( 'api.prefix' ),
 			$logger
 		);
 	},

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -131,7 +131,7 @@ return array(
 			$vaulted_credit_card_handler,
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'api.endpoint.order' ),
-			$container->get('save-payment-methods.endpoint.capture-card-payment'),
+			$container->get( 'save-payment-methods.endpoint.capture-card-payment' ),
 			$container->get( 'api.prefix' ),
 			$logger
 		);

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -177,8 +177,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 * @param VaultedCreditCardHandler $vaulted_credit_card_handler The vaulted credit card handler.
 	 * @param Environment              $environment The environment.
 	 * @param OrderEndpoint            $order_endpoint The order endpoint.
-	 * @param CaptureCardPayment $capture_card_payment Capture card payment.
-	 * @param string $prefix The prefix.
+	 * @param CaptureCardPayment       $capture_card_payment Capture card payment.
+	 * @param string                   $prefix The prefix.
 	 * @param LoggerInterface          $logger The logger.
 	 */
 	public function __construct(
@@ -213,8 +213,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$this->vaulted_credit_card_handler = $vaulted_credit_card_handler;
 		$this->environment                 = $environment;
 		$this->order_endpoint              = $order_endpoint;
-		$this->capture_card_payment = $capture_card_payment;
-		$this->prefix = $prefix;
+		$this->capture_card_payment        = $capture_card_payment;
+		$this->prefix                      = $prefix;
 		$this->logger                      = $logger;
 
 		if ( $state->current_state() === State::STATE_ONBOARDED ) {
@@ -411,14 +411,15 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			);
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$card_payment_token_id = wc_clean( wp_unslash( $_POST['wc-ppcp-credit-card-gateway-payment-token'] ?? '' ) );
-		if($card_payment_token_id) {
+		if ( $card_payment_token_id ) {
 			$tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id() );
 			foreach ( $tokens as $token ) {
 				if ( $token->get_id() === (int) $card_payment_token_id ) {
-					$custom_id = $wc_order->get_order_number();
-					$invoice_id      = $this->prefix . $wc_order->get_order_number();
-					$create_order = $this->capture_card_payment->create_order($token->get_token(), $custom_id, $invoice_id);
+					$custom_id    = $wc_order->get_order_number();
+					$invoice_id   = $this->prefix . $wc_order->get_order_number();
+					$create_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id );
 
 					$order = $this->order_endpoint->order( $create_order->id );
 					$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );

--- a/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 use Mockery;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CaptureCardPayment;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use WC_Order;
@@ -31,6 +32,8 @@ class CreditCardGatewayTest extends TestCase
 	private $state;
 	private $transactionUrlProvider;
 	private $subscriptionHelper;
+	private $captureCardPayment;
+	private $prefix;
 	private $logger;
 	private $paymentsEndpoint;
 	private $vaultedCreditCardHandler;
@@ -51,6 +54,8 @@ class CreditCardGatewayTest extends TestCase
 		$this->state = Mockery::mock(State::class);
 		$this->transactionUrlProvider = Mockery::mock(TransactionUrlProvider::class);
 		$this->subscriptionHelper = Mockery::mock(SubscriptionHelper::class);
+		$this->captureCardPayment = Mockery::mock(CaptureCardPayment::class);
+		$this->prefix = 'some-prefix';
 		$this->logger = Mockery::mock(LoggerInterface::class);
 		$this->paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
 		$this->vaultedCreditCardHandler = Mockery::mock(VaultedCreditCardHandler::class);
@@ -77,6 +82,8 @@ class CreditCardGatewayTest extends TestCase
 			$this->vaultedCreditCardHandler,
 			$this->environment,
 			$this->orderEndpoint,
+			$this->captureCardPayment,
+			$this->prefix,
 			$this->logger
 		);
 	}


### PR DESCRIPTION
`invoice_id` should be part of the API call to better prevent potential duplicate charges.

This PR  creates the WC order first and then send its id along when creating the PayPal order.