### PR TITLE
Pay later messaging configurator improvements (2811)

### DIFF
--- a/modules/ppcp-paylater-block/resources/js/edit.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.js
@@ -194,12 +194,11 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
                         help={ __( 'Used for the analytics dashboard in the merchant account.', 'woocommerce-paypal-payments' ) }
                         options={ [
                             { label: __( 'Detect automatically', 'woocommerce-paypal-payments' ), value: 'auto' },
+                            { label: __( 'Product Page', 'woocommerce-paypal-payments' ), value: 'product-page' },
                             { label: __( 'Cart', 'woocommerce-paypal-payments' ), value: 'cart' },
-                            { label: __( 'Payment', 'woocommerce-paypal-payments' ), value: 'payment' },
-                            { label: __( 'Product', 'woocommerce-paypal-payments' ), value: 'product' },
-                            { label: __( 'Product list', 'woocommerce-paypal-payments' ), value: 'product-list' },
+                            { label: __( 'Checkout', 'woocommerce-paypal-payments' ), value: 'checkout' },
                             { label: __( 'Home', 'woocommerce-paypal-payments' ), value: 'home' },
-                            { label: __( 'Category', 'woocommerce-paypal-payments' ), value: 'category' },
+                            { label: __( 'Shop', 'woocommerce-paypal-payments' ), value: 'shop' },
                         ] }
                         value={ placement }
                         onChange={ ( value ) => setAttributes( { placement: value } ) }

