### PR TITLE
Implement manual connection endpoint

### DIFF
--- a/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
@@ -14,7 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use Psr\Log\LoggerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
  * Class PayPalBearer
@@ -28,7 +28,7 @@ class PayPalBearer implements Bearer {
 	/**
 	 * The settings.
 	 *
-	 * @var Settings
+	 * @var ContainerInterface
 	 */
 	protected $settings;
 
@@ -70,12 +70,12 @@ class PayPalBearer implements Bearer {
 	/**
 	 * PayPalBearer constructor.
 	 *
-	 * @param Cache           $cache The cache.
-	 * @param string          $host The host.
-	 * @param string          $key The key.
-	 * @param string          $secret The secret.
-	 * @param LoggerInterface $logger The logger.
-	 * @param Settings        $settings The settings.
+	 * @param Cache              $cache The cache.
+	 * @param string             $host The host.
+	 * @param string             $key The key.
+	 * @param string             $secret The secret.
+	 * @param LoggerInterface    $logger The logger.
+	 * @param ContainerInterface $settings The settings.
 	 */
 	public function __construct(
 		Cache $cache,

--- a/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
@@ -83,7 +83,7 @@ class PayPalBearer implements Bearer {
 		string $key,
 		string $secret,
 		LoggerInterface $logger,
-		Settings $settings
+		ContainerInterface $settings
 	) {
 
 		$this->cache    = $cache;
@@ -136,8 +136,7 @@ class PayPalBearer implements Bearer {
 			$error = new RuntimeException(
 				__( 'Could not create token.', 'woocommerce-paypal-payments' )
 			);
-			$this->logger->log(
-				'warning',
+			$this->logger->warning(
 				$error->getMessage(),
 				array(
 					'args'     => $args,

--- a/modules/ppcp-api-client/src/Helper/Cache.php
+++ b/modules/ppcp-api-client/src/Helper/Cache.php
@@ -58,7 +58,7 @@ class Cache {
 	 *
 	 * @param string $key The key.
 	 */
-	public function delete( string $key ) {
+	public function delete( string $key ): void {
 		delete_transient( $this->prefix . $key );
 	}
 

--- a/modules/ppcp-api-client/src/Helper/InMemoryCache.php
+++ b/modules/ppcp-api-client/src/Helper/InMemoryCache.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * An in-memory version of Cache.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Helper
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+/**
+ * An in-memory version of Cache. The data is kept only within the class instance.
+ */
+class InMemoryCache extends Cache {
+	/**
+	 * The in-memory storage.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $data = array();
+
+	/**
+	 * InMemoryCache constructor
+	 */
+	public function __construct() {
+		parent::__construct( '' );
+	}
+
+	/**
+	 * Gets a value.
+	 *
+	 * @param string $key The key under which the value is stored.
+	 *
+	 * @return mixed
+	 */
+	public function get( string $key ) {
+		if ( ! array_key_exists( $key, $this->data ) ) {
+			return false;
+		}
+		return $this->data[ $key ];
+	}
+
+	/**
+	 * Deletes a cache.
+	 *
+	 * @param string $key The key.
+	 */
+	public function delete( string $key ): void {
+		unset( $this->data[ $key ] );
+	}
+
+	/**
+	 * Caches a value.
+	 *
+	 * @param string $key The key under which the value should be cached.
+	 * @param mixed  $value The value to cache.
+	 * @param int    $expiration Unused.
+	 *
+	 * @return bool
+	 */
+	public function set( string $key, $value, int $expiration = 0 ): bool {
+		$this->data[ $key ] = $value;
+		return true;
+	}
+}

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepWelcome.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepWelcome.js
@@ -100,6 +100,8 @@ const WelcomeForm = ( { setCompleted } ) => {
 				throw new Error( 'Request failed.' );
 			}
 
+            console.log(`Merchant ID: ${res.merchantId}, email: ${res.email}`);
+
 			setCompleted( true );
 		} catch ( exc ) {
 			console.error( exc );

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -47,7 +47,11 @@ return array(
 		return new OnboardingRestEndpoint( $container->get( 'settings.data.onboarding' ) );
 	},
 	'settings.rest.connect_manual'                => static function ( ContainerInterface $container ) : ConnectManualRestEndpoint {
-		return new ConnectManualRestEndpoint();
+		return new ConnectManualRestEndpoint(
+			$container->get( 'api.paypal-host-production' ),
+			$container->get( 'api.paypal-host-sandbox' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
+		);
 	},
 	'settings.casual-selling.supported-countries' => static function ( ContainerInterface $container ) : array {
 		return array(

--- a/modules/ppcp-settings/src/Endpoint/ConnectManualRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/ConnectManualRestEndpoint.php
@@ -9,6 +9,15 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Endpoint;
 
+use Exception;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use stdClass;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\InMemoryCache;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WP_REST_Server;
 use WP_REST_Response;
 use WP_REST_Request;
@@ -17,6 +26,28 @@ use WP_REST_Request;
  * REST controller for connection via manual credentials input.
  */
 class ConnectManualRestEndpoint extends RestEndpoint {
+
+	/**
+	 * The API host for the live mode.
+	 *
+	 * @var string
+	 */
+	private string $live_host;
+
+	/**
+	 * The API host for the sandbox mode.
+	 *
+	 * @var string
+	 */
+	private string $sandbox_host;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
 	/**
 	 * The base path for this REST controller.
 	 *
@@ -43,6 +74,24 @@ class ConnectManualRestEndpoint extends RestEndpoint {
 			'sanitize' => 'to_boolean',
 		),
 	);
+
+	/**
+	 * ConnectManualRestEndpoint constructor.
+	 *
+	 * @param string          $live_host The API host for the live mode.
+	 * @param string          $sandbox_host The API host for the sandbox mode.
+	 * @param LoggerInterface $logger The logger.
+	 */
+	public function __construct(
+		string $live_host,
+		string $sandbox_host,
+		LoggerInterface $logger
+	) {
+
+		$this->live_host    = $live_host;
+		$this->sandbox_host = $sandbox_host;
+		$this->logger       = $logger;
+	}
 
 	/**
 	 * Configure REST API routes.
@@ -72,21 +121,116 @@ class ConnectManualRestEndpoint extends RestEndpoint {
 			$this->field_map
 		);
 
-		if ( ! isset( $data['client_id'] ) || empty( $data['client_id'] )
-		|| ! isset( $data['client_secret'] ) || empty( $data['client_secret'] ) ) {
+		$client_id     = $data['client_id'] ?? '';
+		$client_secret = $data['client_secret'] ?? '';
+		$use_sandbox   = (bool) ( $data['use_sandbox'] ?? false );
+
+		if ( empty( $client_id ) || empty( $client_secret ) ) {
 			return rest_ensure_response(
 				array(
 					'success' => false,
+					'message' => 'No client ID or secret provided.',
 				)
 			);
 		}
 
+		try {
+			$payee = $this->request_payee( $client_id, $client_secret, $use_sandbox );
+		} catch ( Exception $exception ) {
+			return rest_ensure_response(
+				array(
+					'success' => false,
+					'message' => $exception->getMessage(),
+				)
+			);
+
+		}
+
 		$result = array(
-			'merchantId' => 'bt_us@woocommerce.com',
-			'email'      => 'AT45V2DGMKLRY',
+			'merchantId' => $payee->merchant_id,
+			'email'      => $payee->email_address,
 			'success'    => true,
 		);
 
 		return rest_ensure_response( $result );
+	}
+
+	/**
+	 * Retrieves the payee object with the merchant data
+	 * by creating a minimal PayPal order.
+	 *
+	 * @param string $client_id The client ID.
+	 * @param string $client_secret The client secret.
+	 * @param bool   $use_sandbox Whether to use the sandbox mode.
+	 * @return stdClass The payee object.
+	 * @throws Exception When failed to retrieve payee.
+	 *
+	 * phpcs:disable Squiz.Commenting
+	 * phpcs:disable Generic.Commenting
+	 */
+	private function request_payee(
+		string $client_id,
+		string $client_secret,
+		bool $use_sandbox
+	) : stdClass {
+
+		$host = $use_sandbox ? $this->sandbox_host : $this->live_host;
+
+		$empty_settings = new class() implements ContainerInterface
+		{
+			public function get( string $id ) {
+				throw new NotFoundException();
+			}
+
+			public function has( string $id ) {
+				return false;
+			}
+		};
+
+		$bearer = new PayPalBearer(
+			new InMemoryCache(),
+			$host,
+			$client_id,
+			$client_secret,
+			$this->logger,
+			$empty_settings
+		);
+
+		$orders = new Orders(
+			$host,
+			$bearer,
+			$this->logger
+		);
+
+		$request_body = array(
+			'intent'         => 'CAPTURE',
+			'purchase_units' => array(
+				array(
+					'amount' => array(
+						'currency_code' => 'USD',
+						'value'         => 1.0,
+					),
+				),
+			),
+		);
+
+		$response = $orders->create( $request_body );
+		$body     = json_decode( $response['body'] );
+
+		$order_id = $body->id;
+
+		$order_response = $orders->order( $order_id );
+		$order_body     = json_decode( $order_response['body'] );
+
+		$pu    = $order_body->purchase_units[0];
+		$payee = $pu->payee;
+		if ( ! is_object( $payee ) ) {
+			throw new RuntimeException( 'Payee not found.' );
+		}
+		if ( ! isset( $payee->merchant_id ) || ! isset( $payee->email_address ) ) {
+			throw new RuntimeException( 'Payee info not found.' );
+		}
+
+		return $payee;
 	}
 }

--- a/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
@@ -136,7 +136,7 @@ class PayPalBearerTest extends TestCase
         $key = 'key';
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldNotReceive('log');
+        $logger->shouldNotReceive('warning');
         $settings = Mockery::mock(Settings::class);
         $settings->shouldReceive('has')->andReturn(true);
         $settings->shouldReceive('get')->andReturn('');
@@ -159,7 +159,7 @@ class PayPalBearerTest extends TestCase
         $key = 'key';
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('log');
+        $logger->shouldReceive('warning');
         $logger->shouldReceive('debug');
         $settings = Mockery::mock(Settings::class);
         $settings->shouldReceive('has')->andReturn(true);
@@ -209,7 +209,7 @@ class PayPalBearerTest extends TestCase
         $key = 'key';
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
-        $logger->shouldReceive('log');
+        $logger->shouldReceive('warning');
         $logger->shouldReceive('debug');
         $settings = Mockery::mock(Settings::class);
         $settings->shouldReceive('has')->andReturn(true);


### PR DESCRIPTION
Implemented the endpoint missing in #2747

The merchant id and email are still not saved anywhere since it will be a part of a more complex task about the new settings storage.

The merchant data is retrieved by creating a basic PayPal order (intent = capture, 1.0 USD) and accessing the Payee object. Not sure if such order config works for all merchants, e.g. maybe some can have currency restrictions?