### PR TITLE
Fastlane display notice when Advanced Card Processing gateway is disabled (3489)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -119,6 +119,7 @@ return array(
 					'html'         => implode(
 						'',
 						array(
+							$container->get( 'axo.settings-conflict-notice' ),
 							$container->get( 'axo.shipping-config-notice' ),
 							$container->get( 'axo.checkout-config-notice' ),
 							$container->get( 'axo.incompatible-plugins-notice' ),

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -83,7 +83,7 @@ return array(
 									->rule()
 									->condition_element( 'axo_enabled', '1' )
 									->action_visible( 'axo_gateway_title' )
-									->action_visible( 'axo_checkout_config_notice' )
+									->action_visible( 'axo_main_notice' )
 									->action_visible( 'axo_privacy' )
 									->action_visible( 'axo_name_on_card' )
 									->action_visible( 'axo_style_heading' )

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -16,7 +16,6 @@ use WooCommerce\PayPalCommerce\Axo\Helper\SettingsNoticeGenerator;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\CartCheckoutDetector;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 return array(
@@ -162,6 +161,16 @@ return array(
 				),
 			)
 		);
+	},
+
+	'axo.settings-conflict-notice'          => static function ( ContainerInterface $container ) : string {
+		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
+		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
+
+		$settings = $container->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+
+		return $settings_notice_generator->generate_settings_conflict_notice( $settings );
 	},
 
 	'axo.checkout-config-notice'            => static function ( ContainerInterface $container ) : string {


### PR DESCRIPTION
Important: This PR depends on the merging of #2432 and #2461.

### Description

This PR introduces a new warning message for Fastlane when a plugin-internal setting conflict was detected.

At this point, a single check is done:
- If the Advanced Card Payments checkbox is unchecked while Fastlane is enabled, a warning is displayed


### Screenshots

| Before | After |
|---|---|
| <img width="1080" alt="2024-07-31_14-16-16" src="https://github.com/user-attachments/assets/b21de809-24fb-490b-8c90-74910c316da2">  | <img width="1080" alt="2024-07-31_14-13-24" src="https://github.com/user-attachments/assets/e358c91a-4c46-4e9f-9f62-f41f13116b8d"> |