### PR TITLE
Axo Block: Load ACDC for logged in users in the Block Checkout (3739)

### DIFF
--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -69,8 +69,8 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				$payment_method_registry->register( $c->get( 'blocks.method' ) );
 
-				// Include ACDC in the Block Checkout only in case Axo doesn't exist or is not available.
-				if ( ! $c->has( 'axoblock.available' ) || ! $c->get( 'axoblock.available' ) ) {
+				// Include ACDC in the Block Checkout only in case Axo doesn't exist or is not available or the user is logged in.
+				if ( ! $c->has( 'axoblock.available' ) || ! $c->get( 'axoblock.available' ) || is_user_logged_in() ) {
 					$payment_method_registry->register( $c->get( 'blocks.advanced-card-method' ) );
 				}
 			}


### PR DESCRIPTION
### Description

This PR adds ACDC loading for logged in users in the Block Checkout.

### Testing instructions

1. Enable ACDC.
2. Navigate to block Checkout as a logged in user.
3. Confirm that the ACDC gateway is available.
