### PR TITLE
Sync shipping options with Venmo when skipping final confirmation on Checkout (2716)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Helper/Helper.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Helper.js
@@ -1,0 +1,22 @@
+/**
+ * @param str
+ * @returns {string}
+ */
+export const toSnakeCase = (str) => {
+    return str.replace(/[\w]([A-Z])/g, function(m) {
+        return m[0] + "_" + m[1];
+    }).toLowerCase();
+}
+
+/**
+ * @param obj
+ * @returns {{}}
+ */
+export const convertKeysToSnakeCase = (obj) => {
+    const newObj = {};
+    Object.keys(obj).forEach((key) => {
+        const newKey = toSnakeCase(key);
+        newObj[newKey] = obj[key];
+    });
+    return newObj;
+}

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -287,7 +287,11 @@ const PayPalComponent = ({
     };
 
     let handleShippingChange = null;
+    let handleShippingOptionsChange = null;
+    let handleShippingAddressChange = null;
     let handleSubscriptionShippingChange = null;
+    let handleSubscriptionShippingOptionsChange = null;
+    let handleSubscriptionShippingAddressChange = null;
     if (shippingData.needsShipping && !config.finalReviewEnabled) {
         handleShippingChange = async (data, actions) => {
             try {
@@ -296,13 +300,15 @@ const PayPalComponent = ({
                     await shippingData.setSelectedRates(shippingOptionId);
                 }
 
-                const address = paypalAddressToWc(data.shipping_address);
+                if (data.shipping_address) {
+                    const address = paypalAddressToWc(data.shipping_address);
 
-                await wp.data.dispatch('wc/store/cart').updateCustomerData({
-                    shipping_address: address,
-                });
+                    await wp.data.dispatch('wc/store/cart').updateCustomerData({
+                        shipping_address: address,
+                    });
 
-                await shippingData.setShippingAddress(address);
+                    await shippingData.setShippingAddress(address);
+                }
 
                 const res = await fetch(config.ajax.update_shipping.endpoint, {
                     method: 'POST',
@@ -325,6 +331,20 @@ const PayPalComponent = ({
             }
         };
 
+        handleShippingOptionsChange = (data, actions) => {
+            handleShippingChange({
+                orderID: data.orderID,
+                selected_shipping_option: data.selectedShippingOption
+            }, actions);
+        };
+
+        handleShippingAddressChange = (data, actions) => {
+            handleShippingChange({
+                orderID: data.orderID,
+                shipping_address: data.shippingAddress
+            }, actions);
+        };
+
         handleSubscriptionShippingChange = async (data, actions) => {
             try {
                 const shippingOptionId = data.selected_shipping_option?.id;
@@ -345,6 +365,20 @@ const PayPalComponent = ({
 
                 actions.reject();
             }
+        };
+
+        handleSubscriptionShippingOptionsChange = (data, actions) => {
+            handleSubscriptionShippingChange({
+                orderID: data.orderID,
+                selected_shipping_option: data.selectedShippingOption
+            }, actions);
+        };
+
+        handleSubscriptionShippingAddressChange = (data, actions) => {
+            handleSubscriptionShippingChange({
+                orderID: data.orderID,
+                shipping_address: data.shippingAddress
+            }, actions);
         };
     }
 
@@ -443,6 +477,8 @@ const PayPalComponent = ({
                 createSubscription={createSubscription}
                 onApprove={handleApproveSubscription}
                 onShippingChange={handleSubscriptionShippingChange}
+                onShippingOptionsChange={handleSubscriptionShippingOptionsChange}
+                onShippingAddressChange={handleSubscriptionShippingAddressChange}
             />
         );
     }
@@ -457,6 +493,8 @@ const PayPalComponent = ({
             createOrder={createOrder}
             onApprove={handleApprove}
             onShippingChange={handleShippingChange}
+            onShippingOptionsChange={handleShippingOptionsChange}
+            onShippingAddressChange={handleShippingAddressChange}
         />
     );
 }


### PR DESCRIPTION
# PR Description
This PR adds support for the `onShippingAddressChange` and `onShippingOptionsChange` on the block pages.

The arguments of these methods are compatible with the old `onShippingChange`. The only change `data` object keys are in camelCase instead of snake_case.

# Issue Description
The current integration for transmitting the shipping options to PayPal is outdated.

PayPal is in the process of enabling syncing the shipping options for Venmo as well. This new flow must be integrated to make the shipping options syncing possible for PayPal and Venmo:

https://developer.paypal.com/docs/checkout/standard/customize/shipping-options/

This likely impacts the behavior here: https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-blocks/resources/js/checkout-block.js#L292-L326 

Apple Pay uses its [own methods via the Apple JSSDK](https://developer.paypal.com/docs/checkout/apm/apple-pay/#link-customizepayment) & Google Pay should not be affected by this.
