### PR TITLE
Hide empty Gpay button div in minicart (2648)

### DIFF
--- a/modules/ppcp-googlepay/resources/css/styles.scss
+++ b/modules/ppcp-googlepay/resources/css/styles.scss
@@ -1,6 +1,10 @@
 .ppcp-button-googlepay {
 	min-height: 40px;
 
+	&:empty {
+		display: none;
+	}
+
 	.gpay-card-info-container,
 	.gpay-button {
 		outline-offset: -1px;


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

Since subscriptions aren't supported for Google Pay, currently the minicart renders an empty GPay button div when a subscription product is added in cart. This PR solves that issue.
