### PR TITLE
Fatal error in logs when we try to pay with Apple Pay as separate gateway (3577)

### DIFF
--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -306,7 +306,8 @@ return array(
 			$container->get( 'wcgateway.processor.refunds' ),
 			$container->get( 'wcgateway.transaction-url-provider' ),
 			$container->get( 'session.handler' ),
-			$container->get( 'applepay.url' )
+			$container->get( 'applepay.url' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 

--- a/modules/ppcp-applepay/src/ApplePayGateway.php
+++ b/modules/ppcp-applepay/src/ApplePayGateway.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Applepay;
 
 use Exception;
+use Psr\Log\LoggerInterface;
 use WC_Order;
 use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -73,6 +74,13 @@ class ApplePayGateway extends WC_Payment_Gateway {
 	private $module_url;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
 	 * ApplePayGateway constructor.
 	 *
 	 * @param OrderProcessor          $order_processor             The Order Processor.
@@ -84,6 +92,7 @@ class ApplePayGateway extends WC_Payment_Gateway {
 	 *                                                             view URL based on order.
 	 * @param SessionHandler          $session_handler             The Session Handler.
 	 * @param string                  $module_url                  The URL to the module.
+	 * @param LoggerInterface         $logger The logger.
 	 */
 	public function __construct(
 		OrderProcessor $order_processor,
@@ -91,7 +100,8 @@ class ApplePayGateway extends WC_Payment_Gateway {
 		RefundProcessor $refund_processor,
 		TransactionUrlProvider $transaction_url_provider,
 		SessionHandler $session_handler,
-		string $module_url
+		string $module_url,
+		LoggerInterface $logger
 	) {
 		$this->id = self::ID;
 
@@ -111,6 +121,7 @@ class ApplePayGateway extends WC_Payment_Gateway {
 		$this->refund_processor            = $refund_processor;
 		$this->transaction_url_provider    = $transaction_url_provider;
 		$this->session_handler             = $session_handler;
+		$this->logger                      = $logger;
 
 		add_action(
 			'woocommerce_update_options_payment_gateways_' . $this->id,

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -267,7 +267,8 @@ return array(
 			$container->get( 'wcgateway.processor.refunds' ),
 			$container->get( 'wcgateway.transaction-url-provider' ),
 			$container->get( 'session.handler' ),
-			$container->get( 'googlepay.url' )
+			$container->get( 'googlepay.url' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 );

--- a/modules/ppcp-googlepay/src/GooglePayGateway.php
+++ b/modules/ppcp-googlepay/src/GooglePayGateway.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Googlepay;
 
 use Exception;
+use Psr\Log\LoggerInterface;
 use WC_Order;
 use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
@@ -73,6 +74,13 @@ class GooglePayGateway extends WC_Payment_Gateway {
 	private $module_url;
 
 	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
 	 * GooglePayGateway constructor.
 	 *
 	 * @param OrderProcessor          $order_processor The Order Processor.
@@ -81,6 +89,7 @@ class GooglePayGateway extends WC_Payment_Gateway {
 	 * @param TransactionUrlProvider  $transaction_url_provider Service providing transaction view URL based on order.
 	 * @param SessionHandler          $session_handler The Session Handler.
 	 * @param string                  $module_url The URL to the module.
+	 * @param LoggerInterface         $logger The logger.
 	 */
 	public function __construct(
 		OrderProcessor $order_processor,
@@ -88,7 +97,8 @@ class GooglePayGateway extends WC_Payment_Gateway {
 		RefundProcessor $refund_processor,
 		TransactionUrlProvider $transaction_url_provider,
 		SessionHandler $session_handler,
-		string $module_url
+		string $module_url,
+		LoggerInterface $logger
 	) {
 		$this->id = self::ID;
 
@@ -113,6 +123,7 @@ class GooglePayGateway extends WC_Payment_Gateway {
 		$this->refund_processor            = $refund_processor;
 		$this->transaction_url_provider    = $transaction_url_provider;
 		$this->session_handler             = $session_handler;
+		$this->logger                      = $logger;
 
 		add_action(
 			'woocommerce_update_options_payment_gateways_' . $this->id,


### PR DESCRIPTION
`Uncaught error call to a member function error on null`

### Steps To Reproduce
- Enable Apple Pay as separate gateway
- Navigate to shop
- Add product to cart
- Navigate to checkout page and select Apple Pay gateway and pay
    - Observe error message on checkout page

### Possible Cause
It seems caused by not injecting the logger into the gateway class, even if not used directly in the class it's used by `handle_payment_failure` method in the trait.