### PR TITLE
Only last payment token is available because a new customer is returned each time (PCP-3860)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PaymentMethodTokensEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentMethodTokensEndpoint.php
@@ -61,18 +61,23 @@ class PaymentMethodTokensEndpoint {
 	 * Creates a setup token.
 	 *
 	 * @param PaymentSource $payment_source The payment source.
+	 * @param string        $customer_id PayPal customer ID.
 	 *
 	 * @return stdClass
 	 *
 	 * @throws RuntimeException When something when wrong with the request.
 	 * @throws PayPalApiException When something when wrong setting up the token.
 	 */
-	public function setup_tokens( PaymentSource $payment_source ): stdClass {
+	public function setup_tokens( PaymentSource $payment_source, string $customer_id = '' ): stdClass {
 		$data = array(
 			'payment_source' => array(
 				$payment_source->name() => $payment_source->properties(),
 			),
 		);
+
+		if ( $customer_id ) {
+			$data['customer']['id'] = $customer_id;
+		}
 
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v3/vault/setup-tokens';
@@ -109,18 +114,23 @@ class PaymentMethodTokensEndpoint {
 	 * Creates a payment token for the given payment source.
 	 *
 	 * @param PaymentSource $payment_source The payment source.
+	 * @param string        $customer_id PayPal customer ID.
 	 *
 	 * @return stdClass
 	 *
 	 * @throws RuntimeException When something when wrong with the request.
 	 * @throws PayPalApiException When something when wrong setting up the token.
 	 */
-	public function create_payment_token( PaymentSource $payment_source ): stdClass {
+	public function create_payment_token( PaymentSource $payment_source, string $customer_id = '' ): stdClass {
 		$data = array(
 			'payment_source' => array(
 				$payment_source->name() => $payment_source->properties(),
 			),
 		);
+
+		if ( $customer_id ) {
+			$data['customer']['id'] = $customer_id;
+		}
 
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v3/vault/payment-tokens';

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
@@ -94,7 +94,9 @@ class CreatePaymentToken implements EndpointInterface {
 				)
 			);
 
-			$result = $this->payment_method_tokens_endpoint->create_payment_token( $payment_source );
+			$customer_id = get_user_meta( get_current_user_id(), '_ppcp_target_customer_id', true );
+
+			$result = $this->payment_method_tokens_endpoint->create_payment_token( $payment_source, $customer_id );
 
 			if ( is_user_logged_in() && isset( $result->customer->id ) ) {
 				$current_user_id = get_current_user_id();

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreateSetupToken.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreateSetupToken.php
@@ -103,7 +103,9 @@ class CreateSetupToken implements EndpointInterface {
 				);
 			}
 
-			$result = $this->payment_method_tokens_endpoint->setup_tokens( $payment_source );
+			$customer_id = get_user_meta( get_current_user_id(), '_ppcp_target_customer_id', true );
+
+			$result = $this->payment_method_tokens_endpoint->setup_tokens( $payment_source, $customer_id );
 
 			wp_send_json_success( $result );
 			return true;

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -166,6 +166,10 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 		add_action(
 			'wp',
 			function() use ( $container ) {
+				if ( $container->get( 'vaulting.vault-v3-enabled' ) ) {
+					return;
+				}
+
 				global $wp;
 
 				if ( isset( $wp->query_vars['delete-payment-method'] ) ) {


### PR DESCRIPTION
We need to send `customer_id` when saving payment token so PayPal will return the same `customer_id` in the response.

### Steps To Reproduce
- Enable Vaulting for ACDC
- Save an ACDC payment from My account / Payment methods / Add payment method
- Save another ACDC payment
- Check payment tokens
- Add product to cart and go to Classic Checkout
- Try place order using the first payment you saved
    - Error: There was an error processing your order

This PR ensures `customer_id` is sent if it exist when saving the payment, so the same `customer_id` will be returned and therefore multiple payments will be available under the same customer id.