### PR TITLE
Problem with Google Pay and Apple Pay button placement on Pay for Order page (3583)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -339,6 +339,12 @@ class ApplePayButton {
 		this.#isInitialized = true;
 		this.applePayConfig = config;
 
+		if ( this.isSeparateGateway ) {
+			document
+				.querySelectorAll( '#ppc-button-applepay-container' )
+				.forEach( ( el ) => el.remove() );
+		}
+
 		if ( ! this.isEligible ) {
 			this.hide();
 		} else {

--- a/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
@@ -461,16 +461,19 @@ export default class PaymentButton {
 	 * @return {boolean} True means that this payment method is selected as current gateway.
 	 */
 	get isCurrentGateway() {
-		if ( ! this.isSeparateGateway ) {
-			return false;
-		}
-
 		/*
 		 * We need to rely on `getCurrentPaymentMethod()` here, as the `CheckoutBootstrap.js`
 		 * module fires the "ButtonEvents.RENDER" event before any PaymentButton instances are
 		 * created. I.e. we cannot observe the initial gateway selection event.
 		 */
-		return this.methodId === getCurrentPaymentMethod();
+		const currentMethod = getCurrentPaymentMethod();
+
+		if ( this.isSeparateGateway ) {
+			return this.methodId === currentMethod;
+		}
+
+		// Button is rendered inside the Smart Buttons block.
+		return PaymentMethods.PAYPAL === currentMethod;
 	}
 
 	/**
@@ -703,7 +706,7 @@ export default class PaymentButton {
 
 		this.applyWrapperStyles();
 
-		if ( this.isEligible && this.isPresent && this.isVisible ) {
+		if ( this.isEligible && this.isCurrentGateway && this.isVisible ) {
 			if ( ! this.isButtonAttached ) {
 				this.log( 'refresh.addButton' );
 				this.addButton();

--- a/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
@@ -114,6 +114,13 @@ export default class PaymentButton {
 	#isInitialized = false;
 
 	/**
+	 * Whether the one-time initialization of the payment gateway is complete.
+	 *
+	 * @type {boolean}
+	 */
+	#gatewayInitialized = false;
+
+	/**
 	 * The button's context.
 	 *
 	 * @type {string}
@@ -715,25 +722,33 @@ export default class PaymentButton {
 	}
 
 	/**
-	 * Makes the custom payment gateway visible by removing initial inline styles from the DOM.
+	 * Makes the payment gateway visible by removing initial inline styles from the DOM.
+	 * Also, removes the button-placeholder container from the smart button block.
 	 *
 	 * Only relevant on the checkout page, i.e., when `this.isSeparateGateway` is `true`
 	 */
 	showPaymentGateway() {
+		if ( this.#gatewayInitialized ) {
+			return;
+		}
+		this.#gatewayInitialized = true;
+
 		if ( ! this.isSeparateGateway || ! this.isEligible ) {
 			return;
 		}
 
-		const styleSelectors = `style[data-hide-gateway="${ this.methodId }"]`;
+		const styleSelector = `style[data-hide-gateway="${ this.methodId }"]`;
+		const wrapperSelector = `#${ this.wrappers.Default }`;
 
-		const styles = document.querySelectorAll( styleSelectors );
+		document
+			.querySelectorAll( styleSelector )
+			.forEach( ( el ) => el.remove() );
 
-		if ( ! styles.length ) {
-			return;
-		}
+		document
+			.querySelectorAll( wrapperSelector )
+			.forEach( ( el ) => el.remove() );
+
 		this.log( 'Show gateway' );
-
-		styles.forEach( ( el ) => el.remove() );
 
 		// This code runs only once, during button initialization, and fixes the initial visibility.
 		this.isVisible = this.isCurrentGateway;


### PR DESCRIPTION
### Description

This PR resolves two placement issues of the Google Pay and Apple Pay buttons on the Pay for Order page.

### Problems

1. When the standard gateway (first one in the list) does not contain the Google Pay button, then directly after page load we did not hide the Google Pay button from the initially selected gateway.
2. When using a separate gateway for Google Pay or Apple Pay, an empty div remained in the PayPal gateway's "smart-button" block.

### Screenshots

**Problem 1:**
| Before | After |
|---|---|
| <img width="1230" alt="2024-08-28_13-30-58" src="https://github.com/user-attachments/assets/f09bd6f0-e569-4e6a-9d77-25da021249a6"> | <img width="1230" alt="2024-08-28_13-30-27" src="https://github.com/user-attachments/assets/4df291f1-e332-4a9e-8d65-f733786a2ae2"> |

**Problem 2:**
| Before | After |
|---|---|
| <img width="1230" alt="2024-08-28_13-33-41" src="https://github.com/user-attachments/assets/a5bc22ff-7a31-4fec-be4e-c5fcca5699ae"> | <img width="1230" alt="2024-08-28_13-37-44" src="https://github.com/user-attachments/assets/71e30478-b946-454b-8ed5-001a68ec0bf1"> |
