### PR TITLE
Fix the Apple Pay button in the editor (2806)

### DIFF
--- a/modules/ppcp-api-client/src/Exception/PayPalApiException.php
+++ b/modules/ppcp-api-client/src/Exception/PayPalApiException.php
@@ -155,11 +155,11 @@ class PayPalApiException extends RuntimeException {
 			return $json->message;
 		}
 		$improved_keys_messages = array(
-			'PAYMENT_DENIED'           => __( 'PayPal rejected the payment. Please reach out to the PayPal support for more information.', 'woocommerce-paypal-payments' ),
-			'TRANSACTION_REFUSED'      => __( 'The transaction has been refused by the payment processor. Please reach out to the PayPal support for more information.', 'woocommerce-paypal-payments' ),
-			'DUPLICATE_INVOICE_ID'     => __( 'The transaction has been refused because the Invoice ID already exists. Please create a new order or reach out to the store owner.', 'woocommerce-paypal-payments' ),
-			'PAYER_CANNOT_PAY'         => __( 'There was a problem processing this transaction. Please reach out to the store owner.', 'woocommerce-paypal-payments' ),
-			'PAYEE_ACCOUNT_RESTRICTED' => __( 'There was a problem processing this transaction. Please reach out to the store owner.', 'woocommerce-paypal-payments' ),
+			'PAYMENT_DENIED'              => __( 'PayPal rejected the payment. Please reach out to the PayPal support for more information.', 'woocommerce-paypal-payments' ),
+			'TRANSACTION_REFUSED'         => __( 'The transaction has been refused by the payment processor. Please reach out to the PayPal support for more information.', 'woocommerce-paypal-payments' ),
+			'DUPLICATE_INVOICE_ID'        => __( 'The transaction has been refused because the Invoice ID already exists. Please create a new order or reach out to the store owner.', 'woocommerce-paypal-payments' ),
+			'PAYER_CANNOT_PAY'            => __( 'There was a problem processing this transaction. Please reach out to the store owner.', 'woocommerce-paypal-payments' ),
+			'PAYEE_ACCOUNT_RESTRICTED'    => __( 'There was a problem processing this transaction. Please reach out to the store owner.', 'woocommerce-paypal-payments' ),
 			'AGREEMENT_ALREADY_CANCELLED' => __( 'The requested agreement is already canceled. Please reach out to the PayPal support for more information.', 'woocommerce-paypal-payments' ),
 		);
 		$improved_errors        = array_filter(

--- a/modules/ppcp-applepay/resources/css/styles.scss
+++ b/modules/ppcp-applepay/resources/css/styles.scss
@@ -46,4 +46,10 @@
 			}
 		}
 	}
+
+	.ppcp-button-applepay {
+		apple-pay-button {
+			display: block;
+		}
+	}
 }

--- a/modules/ppcp-applepay/resources/js/ApplepayManagerBlockEditor.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayManagerBlockEditor.js
@@ -1,0 +1,36 @@
+import ApplepayButton from "./ApplepayButton";
+
+class ApplepayManagerBlockEditor {
+
+    constructor(buttonConfig, ppcpConfig) {
+        this.buttonConfig = buttonConfig;
+        this.ppcpConfig = ppcpConfig;
+        this.applePayConfig = null;
+    }
+
+    init() {
+        (async () => {
+            await this.config();
+        })();
+    }
+
+    async config() {
+        try {
+            this.applePayConfig = await paypal.Applepay().config();
+
+            const button = new ApplepayButton(
+                this.ppcpConfig.context,
+                null,
+                this.buttonConfig,
+                this.ppcpConfig,
+            );
+
+            button.init(this.applePayConfig);
+
+        } catch (error) {
+            console.error('Failed to initialize Apple Pay:', error);
+        }
+    }
+}
+
+export default ApplepayManagerBlockEditor;

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -2,9 +2,10 @@ import {useEffect, useState} from '@wordpress/element';
 import {registerExpressPaymentMethod} from '@woocommerce/blocks-registry';
 import {loadPaypalScript} from '../../../ppcp-button/resources/js/modules/Helper/ScriptLoading'
 import {cartHasSubscriptionProducts} from '../../../ppcp-blocks/resources/js/Helper/Subscription'
-import ApplepayManager from "./ApplepayManager";
 import {loadCustomScript} from "@paypal/paypal-js";
 import CheckoutHandler from "./Context/CheckoutHandler";
+import ApplepayManager from "./ApplepayManager";
+import ApplepayManagerBlockEditor from "./ApplepayManagerBlockEditor";
 
 const ppcpData = wc.wcSettings.getSetting('ppcp-gateway_data');
 const ppcpConfig = ppcpData.scriptData;
@@ -16,13 +17,14 @@ if (typeof window.PayPalCommerceGateway === 'undefined') {
     window.PayPalCommerceGateway = ppcpConfig;
 }
 
