### PR TITLE
Unsuccessfully payment from product page with Apple Pay button (3695)

### DIFF
--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
@@ -46,7 +46,7 @@ class SingleProductHandler extends BaseHandler {
 					countryCode: data.country_code,
 					currencyCode: data.currency_code,
 					totalPriceStatus: 'FINAL',
-					totalPrice: data.total_str,
+					totalPrice: data.total,
 				} );
 			}, products );
 		} );


### PR DESCRIPTION
### Description

This PR addresses an Apple Pay bug that was introduced with a recent change in an Ajax endpoint.

**Scope**

- On the "Single Product" page, the Apple Pay button was broken
- Reason: An Ajax endpoint changed the property-name that contains the product's price
- This change was required for a Google Pay modification, without updating Apple Pay code
- There are no other occurrences that need to be updated - the modified endpoint is only used by Google Pay and Apple Pay