### PR TITLE
Axo Blocks: Localize strings

### DIFF
--- a/modules/ppcp-axo-block/resources/js/components/Card/CardChangeButton.js
+++ b/modules/ppcp-axo-block/resources/js/components/Card/CardChangeButton.js
@@ -1,4 +1,5 @@
 import { createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 const CardChangeButton = ( { onChangeButtonClick } ) =>
 	createElement(
@@ -12,7 +13,7 @@ const CardChangeButton = ( { onChangeButtonClick } ) =>
 				onChangeButtonClick();
 			},
 		},
-		'Choose a different card'
+		__( 'Choose a different card', 'woocommerce-paypal-payments' )
 	);
 
 export default CardChangeButton;

--- a/modules/ppcp-axo-block/resources/js/components/EmailButton/EmailButton.js
+++ b/modules/ppcp-axo-block/resources/js/components/EmailButton/EmailButton.js
@@ -1,5 +1,6 @@
 import { STORE_NAME } from '../../stores/axoStore';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 const EmailButton = ( { handleSubmit } ) => {
 	const { isGuest, isAxoActive, isEmailSubmitted } = useSelect(
@@ -29,7 +30,7 @@ const EmailButton = ( { handleSubmit } ) => {
 					visibility: isEmailSubmitted ? 'hidden' : 'visible',
 				} }
 			>
-				Continue
+				{ __( 'Continue', 'woocommerce-paypal-payments' ) }
 			</span>
 			{ isEmailSubmitted && (
 				<span

--- a/modules/ppcp-axo-block/resources/js/components/Payment/Payment.js
+++ b/modules/ppcp-axo-block/resources/js/components/Payment/Payment.js
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { Card } from '../Card';
 import { STORE_NAME } from '../../stores/axoStore';
 
@@ -32,7 +33,10 @@ export const Payment = ( { fastlaneSdk, card, onPaymentLoad } ) => {
 		}
 		return (
 			<div id="ppcp-axo-block-radio-content">
-				Enter your email address above to continue.
+				{ __(
+					'Enter your email address above to continue.',
+					'woocommerce-paypal-payments'
+				) }
 			</div>
 		);
 	}

--- a/modules/ppcp-axo-block/resources/js/components/Shipping/ShippingChangeButton.js
+++ b/modules/ppcp-axo-block/resources/js/components/Shipping/ShippingChangeButton.js
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+
 const ShippingChangeButton = ( { onChangeShippingAddressClick } ) => (
 	<a
 		className="wc-block-axo-change-link"
@@ -7,7 +9,10 @@ const ShippingChangeButton = ( { onChangeShippingAddressClick } ) => (
 			onChangeShippingAddressClick();
 		} }
 	>
-		Choose a different shipping address
+		{ __(
+			'Choose a different shipping address',
+			'woocommerce-paypal-payments'
+		) }
 	</a>
 );
 

--- a/modules/ppcp-axo-block/resources/js/index.js
+++ b/modules/ppcp-axo-block/resources/js/index.js
@@ -1,4 +1,5 @@
-import { useState } from '@wordpress/element';
+import { useState, createElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 
 // Hooks
@@ -76,7 +77,7 @@ const Axo = ( props ) => {
 			onChangeButtonClick={ onChangeCardButtonClick }
 		/>
 	) : (
-		<div>Loading Fastlane...</div>
+		<>{ __( 'Loading Fastlane…', 'woocommerce-paypal-payments' ) }</>
 	);
 };
 
@@ -89,7 +90,7 @@ registerPaymentMethod( {
 		/>
 	),
 	content: <Axo />,
-	edit: <h1>This is Axo Blocks in the editor</h1>,
+	edit: createElement( ppcpConfig.title ),
 	ariaLabel: ppcpConfig.title,
 	canMakePayment: () => true,
 	supports: {

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -243,7 +243,6 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 			),
 			'logging_enabled'           => $this->settings->has( 'logging_enabled' ) ? $this->settings->get( 'logging_enabled' ) : '',
 			'wp_debug'                  => defined( 'WP_DEBUG' ) && WP_DEBUG,
-			'billing_email_button_text' => __( 'Continue', 'woocommerce-paypal-payments' ),
 		);
 	}
 }


### PR DESCRIPTION
### Description

This PR adds string localization to the block checkout Fastlane related code.

### Solution

The strings are being localized on the frontend via `{ __ } from '@wordpress/i18n'`