### PR TITLE
Make PayPal Subscription products unique in cart (2556)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/resources/js/paypal-subscription.js
+++ b/modules/ppcp-paypal-subscriptions/resources/js/paypal-subscription.js
@@ -38,6 +38,9 @@ document.addEventListener(
 
             const subscriptionTrial = document.querySelector('._subscription_trial_length_field');
             subscriptionTrial.style.display = 'none';
+
+            const soldIndividually = document.querySelector( '#_sold_individually' );
+            soldIndividually.setAttribute( 'disabled', 'disabled' );
         }
 
         const setupProducts = () => {

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -87,29 +87,35 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 			12
 		);
 
-		add_filter( 'woocommerce_add_to_cart_validation', function
-		(
-			$passed_validation,
-			$product_id
-		) {
-			if ( WC()->cart->is_empty() ) {
+		add_filter(
+			'woocommerce_add_to_cart_validation',
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			function ( $passed_validation, $product_id ) {
+				if ( WC()->cart->is_empty() ) {
+					return $passed_validation;
+				}
+
+				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+					if ( get_post_meta( $cart_item['product_id'], 'ppcp_subscription_product', true ) ) {
+						wc_add_notice( __( 'You can only have one subscription product in your cart.', 'woocommerce-paypal-payments' ), 'error' );
+						return false;
+					}
+
+					if ( get_post_meta( $product_id, 'ppcp_subscription_product', true ) ) {
+						wc_add_notice( __( 'You cannot add a subscription product to a cart with other items.', 'woocommerce-paypal-payments' ), 'error' );
+						return false;
+					}
+				}
+
 				return $passed_validation;
-			}
-
-			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-				if ( get_post_meta( $cart_item['product_id'], 'ppcp_subscription_product', true ) ) {
-					wc_add_notice(__('You can only have one subscription product in your cart.', 'woocommerce-paypal-payments'), 'error');
-					return false;
-				}
-
-				if ( get_post_meta( $product_id, 'ppcp_subscription_product', true ) ) {
-					wc_add_notice(__('You cannot add a subscription product to a cart with other items.', 'woocommerce-paypal-payments'), 'error');
-					return false;
-				}
-			}
-
-			return $passed_validation;
-		}, 10, 2);
+			},
+			10,
+			2
+		);
 
 		add_action(
 			'woocommerce_save_product_variation',

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -695,7 +695,7 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 				$subscriptions_api_handler->update_plan( $product );
 
 				if ( $product->get_meta( '_ppcp_enable_subscription_product', true ) === 'yes' ) {
-					update_metadata( 'post', $product->get_id(), '_sold_individually', 'yes', 'no' );
+					$product->set_sold_individually( true );
 				}
 
 				return;

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -80,6 +80,10 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 					return;
 				}
 
+				if ( $product->get_meta( '_ppcp_enable_subscription_product', true ) === 'yes' ) {
+					update_metadata( 'post', $product_id, '_sold_individually', 'yes', 'no' );
+				}
+
 				$subscriptions_api_handler = $c->get( 'paypal-subscriptions.api-handler' );
 				assert( $subscriptions_api_handler instanceof SubscriptionsApiHandler );
 				$this->update_subscription_product_meta( $product, $subscriptions_api_handler );

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -80,9 +80,7 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 					return;
 				}
 
-				if ( $product->get_meta( '_ppcp_enable_subscription_product', true ) === 'yes' ) {
-					update_metadata( 'post', $product_id, '_sold_individually', 'yes', 'no' );
-				}
+
 
 				$subscriptions_api_handler = $c->get( 'paypal-subscriptions.api-handler' );
 				assert( $subscriptions_api_handler instanceof SubscriptionsApiHandler );
@@ -697,6 +695,11 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 			if ( $product->meta_exists( 'ppcp_subscription_product' ) && $product->meta_exists( 'ppcp_subscription_plan' ) ) {
 				$subscriptions_api_handler->update_product( $product );
 				$subscriptions_api_handler->update_plan( $product );
+
+				if ( $product->get_meta( '_ppcp_enable_subscription_product', true ) === 'yes' ) {
+					update_metadata( 'post', $product->get_id(), '_sold_individually', 'yes', 'no' );
+				}
+
 				return;
 			}
 

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -94,18 +94,21 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function ( $passed_validation, $product_id ) {
+			static function ( $passed_validation, $product_id ) {
 				if ( WC()->cart->is_empty() ) {
 					return $passed_validation;
 				}
 
 				foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-					if ( get_post_meta( $cart_item['product_id'], 'ppcp_subscription_product', true ) ) {
+					$cart_product = wc_get_product( $cart_item['product_id'] );
+					if ( $cart_product && $cart_product->get_meta( 'ppcp_subscription_product', true ) ) {
 						wc_add_notice( __( 'You can only have one subscription product in your cart.', 'woocommerce-paypal-payments' ), 'error' );
 						return false;
 					}
 
-					if ( get_post_meta( $product_id, 'ppcp_subscription_product', true ) ) {
+					$product = wc_get_product( $product_id );
+
+					if ( $product && $product->get_meta( 'ppcp_subscription_product', true ) ) {
 						wc_add_notice( __( 'You cannot add a subscription product to a cart with other items.', 'woocommerce-paypal-payments' ), 'error' );
 						return false;
 					}

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -80,8 +80,6 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 					return;
 				}
 
-				$foo = $product;
-
 				$subscriptions_api_handler = $c->get( 'paypal-subscriptions.api-handler' );
 				assert( $subscriptions_api_handler instanceof SubscriptionsApiHandler );
 				$this->update_subscription_product_meta( $product, $subscriptions_api_handler );

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -80,8 +80,6 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 					return;
 				}
 
-
-
 				$subscriptions_api_handler = $c->get( 'paypal-subscriptions.api-handler' );
 				assert( $subscriptions_api_handler instanceof SubscriptionsApiHandler );
 				$this->update_subscription_product_meta( $product, $subscriptions_api_handler );


### PR DESCRIPTION
### Description

If there is a PayPal Subscription product in the cart, that can be the _only_ product in the cart.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Add a PayPal Subscription product in the cart;
2. Try to add another product in the cart;
3. The error notice should appear prompting the user that PayPal subscription should be a unique item in the cart;
![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/46271505/2f4cfa85-f729-4079-8586-f69c0add4c7f)
