### PR TITLE
Release 2.8.0-rc2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Enhancement - Enable shipping callback for WC subscriptions #2259
 * Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
 * Enhancement - Improve "Could not retrieve order" error message #2271
+* Enhancement - Add block Checkout compatibility to Advanced Card Processing #2246
 
 = 2.7.1 - 2024-05-28 =
 * Fix - Ensure package tracking data is sent to original PayPal transaction #2180

--- a/readme.txt
+++ b/readme.txt
@@ -179,18 +179,6 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 
 == Changelog ==
 
-= 2.7.1 - 2024-05-28 =
-* Fix - Ensure package tracking data is sent to original PayPal transaction #2180
-* Fix - Set the 'Woo_PPCP' as a default value for data-partner-attribution-id #2188
-* Fix - Allow PUI Gateway for refund processor #2192
-* Fix - Notice on newly created block cart checkout #2211
-* Fix - Apple Pay button in the editor #2177
-* Fix - Allow shipping callback and skipping confirmation page from any express button #2236
-* Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
-* Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
-* Fix - Enable the Shipping Callback handlers #2266
-* Enhancement - Use admin theme color #1602
-
 = 2.8.0 - xxxx-xx-xx =
 * Fix - Calculate totals after adding shipping to include taxes #2296
 * Fix - Package tracking integration throws error in 2.7.1 #2289
@@ -202,6 +190,19 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Enhancement - Enable shipping callback for WC subscriptions #2259
 * Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
 * Enhancement - Improve "Could not retrieve order" error message #2271
+* Enhancement - Add block Checkout compatibility to Advanced Card Processing #2246
+
+= 2.7.1 - 2024-05-28 =
+* Fix - Ensure package tracking data is sent to original PayPal transaction #2180
+* Fix - Set the 'Woo_PPCP' as a default value for data-partner-attribution-id #2188
+* Fix - Allow PUI Gateway for refund processor #2192
+* Fix - Notice on newly created block cart checkout #2211
+* Fix - Apple Pay button in the editor #2177
+* Fix - Allow shipping callback and skipping confirmation page from any express button #2236
+* Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
+* Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
+* Fix - Enable the Shipping Callback handlers #2266
+* Enhancement - Use admin theme color #1602
 
 = 2.7.0 - 2024-04-30 =
 * Fix - Zero sum subscriptions cause CANNOT_BE_ZERO_OR_NEGATIVE when using Vault v3 #2152


### PR DESCRIPTION
[2.8.0-rc1](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.8.0-rc1) plus:
* Enhancement - Add block Checkout compatibility to Advanced Card Processing #2246