### PR TITLE
AXO: Fix the layout with the Twenty Twenty-Four theme (3249)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -277,10 +277,13 @@ class AxoManager {
 
             this.el.watermarkContainer.show();
 
+            // Add class to customer details container.
+            this.$(this.el.axoCustomerDetails.selector).addClass('col-1');
         } else {
             this.shippingView.deactivate();
             this.billingView.deactivate();
             this.cardView.deactivate();
+            this.$(this.el.axoCustomerDetails.selector).removeClass('col-1');
         }
 
         if (scenario.axoPaymentContainer) {


### PR DESCRIPTION
### Description

This PR adds the `col-1` to the customer details container in order to fix the layout in themes like Twenty Twenty-Four.


### Steps to Test

1. Enable Fastlane.
2. Activate the 2024 theme.
3. Make sure the layout displays correctly in the Ryan flow.

### Screenshots

|Before|After|
|-|-|
|![before_col-1](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/46b6140b-319b-4faa-b6aa-c3cb889209cb)|![after_col-1](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/25d7f243-2ca8-4728-bf76-35fc4f6431e3)|
