### PR TITLE
Axo Blocks: Check whether the Card Element container exists before trying to render it

### DIFF
--- a/modules/ppcp-axo-block/resources/js/components/Payment/Payment.js
+++ b/modules/ppcp-axo-block/resources/js/components/Payment/Payment.js
@@ -1,9 +1,11 @@
-import { useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useCallback, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { Card } from '../Card';
 import { STORE_NAME } from '../../stores/axoStore';
 
 export const Payment = ( { fastlaneSdk, card, onPaymentLoad } ) => {
+	const [ isCardElementReady, setIsCardElementReady ] = useState( false );
+
 	const isGuest = useSelect( ( select ) =>
 		select( STORE_NAME ).getIsGuest()
 	);
@@ -13,14 +15,26 @@ export const Payment = ( { fastlaneSdk, card, onPaymentLoad } ) => {
 	);
 
 	const loadPaymentComponent = useCallback( async () => {
-		if ( isGuest && isEmailLookupCompleted ) {
+		if ( isGuest && isEmailLookupCompleted && isCardElementReady ) {
 			const paymentComponent = await fastlaneSdk.FastlaneCardComponent(
 				{}
 			);
 			paymentComponent.render( `#fastlane-card` );
 			onPaymentLoad( paymentComponent );
 		}
-	}, [ isGuest, isEmailLookupCompleted, fastlaneSdk, onPaymentLoad ] );
+	}, [
+		isGuest,
+		isEmailLookupCompleted,
+		isCardElementReady,
+		fastlaneSdk,
+		onPaymentLoad,
+	] );
+
+	useEffect( () => {
+		if ( isGuest && isEmailLookupCompleted ) {
+			setIsCardElementReady( true );
+		}
+	}, [ isGuest, isEmailLookupCompleted ] );
 
 	useEffect( () => {
 		loadPaymentComponent();


### PR DESCRIPTION
### Description

Currently when performing a successful lookup there is the following error in the console: `could not find container to render FastlaneCardComponent `

### Solution

This PR adds state that helps to check whether the container exists before attempting to render the component into it.

### Screenshots

|Before|After|
|-|-|
|![Block_Checkout_–_WooCommerce_PayPal_Payments-2](https://github.com/user-attachments/assets/9c69c6e9-5d82-456b-8b10-31cad2738663)|![Block_Checkout_–_WooCommerce_PayPal_Payments_after](https://github.com/user-attachments/assets/8d2e865f-6d53-4ee8-86f3-5e20809703ca)|




