### PR TITLE
APMs via Orders API adjustments (3317)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -31,6 +31,7 @@ return function ( string $root_dir ): iterable {
 		( require "$modules_dir/ppcp-uninstall/module.php" )(),
 		( require "$modules_dir/ppcp-blocks/module.php" )(),
 		( require "$modules_dir/ppcp-paypal-subscriptions/module.php" )(),
+		( require "$modules_dir/ppcp-local-alternative-payment-methods/module.php" )(),
 	);
 	// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
 
@@ -86,13 +87,6 @@ return function ( string $root_dir ): iterable {
 		getenv( 'PCP_AXO_ENABLED' ) === '1'
 	) ) {
 		$modules[] = ( require "$modules_dir/ppcp-axo/module.php" )();
-	}
-
-	if ( apply_filters(
-		'woocommerce.feature-flags.woocommerce_paypal_payments.local_apms_enabled',
-		getenv( 'PCP_LOCAL_APMS_ENABLED' ) === '1'
-	) ) {
-		$modules[] = ( require "$modules_dir/ppcp-local-alternative-payment-methods/module.php" )();
 	}
 
 	return $modules;

--- a/modules/ppcp-api-client/src/Endpoint/Orders.php
+++ b/modules/ppcp-api-client/src/Endpoint/Orders.php
@@ -97,8 +97,15 @@ class Orders {
 
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( ! in_array( $status_code, array( 200, 201 ), true ) ) {
+			$body = json_decode( $response['body'] );
+
+			$message = $body->details[0]->description ?? '';
+			if ( $message ) {
+				throw new RuntimeException( $message );
+			}
+
 			throw new PayPalApiException(
-				json_decode( $response['body'] ),
+				$body,
 				$status_code
 			);
 		}
@@ -111,15 +118,15 @@ class Orders {
 	 *
 	 * @link https://developer.paypal.com/docs/api/orders/v2/#orders_confirm
 	 *
-	 * @param array $request_body The request body.
+	 * @param array  $request_body The request body.
 	 * @param string $id PayPal order ID.
 	 * @return array
 	 * @throws RuntimeException If something went wrong with the request.
 	 * @throws PayPalApiException If something went wrong with the PayPal API request.
 	 */
-	public function confirm_payment_source(array $request_body, string $id): array {
+	public function confirm_payment_source( array $request_body, string $id ): array {
 		$bearer = $this->bearer->bearer();
-		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $id .'/confirm-payment-source';
+		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $id . '/confirm-payment-source';
 
 		$args = array(
 			'method'  => 'POST',

--- a/modules/ppcp-api-client/src/Endpoint/Orders.php
+++ b/modules/ppcp-api-client/src/Endpoint/Orders.php
@@ -96,6 +96,47 @@ class Orders {
 		}
 
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( ! in_array( $status_code, array( 200, 201 ), true ) ) {
+			throw new PayPalApiException(
+				json_decode( $response['body'] ),
+				$status_code
+			);
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Confirms the given order.
+	 *
+	 * @link https://developer.paypal.com/docs/api/orders/v2/#orders_confirm
+	 *
+	 * @param array $request_body The request body.
+	 * @param string $id PayPal order ID.
+	 * @return array
+	 * @throws RuntimeException If something went wrong with the request.
+	 * @throws PayPalApiException If something went wrong with the PayPal API request.
+	 */
+	public function confirm_payment_source(array $request_body, string $id): array {
+		$bearer = $this->bearer->bearer();
+		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $id .'/confirm-payment-source';
+
+		$args = array(
+			'method'  => 'POST',
+			'headers' => array(
+				'Authorization'     => 'Bearer ' . $bearer->token(),
+				'Content-Type'      => 'application/json',
+				'PayPal-Request-Id' => uniqid( 'ppcp-', true ),
+			),
+			'body'    => wp_json_encode( $request_body ),
+		);
+
+		$response = $this->request( $url, $args );
+		if ( $response instanceof WP_Error ) {
+			throw new RuntimeException( $response->get_error_message() );
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( $status_code !== 200 ) {
 			throw new PayPalApiException(
 				json_decode( $response['body'] ),

--- a/modules/ppcp-api-client/src/Endpoint/Orders.php
+++ b/modules/ppcp-api-client/src/Endpoint/Orders.php
@@ -145,8 +145,15 @@ class Orders {
 
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( $status_code !== 200 ) {
+			$body = json_decode( $response['body'] );
+
+			$message = $body->details[0]->description ?? '';
+			if ( $message ) {
+				throw new RuntimeException( $message );
+			}
+
 			throw new PayPalApiException(
-				json_decode( $response['body'] ),
+				$body,
 				$status_code
 			);
 		}

--- a/modules/ppcp-local-alternative-payment-methods/resources/js/multibanco-payment-method.js
+++ b/modules/ppcp-local-alternative-payment-methods/resources/js/multibanco-payment-method.js
@@ -1,0 +1,18 @@
+import { registerPaymentMethod } from '@woocommerce/blocks-registry';
+import { APM } from './apm-block';
+
+const config = wc.wcSettings.getSetting( 'ppcp-multibanco_data' );
+
+registerPaymentMethod( {
+	name: config.id,
+	label: <div dangerouslySetInnerHTML={ { __html: config.title } } />,
+	content: <APM config={ config } />,
+	edit: <div></div>,
+	ariaLabel: config.title,
+	canMakePayment: () => {
+		return true;
+	},
+	supports: {
+		features: config.supports,
+	},
+} );

--- a/modules/ppcp-local-alternative-payment-methods/services.php
+++ b/modules/ppcp-local-alternative-payment-methods/services.php
@@ -60,6 +60,11 @@ return array(
 				'countries'  => array( 'AT', 'DE', 'DK', 'EE', 'ES', 'FI', 'GB', 'LT', 'LV', 'NL', 'NO', 'SE' ),
 				'currencies' => array( 'EUR', 'DKK', 'SEK', 'GBP', 'NOK' ),
 			),
+			'multibanco' => array(
+				'id'         => MultibancoGateway::ID,
+				'countries'  => array( 'PT' ),
+				'currencies' => array( 'EUR' ),
+			),
 		);
 	},
 	'ppcp-local-apms.bancontact.wc-gateway'     => static function ( ContainerInterface $container ): BancontactGateway {
@@ -118,6 +123,14 @@ return array(
 			$container->get( 'wcgateway.transaction-url-provider' )
 		);
 	},
+	'ppcp-local-apms.multibanco.wc-gateway'     => static function ( ContainerInterface $container ): MultibancoGateway {
+		return new MultibancoGateway(
+			$container->get( 'api.endpoint.orders' ),
+			$container->get( 'api.factory.purchase-unit' ),
+			$container->get( 'wcgateway.processor.refunds' ),
+			$container->get( 'wcgateway.transaction-url-provider' )
+		);
+	},
 	'ppcp-local-apms.bancontact.payment-method' => static function( ContainerInterface $container ): BancontactPaymentMethod {
 		return new BancontactPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
@@ -165,6 +178,13 @@ return array(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.trustly.wc-gateway' )
+		);
+	},
+	'ppcp-local-apms.multibanco.payment-method'    => static function( ContainerInterface $container ): MultibancoPaymentMethod {
+		return new MultibancoPaymentMethod(
+			$container->get( 'ppcp-local-apms.url' ),
+			$container->get( 'ppcp.asset-version' ),
+			$container->get( 'ppcp-local-apms.multibanco.wc-gateway' )
 		);
 	},
 );

--- a/modules/ppcp-local-alternative-payment-methods/services.php
+++ b/modules/ppcp-local-alternative-payment-methods/services.php
@@ -180,7 +180,7 @@ return array(
 			$container->get( 'ppcp-local-apms.trustly.wc-gateway' )
 		);
 	},
-	'ppcp-local-apms.multibanco.payment-method'    => static function( ContainerInterface $container ): MultibancoPaymentMethod {
+	'ppcp-local-apms.multibanco.payment-method' => static function( ContainerInterface $container ): MultibancoPaymentMethod {
 		return new MultibancoPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),

--- a/modules/ppcp-local-alternative-payment-methods/src/BancontactGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/BancontactGateway.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -176,6 +177,9 @@ class BancontactGateway extends WC_Payment_Gateway {
 		}
 
 		$body = json_decode( $response['body'] );
+
+		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $body->id );
+		$wc_order->save_meta_data();
 
 		$payer_action = '';
 		foreach ( $body->links as $link ) {

--- a/modules/ppcp-local-alternative-payment-methods/src/BlikGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/BlikGateway.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -177,6 +178,9 @@ class BlikGateway extends WC_Payment_Gateway {
 		}
 
 		$body = json_decode( $response['body'] );
+
+		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $body->id );
+		$wc_order->save_meta_data();
 
 		$payer_action = '';
 		foreach ( $body->links as $link ) {

--- a/modules/ppcp-local-alternative-payment-methods/src/EPSGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/EPSGateway.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -176,6 +177,9 @@ class EPSGateway extends WC_Payment_Gateway {
 		}
 
 		$body = json_decode( $response['body'] );
+
+		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $body->id );
+		$wc_order->save_meta_data();
 
 		$payer_action = '';
 		foreach ( $body->links as $link ) {

--- a/modules/ppcp-local-alternative-payment-methods/src/IDealGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/IDealGateway.php
@@ -119,6 +119,13 @@ class IDealGateway extends WC_Payment_Gateway {
 				'desc_tip'    => true,
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-paypal-payments' ),
 			),
+			'bic'         => array(
+				'title'       => __( 'BIC', 'woocommerce-paypal-payments' ),
+				'type'        => 'text',
+				'default'     => '',
+				'desc_tip'    => true,
+				'description' => __( 'Business identification number (BIC) to identify the specific bank.', 'woocommerce-paypal-payments' ),
+			),
 		);
 	}
 
@@ -139,7 +146,10 @@ class IDealGateway extends WC_Payment_Gateway {
 			'country_code' => $wc_order->get_billing_country(),
 			'name'         => $wc_order->get_billing_first_name() . ' ' . $wc_order->get_billing_last_name(),
 		);
-		// TODO get "bic" from gateway settings.
+		$bic            = $this->get_option( 'bic' ) ?? '';
+		if ( $bic ) {
+			$payment_source['bic'] = $bic;
+		}
 
 		$request_body = array(
 			'intent'                 => 'CAPTURE',

--- a/modules/ppcp-local-alternative-payment-methods/src/IDealGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/IDealGateway.php
@@ -119,13 +119,6 @@ class IDealGateway extends WC_Payment_Gateway {
 				'desc_tip'    => true,
 				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-paypal-payments' ),
 			),
-			'bic'         => array(
-				'title'       => __( 'BIC', 'woocommerce-paypal-payments' ),
-				'type'        => 'text',
-				'default'     => '',
-				'desc_tip'    => true,
-				'description' => __( 'Business identification number (BIC) to identify the specific bank.', 'woocommerce-paypal-payments' ),
-			),
 		);
 	}
 
@@ -142,19 +135,13 @@ class IDealGateway extends WC_Payment_Gateway {
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$amount        = $purchase_unit->amount()->to_array();
 
-		$payment_source = array(
-			'country_code' => $wc_order->get_billing_country(),
-			'name'         => $wc_order->get_billing_first_name() . ' ' . $wc_order->get_billing_last_name(),
-		);
-		$bic            = $this->get_option( 'bic' ) ?? '';
-		if ( $bic ) {
-			$payment_source['bic'] = $bic;
-		}
-
 		$request_body = array(
 			'intent'                 => 'CAPTURE',
 			'payment_source'         => array(
-				'ideal' => $payment_source,
+				'ideal' => array(
+					'country_code' => $wc_order->get_billing_country(),
+					'name'         => $wc_order->get_billing_first_name() . ' ' . $wc_order->get_billing_last_name(),
+				),
 			),
 			'processing_instruction' => 'ORDER_COMPLETE_ON_PAYMENT_APPROVAL',
 			'purchase_units'         => array(

--- a/modules/ppcp-local-alternative-payment-methods/src/IDealGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/IDealGateway.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -178,6 +179,9 @@ class IDealGateway extends WC_Payment_Gateway {
 		}
 
 		$body = json_decode( $response['body'] );
+
+		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $body->id );
+		$wc_order->save_meta_data();
 
 		$payer_action = '';
 		foreach ( $body->links as $link ) {

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class LocalAlternativePaymentMethodsModule
@@ -35,6 +36,13 @@ class LocalAlternativePaymentMethodsModule implements ModuleInterface {
 	 * {@inheritDoc}
 	 */
 	public function run( ContainerInterface $c ): void {
+		$settings = $c->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+
+		if ( ! $settings->has( 'allow_local_apm_gateways' ) || $settings->get( 'allow_local_apm_gateways' ) !== true ) {
+			return;
+		}
+
 		add_filter(
 			'woocommerce_payment_gateways',
 			/**

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -11,13 +11,10 @@ namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use WC_Order;
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
-use WooCommerce\PayPalCommerce\ApiClient\Factory\CaptureFactory;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Container\ServiceProvider;
 use WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface;
 use WooCommerce\PayPalCommerce\Vendor\Interop\Container\ServiceProviderInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\FeesUpdater;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -178,6 +178,18 @@ class LocalAlternativePaymentMethodsModule implements ModuleInterface {
 			10,
 			2
 		);
+
+		add_filter(
+			'woocommerce_paypal_payments_allowed_refund_payment_methods',
+			function( array $payment_methods ) use ( $c ): array {
+				$local_payment_methods = $c->get( 'ppcp-local-apms.payment-methods' );
+				foreach ( $local_payment_methods as $payment_method ) {
+					$payment_methods[] = $payment_method['id'];
+				}
+
+				return $payment_methods;
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-local-alternative-payment-methods/src/MultibancoGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/MultibancoGateway.php
@@ -1,0 +1,233 @@
+<?php
+/**
+ * The Multibanco payment gateway.
+ *
+ * @package WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
+
+use WC_Payment_Gateway;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
+
+/**
+ * Class BancontactGateway
+ */
+class MultibancoGateway extends WC_Payment_Gateway {
+
+	const ID = 'ppcp-multibanco';
+
+	/**
+	 * PayPal Orders endpoint.
+	 *
+	 * @var Orders
+	 */
+	private $orders_endpoint;
+
+	/**
+	 * Purchase unit factory.
+	 *
+	 * @var PurchaseUnitFactory
+	 */
+	private $purchase_unit_factory;
+
+	/**
+	 * The Refund Processor.
+	 *
+	 * @var RefundProcessor
+	 */
+	private $refund_processor;
+
+	/**
+	 * Service able to provide transaction url for an order.
+	 *
+	 * @var TransactionUrlProvider
+	 */
+	protected $transaction_url_provider;
+
+	/**
+	 * MultibancoGateway constructor.
+	 *
+	 * @param Orders                 $orders_endpoint PayPal Orders endpoint.
+	 * @param PurchaseUnitFactory    $purchase_unit_factory Purchase unit factory.
+	 * @param RefundProcessor        $refund_processor The Refund Processor.
+	 * @param TransactionUrlProvider $transaction_url_provider Service providing transaction view URL based on order.
+	 */
+	public function __construct(
+		Orders $orders_endpoint,
+		PurchaseUnitFactory $purchase_unit_factory,
+		RefundProcessor $refund_processor,
+		TransactionUrlProvider $transaction_url_provider
+	) {
+		$this->id = self::ID;
+
+		$this->supports = array(
+			'refunds',
+			'products',
+		);
+
+		$this->method_title       = __( 'Multibanco', 'woocommerce-paypal-payments' );
+		$this->method_description = __( 'A popular and trusted electronic payment method in Belgium, used by Belgian customers with Multibanco cards issued by local banks. Transactions are processed in EUR.', 'woocommerce-paypal-payments' );
+
+		$this->title       = $this->get_option( 'title', __( 'Multibanco', 'woocommerce-paypal-payments' ) );
+		$this->description = $this->get_option( 'description', '' );
+
+		$this->icon = esc_url( 'https://www.paypalobjects.com/images/checkout/alternative_payments/paypal_bancontact_color.svg' );
+
+		$this->init_form_fields();
+		$this->init_settings();
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+
+		$this->orders_endpoint          = $orders_endpoint;
+		$this->purchase_unit_factory    = $purchase_unit_factory;
+		$this->refund_processor         = $refund_processor;
+		$this->transaction_url_provider = $transaction_url_provider;
+	}
+
+	/**
+	 * Initialize the form fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'enabled'     => array(
+				'title'       => __( 'Enable/Disable', 'woocommerce-paypal-payments' ),
+				'type'        => 'checkbox',
+				'label'       => __( 'Multibanco', 'woocommerce-paypal-payments' ),
+				'default'     => 'no',
+				'desc_tip'    => true,
+				'description' => __( 'Enable/Disable Multibanco payment gateway.', 'woocommerce-paypal-payments' ),
+			),
+			'title'       => array(
+				'title'       => __( 'Title', 'woocommerce-paypal-payments' ),
+				'type'        => 'text',
+				'default'     => $this->title,
+				'desc_tip'    => true,
+				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-paypal-payments' ),
+			),
+			'description' => array(
+				'title'       => __( 'Description', 'woocommerce-paypal-payments' ),
+				'type'        => 'text',
+				'default'     => $this->description,
+				'desc_tip'    => true,
+				'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-paypal-payments' ),
+			),
+		);
+	}
+
+	/**
+	 * Processes the order.
+	 *
+	 * @param int $order_id The WC order ID.
+	 * @return array
+	 */
+	public function process_payment( $order_id ) {
+		$wc_order = wc_get_order( $order_id );
+		$wc_order->update_status( 'on-hold', __( 'Awaiting Multibanco to confirm the payment.', 'woocommerce-paypal-payments' ) );
+
+		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
+		$amount        = $purchase_unit->amount()->to_array();
+
+		$request_body = array(
+			'intent'                 => 'CAPTURE',
+			'purchase_units'         => array(
+				array(
+					'reference_id' => $purchase_unit->reference_id(),
+					'amount'       => array(
+						'currency_code' => $amount['currency_code'],
+						'value'         => $amount['value'],
+					),
+					'custom_id'    => $purchase_unit->custom_id(),
+					'invoice_id'   => $purchase_unit->invoice_id(),
+				),
+			),
+		);
+
+		try {
+			$response = $this->orders_endpoint->create( $request_body );
+			$body = json_decode( $response['body'] );
+
+			$request_body = array(
+				'payment_source'         => array(
+					'multibanco' => array(
+						'country_code' => $wc_order->get_billing_country(),
+						'name'         => $wc_order->get_billing_first_name() . ' ' . $wc_order->get_billing_last_name(),
+					),
+				),
+				'processing_instruction' => 'ORDER_COMPLETE_ON_PAYMENT_APPROVAL',
+				'application_context'    => array(
+					'locale'     => 'en-PT',
+					'return_url' => $this->get_return_url( $wc_order ),
+					'cancel_url' => add_query_arg( 'cancelled', 'true', $this->get_return_url( $wc_order ) ),
+				),
+			);
+
+			$response = $this->orders_endpoint->confirm_payment_source($request_body,$body->id);
+			$body = json_decode( $response['body'] );
+
+			$payer_action = '';
+			foreach ( $body->links as $link ) {
+				if ( $link->rel === 'payer-action' ) {
+					$payer_action = $link->href;
+				}
+			}
+
+			WC()->cart->empty_cart();
+
+			return array(
+				'result'   => 'success',
+				'redirect' => $this->get_return_url( $wc_order ),
+				'payer_action' => $payer_action,
+			);
+
+		} catch ( RuntimeException $exception ) {
+			$wc_order->update_status(
+				'failed',
+				$exception->getMessage()
+			);
+
+			return array(
+				'result'   => 'failure',
+				'redirect' => wc_get_checkout_url(),
+			);
+		}
+	}
+
+	/**
+	 * Process refund.
+	 *
+	 * If the gateway declares 'refunds' support, this will allow it to refund.
+	 * a passed in amount.
+	 *
+	 * @param  int    $order_id Order ID.
+	 * @param  float  $amount Refund amount.
+	 * @param  string $reason Refund reason.
+	 * @return boolean True or false based on success, or a WP_Error object.
+	 */
+	public function process_refund( $order_id, $amount = null, $reason = '' ) {
+		$order = wc_get_order( $order_id );
+		if ( ! is_a( $order, \WC_Order::class ) ) {
+			return false;
+		}
+		return $this->refund_processor->process( $order, (float) $amount, (string) $reason );
+	}
+
+	/**
+	 * Return transaction url for this gateway and given order.
+	 *
+	 * @param \WC_Order $order WC order to get transaction url by.
+	 *
+	 * @return string
+	 */
+	public function get_transaction_url( $order ): string {
+		$this->view_transaction_url = $this->transaction_url_provider->get_transaction_url_base( $order );
+
+		return parent::get_transaction_url( $order );
+	}
+}

--- a/modules/ppcp-local-alternative-payment-methods/src/MultibancoGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/MultibancoGateway.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -179,6 +180,9 @@ class MultibancoGateway extends WC_Payment_Gateway {
 			}
 
 			WC()->cart->empty_cart();
+
+			$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $body->id );
+			$wc_order->save_meta_data();
 
 			return array(
 				'result'   => 'success',

--- a/modules/ppcp-local-alternative-payment-methods/src/MultibancoPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/MultibancoPaymentMethod.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Multibanco payment method.
+ *
+ * @package WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
+
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+
+/**
+ * Class BancontactPaymentMethod
+ */
+class MultibancoPaymentMethod extends AbstractPaymentMethodType {
+
+	/**
+	 * The URL of this module.
+	 *
+	 * @var string
+	 */
+	private $module_url;
+
+	/**
+	 * The assets version.
+	 *
+	 * @var string
+	 */
+	private $version;
+
+	/**
+	 * Multibanco WC gateway.
+	 *
+	 * @var BancontactGateway
+	 */
+	private $gateway;
+
+	/**
+	 * MultibancoPaymentMethod constructor.
+	 *
+	 * @param string            $module_url The URL of this module.
+	 * @param string            $version The assets version.
+	 * @param MultibancoGateway $gateway Multibanco WC gateway.
+	 */
+	public function __construct(
+		string $module_url,
+		string $version,
+		MultibancoGateway $gateway
+	) {
+		$this->module_url = $module_url;
+		$this->version    = $version;
+		$this->gateway    = $gateway;
+
+		$this->name = MultibancoGateway::ID;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function initialize() {}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function is_active() {
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_payment_method_script_handles() {
+		wp_register_script(
+			'ppcp-multibanco-payment-method',
+			trailingslashit( $this->module_url ) . 'assets/js/multibanco-payment-method.js',
+			array(),
+			$this->version,
+			true
+		);
+
+		return array( 'ppcp-multibanco-payment-method' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_payment_method_data() {
+		return array(
+			'id'          => $this->name,
+			'title'       => $this->gateway->title,
+			'description' => $this->gateway->description,
+			'icon'        => esc_url( 'https://www.paypalobjects.com/images/checkout/alternative_payments/paypal_bancontact_color.svg' ),
+		);
+	}
+}

--- a/modules/ppcp-local-alternative-payment-methods/src/MyBankGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/MyBankGateway.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -176,6 +177,9 @@ class MyBankGateway extends WC_Payment_Gateway {
 		}
 
 		$body = json_decode( $response['body'] );
+
+		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $body->id );
+		$wc_order->save_meta_data();
 
 		$payer_action = '';
 		foreach ( $body->links as $link ) {

--- a/modules/ppcp-local-alternative-payment-methods/src/P24Gateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/P24Gateway.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -177,6 +178,9 @@ class P24Gateway extends WC_Payment_Gateway {
 		}
 
 		$body = json_decode( $response['body'] );
+
+		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $body->id );
+		$wc_order->save_meta_data();
 
 		$payer_action = '';
 		foreach ( $body->links as $link ) {

--- a/modules/ppcp-local-alternative-payment-methods/src/TrustlyGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/TrustlyGateway.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\TransactionUrlProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -176,6 +177,9 @@ class TrustlyGateway extends WC_Payment_Gateway {
 		}
 
 		$body = json_decode( $response['body'] );
+
+		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $body->id );
+		$wc_order->save_meta_data();
 
 		$payer_action = '';
 		foreach ( $body->links as $link ) {

--- a/modules/ppcp-local-alternative-payment-methods/webpack.config.js
+++ b/modules/ppcp-local-alternative-payment-methods/webpack.config.js
@@ -30,6 +30,9 @@ module.exports = {
 		'trustly-payment-method': path.resolve(
 			'./resources/js/trustly-payment-method.js'
 		),
+		'multibanco-payment-method': path.resolve(
+			'./resources/js/multibanco-payment-method.js'
+		),
 	},
 	output: {
 		path: path.resolve( __dirname, 'assets/' ),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1183,7 +1183,8 @@ return array(
 	'wcgateway.helper.fees-updater'                        => static function ( ContainerInterface $container ): FeesUpdater {
 		return new FeesUpdater(
 			$container->get( 'api.endpoint.orders' ),
-			$container->get( 'api.factory.capture' )
+			$container->get( 'api.factory.capture' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -75,20 +75,6 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 
 return array(
-	'wcgateway.plugin-version'                             => static function( ContainerInterface $container ): string {
-		if ( ! function_exists( 'get_plugin_data' ) ) {
-			/**
-			 * Skip check for WP files.
-			 *
-			 * @psalm-suppress MissingFile
-			 */
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		$plugin_data              = get_plugin_data( dirname( realpath( __FILE__ ), 3 ) . '/woocommerce-paypal-payments.php', false );
-
-		return $plugin_data['Version'] ?? '';
-	},
 	'wcgateway.paypal-gateway'                             => static function ( ContainerInterface $container ): PayPalGateway {
 		$order_processor     = $container->get( 'wcgateway.order-processor' );
 		$settings_renderer   = $container->get( 'wcgateway.settings.render' );
@@ -797,7 +783,7 @@ return array(
 				'desc_tip'     => true,
 				'label'        => __( 'Moves the alternative payment methods from the PayPal gateway into their own dedicated gateways.', 'woocommerce-paypal-payments' ),
 				'description'  => __( 'By default, alternative payment methods are displayed in the Standard Payments payment gateway. This setting creates a gateway for each alternative payment method.', 'woocommerce-paypal-payments' ),
-				'default'      => $container->get( 'wcgateway.plugin-version' ) > '2.8.3',
+				'default'      => true,
 				'screens'      => array(
 					State::STATE_START,
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -776,6 +776,20 @@ return array(
 				'requirements' => array(),
 				'gateway'      => 'paypal',
 			),
+			'allow_local_apm_gateways'    => array(
+				'title'        => __( 'Create gateway for alternative payment methods', 'woocommerce-paypal-payments' ),
+				'type'         => 'checkbox',
+				'desc_tip'     => true,
+				'label'        => __( 'Moves the alternative payment methods from the PayPal gateway into their own dedicated gateways.', 'woocommerce-paypal-payments' ),
+				'description'  => __( 'By default, alternative payment methods are displayed in the Standard Payments payment gateway. This setting creates a gateway for each alternative payment method.', 'woocommerce-paypal-payments' ),
+				'default'      => true,
+				'screens'      => array(
+					State::STATE_START,
+					State::STATE_ONBOARDED,
+				),
+				'requirements' => array(),
+				'gateway'      => 'paypal',
+			),
 			'disable_cards'               => array(
 				'title'        => __( 'Disable specific credit cards', 'woocommerce-paypal-payments' ),
 				'type'         => 'ppcp-multiselect',

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -783,7 +783,7 @@ return array(
 				'desc_tip'     => true,
 				'label'        => __( 'Moves the alternative payment methods from the PayPal gateway into their own dedicated gateways.', 'woocommerce-paypal-payments' ),
 				'description'  => __( 'By default, alternative payment methods are displayed in the Standard Payments payment gateway. This setting creates a gateway for each alternative payment method.', 'woocommerce-paypal-payments' ),
-				'default'      => true,
+				'default'      => false,
 				'screens'      => array(
 					State::STATE_START,
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -75,6 +75,20 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 
 return array(
+	'wcgateway.plugin-version'                             => static function( ContainerInterface $container ): string {
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			/**
+			 * Skip check for WP files.
+			 *
+			 * @psalm-suppress MissingFile
+			 */
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugin_data              = get_plugin_data( dirname( realpath( __FILE__ ), 3 ) . '/woocommerce-paypal-payments.php', false );
+
+		return $plugin_data['Version'] ?? '';
+	},
 	'wcgateway.paypal-gateway'                             => static function ( ContainerInterface $container ): PayPalGateway {
 		$order_processor     = $container->get( 'wcgateway.order-processor' );
 		$settings_renderer   = $container->get( 'wcgateway.settings.render' );
@@ -783,7 +797,7 @@ return array(
 				'desc_tip'     => true,
 				'label'        => __( 'Moves the alternative payment methods from the PayPal gateway into their own dedicated gateways.', 'woocommerce-paypal-payments' ),
 				'description'  => __( 'By default, alternative payment methods are displayed in the Standard Payments payment gateway. This setting creates a gateway for each alternative payment method.', 'woocommerce-paypal-payments' ),
-				'default'      => true,
+				'default'      => $container->get( 'wcgateway.plugin-version' ) > '2.8.3',
 				'screens'      => array(
 					State::STATE_START,
 					State::STATE_ONBOARDED,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -27,6 +27,7 @@ use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\RenderReauthorizeAction;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CaptureCardPayment;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\FeesUpdater;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\FeesRenderer;
@@ -1178,6 +1179,12 @@ return array(
 		$order_endpoint    = $container->get( 'api.endpoint.order' );
 		$logger            = $container->get( 'woocommerce.logger.woocommerce' );
 		return new RefundFeesUpdater( $order_endpoint, $logger );
+	},
+	'wcgateway.helper.fees-updater'                        => static function ( ContainerInterface $container ): FeesUpdater {
+		return new FeesUpdater(
+			$container->get( 'api.endpoint.orders' ),
+			$container->get( 'api.factory.capture' )
+		);
 	},
 
 	'button.helper.messages-disclaimers'                   => static function ( ContainerInterface $container ): MessagesDisclaimers {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -195,7 +195,7 @@ class PayUponInvoice {
 		);
 
 		add_action(
-			'ppcp_payment_capture_completed_webhook_handler',
+			'woocommerce_paypal_payments_payment_capture_completed_webhook_handler',
 			function ( WC_Order $wc_order, string $order_id ) {
 				try {
 					if ( $wc_order->get_payment_method() !== PayUponInvoiceGateway::ID ) {

--- a/modules/ppcp-wc-gateway/src/Helper/FeesUpdater.php
+++ b/modules/ppcp-wc-gateway/src/Helper/FeesUpdater.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * The FeesUpdater helper.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Helper;
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\CaptureFactory;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+/**
+ * Class FeesUpdater
+ */
+class FeesUpdater {
+
+	/**
+	 * The orders' endpoint.
+	 *
+	 * @var Orders
+	 */
+	private $orders_endpoint;
+
+	/**
+	 * The capture factory.
+	 *
+	 * @var CaptureFactory
+	 */
+	private $capture_factory;
+
+	/**
+	 * FeesUpdater constructor.
+	 *
+	 * @param Orders $orders_endpoint The orders' endpoint.
+	 * @param CaptureFactory $capture_factory The capture factory.
+	 */
+	public function __construct(Orders $orders_endpoint, CaptureFactory $capture_factory) {
+		$this->orders_endpoint = $orders_endpoint;
+		$this->capture_factory = $capture_factory;
+	}
+
+	/**
+	 * Updates the fees meta for a given order.
+	 *
+	 * @param string             $order_id
+	 * @param WC_Order           $wc_order
+	 * @return void
+	 */
+	public function update( string $order_id, WC_Order $wc_order ): void {
+		$order = $this->orders_endpoint->order( $order_id );
+		$body  = json_decode( $order['body'] );
+
+		$capture   = $this->capture_factory->from_paypal_response( $body->purchase_units[0]->payments->captures[0] );
+		$breakdown = $capture->seller_receivable_breakdown();
+		if ( $breakdown ) {
+			$wc_order->update_meta_data( PayPalGateway::FEES_META_KEY, $breakdown->to_array() );
+			$paypal_fee = $breakdown->paypal_fee();
+			if ( $paypal_fee ) {
+				$wc_order->update_meta_data( 'PayPal Transaction Fee', (string) $paypal_fee->value() );
+			}
+
+			$wc_order->save_meta_data();
+		}
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Helper/FeesUpdater.php
+++ b/modules/ppcp-wc-gateway/src/Helper/FeesUpdater.php
@@ -9,9 +9,11 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
+use Psr\Log\LoggerInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\CaptureFactory;
+use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 /**
@@ -34,26 +36,52 @@ class FeesUpdater {
 	private $capture_factory;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
 	 * FeesUpdater constructor.
 	 *
-	 * @param Orders $orders_endpoint The orders' endpoint.
-	 * @param CaptureFactory $capture_factory The capture factory.
+	 * @param Orders          $orders_endpoint The orders' endpoint.
+	 * @param CaptureFactory  $capture_factory The capture factory.
+	 * @param LoggerInterface $logger The logger.
 	 */
-	public function __construct(Orders $orders_endpoint, CaptureFactory $capture_factory) {
+	public function __construct(
+		Orders $orders_endpoint,
+		CaptureFactory $capture_factory,
+		LoggerInterface $logger
+	) {
 		$this->orders_endpoint = $orders_endpoint;
 		$this->capture_factory = $capture_factory;
+		$this->logger          = $logger;
 	}
 
 	/**
 	 * Updates the fees meta for a given order.
 	 *
-	 * @param string             $order_id
-	 * @param WC_Order           $wc_order
+	 * @param string   $order_id PayPal order ID.
+	 * @param WC_Order $wc_order WC order.
 	 * @return void
 	 */
 	public function update( string $order_id, WC_Order $wc_order ): void {
-		$order = $this->orders_endpoint->order( $order_id );
-		$body  = json_decode( $order['body'] );
+		try {
+			$order = $this->orders_endpoint->order( $order_id );
+		} catch ( RuntimeException $exception ) {
+			$this->logger->warning(
+				sprintf(
+					'Could not get PayPal order %1$s when trying to update fees for WC order #%2$s',
+					$order_id,
+					$wc_order->get_id()
+				)
+			);
+
+			return;
+		}
+
+		$body = json_decode( $order['body'] );
 
 		$capture   = $this->capture_factory->from_paypal_response( $body->purchase_units[0]->payments->captures[0] );
 		$breakdown = $capture->seller_receivable_breakdown();

--- a/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
@@ -109,7 +109,11 @@ class RefundProcessor {
 	 */
 	public function process( WC_Order $wc_order, float $amount = null, string $reason = '' ) : bool {
 		try {
-			if ( ! in_array( $wc_order->get_payment_method(), array( PayPalGateway::ID, CreditCardGateway::ID, CardButtonGateway::ID, PayUponInvoiceGateway::ID ), true ) ) {
+			$allowed_refund_payment_methods = apply_filters(
+				'woocommerce_paypal_payments_allowed_refund_payment_methods',
+				array( PayPalGateway::ID, CreditCardGateway::ID, CardButtonGateway::ID, PayUponInvoiceGateway::ID )
+			);
+			if ( ! in_array( $wc_order->get_payment_method(), $allowed_refund_payment_methods, true ) ) {
 				return true;
 			}
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -504,7 +504,7 @@ class WCGatewayModule implements ModuleInterface {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof ContainerInterface );
 
-				if ( ! $installed_plugin_version && $settings->has( 'allow_local_apm_gateways' ) ) {
+				if ( ! $installed_plugin_version ) {
 					$settings->set( 'allow_local_apm_gateways', true );
 					$settings->persist();
 				}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -506,6 +506,7 @@ class WCGatewayModule implements ModuleInterface {
 
 				if ( ! $installed_plugin_version && $settings->has( 'allow_local_apm_gateways' ) ) {
 					$settings->set( 'allow_local_apm_gateways', true );
+					$settings->persist();
 				}
 			}
 		);

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -502,7 +502,7 @@ class WCGatewayModule implements ModuleInterface {
 			'woocommerce_paypal_payments_gateway_migrate',
 			function( string $installed_plugin_version ) use ( $c ) {
 				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof ContainerInterface );
+				assert( $settings instanceof Settings );
 
 				if ( ! $installed_plugin_version ) {
 					$settings->set( 'allow_local_apm_gateways', true );

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -497,6 +497,18 @@ class WCGatewayModule implements ModuleInterface {
 				return $fields;
 			}
 		);
+
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			function( string $installed_plugin_version ) use ( $c ) {
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof ContainerInterface );
+
+				if ( ! $installed_plugin_version && $settings->has( 'allow_local_apm_gateways' ) ) {
+					$settings->set( 'allow_local_apm_gateways', true );
+				}
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php
@@ -105,7 +105,7 @@ class PaymentCaptureCompleted implements RequestHandler {
 		/**
 		 * Allow access to the webhook logic before updating the WC order.
 		 */
-		do_action( 'ppcp_payment_capture_completed_webhook_handler', $wc_order, $order_id );
+		do_action( 'woocommerce_paypal_payments_payment_capture_completed_webhook_handler', $wc_order, $order_id );
 
 		if ( $wc_order->get_status() !== 'on-hold' ) {
 			return $this->success_response();

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -106,7 +106,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 				/**
 				 * The hook fired when the plugin is installed or updated.
 				 */
-				do_action( 'woocommerce_paypal_payments_gateway_migrate' );
+				do_action( 'woocommerce_paypal_payments_gateway_migrate', $installed_plugin_version );
 
 				if ( $installed_plugin_version ) {
 					/**


### PR DESCRIPTION
This PR include adjustments and additions for #2511.
- Multibanco: voucher payment flow
- Setting for enabling the feature 
- Display user-friendly error message if it exist in the response
- Display PayPal fees and tracking metabox in WC order
- Ensure refunds works from PayPal and from WC order
- iDeal: add “bic” field