### PR TITLE
Fix problems with autoptimize plugin (2170)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -407,6 +407,11 @@ class ApplePayButton {
 			.querySelectorAll( 'style#ppcp-hide-apple-pay' )
 			.forEach( ( el ) => el.remove() );
 
+        const paymentMethodAppleLi = document.querySelector('.wc_payment_method.payment_method_ppcp-applepay' );
+        if (paymentMethodAppleLi.style.display === 'none' || paymentMethodAppleLi.style.display === '') {
+            paymentMethodAppleLi.style.display = 'block';
+        }
+
 		this.allElements.forEach( ( element ) => {
 			element.style.display = '';
 		} );

--- a/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsFreeTrialRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsFreeTrialRenderer.js
@@ -38,6 +38,12 @@ class CardFieldsFreeTrialRenderer {
 		if ( hideDccGateway ) {
 			hideDccGateway.parentNode.removeChild( hideDccGateway );
 		}
+        const dccGatewayLi = document.querySelector(
+            '.wc_payment_method.payment_method_ppcp-credit-card-gateway'
+        );
+        if (dccGatewayLi.style.display === 'none' || dccGatewayLi.style.display === '') {
+            dccGatewayLi.style.display = 'block';
+        }
 
 		this.errorHandler.clear();
 

--- a/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js
@@ -44,6 +44,12 @@ class CardFieldsRenderer {
 		if ( hideDccGateway ) {
 			hideDccGateway.parentNode.removeChild( hideDccGateway );
 		}
+        const dccGatewayLi = document.querySelector(
+            '.wc_payment_method.payment_method_ppcp-credit-card-gateway'
+        );
+        if (dccGatewayLi.style.display === 'none' || dccGatewayLi.style.display === '') {
+            dccGatewayLi.style.display = 'block';
+        }
 
 		const cardFields = paypal.CardFields( {
 			createOrder: contextConfig.createOrder,

--- a/modules/ppcp-button/resources/js/modules/Renderer/HostedFieldsRenderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/HostedFieldsRenderer.js
@@ -52,6 +52,12 @@ class HostedFieldsRenderer {
 			if ( hideDccGateway ) {
 				hideDccGateway.parentNode.removeChild( hideDccGateway );
 			}
+            const dccGatewayLi = document.querySelector(
+                '.wc_payment_method.payment_method_ppcp-credit-card-gateway'
+            );
+            if (dccGatewayLi.style.display === 'none' || dccGatewayLi.style.display === '') {
+                dccGatewayLi.style.display = 'block';
+            }
 
 			const cardNumberField = document.querySelector(
 				'#ppcp-credit-card-gateway-card-number'

--- a/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
@@ -763,10 +763,15 @@ export default class PaymentButton {
 
 		const styleSelector = `style[data-hide-gateway="${ this.methodId }"]`;
 		const wrapperSelector = `#${ this.wrappers.Default }`;
+        const paymentMethodLi = document.querySelector(`.wc_payment_method.payment_method_${ this.methodId }`);
 
 		document
 			.querySelectorAll( styleSelector )
 			.forEach( ( el ) => el.remove() );
+
+        if (paymentMethodLi.style.display === 'none' || paymentMethodLi.style.display === '') {
+            paymentMethodLi.style.display = 'block';
+        }
 
 		document
 			.querySelectorAll( wrapperSelector )


### PR DESCRIPTION
When the Autoptimize plugin is active and the three options are checked:
- Aggregate CSS-files?
- Also aggregate inline CSS?
- Also optimize shop cart/ checkout?

Some Gateways will not be shown on the classic checkout page.

That is because the CSS for hiding the gateway initial will be removed from HTML and added to a CSS file, then the JS can't remove it from DOM.