### PR TITLE
Use admin theme color for the Pay Later messaging configurator

### DIFF
--- a/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
+++ b/modules/ppcp-paylater-configurator/resources/css/paylater-configurator.scss
@@ -48,6 +48,45 @@
 		margin-right: 16px;
 		border-top-color: #B1B7BD;
 	}
+
+	.css-168cq4n-checkbox_input:checked + label > span > span:first-of-type {
+		background-color: var(--wp-admin-theme-color);
+		border-color: var(--wp-admin-theme-color);
+	}
+
+	.css-168cq4n-checkbox_input:focus + label > span > span:first-of-type {
+		outline: var(--wp-admin-theme-color);
+	}
+
+	span[class*="-svg-size_sm-SelectedMain-selected_icon"],
+	span[class*="-svg-size_xs-selected_icon"] {
+		color: var(--wp-admin-theme-color);
+	}
+
+	button[class*="-dropdown_menu_button-text_field_value_sm-active-active"] {
+		outline: var(--wp-admin-theme-color) solid 0.125rem;
+	}
+
+	button[class*="-dropdown_menu_button-text_field_value_sm-active"] {
+		&:focus {
+			outline: var(--wp-admin-theme-color) solid 0.125rem;
+		}
+	}
+
+	.css-gzgyp8-control:checked ~ label {
+		background-color: var(--wp-admin-theme-color);
+		border: var(--wp-admin-theme-color);
+		outline: var(--wp-admin-theme-color) solid 0.125rem;
+	}
+
+	.css-gzgyp8-control:focus ~ label {
+		outline: var(--wp-admin-theme-color) solid 0.125rem;
+	}
+
+	.css-gzgyp8-control:checked ~ span {
+		border: 0.0625rem solid var(--wp-admin-theme-color);
+	}
+	
 }
 
 #field-pay_later_messaging_heading h3{


### PR DESCRIPTION
**Issue**: #1602 

### Description
In a few places on the `Pay Later`, links do not follow the admin theme color. In this PR I have used `var(--wp-admin-theme-color)` for thos elements to make them render with the admin theme color.

### Steps to Test
- Create a test site (use your local site or a JN site)
- Build the plugin from this branch and upload it to your site.
- Go to `<your_site/wp-admin/profile.php` and choose an `Admin Color Scheme` except default. (I have used `Sunrise` in the screenshots).
- Go to **WooCommerce > Settings > Payments > Paypal**. On the `Standard Payments` tab disable `Vaulting`.
- Go to the `Pay Later` tab and confirm that in the `Customize your messaging` section, the checkboxes, selectors and the toggle are following the admin theme color.

**Before**

![before pp](https://github.com/woocommerce/woocommerce-paypal-payments/assets/33387139/5055fd0f-c2d2-4072-a50e-272ace35aefe)

**After**

![after pp](https://github.com/woocommerce/woocommerce-paypal-payments/assets/33387139/a8cf56c6-940e-49da-8950-10ade7ffb252)
