### PR TITLE
Improve WC order query for compatibility layer (2670)

### DIFF
--- a/.psalm/stubs.php
+++ b/.psalm/stubs.php
@@ -1,4 +1,6 @@
 <?php
+namespace Automattic\WooCommerce\Internal\DataStores\Orders;
+
 if (!defined('PAYPAL_INTEGRATION_DATE')) {
 	define('PAYPAL_INTEGRATION_DATE', '2023-06-02');
 }
@@ -68,4 +70,8 @@ class WP_HTML_Tag_Processor {
 	public function next_tag( $query = null ) {}
 	public function set_attribute( $name, $value ) {}
 	public function get_updated_html() {}
+}
+
+class OrdersTableDataStore {
+	public static function get_orders_table_name() {}
 }

--- a/.psalm/stubs.php
+++ b/.psalm/stubs.php
@@ -1,6 +1,4 @@
 <?php
-namespace Automattic\WooCommerce\Internal\DataStores\Orders;
-
 if (!defined('PAYPAL_INTEGRATION_DATE')) {
 	define('PAYPAL_INTEGRATION_DATE', '2023-06-02');
 }
@@ -65,13 +63,17 @@ function as_schedule_single_action( $timestamp, $hook, $args = array(), $group =
 /**
  * HTML API: WP_HTML_Tag_Processor class
  */
-class WP_HTML_Tag_Processor {
-	public function __construct( $html ) {}
-	public function next_tag( $query = null ) {}
-	public function set_attribute( $name, $value ) {}
-	public function get_updated_html() {}
+namespace {
+	class WP_HTML_Tag_Processor {
+		public function __construct( $html ) {}
+		public function next_tag( $query = null ) {}
+		public function set_attribute( $name, $value ) {}
+		public function get_updated_html() {}
+	}
 }
 
-class OrdersTableDataStore {
-	public static function get_orders_table_name() {}
+namespace Automattic\WooCommerce\Internal\DataStores\Orders {
+	class OrdersTableDataStore {
+		public static function get_orders_table_name() {}
+	}
 }

--- a/modules/ppcp-compat/src/PPEC/PPECHelper.php
+++ b/modules/ppcp-compat/src/PPEC/PPECHelper.php
@@ -7,6 +7,7 @@
 
 namespace WooCommerce\PayPalCommerce\Compat\PPEC;
 
+use Automattic\WooCommerce\Internal\DataStores\Orders\OrdersTableDataStore;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 
 /**
@@ -74,14 +75,17 @@ class PPECHelper {
 			return $has_ppec_subscriptions === 'true';
 		}
 
+		$wc_orders_table = OrdersTableDataStore::get_orders_table_name();
+
 		global $wpdb;
-		if ( class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled() && isset( $wpdb->wc_orders ) ) {
-			$result = $wpdb->get_var(
-				$wpdb->prepare(
-					"SELECT 1 FROM {$wpdb->wc_orders} WHERE payment_method = %s",
-					self::PPEC_GATEWAY_ID
-				)
+		if ( $wc_orders_table && class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$query = $wpdb->prepare(
+				'SELECT 1 FROM %s WHERE payment_method = %s',
+				$wc_orders_table,
+				self::PPEC_GATEWAY_ID
 			);
+			// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			$result = $wpdb->get_var( $query );
 		} else {
 			$result = $wpdb->get_var(
 				$wpdb->prepare(


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

We use $wpdb->wc_orders for retrieving WC Orders table name. WC offers utility class for that.

Feedback link: https://github.com/woocommerce/woocommerce-paypal-payments/pull/1996#issuecomment-1943465782