### PR TITLE
Axo Block: Add the tracking meta tag in the Block Checkout (3757)

### DIFF
--- a/modules/ppcp-axo-block/resources/js/plugins/AxoDetectionTagLoader.js
+++ b/modules/ppcp-axo-block/resources/js/plugins/AxoDetectionTagLoader.js
@@ -1,0 +1,27 @@
+import { registerPlugin } from '@wordpress/plugins';
+import { useEffect, useRef } from '@wordpress/element';
+
+const AxoDetectionTagLoader = () => {
+	const metaAdded = useRef( false );
+	const axoMetaConfig = window.wc_ppcp_axo_meta;
+	const isAxoEnabled = axoMetaConfig?.isAxoEnabled;
+
+	useEffect( () => {
+		if ( ! metaAdded.current ) {
+			const meta = document.createElement( 'meta' );
+			meta.name = 'ppcp.axo';
+			meta.content = isAxoEnabled
+				? 'ppcp.axo.enabled'
+				: 'ppcp.axo.disabled';
+			document.head.appendChild( meta );
+			metaAdded.current = true;
+		}
+	}, [ isAxoEnabled ] );
+
+	return null;
+};
+
+registerPlugin( 'wc-ppcp-axo-detection-tag-loader', {
+	render: AxoDetectionTagLoader,
+	scope: 'woocommerce-checkout',
+} );

--- a/modules/ppcp-axo-block/webpack.config.js
+++ b/modules/ppcp-axo-block/webpack.config.js
@@ -9,7 +9,10 @@ module.exports = {
 	target: 'web',
 	plugins: [ new DependencyExtractionWebpackPlugin() ],
 	entry: {
-		'index': path.resolve( './resources/js/index.js' ),
+		index: path.resolve( './resources/js/index.js' ),
+		AxoDetectionTagLoader: path.resolve(
+			'./resources/js/plugins/AxoDetectionTagLoader.js'
+		),
 		gateway: path.resolve( './resources/css/gateway.scss' ),
 	},
 	output: {


### PR DESCRIPTION
### Description

This PR adds the `ppcp.axo.enabled` meta tag in the Block Checkout when Axo is `enabled`.

### Steps to test

1. Enable `ACDC` and `Fastlane`.
2. Add the `Checkout` block to a page.
3. Ensure that the `<meta name="ppcp.axo" content="ppcp.axo.enabled">` meta tag is present when Fastlane is enabled and present in the Block Checkout.
3. Ensure that the `<meta name="ppcp.axo" content="ppcp.axo.disabled">` meta tag is present when Fastlane is disabled and not present in the Block Checkout.

### Screenshots

N/A