### PR TITLE
Messages Bootstrap: Add a render retry functionality (3020)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MessagesBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MessagesBootstap.js
@@ -11,22 +11,20 @@ class MessagesBootstrap {
         }
     }
 
-    init() {
+    async init() {
         if (this.gateway.messages?.block?.enabled) {
-            this.discoverBlocks();
+            await this.attemptDiscoverBlocks(3);  // Try up to 3 times
         }
         jQuery(document.body).on('ppcp_cart_rendered ppcp_checkout_rendered', () => {
             this.render();
         });
         jQuery(document.body).on('ppcp_script_data_changed', (e, data) => {
             this.gateway = data;
-
             this.render();
         });
         jQuery(document.body).on('ppcp_cart_total_updated ppcp_checkout_total_updated ppcp_product_total_updated ppcp_block_cart_total_updated', (e, amount) => {
             if (this.lastAmount !== amount) {
                 this.lastAmount = amount;
-
                 this.render();
             }
         });
@@ -34,13 +32,39 @@ class MessagesBootstrap {
         this.render();
     }
 
+    attemptDiscoverBlocks(retries) {
+        return new Promise((resolve, reject) => {
+            this.discoverBlocks().then(found => {
+                if (!found && retries > 0) {
+                    setTimeout(() => {
+                        this.attemptDiscoverBlocks(retries - 1).then(resolve);
+                    }, 2000);  // Wait 2 seconds before retrying
+                } else {
+                    resolve();
+                }
+            });
+        });
+    }
+
     discoverBlocks() {
-        Array.from(document.querySelectorAll('.ppcp-paylater-message-block')).forEach(blockElement => {
-            const config = {wrapper: '#' + blockElement.id};
-            if (!blockElement.getAttribute('data-pp-placement')) {
-                config.placement = this.gateway.messages.placement;
+        return new Promise((resolve) => {
+            const elements = document.querySelectorAll('.ppcp-messages');
+            if (elements.length === 0) {
+                resolve(false);
+                return;
             }
-            this.renderers.push(new MessageRenderer(config));
+
+            Array.from(elements).forEach(blockElement => {
+                if (!blockElement.id) {
+                    blockElement.id = `ppcp-message-${Math.random().toString(36).substr(2, 9)}`;  // Ensure each block has a unique ID
+                }
+                const config = {wrapper: '#' + blockElement.id};
+                if (!blockElement.getAttribute('data-pp-placement')) {
+                    config.placement = this.gateway.messages.placement;
+                }
+                this.renderers.push(new MessageRenderer(config));
+            });
+            resolve(true);
         });
     }
 

--- a/modules/ppcp-paylater-wc-blocks/services.php
+++ b/modules/ppcp-paylater-wc-blocks/services.php
@@ -12,7 +12,7 @@ namespace WooCommerce\PayPalCommerce\PayLaterWCBlocks;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
-	'paylater-wc-blocks.url'      => static function ( ContainerInterface $container ): string {
+	'paylater-wc-blocks.url'               => static function ( ContainerInterface $container ): string {
 		/**
 		 * Cannot return false for this path.
 		 *
@@ -24,7 +24,35 @@ return array(
 		);
 	},
 
-	'paylater-wc-blocks.renderer' => static function (): PayLaterWCBlocksRenderer {
-		return new PayLaterWCBlocksRenderer();
+	'paylater-wc-blocks.cart-renderer'     => static function ( ContainerInterface $container ): PayLaterWCBlocksRenderer {
+		$settings = $container->get( 'wcgateway.settings' );
+		return new PayLaterWCBlocksRenderer(
+			array(
+				'placement'  => 'cart',
+				'layout'     => $settings->has( 'pay_later_cart_message_layout' ) ? $settings->get( 'pay_later_cart_message_layout' ) : '',
+				'position'   => $settings->has( 'pay_later_cart_message_position' ) ? $settings->get( 'pay_later_cart_message_position' ) : '',
+				'logo'       => $settings->has( 'pay_later_cart_message_logo' ) ? $settings->get( 'pay_later_cart_message_logo' ) : '',
+				'text_size'  => $settings->has( 'pay_later_cart_message_text_size' ) ? $settings->get( 'pay_later_cart_message_text_size' ) : '',
+				'color'      => $settings->has( 'pay_later_cart_message_color' ) ? $settings->get( 'pay_later_cart_message_color' ) : '',
+				'flex_color' => $settings->has( 'pay_later_cart_message_flex_color' ) ? $settings->get( 'pay_later_cart_message_flex_color' ) : '',
+				'flex_ratio' => $settings->has( 'pay_later_cart_message_flex_ratio' ) ? $settings->get( 'pay_later_cart_message_flex_ratio' ) : '',
+			)
+		);
+	},
+	'paylater-wc-blocks.checkout-renderer' => static function ( ContainerInterface $container ): PayLaterWCBlocksRenderer {
+		$settings = $container->get( 'wcgateway.settings' );
+		return new PayLaterWCBlocksRenderer(
+			array(
+				'payment',
+				'layout'     => $settings->has( 'pay_later_checkout_message_layout' ) ? $settings->get( 'pay_later_checkout_message_layout' ) : '',
+				'position'   => $settings->has( 'pay_later_checkout_message_position' ) ? $settings->get( 'pay_later_checkout_message_position' ) : '',
+				'logo'       => $settings->has( 'pay_later_checkout_message_logo' ) ? $settings->get( 'pay_later_checkout_message_logo' ) : '',
+				'text_size'  => $settings->has( 'pay_later_checkout_message_text_size' ) ? $settings->get( 'pay_later_checkout_message_text_size' ) : '',
+				'color'      => $settings->has( 'pay_later_checkout_message_color' ) ? $settings->get( 'pay_later_checkout_message_color' ) : '',
+				'flex_color' => $settings->has( 'pay_later_checkout_message_flex_color' ) ? $settings->get( 'pay_later_checkout_message_flex_color' ) : '',
+				'flex_ratio' => $settings->has( 'pay_later_checkout_message_flex_ratio' ) ? $settings->get( 'pay_later_checkout_message_flex_ratio' ) : '',
+			)
+		);
 	},
 );
+

--- a/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksRenderer.php
+++ b/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksRenderer.php
@@ -15,6 +15,70 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
  * Class PayLaterWCBlocksRenderer
  */
 class PayLaterWCBlocksRenderer {
+	/**
+	 * The placement.
+	 *
+	 * @var string
+	 */
+	private $placement;
+	/**
+	 * The layout.
+	 *
+	 * @var string
+	 */
+	private $layout;
+	/**
+	 * The position.
+	 *
+	 * @var string
+	 */
+	private $position;
+	/**
+	 * The logo.
+	 *
+	 * @var string
+	 */
+	private $logo;
+	/**
+	 * The text size.
+	 *
+	 * @var string
+	 */
+	private $text_size;
+	/**
+	 * The color.
+	 *
+	 * @var string
+	 */
+	private $color;
+	/**
+	 * The flex color.
+	 *
+	 * @var string
+	 */
+	private $flex_color;
+	/**
+	 * The flex ratio.
+	 *
+	 * @var string
+	 */
+	private $flex_ratio;
+
+	/**
+	 * PayLaterWCBlocksRenderer constructor.
+	 *
+	 * @param array $config The configuration.
+	 */
+	public function __construct( array $config ) {
+		$this->placement  = $config['placement'] ?? '';
+		$this->layout     = $config['layout'] ?? 'text';
+		$this->position   = $config['position'] ?? '';
+		$this->logo       = $config['logo'] ?? '';
+		$this->text_size  = $config['text_size'] ?? '';
+		$this->color      = $config['color'] ?? '';
+		$this->flex_color = $config['flex_color'] ?? '';
+		$this->flex_ratio = $config['flex_ratio'] ?? '';
+	}
 
 	/**
 	 * Renders the WC Pay Later Messaging blocks.
@@ -24,9 +88,44 @@ class PayLaterWCBlocksRenderer {
 	 * @param ContainerInterface $c The container.
 	 * @return string|void
 	 */
-	public function render( array $attributes, string $location, ContainerInterface $c ) {
+	public function render(
+		array $attributes,
+		string $location,
+		ContainerInterface $c
+	) {
 		if ( PayLaterWCBlocksModule::is_placement_enabled( $c->get( 'wcgateway.settings.status' ), $location ) ) {
-			return '<div id="' . esc_attr( $attributes['ppcpId'] ?? '' ) . '" data-block-name="' . esc_attr( $attributes['blockId'] ?? '' ) . '" class="ppcp-messages" data-partner-attribution-id="Woo_PPCP"></div>';
+
+			$html = '<div id="' . esc_attr( $attributes['ppcpId'] ?? '' ) . '" class="ppcp-messages" data-partner-attribution-id="Woo_PPCP"></div>';
+
+			$processor = new \WP_HTML_Tag_Processor( $html );
+
+			if ( $processor->next_tag( 'div' ) ) {
+				$processor->set_attribute( 'data-block-name', esc_attr( $attributes['blockId'] ?? '' ) );
+				$processor->set_attribute( 'class', 'ppcp-messages' );
+				$processor->set_attribute( 'data-partner-attribution-id', 'Woo_PPCP' );
+
+				if ( $this->layout === 'flex' ) {
+					$processor->set_attribute( 'data-pp-style-layout', 'flex' );
+					$processor->set_attribute( 'data-pp-style-color', esc_attr( $this->flex_color ) );
+					$processor->set_attribute( 'data-pp-style-ratio', esc_attr( $this->flex_ratio ) );
+				} else {
+					$processor->set_attribute( 'data-pp-style-layout', 'text' );
+					$processor->set_attribute( 'data-pp-style-logo-type', esc_attr( $this->logo ) );
+					$processor->set_attribute( 'data-pp-style-logo-position', esc_attr( $this->position ) );
+					$processor->set_attribute( 'data-pp-style-text-color', esc_attr( $this->color ) );
+					$processor->set_attribute( 'data-pp-style-text-size', esc_attr( $this->text_size ) );
+				}
+
+				$processor->set_attribute( 'data-pp-placement', esc_attr( $this->placement ) );
+			}
+
+			$updated_html = $processor->get_updated_html();
+
+			return sprintf(
+				'<div %1$s>%2$s</div>',
+				wp_kses_data( get_block_wrapper_attributes() ),
+				$updated_html
+			);
 		}
 	}
 }

--- a/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksUtils.php
+++ b/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksUtils.php
@@ -59,7 +59,7 @@ class PayLaterWCBlocksUtils {
 	 * @return false|string Rendered content.
 	 */
 	public static function render_paylater_block( string $block_id, string $ppcp_id, string $context, $container ) {
-		$renderer = $container->get( 'paylater-wc-blocks.renderer' );
+		$renderer = $container->get( 'paylater-wc-blocks.' . $context . '-renderer' );
 		ob_start();
 		// phpcs:ignore -- No need to escape it, the PayLaterWCBlocksRenderer class is responsible for escaping.
 		echo $renderer->render(


### PR DESCRIPTION
### PR Description

This PR fixes the issue with the Paylater Messaging blocks not being rendered correctly in the Block context, both in the editor and the page (due to the fact their markup sometimes takes a little longer to get outputted on the page).

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Ensure you are testing on a "live site" (I recommend the Live Link feature in Local by Flywheel).
2. Open the Cart and Checkout block pages in the editor and place the **PayPal Pay Later messaging** block on the page (so now there's both the Cart/Checkout - PayPal Pay Later messaging and the regular block).
3. Save and reload the editor pages without cache.
4. Visit the Block Cart and Block Checkout pages and also reload without cache.
5. Visit the regular Cart and Checkout pages also reload without cache.
7. Make sure that in all cases the Paylater messages load correctly.

### Screenshots
|Before|After|
|-|-|
|<img width="1073" alt="Page__Cart" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/f17b19a7-1b8c-4787-9d02-b8127f8be8a1">|<img width="1066" alt="Page__Cart" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/470a049d-804f-42a8-8900-c96cc0149451">|