### PR TITLE
Fix Google Pay button on non-checkout pages (#3493)

### DIFF
--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -292,24 +292,33 @@ class GooglepayButton {
 	onButtonClick() {
 		this.log( 'onButtonClick', this.context );
 
-		this.contextHandler.validateForm().then(
-			() => {
-				window.ppcpFundingSource = 'googlepay';
+		const initiatePaymentRequest = () => {
+			window.ppcpFundingSource = 'googlepay';
 
-				const paymentDataRequest = this.paymentDataRequest();
+			const paymentDataRequest = this.paymentDataRequest();
 
-				this.log(
-					'onButtonClick: paymentDataRequest',
-					paymentDataRequest,
-					this.context
-				);
+			this.log(
+				'onButtonClick: paymentDataRequest',
+				paymentDataRequest,
+				this.context
+			);
 
-				this.paymentsClient.loadPaymentData( paymentDataRequest );
-			},
-			() => {
-				console.error( '[GooglePayButton] Form validation failed.' );
-			}
-		);
+			this.paymentsClient.loadPaymentData( paymentDataRequest );
+		};
+
+		if ( 'function' === typeof this.contextHandler.validateForm ) {
+			// During regular checkout, validate the checkout form before initiating the payment.
+			this.contextHandler
+				.validateForm()
+				.then( initiatePaymentRequest, () => {
+					console.error(
+						'[GooglePayButton] Form validation failed.'
+					);
+				} );
+		} else {
+			// This is the flow on product page, cart, and other non-checkout pages.
+			initiatePaymentRequest();
+		}
 	}
 
 	paymentDataRequest() {


### PR DESCRIPTION
### Description

Addresses an issue that was introduced in the previous PR #2474:

- The form validation added by that PR is only relevant on checkout pages.
- On any non-checkout page, the Google Pay button did not work anymore.

### Solution

A new condition first checks, if form validation is possible:
- If form validation is available (on checkout), it will be done before initiating the payment process
- On pages that do not contain any form or validation logic, the payment process is directly initialized on button press (as before the PR)