### PR TITLE
Update static meta value for Fastlane feature detection (3492)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -194,9 +194,18 @@ class AxoModule implements ModuleInterface {
 
 				add_action(
 					'wp_head',
-					function () {
+					function () use ( $c ) {
 						// phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 						echo '<script async src="https://www.paypalobjects.com/insights/v1/paypal-insights.sandbox.min.js"></script>';
+
+						// Add meta tag to allow feature-detection of the site's AXO payment state.
+						$settings = $c->get( 'wcgateway.settings' );
+						assert( $settings instanceof Settings );
+
+						printf(
+							'<meta name="ppcp.axo" content="%s" />',
+							$settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' ) ? 'enabled' : 'disabled'
+						);
 					}
 				);
 

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -202,9 +202,8 @@ class AxoModule implements ModuleInterface {
 						$settings = $c->get( 'wcgateway.settings' );
 						assert( $settings instanceof Settings );
 
-						printf(
-							'<meta name="ppcp.axo" content="%s" />',
-							$settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' ) ? 'enabled' : 'disabled'
+						$this->add_feature_detection_tag(
+							$settings->has( 'axo_enabled' ) && $settings->get( 'axo_enabled' )
 						);
 					}
 				);
@@ -404,5 +403,24 @@ class AxoModule implements ModuleInterface {
 	private function is_excluded_endpoint(): bool {
 		// Exclude the Order Pay endpoint.
 		return is_wc_endpoint_url( 'order-pay' );
+	}
+
+	/**
+	 * Outputs a meta tag to allow feature detection on certain pages.
+	 *
+	 * @param bool $axo_enabled Whether the gateway is enabled.
+	 * @return void
+	 */
+	private function add_feature_detection_tag( bool $axo_enabled ) {
+		$show_tag = is_checkout() || is_cart() || is_shop();
+
+		if ( ! $show_tag ) {
+			return;
+		}
+
+		printf(
+			'<meta name="ppcp.axo" content="%s" />',
+			$axo_enabled ? 'enabled' : 'disabled'
+		);
 	}
 }

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -419,7 +419,7 @@ class AxoModule implements ModuleInterface {
 		}
 
 		printf(
-			'<meta name="ppcp.axo" content="%s" />',
+			'<meta name="ppcp.axo" content="ppcp.axo.%s" />',
 			$axo_enabled ? 'enabled' : 'disabled'
 		);
 	}


### PR DESCRIPTION
### Description

The initial version of this PR added the HTML tag `<meta name="ppcp.axo" content="enabled" />` to sites that use Fastlane.

Automated monitoring had problems detecting the multi-word phrase, so this PR modifies the content of the meta-tag to `ppcp.axo.enabled` or `ppcp.axo.disabled`

- Meta tag is only output on checkout, cart and main shop pages.
- The tag is only used for monitoring and feature detection. It's not used internally by the plugin.

<details>
<summary><strong>📸 Screenshot</strong></summary>

<img width="748" alt="2024-08-12_18-10-35" src="https://github.com/user-attachments/assets/4be9392b-0da1-4abf-9686-8376892bc67b">

</details>