### PR TITLE
Add Custom Placeholder Handling when rendering the card fields (3736)

### DIFF
--- a/modules/ppcp-card-fields/resources/js/Render.js
+++ b/modules/ppcp-card-fields/resources/js/Render.js
@@ -8,11 +8,17 @@ function renderField( cardField, inputField ) {
 
 	// Insert the PayPal card field after the original input field.
 	const styles = cardFieldStyles( inputField );
-	cardField( { style: { input: styles } } ).render( inputField.parentNode );
+    const fieldOptions = {style: { input: styles },};
 
-	// Hide the original input field.
-	hide( inputField, true );
-	inputField.hidden = true;
+    if ( inputField.getAttribute( 'placeholder' ) ) {
+        fieldOptions.placeholder = inputField.getAttribute( 'placeholder' );
+    }
+
+    cardField( fieldOptions ).render( inputField.parentNode );
+
+    // Hide the original input field.
+    hide( inputField, true );
+    inputField.hidden = true;
 }
 
 export function renderFields( cardFields ) {


### PR DESCRIPTION
# PR Description

The issue happens because when extracting the card fields logic to corresponding modules we forgot about Custom Placeholder Handling: In old  code, we checked if the fields had a placeholder attribute and set it in the field options. This is missing in the new `renderField` function causing the problem with translations.
The PR will fix the problem described above by adding the custom placeholder handling functionality.
 
# Issue Description

The translations are no longer applied to Card fields in 2.9.0+ even if the string is still translatable and translations are available.

### Steps to Test

1. Check the card field on classic checkout.
