### PR TITLE
Enable the Shipping Callback handlers (3177)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -102,10 +102,10 @@ class Renderer {
                 },
             };
 
-            // Check the condition and add the onShippingOptionsChange handler if needed
+            // Check the condition and add the handler if needed
             if (this.shouldHandleShippingInPaypal(venmoButtonClicked)) {
-                options.onShippingOptionsChange = (data, actions) => null;
-                options.onShippingAddressChange = (data, actions) => null;
+                options.onShippingOptionsChange = (data, actions) => handleShippingOptionsChange(data, actions, this.defaultSettings);
+                options.onShippingAddressChange = (data, actions) => handleShippingAddressChange(data, actions, this.defaultSettings);
             }
 
             return options;


### PR DESCRIPTION
# PR Description

The PR will fix the problem described below. Also:

- When shipping callback is disabled the arrow of the express button should work as expected
- When shipping callback is enabled the arrow of the express button doesn’t work correctly (ongoing discussion with PayPal, most likely problem on their end)

# Issue Description

Shipping callback doesn't work in [2.7.1-rc5](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.7.1-rc5) cause it was commented out when fixing [The arrow of the express button ](https://github.com/woocommerce/woocommerce-paypal-payments/issues/2254)