### PR TITLE
Multiple calls to POST /v1/oauth2/token?grant_type=client_credentials&response_type=id_token (3766)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -834,11 +834,15 @@ return array(
 	'api.client-credentials-cache'                   => static function( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-client-credentials-cache' );
 	},
+	'api.user-id-token-cache'                        => static function( ContainerInterface $container ): Cache {
+		return new Cache( 'ppcp-id-token-cache' );
+	},
 	'api.user-id-token'                              => static function( ContainerInterface $container ): UserIdToken {
 		return new UserIdToken(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'api.client-credentials' )
+			$container->get( 'api.client-credentials' ),
+			$container->get( 'api.user-id-token-cache' )
 		);
 	},
 	'api.sdk-client-token'                           => static function( ContainerInterface $container ): SdkClientToken {

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -11,6 +11,7 @@ use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WP_Error;
 
 /**
@@ -19,6 +20,8 @@ use WP_Error;
 class UserIdToken {
 
 	use RequestTrait;
+
+	const CACHE_KEY = 'id-token-key';
 
 	/**
 	 * The host.
@@ -42,20 +45,30 @@ class UserIdToken {
 	private $client_credentials;
 
 	/**
+	 * The cache.
+	 *
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
 	 * UserIdToken constructor.
 	 *
 	 * @param string            $host The host.
 	 * @param LoggerInterface   $logger The logger.
 	 * @param ClientCredentials $client_credentials The client credentials.
+	 * @param Cache             $cache The cache.
 	 */
 	public function __construct(
 		string $host,
 		LoggerInterface $logger,
-		ClientCredentials $client_credentials
+		ClientCredentials $client_credentials,
+		Cache $cache
 	) {
 		$this->host               = $host;
 		$this->logger             = $logger;
 		$this->client_credentials = $client_credentials;
+		$this->cache              = $cache;
 	}
 
 	/**
@@ -69,6 +82,11 @@ class UserIdToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function id_token( string $target_customer_id = '' ): string {
+		$session_customer_id = WC()->session->get_customer_id() ?? '';
+		if ( $session_customer_id && $this->cache->has( self::CACHE_KEY . (string) $session_customer_id ) ) {
+			return $this->cache->get( self::CACHE_KEY . (string) $session_customer_id );
+		}
+
 		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=id_token';
 		if ( $target_customer_id ) {
 			$url = add_query_arg(
@@ -98,6 +116,12 @@ class UserIdToken {
 			throw new PayPalApiException( $json, $status_code );
 		}
 
-		return $json->id_token;
+		$id_token = $json->id_token;
+
+		if ( $session_customer_id ) {
+			$this->cache->set( self::CACHE_KEY . (string) $session_customer_id, $id_token, 5 );
+		}
+
+		return $id_token;
 	}
 }

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -82,7 +82,7 @@ class UserIdToken {
 	 * @throws RuntimeException If something unexpected happens.
 	 */
 	public function id_token( string $target_customer_id = '' ): string {
-		$session_customer_id = WC()->session->get_customer_id() ?? '';
+		$session_customer_id = WC()->session->get_customer_id() ?: '';
 		if ( $session_customer_id && $this->cache->has( self::CACHE_KEY . (string) $session_customer_id ) ) {
 			return $this->cache->get( self::CACHE_KEY . (string) $session_customer_id );
 		}


### PR DESCRIPTION
There are multiple calls to `POST /v1/oauth2/token?grant_type=client_credentials&response_type=id_token` within a short period of seconds.

This PR caches the response for 5 seconds reducing the number of calls to the same endpoint.

### Steps to Reproduce
- Enable Vaulting for PayPal payment
- Add product to cart and visit Cart page
- Check logs, notice multiple entries to the same endpoint within a short period of seconds:
```
2024-10-04T11:49:58+00:00 DEBUG POST https://api-m.sandbox.paypal.com/v1/oauth2/token?grant_type=client_credentials&response_type=id_token
2024-10-04T11:49:59+00:00 DEBUG POST https://api-m.sandbox.paypal.com/v1/oauth2/token?grant_type=client_credentials&response_type=id_token
2024-10-04T11:50:09+00:00 DEBUG POST https://api-m.sandbox.paypal.com/v1/oauth2/token?grant_type=client_credentials&response_type=id_token
```