### PR TITLE
Fastlane remove Privacy setting (3720)

### DIFF
--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -83,7 +83,6 @@ return array(
 									->rule()
 									->condition_element( 'axo_enabled', '1' )
 									->action_visible( 'axo_main_notice' )
-									->action_visible( 'axo_privacy' )
 									->action_visible( 'axo_style_heading' )
 									->action_class( 'axo_enabled', 'active' )
 									->to_array(),
@@ -130,22 +129,6 @@ return array(
 					),
 					'requirements' => array( 'dcc', 'axo' ),
 					'gateway'      => array( 'dcc', 'axo' ),
-				),
-				'axo_privacy'                        => array(
-					'title'        => __( 'Privacy', 'woocommerce-paypal-payments' ),
-					'type'         => 'select',
-					'description'  => __(
-						'PayPal powers this accelerated checkout solution from Fastlane. Since you\'ll share consumers\' email address with PayPal, please consult your legal advisors on the appropriate privacy setting for your business.',
-						'woocommerce-paypal-payments'
-					),
-					'classes'      => array( 'ppcp-field-indent' ),
-					'class'        => array(),
-					'input_class'  => array( 'wc-enhanced-select' ),
-					'default'      => 'yes',
-					'options'      => PropertiesDictionary::privacy_options(),
-					'screens'      => array( State::STATE_ONBOARDED ),
-					'gateway'      => array( 'dcc', 'axo' ),
-					'requirements' => array( 'axo' ),
 				),
 				'axo_style_heading'                  => array(
 					'heading'      => __( 'Advanced Style Settings (optional)', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-axo/src/Helper/PropertiesDictionary.php
+++ b/modules/ppcp-axo/src/Helper/PropertiesDictionary.php
@@ -15,18 +15,6 @@ namespace WooCommerce\PayPalCommerce\Axo\Helper;
 class PropertiesDictionary {
 
 	/**
-	 * Returns the list of possible privacy options.
-	 *
-	 * @return array
-	 */
-	public static function privacy_options(): array {
-		return array(
-			'yes' => __( 'Yes (Recommended)', 'woocommerce-paypal-payments' ),
-			'no'  => __( 'No', 'woocommerce-paypal-payments' ),
-		);
-	}
-
-	/**
 	 * Returns the list of possible cardholder name options.
 	 *
 	 * @return array

--- a/modules/ppcp-wc-gateway/src/Helper/DCCGatewayConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCGatewayConfiguration.php
@@ -35,6 +35,14 @@ class DCCGatewayConfiguration {
 	private string $show_name_on_card;
 
 	/**
+	 * Whether the Fastlane watermark should be hidden on the front-end.
+	 *
+	 * @var bool
+	 */
+	private bool $hide_fastlane_watermark = false;
+
+
+	/**
 	 * Initializes the gateway details based on the provided Settings instance.
 	 *
 	 * @throws NotFoundException If an expected gateway setting is not found.
@@ -57,6 +65,16 @@ class DCCGatewayConfiguration {
 		$this->show_name_on_card = in_array( $show_on_card, $valid_options, true )
 			? $show_on_card
 			: $valid_options[0];
+
+		/**
+		 * Moved from setting "axo_privacy" to a hook-only filter:
+		 * Changing this to true (and hiding the watermark) has potential legal
+		 * consequences, and therefore is generally discouraged.
+		 */
+		$this->hide_fastlane_watermark = add_filter(
+			'woocommerce_paypal_payments_fastlane_watermark_enabled',
+			'__return_false'
+		);
 	}
 
 	/**
@@ -75,5 +93,17 @@ class DCCGatewayConfiguration {
 	 */
 	public function show_name_on_card() : string {
 		return $this->show_name_on_card;
+	}
+
+	/**
+	 * Whether to display the watermark (text branding) for the Fastlane payment
+	 * method in the front end.
+	 *
+	 * Note: This setting is planned but not implemented yet.
+	 *
+	 * @retun bool True means, the default watermark is displayed to customers.
+	 */
+	public function show_fastlane_watermark() : bool {
+		return ! $this->hide_fastlane_watermark;
 	}
 }


### PR DESCRIPTION
### Description

This PR removes the UI element to change the "Privacy" setting from the Fastlane settings.

**Note**
- It turns out that this setting was not used yet; removing it from the UI has no impact
- It's still planned to implement the setting in the future, but using a hook, and not a UI option

### Screenshots

| Before | After |
|---|---|
| ![2024-09-26_16-52-13](https://github.com/user-attachments/assets/74f7bb89-583f-40ec-88da-a33e94a9f640) | ![2024-09-26_16-52-49](https://github.com/user-attachments/assets/c255bc16-9c21-4b27-ae7e-179c0d995c70) |