### PR TITLE
Sold individually checkbox automatically disabled after adding product to the cart more then once (3362)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -107,7 +107,13 @@ class PayPalSubscriptionsModule implements ModuleInterface {
 					return $passed_validation;
 				}
 
-				$product  = wc_get_product( $product_id );
+				$product = wc_get_product( $product_id );
+
+				if ( ! ( is_a( $product, WC_Product::class ) ) ) {
+					wc_add_notice( __( 'Cannot add this product to cart (invalid product).', 'woocommerce-paypal-payments' ), 'error' );
+					return false;
+				}
+
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

The plugin changes the `Sold individually` value on regular products when adding a product to the cart.

### Steps to Test

1. Go to the product data Inventory tab and set the product to be sold individually.
2. Add the product to the cart.
3. Refresh the page and observe that the "Sold Individually" setting has changed to false. The quantity input field will also be visible on the product page.