### PR TITLE
Saved PayPal account isn't displayed on checkout (3520)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -1669,8 +1669,7 @@ return array(
 		return new UserIdToken(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'api.client-credentials' ),
-			$container->get( 'api.client-credentials-cache' )
+			$container->get( 'api.client-credentials' )
 		);
 	},
 	'api.sdk-client-token'                           => static function( ContainerInterface $container ): SdkClientToken {

--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -96,18 +96,6 @@ class ApiModule implements ModuleInterface {
 			10,
 			2
 		);
-
-		add_action(
-			'wp_logout',
-			function( int $user_id ) use ( $c ) {
-				$client_credentials_cache = $c->get( 'api.client-credentials-cache' );
-				assert( $client_credentials_cache instanceof Cache );
-
-				if ( $client_credentials_cache->has( UserIdToken::CACHE_KEY . '-' . (string) $user_id ) ) {
-					$client_credentials_cache->delete( UserIdToken::CACHE_KEY . '-' . (string) $user_id );
-				}
-			}
-		);
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -82,10 +82,6 @@ class UserIdToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function id_token( string $target_customer_id = '' ): string {
-		if ( $this->cache->has( self::CACHE_KEY . '-' . (string) get_current_user_id() ) ) {
-			return $this->cache->get( self::CACHE_KEY . '-' . (string) get_current_user_id() );
-		}
-
 		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=id_token';
 		if ( $target_customer_id ) {
 			$url = add_query_arg(
@@ -115,11 +111,6 @@ class UserIdToken {
 			throw new PayPalApiException( $json, $status_code );
 		}
 
-		$id_token   = $json->id_token;
-		$expires_in = (int) $json->expires_in;
-
-		$this->cache->set( self::CACHE_KEY . '-' . (string) get_current_user_id(), $id_token, $expires_in );
-
-		return $id_token;
+		return $json->id_token;
 	}
 }

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -11,7 +11,6 @@ use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WP_Error;
 
 /**
@@ -20,8 +19,6 @@ use WP_Error;
 class UserIdToken {
 
 	use RequestTrait;
-
-	const CACHE_KEY = 'user-id-token-key';
 
 	/**
 	 * The host.
@@ -45,30 +42,20 @@ class UserIdToken {
 	private $client_credentials;
 
 	/**
-	 * The cache.
-	 *
-	 * @var Cache
-	 */
-	private $cache;
-
-	/**
 	 * UserIdToken constructor.
 	 *
 	 * @param string            $host The host.
 	 * @param LoggerInterface   $logger The logger.
 	 * @param ClientCredentials $client_credentials The client credentials.
-	 * @param Cache             $cache The cache.
 	 */
 	public function __construct(
 		string $host,
 		LoggerInterface $logger,
-		ClientCredentials $client_credentials,
-		Cache $cache
+		ClientCredentials $client_credentials
 	) {
 		$this->host               = $host;
 		$this->logger             = $logger;
 		$this->client_credentials = $client_credentials;
-		$this->cache              = $cache;
 	}
 
 	/**

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -31,6 +31,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Endpoint\SubscriptionChangePaymentMethod;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
  * Class SavePaymentMethodsModule
@@ -84,6 +85,12 @@ class SavePaymentMethodsModule implements ModuleInterface {
 		add_filter(
 			'woocommerce_paypal_payments_localized_script_data',
 			function( array $localized_script_data ) use ( $c ) {
+				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscriptions_helper instanceof SubscriptionHelper );
+				if ( ! is_user_logged_in() && ! $subscriptions_helper->cart_contains_subscription() ) {
+					return $localized_script_data;
+				}
+
 				$api = $c->get( 'api.user-id-token' );
 				assert( $api instanceof UserIdToken );
 


### PR DESCRIPTION
In #2491 we introduced cache for access tokens used for adding `data-user-id-token` to the  JSSDK , this is causing issues when reusing the cached access token for example not displaying the saved payment token in the PayPal button.

This PR removes cache logic for access tokens used in `data-user-id-token`. It also ensures `data-user-id-token` is only added to guest users with WC Subscriptions product in the cart.

### Steps to reproduce
- Navigate to Shop → My account → Payment methods
- Save a PayPal account
- Add product to the cart
- Navigate to checkout

Actual result: Saved PayPal account isn’t displayed on checkout.
Expected Result: Saved PayPal account should be displayed on checkout.