### PR TITLE
New SettingsInterface

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -15,7 +15,7 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 /**
  * Class Settings
  */
-class Settings implements ContainerInterface {
+class Settings implements SettingsGetterInterface, ContainerInterface {
 
 	const KEY               = 'woocommerce-ppcp-settings';
 	const CONNECTION_TAB_ID = 'ppcp-connection';
@@ -101,6 +101,19 @@ class Settings implements ContainerInterface {
 	public function has( $id ) {
 		$this->load();
 		return array_key_exists( $id, $this->settings );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Replaces `$settings->has() ? $settings->get() : $default` chains.
+	 */
+	public function get_value( string $key, $default = null ) {
+		try {
+			return $this->get( $key );
+		} catch ( NotFoundException $e ) {
+			return $default;
+		}
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsGetterInterface.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsGetterInterface.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Interface for settings-accessor classes.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Settings
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
+
+/**
+ * Interface for accessing plugin settings (read-only).
+ *
+ * Implements a WordPress-like settings access signature: `get_value()` is inspired by the
+ * `get_option()` core method.
+ *
+ * In contrast to the `ContainerInterface`, this interface will never throw an Exception.
+ */
+interface SettingsGetterInterface {
+	/**
+	 * Get a single value from stored settings.
+	 *
+	 * @param string $key     The key to retrieve.
+	 * @param mixed  $default The default value if the key is not found.
+	 *
+	 * @return mixed The value or the default.
+	 */
+	public function get_value( string $key, $default = null );
+}


### PR DESCRIPTION
### Description

Simplifies settings-access for developers, and helps to keep code concise and easy to maintain.

### Reason

The current [`Settings` class](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a152027772b8a4379018b3f1308642f6090229c3/modules/ppcp-wc-gateway/src/Settings/Settings.php#L18), which implements the PSR [`ContainerInterface`](https://www.php-fig.org/psr/psr-11/#3-interfaces), led to several challenges in our codebase.

1. Developers often need to use [complex and repetitive patterns](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a152027772b8a4379018b3f1308642f6090229c3/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php#L143-L146) to safely retrieve settings
2. Static analysis tools frequently raise warnings about potential unhandled exceptions. Those exceptions need to handled instantly or [propagated via `@throws` annotations](https://github.com/woocommerce/woocommerce-paypal-payments/blob/a152027772b8a4379018b3f1308642f6090229c3/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php#L124).

### New SettingsGetterInterface

The `Settings` class implements the new `SettingsGetterInterface` which provides the single method `get_value()`

1. Improves developer experience with a more intuitive and WordPress-ish API, without the possibility of throwing an
   exception
2. Better support static analysis tools - no throws, ternary operators
3. Maintains backward compatibility with existing code for gradual adoption


### Before-After Comparison

#### Current

```php
/** @throws NotFoundException */
function ( ContainerInterface $container ): bool {
    $settings = $container->get( 'wcgateway.settings' );
    assert( $settings instanceof ContainerInterface );

    return $settings->has( 'allow_card_button_gateway' ) ?
        (bool) $settings->get( 'allow_card_button_gateway' ) :
        $container->get( 'wcgateway.settings.allow_card_button_gateway.default' );
}

...

$type = $this->settings->has( 'applepay_button_type' ) ?
    $this->settings->get( 'applepay_button_type' ) : 
    '';
$checkout_data_mode = $this->settings->has( 'applepay_checkout_data_mode' ) ? 
    $this->settings->get( 'applepay_checkout_data_mode' ) :
    PropertiesDictionary::BILLING_DATA_MODE_DEFAULT;
```

**Downsides**

- `ContainerInterface::get()` can throw an exception that needs to be handled
- Prone to errors due to repeated settings-key string
- Not the best pattern for accessing setting values

#### Proposed

```php
function ( ContainerInterface $container ): bool {
    $settings = $container->get( 'wcgateway.settings' );
    assert( $settings instanceof SettingsGetterInterface );

    return $settings->get_value(
        'allow_card_button_gateway',
        (bool) $container->get( 'wcgateway.settings.allow_card_button_gateway.default' )
     );
}

...

$type = $this->settings->get_value( 'applepay_button_type', '' );
$checkout_data_mode = $this->settings->get_value(
    'applepay_checkout_data_mode',
    PropertiesDictionary::BILLING_DATA_MODE_DEFAULT
);
```

**Benefits**

- No Exception handling, or annotation
- Concise and more intuitive to maintain
- Same pattern that's used by WordPress (`get_option()`, `get_post_meta()`, etc.) of always returning a value and never throwing anything

### Change ideas

- Add logging to the `get_value()` method to log access to undefined setting keys.


### Next steps

1. After adding this new Interface, we gradually migrate code from `$s->has( $key ) ? $s->get( $key ) : $default` to `$s->get_value( $key, $default )`
2. Eventually, we can drop the `ContainerInterface` from the Settings container