### PR TITLE
Apple Pay: Fix when shipping is disabled (3120)

### DIFF
--- a/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
@@ -24,7 +24,7 @@ class BaseHandler {
     }
 
     shippingAllowed() {
-        return true;
+        return this.buttonConfig.product.needsShipping;
     }
 
     transactionInfo() {

--- a/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
@@ -12,10 +12,6 @@ class PayNowHandler extends BaseHandler {
         return true;
     }
 
-    shippingAllowed() {
-        return false;
-    }
-
     transactionInfo() {
         return new Promise(async (resolve, reject) => {
             const data = this.ppcpConfig['pay_now'];


### PR DESCRIPTION
### Description

This PR fixes:
- Issue with `shippingAllowed()` boolean being hardcoded resulting in incorrect shipping data being sent to Apple Pay. 

### Steps to Test

1. Activate Apple Pay.
2. Confirm Apple Pay orders go through for both enabled and disabled shipping.

### Screenshots

N/A
