### PR TITLE
Improve funding source names (1944)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1318,7 +1318,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 				$disable_funding,
 				array_diff(
 					array_keys( $this->all_funding_sources ),
-					array( 'venmo', 'paylater' )
+					array( 'venmo', 'paylater', 'paypal' )
 				)
 			);
 		}
@@ -1338,6 +1338,14 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 		} else {
 			$disable_funding[] = 'paylater';
 		}
+
+		// Make sure paypal is not sent in disable funding.
+		$disable_funding = array_filter(
+			$disable_funding,
+			function( $value ) {
+				return $value !== 'paypal';
+			}
+		);
 
 		if ( count( $disable_funding ) > 0 ) {
 			$params['disable-funding'] = implode( ',', array_unique( $disable_funding ) );

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1339,11 +1339,17 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			$disable_funding[] = 'paylater';
 		}
 
-		// Make sure paypal is not sent in disable funding.
 		$disable_funding = array_filter(
 			$disable_funding,
-			function( $value ) {
-				return $value !== 'paypal';
+			/**
+			 * Make sure paypal is not sent in disable funding.
+			 *
+			 * @param string $funding_source The funding_source.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function( $funding_source ) {
+				return $funding_source !== 'paypal';
 			}
 		);
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -962,7 +962,8 @@ return array(
 			'sofort'     => _x( 'Sofort', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'venmo'      => _x( 'Venmo', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'trustly'    => _x( 'Trustly', 'Name of payment method', 'woocommerce-paypal-payments' ),
-			'paylater'   => _x( 'Pay Later', 'Name of payment method', 'woocommerce-paypal-payments' ),
+			'paylater'   => _x( 'PayPal Pay Later', 'Name of payment method', 'woocommerce-paypal-payments' ),
+			'paypal'     => _x( 'PayPal', 'Name of payment method', 'woocommerce-paypal-payments' ),
 		);
 	},
 
@@ -985,6 +986,7 @@ return array(
 			array_flip(
 				array(
 					'paylater',
+					'paypal',
 				)
 			)
 		);

--- a/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
+++ b/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
@@ -34,7 +34,7 @@ class FundingSourceRenderer {
 	 *
 	 * @var string[]
 	 */
-	protected $own_funding_sources = array( 'venmo', 'paylater' );
+	protected $own_funding_sources = array( 'venmo', 'paylater', 'paypal' );
 
 	/**
 	 * FundingSourceRenderer constructor.


### PR DESCRIPTION
# PR Description
This PR adds the `paypal` funding source to the funding sources array, while taking measures for it not to be added to the `disable-funding` configuration.

# Issue Description

The funding source name should not be impacted by the gateway title. So regardless of what the payment gateway title for the PayPal gateway is, the payment method in the order would say PayPal. 
Some users also reported that Pay Later is too generic of a payment method title, so we will change it to PayPal Pay Later.

This would be possible by [extending this service](https://github.com/woocommerce/woocommerce-paypal-payments/blob/895cc486d4dca6da801cdecb9fe468cdfc162fe2/modules/ppcp-wc-gateway/services.php#L911-L924) with another option for paypal, like this:
`'paypal'    => _x( 'PayPal', 'Name of payment method', 'woocommerce-paypal-payments' ),`

While at it, the Pay Later should be more descriptive by naming it PayPal Pay Later:
`'paylater'    => _x( 'PayPal Pay Later', 'Name of payment method', 'woocommerce-paypal-payments' ),`

However, the first change alone would result in the funding source PayPal (via PayPal) being displayed.

So to remove the (via PayPal) from the paypal payment method , we must [modify this array](https://github.com/woocommerce/woocommerce-paypal-payments/blob/895cc486d4dca6da801cdecb9fe468cdfc162fe2/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php#L37) to include paypal:
`protected $own_funding_sources = array( 'paylater', 'paypal', 'venmo' );`

The only remaining problem is that PayPal would appear in the Disable Alternative Payment Methods setting, which they must be excluded from (as it would break the PayPal script when selected and Pay Later can be disabled on the Pay Later tab).