### PR TITLE
Use the latest branch in the packaging workflow

### DIFF
--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -27,7 +27,7 @@ jobs:
 
   create_archive:
     needs: check_version
-    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@feature/PROD-171-rector-archive
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@feature/prefixed-archives
     with:
       PHP_VERSION: 7.2
       PLUGIN_MAIN_FILE: ./woocommerce-paypal-payments.php


### PR DESCRIPTION
Updated the workflow branch since the previous one was merged and also it now includes the fix for this breaking change: https://github.com/actions/upload-artifact/issues/602