### PR TITLE
Do not display split local APMs when PayPal is not enabled (3781)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -60,7 +60,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 			 */
 			function ( $methods ) use ( $c ) {
 				$onboarding_state = $c->get( 'onboarding.state' );
-				if ( $onboarding_state->current_state() >= State::STATE_START ) {
+				if ( $onboarding_state->current_state() === State::STATE_START ) {
 					return $methods;
 				}
 

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
 
 use WC_Order;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -58,6 +59,11 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function ( $methods ) use ( $c ) {
+				$onboarding_state = $c->get( 'onboarding.state' );
+				if ( $onboarding_state->current_state() >= State::STATE_START ) {
+					return $methods;
+				}
+
 				if ( ! is_array( $methods ) ) {
 					return $methods;
 				}


### PR DESCRIPTION
### Description

This PR check the onboarding state before adding payment gateways using `woocommerce_payment_gateways` filter.