### PR TITLE
Do not add tax info into order meta during order creation

### DIFF
--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -303,13 +303,6 @@ class WooCommerceOrderCreator {
 
 		$item->set_tax_class( $product->get_tax_class() );
 		$item->set_total_tax( (float) array_sum( $taxes ) );
-
-		foreach ( $taxes as $tax_rate_id => $tax_amount ) {
-			if ( $tax_amount > 0 ) {
-				$item->add_meta_data( 'tax_rate_id', $tax_rate_id, true );
-				$item->add_meta_data( 'tax_amount', $tax_amount, true );
-			}
-		}
 	}
 
 	/**


### PR DESCRIPTION
# PR Description

The PR will remove the tax meta adding funtilnaoity.
 
# Issue Description

On the order-received page, the buyer sees product tax meta which is not supposed to be visible:

![image-20240729-085102](https://github.com/user-attachments/assets/5664d9ee-4164-4bbe-94a3-a2e398807ba0)


### Steps to Reproduce

1. Enable taxes
2. Enable shipping callback in PayPal Payments
3. Buy a product via express button
4. Observe tax meta on order-received page
