### PR TITLE
Improve "Could not retrieve order" error message (3131)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -220,9 +220,14 @@ class OrderProcessor {
 				);
 
 				throw new PayPalOrderMissingException(
-					__(
-						'Could not retrieve order. Maybe it was already completed or this browser is not supported. Please check your email or try again with a different browser.',
-						'woocommerce-paypal-payments'
+					sprintf(
+						// translators: %s: Order history URL on My Account section.
+						esc_attr__(
+							'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.',
+							// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Intentionally "woocommerce" to reflect the original message.
+							'woocommerce'
+						),
+						esc_url( wc_get_account_endpoint_url( 'orders' ) )
 					)
 				);
 			}


### PR DESCRIPTION
This error message on the Checkout page has never been descriptive enough and by now includes outdated information:
[woocommerce-paypal-payments/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php at 06d80325c9551df6807a7dc4fcedbf7b2631cfcb · woocommerce/woocommerce-paypal-payments](https://github.com/woocommerce/woocommerce-paypal-payments/blob/06d80325c9551df6807a7dc4fcedbf7b2631cfcb/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php#L224)  


> Could not retrieve order. Maybe it was already completed or this browser is not supported. Please check your email or try again with a different browser.

 For a better user experience, we should reuse a WooCommerce string:
[woocommerce/plugins/woocommerce/includes/class-wc-frontend-scripts.php at f5713b3f9412bc8d89f1f88a71abfe87dc879695 · woocommerce/woocommerce](https://github.com/woocommerce/woocommerce/blob/f5713b3f9412bc8d89f1f88a71abfe87dc879695/plugins/woocommerce/includes/class-wc-frontend-scripts.php#L545) 

> There was an error processing your order. Please check for any charges in your payment method and review your [order history](http://example.com/my-account/orders/) before placing the order again.
 
