### PR TITLE
Fastlane Settings UI improvements (2956)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -122,7 +122,7 @@ return array(
 						'woocommerce-paypal-payments'
 					),
 					'default'      => __(
-						'Fastlane Debit & Credit Cards',
+						'Debit & Credit Cards',
 						'woocommerce-paypal-payments'
 					),
 					'screens'      => array(

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -57,9 +57,9 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(
-						'dcc',
+						array('dcc', 'axo'),
 					),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_enabled'                        => array(
 					'title'             => __( 'Fastlane', 'woocommerce-paypal-payments' ),
@@ -75,7 +75,7 @@ return array(
 						. '</p>',
 					'default'           => 'yes',
 					'screens'           => array( State::STATE_ONBOARDED ),
-					'gateway'           => 'dcc',
+					'gateway'           => array('dcc', 'axo'),
 					'requirements'      => array(),
 					'custom_attributes' => array(
 						'data-ppcp-display' => wp_json_encode(
@@ -129,7 +129,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_privacy'                        => array(
 					'title'        => __( 'Privacy', 'woocommerce-paypal-payments' ),
@@ -145,7 +145,7 @@ return array(
 					'default'      => 'yes',
 					'options'      => PropertiesDictionary::privacy_options(),
 					'screens'      => array( State::STATE_ONBOARDED ),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 					'requirements' => array(),
 				),
 				'axo_style_heading'                  => array(
@@ -179,9 +179,9 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(
-						'dcc',
+						array('dcc', 'axo'),
 					),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 
 				'axo_style_root_heading'             => array(
@@ -193,8 +193,8 @@ return array(
 					),
 					'classes'      => array( 'ppcp-field-indent' ),
 					'screens'      => array( State::STATE_ONBOARDED ),
-					'requirements' => array( 'dcc' ),
-					'gateway'      => 'dcc',
+					'requirements' => array( array('dcc', 'axo') ),
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_root_bg_color'            => array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
@@ -204,7 +204,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_root_error_color'         => array(
 					'title'        => __( 'Error Color', 'woocommerce-paypal-payments' ),
@@ -214,7 +214,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_root_font_family'         => array(
 					'title'        => __( 'Font Family', 'woocommerce-paypal-payments' ),
@@ -224,7 +224,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_root_font_size_base'      => array(
 					'title'        => __( 'Font Size Base', 'woocommerce-paypal-payments' ),
@@ -234,7 +234,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_root_padding'             => array(
 					'title'        => __( 'Padding', 'woocommerce-paypal-payments' ),
@@ -244,7 +244,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_root_primary_color'       => array(
 					'title'        => __( 'Primary Color', 'woocommerce-paypal-payments' ),
@@ -254,7 +254,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_input_heading'            => array(
 					'heading'      => __( 'Input Settings', 'woocommerce-paypal-payments' ),
@@ -265,8 +265,8 @@ return array(
 					),
 					'classes'      => array( 'ppcp-field-indent' ),
 					'screens'      => array( State::STATE_ONBOARDED ),
-					'requirements' => array( 'dcc' ),
-					'gateway'      => 'dcc',
+					'requirements' => array( array('dcc', 'axo') ),
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_input_bg_color'           => array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
@@ -276,7 +276,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_input_border_radius'      => array(
 					'title'        => __( 'Border Radius', 'woocommerce-paypal-payments' ),
@@ -286,7 +286,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_input_border_color'       => array(
 					'title'        => __( 'Border Color', 'woocommerce-paypal-payments' ),
@@ -296,7 +296,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_input_border_width'       => array(
 					'title'        => __( 'Border Width', 'woocommerce-paypal-payments' ),
@@ -306,7 +306,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_input_text_color_base'    => array(
 					'title'        => __( 'Text Color Base', 'woocommerce-paypal-payments' ),
@@ -316,7 +316,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 				'axo_style_input_focus_border_color' => array(
 					'title'        => __( 'Focus Border Color', 'woocommerce-paypal-payments' ),
@@ -326,7 +326,7 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array(),
-					'gateway'      => 'dcc',
+					'gateway'      => array('dcc', 'axo'),
 				),
 
 			)

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -132,6 +132,11 @@ return array(
 				'axo_privacy'                        => array(
 					'title'        => __( 'Privacy', 'woocommerce-paypal-payments' ),
 					'type'         => 'select',
+					'label'        => __(
+						'Require customers to confirm express payments from the Cart and Express Checkout on the checkout page.
+<p class="description">PayPal powers this accelerated checkout solution from Fastlane. Since you\'ll share consumers\' email addresses with PayPal, please consult your legal advisors on the apropriate privacy setting for your business.</p>',
+						'woocommerce-paypal-payments'
+					),
 					'desc_tip'     => true,
 					'description'  => __(
 						'This setting will control whether Fastlane branding is shown by email field.',

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -56,10 +56,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(
-						array('dcc', 'axo'),
-					),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'dcc', 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_enabled'                        => array(
 					'title'             => __( 'Fastlane', 'woocommerce-paypal-payments' ),
@@ -75,8 +73,8 @@ return array(
 						. '</p>',
 					'default'           => 'yes',
 					'screens'           => array( State::STATE_ONBOARDED ),
-					'gateway'           => array('dcc', 'axo'),
-					'requirements'      => array(),
+					'gateway'           => array( 'dcc', 'axo' ),
+					'requirements'      => array( 'axo' ),
 					'custom_attributes' => array(
 						'data-ppcp-display' => wp_json_encode(
 							array(
@@ -128,8 +126,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_privacy'                        => array(
 					'title'        => __( 'Privacy', 'woocommerce-paypal-payments' ),
@@ -145,8 +143,8 @@ return array(
 					'default'      => 'yes',
 					'options'      => PropertiesDictionary::privacy_options(),
 					'screens'      => array( State::STATE_ONBOARDED ),
-					'gateway'      => array('dcc', 'axo'),
-					'requirements' => array(),
+					'gateway'      => array( 'dcc', 'axo' ),
+					'requirements' => array( 'axo' ),
 				),
 				'axo_style_heading'                  => array(
 					'heading'      => __( 'Advanced Style Settings (optional)', 'woocommerce-paypal-payments' ),
@@ -178,10 +176,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(
-						array('dcc', 'axo'),
-					),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'dcc', 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 
 				'axo_style_root_heading'             => array(
@@ -193,8 +189,8 @@ return array(
 					),
 					'classes'      => array( 'ppcp-field-indent' ),
 					'screens'      => array( State::STATE_ONBOARDED ),
-					'requirements' => array( array('dcc', 'axo') ),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'dcc', 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_root_bg_color'            => array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
@@ -204,8 +200,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_root_error_color'         => array(
 					'title'        => __( 'Error Color', 'woocommerce-paypal-payments' ),
@@ -215,8 +211,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_root_font_family'         => array(
 					'title'        => __( 'Font Family', 'woocommerce-paypal-payments' ),
@@ -226,8 +222,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_root_font_size_base'      => array(
 					'title'        => __( 'Font Size Base', 'woocommerce-paypal-payments' ),
@@ -237,8 +233,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_root_padding'             => array(
 					'title'        => __( 'Padding', 'woocommerce-paypal-payments' ),
@@ -248,19 +244,19 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_root_primary_color'       => array(
 					'title'        => __( 'Primary Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'	   => '#0057ff',
+					'default'      => '#0057ff',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_input_heading'            => array(
 					'heading'      => __( 'Input Settings', 'woocommerce-paypal-payments' ),
@@ -271,8 +267,8 @@ return array(
 					),
 					'classes'      => array( 'ppcp-field-indent' ),
 					'screens'      => array( State::STATE_ONBOARDED ),
-					'requirements' => array( array('dcc', 'axo') ),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'dcc', 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_input_bg_color'           => array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
@@ -282,8 +278,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_input_border_radius'      => array(
 					'title'        => __( 'Border Radius', 'woocommerce-paypal-payments' ),
@@ -293,8 +289,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_input_border_color'       => array(
 					'title'        => __( 'Border Color', 'woocommerce-paypal-payments' ),
@@ -304,8 +300,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_input_border_width'       => array(
 					'title'        => __( 'Border Width', 'woocommerce-paypal-payments' ),
@@ -315,8 +311,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_input_text_color_base'    => array(
 					'title'        => __( 'Text Color Base', 'woocommerce-paypal-payments' ),
@@ -326,8 +322,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_style_input_focus_border_color' => array(
 					'title'        => __( 'Focus Border Color', 'woocommerce-paypal-payments' ),
@@ -337,8 +333,8 @@ return array(
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
-					'requirements' => array(),
-					'gateway'      => array('dcc', 'axo'),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
 				),
 
 			)

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -200,6 +200,7 @@ return array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '#ffffff',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -210,6 +211,7 @@ return array(
 					'title'        => __( 'Error Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '#d9360b',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -220,6 +222,7 @@ return array(
 					'title'        => __( 'Font Family', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => 'PayPal Open',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -230,6 +233,7 @@ return array(
 					'title'        => __( 'Font Size Base', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '16px',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -240,6 +244,7 @@ return array(
 					'title'        => __( 'Padding', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '4px',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -250,6 +255,7 @@ return array(
 					'title'        => __( 'Primary Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'	   => '#0057ff',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -272,6 +278,7 @@ return array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '#ffffff',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -282,6 +289,7 @@ return array(
 					'title'        => __( 'Border Radius', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '0.25em',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -292,6 +300,7 @@ return array(
 					'title'        => __( 'Border Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '#dadddd',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -302,6 +311,7 @@ return array(
 					'title'        => __( 'Border Width', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '1px',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -312,6 +322,7 @@ return array(
 					'title'        => __( 'Text Color Base', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '#010b0d',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -322,6 +333,7 @@ return array(
 					'title'        => __( 'Focus Border Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '#0057ff',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -63,6 +63,7 @@ return array(
 
 	'axo.gateway'                           => static function ( ContainerInterface $container ): AxoGateway {
 		return new AxoGateway(
+			$container->get( 'wcgateway.settings.render' ),
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'wcgateway.order-processor' ),

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -149,7 +149,7 @@ class AxoGateway extends WC_Payment_Gateway {
 		$this->card_icons           = $card_icons;
 
 		$this->method_title       = __( 'Fastlane Debit & Credit Cards', 'woocommerce-paypal-payments' );
-		$this->method_description = __( 'Accept credit cards with Fastlane’s latest solution.', 'woocommerce-paypal-payments' );
+		$this->method_description = __( 'PayPal Fastlane offers an accelerated checkout experience that recognizes guest shoppers and autofills their details so they can pay in seconds.', 'woocommerce-paypal-payments' );
 
 		$is_axo_enabled = $this->ppcp_settings->has( 'axo_enabled' ) && $this->ppcp_settings->get( 'axo_enabled' );
 		$this->update_option( 'enabled', $is_axo_enabled ? 'yes' : 'no' );

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -21,17 +21,26 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingPreferenceFactory;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\GatewaySettingsRendererTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderMetaTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
 
 /**
  * Class AXOGateway.
  */
 class AxoGateway extends WC_Payment_Gateway {
-	use OrderMetaTrait;
+	use OrderMetaTrait, GatewaySettingsRendererTrait;
 
 	const ID = 'ppcp-axo-gateway';
+
+	/**
+	 * The Settings Renderer.
+	 *
+	 * @var SettingsRenderer
+	 */
+	protected $settings_renderer;
 
 	/**
 	 * The settings.
@@ -106,6 +115,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	/**
 	 * AXOGateway constructor.
 	 *
+	 * @param SettingsRenderer          $settings_renderer The settings renderer.
 	 * @param ContainerInterface        $ppcp_settings The settings.
 	 * @param string                    $wcgateway_module_url The WcGateway module URL.
 	 * @param OrderProcessor            $order_processor The Order processor.
@@ -118,6 +128,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @param LoggerInterface           $logger The logger.
 	 */
 	public function __construct(
+		SettingsRenderer $settings_renderer,
 		ContainerInterface $ppcp_settings,
 		string $wcgateway_module_url,
 		OrderProcessor $order_processor,
@@ -131,6 +142,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	) {
 		$this->id = self::ID;
 
+		$this->settings_renderer    = $settings_renderer;
 		$this->ppcp_settings        = $ppcp_settings;
 		$this->wcgateway_module_url = $wcgateway_module_url;
 		$this->order_processor      = $order_processor;
@@ -180,6 +192,9 @@ class AxoGateway extends WC_Payment_Gateway {
 				'default'     => 'no',
 				'desc_tip'    => true,
 				'description' => __( 'Enable/Disable AXO payment gateway.', 'woocommerce-paypal-payments' ),
+			),
+			'ppcp'    => array(
+				'type' => 'ppcp',
 			),
 		);
 	}
@@ -321,4 +336,12 @@ class AxoGateway extends WC_Payment_Gateway {
 		return parent::get_title();
 	}
 
+	/**
+	 * Returns the settings renderer.
+	 *
+	 * @return SettingsRenderer
+	 */
+	protected function settings_renderer(): SettingsRenderer {
+		return $this->settings_renderer;
+	}
 }

--- a/modules/ppcp-wc-gateway/resources/css/common.scss
+++ b/modules/ppcp-wc-gateway/resources/css/common.scss
@@ -90,4 +90,10 @@ $background-ident-color: #fbfbfb;
 			}
 		}
 	}
+
+	.ppcp-settings-field-select {
+		p.description {
+			margin-bottom: 1em;
+		}
+	}
 }

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -195,6 +195,7 @@ return array(
 				CardButtonGateway::ID,
 				OXXOGateway::ID,
 				Settings::PAY_LATER_TAB_ID,
+				AxoGateway::ID,
 			),
 			true
 		);

--- a/modules/ppcp-wc-gateway/src/Settings/PageMatcherTrait.php
+++ b/modules/ppcp-wc-gateway/src/Settings/PageMatcherTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -37,6 +38,7 @@ trait PageMatcherTrait {
 			Settings::PAY_LATER_TAB_ID  => Settings::PAY_LATER_TAB_ID,
 			CreditCardGateway::ID       => 'dcc', // TODO: consider using just the gateway ID for PayPal and DCC too.
 			CardButtonGateway::ID       => CardButtonGateway::ID,
+			AxoGateway::ID           	=> 'axo',
 		);
 		return array_key_exists( $current_page_id, $gateway_page_id_map )
 			&& in_array( $gateway_page_id_map[ $current_page_id ], $allowed_gateways, true );

--- a/modules/ppcp-wc-gateway/src/Settings/PageMatcherTrait.php
+++ b/modules/ppcp-wc-gateway/src/Settings/PageMatcherTrait.php
@@ -38,7 +38,7 @@ trait PageMatcherTrait {
 			Settings::PAY_LATER_TAB_ID  => Settings::PAY_LATER_TAB_ID,
 			CreditCardGateway::ID       => 'dcc', // TODO: consider using just the gateway ID for PayPal and DCC too.
 			CardButtonGateway::ID       => CardButtonGateway::ID,
-			AxoGateway::ID           	=> 'axo',
+			AxoGateway::ID              => 'axo',
 		);
 		return array_key_exists( $current_page_id, $gateway_page_id_map )
 			&& in_array( $gateway_page_id_map[ $current_page_id ], $allowed_gateways, true );

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -369,6 +369,12 @@ $data_rows_html
 			) {
 				continue;
 			}
+			if (
+				in_array( 'axo', $config['requirements'], true )
+				&& $this->api_shop_country !== 'US'
+			) {
+				continue;
+			}
 			$value        = $this->settings->has( $field ) ? $this->settings->get( $field ) : ( isset( $config['value'] ) ? $config['value']() : null );
 			$key          = 'ppcp[' . $field . ']';
 			$id           = 'ppcp-' . $field;


### PR DESCRIPTION
### Description

This PR will make the following changes to Fastlane settings:

- Add Fastlane settings to the AXO gateway configuration page
- Add default values to the Fastlane style settings
- Change AXO gateway description from `Accept credit cards with Fastlane's latest solution`. to `PayPal Fastlane offers an accelerated checkout experience that recognizes guest shoppers and autofills their details so they can pay in seconds.`
- Change gateway title from `Fastlane Debit & Credit Cards` to `Debit & Credit Cards`
- Hide Fastlane setting in Advanced Card Processing tab is WC store location is not US
- Add slightly greyed-out description text below `Privacy` dropdown: `PayPal powers this accelerated checkout solution from Fastlane. Since you'll share consumers' email addresses with PayPal, please consult your legal advisors on the apropriate privacy setting for your business.`

**Important**: This PR does not add any special styling or color pickers to the Fastlane styling settings, it remains as a To-Do.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Go to WooCommerce > Settings > Payments > Fastlane Debit & Credit Cards. Ensure the Fastlane settings are displaying below the Enable/Disable checkbox.
 
![WooCommerce_settings_‹_paypal_—_WordPress](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/85258d4d-fdde-42fc-82a5-7dc4c22add0c)

2. Make sure the `Advanced Style Settings` have default values:

![WooCommerce_settings_‹_paypal_—_WordPress](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/fa69ef41-bb99-41b5-b756-b62a97211303)

3. Make sure the description and title have been updated:

![WooCommerce_settings_‹_paypal_—_WordPress](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/c472deb3-f0d2-4dce-b57f-38637134fb85)

![WooCommerce_settings_‹_paypal_—_WordPress](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/1203ba75-c278-483c-b41a-2f938fdc9734)

4. Verify that the Fastlane settings are hidden if the WC store location is not US.
5. Verify that the `Privacy` setting now has an additional description:

![WooCommerce_settings_‹_paypal_—_WordPress](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/8a32015a-3fbf-4086-baba-9c7a433923fc)

`Please note that the default values will not be displayed if you have previously saved settings with the empty Fastlane fields.
`
