### PR TITLE
AXO: Fix PHPCS error

### DIFF
--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -197,7 +197,7 @@ class AxoManager {
 					'CA' => WC()->countries->get_states( 'CA' ),
 				),
 			),
-			'module_url' => untrailingslashit( $this->module_url ),
+			'module_url'    => untrailingslashit( $this->module_url ),
 		);
 	}
 

--- a/modules/ppcp-blocks/extensions.php
+++ b/modules/ppcp-blocks/extensions.php
@@ -54,10 +54,11 @@ return array(
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 
 		if ( $subscription_helper->plugin_is_active() ) {
-			$label .= __(
-				'<div class="ppcp-notice ppcp-notice-warning"><p><span class="highlight">Important:</span> Cannot be deactivated while the WooCommerce Subscriptions plugin is active.</p></div>',
+			$notice_content = __(
+				'<span class="highlight">Important:</span> Cannot be deactivated while the WooCommerce Subscriptions plugin is active.',
 				'woocommerce-paypal-payments'
 			);
+			$label .= '<div class="ppcp-notice ppcp-notice-warning"><p>' . $notice_content . '</p></div>';
 		}
 
 		$should_disable_checkbox = $subscription_helper->plugin_is_active() || apply_filters( 'woocommerce_paypal_payments_toggle_final_review_checkbox', false );


### PR DESCRIPTION
### Description

This PR fixes PHPCS error in the AXO module:

```
-----------------------------------------------------------------------------------------------
 58 | WARNING | Strings should not be wrapped in HTML (WordPress.WP.I18n.NoHtmlWrappedStrings)

```