### PR TITLE
Add Package Tracking compatibility with DHL Shipping plugin (3390)

### DIFF
--- a/modules/ppcp-compat/resources/js/tracking-compat.js
+++ b/modules/ppcp-compat/resources/js/tracking-compat.js
@@ -92,6 +92,17 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		} );
 	}
 
+	jQuery( document ).on(
+		'mouseover mouseout',
+		'#dhl_delete_label',
+		function ( event ) {
+			jQuery( '#ppcp-shipment-status' )
+				.val( 'CANCELLED' )
+				.trigger( 'change' );
+			document.querySelector( '.update_shipment' ).click();
+		}
+	);
+
 	if (
 		wcShippingTaxSyncEnabled &&
 		typeof wcShippingTaxSyncEnabled !== 'undefined'

--- a/modules/ppcp-compat/resources/js/tracking-compat.js
+++ b/modules/ppcp-compat/resources/js/tracking-compat.js
@@ -15,6 +15,8 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	);
 	const wcShipmentTaxBuyLabelButtonSelector =
 		'.components-modal__screen-overlay .label-purchase-modal__sidebar .purchase-section button.components-button';
+	const dhlGenerateLabelButton =
+		document.getElementById( 'dhl-label-button' );
 
 	const toggleLoaderVisibility = function () {
 		const loader = document.querySelector( '.ppcp-tracking-loader' );
@@ -33,6 +35,20 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const waitForTrackingUpdate = function ( elementToCheck ) {
 		if ( elementToCheck.css( 'display' ) !== 'none' ) {
 			setTimeout( () => waitForTrackingUpdate( elementToCheck ), 100 );
+		} else {
+			jQuery( orderTrackingContainerSelector ).load(
+				loadLocation,
+				'',
+				function () {
+					toggleLoaderVisibility();
+				}
+			);
+		}
+	};
+
+	const waitForButtonRemoval = function ( button ) {
+		if ( document.body.contains( button ) ) {
+			setTimeout( () => waitForButtonRemoval( button ), 100 );
 		} else {
 			jQuery( orderTrackingContainerSelector ).load(
 				loadLocation,
@@ -67,9 +83,18 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	if (
+		typeof dhlGenerateLabelButton !== 'undefined' &&
+		dhlGenerateLabelButton != null
+	) {
+		dhlGenerateLabelButton.addEventListener( 'click', function ( event ) {
+			toggleLoaderVisibility();
+			waitForButtonRemoval( dhlGenerateLabelButton );
+		} );
+	}
+
+	if (
 		wcShippingTaxSyncEnabled &&
-		typeof wcShippingTaxSyncEnabled !== 'undefined' &&
-		wcShippingTaxSyncEnabled != null
+		typeof wcShippingTaxSyncEnabled !== 'undefined'
 	) {
 		document.addEventListener( 'click', function ( event ) {
 			const wcShipmentTaxBuyLabelButton = event.target.closest(

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -77,6 +77,9 @@ return array(
 	'compat.ywot.is_supported_plugin_version_active' => function (): bool {
 		return function_exists( 'yith_ywot_init' );
 	},
+	'compat.dhl.is_supported_plugin_version_active'  => function (): bool {
+		return function_exists( 'PR_DHL' );
+	},
 	'compat.shipstation.is_supported_plugin_version_active' => function (): bool {
 		return function_exists( 'woocommerce_shipstation_init' );
 	},

--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\OrderTracking;
 
+use WooCommerce\PayPalCommerce\OrderTracking\Integration\DhlShipmentIntegration;
 use WooCommerce\PayPalCommerce\OrderTracking\Integration\GermanizedShipmentIntegration;
 use WooCommerce\PayPalCommerce\OrderTracking\Integration\ShipmentTrackingIntegration;
 use WooCommerce\PayPalCommerce\OrderTracking\Integration\ShipStationIntegration;
@@ -118,6 +119,7 @@ return array(
 		$is_gzd_active             = $container->get( 'compat.gzd.is_supported_plugin_version_active' );
 		$is_wc_shipment_active     = $container->get( 'compat.wc_shipment_tracking.is_supported_plugin_version_active' );
 		$is_yith_ywot_active       = $container->get( 'compat.ywot.is_supported_plugin_version_active' );
+		$is_dhl_de_active          = $container->get( 'compat.dhl.is_supported_plugin_version_active' );
 		$is_ship_station_active    = $container->get( 'compat.shipstation.is_supported_plugin_version_active' );
 		$is_wc_shipping_tax_active = $container->get( 'compat.wc_shipping_tax.is_supported_plugin_version_active' );
 
@@ -133,6 +135,10 @@ return array(
 
 		if ( $is_yith_ywot_active ) {
 			$integrations[] = new YithShipmentIntegration( $shipment_factory, $logger, $endpoint );
+		}
+
+		if ( $is_dhl_de_active ) {
+			$integrations[] = new DhlShipmentIntegration( $shipment_factory, $logger, $endpoint );
 		}
 
 		if ( $is_ship_station_active ) {

--- a/modules/ppcp-order-tracking/src/Integration/DhlShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/DhlShipmentIntegration.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * The Shipment integration for DHL Shipping Germany for WooCommerce plugin.
+ *
+ * @package WooCommerce\PayPalCommerce\OrderTracking\Integration
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\OrderTracking\Integration;
+
+use Psr\Log\LoggerInterface;
+use WC_Order;
+use Exception;
+use WooCommerce\PayPalCommerce\Compat\Integration;
+use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
+use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
+use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
+
+/**
+ * Class DhlShipmentIntegration
+ */
+class DhlShipmentIntegration implements Integration {
+
+	use TransactionIdHandlingTrait;
+
+	/**
+	 * The shipment factory.
+	 *
+	 * @var ShipmentFactoryInterface
+	 */
+	protected $shipment_factory;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	protected $logger;
+
+	/**
+	 * The order tracking endpoint.
+	 *
+	 * @var OrderTrackingEndpoint
+	 */
+	protected $endpoint;
+
+	/**
+	 * The DhlShipmentIntegration constructor.
+	 *
+	 * @param ShipmentFactoryInterface $shipment_factory The shipment factory.
+	 * @param LoggerInterface          $logger The logger.
+	 * @param OrderTrackingEndpoint    $endpoint The order tracking endpoint.
+	 */
+	public function __construct(
+		ShipmentFactoryInterface $shipment_factory,
+		LoggerInterface $logger,
+		OrderTrackingEndpoint $endpoint
+	) {
+		$this->shipment_factory = $shipment_factory;
+		$this->logger           = $logger;
+		$this->endpoint         = $endpoint;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function integrate(): void {
+		add_action(
+			'pr_save_dhl_label_tracking',
+			function( int $order_id, array $tracking_details ) {
+				try {
+					$wc_order = wc_get_order( $order_id );
+					if ( ! is_a( $wc_order, WC_Order::class ) ) {
+						return;
+					}
+
+					$foo = $tracking_details;
+
+					$paypal_order    = ppcp_get_paypal_order( $wc_order );
+					$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
+					$tracking_number = $tracking_details['tracking_number'];
+					$carrier         = $tracking_details['carrier'];
+
+					if ( ! $tracking_number || ! is_string( $tracking_number ) || ! $carrier || ! is_string( $carrier ) || ! $capture_id ) {
+						return;
+					}
+
+					$ppcp_shipment = $this->shipment_factory->create_shipment(
+						$order_id,
+						$capture_id,
+						$tracking_number,
+						'SHIPPED',
+						'DE_DHL',
+						$carrier,
+						array()
+					);
+
+					$tracking_information = $this->endpoint->get_tracking_information( $order_id, $tracking_number );
+
+					$tracking_information
+						? $this->endpoint->update_tracking_information( $ppcp_shipment, $order_id )
+						: $this->endpoint->add_tracking_information( $ppcp_shipment, $order_id );
+
+				} catch ( Exception $exception ) {
+					return;
+				}
+			},
+			600,
+			2
+		);
+	}
+}

--- a/modules/ppcp-order-tracking/src/Integration/DhlShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/DhlShipmentIntegration.php
@@ -76,8 +76,6 @@ class DhlShipmentIntegration implements Integration {
 						return;
 					}
 
-					$foo = $tracking_details;
-
 					$paypal_order    = ppcp_get_paypal_order( $wc_order );
 					$capture_id      = $this->get_paypal_order_transaction_id( $paypal_order );
 					$tracking_number = $tracking_details['tracking_number'];


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

Added compatibility with [DHL Shipping Germany for WooCommerce](https://wordpress.org/plugins/dhl-for-woocommerce/) plugin

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Activate and configure DHL plugin;
2. Create order;
3. Go to order edit page;
4. Click 'Generate Label' under DHL plugin section;
5. Observe the shipment in PayPal Package Tracking seciton.
  ![image](https://github.com/user-attachments/assets/8d40aac8-6857-4199-9a56-10ad7f737fef)

