### PR TITLE
Use client credentials for user tokens (3518)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -1657,7 +1657,7 @@ return array(
 			return new PurchaseUnitSanitizer( $behavior, $line_name );
 		}
 	),
-	'api.client-credentials' => static function(ContainerInterface $container): ClientCredentials {
+	'api.client-credentials'                         => static function( ContainerInterface $container ): ClientCredentials {
 		return new ClientCredentials(
 			$container->get( 'wcgateway.settings' )
 		);
@@ -1666,14 +1666,16 @@ return array(
 		return new UserIdToken(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'api.client-credentials' )
+			$container->get( 'api.client-credentials' ),
+			new Cache( 'ppcp-client-credentials-cache' )
 		);
 	},
 	'api.sdk-client-token'                           => static function( ContainerInterface $container ): SdkClientToken {
 		return new SdkClientToken(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'api.client-credentials' )
+			$container->get( 'api.client-credentials' ),
+			new Cache( 'ppcp-client-credentials-cache' )
 		);
 	},
 );

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -1662,12 +1662,15 @@ return array(
 			$container->get( 'wcgateway.settings' )
 		);
 	},
+	'api.client-credentials-cache'                   => static function( ContainerInterface $container ): Cache {
+		return new Cache( 'ppcp-client-credentials-cache' );
+	},
 	'api.user-id-token'                              => static function( ContainerInterface $container ): UserIdToken {
 		return new UserIdToken(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'api.client-credentials' ),
-			new Cache( 'ppcp-client-credentials-cache' )
+			$container->get( 'api.client-credentials-cache' )
 		);
 	},
 	'api.sdk-client-token'                           => static function( ContainerInterface $container ): SdkClientToken {
@@ -1675,7 +1678,7 @@ return array(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'api.client-credentials' ),
-			new Cache( 'ppcp-client-credentials-cache' )
+			$container->get( 'api.client-credentials-cache' )
 		);
 	},
 );

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\ClientCredentials;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentMethodTokensEndpoint;
@@ -1656,18 +1657,23 @@ return array(
 			return new PurchaseUnitSanitizer( $behavior, $line_name );
 		}
 	),
+	'api.client-credentials' => static function(ContainerInterface $container): ClientCredentials {
+		return new ClientCredentials(
+			$container->get( 'wcgateway.settings' )
+		);
+	},
 	'api.user-id-token'                              => static function( ContainerInterface $container ): UserIdToken {
 		return new UserIdToken(
 			$container->get( 'api.host' ),
-			$container->get( 'api.bearer' ),
-			$container->get( 'woocommerce.logger.woocommerce' )
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'api.client-credentials' )
 		);
 	},
 	'api.sdk-client-token'                           => static function( ContainerInterface $container ): SdkClientToken {
 		return new SdkClientToken(
 			$container->get( 'api.host' ),
-			$container->get( 'api.bearer' ),
-			$container->get( 'woocommerce.logger.woocommerce' )
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'api.client-credentials' )
 		);
 	},
 );

--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
 use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderTransient;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
@@ -93,6 +96,21 @@ class ApiModule implements ModuleInterface {
 			},
 			10,
 			2
+		);
+
+		add_action(
+			'wp_logout',
+			function() use ( $c ) {
+				$client_credentials_cache = $c->get( 'api.client-credentials-cache' );
+				assert( $client_credentials_cache instanceof Cache );
+
+				if ( $client_credentials_cache->has( UserIdToken::CACHE_KEY ) ) {
+					$client_credentials_cache->delete( UserIdToken::CACHE_KEY );
+				}
+				if ( $client_credentials_cache->has( SdkClientToken::CACHE_KEY ) ) {
+					$client_credentials_cache->delete( SdkClientToken::CACHE_KEY );
+				}
+			}
 		);
 	}
 

--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
 use WC_Order;
