### PR TITLE
AXO: Ensure Fastlane scripts do not load when PayPal is disabled (3075)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -77,9 +77,10 @@ class AxoModule implements ModuleInterface {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
+				$is_paypal_enabled = $settings->has( 'paypal_enabled' ) && $settings->get( 'paypal_enabled' ) ?? false;
 				$is_dcc_enabled = $settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' ) ?? false;
 
-				if ( ! $is_dcc_enabled ) {
+				if ( ! $is_paypal_enabled || ! $is_dcc_enabled ) {
 					return $methods;
 				}
 
@@ -144,11 +145,17 @@ class AxoModule implements ModuleInterface {
 			function () use ( $c ) {
 				$module = $this;
 
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				$is_paypal_enabled = $settings->has( 'paypal_enabled' ) && $settings->get( 'paypal_enabled' ) ?? false;
+
 				$subscription_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscription_helper instanceof SubscriptionHelper );
 
 				// Check if the module is applicable, correct country, currency, ... etc.
-				if ( ! $c->get( 'axo.eligible' )
+				if ( ! $is_paypal_enabled
+					|| ! $c->get( 'axo.eligible' )
 					|| 'continuation' === $c->get( 'button.context' )
 					|| $subscription_helper->cart_contains_subscription() ) {
 					return;


### PR DESCRIPTION
### Description

This PR disables Fastlane when PayPal is disabled.


### Steps to Test

1. Enable Fastlane.
2. Disable the main PayPal setting.
3. Verify AXO isn't being loaded for the guest checkout.

### Screenshots

|Before|After|
|-|-|
|![paypal_disabled_before](https://github.com/user-attachments/assets/36d56e45-8766-44db-90af-a2d50a2378c9)|![Page__Checkout](https://github.com/user-attachments/assets/d7bc8f09-0d5d-4ec8-be1e-f1eea984abfc)|
