### PR TITLE
Improve tooltip information for tagline (2819)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php
@@ -126,7 +126,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'label'        => __( 'Enable tagline', 'woocommerce-paypal-payments' ),
 			'desc_tip'     => true,
 			'description'  => __(
-				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
+				'Enable to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(
@@ -272,7 +272,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'label'        => __( 'Enable tagline', 'woocommerce-paypal-payments' ),
 			'desc_tip'     => true,
 			'description'  => __(
-				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
+				'Enable to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(
@@ -412,7 +412,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'default'      => false,
 			'desc_tip'     => true,
 			'description'  => __(
-				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
+				'Enable to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(
@@ -552,7 +552,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'default'      => false,
 			'desc_tip'     => true,
 			'description'  => __(
-				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
+				'Enable to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(
@@ -692,7 +692,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'default'      => false,
 			'desc_tip'     => true,
 			'description'  => __(
-				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
+				'Enable to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php
@@ -126,7 +126,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'label'        => __( 'Enable tagline', 'woocommerce-paypal-payments' ),
 			'desc_tip'     => true,
 			'description'  => __(
-				'Add the tagline. This line will only show up, if you select a horizontal layout.',
+				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(
@@ -272,7 +272,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'label'        => __( 'Enable tagline', 'woocommerce-paypal-payments' ),
 			'desc_tip'     => true,
 			'description'  => __(
-				'Add the tagline. This line will only show up, if you select a horizontal layout.',
+				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(
@@ -412,7 +412,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'default'      => false,
 			'desc_tip'     => true,
 			'description'  => __(
-				'Add the tagline. This line will only show up, if you select a horizontal layout.',
+				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(
@@ -552,7 +552,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'default'      => false,
 			'desc_tip'     => true,
 			'description'  => __(
-				'Add the tagline. This line will only show up, if you select a horizontal layout.',
+				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(
@@ -692,7 +692,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'default'      => false,
 			'desc_tip'     => true,
 			'description'  => __(
-				'Add the tagline. This line will only show up, if you select a horizontal layout.',
+				'Check to show the tagline below the payment button. Requires button width of 300px minimum to appear.',
 				'woocommerce-paypal-payments'
 			),
 			'screens'      => array(


### PR DESCRIPTION
### Description

This PR replaces the `Add the tagline. This line will only show up, if you select a horizontal layout.` hint with:
`Enable to show the tagline below the payment button. Requires button width of 300px minimum to appear.`.


### Original Issue
The merchant should be able to find information about the minimum width of PayPal buttons (In order to be able to see the tagline in the horizontal button layout).

<img width="654" alt="_obraz_PNG__658×272 pikseli_" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/e8634113-b768-46f2-a365-dfbe4acc5bb7">


### Steps to Test
1. Go to the `Standard Payments` tab in the PayPal settings.
2. Scroll down to Single Product, Classic Cart, or Classic Checkout settings, and make sure the `Button Layout` is set to `Horizontal`, verify the Tagline hint is correct.


### Screenshots
|Before|After|
|-|-|
|<img width="717" alt="tagline_before" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/3f0df857-d760-4040-a7a2-b7b185f7d093">|<img width="713" alt="tagline_after_with_arrow_png" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/4fcee242-deeb-4fe2-ba15-6d3da707ca38">|

