### PR TITLE
AXO: Add a notice when incompatible plugins are active (3474)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -116,7 +116,14 @@ return array(
 				),
 				'axo_main_notice'                    => array(
 					'heading'      => '',
-					'html'         => $container->get( 'axo.shipping-config-notice' ) . $container->get( 'axo.checkout-config-notice' ),
+					'html'         => implode(
+						'',
+						array(
+							$container->get( 'axo.shipping-config-notice' ),
+							$container->get( 'axo.checkout-config-notice' ),
+							$container->get( 'axo.incompatible-plugins-notice' ),
+						)
+					),
 					'type'         => 'ppcp-html',
 					'classes'      => array( 'ppcp-field-indent' ),
 					'class'        => array(),

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -178,6 +178,13 @@ return array(
 		return $settings_notice_generator->generate_shipping_notice();
 	},
 
+	'axo.incompatible-plugins-notice'       => static function ( ContainerInterface $container ) : string {
+		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
+		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
+
+		return $settings_notice_generator->generate_incompatible_plugins_notice();
+	},
+
 	'axo.smart-button-location-notice'      => static function ( ContainerInterface $container ) : string {
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );

--- a/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
+++ b/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
@@ -89,4 +89,42 @@ class SettingsNoticeGenerator {
 
 		return $notice_content ? '<div class="ppcp-notice ppcp-notice-error"><p>' . $notice_content . '</p></div>' : '';
 	}
+
+	/**
+	 * Generates the incompatible plugins notice.
+	 *
+	 * @return string
+	 */
+	public function generate_incompatible_plugins_notice(): string {
+		$incompatible_plugins = array(
+			'Elementor'  => did_action( 'elementor/loaded' ),
+			'CheckoutWC' => defined( 'CFW_NAME' ),
+		);
+
+		$active_plugins_list = array_filter( $incompatible_plugins );
+
+		if ( empty( $active_plugins_list ) ) {
+			return '';
+		}
+
+		$incompatible_plugin_items = array_map(
+			function ( $plugin ) {
+				return "<li>{$plugin}</li>";
+			},
+			array_keys( $active_plugins_list )
+		);
+
+		$plugins_settings_link = esc_url( admin_url( 'plugins.php' ) );
+		$notice_content        = sprintf(
+		/* translators: %1$s: URL to the plugins settings page. %2$s: List of incompatible plugins. */
+			__(
+				'<span class="highlight">Note:</span> The accelerated guest buyer experience provided by Fastlane may not be fully compatible with some of the following <a href="%1$s">active plugins</a>: <ul class="ppcp-notice-list">%2$s</ul>',
+				'woocommerce-paypal-payments'
+			),
+			$plugins_settings_link,
+			implode( '', $incompatible_plugin_items )
+		);
+
+		return '<div class="ppcp-notice"><p>' . $notice_content . '</p></div>';
+	}
 }

--- a/modules/ppcp-wc-gateway/resources/css/common.scss
+++ b/modules/ppcp-wc-gateway/resources/css/common.scss
@@ -133,6 +133,11 @@ $background-ident-color: #fbfbfb;
 				}
 			}
 
+			.ppcp-notice-list {
+				list-style-type: disc;
+				padding-left: 20px;
+			}
+
 			th, td {
 				border-top: 1px solid $border-color;
 			}


### PR DESCRIPTION
_Important: This PR depends on the merging of https://github.com/woocommerce/woocommerce-paypal-payments/pull/2432._

### Description

This PR adds a notice in the main Fastlane settings area warning the merchant in case incompatible plugins are detected.


### Steps to Test

1. Enable Fastlane.
2. Enable the Elementor and/or CheckoutWC plugins.
3. Verify the warning is being displayed correctly.

### Screenshots

|Before|After|
|-|-|
|![WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress](https://github.com/user-attachments/assets/8cf2f4dc-0713-4ec7-bb7f-297107ff94fc)|![WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress](https://github.com/user-attachments/assets/1756abd2-862e-4a2e-ad48-c7a55160c189)|
