### PR TITLE
Filter to hide PayPal email address not working on order detail (2925)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -459,6 +459,10 @@ class WCGatewayModule implements ModuleInterface {
 			function ( $fields ) {
 				global $theorder;
 
+				if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_paypal_email', true ) ) {
+					return $fields;
+				}
+
 				if ( ! is_array( $fields ) ) {
 					return $fields;
 				}


### PR DESCRIPTION
# PR Description
This PR implements a filter to suppress the display of the PayPal email address on the order detail page.

# Issue Description
The filter to hide the PayPal email address on the order detail page (`woocommerce_paypal_payments_order_details_show_paypal_email`) is not working.
