### PR TITLE
Fastlane use Advanced Card Processing gateway icon selector (3681)

### DIFF
--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -76,34 +76,13 @@ return array(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'wcgateway.order-processor' ),
-			$container->get( 'axo.card_icons' ),
+			$container->get( 'wcgateway.credit-card-icons' ),
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'api.factory.purchase-unit' ),
 			$container->get( 'api.factory.shipping-preference' ),
 			$container->get( 'wcgateway.transaction-url-provider' ),
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
-		);
-	},
-
-	'axo.card_icons'                         => static function ( ContainerInterface $container ): array {
-		return array(
-			array(
-				'title' => 'Visa',
-				'file'  => 'visa-dark.svg',
-			),
-			array(
-				'title' => 'MasterCard',
-				'file'  => 'mastercard-dark.svg',
-			),
-			array(
-				'title' => 'American Express',
-				'file'  => 'amex.svg',
-			),
-			array(
-				'title' => 'Discover',
-				'file'  => 'discover.svg',
-			),
 		);
 	},
 

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -77,7 +77,6 @@ return array(
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'wcgateway.order-processor' ),
 			$container->get( 'axo.card_icons' ),
-			$container->get( 'axo.card_icons.axo' ),
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'api.factory.purchase-unit' ),
 			$container->get( 'api.factory.shipping-preference' ),
@@ -104,39 +103,6 @@ return array(
 			array(
 				'title' => 'Discover',
 				'file'  => 'discover.svg',
-			),
-		);
-	},
-
-	'axo.card_icons.axo'                     => static function ( ContainerInterface $container ): array {
-		return array(
-			array(
-				'title' => 'Visa',
-				'file'  => 'visa-light.svg',
-			),
-			array(
-				'title' => 'MasterCard',
-				'file'  => 'mastercard-light.svg',
-			),
-			array(
-				'title' => 'Amex',
-				'file'  => 'amex-light.svg',
-			),
-			array(
-				'title' => 'Discover',
-				'file'  => 'discover-light.svg',
-			),
-			array(
-				'title' => 'Diners Club',
-				'file'  => 'dinersclub-light.svg',
-			),
-			array(
-				'title' => 'JCB',
-				'file'  => 'jcb-light.svg',
-			),
-			array(
-				'title' => 'UnionPay',
-				'file'  => 'unionpay-light.svg',
 			),
 		);
 	},

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -119,7 +119,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @param ContainerInterface        $ppcp_settings The settings.
 	 * @param string                    $wcgateway_module_url The WcGateway module URL.
 	 * @param OrderProcessor            $order_processor The Order processor.
-	 * @param array                     $card_icons The card icons.
+	 * @param array                     $card_icons      The card icons.
 	 * @param OrderEndpoint             $order_endpoint The order endpoint.
 	 * @param PurchaseUnitFactory       $purchase_unit_factory The purchase unit factory.
 	 * @param ShippingPreferenceFactory $shipping_preference_factory The shipping preference factory.
