### PR TITLE
Release 2.8.0-rc1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,17 @@
 *** Changelog ***
 
+= 2.8.0 - xxxx-xx-xx =
+* Fix - Calculate totals after adding shipping to include taxes #2296
+* Fix - Package tracking integration throws error in 2.7.1 #2289
+* Fix - Make PayPal Subscription products unique in cart #2265
+* Fix - PayPal declares subscription support when merchant not enabled for Reference Transactions #2282
+* Fix - Google Pay and Apple Pay Settings button from Connection tab have wrong links #2273
+* Fix - Smart Buttons in Block Checkout not respecting the location setting (2830) #2278
+* Fix - Disable Pay Upon Invoice if billing/shipping country not set #2281
+* Enhancement - Enable shipping callback for WC subscriptions #2259
+* Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
+* Enhancement - Improve "Could not retrieve order" error message #2271
+
 = 2.7.1 - 2024-05-28 =
 * Fix - Ensure package tracking data is sent to original PayPal transaction #2180
 * Fix - Set the 'Woo_PPCP' as a default value for data-partner-attribution-id #2188

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "2.7.1",
+  "version": "2.8.0",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, checkout, cart, pay later, apple
 Requires at least: 5.3
 Tested up to: 6.5
 Requires PHP: 7.2
-Stable tag: 2.7.1
+Stable tag: 2.8.0
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -190,6 +190,18 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
 * Fix - Enable the Shipping Callback handlers #2266
 * Enhancement - Use admin theme color #1602
+
+= 2.8.0 - xxxx-xx-xx =
+* Fix - Calculate totals after adding shipping to include taxes #2296
+* Fix - Package tracking integration throws error in 2.7.1 #2289
+* Fix - Make PayPal Subscription products unique in cart #2265
+* Fix - PayPal declares subscription support when merchant not enabled for Reference Transactions #2282
+* Fix - Google Pay and Apple Pay Settings button from Connection tab have wrong links #2273
+* Fix - Smart Buttons in Block Checkout not respecting the location setting (2830) #2278
+* Fix - Disable Pay Upon Invoice if billing/shipping country not set #2281
+* Enhancement - Enable shipping callback for WC subscriptions #2259
+* Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
+* Enhancement - Improve "Could not retrieve order" error message #2271
 
 = 2.7.0 - 2024-04-30 =
 * Fix - Zero sum subscriptions cause CANNOT_BE_ZERO_OR_NEGATIVE when using Vault v3 #2152

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,14 +3,14 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     2.7.1
+ * Version:     2.8.0
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.2
  * Requires Plugins: woocommerce
  * WC requires at least: 3.9
- * WC tested up to: 8.8
+ * WC tested up to: 8.9
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce
@@ -26,7 +26,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2024-05-13' );
+define( 'PAYPAL_INTEGRATION_DATE', '2024-06-03' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );
 ! defined( 'CONNECT_WOO_SANDBOX_CLIENT_ID' ) && define( 'CONNECT_WOO_SANDBOX_CLIENT_ID', 'AYmOHbt1VHg-OZ_oihPdzKEVbU3qg0qXonBcAztuzniQRaKE0w1Hr762cSFwd4n8wxOl-TCWohEa0XM_' );


### PR DESCRIPTION
* Fix - Calculate totals after adding shipping to include taxes #2296
* Fix - Package tracking integration throws error in 2.7.1 #2289
* Fix - Make PayPal Subscription products unique in cart #2265
* Fix - PayPal declares subscription support when merchant not enabled for Reference Transactions #2282
* Fix - Google Pay and Apple Pay Settings button from Connection tab have wrong links #2273
* Fix - Smart Buttons in Block Checkout not respecting the location setting (2830) #2278
* Fix - Disable Pay Upon Invoice if billing/shipping country not set #2281
* Enhancement - Enable shipping callback for WC subscriptions #2259
* Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
* Enhancement - Improve "Could not retrieve order" error message #2271