### PR TITLE
Release 2.7.1-rc2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,8 @@
 * Fix - Allow PUI Gateway for refund processor #2192
 * Fix - Notice on newly created block cart checkout #2211
 * Fix - Apple Pay button in the editor #2177
+* Fix - Allow shipping callback and skipping confirmation page from any express button #2236
+* Enhancement - Use admin theme color #1602
 
 = 2.7.0 - 2024-04-30 =
 * Fix - Zero sum subscriptions cause CANNOT_BE_ZERO_OR_NEGATIVE when using Vault v3 #2152

--- a/readme.txt
+++ b/readme.txt
@@ -185,6 +185,8 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Allow PUI Gateway for refund processor #2192
 * Fix - Notice on newly created block cart checkout #2211
 * Fix - Apple Pay button in the editor #2177
+* Fix - Allow shipping callback and skipping confirmation page from any express button #2236
+* Enhancement - Use admin theme color #1602
 
 = 2.7.0 - 2024-04-30 =
 * Fix - Zero sum subscriptions cause CANNOT_BE_ZERO_OR_NEGATIVE when using Vault v3 #2152


### PR DESCRIPTION
[2.7.1-rc1](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.7.1-rc1) plus:
* Fix - Allow shipping callback and skipping confirmation page from any express button #2236
* Enhancement - Use admin theme color #1602