### PR TITLE
Shipping methods during callback not updated correctly (3305)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -606,9 +606,11 @@ const PayPalComponent = ( {
 		}
 
 		return ( data, actions ) => {
-			shouldHandleShippingInPayPal()
+            let shippingAddressChange = shouldHandleShippingInPayPal()
 				? handleShippingAddressChange( data, actions )
 				: null;
+
+            return shippingAddressChange;
 		};
 	};
 

--- a/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
+++ b/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
@@ -22,7 +22,8 @@ use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
  * Class UpdateShippingEndpoint
  */
 class UpdateShippingEndpoint implements EndpointInterface {
-	const ENDPOINT = 'ppc-update-shipping';
+	const ENDPOINT              = 'ppc-update-shipping';
+	const WC_STORE_API_ENDPOINT = '/wp-json/wc/store/cart/';
 
 	/**
 	 * The Request Data Helper.

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -141,6 +141,7 @@ class Renderer {
 			// Check the condition and add the handler if needed
 			if ( this.defaultSettings.should_handle_shipping_in_paypal ) {
 				options.onShippingOptionsChange = ( data, actions ) => {
+                    let shippingOptionsChange =
 					! this.isVenmoButtonClickedWhenVaultingIsEnabled(
 						venmoButtonClicked
 					)
@@ -150,8 +151,11 @@ class Renderer {
 								this.defaultSettings
 						  )
 						: null;
+
+                    return shippingOptionsChange
 				};
 				options.onShippingAddressChange = ( data, actions ) => {
+                    let shippingAddressChange =
 					! this.isVenmoButtonClickedWhenVaultingIsEnabled(
 						venmoButtonClicked
 					)
@@ -161,6 +165,8 @@ class Renderer {
 								this.defaultSettings
 						  )
 						: null;
+
+                    return shippingAddressChange
 				};
 			}
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1165,11 +1165,11 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 				),
 				'update_customer_shipping'       => array(
 					'shipping_options'       => array(
-						'endpoint' => '/wp-json/wc/store/cart/select-shipping-rate',
+						'endpoint' => home_url( UpdateShippingEndpoint::WC_STORE_API_ENDPOINT . 'select-shipping-rate'),
 					),
 					'shipping_address'       => array(
-						'cart_endpoint'            => '/wp-json/wc/store/cart/',
-						'update_customer_endpoint' => '/wp-json/wc/store/v1/cart/update-customer/',
+						'cart_endpoint'            => home_url( UpdateShippingEndpoint::WC_STORE_API_ENDPOINT ),
+						'update_customer_endpoint' => home_url( UpdateShippingEndpoint::WC_STORE_API_ENDPOINT . 'update-customer'),
 					),
 					'wp_rest_nonce'          => wp_create_nonce( 'wc_store_api' ),
 					'update_shipping_method' => \WC_AJAX::get_endpoint( 'update_shipping_method' ),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1165,11 +1165,11 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 				),
 				'update_customer_shipping'       => array(
 					'shipping_options'       => array(
-						'endpoint' => home_url( UpdateShippingEndpoint::WC_STORE_API_ENDPOINT . 'select-shipping-rate'),
+						'endpoint' => home_url( UpdateShippingEndpoint::WC_STORE_API_ENDPOINT . 'select-shipping-rate' ),
 					),
 					'shipping_address'       => array(
 						'cart_endpoint'            => home_url( UpdateShippingEndpoint::WC_STORE_API_ENDPOINT ),
-						'update_customer_endpoint' => home_url( UpdateShippingEndpoint::WC_STORE_API_ENDPOINT . 'update-customer'),
+						'update_customer_endpoint' => home_url( UpdateShippingEndpoint::WC_STORE_API_ENDPOINT . 'update-customer' ),
 					),
 					'wp_rest_nonce'          => wp_create_nonce( 'wc_store_api' ),
 					'update_shipping_method' => \WC_AJAX::get_endpoint( 'update_shipping_method' ),


### PR DESCRIPTION
# PR Description

The PR will address the following 2 issues:

1. Wrap the shipping endpoint URLs in the `home_url()` to fix the problem of site URL
2. Add `return` inside shipping address change callbacks to fix the problem with shipping methods

# Issue Description

The shipping methods in the PayPal popup maybe “one refresh behind” of what should be displayed when the shipping callback is enabled.

### Steps to Reproduce

1. enable shipping callback
3. log out & clear session
4. click PayPal button
5. observe no shipping options are displayed in the popup
6. select an address A in the popup
7. observe the originally missing default shipping method appears
8. change to a different address B
9. observe the shipping options for the address A display

