### PR TITLE
Fix the Smart Buttons in Block Checkout not respecting the location setting (2830)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -568,7 +568,7 @@ if(cartHasSubscriptionProducts(config.scriptData)) {
     features.push('subscriptions');
 }
 
-if (block_enabled) {
+if (block_enabled && config.enabled) {
     if ((config.addPlaceOrderMethod || config.usePlaceOrder) && !config.scriptData.continuation) {
         let descriptionElement = <div dangerouslySetInnerHTML={{__html: config.description}}></div>;
         if (config.placeOrderButtonDescription) {


### PR DESCRIPTION
### Description

This PR fixes the Smart Buttons not respecting the Smart Button Location setting for the Block Checkout (Express Checkout):

### Steps to Test
1. Test with the `Express Checkout` location enabled/disabled, and make sure that the Smart Buttons are being displayed/hidden accordingly on the Checkout block (both in the editor and the page).

### Screenshots
![Cursor_i_WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/edfab19d-1e74-4452-8aec-c09a1385f7d0)
