### PR TITLE
Don't render tracking metaBox if can't retrieve PayPal order (3289)

### DIFF
--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -80,7 +80,7 @@ class MetaBoxRenderer {
 	 * Renders the order tracking MetaBox.
 	 *
 	 * @param WC_Order $wc_order The WC order.
-	 * @param string $capture_id The PayPal order capture ID.
+	 * @param string   $capture_id The PayPal order capture ID.
 	 */
 	public function render( WC_Order $wc_order, string $capture_id ): void {
 		$order_items      = $wc_order->get_items();

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -13,10 +13,6 @@ use Exception;
 use WC_Order;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
-use WP_Post;
-
-use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class MetaBoxRenderer
@@ -28,8 +24,6 @@ use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
  * @psalm-type Carriers = array<CarrierType, Carrier>
  */
 class MetaBoxRenderer {
-
-	use TransactionIdHandlingTrait;
 
 	/**
 	 * Allowed shipping statuses.
@@ -85,21 +79,10 @@ class MetaBoxRenderer {
 	/**
 	 * Renders the order tracking MetaBox.
 	 *
-	 * @param mixed $post_or_order_object Either WP_Post or WC_Order when COT is data source.
+	 * @param WC_Order $wc_order The WC order.
+	 * @param string $capture_id The PayPal order capture ID.
 	 */
-	public function render( $post_or_order_object ): void {
-		$wc_order = ( $post_or_order_object instanceof WP_Post ) ? wc_get_order( $post_or_order_object->ID ) : $post_or_order_object;
-		if ( ! $wc_order instanceof WC_Order ) {
-			return;
-		}
-
-		$paypal_order = ppcp_get_paypal_order( $wc_order );
-		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order ) ?? '';
-
-		if ( ! $capture_id ) {
-			return;
-		}
-
+	public function render( WC_Order $wc_order, string $capture_id ): void {
 		$order_items      = $wc_order->get_items();
 		$order_item_count = ! empty( $order_items ) ? count( $order_items ) : 0;
 

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -89,6 +89,15 @@ class OrderTrackingModule implements ModuleInterface {
 
 		add_action(
 			'add_meta_boxes',
+			/**
+			 * Adds the tracking metabox.
+			 *
+			 * @param string $post_type The post type.
+			 * @param WP_Post|WC_Order $post_or_order_object The post/order object.
+			 * @return void
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
 			function( string $post_type, $post_or_order_object ) use ( $meta_box_renderer, $bearer ) {
 				if ( ! $this->is_tracking_enabled( $bearer ) ) {
 					return;

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -89,7 +89,7 @@ class OrderTrackingModule implements ModuleInterface {
 
 		add_action(
 			'add_meta_boxes',
-			function(string $post_type, $post_or_order_object) use ( $meta_box_renderer, $bearer ) {
+			function( string $post_type, $post_or_order_object ) use ( $meta_box_renderer, $bearer ) {
 				if ( ! $this->is_tracking_enabled( $bearer ) ) {
 					return;
 				}
@@ -101,11 +101,11 @@ class OrderTrackingModule implements ModuleInterface {
 
 				try {
 					$paypal_order = ppcp_get_paypal_order( $wc_order );
-				} catch (Exception $exception) {
+				} catch ( Exception $exception ) {
 					return;
 				}
 
-				$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order ) ?? '';
+				$capture_id = $this->get_paypal_order_transaction_id( $paypal_order ) ?? '';
 
 				if ( ! $capture_id ) {
 					return;
@@ -124,7 +124,7 @@ class OrderTrackingModule implements ModuleInterface {
 				add_meta_box(
 					'ppcp_order-tracking',
 					__( 'PayPal Package Tracking', 'woocommerce-paypal-payments' ),
-					static function () use( $meta_box_renderer , $wc_order, $capture_id ): void {
+					static function () use ( $meta_box_renderer, $wc_order, $capture_id ): void {
 						$meta_box_renderer->render( $wc_order, $capture_id );
 					},
 					$screen,

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
+use Exception;
+use WC_Order;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
@@ -18,13 +20,16 @@ use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\OrderTracking\Assets\OrderEditPageAssets;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
+use WP_Post;
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class OrderTrackingModule
  */
 class OrderTrackingModule implements ModuleInterface {
 
-	use TrackingAvailabilityTrait;
+	use TrackingAvailabilityTrait, TransactionIdHandlingTrait;
 
 	public const PPCP_TRACKING_INFO_META_NAME = '_ppcp_paypal_tracking_info_meta_name';
 
@@ -80,10 +85,29 @@ class OrderTrackingModule implements ModuleInterface {
 		);
 
 		$meta_box_renderer = $c->get( 'order-tracking.meta-box.renderer' );
+		assert( $meta_box_renderer instanceof MetaBoxRenderer );
+
 		add_action(
 			'add_meta_boxes',
-			function() use ( $meta_box_renderer, $bearer ) {
+			function(string $post_type, $post_or_order_object) use ( $meta_box_renderer, $bearer ) {
 				if ( ! $this->is_tracking_enabled( $bearer ) ) {
+					return;
+				}
+
+				$wc_order = ( $post_or_order_object instanceof WP_Post ) ? wc_get_order( $post_or_order_object->ID ) : $post_or_order_object;
+				if ( ! $wc_order instanceof WC_Order ) {
+					return;
+				}
+
+				try {
+					$paypal_order = ppcp_get_paypal_order( $wc_order );
+				} catch (Exception $exception) {
+					return;
+				}
+
+				$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order ) ?? '';
+
+				if ( ! $capture_id ) {
 					return;
 				}
 
@@ -100,7 +124,9 @@ class OrderTrackingModule implements ModuleInterface {
 				add_meta_box(
 					'ppcp_order-tracking',
 					__( 'PayPal Package Tracking', 'woocommerce-paypal-payments' ),
-					array( $meta_box_renderer, 'render' ),
+					static function () use( $meta_box_renderer , $wc_order, $capture_id ): void {
+						$meta_box_renderer->render( $wc_order, $capture_id );
+					},
 					$screen,
 					'side',
 					'high'


### PR DESCRIPTION
# PR Description

The logic for not rendering metabox is moved from renderer to module's `run` method where the [add_meta_boxes](https://developer.wordpress.org/reference/hooks/add_meta_boxes/) action is used. This allows to early return before the [add_meta_box](https://developer.wordpress.org/reference/functions/add_meta_box/) is called, preventing the metabox from being rendered at all.
Additionally, if the PayPal order cannot be retrieved, the metabox will not be rendered.

# Issue Description

When PayPal order cannot be retrieved the order tracking metaBox shows fatal error and breaks the page. This can happen for example if the merchant account is changed.

```
Fatal error: Uncaught WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException: Could not retrieve order. in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php:484 Stack trace: #0 /var/www/html/wp-content/plugins/woocommerce-paypal-payments/api/order-functions.php(48): WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint->order('53011713EK26700...') #1 /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-order-tracking/src/MetaBoxRenderer.php(96): WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order('53011713EK26700...') #2 /var/www/html/wp-admin/includes/template.php(1456): WooCommerce\PayPalCommerce\OrderTracking\MetaBoxRenderer->render(Object(WC_Order), Array) #3 /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php(496): do_meta_boxes(Object(WP_Screen), 'normal', Object(WC_Order)) #4 /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php(405): Automattic\WooCommerce\Internal\Admin\Orders\Edit->render_meta_boxes() #5 /var/www/html/wp-content/plugins/woocommerce/src/Internal/Admin/Orders/PageController.php(293): Automattic\WooCommerce\Internal\Admin\Orders\Edit->display() #6 /var/www/html/wp-includes/class-wp-hook.php(324): Automattic\WooCommerce\Internal\Admin\Orders\PageController->output('') #7 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array) #8 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #9 /var/www/html/wp-admin/admin.php(259): do_action('woocommerce_pag...') #10 {main} thrown in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php on line 484
```

### Steps To Reproduce

- Buy a product.
- Change merchant account.
- Visit the order page

