### PR TITLE
Axo: Remove the submit button when Fastlane is disabled (3504)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -222,8 +222,10 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				// Render submit button.
 				add_action(
 					$manager->checkout_button_renderer_hook(),
-					static function () use ( $c, $manager ) {
-						$manager->render_checkout_button();
+					static function () use ( $c, $manager, $module ) {
+						if ( $module->should_render_fastlane( $c ) ) {
+							$manager->render_checkout_button();
+						}
 					}
 				);
 


### PR DESCRIPTION
### Description

This PR removes the Axo submit button from the markup when Fastlane is disabled.

### Steps to test

1. Disable Fastlane.
2. Visit the Classic Checkout.
3. Make sure `<button id="place_order" type="button" class="button alt ppcp-axo-order-button wp-element-button">Place order</button>` is not present in the markup.

### Screenshots

N/A