### PR TITLE
Do not request id_token for guest users (3264)

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -84,6 +84,10 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		add_filter(
 			'woocommerce_paypal_payments_localized_script_data',
 			function( array $localized_script_data ) use ( $c ) {
+				if ( ! is_user_logged_in() ) {
+					return $localized_script_data;
+				}
+
 				$api = $c->get( 'api.user-id-token' );
 				assert( $api instanceof UserIdToken );
 


### PR DESCRIPTION
Some merchants are getting `RATE_LIMIT_REACHED` returned after multiple calls on [id_token](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-api-client/src/Authentication/UserIdToken.php#L74). This PR ensures id token is not requested for guest users.