### PR TITLE
Google Pay and Apple Pay as separate gateways does not show button when checkout remove from button locations (3830)

### DIFF
--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -168,6 +168,20 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 			}
 		);
 
+		add_filter(
+			'woocommerce_paypal_payments_selected_button_locations',
+			function( array $locations, string $setting_name ) {
+				$gateway = WC()->payment_gateways()->payment_gateways()[ ApplePayGateway::ID ] ?? '';
+				if ( $gateway && $gateway->enabled === 'yes' && $setting_name === 'smart_button_locations' ) {
+					$locations[] = 'checkout';
+				}
+
+				return $locations;
+			},
+			10,
+			2
+		);
+
 		return true;
 	}
 

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -170,7 +170,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_filter(
 			'woocommerce_paypal_payments_selected_button_locations',
-			function( array $locations, string $setting_name ) {
+			function( array $locations, string $setting_name ): array {
 				$gateway = WC()->payment_gateways()->payment_gateways()[ ApplePayGateway::ID ] ?? '';
 				if ( $gateway && $gateway->enabled === 'yes' && $setting_name === 'smart_button_locations' ) {
 					$locations[] = 'checkout';

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -220,7 +220,7 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		add_filter(
 			'woocommerce_paypal_payments_selected_button_locations',
-			function( array $locations, string $setting_name ) {
+			function( array $locations, string $setting_name ): array {
 				$gateway = WC()->payment_gateways()->payment_gateways()[ GooglePayGateway::ID ] ?? '';
 				if ( $gateway && $gateway->enabled === 'yes' && $setting_name === 'smart_button_locations' ) {
 					$locations[] = 'checkout';

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -218,6 +218,20 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			}
 		);
 
+		add_filter(
+			'woocommerce_paypal_payments_selected_button_locations',
+			function( array $locations, string $setting_name ) {
+				$gateway = WC()->payment_gateways()->payment_gateways()[ GooglePayGateway::ID ] ?? '';
+				if ( $gateway && $gateway->enabled === 'yes' && $setting_name === 'smart_button_locations' ) {
+					$locations[] = 'checkout';
+				}
+
+				return $locations;
+			},
+			10,
+			2
+		);
+
 		return true;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -123,7 +123,11 @@ class SettingsStatus {
 	protected function is_enabled_for_location( string $setting_name, string $location ): bool {
 		$location = $this->normalize_location( $location );
 
-		$selected_locations = $this->settings->has( $setting_name ) ? $this->settings->get( $setting_name ) : array();
+		$selected_locations = apply_filters(
+			'woocommerce_paypal_payments_selected_button_locations',
+			$this->settings->has( $setting_name ) ? $this->settings->get( $setting_name ) : array(),
+			$setting_name
+		);
 
 		if ( empty( $selected_locations ) ) {
 			return false;


### PR DESCRIPTION
Google Pay and Apple Pay as separate gateways - Place order button when classic checkout removed from smart button location.

### Steps To Reproduce
- Navigate to Standard payments tab and remove Classic Checkout from smart button location
- Enable Google Pay and Apple Pay on Advanced card processing tab
- Navigate to Payments tab and enable Google Pay and Apple Pay as separate gateways
- Navigate to shop, add product to cart
- Navigate to classic checkout page
- Select Google Pay gateway
    - Observe Place order button
- Select Apple Pay
    - Observe Place order button

As we are removing the classic checkout button location (`checkout`), the existing logic does not render ApplePay and GooglePay buttons when enabled as payment gateway.

This PR fixes the issue by adding a filter that allows adding button locations programmatically and use it to conditionally add the `checkout` location. 