### PR TITLE
PayPal declares subscription support when merchant not enabled for Reference Transactions (2068)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -394,7 +394,18 @@ class SettingsListener {
 
 		if ( $reference_transaction_enabled !== true ) {
 			$this->settings->set( 'vault_enabled', false );
-			$this->settings->set( 'subscriptions_mode', 'subscriptions_api' );
+
+			/**
+			 * If Vaulting-API was previously enabled, then fall-back to the
+			 * PayPal subscription mode, to ensure subscriptions are still
+			 * possible on this shop.
+			 *
+			 * This can happen when switching to a different PayPal merchant account
+			 */
+			if ( 'vaulting_api' === $subscription_mode ) {
+				$this->settings->set( 'subscriptions_mode', 'subscriptions_api' );
+			}
+
 			$this->settings->persist();
 		}
 


### PR DESCRIPTION
#### Summary:
Since version 2.3.0-rc2 of the WooCommerce Subscriptions plugin, PayPal subscriptions cannot be disabled if the merchant is not enabled for Reference Transactions (RT, also known as "vaulting").

#### Technical Details:
- The issue arises because the database setting value for Subscription Mode is incorrectly saved as `subscriptions_api`, regardless of the selected option.
- The correct value is sent from the browser (visible via the network tab), but it gets reset when saving the settings page.

#### Expected Behavior:
- When the connected PayPal merchant is not enabled for RT and the Subscriptions Mode is set to "Disable PayPal for subscriptions", the PayPal gateway should not declare support for subscriptions.

#### Fix Implemented:
- Corrected the logic to ensure the proper value is saved and retained in the database for the Subscriptions Mode setting.
- Verified that the correct value is sent from the browser and saved in the database, preventing it from resetting to `subscriptions_api`.

![2024-05-29_16-35-02](https://github.com/woocommerce/woocommerce-paypal-payments/assets/2669200/0c3aba77-0d40-497b-9da7-1101305d016f)

![2024-05-29_14-49-49](https://github.com/woocommerce/woocommerce-paypal-payments/assets/2669200/f7485320-3d5c-4b79-9763-37057668798f)
