### PR TITLE
AXO: Fix the Classic Checkout and Cart shortcode check (3129)

### DIFF
--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -197,7 +197,7 @@ class AxoManager {
 					'CA' => WC()->countries->get_states( 'CA' ),
 				),
 			),
-			'module_url' => untrailingslashit( $this->module_url ),
+			'module_url'    => untrailingslashit( $this->module_url ),
 		);
 	}
 

--- a/modules/ppcp-wc-gateway/src/Helper/CartCheckoutDetector.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CartCheckoutDetector.php
@@ -114,7 +114,7 @@ class CartCheckoutDetector {
 	 */
 	public static function has_classic_checkout(): bool {
 		$checkout_page_id = wc_get_page_id( 'checkout' );
-		return $checkout_page_id && has_block( 'woocommerce/classic-shortcode', $checkout_page_id );
+		return $checkout_page_id && ( has_block( 'woocommerce/classic-shortcode', $checkout_page_id ) || self::has_classic_shortcode( $checkout_page_id, 'woocommerce_checkout' ) );
 	}
 
 	/**
@@ -124,6 +124,25 @@ class CartCheckoutDetector {
 	 */
 	public static function has_classic_cart(): bool {
 		$cart_page_id = wc_get_page_id( 'cart' );
-		return $cart_page_id && has_block( 'woocommerce/classic-shortcode', $cart_page_id );
+		return $cart_page_id && ( has_block( 'woocommerce/classic-shortcode', $cart_page_id ) || self::has_classic_shortcode( $cart_page_id, 'woocommerce_cart' ) );
+	}
+
+	/**
+	 * Check if a page has a specific shortcode.
+	 *
+	 * @param int    $page_id   The ID of the page.
+	 * @param string $shortcode The shortcode to check for.
+	 *
+	 * @return bool
+	 */
+	private static function has_classic_shortcode( int $page_id, string $shortcode ): bool {
+		if ( ! $page_id ) {
+			return false;
+		}
+
+		$page         = get_post( $page_id );
+		$page_content = is_object($page) ? $page->post_content : '';
+
+		return str_contains( $page_content, $shortcode );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/CartCheckoutDetector.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CartCheckoutDetector.php
@@ -141,7 +141,7 @@ class CartCheckoutDetector {
 		}
 
 		$page         = get_post( $page_id );
-		$page_content = is_object($page) ? $page->post_content : '';
+		$page_content = is_object( $page ) ? $page->post_content : '';
 
 		return str_contains( $page_content, $shortcode );
 	}


### PR DESCRIPTION
### Description

This PR fixes the issue with Fastlane and Advanced Card Processing payment methods appearing for guest buyers simultaneously when the WooCommerce checkout page is using the `[woocommerce_checkout]`.

### Steps to Test

1. Set the WooCommerce Checkout page content to use the `[woocommerce_checkout]` shortcode.
2. Follow the Fastlane checkout flow as a guest customer. Ensure only the Fastlane payment method is available in the checkout.

### Screenshots
N/A