### PR TITLE
Add support for WC Bookings when skipping checkout confirmation

### DIFF
--- a/.psalm/wc-bookings.php
+++ b/.psalm/wc-bookings.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Validate and create a new booking manually.
+ *
+ * @version  1.10.7
+ * @see      WC_Booking::new_booking() for available $new_booking_data args
+ * @param    int    $product_id you are booking
+ * @param    array  $new_booking_data
+ * @param    string $status
+ * @param    bool   $exact If false, the function will look for the next available block after your start date if the date is unavailable.
+ * @return   mixed  WC_Booking object on success or false on fail
+ */
+function create_wc_booking( $product_id, $new_booking_data = array(), $status = 'confirmed', $exact = false ) {}

--- a/.psalm/wc-bookings.php
+++ b/.psalm/wc-bookings.php
@@ -12,3 +12,9 @@
  * @return   mixed  WC_Booking object on success or false on fail
  */
 function create_wc_booking( $product_id, $new_booking_data = array(), $status = 'confirmed', $exact = false ) {}
+
+/**
+ * Returns true if the product is a booking product, false if not
+ * @return bool
+ */
+function is_wc_booking_product( $product ) {}

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -95,6 +95,8 @@ class WooCommerceOrderCreator {
 		$wc_order->calculate_totals();
 		$wc_order->save();
 
+		do_action( 'woocommerce_paypal_payments_shipping_callback_woocommerce_order_created', $wc_order, $wc_cart );
+
 		return $wc_order;
 	}
 

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -83,6 +83,9 @@ return array(
 	'compat.wc_shipping_tax.is_supported_plugin_version_active' => function (): bool {
 		return class_exists( 'WC_Connect_Loader' );
 	},
+	'compat.wc_bookings.is_supported_plugin_version_active' => function (): bool {
+		return class_exists( 'WC_Bookings' );
+	},
 
 	'compat.module.url'                              => static function ( ContainerInterface $container ): string {
 		/**

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -446,7 +446,7 @@ class CompatModule implements ModuleInterface {
 								$booking_data['persons'] = $cart_item['booking']['_persons'];
 							}
 
-							create_wc_booking( $cart_item['product_id'], $booking_data, 'pending-confirmation' );
+							create_wc_booking( $cart_item['product_id'], $booking_data, 'unpaid' );
 						}
 					}
 				} catch ( Exception $exception ) {

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -417,6 +417,12 @@ class CompatModule implements ModuleInterface {
 						}
 
 						foreach ( $wc_order->get_items() as $wc_order_item ) {
+							$product = wc_get_product( $wc_order_item->get_product_id() );
+
+							if ( ! is_wc_booking_product( $product ) ) {
+								continue;
+							}
+
 							$booking_data = array(
 								'cost'           => $cart_item['booking']['_cost'] ?? 0,
 								'start_date'     => $cart_item['booking']['_start_date'] ?? 0,
@@ -434,7 +440,7 @@ class CompatModule implements ModuleInterface {
 								$booking_data['persons'] = $cart_item['booking']['_persons'];
 							}
 
-							create_wc_booking( $cart_item['product_id'], $booking_data, 'unpaid' );
+							create_wc_booking( $cart_item['product_id'], $booking_data, 'pending-confirmation' );
 						}
 					}
 				} catch ( Exception $exception ) {

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -434,7 +434,7 @@ class CompatModule implements ModuleInterface {
 								$booking_data['persons'] = $cart_item['booking']['_persons'];
 							}
 
-							create_wc_booking( $cart_item['product_id'], $booking_data, $wc_order->get_status() );
+							create_wc_booking( $cart_item['product_id'], $booking_data, 'unpaid' );
 						}
 					}
 				} catch ( Exception $exception ) {

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -13,6 +13,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use WC_Cart;
 use WC_Order;
+use WC_Order_Item_Product;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
@@ -417,7 +418,12 @@ class CompatModule implements ModuleInterface {
 						}
 
 						foreach ( $wc_order->get_items() as $wc_order_item ) {
-							$product = wc_get_product( $wc_order_item->get_product_id() );
+							if ( ! is_a( $wc_order_item, WC_Order_Item_Product::class ) ) {
+								continue;
+							}
+
+							$product_id = $wc_order_item->get_variation_id() ?: $wc_order_item->get_product_id();
+							$product    = wc_get_product( $product_id );
 
 							if ( ! is_wc_booking_product( $product ) ) {
 								continue;

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -35,6 +35,7 @@
     	<file name=".psalm/wcblocks.php"/>
     	<file name=".psalm/wcs.php"/>
     	<file name=".psalm/gzd.php"/>
+    	<file name=".psalm/wc-bookings.php"/>
     	<file name=".psalm/wpcli.php"/>
 		<file name="vendor/php-stubs/wordpress-stubs/wordpress-stubs.php"/>
 		<file name="vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php"/>


### PR DESCRIPTION
# PR Description

The PR will add compatibility layer for the WC Bookings plugin
 
# Issue Description

When Require final confirmation on checkout is unchecked and the PayPal button on a single product page for a bookable product is used, no booking is created.

### Steps to Reproduce

1. Enable the shipping callback
2. Create bookable product
3. From single product page or cart page try to buy
4. Observe the order is created without booking
