### PR TITLE
Keep only 5 tags in readme.txt (3648)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WooCommerce PayPal Payments ===
 Contributors: woocommerce, automattic, syde
-Tags: woocommerce, paypal, payments, ecommerce, checkout, cart, pay later, apple pay, subscriptions, debit card, credit card, google pay
+Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 5.3
 Tested up to: 6.6
 Requires PHP: 7.2


### PR DESCRIPTION
wp .org now allows only 5 tags.
