### PR TITLE
Fix the notice on newly created block cart checkout (3060)

### DIFF
--- a/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksRenderer.php
+++ b/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksRenderer.php
@@ -119,13 +119,7 @@ class PayLaterWCBlocksRenderer {
 				$processor->set_attribute( 'data-pp-placement', esc_attr( $this->placement ) );
 			}
 
-			$updated_html = $processor->get_updated_html();
-
-			return sprintf(
-				'<div %1$s>%2$s</div>',
-				wp_kses_data( get_block_wrapper_attributes() ),
-				$updated_html
-			);
+			return $processor->get_updated_html();
 		}
 	}
 }


### PR DESCRIPTION
### Description

This PR fixes the `**Notice**: Trying to access array offset on value of type null in **/var/www/html/.ddev/wordpress/wp-includes/class-wp-block-supports.php** on line **98**` notice that gets displayed in the block cart and checkout.

### Steps to Test

1. Test with a new WooCommerce installation, or delete the existing Checkout/Cart pages and then utilize the `WooCommerce > Status > Tools > Create default WooCommerce pages`.

### Screenshots
|Before|After|
|-|-|
|![Checkout_–_paypal](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/9ad296f1-9e61-445e-8017-028abecd5159)|![Checkout_–_paypal](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/ac81d329-0983-46ae-ba8c-8f99e04fd21e)|