### PR TITLE
Release 2.8.1-rc1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,15 +1,15 @@
 *** Changelog ***
 
 = 2.8.1 - xxxx-xx-xx =
-* Fix - Don't render tracking metaBox if can't retrieve PayPal order #2360
-* Fix - Fatal error when the ppcp-paylater-configurator module is disabled (3207) #2327
-* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving them to Advanced Card Processing tab #2325
-* Fix - Fix Smart Buttons on Elementor checkout #2284
-* Fix - Add WPML compatibility to the settings #2308
-* Enhancement - Add filter for adding more contexts in can_render_dcc checker #2346
+* Fix - Don't render tracking metabox if PayPal order does not belong to connected merchant #2360
+* Fix - Fatal error when the ppcp-paylater-configurator module is disabled via code snippet #2327
+* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving the configuration to Advanced Card Processing tab #2325
+* Fix - Fix Smart Buttons on Elementor checkout widget #2284
+* Enhancement - Add filter for certain settings to allow gateway translation e.g. via WPML #2308
+* Enhancement - Filter for adding more contexts in can_render_dcc checker #2346
 * Enhancement - Do not request id_token for guest users #2283
-* Enhancement - Only prevent multiple subscription products in cart if PayPal Subscription API is active #2320
-* Enhancement - Add Litespeed Cache and W3 Total Cache compatibility #2316
+* Enhancement - Prevent multiple PayPal Subscription products in the cart if PayPal Subscription API is active #2320
+* Enhancement - Prevent script caching & minification from Litespeed Cache and W3 Total Cache plugins #2316
 
 = 2.8.0 - 2024-06-11 =
 * Fix - Calculate totals after adding shipping to include taxes #2296

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,16 @@
 *** Changelog ***
 
+= 2.8.1 - xxxx-xx-xx =
+* Fix - Don't render tracking metaBox if can't retrieve PayPal order #2360
+* Fix - Fatal error when the ppcp-paylater-configurator module is disabled (3207) #2327
+* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving them to Advanced Card Processing tab #2325
+* Fix - Fix Smart Buttons on Elementor checkout #2284
+* Fix - Add WPML compatibility to the settings #2308
+* Enhancement - Add filter for adding more contexts in can_render_dcc checker #2346
+* Enhancement - Do not request id_token for guest users #2283
+* Enhancement - Only prevent multiple subscription products in cart if PayPal Subscription API is active #2320
+* Enhancement - Add Litespeed Cache and W3 Total Cache compatibility #2316
+
 = 2.8.0 - 2024-06-11 =
 * Fix - Calculate totals after adding shipping to include taxes #2296
 * Fix - Package tracking integration throws error in 2.7.1 #2289

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, checkout, cart, pay later, apple
 Requires at least: 5.3
 Tested up to: 6.5
 Requires PHP: 7.2
-Stable tag: 2.8.0
+Stable tag: 2.8.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -178,6 +178,17 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 6. Main settings screen.
 
 == Changelog ==
+
+= 2.8.1 - xxxx-xx-xx =
+* Fix - Don't render tracking metaBox if can't retrieve PayPal order #2360
+* Fix - Fatal error when the ppcp-paylater-configurator module is disabled (3207) #2327
+* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving them to Advanced Card Processing tab #2325
+* Fix - Fix Smart Buttons on Elementor checkout #2284
+* Fix - Add WPML compatibility to the settings #2308
+* Enhancement - Add filter for adding more contexts in can_render_dcc checker #2346
+* Enhancement - Do not request id_token for guest users #2283
+* Enhancement - Only prevent multiple subscription products in cart if PayPal Subscription API is active #2320
+* Enhancement - Add Litespeed Cache and W3 Total Cache compatibility #2316
 
 = 2.8.0 - 2024-06-11 =
 * Fix - Calculate totals after adding shipping to include taxes #2296

--- a/readme.txt
+++ b/readme.txt
@@ -180,15 +180,15 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 == Changelog ==
 
 = 2.8.1 - xxxx-xx-xx =
-* Fix - Don't render tracking metaBox if can't retrieve PayPal order #2360
-* Fix - Fatal error when the ppcp-paylater-configurator module is disabled (3207) #2327
-* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving them to Advanced Card Processing tab #2325
-* Fix - Fix Smart Buttons on Elementor checkout #2284
-* Fix - Add WPML compatibility to the settings #2308
-* Enhancement - Add filter for adding more contexts in can_render_dcc checker #2346
+* Fix - Don't render tracking metabox if PayPal order does not belong to connected merchant #2360
+* Fix - Fatal error when the ppcp-paylater-configurator module is disabled via code snippet #2327
+* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving the configuration to Advanced Card Processing tab #2325
+* Fix - Fix Smart Buttons on Elementor checkout widget #2284
+* Enhancement - Add filter for certain settings to allow gateway translation e.g. via WPML #2308
+* Enhancement - Filter for adding more contexts in can_render_dcc checker #2346
 * Enhancement - Do not request id_token for guest users #2283
-* Enhancement - Only prevent multiple subscription products in cart if PayPal Subscription API is active #2320
-* Enhancement - Add Litespeed Cache and W3 Total Cache compatibility #2316
+* Enhancement - Prevent multiple PayPal Subscription products in the cart if PayPal Subscription API is active #2320
+* Enhancement - Prevent script caching & minification from Litespeed Cache and W3 Total Cache plugins #2316
 
 = 2.8.0 - 2024-06-11 =
 * Fix - Calculate totals after adding shipping to include taxes #2296

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,14 +3,14 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     2.8.0
+ * Version:     2.8.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.2
  * Requires Plugins: woocommerce
  * WC requires at least: 3.9
- * WC tested up to: 8.9
+ * WC tested up to: 9.0
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce
@@ -26,7 +26,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2024-06-03' );
+define( 'PAYPAL_INTEGRATION_DATE', '2024-06-25' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );
 ! defined( 'CONNECT_WOO_SANDBOX_CLIENT_ID' ) && define( 'CONNECT_WOO_SANDBOX_CLIENT_ID', 'AYmOHbt1VHg-OZ_oihPdzKEVbU3qg0qXonBcAztuzniQRaKE0w1Hr762cSFwd4n8wxOl-TCWohEa0XM_' );


### PR DESCRIPTION
* Fix - Don't render tracking metaBox if can't retrieve PayPal order #2360
* Fix - Fatal error when the ppcp-paylater-configurator module is disabled (3207) #2327
* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving them to Advanced Card Processing tab #2325
* Fix - Fix Smart Buttons on Elementor checkout #2284
* Fix - Add WPML compatibility to the settings #2308
* Enhancement - Add filter for adding more contexts in can_render_dcc checker #2346
* Enhancement - Do not request id_token for guest users #2283
* Enhancement - Only prevent multiple subscription products in cart if PayPal Subscription API is active #2320
* Enhancement - Add Litespeed Cache and W3 Total Cache compatibility #2316