### PR TITLE
Update Advanced PayPal Wallet strings (3054)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1461,7 +1461,7 @@ return array(
 
 		$button_text = $enabled
 			? esc_html__( 'Settings', 'woocommerce-paypal-payments' )
-			: esc_html__( 'Enable Advanced PayPal Wallet', 'woocommerce-paypal-payments' );
+			: esc_html__( 'Enable saving PayPal & Venmo', 'woocommerce-paypal-payments' );
 
 		$enable_url = $environment->current_environment_is( Environment::PRODUCTION )
 			? $container->get( 'wcgateway.enable-reference-transactions-url-live' )

--- a/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
@@ -263,7 +263,7 @@ class SettingsPageAssets {
 					'reference_transaction_enabled'  => $this->billing_agreements_endpoint->reference_transaction_enabled(),
 					'vaulting_must_enable_advanced_wallet_message' => sprintf(
 						// translators: %1$s and %2$s are the opening and closing of HTML <a> tag.
-						esc_html__( 'Your PayPal account must be enabled for the %1$sAdvanced PayPal Wallet%2$s to use PayPal Vaulting.', 'woocommerce-paypal-payments' ),
+						esc_html__( 'Your PayPal account must be eligible to %1$ssave PayPal and Venmo payment methods%2$s to enable PayPal Vaulting.', 'woocommerce-paypal-payments' ),
 						'<a href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#field-credentials_feature_onboarding_heading">',
 						'</a>'
 					),

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -411,7 +411,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
 		'ppcp_reference_transactions_status'            => array(
-			'title'        => __( 'Advanced PayPal Wallet', 'woocommerce-paypal-payments' ),
+			'title'        => __( 'Save PayPal & Venmo payment methods', 'woocommerce-paypal-payments' ),
 			'type'         => 'ppcp-text',
 			'text'         => $container->get( 'wcgateway.settings.connection.reference-transactions-status-text' ),
 			'screens'      => array(


### PR DESCRIPTION
### Description

This PR updates `Advanced PayPal Wallet` strings to `Save PayPal & Venmo payment methods`.


### Steps to Test

1. Go to PayPal settings > Connection tab, and verify the string has been updated.

### Screenshots
N/A