### PR TITLE
W3 Total Cache: Remove type from file parameter as sometimes null gets passed causing errors (3346)

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -368,6 +368,15 @@ class CompatModule implements ModuleInterface {
 		// W3 Total Cache.
 		add_filter(
 			'w3tc_minify_js_do_tag_minification',
+			/**
+			 * Filter callback for 'w3tc_minify_js_do_tag_minification'.
+			 *
+			 * @param bool $do_tag_minification Whether to do tag minification.
+			 * @param string $script_tag The script tag.
+			 * @param string|null $file The file path.
+			 * @return bool Whether to do tag minification.
+			 * @psalm-suppress MissingClosureParamType
+			 */
 			function( bool $do_tag_minification, string $script_tag, $file ) {
 				if ( $file && strpos( $file, 'ppcp' ) !== false ) {
 					return false;

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -368,7 +368,7 @@ class CompatModule implements ModuleInterface {
 		// W3 Total Cache.
 		add_filter(
 			'w3tc_minify_js_do_tag_minification',
-			function( bool $do_tag_minification, string $script_tag, string $file ) {
+			function( bool $do_tag_minification, string $script_tag, $file ) {
 				if ( $file && strpos( $file, 'ppcp' ) !== false ) {
 					return false;
 				}


### PR DESCRIPTION
### Description

This PR removes the type from the `$file` parameter in the `w3tc_minify_js_do_tag_minification` filter removing errors when `null` gets passed.


### Steps to Test

1. Enable W3 Total Cache file minifying.
2. Navigate to the checkout page.
3. Ensure there are no errors.

### Screenshots

|Before|After|
|-|-|
|![Page__Checkout](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/1c8ccd00-f4b2-4435-b3c5-9b49595ac972)|![Page__Checkout](https://github.com/woocommerce/woocommerce-paypal-payments/assets/905781/847474c8-fd38-4d93-bccb-73c13d619bbc)|
