### PR TITLE
All products "Sold individually" when PayPal Subscriptions selected as Subscriptions Mode (3353)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -58,6 +58,14 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function( $product_id ) use ( $c ) {
+				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscriptions_helper instanceof SubscriptionHelper );
+
+				$connect_subscription = wc_clean( wp_unslash( $_POST['_ppcp_enable_subscription_product'] ?? '' ) );
+				if ( ! $subscriptions_helper->plugin_is_active() || $connect_subscription !== 'yes' ) {
+					return;
+				}
+
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 


### PR DESCRIPTION
When the PayPal Subscriptions API is enabled, the "Limit purchases to 1 item per order" checkbox automatically activates for all products and cannot be unchecked.

### Steps To Reproduce
- Create a simple product.
- Navigate to the inventory settings.
- Uncheck "Sold individually" within the "Limit purchases to 1 item per order" section.
- Refresh the page to confirm that the setting remains checked.

### Expected behavior
The “Sold individually” checkbox is only force-checked for subscription products connected to a PayPal Subscription plan. It should not apply to regular simple products, or subscription products not connected to PayPal.