### PR TITLE
Disable markup in get_plugin_data() returns to fix an issue with wptexturize() (652)

### DIFF
--- a/src/FilePathPluginFactory.php
+++ b/src/FilePathPluginFactory.php
@@ -98,7 +98,7 @@ class FilePathPluginFactory implements FilePathPluginFactoryInterface {
 			$this->create_version( $plugin_data['Version'] ),
 			$base_dir,
 			$base_name,
-			'blah',
+			$plugin_data['Title'],
 			$plugin_data['Description'],
 			$text_domain,
 			$this->create_version( $plugin_data['RequiresPHP'] ),

--- a/src/FilePathPluginFactory.php
+++ b/src/FilePathPluginFactory.php
@@ -65,7 +65,7 @@ class FilePathPluginFactory implements FilePathPluginFactoryInterface {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		$plugin_data = get_plugin_data( $filePath );
+		$plugin_data = get_plugin_data( $filePath, false );
 		if ( empty( $plugin_data ) ) {
 			throw new UnexpectedValueException(
 				sprintf(
@@ -98,7 +98,7 @@ class FilePathPluginFactory implements FilePathPluginFactoryInterface {
 			$this->create_version( $plugin_data['Version'] ),
 			$base_dir,
 			$base_name,
-			$plugin_data['Title'],
+			'blah',
 			$plugin_data['Description'],
 			$text_domain,
 			$this->create_version( $plugin_data['RequiresPHP'] ),

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -97,7 +97,7 @@ define( 'PAYPAL_INTEGRATION_DATE', '2024-03-12' );
 				 */
 				require_once ABSPATH . 'wp-admin/includes/plugin.php';
 			}
-			$plugin_data              = get_plugin_data( __DIR__ . '/woocommerce-paypal-payments.php' );
+			$plugin_data              = get_plugin_data( __DIR__ . '/woocommerce-paypal-payments.php', false );
 			$plugin_version           = $plugin_data['Version'] ?? null;
 			$installed_plugin_version = get_option( 'woocommerce-ppcp-version' );
 			if ( $installed_plugin_version !== $plugin_version ) {


### PR DESCRIPTION
### Description

This PR disables HTML markup in `get_plugin_data()` returns in order to fix the issue with incorrect early initialization of `wptexturize()`.

Fixes #2064.

### Original Issue

![hello](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/2d907467-0840-4650-8db8-158a4fedf8d2)

When PayPal Payments is active, some ASCII conversion appears to be happening which causes “quotes” to be converted to “fancy quotes” even though this should not be the case for languages such as Hebrew or German (formal).

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. In Settings → General  → Site Language set the language to German (Deutsch).
2. Make sure you have a page with content that includes "quotes".
3. Disable/Enable the WooCommerce PayPal Payments plugin.
4. The quotes should be displaying the same regardless of the WooCommerce PayPal Payments activation status.

### Screenshots
|Before|After|
|-|-|
|<img width="567" alt="hello" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/d427800d-0333-4d1b-bc74-f663332d0125">|<img width="541" alt="“_Hello”_–_WooCommerce_PayPal_Payments" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/8d0c3989-1b49-459f-ab6e-523ae2b6c881">|

### Note

Disabling the markup in the `get_plugin_data()` return data strips all HTML from the plugin data. However, I did not find any instance where this would affect plugin details being displayed incorrectly on the front end.


|Before|After|
|-|-|
|<img width="1230" alt="woocommerce-paypal-payments_ddev_site_8080_sample-page" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/9a9161b6-1f14-4216-9cb7-b81ec7c70a2f">|<img width="1230" alt="woocommerce-paypal-payments_ddev_site_8080_sample-page-2" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/a78e5b46-5bc4-4ad1-a5c7-9524d68800dd">|
