### PR TITLE
Fix Fastlane billing state province only mapped to active billing country selection (3063)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -34,6 +34,8 @@ class AxoManager {
             card: null,
         };
 
+        this.states = this.axoConfig.woocommerce.states;
+
         this.el = new DomElementCollection();
 
         this.styles = {
@@ -46,7 +48,7 @@ class AxoManager {
 
         this.registerEventHandlers();
 
-        this.shippingView = new ShippingView(this.el.shippingAddressContainer.selector, this.el);
+        this.shippingView = new ShippingView(this.el.shippingAddressContainer.selector, this.el, this.states );
         this.billingView = new BillingView(this.el.billingAddressContainer.selector, this.el);
         this.cardView = new CardView(this.el.paymentContainer.selector + '-details', this.el, this);
 

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -2,9 +2,9 @@ import FormFieldGroup from "../Components/FormFieldGroup";
 
 class ShippingView {
 
-    constructor(selector, elements) {
+    constructor(selector, elements, states) {
         this.el = elements;
-
+        this.states = states;
         this.group = new FormFieldGroup({
             baseSelector: '.woocommerce-checkout',
             contentSelector: selector,
@@ -34,6 +34,10 @@ class ShippingView {
                         </div>
                     `;
                 }
+                const countryCode = data.value('countryCode');
+                const stateCode = data.value('stateCode');
+                const stateName = (this.states[countryCode] && this.states[countryCode][stateCode]) ? this.states[countryCode][stateCode] : stateCode;
+
                 return `
                     <div style="margin-bottom: 20px;">
                         <div class="axo-checkout-header-section">
@@ -45,8 +49,8 @@ class ShippingView {
                         <div>${data.value('firstName')} ${data.value('lastName')}</div>
                         <div>${data.value('street1')}</div>
                         <div>${data.value('street2')}</div>
-                        <div>${data.value('city')}, ${valueOfSelect('#billing_state', data.value('stateCode'))} ${data.value('postCode')} </div>
-                        <div>${valueOfSelect('#billing_country', data.value('countryCode'))}</div>
+                        <div>${data.value('city')}, ${stateName} ${data.value('postCode')}</div>
+                        <div>${valueOfSelect('#billing_country', countryCode)}</div>
                         <div>${data.value('phone')}</div>
                     </div>
                 `;

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -191,6 +191,12 @@ class AxoManager {
 				),
 			),
 			'name_on_card'  => $this->settings->has( 'axo_name_on_card' ) ? $this->settings->get( 'axo_name_on_card' ) : '',
+			'woocommerce'   => array(
+				'states' => array(
+					'US' => WC()->countries->get_states( 'US' ),
+					'CA' => WC()->countries->get_states( 'CA' ),
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
### Description

This PR fixes the mapping issue of the US and Canada state codes to full names for shipping details.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Go through the AXO Ryan flow and ensure the State data appears as a Full name regardless of switching between addresses (US to Canada etc.)

### Screenshots
|Before|After|
|-|-|
|![Checkout_–_WooCommerce_PayPal_Payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/03a6a908-d850-473d-b50e-85271373a80e)|![Checkout_–_WooCommerce_PayPal_Payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/0b060e58-962e-405d-88a3-9fc8eb581578)|

