### PR TITLE
Remove shipping callback for Venmo express button (3324)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -505,6 +505,30 @@ const PayPalComponent = ({
 
     const PayPalButton = paypal.Buttons.driver("react", { React, ReactDOM });
 
+    const getOnShippingOptionsChange = (fundingSource) => {
+        if(fundingSource === 'venmo') {
+            return null;
+        }
+
+        return (data, actions) => {
+            shouldHandleShippingInPayPal()
+                ? handleShippingOptionsChange(data, actions)
+                : null;
+        };
+    }
+
+    const getOnShippingAddressChange = (fundingSource) => {
+        if(fundingSource === 'venmo') {
+            return null;
+        }
+
+        return (data, actions) => {
+            shouldHandleShippingInPayPal()
+                ? handleShippingAddressChange(data, actions)
+                : null;
+        };
+    }
+
     if(isPayPalSubscription(config.scriptData)) {
         return (
             <PayPalButton
@@ -515,16 +539,8 @@ const PayPalComponent = ({
                 onError={onClose}
                 createSubscription={createSubscription}
                 onApprove={handleApproveSubscription}
-                onShippingOptionsChange={(data, actions) => {
-                    shouldHandleShippingInPayPal()
-                        ? handleSubscriptionShippingOptionsChange(data, actions)
-                        : null;
-                }}
-                onShippingAddressChange={(data, actions) => {
-                    shouldHandleShippingInPayPal()
-                        ? handleSubscriptionShippingAddressChange(data, actions)
-                        : null;
-                }}
+                onShippingOptionsChange={getOnShippingOptionsChange(fundingSource)}
+                onShippingAddressChange={getOnShippingAddressChange(fundingSource)}
             />
         );
     }
@@ -538,16 +554,8 @@ const PayPalComponent = ({
             onError={onClose}
             createOrder={createOrder}
             onApprove={handleApprove}
-            onShippingOptionsChange={(data, actions) => {
-                shouldHandleShippingInPayPal()
-                    ? handleShippingOptionsChange(data, actions)
-                    : null;
-            }}
-            onShippingAddressChange={(data, actions) => {
-                shouldHandleShippingInPayPal()
-                    ? handleShippingAddressChange(data, actions)
-                    : null;
-            }}
+            onShippingOptionsChange={getOnShippingOptionsChange(fundingSource)}
+            onShippingAddressChange={getOnShippingAddressChange(fundingSource)}
         />
     );
 }


### PR DESCRIPTION
Venmo button is not rendered in express checkout buttons due to a JS SDK error:

![Captura de pantalla 2024-06-28 a las 10 37 23](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/d2907089-d264-4e17-9d66-d0dd631d59c4)

### Steps To Reproduce
- Set WC store country as US and currency to US Dollar
- Add product to cart and visit block checkout page
    - Venmo button container is empty
    - JS error “venmo is not eligible” in browser console

### Possible cause
When [including](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-blocks/resources/js/checkout-block.js#L541-L550) `onShippingOptionsChange` and/or `onShippingAddressChange` to the Venmo button, it currently throws the JS error.

We are already checking for the above condition [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-blocks/resources/js/checkout-block.js#L308) but the JS SDK error is thrown before that check is reached.

### Suggested solution
Add an early condition for `venmo` that will be executed before JS SDK is executed.