### PR TITLE
Release 2.9.1-rc1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,21 @@
 *** Changelog ***
 
+= 2.9.1 - xxxx-xx-xx =
+* Fix - Improve card fields hiding #2574
+* Fix - Google Pay: Shipping callback not calculating totals correctly on Single Product page #2513
+* Fix - Fix shipping callback condition in status report #2578
+* Fix - Can't Disconnect Account #2539
+* Fix - Google Pay billing data without shipping callback #2525
+* Fix - Standard payment tab - Google Pay and Apple Pay button - Shape from one location is applied to all until saving changes #2419
+* Enhancement - Allow to override the list of Pay Later supported countries #2563
+* Enhancement - Add more feature statuses into system report #2550
+* Enhancement - Use SVG for APM gateway icons #2509
+* Enhancement - Add inline notice to inform users about ACDC block Checkout support if the store uses a Classic Checkout setup #2422
+* Enhancement - Remove leftover console.log #2589
+* Enhancement - Require PHP 7.4+, WP 6.3+, WC 6.9+ #2556
+* Enhancement - Modularity module migration #1944
+* Enhancement - Keep only 5 tags in readme.txt #2562
+
 = 2.9.0 - 2024-09-02 =
 * Fix - Fatal error in Block Editor when using WooCommerce blocks #2534
 * Fix - Can't pay from block pages when the shipping callback is enabled and no shipping methods defined #2429

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "2.9.0",
+  "version": "2.9.1",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 2.9.0
+Stable tag: 2.9.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -178,6 +178,22 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 6. Main settings screen.
 
 == Changelog ==
+
+= 2.9.1 - xxxx-xx-xx =
+* Fix - Improve card fields hiding #2574
+* Fix - Google Pay: Shipping callback not calculating totals correctly on Single Product page #2513
+* Fix - Fix shipping callback condition in status report #2578
+* Fix - Can't Disconnect Account #2539
+* Fix - Google Pay billing data without shipping callback #2525
+* Fix - Standard payment tab - Google Pay and Apple Pay button - Shape from one location is applied to all until saving changes #2419
+* Enhancement - Allow to override the list of Pay Later supported countries #2563
+* Enhancement - Add more feature statuses into system report #2550
+* Enhancement - Use SVG for APM gateway icons #2509
+* Enhancement - Add inline notice to inform users about ACDC block Checkout support if the store uses a Classic Checkout setup #2422
+* Enhancement - Remove leftover console.log #2589
+* Enhancement - Require PHP 7.4+, WP 6.3+, WC 6.9+ #2556
+* Enhancement - Modularity module migration #1944
+* Enhancement - Keep only 5 tags in readme.txt #2562
 
 = 2.9.0 - 2024-09-02 =
 * Fix - Fatal error in Block Editor when using WooCommerce blocks #2534

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,14 +3,14 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     2.9.0
+ * Version:     2.9.1
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.4
  * Requires Plugins: woocommerce
  * WC requires at least: 6.9
- * WC tested up to: 9.2
+ * WC tested up to: 9.3
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce
@@ -26,7 +26,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2024-08-28' );
+define( 'PAYPAL_INTEGRATION_DATE', '2024-09-16' );
 define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );


### PR DESCRIPTION
* Fix - Improve card fields hiding #2574
* Fix - Google Pay: Shipping callback not calculating totals correctly on Single Product page #2513
* Fix - Fix shipping callback condition in status report #2578
* Fix - Can't Disconnect Account #2539
* Fix - Google Pay billing data without shipping callback #2525
* Fix - Standard payment tab - Google Pay and Apple Pay button - Shape from one location is applied to all until saving changes #2419
* Enhancement - Allow to override the list of Pay Later supported countries #2563
* Enhancement - Add more feature statuses into system report #2550
* Enhancement - Use SVG for APM gateway icons #2509
* Enhancement - Add inline notice to inform users about ACDC block Checkout support if the store uses a Classic Checkout setup #2422
* Enhancement - Remove leftover console.log #2589
* Enhancement - Require PHP 7.4+, WP 6.3+, WC 6.9+ #2556
* Enhancement - Modularity module migration #1944
* Enhancement - Keep only 5 tags in readme.txt #2562