-const ApplePayComponent = () => {
+const ApplePayComponent = ( props ) => {
     const [bootstrapped, setBootstrapped] = useState(false);
     const [paypalLoaded, setPaypalLoaded] = useState(false);
     const [applePayLoaded, setApplePayLoaded] = useState(false);
 
     const bootstrap = function () {
-        const manager = new ApplepayManager(buttonConfig, ppcpConfig);
+        const ManagerClass = props.isEditing ? ApplepayManagerBlockEditor : ApplepayManager;
+        const manager = new ManagerClass(buttonConfig, ppcpConfig);
         manager.init();
     };
 
@@ -31,6 +33,8 @@ const ApplePayComponent = () => {
         loadCustomScript({ url: buttonConfig.sdk_url }).then(() => {
             setApplePayLoaded(true);
         });
+
+        ppcpConfig.url_params.components += ',applepay';
 
         // Load PayPal
         loadPaypalScript(ppcpConfig, () => {
@@ -46,7 +50,10 @@ const ApplePayComponent = () => {
     }, [paypalLoaded, applePayLoaded]);
 
     return (
-        <div id={buttonConfig.button.wrapper.replace('#', '')} className="ppcp-button-apm ppcp-button-applepay"></div>
+        <div
+            id={buttonConfig.button.wrapper.replace('#', '')}
+            className="ppcp-button-apm ppcp-button-applepay">
+        </div>
     );
 }
 

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -92,6 +92,7 @@ class ApplepayModule implements ModuleInterface {
 				}
 
 				$module->load_admin_assets( $c, $apple_payment_method );
+				$module->load_block_editor_assets( $c, $apple_payment_method );
 			},
 			1
 		);
@@ -178,6 +179,13 @@ class ApplepayModule implements ModuleInterface {
 			}
 		);
 		add_action(
+			'enqueue_block_editor_assets',
+			function () use ( $c, $button ) {
+				$button->enqueue_admin_styles();
+			}
+		);
+
+		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
 			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				$payment_method_registry->register( $c->get( 'applepay.blocks-payment-method' ) );
@@ -207,6 +215,7 @@ class ApplepayModule implements ModuleInterface {
 				 * @psalm-suppress UndefinedInterfaceMethod
 				 */
 				$button->enqueue_admin();
+				$button->enqueue_admin_styles();
 			}
 		);
 
@@ -218,6 +227,21 @@ class ApplepayModule implements ModuleInterface {
 					$settings['components'][] = 'applepay';
 				}
 				return $settings;
+			}
+		);
+	}
+
+	public function load_block_editor_assets( ContainerInterface $c, ApplePayButton $button ): void {
+		// Enqueue backend scripts.
+		add_action(
+			'enqueue_block_editor_assets',
+			static function () use ( $c, $button ) {
+				/**
+				 * Should add this to the ButtonInterface.
+				 *
+				 * @psalm-suppress UndefinedInterfaceMethod
+				 */
+				$button->enqueue_admin_styles();
 			}
 		);
 	}

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -231,6 +231,13 @@ class ApplepayModule implements ModuleInterface {
 		);
 	}
 
