### PR TITLE
Saved PayPal account isn't displayed on checkout (3520)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -88,5 +88,12 @@ return function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-axo/module.php" )();
 	}
 
+	if ( apply_filters(
+		'woocommerce.feature-flags.woocommerce_paypal_payments.local_apms_enabled',
+		getenv( 'PCP_LOCAL_APMS_ENABLED' ) === '1'
+	) ) {
+		$modules[] = ( require "$modules_dir/ppcp-local-alternative-payment-methods/module.php" )();
+	}
+
 	return $modules;
 };

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient;
 
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentMethodTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\CardAuthenticationResult;
@@ -237,6 +238,12 @@ return array(
 			$container->get( 'wcgateway.is-fraudnet-enabled' ),
 			$container->get( 'wcgateway.fraudnet' ),
 			$bn_code
+		);
+	},
+	'api.endpoint.orders' => static function (ContainerInterface $container): Orders {
+		return new Orders(
+			$container->get( 'api.host' ),
+			$container->get( 'api.bearer' )
 		);
 	},
 	'api.endpoint.billing-agreements'                => static function ( ContainerInterface $container ): BillingAgreementsEndpoint {

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -82,7 +82,7 @@ class UserIdToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function id_token( string $target_customer_id = '' ): string {
-		if ( $this->cache->has( self::CACHE_KEY . '-' . (string) get_current_user_id() ) ) {
+		if ( get_current_user_id() !== 0 && $this->cache->has( self::CACHE_KEY . '-' . (string) get_current_user_id() ) ) {
 			return $this->cache->get( self::CACHE_KEY . '-' . (string) get_current_user_id() );
 		}
 
@@ -118,7 +118,9 @@ class UserIdToken {
 		$id_token   = $json->id_token;
 		$expires_in = (int) $json->expires_in;
 
-		$this->cache->set( self::CACHE_KEY . '-' . (string) get_current_user_id(), $id_token, $expires_in );
+		if ( get_current_user_id() !== 0 ) {
+			$this->cache->set( self::CACHE_KEY . '-' . (string) get_current_user_id(), $id_token, $expires_in );
+		}
 
 		return $id_token;
 	}

--- a/modules/ppcp-api-client/src/Endpoint/Orders.php
+++ b/modules/ppcp-api-client/src/Endpoint/Orders.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Orders API endpoints.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Endpoint
+ * @link https://developer.paypal.com/docs/api/orders/v2/ Orders API documentation.
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
+
+use RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WP_Error;
+
+/**
+ * Class Orders
+ */
+class Orders {
+
+	/**
+	 * The host.
+	 *
+	 * @var string
+	 */
+	private $host;
+
+	/**
+	 * The bearer.
+	 *
+	 * @var Bearer
+	 */
+	private $bearer;
+
+	/**
+	 * Orders constructor.
+	 *
+	 * @param string $host
+	 * @param Bearer $bearer
+	 */
+	public function __construct(
+		string $host,
+		Bearer $bearer
+	) {
+		$this->host = $host;
+		$this->bearer = $bearer;
+	}
+
+	public function create(array $request_body, array $headers = array()): array {
+		$bearer = $this->bearer->bearer();
+		$url  = trailingslashit( $this->host ) . 'v2/checkout/orders';
+
+		$default_headers = array(
+			'Authorization' => 'Bearer ' . $bearer->token(),
+			'Content-Type' => 'application/json',
+		);
+		$headers = array_merge(
+			$default_headers,
+			$headers
+		);
+
+		$args = array(
+			'method'  => 'POST',
+			'headers' => $headers,
+			'body'    => wp_json_encode( $request_body ),
+		);
+
+		$response = wp_remote_get( $url, $args );
+		if ( $response instanceof WP_Error ) {
+			throw new RuntimeException( $response->get_error_message() );
+		}
+
+		return $response;
+	}
+}

--- a/modules/ppcp-local-alternative-payment-methods/composer.json
+++ b/modules/ppcp-local-alternative-payment-methods/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "woocommerce/ppcp-local-alternative-payment-methods",
+    "type": "dhii-mod",
+    "description": "Country based Alternative Payment Methods module",
+    "license": "GPL-2.0",
+    "require": {
+        "php": "^7.2 | ^8.0",
+        "dhii/module-interface": "^0.3.0-alpha1"
+    },
+    "autoload": {
+        "psr-4": {
+            "WooCommerce\\PayPalCommerce\\LocalAlternativePaymentMethods\\": "src"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/modules/ppcp-local-alternative-payment-methods/extensions.php
+++ b/modules/ppcp-local-alternative-payment-methods/extensions.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * The local alternative payment methods module extensions.
+ *
+ * @package WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
+
+return array();

--- a/modules/ppcp-local-alternative-payment-methods/module.php
+++ b/modules/ppcp-local-alternative-payment-methods/module.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * The local alternative payment methods module.
+ *
+ * @package WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+
+return static function (): ModuleInterface {
+	return new LocalAlternativePaymentMethodsModule();
+};

--- a/modules/ppcp-local-alternative-payment-methods/services.php
+++ b/modules/ppcp-local-alternative-payment-methods/services.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
 
-return array(
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
+return array(
+	'ppcp-local-apms.bancontact.wc-gateway' =>  static function ( ContainerInterface $container ): BancontactGateway {
+		return new BancontactGateway();
+	},
 );

--- a/modules/ppcp-local-alternative-payment-methods/services.php
+++ b/modules/ppcp-local-alternative-payment-methods/services.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * The local alternative payment methods module services.
+ *
+ * @package WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
+
+return array(
+
+);

--- a/modules/ppcp-local-alternative-payment-methods/src/BancontactGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/BancontactGateway.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * The Bancontact payment gateway.
+ *
+ * @package WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
+
+use WC_Payment_Gateway;
+
+class BancontactGateway extends WC_Payment_Gateway {
+
+	const ID = 'ppcp-bancontact';
+
+	public function __construct() {
+		$this->id = self::ID;
+
+		$this->method_title       = __( 'Bancontact', 'woocommerce-paypal-payments' );
+		$this->method_description = __( 'Bancontact', 'woocommerce-paypal-payments' );
+
+		$this->title       = $this->get_option( 'title', __( 'Bancontact', 'woocommerce-paypal-payments' ) );
+		$this->description = $this->get_option( 'description', '' );
+
+		$this->icon = esc_url( 'https://www.paypalobjects.com/images/checkout/alternative_payments/paypal_bancontact_color.svg' );
+
+		$this->init_form_fields();
+		$this->init_settings();
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+	}
+
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'enabled'     => array(
+				'title'       => __( 'Enable/Disable', 'woocommerce-paypal-payments' ),
+				'type'        => 'checkbox',
+				'label'       => __( 'Bancontact', 'woocommerce-paypal-payments' ),
+				'default'     => 'no',
+				'desc_tip'    => true,
+				'description' => __( 'Enable/Disable Bancontact payment gateway.', 'woocommerce-paypal-payments' ),
+			),
+			'title'       => array(
+				'title'       => __( 'Title', 'woocommerce-paypal-payments' ),
+				'type'        => 'text',
+				'default'     => $this->title,
+				'desc_tip'    => true,
+				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-paypal-payments' ),
+			),
+			'description' => array(
+				'title'       => __( 'Description', 'woocommerce-paypal-payments' ),
+				'type'        => 'text',
+				'default'     => $this->description,
+				'desc_tip'    => true,
+				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-paypal-payments' ),
+			),
+		);
+	}
+
+	public function process_payment( $order_id ) {
+		$wc_order = wc_get_order( $order_id );
+
+
+
+		return array(
+			'result'   => 'success',
+			'redirect' => $this->get_return_url( $wc_order ),
+		);
+	}
+}

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -30,6 +30,10 @@ class LocalAlternativePaymentMethodsModule implements ModuleInterface {
 	}
 
 	public function run(ContainerInterface $c): void {
+		add_filter('woocommerce_payment_gateways', function ($methods) use ($c) {
+			$methods[] = $c->get('ppcp-local-apms.bancontact.wc-gateway');
 
+			return $methods;
+		});
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * The local alternative payment methods module.
+ *
+ * @package WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
+
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
+use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
+use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Class LocalAlternativePaymentMethodsModule
+ */
+class LocalAlternativePaymentMethodsModule implements ModuleInterface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setup(): ServiceProviderInterface {
+		return new ServiceProvider(
+			require __DIR__ . '/../services.php',
+			require __DIR__ . '/../extensions.php'
+		);
+	}
+
+	public function run(ContainerInterface $c): void {
+
+	}
+}

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -31,6 +31,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Endpoint\SubscriptionChangePaymentMethod;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
  * Class SavePaymentMethodsModule
@@ -84,6 +85,12 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		add_filter(
 			'woocommerce_paypal_payments_localized_script_data',
 			function( array $localized_script_data ) use ( $c ) {
+				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscriptions_helper instanceof SubscriptionHelper );
+				if ( ! is_user_logged_in() && ! $subscriptions_helper->cart_contains_subscription() ) {
+					return $localized_script_data;
+				}
+
 				$api = $c->get( 'api.user-id-token' );
 				assert( $api instanceof UserIdToken );
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;

--- a/tests/PHPUnit/ApiClient/Endpoint/OrdersTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrdersTest.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+class OrdersTest extends TestCase
+{
+	public function test_create() {
+		$bearer = Mockery::mock(Bearer::class);
+		$token = Mockery::mock(Token::class);
+		$token->shouldReceive('token')->andReturn('');
+		$bearer->shouldReceive('bearer')->andReturn($token);
+
+		$sut = new Orders('', $bearer);
+
+		expect('wp_remote_get')->andReturn([]);
+
+		$this->assertEquals([], $sut->create([]));
+	}
+}

--- a/tests/e2e/PHPUnit/OrdersTest.php
+++ b/tests/e2e/PHPUnit/OrdersTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace WooCommerce\PayPalCommerce\Tests\E2e;
+
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
+
+class OrdersTest extends TestCase
+{
+	public function test_create()
+	{
+		$host = 'https://api-m.sandbox.paypal.com';
+		$container = $this->getContainer();
+
+		$orders = new Orders($host, $container->get('api.bearer'));
+
+		$requestBody = [
+			"intent" => "CAPTURE",
+			"payment_source" => [
+				"bancontact" => [
+					"country_code" => "BE",
+					"name" => "John Doe"
+				]
+			],
+			"processing_instruction" => "ORDER_COMPLETE_ON_PAYMENT_APPROVAL",
+			"purchase_units" => [
+				[
+					"reference_id" => "d9f80740-38f0-11e8-b467-0ed5f89f718b",
+					"amount" => [
+						"currency_code" => "EUR",
+						"value" => "1.00"
+					],
+				]
+			],
+			"application_context" => [
+				"locale" => "en-BE",
+				"return_url" => "https://example.com/returnUrl",
+				"cancel_url" => "https://example.com/cancelUrl"
+			]
+		];
+
+		$headers = array(
+			'PayPal-Request-Id' => uniqid( 'ppcp-', true ),
+		);
+
+		$result = $orders->create($requestBody, $headers);
+
+		$this->assertEquals(200, $result['response']['code']);
+	}
+}


### PR DESCRIPTION
In #2491 we introduced cache for access tokens used for adding `data-user-id-token` to the  JSSDK , this is causing issues when reusing the cached access token for example not displaying the saved payment token in the PayPal button.

This PR removes cache logic for access tokens used in `data-user-id-token`.

### Steps to reproduce
- Navigate to Shop → My account → Payment methods
- Save a PayPal account
- Add product to the cart
- Navigate to checkout

Actual result: Saved PayPal account isn’t displayed on checkout.
Expected Result: Saved PayPal account should be displayed on checkout.