### PR TITLE
Fix fatal errors when subscriptions classes are not available

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -89,7 +89,7 @@ class SubscriptionHelper {
 	 */
 	public function accept_only_automatic_payment_gateways(): bool {
 
-		if ( ! $this->plugin_is_active() ) {
+		if ( ! $this->plugin_is_active() || ! class_exists( \WC_Subscriptions_Admin::class ) ) {
 			return false;
 		}
 		$accept_manual_renewals = 'no' !== get_option(


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

This PR fixes a fatal error thrown when subscription classes are not available. Despite checking for the existence of some of the subscriptions classes, the class used in the `accept_only_automatic_payment_gateways` method is not verified. We introduce that check here. Without it, the following error happens:
```
2023-04-03T01:51:06+00:00 CRITICAL Uncaught Error: Class "WC_Subscriptions_Admin" not found in wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-subscription/src/Helper/SubscriptionHelper.php:91
Stack trace:
#0 wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-button/src/Assets/SmartButton.php(763): WooCommerce\PayPalCommerce\Subscription\Helper\SubscriptionHelper->accept_only_automatic_payment_gateways()
#1 wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-button/src/Assets/SmartButton.php(242): WooCommerce\PayPalCommerce\Button\Assets\SmartButton->has_subscriptions()
#2 wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-button/src/ButtonModule.php(57): WooCommerce\PayPalCommerce\Button\Assets\SmartButton->render_wrapper()
#3 wp-includes/class-wp-hook.php(308): WooCommerce\PayPalCommerce\Button\ButtonModule::WooCommerce\PayPalCommerce\Button\{closure}(Object(WP))
```

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

- Install the extension together with WooCommerce Subscriptions
- Include an `exit` before the `WC_Subscriptions` class declaration
- Add a Subscription Product to the cart
- Visit the checkout page
- Confirm that with this change no fatal errors are thrown

