### PR TITLE
Fastlane spinner does not disappear once the watermark (3717)

### DIFF
--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -8,6 +8,7 @@
 	}
 
 	&.loader:before {
+		display: block; /* Same as WooCommerce's `@mixin loader()` uses */
 		height: 12px;
 		width: 12px;
 		margin-left: -6px;

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -3,6 +3,10 @@
 	margin-top: 10px;
 	position: relative;
 
+	&:before {
+		display: none;
+	}
+
 	&.loader:before {
 		height: 12px;
 		width: 12px;

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -80,11 +80,11 @@
 }
 
 .ppcp-axo-order-button {
-		float: none;
-		width: 100%;
-		box-sizing: border-box;
-		margin: var(--global-md-spacing) 0 1em;
-		padding: 0.6em 1em;
+	float: none;
+	width: 100%;
+	box-sizing: border-box;
+	margin: var(--global-md-spacing) 0 1em;
+	padding: 0.6em 1em;
 }
 
 .ppcp-axo-watermark-loading {


### PR DESCRIPTION
### Description

This PR solves a visual glitch in Safari, where a loader was not correctly hidden after removing it.

Apparently, this is a rendering bug in Webkit, which can be easily bypassed by explicitly hiding the pseudo-element when it’s not needed anymore.