### PR TITLE
Axo: Remove Axo from the Checkout block in the editor and add an ACDC card preview (3740)

### DIFF
--- a/modules/ppcp-axo-block/src/AxoBlockModule.php
+++ b/modules/ppcp-axo-block/src/AxoBlockModule.php
@@ -102,7 +102,13 @@ class AxoBlockModule implements ServiceModule, ExtendingModule, ExecutableModule
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
 			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
-				$payment_method_registry->register( $c->get( 'axoblock.method' ) );
+				/* Only register the method if we are not in the admin
+				 * (to avoid two Debit & Credit Cards gateways in the
+				 * checkout block in the editor: one from ACDC one from Axo).
+				 */
+				if ( ! is_admin() ) {
+					$payment_method_registry->register( $c->get( 'axoblock.method' ) );
+				}
 			}
 		);
 

--- a/modules/ppcp-axo-block/src/AxoBlockModule.php
+++ b/modules/ppcp-axo-block/src/AxoBlockModule.php
@@ -102,7 +102,8 @@ class AxoBlockModule implements ServiceModule, ExtendingModule, ExecutableModule
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
 			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
-				/* Only register the method if we are not in the admin
+				/*
+				 * Only register the method if we are not in the admin
 				 * (to avoid two Debit & Credit Cards gateways in the
 				 * checkout block in the editor: one from ACDC one from Axo).
 				 */

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -187,13 +187,13 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 		}
 
 		return array(
-			'environment'               => array(
+			'environment'     => array(
 				'is_sandbox' => $this->environment->current_environment() === 'sandbox',
 			),
-			'widgets'                   => array(
+			'widgets'         => array(
 				'email' => 'render',
 			),
-			'insights'                  => array(
+			'insights'        => array(
 				'enabled'    => defined( 'WP_DEBUG' ) && WP_DEBUG,
 				'client_id'  => ( $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : null ),
 				'session_id' =>
@@ -207,7 +207,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 						: null, // Set to null if WC()->cart is null or get_total doesn't exist.
 				),
 			),
-			'style_options'             => array(
+			'style_options'   => array(
 				'root'  => array(
 					'backgroundColor' => $this->settings->has( 'axo_style_root_bg_color' ) ? $this->settings->get( 'axo_style_root_bg_color' ) : '',
 					'errorColor'      => $this->settings->has( 'axo_style_root_error_color' ) ? $this->settings->get( 'axo_style_root_error_color' ) : '',
@@ -226,23 +226,23 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 					'focusBorderColor' => $this->settings->has( 'axo_style_input_focus_border_color' ) ? $this->settings->get( 'axo_style_input_focus_border_color' ) : '',
 				),
 			),
-			'name_on_card'              => $this->dcc_configuration->show_name_on_card(),
-			'woocommerce'               => array(
+			'name_on_card'    => $this->dcc_configuration->show_name_on_card(),
+			'woocommerce'     => array(
 				'states' => array(
 					'US' => WC()->countries->get_states( 'US' ),
 					'CA' => WC()->countries->get_states( 'CA' ),
 				),
 			),
-			'icons_directory'           => esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/',
-			'module_url'                => untrailingslashit( $this->module_url ),
-			'ajax'                      => array(
+			'icons_directory' => esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/',
+			'module_url'      => untrailingslashit( $this->module_url ),
+			'ajax'            => array(
 				'frontend_logger' => array(
 					'endpoint' => \WC_AJAX::get_endpoint( FrontendLoggerEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),
 				),
 			),
-			'logging_enabled'           => $this->settings->has( 'logging_enabled' ) ? $this->settings->get( 'logging_enabled' ) : '',
-			'wp_debug'                  => defined( 'WP_DEBUG' ) && WP_DEBUG,
+			'logging_enabled' => $this->settings->has( 'logging_enabled' ) ? $this->settings->get( 'logging_enabled' ) : '',
+			'wp_debug'        => defined( 'WP_DEBUG' ) && WP_DEBUG,
 		);
 	}
 }

--- a/modules/ppcp-blocks/resources/js/advanced-card-checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/advanced-card-checkout-block.js
@@ -7,7 +7,7 @@ registerPaymentMethod( {
 	name: config.id,
 	label: <div dangerouslySetInnerHTML={ { __html: config.title } } />,
 	content: <CardFields config={ config } />,
-	edit: <div></div>,
+	edit: <CardFields config={ config } />,
 	ariaLabel: config.title,
 	canMakePayment: () => {
 		return true;


### PR DESCRIPTION
### Description

This PR removes Axo from the editor in the Checkout block (to avoid two Debit & Credit Cards gateways in the checkout block in the editor: one from ACDC and one from Axo).

It also adds the `Card` component for ACDC in the editor.

### Screenshots

|Before|After|
|-|-|
|<img width="1003" alt="Edit_Page_“Block_Checkout”_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/3f5562e8-e71f-43b6-94ce-8162ceacd7bc">|<img width="1001" alt="Edit_Page_“Block_Checkout”_‹_WooCommerce_PayPal_Payments_—_WordPress_i_S6E34_-_CHILL_AND_BE_PLUMP" src="https://github.com/user-attachments/assets/d7d2f709-703d-4a32-b6ff-2385ba9016c3">|
