### PR TITLE
Apple Pay and Google Pay buttons don't appear in PayPal Button stack on multi-step Checkout (3250)

### DIFF
--- a/modules/ppcp-applepay/resources/js/boot.js
+++ b/modules/ppcp-applepay/resources/js/boot.js
@@ -1,6 +1,7 @@
 import {loadCustomScript} from "@paypal/paypal-js";
 import {loadPaypalScript} from "../../../ppcp-button/resources/js/modules/Helper/ScriptLoading";
 import ApplepayManager from "./ApplepayManager";
+import { debounce } from '../../../ppcp-blocks/resources/js/Helper/debounce';
 
 (function ({
                buttonConfig,
@@ -15,19 +16,19 @@ import ApplepayManager from "./ApplepayManager";
         manager.init();
     };
 
-    jQuery(document.body).on('updated_cart_totals updated_checkout', () => {
+    const refresh = debounce(function() {
         if (manager) {
             manager.reinit();
         }
-    });
+    }, 50);
+
+    jQuery(document).on('ppcp_refresh_payment_buttons', refresh);
+
+    jQuery(document.body).on('updated_cart_totals updated_checkout', refresh);
 
     // Use set timeout as it's unnecessary to refresh upon Minicart initial render.
     setTimeout(() => {
-        jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', () => {
-            if (manager) {
-                manager.reinit();
-            }
-        });
+        jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', refresh);
     }, 1000);
 
     document.addEventListener(

--- a/modules/ppcp-applepay/resources/js/boot.js
+++ b/modules/ppcp-applepay/resources/js/boot.js
@@ -1,7 +1,7 @@
 import {loadCustomScript} from "@paypal/paypal-js";
 import {loadPaypalScript} from "../../../ppcp-button/resources/js/modules/Helper/ScriptLoading";
 import ApplepayManager from "./ApplepayManager";
-import { debounce } from '../../../ppcp-blocks/resources/js/Helper/debounce';
+import {setupButtonEvents} from '../../../ppcp-button/resources/js/modules/Helper/ButtonRefreshHelper';
 
 (function ({
                buttonConfig,
@@ -16,20 +16,11 @@ import { debounce } from '../../../ppcp-blocks/resources/js/Helper/debounce';
         manager.init();
     };
 
-    const refresh = debounce(function() {
+    setupButtonEvents(function() {
         if (manager) {
             manager.reinit();
         }
-    }, 50);
-
-    jQuery(document).on('ppcp_refresh_payment_buttons', refresh);
-
-    jQuery(document.body).on('updated_cart_totals updated_checkout', refresh);
-
-    // Use set timeout as it's unnecessary to refresh upon Minicart initial render.
-    setTimeout(() => {
-        jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', refresh);
-    }, 1000);
+    });
 
     document.addEventListener(
         'DOMContentLoaded',

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -17,6 +17,7 @@ import {
 import {setVisibleByClass} from "./modules/Helper/Hiding";
 import {isChangePaymentPage} from "./modules/Helper/Subscriptions";
 import FreeTrialHandler from "./modules/ActionHandler/FreeTrialHandler";
+import MultistepCheckoutHelper from "./modules/Helper/MultistepCheckoutHelper";
 import FormSaver from './modules/Helper/FormSaver';
 import FormValidator from "./modules/Helper/FormValidator";
 import {loadPaypalScript} from "./modules/Helper/ScriptLoading";
@@ -52,6 +53,8 @@ const bootstrap = () => {
     ) : null;
 
     const freeTrialHandler = new FreeTrialHandler(PayPalCommerceGateway, checkoutFormSelector, formSaver, formValidator, spinner, errorHandler);
+
+    new MultistepCheckoutHelper(checkoutFormSelector);
 
     jQuery('form.woocommerce-checkout input').on('keydown', e => {
         if (e.key === 'Enter' && [

--- a/modules/ppcp-button/resources/js/modules/Helper/ButtonRefreshHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ButtonRefreshHelper.js
@@ -1,0 +1,37 @@
+import { debounce } from '../../../../../ppcp-blocks/resources/js/Helper/debounce';
+
+const REFRESH_BUTTON_EVENT = 'ppcp_refresh_payment_buttons';
+
+/**
+ * Triggers a refresh of the payment buttons.
+ * This function dispatches a custom event that the button components listen for.
+ *
+ * Use this function on the front-end to update payment buttons after the checkout form was updated.
+ */
+export function refreshButtons() {
+    document.dispatchEvent(new Event(REFRESH_BUTTON_EVENT));
+}
+
+/**
+ * Sets up event listeners for various cart and checkout update events.
+ * When these events occur, it triggers a refresh of the payment buttons.
+ *
+ * @param {Function} refresh - Callback responsible to re-render the payment button.
+ */
+export function setupButtonEvents(refresh) {
+    const miniCartInitDelay = 1000;
+    const debouncedRefresh = debounce(refresh, 50);
+
+    // Listen for our custom refresh event.
+    document.addEventListener(REFRESH_BUTTON_EVENT, debouncedRefresh);
+
+    // Listen for cart and checkout update events.
+    document.body.addEventListener('updated_cart_totals', debouncedRefresh);
+    document.body.addEventListener('updated_checkout', debouncedRefresh);
+
+    // Use setTimeout for fragment events to avoid unnecessary refresh on initial render.
+    setTimeout(() => {
+        document.body.addEventListener('wc_fragments_loaded', debouncedRefresh);
+        document.body.addEventListener('wc_fragments_refreshed', debouncedRefresh);
+    }, miniCartInitDelay);
+}

--- a/modules/ppcp-button/resources/js/modules/Helper/MultistepCheckoutHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/MultistepCheckoutHelper.js
@@ -1,3 +1,5 @@
+import { refreshButtons } from './ButtonRefreshHelper';
+
 /**
  * The MultistepCheckoutHelper class ensures the initialization of payment buttons
  * on websites using a multistep checkout plugin. These plugins usually hide the
@@ -105,16 +107,9 @@ class MultistepCheckoutHelper {
      */
     checkElement() {
         if (this.isVisible) {
-            this.refreshButtons();
+            refreshButtons();
             this.stop();
         }
-    }
-
-    /**
-     * Initializes the payment buttons on the visibility of wrapper.
-     */
-    refreshButtons() {
-        document.dispatchEvent(new Event('ppcp_refresh_payment_buttons'));
     }
 }
 

--- a/modules/ppcp-button/resources/js/modules/Helper/MultistepCheckoutHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/MultistepCheckoutHelper.js
@@ -1,0 +1,121 @@
+/**
+ * The MultistepCheckoutHelper class ensures the initialization of payment buttons
+ * on websites using a multistep checkout plugin. These plugins usually hide the
+ * payment button on page load up and reveal it later using JS. During the
+ * invisibility period of wrappers, some payment buttons fail to initialize,
+ * so we wait for the payment element to be visible.
+ *
+ * @property {HTMLElement} form - Checkout form element.
+ * @property {HTMLElement} triggerElement - Element, which visibility we need to detect.
+ * @property {boolean} isVisible - Whether the triggerElement is visible.
+ */
+class MultistepCheckoutHelper {
+
+    /**
+     * Configuration that defines the HTML selector for the component we are waiting to be visible.
+     * @type {string}
+     */
+    #triggerElementSelector = '.woocommerce-checkout-payment';
+
+    /**
+     * Interval (in milliseconds) in which the visibility of the trigger element is checked.
+     * @type {number}
+     */
+    #intervalTime = 150;
+
+    /**
+     * The interval ID returned by the setInterval() method.
+     * @type {number|false}
+     */
+    #intervalId;
+
+    /**
+     * Selector passed to the constructor that identifies the checkout form
+     * @type {string}
+     */
+    #formSelector;
+
+    /**
+     * @param {string} formSelector - Selector of the checkout form
+     */
+    constructor(formSelector) {
+        this.#formSelector = formSelector;
+        this.#intervalId = false;
+
+        /*
+         Start the visibility checker after a brief delay. This allows eventual multistep plugins to
+         dynamically prepare the checkout page, so we can decide whether this helper is needed.
+         */
+        setTimeout(() => {
+            if (this.form && !this.isVisible) {
+                this.start();
+            }
+        }, 250);
+    }
+
+    /**
+     * The checkout form element.
+     * @returns {Element|null} - Form element or null.
+     */
+    get form() {
+        return document.querySelector(this.#formSelector);
+    }
+
+    /**
+     * The element which must be visible before payment buttons should be initialized.
+     * @returns {Element|null} - Trigger element or null.
+     */
+    get triggerElement() {
+        return this.form?.querySelector(this.#triggerElementSelector);
+    }
+
+    /**
+     * Checks the visibility of the payment button wrapper.
+     * @returns {boolean} - returns boolean value on the basis of visibility of element.
+     */
+    get isVisible() {
+        const box = this.triggerElement?.getBoundingClientRect();
+
+        return !!(box && box.width && box.height);
+    }
+
+    /**
+     * Starts the observation of the DOM, initiates monitoring the checkout form.
+     * To ensure multiple calls to start don't create multiple intervals, we first call stop.
+     */
+    start() {
+        this.stop();
+        this.#intervalId = setInterval(() => this.checkElement(), this.#intervalTime);
+    }
+
+    /**
+     * Stops the observation of the checkout form.
+     * Multiple calls to stop are safe as clearInterval doesn't throw if provided ID doesn't exist.
+     */
+    stop() {
+        if (this.#intervalId) {
+            clearInterval(this.#intervalId);
+            this.#intervalId = false;
+        }
+    }
+
+    /**
+     * Checks if the trigger element is visible.
+     * If visible, it initialises the payment buttons and stops the observation.
+     */
+    checkElement() {
+        if (this.isVisible) {
+            this.refreshButtons();
+            this.stop();
+        }
+    }
+
+    /**
+     * Initializes the payment buttons on the visibility of wrapper.
+     */
+    refreshButtons() {
+        document.dispatchEvent(new Event('ppcp_refresh_payment_buttons'));
+    }
+}
+
+export default MultistepCheckoutHelper;

--- a/modules/ppcp-button/resources/js/modules/Helper/MultistepCheckoutHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/MultistepCheckoutHelper.js
@@ -1,5 +1,7 @@
 import { refreshButtons } from './ButtonRefreshHelper';
 
+const DEFAULT_TRIGGER_ELEMENT_SELECTOR = '.woocommerce-checkout-payment';
+
 /**
  * The MultistepCheckoutHelper class ensures the initialization of payment buttons
  * on websites using a multistep checkout plugin. These plugins usually hide the
@@ -14,10 +16,10 @@ import { refreshButtons } from './ButtonRefreshHelper';
 class MultistepCheckoutHelper {
 
     /**
-     * Configuration that defines the HTML selector for the component we are waiting to be visible.
+     * Selector that defines the HTML element we are waiting to become visible.
      * @type {string}
      */
-    #triggerElementSelector = '.woocommerce-checkout-payment';
+    #triggerElementSelector;
 
     /**
      * Interval (in milliseconds) in which the visibility of the trigger element is checked.
@@ -39,9 +41,11 @@ class MultistepCheckoutHelper {
 
     /**
      * @param {string} formSelector - Selector of the checkout form
+     * @param {string} triggerElementSelector - Optional. Selector of the dependant element.
      */
-    constructor(formSelector) {
+    constructor(formSelector, triggerElementSelector = '') {
         this.#formSelector = formSelector;
+        this.#triggerElementSelector = triggerElementSelector || DEFAULT_TRIGGER_ELEMENT_SELECTOR;
         this.#intervalId = false;
 
         /*

--- a/modules/ppcp-googlepay/resources/js/boot.js
+++ b/modules/ppcp-googlepay/resources/js/boot.js
@@ -1,6 +1,7 @@
 import {loadCustomScript} from "@paypal/paypal-js";
 import {loadPaypalScript} from "../../../ppcp-button/resources/js/modules/Helper/ScriptLoading";
 import GooglepayManager from "./GooglepayManager";
+import { debounce } from '../../../ppcp-blocks/resources/js/Helper/debounce';
 
 (function ({
    buttonConfig,
@@ -15,19 +16,19 @@ import GooglepayManager from "./GooglepayManager";
         manager.init();
     };
 
-    jQuery(document.body).on('updated_cart_totals updated_checkout', () => {
+    const refresh = debounce(function() {
         if (manager) {
             manager.reinit();
         }
-    });
+    }, 50);
+
+    jQuery(document).on('ppcp_refresh_payment_buttons', refresh);
+
+    jQuery(document.body).on('updated_cart_totals updated_checkout', refresh);
 
     // Use set timeout as it's unnecessary to refresh upon Minicart initial render.
     setTimeout(() => {
-        jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', () => {
-            if (manager) {
-                manager.reinit();
-            }
-        });
+        jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', refresh);
     }, 1000);
 
     document.addEventListener(

--- a/modules/ppcp-googlepay/resources/js/boot.js
+++ b/modules/ppcp-googlepay/resources/js/boot.js
@@ -1,7 +1,7 @@
 import {loadCustomScript} from "@paypal/paypal-js";
 import {loadPaypalScript} from "../../../ppcp-button/resources/js/modules/Helper/ScriptLoading";
 import GooglepayManager from "./GooglepayManager";
-import { debounce } from '../../../ppcp-blocks/resources/js/Helper/debounce';
+import {setupButtonEvents} from '../../../ppcp-button/resources/js/modules/Helper/ButtonRefreshHelper';
 
 (function ({
    buttonConfig,
@@ -16,20 +16,11 @@ import { debounce } from '../../../ppcp-blocks/resources/js/Helper/debounce';
         manager.init();
     };
 
-    const refresh = debounce(function() {
+    setupButtonEvents(function() {
         if (manager) {
             manager.reinit();
         }
-    }, 50);
-
-    jQuery(document).on('ppcp_refresh_payment_buttons', refresh);
-
-    jQuery(document.body).on('updated_cart_totals updated_checkout', refresh);
-
-    // Use set timeout as it's unnecessary to refresh upon Minicart initial render.
-    setTimeout(() => {
-        jQuery(document.body).on('wc_fragments_loaded wc_fragments_refreshed', refresh);
-    }, 1000);
+    });
 
     document.addEventListener(
         'DOMContentLoaded',


### PR DESCRIPTION
### Problem
Apple Pay and Google Pay buttons are not displayed during the payment step when using multistep checkout plugins.

### Reason
Multistep checkout plugins hide elements of the checkout page using JavaScript and display them at later steps to create a wizard-like experience. Since the payment buttons are in the last step, they remain hidden on page load and do not initialize as expected.

### Solution
Implement a simple timer that periodically checks the visibility of the payment-wrapper element and initializes the payment buttons once it becomes visible.

**Implementation**
- Added a new helper class to monitor the visibility of the payment-wrapper element on page load.
- If the payment-wrapper is visible, the helper exits without action.
- If the payment-wrapper is hidden, an interval timer checks the DOM every 150ms.
- When the payment-wrapper becomes visible, a custom event is triggered.
- Event listeners in the ApplePay and GooglePay modules refresh the buttons when the custom event is received.