### PR TITLE
Settings UI: Migrate to two column design

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_settings-wrapper.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_settings-wrapper.scss
@@ -17,21 +17,35 @@
 	}
 
 	&-settings-card {
-		background-color: $color-white;
-		padding: 48px;
-		border-radius: 8px;
-		box-shadow: 0 2px 4px 0 #0000001A;
+		@media screen and (min-width: 960px) {
+			display: flex;
+			gap: 48px;
+		}
+
 		@media screen and (max-width: 480px) {
 			padding: 24px;
 		}
 
 		&__header {
 			display: flex;
-			align-items: center;
 			gap: 18px;
 			padding-bottom: 18px;
 			border-bottom: 2px solid $color-gray-700;
 			margin-bottom: 32px;
+
+			@media screen and (min-width: 960px) {
+				width: 280px;
+				flex-shrink: 0;
+				border-bottom: none;
+				margin-bottom: 0;
+				padding-bottom: 0;
+			}
+		}
+
+		&__content {
+			@media screen and (min-width: 960px) {
+				flex: 1;
+			}
 		}
 
 		&__title {

--- a/modules/ppcp-settings/resources/css/components/screens/_settings-global.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_settings-global.scss
@@ -1,0 +1,7 @@
+body:has(.ppcp-r-container--settings) {
+	background-color: #fff !important;
+
+	.notice, .nav-tab-wrapper.woo-nav-tab-wrapper, .woocommerce-layout, .wrap.woocommerce form > h2, #screen-meta-links {
+		display: none !important;
+	}
+}

--- a/modules/ppcp-settings/resources/css/components/screens/_settings.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_settings.scss
@@ -1,0 +1,8 @@
+.ppcp-r-tabs.settings,
+.ppcp-r-container--settings {
+	--max-container-width: var(--max-width-settings);
+
+	.ppcp-r-inner-container {
+		max-width: var(--max-container-width);
+	}
+}

--- a/modules/ppcp-settings/resources/css/style.scss
+++ b/modules/ppcp-settings/resources/css/style.scss
@@ -20,10 +20,12 @@
 	@import './components/reusable-components/spinner-overlay';
 	@import './components/reusable-components/welcome-docs';
 	@import './components/screens/onboarding';
+	@import './components/screens/settings';
 	@import './components/screens/overview/tab-overview';
 	@import './components/screens/overview/tab-payment-methods';
-	@import 'components/screens/overview/tab-settings';
+	@import './components/screens/overview/tab-settings';
 }
 
 @import './components/reusable-components/payment-method-modal';
 @import './components/screens/onboarding-global';
+@import './components/screens/settings-global';

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Navigation.js
@@ -1,16 +1,14 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {useOnboardingStepBusiness, useOnboardingStepProducts} from "../../data";
-import data from "../../utils/data";
+import {
+	useOnboardingStepBusiness,
+	useOnboardingStepProducts,
+} from '../../data';
+import data from '../../utils/data';
 
