### PR TITLE
Add local APM gateways only if PayPal gateway is enabled (3884)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -47,7 +47,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 		$settings = $c->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
-		if ( ! $settings->has( 'allow_local_apm_gateways' ) || $settings->get( 'allow_local_apm_gateways' ) !== true ) {
+		if ( ! self::should_add_local_apm_gateways( $settings ) ) {
 			return true;
 		}
 
@@ -209,5 +209,18 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if the local APMs should be added to the available payment gateways.
+	 *
+	 * @param Settings $settings PayPal gateway settings.
+	 * @return bool
+	 */
+	private function should_add_local_apm_gateways( Settings $settings ): bool {
+		return $settings->has( 'enabled' )
+			&& $settings->get( 'enabled' ) === true
+			&& $settings->has( 'allow_local_apm_gateways' )
+			&& $settings->get( 'allow_local_apm_gateways' ) === true;
 	}
 }


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

This PR introduces an extra condition to enable the local APMs, requiring the PayPal payment gateway to be enabled in order to display the additional local APM gateways.

### Steps to Test
- Navigate to WC → Settings → Payments → PayPal and disable it
- Navigate back to Payment tab
- Observe APMs are in payment list
- Enable one of them or all (set proper currency in General tab)
- Navigate to shop, add product to cart, navigate to checkout page
- Select proper country to test
    - Observe APM is visible

- Verify that the local APMs are no longer showing up on the payment gateways table when the PayPal gateway is disabled.