### PR TITLE
Release 2.7.1-rc6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Allow shipping callback and skipping confirmation page from any express button #2236
 * Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
 * Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
+* Fix - Enable the Shipping Callback handlers #2266
 * Enhancement - Use admin theme color #1602
 
 = 2.7.0 - 2024-04-30 =

--- a/readme.txt
+++ b/readme.txt
@@ -188,6 +188,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Allow shipping callback and skipping confirmation page from any express button #2236
 * Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
 * Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
+* Fix - Enable the Shipping Callback handlers #2266
 * Enhancement - Use admin theme color #1602
 
 = 2.7.0 - 2024-04-30 =


### PR DESCRIPTION
[2.7.1-rc5](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.7.1-rc5) plus: 
* Fix - Enable the Shipping Callback handlers #2266