### PR TITLE
Remove all Sofort references as it has been deprecated (2724)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -962,7 +962,6 @@ return array(
 			'ideal'      => _x( 'iDEAL', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'mybank'     => _x( 'MyBank', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'p24'        => _x( 'Przelewy24', 'Name of payment method', 'woocommerce-paypal-payments' ),
-			'sofort'     => _x( 'Sofort', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'venmo'      => _x( 'Venmo', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'trustly'    => _x( 'Trustly', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'paylater'   => _x( 'Pay Later', 'Name of payment method', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
+++ b/modules/ppcp-wc-gateway/src/FundingSource/FundingSourceRenderer.php
@@ -63,7 +63,7 @@ class FundingSourceRenderer {
 				return $this->funding_sources[ $id ];
 			}
 			return sprintf(
-				/* translators: %s - Sofort, BLIK, iDeal, Mercado Pago, etc. */
+				/* translators: %s - BLIK, iDeal, Mercado Pago, etc. */
 				__( '%s (via PayPal)', 'woocommerce-paypal-payments' ),
 				$this->funding_sources[ $id ]
 			);
@@ -84,7 +84,7 @@ class FundingSourceRenderer {
 
 		if ( array_key_exists( $id, $this->funding_sources ) ) {
 			return sprintf(
-				/* translators: %s - Sofort, BLIK, iDeal, Mercado Pago, etc. */
+				/* translators: %s - BLIK, iDeal, Mercado Pago, etc. */
 				__( 'Pay via %s.', 'woocommerce-paypal-payments' ),
 				$this->funding_sources[ $id ]
 			);

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -65,7 +65,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			<a href="https://woo.com/document/woocommerce-paypal-payments/#paypal-card-processing-acdc" target="_blank"><img alt="American Express" src="' . esc_url( $module_url ) . 'assets/images/amex.svg"/></a>
 			<a href="https://woo.com/document/woocommerce-paypal-payments/#paypal-card-processing-acdc" target="_blank"><img alt="Discover" src="' . esc_url( $module_url ) . 'assets/images/discover.svg"/></a>
 			<a href="https://woo.com/document/woocommerce-paypal-payments/#alternative-payment-methods" target="_blank"><img alt="iDEAL" src="' . esc_url( $module_url ) . 'assets/images/ideal-dark.svg"/></a>
-			<a href="https://woo.com/document/woocommerce-paypal-payments/#alternative-payment-methods" target="_blank"><img alt="Sofort" src="' . esc_url( $module_url ) . 'assets/images/sofort.svg"/></a>
+			<a href="https://woo.com/document/woocommerce-paypal-payments/#alternative-payment-methods" target="_blank"><img alt="BLIK" src="' . esc_url( $module_url ) . 'assets/images/blik.svg"/></a>
 		</div>
 		<div class="ppcp-onboarding-header-apm-logos">
 			<a href="https://woo.com/document/woocommerce-paypal-payments/#apple-pay" target="_blank"><img alt="Apple Pay" src="' . esc_url( $module_url ) . 'assets/images/button-Apple-Pay.png"/></a>

--- a/tests/Playwright/.env.example
+++ b/tests/Playwright/.env.example
@@ -13,7 +13,7 @@ PRODUCT_ID=123
 
 SUBSCRIPTION_URL="/product/sub"
 
-APM_ID="sofort"
+APM_ID="paypal"
 
 WP_MERCHANT_USER="admin"
 WP_MERCHANT_PASSWORD="admin"


### PR DESCRIPTION
### Description

This PR removes all `Sofort` references from the code as this payment method has been deprecated.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. In Settings → Payments  → Connection → Account Setup make sure the Sofort icon has been replaced with the BLIK icon.

### Screenshots
|Before|After|
|-|-|
|<img width="439" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/09c3719a-0337-45e1-9c01-0e338bac8c34">|<img width="440" alt="after blik" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/3625f392-ac24-4265-a5d6-eff6e3af49b6">|
