### PR TITLE
PayPal webhooks are being indiscriminately deleted.

### DIFF
--- a/modules/ppcp-webhooks/src/WebhookRegistrar.php
+++ b/modules/ppcp-webhooks/src/WebhookRegistrar.php
@@ -121,7 +121,11 @@ class WebhookRegistrar {
 			$webhooks = $this->endpoint->list();
 			foreach ( $webhooks as $webhook ) {
 				try {
-					$this->endpoint->delete( $webhook );
+					if( $stored_webhook = get_option( self::KEY ) ) {
+						if( $stored_webhook['id'] === $webhook->id() ) {
+							$this->endpoint->delete( $webhook );
+						}
+					}
 				} catch ( RuntimeException $deletion_error ) {
 					$this->logger->error( "Failed to delete webhook {$webhook->id()}: {$deletion_error->getMessage()}" );
 				}


### PR DESCRIPTION
PayPal webhooks are being indiscriminately deleted. This change ensures only this plugin's webhook is deleted.

**Issue**: #2337

Closes #2337 
