### PR TITLE
AXO: Remove restriction for the Force shipping to the customer billin… (3647)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -120,7 +120,6 @@ return array(
 						'',
 						array(
 							$container->get( 'axo.settings-conflict-notice' ),
-							$container->get( 'axo.shipping-config-notice' ),
 							$container->get( 'axo.checkout-config-notice' ),
 							$container->get( 'axo.incompatible-plugins-notice' ),
 						)

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -180,13 +180,6 @@ return array(
 		return $settings_notice_generator->generate_checkout_notice();
 	},
 
-	'axo.shipping-config-notice'             => static function ( ContainerInterface $container ) : string {
-		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
-		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
-
-		return $settings_notice_generator->generate_shipping_notice();
-	},
-
 	'axo.incompatible-plugins-notice'        => static function ( ContainerInterface $container ) : string {
 		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
 		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -99,10 +99,6 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 					return $methods;
 				}
 
-				if ( ! $this->is_compatible_shipping_config() ) {
-					return $methods;
-				}
-
 				$methods[] = $gateway;
 				return $methods;
 			},
@@ -173,7 +169,7 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 					|| ! $c->get( 'axo.eligible' )
 					|| 'continuation' === $c->get( 'button.context' )
 					|| $subscription_helper->cart_contains_subscription()
-					|| ! $this->is_compatible_shipping_config() ) {
+				) {
 					return;
 				}
 
@@ -357,7 +353,6 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		return ! is_user_logged_in()
 			&& CartCheckoutDetector::has_classic_checkout()
-			&& $this->is_compatible_shipping_config()
 			&& $is_axo_enabled
 			&& $is_dcc_enabled
 			&& ! $this->is_excluded_endpoint();
@@ -412,15 +407,6 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 	private function is_excluded_endpoint(): bool {
 		// Exclude the Order Pay endpoint.
 		return is_wc_endpoint_url( 'order-pay' );
-	}
-
-	/**
-	 * Condition to evaluate if the shipping configuration is compatible.
-	 *
-	 * @return bool
-	 */
-	private function is_compatible_shipping_config(): bool {
-		return ! wc_shipping_enabled() || ( wc_shipping_enabled() && ! wc_ship_to_billing_address_only() );
 	}
 
 	/**

--- a/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
+++ b/modules/ppcp-axo/src/Helper/SettingsNoticeGenerator.php
@@ -104,30 +104,6 @@ class SettingsNoticeGenerator {
 	}
 
 	/**
-	 * Generates the shipping notice.
-	 *
-	 * @return string
-	 */
-	public function generate_shipping_notice(): string {
-		$shipping_settings_link = admin_url( 'admin.php?page=wc-settings&tab=shipping&section=options' );
-
-		$notice_content = '';
-
-		if ( wc_shipping_enabled() && wc_ship_to_billing_address_only() ) {
-			$notice_content = sprintf(
-			/* translators: %1$s: URL to the Shipping destination settings page. */
-				__(
-					'<span class="highlight">Warning:</span> The <a href="%1$s">Shipping destination</a> of your store is currently configured to <code>Force shipping to the customer billing address</code>. To enable Fastlane and accelerate payments, the shipping destination must be configured either to <code>Default to customer shipping address</code> or <code>Default to customer billing address</code> so buyers can set separate billing and shipping details.',
-					'woocommerce-paypal-payments'
-				),
-				esc_url( $shipping_settings_link )
-			);
-		}
-
-		return $notice_content ? '<div class="ppcp-notice ppcp-notice-error"><p>' . $notice_content . '</p></div>' : '';
-	}
-
-	/**
 	 * Generates the incompatible plugins notice.
 	 *
 	 * @return string


### PR DESCRIPTION
### Description

This PR re-adds support for the `Force shipping to the customer billing address` setting for Fastlane.

### Steps to Test

1. In `Shipping > Shipping options` set `Shipping destination` to `Force shipping to the customer billing address`.
2. Open classic checkout and make sure you can check out with Fastlane.

### Screenshots

N/A