### PR TITLE
Set email when creating order for express payment

### DIFF
--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Button\Helper;
 use Exception;
 use RuntimeException;
 use WC_Cart;
+use WC_Customer;
 use WC_Data_Exception;
 use WC_Order;
 use WC_Order_Item_Product;
@@ -190,6 +191,7 @@ class WooCommerceOrderCreator {
 	 * @param WC_Cart       $wc_cart The Cart.
 	 * @return void
 	 * @throws WC_Data_Exception|RuntimeException When failing to configure shipping.
+	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
 	protected function configure_shipping( WC_Order $wc_order, ?Payer $payer, ?Shipping $shipping, WC_Cart $wc_cart ): void {
 		$shipping_address = null;
@@ -200,7 +202,16 @@ class WooCommerceOrderCreator {
 			$address    = $payer->address();
 			$payer_name = $payer->name();
 
+			$wc_email    = null;
+			$wc_customer = WC()->customer;
+			if ( $wc_customer instanceof WC_Customer ) {
+				$wc_email = $wc_customer->get_email();
+			}
+
+			$email = $wc_email ?: $payer->email_address();
+
 			$billing_address = array(
+				'email'      => $email ? $email : '',
 				'first_name' => $payer_name ? $payer_name->given_name() : '',
 				'last_name'  => $payer_name ? $payer_name->surname() : '',
 				'address_1'  => $address ? $address->address_line_1() : '',

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -95,7 +95,7 @@ class WooCommerceOrderCreator {
 			$this->configure_payment_source( $wc_order );
 			$this->configure_customer( $wc_order );
 			$this->configure_line_items( $wc_order, $wc_cart, $payer, $shipping );
-			$this->configure_shipping( $wc_order, $payer, $shipping, $wc_cart );
+			$this->configure_addresses( $wc_order, $payer, $shipping, $wc_cart );
 			$this->configure_coupons( $wc_order, $wc_cart->get_applied_coupons() );
 
 			$wc_order->calculate_totals();
@@ -163,7 +163,7 @@ class WooCommerceOrderCreator {
 				$item->set_total( $subscription_total );
 
 				$subscription->add_product( $product );
-				$this->configure_shipping( $subscription, $payer, $shipping, $wc_cart );
+				$this->configure_addresses( $subscription, $payer, $shipping, $wc_cart );
 				$this->configure_payment_source( $subscription );
 				$this->configure_coupons( $subscription, $wc_cart->get_applied_coupons() );
 
@@ -193,7 +193,7 @@ class WooCommerceOrderCreator {
 	 * @throws WC_Data_Exception|RuntimeException When failing to configure shipping.
 	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
-	protected function configure_shipping( WC_Order $wc_order, ?Payer $payer, ?Shipping $shipping, WC_Cart $wc_cart ): void {
+	protected function configure_addresses( WC_Order $wc_order, ?Payer $payer, ?Shipping $shipping, WC_Cart $wc_cart ): void {
 		$shipping_address = null;
 		$billing_address  = null;
 		$shipping_options = null;

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -211,7 +211,7 @@ class WooCommerceOrderCreator {
 			$email = $wc_email ?: $payer->email_address();
 
 			$billing_address = array(
-				'email'      => $email ? $email : '',
+				'email'      => $email ?: '',
 				'first_name' => $payer_name ? $payer_name->given_name() : '',
 				'last_name'  => $payer_name ? $payer_name->surname() : '',
 				'address_1'  => $address ? $address->address_line_1() : '',


### PR DESCRIPTION
Looks like the email was not set in `WooCommerceOrderCreator`, so for guest orders via express checkout with disabled confirmation it was remaining empty (for logged in customers it was setting email to the WP user email if empty during saving).

So now setting the order email to the email from `WC()->customer` (retrieving `email` instead of `billing_email` because it seems to be the WC behavior) , or to the PayPal payer email if empty.

### Steps to Test

GIVEN the PayPal shipping callback is enabled
AND the customer is a guest user
WHEN completing a PayPal express payment
THEN the WooCommerce order displays the buyer's PayPal email address in both the regular Email and PayPal Email fields

GIVEN the PayPal shipping callback is enabled
AND the customer is a logged-in user with a saved email address in their profile
WHEN completing a PayPal express payment
THEN the WooCommerce order displays the email address from the buyer's WooCommerce profile in the regular Email field
AND the PayPal account email address in the PayPal Email field