### PR TITLE
Fastlane update shipping options & taxes when changing address (3541)

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -801,8 +801,6 @@ class AxoManager {
 	}
 
 	async onChangeEmail() {
-		this.clearData();
-
 		if ( ! this.status.active ) {
 			log( 'Email checking skipped, AXO not active.' );
 			return;
@@ -813,11 +811,17 @@ class AxoManager {
 			return;
 		}
 
+		if ( this.data.email === this.emailInput.value ) {
+			log( 'Email has not changed since last validation.' );
+			return;
+		}
+
 		log(
 			`Email changed: ${
 				this.emailInput ? this.emailInput.value : '<empty>'
 			}`
 		);
+		this.clearData();
 
 		this.emailInput.value = this.stripSpaces( this.emailInput.value );
 

--- a/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
+++ b/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
@@ -13,7 +13,6 @@ class FormFieldGroup {
 		this.#fields = config.fields || {};
 		this.#template = config.template;
 		this.#stored = new Map();
-
 	}
 
 	setData( data ) {
@@ -44,6 +43,25 @@ class FormFieldGroup {
 				this.#data
 			);
 		return value ? value : '';
+	}
+
+	/**
+	 * Changes the value of the input field.
+	 *
+	 * @param {Element|null}   field
+	 * @param {string|boolean} value
+	 */
+	#setFieldValue( field, value ) {
+		if ( ! field ) {
+			return false;
+		}
+
+		if ( 'checkbox' === field.type || 'radio' === field.type ) {
+			value = !! value;
+			field.checked = value;
+		} else {
+			field.value = value;
+		}
 	}
 
 	/**
@@ -151,8 +169,10 @@ class FormFieldGroup {
 		const storeValue = ( field, name ) => {
 			if ( 'checkbox' === field.type || 'radio' === field.type ) {
 				this.#stored.set( name, field.checked );
+				this.#setFieldValue( field, this.dataValue( name ) );
 			} else {
 				this.#stored.set( name, field.value );
+				this.#setFieldValue( field, '' );
 			}
 		};
 
@@ -172,22 +192,11 @@ class FormFieldGroup {
 	 * This function iterates through the stored form fields and resets their values or states.
 	 */
 	restoreFormData() {
-		const restoreValue = ( field, name ) => {
-			if ( 'checkbox' === field.type || 'radio' === field.type ) {
-				field.checked = this.#stored.get( name );
-			} else {
-				field.value = this.#stored.get( name );
-			}
-		};
-
 		this.loopFields( ( { inputSelector }, fieldKey ) => {
 			if ( inputSelector && this.#stored.has( fieldKey ) ) {
 				const elInput = document.querySelector( inputSelector );
 
-				if ( elInput ) {
-					restoreValue( elInput, fieldKey );
-				}
-
+				this.#setFieldValue( elInput, this.#stored.get( fieldKey ) );
 				this.#stored.delete( fieldKey );
 			}
 		} );

--- a/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
+++ b/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
@@ -90,13 +90,11 @@ class FormFieldGroup {
 			this.showField( this.#contentSelector );
 		}
 
-		Object.keys( this.fields ).forEach( ( key ) => {
-			const field = this.fields[ key ];
-
-			if ( this.active && ! field.showInput ) {
-				this.hideField( field.selector );
+		this.loopFields( ( { selector } ) => {
+			if ( this.#active /* && ! field.showInput */ ) {
+				this.hideField( selector );
 			} else {
-				this.showField( field.selector );
+				this.showField( selector );
 			}
 		} );
 
@@ -107,16 +105,37 @@ class FormFieldGroup {
 				},
 				isEmpty: () => {
 					let isEmpty = true;
-					Object.keys( this.fields ).forEach( ( fieldKey ) => {
+
+					this.loopFields( ( field, fieldKey ) => {
 						if ( this.dataValue( fieldKey ) ) {
 							isEmpty = false;
 							return false;
 						}
 					} );
+
 					return isEmpty;
 				},
 			} );
 		}
+	}
+
+	/**
+	 * Invoke a callback on every field in the current group.
+	 *
+	 * @param {(field: object, key: string) => void} callback
+	 */
+	loopFields( callback ) {
+		Object.keys( this.#fields ).forEach( ( key ) => {
+			const field = this.#fields[ key ];
+			const fieldSelector = `${ this.#baseSelector } ${ field.selector }`;
+
+			callback(
+				{
+					...field,
+				},
+				key
+			);
+		} );
 	}
 
 	showField( selector ) {
@@ -159,9 +178,7 @@ class FormFieldGroup {
 	}
 
 	toSubmitData( data ) {
-		Object.keys( this.fields ).forEach( ( fieldKey ) => {
-			const field = this.fields[ fieldKey ];
-
+		this.loopFields( ( field, fieldKey ) => {
 			if ( ! field.valuePath || ! field.selector ) {
 				return true;
 			}

--- a/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
+++ b/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
@@ -151,20 +151,17 @@ class FormFieldGroup {
 	 * @param {(field: object, key: string) => void} callback
 	 */
 	loopFields( callback ) {
-		Object.keys( this.#fields ).forEach( ( key ) => {
-			const field = this.#fields[ key ];
-			const fieldSelector = `${ this.#baseSelector } ${ field.selector }`;
+		for ( const [ key, field ] of Object.entries( this.#fields ) ) {
+			const { selector, inputName } = field;
+			const inputSelector = `${ selector } [name="${ inputName }"]`;
 
-			callback(
-				{
-					inputSelector: field.inputName
-						? `${ fieldSelector } [name="${ field.inputName }"]`
-						: '',
-					...field,
-				},
-				key
-			);
-		} );
+			const fieldInfo = {
+				inputSelector: inputName ? inputSelector : '',
+				...field,
+			};
+
+			callback( fieldInfo, key );
+		}
 	}
 
 	/**

--- a/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
+++ b/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
@@ -210,14 +210,28 @@ class FormFieldGroup {
 	 * This function iterates through the stored form fields and resets their values or states.
 	 */
 	restoreFormData() {
-		this.loopFields( ( { inputSelector }, fieldKey ) => {
-			if ( inputSelector && this.#stored.has( fieldKey ) ) {
-				const elInput = document.querySelector( inputSelector );
+		let formHasChanged = false;
 
-				this.#setFieldValue( elInput, this.#stored.get( fieldKey ) );
-				this.#stored.delete( fieldKey );
+		// Reset form fields to their initial state.
+		this.loopFields( ( { inputSelector }, fieldKey ) => {
+			if ( ! this.#stored.has( fieldKey ) ) {
+				return;
+			}
+
+			const elInput = inputSelector
+				? document.querySelector( inputSelector )
+				: null;
+			const oldValue = this.#stored.get( fieldKey );
+			this.#stored.delete( fieldKey );
+
+			if ( this.#setFieldValue( elInput, oldValue ) ) {
+				formHasChanged = true;
 			}
 		} );
+
+		if ( formHasChanged ) {
+			document.body.dispatchEvent( new Event( 'update_checkout' ) );
+		}
 	}
 
 	/**

--- a/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
+++ b/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
@@ -53,10 +53,25 @@ class FormFieldGroup {
 	 * @return {boolean} True indicates that the previous value was different from the new value.
 	 */
 	#setFieldValue( field, value ) {
+		let oldVal;
+
+		const isValidOption = () => {
+			for ( let i = 0; i < field.options.length; i++ ) {
+				if ( field.options[ i ].value === value ) {
+					return true;
+				}
+			}
+			return false;
+		};
+
 		if ( ! field ) {
 			return false;
 		}
-		let oldVal;
+
+		// If an invalid option is provided, do nothing.
+		if ( 'SELECT' === field.tagName && ! isValidOption() ) {
+			return false;
+		}
 
 		if ( 'checkbox' === field.type || 'radio' === field.type ) {
 			value = !! value;

--- a/modules/ppcp-axo/resources/js/Views/BillingView.js
+++ b/modules/ppcp-axo/resources/js/Views/BillingView.js
@@ -45,42 +45,52 @@ class BillingView {
 				firstName: {
 					selector: '#billing_first_name_field',
 					valuePath: null,
+					inputName: 'billing_first_name',
 				},
 				lastName: {
 					selector: '#billing_last_name_field',
 					valuePath: null,
+					inputName: 'billing_last_name',
 				},
 				street1: {
 					selector: '#billing_address_1_field',
 					valuePath: 'billing.address.addressLine1',
+					inputName: 'billing_address_1',
 				},
 				street2: {
 					selector: '#billing_address_2_field',
 					valuePath: null,
+					inputName: 'billing_address_2',
 				},
 				postCode: {
 					selector: '#billing_postcode_field',
 					valuePath: 'billing.address.postalCode',
+					inputName: 'billing_postcode',
 				},
 				city: {
 					selector: '#billing_city_field',
 					valuePath: 'billing.address.adminArea2',
+					inputName: 'billing_city',
 				},
 				stateCode: {
 					selector: '#billing_state_field',
 					valuePath: 'billing.address.adminArea1',
+					inputName: 'billing_state',
 				},
 				countryCode: {
 					selector: '#billing_country_field',
 					valuePath: 'billing.address.countryCode',
+					inputName: 'billing_country',
 				},
 				company: {
 					selector: '#billing_company_field',
 					valuePath: null,
+					inputName: 'billing_company',
 				},
 				phone: {
 					selector: '#billing_phone_field',
 					valuePath: 'billing.phoneNumber',
+					inputName: 'billing_phone',
 				},
 			},
 		} );

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -90,42 +90,52 @@ class ShippingView {
 					key: 'firstName',
 					selector: '#shipping_first_name_field',
 					valuePath: 'shipping.name.firstName',
+					inputName: 'shipping_first_name',
 				},
 				lastName: {
 					selector: '#shipping_last_name_field',
 					valuePath: 'shipping.name.lastName',
+					inputName: 'shipping_last_name',
 				},
 				street1: {
 					selector: '#shipping_address_1_field',
 					valuePath: 'shipping.address.addressLine1',
+					inputName: 'shipping_address_1',
 				},
 				street2: {
 					selector: '#shipping_address_2_field',
 					valuePath: null,
+					inputName: 'shipping_address_2',
 				},
 				postCode: {
 					selector: '#shipping_postcode_field',
 					valuePath: 'shipping.address.postalCode',
+					inputName: 'shipping_postcode',
 				},
 				city: {
 					selector: '#shipping_city_field',
 					valuePath: 'shipping.address.adminArea2',
+					inputName: 'shipping_city',
 				},
 				stateCode: {
 					selector: '#shipping_state_field',
 					valuePath: 'shipping.address.adminArea1',
+					inputName: 'shipping_state',
 				},
 				countryCode: {
 					selector: '#shipping_country_field',
 					valuePath: 'shipping.address.countryCode',
+					inputName: 'shipping_country',
 				},
 				company: {
 					selector: '#shipping_company_field',
 					valuePath: null,
+					inputName: 'shipping_company',
 				},
 				shipDifferentAddress: {
 					selector: '#ship-to-different-address',
 					valuePath: null,
+					inputName: 'ship_to_different_address',
 				},
 				phone: {
 					//'selector': '#billing_phone_field', // There is no shipping phone field.

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -136,6 +136,8 @@ class ShippingView {
 					selector: '#ship-to-different-address',
 					valuePath: null,
 					inputName: 'ship_to_different_address',
+					// Used by Woo to ensure correct location for taxes & shipping cost.
+					valueCallback: () => true,
 				},
 				phone: {
 					//'selector': '#billing_phone_field', // There is no shipping phone field.
@@ -173,6 +175,7 @@ class ShippingView {
 
 	activate() {
 		this.group.activate();
+		this.group.syncDataToForm();
 	}
 
 	deactivate() {
@@ -185,6 +188,7 @@ class ShippingView {
 
 	setData( data ) {
 		this.group.setData( data );
+		this.group.syncDataToForm();
 	}
 
 	toSubmitData( data ) {


### PR DESCRIPTION
### Description

This PR improves the Fastlane integration in the classic checkout page for existing Fastlane users ("Ryan flow").

After authentication via the OTP, the shipping address provided by Fastlane is used to determine shipping-options and taxes.

### Technical details

- When entering the Ryan flow, the values of existing checkout form fields are copied to an internal storage object -- see `storeFormData()`
- When exiting the Ryan flow, the form fields are reset to their previous state -- see `restoreFormData ()`
- When the shipping address changes in the Fastlane UI, the address is applied to the hidden form, and an Ajax call is triggered to update the cart details -- see `syncDataToForm ()`
- This PR also includes some general improvements; mainly making the internal properties of `FormFieldGroup ` private (`#`-prefix)

### Steps to Test

1. Go to the classic checkout page with Fastlane enabled
2. Enter Ryan flow, by providing an existing Fastlane test-email; complete the OTP modal
3. Check: When the Fastlane shipping address is displayed, the cart on the right side updates to display correct shipping and tax values
4. Change the shipping address using the "Edit" link, and verify that the cart updates to display the new, correct shipping and tax values

<details>
<summary><strong>🎥 Cart-sync in action</strong></summary>

---

Keep an eye on the taxes on the right side:

https://github.com/user-attachments/assets/2147059a-9c45-456f-b56f-0c4bb6362952

</details>