### PR TITLE
Use the PayPal icons instead of WC ones (3687)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/resources/js/apm-block.js
+++ b/modules/ppcp-local-alternative-payment-methods/resources/js/apm-block.js
@@ -1,9 +1,16 @@
 export function APM( { config, components } ) {
 	const { PaymentMethodIcons } = components;
 
-	return (
-		<div>
-			<PaymentMethodIcons icons={ [ config.icon ] } align="right" />
-		</div>
-	);
+    return (
+        <div>
+            <div
+                className="wc-block-components-payment-method-icons wc-block-components-payment-method-icons--align-right">
+                <img
+                    className={`wc-block-components-payment-method-icon wc-block-components-payment-method-icon--${config.id}`}
+                    src={config.icon}
+                    alt={config.title}
+                />
+            </div>
+        </div>
+    );
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/BancontactPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/BancontactPaymentMethod.php
@@ -91,7 +91,7 @@ class BancontactPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $this->gateway->title,
 			'description' => $this->gateway->description,
-			'icon'        => 'bancontact',
+			'icon'        => $this->gateway->icon,
 		);
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/BlikPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/BlikPaymentMethod.php
@@ -91,7 +91,7 @@ class BlikPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $this->gateway->title,
 			'description' => $this->gateway->description,
-			'icon'        => 'blik',
+			'icon'        => $this->gateway->icon,
 		);
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/EPSPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/EPSPaymentMethod.php
@@ -91,7 +91,7 @@ class EPSPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $this->gateway->title,
 			'description' => $this->gateway->description,
-			'icon'        => 'eps',
+			'icon'        => $this->gateway->icon,
 		);
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/IDealPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/IDealPaymentMethod.php
@@ -91,7 +91,7 @@ class IDealPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $this->gateway->title,
 			'description' => $this->gateway->description,
-			'icon'        => 'ideal',
+			'icon'        => $this->gateway->icon,
 		);
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/MultibancoPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/MultibancoPaymentMethod.php
@@ -91,7 +91,7 @@ class MultibancoPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $this->gateway->title,
 			'description' => $this->gateway->description,
-			'icon'        => 'multibanco',
+			'icon'        => $this->gateway->icon,
 		);
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/MyBankPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/MyBankPaymentMethod.php
@@ -91,7 +91,7 @@ class MyBankPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $this->gateway->title,
 			'description' => $this->gateway->description,
-			'icon'        => 'mybank',
+			'icon'        => $this->gateway->icon,
 		);
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/P24PaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/P24PaymentMethod.php
@@ -91,7 +91,7 @@ class P24PaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $this->gateway->title,
 			'description' => $this->gateway->description,
-			'icon'        => 'p24',
+			'icon'        => $this->gateway->icon,
 		);
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/TrustlyPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/TrustlyPaymentMethod.php
@@ -91,7 +91,7 @@ class TrustlyPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $this->gateway->title,
 			'description' => $this->gateway->description,
-			'icon'        => 'trustly',
+			'icon'        => $this->gateway->icon,
 		);
 	}
 }


### PR DESCRIPTION
# PR Description

The issue happens because the plugin relies on Woo icons and therefor the unsupported by Woo icons such as MyBank, Blik and Trustly will not be displayed. The PR will fix this by changing the logic to support PayPal custom icons for APM-s 
 
# Issue Description

Missing logo on block checkout page for APM-s MyBank, Blik and Trustly.


### Steps to Test

1. Set currency EUR (MyBank or Trustly) or PLN (Blik)
2. Navigate to shop and add product to cart
3. Navigate to block checkout page
4. Set country (Italy → MyBank or Austria → Trustly or Poland → Blik)
5. Observe no logos are showing for mention APM-s
