### PR TITLE
AXO: Add warning when shipping config is not compatible (3392)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -126,6 +126,18 @@ return array(
 					'requirements' => array( 'dcc', 'axo' ),
 					'gateway'      => array( 'dcc', 'axo' ),
 				),
+				'axo_shipping_config_notice'         => array(
+					'heading'      => '',
+					'html'         => $container->get( 'axo.shipping-config-notice' ),
+					'type'         => 'ppcp-html',
+					'classes'      => array( 'ppcp-field-indent' ),
+					'class'        => array(),
+					'screens'      => array(
+						State::STATE_ONBOARDED,
+					),
+					'requirements' => array( 'dcc', 'axo' ),
+					'gateway'      => array( 'dcc', 'axo' ),
+				),
 				'axo_gateway_title'                  => array(
 					'title'        => __( 'Gateway Title', 'woocommerce-paypal-payments' ),
 					'type'         => 'text',

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -114,21 +114,9 @@ return array(
 					),
 					'classes'           => array( 'ppcp-valign-label-middle', 'ppcp-align-label-center' ),
 				),
-				'axo_checkout_config_notice'         => array(
+				'axo_main_notice'                    => array(
 					'heading'      => '',
-					'html'         => $container->get( 'axo.checkout-config-notice' ),
-					'type'         => 'ppcp-html',
-					'classes'      => array( 'ppcp-field-indent' ),
-					'class'        => array(),
-					'screens'      => array(
-						State::STATE_ONBOARDED,
-					),
-					'requirements' => array( 'dcc', 'axo' ),
-					'gateway'      => array( 'dcc', 'axo' ),
-				),
-				'axo_shipping_config_notice'         => array(
-					'heading'      => '',
-					'html'         => $container->get( 'axo.shipping-config-notice' ),
+					'html'         => $container->get( 'axo.shipping-config-notice' ) . $container->get( 'axo.checkout-config-notice' ),
 					'type'         => 'ppcp-html',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'class'        => array(),

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -25,7 +25,7 @@ return array(
 		$apm_applies = $container->get( 'axo.helpers.apm-applies' );
 		assert( $apm_applies instanceof ApmApplies );
 
-		return $apm_applies->for_country_currency() && $apm_applies->for_settings();
+		return $apm_applies->for_country_currency();
 	},
 
 	'axo.helpers.apm-applies'               => static function ( ContainerInterface $container ) : ApmApplies {
@@ -202,7 +202,6 @@ return array(
 
 		return '<div class="ppcp-notice ppcp-notice-error"><p>' . $notice_content . '</p></div>';
 	},
-
 	'axo.smart-button-location-notice'      => static function ( ContainerInterface $container ) : string {
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
@@ -229,6 +228,24 @@ return array(
 		}
 
 		return '<div class="ppcp-notice ppcp-notice-warning"><p>' . $notice_content . '</p></div>';
+	},
+	'axo.shipping-config-notice'            => static function ( ContainerInterface $container ) : string {
+		$shipping_settings_link = admin_url( 'admin.php?page=wc-settings&tab=shipping&section=options' );
+
+		if ( wc_shipping_enabled() && wc_ship_to_billing_address_only() ) {
+			$notice_content = sprintf(
+			/* translators: %1$s: URL to the Shipping destination settings page. */
+				__(
+					'<span class="highlight">Warning:</span> The <a href="%1$s">Shipping destination</a> of your store is currently configured to <code>Force shipping to the customer billing address</code>. To enable Fastlane and accelerate payments, the shipping destination must be configured either to <code>Default to customer shipping address</code> or <code>Default to customer billing address</code> so buyers can set separate billing and shipping details.',
+					'woocommerce-paypal-payments'
+				),
+				esc_url( $shipping_settings_link )
+			);
+		} else {
+			return '';
+		}
+
+		return '<div class="ppcp-notice ppcp-notice-error"><p>' . $notice_content . '</p></div>';
 	},
 	'axo.endpoint.frontend-logger'          => static function ( ContainerInterface $container ): FrontendLoggerEndpoint {
 		return new FrontendLoggerEndpoint(

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -87,6 +87,10 @@ class AxoModule implements ModuleInterface {
 					return $methods;
 				}
 
+				if ( ! $this->is_compatible_shipping_config() ) {
+					return $methods;
+				}
+
 				$methods[] = $gateway;
 				return $methods;
 			},
@@ -150,7 +154,8 @@ class AxoModule implements ModuleInterface {
 				// Check if the module is applicable, correct country, currency, ... etc.
 				if ( ! $c->get( 'axo.eligible' )
 					|| 'continuation' === $c->get( 'button.context' )
-					|| $subscription_helper->cart_contains_subscription() ) {
+					|| $subscription_helper->cart_contains_subscription()
+					|| ! $this->is_compatible_shipping_config() ) {
 					return;
 				}
 

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -341,6 +341,7 @@ class AxoModule implements ModuleInterface {
 
 		return ! is_user_logged_in()
 			&& CartCheckoutDetector::has_classic_checkout()
+			&& $this->is_compatible_shipping_config()
 			&& $is_axo_enabled
 			&& $is_dcc_enabled
 			&& ! $this->is_excluded_endpoint();
@@ -395,5 +396,14 @@ class AxoModule implements ModuleInterface {
 	private function is_excluded_endpoint(): bool {
 		// Exclude the Order Pay endpoint.
 		return is_wc_endpoint_url( 'order-pay' );
+	}
+
+	/**
+	 * Condition to evaluate if the shipping configuration is compatible.
+	 *
+	 * @return bool
+	 */
+	private function is_compatible_shipping_config(): bool {
+		return ! wc_shipping_enabled() || ( wc_shipping_enabled() && ! wc_ship_to_billing_address_only() );
 	}
 }

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -409,6 +409,6 @@ class AxoModule implements ModuleInterface {
 	 * @return bool
 	 */
 	private function is_compatible_shipping_config(): bool {
-		return ! wc_shipping_enabled() || ( wc_shipping_enabled() && ! wc_ship_to_billing_address_only() );
+		return ! wc_shipping_enabled() || ! wc_ship_to_billing_address_only();
 	}
 }

--- a/modules/ppcp-axo/src/Helper/ApmApplies.php
+++ b/modules/ppcp-axo/src/Helper/ApmApplies.php
@@ -64,19 +64,4 @@ class ApmApplies {
 		}
 		return in_array( $this->currency, $this->allowed_country_currency_matrix[ $this->country ], true );
 	}
-
-	/**
-	 * Returns whether the settings are compatible with AXO.
-	 *
-	 * @return bool
-	 */
-	public function for_settings(): bool {
-		if ( get_option( 'woocommerce_ship_to_destination' ) === 'billing_only' ) { // Force shipping to the customer billing address.
-			return false;
-		}
-		return true;
-	}
-
-
-
 }

--- a/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
+++ b/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Settings notice generator.
+ * Generates the settings notices.
+ *
+ * @package WooCommerce\PayPalCommerce\Axo\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Axo\Helper;
+
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CartCheckoutDetector;
+
+/**
+ * Class SettingsNoticeGenerator
+ */
+class SettingsNoticeGenerator {
+
+	/**
+	 * Generates the checkout notice.
+	 *
+	 * @return string
+	 */
+	public function generate_checkout_notice(): string {
+		$checkout_page_link       = esc_url( get_edit_post_link( wc_get_page_id( 'checkout' ) ) ?? '' );
+		$block_checkout_docs_link = __(
+			'https://woocommerce.com/document/cart-checkout-blocks-status/#reverting-to-the-cart-and-checkout-shortcodes',
+			'woocommerce-paypal-payments'
+		);
+
+		$notice_content = '';
+
+		if ( CartCheckoutDetector::has_elementor_checkout() ) {
+			$notice_content = sprintf(
+			/* translators: %1$s: URL to the Checkout edit page. %2$s: URL to the block checkout docs. */
+				__(
+					'<span class="highlight">Warning:</span> The <a href="%1$s">Checkout page</a> of your store currently uses the <code>Elementor Checkout widget</code>. To enable Fastlane and accelerate payments, the page must include either the <code>Classic Checkout</code> or the <code>[woocommerce_checkout]</code> shortcode. See <a href="%2$s">this page</a> for instructions on how to switch to the classic layout.',
+					'woocommerce-paypal-payments'
+				),
+				esc_url( $checkout_page_link ),
+				esc_url( $block_checkout_docs_link )
+			);
+		} elseif ( CartCheckoutDetector::has_block_checkout() ) {
+			$notice_content = sprintf(
+			/* translators: %1$s: URL to the Checkout edit page. %2$s: URL to the block checkout docs. */
+				__(
+					'<span class="highlight">Warning:</span> The <a href="%1$s">Checkout page</a> of your store currently uses the WooCommerce <code>Checkout</code> block. To enable Fastlane and accelerate payments, the page must include either the <code>Classic Checkout</code> or the <code>[woocommerce_checkout]</code> shortcode. See <a href="%2$s">this page</a> for instructions on how to switch to the classic layout.',
+					'woocommerce-paypal-payments'
+				),
+				esc_url( $checkout_page_link ),
+				esc_url( $block_checkout_docs_link )
+			);
+		} elseif ( ! CartCheckoutDetector::has_classic_checkout() ) {
+			$notice_content = sprintf(
+			/* translators: %1$s: URL to the Checkout edit page. %2$s: URL to the block checkout docs. */
+				__(
+					'<span class="highlight">Warning:</span> The <a href="%1$s">Checkout page</a> of your store does not seem to be properly configured or uses an incompatible <code>third-party Checkout</code> solution. To enable Fastlane and accelerate payments, the page must include either the <code>Classic Checkout</code> or the <code>[woocommerce_checkout]</code> shortcode. See <a href="%2$s">this page</a> for instructions on how to switch to the classic layout.',
+					'woocommerce-paypal-payments'
+				),
+				esc_url( $checkout_page_link ),
+				esc_url( $block_checkout_docs_link )
+			);
+		}
+
+		return $notice_content ? '<div class="ppcp-notice ppcp-notice-error"><p>' . $notice_content . '</p></div>' : '';
+	}
+
+	/**
+	 * Generates the shipping notice.
+	 *
+	 * @return string
+	 */
+	public function generate_shipping_notice(): string {
+		$shipping_settings_link = admin_url( 'admin.php?page=wc-settings&tab=shipping&section=options' );
+
+		$notice_content = '';
+
+		if ( wc_shipping_enabled() && wc_ship_to_billing_address_only() ) {
+			$notice_content = sprintf(
+			/* translators: %1$s: URL to the Shipping destination settings page. */
+				__(
+					'<span class="highlight">Warning:</span> The <a href="%1$s">Shipping destination</a> of your store is currently configured to <code>Force shipping to the customer billing address</code>. To enable Fastlane and accelerate payments, the shipping destination must be configured either to <code>Default to customer shipping address</code> or <code>Default to customer billing address</code> so buyers can set separate billing and shipping details.',
+					'woocommerce-paypal-payments'
+				),
+				esc_url( $shipping_settings_link )
+			);
+		}
+
+		return $notice_content ? '<div class="ppcp-notice ppcp-notice-error"><p>' . $notice_content . '</p></div>' : '';
+	}
+}


### PR DESCRIPTION
### Description

This PR disables Fastlane when shipping is enabled and the `Force shipping to the customer billing address` option is selected in the shipping settings.

It also adds a warning in the Fastlane settings.


### Steps to Test

1. Enable Fastlane.
2. Enable shipping and set the settings to `Force shipping to the customer billing address`.
3. Verify the warning is being displayed correctly.
4. Ensure Fastlane doesn't load for the guest checkout.
5. Make sure there's no notice and Fastlane works correctly when shipping is set to a different option or if shipping is disabled altogether.

### Screenshots

|Before|After|
|-|-|
|![WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress_i_Porównaj_serwisy_turystyczne](https://github.com/user-attachments/assets/7f2b9c02-4a0d-4413-989d-91a9f8cfc43f)|![WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress_i_Porównaj_serwisy_turystyczne](https://github.com/user-attachments/assets/2a741dca-b8cb-46a3-a807-595551163982)|
