### PR TITLE
Fastlane: Remove Gateway Title, and move Cardholder Name to Advanced Card Processing (3680)

### DIFF
--- a/modules/ppcp-axo-block/services.php
+++ b/modules/ppcp-axo-block/services.php
@@ -35,6 +35,7 @@ return array(
 			$container->get( 'axo.gateway' ),
 			fn() : SmartButtonInterface => $container->get( 'button.smart-button' ),
 			$container->get( 'wcgateway.settings' ),
+			$container->get( 'wcgateway.configuration.dcc' ),
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'wcgateway.url' )
 		);

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -88,7 +88,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	 * @param SmartButtonInterface|callable $smart_button         The smart button script loading
 	 *                                                            handler.
 	 * @param Settings                      $settings             The settings.
-	 * @param DCCGatewayConfiguration	    $dcc_configuration    The DCC gateway settings.
+	 * @param DCCGatewayConfiguration       $dcc_configuration    The DCC gateway settings.
 	 * @param Environment                   $environment          The environment object.
 	 * @param string                        $wcgateway_module_url The WcGateway module URL.
 	 */
@@ -98,7 +98,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 		WC_Payment_Gateway $gateway,
 		$smart_button,
 		Settings $settings,
-		DCCGatewayConfiguration	$dcc_configuration,
+		DCCGatewayConfiguration $dcc_configuration,
 		Environment $environment,
 		string $wcgateway_module_url
 	) {

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCGatewayConfiguration;
 
 /**
  * Class AxoBlockPaymentMethod
@@ -58,6 +59,13 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	protected $settings;
 
 	/**
+	 * The DCC gateway settings.
+	 *
+	 * @var DCCGatewayConfiguration
+	 */
+	protected DCCGatewayConfiguration $dcc_configuration;
+
+	/**
 	 * The environment object.
 	 *
 	 * @var Environment
@@ -80,6 +88,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	 * @param SmartButtonInterface|callable $smart_button         The smart button script loading
 	 *                                                            handler.
 	 * @param Settings                      $settings             The settings.
+	 * @param DCCGatewayConfiguration	    $dcc_configuration    The DCC gateway settings.
 	 * @param Environment                   $environment          The environment object.
 	 * @param string                        $wcgateway_module_url The WcGateway module URL.
 	 */
@@ -89,6 +98,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 		WC_Payment_Gateway $gateway,
 		$smart_button,
 		Settings $settings,
+		DCCGatewayConfiguration	$dcc_configuration,
 		Environment $environment,
 		string $wcgateway_module_url
 	) {
@@ -98,6 +108,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 		$this->gateway              = $gateway;
 		$this->smart_button         = $smart_button;
 		$this->settings             = $settings;
+		$this->dcc_configuration    = $dcc_configuration;
 		$this->environment          = $environment;
 		$this->wcgateway_module_url = $wcgateway_module_url;
 
@@ -215,7 +226,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 					'focusBorderColor' => $this->settings->has( 'axo_style_input_focus_border_color' ) ? $this->settings->get( 'axo_style_input_focus_border_color' ) : '',
 				),
 			),
