### PR TITLE
Fix the two AXO bugs: Billing details missing and select another... (3168)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -261,9 +261,10 @@ class AxoManager {
         if (scenario.axoProfileViews) {
 
             this.shippingView.activate();
+            this.cardView.activate();
 
             if (this.status.hasCard) {
-                this.cardView.activate();
+                this.billingView.activate();
             }
 
             // Move watermark to after shipping.

--- a/modules/ppcp-axo/resources/js/Views/CardView.js
+++ b/modules/ppcp-axo/resources/js/Views/CardView.js
@@ -20,10 +20,6 @@ class CardView {
                 if (data.isEmpty()) {
                     return `
                         <div style="margin-bottom: 20px; text-align: center;">
-                            <div style="border:2px solid #cccccc; border-radius: 10px; padding: 26px 20px; margin-bottom: 20px; background-color:#f6f6f6">
-                                <div>Please fill in your card details.</div>
-                            </div>
-                            <h4><a href="javascript:void(0)" ${this.el.changeCardLink.attributes}>Add card details</a></h4>
                             ${selectOtherPaymentMethod()}
                         </div>
                     `;


### PR DESCRIPTION
### Description

This PR fixes the bugs:
- Billing fields appearing in a Ryan flow with existing card/billing data (instead of the actual Billing Data)
- 'Select other payment method' missing when the customer has a profile but doesn't have a card


### Screenshots

#### Billing fields appearing in a Ryan flow with existing card/billing data (instead of the actual Billing Data)

|Before|After|
|-|-|
|![billing_before](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/5e541f46-a467-4743-83ad-1514a691e23a)|![billing_after](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/49f2e843-7b55-4133-bfa9-c45d738a638a)|

####  'Select other payment method' missing when the customer has a profile but doesn't have a card

|Before|After|
|-|-|
|![chose_another_before](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/654dca94-9f06-4b63-ab85-3492916a5c9a)|![another_payment_method_link_after](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/66ee1902-3daf-4f79-953e-93844e861c9e)|

