### PR TITLE
AXO: Add a Continue button next to the email input (3208)

### DIFF
--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -12,6 +12,19 @@
 	}
 }
 
+.email-submit-button {
+	position: relative;
+	.loader:before {
+		display: inline;
+		height: 12px;
+		width: 12px;
+		margin-left: -6px;
+		margin-top: -6px;
+		left: auto;
+		right: auto;
+	}
+}
+
 .ppcp-axo-payment-container {
 	padding: 1rem 0;
 	background-color: #ffffff;
@@ -101,7 +114,7 @@
 }
 
 .email-submit-button {
-	padding: 5px 10px;
+	padding: 5px 20px;
 	background-color: #007cba;
 	color: white;
 	border: none;

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -28,6 +28,16 @@
 	}
 }
 
+.ppcp-axo-billing-email-submit-button {
+	&-hidden {
+		opacity: 0;
+	}
+
+	&-loaded:not([disabled]) {
+		opacity: 1;
+	}
+}
+
 .ppcp-axo-payment-container {
 	padding: 1rem 0;
 	background-color: #ffffff;
@@ -106,15 +116,7 @@
 	}
 }
 
-.ppcp-axo-billing-email-submit-button-hidden {
-	opacity: 0;
-}
-
-.ppcp-axo-billing-email-submit-button-loaded:not([disabled]) {
-	opacity: 1;
-}
-
-#billing_email_field .woocommerce-input-wrapper {
+.ppcp-axo-customer-details #billing_email_field .woocommerce-input-wrapper {
 	display: flex;
 	align-items: center;
 
@@ -129,7 +131,7 @@
 		width: 100%;
 		margin-top: 0.5rem;
 	}
-	#billing_email_field .woocommerce-input-wrapper {
+	.ppcp-axo-customer-details #billing_email_field .woocommerce-input-wrapper {
 		display: block;
 
 		input {
@@ -137,4 +139,5 @@
 		}
 	}
 }
+
 

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -12,8 +12,11 @@
 	}
 }
 
-.email-submit-button {
+#ppcp-axo-billing-email-submit-button {
+	margin-top: 0;
 	position: relative;
+	transition: opacity 0.3s ease;
+
 	.loader:before {
 		display: inline;
 		height: 12px;
@@ -103,30 +106,35 @@
 	}
 }
 
+.ppcp-axo-billing-email-submit-button-hidden {
+	opacity: 0;
+}
+
+.ppcp-axo-billing-email-submit-button-loaded:not([disabled]) {
+	opacity: 1;
+}
+
 #billing_email_field .woocommerce-input-wrapper {
 	display: flex;
 	align-items: center;
+
+	input {
+		flex: 1;
+		margin-right: 10px;
+	}
 }
 
-#billing_email_field .woocommerce-input-wrapper input {
-	flex: 1;
-	margin-right: 10px;
-}
+@media screen and (max-width: 719px) {
+	#ppcp-axo-billing-email-submit-button {
+		width: 100%;
+		margin-top: 0.5rem;
+	}
+	#billing_email_field .woocommerce-input-wrapper {
+		display: block;
 
-.email-submit-button {
-	padding: 5px 20px;
-	background-color: #007cba;
-	color: white;
-	border: none;
-	border-radius: 3px;
-	cursor: pointer;
-	flex-shrink: 0;
-	opacity: 0;
-	transition: opacity 0.3s ease; /* Add transition for opacity */
+		input {
+			margin-right: 0;
+		}
+	}
 }
-
-#billing_email_field .woocommerce-input-wrapper.show-button .email-submit-button {
-	opacity: 1; /* Show the button */
-}
-
 

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -89,3 +89,31 @@
 		max-height: 25px;
 	}
 }
