### PR TITLE
Fix the step counter in block checkout in the initial Fastlane stage (3693)

### DIFF
--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -278,3 +278,10 @@ a.wc-block-axo-change-link {
 #shipping-fields .wc-block-components-checkout-step__heading {
 	display: flex;
 }
+
+// 11. Fix Step Numbering
+body.ppcp-recalculate {
+	.wc-block-checkout__form--with-step-numbers .wc-block-components-checkout-step--with-step-number .wc-block-components-checkout-step__title:before {
+		content: ' ' !important;
+	}
+}

--- a/modules/ppcp-axo-block/resources/js/helpers/classnamesManager.js
+++ b/modules/ppcp-axo-block/resources/js/helpers/classnamesManager.js
@@ -96,6 +96,7 @@ export const setupCheckoutBlockClassToggles = () => {
 		} else {
 			targetElement.classList.remove( axoLoadedClass );
 		}
+		triggerCounterRecalculation();
 
 		if ( ! isGuest ) {
 			targetElement.classList.add( authClass );
@@ -142,4 +143,18 @@ export const initializeClassToggles = () => {
 			unsubscribeContactInfo();
 		}
 	};
+};
+
+/**
+ * Fixes the number values on the block checkout page, when step numbering is enabled.
+ *
+ * We briefly add a CSS class to the body, that modifies the counter's CSS attributes.
+ * Changing _any_ attribute of the counter element triggers the recalculation of the counters.
+ */
+export const triggerCounterRecalculation = () => {
+	document.body.classList.add( 'ppcp-recalculate' );
+
+	requestAnimationFrame( () => {
+		document.body.classList.remove( 'ppcp-recalculate' );
+	} );
 };


### PR DESCRIPTION
### Description

This PR adds logic to recalculate the step numbering in the block checkout during the initial Fastlane stage.

In that phase, only two steps are visible: The email address and the payment methods. In the default step order, those steps are numbered "1" and "5" (when shipping & shipping options are available), which looks weird.

### Solution

The step numbers are already implemented by WooCommerce using CSS counter-attributes. What is missing is a recalculation of the CSS counter value after hiding or showing steps.

A new JS function briefly adds a CSS class to the body, which changes a counter-attribute using `!important` - this triggers the desired recalculation of the counter values.

### Screenshots

| Before | After |
|---|---|
| ![2024-09-17_17-47-52](https://github.com/user-attachments/assets/bdb66fcc-e535-47b0-b286-e4407292e838) | ![2024-09-17_17-47-32](https://github.com/user-attachments/assets/d891e0ba-a588-4251-8baa-22c250baa992) |