@@ -285,9 +285,8 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_icon() {
-		$icon      = parent::get_icon();
-		$icons     = $this->card_icons;
-		$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/';
+		$icon  = parent::get_icon();
+		$icons = $this->card_icons;
 
 		if ( ! $icons ) {
 			return $icon;
@@ -298,8 +297,8 @@ class AxoGateway extends WC_Payment_Gateway {
 		foreach ( $icons as $card ) {
 			$images[] = '<img
 				class="ppcp-card-icon"
-				title="' . $card['title'] . '"
-				src="' . $icons_src . $card['file'] . '"
+				title="' . esc_attr( $card['title'] ) . '"
+				src="' . esc_url( $card['url'] ) . '"
 			> ';
 		}
 

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -71,13 +71,6 @@ class AxoGateway extends WC_Payment_Gateway {
 	protected $card_icons;
 
 	/**
-	 * The AXO card icons.
-	 *
-	 * @var array
-	 */
-	protected $card_icons_axo;
-
-	/**
 	 * The order endpoint.
 	 *
 	 * @var OrderEndpoint
@@ -127,7 +120,6 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @param string                    $wcgateway_module_url The WcGateway module URL.
 	 * @param OrderProcessor            $order_processor The Order processor.
 	 * @param array                     $card_icons The card icons.
-	 * @param array                     $card_icons_axo The card icons.
 	 * @param OrderEndpoint             $order_endpoint The order endpoint.
 	 * @param PurchaseUnitFactory       $purchase_unit_factory The purchase unit factory.
 	 * @param ShippingPreferenceFactory $shipping_preference_factory The shipping preference factory.
@@ -141,7 +133,6 @@ class AxoGateway extends WC_Payment_Gateway {
 		string $wcgateway_module_url,
 		OrderProcessor $order_processor,
 		array $card_icons,
-		array $card_icons_axo,
 		OrderEndpoint $order_endpoint,
 		PurchaseUnitFactory $purchase_unit_factory,
 		ShippingPreferenceFactory $shipping_preference_factory,
@@ -156,7 +147,6 @@ class AxoGateway extends WC_Payment_Gateway {
 		$this->wcgateway_module_url = $wcgateway_module_url;
 		$this->order_processor      = $order_processor;
 		$this->card_icons           = $card_icons;
-		$this->card_icons_axo       = $card_icons_axo;
 
 		$this->method_title       = __( 'Fastlane Debit & Credit Cards', 'woocommerce-paypal-payments' );
 		$this->method_description = __( 'Fastlane accelerates the checkout experience for guest shoppers and autofills their details so they can pay in seconds. When enabled, Fastlane is presented as the default payment method for guests.', 'woocommerce-paypal-payments' );
@@ -299,12 +289,7 @@ class AxoGateway extends WC_Payment_Gateway {
 		$icons     = $this->card_icons;
 		$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/';
 
-		if ( $this->card_icons_axo ) {
-			$icons     = $this->card_icons_axo;
-			$icons_src = esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/';
-		}
-
-		if ( empty( $this->card_icons ) ) {
+		if ( ! $icons ) {
 			return $icon;
 		}
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -132,10 +132,13 @@ return array(
 		$payments_endpoint = $container->get( 'api.endpoint.payments' );
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 		$vaulted_credit_card_handler = $container->get( 'vaulting.credit-card-handler' );
+		$icons = $container->get( 'wcgateway.credit-card-icons' );
+
 		return new CreditCardGateway(
 			$settings_renderer,
 			$order_processor,
 			$settings,
+			$icons,
 			$module_url,
 			$session_handler,
 			$refund_processor,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -153,6 +153,68 @@ return array(
 			$logger
 		);
 	},
+	'wcgateway.credit-card-labels'                         => static function ( ContainerInterface $container ) : array {
+		return array(
+			'visa'       => _x(
+				'Visa',
+				'Name of credit card',
+				'woocommerce-paypal-payments'
+			),
+			'mastercard' => _x(
+				'Mastercard',
+				'Name of credit card',
+				'woocommerce-paypal-payments'
+			),
+			'amex'       => _x(
+				'American Express',
+				'Name of credit card',
+				'woocommerce-paypal-payments'
+			),
+			'discover'   => _x(
+				'Discover',
+				'Name of credit card',
+				'woocommerce-paypal-payments'
+			),
+			'jcb'        => _x(
+				'JCB',
+				'Name of credit card',
+				'woocommerce-paypal-payments'
+			),
+			'elo'        => _x(
+				'Elo',
+				'Name of credit card',
+				'woocommerce-paypal-payments'
+			),
+			'hiper'      => _x(
+				'Hiper',
+				'Name of credit card',
+				'woocommerce-paypal-payments'
+			),
+		);
+	},
+	'wcgateway.credit-card-icons'                          => static function ( ContainerInterface $container ) : array {
+		$settings = $container->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+
+		$icons  = $settings->has( 'card_icons' ) ? (array) $settings->get( 'card_icons' ) : array();
+		$labels = $container->get( 'wcgateway.credit-card-labels' );
+
+		$module_url = $container->get( 'wcgateway.url' );
+		$url_root   = esc_url( $module_url ) . 'assets/images/';
+
+		$icons_with_label = array();
+		foreach ( $icons as $icon ) {
+			$type = str_replace( '-dark', '', $icon );
+
+			$icons_with_label[] = array(
+				'type'  => $type,
+				'title' => ucwords( $labels[ $type ] ?? $type ),
+				'url'   => "$url_root/$icon.svg",
+			);
+		}
+
+		return $icons_with_label;
+	},
 	'wcgateway.card-button-gateway'                        => static function ( ContainerInterface $container ): CardButtonGateway {
 		return new CardButtonGateway(
 			$container->get( 'wcgateway.settings.render' ),

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -60,6 +60,13 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	protected $order_processor;
 
 	/**
+	 * The card icons.
+	 *
+	 * @var array
+	 */
+	protected $card_icons;
+
+	/**
 	 * The settings.
 	 *
 	 * @var ContainerInterface
@@ -184,6 +191,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 * @param SettingsRenderer         $settings_renderer The Settings Renderer.
 	 * @param OrderProcessor           $order_processor The Order processor.
 	 * @param ContainerInterface       $config The settings.
+	 * @param array                    $card_icons The card icons.
 	 * @param string                   $module_url The URL to the module.
 	 * @param SessionHandler           $session_handler The Session Handler.
 	 * @param RefundProcessor          $refund_processor The refund processor.
@@ -204,6 +212,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		SettingsRenderer $settings_renderer,
 		OrderProcessor $order_processor,
 		ContainerInterface $config,
+		array $card_icons,
 		string $module_url,
 		SessionHandler $session_handler,
 		RefundProcessor $refund_processor,
@@ -264,6 +273,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			$this->config->get( 'dcc_gateway_title' ) : $this->method_title;
 		$this->description        = $this->config->has( 'dcc_gateway_description' ) ?
 			$this->config->get( 'dcc_gateway_description' ) : $this->method_description;
+		$this->card_icons         = $card_icons;
 
 		$this->init_form_fields();
 		$this->init_settings();
@@ -339,72 +349,24 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 * @return string
 	 */
 	public function get_icon() {
-		$icon = parent::get_icon();
+		$icon  = parent::get_icon();
+		$icons = $this->card_icons;
 
-		$icons = $this->config->has( 'card_icons' ) ? (array) $this->config->get( 'card_icons' ) : array();
-		if ( empty( $icons ) ) {
+		if ( ! $icons ) {
 			return $icon;
 		}
 
-		$title_options = $this->card_labels();
-		$images        = array_map(
-			function ( string $type ) use ( $title_options ): string {
-				$striped_dark = str_replace( '-dark', '', $type );
-				return '<img
-                 title="' . esc_attr( $title_options[ $striped_dark ] ) . '"
-                 src="' . esc_url( $this->module_url ) . 'assets/images/' . esc_attr( $type ) . '.svg"
-                 class="ppcp-card-icon"
-                > ';
-			},
-			$icons
-		);
+		$images = array();
+
+		foreach ( $icons as $card ) {
+			$images[] = '<img
+				class="ppcp-card-icon"
+				title="' . esc_attr( $card['title'] ) . '"
+				src="' . esc_url( $card['url'] ) . '"
+			> ';
+		}
 
 		return implode( '', $images );
-	}
-
-	/**
-	 * Returns an array of credit card names.
-	 *
-	 * @return array
-	 */
-	private function card_labels(): array {
-		return array(
-			'visa'       => _x(
-				'Visa',
-				'Name of credit card',
-				'woocommerce-paypal-payments'
-			),
-			'mastercard' => _x(
-				'Mastercard',
-				'Name of credit card',
-				'woocommerce-paypal-payments'
-			),
-			'amex'       => _x(
-				'American Express',
-				'Name of credit card',
-				'woocommerce-paypal-payments'
-			),
-			'discover'   => _x(
-				'Discover',
-				'Name of credit card',
-				'woocommerce-paypal-payments'
-			),
-			'jcb'        => _x(
-				'JCB',
-				'Name of credit card',
-				'woocommerce-paypal-payments'
-			),
-			'elo'        => _x(
-				'Elo',
-				'Name of credit card',
-				'woocommerce-paypal-payments'
-			),
-			'hiper'      => _x(
-				'Hiper',
-				'Name of credit card',
-				'woocommerce-paypal-payments'
-			),
-		);
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
@@ -28,6 +28,7 @@ class CreditCardGatewayTest extends TestCase
 	private $settingsRenderer;
 	private $orderProcessor;
 	private $config;
+	private $creditCardIcons;
 	private $moduleUrl;
 	private $sessionHandler;
 	private $refundProcessor;
@@ -52,6 +53,7 @@ class CreditCardGatewayTest extends TestCase
 		$this->settingsRenderer = Mockery::mock(SettingsRenderer::class);
 		$this->orderProcessor = Mockery::mock(OrderProcessor::class);
 		$this->config = Mockery::mock(ContainerInterface::class);
+		$this->creditCardIcons = [];
 		$this->moduleUrl = '';
 		$this->sessionHandler = Mockery::mock(SessionHandler::class);
 		$this->refundProcessor = Mockery::mock(RefundProcessor::class);
@@ -78,6 +80,7 @@ class CreditCardGatewayTest extends TestCase
 			$this->settingsRenderer,
 			$this->orderProcessor,
 			$this->config,
+			$this->creditCardIcons,
 			$this->moduleUrl,
 			$this->sessionHandler,
 			$this->refundProcessor,


### PR DESCRIPTION
### Description

This PR consolidates the gateway icons displayed by ACDC (Credit Card) and AXO (Fastlane). Both "gateways" display the icons, that are defined in the "Advanced Card Processing" settings.

Note: Applies to the classic checkout

### Screenshots

<img width="702" alt="2024-09-13_19-00-59" src="https://github.com/user-attachments/assets/27b064fa-a6ae-4afe-87b7-0c9306259be5">

<img width="672" alt="2024-09-13_19-00-36" src="https://github.com/user-attachments/assets/d471641b-db38-4fe4-a39d-324f6a61b3fe">
