### PR TITLE
Axo: Remove fixed container background color from the Ryan credit card component (3747)

### DIFF
--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -74,7 +74,6 @@
 
 .ppcp-axo-payment-container {
 	padding: 1rem 0;
-	background-color: #ffffff;
 
 	&.axo-hidden {
 		display: none;
@@ -107,6 +106,7 @@
 		display: flex;
 		align-items: baseline;
 		gap: 1em;
+		margin-bottom: 1em;
 	}
 
 	.axo-checkout-card-preview {


### PR DESCRIPTION
### Description

This PR removes the fixed white background from the Ryan credit card component in the classic checkout.

Best to test with the Twenty Twenty-One theme.

### Screenshots

|Before|After|
|-|-|
|<img width="1142" alt="Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/a5b12eaa-c2a7-495b-ad64-e8ed74d9665c">|<img width="1109" alt="Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/801d9b7a-1a81-4b69-89c8-03ba056fe326">|
