### PR TITLE
AXO: Add whitespace stripping on submission (3156)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -709,6 +709,8 @@ class AxoManager {
 			}`
 		);
 
+		this.emailInput.value = this.stripSpaces( this.emailInput.value );
+
 		this.$( this.el.paymentContainer.selector + '-detail' ).html( '' );
 		this.$( this.el.paymentContainer.selector + '-form' ).html( '' );
 
@@ -1132,6 +1134,10 @@ class AxoManager {
 	validateEmailFormat( value ) {
 		const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 		return emailPattern.test( value );
+	}
+
+	stripSpaces( str ) {
+		return str.replace( /\s+/g, '' );
 	}
 
 	validateEmail( billingEmail ) {


### PR DESCRIPTION
### Description

This PR strips all the whitespace from the email input on submission.


### Steps to Test

1. Use Firefox.
2. Open the Fastlane checkout.
3. Try adding spaces in the beginning, middle and end of the email string.
4. Submit or hit enter.
5. Confirm that it triggers the e-mail lookup/OTP correctly.

### Screenshots

N/A
