### PR TITLE
Axo Block: Always display the Fastlane watermark in the includeAdditionalInfo mode (3778)

### DIFF
--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -259,8 +259,8 @@ a.wc-block-axo-change-link {
 .wp-block-woocommerce-checkout-fields-block:not(.wc-block-axo-is-loaded) {
 	.wc-block-checkout-axo-block-watermark-container {
 		display: flex;
-		justify-content: left;
-		margin-left: 10px;
+		justify-content: right;
+		margin-right: 10px;
 		align-items: center;
 		position: relative;
 

--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -174,9 +174,6 @@ $fast-transition-duration: 0.5s;
 		grid-area: watermark;
 		justify-self: end;
 		grid-column: 1;
-	}
-
-	&:not(.wc-block-axo-is-authenticated) .wc-block-checkout-axo-block-watermark-container {
 		margin-top: 0;
 	}
 

--- a/modules/ppcp-axo-block/resources/js/components/Watermark/WatermarkManager.js
+++ b/modules/ppcp-axo-block/resources/js/components/Watermark/WatermarkManager.js
@@ -16,9 +16,6 @@ import {
  */
 const WatermarkManager = ( { fastlaneSdk } ) => {
 	// Select relevant states from the AXO store
-	const isGuest = useSelect( ( select ) =>
-		select( STORE_NAME ).getIsGuest()
-	);
 	const isAxoActive = useSelect( ( select ) =>
 		select( STORE_NAME ).getIsAxoActive()
 	);
@@ -34,7 +31,6 @@ const WatermarkManager = ( { fastlaneSdk } ) => {
 				isAxoActive,
 				isAxoScriptLoaded,
 				fastlaneSdk,
-				isGuest,
 			} );
 		} else {
 			// Remove watermark when AXO is inactive and not loading
@@ -43,7 +39,7 @@ const WatermarkManager = ( { fastlaneSdk } ) => {
 
 		// Cleanup function to remove watermark on unmount
 		return removeWatermark;
-	}, [ fastlaneSdk, isGuest, isAxoActive, isAxoScriptLoaded ] );
+	}, [ fastlaneSdk, isAxoActive, isAxoScriptLoaded ] );
 
 	// This component doesn't render anything directly
 	return null;

--- a/modules/ppcp-axo-block/resources/js/components/Watermark/utils.js
+++ b/modules/ppcp-axo-block/resources/js/components/Watermark/utils.js
@@ -112,13 +112,11 @@ export const renderWatermarkContent = ( content ) => {
  * @param {boolean} params.isAxoActive       - Whether AXO is active.
  * @param {boolean} params.isAxoScriptLoaded - Whether AXO script is loaded.
  * @param {Object}  params.fastlaneSdk       - The Fastlane SDK instance.
- * @param {boolean} params.isGuest           - Whether the user is a guest.
  */
 export const updateWatermarkContent = ( {
 	isAxoActive,
 	isAxoScriptLoaded,
 	fastlaneSdk,
-	isGuest,
 } ) => {
 	if ( ! isAxoActive && ! isAxoScriptLoaded ) {
 		// Show loading spinner
@@ -134,7 +132,7 @@ export const updateWatermarkContent = ( {
 			createElement( Watermark, {
 				fastlaneSdk,
 				name: 'fastlane-watermark-email',
-				includeAdditionalInfo: isGuest,
+				includeAdditionalInfo: true,
 			} )
 		);
 	} else {


### PR DESCRIPTION
### Description

Before this PR the Fastlane Watermark (under the email input) would display in the `includeAdditionalInfo` mode only for guest users.

This PR ensures that it always displays in the `includeAdditionalInfo` mode (including after performing the successful email lookup).


### Steps to test

1. Open the Block Checkout page with Fastlane enabled.
2. Ensure the Watermark loading spinner displays on the right.
3. Ensure the Watermark displays correctly in the `includeAdditionalInfo` mode both on load and after the (successful email lookup).

### Screenshots

#### Before the lookup

|Before|After|
|-|-|
|<img width="925" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/d729eb33-f138-4cb4-8106-393950cda51b">|<img width="969" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/f96ba994-13e1-4d53-9c0e-d2bb38c0933e">|

#### After the lookup

|Before|After|
|-|-|
|<img width="910" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/d261cf3f-515c-4fac-b297-d7d8e33312b1">|<img width="850" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/c633573a-e691-4d44-af83-74c2ceefa159">|
