### PR TITLE
Display onboarding in full screen view without WC header, refactor the navigation (3838)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -90,7 +90,12 @@ return function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-axo-block/module.php" )();
 	}
 
-	$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
+	if ( apply_filters(
+		'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
+		getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
+	) ) {
+		$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
+	}
 
 	return $modules;
 };

--- a/modules.php
+++ b/modules.php
@@ -90,12 +90,7 @@ return function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-axo-block/module.php" )();
 	}
 
-	if ( apply_filters(
-		'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
-		getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
-	) ) {
-		$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
-	}
+	$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
 
 	return $modules;
 };

--- a/modules/ppcp-settings/images/icon-arrow-left.svg
+++ b/modules/ppcp-settings/images/icon-arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="12" viewBox="0 0 8 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6.44497 12.0046L0.986328 6.00011L6.44497 -0.00439453L7.55488 1.00461L3.01352 6.00011L7.55488 10.9956L6.44497 12.0046Z" fill="#070707"/>
+</svg>

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_button.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_button.scss
@@ -17,7 +17,7 @@ button.components-button, a.components-button {
 	}
 
 	&.is-primary {
-		@include font(13, 16, 500);
+		@include font(13, 20, 400);
 		color:$color-white;
 	}
 

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
@@ -1,19 +1,41 @@
 .ppcp-r-navigation {
 	display: flex;
-	justify-content: flex-end;
+	justify-content: space-between;
 	align-items: center;
-	gap: 12px;
+	padding: 24px 48px;
+	margin: 0 -20px 48px -20px;
+	border-bottom: 1px solid $color-gray-300;
 
-	.is-primary {
-		min-width: 196px;
+	button.is-primary {
+		padding: 10px 18px;
 		justify-content: center;
+		margin: 0 0 0 12px;
+		&:not(:disabled) {
+			background-color: $color-blueberry;
+		}
 	}
 
-	.is-tertiary {
-		padding: 10px 17px;
-
-		&:hover {
-			background-color: transparent;
+	button.is-tertiary {
+		@include font(16, 24, 600);
+		color: $color-gray-900;
+		&:hover{
+			background-color:none;
+			background:none;
 		}
+
+		span {
+			padding: 0 12px 0 0;
+		}
+	}
+
+	&--right a{
+		@include font(13, 20, 400);
+		color: $color-blueberry;
+		text-decoration: none;
+	}
+
+	@media screen and (max-width: 480px) {
+		flex-wrap: wrap;
+		row-gap: 8px;
 	}
 }

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
@@ -5,6 +5,7 @@
 	padding: 24px 48px;
 	margin: 0 -20px 48px -20px;
 	border-bottom: 1px solid $color-gray-300;
+	position: relative;
 
 	button.is-primary {
 		padding: 10px 18px;
@@ -34,8 +35,20 @@
 		text-decoration: none;
 	}
 
+	&--progress-bar {
+		position: absolute;
+		bottom: 0px;
+		left: 0;
+		background-color: $color-blueberry;
+		height: 4px;
+	}
+
 	@media screen and (max-width: 480px) {
 		flex-wrap: wrap;
 		row-gap: 8px;
+
+		&--progress-bar {
+			display:none;
+		}
 	}
 }

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
@@ -1,54 +1,60 @@
-.ppcp-r-navigation {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
+.ppcp-r-navigation-container {
 	padding: 24px 48px;
 	margin: 0 -20px 48px -20px;
 	border-bottom: 1px solid $color-gray-300;
 	position: relative;
 
-	button.is-primary {
-		padding: 10px 18px;
-		justify-content: center;
-		margin: 0 0 0 12px;
-		&:not(:disabled) {
+	.ppcp-r-navigation {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+
+		button.is-primary {
+			padding: 10px 18px;
+			justify-content: center;
+			margin: 0 0 0 12px;
+			&:not(:disabled) {
+				background-color: $color-blueberry;
+			}
+		}
+
+		button.is-tertiary {
+			@include font(16, 24, 600);
+			color: $color-gray-900;
+			&:hover{
+				background-color:none;
+				background:none;
+			}
+
+			span {
+				padding: 0 12px 0 0;
+			}
+		}
+
+		&--right a{
+			@include font(13, 20, 400);
+			color: $color-blueberry;
+			text-decoration: none;
+		}
+
+		&--progress-bar {
+			position: absolute;
+			bottom: 0px;
+			left: 0;
 			background-color: $color-blueberry;
+			height: 4px;
 		}
-	}
-
-	button.is-tertiary {
-		@include font(16, 24, 600);
-		color: $color-gray-900;
-		&:hover{
-			background-color:none;
-			background:none;
-		}
-
-		span {
-			padding: 0 12px 0 0;
-		}
-	}
-
-	&--right a{
-		@include font(13, 20, 400);
-		color: $color-blueberry;
-		text-decoration: none;
-	}
-
-	&--progress-bar {
-		position: absolute;
-		bottom: 0px;
-		left: 0;
-		background-color: $color-blueberry;
-		height: 4px;
 	}
 
 	@media screen and (max-width: 480px) {
-		flex-wrap: wrap;
-		row-gap: 8px;
+		padding: 24px 35px;
+		.ppcp-r-navigation {
+			flex-wrap: wrap;
+			row-gap: 8px;
 
-		&--progress-bar {
-			display:none;
+			&--progress-bar {
+				display: none;
+			}
 		}
 	}
 }

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
@@ -25,9 +25,14 @@
 				background-color:none;
 				background:none;
 			}
+		}
 
-			span {
-				padding: 0 12px 0 0;
+		&--left {
+			&__link {
+				@include font(20, 28, 400);
+				color: $color-gray-900;
+				text-decoration: none;
+				padding: 0 0 0 18px;
 			}
 		}
 

--- a/modules/ppcp-settings/resources/css/components/screens/_onboarding-global.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_onboarding-global.scss
@@ -1,7 +1,7 @@
 body:has(.ppcp-r-container--onboarding) {
 	background-color: #fff !important;
 
-	.notice, .nav-tab-wrapper.woo-nav-tab-wrapper, .woocommerce-layout {
+	.notice, .nav-tab-wrapper.woo-nav-tab-wrapper, .woocommerce-layout, .wrap.woocommerce h2:first-of-type {
 		display: none !important;
 	}
 }

--- a/modules/ppcp-settings/resources/css/components/screens/_onboarding-global.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_onboarding-global.scss
@@ -1,0 +1,7 @@
+body:has(.ppcp-r-container--onboarding) {
+	background-color: #fff !important;
+
+	.notice, .nav-tab-wrapper.woo-nav-tab-wrapper, .woocommerce-layout {
+		display: none !important;
+	}
+}

--- a/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
@@ -109,6 +109,22 @@
 		justify-content: center;
 		padding: 8px;
 		margin: 0 0 48px 0;
+
+		@media screen and (max-width: 480px) {
+			flex-wrap: wrap;
+			row-gap: 8px;
+			&__col {
+				width: 100%;
+				text-align: center;
+				border-right: 0;
+				padding-right: 0;
+
+				&:not(:last-child) {
+					border-bottom: 1px solid $color-gray-200;
+					padding-bottom: 8px;
+				}
+			}
+		}
 	}
 
 	&__col {
@@ -132,22 +148,6 @@
 
 	.ppcp-r-page-welcome-mode-separator {
 		margin: 8px 0 16px 0;
-	}
-
-	@media screen and (max-width: 480px) {
-		flex-wrap: wrap;
-		row-gap: 8px;
-		&__col {
-			width: 100%;
-			text-align: center;
-
-			&:not(:last-child) {
-				border-bottom: 1px solid $color-gray-200;
-				border-right: 0;
-				padding-right: 0;
-				padding-bottom: 8px;
-			}
-		}
 	}
 }
 

--- a/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
@@ -113,17 +113,6 @@
 		@media screen and (max-width: 480px) {
 			flex-wrap: wrap;
 			row-gap: 8px;
-			&__col {
-				width: 100%;
-				text-align: center;
-				border-right: 0;
-				padding-right: 0;
-
-				&:not(:last-child) {
-					border-bottom: 1px solid $color-gray-200;
-					padding-bottom: 8px;
-				}
-			}
 		}
 	}
 
@@ -143,6 +132,17 @@
 			padding-right: 48px;
 			border-right: 1px solid $color-gray-200;
 			margin-right: 48px;
+		}
+
+		@media screen and (max-width: 480px) {
+			width: 100%;
+			text-align: center;
+			border-right: 0 !important;
+			padding-right: 0 !important;
+
+			&:not(:last-child) {
+				padding-bottom: 8px;
+			}
 		}
 	}
 

--- a/modules/ppcp-settings/resources/css/style.scss
+++ b/modules/ppcp-settings/resources/css/style.scss
@@ -23,3 +23,4 @@
 }
 
 @import './components/reusable-components/payment-method-modal';
+@import './components/screens/onboarding-global';

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
@@ -1,12 +1,13 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import {useOnboardingStepBusiness, useOnboardingStepProducts} from "../../data";
+import data from "../../utils/data";
 
 const Navigation = ( {
 	setStep,
 	setCompleted,
 	currentStep,
-	stepperOrder,
-	canProceeedCallback = () => true,
+	stepperOrder
 } ) => {
 	const navigateBy = ( stepDirection ) => {
 		let newStep = currentStep + stepDirection;
@@ -23,20 +24,52 @@ const Navigation = ( {
 		}
 	};
 
+    const { products, toggleProduct } = useOnboardingStepProducts();
+    const { isCasualSeller, setIsCasualSeller } = useOnboardingStepBusiness();
+
+    let navigationTitle = '';
+    let disabled = false;
+
+    switch ( currentStep ) {
+        case 1:
+            navigationTitle = __( 'Set up store type', 'woocommerce-paypal-payments' );
+            disabled = isCasualSeller === null
+            break;
+        case 2:
+            navigationTitle = __( 'Select product types', 'woocommerce-paypal-payments' );
+            disabled = products.length < 1
+            break;
+        case 3:
+            navigationTitle = __( 'Choose checkout options', 'woocommerce-paypal-payments' );
+        case 4:
+            navigationTitle = __( 'Connect your PayPal account', 'woocommerce-paypal-payments' );
+            break;
+        default:
+            navigationTitle = __( 'PayPal Payments', 'woocommerce-paypal-payments' );
+    }
+
 	return (
-		<div className="ppcp-r-navigation">
-			<Button variant="tertiary" onClick={ () => navigateBy( -1 ) }>
-				{ __( 'Back', 'woocommerce-paypal-payments' ) }
-			</Button>
-			<Button
-				variant="primary"
-				disabled={ ! canProceeedCallback() }
-				onClick={ () => navigateBy( 1 ) }
-			>
-				{ __( 'Next', 'woocommerce-paypal-payments' ) }
-			</Button>
-		</div>
-	);
+        <div className="ppcp-r-navigation">
+            <div className="ppcp-r-navigation--left">
+                <Button variant="tertiary" onClick={ () => navigateBy( -1 ) }>
+                    <span>{ data().getImage( 'icon-arrow-left.svg' ) }</span>{ navigationTitle }
+                </Button>
+            </div>
+            { currentStep > 0 && (
+                <div className="ppcp-r-navigation--right">
+                    <a href="wp-admin/admin.php?page=wc-settings&amp;tab=checkout"
+                       aria-label="Return to payments">{__('Save and exit', 'woocommerce-paypal-payments')}</a>
+                    <Button
+                        variant="primary"
+                        disabled={ disabled }
+                        onClick={ () => navigateBy( 1 ) }
+                    >
+                        { __('Continue', 'woocommerce-paypal-payments') }
+                    </Button>
+                </div>
+            ) }
+        </div>
+    );
 };
 
 export default Navigation;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
@@ -9,6 +9,8 @@ const Navigation = ( {
 	currentStep,
 	stepperOrder
 } ) => {
+    const isLastStep = () => currentStep + 1 === stepperOrder.length;
+    const isFistStep = () => currentStep === 0;
 	const navigateBy = ( stepDirection ) => {
 		let newStep = currentStep + stepDirection;
 
@@ -29,8 +31,6 @@ const Navigation = ( {
 
     let navigationTitle = '';
     let disabled = false;
-    let isLastStep = currentStep + 1 === stepperOrder.length;
-    let isFistStep = currentStep === 0;
 
     switch ( currentStep ) {
         case 1:
@@ -54,30 +54,45 @@ const Navigation = ( {
         <div className="ppcp-r-navigation-container">
             <div className="ppcp-r-navigation">
                 <div className="ppcp-r-navigation--left">
-                    <Button variant="tertiary" onClick={ () => navigateBy( -1 ) }>
-                        <span>{ data().getImage( 'icon-arrow-left.svg' ) }</span>{ navigationTitle }
-                    </Button>
+                    <span>{data().getImage('icon-arrow-left.svg')}</span>
+                    {!isFistStep() ? (
+                        <Button variant="tertiary" onClick={() => navigateBy(-1)}>
+                            {navigationTitle}
+                        </Button>
+                    ) : (
+                        <a
+                            className="ppcp-r-navigation--left__link"
+                            href={global.ppcpSettings.wcPaymentsTabUrl}
+                            aria-label={__('Return to payments', 'woocommerce-paypal-payments')}
+                        >
+                            {navigationTitle}
+                        </a>
+                    )}
                 </div>
-                { ! isFistStep && (
+                {!isFistStep() && (
                     <div className="ppcp-r-navigation--right">
-                        <a href={ global.ppcpSettings.wcPaymentsTabUrl }
-                           aria-label="Return to payments">{__('Save and exit', 'woocommerce-paypal-payments')}</a>
-                        { ! isLastStep && (
+                        <a
+                            href={ global.ppcpSettings.wcPaymentsTabUrl }
+                            aria-label={ __( 'Return to payments', 'woocommerce-paypal-payments' ) }
+                        >
+                            { __( 'Save and exit', 'woocommerce-paypal-payments' ) }
+                        </a>
+                        {!isLastStep() && (
                             <Button
                                 variant="primary"
                                 disabled={ disabled }
                                 onClick={ () => navigateBy( 1 ) }
                             >
-                                { __('Continue', 'woocommerce-paypal-payments') }
+                                { __( 'Continue', 'woocommerce-paypal-payments' ) }
                             </Button>
-                        ) }
+                        )}
                     </div>
-                ) }
+                )}
                 <div
                     className="ppcp-r-navigation--progress-bar"
-                    style={ {
+                    style={{
                         width: `${ ( currentStep / ( stepperOrder.length - 1 ) ) * 90 }%`
-                    } }
+                    }}
                 ></div>
             </div>
         </div>

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
@@ -68,6 +68,12 @@ const Navigation = ( {
                     </Button>
                 </div>
             ) }
+            <div
+                className="ppcp-r-navigation--progress-bar"
+                style={ {
+                    width: `${ ( currentStep / ( stepperOrder.length - 1 ) ) * 90 }%`
+                } }
+            ></div>
         </div>
     );
 };

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
@@ -29,6 +29,8 @@ const Navigation = ( {
 
     let navigationTitle = '';
     let disabled = false;
+    let isLastStep = currentStep + 1 === stepperOrder.length;
+    let isFistStep = currentStep === 0;
 
     switch ( currentStep ) {
         case 1:
@@ -49,31 +51,35 @@ const Navigation = ( {
     }
 
 	return (
-        <div className="ppcp-r-navigation">
-            <div className="ppcp-r-navigation--left">
-                <Button variant="tertiary" onClick={ () => navigateBy( -1 ) }>
-                    <span>{ data().getImage( 'icon-arrow-left.svg' ) }</span>{ navigationTitle }
-                </Button>
-            </div>
-            { currentStep > 0 && (
-                <div className="ppcp-r-navigation--right">
-                    <a href="wp-admin/admin.php?page=wc-settings&amp;tab=checkout"
-                       aria-label="Return to payments">{__('Save and exit', 'woocommerce-paypal-payments')}</a>
-                    <Button
-                        variant="primary"
-                        disabled={ disabled }
-                        onClick={ () => navigateBy( 1 ) }
-                    >
-                        { __('Continue', 'woocommerce-paypal-payments') }
+        <div className="ppcp-r-navigation-container">
+            <div className="ppcp-r-navigation">
+                <div className="ppcp-r-navigation--left">
+                    <Button variant="tertiary" onClick={ () => navigateBy( -1 ) }>
+                        <span>{ data().getImage( 'icon-arrow-left.svg' ) }</span>{ navigationTitle }
                     </Button>
                 </div>
-            ) }
-            <div
-                className="ppcp-r-navigation--progress-bar"
-                style={ {
-                    width: `${ ( currentStep / ( stepperOrder.length - 1 ) ) * 90 }%`
-                } }
-            ></div>
+                { ! isFistStep && (
+                    <div className="ppcp-r-navigation--right">
+                        <a href="wp-admin/admin.php?page=wc-settings&amp;tab=checkout"
+                           aria-label="Return to payments">{__('Save and exit', 'woocommerce-paypal-payments')}</a>
+                        { ! isLastStep && (
+                            <Button
+                                variant="primary"
+                                disabled={ disabled }
+                                onClick={ () => navigateBy( 1 ) }
+                            >
+                                { __('Continue', 'woocommerce-paypal-payments') }
+                            </Button>
+                        ) }
+                    </div>
+                ) }
+                <div
+                    className="ppcp-r-navigation--progress-bar"
+                    style={ {
+                        width: `${ ( currentStep / ( stepperOrder.length - 1 ) ) * 90 }%`
+                    } }
+                ></div>
+            </div>
         </div>
     );
 };

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
@@ -60,7 +60,7 @@ const Navigation = ( {
                 </div>
                 { ! isFistStep && (
                     <div className="ppcp-r-navigation--right">
-                        <a href="wp-admin/admin.php?page=wc-settings&amp;tab=checkout"
+                        <a href={ global.ppcpSettings.wcPaymentsTabUrl }
                            aria-label="Return to payments">{__('Save and exit', 'woocommerce-paypal-payments')}</a>
                         { ! isLastStep && (
                             <Button

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Onboarding.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Onboarding.js
@@ -1,6 +1,8 @@
 import Container from '../../ReusableComponents/Container';
 import { useOnboardingStep } from '../../../data';
 import { getSteps } from './availableSteps';
+import {__} from "@wordpress/i18n";
+import Navigation from "../../ReusableComponents/Navigation";
 
 const getCurrentStep = ( requestedStep, steps ) => {
 	const isValidStep = ( step ) =>
@@ -20,16 +22,24 @@ const Onboarding = () => {
 	const CurrentStepComponent = getCurrentStep( step, steps );
 
 	return (
-		<Container page="onboarding">
-			<div className="ppcp-r-card">
-				<CurrentStepComponent
-					setStep={ setStep }
-					currentStep={ step }
-					setCompleted={ setCompleted }
-					stepperOrder={ steps }
-				/>
-			</div>
-		</Container>
+        <>
+            <Navigation
+                setStep={ setStep }
+                currentStep={ step }
+                setCompleted={ setCompleted }
+                stepperOrder={ steps }
+            />
+            <Container page="onboarding">
+                <div className="ppcp-r-card">
+                    <CurrentStepComponent
+                        setStep={ setStep }
+                        currentStep={ step }
+                        setCompleted={ setCompleted }
+                        stepperOrder={ steps }
+                    />
+                </div>
+            </Container>
+        </>
 	);
 };
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepBusiness.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepBusiness.js
@@ -4,7 +4,6 @@ import SelectBox from '../../ReusableComponents/SelectBox';
 import { __ } from '@wordpress/i18n';
 import PaymentMethodIcons from '../../ReusableComponents/PaymentMethodIcons';
 import { useOnboardingStepBusiness } from '../../../data';
-import Navigation from '../../ReusableComponents/Navigation';
 import { BUSINESS_TYPES } from '../../../data/constants';
 
 const BUSINESS_RADIO_GROUP_NAME = 'business';

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepBusiness.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepBusiness.js
@@ -101,13 +101,6 @@ const StepBusiness = ( {
 						/>
 					</SelectBox>
 				</SelectBoxWrapper>
-				<Navigation
-					setStep={ setStep }
-					currentStep={ currentStep }
-					stepperOrder={ stepperOrder }
-					setCompleted={ setCompleted }
-					canProceeedCallback={ () => isCasualSeller !== null }
-				/>
 			</div>
 		</div>
 	);

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepProducts.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepProducts.js
@@ -1,5 +1,4 @@
 import OnboardingHeader from '../../ReusableComponents/OnboardingHeader';
-import Navigation from '../../ReusableComponents/Navigation';
 import { __ } from '@wordpress/i18n';
 import SelectBox from '../../ReusableComponents/SelectBox';
 import SelectBoxWrapper from '../../ReusableComponents/SelectBoxWrapper';

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepProducts.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepProducts.js
@@ -121,13 +121,6 @@ const StepProducts = ( {
 						</a>
 					</SelectBox>
 				</SelectBoxWrapper>
-				<Navigation
-					setStep={ setStep }
-					currentStep={ currentStep }
-					stepperOrder={ stepperOrder }
-					setCompleted={ setCompleted }
-					canProceeedCallback={ () => products.length > 0 }
-				/>
 			</div>
 		</div>
 	);

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -85,10 +85,11 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					'ppcp-admin-settings',
 					'ppcpSettings',
 					array(
-						'assets' => array(
+						'assets'           => array(
 							'imagesUrl' => $module_url . '/images/',
 						),
-						'debug'  => defined( 'WP_DEBUG' ) && WP_DEBUG,
+						'wcPaymentsTabUrl' => admin_url( 'admin.php?page=wc-settings&tab=checkout' ),
+						'debug'            => defined( 'WP_DEBUG' ) && WP_DEBUG,
 					)
 				);
 			}


### PR DESCRIPTION
# PR Description

Updates the onboarding wizard screen:

- Applied the white BG
- Hide WC navigation, notices, etc
- Refactored the navigation component to match the new design
   - Added the buttons
   - Added the progress bar

<img width="1580" alt="Screenshot 2024-11-08 at 15 40 21" src="https://github.com/user-attachments/assets/03e4e4b1-bd31-4bff-986c-712c7f33bba2">
<img width="1603" alt="Screenshot 2024-11-08 at 15 40 29" src="https://github.com/user-attachments/assets/ad2e5097-49d9-466e-af3c-e2adec9aa45c">
<img width="1580" alt="Screenshot 2024-11-08 at 15 40 39" src="https://github.com/user-attachments/assets/7e309e87-98b2-4ba6-bad8-5bad87db7fc6">
