### PR TITLE
Release 2.8.0-rc4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - Google Pay and Apple Pay Settings button from Connection tab have wrong links #2273
 * Fix - Smart Buttons in Block Checkout not respecting the location setting (2830) #2278
 * Fix - Disable Pay Upon Invoice if billing/shipping country not set #2281
+* Fix - Critical error on pay for order page when we try to pay with ACDC gateway #2321
 * Enhancement - Enable shipping callback for WC subscriptions #2259
 * Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
 * Enhancement - Improve "Could not retrieve order" error message #2271

--- a/readme.txt
+++ b/readme.txt
@@ -187,6 +187,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Google Pay and Apple Pay Settings button from Connection tab have wrong links #2273
 * Fix - Smart Buttons in Block Checkout not respecting the location setting (2830) #2278
 * Fix - Disable Pay Upon Invoice if billing/shipping country not set #2281
+* Fix - Critical error on pay for order page when we try to pay with ACDC gateway #2321
 * Enhancement - Enable shipping callback for WC subscriptions #2259
 * Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
 * Enhancement - Improve "Could not retrieve order" error message #2271


### PR DESCRIPTION
[2.8.0-rc3](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.8.0-rc3) plus:
* Fix - Critical error on pay for order page when we try to pay with ACDC gateway #2321