### PR TITLE
AXO: Make AXO the default payment method for guest customers (3088)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -69,7 +69,7 @@ return array(
 					'type'              => 'checkbox',
 					'label'             => __( 'Enable Fastlane by PayPal', 'woocommerce-paypal-payments' )
 						. '<p class="description">'
-						. __( 'Help accelerate checkout for guests with PayPal\'s autofill solution.', 'woocommerce-paypal-payments' )
+						. __( 'Help accelerate the checkout process for guests with PayPal\'s autofill solution. When enabled, Fastlane is presented as the default payment method for guests.', 'woocommerce-paypal-payments' )
 						. '</p>',
 					'default'           => 'yes',
 					'screens'           => array( State::STATE_ONBOARDED ),

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Axo\Assets\AxoManager;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
@@ -196,6 +197,16 @@ class AxoModule implements ModuleInterface {
 					},
 					10,
 					2
+				);
+
+				// Set Axo as the default payment method on checkout for guest customers.
+				add_action(
+					'template_redirect',
+					function () {
+						if ( ! is_user_logged_in() && is_checkout() && ! is_wc_endpoint_url() ) {
+							WC()->session->set( 'chosen_payment_method', AxoGateway::ID );
+						}
+					}
 				);
 
 			},

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CartCheckoutDetector;
 
 /**
  * Class AxoModule
@@ -202,8 +203,11 @@ class AxoModule implements ModuleInterface {
 				// Set Axo as the default payment method on checkout for guest customers.
 				add_action(
 					'template_redirect',
-					function () {
-						if ( ! is_user_logged_in() && is_checkout() && ! is_wc_endpoint_url() ) {
+					function () use ( $c ) {
+						$settings = $c->get( 'wcgateway.settings' );
+						assert( $settings instanceof Settings );
+
+						if ( $this->should_render_fastlane( $settings ) ) {
 							WC()->session->set( 'chosen_payment_method', AxoGateway::ID );
 						}
 					}
@@ -270,11 +274,22 @@ class AxoModule implements ModuleInterface {
 	 * @return bool
 	 */
 	private function hide_credit_card_when_using_fastlane( array $methods, Settings $settings ): bool {
+		return $this->should_render_fastlane( $settings ) && isset( $methods[ CreditCardGateway::ID ] );
+	}
+
+	/**
+	 * Condition to evaluate if Fastlane should be rendered.
+	 *
+	 * Fastlane should only render on the classic checkout, when Fastlane is enabled in the settings and also only for guest customers.
+	 *
+	 * @param Settings $settings The settings.
+	 * @return bool
+	 */
+	private function should_render_fastlane( Settings $settings): bool {
 		$is_axo_enabled = $settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' ) ?? false;
 
-		return ! is_admin()
-			&& is_user_logged_in() === false
-			&& isset( $methods[ CreditCardGateway::ID ] )
+		return ! is_user_logged_in()
+			&& CartCheckoutDetector::has_classic_checkout()
 			&& $is_axo_enabled;
 	}
 }

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -159,7 +159,7 @@ class AxoGateway extends WC_Payment_Gateway {
 		$this->card_icons_axo       = $card_icons_axo;
 
 		$this->method_title       = __( 'Fastlane Debit & Credit Cards', 'woocommerce-paypal-payments' );
-		$this->method_description = __( 'PayPal Fastlane offers an accelerated checkout experience that recognizes guest shoppers and autofills their details so they can pay in seconds.', 'woocommerce-paypal-payments' );
+		$this->method_description = __( 'Fastlane accelerates the checkout experience for guest shoppers and autofills their details so they can pay in seconds. When enabled, Fastlane is presented as the default payment method for guests.', 'woocommerce-paypal-payments' );
 
 		$is_axo_enabled = $this->ppcp_settings->has( 'axo_enabled' ) && $this->ppcp_settings->get( 'axo_enabled' );
 		$this->update_option( 'enabled', $is_axo_enabled ? 'yes' : 'no' );


### PR DESCRIPTION
### Description

This PR makes AXO the default payment method for guest users (when AXO is enabled).

### Steps to Test

1. Enable Fastlane.
2. Re-order the payment gateways so that Fastlane **is not** on the top.
3. Log out and test the checkout flow.
4. Make sure Fastlane is selected when you enter the Checkout page.

### Screenshots
N/A