### PR TITLE
Static meta comment in HTML source when Fastlane is active (3492)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -194,9 +194,18 @@ class AxoModule implements ModuleInterface {
 
 				add_action(
 					'wp_head',
-					function () {
+					function () use ( $c ) {
 						// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 						echo '<script async src="https://www.paypalobjects.com/insights/v1/paypal-insights.sandbox.min.js"></script>';
+
+						// Add meta tag to allow feature-detection of the site's AXO payment state.
+						$settings = $c->get( 'wcgateway.settings' );
+						assert( $settings instanceof Settings );
+
+						printf(
+							'<meta name="ppcp.axo" content="%s" />',
+							$settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' ) ? 'enabled' : 'disabled'
+						);
 					}
 				);
 

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -202,9 +202,8 @@ class AxoModule implements ModuleInterface {
 						$settings = $c->get( 'wcgateway.settings' );
 						assert( $settings instanceof Settings );
 
-						printf(
-							'<meta name="ppcp.axo" content="%s" />',
-							$settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' ) ? 'enabled' : 'disabled'
+						$this->add_feature_detection_tag(
+							$settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' )
 						);
 					}
 				);
@@ -404,5 +403,24 @@ class AxoModule implements ModuleInterface {
 	private function is_excluded_endpoint(): bool {
 		// Exclude the Order Pay endpoint.
 		return is_wc_endpoint_url( 'order-pay' );
+	}
+
+	/**
+	 * Outputs a meta tag to allow feature detection on certain pages.
+	 *
+	 * @param bool $axo_enabled Whether the gateway is enabled.
+	 * @return void
+	 */
+	private function add_feature_detection_tag( bool $axo_enabled ) {
+		$show_tag = is_checkout() || is_cart() || is_shop();
+
+		if ( ! $show_tag ) {
+			return;
+		}
+
+		printf(
+			'<meta name="ppcp.axo" content="%s" />',
+			$axo_enabled ? 'enabled' : 'disabled'
+		);
 	}
 }


### PR DESCRIPTION
### Description

This PR adds a static meta-tag to the head section of every page. The new meta tag reflects the AXO gateway status (enabled/disabled).

```html
<meta name="ppcp.axo" content="disabled" />
<meta name="ppcp.axo" content="enabled" />
```

<details>
<summary><strong>Screenshot</strong></summary>

<img width="743" alt="2024-07-31_11-47-35" src="https://github.com/user-attachments/assets/fd534d05-b0e3-4ea3-8a3d-ddc2e45387ee">

</details>