+	/**
+	 * Enqueues the editor assets.
+	 *
+	 * @param ContainerInterface $c The container.
+	 * @param ApplePayButton     $button The button.
+	 * @return void
+	 */
 	public function load_block_editor_assets( ContainerInterface $c, ApplePayButton $button ): void {
 		// Enqueue backend scripts.
 		add_action(

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -468,9 +468,9 @@ class ApplePayButton implements ButtonInterface {
 			return false;
 		}
 		return wp_verify_nonce(
-				$nonce,
-				'woocommerce-process_checkout'
-			) === 1;
+			$nonce,
+			'woocommerce-process_checkout'
+		) === 1;
 	}
 
 	/**
@@ -559,11 +559,11 @@ class ApplePayButton implements ButtonInterface {
 				list(
 					$shipping_methods_array, $selected_shipping_method
 					) = $this->cart_shipping_methods(
-					$cart,
-					$customer_address,
-					$shipping_method,
-					$shipping_method_id
-				);
+						$cart,
+						$customer_address,
+						$shipping_method,
+						$shipping_method_id
+					);
 			}
 			$cart->calculate_shipping();
 			$cart->calculate_fees();
@@ -717,7 +717,7 @@ class ApplePayButton implements ButtonInterface {
 	 */
 	protected function calculate_totals_cart_page(
 		array $customer_address,
-			  $shipping_method = null
+		$shipping_method = null
 	): array {
 
 		$results = array();
@@ -742,11 +742,11 @@ class ApplePayButton implements ButtonInterface {
 				list(
 					$shipping_methods_array, $selected_shipping_method
 					)               = $this->cart_shipping_methods(
-					$cart,
-					$customer_address,
-					$shipping_method,
-					$shipping_method_id
-				);
+						$cart,
+						$customer_address,
+						$shipping_method,
+						$shipping_method_id
+					);
 			}
 			$cart->calculate_shipping();
 			$cart->calculate_fees();

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -468,9 +468,9 @@ class ApplePayButton implements ButtonInterface {
 			return false;
 		}
 		return wp_verify_nonce(
-			$nonce,
-			'woocommerce-process_checkout'
-		) === 1;
+				$nonce,
+				'woocommerce-process_checkout'
+			) === 1;
 	}
 
 	/**
@@ -559,11 +559,11 @@ class ApplePayButton implements ButtonInterface {
 				list(
 					$shipping_methods_array, $selected_shipping_method
 					) = $this->cart_shipping_methods(
-						$cart,
-						$customer_address,
-						$shipping_method,
-						$shipping_method_id
-					);
+					$cart,
+					$customer_address,
+					$shipping_method,
+					$shipping_method_id
+				);
 			}
 			$cart->calculate_shipping();
 			$cart->calculate_fees();
@@ -717,7 +717,7 @@ class ApplePayButton implements ButtonInterface {
 	 */
 	protected function calculate_totals_cart_page(
 		array $customer_address,
-		$shipping_method = null
+			  $shipping_method = null
 	): array {
 
 		$results = array();
@@ -742,11 +742,11 @@ class ApplePayButton implements ButtonInterface {
 				list(
 					$shipping_methods_array, $selected_shipping_method
 					)               = $this->cart_shipping_methods(
-						$cart,
-						$customer_address,
-						$shipping_method,
-						$shipping_method_id
-					);
+					$cart,
+					$customer_address,
+					$shipping_method,
+					$shipping_method_id
+				);
 			}
 			$cart->calculate_shipping();
 			$cart->calculate_fees();
@@ -1044,17 +1044,9 @@ class ApplePayButton implements ButtonInterface {
 	}
 
 	/**
-	 * Enqueues scripts/styles for admin.
+	 * Enqueues scripts for admin.
 	 */
 	public function enqueue_admin(): void {
-		wp_register_style(
-			'wc-ppcp-applepay-admin',
-			untrailingslashit( $this->module_url ) . '/assets/css/styles.css',
-			array(),
-			$this->version
-		);
-		wp_enqueue_style( 'wc-ppcp-applepay-admin' );
-
 		wp_register_script(
 			'wc-ppcp-applepay-admin',
 			untrailingslashit( $this->module_url ) . '/assets/js/boot-admin.js',
@@ -1069,6 +1061,19 @@ class ApplePayButton implements ButtonInterface {
 			'wc_ppcp_applepay_admin',
 			$this->script_data_for_admin()
 		);
+	}
+
+	/**
+	 * Enqueues styles for admin.
+	 */
+	public function enqueue_admin_styles(): void {
+		wp_register_style(
+			'wc-ppcp-applepay-admin',
+			untrailingslashit( $this->module_url ) . '/assets/css/styles.css',
+			array(),
+			$this->version
+		);
+		wp_enqueue_style( 'wc-ppcp-applepay-admin' );
 	}
 
 	/**

--- a/modules/ppcp-applepay/src/Assets/BlocksPaymentMethod.php
+++ b/modules/ppcp-applepay/src/Assets/BlocksPaymentMethod.php
@@ -103,12 +103,18 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	public function get_payment_method_data() {
 		$paypal_data = $this->paypal_payment_method->get_payment_method_data();
 
+		if ( is_admin() ) {
+			$script_data = $this->button->script_data_for_admin();
+		} else {
+			$script_data = $this->button->script_data();
+		}
+
 		return array(
 			'id'          => $this->name,
 			'title'       => $paypal_data['title'], // TODO : see if we should use another.
 			'description' => $paypal_data['description'], // TODO : see if we should use another.
 			'enabled'     => $paypal_data['enabled'], // This button is enabled when PayPal buttons are.
-			'scriptData'  => $this->button->script_data(),
+			'scriptData'  => $script_data,
 		);
 	}
 }


### PR DESCRIPTION
### Description

This PR fixes the Apple Pay button in the editor.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Enable Apple Pay.
2. Test the Cart and Checkout block pages.
3. The button should work correctly both in the editor and the page.
4. Make sure the PayLater Message blocks render correctly.

### Screenshots
|Before|After|
|-|-|
|<img width="1230" alt="Edit_Page_“Checkout”_‹_paypal_—_WordPress-2" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/d9122952-60b4-47dd-b08e-bdbd82c32f8f">|<img width="1367" alt="Edit_Page_“Checkout”_‹_paypal_—_WordPress" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/f3d76383-2375-49d1-a55d-b362843a0fe5">|