### PR TITLE
feature request: more fraud prevention capabilities by storing additional data in the order (285)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -990,11 +990,21 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 		if ( $this->settings->has( '3d_secure_contingency' ) ) {
 			$value = $this->settings->get( '3d_secure_contingency' );
 			if ( $value ) {
-				return $value;
+				return $this->return_3ds_contingency( $value );
 			}
 		}
 
-		return 'SCA_WHEN_REQUIRED';
+		return $this->return_3ds_contingency( 'SCA_WHEN_REQUIRED' );
+	}
+
+	/**
+	 * Processes and returns the 3D Secure contingency.
+	 *
+	 * @param string $contingency The ThreeD secure contingency.
+	 * @return string
+	 */
+	private function return_3ds_contingency( string $contingency ): string {
+		return apply_filters( 'woocommerce_paypal_payments_three_d_secure_contingency', $contingency );
 	}
 
 	/**

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -330,8 +330,14 @@ class CreateOrderEndpoint implements EndpointInterface {
 				$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 				$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
 
-				$payer = $order->payer();
-				if ( $payer ) {
+				$payment_source      = $order->payment_source();
+				$payment_source_name = $payment_source ? $payment_source->name() : null;
+				$payer               = $order->payer();
+				if (
+					$payer
+					&& $payment_source_name
+					&& in_array( $payment_source_name, PayPalGateway::PAYMENT_SOURCES_WITH_PAYER_EMAIL, true )
+				) {
 					$payer_email = $payer->email_address();
 					if ( $payer_email ) {
 						$wc_order->update_meta_data( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY, $payer_email );

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -329,6 +329,15 @@ class CreateOrderEndpoint implements EndpointInterface {
 			if ( 'pay-now' === $data['context'] && is_a( $wc_order, \WC_Order::class ) ) {
 				$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 				$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
+
+				$payer = $order->payer();
+				if ( $payer ) {
+					$payer_email = $payer->email_address();
+					if ( $payer_email ) {
+						$wc_order->update_meta_data( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY, $payer_email );
+					}
+				}
+
 				$wc_order->save_meta_data();
 
 				do_action( 'woocommerce_paypal_payments_woocommerce_order_created', $wc_order, $order );

--- a/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
+++ b/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
@@ -159,6 +159,15 @@ class EarlyOrderHandler {
 		$wc_order = wc_get_order( $order_id );
 		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 		$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
+
+		$payer = $order->payer();
+		if ( $payer && $wc_order instanceof \WC_Order ) {
+			$payer_email = $payer->email_address();
+			if ( $payer_email ) {
+				$wc_order->update_meta_data( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY, $payer_email );
+			}
+		}
+
 		$wc_order->save_meta_data();
 
 		/**

--- a/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
+++ b/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
@@ -160,8 +160,15 @@ class EarlyOrderHandler {
 		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 		$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
 
-		$payer = $order->payer();
-		if ( $payer && $wc_order instanceof \WC_Order ) {
+		$payment_source      = $order->payment_source();
+		$payment_source_name = $payment_source ? $payment_source->name() : null;
+		$payer               = $order->payer();
+		if (
+			$payer
+			&& $payment_source_name
+			&& in_array( $payment_source_name, PayPalGateway::PAYMENT_SOURCES_WITH_PAYER_EMAIL, true )
+			&& $wc_order instanceof \WC_Order
+		) {
 			$payer_email = $payer->email_address();
 			if ( $payer_email ) {
 				$wc_order->update_meta_data( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY, $payer_email );

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -115,17 +115,19 @@ class CardFieldsModule implements ModuleInterface {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
+				$three_d_secure_contingency =
+					$settings->has( '3d_secure_contingency' )
+						? apply_filters( 'woocommerce_paypal_payments_three_d_secure_contingency', $settings->get( '3d_secure_contingency' ) )
+						: '';
+
 				if (
-				$settings->has( '3d_secure_contingency' )
-				&& (
-					$settings->get( '3d_secure_contingency' ) === 'SCA_ALWAYS'
-					|| $settings->get( '3d_secure_contingency' ) === 'SCA_WHEN_REQUIRED'
-				)
+					$three_d_secure_contingency === 'SCA_ALWAYS'
+					|| $three_d_secure_contingency === 'SCA_WHEN_REQUIRED'
 				) {
 					$data['payment_source']['card'] = array(
 						'attributes' => array(
 							'verification' => array(
-								'method' => $settings->get( '3d_secure_contingency' ),
+								'method' => $three_d_secure_contingency,
 							),
 						),
 					);

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -281,7 +281,11 @@ class SavePaymentMethodsModule implements ModuleInterface {
 
 					$settings = $c->get( 'wcgateway.settings' );
 					assert( $settings instanceof Settings );
-					$verification_method = $settings->has( '3d_secure_contingency' ) ? $settings->get( '3d_secure_contingency' ) : '';
+
+					$verification_method =
+						$settings->has( '3d_secure_contingency' )
+							? apply_filters( 'woocommerce_paypal_payments_three_d_secure_contingency', $settings->get( '3d_secure_contingency' ) )
+							: '';
 
 					$change_payment_method = wc_clean( wp_unslash( $_GET['change_payment_method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification
 

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -48,6 +48,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	const ORDER_ID_META_KEY             = '_ppcp_paypal_order_id';
 	const ORDER_PAYMENT_MODE_META_KEY   = '_ppcp_paypal_payment_mode';
 	const ORDER_PAYMENT_SOURCE_META_KEY = '_ppcp_paypal_payment_source';
+	const ORDER_PAYER_EMAIL_META_KEY    = '_ppcp_paypal_payer_email';
 	const FEES_META_KEY                 = '_ppcp_paypal_fees';
 	const REFUND_FEES_META_KEY          = '_ppcp_paypal_refund_fees';
 	const REFUNDS_META_KEY              = '_ppcp_refunds';

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -56,6 +56,11 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	const FRAUD_RESULT_META_KEY         = '_ppcp_paypal_fraud_result';
 
 	/**
+	 * List of payment sources wich we are expected to store the payer email in the WC Order metadata.
+	 */
+	const PAYMENT_SOURCES_WITH_PAYER_EMAIL = array( 'paypal', 'paylater', 'venmo' );
+
+	/**
 	 * The Settings Renderer.
 	 *
 	 * @var SettingsRenderer

--- a/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
@@ -52,6 +52,7 @@ trait CreditCardOrderInfoHandlingTrait {
                                                                 <li>%1$s</li>
                                                                 <li>%2$s</li>
                                                                 <li>%3$s</li>
+                                                                <li>%4$s</li>
                                                             </ul>';
 			$three_d_response_order_note_result        = sprintf(
 				$three_d_response_order_note_result_format,
@@ -60,7 +61,9 @@ trait CreditCardOrderInfoHandlingTrait {
 				/* translators: %s is enrollment status */
 				sprintf( __( 'Enrollment Status: %s', 'woocommerce-paypal-payments' ), esc_html( $result->enrollment_status() ) ),
 				/* translators: %s is authentication status */
