### PR TITLE
Remove BCDC button from block Express Checkout area (3319)

### DIFF
--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 use WooCommerce\PayPalCommerce\Button\Helper\CheckoutFormSaver;
 use WooCommerce\PayPalCommerce\Button\Endpoint\SaveCheckoutFormEndpoint;
 use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
+use WooCommerce\PayPalCommerce\Button\Helper\DisabledFundingSources;
 use WooCommerce\PayPalCommerce\Button\Helper\WooCommerceOrderCreator;
 use WooCommerce\PayPalCommerce\Button\Validation\CheckoutFormValidator;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ValidateCheckoutEndpoint;
@@ -149,7 +150,8 @@ return array(
 			$container->get( 'vaulting.vault-v3-enabled' ),
 			$container->get( 'api.endpoint.payment-tokens' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'button.handle-shipping-in-paypal' )
+			$container->get( 'button.handle-shipping-in-paypal' ),
+			$container->get( 'button.helper.disabled-funding-sources' )
 		);
 	},
 	'button.url'                                  => static function ( ContainerInterface $container ): string {
@@ -306,12 +308,10 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-
 	'button.helper.cart-products'                 => static function ( ContainerInterface $container ): CartProductsHelper {
 		$data_store = \WC_Data_Store::load( 'product' );
 		return new CartProductsHelper( $data_store );
 	},
-
 	'button.helper.three-d-secure'                => static function ( ContainerInterface $container ): ThreeDSecure {
 		return new ThreeDSecure(
 			$container->get( 'api.factory.card-authentication-result-factory' ),
@@ -323,7 +323,12 @@ return array(
 			$container->get( 'api.shop.country' )
 		);
 	},
-
+	'button.helper.disabled-funding-sources'      => static function ( ContainerInterface $container ): DisabledFundingSources {
+		return new DisabledFundingSources(
+			$container->get( 'wcgateway.settings' ),
+			$container->get( 'wcgateway.all-funding-sources' )
+		);
+	},
 	'button.is-logged-in'                         => static function ( ContainerInterface $container ): bool {
 		return is_user_logged_in();
 	},

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -32,6 +32,7 @@ use WooCommerce\PayPalCommerce\Button\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\StartPayPalVaultingEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ValidateCheckoutEndpoint;
 use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
+use WooCommerce\PayPalCommerce\Button\Helper\DisabledFundingSources;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\PayLaterBlock\PayLaterBlockModule;
@@ -226,6 +227,13 @@ class SmartButton implements SmartButtonInterface {
 	private $should_handle_shipping_in_paypal;
 
 	/**
+	 * List of funding sources to be disabled.
+	 *
+	 * @var DisabledFundingSources
+	 */
+	private $disabled_funding_sources;
+
+	/**
 	 * SmartButton constructor.
 	 *
 	 * @param string                 $module_url The URL to the module.
@@ -251,6 +259,7 @@ class SmartButton implements SmartButtonInterface {
 	 * @param PaymentTokensEndpoint  $payment_tokens_endpoint Payment tokens endpoint.
 	 * @param LoggerInterface        $logger The logger.
 	 * @param bool                   $should_handle_shipping_in_paypal Whether the shipping should be handled in PayPal.
+	 * @param DisabledFundingSources $disabled_funding_sources List of funding sources to be disabled.
 	 */
 	public function __construct(
 		string $module_url,
@@ -275,7 +284,8 @@ class SmartButton implements SmartButtonInterface {
 		bool $vault_v3_enabled,
 		PaymentTokensEndpoint $payment_tokens_endpoint,
 		LoggerInterface $logger,
-		bool $should_handle_shipping_in_paypal
+		bool $should_handle_shipping_in_paypal,
+		DisabledFundingSources $disabled_funding_sources
 	) {
 
 		$this->module_url                        = $module_url;
@@ -301,6 +311,7 @@ class SmartButton implements SmartButtonInterface {
 		$this->logger                            = $logger;
 		$this->payment_tokens_endpoint           = $payment_tokens_endpoint;
 		$this->should_handle_shipping_in_paypal  = $should_handle_shipping_in_paypal;
+		$this->disabled_funding_sources          = $disabled_funding_sources;
 	}
 
 	/**
@@ -1400,54 +1411,18 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			}
 		}
 
-		$disable_funding = $this->settings->has( 'disable_funding' )
-			? $this->settings->get( 'disable_funding' )
-			: array();
-
-		if ( ! is_checkout() ) {
-			$disable_funding[] = 'card';
-		}
-
-		$is_dcc_enabled = $this->settings->has( 'dcc_enabled' ) && $this->settings->get( 'dcc_enabled' );
-
-		$available_gateways       = WC()->payment_gateways->get_available_payment_gateways();
-		$is_separate_card_enabled = isset( $available_gateways[ CardButtonGateway::ID ] );
-
-		if ( is_checkout() && ( $is_dcc_enabled || $is_separate_card_enabled ) ) {
-			$key = array_search( 'card', $disable_funding, true );
-			if ( false !== $key ) {
-				unset( $disable_funding[ $key ] );
-			}
-		}
-
-		if ( in_array( $context, array( 'checkout-block', 'cart-block' ), true ) ) {
-			$disable_funding = array_merge(
-				$disable_funding,
-				array_diff(
-					array_keys( $this->all_funding_sources ),
-					array( 'venmo', 'paylater', 'paypal', 'card' )
-				)
-			);
-		}
-
-		if ( $this->is_free_trial_cart() ) {
-			$all_sources = array_keys( $this->all_funding_sources );
-			if ( $is_dcc_enabled || $is_separate_card_enabled ) {
-				$all_sources = array_diff( $all_sources, array( 'card' ) );
-			}
-			$disable_funding = $all_sources;
-		}
+		$disabled_funding_sources = $this->disabled_funding_sources->sources( $context );
 
 		$enable_funding = array( 'venmo' );
 
 		if ( $this->is_pay_later_button_enabled_for_location( $context ) ) {
 			$enable_funding[] = 'paylater';
 		} else {
-			$disable_funding[] = 'paylater';
+			$disabled_funding_sources[] = 'paylater';
 		}
 
-		$disable_funding = array_filter(
-			$disable_funding,
+		$disabled_funding_sources = array_filter(
+			$disabled_funding_sources,
 			/**
 			 * Make sure paypal is not sent in disable funding.
 			 *
@@ -1460,8 +1435,8 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			}
 		);
 
-		if ( count( $disable_funding ) > 0 ) {
-			$params['disable-funding'] = implode( ',', array_unique( $disable_funding ) );
+		if ( count( $disabled_funding_sources ) > 0 ) {
+			$params['disable-funding'] = implode( ',', array_unique( $disabled_funding_sources ) );
 		}
 
 		if ( $this->is_free_trial_cart() ) {

--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -58,16 +58,28 @@ class DisabledFundingSources {
 			? $this->settings->get( 'disable_funding' )
 			: array();
 
-		if ( ! is_checkout() ) {
+		$is_dcc_enabled = $this->settings->has( 'dcc_enabled' ) && $this->settings->get( 'dcc_enabled' );
+
+		if (
+			! is_checkout()
+			|| ( $is_dcc_enabled && in_array( $context, array( 'checkout-block', 'cart-block' ), true ) )
+		) {
 			$disable_funding[] = 'card';
 		}
-
-		$is_dcc_enabled = $this->settings->has( 'dcc_enabled' ) && $this->settings->get( 'dcc_enabled' );
 
 		$available_gateways       = WC()->payment_gateways->get_available_payment_gateways();
 		$is_separate_card_enabled = isset( $available_gateways[ CardButtonGateway::ID ] );
 
-		if ( is_checkout() && ( $is_dcc_enabled || $is_separate_card_enabled ) ) {
+		if (
+			(
+				is_checkout()
+				&& ! in_array( $context, array( 'checkout-block', 'cart-block' ), true )
+			)
+			&& (
+				$is_dcc_enabled
+				|| $is_separate_card_enabled
+			)
+		) {
 			$key = array_search( 'card', $disable_funding, true );
 			if ( false !== $key ) {
 				unset( $disable_funding[ $key ] );

--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -53,7 +53,7 @@ class DisabledFundingSources {
 	 * @return array|int[]|mixed|string[]
 	 * @throws NotFoundException When the setting is not found.
 	 */
-	public function sources( $context ) {
+	public function sources( string $context ) {
 		$disable_funding = $this->settings->has( 'disable_funding' )
 			? $this->settings->get( 'disable_funding' )
 			: array();

--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Creates the list of disabled funding sources.
+ *
+ * @package WooCommerce\PayPalCommerce\Button\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Helper;
+
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
+
+/**
+ * Class DisabledFundingSources
+ */
+class DisabledFundingSources {
+
+	use FreeTrialHandlerTrait;
+
+	/**
+	 * The settings.
+	 *
+	 * @var Settings
+	 */
+	private $settings;
+
+	/**
+	 * All existing funding sources.
+	 *
+	 * @var array
+	 */
+	private $all_funding_sources;
+
+	/**
+	 * DisabledFundingSources constructor.
+	 *
+	 * @param Settings $settings The settings.
+	 * @param array    $all_funding_sources All existing funding sources.
+	 */
+	public function __construct( Settings $settings, array $all_funding_sources ) {
+		$this->settings            = $settings;
+		$this->all_funding_sources = $all_funding_sources;
+	}
+
+	/**
+	 * Returns the list of funding sources to be disabled.
+	 *
+	 * @param string $context The context.
+	 * @return array|int[]|mixed|string[]
+	 * @throws NotFoundException When the setting is not found.
+	 */
+	public function sources( $context ) {
+		$disable_funding = $this->settings->has( 'disable_funding' )
+			? $this->settings->get( 'disable_funding' )
+			: array();
+
+		if ( ! is_checkout() ) {
+			$disable_funding[] = 'card';
+		}
+
+		$is_dcc_enabled = $this->settings->has( 'dcc_enabled' ) && $this->settings->get( 'dcc_enabled' );
+
+		$available_gateways       = WC()->payment_gateways->get_available_payment_gateways();
+		$is_separate_card_enabled = isset( $available_gateways[ CardButtonGateway::ID ] );
+
+		if ( is_checkout() && ( $is_dcc_enabled || $is_separate_card_enabled ) ) {
+			$key = array_search( 'card', $disable_funding, true );
+			if ( false !== $key ) {
+				unset( $disable_funding[ $key ] );
+			}
+		}
+
+		if ( in_array( $context, array( 'checkout-block', 'cart-block' ), true ) ) {
+			$disable_funding = array_merge(
+				$disable_funding,
+				array_diff(
+					array_keys( $this->all_funding_sources ),
+					array( 'venmo', 'paylater', 'paypal', 'card' )
+				)
+			);
+		}
+
+		if ( $this->is_free_trial_cart() ) {
+			$all_sources = array_keys( $this->all_funding_sources );
+			if ( $is_dcc_enabled || $is_separate_card_enabled ) {
+				$all_sources = array_diff( $all_sources, array( 'card' ) );
+			}
+			$disable_funding = $all_sources;
+		}
+
+		return $disable_funding;
+	}
+}

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Helper;
+
+use Mockery;
+use WC_Payment_Gateways;
+use WooCommerce;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use function Brain\Monkey\Functions\when;
+
+class DisabledFundingSourcesTest extends TestCase
+{
+	private $settings;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->settings = Mockery::mock(Settings::class);
+	}
+
+	public function test_is_checkout_true_does_not_add_card()
+	{
+		$sut = new DisabledFundingSources($this->settings, []);
+
+		$this->setExpectations();
+		$this->setWcPaymentGateways();
+
+		when('is_checkout')->justReturn(true);
+
+		$this->assertEquals([], $sut->sources(''));
+	}
+
+	public function test_is_checkout_false_adds_card()
+	{
+		$sut = new DisabledFundingSources($this->settings, []);
+
+		$this->setExpectations();
+		$this->setWcPaymentGateways();
+
+		when('is_checkout')->justReturn(false);
+
+		$this->assertEquals(['card'], $sut->sources('checkout-block'));
+	}
+
+	public function test_checkout_block_context_adds_source()
+	{
+		$sut = new DisabledFundingSources($this->settings, [
+			'card' => 'Credit or debit cards',
+			'paypal' => 'PayPal',
+			'foo' => 'Bar',
+		]);
+
+		$this->setExpectations();
+		$this->setWcPaymentGateways();
+
+		when('is_checkout')->justReturn(true);
+
+		$this->assertEquals(['foo'], $sut->sources('checkout-block'));
+	}
+
+	private function setExpectations(
+		array $disabledFundings = [],
+		bool  $dccEnambled = true
+	): void
+	{
+		$this->settings->shouldReceive('has')
+			->with('disable_funding')
+			->andReturn(true);
+
+		$this->settings->shouldReceive('get')
+			->with('disable_funding')
+			->andReturn($disabledFundings);
+
+		$this->settings->shouldReceive('has')
+			->with('dcc_enabled')
+			->andReturn(true);
+
+		$this->settings->shouldReceive('get')
+			->with('dcc_enabled')
+			->andReturn($dccEnambled);
+	}
+
+	private function setWcPaymentGateways(array $paymentGateways = []): void
+	{
+		$woocommerce = Mockery::mock(WooCommerce::class);
+		$payment_gateways = Mockery::mock(WC_Payment_Gateways::class);
+		when('WC')->justReturn($woocommerce);
+		$woocommerce->payment_gateways = $payment_gateways;
+		$payment_gateways->shouldReceive('get_available_payment_gateways')
+			->andReturn($paymentGateways);
+	}
+}

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -21,7 +21,11 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->settings = Mockery::mock(Settings::class);
 	}
 
-	public function test_is_checkout_true_does_not_add_card()
+	/**
+	 * Block checkout page configured in WC "Checkout page" setting,
+	 * `is_checkout` returns true when visiting the block checkout page.
+	 */
+	public function test_is_checkout_true_add_card_when_checkout_block_context()
 	{
 		$sut = new DisabledFundingSources($this->settings, []);
 
@@ -30,10 +34,14 @@ class DisabledFundingSourcesTest extends TestCase
 
 		when('is_checkout')->justReturn(true);
 
-		$this->assertEquals([], $sut->sources(''));
+		$this->assertEquals(['card'], $sut->sources('checkout-block'));
 	}
 
-	public function test_is_checkout_false_adds_card()
+	/**
+	 * Classic checkout page configured in WC "Checkout page" setting,
+	 * `is_checkout` returns false when visiting the block checkout page.
+	 */
+	public function test_is_checkout_false_add_card_when_checkout_context()
 	{
 		$sut = new DisabledFundingSources($this->settings, []);
 
@@ -42,10 +50,10 @@ class DisabledFundingSourcesTest extends TestCase
 
 		when('is_checkout')->justReturn(false);
 
-		$this->assertEquals(['card'], $sut->sources('checkout-block'));
+		$this->assertEquals(['card'], $sut->sources('checkout'));
 	}
 
-	public function test_checkout_block_context_adds_source()
+	public function test_is_checkout_true_add_allowed_sources_when_checkout_block_context()
 	{
 		$sut = new DisabledFundingSources($this->settings, [
 			'card' => 'Credit or debit cards',
@@ -58,7 +66,7 @@ class DisabledFundingSourcesTest extends TestCase
 
 		when('is_checkout')->justReturn(true);
 
-		$this->assertEquals(['foo'], $sut->sources('checkout-block'));
+		$this->assertEquals(['card', 'foo'], $sut->sources('checkout-block'));
 	}
 
 	private function setExpectations(


### PR DESCRIPTION
In some sites we are seeing how the express card button is displayed when ACDC is enabled, that should not be the case as it could cause issues when both are enabled at the same time. The expected result should be the express card button not rendered when ACDC is enabled.

![image-20240625-171527](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/b39e7a61-fefc-4d68-a469-5998ce5bd918)

The problem is happening in block checkout pages where in WC Settings the “Checkout page” is configured to use a block checkout page,[ the code responsible](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-button/src/Assets/SmartButton.php#L1407-L1409) to add `card`  to `disable-funding` uses `is_checkout` which will return `true` or `false` depending on the above configuration.

In this case, `is_checkout` returns `true` and therefore `card` is not added to `disable-funding` making the button visible.

### Steps to reproduce
- Go to WC settings / Advanced
- In “Page setup” set a block checkout page for “Checkout page”
- Ensure ACDC is enabled
- Add product to cart and visit a block checkout page
    - express card button is visible

### Changes introduced
- Extracts the logic responsible of creating the list of disabled funding sources into a new class.
- Add unit tests to cover code parts related to the issue.
- Add new condition to ensure `card` is added to disabled funding source when context is either block checkout or block cart.

### Acceptance Criteria
**GIVEN** the Advanced Card Processing is enabled
**WHEN** navigating to the block Checkout
**THEN** the BCDC button does not appear in the Express Checkout area