### PR TITLE
Incorrect Pricing Issue with Variable Subscriptions in PayPal Subscriptions Mode (2920)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -120,8 +120,13 @@ const PayPalComponent = ({
     };
 
     const createSubscription = async (data, actions) => {
+        let planId = config.scriptData.subscription_plan_id;
+        if (config.scriptData.variable_paypal_subscription_variation_from_cart !== '') {
+            planId = config.scriptData.variable_paypal_subscription_variation_from_cart;
+        }
+
         return actions.subscription.create({
-            'plan_id': config.scriptData.subscription_plan_id
+            'plan_id': planId
         });
     };
 

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
@@ -9,11 +9,11 @@ class CartActionHandler {
         this.errorHandler = errorHandler;
     }
 
-    subscriptionsConfiguration() {
+    subscriptionsConfiguration(subscription_plan_id) {
         return {
             createSubscription: (data, actions) => {
                 return actions.subscription.create({
-                    'plan_id': this.config.subscription_plan_id
+                    'plan_id': subscription_plan_id
                 });
             },
             onApprove: (data, actions) => {

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -12,7 +12,7 @@ class CheckoutActionHandler {
         this.spinner = spinner;
     }
 
-    subscriptionsConfiguration(subscription_plan) {
+    subscriptionsConfiguration(subscription_plan_id) {
         return {
             createSubscription: async (data, actions) => {
                 try {
@@ -22,7 +22,7 @@ class CheckoutActionHandler {
                 }
 
                 return actions.subscription.create({
-                    'plan_id': subscription_plan
+                    'plan_id': subscription_plan_id
                 });
             },
             onApprove: (data, actions) => {

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -12,7 +12,7 @@ class CheckoutActionHandler {
         this.spinner = spinner;
     }
 
-    subscriptionsConfiguration() {
+    subscriptionsConfiguration(subscription_plan) {
         return {
             createSubscription: async (data, actions) => {
                 try {
@@ -22,7 +22,7 @@ class CheckoutActionHandler {
                 }
 
                 return actions.subscription.create({
-                    'plan_id': this.config.subscription_plan_id
+                    'plan_id': subscription_plan
                 });
             },
             onApprove: (data, actions) => {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstap.js
@@ -90,7 +90,12 @@ class CartBootstrap {
             PayPalCommerceGateway.data_client_id.has_subscriptions
             && PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled
         ) {
-            this.renderer.render(actionHandler.subscriptionsConfiguration());
+            let subscription_plan_id = PayPalCommerceGateway.subscription_plan_id
+            if(PayPalCommerceGateway.variable_paypal_subscription_variation_from_cart !== '') {
+                subscription_plan_id = PayPalCommerceGateway.variable_paypal_subscription_variation_from_cart
+            }
+
+            this.renderer.render(actionHandler.subscriptionsConfiguration(subscription_plan_id));
 
             if(!PayPalCommerceGateway.subscription_product_allowed) {
                 this.gateway.button.is_disabled = true;

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -106,7 +106,11 @@ class CheckoutBootstap {
             PayPalCommerceGateway.data_client_id.has_subscriptions
             && PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled
         ) {
-            this.renderer.render(actionHandler.subscriptionsConfiguration(), {}, actionHandler.configuration());
+            let subscription_plan_id = PayPalCommerceGateway.subscription_plan_id
+            if(PayPalCommerceGateway.variable_paypal_subscription_variation_from_cart !== '') {
+                subscription_plan_id = PayPalCommerceGateway.variable_paypal_subscription_variation_from_cart
+            }
+            this.renderer.render(actionHandler.subscriptionsConfiguration(subscription_plan_id), {}, actionHandler.configuration());
 
             if(!PayPalCommerceGateway.subscription_product_allowed) {
                 this.gateway.button.is_disabled = true;

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1111,6 +1111,7 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 			'subscription_plan_id'                    => $this->subscription_helper->paypal_subscription_id(),
 			'vault_v3_enabled'                        => $this->vault_v3_enabled,
 			'variable_paypal_subscription_variations' => $this->subscription_helper->variable_paypal_subscription_variations(),
+			'variable_paypal_subscription_variation_from_cart' => $this->subscription_helper->paypal_subscription_variation_from_cart(),
 			'subscription_product_allowed'            => $this->subscription_helper->checkout_subscription_product_allowed(),
 			'locations_with_subscription_product'     => $this->subscription_helper->locations_with_subscription_product(),
 			'enforce_vault'                           => $this->has_subscriptions(),

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -315,4 +315,29 @@ class SubscriptionHelper {
 
 		return '';
 	}
+
+	/**
+	 * Returns the variation subscription plan id from the cart.
+	 *
+	 * @return string
+	 */
+	public function paypal_subscription_variation_from_cart(): string {
+		$cart = WC()->cart ?? null;
+		if ( ! $cart || $cart->is_empty() ) {
+			return '';
+		}
+
+		$items = $cart->get_cart_contents();
+		foreach ( $items as $item ) {
+			$variation_id = $item['variation_id'] ?? 0;
+			if ( $variation_id ) {
+				$variation_product = wc_get_product( $variation_id ) ?? '';
+				if ( $variation_product && $variation_product->meta_exists( 'ppcp_subscription_plan' ) ) {
+					return $variation_product->get_meta( 'ppcp_subscription_plan' )['id'];
+				}
+			}
+		}
+
+		return '';
+	}
 }


### PR DESCRIPTION
There is an incorrect amount issue when selecting a variable subscription variation that is not the first variation in the list.

This PR ensures that correct variation amount is sent to PayPal by getting the variation from the cart.

### Steps to reproduce
- Set "Subscriptions Mode" as PayPal Subscriptions in PayPal gateway settings
- Create and connect a Variable Subscription product with at least 2 variations
- Go to shop and visit the variable subscription product
- Select a variation that is not the first variation in the list
- Click “Sign up now" button
- Go to Checkout and click PayPal button
    - Notice amount is from first variation instead of the selected one

### Acceptance Criteria
Select second variation and click “Sign up now” button on Product page, then choose one of the following ensuring the amount sent to PayPal is correct:
- Click PayPal button from Classic Cart page and finish payment in Checkout
- Click PayPal button from Classic Checkout page and finish payment
- Click PayPal button from Block Cart page and finish payment in Checkout
- Click PayPal button from Block Checkout page and finish payment