### PR TITLE
Do not exclude block.json in .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -14,7 +14,8 @@ tests
 .phpunit.result.cache
 babel.config.json
 node_modules
-modules/*/resources
+modules/*/resources/css
+modules/*/resources/js/**/*.js
 *.lock
 webpack.config.js
 wp-cli.yml


### PR DESCRIPTION
Excluding the whole `resources` dir during packaging also excludes `block.json` in this module https://github.com/woocommerce/woocommerce-paypal-payments/blob/db05ae973d997ea81eaea2029bc54f677c6dbc33/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php#L196
So now excluding only CSS and *.js. Luckily the WP-CLI `dist` command processes `.distignore` via a `.gitignore` library, which means that empty dirs are also excluded and all other modules do not have an empty `resources` dir in the package.