+
+#billing_email_field .woocommerce-input-wrapper {
+	display: flex;
+	align-items: center;
+}
+
+#billing_email_field .woocommerce-input-wrapper input {
+	flex: 1;
+	margin-right: 10px;
+}
+
+.email-submit-button {
+	padding: 5px 10px;
+	background-color: #007cba;
+	color: white;
+	border: none;
+	border-radius: 3px;
+	cursor: pointer;
+	flex-shrink: 0;
+	opacity: 0;
+	transition: opacity 0.3s ease; /* Add transition for opacity */
+}
+
+#billing_email_field .woocommerce-input-wrapper.show-button .email-submit-button {
+	opacity: 1; /* Show the button */
+}
+
+

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -12,10 +12,17 @@
 	}
 }
 
+#ppcp-axo-billing-email-field-wrapper {
+	display: flex;
+	gap: 0.5rem;
+}
+
 #ppcp-axo-billing-email-submit-button {
 	margin-top: 0;
 	position: relative;
 	transition: opacity 0.3s ease;
+	flex: 0 1 auto;
+	align-self: flex-start;
 
 	.loader:before {
 		display: inline;
@@ -117,27 +124,20 @@
 }
 
 .ppcp-axo-customer-details #billing_email_field .woocommerce-input-wrapper {
-	display: flex;
-	align-items: center;
-
-	input {
-		flex: 1;
-		margin-right: 10px;
-	}
+	flex: 1 1 auto;
 }
 
 @media screen and (max-width: 719px) {
-	#ppcp-axo-billing-email-submit-button {
-		width: 100%;
-		margin-top: 0.5rem;
-	}
-	.ppcp-axo-customer-details #billing_email_field .woocommerce-input-wrapper {
-		display: block;
+	#ppcp-axo-billing-email {
+		&-field-wrapper {
+			flex-direction: column;
+		}
 
-		input {
-			margin-right: 0;
+		&-submit-button {
+			align-self: auto;
 		}
 	}
 }
+
 
 

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -167,17 +167,14 @@ class AxoManager {
                 ev.preventDefault();
                 log(`Enter key attempt - emailInput: ${this.emailInput.value}`);
                 log(`this.lastEmailCheckedIdentity: ${this.lastEmailCheckedIdentity}`);
+                this.validateEmail(this.el.fieldBillingEmail.selector);
                 if (this.emailInput && this.lastEmailCheckedIdentity !== this.emailInput.value) {
                     await this.onChangeEmail();
                 }
             }
         });
 
-        this.$('form.woocommerce-checkout input').on('click', async (ev) => {
-            if (document.querySelector(this.el.billingEmailSubmitButton.selector).hasAttribute('disabled')) {
-                document.querySelector(this.el.billingEmailSubmitButton.selector).removeAttribute('disabled');
-            }
-        });
+        this.reEnableEmailInput();
 
         // Clear last email checked identity when email field is focused.
         this.$('#billing_email_field input').on('focus', (ev) => {
@@ -479,7 +476,7 @@ class AxoManager {
             // Move email to the AXO container.
             let emailRow = document.querySelector(this.el.fieldBillingEmail.selector);
             wrapperElement.prepend(emailRow);
-            document.querySelector(this.el.billingEmailFieldWrapper.selector).prepend(document.querySelector('#billing_email_field .woocommerce-input-wrapper'))
+            document.querySelector(this.el.billingEmailFieldWrapper.selector).prepend(document.querySelector('#billing_email_field .woocommerce-input-wrapper'));
         }
     }
 
@@ -534,8 +531,8 @@ class AxoManager {
 
             document.querySelector(this.el.billingEmailSubmitButton.selector).offsetHeight;
             document.querySelector(this.el.billingEmailSubmitButton.selector).classList.remove('ppcp-axo-billing-email-submit-button-hidden');
-            document.querySelector(this.el.billingEmailSubmitButton.selector).offsetHeight;
-            document.querySelector(this.el.billingEmailSubmitButton.selector).classList.add('ppcp-axo-billing-email-submit-button-loaded');        }
+            document.querySelector(this.el.billingEmailSubmitButton.selector).classList.add('ppcp-axo-billing-email-submit-button-loaded');
+        }
     }
 
     watchEmail() {
@@ -549,6 +546,7 @@ class AxoManager {
                 log(`Change event attempt - emailInput: ${this.emailInput.value}`);
                 log(`this.lastEmailCheckedIdentity: ${this.lastEmailCheckedIdentity}`);
                 if (this.emailInput && this.lastEmailCheckedIdentity !== this.emailInput.value) {
+                    this.validateEmail(this.el.fieldBillingEmail.selector);
                     this.onChangeEmail();
                 }
             });
