### PR TITLE
Disable PayPal Shipping callback by default (3547)

### DIFF
--- a/modules/ppcp-blocks/extensions.php
+++ b/modules/ppcp-blocks/extensions.php
@@ -61,7 +61,7 @@ return array(
 					'title'        => __( 'Require final confirmation on checkout', 'woocommerce-paypal-payments' ),
 					'type'         => 'checkbox',
 					'label'        => $label,
-					'default'      => false,
+					'default'      => true,
 					'screens'      => array( State::STATE_START, State::STATE_ONBOARDED ),
 					'requirements' => array(),
 					'gateway'      => 'paypal',


### PR DESCRIPTION
### Description

This PR changes the default state of a plugin setting for new installations.

**Affected Setting**
<img width="1200" alt="2024-08-21_18-50-34" src="https://github.com/user-attachments/assets/f7cf10ab-7adb-4805-8bec-550ff4adb9db">

### How to test

**Preparation:**

- Option 1: Install the plugin on a new site for the first time
- Option 2: Delete the existing plugin settings via SQL

<details>
<summary><strong>Sample: Reset plugin settings</strong></summary>

- SQL: `DELETE FROM wp_options WHERE option_key = "woocommerce-ppcp-settings";`
- WP CLI: `wp option delete woocommerce-ppcp-settings`
- DDEV: `ddev wp option delete woocommerce-ppcp-settings`

</details>

**Test:**

1. Connect the plugin to a PayPal merchant account
2. Open the plugin settings on the **Standard Payments** tab and verify the checkout is checked 