### PR TITLE
Check if paylater-configurator service exists (module can be disabled)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1786,7 +1786,7 @@ return array(
 
 		$list_of_config = array();
 
-		if ( $container->get( 'paylater-configurator.is-available' ) ) {
+		if ( $container->has( 'paylater-configurator.is-available' ) && $container->get( 'paylater-configurator.is-available' ) ) {
 			$list_of_config[] = array(
 				'id'           => 'pay-later-messaging-task',
 				'title'        => __( 'Configure PayPal Pay Later messaging', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
#2586 added a service in the gateway module accessing the `paylater-configurator.is-available` service. The `paylater-configurator` module can be disabled via filter/env vars, and its services will be missing causing an error.

I added a `has` check to fix that, not sure if there are any better solutions.