### PR TITLE
 Apple Pay: Add support for Button Options in the Block Checkout (3827)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -93,6 +93,24 @@ class ApplePayButton extends PaymentButton {
 	#product = {};
 
 	/**
+	 * The start time of the configuration process.
+	 * @type {number}
+	 */
+	#configureStartTime = 0;
+
+	/**
+	 * The maximum time to wait for buttonAttributes before proceeding with initialization.
+	 * @type {number}
+	 */
+	#maxWaitTime = 1000;
+
+	/**
+	 * The stored button attributes.
+	 * @type {Object|null}
+	 */
+	#storedButtonAttributes = null;
+
+	/**
 	 * @inheritDoc
 	 */
 	static getWrappers( buttonConfig, ppcpConfig ) {
@@ -125,7 +143,8 @@ class ApplePayButton extends PaymentButton {
 		externalHandler,
 		buttonConfig,
 		ppcpConfig,
-		contextHandler
+		contextHandler,
+		buttonAttributes
 	) {
 		// Disable debug output in the browser console:
 		// buttonConfig.is_debug = false;
@@ -135,7 +154,8 @@ class ApplePayButton extends PaymentButton {
 			externalHandler,
 			buttonConfig,
 			ppcpConfig,
-			contextHandler
+			contextHandler,
+			buttonAttributes
 		);
 
 		this.init = this.init.bind( this );
@@ -221,6 +241,20 @@ class ApplePayButton extends PaymentButton {
 		);
 
 		invalidIf(
+			() =>
+				this.buttonAttributes?.height &&
+				isNaN( parseInt( this.buttonAttributes.height ) ),
+			'Invalid height in buttonAttributes'
+		);
+
+		invalidIf(
+			() =>
+				this.buttonAttributes?.borderRadius &&
+				isNaN( parseInt( this.buttonAttributes.borderRadius ) ),
+			'Invalid borderRadius in buttonAttributes'
+		);
+
+		invalidIf(
 			() => ! this.contextHandler?.validateContext(),
 			`Invalid context handler.`
 		);
@@ -229,12 +263,60 @@ class ApplePayButton extends PaymentButton {
 	/**
 	 * Configures the button instance. Must be called before the initial `init()`.
 	 *
-	 * @param {Object}          apiConfig       - API configuration.
-	 * @param {TransactionInfo} transactionInfo - Transaction details.
+	 * @param {Object}          apiConfig        - API configuration.
+	 * @param {TransactionInfo} transactionInfo  - Transaction details.
+	 * @param {Object}          buttonAttributes - Button attributes.
 	 */
-	configure( apiConfig, transactionInfo ) {
+	configure( apiConfig, transactionInfo, buttonAttributes = {} ) {
+		// Start timing on first configure call
+		if ( ! this.#configureStartTime ) {
+			this.#configureStartTime = Date.now();
+		}
+
+		// If valid buttonAttributes, store them
+		if ( buttonAttributes?.height && buttonAttributes?.borderRadius ) {
+			this.#storedButtonAttributes = { ...buttonAttributes };
+		}
+
+		// Use stored attributes if current ones are missing
+		const attributes = buttonAttributes?.height
+			? buttonAttributes
+			: this.#storedButtonAttributes;
+
+		// Check if we've exceeded wait time
+		const timeWaited = Date.now() - this.#configureStartTime;
+		if ( timeWaited > this.#maxWaitTime ) {
+			this.log(
+				'ApplePay: Timeout waiting for buttonAttributes - proceeding with initialization'
+			);
+			this.#applePayConfig = apiConfig;
+			this.#transactionInfo = transactionInfo;
+			this.buttonAttributes = attributes || buttonAttributes;
+			this.init();
+			return;
+		}
+
+		// Block any initialization until we have valid buttonAttributes
+		if ( ! attributes?.height || ! attributes?.borderRadius ) {
+			setTimeout(
+				() =>
+					this.configure(
+						apiConfig,
+						transactionInfo,
+						buttonAttributes
+					),
+				100
+			);
+			return;
+		}
+
+		// Reset timer for future configure calls
+		this.#configureStartTime = 0;
+
 		this.#applePayConfig = apiConfig;
 		this.#transactionInfo = transactionInfo;
+		this.buttonAttributes = attributes;
+		this.init();
 	}
 
 	init() {
@@ -321,17 +403,35 @@ class ApplePayButton extends PaymentButton {
 	applyWrapperStyles() {
 		super.applyWrapperStyles();
 
-		const { height } = this.style;
+		const wrapper = this.wrapperElement;
+		if ( ! wrapper ) {
+			return;
+		}
 
-		if ( height ) {
-			const wrapper = this.wrapperElement;
+		// Try stored attributes if current ones are missing
+		const attributes =
+			this.buttonAttributes?.height || this.buttonAttributes?.borderRadius
+				? this.buttonAttributes
+				: this.#storedButtonAttributes;
 
-			wrapper.style.setProperty(
-				'--apple-pay-button-height',
-				`${ height }px`
-			);
+		// Apply height if available
+		if ( attributes?.height ) {
+			const height = parseInt( attributes.height, 10 );
+			if ( ! isNaN( height ) ) {
+				wrapper.style.setProperty(
+					'--apple-pay-button-height',
+					`${ height }px`
+				);
+				wrapper.style.height = `${ height }px`;
+			}
+		}
 
-			wrapper.style.height = `${ height }px`;
+		// Apply border radius if available
+		if ( attributes?.borderRadius ) {
+			const borderRadius = parseInt( attributes.borderRadius, 10 );
+			if ( ! isNaN( borderRadius ) ) {
+				wrapper.style.borderRadius = `${ borderRadius }px`;
+			}
 		}
 	}
 
@@ -342,11 +442,22 @@ class ApplePayButton extends PaymentButton {
 	addButton() {
 		const { color, type, language } = this.style;
 
+		// If current buttonAttributes are missing, try to use stored ones
+		if (
+			! this.buttonAttributes?.height &&
+			this.#storedButtonAttributes?.height
+		) {
+			this.buttonAttributes = { ...this.#storedButtonAttributes };
+		}
+
 		const button = document.createElement( 'apple-pay-button' );
 		button.id = 'apple-' + this.wrapperId;
+
 		button.setAttribute( 'buttonstyle', color );
 		button.setAttribute( 'type', type );
 		button.setAttribute( 'locale', language );
+
+		button.style.display = 'block';
 
 		button.addEventListener( 'click', ( evt ) => {
 			evt.preventDefault();

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -414,24 +414,32 @@ class ApplePayButton extends PaymentButton {
 				? this.buttonAttributes
 				: this.#storedButtonAttributes;
 
-		// Apply height if available
-		if ( attributes?.height ) {
-			const height = parseInt( attributes.height, 10 );
-			if ( ! isNaN( height ) ) {
-				wrapper.style.setProperty(
-					'--apple-pay-button-height',
-					`${ height }px`
-				);
-				wrapper.style.height = `${ height }px`;
-			}
+		const defaultHeight = 48;
+		const defaultBorderRadius = 4;
+
+		const height = attributes?.height
+			? parseInt( attributes.height, 10 )
+			: defaultHeight;
+
+		if ( ! isNaN( height ) ) {
+			wrapper.style.setProperty(
+				'--apple-pay-button-height',
+				`${ height }px`
+			);
+			wrapper.style.height = `${ height }px`;
+		} else {
+			wrapper.style.setProperty(
+				'--apple-pay-button-height',
+				`${ defaultHeight }px`
+			);
+			wrapper.style.height = `${ defaultHeight }px`;
 		}
 
-		// Apply border radius if available
-		if ( attributes?.borderRadius ) {
-			const borderRadius = parseInt( attributes.borderRadius, 10 );
-			if ( ! isNaN( borderRadius ) ) {
-				wrapper.style.borderRadius = `${ borderRadius }px`;
-			}
+		const borderRadius = attributes?.borderRadius
+			? parseInt( attributes.borderRadius, 10 )
+			: defaultBorderRadius;
+		if ( ! isNaN( borderRadius ) ) {
+			wrapper.style.borderRadius = `${ borderRadius }px`;
 		}
 	}
 

--- a/modules/ppcp-applepay/resources/js/ApplepayManagerBlockEditor.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayManagerBlockEditor.js
@@ -4,11 +4,13 @@ const ApplePayManagerBlockEditor = ( {
 	namespace,
 	buttonConfig,
 	ppcpConfig,
+	buttonAttributes,
 } ) => (
 	<ApplepayButton
 		namespace={ namespace }
 		buttonConfig={ buttonConfig }
 		ppcpConfig={ ppcpConfig }
+		buttonAttributes={ buttonAttributes }
 	/>
 );
 

--- a/modules/ppcp-applepay/resources/js/Block/components/ApplePayButton.js
+++ b/modules/ppcp-applepay/resources/js/Block/components/ApplePayButton.js
@@ -4,7 +4,12 @@ import usePayPalScript from '../hooks/usePayPalScript';
 import useApplepayScript from '../hooks/useApplepayScript';
 import useApplepayConfig from '../hooks/useApplepayConfig';
 
-const ApplepayButton = ( { namespace, buttonConfig, ppcpConfig } ) => {
+const ApplepayButton = ( {
+	namespace,
+	buttonConfig,
+	ppcpConfig,
+	buttonAttributes,
+} ) => {
 	const [ buttonHtml, setButtonHtml ] = useState( '' );
 	const [ buttonElement, setButtonElement ] = useState( null );
 	const [ componentFrame, setComponentFrame ] = useState( null );
@@ -31,19 +36,42 @@ const ApplepayButton = ( { namespace, buttonConfig, ppcpConfig } ) => {
 		namespace,
 		buttonConfig,
 		ppcpConfig,
-		applepayConfig
+		applepayConfig,
+		buttonAttributes
 	);
 
 	useEffect( () => {
-		if ( applepayButton ) {
-			setButtonHtml( applepayButton.outerHTML );
+		if ( ! applepayButton || ! buttonElement ) {
+			return;
 		}
-	}, [ applepayButton ] );
+
+		setButtonHtml( applepayButton.outerHTML );
+
+		// Add timeout to ensure button is displayed after render
+		setTimeout( () => {
+			const button = buttonElement.querySelector( 'apple-pay-button' );
+			if ( button ) {
+				button.style.display = 'block';
+			}
+		}, 100 ); // Add a small delay to ensure DOM is ready
+	}, [ applepayButton, buttonElement ] );
 
 	return (
 		<div
 			ref={ setButtonElement }
 			dangerouslySetInnerHTML={ { __html: buttonHtml } }
+			style={ {
+				height: buttonAttributes?.height
+					? `${ buttonAttributes.height }px`
+					: undefined,
+				'--apple-pay-button-height': buttonAttributes?.height
+					? `${ buttonAttributes.height }px`
+					: undefined,
+				borderRadius: buttonAttributes?.borderRadius
+					? `${ buttonAttributes.borderRadius }px`
+					: undefined,
+				overflow: 'hidden',
+			} }
 		/>
 	);
 };

--- a/modules/ppcp-applepay/resources/js/Block/components/ApplePayButton.js
+++ b/modules/ppcp-applepay/resources/js/Block/components/ApplePayButton.js
@@ -63,10 +63,10 @@ const ApplepayButton = ( {
 			style={ {
 				height: buttonAttributes?.height
 					? `${ buttonAttributes.height }px`
-					: undefined,
+					: '48px',
 				'--apple-pay-button-height': buttonAttributes?.height
 					? `${ buttonAttributes.height }px`
-					: undefined,
+					: '48px',
 				borderRadius: buttonAttributes?.borderRadius
 					? `${ buttonAttributes.borderRadius }px`
 					: undefined,

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -19,7 +19,7 @@ if ( typeof window.PayPalCommerceGateway === 'undefined' ) {
 	window.PayPalCommerceGateway = ppcpConfig;
 }
 
-const ApplePayComponent = ( { isEditing } ) => {
+const ApplePayComponent = ( { isEditing, buttonAttributes } ) => {
 	const [ paypalLoaded, setPaypalLoaded ] = useState( false );
 	const [ applePayLoaded, setApplePayLoaded ] = useState( false );
 	const wrapperRef = useRef( null );
@@ -57,8 +57,13 @@ const ApplePayComponent = ( { isEditing } ) => {
 
 		buttonConfig.reactWrapper = wrapperRef.current;
 
-		new ManagerClass( namespace, buttonConfig, ppcpConfig );
-	}, [ paypalLoaded, applePayLoaded, isEditing ] );
+		new ManagerClass(
+			namespace,
+			buttonConfig,
+			ppcpConfig,
+			buttonAttributes
+		);
+	}, [ paypalLoaded, applePayLoaded, isEditing, buttonAttributes ] );
 
 	if ( isEditing ) {
 		return (
@@ -66,6 +71,7 @@ const ApplePayComponent = ( { isEditing } ) => {
 				namespace={ namespace }
 				buttonConfig={ buttonConfig }
 				ppcpConfig={ ppcpConfig }
+				buttonAttributes={ buttonAttributes }
 			/>
 		);
 	}

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -108,5 +108,6 @@ registerExpressPaymentMethod( {
 	canMakePayment: () => buttonData.enabled,
 	supports: {
 		features,
+		style: [ 'height', 'borderRadius' ],
 	},
 } );


### PR DESCRIPTION
### Description

This PR will add support for the [Button Options ](https://developer.woocommerce.com/2024/10/28/more-options-coming-to-the-express-checkout/)  (`height` and `borderRadius`) to the Apple Pay express button in the Block Checkout.

### Steps to test

1. Ensure you are using WooCommerce [9.4.0](https://github.com/woocommerce/woocommerce/releases/tag/9.4.0-rc.3).
2. In the Checkout block, test with Button Settings enabled and disabled.
3. Ensure the Apple Pay button correctly inherits the settings both in the editor and in the Block Checkout.
 
<img width="1334" alt="Edit_Page_“Block_Checkout”_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/13a916e5-4104-400a-9ca0-612453e87586">


<hr />

### Screenshots

|Before|After|
|-|-|
|<img width="769" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/baf546af-e55d-4334-a87a-379ed86b4d91">|<img width="762" alt="Block_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/2fca5b00-66fa-4e0d-a003-1d97192495b5">|
