### PR TITLE
AXO: Disable logging when WP_DEBUG is set to false (3252)

### DIFF
--- a/modules/ppcp-axo/resources/js/Helper/Debug.js
+++ b/modules/ppcp-axo/resources/js/Helper/Debug.js
@@ -1,6 +1,7 @@
 export function log(message, level = 'info') {
+    const wpDebug = window.wc_ppcp_axo?.wp_debug;
     const endpoint = window.wc_ppcp_axo?.ajax?.frontend_logger?.endpoint;
-    if(!endpoint) {
+    if(!wpDebug || !endpoint) {
         return;
     }
 

--- a/modules/ppcp-axo/resources/js/Helper/Debug.js
+++ b/modules/ppcp-axo/resources/js/Helper/Debug.js
@@ -1,7 +1,7 @@
 export function log(message, level = 'info') {
     const wpDebug = window.wc_ppcp_axo?.wp_debug;
     const endpoint = window.wc_ppcp_axo?.ajax?.frontend_logger?.endpoint;
-    if(!wpDebug || !endpoint) {
+    if (!endpoint) {
         return;
     }
 
@@ -16,12 +16,14 @@ export function log(message, level = 'info') {
             }
         })
     }).then(() => {
-        switch (level) {
-            case 'error':
-                console.error(`[AXO] ${message}`);
-                break;
-            default:
-                console.log(`[AXO] ${message}`);
+        if (wpDebug) {
+            switch (level) {
+                case 'error':
+                    console.error(`[AXO] ${message}`);
+                    break;
+                default:
+                    console.log(`[AXO] ${message}`);
+            }
         }
     });
 }

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -169,7 +169,7 @@ class AxoManager {
 				'email' => 'render',
 			),
 			'insights'                  => array(
-				'enabled'    => true,
+				'enabled'    => defined( 'WP_DEBUG' ) && WP_DEBUG,
 				'client_id'  => ( $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : null ),
 				'session_id' =>
 					substr(
@@ -216,7 +216,7 @@ class AxoManager {
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),
 				),
 			),
-			'wp_debug'        => defined( 'WP_DEBUG' ) && WP_DEBUG,
+			'wp_debug'                  => defined( 'WP_DEBUG' ) && WP_DEBUG,
 			'billing_email_button_text' => __( 'Continue', 'woocommerce-paypal-payments' ),
 		);
 	}

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -216,7 +216,7 @@ class AxoManager {
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),
 				),
 			),
-			'wp_debug'        => defined('WP_DEBUG') && WP_DEBUG,
+			'wp_debug'        => defined( 'WP_DEBUG' ) && WP_DEBUG,
 		);
 	}
 

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -216,7 +216,7 @@ class AxoManager {
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),
 				),
 			),
-			'wp_debug'        => \WP_DEBUG,
+			'wp_debug'        => defined('WP_DEBUG') && WP_DEBUG,
 		);
 	}
 

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -216,6 +216,7 @@ class AxoManager {
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),
 				),
 			),
+			'wp_debug'        => \WP_DEBUG,
 		);
 	}
 


### PR DESCRIPTION
### Description

This PR disables Fastlane logging when `WP_DEBUG` is set to `false`.


### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Make sure `WP_DEBUG` is set to `false`.
2. Open the Fastlane checkout.
3. Open the console log, and make sure there are no [AXO] log entries.


### Screenshots

#### Desktop
|Before|After|
|-|-|
|![Cursor_i_Checkout_–_WooCommerce_PayPal_Payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/0c26b681-a702-4983-abce-b197d795eccf)|![Checkout_–_WooCommerce_PayPal_Payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/eea926a4-20c0-4133-b843-baac49f01843)|
