### PR TITLE
2.8.1-alpha1 - Server 500 error when adding to cart >1 product if PCP is activated (3300)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -102,7 +102,9 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 				$product = wc_get_product( $product_id );
 
 				$settings           = $c->get( 'wcgateway.settings' );
-				$subscriptions_mode = $settings->get( 'subscriptions_mode' );
+				assert($settings instanceof Settings);
+
+				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
 
 				if ( 'subscriptions_api' !== $subscriptions_mode ) {
 					if ( $product && $product->get_sold_individually() ) {

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -101,8 +101,8 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 
 				$product = wc_get_product( $product_id );
 
-				$settings           = $c->get( 'wcgateway.settings' );
-				assert($settings instanceof Settings);
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
 
 				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
 


### PR DESCRIPTION
Adding second product to the cart causes 500 server error for both UI or API.

### Steps To Reproduce
- On fresh site install 2.8.1
- Activate WooCommerce and PCP
- Navigate to the shop on frontend
- Add 1 product to the clear cart
- Add 1 more product

### Possible cause
[NotFoundException](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-wc-gateway/src/Settings/Settings.php#L89) from Settings.php is thrown [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php#L105) when subscriptions_mode settings does not exist.

### Suggested solution
To avoid this situation either use [has](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-wc-gateway/src/Settings/Settings.php#L101) or use a try/catch to handle the exception:
```
$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
```