### PR TITLE
Allow to override the list of Pay Later supported countries

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -1642,6 +1642,21 @@ return array(
 			'SE',
 		);
 	},
+
+	'api.paylater-countries'                         => static function ( ContainerInterface $container ) : array {
+		return apply_filters(
+			'woocommerce_paypal_payments_supported_paylater_countries',
+			array(
+				'US',
+				'DE',
+				'GB',
+				'FR',
+				'AU',
+				'IT',
+				'ES',
+			)
+		);
+	},
 	'api.order-helper'                               => static function( ContainerInterface $container ): OrderHelper {
 		return new OrderHelper();
 	},

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -320,6 +320,7 @@ return array(
 	},
 	'button.helper.messages-apply'                => static function ( ContainerInterface $container ): MessagesApply {
 		return new MessagesApply(
+			$container->get( 'api.paylater-countries' ),
 			$container->get( 'api.shop.country' )
 		);
 	},

--- a/modules/ppcp-button/src/Helper/MessagesApply.php
+++ b/modules/ppcp-button/src/Helper/MessagesApply.php
@@ -18,17 +18,9 @@ class MessagesApply {
 	/**
 	 * In which countries credit messaging is available.
 	 *
-	 * @var array
+	 * @var string[]
 	 */
-	private $countries = array(
-		'US',
-		'DE',
-		'GB',
-		'FR',
-		'AU',
-		'IT',
-		'ES',
-	);
+	private $allowed_countries;
 
 	/**
 	 * 2-letter country code of the shop.
@@ -40,10 +32,12 @@ class MessagesApply {
 	/**
 	 * MessagesApply constructor.
 	 *
-	 * @param string $country 2-letter country code of the shop.
+	 * @param string[] $allowed_countries In which countries credit messaging is available.
+	 * @param string   $country 2-letter country code of the shop.
 	 */
-	public function __construct( string $country ) {
-		$this->country = $country;
+	public function __construct( array $allowed_countries, string $country ) {
+		$this->allowed_countries = $allowed_countries;
+		$this->country           = $country;
 	}
 
 	/**
@@ -52,6 +46,6 @@ class MessagesApply {
 	 * @return bool
 	 */
 	public function for_country(): bool {
-		return in_array( $this->country, $this->countries, true );
+		return in_array( $this->country, $this->allowed_countries, true );
 	}
 }


### PR DESCRIPTION
Added `woocommerce_paypal_payments_supported_paylater_countries` filter for the Pay Later countries allowing to enable it when shop is set to an unsupported country, similar to ACDC.