### PR TITLE
Hook into the "Things to do next" section to add custom tasks (3659)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1782,10 +1782,11 @@ return array(
 	 *     id: string,
 	 *     title: string,
 	 *     description: string,
-	 *     redirect_url: string
+	 *     redirect_url: string,
+	 *     is_enabled: bool
 	 * }>
 	 */
-	'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' => static function(): array {
+	'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' => static function( ContainerInterface $container ): array {
 		$section_id       = PayPalGateway::ID;
 		$pay_later_tab_id = Settings::PAY_LATER_TAB_ID;
 
@@ -1795,6 +1796,7 @@ return array(
 				'title'        => __( 'Configure PayPal Pay Later messaging', 'woocommerce-paypal-payments' ),
 				'description'  => __( 'Decide where you want dynamic Pay Later messaging to show up and how you want it to look on your site.', 'woocommerce-paypal-payments' ),
 				'redirect_url' => admin_url("admin.php?page=wc-settings&tab=checkout&section={$section_id}&ppcp-tab={$pay_later_tab_id}"),
+				'is_enabled'   => $container->get('paylater-configurator.is-available'),
 			),
 		);
 	},
@@ -1816,7 +1818,8 @@ return array(
 			$title = $config['title'] ?? '';
 			$description = $config['description'] ?? '';
 			$redirect_url = $config['redirect_url'] ?? '';
-			$simple_redirect_tasks[] = $simple_redirect_task_factory->create_task( $id, $title, $description, $redirect_url );
+			$is_enabled = $config['is_enabled'] ?? false;
+			$simple_redirect_tasks[] = $simple_redirect_task_factory->create_task( $id, $title, $description, $redirect_url, $is_enabled );
 		}
 
 		return $simple_redirect_tasks;

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1791,12 +1791,12 @@ return array(
 
 		$list_of_config = array();
 
-		if ( $container->get('paylater-configurator.is-available') ) {
+		if ( $container->get( 'paylater-configurator.is-available' ) ) {
 			$list_of_config[] = array(
 				'id'           => 'pay-later-messaging-task',
 				'title'        => __( 'Configure PayPal Pay Later messaging', 'woocommerce-paypal-payments' ),
 				'description'  => __( 'Decide where you want dynamic Pay Later messaging to show up and how you want it to look on your site.', 'woocommerce-paypal-payments' ),
-				'redirect_url' => admin_url("admin.php?page=wc-settings&tab=checkout&section={$section_id}&ppcp-tab={$pay_later_tab_id}"),
+				'redirect_url' => admin_url( "admin.php?page=wc-settings&tab=checkout&section={$section_id}&ppcp-tab={$pay_later_tab_id}" ),
 			);
 		}
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1790,15 +1790,18 @@ return array(
 		$section_id       = PayPalGateway::ID;
 		$pay_later_tab_id = Settings::PAY_LATER_TAB_ID;
 
-		return array(
-			array(
+		$list_of_config = array();
+
+		if ( $container->get('paylater-configurator.is-available') ) {
+			$list_of_config[] = array(
 				'id'           => 'pay-later-messaging-task',
 				'title'        => __( 'Configure PayPal Pay Later messaging', 'woocommerce-paypal-payments' ),
 				'description'  => __( 'Decide where you want dynamic Pay Later messaging to show up and how you want it to look on your site.', 'woocommerce-paypal-payments' ),
 				'redirect_url' => admin_url("admin.php?page=wc-settings&tab=checkout&section={$section_id}&ppcp-tab={$pay_later_tab_id}"),
-				'is_enabled'   => $container->get('paylater-configurator.is-available'),
-			),
-		);
+			);
+		}
+
+		return $list_of_config;
 	},
 
 	/**
@@ -1818,8 +1821,7 @@ return array(
 			$title = $config['title'] ?? '';
 			$description = $config['description'] ?? '';
 			$redirect_url = $config['redirect_url'] ?? '';
-			$is_enabled = $config['is_enabled'] ?? false;
-			$simple_redirect_tasks[] = $simple_redirect_task_factory->create_task( $id, $title, $description, $redirect_url, $is_enabled );
+			$simple_redirect_tasks[] = $simple_redirect_task_factory->create_task( $id, $title, $description, $redirect_url );
 		}
 
 		return $simple_redirect_tasks;

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1782,8 +1782,7 @@ return array(
 	 *     id: string,
 	 *     title: string,
 	 *     description: string,
-	 *     redirect_url: string,
-	 *     is_enabled: bool
+	 *     redirect_url: string
 	 * }>
 	 */
 	'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' => static function( ContainerInterface $container ): array {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -29,6 +29,11 @@ use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CaptureCardPayment;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CartCheckoutDetector;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\FeesUpdater;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Factory\SimpleRedirectTaskFactory;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Factory\SimpleRedirectTaskFactoryInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Registrar\TaskRegistrar;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Registrar\TaskRegistrarInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Tasks\SimpleRedirectTask;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\FeesRenderer;
@@ -1761,5 +1766,59 @@ return array(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
+	},
+
+	'wcgateway.settings.wc-tasks.simple-redirect-task-factory' => static function(): SimpleRedirectTaskFactoryInterface {
+		return new SimpleRedirectTaskFactory();
+	},
+	'wcgateway.settings.wc-tasks.task-registrar'           => static function(): TaskRegistrarInterface {
+		return new TaskRegistrar();
+	},
+
+	/**
+	 * A configuration for simple redirect wc tasks.
+	 *
+	 * @returns array<array{
+	 *     id: string,
+	 *     title: string,
+	 *     description: string,
+	 *     redirect_url: string
+	 * }>
+	 */
+	'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' => static function(): array {
+		$section_id       = PayPalGateway::ID;
+		$pay_later_tab_id = Settings::PAY_LATER_TAB_ID;
+
+		return array(
+			array(
+				'id'           => 'pay-later-messaging-task',
+				'title'        => __( 'Configure PayPal Pay Later messaging', 'woocommerce-paypal-payments' ),
+				'description'  => __( 'Decide where you want dynamic Pay Later messaging to show up and how you want it to look on your site.', 'woocommerce-paypal-payments' ),
+				'redirect_url' => admin_url("admin.php?page=wc-settings&tab=checkout&section={$section_id}&ppcp-tab={$pay_later_tab_id}"),
+			),
+		);
+	},
+
+	/**
+	 * Retrieves the list of simple redirect task instances.
+	 *
+	 * @returns SimpleRedirectTask[]
+	 */
+	'wcgateway.settings.wc-tasks.simple-redirect-tasks'    => static function( ContainerInterface $container ): array {
+		$simple_redirect_tasks_config = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' );
+		$simple_redirect_task_factory = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-task-factory' );
+		assert( $simple_redirect_task_factory instanceof SimpleRedirectTaskFactoryInterface );
+
+		$simple_redirect_tasks = array();
+
+		foreach ( $simple_redirect_tasks_config as $config ) {
+			$id = $config['id'] ?? '';
+			$title = $config['title'] ?? '';
+			$description = $config['description'] ?? '';
+			$redirect_url = $config['redirect_url'] ?? '';
+			$simple_redirect_tasks[] = $simple_redirect_task_factory->create_task( $id, $title, $description, $redirect_url );
+		}
+
+		return $simple_redirect_tasks;
 	},
 );

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactory.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactory.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * A factory to create simple redirect task.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Settings
+ */
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Factory;
+
+use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Tasks\SimpleRedirectTask;
+
+/**
+ * A factory to create simple redirect task.
+ */
+class SimpleRedirectTaskFactory implements SimpleRedirectTaskFactoryInterface {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function create_task( string $id, string $title, string $description, string $redirect_url ): SimpleRedirectTask {
+		return new SimpleRedirectTask( $id, $title, $description, $redirect_url );
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactory.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactory.php
@@ -17,7 +17,7 @@ class SimpleRedirectTaskFactory implements SimpleRedirectTaskFactoryInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function create_task( string $id, string $title, string $description, string $redirect_url, bool $is_enabled ): SimpleRedirectTask {
-		return new SimpleRedirectTask( $id, $title, $description, $redirect_url, $is_enabled );
+	public function create_task( string $id, string $title, string $description, string $redirect_url ): SimpleRedirectTask {
+		return new SimpleRedirectTask( $id, $title, $description, $redirect_url );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactory.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactory.php
@@ -17,7 +17,7 @@ class SimpleRedirectTaskFactory implements SimpleRedirectTaskFactoryInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function create_task( string $id, string $title, string $description, string $redirect_url ): SimpleRedirectTask {
-		return new SimpleRedirectTask( $id, $title, $description, $redirect_url );
+	public function create_task( string $id, string $title, string $description, string $redirect_url, bool $is_enabled ): SimpleRedirectTask {
+		return new SimpleRedirectTask( $id, $title, $description, $redirect_url, $is_enabled );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactoryInterface.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Responsible for creating the simple redirect task.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Settings
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Factory;
+
+use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Tasks\SimpleRedirectTask;
+
+interface SimpleRedirectTaskFactoryInterface {
+
+	/**
+	 * Creates the simple redirect task.
+	 *
+	 * @param string $id The task ID.
+	 * @param string $title The task title.
+	 * @param string $description The task description.
+	 * @param string $redirect_url The redirection URL.
+	 * @return SimpleRedirectTask The task.
+	 */
+	public function create_task( string $id, string $title, string $description, string $redirect_url ): SimpleRedirectTask;
+}

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactoryInterface.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactoryInterface.php
@@ -20,8 +20,7 @@ interface SimpleRedirectTaskFactoryInterface {
 	 * @param string $title The task title.
 	 * @param string $description The task description.
 	 * @param string $redirect_url The redirection URL.
-	 * @param bool   $is_enabled Whether the task is enabled.
 	 * @return SimpleRedirectTask The task.
 	 */
-	public function create_task( string $id, string $title, string $description, string $redirect_url, bool $is_enabled ): SimpleRedirectTask;
+	public function create_task( string $id, string $title, string $description, string $redirect_url ): SimpleRedirectTask;
 }

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactoryInterface.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Factory/SimpleRedirectTaskFactoryInterface.php
@@ -20,7 +20,8 @@ interface SimpleRedirectTaskFactoryInterface {
 	 * @param string $title The task title.
 	 * @param string $description The task description.
 	 * @param string $redirect_url The redirection URL.
+	 * @param bool   $is_enabled Whether the task is enabled.
 	 * @return SimpleRedirectTask The task.
 	 */
-	public function create_task( string $id, string $title, string $description, string $redirect_url ): SimpleRedirectTask;
+	public function create_task( string $id, string $title, string $description, string $redirect_url, bool $is_enabled ): SimpleRedirectTask;
 }

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Registers the tasks inside the "Things to do next" WC section.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Settings
+ */
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Registrar;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+use RuntimeException;
+use WP_Error;
+
+/**
+ * Registers the tasks inside the "Things to do next" WC section.
+ */
+class TaskRegistrar implements TaskRegistrarInterface {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws RuntimeException If problem registering.
+	 */
+	public function register( array $tasks ): void {
+		foreach ( $tasks as $task ) {
+			$added_task = TaskLists::add_task( 'extended', $task );
+			if ( $added_task instanceof WP_Error ) {
+				throw new RuntimeException( $added_task->get_error_message() );
+			}
+		}
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
@@ -9,7 +9,6 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Registrar;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use RuntimeException;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Tasks\SimpleRedirectTask;
 use WP_Error;
 
 /**
@@ -24,10 +23,6 @@ class TaskRegistrar implements TaskRegistrarInterface {
 	 */
 	public function register( array $tasks ): void {
 		foreach ( $tasks as $task ) {
-			if ( $task instanceof SimpleRedirectTask && ! $task->is_enabled() ) {
-				continue;
-			}
-
 			$added_task = TaskLists::add_task( 'extended', $task );
 			if ( $added_task instanceof WP_Error ) {
 				throw new RuntimeException( $added_task->get_error_message() );

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
@@ -25,7 +25,7 @@ class TaskRegistrar implements TaskRegistrarInterface {
 	public function register( array $tasks ): void {
 		foreach ( $tasks as $task ) {
 			if ( $task instanceof SimpleRedirectTask && ! $task->is_enabled() ) {
-				return;
+				continue;
 			}
 
 			$added_task = TaskLists::add_task( 'extended', $task );

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
@@ -9,6 +9,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Registrar;
 
 use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Tasks\SimpleRedirectTask;
 use WP_Error;
 
 /**
@@ -23,6 +24,10 @@ class TaskRegistrar implements TaskRegistrarInterface {
 	 */
 	public function register( array $tasks ): void {
 		foreach ( $tasks as $task ) {
+			if ( $task instanceof SimpleRedirectTask && ! $task->is_enabled() ) {
+				return;
+			}
+
 			$added_task = TaskLists::add_task( 'extended', $task );
 			if ( $added_task instanceof WP_Error ) {
 				throw new RuntimeException( $added_task->get_error_message() );

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrarInterface.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrarInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Responsible for registering the tasks inside the "Things to do next" WC section.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Settings
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Registrar;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+use RuntimeException;
+
+interface TaskRegistrarInterface {
+
+	/**
+	 * Registers the tasks inside "Things to do next" WC section.
+	 *
+	 * @param Task[] $tasks The list of tasks.
+	 * @return void
+	 * @throws RuntimeException If problem registering.
+	 */
+	public function register( array $tasks ): void;
+}

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Tasks/SimpleRedirectTask.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Tasks/SimpleRedirectTask.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Represents the Task for simple redirection. See "Things to do next" WC section.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Settings
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcTasks\Tasks;
+
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\Task;
+
+/**
+ * Class SimpleRedirectTask
+ */
+class SimpleRedirectTask extends Task {
+
+	/**
+	 * The task ID.
+	 *
+	 * @var string
+	 */
+	protected string $id;
+
+	/**
+	 * The task title.
+	 *
+	 * @var string
+	 */
+	protected string $title;
+
+	/**
+	 * The task description.
+	 *
+	 * @var string
+	 */
+	protected string $description;
+
+	/**
+	 * The redirection URL.
+	 *
+	 * @var string
+	 */
+	protected string $redirect_url;
+
+	/**
+	 * SimpleRedirectTask constructor.
+	 *
+	 * @param string $id The task ID.
+	 * @param string $title The task title.
+	 * @param string $description The task description.
+	 * @param string $redirect_url The redirection URL.
+	 */
+	public function __construct( string $id, string $title, string $description, string $redirect_url ) {
+		parent::__construct();
+
+		$this->id           = $id;
+		$this->title        = $title;
+		$this->description  = $description;
+		$this->redirect_url = $redirect_url;
+	}
+
+	/**
+	 * The task ID.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return $this->id;
+	}
+
+	/**
+	 * The task title.
+	 *
+	 * @return string
+	 */
+	public function get_title(): string {
+		return $this->title;
+	}
+
+	/**
+	 * The task content.
+	 *
+	 * @return string
+	 */
+	public function get_content(): string {
+		return '';
+	}
+
+	/**
+	 * The task time.
+	 *
+	 * @return string
+	 */
+	public function get_time(): string {
+		return $this->description;
+	}
+
+	/**
+	 * The task redirection URL.
+	 *
+	 * @return string
+	 */
+	public function get_action_url(): string {
+		return $this->redirect_url;
+	}
+
+	/**
+	 * The task completion.
+	 *
+	 * We need to set the task completed when the redirection happened for the first time.
+	 * So this method of a parent class should be overridden.
+	 *
+	 * @return bool
+	 */
+	public function is_complete(): bool {
+		return parent::is_visited();
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Tasks/SimpleRedirectTask.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Tasks/SimpleRedirectTask.php
@@ -45,20 +45,30 @@ class SimpleRedirectTask extends Task {
 	protected string $redirect_url;
 
 	/**
+	 * Whether the task is enabled.
+	 *
+	 * @var bool
+	 */
+	protected bool $is_enabled;
+
+
+	/**
 	 * SimpleRedirectTask constructor.
 	 *
 	 * @param string $id The task ID.
 	 * @param string $title The task title.
 	 * @param string $description The task description.
 	 * @param string $redirect_url The redirection URL.
+	 * @param bool   $is_enabled Whether the task is enabled.
 	 */
-	public function __construct( string $id, string $title, string $description, string $redirect_url ) {
+	public function __construct( string $id, string $title, string $description, string $redirect_url, bool $is_enabled ) {
 		parent::__construct();
 
 		$this->id           = $id;
 		$this->title        = $title;
 		$this->description  = $description;
 		$this->redirect_url = $redirect_url;
+		$this->is_enabled = $is_enabled;
 	}
 
 	/**
@@ -104,6 +114,15 @@ class SimpleRedirectTask extends Task {
 	 */
 	public function get_action_url(): string {
 		return $this->redirect_url;
+	}
+
+	/**
+	 * Whether the task is enabled.
+	 *
+	 * @return bool
+	 */
+	public function is_enabled(): bool {
+		return $this->is_enabled;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Tasks/SimpleRedirectTask.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Tasks/SimpleRedirectTask.php
@@ -45,30 +45,20 @@ class SimpleRedirectTask extends Task {
 	protected string $redirect_url;
 
 	/**
-	 * Whether the task is enabled.
-	 *
-	 * @var bool
-	 */
-	protected bool $is_enabled;
-
-
-	/**
 	 * SimpleRedirectTask constructor.
 	 *
 	 * @param string $id The task ID.
 	 * @param string $title The task title.
 	 * @param string $description The task description.
 	 * @param string $redirect_url The redirection URL.
-	 * @param bool   $is_enabled Whether the task is enabled.
 	 */
-	public function __construct( string $id, string $title, string $description, string $redirect_url, bool $is_enabled ) {
+	public function __construct( string $id, string $title, string $description, string $redirect_url ) {
 		parent::__construct();
 
 		$this->id           = $id;
 		$this->title        = $title;
 		$this->description  = $description;
 		$this->redirect_url = $redirect_url;
-		$this->is_enabled = $is_enabled;
 	}
 
 	/**
@@ -114,15 +104,6 @@ class SimpleRedirectTask extends Task {
 	 */
 	public function get_action_url(): string {
 		return $this->redirect_url;
-	}
-
-	/**
-	 * Whether the task is enabled.
-	 *
-	 * @return bool
-	 */
-	public function is_enabled(): bool {
-		return $this->is_enabled;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -843,7 +843,11 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	 */
 	protected function register_wc_tasks( ContainerInterface $container ): void {
 		$simple_redirect_tasks = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-tasks' );
-		$task_registrar        = $container->get( 'wcgateway.settings.wc-tasks.task-registrar' );
+		if ( empty( $simple_redirect_tasks ) ) {
+			return;
+		}
+
+		$task_registrar = $container->get( 'wcgateway.settings.wc-tasks.task-registrar' );
 		assert( $task_registrar instanceof TaskRegistrarInterface );
 
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -10,5 +10,6 @@ require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway_CC.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Ajax.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Checkout.php';
+require_once TESTS_ROOT_DIR . '/stubs/Task.php';
 
 Hamcrest\Util::registerGlobalFunctions();

--- a/tests/stubs/Task.php
+++ b/tests/stubs/Task.php
@@ -1,8 +1,21 @@
 <?php
 declare(strict_types=1);
 
+namespace Automattic\WooCommerce\Admin\Features\OnboardingTasks;
+
+use Automattic\WooCommerce\Internal\Admin\WCAdminUser;
+
 abstract class Task
 {
+
+	/**
+	 * Constructor
+	 *
+	 * @param TaskList|null $task_list Parent task list.
+	 */
+	public function __construct( $task_list = null ) {
+		$this->task_list = $task_list;
+	}
 
 	/**
 	 * ID.

--- a/tests/stubs/Task.php
+++ b/tests/stubs/Task.php
@@ -1,9 +1,7 @@
 <?php
 declare(strict_types=1);
 
-namespace stubs;
-
-class Task
+abstract class Task
 {
 
 	/**

--- a/tests/stubs/Task.php
+++ b/tests/stubs/Task.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace stubs;
+
+class Task
+{
+
+	/**
+	 * ID.
+	 *
+	 * @return string
+	 */
+	abstract public function get_id();
+
+	/**
+	 * Title.
+	 *
+	 * @return string
+	 */
+	abstract public function get_title();
+
+	/**
+	 * Content.
+	 *
+	 * @return string
+	 */
+	abstract public function get_content();
+
+	/**
+	 * Time.
+	 *
+	 * @return string
+	 */
+	abstract public function get_time();
+}


### PR DESCRIPTION
# PR Description

The PR will introduce the functionality to add "simple redirection tasks" when we need just to redirect to settings page and mark the task as completed. Also the architecture will allow to add different then "simple redirection" tasks in future if needed.
 
# Issue Description

For our settings revamp, we want to take advantage of the onboarding actions in WooCommerce by hooking into “Things to do next” displayed on the WooCommerce Home section.


### Steps to Test

1. Check the WooCommerce “Things to do next” section.
2. See if the "Configure PayPal Pay Later messaging" exists.
3. Clicking on Task should redirect to Pay Later messaging settings.
4. When visiting again the “Things to do next” section, the task should be marked as completed.

<img width="798" alt="Screenshot 2024-09-11 at 19 30 30" src="https://github.com/user-attachments/assets/6969926b-6a1d-4ac3-86b4-fdf620561cb0">

