### PR TITLE
Fastlane Checkout visual fixes (3030)

### DIFF
--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -39,3 +39,9 @@
 .ppcp-axo-customer-details {
 	margin-bottom: 40px;
 }
+
+.axo-checkout-header-section {
+	display: flex;
+	align-items: baseline;
+	gap: 1em;
+}

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -4,6 +4,7 @@
 
 	.ppcp-card-icon {
 		float: left !important;
+		max-height: 25px;
 	}
 }
 

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -45,3 +45,11 @@
 	align-items: baseline;
 	gap: 1em;
 }
+
+.ppcp-axo-order-button {
+		float: none;
+		width: 100%;
+		box-sizing: border-box;
+		margin: var(--global-md-spacing) 0 1em;
+		padding: 0.6em 1em;
+}

--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -40,7 +40,6 @@ class BillingView {
                             <h3>Billing</h3>
                             <a href="javascript:void(0)" ${this.el.changeBillingAddressLink.attributes}>Edit</a>
                         </div>
-                        <a href="javascript:void(0)" ${this.el.changeBillingAddressLink.attributes}>Edit</a>
                         <div>${data.value('email')}</div>
                         <div>${data.value('company')}</div>
                         <div>${data.value('firstName')} ${data.value('lastName')}</div>

--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -26,14 +26,21 @@ class BillingView {
                 if (data.isEmpty()) {
                     return `
                         <div style="margin-bottom: 20px;">
-                            <h3>Billing <a href="javascript:void(0)" ${this.el.changeBillingAddressLink.attributes} style="margin-left: 20px;">Edit</a></h3>
+                            <div class="axo-checkout-header-section">
+                                <h3>Billing</h3>
+                                <a href="javascript:void(0)" ${this.el.changeBillingAddressLink.attributes}>Edit</a>
+                            </div>
                             <div>Please fill in your billing details.</div>
                         </div>
                     `;
                 }
                 return `
                     <div style="margin-bottom: 20px;">
-                        <h3>Billing <a href="javascript:void(0)" ${this.el.changeBillingAddressLink.attributes} style="margin-left: 20px;">Edit</a></h3>
+                        <div class="axo-checkout-header-section">
+                            <h3>Billing</h3>
+                            <a href="javascript:void(0)" ${this.el.changeBillingAddressLink.attributes}>Edit</a>
+                        </div>
+                        <a href="javascript:void(0)" ${this.el.changeBillingAddressLink.attributes}>Edit</a>
                         <div>${data.value('email')}</div>
                         <div>${data.value('company')}</div>
                         <div>${data.value('firstName')} ${data.value('lastName')}</div>

--- a/modules/ppcp-axo/resources/js/Views/CardView.js
+++ b/modules/ppcp-axo/resources/js/Views/CardView.js
@@ -40,7 +40,10 @@ class CardView {
 
                 return `
                     <div style="margin-bottom: 20px;">
-                        <h3>Card Details <a href="javascript:void(0)" ${this.el.changeCardLink.attributes} style="margin-left: 20px;">Edit</a></h3>
+                        <div class="axo-checkout-header-section">
+                            <h3>Card Details</h3>
+                            <a href="javascript:void(0)" ${this.el.changeCardLink.attributes}>Edit</a>
+                        </div>
                         <div style="border:2px solid #cccccc; border-radius: 10px; padding: 16px 20px; background-color:#f6f6f6">
                             <div style="float: right;">
                                 <img

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -26,14 +26,20 @@ class ShippingView {
                 if (data.isEmpty()) {
                     return `
                         <div style="margin-bottom: 20px;">
-                            <h3>Shipping <a href="javascript:void(0)" ${this.el.changeShippingAddressLink.attributes} style="margin-left: 20px;">Edit</a></h3>
+                            <div class="axo-checkout-header-section">
+                                <h3>Shipping</h3>
+                                <a href="javascript:void(0)" ${this.el.changeShippingAddressLink.attributes}>Edit</a>
+                            </div>
                             <div>Please fill in your shipping details.</div>
                         </div>
                     `;
                 }
                 return `
                     <div style="margin-bottom: 20px;">
-                        <h3>Shipping <a href="javascript:void(0)" ${this.el.changeShippingAddressLink.attributes} style="margin-left: 20px;">Edit</a></h3>
+                        <div class="axo-checkout-header-section">
+                            <h3>Shipping</h3>
+                            <a href="javascript:void(0)" ${this.el.changeShippingAddressLink.attributes}>Edit</a>
+                        </div>
                         <div>${data.value('company')}</div>
                         <div>${data.value('firstName')} ${data.value('lastName')}</div>
                         <div>${data.value('street1')}</div>


### PR DESCRIPTION
### Description

This PR will add the following visual improvements to the Axo checkout:
- The gateway icons are uniformly sized and wrap around if there is not enough space
- "Card Details" text behind the card icons displays correctly
- “Edit” link styling improvement
- "Place order" button is full-width


### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


Go to the Ryan flow Fastlane checkout and verify the following visual changes:

#### The gateway icons are uniformly sized and wrap around if there is not enough space + "Card Details" text behind the card icons displays correctly

|Before|After|
|-|-|
|![Checkout_–_Nauseating_Cheese](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/de11d0dc-2024-4cfc-adf2-7699153ab6ba)|![Checkout_–_Permissible_Mice](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/b8d2f586-cbab-4fe5-ac99-a060b2f1b796)|

#### “Edit” link styling improvement

|Before|After|
|-|-|
|![Checkout_–_Permissible_Mice_i_Comparing_trunk___PCP-3030-fastlane-improvements-for-kadence-theme_·_woocommerce_woocommerce-paypal-payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/445a40c9-d473-492a-82a2-b8062551bcc8)|![Checkout_–_Permissible_Mice](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/9d5851f2-032e-4b0e-a389-083135441296)|

#### "Place order" button is full-width

|Before|After|
|-|-|
|![Checkout_–_Permissible_Mice](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/8b43fa23-6b73-4dc4-93e6-9ac032d23700)|![Checkout_–_Permissible_Mice](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/9ad195a8-c6b1-4cd7-b81d-7b4028e03794)|
