### PR TITLE
Do not add shipping handlers when the "final confirmation" is checked

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -70,7 +70,6 @@ class Renderer {
 
     shouldHandleShippingInPaypal = (venmoButtonClicked) => {
         if (!this.defaultSettings.should_handle_shipping_in_paypal) {
-            console.log('no')
             return false;
         }
 
@@ -105,8 +104,8 @@ class Renderer {
 
             // Check the condition and add the onShippingOptionsChange handler if needed
             if (this.shouldHandleShippingInPaypal(venmoButtonClicked)) {
-                options.onShippingOptionsChange = (data, actions) => handleShippingOptionsChange(data, actions, this.defaultSettings);
-                options.onShippingAddressChange = (data, actions) => handleShippingAddressChange(data, actions, this.defaultSettings);
+                options.onShippingOptionsChange = (data, actions) => null;
+                options.onShippingAddressChange = (data, actions) => null;
             }
 
             return options;

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -91,20 +91,26 @@ class Renderer {
         let venmoButtonClicked = false;
 
         const buttonsOptions = () => {
-            return {
+            const options = {
                 style,
                 ...contextConfig,
-                onClick:  this.onSmartButtonClick,
+                onClick: this.onSmartButtonClick,
                 onInit: (data, actions) => {
                     if (this.onSmartButtonsInit) {
                         this.onSmartButtonsInit(data, actions);
                     }
                     this.handleOnButtonsInit(wrapper, data, actions);
                 },
-                onShippingOptionsChange: (data, actions) => this.shouldHandleShippingInPaypal(venmoButtonClicked) ? handleShippingOptionsChange(data, actions, this.defaultSettings) : null,
-                onShippingAddressChange: (data, actions) => this.shouldHandleShippingInPaypal(venmoButtonClicked) ? handleShippingAddressChange(data, actions, this.defaultSettings) : null,
+            };
+
+            // Check the condition and add the onShippingOptionsChange handler if needed
+            if (this.shouldHandleShippingInPaypal(venmoButtonClicked)) {
+                options.onShippingOptionsChange = (data, actions) => handleShippingOptionsChange(data, actions, this.defaultSettings);
+                options.onShippingAddressChange = (data, actions) => handleShippingAddressChange(data, actions, this.defaultSettings);
             }
-        }
+
+            return options;
+        };
 
         jQuery(document)
             .off(this.reloadEventName, wrapper)


### PR DESCRIPTION
# PR Description

The PR ensures the error doesn't happen when the "final confirmation" is checked (shipping callback is disabled) on classic pages

# Issue Description

Currently when Vaulting is active and a PayPal account is saved in the Vault, the dropdown on the PayPal button doesn’t work and triggers an error. This happens both on classic and block pages, the only difference is that on classic pages it happens even when "final confirmation" is checked