### PR TITLE
Saved payment token deleted after payment with another saved payment token (2934)

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -141,7 +141,7 @@ class SavePaymentMethodsModule implements ModuleInterface {
 									'vault' => array(
 										'store_in_vault' => 'ON_SUCCESS',
 										'usage_type'     => 'MERCHANT',
-										'permit_multiple_payment_tokens' => apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', true ),
+										'permit_multiple_payment_tokens' => apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', false ),
 									),
 								),
 							),
@@ -167,7 +167,7 @@ class SavePaymentMethodsModule implements ModuleInterface {
 									'vault' => array(
 										'store_in_vault' => 'ON_SUCCESS',
 										'usage_type'     => 'MERCHANT',
-										'permit_multiple_payment_tokens' => apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', true ),
+										'permit_multiple_payment_tokens' => apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', false ),
 									),
 								),
 							),


### PR DESCRIPTION
In 2.6.1 we are introducing logic to [consolidate payment tokens between PayPal and WC Payment tokens](https://github.com/woocommerce/woocommerce-paypal-payments/pull/2106), as we also introduced `permit_multiple_payment_tokens` vault parameter in a recent version to allow saving multiple PayPal payments (like Venmo) the problem is that consolidation logic like deleting wrong tokens does not work as `permit_multiple_payment_tokens` vault parameter returns a new customer id every time a new payment is saved and therefore subsequent PayPal calls to retrieve the existing tokens for the customer returns only the tokens for the last customer id.

This PR fixes the above issue by reversing `woocommerce_paypal_payments_permit_multiple_payment_tokens`  filter to false, disabling multiple payment tokens by default.