### PR TITLE
Wrong string in smart button preview on Standard Payments tab (3360)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php
@@ -28,7 +28,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 
 	$has_enabled_separate_button_gateways = $container->get( 'wcgateway.settings.has_enabled_separate_button_gateways' );
 
-	$preview_message = __( 'Standard Card Button Styling Preview', 'woocommerce-paypal-payments' );
+	$preview_message = __( 'Button Styling Preview', 'woocommerce-paypal-payments' );
 
 	$axo_smart_button_location_notice = $container->has( 'axo.smart-button-location-notice' ) ? $container->get( 'axo.smart-button-location-notice' ) : '';
 


### PR DESCRIPTION
### Description:

Fixed a wrong label for the button-preview in the "Standard Payments" tab of the plugin settings page.

### Source:

The following commit accidentally changed the preview label (copy-paste error):
https://github.com/woocommerce/woocommerce-paypal-payments/blob/d2f0cb1c3123ff175a1b5db4a7a472390aab3268/modules/ppcp-wc-gateway/src/Settings/Fields/paypal-smart-button-fields.php#L31