### PR TITLE
Apple Pay: Fix switching between shipping methods inside the modal (3522)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -644,10 +644,12 @@ class ApplepayButton {
 				return {
 					action: 'ppcp_update_shipping_method',
 					shipping_method: event.shippingMethod,
-					simplified_contact:
-						this.updatedContactInfo ||
-						this.initialPaymentRequest.shippingContact ||
-						this.initialPaymentRequest.billingContact,
+					simplified_contact: this.hasValidContactInfo(
+						this.updatedContactInfo
+					)
+						? this.updatedContactInfo
+						: this.initialPaymentRequest?.shippingContact ??
+						  this.initialPaymentRequest?.billingContact,
 					product_id,
 					products: JSON.stringify( this.products ),
 					caller_page: 'productDetail',
@@ -662,10 +664,12 @@ class ApplepayButton {
 				return {
 					action: 'ppcp_update_shipping_method',
 					shipping_method: event.shippingMethod,
-					simplified_contact:
-						this.updatedContactInfo ||
-						this.initialPaymentRequest.shippingContact ||
-						this.initialPaymentRequest.billingContact,
+					simplified_contact: this.hasValidContactInfo(
+						this.updatedContactInfo
+					)
+						? this.updatedContactInfo
+						: this.initialPaymentRequest?.shippingContact ??
+						  this.initialPaymentRequest?.billingContact,
 					caller_page: 'cart',
 					'woocommerce-process-checkout-nonce': this.nonce,
 				};
@@ -947,6 +951,12 @@ class ApplepayButton {
 		);
 
 		return btoa( utf8Str );
+	}
+
+	hasValidContactInfo( value ) {
+		return Array.isArray( value )
+			? value.length > 0
+			: Object.keys( value || {} ).length > 0;
 	}
 }
 


### PR DESCRIPTION
### Description

This PR fixes the Apple Pay shipping method switching inside the Apple Pay modal in Classic Checkout.

### Steps to Test

1. Enable shipping and make sure you have more than 1 shipping method.
2. Test the shipping method switching inside the Apple Pay modal in Classic Checkout, Classic Cart and Single Product pages.

### Screenshots
![bez_nazwy_i_Page__Checkout-4_png](https://github.com/user-attachments/assets/083ab2ca-fcc2-44f3-a78a-e6398fcbb457)

