### PR TITLE
Fix Large Fastlane checkout icons (3073)

### DIFF
--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -43,3 +43,7 @@
 		margin: var(--global-md-spacing) 0 1em;
 		padding: 0.6em 1em;
 }
+
+label[for="payment_method_ppcp-axo-gateway"] .ppcp-card-icon {
+	max-height: 25px;
+}


### PR DESCRIPTION
### Description

This PR fixed the 'too large' icons in the AXO checkout.

### Steps to Test

1. Go through the AXO checkout and ensure the icons are displaying correctly.

### Screenshots
|Before|After|
|-|-|
|![Checkout_–_hallowed-spider-33f508_instawp_xyz](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/2660e305-860f-439a-a439-476d929bae45)|![Checkout_–_hallowed-spider-33f508_instawp_xyz](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/8323c6dc-4681-4df9-964e-c387e63c4000)|