### PR TITLE
Add tax configurator when programmatically creating WC orders (3394)

### DIFF
--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -14,8 +14,10 @@ use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Product;
 use WC_Order_Item_Shipping;
+use WC_Product;
 use WC_Subscription;
 use WC_Subscriptions_Product;
+use WC_Tax;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
@@ -106,6 +108,7 @@ class WooCommerceOrderCreator {
 	 * @param Payer|null    $payer The payer.
 	 * @param Shipping|null $shipping The shipping.
 	 * @return void
+	 * @psalm-suppress InvalidScalarArgument
 	 */
 	protected function configure_line_items( WC_Order $wc_order, WC_Cart $wc_cart, ?Payer $payer, ?Shipping $shipping ): void {
 		$cart_contents = $wc_cart->get_cart();
@@ -130,18 +133,20 @@ class WooCommerceOrderCreator {
 				return;
 			}
 
-			$total = $product->get_price() * $quantity;
+			$subtotal = wc_get_price_excluding_tax( $product, array( 'qty' => $quantity ) );
 
 			$item->set_name( $product->get_name() );
-			$item->set_subtotal( $total );
-			$item->set_total( $total );
+			$item->set_subtotal( $subtotal );
+			$item->set_total( $subtotal );
+
+			$this->configure_taxes( $product, $item, $subtotal );
 
 			$product_id = $product->get_id();
 
 			if ( $this->is_subscription( $product_id ) ) {
 				$subscription       = $this->create_subscription( $wc_order, $product_id );
 				$sign_up_fee        = WC_Subscriptions_Product::get_sign_up_fee( $product );
-				$subscription_total = $total + $sign_up_fee;
+				$subscription_total = (float) $subtotal + (float) $sign_up_fee;
 
 				$item->set_subtotal( $subscription_total );
 				$item->set_total( $subscription_total );
@@ -279,6 +284,30 @@ class WooCommerceOrderCreator {
 	protected function configure_coupons( WC_Order $wc_order, array $coupons ): void {
 		foreach ( $coupons as $coupon_code ) {
 			$wc_order->apply_coupon( $coupon_code );
+		}
+	}
+
+	/**
+	 * Configures the taxes.
+	 *
+	 * @param WC_Product            $product The Product.
+	 * @param WC_Order_Item_Product $item The line item.
+	 * @param float|string          $subtotal The subtotal.
+	 * @return void
+	 * @psalm-suppress InvalidScalarArgument
+	 */
+	protected function configure_taxes( WC_Product $product, WC_Order_Item_Product $item, $subtotal ): void {
+		$tax_rates = WC_Tax::get_rates( $product->get_tax_class() );
+		$taxes     = WC_Tax::calc_tax( $subtotal, $tax_rates, true );
+
+		$item->set_tax_class( $product->get_tax_class() );
+		$item->set_total_tax( (float) array_sum( $taxes ) );
+
+		foreach ( $taxes as $tax_rate_id => $tax_amount ) {
+			if ( $tax_amount > 0 ) {
+				$item->add_meta_data( 'tax_rate_id', $tax_rate_id, true );
+				$item->add_meta_data( 'tax_amount', $tax_amount, true );
+			}
 		}
 	}
 


### PR DESCRIPTION
# PR Description

The PR will add the tax configurator when programmatically creating WC orders
 
# Issue Description

When shipping callback is enabled we programmatically create WC orders.
However the taxes are incorrectly calculated for order total.

### Steps to Reproduce

1. Enable tax rates
2. Buy the product with shipping callback disabled.
3. Buy the same product with shipping callback enabled.

<img width="1312" alt="Screenshot 2024-07-17 at 17 07 35" src="https://github.com/user-attachments/assets/95787c23-0ae8-4da6-9fb1-dd9c37096178">

<img width="1311" alt="Screenshot 2024-07-17 at 17 07 52" src="https://github.com/user-attachments/assets/ca2750f5-458c-42d9-b5e4-add471555dfa">


