### PR TITLE
Implement the "Enable Fastlane" checkbox (3662)

### DIFF
--- a/modules/ppcp-axo-block/extensions.php
+++ b/modules/ppcp-axo-block/extensions.php
@@ -5,10 +5,8 @@
  * @package WooCommerce\PayPalCommerce\AxoBlock
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AxoBlock;
 
-
-return array(
-);
+return array();

--- a/modules/ppcp-axo-block/module.php
+++ b/modules/ppcp-axo-block/module.php
@@ -5,10 +5,10 @@
  * @package WooCommerce\PayPalCommerce\AxoBlock
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AxoBlock;
 
-return static function (): AxoBlockModule {
+return static function () : AxoBlockModule {
 	return new AxoBlockModule();
 };

--- a/modules/ppcp-axo-block/resources/js/index.js
+++ b/modules/ppcp-axo-block/resources/js/index.js
@@ -19,7 +19,8 @@ import { removeShippingChangeButton } from './helpers/shippingChangeButtonManage
 // Event handlers
 import { onEmailSubmit } from './events/fastlaneEmailManager';
 
-const ppcpConfig = wc.wcSettings.getSetting( 'ppcp-credit-card-gateway_data' );
+const gatewayHandle = 'ppcp-axo-gateway';
+const ppcpConfig = wc.wcSettings.getSetting( `${ gatewayHandle }_data` );
 
 if ( typeof window.PayPalCommerceGateway === 'undefined' ) {
 	window.PayPalCommerceGateway = ppcpConfig;

--- a/modules/ppcp-axo-block/services.php
+++ b/modules/ppcp-axo-block/services.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce\Axo
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AxoBlock;
 
@@ -14,10 +14,10 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
 	// If AXO Block is configured and onboarded.
-	'axoblock.available'                         => static function ( ContainerInterface $container ): bool {
+	'axoblock.available' => static function ( ContainerInterface $container ) : bool {
 		return true;
 	},
-	'axoblock.url'                           => static function ( ContainerInterface $container ): string {
+	'axoblock.url'       => static function ( ContainerInterface $container ) : string {
 		/**
 		 * The path cannot be false.
 		 *
@@ -28,14 +28,12 @@ return array(
 			dirname( realpath( __FILE__ ), 3 ) . '/woocommerce-paypal-payments.php'
 		);
 	},
-	'axoblock.method'          => static function( ContainerInterface $container ): AxoBlockPaymentMethod {
+	'axoblock.method'    => static function ( ContainerInterface $container ) : AxoBlockPaymentMethod {
 		return new AxoBlockPaymentMethod(
 			$container->get( 'axoblock.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'wcgateway.credit-card-gateway' ),
-			function () use ( $container ): SmartButtonInterface {
-				return $container->get( 'button.smart-button' );
-			},
+			fn() : SmartButtonInterface => $container->get( 'button.smart-button' ),
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'wcgateway.url' )

--- a/modules/ppcp-axo-block/services.php
+++ b/modules/ppcp-axo-block/services.php
@@ -32,7 +32,7 @@ return array(
 		return new AxoBlockPaymentMethod(
 			$container->get( 'axoblock.url' ),
 			$container->get( 'ppcp.asset-version' ),
-			$container->get( 'wcgateway.credit-card-gateway' ),
+			$container->get( 'axo.gateway' ),
 			fn() : SmartButtonInterface => $container->get( 'button.smart-button' ),
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'onboarding.environment' ),

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -14,7 +14,7 @@ use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodTyp
 use WooCommerce\PayPalCommerce\Axo\FrontendLoggerEndpoint;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
-use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
@@ -92,7 +92,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 		Environment $environment,
 		string $wcgateway_module_url
 	) {
-		$this->name                 = CreditCardGateway::ID;
+		$this->name                 = AxoGateway::ID;
 		$this->module_url           = $module_url;
 		$this->version              = $version;
 		$this->gateway              = $gateway;

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce\AxoBlock
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AxoBlock;
 
@@ -73,13 +73,14 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	/**
 	 * AdvancedCardPaymentMethod constructor.
 	 *
-	 * @param string                        $module_url The URL of this module.
-	 * @param string                        $version The assets version.
-	 * @param CreditCardGateway             $gateway Credit card gateway.
-	 * @param SmartButtonInterface|callable $smart_button The smart button script loading handler.
-	 * @param Settings                      $settings The settings.
-	 * @param Environment                   $environment The environment object.
-	 * @param string          $wcgateway_module_url The WcGateway module URL.
+	 * @param string                        $module_url           The URL of this module.
+	 * @param string                        $version              The assets version.
+	 * @param CreditCardGateway             $gateway              Credit card gateway.
+	 * @param SmartButtonInterface|callable $smart_button         The smart button script loading
+	 *                                                            handler.
+	 * @param Settings                      $settings             The settings.
+	 * @param Environment                   $environment          The environment object.
+	 * @param string                        $wcgateway_module_url The WcGateway module URL.
 	 */
 	public function __construct(
 		string $module_url,
@@ -90,12 +91,12 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 		Environment $environment,
 		string $wcgateway_module_url
 	) {
-		$this->name            = CreditCardGateway::ID;
-		$this->module_url      = $module_url;
-		$this->version         = $version;
-		$this->gateway         = $gateway;
-		$this->smart_button    = $smart_button;
-		$this->settings = $settings;
+		$this->name                 = CreditCardGateway::ID;
+		$this->module_url           = $module_url;
+		$this->version              = $version;
+		$this->gateway              = $gateway;
+		$this->smart_button         = $smart_button;
+		$this->settings             = $settings;
 		$this->environment          = $environment;
 		$this->wcgateway_module_url = $wcgateway_module_url;
 
@@ -110,29 +111,29 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function is_active() {
+	public function is_active() : bool {
 		return true;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_payment_method_script_handles() {
+	public function get_payment_method_script_handles() : array {
 		$script_path       = 'assets/js/index.js';
 		$script_asset_path = trailingslashit( $this->module_url ) . 'assets/js/index.asset.php';
 		$script_asset      = file_exists( $script_asset_path )
-			? require( $script_asset_path )
+			? require $script_asset_path
 			: array(
 				'dependencies' => array(),
-				'version'      => '1.0.0'
+				'version'      => '1.0.0',
 			);
 		$script_url        = trailingslashit( $this->module_url ) . $script_path;
 
 		wp_register_script(
 			'ppcp-axo-block',
 			$script_url,
-			$script_asset[ 'dependencies' ],
-			$script_asset[ 'version' ],
+			$script_asset['dependencies'],
+			$script_asset['version'],
 			true
 		);
 
@@ -142,19 +143,25 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 			$this->script_data()
 		);
 
-		return [ 'ppcp-axo-block' ];
+		return array( 'ppcp-axo-block' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public function get_payment_method_data() {
-		return [
-			'id' => $this->name,
+		return array(
+			'id'          => $this->name,
 			'title'       => 'Debit & Credit Cards',
 			'description' => 'Axo Description',
-			'supports'    =>  array_filter( $this->gateway->supports, [ $this->gateway, 'supports' ] ),
-		];
+			'supports'    => array_filter(
+				$this->gateway->supports,
+				array(
+					$this->gateway,
+					'supports',
+				)
+			),
+		);
 	}
 
 	/**
@@ -162,8 +169,11 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	 *
 	 * @return array
 	 */
-	private function script_data(): array
-	{	if(is_admin()) { return array(); }
+	private function script_data() : array {
+		if ( is_admin() ) {
+			return array();
+		}
+
 		return array(
 			'environment'               => array(
 				'is_sandbox' => $this->environment->current_environment() === 'sandbox',
@@ -175,14 +185,14 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 				'enabled'    => defined( 'WP_DEBUG' ) && WP_DEBUG,
 				'client_id'  => ( $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : null ),
 				'session_id' =>
-					(WC()->session && method_exists(WC()->session, 'get_customer_unique_id'))
-						? substr(md5(WC()->session->get_customer_unique_id()), 0, 16)
+					( WC()->session && method_exists( WC()->session, 'get_customer_unique_id' ) )
+						? substr( md5( WC()->session->get_customer_unique_id() ), 0, 16 )
 						: '',
-				'amount' => array(
+				'amount'     => array(
 					'currency_code' => get_woocommerce_currency(),
-					'value'         => (WC()->cart && method_exists(WC()->cart, 'get_total'))
-						? WC()->cart->get_total('numeric')
-						: null, // Set to null if WC()->cart is null or get_total doesn't exist
+					'value'         => ( WC()->cart && method_exists( WC()->cart, 'get_total' ) )
+						? WC()->cart->get_total( 'numeric' )
+						: null, // Set to null if WC()->cart is null or get_total doesn't exist.
 				),
 			),
 			'style_options'             => array(
@@ -224,5 +234,4 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 			'billing_email_button_text' => __( 'Continue', 'woocommerce-paypal-payments' ),
 		);
 	}
-
 }

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -113,7 +113,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	 * {@inheritDoc}
 	 */
 	public function is_active() : bool {
-		return true;
+		return $this->gateway->is_available();
 	}
 
 	/**

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AxoBlock;
 
+use WC_Payment_Gateway;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use WooCommerce\PayPalCommerce\Axo\FrontendLoggerEndpoint;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
@@ -38,7 +39,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	/**
 	 * Credit card gateway.
 	 *
-	 * @var CreditCardGateway
+	 * @var WC_Payment_Gateway
 	 */
 	private $gateway;
 
@@ -75,7 +76,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	 *
 	 * @param string                        $module_url           The URL of this module.
 	 * @param string                        $version              The assets version.
-	 * @param CreditCardGateway             $gateway              Credit card gateway.
+	 * @param WC_Payment_Gateway            $gateway              Credit card gateway.
 	 * @param SmartButtonInterface|callable $smart_button         The smart button script loading
 	 *                                                            handler.
 	 * @param Settings                      $settings             The settings.
@@ -85,7 +86,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	public function __construct(
 		string $module_url,
 		string $version,
-		CreditCardGateway $gateway,
+		WC_Payment_Gateway $gateway,
 		$smart_button,
 		Settings $settings,
 		Environment $environment,


### PR DESCRIPTION
### Description

Changes the AXO block integration to use the `AxoGateway` instead of the `CreditCardGateway` provider.

#### Most obvious change:

The AXO block integration can be toggled via the existing "Enable Fastlane" checkbox on the Advanced Card Processing tab, identical to the integration on the classic checkout page.

Key change in commit https://github.com/woocommerce/woocommerce-paypal-payments/pull/2575/commits/83bf19cbc54ad1990082a701f10fd96415f5c59a