### PR TITLE
Add AMEX support for Advanced Card Processing in China (3453)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -1443,6 +1443,7 @@ return array(
 				'CN' => array(
 					'mastercard' => array(),
 					'visa'       => array(),
+					'amex'       => array(),
 				),
 				'CY' => array(
 					'mastercard' => array(),


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

PayPal requested that we add AMEX support for China in Advanced Card Processing.