### PR TITLE
AXO: Disable Fastlane when ACDC is disabled (3128)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -74,6 +74,19 @@ class AxoModule implements ModuleInterface {
 					return $methods;
 				}
 
+				if ( is_user_logged_in() ) {
+					return $methods;
+				}
+
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				$is_dcc_enabled = $settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' ) ?? false;
+
+				if ( ! $is_dcc_enabled ) {
+					return $methods;
+				}
+
 				$methods[] = $gateway;
 				return $methods;
 			},
@@ -325,10 +338,12 @@ class AxoModule implements ModuleInterface {
 	 */
 	private function should_render_fastlane( Settings $settings ): bool {
 		$is_axo_enabled = $settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' ) ?? false;
+		$is_dcc_enabled = $settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' ) ?? false;
 
 		return ! is_user_logged_in()
 			&& CartCheckoutDetector::has_classic_checkout()
-			&& $is_axo_enabled;
+			&& $is_axo_enabled
+			&& $is_dcc_enabled;
 	}
 
 	/**


### PR DESCRIPTION
### Description

This PR disables Fastlane when ACDC is disabled.


### Steps to Test

1. Enable Fastlane.
2. Disable ACDC.
3. Confirm that Fastlane doesn't (try to) get loaded on the checkout page.

### Screenshots

|Before|After|
|-|-|
|![before](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/82121c5b-4094-4d2b-be75-775adfa63c3f)|![Window_i_Checkout_–_WooCommerce_PayPal_Payments](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/5a05c060-f72d-401f-ad87-655980dfb5ca)|
