### PR TITLE
Axo Block: Display card fields for authenticated cardless profiles (3767)

### DIFF
--- a/modules/ppcp-axo-block/resources/js/components/Payment/Payment.js
+++ b/modules/ppcp-axo-block/resources/js/components/Payment/Payment.js
@@ -42,8 +42,12 @@ export const Payment = ( { fastlaneSdk, onPaymentLoad } ) => {
 			const paymentComponent = await fastlaneSdk.FastlaneCardComponent(
 				{}
 			);
-			paymentComponent.render( `#fastlane-card` );
-			onPaymentLoad( paymentComponent );
+			// Check if the container exists before rendering
+			const cardContainer = document.querySelector( '#fastlane-card' );
+			if ( cardContainer ) {
+				paymentComponent.render( `#fastlane-card` );
+				onPaymentLoad( paymentComponent );
+			}
 		}
 	}, [
 		isGuest,

--- a/modules/ppcp-axo-block/resources/js/hooks/useAxoCleanup.js
+++ b/modules/ppcp-axo-block/resources/js/hooks/useAxoCleanup.js
@@ -18,7 +18,8 @@ import useCustomerData from './useCustomerData';
  */
 const useAxoCleanup = () => {
 	// Get dispatch functions from the AXO store
-	const { setIsAxoActive, setIsGuest } = useDispatch( STORE_NAME );
+	const { setIsAxoActive, setIsGuest, setIsEmailLookupCompleted } =
+		useDispatch( STORE_NAME );
 
 	// Get functions to update WooCommerce shipping and billing addresses
 	const {
@@ -45,6 +46,7 @@ const useAxoCleanup = () => {
 			// Reset AXO state
 			setIsAxoActive( false );
 			setIsGuest( true );
+			setIsEmailLookupCompleted( false );
 
 			// Remove AXO UI elements
 			removeShippingChangeButton();


### PR DESCRIPTION
### Description

This PR adds better handling for cases in the Block Checkout when profile data is missing card details. In such cases, we display the card fields.

### Screenshots

|Before|After|
|-|-|
|<img width="761" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/0309540d-6dc2-44dd-966c-3bdd3c107b91">|<img width="790" alt="Notification_Center" src="https://github.com/user-attachments/assets/746f56e7-daa6-4b35-9763-bd61ebbf4d11">|
