### PR TITLE
Card fields hidden due to css class override from external code.

### DIFF
--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -7,7 +7,7 @@
 	padding: 1rem 0;
 	background-color: #ffffff;
 
-	&.hidden {
+	&.axo-hidden {
 		display: none;
 	}
 }

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -437,7 +437,7 @@ class AxoManager {
         if (!document.querySelector(pc.selector)) {
             const gatewayPaymentContainer = document.querySelector('.payment_method_ppcp-axo-gateway');
             gatewayPaymentContainer.insertAdjacentHTML('beforeend', `
-                <div id="${pc.id}" class="${pc.className} hidden">
+                <div id="${pc.id}" class="${pc.className} axo-hidden">
                     <div id="${pc.id}-form" class="${pc.className}-form"></div>
                     <div id="${pc.id}-details" class="${pc.className}-details"></div>
                 </div>


### PR DESCRIPTION
This PR renames `.hidden` css class to prevent being overridden from external code.