-			'name_on_card'              => $this->settings->has( 'axo_name_on_card' ) ? $this->settings->get( 'axo_name_on_card' ) : '',
+			'name_on_card'              => $this->dcc_configuration->show_name_on_card(),
 			'woocommerce'               => array(
 				'states' => array(
 					'US' => WC()->countries->get_states( 'US' ),

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -82,7 +82,6 @@ return array(
 								$display_manager
 									->rule()
 									->condition_element( 'axo_enabled', '1' )
-									->action_visible( 'axo_gateway_title' )
 									->action_visible( 'axo_main_notice' )
 									->action_visible( 'axo_privacy' )
 									->action_visible( 'axo_name_on_card' )
@@ -131,25 +130,6 @@ return array(
 						State::STATE_ONBOARDED,
 					),
 					'requirements' => array( 'dcc', 'axo' ),
-					'gateway'      => array( 'dcc', 'axo' ),
-				),
-				'axo_gateway_title'                  => array(
-					'title'        => __( 'Gateway Title', 'woocommerce-paypal-payments' ),
-					'type'         => 'text',
-					'classes'      => array( 'ppcp-field-indent' ),
-					'desc_tip'     => true,
-					'description'  => __(
-						'This controls the title of the Fastlane gateway the user sees on checkout.',
-						'woocommerce-paypal-payments'
-					),
-					'default'      => __(
-						'Debit & Credit Cards',
-						'woocommerce-paypal-payments'
-					),
-					'screens'      => array(
-						State::STATE_ONBOARDED,
-					),
-					'requirements' => array( 'axo' ),
 					'gateway'      => array( 'dcc', 'axo' ),
 				),
 				'axo_privacy'                        => array(

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -84,7 +84,6 @@ return array(
 									->condition_element( 'axo_enabled', '1' )
 									->action_visible( 'axo_main_notice' )
 									->action_visible( 'axo_privacy' )
-									->action_visible( 'axo_name_on_card' )
 									->action_visible( 'axo_style_heading' )
 									->action_class( 'axo_enabled', 'active' )
 									->to_array(),
@@ -144,19 +143,6 @@ return array(
 					'input_class'  => array( 'wc-enhanced-select' ),
 					'default'      => 'yes',
 					'options'      => PropertiesDictionary::privacy_options(),
-					'screens'      => array( State::STATE_ONBOARDED ),
-					'gateway'      => array( 'dcc', 'axo' ),
-					'requirements' => array( 'axo' ),
-				),
-				'axo_name_on_card'                   => array(
-					'title'        => __( 'Cardholder Name', 'woocommerce-paypal-payments' ),
-					'type'         => 'select',
-					'default'      => 'yes',
-					'options'      => PropertiesDictionary::cardholder_name_options(),
-					'classes'      => array( 'ppcp-field-indent' ),
-					'class'        => array(),
-					'input_class'  => array( 'wc-enhanced-select' ),
-					'description'  => __( 'This setting will control whether or not the cardholder name is displayed in the card field\'s UI.', 'woocommerce-paypal-payments' ),
 					'screens'      => array( State::STATE_ONBOARDED ),
 					'gateway'      => array( 'dcc', 'axo' ),
 					'requirements' => array( 'axo' ),

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -74,6 +74,7 @@ return array(
 		return new AxoGateway(
 			$container->get( 'wcgateway.settings.render' ),
 			$container->get( 'wcgateway.settings' ),
+			$container->get( 'wcgateway.configuration.dcc' ),
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'session.handler' ),
 			$container->get( 'wcgateway.order-processor' ),

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -29,6 +29,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\ProcessPaymentTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\GatewayGenericException;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCGatewayConfiguration;
 
 /**
  * Class AXOGateway.
@@ -51,6 +52,13 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @var ContainerInterface
 	 */
 	protected $ppcp_settings;
+
+	/**
+	 * Gateway configuration object, providing relevant settings.
+	 *
+	 * @var DCCGatewayConfiguration
+	 */
+	protected DCCGatewayConfiguration $dcc_configuration;
 
 	/**
 	 * The WcGateway module URL.
@@ -127,6 +135,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 *
 	 * @param SettingsRenderer          $settings_renderer The settings renderer.
 	 * @param ContainerInterface        $ppcp_settings The settings.
+	 * @param DCCGatewayConfiguration   $dcc_configuration The DCC Gateway configuration.
 	 * @param string                    $wcgateway_module_url The WcGateway module URL.
 	 * @param SessionHandler            $session_handler The Session Handler.
 	 * @param OrderProcessor            $order_processor The Order processor.
@@ -141,6 +150,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	public function __construct(
 		SettingsRenderer $settings_renderer,
 		ContainerInterface $ppcp_settings,
+		DCCGatewayConfiguration $dcc_configuration,
 		string $wcgateway_module_url,
 		SessionHandler $session_handler,
 		OrderProcessor $order_processor,
@@ -156,6 +166,7 @@ class AxoGateway extends WC_Payment_Gateway {
 
 		$this->settings_renderer    = $settings_renderer;
 		$this->ppcp_settings        = $ppcp_settings;
+		$this->dcc_configuration    = $dcc_configuration;
 		$this->wcgateway_module_url = $wcgateway_module_url;
 		$this->session_handler      = $session_handler;
 		$this->order_processor      = $order_processor;
@@ -167,9 +178,7 @@ class AxoGateway extends WC_Payment_Gateway {
 		$is_axo_enabled = $this->ppcp_settings->has( 'axo_enabled' ) && $this->ppcp_settings->get( 'axo_enabled' );
 		$this->update_option( 'enabled', $is_axo_enabled ? 'yes' : 'no' );
 
-		$this->title = $this->ppcp_settings->has( 'axo_gateway_title' )
-			? $this->ppcp_settings->get( 'axo_gateway_title' )
-			: $this->get_option( 'title', $this->method_title );
+		$this->title = $this->dcc_configuration->gateway_title( $this->get_option( 'title', $this->method_title ) );
 
 		$this->description = __( 'Enter your email address above to continue.', 'woocommerce-paypal-payments' );
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1278,6 +1278,13 @@ return array(
 		return new TransactionUrlProvider( $sandbox_url_base, $live_url_base );
 	},
 
+	'wcgateway.configuration.dcc'                          => static function ( ContainerInterface $container ) : DCCGatewayConfiguration {
+		$settings = $container->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+
+		return new DCCGatewayConfiguration( $settings );
+	},
+
 	'wcgateway.helper.dcc-product-status'                  => static function ( ContainerInterface $container ) : DCCProductStatus {
 
 		$settings         = $container->get( 'wcgateway.settings' );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -624,8 +624,8 @@ return array(
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 		assert( $subscription_helper instanceof SubscriptionHelper );
 
-		$config = $container->get( 'wcgateway.helper.dcc-configuration' );
-		assert( $config instanceof DCCGatewayConfiguration );
+		$dcc_configuration = $container->get( 'wcgateway.configuration.dcc' );
+		assert( $dcc_configuration instanceof DCCGatewayConfiguration );
 
 		$fields              = array(
 			'checkout_settings_heading'   => array(
@@ -985,7 +985,7 @@ return array(
 			'dcc_name_on_card'            => array(
 				'title'        => __( 'Cardholder Name', 'woocommerce-paypal-payments' ),
 				'type'         => 'select',
-				'default'      => $config->get_default_cardholder_name(),
+				'default'      => $dcc_configuration->show_name_on_card(),
 				'options'      => PropertiesDictionary::cardholder_name_options(),
 				'classes'      => array(),
 				'class'        => array(),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -78,6 +78,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\SectionsRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsListener;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
+use WooCommerce\PayPalCommerce\Axo\Helper\PropertiesDictionary;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCGatewayConfiguration;
 
@@ -623,6 +624,9 @@ return array(
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 		assert( $subscription_helper instanceof SubscriptionHelper );
 
+		$config = $container->get( 'wcgateway.helper.dcc-configuration' );
+		assert( $config instanceof DCCGatewayConfiguration );
+
 		$fields              = array(
 			'checkout_settings_heading'   => array(
 				'heading'      => __( 'Standard Payments Settings', 'woocommerce-paypal-payments' ),
@@ -977,6 +981,20 @@ return array(
 					'dcc',
 				),
 				'gateway'      => 'dcc',
+			),
+			'dcc_name_on_card'            => array(
+				'title'        => __( 'Cardholder Name', 'woocommerce-paypal-payments' ),
+				'type'         => 'select',
+				'default'      => $config->get_default_cardholder_name(),
+				'options'      => PropertiesDictionary::cardholder_name_options(),
+				'classes'      => array(),
+				'class'        => array(),
+				'input_class'  => array( 'wc-enhanced-select' ),
+				'desc_tip'     => true,
+				'description'  => __( 'This setting will control whether or not the cardholder name is displayed in the card field\'s UI.', 'woocommerce-paypal-payments' ),
+				'screens'      => array( State::STATE_ONBOARDED ),
+				'gateway'      => array( 'dcc', 'axo' ),
+				'requirements' => array( 'axo' ),
 			),
 			'3d_secure_heading'           => array(
 				'heading'      => __( '3D Secure', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -79,6 +79,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsListener;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCGatewayConfiguration;
 
 return array(
 	'wcgateway.paypal-gateway'                             => static function ( ContainerInterface $container ): PayPalGateway {
@@ -123,6 +124,7 @@ return array(
 		$order_processor     = $container->get( 'wcgateway.order-processor' );
 		$settings_renderer   = $container->get( 'wcgateway.settings.render' );
 		$settings            = $container->get( 'wcgateway.settings' );
+		$dcc_configuration   = $container->get( 'wcgateway.configuration.dcc' );
 		$module_url          = $container->get( 'wcgateway.url' );
 		$session_handler     = $container->get( 'session.handler' );
 		$refund_processor    = $container->get( 'wcgateway.processor.refunds' );
@@ -138,6 +140,7 @@ return array(
 			$settings_renderer,
 			$order_processor,
 			$settings,
+			$dcc_configuration,
 			$icons,
 			$module_url,
 			$session_handler,

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -35,6 +35,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
 use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCGatewayConfiguration;
 
 /**
  * Class CreditCardGateway
@@ -72,6 +73,13 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 * @var ContainerInterface
 	 */
 	protected $config;
+
+	/**
+	 * The DCC Gateway Configuration.
+	 *
+	 * @var DCCGatewayConfiguration
+	 */
+	protected DCCGatewayConfiguration $dcc_configuration;
 
 	/**
 	 * The vaulted credit card handler.
@@ -191,6 +199,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 * @param SettingsRenderer         $settings_renderer The Settings Renderer.
 	 * @param OrderProcessor           $order_processor The Order processor.
 	 * @param ContainerInterface       $config The settings.
+	 * @param DCCGatewayConfiguration  $dcc_configuration The DCC Gateway Configuration.
 	 * @param array                    $card_icons The card icons.
 	 * @param string                   $module_url The URL to the module.
 	 * @param SessionHandler           $session_handler The Session Handler.
@@ -212,6 +221,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		SettingsRenderer $settings_renderer,
 		OrderProcessor $order_processor,
 		ContainerInterface $config,
+		DCCGatewayConfiguration $dcc_configuration,
 		array $card_icons,
 		string $module_url,
 		SessionHandler $session_handler,
@@ -233,6 +243,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$this->settings_renderer           = $settings_renderer;
 		$this->order_processor             = $order_processor;
 		$this->config                      = $config;
+		$this->dcc_configuration           = $dcc_configuration;
 		$this->module_url                  = $module_url;
 		$this->session_handler             = $session_handler;
 		$this->refund_processor            = $refund_processor;
@@ -269,8 +280,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			'Accept debit and credit cards, and local payment methods with PayPal’s latest solution.',
 			'woocommerce-paypal-payments'
 		);
-		$this->title              = $this->config->has( 'dcc_gateway_title' ) ?
-			$this->config->get( 'dcc_gateway_title' ) : $this->method_title;
+		$this->title              = $this->dcc_configuration->gateway_title();
 		$this->description        = $this->config->has( 'dcc_gateway_description' ) ?
 			$this->config->get( 'dcc_gateway_description' ) : $this->method_description;
 		$this->card_icons         = $card_icons;

--- a/modules/ppcp-wc-gateway/src/Helper/DCCGatewayConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCGatewayConfiguration.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Encapsulates all configuration details for "Credit & Debit Card" gateway.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Helper
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Axo\Helper\PropertiesDictionary;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+
+/**
+ * A simple DTO that provides convenient access to the DCC/AXO gateway settings.
+ *
+ * This class should not implement business logic, but only provide a convenient
+ * way to access gateway settings by wrapping the Settings instance.
+ */
+class DCCGatewayConfiguration {
+	private string $gateway_title;
+	private string $show_name_on_card;
+
+	/**
+	 * Initializes the gateway details based on the provided Settings instance.
+	 *
+	 * @throws NotFoundException If an expected gateway setting is not found.
+	 *
+	 * @param Settings $settings Plugin settings instance.
+	 */
+	public function __construct( Settings $settings ) {
+		$this->gateway_title = $settings->has( 'dcc_gateway_title' ) ?
+			$settings->get( 'dcc_gateway_title' ) : '';
+
+		$show_on_card = '';
+		if ( $settings->has( 'dcc_name_on_card' ) ) {
+			$show_on_card = $settings->get( 'dcc_name_on_card' );
+		} elseif ( $settings->has( 'axo_name_on_card' ) ) {
+			// Legacy. The AXO gateway setting was replaced by the DCC setting.
+			$show_on_card = $settings->get( 'axo_name_on_card' );
+		}
+		$valid_options = array_keys( PropertiesDictionary::cardholder_name_options() );
+
+		$this->show_name_on_card = in_array( $show_on_card, $valid_options, true )
+			? $show_on_card
+			: $valid_options[0];
+	}
+
+	/**
+	 * User facing title of the gateway.
+	 *
+	 * @return string Display title of the gateway.
+	 */
+	public function gateway_title() : string {
+		return $this->gateway_title ?: __( 'Advanced Card Processing', 'woocommerce-paypal-payments' );
+	}
+
+	/**
+	 * Whether to show a field for the cardholder's name in the payment form.
+	 *
+	 * @return string [yes|no]
+	 */
+	public function show_name_on_card() : string {
+		return $this->show_name_on_card;
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Helper/DCCGatewayConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCGatewayConfiguration.php
@@ -20,7 +20,18 @@ use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
  * way to access gateway settings by wrapping the Settings instance.
  */
 class DCCGatewayConfiguration {
+	/**
+	 * Gateway title.
+	 *
+	 * @var string
+	 */
 	private string $gateway_title;
+
+	/**
+	 * Whether to display the cardholder's name on the payment form.
+	 *
+	 * @var string
+	 */
 	private string $show_name_on_card;
 
 	/**

--- a/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
@@ -20,6 +20,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CaptureCardPayment;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCGatewayConfiguration;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use function Brain\Monkey\Functions\when;
 
@@ -28,6 +29,7 @@ class CreditCardGatewayTest extends TestCase
 	private $settingsRenderer;
 	private $orderProcessor;
 	private $config;
+	private $dcc_configuration;
 	private $creditCardIcons;
 	private $moduleUrl;
 	private $sessionHandler;
@@ -53,6 +55,7 @@ class CreditCardGatewayTest extends TestCase
 		$this->settingsRenderer = Mockery::mock(SettingsRenderer::class);
 		$this->orderProcessor = Mockery::mock(OrderProcessor::class);
 		$this->config = Mockery::mock(ContainerInterface::class);
+		$this->dcc_configuration = Mockery::mock(DCCGatewayConfiguration::class);
 		$this->creditCardIcons = [];
 		$this->moduleUrl = '';
 		$this->sessionHandler = Mockery::mock(SessionHandler::class);
@@ -73,6 +76,7 @@ class CreditCardGatewayTest extends TestCase
 		$this->state->shouldReceive('current_state')->andReturn(State::STATE_ONBOARDED);
 		$this->config->shouldReceive('has')->andReturn(true);
 		$this->config->shouldReceive('get')->andReturn('');
+		$this->dcc_configuration->shouldReceive('gateway_title')->andReturn('');
 
 		when('wc_clean')->returnArg();
 
@@ -80,6 +84,7 @@ class CreditCardGatewayTest extends TestCase
 			$this->settingsRenderer,
 			$this->orderProcessor,
 			$this->config,
+			$this->dcc_configuration,
 			$this->creditCardIcons,
 			$this->moduleUrl,
 			$this->sessionHandler,


### PR DESCRIPTION
### Description

This PR resolves some setting duplicates and starts the merging process of the Fastlane and Credit Card gateways.

AXO and DCC are separate gateways in the codebase but should be integrated as a single gateway. Eventually, the AXO gateway will be merged into the DCC code.

### Specific changes

1. Added a [new configuration class](https://github.com/woocommerce/woocommerce-paypal-payments/commit/8712e37587d6de21d21246f097a0bc2b74533cff) that is reused by AXO and DCC to utilize the same settings.
2. Removed the deprecated AXO gateway title setting field.
3. Moved the Cardholder Name setting from AXO to DCC settings.

### Reasons for the new configuration class

- Simplifies the incremental merging of both gateways.
- Reduces code duplication across the codebase.
- Enhances alignment and consistency between the gateways while they remain separate.
- Type safe setting values
- Central config-object helps to keep the gateway transparent
- Helps to decouple code from the settings-instance

### Next steps

If approved, the next steps to implement this would be:

1. Create an Interface for the DCC configuration
2. Move all other relevant settings into the class, like `->dcc_enabled()` or `->axo_styles_root()`
3. Maybe introduce similar configuration classes for the other gateways

### Screenshots

| Before | After |
|---|---|
| ![2024-09-18_15-55-38](https://github.com/user-attachments/assets/753af384-ccac-48d2-a450-86fead4e2240) | ![2024-09-18_15-50-29](https://github.com/user-attachments/assets/ae5f4ab2-c888-440c-97b8-37566357065b) |