### PR TITLE
Extend the list of Fastlane incompatible plugins(3616)

### DIFF
--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -294,8 +294,8 @@ return array(
 
 		$active_plugins_list = array_filter(
 			$incompatible_plugins,
-			function( $plugin ) {
-				return $plugin['isActive'];
+			function( array $plugin ): bool {
+				return (bool) $plugin['isActive'];
 			}
 		);
 

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -232,7 +232,7 @@ return array(
 	/**
 	 * The list of Fastlane incompatible plugins.
 	 *
-	 * @returns array<array{name: string, isActive: bool}>
+	 * @returns array<array{name: string, is_active: bool}>
 	 */
 	'axo.fastlane-incompatible-plugins'      => static function () : array {
 		/**
@@ -242,48 +242,48 @@ return array(
 			'woocommerce_paypal_payments_fastlane_incompatible_plugins',
 			array(
 				array(
-					'name'     => 'Elementor',
-					'isActive' => did_action( 'elementor/loaded' ),
+					'name'      => 'Elementor',
+					'is_active' => did_action( 'elementor/loaded' ),
 				),
 				array(
-					'name'     => 'CheckoutWC',
-					'isActive' => defined( 'CFW_NAME' ),
+					'name'      => 'CheckoutWC',
+					'is_active' => defined( 'CFW_NAME' ),
 				),
 				array(
-					'name'     => 'Direct Checkout for WooCommerce',
-					'isActive' => defined( 'QLWCDC_PLUGIN_NAME' ),
+					'name'      => 'Direct Checkout for WooCommerce',
+					'is_active' => defined( 'QLWCDC_PLUGIN_NAME' ),
 				),
 				array(
-					'name'     => 'Multi-Step Checkout for WooCommerce',
-					'isActive' => class_exists( 'WPMultiStepCheckout' ),
+					'name'      => 'Multi-Step Checkout for WooCommerce',
+					'is_active' => class_exists( 'WPMultiStepCheckout' ),
 				),
 				array(
-					'name'     => 'Fluid Checkout for WooCommerce',
-					'isActive' => class_exists( 'FluidCheckout' ),
+					'name'      => 'Fluid Checkout for WooCommerce',
+					'is_active' => class_exists( 'FluidCheckout' ),
 				),
 				array(
-					'name'     => 'MultiStep Checkout for WooCommerce',
-					'isActive' => class_exists( 'THWMSCF_Multistep_Checkout' ),
+					'name'      => 'MultiStep Checkout for WooCommerce',
+					'is_active' => class_exists( 'THWMSCF_Multistep_Checkout' ),
 				),
 				array(
-					'name'     => 'WooCommerce Subscriptions',
-					'isActive' => class_exists( 'WC_Subscriptions' ),
+					'name'      => 'WooCommerce Subscriptions',
+					'is_active' => class_exists( 'WC_Subscriptions' ),
 				),
 				array(
-					'name'     => 'CartFlows',
-					'isActive' => class_exists( 'Cartflows_Loader' ),
+					'name'      => 'CartFlows',
+					'is_active' => class_exists( 'Cartflows_Loader' ),
 				),
 				array(
-					'name'     => 'FunnelKit Funnel Builder',
-					'isActive' => class_exists( 'WFFN_Core' ),
+					'name'      => 'FunnelKit Funnel Builder',
+					'is_active' => class_exists( 'WFFN_Core' ),
 				),
 				array(
-					'name'     => 'WooCommerce One Page Checkout',
-					'isActive' => class_exists( 'PP_One_Page_Checkout' ),
+					'name'      => 'WooCommerce One Page Checkout',
+					'is_active' => class_exists( 'PP_One_Page_Checkout' ),
 				),
 				array(
-					'name'     => 'All Products for Woo Subscriptions',
-					'isActive' => class_exists( 'WCS_ATT' ),
+					'name'      => 'All Products for Woo Subscriptions',
+					'is_active' => class_exists( 'WCS_ATT' ),
 				),
 			)
 		);
@@ -295,7 +295,7 @@ return array(
 		$active_plugins_list = array_filter(
 			$incompatible_plugins,
 			function( array $plugin ): bool {
-				return (bool) $plugin['isActive'];
+				return (bool) $plugin['is_active'];
 			}
 		);
 

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -21,14 +21,14 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 return array(
 
 	// If AXO can be configured.
-	'axo.eligible'                          => static function ( ContainerInterface $container ): bool {
+	'axo.eligible'                           => static function ( ContainerInterface $container ): bool {
 		$apm_applies = $container->get( 'axo.helpers.apm-applies' );
 		assert( $apm_applies instanceof ApmApplies );
 
 		return $apm_applies->for_country_currency();
 	},
 
-	'axo.helpers.apm-applies'               => static function ( ContainerInterface $container ) : ApmApplies {
+	'axo.helpers.apm-applies'                => static function ( ContainerInterface $container ) : ApmApplies {
 		return new ApmApplies(
 			$container->get( 'axo.supported-country-currency-matrix' ),
 			$container->get( 'api.shop.currency' ),
@@ -36,16 +36,16 @@ return array(
 		);
 	},
 
-	'axo.helpers.settings-notice-generator' => static function ( ContainerInterface $container ) : SettingsNoticeGenerator {
-		return new SettingsNoticeGenerator();
+	'axo.helpers.settings-notice-generator'  => static function ( ContainerInterface $container ) : SettingsNoticeGenerator {
+		return new SettingsNoticeGenerator( $container->get( 'axo.fastlane-incompatible-plugin-names' ) );
 	},
 
 	// If AXO is configured and onboarded.
-	'axo.available'                         => static function ( ContainerInterface $container ): bool {
+	'axo.available'                          => static function ( ContainerInterface $container ): bool {
 		return true;
 	},
 
-	'axo.url'                               => static function ( ContainerInterface $container ): string {
+	'axo.url'                                => static function ( ContainerInterface $container ): string {
 		$path = realpath( __FILE__ );
 		if ( false === $path ) {
 			return '';
@@ -56,7 +56,7 @@ return array(
 		);
 	},
 
-	'axo.manager'                           => static function ( ContainerInterface $container ): AxoManager {
+	'axo.manager'                            => static function ( ContainerInterface $container ): AxoManager {
 		return new AxoManager(
 			$container->get( 'axo.url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -70,7 +70,7 @@ return array(
 		);
 	},
 
-	'axo.gateway'                           => static function ( ContainerInterface $container ): AxoGateway {
+	'axo.gateway'                            => static function ( ContainerInterface $container ): AxoGateway {
 		return new AxoGateway(
 			$container->get( 'wcgateway.settings.render' ),
 			$container->get( 'wcgateway.settings' ),
@@ -87,7 +87,7 @@ return array(
 		);
 	},
 
-	'axo.card_icons'                        => static function ( ContainerInterface $container ): array {
+	'axo.card_icons'                         => static function ( ContainerInterface $container ): array {
 		return array(
 			array(
 				'title' => 'Visa',
@@ -108,7 +108,7 @@ return array(
 		);
 	},
 
-	'axo.card_icons.axo'                    => static function ( ContainerInterface $container ): array {
+	'axo.card_icons.axo'                     => static function ( ContainerInterface $container ): array {
 		return array(
 			array(
 				'title' => 'Visa',
@@ -144,7 +144,7 @@ return array(
 	/**
 	 * The matrix which countries and currency combinations can be used for AXO.
 	 */
-	'axo.supported-country-currency-matrix' => static function ( ContainerInterface $container ) : array {
+	'axo.supported-country-currency-matrix'  => static function ( ContainerInterface $container ) : array {
 		/**
 		 * Returns which countries and currency combinations can be used for AXO.
 		 */
@@ -163,7 +163,7 @@ return array(
 		);
 	},
 
-	'axo.settings-conflict-notice'          => static function ( ContainerInterface $container ) : string {
+	'axo.settings-conflict-notice'           => static function ( ContainerInterface $container ) : string {
 		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
 		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
 
@@ -173,28 +173,28 @@ return array(
 		return $settings_notice_generator->generate_settings_conflict_notice( $settings );
 	},
 
-	'axo.checkout-config-notice'            => static function ( ContainerInterface $container ) : string {
+	'axo.checkout-config-notice'             => static function ( ContainerInterface $container ) : string {
 		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
 		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
 
 		return $settings_notice_generator->generate_checkout_notice();
 	},
 
-	'axo.shipping-config-notice'            => static function ( ContainerInterface $container ) : string {
+	'axo.shipping-config-notice'             => static function ( ContainerInterface $container ) : string {
 		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
 		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
 
 		return $settings_notice_generator->generate_shipping_notice();
 	},
 
-	'axo.incompatible-plugins-notice'       => static function ( ContainerInterface $container ) : string {
+	'axo.incompatible-plugins-notice'        => static function ( ContainerInterface $container ) : string {
 		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
 		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
 
 		return $settings_notice_generator->generate_incompatible_plugins_notice();
 	},
 
-	'axo.smart-button-location-notice'      => static function ( ContainerInterface $container ) : string {
+	'axo.smart-button-location-notice'       => static function ( ContainerInterface $container ) : string {
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
@@ -222,10 +222,92 @@ return array(
 		return '<div class="ppcp-notice ppcp-notice-warning"><p>' . $notice_content . '</p></div>';
 	},
 
-	'axo.endpoint.frontend-logger'          => static function ( ContainerInterface $container ): FrontendLoggerEndpoint {
+	'axo.endpoint.frontend-logger'           => static function ( ContainerInterface $container ): FrontendLoggerEndpoint {
 		return new FrontendLoggerEndpoint(
 			$container->get( 'button.request-data' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
+		);
+	},
+
+	/**
+	 * The list of Fastlane incompatible plugins.
+	 *
+	 * @returns array<array{name: string, isActive: bool}>
+	 */
+	'axo.fastlane-incompatible-plugins'      => static function () : array {
+		/**
+		 * Filters the list of Fastlane incompatible plugins.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_fastlane_incompatible_plugins',
+			array(
+				array(
+					'name'     => 'Elementor',
+					'isActive' => did_action( 'elementor/loaded' ),
+				),
+				array(
+					'name'     => 'CheckoutWC',
+					'isActive' => defined( 'CFW_NAME' ),
+				),
+				array(
+					'name'     => 'Direct Checkout for WooCommerce',
+					'isActive' => defined( 'QLWCDC_PLUGIN_NAME' ),
+				),
+				array(
+					'name'     => 'Multi-Step Checkout for WooCommerce',
+					'isActive' => class_exists( 'WPMultiStepCheckout' ),
+				),
+				array(
+					'name'     => 'Fluid Checkout for WooCommerce',
+					'isActive' => class_exists( 'FluidCheckout' ),
+				),
+				array(
+					'name'     => 'MultiStep Checkout for WooCommerce',
+					'isActive' => class_exists( 'THWMSCF_Multistep_Checkout' ),
+				),
+				array(
+					'name'     => 'WooCommerce Subscriptions',
+					'isActive' => class_exists( 'WC_Subscriptions' ),
+				),
+				array(
+					'name'     => 'CartFlows',
+					'isActive' => class_exists( 'Cartflows_Loader' ),
+				),
+				array(
+					'name'     => 'FunnelKit Funnel Builder',
+					'isActive' => class_exists( 'WFFN_Core' ),
+				),
+				array(
+					'name'     => 'WooCommerce One Page Checkout',
+					'isActive' => class_exists( 'PP_One_Page_Checkout' ),
+				),
+				array(
+					'name'     => 'All Products for Woo Subscriptions',
+					'isActive' => class_exists( 'WCS_ATT' ),
+				),
+			)
+		);
+	},
+
+	'axo.fastlane-incompatible-plugin-names' => static function ( ContainerInterface $container ) : array {
+		$incompatible_plugins = $container->get( 'axo.fastlane-incompatible-plugins' );
+
+		$active_plugins_list = array_filter(
+			$incompatible_plugins,
+			function( $plugin ) {
+				return $plugin['isActive'];
+			}
+		);
+
+		if ( empty( $active_plugins_list ) ) {
+			return [];
+		}
+
+		return array_map(
+			function ( array $plugin ): string {
+				return "<li>{$plugin['name']}</li>";
+			},
+			$active_plugins_list
 		);
 	},
 );

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -300,7 +300,7 @@ return array(
 		);
 
 		if ( empty( $active_plugins_list ) ) {
-			return [];
+			return array();
 		}
 
 		return array_map(

--- a/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
+++ b/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
@@ -117,9 +117,24 @@ class SettingsNoticeGenerator {
 	 * @return string
 	 */
 	public function generate_incompatible_plugins_notice(): string {
-		$incompatible_plugins = array(
-			'Elementor'  => did_action( 'elementor/loaded' ),
-			'CheckoutWC' => defined( 'CFW_NAME' ),
+		/**
+		 * Filters the list of Fastlane incompatible plugins.
+		 */
+		$incompatible_plugins = apply_filters(
+			'woocommerce_paypal_payments_fastlane_incompatible_plugins',
+			array(
+				'Elementor'                     => did_action( 'elementor/loaded' ),
+				'CheckoutWC'                    => defined( 'CFW_NAME' ),
+				'WCDirectCheckout'              => defined( 'QLWCDC_PLUGIN_NAME' ),
+				'WPMultiStepCheckout'           => class_exists( 'WPMultiStepCheckout' ),
+				'FluidCheckout'                 => class_exists( 'FluidCheckout' ),
+				'THWMSCF_Multistep_Checkout'    => class_exists( 'THWMSCF_Multistep_Checkout' ),
+				'WC_Subscriptions'              => class_exists( 'WC_Subscriptions' ),
+				'Cartflows'                     => class_exists( 'Cartflows_Loader' ),
+				'FunnelKitFunnelBuilder'        => class_exists( 'WFFN_Core' ),
+				'WCAllProductsForSubscriptions' => class_exists( 'WCS_ATT' ),
+				'WCOnePageCheckout'             => class_exists( 'PP_One_Page_Checkout' ),
+			)
 		);
 
 		$active_plugins_list = array_filter( $incompatible_plugins );

--- a/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
+++ b/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
@@ -111,7 +111,7 @@ class SettingsNoticeGenerator {
 	public function generate_shipping_notice(): string {
 		$shipping_settings_link = admin_url( 'admin.php?page=wc-settings&tab=shipping&section=options' );
 
-		$notice_content = 'asd';
+		$notice_content = '';
 
 		if ( wc_shipping_enabled() && wc_ship_to_billing_address_only() ) {
 			$notice_content = sprintf(

--- a/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
+++ b/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
@@ -19,6 +19,22 @@ use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
  */
 class SettingsNoticeGenerator {
 	/**
+	 * The list of Fastlane incompatible plugin names.
+	 *
+	 * @var string[]
+	 */
+	protected $incompatible_plugin_names;
+
+	/**
+	 * SettingsNoticeGenerator constructor.
+	 *
+	 * @param string[] $incompatible_plugin_names The list of Fastlane incompatible plugin names.
+	 */
+	public function __construct( array $incompatible_plugin_names ) {
+		$this->incompatible_plugin_names = $incompatible_plugin_names;
+	}
+
+	/**
 	 * Generates the full HTML of the notification.
 	 *
 	 * @param string $message  HTML of the inner message contents.
@@ -95,7 +111,7 @@ class SettingsNoticeGenerator {
 	public function generate_shipping_notice(): string {
 		$shipping_settings_link = admin_url( 'admin.php?page=wc-settings&tab=shipping&section=options' );
 
-		$notice_content = '';
+		$notice_content = 'asd';
 
 		if ( wc_shipping_enabled() && wc_ship_to_billing_address_only() ) {
 			$notice_content = sprintf(
@@ -117,38 +133,9 @@ class SettingsNoticeGenerator {
 	 * @return string
 	 */
 	public function generate_incompatible_plugins_notice(): string {
-		/**
-		 * Filters the list of Fastlane incompatible plugins.
-		 */
-		$incompatible_plugins = apply_filters(
-			'woocommerce_paypal_payments_fastlane_incompatible_plugins',
-			array(
-				'Elementor'                     => did_action( 'elementor/loaded' ),
-				'CheckoutWC'                    => defined( 'CFW_NAME' ),
-				'WCDirectCheckout'              => defined( 'QLWCDC_PLUGIN_NAME' ),
-				'WPMultiStepCheckout'           => class_exists( 'WPMultiStepCheckout' ),
-				'FluidCheckout'                 => class_exists( 'FluidCheckout' ),
-				'THWMSCF_Multistep_Checkout'    => class_exists( 'THWMSCF_Multistep_Checkout' ),
-				'WC_Subscriptions'              => class_exists( 'WC_Subscriptions' ),
-				'Cartflows'                     => class_exists( 'Cartflows_Loader' ),
-				'FunnelKitFunnelBuilder'        => class_exists( 'WFFN_Core' ),
-				'WCAllProductsForSubscriptions' => class_exists( 'WCS_ATT' ),
-				'WCOnePageCheckout'             => class_exists( 'PP_One_Page_Checkout' ),
-			)
-		);
-
-		$active_plugins_list = array_filter( $incompatible_plugins );
-
-		if ( empty( $active_plugins_list ) ) {
+		if ( empty( $this->incompatible_plugin_names ) ) {
 			return '';
 		}
-
-		$incompatible_plugin_items = array_map(
-			function ( $plugin ) {
-				return "<li>{$plugin}</li>";
-			},
-			array_keys( $active_plugins_list )
-		);
 
 		$plugins_settings_link = esc_url( admin_url( 'plugins.php' ) );
 		$notice_content        = sprintf(
@@ -158,7 +145,7 @@ class SettingsNoticeGenerator {
 				'woocommerce-paypal-payments'
 			),
 			$plugins_settings_link,
-			implode( '', $incompatible_plugin_items )
+			implode( '', $this->incompatible_plugin_names )
 		);
 
 		return '<div class="ppcp-notice"><p>' . $notice_content . '</p></div>';


### PR DESCRIPTION
# PR Description

The PR will Extend the list of Fastlane incompatible plugins, adding: 

- [Direct Checkout for WooCommerce](https://wordpress.org/plugins/woocommerce-direct-checkout/)
- [Multi-Step Checkout for WooCommerce](https://wordpress.org/plugins/wp-multi-step-checkout/)
- [Fluid Checkout for WooCommerce](https://wordpress.org/plugins/fluid-checkout/)
- [MultiStep Checkout for WooCommerce](https://wordpress.org/plugins/woo-multistep-checkout/)
- [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/)
- [Cartflows](https://wordpress.org/plugins/cartflows/)
- [FunnelKit Funnel Builder](https://wordpress.org/plugins/funnel-builder/)
- [WooCommerce One Page Checkout](https://woocommerce.com/products/woocommerce-one-page-checkout/)

Additionally the PR will provide a filter to change/extend this list.
Example to add new incompatible plugin:

```
add_filter(
	'woocommerce_paypal_payments_fastlane_incompatible_plugins',
	static function (array $incompatible_plugins): array {
		$incompatible_plugins[] = [
			'name' => 'Your Plugin Name',
			'is_active' => class_exists( 'YourPluginClass' ),
		];
		return $incompatible_plugins;
	}
);
```

Example to remove incompatible plugin:

```
add_filter(
	'woocommerce_paypal_payments_fastlane_incompatible_plugins',
	static function (array $incompatible_plugins): array {
		foreach ($incompatible_plugins as $key => $plugin) {
			$pluginName = $plugin['name'] ?? '';
			if ($pluginName === 'Elementor') {
				unset($incompatible_plugins[$key]);
			}
		}
		return $incompatible_plugins;
	}
);
```
 
# Issue Description

We need to Extend the list of Fastlane incompatible plugins and additionally provide a filter to change the list.