### PR TITLE
Remove AMEX support for ACDC when store location is set to China (3536)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -1444,7 +1444,6 @@ return array(
 				'CN' => array(
 					'mastercard' => array(),
 					'visa'       => array(),
-					'amex'       => array(),
 				),
 				'CY' => array(
 					'mastercard' => array(),


### PR DESCRIPTION
### Description

Disable card payments via American Express for WooCommerce stores in China.

### Steps to test

1. Set the store country to China in the WooCommerce Settings

**Verify**
1. Visit the PayPal payments settings → Advanced Card Processing tab. "American Express" must not be displayed in the setting "Show logo of the following credit cards"
2. Perform a checkout, trying to pay using an Amex card. Payment must be declined with the message stating "we do not accept this card"

<img width="682" alt="2024-08-21_16-03-42" src="https://github.com/user-attachments/assets/5655f67c-0682-4a62-a61e-ff9e6775ddb3">