### PR TITLE
AXO: Temporarily hide the Fastlane payment method (3491)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -66,7 +66,7 @@ class AxoModule implements ModuleInterface {
 
 				// Add the gateway in admin area.
 				if ( is_admin() ) {
-					$methods[] = $gateway;
+					// $methods[] = $gateway; - Temporarily remove Fastlane from the payment gateway list in admin area.
 					return $methods;
 				}
 


### PR DESCRIPTION
### Description

This PR hides Fastlane from the payment gateway list in the admin settings until PCP-3056 refactor is complete.

### Steps to Test

1. Enable Fastlane.
2. Make sure Fastlane is not present as a separate payment gateway in admin.

### Screenshots

|Before|After|
|-|-|
|![WooCommerce_settings_‹_paypal_—_WordPress](https://github.com/user-attachments/assets/5321c4b7-3921-4814-ab3e-4b65e7b8046f)|![WooCommerce_settings_‹_paypal_—_WordPress](https://github.com/user-attachments/assets/c722c92b-ee5a-403b-aa63-2806497bcd46)|
