### PR TITLE
PayPal declares subscription support when for Subscription mode is set Disable PayPal for subscription (3378)

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -416,7 +416,7 @@ class WcSubscriptionsModule implements ModuleInterface {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
-				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : null;
+				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
 
 				if ( 'disable_paypal_subscriptions' !== $subscriptions_mode && $subscriptions_helper->plugin_is_active() ) {
 					$supports = array(
@@ -472,7 +472,7 @@ class WcSubscriptionsModule implements ModuleInterface {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
-				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : null;
+				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
 
 				if ( 'disable_paypal_subscriptions' !== $subscriptions_mode && $subscriptions_helper->plugin_is_active() ) {
 					$supports = array(

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -444,7 +444,12 @@ class WcSubscriptionsModule implements ModuleInterface {
 				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscriptions_helper instanceof SubscriptionHelper );
 
-				if ( $subscriptions_helper->plugin_is_active() ) {
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				$vaulting_enabled = $settings->has( 'vault_enabled_dcc' ) && $settings->get( 'vault_enabled_dcc' );
+
+				if ( $vaulting_enabled && $subscriptions_helper->plugin_is_active() ) {
 					$supports = array(
 						'subscriptions',
 						'subscription_cancellation',

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -416,7 +416,9 @@ class WcSubscriptionsModule implements ModuleInterface {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
-				if ( $subscriptions_helper->plugin_is_active() ) {
+				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : null;
+
+				if ( 'disable_paypal_subscriptions' !== $subscriptions_mode && $subscriptions_helper->plugin_is_active() ) {
 					$supports = array(
 						'subscriptions',
 						'subscription_cancellation',
@@ -467,7 +469,12 @@ class WcSubscriptionsModule implements ModuleInterface {
 				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscriptions_helper instanceof SubscriptionHelper );
 
-				if ( $subscriptions_helper->plugin_is_active() ) {
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : null;
+
+				if ( 'disable_paypal_subscriptions' !== $subscriptions_mode && $subscriptions_helper->plugin_is_active() ) {
 					$supports = array(
 						'subscriptions',
 						'subscription_cancellation',


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

When disabling subscription functionality in the Standard Payments tab, PayPal still declares support for subscriptions.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Navigate to WC → Settings → General → Payments → PayPal
2. For Subscription mode set Disable PayPal for subscription (also for acdc disable Vaulting)
3. Navigate to Payment tab and observe subscription support still declared (**now fixed**)

- Before:
  ![image](https://github.com/user-attachments/assets/51326b5b-4788-4ab0-a82c-ce355dd2b12a)
- After:
  ![image](https://github.com/user-attachments/assets/cdee820b-d08e-49b6-8879-b578ee24a892)

