### PR TITLE
Release 2.7.1-rc4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,8 @@
 * Fix - Notice on newly created block cart checkout #2211
 * Fix - Apple Pay button in the editor #2177
 * Fix - Allow shipping callback and skipping confirmation page from any express button #2236
+* Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
+* Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
 * Enhancement - Use admin theme color #1602
 
 = 2.7.0 - 2024-04-30 =

--- a/readme.txt
+++ b/readme.txt
@@ -186,6 +186,8 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Notice on newly created block cart checkout #2211
 * Fix - Apple Pay button in the editor #2177
 * Fix - Allow shipping callback and skipping confirmation page from any express button #2236
+* Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
+* Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
 * Enhancement - Use admin theme color #1602
 
 = 2.7.0 - 2024-04-30 =


### PR DESCRIPTION
[2.7.1-rc3](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.7.1-rc3) plus:
* Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
* Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251