### PR TITLE
Hide the screen meta links from onboarding screen (3934)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/screens/_onboarding-global.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_onboarding-global.scss
@@ -1,7 +1,7 @@
 body:has(.ppcp-r-container--onboarding) {
 	background-color: #fff !important;
 
-	.notice, .nav-tab-wrapper.woo-nav-tab-wrapper, .woocommerce-layout, .wrap.woocommerce form > h2 {
+	.notice, .nav-tab-wrapper.woo-nav-tab-wrapper, .woocommerce-layout, .wrap.woocommerce form > h2, #screen-meta-links {
 		display: none !important;
 	}
 }


### PR DESCRIPTION
# PR Description

Hides the screen meta links ("Help" dropdown) from onboarding screen
