### PR TITLE
Ensure package tracking data is sent to original PayPal transaction (3015)

### DIFF
--- a/modules/ppcp-order-tracking/resources/js/order-edit-page.js
+++ b/modules/ppcp-order-tracking/resources/js/order-edit-page.js
@@ -9,7 +9,7 @@ document.addEventListener(
 
         const includeAllItemsCheckbox = document.getElementById('include-all-items');
         const shipmentsWrapper = '#ppcp_order-tracking .ppcp-tracking-column.shipments';
-        const transactionId = document.querySelector('.ppcp-tracking-transaction_id');
+        const captureId = document.querySelector('.ppcp-tracking-capture_id');
         const orderId = document.querySelector('.ppcp-tracking-order_id');
         const carrier = document.querySelector('.ppcp-tracking-carrier');
         const carrierNameOther = document.querySelector('.ppcp-tracking-carrier_name_other');
@@ -86,7 +86,7 @@ document.addEventListener(
                     credentials: 'same-origin',
                     body: JSON.stringify({
                         nonce: config.ajax.tracking_info.nonce,
-                        transaction_id: transactionId ? transactionId.value : null,
+                        capture_id: captureId ? captureId.value : null,
                         tracking_number: trackingNumber ? trackingNumber.value : null,
                         status: status ? status.value : null,
                         carrier: carrier ? carrier.value : null,
@@ -113,6 +113,7 @@ document.addEventListener(
                     if (noShipemntsContainer) {
                         noShipemntsContainer.parentNode.removeChild(noShipemntsContainer);
                     }
+                    trackingNumber.value = ''
                 });
             })
         }
