### PR TITLE
AXO: Disable payment method selection during OTP interaction (3174)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -571,7 +571,9 @@ class AxoManager {
             page_type: 'checkout'
         });
 
+        this.disableGatewaySelection();
         await this.lookupCustomerByEmail();
+        this.enableGatewaySelection();
     }
 
     async lookupCustomerByEmail() {
@@ -657,6 +659,14 @@ class AxoManager {
                 this.cardComponentData()
             )).render(this.el.paymentContainer.selector + '-form');
         }
+    }
+
+    disableGatewaySelection() {
+        this.$('.wc_payment_methods input').prop('disabled', true);
+    }
+
+    enableGatewaySelection() {
+        this.$('.wc_payment_methods input').prop('disabled', false);
     }
 
     clearData() {


### PR DESCRIPTION
### Description

AXO: This PR disables payment method selection during OTP interaction to prevent users from exiting the Fastlane flow unexpectedly.

### Steps to Test
1. Visit checkout as a guest.
2. Enter Ryan email address
3. Before OTP triggers, immediately try to switch payment methods, e.g. to PayPal
4. Confirm that the payment method selection is disabled
5. After confirming the OTP make sure you can change the payment method again.


1. Go through the Axo Ryan flow.
2. Make sure the Billing Details are not being displayed on the page.

### Screenshots
N/A