### PR TITLE
AXO: Fix the Has Profile/No CC scenario

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -24,7 +24,8 @@ class AxoManager {
             active: false,
             validEmail: false,
             hasProfile: false,
-            useEmailWidget: this.useEmailWidget()
+            useEmailWidget: this.useEmailWidget(),
+            hasCard: false,
         };
 
         this.data = {
@@ -257,11 +258,12 @@ class AxoManager {
         }
 
         if (scenario.axoProfileViews) {
-            this.el.billingAddressContainer.hide();
 
             this.shippingView.activate();
-            this.billingView.activate();
-            this.cardView.activate();
+
+            if (this.status.hasCard) {
+                this.cardView.activate();
+            }
 
             // Move watermark to after shipping.
             this.$(this.el.shippingAddressContainer.selector).after(
@@ -584,12 +586,20 @@ class AxoManager {
                 log(JSON.stringify(authResponse));
 
                 const shippingData = authResponse.profileData.shippingAddress;
-                if(shippingData) {
+                if (shippingData) {
                     this.setShipping(shippingData);
                 }
 
+                if (authResponse.profileData.card) {
+                    this.setStatus('hasCard', true);
+                } else {
+                    this.cardComponent = (await this.fastlane.FastlaneCardComponent(
+                        this.cardComponentData()
+                    )).render(this.el.paymentContainer.selector + '-form');
+                }
+
                 const cardBillingAddress = authResponse.profileData?.card?.paymentSource?.card?.billingAddress;
-                if(cardBillingAddress) {
+                if (cardBillingAddress) {
                     this.setCard(authResponse.profileData.card);
 
                     const billingData = {


### PR DESCRIPTION
### Description

This PR fixes the No Card or Card of unsupported brand scenario.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Go through the Axo flow utilizing the profile with no card and verify the card component and billing details fields render correctly.

### Screenshots
|Before|After|
|-|-|
|![Checkout_–_WooCommerce_PayPal_Payments_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/0a6966d9-d379-4f71-8515-727d1cea5f3c)|![Checkout_–_WooCommerce_PayPal_Payments_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/57f3fe17-4385-4a55-965a-be2161ff1062)|