### PR TITLE
Axo: Move watermark to the right side (3743)

### DIFF
--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -1,7 +1,12 @@
 .ppcp-axo-watermark-container {
-	max-width: 200px;
-	margin-top: 10px;
-	position: relative;
+	justify-self: end;
+	align-self: end;
+	margin-top: 5px;
+
+	&.loader {
+		width: 15px;
+		align-self: center;
+	}
 
 	&.loader:before {
 		height: 12px;
@@ -9,15 +14,30 @@
 		margin-left: -6px;
 		margin-top: -6px;
 		left: 12px;
+		position: relative;
 	}
 }
 
 #ppcp-axo-billing-email-field-wrapper {
 	display: flex;
 	gap: 0.5rem;
+
+	.woocommerce-input-wrapper {
+		display: grid;
+		grid-template-areas:
+			"input"
+			"watermark"
+			"button";
+		grid-template-columns: 1fr;
+		gap: 6px;
+		align-items: start;
+		width: 100%;
+	}
 }
 
 #ppcp-axo-billing-email-submit-button {
+	grid-area: button;
+	width: 100%;
 	margin-top: 0;
 	position: relative;
 	transition: opacity 0.3s ease;
@@ -36,6 +56,8 @@
 }
 
 .ppcp-axo-billing-email-submit-button {
+	position: relative;
+
 	&-hidden {
 		opacity: 0;
 	}
@@ -80,11 +102,11 @@
 }
 
 .ppcp-axo-order-button {
-		float: none;
-		width: 100%;
-		box-sizing: border-box;
-		margin: var(--global-md-spacing) 0 1em;
-		padding: 0.6em 1em;
+	float: none;
+	width: 100%;
+	box-sizing: border-box;
+	margin: var(--global-md-spacing) 0 1em;
+	padding: 0.6em 1em;
 }
 
 .ppcp-axo-watermark-loading {
@@ -123,10 +145,6 @@
 	}
 }
 
-.ppcp-axo-customer-details #billing_email_field .woocommerce-input-wrapper {
-	flex: 1 1 auto;
-}
-
 @media screen and (max-width: 719px) {
 	#ppcp-axo-billing-email {
 		&-field-wrapper {
@@ -137,7 +155,33 @@
 			align-self: auto;
 		}
 	}
+
+	input[type="email"] {
+		grid-area: input;
+		width: 100%;
+	}
+
+	#ppcp-axo-billing-email-submit-button {
+		align-self: center;
+	}
 }
 
 
+@media (min-width: 783px) {
+	#ppcp-axo-billing-email-field-wrapper .woocommerce-input-wrapper {
+		grid-template-areas:
+			"input button"
+			"watermark watermark";
+		grid-template-columns: 1fr auto;
+		gap: 6px 8px;
+	}
 
+	input[type="email"] {
+		align-self: center;
+	}
+
+	#ppcp-axo-billing-email-submit-button {
+		align-self: center;
+		width: auto;
+	}
+}

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -689,28 +689,37 @@ class AxoManager {
 			this.el.billingEmailSubmitButtonSpinner;
 
 		if ( ! document.querySelector( billingEmailSubmitButton.selector ) ) {
-			document
-				.querySelector( this.el.billingEmailFieldWrapper.selector )
-				.insertAdjacentHTML(
-					'beforeend',
-					`
-                <button type="button" id="${ billingEmailSubmitButton.id }" class="${ billingEmailSubmitButton.className }">
-                    ${ this.axoConfig.billing_email_button_text }
-                    <span id="${ billingEmailSubmitButtonSpinner.id }"></span>
-                </button>
-            `
-				);
+			const wrapper = document.querySelector(
+				'#billing_email_field .woocommerce-input-wrapper'
+			);
+			const watermarkContainer = document.querySelector(
+				'#ppcp-axo-watermark-container'
+			);
 
-			document.querySelector( this.el.billingEmailSubmitButton.selector )
-				.offsetHeight;
-			document
-				.querySelector( this.el.billingEmailSubmitButton.selector )
-				.classList.remove(
-					'ppcp-axo-billing-email-submit-button-hidden'
-				);
-			document
-				.querySelector( this.el.billingEmailSubmitButton.selector )
-				.classList.add( 'ppcp-axo-billing-email-submit-button-loaded' );
+			wrapper.insertAdjacentHTML(
+				'beforeend',
+				`
+            <button type="button" id="${ billingEmailSubmitButton.id }" class="${ billingEmailSubmitButton.className }">
+                ${ this.axoConfig.billing_email_button_text }
+                <span id="${ billingEmailSubmitButtonSpinner.id }"></span>
+            </button>
+            `
+			);
+
+			const buttonElement = document.querySelector(
+				billingEmailSubmitButton.selector
+			);
+
+			// Reorder button to ensure it's before the watermark container
+			wrapper.insertBefore( buttonElement, watermarkContainer );
+
+			buttonElement.offsetHeight;
+			buttonElement.classList.remove(
+				'ppcp-axo-billing-email-submit-button-hidden'
+			);
+			buttonElement.classList.add(
+				'ppcp-axo-billing-email-submit-button-loaded'
+			);
 		}
 	}
 


### PR DESCRIPTION
### Description

This PR moves the watermark to the right side (in the classic checkout).

### Screenshots

#### Desktop

|Before|After|
|-|-|
|<img width="778" alt="before" src="https://github.com/user-attachments/assets/fb992b9f-208d-4419-bcb1-dce6294755ac">|<img width="787" alt="after" src="https://github.com/user-attachments/assets/6b6c483c-bfa5-42ef-8af6-28bf54f5cff8">|

#### Mobile

|Before|After|
|-|-|
|<img width="672" alt="before" src="https://github.com/user-attachments/assets/e14ec9d8-c6e3-4a81-9c54-dfdbed01147f">|<img width="658" alt="Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/bc661650-7728-44d0-ac3b-8e97cba8f165">|