### PR TITLE
Google Pay: Fix issuse with data.paymentSource being undefined (3313)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -87,18 +87,20 @@ const PayPalComponent = ({
 
     const createOrder = async (data, actions) => {
         try {
+            const requestBody = {
+                nonce: config.scriptData.ajax.create_order.nonce,
+                bn_code: '',
+                context: config.scriptData.context,
+                payment_method: 'ppcp-gateway',
+                funding_source: window.ppcpFundingSource ?? 'paypal',
+                createaccount: false,
+                ...(data?.paymentSource && { payment_source: data.paymentSource })
+            };
+
             const res = await fetch(config.scriptData.ajax.create_order.endpoint, {
                 method: 'POST',
                 credentials: 'same-origin',
-                body: JSON.stringify({
-                    nonce: config.scriptData.ajax.create_order.nonce,
-                    bn_code: '',
-                    context: config.scriptData.context,
-                    payment_method: 'ppcp-gateway',
-                    funding_source: window.ppcpFundingSource ?? 'paypal',
-                    createaccount: false,
-                    payment_source: data.paymentSource
-                }),
+                body: JSON.stringify(requestBody),
             });
 
             const json = await res.json();

--- a/modules/ppcp-googlepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/BaseHandler.js
@@ -18,7 +18,8 @@ class BaseHandler {
     }
 
     shippingAllowed() {
-        return true;
+        // Status of the shipping settings in WooCommerce.
+        return this.buttonConfig.shipping.configured;
     }
 
     transactionInfo() {

--- a/modules/ppcp-googlepay/resources/js/Context/CheckoutBlockHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/CheckoutBlockHandler.js
@@ -2,10 +2,6 @@ import BaseHandler from "./BaseHandler";
 
 class CheckoutBlockHandler extends BaseHandler{
 
-    shippingAllowed() {
-        return false;
-    }
-
     createOrder() {
         return this.externalHandler.createOrder();
     }

--- a/modules/ppcp-googlepay/resources/js/Context/CheckoutHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/CheckoutHandler.js
@@ -6,10 +6,6 @@ import FormValidator from "../../../../ppcp-button/resources/js/modules/Helper/F
 
 class CheckoutHandler extends BaseHandler {
 
-    shippingAllowed() {
-        return false;
-    }
-
     transactionInfo() {
         return new Promise(async (resolve, reject) => {
 

--- a/modules/ppcp-googlepay/resources/js/Context/PayNowHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/PayNowHandler.js
@@ -12,10 +12,6 @@ class PayNowHandler extends BaseHandler {
         return true;
     }
 
-    shippingAllowed() {
-        return false;
-    }
-
     transactionInfo() {
         return new Promise(async (resolve, reject) => {
             const data = this.ppcpConfig['pay_now'];

--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -279,7 +279,7 @@ class GooglepayButton {
             updatedData.total_str = transactionInfo.totalPrice;
 
             // Handle unserviceable address.
-            if(!updatedData.shipping_options || !updatedData.shipping_options.shippingOptions.length) {
+            if (!(updatedData.shipping_options?.shippingOptions?.length)) {
                 paymentDataRequestUpdate.error = this.unserviceableShippingAddressError();
                 resolve(paymentDataRequestUpdate);
                 return;

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -412,6 +412,7 @@ class Button implements ButtonInterface {
 			'enabled' => $this->settings->has( 'googlepay_button_shipping_enabled' )
 				? boolval( $this->settings->get( 'googlepay_button_shipping_enabled' ) )
 				: false,
+			'configured' => wc_shipping_enabled() && wc_get_shipping_method_count( false, true ) > 0,
 		);
 
 		if ( $shipping['enabled'] ) {


### PR DESCRIPTION
### Description

This PR fixes:
- Issue with `data.paymentSource` being undefined for Google Pay and throwing an error.
- Issue with `shippingAllowed()` boolean being hardcoded resulting in incorrect shipping data being sent to Google Pay. 

### Steps to Test

1. Activate Google Pay.
2. Test the following scenarios for Classic Cart/Checkout and Block Cart/Checkout pages:
- Shipping callback disabled / shipping not configured
- Shipping callback enabled  / shipping not configured
- Shipping callback disabled  / shipping configured
- Shipping callback enabled / shipping not configured
3. Confirm Google Pay orders go through for each scenario.

### Screenshots

N/A
