### PR TITLE
AXO: Disable Fastlane for Order Pay endpoint (3256)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -386,6 +386,6 @@ class AxoModule implements ModuleInterface {
 	 */
 	private function is_excluded_endpoint(): bool {
 		// Exclude the Order Pay endpoint.
-		return is_wc_endpoint_url('order-pay');
+		return is_wc_endpoint_url( 'order-pay' );
 	}
 }

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -74,6 +74,10 @@ class AxoModule implements ModuleInterface {
 					return $methods;
 				}
 
+				if ( $this->is_excluded_endpoint() ) {
+					return $methods;
+				}
+
 				$methods[] = $gateway;
 				return $methods;
 			},
@@ -328,7 +332,8 @@ class AxoModule implements ModuleInterface {
 
 		return ! is_user_logged_in()
 			&& CartCheckoutDetector::has_classic_checkout()
-			&& $is_axo_enabled;
+			&& $is_axo_enabled
+			&& ! $this->is_excluded_endpoint();
 	}
 
 	/**
@@ -372,5 +377,15 @@ class AxoModule implements ModuleInterface {
 				12
 			);
 		}
+	}
+
+	/**
+	 * Condition to evaluate if the current endpoint is excluded.
+	 *
+	 * @return bool
+	 */
+	private function is_excluded_endpoint(): bool {
+		// Exclude the Order Pay endpoint.
+		return is_wc_endpoint_url('order-pay');
 	}
 }


### PR DESCRIPTION
### Description

This PR disables Fastlane for the Order Pay (`order-pay`) endpoint.


### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Make sure you can access the Order Pay page without being logged in. Code snippet [here](https://www.businessbloomer.com/woocommerce-allow-to-pay-for-order-without-login/).
2. Open an Order Pay page for an order:
![Edit_order__27_‹_WooCommerce_PayPal_Payments_—_WordPress](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/825043f1-b04e-4715-a03a-778b5e78437d)
3. Confirm that Fastlane isn't available.

### Screenshots

|Before|After|
|-|-|
|![before_axo_disabled](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/893ed708-d684-4525-ba51-72253ddb1abb)|![after_disable_axo](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/42258b79-d696-42a0-bcd8-63d4fbbdbe1d)|
