### PR TITLE
When there isn't any shipping option for the address the order is still created from classic cart

### DIFF
--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
@@ -20,10 +20,7 @@ const onApprove = ( context, errorHandler ) => {
 			} )
 			.then( ( data ) => {
 				if ( ! data.success ) {
-					errorHandler.genericError();
-					return actions.restart().catch( ( err ) => {
-						errorHandler.genericError();
-					} );
+                    location.href = context.config.redirect;
 				}
 
 				const orderReceivedUrl = data.data?.order_received_url;

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -154,7 +154,7 @@ class WooCommerceOrderCreator {
 				$item->set_total( $subscription_total );
 
 				$subscription->add_product( $product );
-				$this->configure_shipping( $subscription, $payer, $shipping );
+				$this->configure_shipping( $subscription, $payer, $shipping, $wc_cart );
 				$this->configure_payment_source( $subscription );
 				$this->configure_coupons( $subscription, $wc_cart->get_applied_coupons() );
 

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button\Helper;
 
+use Exception;
 use RuntimeException;
 use WC_Cart;
+use WC_Data_Exception;
 use WC_Order;
 use WC_Order_Item_Product;
 use WC_Order_Item_Shipping;
@@ -83,17 +85,22 @@ class WooCommerceOrderCreator {
 			throw new RuntimeException( 'Problem creating WC order.' );
 		}
 
-		$payer    = $order->payer();
-		$shipping = $order->purchase_units()[0]->shipping();
+		try {
+			$payer    = $order->payer();
+			$shipping = $order->purchase_units()[0]->shipping();
 
-		$this->configure_payment_source( $wc_order );
-		$this->configure_customer( $wc_order );
-		$this->configure_line_items( $wc_order, $wc_cart, $payer, $shipping );
-		$this->configure_shipping( $wc_order, $payer, $shipping );
-		$this->configure_coupons( $wc_order, $wc_cart->get_applied_coupons() );
+			$this->configure_payment_source( $wc_order );
+			$this->configure_customer( $wc_order );
+			$this->configure_line_items( $wc_order, $wc_cart, $payer, $shipping );
+			$this->configure_shipping( $wc_order, $payer, $shipping, $wc_cart );
+			$this->configure_coupons( $wc_order, $wc_cart->get_applied_coupons() );
 
-		$wc_order->calculate_totals();
-		$wc_order->save();
+			$wc_order->calculate_totals();
+			$wc_order->save();
+		} catch ( Exception $exception ) {
+			$wc_order->delete( true );
+			throw new RuntimeException( 'Failed to create WooCommerce order: ' . $exception->getMessage() );
+		}
 
 		return $wc_order;
 	}
@@ -172,9 +179,11 @@ class WooCommerceOrderCreator {
 	 * @param WC_Order      $wc_order The WC order.
 	 * @param Payer|null    $payer The payer.
 	 * @param Shipping|null $shipping The shipping.
+	 * @param WC_Cart       $wc_cart The Cart.
 	 * @return void
+	 * @throws WC_Data_Exception|RuntimeException When failing to configure shipping.
 	 */
-	protected function configure_shipping( WC_Order $wc_order, ?Payer $payer, ?Shipping $shipping ): void {
+	protected function configure_shipping( WC_Order $wc_order, ?Payer $payer, ?Shipping $shipping, WC_Cart $wc_cart ): void {
 		$shipping_address = null;
 		$billing_address  = null;
 		$shipping_options = null;
@@ -210,6 +219,10 @@ class WooCommerceOrderCreator {
 			);
 
 			$shipping_options = $shipping->options()[0] ?? '';
+		}
+
+		if ( $wc_cart->needs_shipping() && empty( $shipping_options ) ) {
+			throw new RuntimeException( 'No shipping method has been selected.' );
 		}
 
 		if ( $shipping_address ) {


### PR DESCRIPTION
# PR Description

The PR will add shipping option validation when programmatically creating WC order and will redirect to continuation if error happens during the approval.
 
# Issue Description

By default when there isn't any shipping option for the address, WC will complain in checkout page and not allow to create order.
This works correctly when used the block cart (redirected to continuation)

For the classic cart or product page the order will be successfully created which is wrong

### Steps to Reproduce

1. Define shipping for example US (flat rate and free)
2. Define shipping for example DE (flat rate and free)
3. Define for rest of the world no shipping
4. Navigate to shop and click on product
5. On PayPal popup add address for example France
6. Observe the order is created 
