### PR TITLE
Improve "Could not retrieve order" error message (3131)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -220,14 +220,9 @@ class OrderProcessor {
 				);
 
 				throw new PayPalOrderMissingException(
-					sprintf(
-						// translators: %s: Order history URL on My Account section.
-						esc_attr__(
-							'There was an error processing your order. Please check for any charges in your payment method and review your <a href="%s">order history</a> before placing the order again.',
-							// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Intentionally "woocommerce" to reflect the original message.
-							'woocommerce'
-						),
-						esc_url( wc_get_account_endpoint_url( 'orders' ) )
+					esc_attr__(
+						'There was an error processing your order. Please check for any charges in your payment method and review your order history before placing the order again.',
+						'woocommerce-paypal-payments'
 					)
 				);
 			}


### PR DESCRIPTION
**Problem:**
The previous adjustment displayed HTML code in the error message.

As we throw a PHP exception, the handler-code escaped the full string, rendering HTML useless. As a first solution, we removed the HTML code from the error string.

**Side effect:**
Since the message is now different from the original WooCommerce message, we cannot use their text domain for translation anymore.



