### PR TITLE
Disable the shipping callback for "venmo" when vaulting is active (3028)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -23,6 +23,9 @@ import {
 import buttonModuleWatcher from "../../../ppcp-button/resources/js/modules/ButtonModuleWatcher";
 import BlockCheckoutMessagesBootstrap from "./Bootstrap/BlockCheckoutMessagesBootstrap";
 import {keysToCamelCase} from "../../../ppcp-button/resources/js/modules/Helper/Utils";
+import {
+    handleShippingOptionsChange
+} from "../../../ppcp-button/resources/js/modules/Helper/ShippingHandler";
 const config = wc.wcSettings.getSetting('ppcp-gateway_data');
 
 window.ppcpFundingSource = config.fundingSource;
@@ -146,7 +149,7 @@ const PayPalComponent = ({
                         shipping_address: addresses.shippingAddress,
                     }),
                 ];
-                if (!config.finalReviewEnabled) {
+                if (shouldHandleShippingInPayPal()) {
                     // set address in UI
                     promises.push(wp.data.dispatch('wc/store/cart').setBillingAddress(addresses.billingAddress));
                     if (shippingData.needsShipping) {
@@ -181,7 +184,7 @@ const PayPalComponent = ({
                 throw new Error(config.scriptData.labels.error.generic)
             }
 
-            if (config.finalReviewEnabled) {
+            if (!shouldHandleShippingInPayPal()) {
                 location.href = getCheckoutRedirectUrl();
             } else {
                 setGotoContinuationOnError(true);
@@ -220,7 +223,7 @@ const PayPalComponent = ({
                         shipping_address: addresses.shippingAddress,
                     }),
                 ];
-                if (!config.finalReviewEnabled) {
+                if (shouldHandleShippingInPayPal()) {
                     // set address in UI
                     promises.push(wp.data.dispatch('wc/store/cart').setBillingAddress(addresses.billingAddress));
                     if (shippingData.needsShipping) {
@@ -255,7 +258,7 @@ const PayPalComponent = ({
                 throw new Error(config.scriptData.labels.error.generic)
             }
 
-            if (config.finalReviewEnabled) {
+            if (!shouldHandleShippingInPayPal()) {
                 location.href = getCheckoutRedirectUrl();
             } else {
                 setGotoContinuationOnError(true);
@@ -297,8 +300,12 @@ const PayPalComponent = ({
         onClick();
     };
 
-    const isVenmoAndVaultingEnabled = () => {
-        return window.ppcpFundingSource === 'venmo' && config.scriptData.vaultingEnabled;
+    const shouldHandleShippingInPayPal = () => {
+        if (config.finalReviewEnabled) {
+            return false;
+        }
+
+        return window.ppcpFundingSource !== 'venmo' || !config.scriptData.vaultingEnabled;
     }
 
     let handleShippingOptionsChange = null;
@@ -306,7 +313,7 @@ const PayPalComponent = ({
     let handleSubscriptionShippingOptionsChange = null;
     let handleSubscriptionShippingAddressChange = null;
 
-    if (shippingData.needsShipping && !config.finalReviewEnabled) {
+    if (shippingData.needsShipping && shouldHandleShippingInPayPal()) {
         handleShippingOptionsChange = async (data, actions) => {
             try {
                 const shippingOptionId = data.selectedShippingOption?.id;
@@ -447,7 +454,7 @@ const PayPalComponent = ({
             if (config.scriptData.continuation) {
                 return true;
             }
-            if (!config.finalReviewEnabled) {
+            if (shouldHandleShippingInPayPal()) {
                 location.href = getCheckoutRedirectUrl();
             }
             return true;
@@ -493,8 +500,16 @@ const PayPalComponent = ({
                 onError={onClose}
                 createSubscription={createSubscription}
                 onApprove={handleApproveSubscription}
-                onShippingOptionsChange={handleSubscriptionShippingOptionsChange}
-                onShippingAddressChange={handleSubscriptionShippingAddressChange}
+                onShippingOptionsChange={(data, actions) => {
+                    shouldHandleShippingInPayPal()
+                        ? handleSubscriptionShippingOptionsChange(data, actions)
+                        : null;
+                }}
+                onShippingAddressChange={(data, actions) => {
+                    shouldHandleShippingInPayPal()
+                        ? handleSubscriptionShippingAddressChange(data, actions)
+                        : null;
+                }}
             />
         );
     }
@@ -508,8 +523,16 @@ const PayPalComponent = ({
             onError={onClose}
             createOrder={createOrder}
             onApprove={handleApprove}
-            onShippingOptionsChange={handleShippingOptionsChange}
-            onShippingAddressChange={handleShippingAddressChange}
+            onShippingOptionsChange={(data, actions) => {
+                shouldHandleShippingInPayPal()
+                    ? handleShippingOptionsChange(data, actions)
+                    : null;
+            }}
+            onShippingAddressChange={(data, actions) => {
+                shouldHandleShippingInPayPal()
+                    ? handleShippingAddressChange(data, actions)
+                    : null;
+            }}
         />
     );
 }

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
@@ -60,8 +60,7 @@ class CartActionHandler {
                     funding_source: window.ppcpFundingSource,
                     bn_code:bnCode,
                     payer,
-                    context:this.config.context,
-                    payment_source: data.paymentSource
+                    context:this.config.context
                 }),
             }).then(function(res) {
                 return res.json();

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -246,7 +246,6 @@ class CreateOrderEndpoint implements EndpointInterface {
 			$this->parsed_request_data = $data;
 			$payment_method            = $data['payment_method'] ?? '';
 			$funding_source            = $data['funding_source'] ?? '';
-			$payment_source            = $data['payment_source'] ?? '';
 			$wc_order                  = null;
 			if ( 'pay-now' === $data['context'] ) {
 				$wc_order = wc_get_order( (int) $data['order_id'] );
@@ -262,7 +261,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 				}
 				$this->purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 			} else {
-				$this->purchase_unit = $this->purchase_unit_factory->from_wc_cart( null, $this->should_handle_shipping_in_paypal( $payment_source ) );
+				$this->purchase_unit = $this->purchase_unit_factory->from_wc_cart( null, $this->should_handle_shipping_in_paypal( $funding_source ) );
 
 				// Do not allow completion by webhooks when started via non-checkout buttons,
 				// it is needed only for some APMs in checkout.
@@ -615,16 +614,16 @@ class CreateOrderEndpoint implements EndpointInterface {
 	/**
 	 * Checks if the shipping should be handled in PayPal popup.
 	 *
-	 * @param string $payment_source The payment source.
+	 * @param string $funding_source The funding source.
 	 * @return bool true if the shipping should be handled in PayPal popup, otherwise false.
 	 */
-	protected function should_handle_shipping_in_paypal( string $payment_source ): bool {
+	protected function should_handle_shipping_in_paypal( string $funding_source ): bool {
 		$is_vaulting_enabled = $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' );
 
 		if ( ! $this->handle_shipping_in_paypal ) {
 			return false;
 		}
 
-		return ! $is_vaulting_enabled || $payment_source !== 'venmo';
+		return ! $is_vaulting_enabled || $funding_source !== 'venmo';
 	}
 }


### PR DESCRIPTION
# PR Description

The PR will address the issue described below.

# Issue Description

When shipping callback is enabled together with PayPal Vaulting, then the Venmo button should not use the shipping callback functionality (it will cause an error).

### Acceptance Criteria

**Given** Venmo is available 
**And** shipping callback and PayPal Vaulting are both active
**When** clicking the Venmo express button (non-Classic Chekcout)
**Then** shipping callback should not be used for the Venmo payment