### PR TITLE
Apple Pay button preview missing in Standard payment and Advanced Processing tabs (3826)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -407,10 +407,17 @@ class ApplePayButton {
 			.querySelectorAll( 'style#ppcp-hide-apple-pay' )
 			.forEach( ( el ) => el.remove() );
 
-        const paymentMethodAppleLi = document.querySelector('.wc_payment_method.payment_method_ppcp-applepay' );
-        if (paymentMethodAppleLi.style.display === 'none' || paymentMethodAppleLi.style.display === '') {
-            paymentMethodAppleLi.style.display = 'block';
-        }
+		const paymentMethodAppleLi = document.querySelector(
+			'.wc_payment_method.payment_method_ppcp-applepay'
+		);
+
+		if (
+			paymentMethodAppleLi &&
+			( paymentMethodAppleLi.style.display === 'none' ||
+				paymentMethodAppleLi.style.display === '' )
+		) {
+			paymentMethodAppleLi.style.display = 'block';
+		}
 
 		this.allElements.forEach( ( element ) => {
 			element.style.display = '';


### PR DESCRIPTION
Apple Pay is missing from on all pages and button styling preview on Standard payment tab and Advanced Processing tab 

### Steps To Reproduce
- Navigate to Advance card proccesing tab and enable Apple Pay
    - Observe button is missing
- Navigate to Standard payment tab
    - Observe button is missing from Button styling preview tab

This PR fix a JS error by checking if the element exist before using it.
