### PR TITLE
Improve Place Order button styling (3330)

### DIFF
--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -237,8 +237,6 @@ class AxoManager {
 	 * Renders the HTML for the AXO submit button.
 	 */
 	public function render_checkout_button(): void {
-		$id = 'ppcp-axo-submit-button-container';
-
 		/**
 		 * The WC filter returning the WC order button text.
 		 * phpcs:disable WordPress.WP.I18n.TextDomainMismatch
@@ -246,10 +244,9 @@ class AxoManager {
 		$label = apply_filters( 'woocommerce_order_button_text', __( 'Place order', 'woocommerce' ) );
 
 		printf(
-			'<div id="%1$s" style="display: none;">
-				<button type="button" class="button alt ppcp-axo-order-button">%2$s</button>
+			'<div id="ppcp-axo-submit-button-container" style="display: none;">
+				<button id="place_order" type="button" class="button alt ppcp-axo-order-button wp-element-button">%1$s</button>
 			</div>',
-			esc_attr( $id ),
 			esc_html( $label )
 		);
 	}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -969,7 +969,6 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	 */
 	public function dcc_renderer() {
 
-		$id = 'ppcp-hosted-fields';
 		if ( ! $this->can_render_dcc() ) {
 			return;
 		}
@@ -982,12 +981,11 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 		// phpcs:enable WordPress.WP.I18n.TextDomainMismatch
 
 		printf(
-			'<div id="%1$s" style="display:none;">
-						<button type="submit" class="button alt ppcp-dcc-order-button" style="display: none;">%2$s</button>
+			'<div id="ppcp-hosted-fields" style="display:none;">
+						<button id="place_order" type="submit" class="button alt ppcp-dcc-order-button wp-element-button" style="display: none;">%1$s</button>
 					</div>
                     <div id="payments-sdk__contingency-lightbox"></div>
                     <style id="ppcp-hide-dcc">.payment_method_ppcp-credit-card-gateway {display:none;}</style>',
-			esc_attr( $id ),
 			esc_html( $label )
 		);
 	}


### PR DESCRIPTION
### Description

This PR disables Fastlane for subscription products.


### Steps to Test

1. Activate the Twenty Twenty-Four theme.
2. Test with Fastlane enabled/disabled, same for ACDC.
3. Confirm that the Place Order button looks styled.

### Screenshots

|Before|After|
|-|-|
|![Page__Checkout_before](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/e628b218-a34b-402c-85f2-b84addc764ba)|![Page__Checkout_after](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/369e4445-4cc4-482b-b4fe-92f034bc4126)|
