### PR TITLE
Fix the fatal error when the ppcp-paylater-configurator module is disabled (3207)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -73,12 +73,12 @@ return function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-paylater-block/module.php" )();
 	}
 
-	if ( PayLaterWCBlocksModule::is_module_loading_required() ) {
-		$modules[] = ( require "$modules_dir/ppcp-paylater-wc-blocks/module.php" )();
-	}
-
 	if ( PayLaterConfiguratorModule::is_enabled() ) {
 		$modules[] = ( require "$modules_dir/ppcp-paylater-configurator/module.php" )();
+
+		if ( PayLaterWCBlocksModule::is_module_loading_required() ) {
+			$modules[] = ( require "$modules_dir/ppcp-paylater-wc-blocks/module.php" )();
+		}
 	}
 
 	if ( apply_filters(


### PR DESCRIPTION
### Description

This PR makes the `ppcp-paylater-wc-blocks` module dependent on `ppcp-paylater-configurator` being loaded (as the WC PayLater Blocks are dependent on the settings of the Pay Later configurator).

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->
1. Install the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
2. Add the following code:
`add_filter( 'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_configurator_enabled', '__return_false' );`
3. Load a page (frontend).
4. Confirm there is no fatal error.

### Screenshots
N/A