### PR TITLE
Check that get_the_ID is valid before using

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -340,7 +340,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			'wp',
 			function() {
 				$page_id = get_the_ID();
-				if ( ! $page_id || ! CartCheckoutDetector::has_elementor_checkout( $page_id ) ) {
+				if ( ! is_numeric( $page_id ) || ! CartCheckoutDetector::has_elementor_checkout( (int) $page_id ) ) {
 					return;
 				}
 


### PR DESCRIPTION
There was a report that sometimes `get_the_ID` returns an invalid/string value, so added an `is_numeric` check and cast to avoid type errors.