### PR TITLE
Fix ACDC gateway not visible on the block Checkout for logged-out users (3780)

### DIFF
--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -69,8 +69,10 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				$payment_method_registry->register( $c->get( 'blocks.method' ) );
 
+				$settings = $c->get( 'wcgateway.settings' );
+
 				// Include ACDC in the Block Checkout only in case Axo doesn't exist or is not available or the user is logged in.
-				if ( ! $c->has( 'axoblock.available' ) || ! $c->get( 'axoblock.available' ) || is_user_logged_in() ) {
+				if ( ! $settings->get( 'axo_enabled' ) || is_user_logged_in() ) {
 					$payment_method_registry->register( $c->get( 'blocks.advanced-card-method' ) );
 				}
 			}


### PR DESCRIPTION
### Description

This PR fixes the ACDC gateway not being visible on block Checkout for logged-out users.

### Description

Instead of checking `$c->has( 'axoblock.available' )`  and `$c->get( 'axoblock.available' )` (which is always `true` for the time being), we should be checking whether the Fastlane setting is enabled: `$settings->get( 'axo_enabled' )`.

### Steps to test

1. Enable ACDC.
2. Log out or open an incognito window.
3. Visit the block Checkout.
4. Confirm that the ACDC gateway loads correctly.
5. Run the same test but being logged in.
6. Try with Fastlane enabled and disabled ensure the behavior is correct.

### Screenshots

N/A