-const Navigation = ( {
-	setStep,
-	setCompleted,
-	currentStep,
-	stepperOrder
-} ) => {
-    const isLastStep = () => currentStep + 1 === stepperOrder.length;
-    const isFistStep = () => currentStep === 0;
+const Navigation = ( { setStep, setCompleted, currentStep, stepperOrder } ) => {
+	const isLastStep = () => currentStep + 1 === stepperOrder.length;
+	const isFistStep = () => currentStep === 0;
 	const navigateBy = ( stepDirection ) => {
 		let newStep = currentStep + stepDirection;
 
@@ -26,77 +24,109 @@ const Navigation = ( {
 		}
 	};
 
-    const { products, toggleProduct } = useOnboardingStepProducts();
-    const { isCasualSeller, setIsCasualSeller } = useOnboardingStepBusiness();
+	const { products, toggleProduct } = useOnboardingStepProducts();
+	const { isCasualSeller, setIsCasualSeller } = useOnboardingStepBusiness();
 
-    let navigationTitle = '';
-    let disabled = false;
+	let navigationTitle = '';
+	let disabled = false;
 
-    switch ( currentStep ) {
-        case 1:
-            navigationTitle = __( 'Set up store type', 'woocommerce-paypal-payments' );
-            disabled = isCasualSeller === null
-            break;
-        case 2:
-            navigationTitle = __( 'Select product types', 'woocommerce-paypal-payments' );
-            disabled = products.length < 1
-            break;
-        case 3:
-            navigationTitle = __( 'Choose checkout options', 'woocommerce-paypal-payments' );
-        case 4:
-            navigationTitle = __( 'Connect your PayPal account', 'woocommerce-paypal-payments' );
-            break;
-        default:
-            navigationTitle = __( 'PayPal Payments', 'woocommerce-paypal-payments' );
-    }
+	switch ( currentStep ) {
+		case 1:
+			navigationTitle = __(
+				'Set up store type',
+				'woocommerce-paypal-payments'
+			);
+			disabled = isCasualSeller === null;
+			break;
+		case 2:
+			navigationTitle = __(
+				'Select product types',
+				'woocommerce-paypal-payments'
+			);
+			disabled = products.length < 1;
+			break;
+		case 3:
+			navigationTitle = __(
+				'Choose checkout options',
+				'woocommerce-paypal-payments'
+			);
+		case 4:
+			navigationTitle = __(
+				'Connect your PayPal account',
+				'woocommerce-paypal-payments'
+			);
+			break;
+		default:
+			navigationTitle = __(
+				'PayPal Payments',
+				'woocommerce-paypal-payments'
+			);
+	}
 
 	return (
-        <div className="ppcp-r-navigation-container">
-            <div className="ppcp-r-navigation">
-                <div className="ppcp-r-navigation--left">
-                    <span>{data().getImage('icon-arrow-left.svg')}</span>
-                    {!isFistStep() ? (
-                        <Button variant="tertiary" onClick={() => navigateBy(-1)}>
-                            {navigationTitle}
-                        </Button>
-                    ) : (
-                        <a
-                            className="ppcp-r-navigation--left__link"
-                            href={global.ppcpSettings.wcPaymentsTabUrl}
-                            aria-label={__('Return to payments', 'woocommerce-paypal-payments')}
-                        >
-                            {navigationTitle}
-                        </a>
-                    )}
-                </div>
-                {!isFistStep() && (
-                    <div className="ppcp-r-navigation--right">
-                        <a
-                            href={ global.ppcpSettings.wcPaymentsTabUrl }
-                            aria-label={ __( 'Return to payments', 'woocommerce-paypal-payments' ) }
-                        >
-                            { __( 'Save and exit', 'woocommerce-paypal-payments' ) }
-                        </a>
-                        {!isLastStep() && (
-                            <Button
-                                variant="primary"
-                                disabled={ disabled }
-                                onClick={ () => navigateBy( 1 ) }
-                            >
-                                { __( 'Continue', 'woocommerce-paypal-payments' ) }
-                            </Button>
-                        )}
-                    </div>
-                )}
-                <div
-                    className="ppcp-r-navigation--progress-bar"
-                    style={{
-                        width: `${ ( currentStep / ( stepperOrder.length - 1 ) ) * 90 }%`
-                    }}
-                ></div>
-            </div>
-        </div>
-    );
+		<div className="ppcp-r-navigation-container">
+			<div className="ppcp-r-navigation">
+				<div className="ppcp-r-navigation--left">
+					<span>{ data().getImage( 'icon-arrow-left.svg' ) }</span>
+					{ ! isFistStep() ? (
+						<Button
+							variant="tertiary"
+							onClick={ () => navigateBy( -1 ) }
+						>
+							{ navigationTitle }
+						</Button>
+					) : (
+						<a
+							className="ppcp-r-navigation--left__link"
+							href={ global.ppcpSettings.wcPaymentsTabUrl }
+							aria-label={ __(
+								'Return to payments',
+								'woocommerce-paypal-payments'
+							) }
+						>
+							{ navigationTitle }
+						</a>
+					) }
+				</div>
+				{ ! isFistStep() && (
+					<div className="ppcp-r-navigation--right">
+						<a
+							href={ global.ppcpSettings.wcPaymentsTabUrl }
+							aria-label={ __(
+								'Return to payments',
+								'woocommerce-paypal-payments'
+							) }
+						>
+							{ __(
+								'Save and exit',
+								'woocommerce-paypal-payments'
+							) }
+						</a>
+						{ ! isLastStep() && (
+							<Button
+								variant="primary"
+								disabled={ disabled }
+								onClick={ () => navigateBy( 1 ) }
+							>
+								{ __(
+									'Continue',
+									'woocommerce-paypal-payments'
+								) }
+							</Button>
+						) }
+					</div>
+				) }
+				<div
+					className="ppcp-r-navigation--progress-bar"
+					style={ {
+						width: `${
+							( currentStep / ( stepperOrder.length - 1 ) ) * 90
+						}%`,
+					} }
+				></div>
+			</div>
+		</div>
+	);
 };
 
 export default Navigation;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsCard.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsCard.js
@@ -9,7 +9,6 @@ const SettingsCard = ( props ) => {
 	return (
 		<div className={ className }>
 			<div className="ppcp-r-settings-card__header">
-				{ data().getImage( props.icon ) }
 				<div className="ppcp-r-settings-card__content-inner">
 					<span className="ppcp-r-settings-card__title">
 						{ props.title }

--- a/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabOverview.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabOverview.js
@@ -24,7 +24,6 @@ const TabOverview = () => {
 			{ todosData.length > 0 && (
 				<SettingsCard
 					className="ppcp-r-tab-overview-todo"
-					icon="icon-overview-list.svg"
 					title={ __(
 						'Things to do next',
 						'woocommerce-paypal-payments'
@@ -52,7 +51,6 @@ const TabOverview = () => {
 			) }
 			<SettingsCard
 				className="ppcp-r-tab-overview-support"
-				icon="icon-overview-support.svg"
 				title={ __( 'Status', 'woocommerce-paypal-payments' ) }
 				description={ __(
 					'Your PayPal account connection details, along with available products and features.',

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings.js
@@ -1,7 +1,6 @@
-import TabNavigation from '../ReusableComponents/TabNavigation';
-import { getSettingsTabs } from './tabs';
 import { useOnboardingStep } from '../../data';
 import Onboarding from './Onboarding/Onboarding';
+import SettingsScreen from './SettingsScreen';
 
 const Settings = () => {
 	const onboardingProgress = useOnboardingStep();
@@ -15,9 +14,7 @@ const Settings = () => {
 		return <Onboarding />;
 	}
 
-	const tabs = getSettingsTabs( onboardingProgress );
-
-	return <TabNavigation tabs={ tabs }></TabNavigation>;
+	return <SettingsScreen />;
 };
 
 export default Settings;

--- a/modules/ppcp-settings/resources/js/Components/Screens/SettingsNavigation.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/SettingsNavigation.js
@@ -1,0 +1,37 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import data from '../../utils/data';
+
+const SettingsNavigation = ( {} ) => {
+	return (
+		<div className="ppcp-r-navigation-container">
+			<div className="ppcp-r-navigation">
+				<div className="ppcp-r-navigation--left">
+					<span>{ data().getImage( 'icon-arrow-left.svg' ) }</span>
+					<a
+						className="ppcp-r-navigation--left__link"
+						href={ global.ppcpSettings.wcPaymentsTabUrl }
+						aria-label={ __(
+							'PayPal Payments',
+							'woocommerce-paypal-payments'
+						) }
+					>
+						{ __(
+							'PayPal Payments',
+							'woocommerce-paypal-payments'
+						) }
+					</a>
+				</div>
+				{
+					<div className="ppcp-r-navigation--right">
+						<Button variant="primary" disabled={ false }>
+							{ __( 'Save', 'woocommerce-paypal-payments' ) }
+						</Button>
+					</div>
+				}
+			</div>
+		</div>
+	);
+};
+
+export default SettingsNavigation;

--- a/modules/ppcp-settings/resources/js/Components/Screens/SettingsScreen.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/SettingsScreen.js
@@ -1,0 +1,19 @@
+import { getSettingsTabs } from './tabs';
+import SettingsNavigation from './SettingsNavigation';
+import Container from '../ReusableComponents/Container';
+import TabNavigation from '../ReusableComponents/TabNavigation';
+
+const SettingsScreen = () => {
+	const tabs = getSettingsTabs();
+
+	return (
+		<>
+			<SettingsNavigation />
+			<Container page="settings">
+				<TabNavigation tabs={ tabs }></TabNavigation>
+			</Container>
+		</>
+	);
+};
+
+export default SettingsScreen;


### PR DESCRIPTION
### Description
This PR migrates the design to two columns as per the latest Figma files.

This PR also removes the icons in the Overview tab (next to the titles).

### Steps to test

1. Make sure the settings are being displayed with headings on the left and content on the right.
2. Ensure the two columns collapse to one on mobile.

### Screenshots

|Before|After|
|-|-|
|<img width="1046" alt="before_ui" src="https://github.com/user-attachments/assets/2bd1d879-280f-41bf-b091-8dcc7175ada6">|<img width="1054" alt="after_ui" src="https://github.com/user-attachments/assets/0c791f26-84c9-4413-9e78-dbdd38f0ec4c">|
