### PR TITLE
Add WPML compatibility to the settings (223)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -154,8 +154,10 @@ class Settings implements ContainerInterface {
 				'woocommerce-paypal-payments'
 			),
 		);
+
 		foreach ( $defaults as $key => $value ) {
 			if ( isset( $this->settings[ $key ] ) ) {
+				$this->settings[ $key ] = apply_filters( 'woocommerce_paypal_payments_settings_value', $this->settings[ $key ], $key );
 				continue;
 			}
 			$this->settings[ $key ] = $value;


### PR DESCRIPTION
### Description

This PR adds a filter `woocommerce_paypal_payments_settings_value` that allows for filtering of plugin settings value.

### Note

I wasn't able to create a compat filter from the compat modules, as the compat module always executes later.

### MU plugin to test

Save the following code to a file, and add it to the `wp-content/mu-plugins` folder:
```
<?php
/*
 * Plugin Name: WooCommerce PayPal Payments Settings Filter
 * Description: Adds a filter to translate WooCommerce PayPal Payments settings before other plugins are loaded.
 * Author: Danny
 * Version: 1.0
 */

add_filter(
    'woocommerce_paypal_payments_settings_value',
    function( $value, $key ) {
        return ! is_array( $value ) ? apply_filters( 'wpml_translate_single_string', $value, 'admin_texts_woocommerce-ppcp-settings', '[woocommerce-ppcp-settings]' . $key ) : $value;
    },
    10,
    2
);
```

### Steps to Test

1. Install WPML, WooCommerce WPML and String Translations.
2. Set it up.
3. Go to the String Translation page in the WPML settings.
4. Search for `Pay via PayPal.`
5. Click on `Can't find the strings you're looking to translate?` and then on the `Choose texts for translation` button.
6. Add the `Pay via PayPal.` to translation and actually translate it.
7. Go to the Checkout page with the translated string.
8. Verify that the translated string appears correctly.
