### PR TITLE
ACDC Block - Credit card is not saved when subscription product is bought as a guest (3213)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/card-fields.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.js
@@ -25,6 +25,14 @@ export function CardFields({config, eventRegistration, emitResponse, components}
     }
 
     const hasSubscriptionProducts = cartHasSubscriptionProducts(config.scriptData);
+    useEffect(() => {
+        localStorage.removeItem('ppcp-save-card-payment');
+
+        if(hasSubscriptionProducts) {
+            localStorage.setItem('ppcp-save-card-payment', 'true');
+        }
+
+    }, [hasSubscriptionProducts])
 
     useEffect(
         () =>

--- a/modules/ppcp-blocks/resources/js/card-fields-config.js
+++ b/modules/ppcp-blocks/resources/js/card-fields-config.js
@@ -35,7 +35,6 @@ export async function onApprove(data) {
     })
         .then((response) => response.json())
         .then((data) => {
-            console.log(data)
             localStorage.removeItem('ppcp-save-card-payment');
         })
         .catch((err) => {


### PR DESCRIPTION
When buying a subscription type product as a guest while ACDC Vaulting is active, the payment method is not saved for the newly created WordPress user.

### Steps To Reproduce
- As admin enable WC Subscriptions plugin and create a new subscription product
- Enable Vaulting for ACDC
- Navigate to shop as guest
- Add subscription product to cart and navigate to block checkout
- Select ACDC gateway, enter credit card data and pay

Navigate to MyAccount → Payment methods
Observe no saved payment methods in list

### Expected behaviour
Payment method is saved a guest user creates an account during the checkout, eg. when buying a subscription type product.

### Possible cause
Current `localStorage` implementation for save payment method check does not work correctly for guest users, it send [save_payment_method](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-blocks/resources/js/card-fields-config.js#L13) as `false`.

### Suggested solution
Ensure`localStorage` sets true on page load when there is a WC subscription product in the cart. It also removes `localStorage` key on page load to avoid previous value being used.