### PR TITLE
Pay by link - Capturing order from guest user causing fatal error when Vaulting is enabled (3326)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
@@ -404,8 +404,10 @@ class AuthorizedPaymentsProcessor {
 	private function all_authorizations( Order $order ): array {
 		$authorizations = array();
 		foreach ( $order->purchase_units() as $purchase_unit ) {
-			foreach ( $purchase_unit->payments()->authorizations() as $authorization ) {
-				$authorizations[] = $authorization;
+			if ( ! is_null( $purchase_unit->payments() ) ) {
+				foreach ( $purchase_unit->payments()->authorizations() as $authorization ) {
+					$authorizations[] = $authorization;
+				}
 			}
 		}
 


### PR DESCRIPTION
A fatal error "call to a member function authorizations() on null" is thrown when trying to capture authorized payment from guest user. 

### Steps to reproduce
- Set intent to Authorize
- Enable Vaulting
- Create manual order for guest user
- Pay for this order
- Capture this order
    - Observe error

![Captura de pantalla 2024-07-01 a las 12 58 32](https://github.com/woocommerce/woocommerce-paypal-payments/assets/456223/f1131896-0c32-462e-9b9a-aedb03936275)

### Possible cause
It is currently possible to create a PurchaseUnit instance with a [null Payments](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-api-client/src/Entity/PurchaseUnit.php#L118) value. The consumer code is calling payment authorizations on a null payments instance and therefore the error "call to a member function authorizations() on null" is thrown.

### Proposed solution
Ensure purchase units payments instance is not null before using it.