@@ -135,7 +136,7 @@ document.addEventListener(
                     credentials: 'same-origin',
                     body: JSON.stringify({
                         nonce: config.ajax.tracking_info.nonce,
-                        transaction_id: transactionId ? transactionId.value : null,
+                        capture_id: captureId ? captureId.value : null,
                         tracking_number: shipmentTrackingNumber ? shipmentTrackingNumber.value : null,
                         status: shipmentStatus ? shipmentStatus.value : null,
                         carrier: shipmentCarrier ? shipmentCarrier.value : null,

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -189,7 +189,6 @@ class OrderTrackingEndpoint {
 		do_action( 'woocommerce_paypal_payments_before_tracking_is_added', $order_id, $shipment_request_data );
 
 		$response = $this->request( $url, $args );
-		write_log($response);
 
 		if ( is_wp_error( $response ) ) {
 			$args = array(
@@ -275,7 +274,7 @@ class OrderTrackingEndpoint {
 		}
 
 		$host         = trailingslashit( $this->host );
-		$paypal_order = ppcp_get_paypal_order($wc_order);
+		$paypal_order = ppcp_get_paypal_order( $wc_order );
 		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
 		$tracker_id   = $this->find_tracker_id( $capture_id, $tracking_number );
 		$url          = "{$host}v1/shipping/trackers/{$tracker_id}";
@@ -324,7 +323,7 @@ class OrderTrackingEndpoint {
 		}
 
 		$host         = trailingslashit( $this->host );
-		$paypal_order = ppcp_get_paypal_order($wc_order);
+		$paypal_order = ppcp_get_paypal_order( $wc_order );
 		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
 		$url          = "{$host}v1/shipping/trackers?transaction_id={$capture_id}";
 
@@ -387,7 +386,7 @@ class OrderTrackingEndpoint {
 		$carrier = $data['carrier'] ?? '';
 
 		$tracking_info = array(
-			'capture_id'     => $data['capture_id'] ?? '',
+			'capture_id'         => $data['capture_id'] ?? '',
 			'status'             => $data['status'] ?? '',
 			'tracking_number'    => $data['tracking_number'] ?? '',
 			'carrier'            => $carrier,
@@ -423,7 +422,7 @@ class OrderTrackingEndpoint {
 		$carrier = $request_values['carrier'] ?? '';
 
 		$data_to_check = array(
-			'capture_id'  	  => $request_values['capture_id'] ?? '',
+			'capture_id'      => $request_values['capture_id'] ?? '',
 			'status'          => $request_values['status'] ?? '',
 			'tracking_number' => $request_values['tracking_number'] ?? '',
 			'carrier'         => $carrier,
@@ -512,7 +511,7 @@ class OrderTrackingEndpoint {
 			unset( $shipment_data['capture_id'] );
 			unset( $shipment_data['items'] );
 			$shipment_data['transaction_id'] = $shipment->capture_id();
-			$shipment_data = array( 'trackers' => array( $shipment_data ) );
+			$shipment_data                   = array( 'trackers' => array( $shipment_data ) );
 		}
 
 		$url  = $this->should_use_new_api ? "{$host}v2/checkout/orders/{$paypal_order_id}/track" : "{$host}v1/shipping/trackers";

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -275,7 +275,7 @@ class OrderTrackingEndpoint {
 
 		$host         = trailingslashit( $this->host );
 		$paypal_order = ppcp_get_paypal_order( $wc_order );
-		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
+		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order ) ?? '';
 		$tracker_id   = $this->find_tracker_id( $capture_id, $tracking_number );
 		$url          = "{$host}v1/shipping/trackers/{$tracker_id}";
 

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -23,13 +23,14 @@ use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * The OrderTrackingEndpoint.
  *
  * @psalm-type SupportedStatuses = 'SHIPPED'|'ON_HOLD'|'DELIVERED'|'CANCELLED'
  * @psalm-type TrackingInfo = array{
- *     transaction_id: string,
+ *     capture_id: string,
  *     status: SupportedStatuses,
  *     tracking_number: string,
  *     carrier: string,
@@ -188,6 +189,7 @@ class OrderTrackingEndpoint {
 		do_action( 'woocommerce_paypal_payments_before_tracking_is_added', $order_id, $shipment_request_data );
 
 		$response = $this->request( $url, $args );
+		write_log($response);
 
 		if ( is_wp_error( $response ) ) {
 			$args = array(
@@ -222,7 +224,7 @@ class OrderTrackingEndpoint {
 	 */
 	public function update_tracking_information( ShipmentInterface $shipment, int $order_id ) : void {
 		$host          = trailingslashit( $this->host );
-		$tracker_id    = $this->find_tracker_id( $shipment->transaction_id(), $shipment->tracking_number() );
+		$tracker_id    = $this->find_tracker_id( $shipment->capture_id(), $shipment->tracking_number() );
 		$url           = "{$host}v1/shipping/trackers/{$tracker_id}";
 		$shipment_data = $shipment->to_array();
 
@@ -272,9 +274,11 @@ class OrderTrackingEndpoint {
 			return null;
 		}
 
-		$host       = trailingslashit( $this->host );
-		$tracker_id = $this->find_tracker_id( $wc_order->get_transaction_id(), $tracking_number );
-		$url        = "{$host}v1/shipping/trackers/{$tracker_id}";
+		$host         = trailingslashit( $this->host );
+		$paypal_order = ppcp_get_paypal_order($wc_order);
+		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
+		$tracker_id   = $this->find_tracker_id( $capture_id, $tracking_number );
+		$url          = "{$host}v1/shipping/trackers/{$tracker_id}";
 
 		$args = array(
 			'method'  => 'GET',
@@ -319,9 +323,10 @@ class OrderTrackingEndpoint {
 			return array();
 		}
 
-		$host           = trailingslashit( $this->host );
-		$transaction_id = $wc_order->get_transaction_id();
-		$url            = "{$host}v1/shipping/trackers?transaction_id={$transaction_id}";
+		$host         = trailingslashit( $this->host );
+		$paypal_order = ppcp_get_paypal_order($wc_order);
+		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
+		$url          = "{$host}v1/shipping/trackers?transaction_id={$capture_id}";
 
 		$args = array(
 			'method'  => 'GET',
@@ -382,7 +387,7 @@ class OrderTrackingEndpoint {
 		$carrier = $data['carrier'] ?? '';
 
 		$tracking_info = array(
-			'transaction_id'     => $data['transaction_id'] ?? '',
+			'capture_id'     => $data['capture_id'] ?? '',
 			'status'             => $data['status'] ?? '',
 			'tracking_number'    => $data['tracking_number'] ?? '',
 			'carrier'            => $carrier,
@@ -395,7 +400,7 @@ class OrderTrackingEndpoint {
 
 		return $this->shipment_factory->create_shipment(
 			$wc_order_id,
-			$tracking_info['transaction_id'],
+			$tracking_info['capture_id'],
 			$tracking_info['tracking_number'],
 			$tracking_info['status'],
 			$tracking_info['carrier'],
@@ -418,7 +423,7 @@ class OrderTrackingEndpoint {
 		$carrier = $request_values['carrier'] ?? '';
 
 		$data_to_check = array(
-			'transaction_id'  => $request_values['transaction_id'] ?? '',
+			'capture_id'  	  => $request_values['capture_id'] ?? '',
 			'status'          => $request_values['status'] ?? '',
 			'tracking_number' => $request_values['tracking_number'] ?? '',
 			'carrier'         => $carrier,
@@ -458,14 +463,14 @@ class OrderTrackingEndpoint {
 	}
 
 	/**
-	 * Finds the tracker ID from given transaction ID and tracking number.
+	 * Finds the tracker ID from given capture ID and tracking number.
 	 *
-	 * @param string $transaction_id The transaction ID.
+	 * @param string $capture_id The capture ID.
 	 * @param string $tracking_number The tracking number.
 	 * @return string The tracker ID.
 	 */
-	protected function find_tracker_id( string $transaction_id, string $tracking_number ): string {
-		return ! empty( $tracking_number ) ? "{$transaction_id}-{$tracking_number}" : "{$transaction_id}-NOTRACKER";
+	protected function find_tracker_id( string $capture_id, string $tracking_number ): string {
+		return ! empty( $tracking_number ) ? "{$capture_id}-{$tracking_number}" : "{$capture_id}-NOTRACKER";
 	}
 
 	/**
@@ -503,21 +508,18 @@ class OrderTrackingEndpoint {
 		$host            = trailingslashit( $this->host );
 		$shipment_data   = $shipment->to_array();
 
-		$old_api_data = $shipment_data;
-		unset( $old_api_data['items'] );
-		$request_shipment_data = array( 'trackers' => array( $old_api_data ) );
-
-		if ( $this->should_use_new_api ) {
-			unset( $shipment_data['transaction_id'] );
-			$shipment_data['capture_id'] = $shipment->transaction_id();
-			$request_shipment_data       = $shipment_data;
+		if ( ! $this->should_use_new_api ) {
+			unset( $shipment_data['capture_id'] );
+			unset( $shipment_data['items'] );
+			$shipment_data['transaction_id'] = $shipment->capture_id();
+			$shipment_data = array( 'trackers' => array( $shipment_data ) );
 		}
 
 		$url  = $this->should_use_new_api ? "{$host}v2/checkout/orders/{$paypal_order_id}/track" : "{$host}v1/shipping/trackers";
 		$args = array(
 			'method'  => 'POST',
 			'headers' => $this->request_headers(),
-			'body'    => wp_json_encode( (array) apply_filters( 'woocommerce_paypal_payments_tracking_data_before_sending', $request_shipment_data, $wc_order->get_id() ) ),
+			'body'    => wp_json_encode( (array) apply_filters( 'woocommerce_paypal_payments_tracking_data_before_sending', $shipment_data, $wc_order->get_id() ) ),
 		);
 
 		return array(

--- a/modules/ppcp-order-tracking/src/Integration/GermanizedShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/GermanizedShipmentIntegration.php
@@ -17,11 +17,15 @@ use Vendidero\Germanized\Shipments\Shipment;
 use Vendidero\Germanized\Shipments\ShipmentItem;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class GermanizedShipmentIntegration.
  */
 class GermanizedShipmentIntegration implements Integration {
+
+	use TransactionIdHandlingTrait;
 
 	/**
 	 * The shipment factory.
@@ -79,8 +83,9 @@ class GermanizedShipmentIntegration implements Integration {
 					return;
 				}
 
+				$paypal_order    = ppcp_get_paypal_order($wc_order);
+				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 				$wc_order_id     = $wc_order->get_id();
-				$transaction_id  = $wc_order->get_transaction_id();
 				$tracking_number = $shipment->get_tracking_id();
 				$carrier         = $shipment->get_shipping_provider();
 
@@ -91,14 +96,14 @@ class GermanizedShipmentIntegration implements Integration {
 					$shipment->get_items()
 				);
 
-				if ( ! $tracking_number || ! $carrier || ! $transaction_id ) {
+				if ( ! $tracking_number || ! $carrier || ! $capture_id ) {
 					return;
 				}
 
 				try {
 					$ppcp_shipment = $this->shipment_factory->create_shipment(
 						$wc_order_id,
-						$transaction_id,
+						$capture_id,
 						$tracking_number,
 						'SHIPPED',
 						'OTHER',

--- a/modules/ppcp-order-tracking/src/Integration/GermanizedShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/GermanizedShipmentIntegration.php
@@ -83,7 +83,7 @@ class GermanizedShipmentIntegration implements Integration {
 					return;
 				}
 
-				$paypal_order    = ppcp_get_paypal_order($wc_order);
+				$paypal_order    = ppcp_get_paypal_order( $wc_order );
 				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 				$wc_order_id     = $wc_order->get_id();
 				$tracking_number = $shipment->get_tracking_id();

--- a/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
@@ -15,11 +15,15 @@ use WC_Order;
 use WooCommerce\PayPalCommerce\Compat\Integration;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class ShipStationIntegration.
  */
 class ShipStationIntegration implements Integration {
+
+	use TransactionIdHandlingTrait;
 
 	/**
 	 * The shipment factory.
@@ -80,19 +84,20 @@ class ShipStationIntegration implements Integration {
 					return;
 				}
 
+				$paypal_order    = ppcp_get_paypal_order($wc_order);
+				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 				$order_id        = $wc_order->get_id();
-				$transaction_id  = $wc_order->get_transaction_id();
 				$tracking_number = $data['tracking_number'] ?? '';
 				$carrier         = $data['carrier'] ?? '';
 
-				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $transaction_id ) {
+				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $capture_id ) {
 					return;
 				}
 
 				try {
 					$ppcp_shipment = $this->shipment_factory->create_shipment(
 						$order_id,
-						$transaction_id,
+						$capture_id,
 						$tracking_number,
 						'SHIPPED',
 						'OTHER',

--- a/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
@@ -84,7 +84,7 @@ class ShipStationIntegration implements Integration {
 					return;
 				}
 
-				$paypal_order    = ppcp_get_paypal_order($wc_order);
+				$paypal_order    = ppcp_get_paypal_order( $wc_order );
 				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 				$order_id        = $wc_order->get_id();
 				$tracking_number = $data['tracking_number'] ?? '';

--- a/modules/ppcp-order-tracking/src/Integration/ShipmentTrackingIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/ShipmentTrackingIntegration.php
@@ -15,13 +15,17 @@ use WC_Order;
 use WooCommerce\PayPalCommerce\Compat\Integration;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
 use WP_REST_Request;
 use WP_REST_Response;
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class ShipmentTrackingIntegration.
  */
 class ShipmentTrackingIntegration implements Integration {
+
+	use TransactionIdHandlingTrait;
 
 	/**
 	 * The shipment factory.
@@ -81,17 +85,18 @@ class ShipmentTrackingIntegration implements Integration {
 					return;
 				}
 
-				$transaction_id  = $wc_order->get_transaction_id();
+				$paypal_order    = ppcp_get_paypal_order($wc_order);
+				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 				$tracking_number = wc_clean( wp_unslash( $_POST['tracking_number'] ?? '' ) );
 				$carrier         = wc_clean( wp_unslash( $_POST['tracking_provider'] ?? '' ) );
 				$carrier_other   = wc_clean( wp_unslash( $_POST['custom_tracking_provider'] ?? '' ) );
 				$carrier         = $carrier ?: $carrier_other ?: '';
 
-				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $transaction_id ) {
+				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $capture_id ) {
 					return;
 				}
 
-				$this->sync_tracking( $order_id, $transaction_id, $tracking_number, $carrier );
+				$this->sync_tracking( $order_id, $capture_id, $tracking_number, $carrier );
 			}
 		);
 
@@ -116,17 +121,18 @@ class ShipmentTrackingIntegration implements Integration {
 					return $response;
 				}
 
-				$transaction_id  = $wc_order->get_transaction_id();
+				$paypal_order    = ppcp_get_paypal_order($wc_order);
+				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 				$tracking_number = $tracking_item['tracking_number'] ?? '';
 				$carrier         = $tracking_item['tracking_provider'] ?? '';
 				$carrier_other   = $tracking_item['custom_tracking_provider'] ?? '';
 				$carrier         = $carrier ?: $carrier_other ?: '';
 
-				if ( ! $tracking_number || ! $carrier || ! $transaction_id ) {
+				if ( ! $tracking_number || ! $carrier || ! $capture_id ) {
 					return $response;
 				}
 
-				$this->sync_tracking( $order_id, $transaction_id, $tracking_number, $carrier );
+				$this->sync_tracking( $order_id, $capture_id, $tracking_number, $carrier );
 
 				return $response;
 			},
@@ -139,21 +145,21 @@ class ShipmentTrackingIntegration implements Integration {
 	 * Syncs (add | update) the PayPal tracking with given info.
 	 *
 	 * @param int    $wc_order_id The WC order ID.
-	 * @param string $transaction_id The transaction ID.
+	 * @param string $capture_id The capture ID.
 	 * @param string $tracking_number The tracking number.
 	 * @param string $carrier The shipment carrier.
 	 * @return void
 	 */
 	protected function sync_tracking(
 		int $wc_order_id,
-		string $transaction_id,
+		string $capture_id,
 		string $tracking_number,
 		string $carrier
 	) {
 		try {
 			$ppcp_shipment = $this->shipment_factory->create_shipment(
 				$wc_order_id,
-				$transaction_id,
+				$capture_id,
 				$tracking_number,
 				'SHIPPED',
 				'OTHER',

--- a/modules/ppcp-order-tracking/src/Integration/ShipmentTrackingIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/ShipmentTrackingIntegration.php
@@ -85,7 +85,7 @@ class ShipmentTrackingIntegration implements Integration {
 					return;
 				}
 
-				$paypal_order    = ppcp_get_paypal_order($wc_order);
+				$paypal_order    = ppcp_get_paypal_order( $wc_order );
 				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 				$tracking_number = wc_clean( wp_unslash( $_POST['tracking_number'] ?? '' ) );
 				$carrier         = wc_clean( wp_unslash( $_POST['tracking_provider'] ?? '' ) );
@@ -121,7 +121,7 @@ class ShipmentTrackingIntegration implements Integration {
 					return $response;
 				}
 
-				$paypal_order    = ppcp_get_paypal_order($wc_order);
+				$paypal_order    = ppcp_get_paypal_order( $wc_order );
 				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 				$tracking_number = $tracking_item['tracking_number'] ?? '';
 				$carrier         = $tracking_item['tracking_provider'] ?? '';

--- a/modules/ppcp-order-tracking/src/Integration/WcShippingTaxIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/WcShippingTaxIntegration.php
@@ -101,10 +101,10 @@ class WcShippingTaxIntegration implements Integration {
 						continue;
 					}
 
-					$paypal_order    = ppcp_get_paypal_order($wc_order);
-					$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
-					$carrier        = $label['carrier_id'] ?? $label['service_name'] ?? '';
-					$items          = array_map( 'intval', $label['product_ids'] ?? array() );
+					$paypal_order = ppcp_get_paypal_order( $wc_order );
+					$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
+					$carrier      = $label['carrier_id'] ?? $label['service_name'] ?? '';
+					$items        = array_map( 'intval', $label['product_ids'] ?? array() );
 
 					if ( ! $carrier || ! $capture_id ) {
 						continue;

--- a/modules/ppcp-order-tracking/src/Integration/WcShippingTaxIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/WcShippingTaxIntegration.php
@@ -16,16 +16,18 @@ use WooCommerce\PayPalCommerce\Compat\Integration;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
 use WooCommerce\PayPalCommerce\OrderTracking\TrackingAvailabilityTrait;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
 use WP_HTTP_Response;
 use WP_REST_Request;
 use WP_REST_Server;
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class WcShippingTaxIntegration.
  */
 class WcShippingTaxIntegration implements Integration {
 
-	use TrackingAvailabilityTrait;
+	use TrackingAvailabilityTrait, TransactionIdHandlingTrait;
 
 	/**
 	 * The shipment factory.
@@ -99,15 +101,16 @@ class WcShippingTaxIntegration implements Integration {
 						continue;
 					}
 
-					$transaction_id = $wc_order->get_transaction_id();
+					$paypal_order    = ppcp_get_paypal_order($wc_order);
+					$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 					$carrier        = $label['carrier_id'] ?? $label['service_name'] ?? '';
 					$items          = array_map( 'intval', $label['product_ids'] ?? array() );
 
-					if ( ! $carrier || ! $transaction_id ) {
+					if ( ! $carrier || ! $capture_id ) {
 						continue;
 					}
 
-					$this->sync_tracking( $order_id, $transaction_id, $tracking_number, $carrier, $items );
+					$this->sync_tracking( $order_id, $capture_id, $tracking_number, $carrier, $items );
 				}
 
 				return $response;
@@ -122,7 +125,7 @@ class WcShippingTaxIntegration implements Integration {
 	 * Syncs (add | update) the PayPal tracking with given info.
 	 *
 	 * @param int    $wc_order_id The WC order ID.
-	 * @param string $transaction_id The transaction ID.
+	 * @param string $capture_id The capture ID.
 	 * @param string $tracking_number The tracking number.
 	 * @param string $carrier The shipment carrier.
 	 * @param int[]  $items The list of line items IDs.
@@ -130,7 +133,7 @@ class WcShippingTaxIntegration implements Integration {
 	 */
 	protected function sync_tracking(
 		int $wc_order_id,
-		string $transaction_id,
+		string $capture_id,
 		string $tracking_number,
 		string $carrier,
 		array $items
@@ -138,7 +141,7 @@ class WcShippingTaxIntegration implements Integration {
 		try {
 			$ppcp_shipment = $this->shipment_factory->create_shipment(
 				$wc_order_id,
-				$transaction_id,
+				$capture_id,
 				$tracking_number,
 				'SHIPPED',
 				'OTHER',

--- a/modules/ppcp-order-tracking/src/Integration/YithShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/YithShipmentIntegration.php
@@ -15,11 +15,15 @@ use WC_Order;
 use WooCommerce\PayPalCommerce\Compat\Integration;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class YithShipmentIntegration.
  */
 class YithShipmentIntegration implements Integration {
+
+	use TransactionIdHandlingTrait;
 
 	/**
 	 * The shipment factory.
@@ -76,20 +80,21 @@ class YithShipmentIntegration implements Integration {
 					return;
 				}
 
-				$transaction_id = $wc_order->get_transaction_id();
+				$paypal_order = ppcp_get_paypal_order($wc_order);
+				$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing
 				$tracking_number = wc_clean( wp_unslash( $_POST['ywot_tracking_code'] ?? '' ) );
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing
 				$carrier = wc_clean( wp_unslash( $_POST['ywot_carrier_name'] ?? '' ) );
 
-				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $transaction_id ) {
+				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $capture_id ) {
 					return;
 				}
 
 				try {
 					$ppcp_shipment = $this->shipment_factory->create_shipment(
 						$order_id,
-						$transaction_id,
+						$capture_id,
 						$tracking_number,
 						'SHIPPED',
 						'OTHER',

--- a/modules/ppcp-order-tracking/src/Integration/YithShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/YithShipmentIntegration.php
@@ -80,7 +80,7 @@ class YithShipmentIntegration implements Integration {
 					return;
 				}
 
-				$paypal_order = ppcp_get_paypal_order($wc_order);
+				$paypal_order = ppcp_get_paypal_order( $wc_order );
 				$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing
 				$tracking_number = wc_clean( wp_unslash( $_POST['ywot_tracking_code'] ?? '' ) );

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -93,10 +93,10 @@ class MetaBoxRenderer {
 			return;
 		}
 
-		try {
-			$paypal_order = ppcp_get_paypal_order( $wc_order );
-			$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
-		} catch ( Exception $exception ) {
+		$paypal_order = ppcp_get_paypal_order( $wc_order );
+		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order ) ?? '';
+
+		if ( ! $capture_id ) {
 			return;
 		}
 

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -94,7 +94,7 @@ class MetaBoxRenderer {
 		}
 
 		try {
-			$paypal_order = ppcp_get_paypal_order($wc_order);
+			$paypal_order = ppcp_get_paypal_order( $wc_order );
 			$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
 		} catch ( Exception $exception ) {
 			return;

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -9,10 +9,14 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
+use Exception;
 use WC_Order;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
 use WP_Post;
+
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class MetaBoxRenderer
@@ -24,6 +28,8 @@ use WP_Post;
  * @psalm-type Carriers = array<CarrierType, Carrier>
  */
 class MetaBoxRenderer {
+
+	use TransactionIdHandlingTrait;
 
 	/**
 	 * Allowed shipping statuses.
@@ -87,7 +93,13 @@ class MetaBoxRenderer {
 			return;
 		}
 
-		$transaction_id   = $wc_order->get_transaction_id() ?: '';
+		try {
+			$paypal_order = ppcp_get_paypal_order($wc_order);
+			$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
+		} catch ( Exception $exception ) {
+			return;
+		}
+
 		$order_items      = $wc_order->get_items();
 		$order_item_count = ! empty( $order_items ) ? count( $order_items ) : 0;
 
@@ -102,8 +114,8 @@ class MetaBoxRenderer {
 			<div class="ppcp-tracking-column">
 				<h3><?php echo esc_html__( 'Share Package Tracking Data with PayPal', 'woocommerce-paypal-payments' ); ?></h3>
 				<p>
-					<label for="ppcp-tracking-transaction_id"><?php echo esc_html__( 'Transaction ID', 'woocommerce-paypal-payments' ); ?></label>
-					<input type="text" disabled class="ppcp-tracking-transaction_id disabled" id="ppcp-tracking-transaction_id" name="ppcp-tracking[transaction_id]" value="<?php echo esc_attr( $transaction_id ); ?>" />
+					<label for="ppcp-tracking-capture_id"><?php echo esc_html__( 'Capture ID', 'woocommerce-paypal-payments' ); ?></label>
+					<input type="text" disabled class="ppcp-tracking-capture_id disabled" id="ppcp-tracking-capture_id" name="ppcp-tracking[capture_id]" value="<?php echo esc_attr( $capture_id ); ?>" />
 				</p>
 				<?php if ( $order_item_count > 1 && $this->should_use_new_api ) : ?>
 					<p>

--- a/modules/ppcp-order-tracking/src/Shipment/Shipment.php
+++ b/modules/ppcp-order-tracking/src/Shipment/Shipment.php
@@ -32,11 +32,11 @@ class Shipment implements ShipmentInterface {
 	private $wc_order_id;
 
 	/**
-	 * The transaction ID.
+	 * The capture ID.
 	 *
 	 * @var string
 	 */
-	protected $transaction_id;
+	protected $capture_id;
 
 	/**
 	 * The tracking number.
@@ -76,7 +76,7 @@ class Shipment implements ShipmentInterface {
 	 * Shipment constructor.
 	 *
 	 * @param int    $wc_order_id The WC order ID.
-	 * @param string $transaction_id The transaction ID.
+	 * @param string $capture_id The capture ID.
 	 * @param string $tracking_number The tracking number.
 	 * @param string $status The shipment status.
 	 * @param string $carrier The shipment carrier.
@@ -85,7 +85,7 @@ class Shipment implements ShipmentInterface {
 	 */
 	public function __construct(
 		int $wc_order_id,
-		string $transaction_id,
+		string $capture_id,
 		string $tracking_number,
 		string $status,
 		string $carrier,
@@ -97,15 +97,15 @@ class Shipment implements ShipmentInterface {
 		$this->carrier            = $carrier;
 		$this->carrier_name_other = $carrier_name_other;
 		$this->line_items         = $line_items;
-		$this->transaction_id     = $transaction_id;
+		$this->capture_id     = $capture_id;
 		$this->wc_order_id        = $wc_order_id;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function transaction_id(): string {
-		return $this->transaction_id;
+	public function capture_id(): string {
+		return $this->capture_id;
 	}
 
 	/**
@@ -228,7 +228,7 @@ class Shipment implements ShipmentInterface {
 	 */
 	public function to_array(): array {
 		$shipment = array(
-			'transaction_id'  => $this->transaction_id(),
+			'capture_id'  => $this->capture_id(),
 			'tracking_number' => $this->tracking_number(),
 			'status'          => $this->status(),
 			'carrier'         => $this->carrier(),

--- a/modules/ppcp-order-tracking/src/Shipment/Shipment.php
+++ b/modules/ppcp-order-tracking/src/Shipment/Shipment.php
@@ -97,7 +97,7 @@ class Shipment implements ShipmentInterface {
 		$this->carrier            = $carrier;
 		$this->carrier_name_other = $carrier_name_other;
 		$this->line_items         = $line_items;
-		$this->capture_id     = $capture_id;
+		$this->capture_id         = $capture_id;
 		$this->wc_order_id        = $wc_order_id;
 	}
 
@@ -228,7 +228,7 @@ class Shipment implements ShipmentInterface {
 	 */
 	public function to_array(): array {
 		$shipment = array(
-			'capture_id'  => $this->capture_id(),
+			'capture_id'      => $this->capture_id(),
 			'tracking_number' => $this->tracking_number(),
 			'status'          => $this->status(),
 			'carrier'         => $this->carrier(),

--- a/modules/ppcp-order-tracking/src/Shipment/ShipmentFactory.php
+++ b/modules/ppcp-order-tracking/src/Shipment/ShipmentFactory.php
@@ -19,13 +19,13 @@ class ShipmentFactory implements ShipmentFactoryInterface {
 	 */
 	public function create_shipment(
 		int $wc_order_id,
-		string $transaction_id,
+		string $capture_id,
 		string $tracking_number,
 		string $status,
 		string $carrier,
 		string $carrier_name_other,
 		array $line_items
 	): ShipmentInterface {
-		return new Shipment( $wc_order_id, $transaction_id, $tracking_number, $status, $carrier, $carrier_name_other, $line_items );
+		return new Shipment( $wc_order_id, $capture_id, $tracking_number, $status, $carrier, $carrier_name_other, $line_items );
 	}
 }

--- a/modules/ppcp-order-tracking/src/Shipment/ShipmentFactoryInterface.php
+++ b/modules/ppcp-order-tracking/src/Shipment/ShipmentFactoryInterface.php
@@ -20,7 +20,7 @@ interface ShipmentFactoryInterface {
 	 * Returns the new shipment instance.
 	 *
 	 * @param int    $wc_order_id The WC order ID.
-	 * @param string $transaction_id The transaction ID.
+	 * @param string $capture_id The capture ID.
 	 * @param string $tracking_number The tracking number.
 	 * @param string $status The shipment status.
 	 * @param string $carrier The shipment carrier.
@@ -32,7 +32,7 @@ interface ShipmentFactoryInterface {
 	 */
 	public function create_shipment(
 		int $wc_order_id,
-		string $transaction_id,
+		string $capture_id,
 		string $tracking_number,
 		string $status,
 		string $carrier,

--- a/modules/ppcp-order-tracking/src/Shipment/ShipmentInterface.php
+++ b/modules/ppcp-order-tracking/src/Shipment/ShipmentInterface.php
@@ -24,7 +24,7 @@ namespace WooCommerce\PayPalCommerce\OrderTracking\Shipment;
  *     tax_rate?: string
  * }
  * @psalm-type shipmentMap = array{
- *     transaction_id: string,
+ *     capture_id: string,
  *     tracking_number: string,
  *     status: string,
  *     carrier: string,
@@ -35,11 +35,11 @@ namespace WooCommerce\PayPalCommerce\OrderTracking\Shipment;
 interface ShipmentInterface {
 
 	/**
-	 * The transaction ID.
+	 * The capture ID.
 	 *
 	 * @return string
 	 */
-	public function transaction_id(): string;
+	public function capture_id(): string;
 
 	/**
 	 * The tracking number.


### PR DESCRIPTION
# PR Description
The PR will refactor the `order-tracking` module and will replace the `$wc_order->get_transaction_id()` with the `get_paypal_order_transaction_id` method.
In this context also the "Transaction ID" label is changed to "Capture ID" inside tracking metabox.

# Issue Description

> Looks like we found a bug that needs some research around package tracking.We've seen a few 422 errors around the .*.track endpoint.Looked at an example and what we saw was that a .track was sent with the capture_id being referenced is a refund transaction ID.The example I saw was a partial refund.

To resolve this issue, PayPal Payments must store the original `capture_id` and only use this for submitting package tracking data, even when the transaction ID in the order was updated, e.g. due to a partial refund.
The package tracking data can never be submitted to anything but the original `capture_id`.

**Steps To Reproduce**
* Capture order
* Do a partial refund on order
* Try to add tracking info.