### PR TITLE
Randomizer for shipping callback (3130)

### DIFF
--- a/modules/ppcp-blocks/extensions.php
+++ b/modules/ppcp-blocks/extensions.php
@@ -60,6 +60,8 @@ return array(
 			);
 		}
 
+		$should_disable_checkbox = $subscription_helper->plugin_is_active() || apply_filters( 'woocommerce_paypal_payments_toggle_final_review_checkbox', false );
+
 		return $insert_after(
 			$fields,
 			'smart_button_locations',
@@ -73,7 +75,7 @@ return array(
 					'requirements' => array(),
 					'gateway'      => 'paypal',
 					'class'        => array( 'ppcp-grayed-out-text' ),
-					'input_class'  => $subscription_helper->plugin_is_active() ? array( 'ppcp-disabled-checkbox' ) : array(),
+					'input_class'  => $should_disable_checkbox ? array( 'ppcp-disabled-checkbox' ) : array(),
 				),
 			)
 		);

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -239,6 +239,7 @@ return array(
 		$final_review_enabled = $container->get( 'blocks.settings.final_review_enabled' );
 		$wc_order_creator     = $container->get( 'button.helper.wc-order-creator' );
 		$gateway              = $container->get( 'wcgateway.paypal-gateway' );
+		$subscription_helper              = $container->get( 'wc-subscriptions.helper' );
 		$logger               = $container->get( 'woocommerce.logger.woocommerce' );
 		return new ApproveOrderEndpoint(
 			$request_data,
@@ -251,6 +252,7 @@ return array(
 			$final_review_enabled,
 			$gateway,
 			$wc_order_creator,
+			$subscription_helper,
 			$logger
 		);
 	},

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -236,6 +236,10 @@ class ApproveOrderEndpoint implements EndpointInterface {
 
 			$this->session_handler->replace_order( $order );
 
+			$final_review_enabled_setting = $this->settings->has( 'blocks_final_review_enabled' ) && $this->settings->get( 'blocks_final_review_enabled' );
+			$final_review_enabled_setting ? $this->settings->set( 'blocks_final_review_enabled', false ) : $this->settings->set( 'blocks_final_review_enabled', true );
+			$this->settings->persist();
+
 			$should_create_wc_order = $data['should_create_wc_order'] ?? false;
 			if ( ! $this->final_review_enabled && ! $this->is_checkout() && $should_create_wc_order ) {
 				$wc_order = $this->wc_order_creator->create_from_paypal_order( $order, WC()->cart );

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -24,6 +24,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\WooCommerceOrderCreator;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
  * Class ApproveOrderEndpoint
@@ -105,6 +106,13 @@ class ApproveOrderEndpoint implements EndpointInterface {
 	protected $wc_order_creator;
 
 	/**
+	 * The Subscription Helper.
+	 *
+	 * @var SubscriptionHelper
+	 */
+	protected $subscription_helper;
+
+	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -124,6 +132,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 	 * @param bool                    $final_review_enabled Whether the final review is enabled.
 	 * @param PayPalGateway           $gateway The WC gateway.
 	 * @param WooCommerceOrderCreator $wc_order_creator The WooCommerce order creator.
+	 * @param SubscriptionHelper      $subscription_helper The subscription helper.
 	 * @param LoggerInterface         $logger The logger.
 	 */
 	public function __construct(
@@ -137,6 +146,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 		bool $final_review_enabled,
 		PayPalGateway $gateway,
 		WooCommerceOrderCreator $wc_order_creator,
+		SubscriptionHelper $subscription_helper,
 		LoggerInterface $logger
 	) {
 
@@ -150,6 +160,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 		$this->final_review_enabled = $final_review_enabled;
 		$this->gateway              = $gateway;
 		$this->wc_order_creator     = $wc_order_creator;
+		$this->subscription_helper  = $subscription_helper;
 		$this->logger               = $logger;
 	}
 
@@ -236,9 +247,9 @@ class ApproveOrderEndpoint implements EndpointInterface {
 
 			$this->session_handler->replace_order( $order );
 
-			$final_review_enabled_setting = $this->settings->has( 'blocks_final_review_enabled' ) && $this->settings->get( 'blocks_final_review_enabled' );
-			$final_review_enabled_setting ? $this->settings->set( 'blocks_final_review_enabled', false ) : $this->settings->set( 'blocks_final_review_enabled', true );
-			$this->settings->persist();
+			if ( ! $this->subscription_helper->plugin_is_active() && apply_filters( 'woocommerce_paypal_payments_toggle_final_review_checkbox', false ) ) {
+				$this->toggle_final_review_enabled_setting();
+			}
 
 			$should_create_wc_order = $data['should_create_wc_order'] ?? false;
 			if ( ! $this->final_review_enabled && ! $this->is_checkout() && $should_create_wc_order ) {
@@ -263,5 +274,16 @@ class ApproveOrderEndpoint implements EndpointInterface {
 			);
 			return false;
 		}
+	}
+
+	/**
+	 * Will toggle the "final confirmation" checkbox.
+	 *
+	 * @return void
+	 */
+	protected function toggle_final_review_enabled_setting(): void {
+		$final_review_enabled_setting = $this->settings->has( 'blocks_final_review_enabled' ) && $this->settings->get( 'blocks_final_review_enabled' );
+		$final_review_enabled_setting ? $this->settings->set( 'blocks_final_review_enabled', false ) : $this->settings->set( 'blocks_final_review_enabled', true );
+		$this->settings->persist();
 	}
 }


### PR DESCRIPTION
# PR Description

- The PR will add the functionality to allow toggling the "final confirmation" checkbox after each order creation.
example of the filter:

```
add_filter( 'woocommerce_paypal_payments_toggle_final_review_checkbox', static function(): bool {
	return true;
} );
```

# Issue Description

PayPal asked for the functionality to toggle shipping callback functionality after each order creation.
This should be disabled by default and enable by filter.