### PR TITLE
Display gateway icons on block checkout even when payment method is not selected (3737)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/card-fields.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.js
@@ -19,11 +19,9 @@ export function CardFields( {
 	config,
 	eventRegistration,
 	emitResponse,
-	components,
 } ) {
 	const { onPaymentSetup } = eventRegistration;
 	const { responseTypes } = emitResponse;
-	const { PaymentMethodIcons } = components;
 
 	const [ cardFieldsForm, setCardFieldsForm ] = useState();
 	const getCardFieldsForm = ( cardFieldsForm ) => {
@@ -95,10 +93,6 @@ export function CardFields( {
 					} }
 				>
 					<PayPalCardFieldsForm />
-					<PaymentMethodIcons
-						icons={ config.card_icons }
-						align="left"
-					/>
 					<CheckoutHandler
 						getCardFieldsForm={ getCardFieldsForm }
 						getSavePayment={ getSavePayment }

--- a/modules/ppcp-blocks/resources/js/advanced-card-checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/advanced-card-checkout-block.js
@@ -1,19 +1,30 @@
-import { registerPaymentMethod } from '@woocommerce/blocks-registry';
-import { CardFields } from './Components/card-fields';
+import {registerPaymentMethod} from '@woocommerce/blocks-registry';
+import {CardFields} from './Components/card-fields';
 
-const config = wc.wcSettings.getSetting( 'ppcp-credit-card-gateway_data' );
+const config = wc.wcSettings.getSetting('ppcp-credit-card-gateway_data');
 
-registerPaymentMethod( {
-	name: config.id,
-	label: <div dangerouslySetInnerHTML={ { __html: config.title } } />,
-	content: <CardFields config={ config } />,
-	edit: <CardFields config={ config } />,
-	ariaLabel: config.title,
-	canMakePayment: () => {
-		return true;
-	},
-	supports: {
-		showSavedCards: true,
-		features: config.supports,
-	},
-} );
+const Label = ({components, config}) => {
+    const {PaymentMethodIcons} = components;
+    return <>
+        <span dangerouslySetInnerHTML={{__html: config.title}}/>
+        <PaymentMethodIcons
+            icons={ config.card_icons }
+            align="right"
+        />
+    </>
+}
+
+registerPaymentMethod({
+    name: config.id,
+    label: <Label config={config}/>,
+    content: <CardFields config={config}/>,
+    edit: <CardFields config={config}/>,
+    ariaLabel: config.title,
+    canMakePayment: () => {
+        return true;
+    },
+    supports: {
+        showSavedCards: true,
+        features: config.supports,
+    },
+});


### PR DESCRIPTION
### Description

This PR adds a custom label for the advanced card checkout block, allowing multiple card icons to be displayed next to the label instead of beneath the iframe fields.
