### PR TITLE
Disable Pay Upon Invoice if billing/shipping country not set (737)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -56,13 +56,13 @@ class PayUponInvoiceHelper {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$billing_country = wc_clean( wp_unslash( $_POST['country'] ?? '' ) );
+		$billing_country = WC()->customer->get_billing_country();
 		if ( empty( $billing_country ) || 'DE' !== $billing_country ) {
 			return false;
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$shipping_country = wc_clean( wp_unslash( $_POST['s_country'] ?? '' ) );
+		$shipping_country = WC()->customer->get_shipping_country();
 		if ( empty( $shipping_country ) || 'DE' !== $shipping_country ) {
 			return false;
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -57,13 +57,13 @@ class PayUponInvoiceHelper {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$billing_country = wc_clean( wp_unslash( $_POST['country'] ?? '' ) );
-		if ( $billing_country && 'DE' !== $billing_country ) {
+		if ( empty( $billing_country ) || 'DE' !== $billing_country ) {
 			return false;
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$shipping_country = wc_clean( wp_unslash( $_POST['s_country'] ?? '' ) );
-		if ( $shipping_country && 'DE' !== $shipping_country ) {
+		if ( empty( $shipping_country ) || 'DE' !== $shipping_country ) {
 			return false;
 		}
 


### PR DESCRIPTION

### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

PUI was only being disabled if the user selected billing/shipping country was anything other than Germany. However, the PUI was not being disabled if the billing/shipping country was not set at all.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Set default customer location to 'No location by default' (WooCommerce -> Settings -> General);
2. Use incognito tab (logged out) to add product to cart;
3. Navigate to checkout page;
4. Notice the absence of PUI method if billing/shipping country is not set, or is set to any other country except Germany.
