### PR TITLE
Remove asterisk and dot to avoid invalid domain error

### DIFF
--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -74,7 +74,7 @@ class SdkClientToken {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$domain = wp_unslash( $_SERVER['HTTP_HOST'] ?? '' );
 
-		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=client_token&intent=sdk_init&domains[]=*.' . $domain;
+		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=client_token&intent=sdk_init&domains[]=' . $domain;
 
 		if ( $target_customer_id ) {
 			$url = add_query_arg(


### PR DESCRIPTION
To fix AXO sdk client token invalid domain error, we must remove `*.` from [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-api-client/src/Authentication/SdkClientToken.php#L77).