### PR TITLE
Axo: Load classic and block integration modules by default (3738)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -84,7 +84,7 @@ return function ( string $root_dir ): iterable {
 
 	if ( apply_filters(
 		'woocommerce.feature-flags.woocommerce_paypal_payments.axo_enabled',
-		getenv( 'PCP_AXO_ENABLED' ) === '1'
+		getenv( 'PCP_AXO_ENABLED' ) !== '0'
 	) ) {
 		$modules[] = ( require "$modules_dir/ppcp-axo/module.php" )();
 		$modules[] = ( require "$modules_dir/ppcp-axo-block/module.php" )();


### PR DESCRIPTION
### Description

This PR adds default loading of Axo modules.

### Testing instructions

1. Make sure Fastlane loads both for Classic Checkout and Block Checkout without the `PCP_AXO_ENABLED` feature flag being set.