### PR TITLE
Product Title: Sanitize before sending to PayPal (2208)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -61,10 +61,10 @@ class ItemFactory {
 
 				$price = (float) $item['line_subtotal'] / (float) $item['quantity'];
 				return new Item(
-					mb_substr( $product->get_name(), 0, 127 ),
+					$this->prepare_item_string( $product->get_name() ),
 					new Money( $price, $this->currency ),
 					$quantity,
-					$this->prepare_description( $product->get_description() ),
+					$this->prepare_item_string( $product->get_description() ),
 					null,
 					$this->prepare_sku( $product->get_sku() ),
 					( $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
@@ -138,10 +138,10 @@ class ItemFactory {
 		$image                     = $product instanceof WC_Product ? wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' ) : '';
 
 		return new Item(
-			mb_substr( $item->get_name(), 0, 127 ),
+			$this->prepare_item_string( $item->get_name() ),
 			new Money( $price_without_tax_rounded, $currency ),
 			$quantity,
-			$product instanceof WC_Product ? $this->prepare_description( $product->get_description() ) : '',
+			$product instanceof WC_Product ? $this->prepare_item_string( $product->get_description() ) : '',
 			null,
 			$product instanceof WC_Product ? $this->prepare_sku( $product->get_sku() ) : '',
 			( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
@@ -160,7 +160,7 @@ class ItemFactory {
 	 */
 	private function from_wc_order_fee( \WC_Order_Item_Fee $item, \WC_Order $order ): Item {
 		return new Item(
-			$item->get_name(),
+			$this->prepare_item_string( $item->get_name() ),
 			new Money( (float) $item->get_amount(), $order->get_currency() ),
 			$item->get_quantity(),
 			'',

--- a/modules/ppcp-api-client/src/Helper/ItemTrait.php
+++ b/modules/ppcp-api-client/src/Helper/ItemTrait.php
@@ -14,7 +14,7 @@ trait ItemTrait {
 	/**
 	 * Cleans up item strings (title and description for example) and prepares them for sending to PayPal.
 	 *
-	 * @param string $description Item description.
+	 * @param string $string Item string.
 	 * @return string
 	 */
 	protected function prepare_item_string( string $string ): string {

--- a/modules/ppcp-api-client/src/Helper/ItemTrait.php
+++ b/modules/ppcp-api-client/src/Helper/ItemTrait.php
@@ -12,14 +12,14 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 trait ItemTrait {
 
 	/**
-	 * Cleanups the description and prepares it for sending to PayPal.
+	 * Cleans up item strings (title and description for example) and prepares them for sending to PayPal.
 	 *
 	 * @param string $description Item description.
 	 * @return string
 	 */
-	protected function prepare_description( string $description ): string {
-		$description = strip_shortcodes( wp_strip_all_tags( $description ) );
-		return substr( $description, 0, 127 ) ?: '';
+	protected function prepare_item_string( string $string ): string {
+		$string = strip_shortcodes( wp_strip_all_tags( $string ) );
+		return substr( $string, 0, 127 ) ?: '';
 	}
 
 	/**

--- a/modules/ppcp-order-tracking/src/Shipment/Shipment.php
+++ b/modules/ppcp-order-tracking/src/Shipment/Shipment.php
@@ -169,10 +169,10 @@ class Shipment implements ShipmentInterface {
 			$image                     = wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' );
 
 			$ppcp_order_item = new Item(
-				mb_substr( $item->get_name(), 0, 127 ),
+				$this->prepare_item_string( $item->get_name() ),
 				new Money( $price_without_tax_rounded, $currency ),
 				$quantity,
-				$this->prepare_description( $product->get_description() ),
+				$this->prepare_item_string( $product->get_description() ),
 				null,
 				$this->prepare_sku( $product->get_sku() ),
 				$product->is_virtual() ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,

--- a/modules/ppcp-paypal-subscriptions/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-paypal-subscriptions/src/SubscriptionsApiHandler.php
@@ -114,7 +114,7 @@ class SubscriptionsApiHandler {
 	 */
 	public function create_product( WC_Product $product ) {
 		try {
-			$subscription_product = $this->products_endpoint->create( $product->get_title(), $this->prepare_description( $product->get_description() ) );
+			$subscription_product = $this->products_endpoint->create( $this->prepare_item_string( $product->get_title() ), $this->prepare_item_string( $product->get_description() ) );
 			$product->update_meta_data( 'ppcp_subscription_product', $subscription_product->to_array() );
 			$product->save();
 		} catch ( RuntimeException $exception ) {
@@ -169,7 +169,7 @@ class SubscriptionsApiHandler {
 				$catalog_product_name        = $catalog_product->name() ?: '';
 				$catalog_product_description = $catalog_product->description() ?: '';
 
-				$wc_product_description = $this->prepare_description( $product->get_description() ) ?: $product->get_title();
+				$wc_product_description = $this->prepare_item_string( $product->get_description() ) ?: $this->prepare_item_string( $product->get_title() );
 
 				if ( $catalog_product_name !== $product->get_title() || $catalog_product_description !== $wc_product_description ) {
 					$data = array();

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -312,11 +312,12 @@ class ItemFactoryTest extends TestCase
 
         $result = $testee->from_wc_order($order);
         $item = current($result);
+
         /**
          * @var Item $item
          */
-        $this->assertEquals(mb_substr($name, 0, 127), $item->name());
-        $this->assertEquals(substr($description, 0, 127), $item->description());
+        $this->assertEquals(substr( strip_shortcodes( wp_strip_all_tags( $name ) ), 0, 127 ), $item->name());
+        $this->assertEquals(substr( strip_shortcodes( wp_strip_all_tags( $description ) ), 0, 127 ), $item->description());
     }
 
     public function testFromPayPalResponse()


### PR DESCRIPTION
## PR Description
This PR replaces the `prepare_description` utility function with `prepare_item_string` making it more universal and suitable for other strings other than just the description (like title for example).

## Issue Description
Currently, the Product Title is not being sanitized correctly before getting sent to PayPal, which can result in HTML tags being present in the order summary.


## Screenshots
|Before|After|
|-|-|
|<img width="567" alt="PayPal_Checkout" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/a28cc901-8c14-4dfa-9446-9e000e02f812">|<img width="565" alt="PayPal_Checkout" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/3d39446b-8117-41c4-89f9-5e672fb24520">|

## Steps to test

1. Navigate to WooCommerce → Settings → Payments
2. Make sure PayPal is enabled.
3. Add a product with some HTML tags in the Product Title. For example: `<sup>Example title</sup>`
4. Add that product to the cart and check out with PayPal.
5. After being redirected to the PayPal page, **click on the order amount in the very top right**.
6. Notice the item product title.