### PR TITLE
Fastlane improvements (3022)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -161,7 +161,7 @@ return array(
 					'class'        => array(),
 					'label'        => __( 'Enable this to display the "Name on Card" field for new Fastlane buyers.', 'woocommerce-paypal-payments' ),
 					'screens'      => array( State::STATE_ONBOARDED ),
-					'gateway'      => array( 'dcc', 'axo' ),
+					'gateway'      => array(),
 					'requirements' => array( 'axo' ),
 				),
 				'axo_style_heading'                  => array(

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -83,6 +83,7 @@ return array(
 									->condition_element( 'axo_enabled', '1' )
 									->action_visible( 'axo_gateway_title' )
 									->action_visible( 'axo_privacy' )
+									->action_visible( 'axo_name_on_card' )
 									->action_visible( 'axo_style_heading' )
 									->action_class( 'axo_enabled', 'active' )
 									->to_array(),
@@ -153,14 +154,12 @@ return array(
 					'requirements' => array( 'axo' ),
 				),
 				'axo_name_on_card'                   => array(
-					'title'        => __( 'Display "Name on Card" field', 'woocommerce-paypal-payments' ),
+					'title'        => __( 'Display Name on Card', 'woocommerce-paypal-payments' ),
 					'type'         => 'checkbox',
 					'default'      => 'yes',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'class'        => array(),
-					'label'        => __( 'Enable "Name on Card" field', 'woocommerce-paypal-payments' ),
-					'desc_tip'     => true,
-					'description'  => __( 'Enable to display the "Name on Card" field for new Fastlane buyers.', 'woocommerce-paypal-payments' ),
+					'label'        => __( 'Enable this to display the "Name on Card" field for new Fastlane buyers.', 'woocommerce-paypal-payments' ),
 					'screens'      => array( State::STATE_ONBOARDED ),
 					'gateway'      => array( 'dcc', 'axo' ),
 					'requirements' => array( 'axo' ),

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -94,6 +94,7 @@ return array(
 									->action_visible( 'axo_style_root_bg_color' )
 									->action_visible( 'axo_style_root_error_color' )
 									->action_visible( 'axo_style_root_font_family' )
+									->action_visible( 'axo_style_root_text_color_base' )
 									->action_visible( 'axo_style_root_font_size_base' )
 									->action_visible( 'axo_style_root_padding' )
 									->action_visible( 'axo_style_root_primary_color' )
@@ -201,7 +202,7 @@ return array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '#ffffff',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -212,7 +213,7 @@ return array(
 					'title'        => __( 'Error Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '#d9360b',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -223,7 +224,18 @@ return array(
 					'title'        => __( 'Font Family', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => 'PayPal Open',
+					'default'      => '',
+					'screens'      => array(
+						State::STATE_ONBOARDED,
+					),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
+				),
+				'axo_style_root_text_color_base'     => array(
+					'title'        => __( 'Text Color Base', 'woocommerce-paypal-payments' ),
+					'type'         => 'text',
+					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -234,7 +246,7 @@ return array(
 					'title'        => __( 'Font Size Base', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '16px',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -245,7 +257,7 @@ return array(
 					'title'        => __( 'Padding', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '4px',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -256,7 +268,7 @@ return array(
 					'title'        => __( 'Primary Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '#0057ff',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -279,7 +291,7 @@ return array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '#ffffff',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -290,7 +302,7 @@ return array(
 					'title'        => __( 'Border Radius', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '0.25em',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -301,7 +313,7 @@ return array(
 					'title'        => __( 'Border Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '#dadddd',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -312,7 +324,7 @@ return array(
 					'title'        => __( 'Border Width', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '1px',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -323,7 +335,7 @@ return array(
 					'title'        => __( 'Text Color Base', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '#010b0d',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),
@@ -334,7 +346,7 @@ return array(
 					'title'        => __( 'Focus Border Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
 					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '#0057ff',
+					'default'      => '',
 					'screens'      => array(
 						State::STATE_ONBOARDED,
 					),

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -135,7 +135,7 @@ return array(
 					'title'        => __( 'Privacy', 'woocommerce-paypal-payments' ),
 					'type'         => 'select',
 					'label'        => __(
-						'Require customers to confirm express payments from the Cart and Express Checkout on the checkout page.
+						'This setting will control whether Fastlane branding is shown by email field.
 <p class="description">PayPal powers this accelerated checkout solution from Fastlane. Since you\'ll share consumers\' email addresses with PayPal, please consult your legal advisors on the apropriate privacy setting for your business.</p>',
 						'woocommerce-paypal-payments'
 					),

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -249,7 +249,7 @@ return array(
 				'axo_style_root_font_family'         => array(
 					'title'        => __( 'Font Family', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
-					'placeholder'  => 'PayPal Open',
+					'placeholder'  => 'PayPal-Open',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -201,61 +201,7 @@ return array(
 				'axo_style_root_bg_color'            => array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
-					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '',
-					'screens'      => array(
-						State::STATE_ONBOARDED,
-					),
-					'requirements' => array( 'axo' ),
-					'gateway'      => array( 'dcc', 'axo' ),
-				),
-				'axo_style_root_error_color'         => array(
-					'title'        => __( 'Error Color', 'woocommerce-paypal-payments' ),
-					'type'         => 'text',
-					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '',
-					'screens'      => array(
-						State::STATE_ONBOARDED,
-					),
-					'requirements' => array( 'axo' ),
-					'gateway'      => array( 'dcc', 'axo' ),
-				),
-				'axo_style_root_font_family'         => array(
-					'title'        => __( 'Font Family', 'woocommerce-paypal-payments' ),
-					'type'         => 'text',
-					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '',
-					'screens'      => array(
-						State::STATE_ONBOARDED,
-					),
-					'requirements' => array( 'axo' ),
-					'gateway'      => array( 'dcc', 'axo' ),
-				),
-				'axo_style_root_text_color_base'     => array(
-					'title'        => __( 'Text Color Base', 'woocommerce-paypal-payments' ),
-					'type'         => 'text',
-					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '',
-					'screens'      => array(
-						State::STATE_ONBOARDED,
-					),
-					'requirements' => array( 'axo' ),
-					'gateway'      => array( 'dcc', 'axo' ),
-				),
-				'axo_style_root_font_size_base'      => array(
-					'title'        => __( 'Font Size Base', 'woocommerce-paypal-payments' ),
-					'type'         => 'text',
-					'classes'      => array( 'ppcp-field-indent' ),
-					'default'      => '',
-					'screens'      => array(
-						State::STATE_ONBOARDED,
-					),
-					'requirements' => array( 'axo' ),
-					'gateway'      => array( 'dcc', 'axo' ),
-				),
-				'axo_style_root_padding'             => array(
-					'title'        => __( 'Padding', 'woocommerce-paypal-payments' ),
-					'type'         => 'text',
+					'placeholder'  => '#ffffff',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(
@@ -267,6 +213,67 @@ return array(
 				'axo_style_root_primary_color'       => array(
 					'title'        => __( 'Primary Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
+					'placeholder'  => '#0057F',
+					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '',
+					'screens'      => array(
+						State::STATE_ONBOARDED,
+					),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
+				),
+				'axo_style_root_error_color'         => array(
+					'title'        => __( 'Error Color', 'woocommerce-paypal-payments' ),
+					'type'         => 'text',
+					'placeholder'  => '#D9360B',
+					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '',
+					'screens'      => array(
+						State::STATE_ONBOARDED,
+					),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
+				),
+				'axo_style_root_font_family'         => array(
+					'title'        => __( 'Font Family', 'woocommerce-paypal-payments' ),
+					'type'         => 'text',
+					'placeholder'  => 'PayPal Open',
+					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '',
+					'screens'      => array(
+						State::STATE_ONBOARDED,
+					),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
+				),
+				'axo_style_root_text_color_base'     => array(
+					'title'        => __( 'Text Color Base', 'woocommerce-paypal-payments' ),
+					'type'         => 'text',
+					'placeholder'  => '#010B0D',
+					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '',
+					'screens'      => array(
+						State::STATE_ONBOARDED,
+					),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
+				),
+				'axo_style_root_font_size_base'      => array(
+					'title'        => __( 'Font Size Base', 'woocommerce-paypal-payments' ),
+					'type'         => 'text',
+					'placeholder'  => '16px',
+					'classes'      => array( 'ppcp-field-indent' ),
+					'default'      => '',
+					'screens'      => array(
+						State::STATE_ONBOARDED,
+					),
+					'requirements' => array( 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
+				),
+				'axo_style_root_padding'             => array(
+					'title'        => __( 'Padding', 'woocommerce-paypal-payments' ),
+					'type'         => 'text',
+					'placeholder'  => '4px',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(
@@ -290,6 +297,7 @@ return array(
 				'axo_style_input_bg_color'           => array(
 					'title'        => __( 'Background Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
+					'placeholder'  => '#ffffff',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(
@@ -301,6 +309,7 @@ return array(
 				'axo_style_input_border_radius'      => array(
 					'title'        => __( 'Border Radius', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
+					'placeholder'  => '0.25em',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(
@@ -312,6 +321,7 @@ return array(
 				'axo_style_input_border_color'       => array(
 					'title'        => __( 'Border Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
+					'placeholder'  => '#DADDDD',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(
@@ -323,6 +333,7 @@ return array(
 				'axo_style_input_border_width'       => array(
 					'title'        => __( 'Border Width', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
+					'placeholder'  => '1px',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(
@@ -334,6 +345,7 @@ return array(
 				'axo_style_input_text_color_base'    => array(
 					'title'        => __( 'Text Color Base', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
+					'placeholder'  => '#010B0D',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(
@@ -345,6 +357,7 @@ return array(
 				'axo_style_input_focus_border_color' => array(
 					'title'        => __( 'Focus Border Color', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
+					'placeholder'  => '#0057FF',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -152,6 +152,19 @@ return array(
 					'gateway'      => array( 'dcc', 'axo' ),
 					'requirements' => array( 'axo' ),
 				),
+				'axo_name_on_card'                   => array(
+					'title'        => __( 'Display "Name on Card" field', 'woocommerce-paypal-payments' ),
+					'type'         => 'checkbox',
+					'default'      => 'yes',
+					'classes'      => array( 'ppcp-field-indent' ),
+					'class'        => array(),
+					'label'        => __( 'Enable "Name on Card" field', 'woocommerce-paypal-payments' ),
+					'desc_tip'     => true,
+					'description'  => __( 'Enable to display the "Name on Card" field for new Fastlane buyers.', 'woocommerce-paypal-payments' ),
+					'screens'      => array( State::STATE_ONBOARDED ),
+					'gateway'      => array( 'dcc', 'axo' ),
+					'requirements' => array( 'axo' ),
+				),
 				'axo_style_heading'                  => array(
 					'heading'      => __( 'Advanced Style Settings (optional)', 'woocommerce-paypal-payments' ),
 					'heading_html' => sprintf(

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -1,13 +1,3 @@
-
-.ppcp-axo-card-icons {
-	padding: 4px 0 16px 25px;
-
-	.ppcp-card-icon {
-		float: left !important;
-		max-height: 25px;
-	}
-}
-
 .ppcp-axo-watermark-container {
 	max-width: 200px;
 	margin-top: 10px;

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -639,10 +639,13 @@ class AxoManager {
     }
 
     cardComponentData() {
+        let fields = {};
+        if(this.axoConfig.name_on_card === '1') {
+            fields.cardholderName = {};
+        }
+
         return {
-            fields: {
-                cardholderName: {} // optionally pass this to show the card holder name
-            },
+            fields: fields,
             styles: this.remove_keys_with_empty_string(this.axoConfig.style_options)
         }
     }

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -463,9 +463,9 @@ class AxoManager {
         this.el.gatewayRadioButton.trigger('change');
     }
 
-    async renderWatermark() {
+    async renderWatermark(includeAdditionalInfo = true) {
         (await this.fastlane.FastlaneWatermarkComponent({
-            includeAdditionalInfo: true
+            includeAdditionalInfo
         })).render(this.el.watermarkContainer.selector);
     }
 
@@ -562,6 +562,8 @@ class AxoManager {
                 this.hideGatewaySelection = true;
                 this.$('.wc_payment_methods label').hide();
 
+                await this.renderWatermark(false);
+
                 this.rerender();
 
             } else {
@@ -576,6 +578,8 @@ class AxoManager {
 
             this.setStatus('validEmail', true);
             this.setStatus('hasProfile', false);
+
+            await this.renderWatermark(true);
 
             this.cardComponent = (await this.fastlane.FastlaneCardComponent(
                 this.cardComponentData()

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -431,7 +431,6 @@ class AxoManager {
             // Move email to the AXO container.
             let emailRow = document.querySelector(this.el.fieldBillingEmail.selector);
             wrapperElement.prepend(emailRow);
-            emailRow.querySelector('input').focus();
         }
     }
 

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -168,12 +168,9 @@ class AxoManager {
             const termsField = document.querySelector("[name='terms-field']");
             if(termsField) {
                 const status = ev.detail;
+                const shouldHide = status.active && status.validEmail === false && status.hasProfile === false;
 
-                if(status.active && status.validEmail === false && status.hasProfile === false) {
-                    termsField.parentElement.style.display = 'none';
-                } else {
-                    termsField.parentElement.style.display = 'block';
-                }
+                termsField.parentElement.style.display = shouldHide ? 'none' : 'block';
             }
         });
     }
@@ -681,7 +678,7 @@ class AxoManager {
 
         return {
             fields: fields,
-            styles: this.delete_keys_with_empty_string(this.axoConfig.style_options)
+            styles: this.deleteKeysWithEmptyString(this.axoConfig.style_options)
         }
     }
 
@@ -785,13 +782,13 @@ class AxoManager {
         return this.axoConfig?.widgets?.email === 'use_widget';
     }
 
-    delete_keys_with_empty_string = (obj) => {
+    deleteKeysWithEmptyString = (obj) => {
         for(let key of Object.keys(obj)){
             if (obj[key] === ''){
                 delete obj[key];
             }
             else if (typeof obj[key] === 'object'){
-                obj[key] = this.delete_keys_with_empty_string(obj[key]);
+                obj[key] = this.deleteKeysWithEmptyString(obj[key]);
                 if (Object.keys(obj[key]).length === 0 ) delete obj[key];
             }
         }

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -547,13 +547,16 @@ class AxoManager {
             if (authResponse.authenticationState === 'succeeded') {
                 log(JSON.stringify(authResponse));
 
-                // Add addresses
                 this.setShipping(authResponse.profileData.shippingAddress);
-                this.setBilling({
-                    address: authResponse.profileData.card.paymentSource.card.billingAddress,
-                    phoneNumber: authResponse.profileData.shippingAddress.phoneNumber.nationalNumber ?? ''
-                });
-                this.setCard(authResponse.profileData.card);
+
+                const billingAddress = authResponse.profileData?.card?.paymentSource?.card?.billingAddress;
+                if(billingAddress) {
+                    this.setBilling({
+                        address: billingAddress,
+                        phoneNumber: authResponse.profileData.shippingAddress.phoneNumber.nationalNumber ?? ''
+                    });
+                    this.setCard(authResponse.profileData.card);
+                }
 
                 this.setStatus('validEmail', true);
                 this.setStatus('hasProfile', true);

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -162,6 +162,20 @@ class AxoManager {
                 ev.preventDefault();
             }
         });
+
+        // Listening to status update event
+        document.addEventListener('axo_status_updated', (ev) => {
+            const termsField = document.querySelector("[name='terms-field']");
+            if(termsField) {
+                const status = ev.detail;
+
+                if(status.active && status.validEmail === false && status.hasProfile === false) {
+                    termsField.parentElement.style.display = 'none';
+                } else {
+                    termsField.parentElement.style.display = 'block';
+                }
+            }
+        });
     }
 
     rerender() {
@@ -346,6 +360,8 @@ class AxoManager {
         this.status[key] = value;
 
         log('Status updated', JSON.parse(JSON.stringify(this.status)));
+
+        document.dispatchEvent(new CustomEvent("axo_status_updated", {detail: this.status}));
 
         this.rerender();
     }

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -642,10 +642,11 @@ class AxoManager {
     }
 
     cardComponentData() {
-        let fields = {};
-        if(this.axoConfig.name_on_card === '1') {
-            fields.cardholderName = {};
-        }
+        const fields = {
+            cardholderName: {
+                enabled: true
+            }
+        };
 
         return {
             fields: fields,

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -642,7 +642,8 @@ class AxoManager {
         return {
             fields: {
                 cardholderName: {} // optionally pass this to show the card holder name
-            }
+            },
+            styles: this.remove_keys_with_empty_string(this.axoConfig.style_options)
         }
     }
 
@@ -741,6 +742,20 @@ class AxoManager {
 
     useEmailWidget() {
         return this.axoConfig?.widgets?.email === 'use_widget';
+    }
+
+    remove_keys_with_empty_string = (obj) => {
+        for(let key of Object.keys(obj)){
+            if (obj[key] === ''){
+                delete obj[key];
+            }
+            else if (typeof obj[key] === 'object'){
+                obj[key] = this.remove_keys_with_empty_string(obj[key]);
+                if (Object.keys(obj[key]).length === 0 ) delete obj[key];
+            }
+        }
+
+        return Array.isArray(obj) ? obj.filter(val => val) : obj;
     }
 
 }

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -626,6 +626,8 @@ class AxoManager {
             this.shippingView.toSubmitData(data);
             this.cardView.toSubmitData(data);
 
+            this.ensureBillingPhoneNumber(data);
+
             this.submit(this.data.card.id, data);
 
         } else { // Gary flow
@@ -771,6 +773,20 @@ class AxoManager {
         return Array.isArray(obj) ? obj.filter(val => val) : obj;
     }
 
+    ensureBillingPhoneNumber(data) {
+        if (data.billing_phone === '') {
+            let phone = '';
+            const cc = this.data?.shipping?.phoneNumber?.countryCode;
+            const number = this.data?.shipping?.phoneNumber?.nationalNumber;
+
+            if (cc) {
+                phone = `+${cc} `;
+            }
+            phone += number;
+
+            data.billing_phone = phone;
+        }
+    }
 }
 
 export default AxoManager;

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -646,7 +646,7 @@ class AxoManager {
 
         return {
             fields: fields,
-            styles: this.remove_keys_with_empty_string(this.axoConfig.style_options)
+            styles: this.delete_keys_with_empty_string(this.axoConfig.style_options)
         }
     }
 
@@ -696,6 +696,9 @@ class AxoManager {
             Object.keys(data).forEach((key) => {
                 formData.set(key, data[key]);
             });
+
+            // Set type of user (Ryan) to be received on WC gateway process payment request.
+            formData.set('fastlane_member', true);
 
             fetch(wc_checkout_params.checkout_url, { // TODO: maybe create a new endpoint to process_payment.
                 method: "POST",
@@ -747,13 +750,13 @@ class AxoManager {
         return this.axoConfig?.widgets?.email === 'use_widget';
     }
 
-    remove_keys_with_empty_string = (obj) => {
+    delete_keys_with_empty_string = (obj) => {
         for(let key of Object.keys(obj)){
             if (obj[key] === ''){
                 delete obj[key];
             }
             else if (typeof obj[key] === 'object'){
-                obj[key] = this.remove_keys_with_empty_string(obj[key]);
+                obj[key] = this.delete_keys_with_empty_string(obj[key]);
                 if (Object.keys(obj[key]).length === 0 ) delete obj[key];
             }
         }

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -586,7 +586,17 @@ class AxoManager {
 
             } else {
                 // authentication failed or canceled by the customer
+                // set status as guest customer
                 log("Authentication Failed")
+
+                this.setStatus('validEmail', true);
+                this.setStatus('hasProfile', false);
+
+                await this.renderWatermark(true);
+
+                this.cardComponent = (await this.fastlane.FastlaneCardComponent(
+                    this.cardComponentData()
+                )).render(this.el.paymentContainer.selector + '-form');
             }
 
         } else {

--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -91,7 +91,7 @@ class BillingView {
                     'selector': '#billing_company_field',
                     'valuePath': null,
                 },
-                phoneNumber: {
+                phone: {
                     'selector': '#billing_phone_field',
                     'valuePath': 'billing.phoneNumber'
                 }

--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -91,7 +91,7 @@ class BillingView {
                     'selector': '#billing_company_field',
                     'valuePath': null,
                 },
-                phone: {
+                phoneNumber: {
                     'selector': '#billing_phone_field',
                     'valuePath': 'billing.phoneNumber'
                 }

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -45,8 +45,7 @@ class ShippingView {
                         <div>${data.value('firstName')} ${data.value('lastName')}</div>
                         <div>${data.value('street1')}</div>
                         <div>${data.value('street2')}</div>
-                        <div>${data.value('postCode')} ${data.value('city')}</div>
-                        <div>${valueOfSelect('#billing_state', data.value('stateCode'))}</div>
+                        <div>${data.value('city')} ${valueOfSelect('#billing_state', data.value('stateCode'))} ${data.value('postCode')} </div>
                         <div>${valueOfSelect('#billing_country', data.value('countryCode'))}</div>
                         <div>${data.value('phone')}</div>
                     </div>

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -45,7 +45,7 @@ class ShippingView {
                         <div>${data.value('firstName')} ${data.value('lastName')}</div>
                         <div>${data.value('street1')}</div>
                         <div>${data.value('street2')}</div>
-                        <div>${data.value('city')} ${valueOfSelect('#billing_state', data.value('stateCode'))} ${data.value('postCode')} </div>
+                        <div>${data.value('city')}, ${valueOfSelect('#billing_state', data.value('stateCode'))} ${data.value('postCode')} </div>
                         <div>${valueOfSelect('#billing_country', data.value('countryCode'))}</div>
                         <div>${data.value('phone')}</div>
                     </div>

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -46,8 +46,8 @@ class ShippingView {
                         <div>${data.value('street1')}</div>
                         <div>${data.value('street2')}</div>
                         <div>${data.value('postCode')} ${data.value('city')}</div>
-                        <div>${valueOfSelect('#shipping_state', data.value('stateCode'))}</div>
-                        <div>${valueOfSelect('#shipping_country', data.value('countryCode'))}</div>
+                        <div>${valueOfSelect('#billing_state', data.value('stateCode'))}</div>
+                        <div>${valueOfSelect('#billing_country', data.value('countryCode'))}</div>
                         <div>${data.value('phone')}</div>
                     </div>
                 `;

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -68,6 +68,7 @@ return array(
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'wcgateway.order-processor' ),
 			$container->get( 'axo.card_icons' ),
+			$container->get( 'axo.card_icons.axo' ),
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'api.factory.purchase-unit' ),
 			$container->get( 'api.factory.shipping-preference' ),
@@ -94,6 +95,35 @@ return array(
 			array(
 				'title' => 'Discover',
 				'file'  => 'discover.svg',
+			),
+		);
+	},
+
+	'axo.card_icons.axo'                    => static function ( ContainerInterface $container ): array {
+		return array(
+			array(
+				'title' => 'Dinersclub',
+				'file'  => 'dinersclub-light.svg',
+			),
+			array(
+				'title' => 'Discover',
+				'file'  => 'discover-light.svg',
+			),
+			array(
+				'title' => 'JCB',
+				'file'  => 'jcb-light.svg',
+			),
+			array(
+				'title' => 'MasterCard',
+				'file'  => 'mastercard-light.svg',
+			),
+			array(
+				'title' => 'UnionPay',
+				'file'  => 'unionpay-light.svg',
+			),
+			array(
+				'title' => 'Visa',
+				'file'  => 'visa-light.svg',
 			),
 		);
 	},

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -151,13 +151,13 @@ class AxoManager {
 	 */
 	private function script_data() {
 		return array(
-			'environment' => array(
+			'environment'   => array(
 				'is_sandbox' => $this->environment->current_environment() === 'sandbox',
 			),
-			'widgets'     => array(
+			'widgets'       => array(
 				'email' => 'render',
 			),
-			'insights'    => array(
+			'insights'      => array(
 				'enabled'    => true,
 				'client_id'  => ( $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : null ),
 				'session_id' =>
@@ -169,6 +169,25 @@ class AxoManager {
 				'amount'     => array(
 					'currency_code' => get_woocommerce_currency(),
 					'value'         => WC()->cart->get_total( 'numeric' ),
+				),
+			),
+			'style_options' => array(
+				'root'  => array(
+					'backgroundColor' => $this->settings->has( 'axo_style_root_bg_color' ) ? $this->settings->get( 'axo_style_root_bg_color' ) : '',
+					'errorColor'      => $this->settings->has( 'axo_style_root_error_color' ) ? $this->settings->get( 'axo_style_root_error_color' ) : '',
+					'fontFamily'      => $this->settings->has( 'axo_style_root_font_family' ) ? $this->settings->get( 'axo_style_root_font_family' ) : '',
+					'textColorBase'   => $this->settings->has( 'axo_style_root_text_color_base' ) ? $this->settings->get( 'axo_style_root_text_color_base' ) : '',
+					'fontSizeBase'    => $this->settings->has( 'axo_style_root_font_size_base' ) ? $this->settings->get( 'axo_style_root_font_size_base' ) : '',
+					'padding'         => $this->settings->has( 'axo_style_root_padding' ) ? $this->settings->get( 'axo_style_root_padding' ) : '',
+					'primaryColor'    => $this->settings->has( 'axo_style_root_primary_color' ) ? $this->settings->get( 'axo_style_root_primary_color' ) : '',
+				),
+				'input' => array(
+					'backgroundColor'  => $this->settings->has( 'axo_style_input_bg_color' ) ? $this->settings->get( 'axo_style_input_bg_color' ) : '',
+					'borderRadius'     => $this->settings->has( 'axo_style_input_border_radius' ) ? $this->settings->get( 'axo_style_input_border_radius' ) : '',
+					'borderColor'      => $this->settings->has( 'axo_style_input_border_color' ) ? $this->settings->get( 'axo_style_input_border_color' ) : '',
+					'borderWidth'      => $this->settings->has( 'axo_style_input_border_width' ) ? $this->settings->get( 'axo_style_input_border_width' ) : '',
+					'textColorBase'    => $this->settings->has( 'axo_style_input_text_color_base' ) ? $this->settings->get( 'axo_style_input_text_color_base' ) : '',
+					'focusBorderColor' => $this->settings->has( 'axo_style_input_focus_border_color' ) ? $this->settings->get( 'axo_style_input_focus_border_color' ) : '',
 				),
 			),
 		);

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -190,6 +190,7 @@ class AxoManager {
 					'focusBorderColor' => $this->settings->has( 'axo_style_input_focus_border_color' ) ? $this->settings->get( 'axo_style_input_focus_border_color' ) : '',
 				),
 			),
+			'name_on_card'  => $this->settings->has( 'axo_name_on_card' ) ? $this->settings->get( 'axo_name_on_card' ) : '',
 		);
 	}
 

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class AxoModule
@@ -91,11 +92,13 @@ class AxoModule implements ModuleInterface {
 					return $methods;
 				}
 
-				if (
-					! is_admin()
-					&& is_user_logged_in() === false
-					&& isset( $methods[ CreditCardGateway::ID ] )
-				) {
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				if ( apply_filters(
+					'woocommerce_paypal_payments_axo_hide_credit_card_gateway',
+					$this->hide_credit_card_when_using_fastlane( $methods, $settings )
+				) ) {
 					unset( $methods[ CreditCardGateway::ID ] );
 				}
 
@@ -246,5 +249,29 @@ class AxoModule implements ModuleInterface {
 	 * @return string|void
 	 */
 	public function getKey() {
+	}
+
+	/**
+	 * Condition to evaluate if Credit Card gateway should be hidden.
+	 *
+	 * @param array $methods
+	 * @param bool $is_axo_enabled
+	 * @return bool
+	 */
+
+	/**
+	 * Condition to evaluate if Credit Card gateway should be hidden.
+	 *
+	 * @param array    $methods WC payment methods.
+	 * @param Settings $settings The settings.
+	 * @return bool
+	 */
+	private function hide_credit_card_when_using_fastlane( array $methods, Settings $settings ): bool {
+		$is_axo_enabled = $settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' ) ?? false;
+
+		return ! is_admin()
+			&& is_user_logged_in() === false
+			&& isset( $methods[ CreditCardGateway::ID ] )
+			&& $is_axo_enabled;
 	}
 }

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -254,14 +254,6 @@ class AxoModule implements ModuleInterface {
 	/**
 	 * Condition to evaluate if Credit Card gateway should be hidden.
 	 *
-	 * @param array $methods
-	 * @param bool $is_axo_enabled
-	 * @return bool
-	 */
-
-	/**
-	 * Condition to evaluate if Credit Card gateway should be hidden.
-	 *
 	 * @param array    $methods WC payment methods.
 	 * @param Settings $settings The settings.
 	 * @return bool

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -20,6 +20,7 @@ use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 
 /**
  * Class AxoModule
@@ -75,6 +76,31 @@ class AxoModule implements ModuleInterface {
 			},
 			1,
 			9
+		);
+
+		// Hides credit card gateway on checkout when using Fastlane.
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function ( $methods ) use ( $c ): array {
+				if ( ! is_array( $methods ) || ! $c->get( 'axo.eligible' ) ) {
+					return $methods;
+				}
+
+				if (
+					! is_admin()
+					&& is_user_logged_in() === false
+					&& isset( $methods[ CreditCardGateway::ID ] )
+				) {
+					unset( $methods[ CreditCardGateway::ID ] );
+				}
+
+				return $methods;
+			}
 		);
 
 		add_action(

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -299,11 +299,6 @@ class AxoGateway extends WC_Payment_Gateway {
 		$icons     = $this->card_icons;
 		$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/';
 
-//		if ( $this->card_icons_axo ) {
-//			$icons     = $this->card_icons_axo;
-//			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
-//		}
-
 		if ( empty( $this->card_icons ) ) {
 			return $icon;
 		}

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -71,6 +71,13 @@ class AxoGateway extends WC_Payment_Gateway {
 	protected $card_icons;
 
 	/**
+	 * The AXO card icons.
+	 *
+	 * @var array
+	 */
+	protected $card_icons_axo;
+
+	/**
 	 * The order endpoint.
 	 *
 	 * @var OrderEndpoint
@@ -120,6 +127,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @param string                    $wcgateway_module_url The WcGateway module URL.
 	 * @param OrderProcessor            $order_processor The Order processor.
 	 * @param array                     $card_icons The card icons.
+	 * @param array                     $card_icons_axo The card icons.
 	 * @param OrderEndpoint             $order_endpoint The order endpoint.
 	 * @param PurchaseUnitFactory       $purchase_unit_factory The purchase unit factory.
 	 * @param ShippingPreferenceFactory $shipping_preference_factory The shipping preference factory.
@@ -133,6 +141,7 @@ class AxoGateway extends WC_Payment_Gateway {
 		string $wcgateway_module_url,
 		OrderProcessor $order_processor,
 		array $card_icons,
+		array $card_icons_axo,
 		OrderEndpoint $order_endpoint,
 		PurchaseUnitFactory $purchase_unit_factory,
 		ShippingPreferenceFactory $shipping_preference_factory,
@@ -147,6 +156,7 @@ class AxoGateway extends WC_Payment_Gateway {
 		$this->wcgateway_module_url = $wcgateway_module_url;
 		$this->order_processor      = $order_processor;
 		$this->card_icons           = $card_icons;
+		$this->card_icons_axo       = $card_icons_axo;
 
 		$this->method_title       = __( 'Fastlane Debit & Credit Cards', 'woocommerce-paypal-payments' );
 		$this->method_description = __( 'PayPal Fastlane offers an accelerated checkout experience that recognizes guest shoppers and autofills their details so they can pay in seconds.', 'woocommerce-paypal-payments' );
@@ -285,18 +295,26 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_icon() {
-		$icon = parent::get_icon();
+		$icon      = parent::get_icon();
+		$icons     = $this->card_icons;
+		$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/';
+
+		if ( $this->card_icons_axo ) {
+			$icons     = $this->card_icons_axo;
+			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
+		}
 
 		if ( empty( $this->card_icons ) ) {
 			return $icon;
 		}
 
 		$images = array();
-		foreach ( $this->card_icons as $card ) {
+
+		foreach ( $icons as $card ) {
 			$images[] = '<img
 				class="ppcp-card-icon"
 				title="' . $card['title'] . '"
-				src="' . esc_url( $this->wcgateway_module_url ) . 'assets/images/' . $card['file'] . '"
+				src="' . $icons_src . $card['file'] . '"
 			> ';
 		}
 

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -300,7 +300,7 @@ class AxoGateway extends WC_Payment_Gateway {
 			> ';
 		}
 
-		return '<div class="ppcp-axo-card-icons">' . implode( '', $images ) . '</div>';
+		return implode( '', $images );
 	}
 
 	/**

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -208,10 +208,13 @@ class AxoGateway extends WC_Payment_Gateway {
 	public function process_payment( $order_id ) {
 		$wc_order = wc_get_order( $order_id );
 
-		$payment_method_title = __( 'Credit Card (via Fastlane by PayPal)', 'woocommerce-paypal-payments' );
-
-		$wc_order->set_payment_method_title( $payment_method_title );
-		$wc_order->save();
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$fastlane_member = wc_clean( wp_unslash( $_POST['fastlane_member'] ?? '' ) );
+		if ( $fastlane_member ) {
+			$payment_method_title = __( 'Debit & Credit Cards (via Fastlane by PayPal)', 'woocommerce-paypal-payments' );
+			$wc_order->set_payment_method_title( $payment_method_title );
+			$wc_order->save();
+		}
 
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -299,10 +299,10 @@ class AxoGateway extends WC_Payment_Gateway {
 		$icons     = $this->card_icons;
 		$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/';
 
-		if ( $this->card_icons_axo ) {
-			$icons     = $this->card_icons_axo;
-			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
-		}
+//		if ( $this->card_icons_axo ) {
+//			$icons     = $this->card_icons_axo;
+//			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
+//		}
 
 		if ( empty( $this->card_icons ) ) {
 			return $icon;

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -803,6 +803,14 @@ return array(
 					'elo'             => _x( 'Elo', 'Name of credit card', 'woocommerce-paypal-payments' ),
 					'hiper'           => _x( 'Hiper', 'Name of credit card', 'woocommerce-paypal-payments' ),
 				),
+				'options_axo'  => array(
+					'dinersclub-light' => _x( 'Diners Club (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'discover-light'   => _x( 'Discover (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'jcb-light'        => _x( 'JCB (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'mastercard-light' => _x( 'Mastercard (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'unionpay-light'   => _x( 'UnionPay (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'visa-light'       => _x( 'Visa (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+				),
 				'screens'      => array(
 					State::STATE_ONBOARDED,
 				),


### PR DESCRIPTION
This PR adds improvements to Fastlane:
- Display country and state with full names (e.g. CA -> Canada)
- Apply advanced styles from Fastlane settings to frontend
- Add a settings option checkbox to enable/disable “Name on Card” field
- Display Payment Method Title on order-received page as:
    - as Gary: Debit & Credit Cards  (use regular payment method title)
    - as Ryan: Debit & Credit Cards (via Fastlane by PayPal) (should enforce  Debit & Credit Cards (via Fastlane by PayPal))
- Remove the i dropper next to Fastlane by PayPal when authenticated in Ryan flow
- Add logic to hide the ACDC gateway on Checkout page when using Fastlane
    - Add `woocommerce_paypal_payments_axo_hide_credit_card_gateway` filter to show/hide programmatically 
- Fastlane radio button scrolls up the page to the hidden email field when in Ryan flow. For now, let’s remove the scrolling up entirely.
- Hide Display Name on Card setting for now (don’t remove, just hide)
- Pass `cardholderName: { enabled: true }` within fields
- Change address display format to `City, State ZIP`
- Hide the terms and conditions checkbox before Fastlane authentication