### PR TITLE
Release 2.9.4-rc1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,28 @@
 *** Changelog ***
 
+= 2.9.4 - xxxx-xx-xx =
+* Fix - Apple Pay button preview missing in Standard payment and Advanced Processing tabs #2755
+* Fix - Set "Sold individually" only for subscription connected to PayPal #2710
+* Fix - Ensure Google Pay button does not appear for subscriptions #2718
+* Fix - PayPal Subscriptions API renewal order not created in WooCommerce #2612
+* Fix - Apple Pay button disappears on Classic Checkout #2722
+* Fix - Google Pay and Apple Pay as separate gateways does not show button when checkout remove from button locations #2756
+* Fix - Add GW refund support for Apple Pay #2746
+* Fix - PayPal Subscriptions cancel and suspend from Subscriptions list page does not work #2632
+* Fix - Displaying of HTML tags in product title on choosing a product for tracking (2801) #2701
+* Fix - Payment with OXXO cause continuation state for next payment #2702
+* Fix - Fix problems with autoptimize plugin #2705
+* Fix - Missing custom field PayPal Transaction Fee for OXXO #2700
+* Enhancement - Extend Advanced Card Processing country/currency feature availability #2754
+* Enhancement - Add void button #2678
+* Enhancement - Use basic redirect gateway when checkout smart buttons disabled #2714
+* Enhancement - Receive button properties from the Checkout Block #2448
+* Enhancement - Run PPEC\DeactivateNote query only in backend #2719
+* Enhancement - Prevent plugin use for "Send only" countries #2721
+* Enhancement - Do not add pay later button in editor #2570
+* Enhancement - Axo: Remove the submit button when Fastlane is disabled #2720
+* Enhancement - Sync the PayPal product page button state to Apple/Google Pay buttons, show alerts #2742
+
 = 2.9.3 - 2024-10-15 =
 * Fix - Multi-currency support #2667
 * Fix - "0.00" amount in Google Pay for virtual products #2636

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "2.9.3",
+  "version": "2.9.4",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 7.4
-Stable tag: 2.9.3
+Stable tag: 2.9.4
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -178,6 +178,29 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 6. Main settings screen.
 
 == Changelog ==
+
+= 2.9.4 - xxxx-xx-xx =
+* Fix - Apple Pay button preview missing in Standard payment and Advanced Processing tabs #2755
+* Fix - Set "Sold individually" only for subscription connected to PayPal #2710
+* Fix - Ensure Google Pay button does not appear for subscriptions #2718
+* Fix - PayPal Subscriptions API renewal order not created in WooCommerce #2612
+* Fix - Apple Pay button disappears on Classic Checkout #2722
+* Fix - Google Pay and Apple Pay as separate gateways does not show button when checkout remove from button locations #2756
+* Fix - Add GW refund support for Apple Pay #2746
+* Fix - PayPal Subscriptions cancel and suspend from Subscriptions list page does not work #2632
+* Fix - Displaying of HTML tags in product title on choosing a product for tracking (2801) #2701
+* Fix - Payment with OXXO cause continuation state for next payment #2702
+* Fix - Fix problems with autoptimize plugin #2705
+* Fix - Missing custom field PayPal Transaction Fee for OXXO #2700
+* Enhancement - Extend Advanced Card Processing country/currency feature availability #2754
+* Enhancement - Add void button #2678
+* Enhancement - Use basic redirect gateway when checkout smart buttons disabled #2714
+* Enhancement - Receive button properties from the Checkout Block #2448
+* Enhancement - Run PPEC\DeactivateNote query only in backend #2719
+* Enhancement - Prevent plugin use for "Send only" countries #2721
+* Enhancement - Do not add pay later button in editor #2570
+* Enhancement - Axo: Remove the submit button when Fastlane is disabled #2720
+* Enhancement - Sync the PayPal product page button state to Apple/Google Pay buttons, show alerts #2742
 
 = 2.9.3 - 2024-10-15 =
 * Fix - Multi-currency support #2667

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     2.9.3
+ * Version:     2.9.4
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
@@ -26,7 +26,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2024-10-11' );
+define( 'PAYPAL_INTEGRATION_DATE', '2024-11-05' );
 define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );


### PR DESCRIPTION
* Fix - Apple Pay button preview missing in Standard payment and Advanced Processing tabs #2755
* Fix - Set "Sold individually" only for subscription connected to PayPal #2710
* Fix - Ensure Google Pay button does not appear for subscriptions #2718
* Fix - PayPal Subscriptions API renewal order not created in WooCommerce #2612
* Fix - Apple Pay button disappears on Classic Checkout #2722
* Fix - Google Pay and Apple Pay as separate gateways does not show button when checkout remove from button locations #2756
* Fix - Add GW refund support for Apple Pay #2746
* Fix - PayPal Subscriptions cancel and suspend from Subscriptions list page does not work #2632
* Fix - Displaying of HTML tags in product title on choosing a product for tracking (2801) #2701
* Fix - Payment with OXXO cause continuation state for next payment #2702
* Fix - Fix problems with autoptimize plugin #2705
* Fix - Missing custom field PayPal Transaction Fee for OXXO #2700
* Enhancement - Extend Advanced Card Processing country/currency feature availability #2754
* Enhancement - Add void button #2678
* Enhancement - Use basic redirect gateway when checkout smart buttons disabled #2714
* Enhancement - Receive button properties from the Checkout Block #2448
* Enhancement - Run PPEC\DeactivateNote query only in backend #2719
* Enhancement - Prevent plugin use for "Send only" countries #2721
* Enhancement - Do not add pay later button in editor #2570
* Enhancement - Axo: Remove the submit button when Fastlane is disabled #2720
* Enhancement - Sync the PayPal product page button state to Apple/Google Pay buttons, show alerts #2742