### PR TITLE
Fastlane Component disappears in Gary flow (3674)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -803,8 +803,8 @@ class AxoManager {
 
 		this.emailInput.value = this.stripSpaces( this.emailInput.value );
 
-		this.$( this.el.paymentContainer.selector + '-detail' ).html( '' );
-		this.$( this.el.paymentContainer.selector + '-form' ).html( '' );
+		this.$( this.el.paymentContainer.selector + '-details' ).html( '' );
+		this.removeFastlaneComponent();
 
 		this.setStatus( 'validEmail', false );
 		this.setStatus( 'hasProfile', false );
@@ -1071,6 +1071,20 @@ class AxoManager {
 			await this.fastlane.FastlaneCardComponent( config );
 
 		return this.cardComponent.render( elem );
+	}
+
+	/**
+	 * Reverts the changes made by `initializeFastlaneComponent()`.
+	 *
+	 * Calling this method will lose any input that the user made inside the
+	 * Fastlane Card Component.
+	 */
+	removeFastlaneComponent() {
+		document.querySelector(
+			this.el.paymentContainer.selector + '-form'
+		).innerHTML = '';
+
+		this.cardComponent = null;
 	}
 
 	/**

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -148,6 +148,15 @@ class AxoManager {
 		return !! this.data.card;
 	}
 
+	/**
+	 * CSS selector to target the Fastlane Card Component wrapper.
+	 *
+	 * @return {string} CSS selector.
+	 */
+	get cardFormSelector() {
+		return this.el.paymentContainer.selector + '-form';
+	}
+
 	registerEventHandlers() {
 		this.$( document ).on(
 			'change',
@@ -1064,7 +1073,7 @@ class AxoManager {
 			return Promise.resolve();
 		}
 
-		const elem = this.el.paymentContainer.selector + '-form';
+		const elem = this.cardFormSelector;
 		const config = this.cardComponentData();
 
 		this.cardComponent =
@@ -1080,9 +1089,7 @@ class AxoManager {
 	 * Fastlane Card Component.
 	 */
 	removeFastlaneComponent() {
-		document.querySelector(
-			this.el.paymentContainer.selector + '-form'
-		).innerHTML = '';
+		document.querySelector( this.cardFormSelector ).innerHTML = '';
 
 		this.cardComponent = null;
 	}


### PR DESCRIPTION
### Description

This PR addresses a bug in the Fastlane Gary flow, where the Card component disappears when changing the email address.

Note: After changing the email address to another Gary email-address, any input in the card form is reset (card details or phone number)