### PR TITLE
Fastlane generate data-client-metadata-id with UUIDv4 (3165)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
@@ -63,9 +63,10 @@ export const loadPaypalScript = (config, onLoaded, onError = null) => {
 
     // Axo SDK options
     const sdkClientToken = config?.axo?.sdk_client_token;
+    const uuid = self.crypto.randomUUID();
     if(sdkClientToken) {
         scriptOptions['data-sdk-client-token'] = sdkClientToken;
-        scriptOptions['data-client-metadata-id'] = 'ppcp-cm-id';
+        scriptOptions['data-client-metadata-id'] = uuid;
     }
 
     // Load PayPal script for special case with data-client-token


### PR DESCRIPTION
Right now, `data-client-metadata-id` field is a static value, but it must be randomly generated. We could use this: [Crypto: randomUUID() method - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID)