### PR TITLE
Fix the "0.00" amount in Google Pay for virtual products (3696)

### DIFF
--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -5,7 +5,6 @@ import {
 import PaymentButton from '../../../ppcp-button/resources/js/modules/Renderer/PaymentButton';
 import widgetBuilder from '../../../ppcp-button/resources/js/modules/Renderer/WidgetBuilder';
 import UpdatePaymentData from './Helper/UpdatePaymentData';
-import TransactionInfo from './Helper/TransactionInfo';
 import { PaymentMethods } from '../../../ppcp-button/resources/js/modules/Helper/CheckoutMethodState';
 import { setPayerData } from '../../../ppcp-button/resources/js/modules/Helper/PayerData';
 import moduleStorage from './Helper/GooglePayStorage';
@@ -42,17 +41,11 @@ import moduleStorage from './Helper/GooglePayStorage';
  *
  * @see https://developers.google.com/pay/api/web/reference/client
  * @typedef {Object} PaymentsClient
- * @property {Function}            createButton         - The convenience method is used to
- *                                                      generate a Google Pay payment button styled with the latest Google Pay branding for
- *                                                      insertion into a webpage.
- * @property {Function}            isReadyToPay         - Use the isReadyToPay(isReadyToPayRequest)
- *                                                      method to determine a user's ability to return a form of payment from the Google Pay API.
- * @property {(Object) => Promise} loadPaymentData      - This method presents a Google Pay payment
- *                                                      sheet that allows selection of a payment method and optionally configured parameters
- * @property {Function}            onPaymentAuthorized  - This method is called when a payment is
- *                                                      authorized in the payment sheet.
- * @property {Function}            onPaymentDataChanged - This method handles payment data changes
- *                                                      in the payment sheet such as shipping address and shipping options.
+ * @property {Function}            createButton         - The convenience method is used to generate a Google Pay payment button styled with the latest Google Pay branding for insertion into a webpage.
+ * @property {Function}            isReadyToPay         - Use the isReadyToPay(isReadyToPayRequest) method to determine a user's ability to return a form of payment from the Google Pay API.
+ * @property {(Object) => Promise} loadPaymentData      - This method presents a Google Pay payment sheet that allows selection of a payment method and optionally configured parameters
+ * @property {Function}            onPaymentAuthorized  - This method is called when a payment is authorized in the payment sheet.
+ * @property {Function}            onPaymentDataChanged - This method handles payment data changes in the payment sheet such as shipping address and shipping options.
  */
 
 /**
@@ -62,18 +55,12 @@ import moduleStorage from './Helper/GooglePayStorage';
  * @typedef {Object} TransactionInfo
  * @property {string} currencyCode     - Required. The ISO 4217 alphabetic currency code.
  * @property {string} countryCode      - Optional. required for EEA countries,
- * @property {string} transactionId    - Optional. A unique ID that identifies a facilitation
- *                                     attempt. Highly encouraged for troubleshooting.
- * @property {string} totalPriceStatus - Required. [ESTIMATED|FINAL] The status of the total price
- *                                     used:
- * @property {string} totalPrice       - Required. Total monetary value of the transaction with an
- *                                     optional decimal precision of two decimal places.
- * @property {Array}  displayItems     - Optional. A list of cart items shown in the payment sheet
- *                                     (e.g. subtotals, sales taxes, shipping charges, discounts etc.).
- * @property {string} totalPriceLabel  - Optional. Custom label for the total price within the
- *                                     display items.
- * @property {string} checkoutOption   - Optional. Affects the submit button text displayed in the
- *                                     Google Pay payment sheet.
+ * @property {string} transactionId    - Optional. A unique ID that identifies a facilitation attempt. Highly encouraged for troubleshooting.
+ * @property {string} totalPriceStatus - Required. [ESTIMATED|FINAL] The status of the total price used.
+ * @property {string} totalPrice       - Required. Total monetary value of the transaction with an optional decimal precision of two decimal places.
+ * @property {Array}  displayItems     - Optional. A list of cart items shown in the payment sheet (e.g. subtotals, sales taxes, shipping charges, discounts etc.).
+ * @property {string} totalPriceLabel  - Optional. Custom label for the total price within the display items.
+ * @property {string} checkoutOption   - Optional. Affects the submit button text displayed in the Google Pay payment sheet.
  */
 
 function payerDataFromPaymentResponse( response ) {

--- a/modules/ppcp-googlepay/resources/js/Helper/TransactionInfo.js
+++ b/modules/ppcp-googlepay/resources/js/Helper/TransactionInfo.js
@@ -8,6 +8,8 @@ export default class TransactionInfo {
 		this.#country = country;
 		this.#currency = currency;
 
+		shippingFee = this.toAmount( shippingFee );
+		total = this.toAmount( total );
 		this.shippingFee = shippingFee;
 		this.amount = total - shippingFee;
 	}


### PR DESCRIPTION
### Description

This PR addresses two issues with Google Pay:

1. When shipping callback is disabled, the Google Pay sheet displayed the total amount of "0.00" instead of the actual product price.
2. In Block Cart, certain plugin constellations led to transmitting the incorrect payment method ID for Google Pay

### Details

#### Issue 1

- It was only a "cosmetic" problem that was confusing for the customer, while the store did charge the correct amount during order processing.
- The bug was caused by lack of shipping cost details, which resulted in shippingFee being set to `NaN`, which could not be used in an invalid total value that was rendered as "0.00"
- Fixed by casting shipping fees to a number: https://github.com/woocommerce/woocommerce-paypal-payments/commit/643a23c6e02f2a13a9b6dbd7a8181c36d0875ca2

#### Issue 2

- Might be a bug in WooCommerce, and will be escalated. The current PR includes a workaround to ensure our plugin always sends the correct payment method on the Block Cart page
- Note that the Google Pay payment from Block Cart currently only works when "Final confirmation on checkout" is enabled, as the express logic is not fully integrated in the Block system
- Fixed using an internal WooCommerce dispatcher: https://github.com/woocommerce/woocommerce-paypal-payments/commit/c852bc92b50b38850ea6d0484e26b9ef797bd515#diff-4031c86ec91715f38d15ad5de3c4cbed531cbc95e7b8e3326aaa9153faa376b8R82-R84