### PR TITLE
JS error in single product when free trial subscription in the cart (2783)

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -241,7 +241,6 @@ document.addEventListener(
         if (!typeof (PayPalCommerceGateway)) {
             console.error('PayPal button could not be configured.');
             return;
-            return;
         }
 
         if (

--- a/modules/ppcp-button/resources/js/modules/Helper/CartSimulator.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/CartSimulator.js
@@ -1,0 +1,95 @@
+import SingleProductActionHandler from "../ActionHandler/SingleProductActionHandler";
+import SimulateCart from "./SimulateCart";
+import BootstrapHelper from "./BootstrapHelper";
+import {strAddWord, strRemoveWord} from "./Utils";
+import merge from "deepmerge";
+
+class CartSimulator {
+
+    constructor(bootstrap) {
+        this.bootstrap = bootstrap;
+    }
+
+    /**
+     * @return
+     */
+    simulate() {
+        const gatewaySettings = this.bootstrap.gateway;
+
+        if (!gatewaySettings.simulate_cart.enabled) {
+            return;
+        }
+
+        const actionHandler = new SingleProductActionHandler(
+            null,
+            null,
+            this.bootstrap.form(),
+            this.bootstrap.errorHandler,
+        );
+
+        const hasSubscriptions = PayPalCommerceGateway.data_client_id.has_subscriptions
+            && PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled;
+
+        const products = hasSubscriptions
+            ? actionHandler.getSubscriptionProducts()
+            : actionHandler.getProducts();
+
+        (new SimulateCart(
+            gatewaySettings.ajax.simulate_cart.endpoint,
+            gatewaySettings.ajax.simulate_cart.nonce,
+        )).simulate((data) => {
+
+            // Trigger event with simulated total.
+            jQuery(document.body).trigger('ppcp_product_total_updated', [data.total]);
+
+            // Hide and show fields.
+            let newData = {};
+            if (typeof data.button.is_disabled === 'boolean') {
+                newData = merge(newData, {button: {is_disabled: data.button.is_disabled}});
+            }
+            if (typeof data.messages.is_hidden === 'boolean') {
+                newData = merge(newData, {messages: {is_hidden: data.messages.is_hidden}});
+            }
+            if (newData) {
+                BootstrapHelper.updateScriptData(this.bootstrap, newData);
+            }
+
+            // Check if single product buttons enabled.
+            if ( gatewaySettings.single_product_buttons_enabled !== '1' ) {
+                return;
+            }
+
+            // Update funding sources.
+            let enableFunding = gatewaySettings.url_params['enable-funding'] || '';
+            let enableFundingBefore = enableFunding;
+
+            let disableFunding = gatewaySettings.url_params['disable-funding'] || '';
+            let disableFundingBefore = disableFunding;
+
+            for (const [fundingSource, funding] of Object.entries(data.funding)) {
+                if (funding.enabled === true) {
+                    enableFunding = strAddWord(enableFunding, fundingSource);
+                    disableFunding = strRemoveWord(disableFunding, fundingSource);
+                } else if (funding.enabled === false) {
+                    enableFunding = strRemoveWord(enableFunding, fundingSource);
+                    disableFunding = strAddWord(disableFunding, fundingSource);
+                }
+            }
+
+            // Detect and update funding changes and reload buttons.
+            if (
+                (enableFunding !== enableFundingBefore) ||
+                (disableFunding !== disableFundingBefore)
+            ) {
+                gatewaySettings.url_params['enable-funding'] = enableFunding;
+                gatewaySettings.url_params['disable-funding'] = disableFunding;
+                jQuery(gatewaySettings.button.wrapper).trigger('ppcp-reload-buttons');
+            }
+
+            this.bootstrap.handleButtonStatus(false);
+
+        }, products);
+    }
+}
+
+export default CartSimulator;


### PR DESCRIPTION
# PR Description
This PR resolves the Javascript error when either `enable-funding` or `disable-funding` is not set.

It also isolates the simulate cart processing in CartSimulator class.

# Issue Description

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'split')
    at xt (Utils.js:26:19)
    at SingleProductBootstap.js:268:37
    at SimulateCart.js:41:38
```

JS error in single product when free trial subscription in the cart.

**Steps To Reproduce**
* Enable WC Subscriptions plugin
* Enable Vaulting and Subscriptions mode Vaulting
* Create a free trial subscription product
* Add a free trial product to the cart
* Visit a single product page