-use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
@@ -100,15 +99,12 @@ class ApiModule implements ModuleInterface {
 
 		add_action(
 			'wp_logout',
-			function() use ( $c ) {
+			function( int $user_id ) use ( $c ) {
 				$client_credentials_cache = $c->get( 'api.client-credentials-cache' );
 				assert( $client_credentials_cache instanceof Cache );
 
-				if ( $client_credentials_cache->has( UserIdToken::CACHE_KEY ) ) {
-					$client_credentials_cache->delete( UserIdToken::CACHE_KEY );
-				}
-				if ( $client_credentials_cache->has( SdkClientToken::CACHE_KEY ) ) {
-					$client_credentials_cache->delete( SdkClientToken::CACHE_KEY );
+				if ( $client_credentials_cache->has( UserIdToken::CACHE_KEY . '-' . (string) $user_id ) ) {
+					$client_credentials_cache->delete( UserIdToken::CACHE_KEY . '-' . (string) $user_id );
 				}
 			}
 		);

--- a/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
+++ b/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * The client credentials.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Authentication
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+/**
+ * Class ClientCredentials
+ */
+class ClientCredentials {
+
+	/**
+	 * The settings.
+	 *
+	 * @var Settings
+	 */
+	protected $settings;
+
+	/**
+	 * ClientCredentials constructor.
+	 *
+	 * @param Settings $settings The settings.
+	 */
+	public function __construct(Settings $settings) {
+		$this->settings = $settings;
+	}
+
+	public function credentials(): string {
+		$client_id = $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : '';
+		$client_secret = $this->settings->has( 'client_secret' ) ? $this->settings->get( 'client_secret' ) : '';
+
+		return 'Basic ' . base64_encode($client_id . ':' . $client_secret);
+	}
+}

--- a/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
+++ b/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
 
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 
 /**
  * Class ClientCredentials
@@ -28,14 +29,21 @@ class ClientCredentials {
 	 *
 	 * @param Settings $settings The settings.
 	 */
-	public function __construct(Settings $settings) {
+	public function __construct( Settings $settings ) {
 		$this->settings = $settings;
 	}
 
+	/**
+	 * Returns encoded client credentials.
+	 *
+	 * @return string
+	 * @throws NotFoundException If setting does not found.
+	 */
 	public function credentials(): string {
-		$client_id = $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : '';
+		$client_id     = $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : '';
 		$client_secret = $this->settings->has( 'client_secret' ) ? $this->settings->get( 'client_secret' ) : '';
 
-		return 'Basic ' . base64_encode($client_id . ':' . $client_secret);
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		return 'Basic ' . base64_encode( $client_id . ':' . $client_secret );
 	}
 }

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -83,7 +83,12 @@ class SdkClientToken {
 	 */
 	public function sdk_client_token( string $target_customer_id = '' ): string {
 		if ( $this->cache->has( self::CACHE_KEY ) ) {
-			return $this->cache->get( self::CACHE_KEY );
+			$user_id      = $this->cache->get( self::CACHE_KEY )['user_id'] ?? 0;
+			$access_token = $this->cache->get( self::CACHE_KEY )['access_token'] ?? '';
+
+			if ( $user_id === get_current_user_id() && $access_token ) {
+				return $access_token;
+			}
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -121,7 +126,13 @@ class SdkClientToken {
 		}
 
 		$access_token = $json->access_token;
-		$this->cache->set( self::CACHE_KEY, $access_token );
+
+		$data = array(
+			'access_token' => $access_token,
+			'user_id'      => get_current_user_id(),
+		);
+
+		$this->cache->set( self::CACHE_KEY, $data );
 
 		return $access_token;
 	}

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -28,13 +28,6 @@ class SdkClientToken {
 	private $host;
 
 	/**
-	 * The bearer.
-	 *
-	 * @var Bearer
-	 */
-	private $bearer;
-
-	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -42,20 +35,27 @@ class SdkClientToken {
 	private $logger;
 
 	/**
+	 * The client credentials.
+	 *
+	 * @var ClientCredentials
+	 */
+	private $client_credentials;
+
+	/**
 	 * SdkClientToken constructor.
 	 *
 	 * @param string          $host The host.
-	 * @param Bearer          $bearer The bearer.
 	 * @param LoggerInterface $logger The logger.
+	 * @param ClientCredentials $client_credentials The client credentials.
 	 */
 	public function __construct(
 		string $host,
-		Bearer $bearer,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		ClientCredentials $client_credentials
 	) {
 		$this->host   = $host;
-		$this->bearer = $bearer;
 		$this->logger = $logger;
+		$this->client_credentials = $client_credentials;
 	}
 
 	/**
@@ -69,8 +69,6 @@ class SdkClientToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function sdk_client_token( string $target_customer_id = '' ): string {
-		$bearer = $this->bearer->bearer();
-
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$domain = wp_unslash( $_SERVER['HTTP_HOST'] ?? '' );
 		$domain = preg_replace( '/^www\./', '', $domain );
@@ -89,7 +87,7 @@ class SdkClientToken {
 		$args = array(
 			'method'  => 'POST',
 			'headers' => array(
-				'Authorization' => 'Bearer ' . $bearer->token(),
+				'Authorization' => $this->client_credentials->credentials(),
 				'Content-Type'  => 'application/x-www-form-urlencoded',
 			),
 		);

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -81,7 +81,7 @@ class SdkClientToken {
 	 */
 	public function sdk_client_token(): string {
 		if ( $this->cache->has( self::CACHE_KEY ) ) {
-			$this->cache->get( self::CACHE_KEY );
+			return $this->cache->get( self::CACHE_KEY );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -80,10 +80,6 @@ class SdkClientToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function sdk_client_token(): string {
-		if ( $this->cache->has( self::CACHE_KEY ) ) {
-			return $this->cache->get( self::CACHE_KEY );
-		}
-
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$domain = wp_unslash( $_SERVER['HTTP_HOST'] ?? '' );
 		$domain = preg_replace( '/^www\./', '', $domain );

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -72,23 +72,16 @@ class SdkClientToken {
 	}
 
 	/**
-	 * Returns `sdk_client_token` which uniquely identifies the payer.
-	 *
-	 * @param string $target_customer_id Vaulted customer id.
+	 * Returns the client token for SDK `data-sdk-client-token`.
 	 *
 	 * @return string
 	 *
 	 * @throws PayPalApiException If the request fails.
 	 * @throws RuntimeException If something unexpected happens.
 	 */
-	public function sdk_client_token( string $target_customer_id = '' ): string {
+	public function sdk_client_token(): string {
 		if ( $this->cache->has( self::CACHE_KEY ) ) {
-			$user_id      = $this->cache->get( self::CACHE_KEY )['user_id'] ?? 0;
-			$access_token = $this->cache->get( self::CACHE_KEY )['access_token'] ?? '';
-
-			if ( $user_id === get_current_user_id() && $access_token ) {
-				return $access_token;
-			}
+			$this->cache->get( self::CACHE_KEY );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -96,15 +89,6 @@ class SdkClientToken {
 		$domain = preg_replace( '/^www\./', '', $domain );
 
 		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=client_token&intent=sdk_init&domains[]=' . $domain;
-
-		if ( $target_customer_id ) {
-			$url = add_query_arg(
-				array(
-					'target_customer_id' => $target_customer_id,
-				),
-				$url
-			);
-		}
 
 		$args = array(
 			'method'  => 'POST',
@@ -126,13 +110,7 @@ class SdkClientToken {
 		}
 
 		$access_token = $json->access_token;
-
-		$data = array(
-			'access_token' => $access_token,
-			'user_id'      => get_current_user_id(),
-		);
-
-		$this->cache->set( self::CACHE_KEY, $data );
+		$this->cache->set( self::CACHE_KEY, $access_token );
 
 		return $access_token;
 	}

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -110,7 +110,9 @@ class SdkClientToken {
 		}
 
 		$access_token = $json->access_token;
-		$this->cache->set( self::CACHE_KEY, $access_token );
+		$expires_in   = (int) $json->expires_in;
+
+		$this->cache->set( self::CACHE_KEY, $access_token, $expires_in );
 
 		return $access_token;
 	}

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -80,6 +80,10 @@ class SdkClientToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function sdk_client_token(): string {
+		if ( $this->cache->has( self::CACHE_KEY ) ) {
+			return $this->cache->get( self::CACHE_KEY );
+		}
+
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$domain = wp_unslash( $_SERVER['HTTP_HOST'] ?? '' );
 		$domain = preg_replace( '/^www\./', '', $domain );

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -83,7 +83,12 @@ class UserIdToken {
 	 */
 	public function id_token( string $target_customer_id = '' ): string {
 		if ( $this->cache->has( self::CACHE_KEY ) ) {
-			return $this->cache->get( self::CACHE_KEY );
+			$user_id  = $this->cache->get( self::CACHE_KEY )['user_id'] ?? 0;
+			$id_token = $this->cache->get( self::CACHE_KEY )['id_token'] ?? '';
+
+			if ( $user_id === get_current_user_id() && $id_token ) {
+				return $id_token;
+			}
 		}
 
 		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=id_token';
@@ -116,7 +121,13 @@ class UserIdToken {
 		}
 
 		$id_token = $json->id_token;
-		$this->cache->set( self::CACHE_KEY, $id_token );
+
+		$data = array(
+			'id_token' => $id_token,
+			'user_id'  => get_current_user_id(),
+		);
+
+		$this->cache->set( self::CACHE_KEY, $data );
 
 		return $id_token;
 	}

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -115,9 +115,10 @@ class UserIdToken {
 			throw new PayPalApiException( $json, $status_code );
 		}
 
-		$id_token = $json->id_token;
+		$id_token   = $json->id_token;
+		$expires_in = (int) $json->expires_in;
 
-		$this->cache->set( self::CACHE_KEY . '-' . (string) get_current_user_id(), $id_token );
+		$this->cache->set( self::CACHE_KEY . '-' . (string) get_current_user_id(), $id_token, $expires_in );
 
 		return $id_token;
 	}

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -28,13 +28,6 @@ class UserIdToken {
 	private $host;
 
 	/**
-	 * The bearer.
-	 *
-	 * @var Bearer
-	 */
-	private $bearer;
-
-	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -42,20 +35,27 @@ class UserIdToken {
 	private $logger;
 
 	/**
+	 * The client credentials.
+	 *
+	 * @var ClientCredentials
+	 */
+	private $client_credentials;
+
+	/**
 	 * UserIdToken constructor.
 	 *
 	 * @param string          $host The host.
-	 * @param Bearer          $bearer The bearer.
 	 * @param LoggerInterface $logger The logger.
+	 * @param ClientCredentials $client_credentials The client credentials.
 	 */
 	public function __construct(
 		string $host,
-		Bearer $bearer,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		ClientCredentials $client_credentials
 	) {
 		$this->host   = $host;
-		$this->bearer = $bearer;
 		$this->logger = $logger;
+		$this->client_credentials = $client_credentials;
 	}
 
 	/**
@@ -69,8 +69,6 @@ class UserIdToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function id_token( string $target_customer_id = '' ): string {
-		$bearer = $this->bearer->bearer();
-
 		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=id_token';
 		if ( $target_customer_id ) {
 			$url = add_query_arg(
@@ -84,7 +82,7 @@ class UserIdToken {
 		$args = array(
 			'method'  => 'POST',
 			'headers' => array(
-				'Authorization' => 'Bearer ' . $bearer->token(),
+				'Authorization' => $this->client_credentials->credentials(),
 				'Content-Type'  => 'application/x-www-form-urlencoded',
 			),
 		);

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -82,13 +82,8 @@ class UserIdToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function id_token( string $target_customer_id = '' ): string {
-		if ( $this->cache->has( self::CACHE_KEY ) ) {
-			$user_id  = $this->cache->get( self::CACHE_KEY )['user_id'] ?? 0;
-			$id_token = $this->cache->get( self::CACHE_KEY )['id_token'] ?? '';
-
-			if ( $user_id === get_current_user_id() && $id_token ) {
-				return $id_token;
-			}
+		if ( $this->cache->has( self::CACHE_KEY . '-' . (string) get_current_user_id() ) ) {
+			return $this->cache->get( self::CACHE_KEY . '-' . (string) get_current_user_id() );
 		}
 
 		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=id_token';
@@ -122,12 +117,7 @@ class UserIdToken {
 
 		$id_token = $json->id_token;
 
-		$data = array(
-			'id_token' => $id_token,
-			'user_id'  => get_current_user_id(),
-		);
-
-		$this->cache->set( self::CACHE_KEY, $data );
+		$this->cache->set( self::CACHE_KEY . '-' . (string) get_current_user_id(), $id_token );
 
 		return $id_token;
 	}

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -280,15 +280,7 @@ class AxoModule implements ModuleInterface {
 		array $localized_script_data
 	): array {
 		try {
-			$target_customer_id = '';
-			if ( is_user_logged_in() ) {
-				$target_customer_id = get_user_meta( get_current_user_id(), '_ppcp_target_customer_id', true );
-				if ( ! $target_customer_id ) {
-					$target_customer_id = get_user_meta( get_current_user_id(), 'ppcp_customer_id', true );
-				}
-			}
-
-			$sdk_client_token             = $api->sdk_client_token( $target_customer_id );
+			$sdk_client_token             = $api->sdk_client_token();
 			$localized_script_data['axo'] = array(
 				'sdk_client_token' => $sdk_client_token,
 			);

--- a/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
@@ -71,7 +71,10 @@ export const loadPaypalScript = ( config, onLoaded, onError = null ) => {
 	}
 
 	// Load PayPal script for special case with data-client-token
-	if ( config.data_client_id?.set_attribute ) {
+	if (
+		config.data_client_id?.set_attribute &&
+		config.vault_v3_enabled !== '1'
+	) {
 		dataClientIdAttributeHandler(
 			scriptOptions,
 			config.data_client_id,

--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -189,9 +189,8 @@ return array(
 		$login_seller_sandbox    = $container->get( 'api.endpoint.login-seller-sandbox' );
 		$partner_referrals_data  = $container->get( 'api.repository.partner-referrals-data' );
 		$settings                = $container->get( 'wcgateway.settings' );
-		$logger = $container->get( 'woocommerce.logger.woocommerce' );
-
 		$cache = new Cache( 'ppcp-paypal-bearer' );
+		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 		return new LoginSellerEndpoint(
 			$request_data,
 			$login_seller_production,
@@ -199,7 +198,8 @@ return array(
 			$partner_referrals_data,
 			$settings,
 			$cache,
-			$logger
+			$logger,
+			new Cache( 'ppcp-client-credentials-cache' )
 		);
 	},
 	'onboarding.endpoint.pui'                   => static function( ContainerInterface $container ) : UpdateSignupLinksEndpoint {

--- a/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
@@ -187,9 +187,6 @@ class LoginSellerEndpoint implements EndpointInterface {
 			if ( $this->cache->has( PayPalBearer::CACHE_KEY ) ) {
 				$this->cache->delete( PayPalBearer::CACHE_KEY );
 			}
-			if ( $this->client_credentials_cache->has( UserIdToken::CACHE_KEY ) ) {
-				$this->client_credentials_cache->delete( UserIdToken::CACHE_KEY );
-			}
 			if ( $this->client_credentials_cache->has( SdkClientToken::CACHE_KEY ) ) {
 				$this->client_credentials_cache->delete( SdkClientToken::CACHE_KEY );
 			}

--- a/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
@@ -12,6 +12,8 @@ namespace WooCommerce\PayPalCommerce\Onboarding\Endpoint;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\LoginSeller;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\PartnerReferralsData;
@@ -77,6 +79,13 @@ class LoginSellerEndpoint implements EndpointInterface {
 	protected $logger;
 
 	/**
+	 * The client credentials cache.
+	 *
+	 * @var Cache
+	 */
+	private $client_credentials_cache;
+
+	/**
 	 * LoginSellerEndpoint constructor.
 	 *
 	 * @param RequestData          $request_data The Request Data.
@@ -86,6 +95,7 @@ class LoginSellerEndpoint implements EndpointInterface {
 	 * @param Settings             $settings The Settings.
 	 * @param Cache                $cache The Cache.
 	 * @param LoggerInterface      $logger The logger.
+	 * @param Cache                $client_credentials_cache The client credentials cache.
 	 */
 	public function __construct(
 		RequestData $request_data,
@@ -94,16 +104,18 @@ class LoginSellerEndpoint implements EndpointInterface {
 		PartnerReferralsData $partner_referrals_data,
 		Settings $settings,
 		Cache $cache,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		Cache $client_credentials_cache
 	) {
 
-		$this->request_data            = $request_data;
-		$this->login_seller_production = $login_seller_production;
-		$this->login_seller_sandbox    = $login_seller_sandbox;
-		$this->partner_referrals_data  = $partner_referrals_data;
-		$this->settings                = $settings;
-		$this->cache                   = $cache;
-		$this->logger                  = $logger;
+		$this->request_data             = $request_data;
+		$this->login_seller_production  = $login_seller_production;
+		$this->login_seller_sandbox     = $login_seller_sandbox;
+		$this->partner_referrals_data   = $partner_referrals_data;
+		$this->settings                 = $settings;
+		$this->cache                    = $cache;
+		$this->logger                   = $logger;
+		$this->client_credentials_cache = $client_credentials_cache;
 	}
 
 	/**
@@ -174,6 +186,12 @@ class LoginSellerEndpoint implements EndpointInterface {
 
 			if ( $this->cache->has( PayPalBearer::CACHE_KEY ) ) {
 				$this->cache->delete( PayPalBearer::CACHE_KEY );
+			}
+			if ( $this->client_credentials_cache->has( UserIdToken::CACHE_KEY ) ) {
+				$this->client_credentials_cache->delete( UserIdToken::CACHE_KEY );
+			}
+			if ( $this->client_credentials_cache->has( SdkClientToken::CACHE_KEY ) ) {
+				$this->client_credentials_cache->delete( SdkClientToken::CACHE_KEY );
 			}
 
 			wp_schedule_single_event(

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -84,10 +84,6 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		add_filter(
 			'woocommerce_paypal_payments_localized_script_data',
 			function( array $localized_script_data ) use ( $c ) {
-				if ( ! is_user_logged_in() ) {
-					return $localized_script_data;
-				}
-
 				$api = $c->get( 'api.user-id-token' );
 				assert( $api instanceof UserIdToken );
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -366,7 +366,8 @@ return array(
 			$container->get( 'api.partner_merchant_id-production' ),
 			$container->get( 'api.partner_merchant_id-sandbox' ),
 			$container->get( 'api.endpoint.billing-agreements' ),
-			$logger
+			$logger,
+			new Cache( 'ppcp-client-credentials-cache' )
 		);
 	},
 	'wcgateway.order-processor'                            => static function ( ContainerInterface $container ): OrderProcessor {

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -502,9 +502,6 @@ class SettingsListener {
 		if ( $this->cache->has( PayPalBearer::CACHE_KEY ) ) {
 			$this->cache->delete( PayPalBearer::CACHE_KEY );
 		}
-		if ( $this->client_credentials_cache->has( UserIdToken::CACHE_KEY ) ) {
-			$this->client_credentials_cache->delete( UserIdToken::CACHE_KEY );
-		}
 		if ( $this->client_credentials_cache->has( SdkClientToken::CACHE_KEY ) ) {
 			$this->client_credentials_cache->delete( SdkClientToken::CACHE_KEY );
 		}

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -12,6 +12,8 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
@@ -165,6 +167,13 @@ class SettingsListener {
 	private $logger;
 
 	/**
+	 * The client credentials cache.
+	 *
+	 * @var Cache
+	 */
+	private $client_credentials_cache;
+
+	/**
 	 * SettingsListener constructor.
 	 *
 	 * @param Settings                  $settings The settings.
@@ -183,6 +192,7 @@ class SettingsListener {
 	 * @param string                    $partner_merchant_id_sandbox Partner merchant ID sandbox.
 	 * @param BillingAgreementsEndpoint $billing_agreements_endpoint Billing Agreements endpoint.
 	 * @param ?LoggerInterface          $logger The logger.
+	 * @param Cache                     $client_credentials_cache The client credentials cache.
 	 */
 	public function __construct(
 		Settings $settings,
@@ -200,7 +210,8 @@ class SettingsListener {
 		string $partner_merchant_id_production,
 		string $partner_merchant_id_sandbox,
 		BillingAgreementsEndpoint $billing_agreements_endpoint,
-		LoggerInterface $logger = null
+		LoggerInterface $logger = null,
+		Cache $client_credentials_cache
 	) {
 
 		$this->settings                       = $settings;
@@ -219,6 +230,7 @@ class SettingsListener {
 		$this->partner_merchant_id_sandbox    = $partner_merchant_id_sandbox;
 		$this->billing_agreements_endpoint    = $billing_agreements_endpoint;
 		$this->logger                         = $logger ?: new NullLogger();
+		$this->client_credentials_cache       = $client_credentials_cache;
 	}
 
 	/**
@@ -489,6 +501,12 @@ class SettingsListener {
 
 		if ( $this->cache->has( PayPalBearer::CACHE_KEY ) ) {
 			$this->cache->delete( PayPalBearer::CACHE_KEY );
+		}
+		if ( $this->client_credentials_cache->has( UserIdToken::CACHE_KEY ) ) {
+			$this->client_credentials_cache->delete( UserIdToken::CACHE_KEY );
+		}
+		if ( $this->client_credentials_cache->has( SdkClientToken::CACHE_KEY ) ) {
+			$this->client_credentials_cache->delete( SdkClientToken::CACHE_KEY );
 		}
 
 		if ( $this->pui_status_cache->has( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY ) ) {

--- a/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
+++ b/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
@@ -43,6 +43,7 @@ class SettingsListenerTest extends ModularTestCase
 		$billing_agreement_endpoint = Mockery::mock(BillingAgreementsEndpoint::class);
 		$subscription_helper = Mockery::mock(SubscriptionHelper::class);
 		$logger = Mockery::mock(LoggerInterface::class);
+		$client_credentials_cache = Mockery::mock(Cache::class);
 
 		$testee = new SettingsListener(
 			$settings,
@@ -60,7 +61,8 @@ class SettingsListenerTest extends ModularTestCase
 			'',
 			'',
 			$billing_agreement_endpoint,
-			$logger
+			$logger,
+			$client_credentials_cache
 		);
 
 		$_GET['section'] = PayPalGateway::ID;

--- a/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
+++ b/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
@@ -96,6 +96,9 @@ class SettingsListenerTest extends ModularTestCase
             ->andReturn(false);
         $dcc_status_cache->shouldReceive('has')
             ->andReturn(false);
+		$client_credentials_cache->shouldReceive('has')->andReturn(true);
+		$client_credentials_cache->shouldReceive('delete');
+
 
 		$testee->listen();
 	}


### PR DESCRIPTION
This PR adds client credentials as authorization when requesting tokens, it also caches the tokens to avoid request rate limitations.