### PR TITLE
Make card fields in block checkout translatable (3769)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/card-fields.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.js
@@ -3,7 +3,10 @@ import { useEffect, useState } from '@wordpress/element';
 import {
 	PayPalScriptProvider,
 	PayPalCardFieldsProvider,
-	PayPalCardFieldsForm,
+    PayPalNameField,
+    PayPalNumberField,
+    PayPalExpiryField,
+    PayPalCVVField,
 } from '@paypal/react-paypal-js';
 
 import { CheckoutHandler } from './checkout-handler';
@@ -14,6 +17,7 @@ import {
 	onApproveSavePayment,
 } from '../card-fields-config';
 import { cartHasSubscriptionProducts } from '../Helper/Subscription';
+import { __ } from '@wordpress/i18n';
 
 export function CardFields( {
 	config,
@@ -92,7 +96,16 @@ export function CardFields( {
 						console.error( err );
 					} }
 				>
-					<PayPalCardFieldsForm />
+                    <PayPalNameField placeholder={ __( 'Cardholder Name (optional)', 'woocommerce-paypal-payments' ) }/>
+                    <PayPalNumberField placeholder={ __( 'Card number', 'woocommerce-paypal-payments' ) }/>
+                    <div style={ { display: "flex", width: "100%" } }>
+                        <div style={ { width: "100%" } }>
+                            <PayPalExpiryField placeholder={ __( 'MM / YY', 'woocommerce-paypal-payments' ) }/>
+                        </div>
+                        <div style={ { width: "100%" } }>
+                            <PayPalCVVField placeholder={ __( 'CVV', 'woocommerce-paypal-payments' ) }/>
+                        </div>
+                    </div>
 					<CheckoutHandler
 						getCardFieldsForm={ getCardFieldsForm }
 						getSavePayment={ getSavePayment }


### PR DESCRIPTION
Make card fieldes placeholders in block checkout translatable.

Translations will be seen when they are generated from wp.org