### PR TITLE
Zero sum subscriptions cause CANNOT_BE_ZERO_OR_NEGATIVE when using Vault v3 (2768)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PaymentMethodTokensEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentMethodTokensEndpoint.php
@@ -115,7 +115,7 @@ class PaymentMethodTokensEndpoint {
 	 * @throws RuntimeException When something when wrong with the request.
 	 * @throws PayPalApiException When something when wrong setting up the token.
 	 */
-	public function create_payment_token(PaymentSource $payment_source ): stdClass {
+	public function create_payment_token( PaymentSource $payment_source ): stdClass {
 		$data = array(
 			'payment_source' => array(
 				$payment_source->name() => $payment_source->properties(),

--- a/modules/ppcp-api-client/src/Endpoint/PaymentMethodTokensEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentMethodTokensEndpoint.php
@@ -115,7 +115,7 @@ class PaymentMethodTokensEndpoint {
 	 * @throws RuntimeException When something when wrong with the request.
 	 * @throws PayPalApiException When something when wrong setting up the token.
 	 */
-	public function payment_tokens( PaymentSource $payment_source ): stdClass {
+	public function create_payment_token(PaymentSource $payment_source ): stdClass {
 		$data = array(
 			'payment_source' => array(
 				$payment_source->name() => $payment_source->properties(),

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -137,7 +137,12 @@ const bootstrap = () => {
         }
 
         const isFreeTrial = PayPalCommerceGateway.is_free_trial_cart;
-        if (isFreeTrial && data.fundingSource !== 'card' && ! PayPalCommerceGateway.subscription_plan_id) {
+        if (
+            isFreeTrial
+            && data.fundingSource !== 'card'
+            && ! PayPalCommerceGateway.subscription_plan_id
+            && ! PayPalCommerceGateway.vault_v3_enabled
+        ) {
             freeTrialHandler.handle();
             return actions.reject();
         }

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -144,6 +144,55 @@ class CheckoutActionHandler {
             }
         }
     }
+
+    addPaymentMethodConfiguration() {
+        return {
+            createVaultSetupToken: async () => {
+                const response = await fetch(this.config.ajax.create_setup_token.endpoint, {
+                    method: "POST",
+                    credentials: 'same-origin',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        nonce: this.config.ajax.create_setup_token.nonce,
+                    })
+                });
+
+                const result = await response.json()
+                if (result.data.id) {
+                    return result.data.id
+                }
+
+                console.error(result)
+            },
+            onApprove: async ({vaultSetupToken}) => {
+                const response = await fetch(this.config.ajax.create_payment_token.endpoint, {
+                    method: "POST",
+                    credentials: 'same-origin',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        nonce: this.config.ajax.create_payment_token.nonce,
+                        vault_setup_token: vaultSetupToken,
+                        return_url: location.href,
+                    })
+                })
+
+                const result = await response.json();
+                if (result.success === true) {
+                    window.location.href = location.href;
+                    return;
+                }
+
+                console.error(result)
+            },
+            onError: (error) => {
+                console.error(error)
+            }
+        }
+    }
 }
 
 export default CheckoutActionHandler;

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -167,22 +167,21 @@ class CheckoutActionHandler {
                 console.error(result)
             },
             onApprove: async ({vaultSetupToken}) => {
-                const response = await fetch(this.config.ajax.create_payment_token.endpoint, {
+                const response = await fetch(this.config.ajax.create_payment_token_for_guest.endpoint, {
                     method: "POST",
                     credentials: 'same-origin',
                     headers: {
                         'Content-Type': 'application/json',
                     },
                     body: JSON.stringify({
-                        nonce: this.config.ajax.create_payment_token.nonce,
+                        nonce: this.config.ajax.create_payment_token_for_guest.nonce,
                         vault_setup_token: vaultSetupToken,
-                        return_url: location.href,
                     })
                 })
 
                 const result = await response.json();
                 if (result.success === true) {
-                    window.location.href = location.href;
+                    document.querySelector('#place_order').click()
                     return;
                 }
 

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -116,6 +116,14 @@ class CheckoutBootstap {
             return;
         }
 
+        if(
+            PayPalCommerceGateway.is_free_trial_cart
+            && PayPalCommerceGateway.vault_v3_enabled
+        ) {
+            this.renderer.render(actionHandler.addPaymentMethodConfiguration(), {}, actionHandler.configuration());
+            return;
+        }
+
         this.renderer.render(actionHandler.configuration(), {}, actionHandler.configuration());
     }
 

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -145,6 +145,7 @@ return array(
 			$container->get( 'button.early-wc-checkout-validation-enabled' ),
 			$container->get( 'button.pay-now-contexts' ),
 			$container->get( 'wcgateway.funding-sources-without-redirect' ),
+			$container->get('vaulting.vault-v3-enabled'),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -145,7 +145,8 @@ return array(
 			$container->get( 'button.early-wc-checkout-validation-enabled' ),
 			$container->get( 'button.pay-now-contexts' ),
 			$container->get( 'wcgateway.funding-sources-without-redirect' ),
-			$container->get('vaulting.vault-v3-enabled'),
+			$container->get( 'vaulting.vault-v3-enabled' ),
+			$container->get( 'api.endpoint.payment-tokens' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -185,18 +185,25 @@ class SmartButton implements SmartButtonInterface {
 	private $funding_sources_without_redirect;
 
 	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
 	 * Session handler.
 	 *
 	 * @var SessionHandler
 	 */
 	private $session_handler;
+
+	/**
+	 * Whether Vault v3 module is enabled.
+	 *
+	 * @var bool
+	 */
+	private $vault_v3_enabled;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
 
 	/**
 	 * SmartButton constructor.
@@ -220,6 +227,7 @@ class SmartButton implements SmartButtonInterface {
 	 * @param bool                   $early_validation_enabled Whether to execute WC validation of the checkout form.
 	 * @param array                  $pay_now_contexts The contexts that should have the Pay Now button.
 	 * @param string[]               $funding_sources_without_redirect The sources that do not cause issues about redirecting (on mobile, ...) and sometimes not returning back.
+	 * @param bool                   $vault_v3_enabled Whether Vault v3 module is enabled.
 	 * @param LoggerInterface        $logger The logger.
 	 */
 	public function __construct(
@@ -242,6 +250,7 @@ class SmartButton implements SmartButtonInterface {
 		bool $early_validation_enabled,
 		array $pay_now_contexts,
 		array $funding_sources_without_redirect,
+		bool $vault_v3_enabled,
 		LoggerInterface $logger
 	) {
 
@@ -264,6 +273,7 @@ class SmartButton implements SmartButtonInterface {
 		$this->early_validation_enabled          = $early_validation_enabled;
 		$this->pay_now_contexts                  = $pay_now_contexts;
 		$this->funding_sources_without_redirect  = $funding_sources_without_redirect;
+		$this->vault_v3_enabled                  = $vault_v3_enabled;
 		$this->logger                            = $logger;
 	}
 
@@ -1063,6 +1073,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			),
 			'cart_contains_subscription'              => $this->subscription_helper->cart_contains_subscription(),
 			'subscription_plan_id'                    => $this->subscription_helper->paypal_subscription_id(),
+			'vault_v3_enabled'                        => $this->vault_v3_enabled,
 			'variable_paypal_subscription_variations' => $this->subscription_helper->variable_paypal_subscription_variations(),
 			'subscription_product_allowed'            => $this->subscription_helper->checkout_subscription_product_allowed(),
 			'locations_with_subscription_product'     => $this->subscription_helper->locations_with_subscription_product(),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1059,46 +1059,46 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			'redirect'                                => wc_get_checkout_url(),
 			'context'                                 => $this->context(),
 			'ajax'                                    => array(
-				'simulate_cart'        => array(
+				'simulate_cart'                  => array(
 					'endpoint' => \WC_AJAX::get_endpoint( SimulateCartEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( SimulateCartEndpoint::nonce() ),
 				),
-				'change_cart'          => array(
+				'change_cart'                    => array(
 					'endpoint' => \WC_AJAX::get_endpoint( ChangeCartEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ChangeCartEndpoint::nonce() ),
 				),
-				'create_order'         => array(
+				'create_order'                   => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CreateOrderEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreateOrderEndpoint::nonce() ),
 				),
-				'approve_order'        => array(
+				'approve_order'                  => array(
 					'endpoint' => \WC_AJAX::get_endpoint( ApproveOrderEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ApproveOrderEndpoint::nonce() ),
 				),
-				'approve_subscription' => array(
+				'approve_subscription'           => array(
 					'endpoint' => \WC_AJAX::get_endpoint( ApproveSubscriptionEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ApproveSubscriptionEndpoint::nonce() ),
 				),
-				'vault_paypal'         => array(
+				'vault_paypal'                   => array(
 					'endpoint' => \WC_AJAX::get_endpoint( StartPayPalVaultingEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( StartPayPalVaultingEndpoint::nonce() ),
 				),
-				'save_checkout_form'   => array(
+				'save_checkout_form'             => array(
 					'endpoint' => \WC_AJAX::get_endpoint( SaveCheckoutFormEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( SaveCheckoutFormEndpoint::nonce() ),
 				),
-				'validate_checkout'    => array(
+				'validate_checkout'              => array(
 					'endpoint' => \WC_AJAX::get_endpoint( ValidateCheckoutEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ValidateCheckoutEndpoint::nonce() ),
 				),
-				'cart_script_params'   => array(
+				'cart_script_params'             => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CartScriptParamsEndpoint::ENDPOINT ),
 				),
-				'create_setup_token'   => array(
+				'create_setup_token'             => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CreateSetupToken::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreateSetupToken::nonce() ),
 				),
-				'create_payment_token' => array(
+				'create_payment_token'           => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentToken::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreatePaymentToken::nonce() ),
 				),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -34,6 +34,8 @@ use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\PayLaterBlock\PayLaterBlockModule;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
@@ -1090,6 +1092,14 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 				),
 				'cart_script_params'   => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CartScriptParamsEndpoint::ENDPOINT ),
+				),
+				'create_setup_token'   => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreateSetupToken::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreateSetupToken::nonce() ),
+				),
+				'create_payment_token' => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentToken::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreatePaymentToken::nonce() ),
 				),
 			),
 			'cart_contains_subscription'              => $this->subscription_helper->cart_contains_subscription(),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -36,6 +36,7 @@ use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\PayLaterBlock\PayLaterBlockModule;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentTokenForGuest;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
@@ -1100,6 +1101,10 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 				'create_payment_token' => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentToken::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreatePaymentToken::nonce() ),
+				),
+				'create_payment_token_for_guest' => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentTokenForGuest::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreatePaymentTokenForGuest::nonce() ),
 				),
 			),
 			'cart_contains_subscription'              => $this->subscription_helper->cart_contains_subscription(),

--- a/modules/ppcp-save-payment-methods/resources/js/add-payment-method.js
+++ b/modules/ppcp-save-payment-methods/resources/js/add-payment-method.js
@@ -12,7 +12,7 @@ import ErrorHandler from "../../../ppcp-button/resources/js/modules/ErrorHandler
 import {cardFieldStyles} from "../../../ppcp-button/resources/js/modules/Helper/CardFieldsHelper";
 
 const errorHandler = new ErrorHandler(
-    PayPalCommerceGateway.labels.error.generic,
+    ppcp_add_payment_method.labels.error.generic,
     document.querySelector('.woocommerce-notices-wrapper')
 );
 

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\SavePaymentMethods;
 
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentTokenForGuest;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Helper\SavePaymentMethodsApplies;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
@@ -809,6 +810,12 @@ return array(
 			$container->get( 'button.request-data' ),
 			$container->get( 'api.endpoint.payment-method-tokens' ),
 			$container->get( 'vaulting.wc-payment-tokens' )
+		);
+	},
+	'save-payment-methods.endpoint.create-payment-token-for-guest' => static function ( ContainerInterface $container ): CreatePaymentTokenForGuest {
+		return new CreatePaymentTokenForGuest(
+			$container->get( 'button.request-data' ),
+			$container->get( 'api.endpoint.payment-method-tokens' )
 		);
 	},
 );

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
@@ -94,7 +94,7 @@ class CreatePaymentToken implements EndpointInterface {
 				)
 			);
 
-			$result = $this->payment_method_tokens_endpoint->payment_tokens( $payment_source );
+			$result = $this->payment_method_tokens_endpoint->create_payment_token( $payment_source );
 
 			if ( is_user_logged_in() && isset( $result->customer->id ) ) {
 				$current_user_id = get_current_user_id();

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentTokenForGuest.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentTokenForGuest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Create payment token for guest user.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Endpoint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint;
+
+use Exception;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentMethodTokensEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
+use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+
+/**
+ * Class UpdateCustomerId
+ */
+class CreatePaymentTokenForGuest implements EndpointInterface {
+
+	const ENDPOINT = 'ppc-update-customer-id';
+
+	/**
+	 * The request data.
+	 *
+	 * @var RequestData
+	 */
+	private $request_data;
+
+	/**
+	 * The payment method tokens endpoint.
+	 *
+	 * @var PaymentMethodTokensEndpoint
+	 */
+	private $payment_method_tokens_endpoint;
+
+	/**
+	 * CreatePaymentToken constructor.
+	 *
+	 * @param RequestData                 $request_data The request data.
+	 * @param PaymentMethodTokensEndpoint $payment_method_tokens_endpoint The payment method tokens endpoint.
+	 */
+	public function __construct(
+		RequestData $request_data,
+		PaymentMethodTokensEndpoint $payment_method_tokens_endpoint
+	) {
+		$this->request_data                   = $request_data;
+		$this->payment_method_tokens_endpoint = $payment_method_tokens_endpoint;
+	}
+
+	/**
+	 * Returns the nonce.
+	 *
+	 * @return string
+	 */
+	public static function nonce(): string {
+		return self::ENDPOINT;
+	}
+
+	/**
+	 * Handles the request.
+	 *
+	 * @return bool
+	 * @throws Exception On Error.
+	 */
+	public function handle_request(): bool {
+		$data = $this->request_data->read_request( $this->nonce() );
+
+		/**
+		 * Suppress ArgumentTypeCoercion
+		 *
+		 * @psalm-suppress ArgumentTypeCoercion
+		 */
+		$payment_source = new PaymentSource(
+			'token',
+			(object) array(
+				'id'   => $data['vault_setup_token'],
+				'type' => 'SETUP_TOKEN',
+			)
+		);
+
+		$result = $this->payment_method_tokens_endpoint->create_payment_token( $payment_source );
+		WC()->session->set( 'ppcp_guest_payment_for_free_trial', $result );
+
+		wp_send_json_success();
+		return true;
+	}
+}

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -317,13 +317,13 @@ class SavePaymentMethodsModule implements ModuleInterface {
 									'nonce'    => wp_create_nonce( SubscriptionChangePaymentMethod::nonce() ),
 								),
 							),
-							'labels' => array(
+							'labels'                  => array(
 								'error' => array(
 									'generic' => __(
 										'Something went wrong. Please try again or choose another payment source.',
 										'woocommerce-paypal-payments'
 									),
-								)
+								),
 							),
 						)
 					);

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -312,6 +312,14 @@ class SavePaymentMethodsModule implements ModuleInterface {
 									'nonce'    => wp_create_nonce( SubscriptionChangePaymentMethod::nonce() ),
 								),
 							),
