### PR TITLE
Add backwards compatibility when address editing state toggling is not available (3725)

### DIFF
--- a/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.js
+++ b/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.js
@@ -85,14 +85,14 @@ export const populateWooFields = (
 
 	const checkoutDispatch = dispatch( CHECKOUT_STORE_KEY );
 
-	// Disable the 'Use same address for billing' checkbox if the method exists.
+	// Uncheck the 'Use same address for billing' checkbox if the method exists.
 	if (
 		typeof checkoutDispatch.__internalSetUseShippingAsBilling === 'function'
 	) {
 		checkoutDispatch.__internalSetUseShippingAsBilling( false );
 	}
 
-	// Save shipping address
+	// Save shipping address.
 	const { address, name, phoneNumber } = profileData.shippingAddress;
 
 	const shippingAddress = {
@@ -110,7 +110,7 @@ export const populateWooFields = (
 	console.log( 'Setting WooCommerce shipping address:', shippingAddress );
 	setWooShippingAddress( shippingAddress );
 
-	// Save billing address
+	// Save billing address.
 	const billingData = profileData.card.paymentSource.card.billingAddress;
 
 	const billingAddress = {

--- a/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.js
+++ b/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.js
@@ -83,8 +83,14 @@ export const populateWooFields = (
 		profileData
 	);
 
-	// Disable the 'Use same address for billing' checkbox
-	dispatch( CHECKOUT_STORE_KEY ).__internalSetUseShippingAsBilling( false );
+	const checkoutDispatch = dispatch( CHECKOUT_STORE_KEY );
+
+	// Disable the 'Use same address for billing' checkbox if the method exists.
+	if (
+		typeof checkoutDispatch.__internalSetUseShippingAsBilling === 'function'
+	) {
+		checkoutDispatch.__internalSetUseShippingAsBilling( false );
+	}
 
 	// Save shipping address
 	const { address, name, phoneNumber } = profileData.shippingAddress;
@@ -121,6 +127,13 @@ export const populateWooFields = (
 	console.log( 'Setting WooCommerce billing address:', billingAddress );
 	setWooBillingAddress( billingAddress );
 
-	dispatch( CHECKOUT_STORE_KEY ).setEditingShippingAddress( false );
-	dispatch( CHECKOUT_STORE_KEY ).setEditingBillingAddress( false );
+	// Collapse shipping address input fields into the card view.
+	if ( typeof checkoutDispatch.setEditingShippingAddress === 'function' ) {
+		checkoutDispatch.setEditingShippingAddress( false );
+	}
+
+	// Collapse billing address input fields into the card view.
+	if ( typeof checkoutDispatch.setEditingBillingAddress === 'function' ) {
+		checkoutDispatch.setEditingBillingAddress( false );
+	}
 };

--- a/modules/ppcp-axo-block/resources/js/hooks/useAddressEditing.js
+++ b/modules/ppcp-axo-block/resources/js/hooks/useAddressEditing.js
@@ -24,14 +24,18 @@ export const useAddressEditing = () => {
 
 	const setShippingAddressEditing = useCallback(
 		( isEditing ) => {
-			setEditingShippingAddress( isEditing );
+			if ( typeof setEditingShippingAddress === 'function' ) {
+				setEditingShippingAddress( isEditing );
+			}
 		},
 		[ setEditingShippingAddress ]
 	);
 
 	const setBillingAddressEditing = useCallback(
 		( isEditing ) => {
-			setEditingBillingAddress( isEditing );
+			if ( typeof setEditingBillingAddress === 'function' ) {
+				setEditingBillingAddress( isEditing );
+			}
 		},
 		[ setEditingBillingAddress ]
 	);


### PR DESCRIPTION
### Description

Add backwards compatibility when address editing state toggling is not available (In WooCommerce 9.3.0 and older).

### Screenshots

N/A

