### PR TITLE
Buttons loading on single product page when the subscription support is not declared  (1815)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -234,6 +234,11 @@ class SingleProductBootstap {
 			this.errorHandler
 		);
 
+        if(!this.gateway.vaultingEnabled){
+            return;
+        }
+
+
 		if (
 			PayPalCommerceGateway.data_client_id.has_subscriptions &&
 			PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -233,11 +233,15 @@ class SingleProductBootstap {
 			this.form(),
 			this.errorHandler
 		);
-
-        if(!this.gateway.vaultingEnabled){
-            return;
-        }
-
+		if (
+			! this.gateway.vaultingEnabled &&
+			[ 'subscription', 'variable-subscription' ].includes(
+				this.gateway.productType
+			) &&
+			this.gateway.manualRenewalEnabled !== '1'
+		) {
+			return;
+		}
 
 		if (
 			PayPalCommerceGateway.data_client_id.has_subscriptions &&

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1318,7 +1318,20 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'should_handle_shipping_in_paypal'        => $this->should_handle_shipping_in_paypal && ! $this->is_checkout(),
 			'needShipping'                            => $this->need_shipping(),
 			'vaultingEnabled'                         => $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ),
+			'productType'                             => null,
+			'manualRenewalEnabled'                    => '',
 		);
+
+		if ( is_product() ) {
+			$product = wc_get_product( get_the_ID() );
+			if ( is_a( $product, \WC_Product::class ) ) {
+				$localize['productType'] = $product->get_type();
+			}
+		}
+
+		if ( class_exists( '\WCS_Manual_Renewal_Manager' ) ) {
+			$localize['manualRenewalEnabled'] = \WCS_Manual_Renewal_Manager::is_manual_renewal_enabled();
+		}
 
 		if ( 'pay-now' === $this->context() ) {
 			$localize['pay_now'] = $this->pay_now_script_data();

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1319,7 +1319,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'needShipping'                            => $this->need_shipping(),
 			'vaultingEnabled'                         => $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ),
 			'productType'                             => null,
-			'manualRenewalEnabled'                    => '',
+			'manualRenewalEnabled'                    => false,
 		);
 
 		if ( is_product() ) {
@@ -1330,7 +1330,11 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 		}
 
 		if ( class_exists( '\WCS_Manual_Renewal_Manager' ) ) {
-			/** @psalm-suppress UndefinedClass */
+			/**
+			 * UndefinedClass We verify the existence of the class prior to invoking a static method.
+			 *
+			 * @psalm-suppress
+			 */
 			$localize['manualRenewalEnabled'] = \WCS_Manual_Renewal_Manager::is_manual_renewal_enabled();
 		}
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1331,9 +1331,9 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 
 		if ( class_exists( '\WCS_Manual_Renewal_Manager' ) ) {
 			/**
-			 * UndefinedClass We verify the existence of the class prior to invoking a static method.
+			 * We verify the existence of the class prior to invoking a static method.
 			 *
-			 * @psalm-suppress
+			 * @psalm-suppress UndefinedClass
 			 */
 			$localize['manualRenewalEnabled'] = \WCS_Manual_Renewal_Manager::is_manual_renewal_enabled();
 		}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1330,6 +1330,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 		}
 
 		if ( class_exists( '\WCS_Manual_Renewal_Manager' ) ) {
+			/** @psalm-suppress UndefinedClass */
 			$localize['manualRenewalEnabled'] = \WCS_Manual_Renewal_Manager::is_manual_renewal_enabled();
 		}
 


### PR DESCRIPTION
### Description
This PR adds a condition that checks if vaulting is enabled before rendering buttons.

