### PR TITLE
AXO: Prevent loading scripts and executing logic in continuation mode (3295)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -148,7 +148,7 @@ class AxoModule implements ModuleInterface {
 				$module = $this;
 
 				// Check if the module is applicable, correct country, currency, ... etc.
-				if ( ! $c->get( 'axo.eligible' ) ) {
+				if ( ! $c->get( 'axo.eligible' ) || 'continuation' === $c->get( 'button.context' ) ) {
 					return;
 				}
 
@@ -252,6 +252,8 @@ class AxoModule implements ModuleInterface {
 					}
 				);
 
+				// Add the markup necessary for displaying overlays and loaders for Axo on the checkout page.
+				$this->add_checkout_loader_markup( $c );
 			},
 			1
 		);
@@ -265,9 +267,6 @@ class AxoModule implements ModuleInterface {
 				$endpoint->handle_request();
 			}
 		);
-
-		// Add the markup necessary for displaying overlays and loaders for Axo on the checkout page.
-		$this->add_checkout_loader_markup( $c );
 	}
 
 	/**

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -137,6 +137,10 @@ trait ContextTrait {
 			case $this->is_block_editor():
 				$context = 'block-editor';
 				break;
+
+			case $this->is_paypal_continuation():
+				$context = 'continuation';
+				break;
 		}
 
 		return apply_filters( 'woocommerce_paypal_payments_context', $context );


### PR DESCRIPTION
### Description

This PR disables Fastlane for PayPal continuation mode.


### Steps to Test

1. Enable Fastlane.
2. Navigate to shop as guest.
3. Go to a single product page and select the PayPal smart button.
4. Log in, and continue to review the order.
5. Confirm that you can successfully complete the payment.

### Screenshots

|Before|After|
|-|-|
|![Page__Checkout_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/218b33d7-0c6d-4285-9f7e-8ac97991c727)|![Page__Checkout_—_tryb_prywatny](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/b7a776b9-54b4-43e8-ba74-e5709373a358)|
