### PR TITLE
Fix standard card button gateway + shipping callback conflict

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -94,10 +94,7 @@ class Renderer {
             return {
                 style,
                 ...contextConfig,
-                onClick: (data, actions) => {
-                    venmoButtonClicked = data.fundingSource === 'venmo'
-                    this.onSmartButtonClick
-                },
+                onClick:  this.onSmartButtonClick,
                 onInit: (data, actions) => {
                     if (this.onSmartButtonsInit) {
                         this.onSmartButtonsInit(data, actions);

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1361,7 +1361,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'integration-date' => PAYPAL_INTEGRATION_DATE,
 			'components'       => implode( ',', $this->components() ),
 			'vault'            => ( $this->can_save_vault_token() || $this->subscription_helper->need_subscription_intent( $subscription_mode ) ) ? 'true' : 'false',
-			'commit'           => 'false',
+			'commit'           => in_array( $context, $this->pay_now_contexts, true ) ? 'true' : 'false',
 			'intent'           => $intent,
 		);
 


### PR DESCRIPTION
# PR Description

The PR will fix the problem mentioned below, by fixing the mistake in JS

# Issue Description

Payment fails when standard card button gateway is used as separate gateway. This happens after adding latest shipping callback functionality.

### Steps To Reproduce

- Enable standard card button gateway
- Navigate to shop, add product to cart, navigate to checkout page
- Select standard card button gateway, enter card data and click on button Pay Now
- Observe error message
- Try to click again on button Debit or Credit card and observe this in console
- Try to reload page and observe continuation state