### PR TITLE
Button Unlinking PayPal Subscriptions plan does not showing for simple subscription (3688)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -66,9 +66,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			function( $product_id ) use ( $c ) {
 				$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscriptions_helper instanceof SubscriptionHelper );
-
-				$connect_subscription = wc_clean( wp_unslash( $_POST['_ppcp_enable_subscription_product'] ?? '' ) );
-				if ( ! $subscriptions_helper->plugin_is_active() || $connect_subscription !== 'yes' ) {
+				if ( ! $subscriptions_helper->plugin_is_active() ) {
 					return;
 				}
 


### PR DESCRIPTION
[0bb7165](https://github.com/woocommerce/woocommerce-paypal-payments/commit/0bb7165273563f3052ca4872536b8d0fc6b1d4b6) introduced an early return when "Connect to PayPal" not sent in the post request making `_ppcp_enable_subscription_product` meta never been updated and therefore Unlink button not shown. 

This PR reverts that change updating the meta value when checkbox is unchecked.

### Steps To Reproduce
- Set Subscription mode to PayPal Subscription
- Create a Simple Subscription product, connect it to plan and Publish
- On same page uncheck checkbox Connect to PayPal and click on button Update
    - Observe button Unlink PayPal Subscription Plan is not showing