### PR TITLE
Fix issue #2114; Changed network_home_url() to home_url() to avoid wr…

### DIFF
--- a/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
+++ b/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
@@ -54,7 +54,7 @@ class ApplicationContextRepository {
 		$payment_preference = $this->settings->has( 'payee_preferred' ) && $this->settings->get( 'payee_preferred' ) ?
 			ApplicationContext::PAYMENT_METHOD_IMMEDIATE_PAYMENT_REQUIRED : ApplicationContext::PAYMENT_METHOD_UNRESTRICTED;
 		$context            = new ApplicationContext(
-			network_home_url( \WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ) ),
+			home_url( \WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ) ),
 			(string) wc_get_checkout_url(),
 			(string) $brand_name,
 			$locale,


### PR DESCRIPTION
Changed network_home_url() to home_url().

<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #2114

---

### Description

Changed network_home_url() to home_url() to avoid wrong return url in multisite setup.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Setup multisite network, woocommerce on sub-page
2. Purchase an item and pay with PayPal, use redirects to paypal page.
3. After payment, the redirect back to the page hits the multisite main page and not the sub-page.

### Documentation
- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

Avoid wrong return url in multisite setup.

Closes #2114 .
