### PR TITLE
Fix webhooks list after onboarding

### DIFF
--- a/modules/ppcp-webhooks/factories.php
+++ b/modules/ppcp-webhooks/factories.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * The webhook module factories.
+ *
+ * @package WooCommerce\PayPalCommerce\Webhooks
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks;
+
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
+use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+return array(
+	'webhook.status.registered-webhooks' => function( ContainerInterface $container ) : array {
+		$endpoint = $container->get( 'api.endpoint.webhook' );
+		assert( $endpoint instanceof WebhookEndpoint );
+
+		$state = $container->get( 'onboarding.state' );
+		if ( $state->current_state() >= State::STATE_ONBOARDED ) {
+			return $endpoint->list();
+		}
+
+		return array();
+	},
+);

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -131,18 +131,6 @@ return array(
 		return $container->get( 'webhook.current' ) !== null;
 	},
 
-	'webhook.status.registered-webhooks'      => function( ContainerInterface $container ) : array {
-		$endpoint = $container->get( 'api.endpoint.webhook' );
-		assert( $endpoint instanceof WebhookEndpoint );
-
-		$state = $container->get( 'onboarding.state' );
-		if ( $state->current_state() >= State::STATE_ONBOARDED ) {
-			return $endpoint->list();
-		}
-
-		return array();
-	},
-
 	'webhook.status.registered-webhooks-data' => function( ContainerInterface $container ) : array {
 		$empty_placeholder = __( 'No webhooks found.', 'woocommerce-paypal-payments' );
 

--- a/modules/ppcp-webhooks/src/WebhookModule.php
+++ b/modules/ppcp-webhooks/src/WebhookModule.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\Onboarding\State;
 use Exception;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
+use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\FactoryModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -27,7 +28,7 @@ use WooCommerce\PayPalCommerce\Webhooks\Status\Assets\WebhooksStatusPageAssets;
 /**
  * Class WebhookModule
  */
-class WebhookModule implements ServiceModule, ExtendingModule, ExecutableModule {
+class WebhookModule implements ServiceModule, FactoryModule, ExtendingModule, ExecutableModule {
 	use ModuleClassNameIdTrait;
 
 	/**
@@ -35,6 +36,13 @@ class WebhookModule implements ServiceModule, ExtendingModule, ExecutableModule 
 	 */
 	public function services(): array {
 		return require __DIR__ . '/../services.php';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function factories(): array {
+		return require __DIR__ . '/../factories.php';
 	}
 
 	/**


### PR DESCRIPTION
We retrieve `webhook.status.registered-webhooks` in the module's `run` when visiting the connection page to register webhooks if not registered yet
https://github.com/woocommerce/woocommerce-paypal-payments/blob/f51dbfc6d35392435600c81d259a1dd61b88f1c6/modules/ppcp-webhooks/src/WebhookModule.php#L136-L146
and we also use this service later when showing the settings
https://github.com/woocommerce/woocommerce-paypal-payments/blob/f51dbfc6d35392435600c81d259a1dd61b88f1c6/modules/ppcp-webhooks/extensions.php#L43-L44
https://github.com/woocommerce/woocommerce-paypal-payments/blob/f51dbfc6d35392435600c81d259a1dd61b88f1c6/modules/ppcp-webhooks/services.php#L146-L151

So it gets cached in `run` and then remains empty during this request even though they are actually registered later.

For now I just moved it into `factories` to avoid caching. Not sure if there are better solutions, one way could be to trigger the registration at the end of onboarding, but it does not seem like a simple and reliable solution, without additional refresh/redirect we may encounter caching issues too (for credentials, ...) + there are multiple ways to onboard. And either way this check + registration can be useful in other cases, such as if onboarding was interrupted at the end, or the webhooks were somehow removed.