### PR TITLE
Google Pay buttons are missing in block checkout (3583)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
@@ -468,6 +468,10 @@ export default class PaymentButton {
 	 * @return {boolean} True means that this payment method is selected as current gateway.
 	 */
 	get isCurrentGateway() {
+		if ( ! PaymentContext.Gateways.includes( this.context ) ) {
+			return true;
+		}
+
 		/*
 		 * We need to rely on `getCurrentPaymentMethod()` here, as the `CheckoutBootstrap.js`
 		 * module fires the "ButtonEvents.RENDER" event before any PaymentButton instances are

--- a/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
@@ -445,6 +445,17 @@ export default class PaymentButton {
 	}
 
 	/**
+	 * Whether the button is placed inside a classic gateway context.
+	 *
+	 * Classic gateway contexts are: Classic checkout, Pay for Order page.
+	 *
+	 * @return {boolean} True indicates, the button is located inside a classic gateway.
+	 */
+	get isInsideClassicGateway() {
+		return PaymentContext.Gateways.includes( this.context );
+	}
+
+	/**
 	 * Determines if the current payment button should be rendered as a stand-alone gateway.
 	 * The return value `false` usually means, that the payment button is bundled with all available
 	 * payment buttons.
@@ -456,19 +467,20 @@ export default class PaymentButton {
 	get isSeparateGateway() {
 		return (
 			this.#buttonConfig.is_wc_gateway_enabled &&
-			PaymentContext.Gateways.includes( this.context )
+			this.isInsideClassicGateway
 		);
 	}
 
 	/**
 	 * Whether the currently selected payment gateway is set to the payment method.
 	 *
-	 * Only relevant on checkout pages, when `this.isSeparateGateway` is true.
+	 * Only relevant on checkout pages where "classic" payment gateways are rendered.
 	 *
 	 * @return {boolean} True means that this payment method is selected as current gateway.
 	 */
 	get isCurrentGateway() {
-		if ( ! PaymentContext.Gateways.includes( this.context ) ) {
+		if ( ! this.isInsideClassicGateway ) {
+			// This means, the button's visibility is managed by another script.
 			return true;
 		}
 
@@ -687,7 +699,7 @@ export default class PaymentButton {
 		} );
 
 		// Events relevant for buttons inside a payment gateway.
-		if ( PaymentContext.Gateways.includes( this.context ) ) {
+		if ( this.isInsideClassicGateway ) {
 			const parentMethod = this.isSeparateGateway
 				? this.methodId
 				: PaymentMethods.PAYPAL;

--- a/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
@@ -732,12 +732,11 @@ export default class PaymentButton {
 	 * Only relevant on the checkout page, i.e., when `this.isSeparateGateway` is `true`
 	 */
 	showPaymentGateway() {
-		if ( this.#gatewayInitialized ) {
-			return;
-		}
-		this.#gatewayInitialized = true;
-
-		if ( ! this.isSeparateGateway || ! this.isEligible ) {
+		if (
+			this.#gatewayInitialized ||
+			! this.isSeparateGateway ||
+			! this.isEligible
+		) {
 			return;
 		}
 
@@ -753,6 +752,7 @@ export default class PaymentButton {
 			.forEach( ( el ) => el.remove() );
 
 		this.log( 'Show gateway' );
+		this.#gatewayInitialized = true;
 
 		// This code runs only once, during button initialization, and fixes the initial visibility.
 		this.isVisible = this.isCurrentGateway;


### PR DESCRIPTION
### Description

This PR addresses a problem introduced by #2542 

### Problem

1. A new condition was introduced to hide the button until the payment gateway was selected that contains the payment button: `if ( this.isCurrentGateway ) ...`
2. The `isCurrentGateway` returned `false` on all pages that do not contain a gateway selector - like the single product page, cart pages, express checkout, etc.

### Solution

Introduced a new check to confirm if the payment button should be rendered inside a "classic payment gateway" - if not, then the `isCurrentGateway` check is [short-circuited and returns true](https://github.com/woocommerce/woocommerce-paypal-payments/pull/2545/commits/72b9fdc251f6d87357537264c2693b0bb3fe68f9).