### PR TITLE
Release 2.6.1-rc4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Pay upon Invoice: Add input validation to Experience Context fields #2092
 * Fix - Disable markup in get_plugin_data() returns to fix an issue with wptexturize() #2094
 * Fix - Problem changing the shipping option in block pages #2142
+* Fix - Saved payment token deleted after payment with another saved payment token #2146
 * Enhancement - Pay later messaging configurator improvements #2107
 * Enhancement - Replace the middleware URL from connect.woocommerce.com to api.woocommerce.com/integrations #2130
 * Enhancement - Remove all Sofort references as it has been deprecated #2124

--- a/readme.txt
+++ b/readme.txt
@@ -184,6 +184,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Pay upon Invoice: Add input validation to Experience Context fields #2092
 * Fix - Disable markup in get_plugin_data() returns to fix an issue with wptexturize() #2094
 * Fix - Problem changing the shipping option in block pages #2142
+* Fix - Saved payment token deleted after payment with another saved payment token #2146
 * Enhancement - Pay later messaging configurator improvements #2107
 * Enhancement - Replace the middleware URL from connect.woocommerce.com to api.woocommerce.com/integrations #2130
 * Enhancement - Remove all Sofort references as it has been deprecated #2124


### PR DESCRIPTION
[2.6.1-rc3](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.6.1-rc3) plus:
* Fix - Saved payment token deleted after payment with another saved payment token #2146