### PR TITLE
Fix the fundingSource is not defined error on Block Checkout (3027)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -508,9 +508,7 @@ const PayPalComponent = ({
     );
 }
 
-const BlockEditorPayPalComponent =  ({
-                                        fundingSource,
-                                    }) => {
+const BlockEditorPayPalComponent = () => {
 
     const urlParams = {
         clientId: 'test',
@@ -523,7 +521,6 @@ const BlockEditorPayPalComponent =  ({
             options={urlParams}
        >
             <PayPalButtons
-                fundingSource={fundingSource}
                 onClick={(data, actions) => {
                     return false;
                 }}
@@ -596,7 +593,7 @@ if (block_enabled) {
             name: config.id,
             label: <div dangerouslySetInnerHTML={{__html: config.title}}/>,
             content: <PayPalComponent isEditing={false}/>,
-            edit: <BlockEditorPayPalComponent fundingSource={fundingSource} />,
+            edit: <BlockEditorPayPalComponent />,
             ariaLabel: config.title,
             canMakePayment: () => {
                 return true;
@@ -612,7 +609,7 @@ if (block_enabled) {
                 paymentMethodId: config.id,
                 label: <div dangerouslySetInnerHTML={{__html: config.title}}/>,
                 content: <PayPalComponent isEditing={false} fundingSource={fundingSource}/>,
-                edit: <BlockEditorPayPalComponent fundingSource={fundingSource} />,
+                edit: <BlockEditorPayPalComponent />,
                 ariaLabel: config.title,
                 canMakePayment: async () => {
                     if (!paypalScriptPromise) {


### PR DESCRIPTION
### Description

This PR fixes the broken Block Checkout (which was caused by a `fundingSource is not defined` error).

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Set block checkout as default.
2.  Navigate to shop.
3. Click on simple product.
4. Click on PayPal button and finish process on PayPal popup.
5. Make sure you can correctly check out on the Block checkout page.

### Screenshots
|Before|After|
|-|-|
|<img width="1084" alt="Page__Checkout" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/79cf6bf7-0fb2-4593-bf14-909692abb563">|<img width="1062" alt="Page__Checkout" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/aba28314-c0b6-4b9e-92bd-a84c8d5b8f2f">|