### PR TITLE
Fix MasterCard in Fastlane component (3679)

### DIFF
--- a/modules/ppcp-axo/resources/js/Views/CardView.js
+++ b/modules/ppcp-axo/resources/js/Views/CardView.js
@@ -28,7 +28,7 @@ class CardView {
 
 				const cardIcons = {
 					VISA: 'visa-light.svg',
-					MASTER_CARD: 'mastercard-light.svg',
+					MASTERCARD: 'mastercard-light.svg',
 					AMEX: 'amex-light.svg',
 					DISCOVER: 'discover-light.svg',
 					DINERS: 'dinersclub-light.svg',


### PR DESCRIPTION
### Description

This PR addresses a minor issue where the MasterCard logo was not displayed in the Fastlane gateway in classic checkout.

### Screenshots

| Before | After |
|---|---|
| ![2024-09-13_17-32-21](https://github.com/user-attachments/assets/c47cce4a-c296-4926-bda6-27a68048327b) | ![2024-09-13_17-31-29](https://github.com/user-attachments/assets/d2a5e832-dc00-495d-b51d-ade7ec2377fe) |