### PR TITLE
Calculate totals after adding shipping to include taxes (3133)

### DIFF
--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -181,6 +181,8 @@ class WooCommerceOrderCreator {
 
 			$wc_order->add_item( $shipping );
 		}
+
+		$wc_order->calculate_totals();
 	}
 
 	/**


### PR DESCRIPTION
# PR Description

The problem happen because of not adding taxes, so the PR fixes it by calling the `calculate_totals` after adding shipping/billing addresses

# Issue Description

Unsuccessfully payment with coupon from short cart when Require final confirmation on checkout is not enabled

### Steps To Reproduce

- Disable Require final confirmation on checkout
- Navigate to shop
- Add product to cart
- Navigate to cart, apply coupon and pay
- Observe the error

