### PR TITLE
Preserve subscription renewal processing when switching Subscriptions Mode or disabling gateway (680)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -185,29 +185,15 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 		$this->paypal_checkout_url_factory = $paypal_checkout_url_factory;
 		$this->order_button_text           = $place_order_button_text;
 
-		$this->supports = array(
-			'refunds',
+		$default_support = array(
 			'products',
+			'refunds',
 		);
 
-		if (
-			( $this->config->has( 'vault_enabled' ) && $this->config->get( 'vault_enabled' ) )
-			|| ( $this->config->has( 'subscriptions_mode' ) && $this->config->get( 'subscriptions_mode' ) === 'subscriptions_api' )
-		) {
-			array_push(
-				$this->supports,
-				'subscriptions',
-				'subscription_cancellation',
-				'subscription_suspension',
-				'subscription_reactivation',
-				'subscription_amount_changes',
-				'subscription_date_changes',
-				'subscription_payment_method_change',
-				'subscription_payment_method_change_customer',
-				'subscription_payment_method_change_admin',
-				'multiple_subscriptions'
-			);
-		}
+		$this->supports = array_merge(
+			$default_support,
+			apply_filters( 'woocommerce_paypal_payments_card_button_gateway_supports', array() )
+		);
 
 		$this->method_title       = __( 'Standard Card Button', 'woocommerce-paypal-payments' );
 		$this->method_description = __( 'The separate payment gateway with the card button. If disabled, the button is included in the PayPal gateway.', 'woocommerce-paypal-payments' );

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -240,38 +240,17 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$this->wc_payment_tokens           = $wc_payment_tokens;
 		$this->logger                      = $logger;
 
-		if ( $state->current_state() === State::STATE_ONBOARDED ) {
-			$this->supports = array( 'refunds' );
-		}
-		if ( $this->config->has( 'dcc_enabled' ) && $this->config->get( 'dcc_enabled' ) ) {
-			$this->supports = array(
-				'refunds',
-				'products',
-			);
+		$default_support = array(
+			'products',
+			'refunds',
+			'tokenization',
+			'add_payment_method',
+		);
 
-			if ( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) ) {
-				$supports = apply_filters(
-					'woocommerce_paypal_payments_credit_card_gateway_vault_supports',
-					array(
-						'subscriptions',
-						'subscription_cancellation',
-						'subscription_suspension',
-						'subscription_reactivation',
-						'subscription_amount_changes',
-						'subscription_date_changes',
-						'subscription_payment_method_change',
-						'subscription_payment_method_change_customer',
-						'subscription_payment_method_change_admin',
-						'multiple_subscriptions',
-					)
-				);
-
-				$this->supports = array_merge(
-					$this->supports,
-					$supports
-				);
-			}
-		}
+		$this->supports = array_merge(
+			$default_support,
+			apply_filters( 'woocommerce_paypal_payments_credit_card_gateway_supports', array() )
+		);
 
 		$this->method_title       = __(
 			'Advanced Card Processing',

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -271,39 +271,17 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->vault_v3_enabled            = $vault_v3_enabled;
 		$this->wc_payment_tokens           = $wc_payment_tokens;
 
-		if ( $this->onboarded ) {
-			$this->supports = array( 'refunds', 'tokenization' );
-		}
-		if ( $this->config->has( 'enabled' ) && $this->config->get( 'enabled' ) ) {
-			$this->supports = array(
-				'refunds',
-				'products',
-			);
+		$default_support = array(
+			'products',
+			'refunds',
+			'tokenization',
+			'add_payment_method',
+		);
 
-			if (
-				( $this->config->has( 'vault_enabled' ) && $this->config->get( 'vault_enabled' ) )
-				|| ( $this->config->has( 'subscriptions_mode' ) && $this->config->get( 'subscriptions_mode' ) === 'subscriptions_api' )
-			) {
-				array_push(
-					$this->supports,
-					'tokenization',
-					'subscriptions',
-					'subscription_cancellation',
-					'subscription_suspension',
-					'subscription_reactivation',
-					'subscription_amount_changes',
-					'subscription_date_changes',
-					'subscription_payment_method_change',
-					'subscription_payment_method_change_customer',
-					'subscription_payment_method_change_admin',
-					'multiple_subscriptions'
-				);
-			} elseif ( $this->config->has( 'subscriptions_mode' ) && $this->config->get( 'subscriptions_mode' ) === 'subscriptions_api' ) {
-				$this->supports[] = 'gateway_scheduled_payments';
-			} elseif ( $this->config->has( 'vault_enabled_dcc' ) && $this->config->get( 'vault_enabled_dcc' ) ) {
-				$this->supports[] = 'tokenization';
-			}
-		}
+		$this->supports = array_merge(
+			$default_support,
+			apply_filters( 'woocommerce_paypal_payments_paypal_gateway_supports', array() )
+		);
 
 		$this->method_title       = $this->define_method_title();
 		$this->method_description = $this->define_method_description();

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -49,6 +49,8 @@ class WcSubscriptionsModule implements ModuleInterface {
 	 * {@inheritDoc}
 	 */
 	public function run( ContainerInterface $c ): void {
+		$this->add_gateways_support( $c );
+
 		add_action(
 			'woocommerce_scheduled_subscription_payment_' . PayPalGateway::ID,
 			/**
@@ -371,5 +373,97 @@ class WcSubscriptionsModule implements ModuleInterface {
 		}
 
 		return $default_fields;
+	}
+
+	/**
+	 * Groups all filters for adding WC Subscriptions gateway support.
+	 *
+	 * @param ContainerInterface $c The container.
+	 * @return void
+	 */
+	private function add_gateways_support( ContainerInterface $c ): void {
+		/**
+		 * Add WC Subscriptions plugin support for PayPal gateway.
+		 */
+		add_filter(
+			'woocommerce_paypal_payments_paypal_gateway_supports',
+			function ( array $supports ) use ( $c ): array {
+				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscriptions_helper instanceof SubscriptionHelper );
+
+				if ( $subscriptions_helper->plugin_is_active() ) {
+					$supports = array(
+						'subscriptions',
+						'subscription_cancellation',
+						'subscription_suspension',
+						'subscription_reactivation',
+						'subscription_amount_changes',
+						'subscription_date_changes',
+						'subscription_payment_method_change',
+						'subscription_payment_method_change_customer',
+						'subscription_payment_method_change_admin',
+						'multiple_subscriptions',
+					);
+				}
+
+				return $supports;
+			}
+		);
+
+		/**
+		 * Add WC Subscriptions plugin support for Credit Card gateway.
+		 */
+		add_filter(
+			'woocommerce_paypal_payments_credit_card_gateway_supports',
+			function ( array $supports ) use ( $c ): array {
+				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscriptions_helper instanceof SubscriptionHelper );
+
+				if ( $subscriptions_helper->plugin_is_active() ) {
+					$supports = array(
+						'subscriptions',
+						'subscription_cancellation',
+						'subscription_suspension',
+						'subscription_reactivation',
+						'subscription_amount_changes',
+						'subscription_date_changes',
+						'subscription_payment_method_change',
+						'subscription_payment_method_change_customer',
+						'subscription_payment_method_change_admin',
+						'multiple_subscriptions',
+					);
+				}
+
+				return $supports;
+			}
+		);
+
+		/**
+		 * Add WC Subscriptions plugin support for Card Button gateway.
+		 */
+		add_filter(
+			'woocommerce_paypal_payments_card_button_gateway_supports',
+			function ( array $supports ) use ( $c ): array {
+				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscriptions_helper instanceof SubscriptionHelper );
+
+				if ( $subscriptions_helper->plugin_is_active() ) {
+					$supports = array(
+						'subscriptions',
+						'subscription_cancellation',
+						'subscription_suspension',
+						'subscription_reactivation',
+						'subscription_amount_changes',
+						'subscription_date_changes',
+						'subscription_payment_method_change',
+						'subscription_payment_method_change_customer',
+						'subscription_payment_method_change_admin',
+						'multiple_subscriptions',
+					);
+				}
+
+				return $supports;
+			}
+		);
 	}
 }

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -382,9 +382,6 @@ class WcSubscriptionsModule implements ModuleInterface {
 	 * @return void
 	 */
 	private function add_gateways_support( ContainerInterface $c ): void {
-		/**
-		 * Add WC Subscriptions plugin support for PayPal gateway.
-		 */
 		add_filter(
 			'woocommerce_paypal_payments_paypal_gateway_supports',
 			function ( array $supports ) use ( $c ): array {
@@ -410,9 +407,6 @@ class WcSubscriptionsModule implements ModuleInterface {
 			}
 		);
 
-		/**
-		 * Add WC Subscriptions plugin support for Credit Card gateway.
-		 */
 		add_filter(
 			'woocommerce_paypal_payments_credit_card_gateway_supports',
 			function ( array $supports ) use ( $c ): array {
@@ -438,9 +432,6 @@ class WcSubscriptionsModule implements ModuleInterface {
 			}
 		);
 
-		/**
-		 * Add WC Subscriptions plugin support for Card Button gateway.
-		 */
 		add_filter(
 			'woocommerce_paypal_payments_card_button_gateway_supports',
 			function ( array $supports ) use ( $c ): array {

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -388,6 +388,9 @@ class WcSubscriptionsModule implements ModuleInterface {
 				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscriptions_helper instanceof SubscriptionHelper );
 
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
 				if ( $subscriptions_helper->plugin_is_active() ) {
 					$supports = array(
 						'subscriptions',
@@ -401,6 +404,10 @@ class WcSubscriptionsModule implements ModuleInterface {
 						'subscription_payment_method_change_admin',
 						'multiple_subscriptions',
 					);
+
+					if ( $settings->has( 'subscriptions_mode' ) && $settings->get( 'subscriptions_mode' ) === 'subscriptions_api' ) {
+						$supports[] = 'gateway_scheduled_payments';
+					}
 				}
 
 				return $supports;


### PR DESCRIPTION
1. When either Vaulting or the gateway is disabled, renewal payments for existing subscriptions will not process correctly.
2. When the Subscriptions Mode setting in PayPal gateway is not configured the same way as an active subscription, it will fail to renew.

### Steps To Reproduce

1.1 PayPal gateway disabled

- PayPal gateway enabled and Subscriptions Mode Vaulting
- Purchase subscription
- Disable PayPal gateway
- Run renewal action manually from Scheduled Actions as currently no action in Order Actions is displayed when PayPal gateway is disabled.
    - “An error has occurred while processing a recent subscription related event…” is displayed in Scheduled Actions screen
    - Renewal Order is not created in the subscription
    - Order note “Unable to change subscription status to “on-hold”.

1.2 ACDC gateway disabled

- ACDC gateway enabled and Subscriptions Mode Vaulting
- Purchase subscription
- Disable ACDC gateway
- Run renewal action manually from Scheduled Actions as currently no action in Order Actions is displayed when PayPal gateway is disabled.
    - “An error has occurred while processing a recent subscription related event…” is displayed in Scheduled Actions screen
    - Renewal Order is not created in the subscription
    - Order note “Unable to change subscription status to “on-hold”.

2.1 Subscription Mode switch from PayPal Vaulting to PayPal Subscriptions 

- PayPal gateway enabled and Subscriptions Mode PayPal Vaulting
- Purchase subscription
- Switch Subscriptions Mode to PayPal Subscriptions
- Trigger renewal manually from subscription
    - This seems to work just fine, renewal order created correctly.

2.2 Subscription Mode switch from PayPal Subscriptions to PayPal Vaulting

- PayPal gateway enabled and Subscriptions Mode PayPal Subscriptions
- Purchase PayPal subscription (create and connect if it does not exist)
- Renewal subscription by sending PayPal `PAYMENT.SALE.COMPLETED` webhook manually (using Postman or cURL…):
    - Define constant to disable webhook verification (ex. in custom plugin):
    
    ```php
    ! defined( 'PAYPAL_WEBHOOK_REQUEST_VERIFICATION' ) && define( 'PAYPAL_WEBHOOK_REQUEST_VERIFICATION', false );
    ```
    
    - Go to the subscription and copy `ppcp_subscription` from Custom Fields, use this value as `billing_agreement_id`.
    
    ```php
    POST http://example.com/wp-json/paypal/v1/incoming
    {
        "id": "I-DONT-CARE",
        "event_type": "PAYMENT.SALE.COMPLETED",
        "resource": {
            "billing_agreement_id": "I-ABC123",
            "id": "I-DONT-CARE-EITHER"
        }
    }
    ```
    
- Switch Subscriptions Mode to PayPal Vaulting
- Renewal subscription again
    - This seems to work just fine, renewal order created correctly.

2.3 Subscription Mode switch from PayPal Vaulting to Disable PayPal for subscriptions

- PayPal gateway enabled and Subscriptions Mode Vaulting
- Purchase subscription
- Switch Subscription Mode from PayPal Vaulting to Disable PayPal for subscriptions
- Run renewal action manually from Scheduled Actions as currently no action in Order Actions is displayed when PayPal gateway is disabled.
    - “An error has occurred while processing a recent subscription related event…” is displayed in Scheduled Actions screen
    - Renewal Order is not created in the subscription
    - Order note “Unable to change subscription status to “on-hold”.

### Possible Cause

1. No WC Subscriptions support is added when [PayPal gateway is disabled](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php#L277). Same happens for Credit card gateway.

### Suggested solution

1. Do not conditionally add gateway support based on gateway settings.

### Acceptance Criteria

- Ensure you can switch settings and does not break existing subscriptions renewal.
- Now you can run manual renewals (only for vaulted subscriptions) from the subscription Order Actions even if the gateway setting is disabled.
- Ensure no related subscriptions (Vaulting and PayPal Subscriptions) functionality is broken by the new changes.