### PR TITLE
Improve context detection

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -167,7 +167,7 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				// Check if the module is applicable, correct country, currency, ... etc.
 				if ( ! $is_paypal_enabled
 					|| ! $c->get( 'axo.eligible' )
-					|| 'continuation' === $c->get( 'button.context' )
+					|| $this->is_paypal_continuation()
 					|| $subscription_helper->cart_contains_subscription()
 				) {
 					return;

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
+use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -30,10 +31,19 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsListener;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 /**
  * Class AxoModule
+ *
+ * @psalm-suppress MissingConstructor
  */
 class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 	use ModuleClassNameIdTrait;
 	use ContextTrait;
+
+	/**
+	 * The session handler for ContextTrait.
+	 *
+	 * @var SessionHandler|null
+	 */
+	protected ?SessionHandler $session_handler;
 
 	/**
 	 * {@inheritDoc}
@@ -155,6 +165,8 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			'wp_loaded',
 			function () use ( $c ) {
 				$module = $this;
+
+				$this->session_handler = $c->get( 'session.handler' );
 
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -173,10 +173,6 @@ trait ContextTrait {
 			case $this->is_block_editor():
 				$context = 'block-editor';
 				break;
-
-			case $this->is_paypal_continuation():
-				$context = 'continuation';
-				break;
 		}
 
 		return apply_filters( 'woocommerce_paypal_payments_context', $context );

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -53,18 +53,26 @@ trait ContextTrait {
 			return true;
 		}
 
-		/**
-		 * The filter returning whether to detect WC checkout ajax requests.
-		 */
-		if ( apply_filters( 'ppcp_check_ajax_checkout', true ) ) {
-			// phpcs:ignore WordPress.Security
-			$wc_ajax = $_GET['wc-ajax'] ?? '';
-			if ( in_array( $wc_ajax, array( 'update_order_review' ), true ) ) {
-				return true;
-			}
+		if ( $this->is_checkout_ajax() ) {
+			return true;
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks if performing the WC checkout ajax requests.
+	 */
+	private function is_checkout_ajax(): bool {
+		/**
+		 * The filter returning whether to detect WC checkout ajax requests.
+		 */
+		if ( ! apply_filters( 'ppcp_check_ajax_checkout', true ) ) {
+			return false;
+		}
+
+		$wc_ajax = $this->wc_ajax_endpoint_name();
+		return in_array( $wc_ajax, array( 'update_order_review' ), true );
 	}
 
 	/**
@@ -75,18 +83,38 @@ trait ContextTrait {
 			return true;
 		}
 
-		/**
-		 * The filter returning whether to detect WC cart ajax requests.
-		 */
-		if ( apply_filters( 'ppcp_check_ajax_cart', true ) ) {
-			// phpcs:ignore WordPress.Security
-			$wc_ajax = $_GET['wc-ajax'] ?? '';
-			if ( in_array( $wc_ajax, array( 'update_shipping_method' ), true ) ) {
-				return true;
-			}
+		if ( $this->is_cart_ajax() ) {
+			return true;
 		}
 
 		return false;
+	}
+
+	/**
+	 * Checks if performing the WC cart ajax requests.
+	 */
+	private function is_cart_ajax(): bool {
+		/**
+		 * The filter returning whether to detect WC checkout ajax requests.
+		 */
+		if ( ! apply_filters( 'ppcp_check_ajax_cart', true ) ) {
+			return false;
+		}
+
+		$wc_ajax = $this->wc_ajax_endpoint_name();
+		return in_array( $wc_ajax, array( 'update_shipping_method' ), true );
+	}
+
+	/**
+	 * Returns the current WC ajax endpoint name or an empty string if not in ajax.
+	 */
+	private function wc_ajax_endpoint_name(): string {
+		// phpcs:ignore WordPress.Security
+		$wc_ajax = $_GET['wc-ajax'] ?? '';
+		if ( ! is_string( $wc_ajax ) ) {
+			return '';
+		}
+		return $wc_ajax;
 	}
 
 	/**
@@ -99,6 +127,14 @@ trait ContextTrait {
 		$context = 'mini-cart';
 
 		switch ( true ) {
+			case $this->is_cart_ajax():
+				$context = 'cart';
+				break;
+
+			case $this->is_checkout_ajax() && ! $this->is_paypal_continuation():
+				$context = 'checkout';
+				break;
+
 			case is_product() || wc_post_content_has_shortcode( 'product_page' ):
 				// Do this check here instead of reordering outside conditions.
 				// In order to have more control over the context.

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -207,6 +207,16 @@ trait ContextTrait {
 	 */
 	private function is_paypal_continuation(): bool {
 		/**
+		 * Cannot guarantee that initialized in all places where this trait is used,
+		 * the Psalm checks seem to work weird and sometimes ignore missing property.
+		 *
+		 * @psalm-suppress RedundantPropertyInitializationCheck
+		 */
+		if ( ! isset( $this->session_handler ) ) {
+			return false;
+		}
+
+		/**
 		 * Property is already defined in trait consumers.
 		 *
 		 * @psalm-suppress UndefinedThisPropertyFetch

--- a/modules/ppcp-googlepay/resources/js/boot.js
+++ b/modules/ppcp-googlepay/resources/js/boot.js
@@ -31,8 +31,10 @@ import moduleStorage from './Helper/GooglePayStorage';
 	}
 
 	function bootstrapCheckout() {
-		if ( context && ! [ 'continuation', 'checkout' ].includes( context ) ) {
-			// Context must be missing/empty, or "continuation"/"checkout" to proceed.
+		if ( context
+            && ! [ 'checkout' ].includes( context )
+            && ! (context === 'mini-cart' && ppcpConfig.continuation) ) {
+			// Context must be missing/empty, or "checkout"/checkout continuation to proceed.
 			return;
 		}
 		if ( ! CheckoutBootstrap.isPageWithCheckoutForm() ) {


### PR DESCRIPTION
Added the detection of the `update_order_review`/`update_shipping_method` ajax requests to fix the possibility of getting a wrong context during these requests, e.g. when the home page contains the cart.

Also removed `continuation` from the context. It was added in https://github.com/woocommerce/woocommerce-paypal-payments/pull/2398 and used in 2 places. I think it is not a good idea to increase complexity of the context, especially if we decide to refactor it in the future. And it was working a bit incorrectly, such as if you are in continuation mode and leave checkout the context still remains `continuation`, while before #2398 it would be `mini-cart` (it was a bit weird however that when you go to the checkout in continuation mode the context becomes `mini-cart` but replacing one weirdness with another one is not great).