### PR TITLE
Fastlane strip www. from merchant URL token

### DIFF
--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -73,6 +73,7 @@ class SdkClientToken {
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$domain = wp_unslash( $_SERVER['HTTP_HOST'] ?? '' );
+		$domain = preg_replace( '/^www\./', '', $domain );
 
 		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=client_token&intent=sdk_init&domains[]=' . $domain;
 


### PR DESCRIPTION
Depending on the server config, the follopwing code may return a domain with `www.`:
```
$domain = $_SERVER['HTTP_HOST'];
```

This is breaking Fastlane. So we must strip the `www.` from the domain.

### Suggested solution
```
$domain = preg_replace('/^www\./', '', $domain);
```