### PR TITLE
Remove ACDC from the block checkout if Axo is present (3692)

### DIFF
--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -70,7 +70,7 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				$payment_method_registry->register( $c->get( 'blocks.method' ) );
 
 				// Include ACDC in the Block Checkout only in case Axo doesn't exist or is not available.
-				if ( !$c->has('axoblock.available' ) || !$c->get( 'axoblock.available' ) ) {
+				if ( ! $c->has( 'axoblock.available' ) || ! $c->get( 'axoblock.available' ) ) {
 					$payment_method_registry->register( $c->get( 'blocks.advanced-card-method' ) );
 				}
 			}

--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -68,7 +68,11 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			'woocommerce_blocks_payment_method_type_registration',
 			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				$payment_method_registry->register( $c->get( 'blocks.method' ) );
-				$payment_method_registry->register( $c->get( 'blocks.advanced-card-method' ) );
+
+				// Include ACDC in the Block Checkout only in case Axo doesn't exist or is not available.
+				if ( !$c->has('axoblock.available' ) || !$c->get( 'axoblock.available' ) ) {
+					$payment_method_registry->register( $c->get( 'blocks.advanced-card-method' ) );
+				}
 			}
 		);
 


### PR DESCRIPTION
### Description

This PR hides ACDC in the Block Checkout if Axo exists and is available.

### Screenshots

|Before|After|
|-|-|
|![Block_Checkout_–_WooCommerce_PayPal_Payments](https://github.com/user-attachments/assets/4cafe9a7-0116-4d31-a378-a5c9dd737bc1)|![Block_Checkout_–_WooCommerce_PayPal_Payments](https://github.com/user-attachments/assets/79e17c12-143c-4782-9565-0e4bf1b9736d)|
