### PR TITLE
Fix Apple Pay button layout (3237)

### DIFF
--- a/modules/ppcp-applepay/resources/css/styles.scss
+++ b/modules/ppcp-applepay/resources/css/styles.scss
@@ -4,21 +4,20 @@
 	--apple-pay-button-min-height: 35px;
 	--apple-pay-button-width: 100%;
 	--apple-pay-button-max-width: 750px;
-	--apple-pay-button-border-radius: 4px;
+	--apple-pay-button-border-radius: var(--apm-button-border-radius);
 	--apple-pay-button-overflow: hidden;
+	--apple-pay-button-box-sizing: border-box;
 
 	.ppcp-width-min & {
 		--apple-pay-button-height: 35px;
 	}
+
 	.ppcp-width-300 & {
 		--apple-pay-button-height: 45px;
 	}
+
 	.ppcp-width-500 & {
 		--apple-pay-button-height: 55px;
-	}
-
-	&.ppcp-button-pill {
-		--apple-pay-button-border-radius: 50px;
 	}
 
 	&.ppcp-button-minicart {

--- a/modules/ppcp-button/resources/css/mixins/apm-button.scss
+++ b/modules/ppcp-button/resources/css/mixins/apm-button.scss
@@ -1,17 +1,19 @@
 
 @mixin button {
+	--apm-button-border-radius: 4px;
+
 	overflow: hidden;
 	min-width: 0;
 	max-width: 750px;
 	line-height: 0;
-	border-radius: 4px;
+	border-radius: var(--apm-button-border-radius);
 
 	// Defaults
 	height: 45px;
 	margin-top: 14px;
 
 	&.ppcp-button-pill {
-		border-radius: 50px;
+		--apm-button-border-radius: 50px;
 	}
 
 	&.ppcp-button-minicart {

--- a/modules/ppcp-googlepay/resources/css/styles.scss
+++ b/modules/ppcp-googlepay/resources/css/styles.scss
@@ -1,5 +1,11 @@
 .ppcp-button-googlepay {
 	min-height: 40px;
+
+	.gpay-card-info-container,
+	.gpay-button {
+		outline-offset: -1px;
+		border-radius: var(--apm-button-border-radius);
+	}
 }
 
 .wp-block-woocommerce-checkout, .wp-block-woocommerce-cart {


### PR DESCRIPTION
### Problem

When using the Apple Pay button color "White with outline", the outline was not visible.
Also, the Google Pay button with color "White" did not display the outline.

### Solution

- Adjusted the CSS for both buttons to contain the outline within the button shape.
- Added new CSS variable `--apm-button-border-radius` to better handle the pill shape outline

### Screenshot

<img width="612" alt="pcp-3237-before-after" src="https://github.com/woocommerce/woocommerce-paypal-payments/assets/2669200/1c564e43-dd80-41ca-af59-74b3b7487f3b">
