### PR TITLE
Fix the Google Pay button in the block Checkout in the editor (3374)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayManagerBlockEditor.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayManagerBlockEditor.js
@@ -15,7 +15,7 @@ class ApplepayManagerBlockEditor {
 
 	async config() {
 		try {
-			this.applePayConfig = await paypal.Applepay().config();
+			this.applePayConfig = await ppcpBlocksEditorPaypalApplepay.Applepay().config();
 
 			const button = new ApplepayButton(
 				this.ppcpConfig.context,

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -12,6 +12,7 @@ const ppcpConfig = ppcpData.scriptData;
 
 const buttonData = wc.wcSettings.getSetting( 'ppcp-applepay_data' );
 const buttonConfig = buttonData.scriptData;
+const dataNamespace = 'ppcpBlocksEditorPaypalApplepay';
 
 if ( typeof window.PayPalCommerceGateway === 'undefined' ) {
 	window.PayPalCommerceGateway = ppcpConfig;
@@ -37,6 +38,10 @@ const ApplePayComponent = ( props ) => {
 		} );
 
 		ppcpConfig.url_params.components += ',applepay';
+
+		if ( props.isEditing ) {
+			ppcpConfig.data_namespace = dataNamespace;
+		}
 
 		// Load PayPal
 		loadPaypalScript( ppcpConfig, () => {

--- a/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
@@ -7,15 +7,25 @@ import { getCurrentPaymentMethod } from './CheckoutMethodState';
 import { v4 as uuidv4 } from 'uuid';
 
 // This component may be used by multiple modules. This assures that options are shared between all instances.
-const options = ( window.ppcpWidgetBuilder = window.ppcpWidgetBuilder || {
-	isLoading: false,
-	onLoadedCallbacks: [],
-	onErrorCallbacks: [],
-} );
+const scriptOptionsMap = {};
+
+const getNamespaceOptions = ( namespace ) => {
+	if ( ! scriptOptionsMap[ namespace ] ) {
+		scriptOptionsMap[ namespace ] = {
+			isLoading: false,
+			onLoadedCallbacks: [],
+			onErrorCallbacks: [],
+		};
+	}
+	return scriptOptionsMap[ namespace ];
+};
 
 export const loadPaypalScript = ( config, onLoaded, onError = null ) => {
-	// If PayPal is already loaded call the onLoaded callback and return.
-	if ( typeof paypal !== 'undefined' ) {
+	const dataNamespace = config?.data_namespace || '';
+	const options = getNamespaceOptions( dataNamespace );
+
+	// If PayPal is already loaded for this namespace, call the onLoaded callback and return.
+	if ( typeof window.paypal !== 'undefined' && ! dataNamespace ) {
 		onLoaded();
 		return;
 	}
@@ -85,6 +95,11 @@ export const loadPaypalScript = ( config, onLoaded, onError = null ) => {
 	const userIdToken = config?.save_payment_methods?.id_token;
 	if ( userIdToken && ! sdkClientToken ) {
 		scriptOptions[ 'data-user-id-token' ] = userIdToken;
+	}
+
+	// Adds data-namespace to script options.
+	if ( dataNamespace ) {
+		scriptOptions.dataNamespace = dataNamespace;
 	}
 
 	// Load PayPal script

--- a/modules/ppcp-googlepay/resources/js/GooglepayManagerBlockEditor.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayManagerBlockEditor.js
@@ -1,0 +1,59 @@
+import GooglepayButton from './GooglepayButton';
+import ContextHandlerFactory from './Context/ContextHandlerFactory';
+
+class GooglepayManagerBlockEditor {
+	constructor( buttonConfig, ppcpConfig ) {
+		this.buttonConfig = buttonConfig;
+		this.ppcpConfig = ppcpConfig;
+		this.googlePayConfig = null;
+		this.transactionInfo = null;
+		this.contextHandler = null;
+	}
+
+	init() {
+		( async () => {
+			await this.config();
+		} )();
+	}
+
+	async config() {
+		try {
+			// Gets GooglePay configuration of the PayPal merchant.
+			this.googlePayConfig = await ppcpBlocksEditorPaypalGooglepay.Googlepay().config();
+
+			// Fetch transaction information.
+			this.transactionInfo = await this.fetchTransactionInfo();
+
+			const button = new GooglepayButton(
+				this.ppcpConfig.context,
+				null,
+				this.buttonConfig,
+				this.ppcpConfig,
+				this.contextHandler
+			);
+
+			button.init( this.googlePayConfig, this.transactionInfo );
+		} catch ( error ) {
+			console.error( 'Failed to initialize Google Pay:', error );
+		}
+	}
+
+	async fetchTransactionInfo() {
+		try {
+			if ( ! this.contextHandler ) {
+				this.contextHandler = ContextHandlerFactory.create(
+					this.ppcpConfig.context,
+					this.buttonConfig,
+					this.ppcpConfig,
+					null
+				);
+			}
+			return null;
+		} catch ( error ) {
+			console.error( 'Error fetching transaction info:', error );
+			throw error;
+		}
+	}
+}
+
+export default GooglepayManagerBlockEditor;

--- a/modules/ppcp-googlepay/resources/js/boot-block.js
+++ b/modules/ppcp-googlepay/resources/js/boot-block.js
@@ -6,24 +6,29 @@ import {
 import { loadPaypalScript } from '../../../ppcp-button/resources/js/modules/Helper/ScriptLoading';
 import GooglepayManager from './GooglepayManager';
 import { loadCustomScript } from '@paypal/paypal-js';
+import GooglepayManagerBlockEditor from './GooglepayManagerBlockEditor';
 
 const ppcpData = wc.wcSettings.getSetting( 'ppcp-gateway_data' );
 const ppcpConfig = ppcpData.scriptData;
 
 const buttonData = wc.wcSettings.getSetting( 'ppcp-googlepay_data' );
 const buttonConfig = buttonData.scriptData;
+const dataNamespace = 'ppcpBlocksEditorPaypalGooglepay';
 
 if ( typeof window.PayPalCommerceGateway === 'undefined' ) {
 	window.PayPalCommerceGateway = ppcpConfig;
 }
 
-const GooglePayComponent = () => {
+const GooglePayComponent = ( props ) => {
 	const [ bootstrapped, setBootstrapped ] = useState( false );
 	const [ paypalLoaded, setPaypalLoaded ] = useState( false );
 	const [ googlePayLoaded, setGooglePayLoaded ] = useState( false );
 
 	const bootstrap = function () {
-		const manager = new GooglepayManager( buttonConfig, ppcpConfig );
+		const ManagerClass = props.isEditing
+			? GooglepayManagerBlockEditor
+			: GooglepayManager;
+		const manager = new ManagerClass( buttonConfig, ppcpConfig );
 		manager.init();
 	};
 
@@ -32,6 +37,12 @@ const GooglePayComponent = () => {
 		loadCustomScript( { url: buttonConfig.sdk_url } ).then( () => {
 			setGooglePayLoaded( true );
 		} );
+
+		ppcpConfig.url_params.components += ',googlepay';
+
+		if ( props.isEditing ) {
+			ppcpConfig.data_namespace = dataNamespace;
+		}
 
 		// Load PayPal
 		loadPaypalScript( ppcpConfig, () => {

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -409,7 +409,7 @@ class Button implements ButtonInterface {
 	 */
 	public function script_data(): array {
 		$shipping = array(
-			'enabled' => $this->settings->has( 'googlepay_button_shipping_enabled' )
+			'enabled'    => $this->settings->has( 'googlepay_button_shipping_enabled' )
 				? boolval( $this->settings->get( 'googlepay_button_shipping_enabled' ) )
 				: false,
 			'configured' => wc_shipping_enabled() && wc_get_shipping_method_count( false, true ) > 0,


### PR DESCRIPTION
### Description

This PR fixes the Google Pay button in the block checkout editor, by refactoring script loading to allow for custom namespaces.

### Steps to Test

1. Test the express buttons in the block Checkout in the editor and the page - verify they are being displayed correctly.
2. Make sure to test with Google Pay and Apple Pay enabled.
3. Make sure as much as possible the script loading script refactor didn't break anything 🙈 

### Screenshots

|Before|After|
|-|-|
|![Edit_Page_“Block_Checkout”_‹_paypal_—_WordPress](https://github.com/user-attachments/assets/5646dcd8-4eb9-4e1a-a12b-27ceae0899a4)|![Edit_Page_“Block_Checkout”_‹_paypal_—_WordPress](https://github.com/user-attachments/assets/aba32059-f1dd-4809-bea9-ac8b8f5efa62)|
