### PR TITLE
Fastlane show Name on Card setting in options (3090)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -161,7 +161,7 @@ return array(
 					'class'        => array(),
 					'label'        => __( 'Enable this to display the "Name on Card" field for new Fastlane buyers.', 'woocommerce-paypal-payments' ),
 					'screens'      => array( State::STATE_ONBOARDED ),
-					'gateway'      => array(),
+					'gateway'      => array( 'dcc', 'axo' ),
 					'requirements' => array( 'axo' ),
 				),
 				'axo_style_heading'                  => array(

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -702,14 +702,12 @@ class AxoManager {
     }
 
     cardComponentData() {
-        const fields = {
-            cardholderName: {
-                enabled: true
-            }
-        };
-
         return {
-            fields: fields,
+            fields: {
+                cardholderName: {
+                    enabled: this.axoConfig.name_on_card === '1'
+                }
+            },
             styles: this.deleteKeysWithEmptyString(this.axoConfig.style_options)
         }
     }


### PR DESCRIPTION
This PR re-enables the setting to show/hide the "Name on Card" field in the Fastlane settings.