### PR TITLE
Card Fields: Add a filter for the CVC field and update the placeholder to match the label (2658)

### DIFF
--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -97,6 +97,17 @@ class CardFieldsModule implements ModuleInterface {
 					}
 				}
 
+				if ( apply_filters( 'woocommerce_paypal_payments_card_fields_translate_card_cvv', true ) ) {
+					if ( isset( $default_fields['card-cvc-field'] ) ) {
+						// Replaces the default card cvc placeholder with a translatable one (which also matches the CVV field label).
+						$default_fields['card-cvc-field'] = str_replace(
+							'CVC',
+							esc_attr__( 'CVV', 'woocommerce-paypal-payments' ),
+							$default_fields['card-cvc-field']
+						);
+					}
+				}
+
 				return $default_fields;
 			},
 			10,

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -97,17 +97,6 @@ class CardFieldsModule implements ModuleInterface {
 					}
 				}
 
-				if ( apply_filters( 'woocommerce_paypal_payments_card_fields_translate_card_cvv', true ) ) {
-					if ( isset( $default_fields['card-cvc-field'] ) ) {
-						// Replaces the default card cvc placeholder with a translatable one (which also matches the CVV field label).
-						$default_fields['card-cvc-field'] = str_replace(
-							'CVC',
-							esc_attr__( 'CVV', 'woocommerce-paypal-payments' ),
-							$default_fields['card-cvc-field']
-						);
-					}
-				}
-
 				return $default_fields;
 			},
 			10,

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -291,8 +291,10 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 */
 	public function form() {
 		add_action( 'gettext', array( $this, 'replace_credit_card_cvv_label' ), 10, 3 );
+		add_action( 'gettext', array( $this, 'replace_credit_card_cvv_placeholder' ), 10, 3 );
 		parent::form();
 		remove_action( 'gettext', 'replace_credit_card_cvv_label' );
+		remove_action( 'gettext', 'replace_credit_card_cvv_placeholder' );
 	}
 
 	/**
@@ -306,6 +308,23 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 */
 	public function replace_credit_card_cvv_label( string $translation, string $text, string $domain ): string {
 		if ( 'woocommerce' !== $domain || 'Card code' !== $text ) {
+			return $translation;
+		}
+
+		return __( 'CVV', 'woocommerce-paypal-payments' );
+	}
+
+	/**
+	 * Replace WooCommerce credit card CVV field placeholder.
+	 *
+	 * @param string $translation Translated text.
+	 * @param string $text Original text to translate.
+	 * @param string $domain Text domain.
+	 *
+	 * @return string Translated field.
+	 */
+	public function replace_credit_card_cvv_placeholder( string $translation, string $text, string $domain ): string {
+		if ( 'woocommerce' !== $domain || 'CVC' !== $text || ! apply_filters( 'woocommerce_paypal_payments_card_fields_translate_card_cvv', true ) ) {
 			return $translation;
 		}
 


### PR DESCRIPTION
## PR Description
This PR adds a `woocommerce_paypal_payments_card_fields_translate_card_cvv` filter (equivalent to the existing `woocommerce_paypal_payments_card_fields_translate_card_number` one) allowing for customization of the default PayPal CVC field placeholder string `CVC`, also making it translatable.

## Issue Description
Currently, the **Advanced Card Processing** CVV field has the default, PayPal `CVC` placeholder, which is less than ideal as it doesn't match the "general" WooCommerce convention for the `CVV` field naming and it differs from the current field label which is `CVV`.

## Screenshots
|Before|After|
|-|-|
|<img width="338" alt="Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/205b46ab-5880-4c1f-81ca-aff0f1b2801a">| <img width="338" alt="Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/5becbc81-7382-4343-ac60-7f7ce6d57ad4">|

## Steps to test

1. Navigate to WooCommerce → Settings → Payments → PayPal
2. Make sure Advanced Card Processing is enabled.
3. Add a product to cart and navigate to the Checkout page.
4. Select the `Debit & Credit Cards` payment method and notice the `CVV` field placeholder.