### PR TITLE
Declare tokenization for ACDC only when vaulting enabled (3645)

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -417,13 +417,14 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 		);
 
 		add_filter(
-			'woocommerce_paypal_payments_credit_card_gateway_vault_supports',
+			'woocommerce_paypal_payments_credit_card_gateway_supports',
 			function( array $supports ) use ( $c ): array {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof ContainerInterface );
 
 				if ( $settings->has( 'vault_enabled_dcc' ) && $settings->get( 'vault_enabled_dcc' ) ) {
 					$supports[] = 'tokenization';
+					$supports[] = 'add_payment_method';
 				}
 
 				return $supports;

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -243,8 +243,6 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$default_support = array(
 			'products',
 			'refunds',
-			'tokenization',
-			'add_payment_method',
 		);
 
 		$this->supports = array_merge(


### PR DESCRIPTION
After #2394 the ACDC gateway was showing the "Save" checkbox even if vaulting is disabled because `tokenization` was always declared in `supports`. Fixed it, now it should check the vaulting setting like before. I think the subscription renewals is still working, though not sure if I fully understand how to test that.

For the PayPal gateway it remains as it is for now, unclear how to handle it properly here (Vaulting vs Vaulting ACDC vs Subscription mode).