### PR TITLE
Additional Fastlane improvements (3058)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -249,7 +249,7 @@ return array(
 				'axo_style_root_font_family'         => array(
 					'title'        => __( 'Font Family', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',
-					'placeholder'  => 'PayPal Open',
+					'placeholder'  => 'PayPal-Open',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'default'      => '',
 					'screens'      => array(

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -1,13 +1,3 @@
-
-.ppcp-axo-card-icons {
-	padding: 4px 0 16px 25px;
-
-	.ppcp-card-icon {
-		float: left !important;
-		max-height: 25px;
-	}
-}
-
 .ppcp-axo-watermark-container {
 	max-width: 200px;
 	margin-top: 10px;

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -68,6 +68,7 @@ return array(
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'wcgateway.order-processor' ),
 			$container->get( 'axo.card_icons' ),
+			$container->get( 'axo.card_icons.axo' ),
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'api.factory.purchase-unit' ),
 			$container->get( 'api.factory.shipping-preference' ),
@@ -94,6 +95,35 @@ return array(
 			array(
 				'title' => 'Discover',
 				'file'  => 'discover.svg',
+			),
+		);
+	},
+
+	'axo.card_icons.axo'                    => static function ( ContainerInterface $container ): array {
+		return array(
+			array(
+				'title' => 'Dinersclub',
+				'file'  => 'dinersclub-light.svg',
+			),
+			array(
+				'title' => 'Discover',
+				'file'  => 'discover-light.svg',
+			),
+			array(
+				'title' => 'JCB',
+				'file'  => 'jcb-light.svg',
+			),
+			array(
+				'title' => 'MasterCard',
+				'file'  => 'mastercard-light.svg',
+			),
+			array(
+				'title' => 'UnionPay',
+				'file'  => 'unionpay-light.svg',
+			),
+			array(
+				'title' => 'Visa',
+				'file'  => 'visa-light.svg',
 			),
 		);
 	},

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -299,11 +299,6 @@ class AxoGateway extends WC_Payment_Gateway {
 		$icons     = $this->card_icons;
 		$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/';
 
-//		if ( $this->card_icons_axo ) {
-//			$icons     = $this->card_icons_axo;
-//			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
-//		}
-
 		if ( empty( $this->card_icons ) ) {
 			return $icon;
 		}

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -71,6 +71,13 @@ class AxoGateway extends WC_Payment_Gateway {
 	protected $card_icons;
 
 	/**
+	 * The AXO card icons.
+	 *
+	 * @var array
+	 */
+	protected $card_icons_axo;
+
+	/**
 	 * The order endpoint.
 	 *
 	 * @var OrderEndpoint
@@ -120,6 +127,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @param string                    $wcgateway_module_url The WcGateway module URL.
 	 * @param OrderProcessor            $order_processor The Order processor.
 	 * @param array                     $card_icons The card icons.
+	 * @param array                     $card_icons_axo The card icons.
 	 * @param OrderEndpoint             $order_endpoint The order endpoint.
 	 * @param PurchaseUnitFactory       $purchase_unit_factory The purchase unit factory.
 	 * @param ShippingPreferenceFactory $shipping_preference_factory The shipping preference factory.
@@ -133,6 +141,7 @@ class AxoGateway extends WC_Payment_Gateway {
 		string $wcgateway_module_url,
 		OrderProcessor $order_processor,
 		array $card_icons,
+		array $card_icons_axo,
 		OrderEndpoint $order_endpoint,
 		PurchaseUnitFactory $purchase_unit_factory,
 		ShippingPreferenceFactory $shipping_preference_factory,
@@ -147,6 +156,7 @@ class AxoGateway extends WC_Payment_Gateway {
 		$this->wcgateway_module_url = $wcgateway_module_url;
 		$this->order_processor      = $order_processor;
 		$this->card_icons           = $card_icons;
+		$this->card_icons_axo       = $card_icons_axo;
 
 		$this->method_title       = __( 'Fastlane Debit & Credit Cards', 'woocommerce-paypal-payments' );
 		$this->method_description = __( 'PayPal Fastlane offers an accelerated checkout experience that recognizes guest shoppers and autofills their details so they can pay in seconds.', 'woocommerce-paypal-payments' );
@@ -285,18 +295,26 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_icon() {
-		$icon = parent::get_icon();
+		$icon      = parent::get_icon();
+		$icons     = $this->card_icons;
+		$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/';
+
+		if ( $this->card_icons_axo ) {
+			$icons     = $this->card_icons_axo;
+			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
+		}
 
 		if ( empty( $this->card_icons ) ) {
 			return $icon;
 		}
 
 		$images = array();
-		foreach ( $this->card_icons as $card ) {
+
+		foreach ( $icons as $card ) {
 			$images[] = '<img
 				class="ppcp-card-icon"
 				title="' . $card['title'] . '"
-				src="' . esc_url( $this->wcgateway_module_url ) . 'assets/images/' . $card['file'] . '"
+				src="' . $icons_src . $card['file'] . '"
 			> ';
 		}
 

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -300,7 +300,7 @@ class AxoGateway extends WC_Payment_Gateway {
 			> ';
 		}
 
-		return '<div class="ppcp-axo-card-icons">' . implode( '', $images ) . '</div>';
+		return implode( '', $images );
 	}
 
 	/**

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -299,10 +299,10 @@ class AxoGateway extends WC_Payment_Gateway {
 		$icons     = $this->card_icons;
 		$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/';
 
-		if ( $this->card_icons_axo ) {
-			$icons     = $this->card_icons_axo;
-			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
-		}
+//		if ( $this->card_icons_axo ) {
+//			$icons     = $this->card_icons_axo;
+//			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
+//		}
 
 		if ( empty( $this->card_icons ) ) {
 			return $icon;

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -803,6 +803,14 @@ return array(
 					'elo'             => _x( 'Elo', 'Name of credit card', 'woocommerce-paypal-payments' ),
 					'hiper'           => _x( 'Hiper', 'Name of credit card', 'woocommerce-paypal-payments' ),
 				),
+				'options_axo'  => array(
+					'dinersclub-light' => _x( 'Diners Club (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'discover-light'   => _x( 'Discover (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'jcb-light'        => _x( 'JCB (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'mastercard-light' => _x( 'Mastercard (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'unionpay-light'   => _x( 'UnionPay (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+					'visa-light'       => _x( 'Visa (light)', 'Name of credit card', 'woocommerce-paypal-payments' ),
+				),
 				'screens'      => array(
 					State::STATE_ONBOARDED,
 				),


### PR DESCRIPTION
### Description

This PR will add:
- A fix for the AXO gateway icon placement
- A fix for the default AXO font family: `PayPal-Open`
- New AXO credit card icons (inactive for now)


### Steps to Test

1. Ensure the credit card icons display next to the radio label
2. Ensure the font family default in the Fastlane settings is: `PayPal-Open`
3. Can't test the new icons now without removing the code comments

### Screenshots
|Before|After|
|-|-|
|![Checkout_–_WooCommerce_PayPal_Payments_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/b75c007a-4000-4de9-8414-81044a3da2af)|![Checkout_–_WooCommerce_PayPal_Payments_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/9c1ad55f-df39-4aa1-b163-f988a9a7301f)|

|Before|After|
|-|-|
|![Notification_Center](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/c9898f9c-503a-4f02-aafb-d2112c5d603c)|![WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/50ad00ac-c4d1-4e76-b079-68fcc8890dd6)|

|Before|After|
|-|-|
|![Checkout_–_WooCommerce_PayPal_Payments_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/b75c007a-4000-4de9-8414-81044a3da2af)|![Checkout_–_WooCommerce_PayPal_Payments_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/99603de2-9b4a-4104-817e-82f694a214e9)|
