### PR TITLE
Add the `data-page-type` attribute for JS SDK (2942)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1428,9 +1428,45 @@ document.querySelector("#payment").before(document.querySelector("#ppcp-messages
 	 * @return array
 	 */
 	private function attributes(): array {
-		return array(
+		$attributes = array(
 			'data-partner-attribution-id' => $this->bn_code_for_context( $this->context() ),
 		);
+
+		$page_type_attribute = $this->page_type_attribute();
+		if ( $page_type_attribute ) {
+			$attributes['data-page-type'] = $page_type_attribute;
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Retrieves the value for page type attribute(data-page-type) used for the JS SDK.
+	 *
+	 * @return string
+	 */
+	protected function page_type_attribute(): string {
+		if ( is_search() ) {
+			return 'search-results';
+		}
+
+		switch ( $this->location() ) {
+			case 'product':
+				return 'product-details';
+			case 'shop':
+				return 'product-listing';
+			case 'home':
+				return 'mini-cart';
+			case 'cart-block':
+			case 'cart':
+				return 'cart';
+			case 'checkout-block':
+			case 'checkout':
+			case 'pay-now':
+				return 'checkout';
+			default:
+				return '';
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

# PR Description
Adds the `data-page-type` as described below.

# Issue Description
We need to add the `data-page-type` [script attribute](https://developer.paypal.com/sdk/js/configuration/#link-datapagetype) to all relevant instances of the JS SDK. The accepted values for this attribute are:

- product-listing
- search-results
- product-details
- mini-cart
- cart
- checkout