### PR TITLE
Add notice when upgrading to plugin version >= 3.0.0 (3191)

### DIFF
--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -222,6 +222,22 @@ define( 'PAYPAL_INTEGRATION_DATE', '2024-06-25' );
 		}
 	);
 
+	add_action(
+		'in_plugin_update_message-woocommerce-paypal-payments/woocommerce-paypal-payments.php',
+		static function( array $plugin_data, \stdClass $new_data ) {
+			if ( version_compare( $plugin_data['Version'], '3.0.0', '<' ) &&
+				version_compare( $new_data->new_version, '3.0.0', '>=' ) ) {
+				printf(
+					'<div class="update-message"><p><strong>%s</strong>: %s</p></div>',
+					esc_html__( 'Warning', 'woocommerce-paypal-payments' ),
+					esc_html__( 'WooCommerce PayPal Payments version 3.0.0 contains significant changes that may impact your website. We strongly recommend reviewing the changes and testing the update on a staging site before updating it on your production environment.', 'woocommerce-paypal-payments' )
+				);
+			}
+		},
+		10,
+		2
+	);
+
 	/**
 	 * Check if WooCommerce is active.
 	 *

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     2.8.0
+ * Version:     2.8.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     2.8.1
+ * Version:     2.8.0
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
@@ -228,7 +228,7 @@ define( 'PAYPAL_INTEGRATION_DATE', '2024-06-25' );
 			if ( version_compare( $plugin_data['Version'], '3.0.0', '<' ) &&
 				version_compare( $new_data->new_version, '3.0.0', '>=' ) ) {
 				printf(
-					'<div class="update-message"><p><strong>%s</strong>: %s</p></div>',
+					'<br /><strong>%s</strong>: %s',
 					esc_html__( 'Warning', 'woocommerce-paypal-payments' ),
 					esc_html__( 'WooCommerce PayPal Payments version 3.0.0 contains significant changes that may impact your website. We strongly recommend reviewing the changes and testing the update on a staging site before updating it on your production environment.', 'woocommerce-paypal-payments' )
 				);


### PR DESCRIPTION
This PR introduces a notice that is hooked into the “update notice” when an update is available for the PayPal Payments plugin, and the version is 3.0 or higher.
- The notice should inform users of potentially significant changes in the 3.0 update.
- The notice advises users to review the update details before proceeding.
- The notice is prominently displayed in the WordPress admin interface on the plugins page, directly below the regular update notice.

Screenshot below or reference:
![image](https://github.com/user-attachments/assets/f45f19c5-9e19-4181-a8ee-83f0d139f779)


The wording of the notice text:
> Warning: WooCommerce PayPal Payments version 3.0.0 contains significant changes that may impact your website. We strongly recommend reviewing the changes and testing the update on a staging site before updating it on your production environment.

Acceptance Criteria
- GIVEN PayPal Payments is installed in a version below 3.0
- WHEN an update to version 3.0 or newer is available
- THEN an warning notice is displayed on the plugins.php and the PayPal Payments settings pages to warn the user about the potential impact of the available update.