### PR TITLE
AXO: Refactor the debug script in order to remove unnecessary logger calls (3490)

### DIFF
--- a/modules/ppcp-axo/resources/js/Helper/Debug.js
+++ b/modules/ppcp-axo/resources/js/Helper/Debug.js
@@ -1,7 +1,19 @@
 export function log( message, level = 'info' ) {
 	const wpDebug = window.wc_ppcp_axo?.wp_debug;
 	const endpoint = window.wc_ppcp_axo?.ajax?.frontend_logger?.endpoint;
-	if ( ! endpoint ) {
+	const loggingEnabled = window.wc_ppcp_axo?.logging_enabled;
+
+	if ( wpDebug ) {
+		switch ( level ) {
+			case 'error':
+				console.error( `[AXO] ${ message }` );
+				break;
+			default:
+				console.log( `[AXO] ${ message }` );
+		}
+	}
+
+	if ( ! endpoint || ! loggingEnabled ) {
 		return;
 	}
 
@@ -15,15 +27,5 @@ export function log( message, level = 'info' ) {
 				level,
 			},
 		} ),
-	} ).then( () => {
-		if ( wpDebug ) {
-			switch ( level ) {
-				case 'error':
-					console.error( `[AXO] ${ message }` );
-					break;
-				default:
-					console.log( `[AXO] ${ message }` );
-			}
-		}
 	} );
 }

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -216,6 +216,7 @@ class AxoManager {
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),
 				),
 			),
+			'logging_enabled'           => $this->settings->has( 'logging_enabled' ) ? $this->settings->get( 'logging_enabled' ) : '',
 			'wp_debug'                  => defined( 'WP_DEBUG' ) && WP_DEBUG,
 			'billing_email_button_text' => __( 'Continue', 'woocommerce-paypal-payments' ),
 		);


### PR DESCRIPTION
### Description

This PR refactors the `Debug.js` script to prevent unnecessary frontend logger calls.

### Steps to Test

1. Enable Fastlane.
2. Enable logging in the Connection tab.
3. Verify logging works correctly.
4. Disable logging in the Connection tab.
5. Verify nothing is being logged and that no calls are being made to `/?wc-ajax=ppc-frontend-logger` in the Classic Checkout with Fastlane.

### Screenshots

|Before|After|
|-|-|
|![Page__Checkout_—_tryb_prywatny](https://github.com/user-attachments/assets/dbe00dc7-7f69-4d35-be30-af19aafbbea6)|![Page__Checkout_—_tryb_prywatny](https://github.com/user-attachments/assets/b53ee749-f720-4bc9-aa7c-4e2d990a4323)|
