### PR TITLE
Replace the middleware URL from connect.woocommerce.com to api.woocommerce.com/integrations (2721)

### DIFF
--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -31,8 +31,8 @@ define( 'PAYPAL_INTEGRATION_DATE', '2024-03-12' );
 ! defined( 'CONNECT_WOO_SANDBOX_CLIENT_ID' ) && define( 'CONNECT_WOO_SANDBOX_CLIENT_ID', 'AYmOHbt1VHg-OZ_oihPdzKEVbU3qg0qXonBcAztuzniQRaKE0w1Hr762cSFwd4n8wxOl-TCWohEa0XM_' );
 ! defined( 'CONNECT_WOO_MERCHANT_ID' ) && define( 'CONNECT_WOO_MERCHANT_ID', 'K8SKZ36LQBWXJ' );
 ! defined( 'CONNECT_WOO_SANDBOX_MERCHANT_ID' ) && define( 'CONNECT_WOO_SANDBOX_MERCHANT_ID', 'MPMFHQTVMBZ6G' );
-! defined( 'CONNECT_WOO_URL' ) && define( 'CONNECT_WOO_URL', 'https://connect.woocommerce.com/ppc' );
-! defined( 'CONNECT_WOO_SANDBOX_URL' ) && define( 'CONNECT_WOO_SANDBOX_URL', 'https://connect.woocommerce.com/ppcsandbox' );
+! defined( 'CONNECT_WOO_URL' ) && define( 'CONNECT_WOO_URL', 'https://api.woocommerce.com/integrations/ppc' );
+! defined( 'CONNECT_WOO_SANDBOX_URL' ) && define( 'CONNECT_WOO_SANDBOX_URL', 'https://api.woocommerce.com/integrations/ppcsandbox' );
 
 ( function () {
 	$autoload_filepath = __DIR__ . '/vendor/autoload.php';


### PR DESCRIPTION
Fixes #2067.

The `connect.woocommerce.com` server is due to be retired. The `api.woocommerce.com` server now provides the connect service. The base URL will now be `api.woocommerce.com/integrations`. All other endpoints should now be accessible from the base URL.