### PR TITLE
replace wc_terms_and_conditions_page_id() to avoid errors (3512)

### DIFF
--- a/modules/ppcp-blocks/extensions.php
+++ b/modules/ppcp-blocks/extensions.php
@@ -44,7 +44,13 @@ return array(
 			'woocommerce-paypal-payments'
 		);
 
-		if ( wc_terms_and_conditions_page_id() > 0 ) {
+		/**
+		 * Replace wc_terms_and_conditions_page_id() function to avoid errors when to avoid errors because of early loading.
+		 */
+		$wc_terms_and_conditions_page_id = apply_filters( 'woocommerce_get_terms_page_id', get_option( 'woocommerce_terms_page_id' ) );
+		$wc_terms_and_conditions_page_id = apply_filters( 'woocommerce_terms_and_conditions_page_id', 0 < $wc_terms_and_conditions_page_id ? absint( $wc_terms_and_conditions_page_id ) : 0 );
+
+		if ( $wc_terms_and_conditions_page_id > 0 ) {
 			$label .= __(
 				'<div class="ppcp-notice ppcp-notice-warning"><p><span class="highlight">Important:</span> Your store has a <a href="/wp-admin/admin.php?page=wc-settings&tab=advanced" target="_blank">Terms and Conditions</a> page configured. Buyers who use a PayPal express payment method will not be able to consent to the terms on the <code>Classic Checkout</code>, as the final checkout confirmation will be skipped.</p></div>',
 				'woocommerce-paypal-payments'


### PR DESCRIPTION
Replace the function `wc_terms_and_conditions_page_id() ` with the code to get directly the page.

Some plugins produce errors like:
`Fatal error: Uncaught Error: Call to undefined function WooCommerce\PayPalCommerce\Blocks\wc_terms_and_conditions_page_id() 
in /home//public_html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-blocks/extensions.php on line 47`

Because the loadings gateways to early.