### PR TITLE
AXO Blocks: Fix the step counter in block checkout in the initial Fastlane stage (3693)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -3,8 +3,8 @@ type: php
 docroot: .ddev/wordpress
 php_version: "7.4"
 webserver_type: apache-fpm
-router_http_port: "80"
-router_https_port: "443"
+router_http_port: "6070"
+router_https_port: "7443"
 xdebug_enabled: false
 additional_hostnames: ['wc-pp']
 additional_fqdns: []
@@ -18,7 +18,7 @@ hooks:
   pre-start:
     - exec-host: "mkdir -p .ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}"
 web_environment:
-  - WP_VERSION=6.3.3
+  - WP_VERSION=6.6.2
   - WP_LOCALE=en_US
   - WP_TITLE=WooCommerce PayPal Payments
   - WP_MULTISITE=true
@@ -26,7 +26,7 @@ web_environment:
   - ADMIN_USER=admin
   - ADMIN_PASS=admin
   - ADMIN_EMAIL=admin@example.com
-  - WC_VERSION=7.7.2
+  - WC_VERSION=9.3.1
 
 # Key features of ddev's config.yaml:
 

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -3,8 +3,8 @@ type: php
 docroot: .ddev/wordpress
 php_version: "7.4"
 webserver_type: apache-fpm
-router_http_port: "6070"
-router_https_port: "7443"
+router_http_port: "80"
+router_https_port: "443"
 xdebug_enabled: false
 additional_hostnames: ['wc-pp']
 additional_fqdns: []
@@ -15,18 +15,18 @@ mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: "2"
 hooks:
-  pre-start:
-    - exec-host: "mkdir -p .ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}"
+    pre-start:
+        - exec-host: "mkdir -p .ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}"
 web_environment:
-  - WP_VERSION=6.6.2
-  - WP_LOCALE=en_US
-  - WP_TITLE=WooCommerce PayPal Payments
-  - WP_MULTISITE=true
-  - WP_MULTISITE_SLUGS=de,es
-  - ADMIN_USER=admin
-  - ADMIN_PASS=admin
-  - ADMIN_EMAIL=admin@example.com
-  - WC_VERSION=9.3.1
+    - WP_VERSION=6.3.3
+    - WP_LOCALE=en_US
+    - WP_TITLE=WooCommerce PayPal Payments
+    - WP_MULTISITE=true
+    - WP_MULTISITE_SLUGS=de,es
+    - ADMIN_USER=admin
+    - ADMIN_PASS=admin
+    - ADMIN_EMAIL=admin@example.com
+    - WC_VERSION=7.7.2
 
 # Key features of ddev's config.yaml:
 

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -15,18 +15,18 @@ mutagen_enabled: false
 use_dns_when_possible: true
 composer_version: "2"
 hooks:
-    pre-start:
-        - exec-host: "mkdir -p .ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}"
+  pre-start:
+    - exec-host: "mkdir -p .ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}"
 web_environment:
-    - WP_VERSION=6.3.3
-    - WP_LOCALE=en_US
-    - WP_TITLE=WooCommerce PayPal Payments
-    - WP_MULTISITE=true
-    - WP_MULTISITE_SLUGS=de,es
-    - ADMIN_USER=admin
-    - ADMIN_PASS=admin
-    - ADMIN_EMAIL=admin@example.com
-    - WC_VERSION=7.7.2
+  - WP_VERSION=6.3.3
+  - WP_LOCALE=en_US
+  - WP_TITLE=WooCommerce PayPal Payments
+  - WP_MULTISITE=true
+  - WP_MULTISITE_SLUGS=de,es
+  - ADMIN_USER=admin
+  - ADMIN_PASS=admin
+  - ADMIN_EMAIL=admin@example.com
+  - WC_VERSION=7.7.2
 
 # Key features of ddev's config.yaml:
 

--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -204,6 +204,19 @@ $fast-transition-duration: 0.5s;
 			}
 		}
 	}
+
+	// 4.8 Counter fix
+	.wc-block-checkout__form {
+		counter-reset: visible-step;
+
+		.wc-block-components-checkout-step--with-step-number {
+			counter-increment: visible-step;
+
+			.wc-block-components-checkout-step__title:before {
+				content: counter(visible-step) ". ";
+			}
+		}
+	}
 }
 
 // 5. Shipping/Card Change Link


### PR DESCRIPTION
### Description

_This is an alternative solution to https://github.com/woocommerce/woocommerce-paypal-payments/pull/2613_

The checkout form steps were not being numbered correctly when Fastlane was loaded (as some sections are getting hidden). This led to steps being incorrectly numbered.

### Solution
CSS-only solution using counters to dynamically number the visible checkout steps.

1. Reset the counter at the form level.
2. Increment the counter for each step with the class wc-block-components-checkout-step--with-step-number.
3. Apply the incremented number to the step title.

### Screenshots

| Before | After |
|---|---|
| ![2024-09-17_17-47-52](https://github.com/user-attachments/assets/bdb66fcc-e535-47b0-b286-e4407292e838) | ![2024-09-17_17-47-32](https://github.com/user-attachments/assets/d891e0ba-a588-4251-8baa-22c250baa992) |