### PR TITLE
Fix disconnect in WC 9.2.0+

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -14,7 +14,8 @@ tests
 .phpunit.result.cache
 babel.config.json
 node_modules
-modules/*/resources
+modules/*/resources/css
+modules/*/resources/js/**/*.js
 *.lock
 webpack.config.js
 wp-cli.yml

--- a/modules/ppcp-onboarding/resources/js/onboarding.js
+++ b/modules/ppcp-onboarding/resources/js/onboarding.js
@@ -326,7 +326,9 @@ window.ppcp_onboarding_productionCallback = function ( ...args ) {
 
 		isDisconnecting = true;
 
-		document.querySelector( '.woocommerce-save-button' ).click();
+        const saveButton = document.querySelector( '.woocommerce-save-button' );
+        saveButton.removeAttribute( 'disabled' );
+        saveButton.click();
 	};
 
 	// Prevent the message about unsaved checkbox/radiobutton when reloading the page.


### PR DESCRIPTION
Fixes #2539

In WC 9.2.0+ the save button is disabled by default until there are some changes: 
https://github.com/woocommerce/woocommerce/blob/19aac5f6fb95ad778359ae6a34d175eb0eaa07bd/plugins/woocommerce/client/legacy/js/admin/settings.js#L114

The disconnect works by simulating a click on it via JS, so now it fails to do that. 

It seems that submitting the form via `submit()` does not work here for some reason, so I just remove the `disabled` attribute before the click.