### PR TITLE
Fix multi-currency support

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\AmountBreakdown;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
@@ -41,20 +42,24 @@ class AmountFactory {
 	private $money_factory;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * AmountFactory constructor.
 	 *
-	 * @param ItemFactory  $item_factory The Item factory.
-	 * @param MoneyFactory $money_factory The Money factory.
-	 * @param string       $currency 3-letter currency code of the shop.
+	 * @param ItemFactory    $item_factory The Item factory.
+	 * @param MoneyFactory   $money_factory The Money factory.
+	 * @param CurrencyGetter $currency The getter of the 3-letter currency code of the shop.
 	 */
-	public function __construct( ItemFactory $item_factory, MoneyFactory $money_factory, string $currency ) {
+	public function __construct(
+		ItemFactory $item_factory,
+		MoneyFactory $money_factory,
+		CurrencyGetter $currency
+	) {
 		$this->item_factory  = $item_factory;
 		$this->money_factory = $money_factory;
 		$this->currency      = $currency;
@@ -68,25 +73,25 @@ class AmountFactory {
 	 * @return Amount
 	 */
 	public function from_wc_cart( \WC_Cart $cart ): Amount {
-		$total = new Money( (float) $cart->get_total( 'numeric' ), $this->currency );
+		$total = new Money( (float) $cart->get_total( 'numeric' ), $this->currency->get() );
 
 		$item_total = (float) $cart->get_subtotal() + (float) $cart->get_fee_total();
-		$item_total = new Money( $item_total, $this->currency );
+		$item_total = new Money( $item_total, $this->currency->get() );
 		$shipping   = new Money(
 			(float) $cart->get_shipping_total(),
-			$this->currency
+			$this->currency->get()
 		);
 
 		$taxes = new Money(
 			(float) $cart->get_total_tax(),
-			$this->currency
+			$this->currency->get()
 		);
 
 		$discount = null;
 		if ( $cart->get_discount_total() ) {
 			$discount = new Money(
 				(float) $cart->get_discount_total(),
-				$this->currency
+				$this->currency->get()
 			);
 		}
 

--- a/modules/ppcp-api-client/src/Factory/BillingCycleFactory.php
+++ b/modules/ppcp-api-client/src/Factory/BillingCycleFactory.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 use stdClass;
 use WC_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\BillingCycle;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 
 /**
  * Class BillingCycleFactory
@@ -21,16 +22,16 @@ class BillingCycleFactory {
 	/**
 	 * The currency.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * BillingCycleFactory constructor.
 	 *
-	 * @param string $currency The currency.
+	 * @param CurrencyGetter $currency The currency.
 	 */
-	public function __construct( string $currency ) {
+	public function __construct( CurrencyGetter $currency ) {
 		$this->currency = $currency;
 	}
 
@@ -51,7 +52,7 @@ class BillingCycleFactory {
 			array(
 				'fixed_price' => array(
 					'value'         => $product->get_meta( '_subscription_price' ),
-					'currency_code' => $this->currency,
+					'currency_code' => $this->currency->get(),
 				),
 			),
 			(int) $product->get_meta( '_subscription_length' )

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -13,6 +13,7 @@ use WC_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ItemTrait;
 
 /**
@@ -23,18 +24,18 @@ class ItemFactory {
 	use ItemTrait;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * ItemFactory constructor.
 	 *
-	 * @param string $currency 3-letter currency code of the shop.
+	 * @param CurrencyGetter $currency The getter of the 3-letter currency code of the shop.
 	 */
-	public function __construct( string $currency ) {
+	public function __construct( CurrencyGetter $currency ) {
 		$this->currency = $currency;
 	}
 
@@ -62,7 +63,7 @@ class ItemFactory {
 				$price = (float) $item['line_subtotal'] / (float) $item['quantity'];
 				return new Item(
 					$this->prepare_item_string( $product->get_name() ),
-					new Money( $price, $this->currency ),
+					new Money( $price, $this->currency->get() ),
 					$quantity,
 					$this->prepare_item_string( $product->get_description() ),
 					null,
@@ -84,7 +85,7 @@ class ItemFactory {
 				function ( \stdClass $fee ): Item {
 					return new Item(
 						$fee->name,
-						new Money( (float) $fee->amount, $this->currency ),
+						new Money( (float) $fee->amount, $this->currency->get() ),
 						1,
 						'',
 						null

--- a/modules/ppcp-api-client/src/Factory/PaymentPreferencesFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PaymentPreferencesFactory.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 use stdClass;
 use WC_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentPreferences;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 
 /**
  * Class PaymentPreferencesFactory
@@ -21,16 +22,16 @@ class PaymentPreferencesFactory {
 	/**
 	 * The currency.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
 	private $currency;
 
 	/**
 	 * PaymentPreferencesFactory constructor.
 	 *
-	 * @param string $currency The currency.
+	 * @param CurrencyGetter $currency The currency.
 	 */
-	public function __construct( string $currency ) {
+	public function __construct( CurrencyGetter $currency ) {
 		$this->currency = $currency;
 	}
 
@@ -44,7 +45,7 @@ class PaymentPreferencesFactory {
 		return new PaymentPreferences(
 			array(
 				'value'         => $product->get_meta( '_subscription_sign_up_fee' ) ?: '0',
-				'currency_code' => $this->currency,
+				'currency_code' => $this->currency->get(),
 			)
 		);
 	}

--- a/modules/ppcp-api-client/src/Helper/CurrencyGetter.php
+++ b/modules/ppcp-api-client/src/Helper/CurrencyGetter.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * The wrapper for retrieving shop currency as late as possible,
+ * to avoid early caching in services, e.g. before multi-currency filters were added.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+/**
+ * Class CurrencyGetter
+ */
+class CurrencyGetter {
+	/**
+	 * Returns the WC currency.
+	 */
+	public function get(): string {
+		$currency = get_woocommerce_currency();
+		if ( $currency ) {
+			return $currency;
+		}
+
+		$currency = get_option( 'woocommerce_currency' );
+		if ( ! $currency ) {
+			return 'NO_CURRENCY'; // Unlikely to happen.
+		}
+
+		return $currency;
+	}
+
+	/**
+	 * Returns the WC currency.
+	 */
+	public function __toString() {
+		return $this->get();
+	}
+}

--- a/modules/ppcp-api-client/src/Helper/DccApplies.php
+++ b/modules/ppcp-api-client/src/Helper/DccApplies.php
@@ -30,11 +30,11 @@ class DccApplies {
 	private $country_card_matrix;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * 2-letter country code of the shop.
@@ -46,16 +46,16 @@ class DccApplies {
 	/**
 	 * DccApplies constructor.
 	 *
-	 * @param array  $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for DCC.
-	 * @param array  $country_card_matrix Which countries support which credit cards. Empty credit card arrays mean no restriction on
-	 *  currency.
-	 * @param string $currency 3-letter currency code of the shop.
-	 * @param string $country 2-letter country code of the shop.
+	 * @param array          $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for DCC.
+	 * @param array          $country_card_matrix Which countries support which credit cards. Empty credit card arrays mean no restriction on
+	 *          currency.
+	 * @param CurrencyGetter $currency The getter of the 3-letter currency code of the shop.
+	 * @param string         $country 2-letter country code of the shop.
 	 */
 	public function __construct(
 		array $allowed_country_currency_matrix,
 		array $country_card_matrix,
-		string $currency,
+		CurrencyGetter $currency,
 		string $country
 	) {
 		$this->allowed_country_currency_matrix = $allowed_country_currency_matrix;
@@ -73,7 +73,7 @@ class DccApplies {
 		if ( ! in_array( $this->country, array_keys( $this->allowed_country_currency_matrix ), true ) ) {
 			return false;
 		}
-		$applies = in_array( $this->currency, $this->allowed_country_currency_matrix[ $this->country ], true );
+		$applies = in_array( $this->currency->get(), $this->allowed_country_currency_matrix[ $this->country ], true );
 		return $applies;
 	}
 
@@ -135,6 +135,6 @@ class DccApplies {
 		 * restrictions, which currencies are supported by a card.
 		 */
 		$supported_currencies = $this->country_card_matrix[ $this->country ][ $card ];
-		return empty( $supported_currencies ) || in_array( $this->currency, $supported_currencies, true );
+		return empty( $supported_currencies ) || in_array( $this->currency->get(), $supported_currencies, true );
 	}
 }

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -34,7 +34,7 @@ return array(
 		return new ApmApplies(
 			$container->get( 'applepay.supported-countries' ),
 			$container->get( 'applepay.supported-currencies' ),
-			$container->get( 'api.shop.currency' ),
+			$container->get( 'api.shop.currency.getter' ),
 			$container->get( 'api.shop.country' )
 		);
 	},

--- a/modules/ppcp-applepay/src/Helper/ApmApplies.php
+++ b/modules/ppcp-applepay/src/Helper/ApmApplies.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Applepay\Helper;
 
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
+
 /**
  * Class ApmApplies
  */
@@ -30,11 +32,11 @@ class ApmApplies {
 	private $allowed_currencies;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * 2-letter country code of the shop.
@@ -46,15 +48,15 @@ class ApmApplies {
 	/**
 	 * DccApplies constructor.
 	 *
-	 * @param array  $allowed_countries The list of which countries can be used for ApplePay.
-	 * @param array  $allowed_currencies The list of which currencies can be used for ApplePay.
-	 * @param string $currency 3-letter currency code of the shop.
-	 * @param string $country 2-letter country code of the shop.
+	 * @param array          $allowed_countries The list of which countries can be used for ApplePay.
+	 * @param array          $allowed_currencies The list of which currencies can be used for ApplePay.
+	 * @param CurrencyGetter $currency The getter of the 3-letter currency code of the shop.
+	 * @param string         $country 2-letter country code of the shop.
 	 */
 	public function __construct(
 		array $allowed_countries,
 		array $allowed_currencies,
-		string $currency,
+		CurrencyGetter $currency,
 		string $country
 	) {
 		$this->allowed_countries  = $allowed_countries;
@@ -78,7 +80,7 @@ class ApmApplies {
 	 * @return bool
 	 */
 	public function for_currency(): bool {
-		return in_array( $this->currency, $this->allowed_currencies, true );
+		return in_array( $this->currency->get(), $this->allowed_currencies, true );
 	}
 
 }

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -187,13 +187,13 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 		}
 
 		return array(
-			'environment'               => array(
+			'environment'     => array(
 				'is_sandbox' => $this->environment->current_environment() === 'sandbox',
 			),
-			'widgets'                   => array(
+			'widgets'         => array(
 				'email' => 'render',
 			),
-			'insights'                  => array(
+			'insights'        => array(
 				'enabled'    => defined( 'WP_DEBUG' ) && WP_DEBUG,
 				'client_id'  => ( $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : null ),
 				'session_id' =>
@@ -207,7 +207,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 						: null, // Set to null if WC()->cart is null or get_total doesn't exist.
 				),
 			),
-			'style_options'             => array(
+			'style_options'   => array(
 				'root'  => array(
 					'backgroundColor' => $this->settings->has( 'axo_style_root_bg_color' ) ? $this->settings->get( 'axo_style_root_bg_color' ) : '',
 					'errorColor'      => $this->settings->has( 'axo_style_root_error_color' ) ? $this->settings->get( 'axo_style_root_error_color' ) : '',
@@ -226,23 +226,23 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 					'focusBorderColor' => $this->settings->has( 'axo_style_input_focus_border_color' ) ? $this->settings->get( 'axo_style_input_focus_border_color' ) : '',
 				),
 			),
-			'name_on_card'              => $this->dcc_configuration->show_name_on_card(),
-			'woocommerce'               => array(
+			'name_on_card'    => $this->dcc_configuration->show_name_on_card(),
+			'woocommerce'     => array(
 				'states' => array(
 					'US' => WC()->countries->get_states( 'US' ),
 					'CA' => WC()->countries->get_states( 'CA' ),
 				),
 			),
-			'icons_directory'           => esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/',
-			'module_url'                => untrailingslashit( $this->module_url ),
-			'ajax'                      => array(
+			'icons_directory' => esc_url( $this->wcgateway_module_url ) . 'assets/images/axo/',
+			'module_url'      => untrailingslashit( $this->module_url ),
+			'ajax'            => array(
 				'frontend_logger' => array(
 					'endpoint' => \WC_AJAX::get_endpoint( FrontendLoggerEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( FrontendLoggerEndpoint::nonce() ),
 				),
 			),
-			'logging_enabled'           => $this->settings->has( 'logging_enabled' ) ? $this->settings->get( 'logging_enabled' ) : '',
-			'wp_debug'                  => defined( 'WP_DEBUG' ) && WP_DEBUG,
+			'logging_enabled' => $this->settings->has( 'logging_enabled' ) ? $this->settings->get( 'logging_enabled' ) : '',
+			'wp_debug'        => defined( 'WP_DEBUG' ) && WP_DEBUG,
 		);
 	}
 }

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -32,7 +32,7 @@ return array(
 	'axo.helpers.apm-applies'                => static function ( ContainerInterface $container ) : ApmApplies {
 		return new ApmApplies(
 			$container->get( 'axo.supported-country-currency-matrix' ),
-			$container->get( 'api.shop.currency' ),
+			$container->get( 'api.shop.currency.getter' ),
 			$container->get( 'api.shop.country' )
 		);
 	},
@@ -65,7 +65,7 @@ return array(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'wcgateway.settings.status' ),
-			$container->get( 'api.shop.currency' ),
+			$container->get( 'api.shop.currency.getter' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'wcgateway.url' )
 		);

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Axo\Assets;
 
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 use WooCommerce\PayPalCommerce\Axo\FrontendLoggerEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -59,11 +60,11 @@ class AxoManager {
 	private $settings_status;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * The logger.
@@ -95,7 +96,7 @@ class AxoManager {
 	 * @param Settings        $settings The Settings.
 	 * @param Environment     $environment The environment object.
 	 * @param SettingsStatus  $settings_status The Settings status helper.
-	 * @param string          $currency 3-letter currency code of the shop.
+	 * @param CurrencyGetter  $currency The getter of the 3-letter currency code of the shop.
 	 * @param LoggerInterface $logger The logger.
 	 * @param string          $wcgateway_module_url The WcGateway module URL.
 	 */
@@ -106,7 +107,7 @@ class AxoManager {
 		Settings $settings,
 		Environment $environment,
 		SettingsStatus $settings_status,
-		string $currency,
+		CurrencyGetter $currency,
 		LoggerInterface $logger,
 		string $wcgateway_module_url
 	) {
@@ -178,7 +179,7 @@ class AxoManager {
 						16
 					),
 				'amount'     => array(
-					'currency_code' => get_woocommerce_currency(),
+					'currency_code' => $this->currency->get(),
 					'value'         => WC()->cart->get_total( 'numeric' ),
 				),
 			),

--- a/modules/ppcp-axo/src/Helper/ApmApplies.php
+++ b/modules/ppcp-axo/src/Helper/ApmApplies.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Axo\Helper;
 
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
+
 /**
  * Class ApmApplies
  */
@@ -23,11 +25,11 @@ class ApmApplies {
 	private $allowed_country_currency_matrix;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * 2-letter country code of the shop.
@@ -39,13 +41,13 @@ class ApmApplies {
 	/**
 	 * DccApplies constructor.
 	 *
-	 * @param array  $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for AXO.
-	 * @param string $currency 3-letter currency code of the shop.
-	 * @param string $country 2-letter country code of the shop.
+	 * @param array          $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for AXO.
+	 * @param CurrencyGetter $currency The getter of the 3-letter currency code of the shop.
+	 * @param string         $country 2-letter country code of the shop.
 	 */
 	public function __construct(
 		array $allowed_country_currency_matrix,
-		string $currency,
+		CurrencyGetter $currency,
 		string $country
 	) {
 		$this->allowed_country_currency_matrix = $allowed_country_currency_matrix;
@@ -62,6 +64,6 @@ class ApmApplies {
 		if ( ! in_array( $this->country, array_keys( $this->allowed_country_currency_matrix ), true ) ) {
 			return false;
 		}
-		return in_array( $this->currency, $this->allowed_country_currency_matrix[ $this->country ], true );
+		return in_array( $this->currency->get(), $this->allowed_country_currency_matrix[ $this->country ], true );
 	}
 }

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -126,7 +126,6 @@ return array(
 		$environment         = $container->get( 'onboarding.environment' );
 		$payment_token_repository = $container->get( 'vaulting.repository.payment-token' );
 		$settings_status = $container->get( 'wcgateway.settings.status' );
-		$currency = $container->get( 'api.shop.currency' );
 		return new SmartButton(
 			$container->get( 'button.url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -141,7 +140,7 @@ return array(
 			$environment,
 			$payment_token_repository,
 			$settings_status,
-			$currency,
+			$container->get( 'api.shop.currency.getter' ),
 			$container->get( 'wcgateway.all-funding-sources' ),
 			$container->get( 'button.basic-checkout-validation-enabled' ),
 			$container->get( 'button.early-wc-checkout-validation-enabled' ),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Blocks\Endpoint\UpdateShippingEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveOrderEndpoint;
@@ -146,11 +147,11 @@ class SmartButton implements SmartButtonInterface {
 	private $payment_token_repository;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * All existing funding sources.
@@ -252,7 +253,7 @@ class SmartButton implements SmartButtonInterface {
 	 * @param Environment            $environment The environment object.
 	 * @param PaymentTokenRepository $payment_token_repository The payment token repository.
 	 * @param SettingsStatus         $settings_status The Settings status helper.
-	 * @param string                 $currency 3-letter currency code of the shop.
+	 * @param CurrencyGetter         $currency The getter of the 3-letter currency code of the shop.
 	 * @param array                  $all_funding_sources All existing funding sources.
 	 * @param bool                   $basic_checkout_validation_enabled Whether the basic JS validation of the form iss enabled.
 	 * @param bool                   $early_validation_enabled Whether to execute WC validation of the checkout form.
@@ -278,7 +279,7 @@ class SmartButton implements SmartButtonInterface {
 		Environment $environment,
 		PaymentTokenRepository $payment_token_repository,
 		SettingsStatus $settings_status,
-		string $currency,
+		CurrencyGetter $currency,
 		array $all_funding_sources,
 		bool $basic_checkout_validation_enabled,
 		bool $early_validation_enabled,
@@ -1119,7 +1120,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'url_params'                              => $url_params,
 			'script_attributes'                       => $this->attributes(),
 			'client_id'                               => $this->client_id,
-			'currency'                                => $this->currency,
+			'currency'                                => $this->currency->get(),
 			'data_client_id'                          => array(
 				'set_attribute'                => ( is_checkout() && $this->dcc_is_enabled() ) || $this->can_save_vault_token(),
 				'endpoint'                     => \WC_AJAX::get_endpoint( DataClientIdEndpoint::ENDPOINT ),
@@ -1393,7 +1394,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 		$subscription_mode = $this->settings->has( 'subscriptions_mode' ) ? $this->settings->get( 'subscriptions_mode' ) : '';
 		$params            = array(
 			'client-id'        => $this->client_id,
-			'currency'         => $this->currency,
+			'currency'         => $this->currency->get(),
 			'integration-date' => PAYPAL_INTEGRATION_DATE,
 			'components'       => implode( ',', $this->components() ),
 			'vault'            => ( $this->can_save_vault_token() || $this->subscription_helper->need_subscription_intent( $subscription_mode ) ) ? 'true' : 'false',

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -177,7 +177,6 @@ return array(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'wcgateway.settings.status' ),
-			$container->get( 'api.shop.currency' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -36,7 +36,7 @@ return array(
 		return new ApmApplies(
 			$container->get( 'googlepay.supported-countries' ),
 			$container->get( 'googlepay.supported-currencies' ),
-			$container->get( 'api.shop.currency' ),
+			$container->get( 'api.shop.currency.getter' ),
 			$container->get( 'api.shop.country' )
 		);
 	},

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -72,13 +72,6 @@ class Button implements ButtonInterface {
 	private $settings_status;
 
 	/**
-	 * 3-letter currency code of the shop.
-	 *
-	 * @var string
-	 */
-	private $currency;
-
-	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -102,7 +95,6 @@ class Button implements ButtonInterface {
 	 * @param Settings        $settings The Settings.
 	 * @param Environment     $environment The environment object.
 	 * @param SettingsStatus  $settings_status The Settings status helper.
-	 * @param string          $currency 3-letter currency code of the shop.
 	 * @param LoggerInterface $logger The logger.
 	 */
 	public function __construct(
@@ -113,7 +105,6 @@ class Button implements ButtonInterface {
 		Settings $settings,
 		Environment $environment,
 		SettingsStatus $settings_status,
-		string $currency,
 		LoggerInterface $logger
 	) {
 
@@ -124,7 +115,6 @@ class Button implements ButtonInterface {
 		$this->settings        = $settings;
 		$this->environment     = $environment;
 		$this->settings_status = $settings_status;
-		$this->currency        = $currency;
 		$this->logger          = $logger;
 	}
 

--- a/modules/ppcp-googlepay/src/Helper/ApmApplies.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmApplies.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Googlepay\Helper;
 
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
+
 /**
  * Class ApmApplies
  */
@@ -30,11 +32,11 @@ class ApmApplies {
 	private $allowed_currencies;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * 2-letter country code of the shop.
@@ -46,15 +48,15 @@ class ApmApplies {
 	/**
 	 * DccApplies constructor.
 	 *
-	 * @param array  $allowed_countries The list of which countries can be used for GooglePay.
-	 * @param array  $allowed_currencies The list of which currencies can be used for GooglePay.
-	 * @param string $currency 3-letter currency code of the shop.
-	 * @param string $country 2-letter country code of the shop.
+	 * @param array          $allowed_countries The list of which countries can be used for GooglePay.
+	 * @param array          $allowed_currencies The list of which currencies can be used for GooglePay.
+	 * @param CurrencyGetter $currency The getter of the 3-letter currency code of the shop.
+	 * @param string         $country 2-letter country code of the shop.
 	 */
 	public function __construct(
 		array $allowed_countries,
 		array $allowed_currencies,
-		string $currency,
+		CurrencyGetter $currency,
 		string $country
 	) {
 		$this->allowed_countries  = $allowed_countries;
@@ -78,7 +80,7 @@ class ApmApplies {
 	 * @return bool
 	 */
 	public function for_currency(): bool {
-		return in_array( $this->currency, $this->allowed_currencies, true );
+		return in_array( $this->currency->get(), $this->allowed_currencies, true );
 	}
 
 }

--- a/modules/ppcp-paypal-subscriptions/services.php
+++ b/modules/ppcp-paypal-subscriptions/services.php
@@ -25,7 +25,7 @@ return array(
 			$container->get( 'api.endpoint.billing-plans' ),
 			$container->get( 'api.factory.billing-cycle' ),
 			$container->get( 'api.factory.payment-preferences' ),
-			$container->get( 'api.shop.currency' ),
+			$container->get( 'api.shop.currency.getter' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-paypal-subscriptions/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-paypal-subscriptions/src/SubscriptionsApiHandler.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\BillingCycleFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PaymentPreferencesFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ProductFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ItemTrait;
 
 /**
@@ -66,9 +67,9 @@ class SubscriptionsApiHandler {
 	/**
 	 * The currency.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * The logger.
@@ -85,7 +86,7 @@ class SubscriptionsApiHandler {
 	 * @param BillingPlans              $billing_plans_endpoint Billing plans endpoint.
 	 * @param BillingCycleFactory       $billing_cycle_factory Billing cycle factory.
 	 * @param PaymentPreferencesFactory $payment_preferences_factory Payment preferences factory.
-	 * @param string                    $currency The currency.
+	 * @param CurrencyGetter            $currency The currency.
 	 * @param LoggerInterface           $logger The logger.
 	 */
 	public function __construct(
@@ -94,7 +95,7 @@ class SubscriptionsApiHandler {
 		BillingPlans $billing_plans_endpoint,
 		BillingCycleFactory $billing_cycle_factory,
 		PaymentPreferencesFactory $payment_preferences_factory,
-		string $currency,
+		CurrencyGetter $currency,
 		LoggerInterface $logger
 	) {
 		$this->products_endpoint           = $products_endpoint;
@@ -253,7 +254,7 @@ class SubscriptionsApiHandler {
 				array(
 					'fixed_price' => array(
 						'value'         => '0',
-						'currency_code' => $this->currency,
+						'currency_code' => $this->currency->get(),
 					),
 				),
 				1
@@ -272,7 +273,7 @@ class SubscriptionsApiHandler {
 			array(
 				'fixed_price' => array(
 					'value'         => $product->get_meta( '_subscription_price' ) ?: $product->get_price(),
-					'currency_code' => $this->currency,
+					'currency_code' => $this->currency->get(),
 				),
 			),
 			(int) $product->get_meta( '_subscription_length' )

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -25,7 +25,7 @@ return array(
 	'save-payment-methods.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ) : SavePaymentMethodsApplies {
 		return new SavePaymentMethodsApplies(
 			$container->get( 'save-payment-methods.supported-country-currency-matrix' ),
-			$container->get( 'api.shop.currency' ),
+			$container->get( 'api.shop.currency.getter' ),
 			$container->get( 'api.shop.country' )
 		);
 	},

--- a/modules/ppcp-save-payment-methods/src/Helper/SavePaymentMethodsApplies.php
+++ b/modules/ppcp-save-payment-methods/src/Helper/SavePaymentMethodsApplies.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\SavePaymentMethods\Helper;
 
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
+
 /**
  * Class SavePaymentMethodsApplies
  */
@@ -22,11 +24,11 @@ class SavePaymentMethodsApplies {
 	private $allowed_country_currency_matrix;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * 2-letter country code of the shop.
@@ -38,13 +40,13 @@ class SavePaymentMethodsApplies {
 	/**
 	 * SavePaymentMethodsApplies constructor.
 	 *
-	 * @param array  $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for Save Payment Methods.
-	 * @param string $currency 3-letter currency code of the shop.
-	 * @param string $country 2-letter country code of the shop.
+	 * @param array          $allowed_country_currency_matrix The matrix which countries and currency combinations can be used for Save Payment Methods.
+	 * @param CurrencyGetter $currency The getter of the 3-letter currency code of the shop.
+	 * @param string         $country 2-letter country code of the shop.
 	 */
 	public function __construct(
 		array $allowed_country_currency_matrix,
-		string $currency,
+		CurrencyGetter $currency,
 		string $country
 	) {
 		$this->allowed_country_currency_matrix = $allowed_country_currency_matrix;
@@ -61,6 +63,6 @@ class SavePaymentMethodsApplies {
 		if ( ! in_array( $this->country, array_keys( $this->allowed_country_currency_matrix ), true ) ) {
 			return false;
 		}
-		return in_array( $this->currency, $this->allowed_country_currency_matrix[ $this->country ], true );
+		return in_array( $this->currency->get(), $this->allowed_country_currency_matrix[ $this->country ], true );
 	}
 }

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -343,7 +343,7 @@ return array(
 	},
 	'wcgateway.notice.currency-unsupported'                => static function ( ContainerInterface $container ): UnsupportedCurrencyAdminNotice {
 		$state                    = $container->get( 'onboarding.state' );
-		$shop_currency            = $container->get( 'api.shop.currency' );
+		$shop_currency            = $container->get( 'api.shop.currency.getter' );
 		$supported_currencies     = $container->get( 'api.supported-currencies' );
 		$is_wc_gateways_list_page = $container->get( 'wcgateway.is-wc-gateways-list-page' );
 		$is_ppcp_settings_page    = $container->get( 'wcgateway.is-ppcp-settings-page' );

--- a/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
@@ -48,11 +49,11 @@ class SettingsPageAssets {
 	private $client_id;
 
 	/**
-	 * 3-letter currency code of the shop.
+	 * The getter of the 3-letter currency code of the shop.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $currency;
+	private CurrencyGetter $currency;
 
 	/**
 	 * 2-letter country code of the shop.
@@ -124,7 +125,7 @@ class SettingsPageAssets {
 	 * @param string                    $version                            The assets version.
 	 * @param SubscriptionHelper        $subscription_helper The subscription helper.
 	 * @param string                    $client_id The PayPal SDK client ID.
-	 * @param string                    $currency 3-letter currency code of the shop.
+	 * @param CurrencyGetter            $currency The getter of the 3-letter currency code of the shop.
 	 * @param string                    $country 2-letter country code of the shop.
 	 * @param Environment               $environment The environment object.
 	 * @param bool                      $is_pay_later_button_enabled Whether Pay Later button is enabled either for checkout, cart or product page.
@@ -140,7 +141,7 @@ class SettingsPageAssets {
 		string $version,
 		SubscriptionHelper $subscription_helper,
 		string $client_id,
-		string $currency,
+		CurrencyGetter $currency,
 		string $country,
 		Environment $environment,
 		bool $is_pay_later_button_enabled,
@@ -224,7 +225,7 @@ class SettingsPageAssets {
 				array(
 					'is_subscriptions_plugin_active' => $this->subscription_helper->plugin_is_active(),
 					'client_id'                      => $this->client_id,
-					'currency'                       => $this->currency,
+					'currency'                       => $this->currency->get(),
 					'country'                        => $this->country,
 					'environment'                    => $this->environment->current_environment(),
 					'integration_date'               => PAYPAL_INTEGRATION_DATE,

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Notice;
 
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -36,9 +37,9 @@ class UnsupportedCurrencyAdminNotice {
 	/**
 	 * The shop currency.
 	 *
-	 * @var string
+	 * @var CurrencyGetter
 	 */
-	private $shop_currency;
+	private CurrencyGetter $shop_currency;
 
 	/**
 	 * Indicates if we're on the WooCommerce gateways list page.
@@ -57,15 +58,15 @@ class UnsupportedCurrencyAdminNotice {
 	/**
 	 * UnsupportedCurrencyAdminNotice constructor.
 	 *
-	 * @param State  $state The state.
-	 * @param string $shop_currency The shop currency.
-	 * @param array  $supported_currencies The supported currencies.
-	 * @param bool   $is_wc_gateways_list_page Indicates if we're on the WooCommerce gateways list page.
-	 * @param bool   $is_ppcp_settings_page Indicates if we're on a PPCP Settings page.
+	 * @param State          $state The state.
+	 * @param CurrencyGetter $shop_currency The shop currency.
+	 * @param array          $supported_currencies The supported currencies.
+	 * @param bool           $is_wc_gateways_list_page Indicates if we're on the WooCommerce gateways list page.
+	 * @param bool           $is_ppcp_settings_page Indicates if we're on a PPCP Settings page.
 	 */
 	public function __construct(
 		State $state,
-		string $shop_currency,
+		CurrencyGetter $shop_currency,
 		array $supported_currencies,
 		bool $is_wc_gateways_list_page,
 		bool $is_ppcp_settings_page
@@ -96,7 +97,7 @@ class UnsupportedCurrencyAdminNotice {
 				'Attention: Your current WooCommerce store currency (%1$s) is not supported by PayPal. Please update your store currency to one that is supported by PayPal to ensure smooth transactions. Visit the %2$sPayPal currency support page%3$s for more information on supported currencies.',
 				'woocommerce-paypal-payments'
 			),
-			$this->shop_currency,
+			$this->shop_currency->get(),
 			'<a href="' . esc_url( $paypal_currency_support_url ) . '">',
 			'</a>'
 		);
@@ -120,7 +121,7 @@ class UnsupportedCurrencyAdminNotice {
 	 * @return bool
 	 */
 	private function currency_supported(): bool {
-		$currency             = $this->shop_currency;
+		$currency             = $this->shop_currency->get();
 		$supported_currencies = $this->supported_currencies;
 		return in_array( $currency, $supported_currencies, true );
 	}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -190,7 +190,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$c->get( 'ppcp.asset-version' ),
 				$c->get( 'wc-subscriptions.helper' ),
 				$c->get( 'button.client_id_for_admin' ),
-				$c->get( 'api.shop.currency' ),
+				$c->get( 'api.shop.currency.getter' ),
 				$c->get( 'api.shop.country' ),
 				$c->get( 'onboarding.environment' ),
 				$settings_status->is_pay_later_button_enabled(),

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\Helper\CurrencyGetterStub;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -15,6 +16,7 @@ use function Brain\Monkey\Functions\when;
 class AmountFactoryTest extends TestCase
 {
 	private $currency = 'EUR';
+	private $currencyGetter;
 
 	private $itemFactory;
 	private $moneyFactory;
@@ -26,7 +28,8 @@ class AmountFactoryTest extends TestCase
 
 		$this->itemFactory = Mockery::mock(ItemFactory::class);
 		$this->moneyFactory = new MoneyFactory();
-		$this->testee = new AmountFactory($this->itemFactory, $this->moneyFactory, $this->currency);
+		$this->currencyGetter = new CurrencyGetterStub($this->currency);
+		$this->testee = new AmountFactory($this->itemFactory, $this->moneyFactory, $this->currencyGetter);
 	}
 
 	public function testFromWcCartDefault()

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -5,6 +5,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\Helper\CurrencyGetterStub;
 use WooCommerce\PayPalCommerce\TestCase;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
@@ -12,9 +13,16 @@ use Mockery;
 
 class ItemFactoryTest extends TestCase
 {
-	private $currency = 'EUR';
+	private $currency;
 
-    public function testFromCartDefault()
+	public function setUp(): void
+	{
+		parent::setUp();
+		
+		$this->currency = new CurrencyGetterStub();
+	}
+
+	public function testFromCartDefault()
     {
         $testee = new ItemFactory($this->currency);
 
@@ -169,7 +177,7 @@ class ItemFactoryTest extends TestCase
         $order = Mockery::mock(\WC_Order::class);
         $order
             ->expects('get_currency')
-            ->andReturn($this->currency);
+            ->andReturn($this->currency->get());
         $order
             ->expects('get_items')
             ->andReturn([$item]);
@@ -228,7 +236,7 @@ class ItemFactoryTest extends TestCase
         $order = Mockery::mock(\WC_Order::class);
         $order
             ->expects('get_currency')
-            ->andReturn($this->currency);
+            ->andReturn($this->currency->get());
         $order
             ->expects('get_items')
             ->andReturn([$item]);
@@ -357,7 +365,7 @@ class ItemFactoryTest extends TestCase
             'quantity' => 1,
             'unit_amount' => (object) [
                 'value' => 1,
-                'currency_code' => $this->currency,
+                'currency_code' => $this->currency->get(),
             ],
             'category' => Item::DIGITAL_GOODS,
         ];

--- a/tests/PHPUnit/Helper/CurrencyGetterStub.php
+++ b/tests/PHPUnit/Helper/CurrencyGetterStub.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Helper;
+
+use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
+
+class CurrencyGetterStub extends CurrencyGetter
+{
+	private string $currency;
+
+	public function __construct(string $currency = 'EUR')
+	{
+		$this->currency = $currency;
+	}
+
+	public function get(): string
+	{
+		return $this->currency;
+	}
+}

--- a/tests/PHPUnit/WcGateway/Assets/SettingsPagesAssetsTest.php
+++ b/tests/PHPUnit/WcGateway/Assets/SettingsPagesAssetsTest.php
@@ -4,6 +4,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Assets;
 
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingAgreementsEndpoint;
+use WooCommerce\PayPalCommerce\Helper\CurrencyGetterStub;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\TestCase;
@@ -25,7 +26,7 @@ class SettingsPagesAssetsTest extends TestCase
             $modulePath,
             $subscriptionsHelper,
             '123',
-            'EUR',
+            new CurrencyGetterStub(),
             'DE',
 			Mockery::mock(Environment::class),
             true,


### PR DESCRIPTION
After migrating to modularity the services are properly cached, which causes problems with plugins overriding the WC currency because we cache it too early (both the `api.shop.currency` service and the classes using it, such as `ItemFactory`).

So I extracted it into the `CurrencyGetter` class, and changed the code to call its `get()` as late as possible.