@@ -586,7 +584,7 @@ class AxoManager {
 
         this.lastEmailCheckedIdentity = this.emailInput.value;
 
-        if (!this.emailInput.value || !this.emailInput.checkValidity()) {
+        if (!this.emailInput.value || !this.emailInput.checkValidity() || !this.validateEmailFormat(this.emailInput.value)) {
             log('The email address is not valid.');
             return;
         }
@@ -935,6 +933,39 @@ class AxoManager {
         if (watermarkLoader) {
             watermarkLoader.classList.toggle(loaderClass);
         }
+    }
+
+    validateEmailFormat(value) {
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return emailPattern.test(value);
+    }
+
+    validateEmail(billingEmail) {
+        const billingEmailSelector = document.querySelector(billingEmail);
+        const value = document.querySelector(billingEmail + ' input').value;
+
+        if (this.validateEmailFormat(value)) {
+            billingEmailSelector.classList.remove('woocommerce-invalid');
+            billingEmailSelector.classList.add('woocommerce-validated');
+            this.setStatus('validEmail', true);
+        } else {
+            billingEmailSelector.classList.remove('woocommerce-validated');
+            billingEmailSelector.classList.add('woocommerce-invalid');
+            this.setStatus('validEmail', false);
+        }
+    }
+
+    reEnableEmailInput() {
+        const reEnableInput = (ev) => {
+            const submitButton = document.querySelector(this.el.billingEmailSubmitButton.selector);
+            if (submitButton.hasAttribute('disabled')) {
+                submitButton.removeAttribute('disabled');
+            }
+        };
+
+        this.$('#billing_email_field input').on('focus', reEnableInput);
+        this.$('#billing_email_field input').on('input', reEnableInput);
+        this.$('#billing_email_field input').on('click', reEnableInput);
     }
 }
 

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -225,8 +225,10 @@ class AxoManager {
 
         if (scenario.defaultSubmitButton) {
             this.el.defaultSubmitButton.show();
+            this.el.billingEmailSubmitButton.hide();
         } else {
             this.el.defaultSubmitButton.hide();
+            this.el.billingEmailSubmitButton.show();
         }
 
         if (scenario.defaultEmailField) {
@@ -252,8 +254,8 @@ class AxoManager {
             this.el.watermarkContainer.show();
 
             // Move watermark to after email.
-            this.$(this.el.fieldBillingEmail.selector).append(
-                this.$(this.el.watermarkContainer.selector)
+            document.querySelector('#billing_email_field .woocommerce-input-wrapper').append(
+                document.querySelector(this.el.watermarkContainer.selector)
             );
         } else {
             this.el.emailWidgetContainer.hide();
@@ -433,10 +435,18 @@ class AxoManager {
             `);
         }
 
+        // billingEmailFieldWrapper
+        const befw = this.el.billingEmailFieldWrapper;
+        if (!document.querySelector(befw.selector)) {
+            document.querySelector('#billing_email_field .woocommerce-input-wrapper').insertAdjacentHTML('afterend', `
+                <div id="${befw.id}"></div>
+            `);
+        }
+
         // Watermark container
         const wc = this.el.watermarkContainer;
         if (!document.querySelector(wc.selector)) {
-            this.emailInput.insertAdjacentHTML('afterend', `
+            document.querySelector(befw.selector).insertAdjacentHTML('beforeend', `
                 <div class="${wc.className}" id="${wc.id}"></div>
             `);
         }
@@ -466,10 +476,10 @@ class AxoManager {
             }
 
         } else {
-
             // Move email to the AXO container.
             let emailRow = document.querySelector(this.el.fieldBillingEmail.selector);
             wrapperElement.prepend(emailRow);
+            document.querySelector(this.el.billingEmailFieldWrapper.selector).prepend(document.querySelector('#billing_email_field .woocommerce-input-wrapper'))
         }
     }
 
@@ -515,7 +525,7 @@ class AxoManager {
         const billingEmailSubmitButtonSpinner = this.el.billingEmailSubmitButtonSpinner;
 
         if (!document.querySelector(billingEmailSubmitButton.selector)) {
-            this.emailInput.insertAdjacentHTML('afterend', `
+            document.querySelector(this.el.billingEmailFieldWrapper.selector).insertAdjacentHTML('beforeend', `
                 <button type="button" id="${billingEmailSubmitButton.id}" class="${billingEmailSubmitButton.className}">
                     ${this.axoConfig.billing_email_button_text}
                     <span id="${billingEmailSubmitButtonSpinner.id}"></span>

--- a/modules/ppcp-axo/resources/js/Components/DomElementCollection.js
+++ b/modules/ppcp-axo/resources/js/Components/DomElementCollection.js
@@ -61,11 +61,14 @@ class DomElementCollection {
         });
 
         this.billingEmailSubmitButton = new DomElement({
+            id: 'ppcp-axo-billing-email-submit-button',
             selector: '#ppcp-axo-billing-email-submit-button',
+            className: 'ppcp-axo-billing-email-submit-button-hidden button alt wp-element-button wc-block-components-button'
         });
 
         this.billingEmailSubmitButtonSpinner = new DomElement({
-            selector: '#ppcp-axo-billing-email-submit-spinner',
+            id: 'ppcp-axo-billing-email-submit-button-spinner',
+            selector: '#ppcp-axo-billing-email-submit-button-spinner',
             className: 'loader ppcp-axo-overlay'
         });
 

--- a/modules/ppcp-axo/resources/js/Components/DomElementCollection.js
+++ b/modules/ppcp-axo/resources/js/Components/DomElementCollection.js
@@ -7,6 +7,10 @@ class DomElementCollection {
             selector: '#payment_method_ppcp-axo-gateway',
         });
 
+        this.gatewayDescription = new DomElement({
+            selector: '.payment_box.payment_method_ppcp-axo-gateway',
+        });
+
         this.defaultSubmitButton = new DomElement({
             selector: '#place_order',
         });

--- a/modules/ppcp-axo/resources/js/Components/DomElementCollection.js
+++ b/modules/ppcp-axo/resources/js/Components/DomElementCollection.js
@@ -60,6 +60,11 @@ class DomElementCollection {
             selector: '#billing_email_field'
         });
 
+        this.billingEmailFieldWrapper = new DomElement({
+            id: 'ppcp-axo-billing-email-field-wrapper',
+            selector: '#ppcp-axo-billing-email-field-wrapper',
+        });
+
         this.billingEmailSubmitButton = new DomElement({
             id: 'ppcp-axo-billing-email-submit-button',
             selector: '#ppcp-axo-billing-email-submit-button',

--- a/modules/ppcp-axo/resources/js/Components/DomElementCollection.js
+++ b/modules/ppcp-axo/resources/js/Components/DomElementCollection.js
@@ -60,6 +60,15 @@ class DomElementCollection {
             selector: '#billing_email_field'
         });
 
+        this.billingEmailSubmitButton = new DomElement({
+            selector: '#ppcp-axo-billing-email-submit-button',
+        });
+
+        this.billingEmailSubmitButtonSpinner = new DomElement({
+            selector: '#ppcp-axo-billing-email-submit-spinner',
+            className: 'loader ppcp-axo-overlay'
+        });
+
         this.submitButtonContainer = new DomElement({
             selector: '#ppcp-axo-submit-button-container',
         });

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -162,13 +162,13 @@ class AxoManager {
 	 */
 	private function script_data() {
 		return array(
-			'environment'     => array(
+			'environment'               => array(
 				'is_sandbox' => $this->environment->current_environment() === 'sandbox',
 			),
-			'widgets'         => array(
+			'widgets'                   => array(
 				'email' => 'render',
 			),
-			'insights'        => array(
+			'insights'                  => array(
 				'enabled'    => true,
 				'client_id'  => ( $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : null ),
 				'session_id' =>
@@ -182,7 +182,7 @@ class AxoManager {
 					'value'         => WC()->cart->get_total( 'numeric' ),
 				),
 			),
-			'style_options'   => array(
+			'style_options'             => array(
 				'root'  => array(
 					'backgroundColor' => $this->settings->has( 'axo_style_root_bg_color' ) ? $this->settings->get( 'axo_style_root_bg_color' ) : '',
 					'errorColor'      => $this->settings->has( 'axo_style_root_error_color' ) ? $this->settings->get( 'axo_style_root_error_color' ) : '',
@@ -201,16 +201,16 @@ class AxoManager {
 					'focusBorderColor' => $this->settings->has( 'axo_style_input_focus_border_color' ) ? $this->settings->get( 'axo_style_input_focus_border_color' ) : '',
 				),
 			),
-			'name_on_card'    => $this->settings->has( 'axo_name_on_card' ) ? $this->settings->get( 'axo_name_on_card' ) : '',
-			'woocommerce'     => array(
+			'name_on_card'              => $this->settings->has( 'axo_name_on_card' ) ? $this->settings->get( 'axo_name_on_card' ) : '',
+			'woocommerce'               => array(
 				'states' => array(
 					'US' => WC()->countries->get_states( 'US' ),
 					'CA' => WC()->countries->get_states( 'CA' ),
 				),
 			),
-			'icons_directory' => esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/',
-			'module_url'      => untrailingslashit( $this->module_url ),
-			'ajax'            => array(
+			'icons_directory'           => esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/',
+			'module_url'                => untrailingslashit( $this->module_url ),
+			'ajax'                      => array(
 				'frontend_logger' => array(
 					'endpoint' => \WC_AJAX::get_endpoint( FrontendLoggerEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -216,6 +216,7 @@ class AxoManager {
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),
 				),
 			),
+			'billing_email_button_text' => __( 'Continue', 'woocommerce-paypal-payments' ),
 		);
 	}
 

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -168,7 +168,7 @@ class AxoGateway extends WC_Payment_Gateway {
 			? $this->ppcp_settings->get( 'axo_gateway_title' )
 			: $this->get_option( 'title', $this->method_title );
 
-		$this->description = __( 'Enter your email address above to proceed.', 'woocommerce-paypal-payments' );
+		$this->description = __( 'Enter your email address to continue.', 'woocommerce-paypal-payments' );
 
 		$this->init_form_fields();
 		$this->init_settings();

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -168,7 +168,7 @@ class AxoGateway extends WC_Payment_Gateway {
 			? $this->ppcp_settings->get( 'axo_gateway_title' )
 			: $this->get_option( 'title', $this->method_title );
 
-		$this->description = $this->get_option( 'description', '' );
+		$this->description = __( 'Enter your email address above to proceed.', 'woocommerce-paypal-payments' );
 
 		$this->init_form_fields();
 		$this->init_settings();


### PR DESCRIPTION
### Description

This PR adds a Continue button near the email input to better communicate the action required to trigger Fastlane email lookup.

It also adds a description to the Fastlane payment gateway radio selection.


### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Open the checkout as a guest to enter the Fastlane checkout experience.
2. Notice the button next to the email input.
3. On mobile make sure the button displays below the watermark.
4. Make sure the overlay and spinner display correctly during email lookup.
5. Make sure the button is hidden when a different payment gateway gets selected.
6. Verify the payment gateway description displays correctly next to the radio.


### Screenshots

#### Desktop
|Before|After|
|-|-|
|![before_desktop](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/c9ed3531-019d-41f6-be9d-f9a94601de5a)|![Checkout_–_WooCommerce_PayPal_Payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/0ce9937e-0689-4af3-9994-d133fefaca8e)|

#### Mobile
|Before|After|
|-|-|
|![mobile_before](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/d027cb55-80c0-4183-8e8f-b5a7d5cd299f)|![Checkout_–_WooCommerce_PayPal_Payments-2](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/c51edf03-ffd7-4094-856b-81f6f8752af3)|