### PR TITLE
PayPal saved payment not shown in PayPal button (3862)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Helper/ConfigProcessor.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ConfigProcessor.js
@@ -6,16 +6,16 @@ const processAxoConfig = ( config ) => {
 	const scriptOptions = {};
 	const sdkClientToken = config?.axo?.sdk_client_token;
 	const uuid = uuidv4().replace( /-/g, '' );
-	if ( sdkClientToken ) {
+	if ( sdkClientToken && config?.user?.is_logged !== true ) {
 		scriptOptions[ 'data-sdk-client-token' ] = sdkClientToken;
 		scriptOptions[ 'data-client-metadata-id' ] = uuid;
 	}
 	return scriptOptions;
 };
 
-const processUserIdToken = ( config, sdkClientToken ) => {
+const processUserIdToken = ( config ) => {
 	const userIdToken = config?.save_payment_methods?.id_token;
-	return userIdToken && ! sdkClientToken
+	return userIdToken && config?.user?.is_logged === true
 		? { 'data-user-id-token': userIdToken }
 		: {};
 };
@@ -26,9 +26,6 @@ export const processConfig = ( config ) => {
 		scriptOptions = merge( scriptOptions, config.script_attributes );
 	}
 	const axoOptions = processAxoConfig( config );
-	const userIdTokenOptions = processUserIdToken(
-		config,
-		axoOptions[ 'data-sdk-client-token' ]
-	);
+	const userIdTokenOptions = processUserIdToken( config );
 	return merge.all( [ scriptOptions, axoOptions, userIdTokenOptions ] );
 };

--- a/modules/ppcp-button/resources/js/modules/Helper/PayPalScriptLoading.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/PayPalScriptLoading.js
@@ -9,7 +9,7 @@ const scriptPromises = new Map();
 const handleDataClientIdAttribute = async ( scriptOptions, config ) => {
 	if (
 		config.data_client_id?.set_attribute &&
-		config.vault_v3_enabled !== '1'
+		config.vault_v3_enabled !== true
 	) {
 		return new Promise( ( resolve, reject ) => {
 			dataClientIdAttributeHandler(

--- a/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ScriptLoading.js
@@ -75,7 +75,7 @@ export const loadPaypalScript = ( config, onLoaded, onError = null ) => {
 	// Axo SDK options
 	const sdkClientToken = config?.axo?.sdk_client_token;
 	const uuid = uuidv4().replace( /-/g, '' );
-	if ( sdkClientToken ) {
+	if ( sdkClientToken && config?.user?.is_logged !== true ) {
 		scriptOptions[ 'data-sdk-client-token' ] = sdkClientToken;
 		scriptOptions[ 'data-client-metadata-id' ] = uuid;
 	}
@@ -96,7 +96,7 @@ export const loadPaypalScript = ( config, onLoaded, onError = null ) => {
 
 	// Adds data-user-id-token to script options.
 	const userIdToken = config?.save_payment_methods?.id_token;
-	if ( userIdToken && ! sdkClientToken ) {
+	if ( userIdToken && config?.user?.is_logged === true ) {
 		scriptOptions[ 'data-user-id-token' ] = userIdToken;
 	}
 


### PR DESCRIPTION
`data-user-id-token` is not added to JSSDK and therefore no saved payment is shown for the customer.

### Steps To Reproduce
- Enable Vaulting for PayPal payment
- Save a PayPal payment either by purchasing a product or via My account / Payment methods / Add payment method
- Visit single product 
    - No saved payment in PayPal button
- Add product to cart and visit Classic Cart page
    - No saved payment in PayPal button
- Visit Classic Checkout page
    - No saved payment in PayPal button

This PR ensures that `data-user-id-token` is only added to the JSSDK when the customer is logged in and `data-sdk-client-token` (for Fastlane) is only added when customer is logged out.