### PR TITLE
Google Pay and Apple Pay Settings button from Connection tab have wrong links (3160)

### DIFF
--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -964,7 +964,7 @@ return array(
 			: $container->get( 'applepay.enable-url-sandbox' );
 
 		$button_url = $enabled
-			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway#field-alternative_payment_methods' )
+			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-credit-card-gateway#ppcp-applepay_button_enabled' )
 			: $enable_url;
 
 		return sprintf(

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -926,7 +926,7 @@ return array(
 			: $container->get( 'googlepay.enable-url-sandbox' );
 
 		$button_url = $enabled
-			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway#field-alternative_payment_methods' )
+			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-credit-card-gateway#ppcp-googlepay_button_enabled' )
 			: $enable_url;
 
 		return sprintf(


### PR DESCRIPTION
We recently moved the _Apple Pay_ and _Google Pay_ configuration from the **Standard Payments** tab to the **Advanced Card Processing** tab.

While doing this, we forgot to update some references, like the **Settings** buttons for Apple Pay and Goolge Pay on the Connection tab when the features are available for the merchant:

![image](https://github.com/woocommerce/woocommerce-paypal-payments/assets/2669200/6c509d0e-e946-495a-ad0b-5dfc7a5aba09)