-				sprintf( __( 'Authentication Status: %s', 'woocommerce-paypal-payments' ), esc_html( $result->authentication_result() ) )
+				sprintf( __( 'Authentication Status: %s', 'woocommerce-paypal-payments' ), esc_html( $result->authentication_result() ) ),
+				/* translators: %s card last digits */
+				sprintf( __( 'Card Last Digits: %s', 'woocommerce-paypal-payments' ), esc_html( $payment_source->properties()->last_digits ?? '' ) )
 			);
 			$three_d_response_order_note = sprintf(
 				$three_d_response_order_note_format,
@@ -76,7 +79,7 @@ trait CreditCardOrderInfoHandlingTrait {
 			/**
 			 * Fired when the 3DS information is added to WC order.
 			 */
-			do_action( 'woocommerce_paypal_payments_thee_d_secure_added', $wc_order, $order );
+			do_action( 'woocommerce_paypal_payments_three_d_secure_added', $wc_order, $order );
 		}
 	}
 

--- a/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
@@ -52,7 +52,6 @@ trait CreditCardOrderInfoHandlingTrait {
                                                                 <li>%1$s</li>
                                                                 <li>%2$s</li>
                                                                 <li>%3$s</li>
-                                                                <li>%4$s</li>
                                                             </ul>';
 			$three_d_response_order_note_result        = sprintf(
 				$three_d_response_order_note_result_format,
@@ -61,9 +60,7 @@ trait CreditCardOrderInfoHandlingTrait {
 				/* translators: %s is enrollment status */
 				sprintf( __( 'Enrollment Status: %s', 'woocommerce-paypal-payments' ), esc_html( $result->enrollment_status() ) ),
 				/* translators: %s is authentication status */
-				sprintf( __( 'Authentication Status: %s', 'woocommerce-paypal-payments' ), esc_html( $result->authentication_result() ) ),
-				/* translators: %s card last digits */
-				sprintf( __( 'Card Last Digits: %s', 'woocommerce-paypal-payments' ), esc_html( $payment_source->properties()->last_digits ?? '' ) )
+				sprintf( __( 'Authentication Status: %s', 'woocommerce-paypal-payments' ), esc_html( $result->authentication_result() ) )
 			);
 			$three_d_response_order_note = sprintf(
 				$three_d_response_order_note_format,
@@ -99,8 +96,9 @@ trait CreditCardOrderInfoHandlingTrait {
 			return;
 		}
 
-		$fraud_responses = $fraud->to_array();
-		$card_brand      = $payment_source->properties()->brand ?? __( 'N/A', 'woocommerce-paypal-payments' );
+		$fraud_responses  = $fraud->to_array();
+		$card_brand       = $payment_source->properties()->brand ?? __( 'N/A', 'woocommerce-paypal-payments' );
+		$card_last_digits = $payment_source->properties()->last_digits ?? __( 'N/A', 'woocommerce-paypal-payments' );
 
 		$avs_response_order_note_title = __( 'Address Verification Result', 'woocommerce-paypal-payments' );
 		/* translators: %1$s is AVS order note title, %2$s is AVS order note result markup */
@@ -112,6 +110,7 @@ trait CreditCardOrderInfoHandlingTrait {
                                                                     <li>%3$s</li>
                                                                 </ul>
                                                                 <li>%4$s</li>
+                                                                <li>%5$s</li>
                                                             </ul>';
 		$avs_response_order_note_result        = sprintf(
 			$avs_response_order_note_result_format,
@@ -122,7 +121,9 @@ trait CreditCardOrderInfoHandlingTrait {
 			/* translators: %s is fraud AVS postal match */
 			sprintf( __( 'Postal Match: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['postal_match'] ) ),
 			/* translators: %s is card brand */
-			sprintf( __( 'Card Brand: %s', 'woocommerce-paypal-payments' ), esc_html( $card_brand ) )
+			sprintf( __( 'Card Brand: %s', 'woocommerce-paypal-payments' ), esc_html( $card_brand ) ),
+			/* translators: %s card last digits */
+			sprintf( __( 'Card Last Digits: %s', 'woocommerce-paypal-payments' ), esc_html( $card_last_digits ) )
 		);
 		$avs_response_order_note = sprintf(
 			$avs_response_order_note_format,

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -45,6 +45,14 @@ trait OrderMetaTrait {
 			$wc_order->update_meta_data( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY, $payment_source );
 		}
 
+		$payer = $order->payer();
+		if ( $payer ) {
+			$payer_email = $payer->email_address();
+			if ( $payer_email ) {
+				$wc_order->update_meta_data( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY, $payer_email );
+			}
+		}
+
 		$wc_order->save();
 
 		do_action( 'woocommerce_paypal_payments_woocommerce_order_created', $wc_order, $order );

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -46,7 +46,11 @@ trait OrderMetaTrait {
 		}
 
 		$payer = $order->payer();
-		if ( $payer ) {
+		if (
+			$payer
+			&& $payment_source
+			&& in_array( $payment_source, PayPalGateway::PAYMENT_SOURCES_WITH_PAYER_EMAIL, true )
+		) {
 			$payer_email = $payer->email_address();
 			if ( $payer_email ) {
 				$wc_order->update_meta_data( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY, $payer_email );

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -449,17 +449,38 @@ class WCGatewayModule implements ModuleInterface {
 			}
 		);
 
-		add_action(
-			'woocommerce_admin_order_data_after_billing_address',
-			function ( \WC_Order $wc_order ) {
-				if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_paypal_email', true ) ) {
-					return;
+		/**
+		 * Param types removed to avoid third-party issues.
+		 *
+		 * @psalm-suppress MissingClosureParamType
+		 */
+		add_filter(
+			'woocommerce_admin_billing_fields',
+			function ( $fields ) {
+				global $theorder;
+
+				if ( ! is_array( $fields ) ) {
+					return $fields;
 				}
 
-				$email = $wc_order->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ?: '';
-				if ( $email ) {
-					echo '<p><strong>' . esc_html__( 'PayPal email address', 'woocommerce-paypal-payments' ) . ':</strong><br>' . esc_attr( $email ) . '</p>';
+				if ( ! $theorder instanceof WC_Order ) {
+					return $fields;
 				}
+
+				$email = $theorder->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ?: '';
+
+				if ( ! $email ) {
+					return $fields;
+				}
+
+				$fields['paypal_email'] = array(
+					'label'             => __( 'PayPal email address', 'woocommerce-paypal-payments' ),
+					'value'             => $email,
+					'wrapper_class'     => 'form-field-wide',
+					'custom_attributes' => array( 'disabled' => 'disabled' ),
+				);
+
+				return $fields;
 			}
 		);
 	}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -473,6 +473,14 @@ class WCGatewayModule implements ModuleInterface {
 					return $fields;
 				}
 
+				// Is payment source is paypal exclude all non paypal funding sources.
+				$payment_source           = $theorder->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) ?: '';
+				$is_paypal_funding_source = ( strpos( $theorder->get_payment_method_title(), '(via PayPal)' ) === false );
+
+				if ( $payment_source === 'paypal' && ! $is_paypal_funding_source ) {
+					return $fields;
+				}
+
 				$fields['paypal_email'] = array(
 					'label'             => __( 'PayPal email address', 'woocommerce-paypal-payments' ),
 					'value'             => $email,

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -448,6 +448,20 @@ class WCGatewayModule implements ModuleInterface {
 				delete_transient( 'ppcp_reference_transaction_enabled' );
 			}
 		);
+
+		add_action(
+			'woocommerce_admin_order_data_after_billing_address',
+			function ( \WC_Order $wc_order ) {
+				if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_paypal_email', true ) ) {
+					return;
+				}
+
+				$email = $wc_order->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ?: '';
+				if ( $email ) {
+					echo '<p><strong>' . esc_html__( 'PayPal buyer account', 'woocommerce-paypal-payments' ) . ':</strong><br>' . esc_attr( $email ) . '</p>';
+				}
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -458,7 +458,7 @@ class WCGatewayModule implements ModuleInterface {
 
 				$email = $wc_order->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ?: '';
 				if ( $email ) {
-					echo '<p><strong>' . esc_html__( 'PayPal buyer account', 'woocommerce-paypal-payments' ) . ':</strong><br>' . esc_attr( $email ) . '</p>';
+					echo '<p><strong>' . esc_html__( 'PayPal email address', 'woocommerce-paypal-payments' ) . ':</strong><br>' . esc_attr( $email ) . '</p>';
 				}
 			}
 		);

--- a/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
+++ b/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
@@ -92,6 +92,8 @@ class VaultedCreditCardHandlerTest extends TestCase
 		$customer = Mockery::mock(WC_Customer::class);
 
 		$payer = Mockery::mock(Payer::class);
+		$payer->shouldReceive('email_address');
+
 		$this->payerFactory->shouldReceive('from_wc_order')
 			->andReturn($payer);
 		$this->shippingPreferenceFactory->shouldReceive('from_state')
@@ -100,6 +102,7 @@ class VaultedCreditCardHandlerTest extends TestCase
 		$order = Mockery::mock(Order::class);
 		$order->shouldReceive('id')->andReturn('1');
 		$order->shouldReceive('intent')->andReturn('CAPTURE');
+		$order->shouldReceive('payer')->andReturn($payer);
 
 		$paymentSource = Mockery::mock(PaymentSource::class);
 		$paymentSource->shouldReceive('name')->andReturn('card');

--- a/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
@@ -89,6 +89,7 @@ private $testee;
 		$order->shouldReceive('id')->andReturn('1');
 		$order->shouldReceive('intent');
 		$order->shouldReceive('payment_source');
+		$order->shouldReceive('payer');
 
 		$this->orderEndpoint
 			->shouldReceive('create')

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -93,6 +93,7 @@ class OrderProcessorTest extends TestCase
 		$currentOrder
 			->shouldReceive('payment_source')
 			->andReturn(null);
+		$currentOrder->shouldReceive('payer');
 
         $wcOrder
             ->shouldReceive('get_meta')
@@ -230,6 +231,7 @@ class OrderProcessorTest extends TestCase
 		$currentOrder
 			->shouldReceive('payment_source')
 			->andReturn(null);
+		$currentOrder->shouldReceive('payer');
 
         $wcOrder
             ->shouldReceive('get_meta')
@@ -357,6 +359,7 @@ class OrderProcessorTest extends TestCase
         $currentOrder
             ->shouldReceive('purchase_units')
             ->andReturn([$purchaseUnit]);
+		$currentOrder->shouldReceive('payer');
 
         $wcOrder
             ->shouldReceive('get_meta')


### PR DESCRIPTION
# PR Description
This PR:
- Adds the PayPal buyer account email to the order details.
- Adds the credit card last 4 digits to the 3D secure order note.
- Adds filters to act upon 3D secure.

# Issue Description

## User Story

As a merchant

I want to implement measures to prevent fraudulent payment activities in my store

So that I don’t have to deal with issuing refunds for fraudulent orders

To prevent fraud, there is some data we could realistically store in the WooCommerce order:
- buyer PayPal account email address
- buyer Card type (Amex/Master/VISA) was added in 2.5.4
- the last four card number digits
- more 3DS data (incl. for authorized payments) was added in 2.5.4  

Some merchants are also requesting hooks to detect e.g. 3D Secure triggers so they can:
- **decide whether 3D Secure should trigger or not**
- perform actions before/after 3D Secure triggered
- perform actions based on whether 3D Secure triggered
- perform actions based on 3D Secure response (e.g. after 3D Secure triggered but before payment is authorized)

The goal may be to only authorize the order based on certain conditions (e.g. 3D Secure triggered)

This will enable any WooCommerce store owner to get some idea of who paid for the order.