### PR TITLE
Fix the package tracking integration throws error in 2.7.1 (3185)

### DIFF
--- a/modules/ppcp-order-tracking/src/Integration/GermanizedShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/GermanizedShipmentIntegration.php
@@ -73,34 +73,34 @@ class GermanizedShipmentIntegration implements Integration {
 		add_action(
 			'woocommerce_gzd_shipment_status_shipped',
 			function( int $shipment_id, Shipment $shipment ) {
-				if ( ! apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) ) {
-					return;
-				}
-
-				$wc_order = $shipment->get_order();
-
-				if ( ! is_a( $wc_order, WC_Order::class ) ) {
-					return;
-				}
-
-				$paypal_order    = ppcp_get_paypal_order( $wc_order );
-				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
-				$wc_order_id     = $wc_order->get_id();
-				$tracking_number = $shipment->get_tracking_id();
-				$carrier         = $shipment->get_shipping_provider();
-
-				$items = array_map(
-					function ( ShipmentItem $item ): int {
-						return $item->get_order_item_id();
-					},
-					$shipment->get_items()
-				);
-
-				if ( ! $tracking_number || ! $carrier || ! $capture_id ) {
-					return;
-				}
-
 				try {
+					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) ) {
+						return;
+					}
+
+					$wc_order = $shipment->get_order();
+
+					if ( ! is_a( $wc_order, WC_Order::class ) ) {
+						return;
+					}
+
+					$paypal_order    = ppcp_get_paypal_order( $wc_order );
+					$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
+					$wc_order_id     = $wc_order->get_id();
+					$tracking_number = $shipment->get_tracking_id();
+					$carrier         = $shipment->get_shipping_provider();
+
+					$items = array_map(
+						function ( ShipmentItem $item ): int {
+							return $item->get_order_item_id();
+						},
+						$shipment->get_items()
+					);
+
+					if ( ! $tracking_number || ! $carrier || ! $capture_id ) {
+						return;
+					}
+
 					$ppcp_shipment = $this->shipment_factory->create_shipment(
 						$wc_order_id,
 						$capture_id,
@@ -118,7 +118,7 @@ class GermanizedShipmentIntegration implements Integration {
 						: $this->endpoint->add_tracking_information( $ppcp_shipment, $wc_order_id );
 
 				} catch ( Exception $exception ) {
-					$this->logger->error( "Couldn't sync tracking information: " . $exception->getMessage() );
+					return;
 				}
 			},
 			500,

--- a/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
@@ -76,25 +76,25 @@ class ShipStationIntegration implements Integration {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function( $wc_order, array $data ) {
-				if ( ! apply_filters( 'woocommerce_paypal_payments_sync_ship_station_tracking', true ) ) {
-					return;
-				}
-
-				if ( ! is_a( $wc_order, WC_Order::class ) ) {
-					return;
-				}
-
-				$paypal_order    = ppcp_get_paypal_order( $wc_order );
-				$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
-				$order_id        = $wc_order->get_id();
-				$tracking_number = $data['tracking_number'] ?? '';
-				$carrier         = $data['carrier'] ?? '';
-
-				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $capture_id ) {
-					return;
-				}
-
 				try {
+					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_ship_station_tracking', true ) ) {
+						return;
+					}
+
+					if ( ! is_a( $wc_order, WC_Order::class ) ) {
+						return;
+					}
+
+					$paypal_order    = ppcp_get_paypal_order( $wc_order );
+					$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
+					$order_id        = $wc_order->get_id();
+					$tracking_number = $data['tracking_number'] ?? '';
+					$carrier         = $data['carrier'] ?? '';
+
+					if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $capture_id ) {
+						return;
+					}
+
 					$ppcp_shipment = $this->shipment_factory->create_shipment(
 						$order_id,
 						$capture_id,
@@ -112,7 +112,7 @@ class ShipStationIntegration implements Integration {
 						: $this->endpoint->add_tracking_information( $ppcp_shipment, $order_id );
 
 				} catch ( Exception $exception ) {
-					$this->logger->error( "Couldn't sync tracking information: " . $exception->getMessage() );
+					return;
 				}
 			},
 			500,

--- a/modules/ppcp-order-tracking/src/Integration/WcShippingTaxIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/WcShippingTaxIntegration.php
@@ -75,42 +75,46 @@ class WcShippingTaxIntegration implements Integration {
 		add_filter(
 			'rest_post_dispatch',
 			function( WP_HTTP_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_HTTP_Response {
-				if ( ! apply_filters( 'woocommerce_paypal_payments_sync_wc_shipping_tax', true ) ) {
+				try {
+					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_wc_shipping_tax', true ) ) {
+						return $response;
+					}
+
+					$params   = $request->get_params();
+					$order_id = (int) ( $params['order_id'] ?? 0 );
+					$label_id = (int) ( $params['label_ids'] ?? 0 );
+
+					if ( ! $order_id || "/wc/v1/connect/label/{$order_id}/{$label_id}" !== $request->get_route() ) {
+						return $response;
+					}
+
+					$data   = $response->get_data() ?? array();
+					$labels = $data['labels'] ?? array();
+
+					foreach ( $labels as $label ) {
+						$tracking_number = $label['tracking'] ?? '';
+						if ( ! $tracking_number ) {
+							continue;
+						}
+
+						$wc_order = wc_get_order( $order_id );
+						if ( ! is_a( $wc_order, WC_Order::class ) ) {
+							continue;
+						}
+
+						$paypal_order = ppcp_get_paypal_order( $wc_order );
+						$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
+						$carrier      = $label['carrier_id'] ?? $label['service_name'] ?? '';
+						$items        = array_map( 'intval', $label['product_ids'] ?? array() );
+
+						if ( ! $carrier || ! $capture_id ) {
+							continue;
+						}
+
+						$this->sync_tracking( $order_id, $capture_id, $tracking_number, $carrier, $items );
+					}
+				} catch ( Exception $exception ) {
 					return $response;
-				}
-
-				$params   = $request->get_params();
-				$order_id = (int) ( $params['order_id'] ?? 0 );
-				$label_id = (int) ( $params['label_ids'] ?? 0 );
-
-				if ( ! $order_id || "/wc/v1/connect/label/{$order_id}/{$label_id}" !== $request->get_route() ) {
-					return $response;
-				}
-
-				$data   = $response->get_data() ?? array();
-				$labels = $data['labels'] ?? array();
-
-				foreach ( $labels as $label ) {
-					$tracking_number = $label['tracking'] ?? '';
-					if ( ! $tracking_number ) {
-						continue;
-					}
-
-					$wc_order = wc_get_order( $order_id );
-					if ( ! is_a( $wc_order, WC_Order::class ) ) {
-						continue;
-					}
-
-					$paypal_order = ppcp_get_paypal_order( $wc_order );
-					$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
-					$carrier      = $label['carrier_id'] ?? $label['service_name'] ?? '';
-					$items        = array_map( 'intval', $label['product_ids'] ?? array() );
-
-					if ( ! $carrier || ! $capture_id ) {
-						continue;
-					}
-
-					$this->sync_tracking( $order_id, $capture_id, $tracking_number, $carrier, $items );
 				}
 
 				return $response;

--- a/modules/ppcp-order-tracking/src/Integration/YithShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/YithShipmentIntegration.php
@@ -71,27 +71,27 @@ class YithShipmentIntegration implements Integration {
 		add_action(
 			'woocommerce_process_shop_order_meta',
 			function( int $order_id ) {
-				if ( ! apply_filters( 'woocommerce_paypal_payments_sync_ywot_tracking', true ) ) {
-					return;
-				}
-
-				$wc_order = wc_get_order( $order_id );
-				if ( ! is_a( $wc_order, WC_Order::class ) ) {
-					return;
-				}
-
-				$paypal_order = ppcp_get_paypal_order( $wc_order );
-				$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing
-				$tracking_number = wc_clean( wp_unslash( $_POST['ywot_tracking_code'] ?? '' ) );
-				// phpcs:ignore WordPress.Security.NonceVerification.Missing
-				$carrier = wc_clean( wp_unslash( $_POST['ywot_carrier_name'] ?? '' ) );
-
-				if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $capture_id ) {
-					return;
-				}
-
 				try {
+					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_ywot_tracking', true ) ) {
+						return;
+					}
+
+					$wc_order = wc_get_order( $order_id );
+					if ( ! is_a( $wc_order, WC_Order::class ) ) {
+						return;
+					}
+
+					$paypal_order = ppcp_get_paypal_order( $wc_order );
+					$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing
+					$tracking_number = wc_clean( wp_unslash( $_POST['ywot_tracking_code'] ?? '' ) );
+					// phpcs:ignore WordPress.Security.NonceVerification.Missing
+					$carrier = wc_clean( wp_unslash( $_POST['ywot_carrier_name'] ?? '' ) );
+
+					if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $capture_id ) {
+						return;
+					}
+
 					$ppcp_shipment = $this->shipment_factory->create_shipment(
 						$order_id,
 						$capture_id,
@@ -109,7 +109,7 @@ class YithShipmentIntegration implements Integration {
 						: $this->endpoint->add_tracking_information( $ppcp_shipment, $order_id );
 
 				} catch ( Exception $exception ) {
-					$this->logger->error( "Couldn't sync tracking information: " . $exception->getMessage() );
+					return;
 				}
 			},
 			500,


### PR DESCRIPTION
# PR Description

The problem described in the description happens on non - PayPal order pages, cause when we cannot find the PayPal order ID from order meta we return the _'PayPal order ID not found in meta.'_ exception.
The PR will surround the integrations in `try/catch` blocks and will exit if error happens -> means not a PayPal order edit page. This is not possible to fix in more elegant way cause the request can come differently (Ajax, Rest)

# Issue Description

After changing the behavior with transaction id/capture id for package tracking, we may have broken our tracking integrations as we have received couple of reports from customers.

### Steps To Reproduce

- Activate the [WooCommerce Shipment Tracking](https://woocommerce.com/de/products/shipment-tracking/) plugin
- Make an order without PayPal ( Cash on delivery for example )
- Visit order edit page and create tracking with WooCommerce Shipment Tracking. 

It will stuck and if you check the log you will see the error.
The other integrations will act the same

