### PR TITLE
Fix folder name and .distignore for packaging workflow

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -14,7 +14,7 @@ tests
 .phpunit.result.cache
 babel.config.json
 node_modules
-resources
+modules/*/resources
 *.lock
 webpack.config.js
 wp-cli.yml

--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -32,5 +32,6 @@ jobs:
       PHP_VERSION: 7.4
       PLUGIN_MAIN_FILE: ./woocommerce-paypal-payments.php
       PLUGIN_VERSION: ${{ needs.check_version.outputs.version }}
+      PLUGIN_FOLDER_NAME: woocommerce-paypal-payments
       ARCHIVE_NAME: woocommerce-paypal-payments-${{ needs.check_version.outputs.version }}
       COMPILE_ASSETS_ARGS: '-vv --env=root'


### PR DESCRIPTION
`PLUGIN_FOLDER_NAME` defaults to `ARCHIVE_NAME`, so setting it to the plugin name instead.

And excluding `resources` via `modules/*/resources` in `.distignore`, otherwise it was also excluding `vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php`.