### PR TITLE
Add filter for disabling `permit_multiple_payment_tokens` vault attribute (2924)

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -141,7 +141,7 @@ class SavePaymentMethodsModule implements ModuleInterface {
 									'vault' => array(
 										'store_in_vault' => 'ON_SUCCESS',
 										'usage_type'     => 'MERCHANT',
-										'permit_multiple_payment_tokens' => true,
+										'permit_multiple_payment_tokens' => apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', true ),
 									),
 								),
 							),
@@ -167,7 +167,7 @@ class SavePaymentMethodsModule implements ModuleInterface {
 									'vault' => array(
 										'store_in_vault' => 'ON_SUCCESS',
 										'usage_type'     => 'MERCHANT',
-										'permit_multiple_payment_tokens' => true,
+										'permit_multiple_payment_tokens' => apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', true ),
 									),
 								),
 							),


### PR DESCRIPTION
We added vault attribute `permit_multiple_payment_tokens` to provide support for multiple PayPal payment like [Venmo](https://developer.paypal.com/docs/multiparty/checkout/save-payment-methods/during-purchase/js-sdk/venmo/#link-serverside), by doing so it now creates a new Payment token on PayPal for every checkout process, to avoid this situation this PR introduces a new filter to allow merchants disable multiple payment tokens feature.

### Acceptance Criteria
Add the following filter and ensure no more than one Payment token is created on PayPal on subsequent checkout processes:
```
add_filter('woocommerce_paypal_payments_permit_multiple_payment_tokens', '__return_false');
```