### PR TITLE
Release 2.8.1-rc2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,11 +5,14 @@
 * Fix - Fatal error when the ppcp-paylater-configurator module is disabled via code snippet #2327
 * Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving the configuration to Advanced Card Processing tab #2325
 * Fix - Fix Smart Buttons on Elementor checkout widget #2284
+* Fix - Pay by link - Capturing order from guest user causing fatal error when Vaulting is enabled #2382
+* Fix - Enable the gateway settings JS file on connection tab #2377
 * Enhancement - Add filter for certain settings to allow gateway translation e.g. via WPML #2308
 * Enhancement - Filter for adding more contexts in can_render_dcc checker #2346
 * Enhancement - Do not request id_token for guest users #2283
 * Enhancement - Prevent multiple PayPal Subscription products in the cart if PayPal Subscription API is active #2320
 * Enhancement - Prevent script caching & minification from Litespeed Cache and W3 Total Cache plugins #2316
+* Enhancement - Remove Giropay references due to deprecation #2379
 
 = 2.8.0 - 2024-06-11 =
 * Fix - Calculate totals after adding shipping to include taxes #2296

--- a/readme.txt
+++ b/readme.txt
@@ -184,11 +184,14 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Fatal error when the ppcp-paylater-configurator module is disabled via code snippet #2327
 * Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving the configuration to Advanced Card Processing tab #2325
 * Fix - Fix Smart Buttons on Elementor checkout widget #2284
+* Fix - Pay by link - Capturing order from guest user causing fatal error when Vaulting is enabled #2382
+* Fix - Enable the gateway settings JS file on connection tab #2377
 * Enhancement - Add filter for certain settings to allow gateway translation e.g. via WPML #2308
 * Enhancement - Filter for adding more contexts in can_render_dcc checker #2346
 * Enhancement - Do not request id_token for guest users #2283
 * Enhancement - Prevent multiple PayPal Subscription products in the cart if PayPal Subscription API is active #2320
 * Enhancement - Prevent script caching & minification from Litespeed Cache and W3 Total Cache plugins #2316
+* Enhancement - Remove Giropay references due to deprecation #2379
 
 = 2.8.0 - 2024-06-11 =
 * Fix - Calculate totals after adding shipping to include taxes #2296


### PR DESCRIPTION
[2.8.1-rc1](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/2.8.1-rc1) plus: 
* Fix - Pay by link - Capturing order from guest user causing fatal error when Vaulting is enabled #2382
* Fix - Enable the gateway settings JS file on connection tab #2377
* Enhancement - Remove Giropay references due to deprecation #2379
