### PR TITLE
Can't pay from block pages when the shipping callback is enabled and no shipping methods defined (3385)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -227,7 +227,7 @@ const PayPalComponent = ( {
 				throw new Error( config.scriptData.labels.error.generic );
 			}
 
-			if ( ! shouldHandleShippingInPayPal() ) {
+			if ( ! shouldskipFinalConfirmation() ) {
 				location.href = getCheckoutRedirectUrl();
 			} else {
 				setGotoContinuationOnError( true );
@@ -318,7 +318,7 @@ const PayPalComponent = ( {
 				throw new Error( config.scriptData.labels.error.generic );
 			}
 
-			if ( ! shouldHandleShippingInPayPal() ) {
+			if ( ! shouldskipFinalConfirmation() ) {
 				location.href = getCheckoutRedirectUrl();
 			} else {
 				setGotoContinuationOnError( true );
@@ -364,15 +364,19 @@ const PayPalComponent = ( {
 	};
 
 	const shouldHandleShippingInPayPal = () => {
-		if ( config.finalReviewEnabled ) {
-			return false;
-		}
-
-		return (
-			window.ppcpFundingSource !== 'venmo' ||
-			! config.scriptData.vaultingEnabled
-		);
+		return shouldskipFinalConfirmation() && config.needShipping
 	};
+
+    const shouldskipFinalConfirmation = () => {
+        if ( config.finalReviewEnabled ) {
+            return false;
+        }
+
+        return (
+            window.ppcpFundingSource !== 'venmo' ||
+            ! config.scriptData.vaultingEnabled
+        );
+    };
 
 	let handleShippingOptionsChange = null;
 	let handleShippingAddressChange = null;
@@ -544,7 +548,7 @@ const PayPalComponent = ( {
 			if ( config.scriptData.continuation ) {
 				return true;
 			}
-			if ( shouldHandleShippingInPayPal() ) {
+			if ( shouldskipFinalConfirmation() ) {
 				location.href = getCheckoutRedirectUrl();
 			}
 			return true;

--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -210,7 +210,6 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		$script_data = $this->smart_button()->script_data();
-		$cart = WC()->cart;
 
 		if ( isset( $script_data['continuation'] ) ) {
 			$url = add_query_arg( array( CancelController::NONCE => wp_create_nonce( CancelController::NONCE ) ), wc_get_checkout_url() );
@@ -255,7 +254,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 				),
 			),
 			'scriptData'                  => $script_data,
-			'needShipping' 	              => $cart && $cart->needs_shipping(),
+			'needShipping'                => WC()->cart->needs_shipping(),
 		);
 	}
 

--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -210,6 +210,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		$script_data = $this->smart_button()->script_data();
+		$cart = WC()->cart;
 
 		if ( isset( $script_data['continuation'] ) ) {
 			$url = add_query_arg( array( CancelController::NONCE => wp_create_nonce( CancelController::NONCE ) ), wc_get_checkout_url() );
@@ -254,6 +255,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 				),
 			),
 			'scriptData'                  => $script_data,
+			'needShipping' 	              => $cart && $cart->needs_shipping(),
 		);
 	}
 

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -139,7 +139,7 @@ class Renderer {
 			};
 
 			// Check the condition and add the handler if needed
-			if ( this.defaultSettings.should_handle_shipping_in_paypal ) {
+			if ( this.defaultSettings.should_handle_shipping_in_paypal && this.defaultSettings.needShipping ) {
 				options.onShippingOptionsChange = ( data, actions ) => {
                     let shippingOptionsChange =
 					! this.isVenmoButtonClickedWhenVaultingIsEnabled(

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1295,7 +1295,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 				'is_logged' => is_user_logged_in(),
 			),
 			'should_handle_shipping_in_paypal'        => $this->should_handle_shipping_in_paypal && ! $this->is_checkout(),
-			'needShipping' 							  => WC()->cart->needs_shipping(),
+			'needShipping'                            => WC()->cart->needs_shipping(),
 			'vaultingEnabled'                         => $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ),
 		);
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1094,6 +1094,8 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 
 		$url_params = $this->url_params();
 
+		$cart = WC()->cart;
+
 		$this->request_data->enqueue_nonce_fix();
 		$localize = array(
 			'url'                                     => add_query_arg( $url_params, 'https://www.paypal.com/sdk/js' ),
@@ -1295,6 +1297,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 				'is_logged' => is_user_logged_in(),
 			),
 			'should_handle_shipping_in_paypal'        => $this->should_handle_shipping_in_paypal && ! $this->is_checkout(),
+			'needShipping' 							  => $cart && $cart->needs_shipping(),
 			'vaultingEnabled'                         => $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ),
 		);
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1094,8 +1094,6 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 
 		$url_params = $this->url_params();
 
-		$cart = WC()->cart;
-
 		$this->request_data->enqueue_nonce_fix();
 		$localize = array(
 			'url'                                     => add_query_arg( $url_params, 'https://www.paypal.com/sdk/js' ),
@@ -1297,7 +1295,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 				'is_logged' => is_user_logged_in(),
 			),
 			'should_handle_shipping_in_paypal'        => $this->should_handle_shipping_in_paypal && ! $this->is_checkout(),
-			'needShipping' 							  => $cart && $cart->needs_shipping(),
+			'needShipping' 							  => WC()->cart->needs_shipping(),
 			'vaultingEnabled'                         => $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ),
 		);
 


### PR DESCRIPTION
# PR Description

The `$cart->needs_shipping()` is checked and if it is `false` we would disable the shipping callback in popup.
The final confirmation will still be skipped
 
# Issue Description

When the shipping callback is enabled and no shipping methods defined the error is shown in PayPal popup if the button is clicked from block pages.
If the button is clicked from classic pages then we can pay but there is error in console

![Screenshot 2024-07-16 at 15 24 12](https://github.com/user-attachments/assets/ee92c4b5-4d53-48ac-891d-b87e59caac4a)

![Screenshot 2024-07-16 at 15 14 32](https://github.com/user-attachments/assets/6d6aee8b-c4c3-4e55-8591-95c52abd6da1)



### Steps to Reproduce

1. From WC shipping settings delete all defined shipping methods
2. Enable the shipping callback
3. Navigate to shop
4. Add product to cart
5. Navigate to block cart or block checkout and click on PayPal
6. Observe the message and we can not pay