### PR TITLE
Axo Block: Fix the Fastlane modal info message text overflow issue (3752)

### DIFF
--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -301,3 +301,13 @@ a.wc-block-axo-change-link {
 #shipping-fields .wc-block-components-checkout-step__heading {
 	display: flex;
 }
+
+// 11. Fastlane modal info message fix
+.wc-block-components-text-input {
+	.wc-block-components-form &,
+	& {
+		paypal-watermark {
+			white-space: wrap;
+		}
+	}
+}


### PR DESCRIPTION
### Description

This PR fixes the Fastlane watermark modal info message text overflow issue.

### Screenshots

|Before|After|
|-|-|
|<img width="1012" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/acf8a59a-6125-474a-9872-245b4cd11262">|<img width="975" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/be8720e6-a4aa-4b63-881b-5135da5c1435">|