+							'labels' => array(
+								'error' => array(
+									'generic' => __(
+										'Something went wrong. Please try again or choose another payment source.',
+										'woocommerce-paypal-payments'
+									),
+								)
+							),
 						)
 					);
 				} catch ( RuntimeException $exception ) {

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -20,6 +20,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentTokenForGuest;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\Vaulting\WooCommercePaymentTokens;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
@@ -366,6 +367,16 @@ class SavePaymentMethodsModule implements ModuleInterface {
 			static function () use ( $c ) {
 				$endpoint = $c->get( 'save-payment-methods.endpoint.create-payment-token' );
 				assert( $endpoint instanceof CreatePaymentToken );
+
+				$endpoint->handle_request();
+			}
+		);
+
+		add_action(
+			'wc_ajax_' . CreatePaymentTokenForGuest::ENDPOINT,
+			static function () use ( $c ) {
+				$endpoint = $c->get( 'save-payment-methods.endpoint.create-payment-token-for-guest' );
+				assert( $endpoint instanceof CreatePaymentTokenForGuest );
 
 				$endpoint->handle_request();
 			}

--- a/modules/ppcp-vaulting/services.php
+++ b/modules/ppcp-vaulting/services.php
@@ -64,4 +64,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
+	'vaulting.vault-v3-enabled'           => static function( ContainerInterface $container ): bool {
+		return $container->has( 'save-payment-methods.eligible' ) && $container->get( 'save-payment-methods.eligible' );
+	},
 );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -104,7 +104,8 @@ return array(
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'api.factory.paypal-checkout-url' ),
 			$container->get( 'wcgateway.place-order-button-text' ),
-			$container->get( 'api.endpoint.payment-tokens' )
+			$container->get( 'api.endpoint.payment-tokens' ),
+			$container->get( 'vaulting.vault-v3-enabled' )
 		);
 	},
 	'wcgateway.credit-card-gateway'                        => static function ( ContainerInterface $container ): CreditCardGateway {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -103,7 +103,8 @@ return array(
 			$api_shop_country,
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'api.factory.paypal-checkout-url' ),
-			$container->get( 'wcgateway.place-order-button-text' )
+			$container->get( 'wcgateway.place-order-button-text' ),
+			$container->get( 'api.endpoint.payment-tokens' )
 		);
 	},
 	'wcgateway.credit-card-gateway'                        => static function ( ContainerInterface $container ): CreditCardGateway {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -105,7 +105,8 @@ return array(
 			$container->get( 'api.factory.paypal-checkout-url' ),
 			$container->get( 'wcgateway.place-order-button-text' ),
 			$container->get( 'api.endpoint.payment-tokens' ),
-			$container->get( 'vaulting.vault-v3-enabled' )
+			$container->get( 'vaulting.vault-v3-enabled' ),
+			$container->get( 'vaulting.wc-payment-tokens' )
 		);
 	},
 	'wcgateway.credit-card-gateway'                        => static function ( ContainerInterface $container ): CreditCardGateway {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -188,6 +188,13 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	private $payment_tokens_endpoint;
 
 	/**
+	 * Whether Vault v3 module is enabled.
+	 *
+	 * @var bool
+	 */
+	private $vault_v3_enabled;
+
+	/**
 	 * PayPalGateway constructor.
 	 *
 	 * @param SettingsRenderer        $settings_renderer The Settings Renderer.
@@ -208,6 +215,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @param callable(string):string $paypal_checkout_url_factory The function return the PayPal checkout URL for the given order ID.
 	 * @param string                  $place_order_button_text The text for the standard "Place order" button.
 	 * @param PaymentTokensEndpoint   $payment_tokens_endpoint Payment tokens endpoint.
+	 * @param bool $vault_v3_enabled Whether Vault v3 module is enabled.
 	 */
 	public function __construct(
 		SettingsRenderer $settings_renderer,
@@ -227,7 +235,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		OrderEndpoint $order_endpoint,
 		callable $paypal_checkout_url_factory,
 		string $place_order_button_text,
-		PaymentTokensEndpoint $payment_tokens_endpoint
+		PaymentTokensEndpoint $payment_tokens_endpoint,
+		bool $vault_v3_enabled
 	) {
 		$this->id                          = self::ID;
 		$this->settings_renderer           = $settings_renderer;
@@ -247,6 +256,9 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->api_shop_country            = $api_shop_country;
 		$this->paypal_checkout_url_factory = $paypal_checkout_url_factory;
 		$this->order_button_text           = $place_order_button_text;
+		$this->order_endpoint          = $order_endpoint;
+		$this->payment_tokens_endpoint = $payment_tokens_endpoint;
+		$this->vault_v3_enabled = $vault_v3_enabled;
 
 		if ( $this->onboarded ) {
 			$this->supports = array( 'refunds', 'tokenization' );
@@ -309,9 +321,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 				'process_admin_options',
 			)
 		);
-
-		$this->order_endpoint          = $order_endpoint;
-		$this->payment_tokens_endpoint = $payment_tokens_endpoint;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -205,25 +205,25 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	/**
 	 * PayPalGateway constructor.
 	 *
-	 * @param SettingsRenderer        $settings_renderer The Settings Renderer.
-	 * @param FundingSourceRenderer   $funding_source_renderer The funding source renderer.
-	 * @param OrderProcessor          $order_processor The Order Processor.
-	 * @param ContainerInterface      $config The settings.
-	 * @param SessionHandler          $session_handler The Session Handler.
-	 * @param RefundProcessor         $refund_processor The Refund Processor.
-	 * @param State                   $state The state.
-	 * @param TransactionUrlProvider  $transaction_url_provider Service providing transaction view URL based on order.
-	 * @param SubscriptionHelper      $subscription_helper The subscription helper.
-	 * @param string                  $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
-	 * @param Environment             $environment The environment.
-	 * @param PaymentTokenRepository  $payment_token_repository The payment token repository.
-	 * @param LoggerInterface         $logger The logger.
-	 * @param string                  $api_shop_country The api shop country.
-	 * @param OrderEndpoint           $order_endpoint The order endpoint.
-	 * @param callable(string):string $paypal_checkout_url_factory The function return the PayPal checkout URL for the given order ID.
-	 * @param string                  $place_order_button_text The text for the standard "Place order" button.
-	 * @param PaymentTokensEndpoint   $payment_tokens_endpoint Payment tokens endpoint.
-	 * @param bool $vault_v3_enabled Whether Vault v3 module is enabled.
+	 * @param SettingsRenderer         $settings_renderer The Settings Renderer.
+	 * @param FundingSourceRenderer    $funding_source_renderer The funding source renderer.
+	 * @param OrderProcessor           $order_processor The Order Processor.
+	 * @param ContainerInterface       $config The settings.
+	 * @param SessionHandler           $session_handler The Session Handler.
+	 * @param RefundProcessor          $refund_processor The Refund Processor.
+	 * @param State                    $state The state.
+	 * @param TransactionUrlProvider   $transaction_url_provider Service providing transaction view URL based on order.
+	 * @param SubscriptionHelper       $subscription_helper The subscription helper.
+	 * @param string                   $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
+	 * @param Environment              $environment The environment.
+	 * @param PaymentTokenRepository   $payment_token_repository The payment token repository.
+	 * @param LoggerInterface          $logger The logger.
+	 * @param string                   $api_shop_country The api shop country.
+	 * @param OrderEndpoint            $order_endpoint The order endpoint.
+	 * @param callable(string):string  $paypal_checkout_url_factory The function return the PayPal checkout URL for the given order ID.
+	 * @param string                   $place_order_button_text The text for the standard "Place order" button.
+	 * @param PaymentTokensEndpoint    $payment_tokens_endpoint Payment tokens endpoint.
+	 * @param bool                     $vault_v3_enabled Whether Vault v3 module is enabled.
 	 * @param WooCommercePaymentTokens $wc_payment_tokens WooCommerce payment tokens.
 	 */
 	public function __construct(
@@ -266,10 +266,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->api_shop_country            = $api_shop_country;
 		$this->paypal_checkout_url_factory = $paypal_checkout_url_factory;
 		$this->order_button_text           = $place_order_button_text;
-		$this->order_endpoint          = $order_endpoint;
-		$this->payment_tokens_endpoint = $payment_tokens_endpoint;
-		$this->vault_v3_enabled = $vault_v3_enabled;
-		$this->wc_payment_tokens = $wc_payment_tokens;
+		$this->order_endpoint              = $order_endpoint;
+		$this->payment_tokens_endpoint     = $payment_tokens_endpoint;
+		$this->vault_v3_enabled            = $vault_v3_enabled;
+		$this->wc_payment_tokens           = $wc_payment_tokens;
 
 		if ( $this->onboarded ) {
 			$this->supports = array( 'refunds', 'tokenization' );
@@ -536,10 +536,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 			&& $this->is_free_trial_order( $wc_order )
 			&& ! $this->subscription_helper->paypal_subscription_id()
 		) {
-			$ppcp_guest_payment_for_free_trial = WC()->session->get( 'ppcp_guest_payment_for_free_trial') ?? null;
-			if($this->vault_v3_enabled && $ppcp_guest_payment_for_free_trial) {
+			$ppcp_guest_payment_for_free_trial = WC()->session->get( 'ppcp_guest_payment_for_free_trial' ) ?? null;
+			if ( $this->vault_v3_enabled && $ppcp_guest_payment_for_free_trial ) {
 				$customer_id = $ppcp_guest_payment_for_free_trial->customer->id ?? '';
-				if($customer_id) {
+				if ( $customer_id ) {
 					update_user_meta( $wc_order->get_customer_id(), '_ppcp_target_customer_id', $customer_id );
 				}
 
@@ -556,7 +556,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 					);
 				}
 
-				WC()->session->set( 'ppcp_guest_payment_for_free_trial', null);
+				WC()->session->set( 'ppcp_guest_payment_for_free_trial', null );
 
 				$wc_order->payment_complete();
 				return $this->handle_payment_success( $wc_order );

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -6,11 +6,13 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\Vaulting\WooCommercePaymentTokens;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
@@ -44,6 +46,9 @@ class WcGatewayTest extends TestCase
 	private $logger;
 	private $apiShopCountry;
 	private $orderEndpoint;
+	private $paymentTokensEndpoint;
+	private $vaultV3Enabled;
+	private $wcPaymentTokens;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -88,6 +93,10 @@ class WcGatewayTest extends TestCase
 
 		$this->logger->shouldReceive('info');
 		$this->logger->shouldReceive('error');
+
+		$this->paymentTokensEndpoint = Mockery::mock(PaymentTokensEndpoint::class);
+		$this->vaultV3Enabled = true;
+		$this->wcPaymentTokens = Mockery::mock(WooCommercePaymentTokens::class);
 	}
 
 	private function createGateway()
@@ -111,7 +120,10 @@ class WcGatewayTest extends TestCase
 			function ($id) {
 				return 'checkoutnow=' . $id;
 			},
-			'Pay via PayPal'
+			'Pay via PayPal',
+			$this->paymentTokensEndpoint,
+			$this->vaultV3Enabled,
+			$this->wcPaymentTokens
 		);
 	}
 

--- a/tests/Playwright/tests/save-payment-methods.spec.js
+++ b/tests/Playwright/tests/save-payment-methods.spec.js
@@ -37,6 +37,53 @@ test('Save during purchase', async ({page}) => {
     await expectOrderReceivedPage(page);
 });
 
+test('PayPal add payment method', async ({page}) => {
+    await loginAsCustomer(page);
+    await page.goto('/my-account/add-payment-method');
+
+    const popup = await openPaypalPopup(page);
+    await loginIntoPaypal(popup);
+    popup.locator('#consentButton').click();
+
+    await page.waitForURL('/my-account/payment-methods');
+});
+
+test('ACDC add payment method', async ({page}) => {
+    await loginAsCustomer(page);
+    await page.goto('/my-account/add-payment-method');
+
+    await page.click("text=Debit & Credit Cards");
+
+    const creditCardNumber = await page.frameLocator('[title="paypal_card_number_field"]').locator('.card-field-number');
+    await creditCardNumber.fill('4005519200000004');
+
+    const expirationDate = await page.frameLocator('[title="paypal_card_expiry_field"]').locator('.card-field-expiry');
+    await expirationDate.fill('01/25');
+
+    const cvv = await page.frameLocator('[title="paypal_card_cvv_field"]').locator('.card-field-cvv');
+    await cvv.fill('123');
+
+    await page.waitForURL('/my-account/payment-methods');
+});
+
+test('PayPal logged-in user free trial subscription without payment token', async ({page}) => {
+    await loginAsCustomer(page);
+
+    await page.goto('/shop');
+    await page.click("text=Sign up now");
+    await page.goto('/classic-checkout');
+
+    const popup = await openPaypalPopup(page);
+    await loginIntoPaypal(popup);
+    popup.locator('#consentButton').click();
+
+    await page.click("text=Proceed to PayPal");
+
+    const title = await page.locator('.entry-title');
+    await expect(title).toHaveText('Order received');
+})
+
+
 
 
 


### PR DESCRIPTION
When using Vault v3, subscriptions with a zero sum cause this error when clicking the PayPal button: `CANNOT_BE_ZERO_OR_NEGATIVE`.

This PR ensures Free Trial Subscription products works with Vault v3.

### Acceptance Criteria
- (PayPal) Guest Checkout free trial subscription flow
    - As guest add free trial subscription to card and go to checkout page
    - Fill checkout form and click PayPal button
    - Acceptance:
        - Order completed correctly
        - Payment saved correctly in My Account / Payment methods
        - Subscription created correctly
        - As admin try to renewal subscription manually
- (PayPal) Logged-in user **without** saved tokens checkout free trial subscription flow
    - As logged in user **without** saved PayPal payment token add free trial subscription to card and go to checkout page
    - Click PayPal button
    - In PayPal modal click “Save and Continue”
    - Acceptance:
        - Order completed correctly
        - Payment saved correctly in My Account / Payment methods
        - Subscription created correctly
        - As admin try to renewal subscription manually
- (PayPal) Logged-in user with saved tokens checkout free trial subscription flow
    - As logged in user with saved PayPal payment token add free trial subscription to card and go to checkout page
    - “Proceed with PayPal” button appears with the saved PayPal account below
    - Click “Proceed with PayPal” button
    - Acceptance:
        - Order completed correctly
        - Subscription created correctly
        - As admin try to renewal subscription manually

- (ACDC) Guest Checkout free trial subscription flow
    - As guest add free trial subscription to card and go to checkout page
    - Fill checkout form and click “Sign up now” button
    - Acceptance:
        - Order completed correctly
        - Payment saved correctly in My Account / Payment methods
        - Subscription created correctly
        - As admin try to renewal subscription manually
- (ACDC) Logged-in user **without** saved tokens checkout free trial subscription flow
    - As logged in user **without** saved PayPal payment token add free trial subscription to card and go to checkout page
    - Click “Sign up now” button
    - Acceptance:
        - Order completed correctly
        - Payment saved correctly in My Account / Payment methods
        - Subscription created correctly
        - As admin try to renewal subscription manually
- (ACDC) Logged-in user with saved tokens checkout free trial subscription flow
    - As logged in user with saved ACDC payment token add free trial subscription to card and go to checkout page
    - Select saved card payment and click “Sign up now” button
    - Acceptance:
        - Order completed correctly
        - Subscription created correctly
        - As admin try to renewal subscription manually