### PR TITLE
AXO: Add AUD, CAD, EUR, GBP, and JPY as supported Fastlane currencies (3239)

### DIFF
--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -153,7 +153,7 @@ return array(
 					'EUR',
 					'GBP',
 					'JPY',
-					'USD'
+					'USD',
 				),
 			)
 		);

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -148,7 +148,12 @@ return array(
 			'woocommerce_paypal_payments_axo_supported_country_currency_matrix',
 			array(
 				'US' => array(
-					'USD',
+					'AUD',
+					'CAD',
+					'EUR',
+					'GBP',
+					'JPY',
+					'USD'
 				),
 			)
 		);


### PR DESCRIPTION
### Description

This PR adds the following currency support to Fastlane: `AUD`, `CAD`, `EUR`, `GBP`, `JPY`.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Set up Fastlane.
2. Set store currency to the supported currency, test for each: `AUD`, `CAD`, `EUR`, `GBP`, `JPY`.
3. Confirm Fastlane correctly appears on Checkout.

### Screenshots

N/A