### PR TITLE
PayPal js files loaded on non PayPal pages (3341)

### DIFF
--- a/modules/ppcp-onboarding/src/Assets/OnboardingAssets.php
+++ b/modules/ppcp-onboarding/src/Assets/OnboardingAssets.php
@@ -96,21 +96,21 @@ class OnboardingAssets {
 	 */
 	public function register(): bool {
 
-		$url = untrailingslashit( $this->module_url ) . '/assets/css/onboarding.css';
 		wp_register_style(
 			'ppcp-onboarding',
-			$url,
+			$this->module_url . '/assets/css/onboarding.css',
 			array(),
 			$this->version
 		);
-		$url = untrailingslashit( $this->module_url ) . '/assets/js/settings.js';
+
 		wp_register_script(
 			'ppcp-settings',
-			$url,
+			$this->module_url . '/assets/js/settings.js',
 			array(),
 			$this->version,
 			true
 		);
+
 		wp_localize_script(
 			'ppcp-settings',
 			'PayPalCommerceSettings',
@@ -122,14 +122,14 @@ class OnboardingAssets {
 			)
 		);
 
-		$url = untrailingslashit( $this->module_url ) . '/assets/js/onboarding.js';
 		wp_register_script(
 			'ppcp-onboarding',
-			$url,
+			$this->module_url . '/assets/js/onboarding.js',
 			array( 'jquery' ),
 			$this->version,
 			true
 		);
+
 		wp_localize_script(
 			'ppcp-onboarding',
 			'PayPalCommerceGatewayOnboarding',
@@ -164,17 +164,22 @@ class OnboardingAssets {
 	/**
 	 * Enqueues the necessary scripts.
 	 *
-	 * @return bool
+	 * @return void
 	 */
-	public function enqueue(): bool {
-		wp_enqueue_style( 'ppcp-onboarding' );
-		wp_enqueue_script( 'ppcp-settings' );
-		if ( ! $this->should_render_onboarding_script() ) {
-			return false;
+	public function enqueue(): void {
+		// Do not enqueue anything when we are not on a PayPal Payments settings tab.
+		if ( ! $this->page_id ) {
+			return;
 		}
 
-		wp_enqueue_script( 'ppcp-onboarding' );
-		return true;
+		// Enqueue general assets for the plugin's settings page.
+		wp_enqueue_script( 'ppcp-settings' );
+		wp_enqueue_style( 'ppcp-onboarding' ); // File also contains general settings styles.
+
+		// Conditionally enqueue the onboarding script, when needed.
+		if ( $this->should_render_onboarding_script() ) {
+			wp_enqueue_script( 'ppcp-onboarding' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Problem:

Some plugin assets (JS files) were loaded on WooCommerce settings pages that did not require them.

**Checks**

- `cart-paylater-block-inserter.js`
  - Reported to load on any "WooCommerce → Settings" tab, but not reproducible
  - Only loaded on (admin) pages that also have the Block Editor, via `enqueue_block_editor_assets `
- `settings.js` **← optimized**
  - Previously loaded on the "WooCommerce → Settings → Payments" tab
  - Now only loaded on "WooCommerce → Settings → Payments → **PayPal**" (and related, like "Advanced Card Processing")
  - Addressed in line `171` of the commit
- Besides the plugin settings tabs ("WooCommerce → Settings → Payments → PayPal"), only two other pages correctly enqueue plugin scripts:
  - Two assets are loaded on the "Order details" page
  - Some assets are loaded in Block Editor, when editing a page/post

### Further Cleanup:

This PR also does minor cleanup of the relevant PHP class

1. Remove unnecessary `trailingslashit()` calls in the `register()` method
2. Change return type of the `enqueue()` method from bool to void - it's only used as an action callback
