### PR TITLE
Place all task registration logic inside the init action (3762)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -848,21 +848,19 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	 * @return void
 	 */
 	protected function register_wc_tasks( ContainerInterface $container ): void {
-		$simple_redirect_tasks = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-tasks' );
-		if ( empty( $simple_redirect_tasks ) ) {
-			return;
-		}
-
-		$task_registrar = $container->get( 'wcgateway.settings.wc-tasks.task-registrar' );
-		assert( $task_registrar instanceof TaskRegistrarInterface );
-
-		$logger = $container->get( 'woocommerce.logger.woocommerce' );
-		assert( $logger instanceof LoggerInterface );
-
 		add_action(
 			'init',
-			static function () use ( $simple_redirect_tasks, $task_registrar, $logger ): void {
+			static function () use ( $container ): void {
+				$logger = $container->get( 'woocommerce.logger.woocommerce' );
+				assert( $logger instanceof LoggerInterface );
 				try {
+					$simple_redirect_tasks = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-tasks' );
+					if ( empty( $simple_redirect_tasks ) ) {
+						return;
+					}
+					$task_registrar = $container->get( 'wcgateway.settings.wc-tasks.task-registrar' );
+					assert( $task_registrar instanceof TaskRegistrarInterface );
+
 					$task_registrar->register( $simple_redirect_tasks );
 				} catch ( Exception $exception ) {
 					$logger->error( "Failed to create a task in the 'Things to do next' section of WC. " . $exception->getMessage() );


### PR DESCRIPTION
### Description
Fatal error on the site when WooCommerce PayPal Payments and Payoneer Checkout Debug are activated.

**The error**: `Uncaught Error: Call to a member function using_index_permalinks()`

`wcgateway.settings.wc-tasks.simple-redirect-tasks`  calls `wcgateway.settings.wc-tasks.simple-redirect-tasks-config` which calls `admin_url` method. When it is called outside the `init` method it causes an issue.  One of the Payoneer debug services that depends on `wp_rewrite` global variable is triggered by `admin_url`. As a result, it fails, because `wp_rewrite` is `null`.

