### PR TITLE
Set the 'Woo_PPCP' as a default value for `data-partner-attribution-id` (2961)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1506,7 +1506,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	private function bn_code_for_context( string $context ): string {
 
 		$codes = $this->bn_codes();
-		return ( isset( $codes[ $context ] ) ) ? $codes[ $context ] : '';
+		return ( isset( $codes[ $context ] ) ) ? $codes[ $context ] : 'Woo_PPCP';
 	}
 
 	/**


### PR DESCRIPTION
# PR Description
The PR will fix the problem described below by setting the `'Woo_PPCP'` as a default value for `data-partner-attribution-id`

# Issue Description

On block Cart and block Checkout, we are not sending the `data-partner-attribution-id` parameter in the JSSDK load.
It should send `data-partner-attribution-id: "Woo_PPCP"` but it actually sends `data-partner-attribution-id: ""`

**Steps To Reproduce**
* Enable PayPal button on classic and block pages
* Navigate to classic page
* Type `PayPalCommerceGateway` in the browser console and enter
* Open the object and observe the `script_attributes`
* Find `data-partner-attribution-id: "Woo_PPCP"`
* Navigate to a block page (block Cart/Checkout)
* Type `wc.wcSettings.getSetting('ppcp-gateway_data').scriptData` in the browser console and enter
* Open the object and observe the `script_attributes`
* Find `data-partner-attribution-id: ""`