### PR TITLE
Enable the gateway settings JS file on connection tab (3309)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -215,6 +215,7 @@ return array(
 				PayPalGateway::ID,
 				CreditCardGateway::ID,
 				CardButtonGateway::ID,
+				Settings::CONNECTION_TAB_ID,
 			),
 			true
 		);


### PR DESCRIPTION
# PR Description

The problem happens because the `gateway-settings.js` file is not enqueued on connection tab.
The PR will make sure the file is enqueued.

# Issue Description

The _Check available features_ button is non functional

### Steps to Reproduce

1. Connect with new merchant
2. Navigate to Connection tab and connect with Google Pay
3. Finish steps on PayPal side and observe merchant has active google on his side
4. Navigate to Connection tab again and click the "check available features" button, observe nothing happened

