### PR TITLE
Apple Pay: Fix the shipping callback (3517)

### DIFF
--- a/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
@@ -1,6 +1,5 @@
 import ErrorHandler from '../../../../ppcp-button/resources/js/modules/ErrorHandler';
 import CartActionHandler from '../../../../ppcp-button/resources/js/modules/ActionHandler/CartActionHandler';
-import { isPayPalSubscription } from '../../../../ppcp-blocks/resources/js/Helper/Subscription';
 
 class BaseHandler {
 	constructor( buttonConfig, ppcpConfig ) {
@@ -24,7 +23,7 @@ class BaseHandler {
 	}
 
 	shippingAllowed() {
-		return this.buttonConfig.product.needsShipping;
+		return this.buttonConfig.product.needShipping;
 	}
 
 	transactionInfo() {
@@ -68,13 +67,6 @@ class BaseHandler {
 
 	actionHandler() {
 		return new CartActionHandler( this.ppcpConfig, this.errorHandler() );
-	}
-
-	errorHandler() {
-		return new ErrorHandler(
-			this.ppcpConfig.labels.error.generic,
-			document.querySelector( '.woocommerce-notices-wrapper' )
-		);
 	}
 
 	errorHandler() {


### PR DESCRIPTION
### Description

This PR fixes the Apple Pay shipping callback.

### Steps to Test

1. Make sure you have shipping enabled and created at least one shipping method.
2. Add a product to the cart.
3. Go to checkout and try to pay with Apple Pay. Make sure the shipping options display in the Apple Pay callback.

### Screenshots

|Before|After|
|-|-|
|<img width="1006" alt="bez_nazwy_i_Page__Checkout-3" src="https://github.com/user-attachments/assets/d1135e05-8bec-4cb9-9649-36e115e9497c">|![bez_nazwy_i_Page__Checkout-2_png](https://github.com/user-attachments/assets/306a87eb-55bc-4d14-95d4-07b75e494c14)|
