### PR TITLE
Add Litespeed Cache and W3 Total Cache compatibility (3190)

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -54,6 +54,18 @@ return array(
 		);
 	},
 
+	'compat.plugin-script-file-names'                => static function( ContainerInterface $container ) : array {
+		return array(
+			'button.js',
+			'gateway-settings.js',
+			'status-page.js',
+			'order-edit-page.js',
+			'fraudnet.js',
+			'tracking-compat.js',
+			'ppcp-clear-db.js',
+		);
+	},
+
 	'compat.gzd.is_supported_plugin_version_active'  => function (): bool {
 		return function_exists( 'wc_gzd_get_shipments_by_order' ); // 3.0+
 	},

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -325,7 +325,7 @@ class CompatModule implements ModuleInterface {
 		// Siteground SG Optimize.
 		add_filter(
 			'sgo_js_minify_exclude',
-			function( $scripts ) use ( $ppcp_script_names ) {
+			function( array $scripts ) use ( $ppcp_script_names ) {
 				return array_merge( $scripts, $ppcp_script_names );
 			}
 		);
@@ -333,7 +333,7 @@ class CompatModule implements ModuleInterface {
 		// LiteSpeed Cache.
 		add_filter(
 			'litespeed_optimize_js_excludes',
-			function( $excluded_js ) use ( $ppcp_script_file_names ) {
+			function( array $excluded_js ) use ( $ppcp_script_file_names ) {
 				return array_merge( $excluded_js, $ppcp_script_file_names );
 			}
 		);
@@ -341,7 +341,7 @@ class CompatModule implements ModuleInterface {
 		// W3 Total Cache.
 		add_filter(
 			'w3tc_minify_js_do_tag_minification',
-			function( $do_tag_minification, $script_tag, $file ) {
+			function( bool $do_tag_minification, string $script_tag, string $file ) {
 				if ( $file && strpos( $file, 'ppcp' ) !== false ) {
 					return false;
 				}


### PR DESCRIPTION
### Description

This PR prevents Litespeed Cache and W3 Total Cache from minifying PayPal Payments JS files.

### Additional info

In addition to Litespeed Cache and W3 Total Cache I have also tried breaking PayPal Payments with the following:
- WP Rocket
- WP Optimize

But actually wasn't able to, so no need for compatibility filtering.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. With `trunk`:
2. Install Litespeed Cache and W3 Total Cache separately.
3. Activate JS minifying and all the most aggressive caching options.
4. Check whether the `button.js` gets minified and bundled into the cached/minified JS file and is not loading individually.
5. Switch to `PCP-3190-prevent-w-3-total-cache-plugin-from-caching-minifying-scripts` and make sure `button.js` loads individually.

### Screenshots
N/A