### PR TITLE
Google Pay: Prevent field validation from being triggered on checkout page load (3493)

### DIFF
--- a/modules/ppcp-googlepay/resources/js/Context/CheckoutHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/CheckoutHandler.js
@@ -4,7 +4,7 @@ import CheckoutActionHandler from '../../../../ppcp-button/resources/js/modules/
 import FormValidator from '../../../../ppcp-button/resources/js/modules/Helper/FormValidator';
 
 class CheckoutHandler extends BaseHandler {
-	formValidator() {
+	validateForm() {
 		return new Promise( async ( resolve, reject ) => {
 			try {
 				const spinner = new Spinner();

--- a/modules/ppcp-googlepay/resources/js/Context/CheckoutHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/CheckoutHandler.js
@@ -4,7 +4,7 @@ import CheckoutActionHandler from '../../../../ppcp-button/resources/js/modules/
 import FormValidator from '../../../../ppcp-button/resources/js/modules/Helper/FormValidator';
 
 class CheckoutHandler extends BaseHandler {
-	transactionInfo() {
+	formValidator() {
 		return new Promise( async ( resolve, reject ) => {
 			try {
 				const spinner = new Spinner();
@@ -23,7 +23,7 @@ class CheckoutHandler extends BaseHandler {
 					: null;
 
 				if ( ! formValidator ) {
-					resolve( super.transactionInfo() );
+					resolve();
 					return;
 				}
 
@@ -42,7 +42,7 @@ class CheckoutHandler extends BaseHandler {
 
 							reject();
 						} else {
-							resolve( super.transactionInfo() );
+							resolve();
 						}
 					} );
 			} catch ( error ) {

--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -292,17 +292,24 @@ class GooglepayButton {
 	onButtonClick() {
 		this.log( 'onButtonClick', this.context );
 
-		const paymentDataRequest = this.paymentDataRequest();
+		this.contextHandler.formValidator().then(
+			() => {
+				window.ppcpFundingSource = 'googlepay';
 
-		this.log(
-			'onButtonClick: paymentDataRequest',
-			paymentDataRequest,
-			this.context
+				const paymentDataRequest = this.paymentDataRequest();
+
+				this.log(
+					'onButtonClick: paymentDataRequest',
+					paymentDataRequest,
+					this.context
+				);
+
+				this.paymentsClient.loadPaymentData( paymentDataRequest );
+			},
+			() => {
+				console.error( '[GooglePayButton] Form validation failed.' );
+			}
 		);
-
-		window.ppcpFundingSource = 'googlepay'; // Do this on another place like on create order endpoint handler.
-
-		this.paymentsClient.loadPaymentData( paymentDataRequest );
 	}
 
 	paymentDataRequest() {

--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -292,7 +292,7 @@ class GooglepayButton {
 	onButtonClick() {
 		this.log( 'onButtonClick', this.context );
 
-		this.contextHandler.formValidator().then(
+		this.contextHandler.validateForm().then(
 			() => {
 				window.ppcpFundingSource = 'googlepay';
 


### PR DESCRIPTION
### Description

This PR prevents the field validation from being triggered on page load (on classic checkout) when the Google Pay button is enabled.

### Steps to Test

1. Enable Google Pay.
2. Add a product to cart and go to the checkout page.
3. Ensure there are no field validation errors on the top of the page.
4. Try selecting the Google Pay button with some of the required fields being empty and make sure the validation gets triggered correctly.
5. Fill out all the required fields and select Google Pay. Ensure you can complete the payment correctly.

### Screenshots

|Before|After|
|-|-|
|![Page__Checkout](https://github.com/user-attachments/assets/2f9f7646-5d44-4222-93df-d5cf60288ddf)|![Page__Checkout](https://github.com/user-attachments/assets/9a99228b-1e60-4fe8-8a22-17c40a8a2da5)|
