### PR TITLE
Add filter for adding more contexts in can_render_dcc checker (3181)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -707,7 +707,11 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 		return $this->settings->has( 'dcc_enabled' ) && $this->settings->get( 'dcc_enabled' )
 			&& $this->settings->has( 'client_id' ) && $this->settings->get( 'client_id' )
 			&& $this->dcc_applies->for_country_currency()
-			&& in_array( $this->context(), array( 'checkout', 'pay-now', 'add-payment-method' ), true );
+			&& in_array(
+				$this->context(),
+				apply_filters( 'woocommerce_paypal_payments_can_render_dcc_contexts', array( 'checkout', 'pay-now', 'add-payment-method' ) ),
+				true
+			);
 	}
 
 	/**


### PR DESCRIPTION
This PR introduces a filter for adding more contexts in `can_render_dcc` checker.

Usage:
```
add_filter('woocommerce_paypal_payments_can_render_dcc_contexts', function(array $contexts) {
	$contexts[] = 'cart';

 	return $contexts;
});
```