### PR TITLE
double slash in messaging configurator script path (3138)

### DIFF
--- a/modules/ppcp-paylater-configurator/services.php
+++ b/modules/ppcp-paylater-configurator/services.php
@@ -17,12 +17,14 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 return array(
 	'paylater-configurator.url'                  => static function ( ContainerInterface $container ): string {
 		/**
+		 * The return value must not contain a trailing slash.
+		 *
 		 * Cannot return false for this path.
 		 *
 		 * @psalm-suppress PossiblyFalseArgument
 		 */
 		return plugins_url(
-			'/modules/ppcp-paylater-configurator/',
+			'/modules/ppcp-paylater-configurator',
 			dirname( realpath( __FILE__ ), 3 ) . '/woocommerce-paypal-payments.php'
 		);
 	},


### PR DESCRIPTION
**Addressed problem**
There is a double slash in the path of the messaging configurator script
<img width="917" alt="image" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/2669200/8ca88267-ccfa-4089-93a8-138ed218f654">


**Steps To Reproduce**
1. set up PayPal Payments in a Pay Later supported region
2. navigate to the Pay Later settings tab
3. open browser consoles
4. check the path of the paylater-configurator script
5. observe double slash in the path