### PR TITLE
Fatal error in Block Editor when using WooCommerce blocks (3564)

### DIFF
--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -13,6 +13,7 @@ use WooCommerce\PayPalCommerce\Blocks\Endpoint\GetPayPalOrderFromSession;
 use WooCommerce\PayPalCommerce\Blocks\Endpoint\UpdateShippingEndpoint;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
+use WC_Cart;
 
 return array(
 	'blocks.url'                           => static function ( ContainerInterface $container ): string {
@@ -27,6 +28,13 @@ return array(
 		);
 	},
 	'blocks.method'                        => static function ( ContainerInterface $container ): PayPalPaymentMethod {
+		/**
+		 * Cart instance; might be null, esp. in customizer or in Block Editor.
+		 *
+		 * @var null|WC_Cart $cart
+		 */
+		$cart = WC()->cart;
+
 		return new PayPalPaymentMethod(
 			$container->get( 'blocks.url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -43,7 +51,8 @@ return array(
 			$container->get( 'wcgateway.use-place-order-button' ),
 			$container->get( 'wcgateway.place-order-button-text' ),
 			$container->get( 'wcgateway.place-order-button-description' ),
-			$container->get( 'wcgateway.all-funding-sources' )
+			$container->get( 'wcgateway.all-funding-sources' ),
+			$cart && $cart->needs_shipping()
 		);
 	},
 	'blocks.advanced-card-method'          => static function( ContainerInterface $container ): AdvancedCardPaymentMethod {

--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -123,6 +123,13 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	private $all_funding_sources;
 
 	/**
+	 * Whether shipping details must be collected during checkout; i.e. paying for physical goods?
+	 *
+	 * @var bool
+	 */
+	private $need_shipping;
+
+	/**
 	 * Assets constructor.
 	 *
 	 * @param string                        $module_url The url of this module.
@@ -139,6 +146,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	 * @param string                        $place_order_button_text The text for the standard "Place order" button.
 	 * @param string                        $place_order_button_description The text for additional "Place order" description.
 	 * @param array                         $all_funding_sources All existing funding sources for PayPal buttons.
+	 * @param bool                          $need_shipping Whether shipping details are required for the purchase.
 	 */
 	public function __construct(
 		string $module_url,
@@ -154,7 +162,8 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		bool $use_place_order,
 		string $place_order_button_text,
 		string $place_order_button_description,
-		array $all_funding_sources
+		array $all_funding_sources,
+		bool $need_shipping
 	) {
 		$this->name                           = PayPalGateway::ID;
 		$this->module_url                     = $module_url;
@@ -171,6 +180,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		$this->place_order_button_text        = $place_order_button_text;
 		$this->place_order_button_description = $place_order_button_description;
 		$this->all_funding_sources            = $all_funding_sources;
+		$this->need_shipping                  = $need_shipping;
 	}
 
 	/**
@@ -254,7 +264,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 				),
 			),
 			'scriptData'                  => $script_data,
-			'needShipping'                => WC()->cart->needs_shipping(),
+			'needShipping'                => $this->need_shipping,
 		);
 	}
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -51,6 +51,8 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WC_Shipping_Method;
+use WC_Cart;
 
 /**
  * Class SmartButton
@@ -1086,6 +1088,22 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	}
 
 	/**
+	 * Whether the current cart contains a product that requires physical shipping.
+	 *
+	 * @return bool True, if any cart item requires shipping.
+	 */
+	private function need_shipping() : bool {
+		/**
+		 * Cart instance; might be null, esp. in customizer or in Block Editor.
+		 *
+		 * @var null|WC_Cart $cart
+		 */
+		$cart = WC()->cart;
+
+		return $cart && $cart->needs_shipping();
+	}
+
+	/**
 	 * The configuration for the smart buttons.
 	 *
 	 * @return array
@@ -1297,7 +1315,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 				'has_wc_card_payment_tokens' => $this->user_has_wc_card_payment_tokens( get_current_user_id() ),
 			),
 			'should_handle_shipping_in_paypal'        => $this->should_handle_shipping_in_paypal && ! $this->is_checkout(),
-			'needShipping'                            => WC()->cart->needs_shipping(),
+			'needShipping'                            => $this->need_shipping(),
 			'vaultingEnabled'                         => $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ),
 		);
 


### PR DESCRIPTION
### Description

This PR resolves fatal errors in the Block Editor and customizer when using WooCommerce cart or checkout blocks.

Caused by PR #2429

Affected classes:
- `PayPalPaymentMethod`
- `SmartButton`

### Solution

- In `PayPalPaymentMethod`, the flag is injected via DI, instead of directly accessing `WC()->cart`
- In both cases, we now use an boolean operator that returns false when cart is null: `$cart && $cart->needs_shipping()`