### PR TITLE
AXO: Fix hiding/showing of the alternative payment gatways (3132)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -156,6 +156,7 @@ class AxoManager {
         this.el.showGatewaySelectionLink.on('click', async () => {
             this.hideGatewaySelection = false;
             this.$('.wc_payment_methods label').show();
+            this.$('.wc_payment_methods input').show();
             this.cardView.refresh();
         });
 
@@ -608,6 +609,7 @@ class AxoManager {
 
                 this.hideGatewaySelection = true;
                 this.$('.wc_payment_methods label').hide();
+                this.$('.wc_payment_methods input').hide();
 
                 await this.renderWatermark(false);
 


### PR DESCRIPTION
### Description

This PR fixes the issue with visible alternative Payment Methods when using AXO and a theme like Twenty Twenty-Four.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Activate the Twenty Twenty-Four theme.
2. Go through the Axo flow utilizing the Ryan profile and verify the payment gateway selection displays correctly.

### Screenshots
|Before|After|
|-|-|
|![Page__Checkout_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/813d3a06-eebb-4810-80a3-ff3e2826f22c)|![Page__Checkout_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/137331a0-afaa-471b-bb78-269f887e0a60)|