### PR TITLE
Pay later messaging configurator & messaging block adjustments (2795)

### DIFF
--- a/modules/ppcp-paylater-block/resources/js/edit.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.js
@@ -7,7 +7,7 @@ import { loadPaypalScript } from '../../../ppcp-button/resources/js/modules/Help
 import PayPalMessages from "./components/PayPalMessages";
 
 export default function Edit( { attributes, clientId, setAttributes } ) {
-    const { layout, logo, position, color, flexColor, flexRatio, placement, id } = attributes;
+    const { layout, logo, position, color, size, flexColor, flexRatio, placement, id } = attributes;
     const isFlex = layout === 'flex';
 
     const [paypalScriptState, setPaypalScriptState] = useState(null);
@@ -30,6 +30,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
         ratio: flexRatio,
         text: {
             color,
+            size
         },
     };
 
@@ -129,10 +130,10 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
                     { !isFlex && (<SelectControl
                         label={__('Logo', 'woocommerce-paypal-payments')}
                         options={[
-                            { label: __('Primary', 'woocommerce-paypal-payments'), value: 'primary' },
-                            { label: __('Alternative', 'woocommerce-paypal-payments'), value: 'alternative' },
+                            { label: __('Full logo', 'woocommerce-paypal-payments'), value: 'primary' },
+                            { label: __('Monogram', 'woocommerce-paypal-payments'), value: 'alternative' },
                             { label: __('Inline', 'woocommerce-paypal-payments'), value: 'inline' },
-                            { label: __('None', 'woocommerce-paypal-payments'), value: 'none' },
+                            { label: __('Message only', 'woocommerce-paypal-payments'), value: 'none' },
                         ]}
                         value={logo}
                         onChange={(value) => setAttributes({logo: value})}
@@ -150,13 +151,23 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
                     { !isFlex && (<SelectControl
                         label={__('Text Color', 'woocommerce-paypal-payments')}
                         options={[
-                            { label: __( 'Black', 'woocommerce-paypal-payments' ), value: 'black' },
-                            { label: __( 'White', 'woocommerce-paypal-payments' ), value: 'white' },
+                            { label: __( 'Black / Blue logo', 'woocommerce-paypal-payments' ), value: 'black' },
+                            { label: __( 'White / White logo', 'woocommerce-paypal-payments' ), value: 'white' },
                             { label: __( 'Monochrome', 'woocommerce-paypal-payments' ), value: 'monochrome' },
-                            { label: __( 'Grayscale', 'woocommerce-paypal-payments' ), value: 'grayscale' },
+                            { label: __( 'Black / Gray logo', 'woocommerce-paypal-payments' ), value: 'grayscale' },
                         ]}
                         value={color}
                         onChange={(value) => setAttributes({color: value})}
+                    />)}
+                    { !isFlex && (<SelectControl
+                        label={__('Text Size', 'woocommerce-paypal-payments')}
+                        options={[
+                            { label: __( 'Small', 'woocommerce-paypal-payments' ), value: '12' },
+                            { label: __( 'Medium', 'woocommerce-paypal-payments' ), value: '14' },
+                            { label: __( 'Large', 'woocommerce-paypal-payments' ), value: '16' },
+                        ]}
+                        value={size}
+                        onChange={(value) => setAttributes({size: value})}
                     />)}
                     { isFlex && (<SelectControl
                         label={__('Color', 'woocommerce-paypal-payments')}
@@ -164,10 +175,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
                             { label: __( 'Blue', 'woocommerce-paypal-payments' ), value: 'blue' },
                             { label: __( 'Black', 'woocommerce-paypal-payments' ), value: 'black' },
                             { label: __( 'White', 'woocommerce-paypal-payments' ), value: 'white' },
-                            { label: __( 'White no border', 'woocommerce-paypal-payments' ), value: 'white-no-border' },
-                            { label: __( 'Gray', 'woocommerce-paypal-payments' ), value: 'gray' },
-                            { label: __( 'Monochrome', 'woocommerce-paypal-payments' ), value: 'monochrome' },
-                            { label: __( 'Grayscale', 'woocommerce-paypal-payments' ), value: 'grayscale' },
+                            { label: __( 'White (no border)', 'woocommerce-paypal-payments' ), value: 'white-no-border' },
                         ]}
                         value={flexColor}
                         onChange={(value) => setAttributes({flexColor: value})}
@@ -175,8 +183,6 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
                     { isFlex && (<SelectControl
                         label={__('Ratio', 'woocommerce-paypal-payments')}
                         options={[
-                            { label: __( '1x1', 'woocommerce-paypal-payments' ), value: '1x1' },
-                            { label: __( '1x4', 'woocommerce-paypal-payments' ), value: '1x4' },
                             { label: __( '8x1', 'woocommerce-paypal-payments' ), value: '8x1' },
                             { label: __( '20x1', 'woocommerce-paypal-payments' ), value: '20x1' },
                         ]}

--- a/modules/ppcp-paylater-block/resources/js/save.js
+++ b/modules/ppcp-paylater-block/resources/js/save.js
@@ -1,7 +1,7 @@
 import { useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-    const { layout, logo, position, color, flexColor, flexRatio, placement, id } = attributes;
+    const { layout, logo, position, color, size, flexColor, flexRatio, placement, id } = attributes;
     const paypalAttributes = layout === 'flex' ? {
         'data-pp-style-layout': 'flex',
         'data-pp-style-color': flexColor,
@@ -11,6 +11,7 @@ export default function save( { attributes } ) {
         'data-pp-style-logo-type': logo,
         'data-pp-style-logo-position': position,
         'data-pp-style-text-color': color,
+        'data-pp-style-text-size': size,
     };
     if (placement && placement !== 'auto') {
         paypalAttributes['data-pp-placement'] = placement;

--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -40,7 +40,7 @@ class PayLaterBlockModule implements ModuleInterface {
 	 * @return bool true if the block is enabled, otherwise false.
 	 */
 	public static function is_block_enabled( SettingsStatus $settings_status ): bool {
-		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'product_preview' );
+		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'woocommerceBlock' );
 	}
 
 	/**

--- a/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
+++ b/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
@@ -43,6 +43,11 @@
 	.css-1yo2lxy-text_body_strong, span.css-16jt5za-text_body, span.css-1yo2lxy-text_body_strong, span {
 		font-size: 14px;
 	}
+
+	hr {
+		margin-right: 16px;
+		border-top-color: rgb(84, 93, 104);
+	}
 }
 
 #field-pay_later_messaging_heading h3{

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -40,7 +40,10 @@ document.addEventListener( 'DOMContentLoaded', () => {
         partnerClientId: PcpPayLaterConfigurator.partnerClientId,
         partnerName: 'WooCommerce',
         bnCode: 'Woo_PPCP',
-        placements: ['cart', 'checkout', 'product', 'shop', 'home', 'product_preview'],
+        placements: ['cart', 'checkout', 'product', 'shop', 'home'],
+        custom_placement:[{
+            message_reference: 'woocommerceBlock',
+        }],
         styleOverrides: {
             button: publishButtonClassName,
             header: PcpPayLaterConfigurator.headerClassName,

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -46,7 +46,7 @@ class ConfigFactory {
 				'color'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black', array( 'black', 'blue', 'white', 'white-no-border' ) ),
 				'ratio'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_ratio", '8x1', array( '8x1', '20x1' ) ),
 			);
-		} elseif($location !== 'woocommerceBlock') {
+		} elseif ( $location !== 'woocommerceBlock' ) {
 			$config = array(
 				'layout'        => 'text',
 				'logo-position' => $this->get_or_default( $settings, "pay_later_{$location}_message_position", 'left' ),
@@ -62,7 +62,7 @@ class ConfigFactory {
 				'status'    => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
 				'placement' => $location,
 			),
-			$config ?? []
+			$config ?? array()
 		);
 	}
 

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -62,7 +62,7 @@ class ConfigFactory {
 				'status'    => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
 				'placement' => $location,
 			),
-			$config
+			$config ?? []
 		);
 	}
 

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -22,12 +22,12 @@ class ConfigFactory {
 	 */
 	public function from_settings( Settings $settings ): array {
 		return array(
-			'cart'            => $this->for_location( $settings, 'cart' ),
-			'checkout'        => $this->for_location( $settings, 'checkout' ),
-			'product'         => $this->for_location( $settings, 'product' ),
-			'shop'            => $this->for_location( $settings, 'shop' ),
-			'home'            => $this->for_location( $settings, 'home' ),
-			'product_preview' => $this->for_location( $settings, 'product_preview' ),
+			'cart'             => $this->for_location( $settings, 'cart' ),
+			'checkout'         => $this->for_location( $settings, 'checkout' ),
+			'product'          => $this->for_location( $settings, 'product' ),
+			'shop'             => $this->for_location( $settings, 'shop' ),
+			'home'             => $this->for_location( $settings, 'home' ),
+			'woocommerceBlock' => $this->for_location( $settings, 'woocommerceBlock' ),
 		);
 	}
 
@@ -46,7 +46,7 @@ class ConfigFactory {
 				'color'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black', array( 'black', 'blue', 'white', 'white-no-border' ) ),
 				'ratio'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_ratio", '8x1', array( '8x1', '20x1' ) ),
 			);
-		} else {
+		} elseif($location !== 'woocommerceBlock') {
 			$config = array(
 				'layout'        => 'text',
 				'logo-position' => $this->get_or_default( $settings, "pay_later_{$location}_message_position", 'left' ),


### PR DESCRIPTION
# PR Description
The PR will:
- Change the `product_preview` to the `custom_placement`
- Link the block availability with the new placement ( `woocommerceBlock` )
- Adjust option labels for messaging block
- Add the "Size" option for text size selection.

# Issue Description
We need to change the `product_preview` to the `custom_placement` and link the block availability with the new placement.
Also need to adjust messaging block labels and add `text-size` option, as it is currently not supported in the Block

<img width="1546" alt="Screenshot 2024-03-14 at 18 01 09" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/11319597/4a713118-0466-418f-a275-6ca1d8331c62">
