### PR TITLE
Pay later messaging configurator improvements (2807)

### DIFF
--- a/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
+++ b/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
@@ -46,7 +46,7 @@
 
 	hr {
 		margin-right: 16px;
-		border-top-color: rgb(84, 93, 104);
+		border-top-color: #B1B7BD;
 	}
 }
 

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -43,8 +43,8 @@ class ConfigFactory {
 		if ( in_array( $location, array( 'shop', 'home' ), true ) ) {
 			$config = array(
 				'layout' => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'flex' ),
-				'color'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black', array( 'black', 'blue', 'white', 'white-no-border' ) ),
-				'ratio'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_ratio", '8x1', array( '8x1', '20x1' ) ),
+				'color'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black' ),
+				'ratio'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_ratio", '8x1' ),
 			);
 		} elseif ( $location !== 'woocommerceBlock' ) {
 			$config = array(

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -42,7 +42,7 @@ class ConfigFactory {
 
 		if ( in_array( $location, array( 'shop', 'home' ), true ) ) {
 			$config = array(
-				'layout' => 'flex',
+				'layout' => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'flex' ),
 				'color'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black', array( 'black', 'blue', 'white', 'white-no-border' ) ),
 				'ratio'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_ratio", '8x1', array( '8x1', '20x1' ) ),
 			);

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -48,7 +48,7 @@ class ConfigFactory {
 			);
 		} elseif ( $location !== 'woocommerceBlock' ) {
 			$config = array(
-				'layout'        => 'text',
+				'layout'        => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'text' ),
 				'logo-position' => $this->get_or_default( $settings, "pay_later_{$location}_message_position", 'left' ),
 				'logo-type'     => $this->get_or_default( $settings, "pay_later_{$location}_message_logo", 'inline' ),
 				'text-color'    => $this->get_or_default( $settings, "pay_later_{$location}_message_color", 'black' ),


### PR DESCRIPTION
# PR Description
The PR will:
- Change the color for the separator in the Configurator: #B1B7BD
- Allow legacy values to be passed to the Configurator

# Issue Description
We need to remove the placement fallback mapping to allow legacy values to be passed to the Configurator for displaying the legacy styling notice.
<img width="1245" alt="Screenshot 2024-03-18 at 17 33 57" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/11319597/6cd636ac-2c85-4a73-86e6-3b5989e50dc8">

Also we need to change the color for the separator in the Configurator to be #B1B7BD
