### PR TITLE
Fix the wrong return_url in multisite setup when using subdomains (2829)

### DIFF
--- a/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
+++ b/modules/ppcp-api-client/src/Repository/ApplicationContextRepository.php
@@ -54,7 +54,7 @@ class ApplicationContextRepository {
 		$payment_preference = $this->settings->has( 'payee_preferred' ) && $this->settings->get( 'payee_preferred' ) ?
 			ApplicationContext::PAYMENT_METHOD_IMMEDIATE_PAYMENT_REQUIRED : ApplicationContext::PAYMENT_METHOD_UNRESTRICTED;
 		$context            = new ApplicationContext(
-			network_home_url( \WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ) ),
+			home_url( \WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ) ),
 			(string) wc_get_checkout_url(),
 			(string) $brand_name,
 			$locale,

--- a/tests/PHPUnit/WcGateway/Repository/ApplicationContextRepositoryTest.php
+++ b/tests/PHPUnit/WcGateway/Repository/ApplicationContextRepositoryTest.php
@@ -36,7 +36,7 @@ class ApplicationContextRepositoryTest extends TestCase
                 ->andReturn($value);
         }
 
-	    expect('network_home_url')
+	    expect('home_url')
 		    ->andReturn('https://example.com/');
 	    expect('wc_get_checkout_url')
 		    ->andReturn('https://example.com/checkout/');


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

# PR Description
Replace the `network_home_url()` with `home_url()` to avoid wrong return url in multisite setup.

# Issue Description
When using a multisite with subdomains or top-level domains, the return URL generated by PayPal Payments always points to the main site of the network.

# Steps to Reproduce

- Setup multisite network, with subdomains (top level domains)
- The store is on sub site.
- Purchase an item and pay with PayPal.
- After payment, the redirect back to the page hits the multisite main page and not the sub-page.