### PR TITLE
AXO: Hide Billing Details in Ryan flow (3173)

### DIFF
--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -34,22 +34,7 @@ class BillingView {
                         </div>
                     `;
                 }
-                return `
-                    <div style="margin-bottom: 20px;">
-                        <div class="axo-checkout-header-section">
-                            <h3>Billing</h3>
-                            <a href="javascript:void(0)" ${this.el.changeBillingAddressLink.attributes}>Edit</a>
-                        </div>
-                        <div>${data.value('email')}</div>
-                        <div>${data.value('company')}</div>
-                        <div>${data.value('firstName')} ${data.value('lastName')}</div>
-                        <div>${data.value('street1')}</div>
-                        <div>${data.value('street2')}</div>
-                        <div>${data.value('postCode')} ${data.value('city')}</div>
-                        <div>${valueOfSelect('#billing_state', data.value('stateCode'))}</div>
-                        <div>${valueOfSelect('#billing_country', data.value('countryCode'))}</div>
-                    </div>
-                `;
+                return ``;
             },
             fields: {
                 email: {

--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -34,7 +34,7 @@ class BillingView {
                         </div>
                     `;
                 }
-                return ``;
+                return '';
             },
             fields: {
                 email: {


### PR DESCRIPTION
### Description

AXO: This PR removes the Billing Details in the Ryan flow.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Go through the Axo Ryan flow.
2. Make sure the Billing Details are not being displayed on the page.

### Screenshots
|Before|After|
|-|-|
|![Checkout_–_WooCommerce_PayPal_Payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/0c60a2ed-acd0-4c86-b78c-13f144adf6d2)|![Checkout_–_WooCommerce_PayPal_Payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/c60b405c-76b2-4a6d-a124-e2c0a3c9437d)|