### PR TITLE
Fastlane frontend improvements (3022)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -160,7 +160,6 @@ class AxoManager {
         this.$('form.woocommerce-checkout input').on('keydown', async (ev) => {
             if(ev.key === 'Enter' && getCurrentPaymentMethod() === 'ppcp-axo-gateway' ) {
                 ev.preventDefault();
-                await this.lookupCustomerByEmail();
             }
         });
     }

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -551,7 +551,8 @@ class AxoManager {
                 // Add addresses
                 this.setShipping(authResponse.profileData.shippingAddress);
                 this.setBilling({
-                    address: authResponse.profileData.card.paymentSource.card.billingAddress
+                    address: authResponse.profileData.card.paymentSource.card.billingAddress,
+                    phoneNumber: authResponse.profileData.shippingAddress.phoneNumber.nationalNumber ?? ''
                 });
                 this.setCard(authResponse.profileData.card);
 

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -230,6 +230,8 @@ class AxoManager {
         }
 
         if (scenario.axoProfileViews) {
+            this.el.billingAddressContainer.hide();
+
             this.shippingView.activate();
             this.billingView.activate();
             this.cardView.activate();

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -6,6 +6,7 @@ import BillingView from "./Views/BillingView";
 import CardView from "./Views/CardView";
 import PayPalInsights from "./Insights/PayPalInsights";
 import {disable,enable} from "../../../ppcp-button/resources/js/modules/Helper/ButtonDisabler";
+import {getCurrentPaymentMethod} from "../../../ppcp-button/resources/js/modules/Helper/CheckoutMethodState";
 
 class AxoManager {
 
@@ -154,6 +155,14 @@ class AxoManager {
             this.cardView.refresh();
         });
 
+        // Prevents sending checkout form when pressing Enter key on input field
+        // and triggers customer lookup
+        this.$('form.woocommerce-checkout input').on('keydown', async (ev) => {
+            if(ev.key === 'Enter' && getCurrentPaymentMethod() === 'ppcp-axo-gateway' ) {
+                ev.preventDefault();
+                await this.lookupCustomerByEmail();
+            }
+        });
     }
 
     rerender() {
@@ -520,6 +529,10 @@ class AxoManager {
             page_type: 'checkout'
         });
 
+        await this.lookupCustomerByEmail();
+    }
+
+    async lookupCustomerByEmail() {
         const lookupResponse = await this.fastlane.identity.lookupCustomerByEmail(this.emailInput.value);
 
         if (lookupResponse.customerContextId) {

--- a/modules/ppcp-axo/resources/js/Components/DomElement.js
+++ b/modules/ppcp-axo/resources/js/Components/DomElement.js
@@ -1,5 +1,3 @@
-import {setVisible} from "../../../../ppcp-button/resources/js/modules/Helper/Hiding";
-
 class DomElement {
 
     constructor(config) {

--- a/modules/ppcp-axo/resources/js/Connection/Fastlane.js
+++ b/modules/ppcp-axo/resources/js/Connection/Fastlane.js
@@ -18,6 +18,7 @@ class Fastlane {
                     resolve();
                 })
                 .catch((error) => {
+                    console.error(error)
                     reject();
                 });
         });

--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -42,6 +42,7 @@ class BillingView {
                         <div>${data.value('postCode')} ${data.value('city')}</div>
                         <div>${valueOfSelect('#billing_state', data.value('stateCode'))}</div>
                         <div>${valueOfSelect('#billing_country', data.value('countryCode'))}</div>
+                        <div>${valueOfSelect('#billing_phone', data.value('phone'))}</div>
                     </div>
                 `;
             },
@@ -84,6 +85,10 @@ class BillingView {
                 company: {
                     'selector': '#billing_company_field',
                     'valuePath': null,
+                },
+                phone: {
+                    'selector': '#billing_phone_field',
+                    'valuePath': null
                 }
             }
         });

--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -42,7 +42,6 @@ class BillingView {
                         <div>${data.value('postCode')} ${data.value('city')}</div>
                         <div>${valueOfSelect('#billing_state', data.value('stateCode'))}</div>
                         <div>${valueOfSelect('#billing_country', data.value('countryCode'))}</div>
-                        <div>${valueOfSelect('#billing_phone', data.value('phone'))}</div>
                     </div>
                 `;
             },
@@ -88,7 +87,7 @@ class BillingView {
                 },
                 phone: {
                     'selector': '#billing_phone_field',
-                    'valuePath': null
+                    'valuePath': 'billing.phoneNumber'
                 }
             }
         });

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -34,6 +34,7 @@ class ShippingView {
                 return `
                     <div style="margin-bottom: 20px;">
                         <h3>Shipping <a href="javascript:void(0)" ${this.el.changeShippingAddressLink.attributes} style="margin-left: 20px;">Edit</a></h3>
+                        <div>${data.value('email')}</div>
                         <div>${data.value('company')}</div>
                         <div>${data.value('firstName')} ${data.value('lastName')}</div>
                         <div>${data.value('street1')}</div>
@@ -46,6 +47,9 @@ class ShippingView {
                 `;
             },
             fields: {
+                email: {
+                    'valuePath': 'email',
+                },
                 firstName: {
                     'key': 'firstName',
                     'selector': '#shipping_first_name_field',

--- a/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
@@ -76,7 +76,7 @@ export const loadPaypalScript = (config, onLoaded, onError = null) => {
 
     // Adds data-user-id-token to script options.
     const userIdToken = config?.save_payment_methods?.id_token;
-    if(userIdToken && getCurrentPaymentMethod() !== 'ppcp-axo-gateway') {
+    if(userIdToken && !sdkClientToken) {
         scriptOptions['data-user-id-token'] = userIdToken;
     }
 

--- a/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
@@ -3,6 +3,7 @@ import {loadScript} from "@paypal/paypal-js";
 import widgetBuilder from "../Renderer/WidgetBuilder";
 import merge from "deepmerge";
 import {keysToCamelCase} from "./Utils";
+import {getCurrentPaymentMethod} from "./CheckoutMethodState";
 
 // This component may be used by multiple modules. This assures that options are shared between all instances.
 let options = window.ppcpWidgetBuilder = window.ppcpWidgetBuilder || {
@@ -75,7 +76,7 @@ export const loadPaypalScript = (config, onLoaded, onError = null) => {
 
     // Adds data-user-id-token to script options.
     const userIdToken = config?.save_payment_methods?.id_token;
-    if(userIdToken && !sdkClientToken) {
+    if(userIdToken && getCurrentPaymentMethod() !== 'ppcp-axo-gateway') {
         scriptOptions['data-user-id-token'] = userIdToken;
     }
 

--- a/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
@@ -75,7 +75,7 @@ export const loadPaypalScript = (config, onLoaded, onError = null) => {
 
     // Adds data-user-id-token to script options.
     const userIdToken = config?.save_payment_methods?.id_token;
-    if(userIdToken) {
+    if(userIdToken && !sdkClientToken) {
         scriptOptions['data-user-id-token'] = userIdToken;
     }
 


### PR DESCRIPTION
- Prevent form submission when hitting the enter key
  - Email lookup should be automatically prompted when hitting enter/tab keys
- In Ryan flow
  - Hide billing address by default
  - Provide a filter to display billing address data
  - Show email address in shipping fields
  - Display country and state with full names
  - Save the shipping phone number passed back from PayPal as the billing phone in WooCommerce

- Apply advanced styles from Fastlane settings to frontend