### PR TITLE
Only prevent multiple subscription products in cart if PayPal Subscription API is active (3215)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -94,12 +94,24 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			static function ( $passed_validation, $product_id ) {
+			static function ( $passed_validation, $product_id ) use ( $c ) {
 				if ( WC()->cart->is_empty() ) {
 					return $passed_validation;
 				}
 
 				$product = wc_get_product( $product_id );
+
+				$settings           = $c->get( 'wcgateway.settings' );
+				$subscriptions_mode = $settings->get( 'subscriptions_mode' );
+
+				if ( 'subscriptions_api' !== $subscriptions_mode ) {
+					if ( $product->get_sold_individually() ) {
+						$product->set_sold_individually( false );
+						$product->save();
+					}
+
+					return $passed_validation;
+				}
 
 				if ( $product && $product->get_meta( '_ppcp_enable_subscription_product', true ) === 'yes' ) {
 					if ( ! $product->get_sold_individually() ) {

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -105,7 +105,7 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 				$subscriptions_mode = $settings->get( 'subscriptions_mode' );
 
 				if ( 'subscriptions_api' !== $subscriptions_mode ) {
-					if ( $product->get_sold_individually() ) {
+					if ( $product && $product->get_sold_individually() ) {
 						$product->set_sold_individually( false );
 						$product->save();
 					}


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Added a check to ensure that subscription products can be added to cart multiple times as long as PayPal Subscription API is not active.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Switch to PayPal Vaulting or disable subscription mode in PayPal plugin settings;
2. Try to add product in cart.
