### PR TITLE
Don't break orders screen when there is an exception for package tracking (3314)

### DIFF
--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -57,7 +57,8 @@ return array(
 			$container->get( 'order-tracking.allowed-shipping-statuses' ),
 			$container->get( 'order-tracking.available-carriers' ),
 			$container->get( 'order-tracking.endpoint.controller' ),
-			$container->get( 'order-tracking.should-use-second-version-of-api' )
+			$container->get( 'order-tracking.should-use-second-version-of-api' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 	'order-tracking.allowed-shipping-statuses'        => static function ( ContainerInterface $container ): array {

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
 use Exception;
+use Psr\Log\LoggerInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentInterface;
@@ -61,6 +62,13 @@ class MetaBoxRenderer {
 	protected $should_use_new_api;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	protected $logger;
+
+	/**
 	 * MetaBoxRenderer constructor.
 	 *
 	 * @param string[]              $allowed_statuses Allowed shipping statuses.
@@ -68,18 +76,21 @@ class MetaBoxRenderer {
 	 * @psalm-param Carriers        $carriers
 	 * @param OrderTrackingEndpoint $order_tracking_endpoint The order tracking endpoint.
 	 * @param bool                  $should_use_new_api Whether new API should be used.
+	 * @param LoggerInterface       $logger The logger.
 	 */
 	public function __construct(
 		array $allowed_statuses,
 		array $carriers,
 		OrderTrackingEndpoint $order_tracking_endpoint,
-		bool $should_use_new_api
+		bool $should_use_new_api,
+		LoggerInterface $logger
 	) {
 
 		$this->allowed_statuses        = $allowed_statuses;
 		$this->carriers                = $carriers;
 		$this->order_tracking_endpoint = $order_tracking_endpoint;
 		$this->should_use_new_api      = $should_use_new_api;
+		$this->logger                  = $logger;
 	}
 
 	/**

--- a/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
+++ b/modules/ppcp-order-tracking/src/MetaBoxRenderer.php
@@ -97,12 +97,17 @@ class MetaBoxRenderer {
 		$order_items      = $wc_order->get_items();
 		$order_item_count = ! empty( $order_items ) ? count( $order_items ) : 0;
 
-		/**
-		 * The shipments
-		 *
-		 * @var ShipmentInterface[] $shipments
-		 */
-		$shipments = $this->order_tracking_endpoint->list_tracking_information( $wc_order->get_id() ) ?? array();
+		try {
+			/**
+			 * The shipments
+			 *
+			 * @var ShipmentInterface[] $shipments
+			 */
+			$shipments = $this->order_tracking_endpoint->list_tracking_information( $wc_order->get_id() ) ?? array();
+		} catch ( Exception $exception ) {
+			$this->logger->log( 'warning', $exception->getMessage() );
+			return;
+		}
 		?>
 		<div class="ppcp-tracking-columns-wrapper">
 			<div class="ppcp-tracking-column">


### PR DESCRIPTION
# PR Description

In edition to #2360 added 1 more `try/catch` which will prevent breaking order page when problem getting the tracking info. Instead it will log the error and will not render the metabox

# Issue Description

When an error happens in order tracking metaBox, it shows the fatal error and breaks the page. 

