### PR TITLE
Load ACDC for Classic and Block checkouts for subscription products (3615)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -375,11 +375,15 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		$dcc_configuration = $c->get( 'wcgateway.configuration.dcc' );
 		assert( $dcc_configuration instanceof DCCGatewayConfiguration );
 
+		$subscription_helper = $c->get( 'wc-subscriptions.helper' );
+		assert( $subscription_helper instanceof SubscriptionHelper );
+
 		return ! is_user_logged_in()
 			&& CartCheckoutDetector::has_classic_checkout()
 			&& $dcc_configuration->use_fastlane()
 			&& ! $this->is_excluded_endpoint()
-			&& is_checkout();
+			&& is_checkout()
+			&& ! $subscription_helper->cart_contains_subscription();
 	}
 
 	/**

--- a/modules/ppcp-blocks/resources/js/advanced-card-checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/advanced-card-checkout-block.js
@@ -1,30 +1,50 @@
-import {registerPaymentMethod} from '@woocommerce/blocks-registry';
-import {CardFields} from './Components/card-fields';
+import { registerPaymentMethod } from '@woocommerce/blocks-registry';
+import { CardFields } from './Components/card-fields';
 
-const config = wc.wcSettings.getSetting('ppcp-credit-card-gateway_data');
+const config = wc.wcSettings.getSetting( 'ppcp-credit-card-gateway_data' );
+const isUserLoggedIn = config?.scriptData?.is_user_logged_in;
+const axoConfig = wc.wcSettings.getSetting( 'ppcp-axo-gateway_data' );
+const axoEnabled = axoConfig !== false;
 
-const Label = ({components, config}) => {
-    const {PaymentMethodIcons} = components;
-    return <>
-        <span dangerouslySetInnerHTML={{__html: config.title}}/>
-        <PaymentMethodIcons
-            icons={ config.card_icons }
-            align="right"
-        />
-    </>
-}
+const Label = ( { components } ) => {
+	const { PaymentMethodIcons } = components;
+	return (
+		<>
+			<span dangerouslySetInnerHTML={ { __html: config?.title } } />
+			<PaymentMethodIcons icons={ config?.card_icons } align="right" />
+		</>
+	);
+};
 
-registerPaymentMethod({
-    name: config.id,
-    label: <Label config={config}/>,
-    content: <CardFields config={config}/>,
-    edit: <CardFields config={config}/>,
-    ariaLabel: config.title,
-    canMakePayment: () => {
-        return true;
-    },
-    supports: {
-        showSavedCards: true,
-        features: config.supports,
-    },
-});
+registerPaymentMethod( {
+	name: config?.id,
+	label: <Label />,
+	content: <CardFields config={ config } />,
+	edit: <CardFields config={ config } />,
+	ariaLabel: config?.title,
+	canMakePayment: ( cartData ) => {
+		const cartItems = cartData?.cart?.cartItems || [];
+
+		// Check if any item in the cart is a subscription
+		const hasSubscription = cartItems.some(
+			( item ) =>
+				item?.type === 'subscription' ||
+				item?.type === 'variable-subscription' ||
+				cartData?.paymentRequirements?.includes( 'subscriptions' )
+		);
+
+		// Show payment method if:
+		// 1. Axo is disabled, OR
+		// 2. User is logged in, OR
+		// 3. Axo is enabled AND cart has subscriptions
+		return !! (
+			! axoEnabled ||
+			isUserLoggedIn ||
+			( axoEnabled && hasSubscription )
+		);
+	},
+	supports: {
+		showSavedCards: true,
+		features: config?.supports,
+	},
+} );

--- a/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
+++ b/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
@@ -110,6 +110,7 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		$script_data = $this->smart_button_instance()->script_data();
+		$script_data = array_merge( $script_data, array( 'is_user_logged_in' => is_user_logged_in() ) );
 
 		return array(
 			'id'                  => $this->name,

--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameI
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
  * Class BlocksModule
@@ -73,10 +74,7 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
-				// Include ACDC in the Block Checkout only in case Axo doesn't exist or is not available or the user is logged in.
-				if ( ( $settings->has( 'axo_enabled' ) && ! $settings->get( 'axo_enabled' ) ) || is_user_logged_in() ) {
-					$payment_method_registry->register( $c->get( 'blocks.advanced-card-method' ) );
-				}
+				$payment_method_registry->register( $c->get( 'blocks.advanced-card-method' ) );
 			}
 		);
 


### PR DESCRIPTION
### Description

This PR fixes the issue with ACDC not loading when a subscription product is in the Cart.

### Steps to test

#### Test Case 1: Subscription Product + Fastlane Enabled
1. Enable Fastlane.
2. Add a subscription product to cart.
3. Navigate to the Classic Checkout and Block Checkout.
4. Verify ACDC is now visible as a payment option.

#### Test Case 2: Regular Product + Fastlane Enabled
1. Enable Fastlane.
2. Add regular a product to cart.
3. Navigate to the Classic Checkout and Block Checkout.
4. Verify Fastlane displays normally.

#### Test Case 3: Mixed Cart (Subscription + Regular Products)
1. Enable Fastlane.
2. Add both subscription and regular products.
3. Navigate to the Classic Checkout and Block Checkout.
4. Verify ACDC is visible due to subscription presence.

### Screenshots
N/A