--- a/modules/ppcp-paylater-block/resources/js/edit.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.js
@@ -194,7 +194,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
                         help={ __( 'Used for the analytics dashboard in the merchant account.', 'woocommerce-paypal-payments' ) }
                         options={ [
                             { label: __( 'Detect automatically', 'woocommerce-paypal-payments' ), value: 'auto' },
-                            { label: __( 'Product Page', 'woocommerce-paypal-payments' ), value: 'product-page' },
+                            { label: __( 'Product Page', 'woocommerce-paypal-payments' ), value: 'product' },
                             { label: __( 'Cart', 'woocommerce-paypal-payments' ), value: 'cart' },
                             { label: __( 'Checkout', 'woocommerce-paypal-payments' ), value: 'checkout' },
                             { label: __( 'Home', 'woocommerce-paypal-payments' ), value: 'home' },

--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -40,7 +40,7 @@ class PayLaterBlockModule implements ModuleInterface {
 	 * @return bool true if the block is enabled, otherwise false.
 	 */
 	public static function is_block_enabled( SettingsStatus $settings_status ): bool {
-		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'woocommerceBlock' );
+		return self::is_module_loading_required() && $settings_status->is_pay_later_messaging_enabled_for_location( 'custom_placement' );
 	}
 
 	/**

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -29,7 +29,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
             setTimeout(() => {
                 saveChangesButton.click(); // Trigger click event on saveChangesButton
                 isSaving = false; // Reset flag when saving is complete
-            }, 500); // Adjust the delay as needed
+            }, 1000); // Adjust the delay as needed
         }
     });
 

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -33,14 +33,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
         }
     });
 
-
     merchantConfigurators.Messaging({
         config: PcpPayLaterConfigurator.config,
         merchantClientId: PcpPayLaterConfigurator.merchantClientId,
         partnerClientId: PcpPayLaterConfigurator.partnerClientId,
         partnerName: 'WooCommerce',
         bnCode: 'Woo_PPCP',
-        placements: ['cart', 'checkout', 'product', 'shop', 'home', 'woocommerceBlock'],
+        placements: ['cart', 'checkout', 'product', 'shop', 'home', 'custom_placement'],
         styleOverrides: {
             button: publishButtonClassName,
             header: PcpPayLaterConfigurator.headerClassName,

--- a/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
+++ b/modules/ppcp-paylater-configurator/resources/js/paylater-configurator.js
@@ -40,10 +40,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
         partnerClientId: PcpPayLaterConfigurator.partnerClientId,
         partnerName: 'WooCommerce',
         bnCode: 'Woo_PPCP',
-        placements: ['cart', 'checkout', 'product', 'shop', 'home'],
-        custom_placement:[{
-            message_reference: 'woocommerceBlock',
-        }],
+        placements: ['cart', 'checkout', 'product', 'shop', 'home', 'woocommerceBlock'],
         styleOverrides: {
             button: publishButtonClassName,
             header: PcpPayLaterConfigurator.headerClassName,

--- a/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
+++ b/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
@@ -99,9 +99,12 @@ class SaveConfig {
 		$this->settings->set( 'pay_later_messaging_enabled', true );
 
 		$enabled_locations = array();
-
 		foreach ( $config as $placement => $data ) {
 			$this->save_config_for_location( $data, $placement );
+
+			if ( $placement === 'custom_placement' ) {
+				$data = $data[0] ?? array();
+			}
 
 			if ( $data['status'] === 'enabled' ) {
 				$enabled_locations[] = $placement;

--- a/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
+++ b/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
@@ -129,7 +129,7 @@ class SaveConfig {
 		$this->set_value_if_present( $config, 'logo-type', "pay_later_{$location}_message_logo" );
 		$this->set_value_if_present( $config, 'logo-color', "pay_later_{$location}_message_color" );
 		$this->set_value_if_present( $config, 'text-size', "pay_later_{$location}_message_text_size" );
-		$this->set_value_if_present( $config, 'text-color', "pay_later_{$location}_message_text_color" );
+		$this->set_value_if_present( $config, 'text-color', "pay_later_{$location}_message_color" );
 	}
 
 	/**

--- a/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
+++ b/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
@@ -129,6 +129,7 @@ class SaveConfig {
 		$this->set_value_if_present( $config, 'logo-type', "pay_later_{$location}_message_logo" );
 		$this->set_value_if_present( $config, 'logo-color', "pay_later_{$location}_message_color" );
 		$this->set_value_if_present( $config, 'text-size', "pay_later_{$location}_message_text_size" );
+		$this->set_value_if_present( $config, 'text-color', "pay_later_{$location}_message_text_color" );
 	}
 
 	/**

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -66,7 +66,7 @@ class ConfigFactory {
 	 *     layout: string,
 	 *     color: string,
 	 *     ratio: string,
-	 *     status: string,
+	 *     status: "disabled"|"enabled",
 	 *     placement: string
 	 * } The configurator config map.
 	 */
@@ -85,7 +85,7 @@ class ConfigFactory {
 	 *
 	 * @param array $selected_locations The list of selected locations.
 	 * @return array{
-	 *     status: string,
+	 *     status: "disabled"|"enabled",
 	 *     message_reference: string
 	 * } The configurator config map.
 	 */
@@ -108,7 +108,7 @@ class ConfigFactory {
 	 *     logo-type: string,
 	 *     text-color: string,
 	 *     text-size: string,
-	 *     status: string,
+	 *     status: "disabled"|"enabled",
 	 *     placement: string
 	 * } The configurator config map.
 	 */
@@ -131,9 +131,9 @@ class ConfigFactory {
 	 * @param string     $key The key.
 	 * @param mixed      $default The default value.
 	 * @param array|null $allowed_values The list of allowed values, or null if all values are allowed.
-	 * @return mixed
+	 * @return string
 	 */
-	private function get_or_default( Settings $settings, string $key, $default, ?array $allowed_values = null ) {
+	private function get_or_default( Settings $settings, string $key, $default, ?array $allowed_values = null ): string {
 		if ( $settings->has( $key ) ) {
 			$value = $settings->get( $key );
 			if ( ! $allowed_values || in_array( $value, $allowed_values, true ) ) {

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -117,7 +117,7 @@ class ConfigFactory {
 			'layout'        => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'text' ),
 			'logo-position' => $this->get_or_default( $settings, "pay_later_{$location}_message_position", 'left' ),
 			'logo-type'     => $this->get_or_default( $settings, "pay_later_{$location}_message_logo", 'inline' ),
-			'text-color'    => $this->get_or_default( $settings, "pay_later_{$location}_message_text_color", 'black' ),
+			'text-color'    => $this->get_or_default( $settings, "pay_later_{$location}_message_color", 'black' ),
 			'text-size'     => $this->get_or_default( $settings, "pay_later_{$location}_message_text_size", '12' ),
 			'status'        => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
 			'placement'     => $location,

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -27,7 +27,7 @@ class ConfigFactory {
 			'product'          => $this->for_location( $settings, 'product' ),
 			'shop'             => $this->for_location( $settings, 'shop' ),
 			'home'             => $this->for_location( $settings, 'home' ),
-			'woocommerceBlock' => $this->for_location( $settings, 'woocommerceBlock' ),
+			'custom_placement' => $this->for_location( $settings, 'woocommerceBlock' ),
 		);
 	}
 
@@ -40,29 +40,87 @@ class ConfigFactory {
 	private function for_location( Settings $settings, string $location ): array {
 		$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
 
-		if ( in_array( $location, array( 'shop', 'home' ), true ) ) {
-			$config = array(
-				'layout' => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'flex' ),
-				'color'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black' ),
-				'ratio'  => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_ratio", '8x1' ),
-			);
-		} elseif ( $location !== 'woocommerceBlock' ) {
-			$config = array(
-				'layout'        => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'text' ),
-				'logo-position' => $this->get_or_default( $settings, "pay_later_{$location}_message_position", 'left' ),
-				'logo-type'     => $this->get_or_default( $settings, "pay_later_{$location}_message_logo", 'inline' ),
-				'text-color'    => $this->get_or_default( $settings, "pay_later_{$location}_message_color", 'black' ),
-				'text-size'     => $this->get_or_default( $settings, "pay_later_{$location}_message_text_size", '12' ),
-
-			);
+		switch ( $location ) {
+			case 'shop':
+			case 'home':
+				$config = $this->for_shop_or_home( $settings, $location, $selected_locations );
+				break;
+			case 'woocommerceBlock':
+				$config = $this->for_woocommerce_block( $selected_locations );
+				break;
+			default:
+				$config = $this->for_default_location( $settings, $location, $selected_locations );
+				break;
 		}
 
-		return array_merge(
-			array(
-				'status'    => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
-				'placement' => $location,
-			),
-			$config ?? array()
+		return $config;
+	}
+
+	/**
+	 * Returns the configurator config for shop, home locations.
+	 *
+	 * @param Settings $settings The settings.
+	 * @param string   $location The location.
+	 * @param string[] $selected_locations The list of selected locations.
+	 * @return array{
+	 *     layout: string,
+	 *     color: string,
+	 *     ratio: string,
+	 *     status: string,
+	 *     placement: string
+	 * } The configurator config map.
+	 */
+	private function for_shop_or_home( Settings $settings, string $location, array $selected_locations ): array {
+		return array(
+			'layout'    => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'flex' ),
+			'color'     => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black' ),
+			'ratio'     => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_ratio", '8x1' ),
+			'status'    => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
+			'placement' => $location,
+		);
+	}
+
+	/**
+	 * Returns the configurator config for woocommerceBlock location.
+	 *
+	 * @param array $selected_locations The list of selected locations.
+	 * @return array{
+	 *     status: string,
+	 *     message_reference: string
+	 * } The configurator config map.
+	 */
+	private function for_woocommerce_block( array $selected_locations ): array {
+		return array(
+			'status'            => in_array( 'woocommerceBlock', $selected_locations, true ) ? 'enabled' : 'disabled',
+			'message_reference' => 'woocommerceBlock',
+		);
+	}
+
+	/**
+	 * Returns the configurator config for default locations.
+	 *
+	 * @param Settings $settings The settings.
+	 * @param string   $location The location.
+	 * @param string[] $selected_locations The list of selected locations.
+	 * @return array{
+	 *     layout: string,
+	 *     logo-position: string,
+	 *     logo-type: string,
+	 *     text-color: string,
+	 *     text-size: string,
+	 *     status: string,
+	 *     placement: string
+	 * } The configurator config map.
+	 */
+	private function for_default_location( Settings $settings, string $location, array $selected_locations ): array {
+		return array(
+			'layout'        => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'text' ),
+			'logo-position' => $this->get_or_default( $settings, "pay_later_{$location}_message_position", 'left' ),
+			'logo-type'     => $this->get_or_default( $settings, "pay_later_{$location}_message_logo", 'inline' ),
+			'text-color'    => $this->get_or_default( $settings, "pay_later_{$location}_message_text_color", 'black' ),
+			'text-size'     => $this->get_or_default( $settings, "pay_later_{$location}_message_text_size", '12' ),
+			'status'        => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
+			'placement'     => $location,
 		);
 	}
 

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -27,7 +27,7 @@ class ConfigFactory {
 			'product'          => $this->for_location( $settings, 'product' ),
 			'shop'             => $this->for_location( $settings, 'shop' ),
 			'home'             => $this->for_location( $settings, 'home' ),
-			'custom_placement' => $this->for_location( $settings, 'woocommerceBlock' ),
+			'custom_placement' => array( $this->for_location( $settings, 'woocommerceBlock' ) ),
 		);
 	}
 
@@ -91,7 +91,7 @@ class ConfigFactory {
 	 */
 	private function for_woocommerce_block( array $selected_locations ): array {
 		return array(
-			'status'            => in_array( 'woocommerceBlock', $selected_locations, true ) ? 'enabled' : 'disabled',
+			'status'            => in_array( 'custom_placement', $selected_locations, true ) ? 'enabled' : 'disabled',
 			'message_reference' => 'woocommerceBlock',
 		);
 	}


### PR DESCRIPTION
# PR Description
This PR will:

- Fix the `custom_placement` schema
- Update the list of placements in the messaging block
- Fix the text color option saving

# Issue Description

We need to fix the `custom_placement` schema to launch the messaging block:
The `custom_placement` should be inside the config and not as a separate entry. Below is the correct way to send the config in.
```
merchantConfigurators.Messaging({
        config: { 
             custom_placement: [{
                 message_reference:"woocommerceBlock",
                 status:"enabled"
             }]
          },
})
```
We also need to update the list of placements in the messaging block to mirror Configurator