### PR TITLE
Improve tab order for "Continue" button (3694)

### DIFF
--- a/modules/ppcp-axo-block/resources/js/components/Watermark/utils.js
+++ b/modules/ppcp-axo-block/resources/js/components/Watermark/utils.js
@@ -27,9 +27,16 @@ export const createWatermarkContainer = () => {
 				'wc-block-checkout-axo-block-watermark-container'
 			);
 
-			emailInput.parentNode.insertBefore(
+			const emailButton = textInputContainer.querySelector(
+				'.wc-block-axo-email-submit-button-container'
+			);
+
+			// If possible, insert the watermark after the "Continue" button.
+			const insertAfterElement = emailButton || emailInput;
+
+			insertAfterElement.parentNode.insertBefore(
 				watermarkReference.container,
-				emailInput.nextSibling
+				insertAfterElement.nextSibling
 			);
 
 			watermarkReference.root = createRoot(


### PR DESCRIPTION
### Description

This PR re-arranges the Fastlane watermark _after_ the "Continue" button in the DOM to improve the tab-sequence when navigating through the form using the keyboard.

The current input order in the email field has a minor accessibility problem:

When pressing the tab-key in the email field, the watermark is focused, and then the Continue button. This adds an extra step when trying to do “enter email → TAB → SPACE” to hit the “Continue” button using a keyboard.

### Solution

By re-arranging the elements in the DOM, the tab sequence can follow a more logical and expected flow.

### New Flow

https://github.com/user-attachments/assets/81da1efb-f68b-40b8-a1b9-019ba9df31d1

_The watermark is focused last_