### PR TITLE
Problem changing the shipping option in block pages (2928)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -299,6 +299,7 @@ const PayPalComponent = ({
             try {
                 const shippingOptionId = data.selectedShippingOption?.id;
                 if (shippingOptionId) {
+                    await wp.data.dispatch('wc/store/cart').selectShippingRate(shippingOptionId);
                     await shippingData.setSelectedRates(shippingOptionId);
                 }
 
@@ -358,6 +359,7 @@ const PayPalComponent = ({
             try {
                 const shippingOptionId = data.selectedShippingOption?.id;
                 if (shippingOptionId) {
+                    await wp.data.dispatch('wc/store/cart').selectShippingRate(shippingOptionId);
                     await shippingData.setSelectedRates(shippingOptionId);
                 }
             } catch (e) {


### PR DESCRIPTION
# PR Description
To fix the issue this PR now explicitly updated the cart on shipping option change.

# Issue Description

When changing the shipping option in the PayPal popup on block pages the selected option reverts to the previous selected.

Currently to reflect the option it has to be selected two times.

## Possible cause

`await shippingData.setSelectedRates(shippingOptionId);` has a delay modifying the cart, so when we update the PayPal order the cart is still not updated.