### PR TITLE
Create setting for users to switch back and forth (3892)

### DIFF
--- a/modules/ppcp-onboarding/src/OnboardingModule.php
+++ b/modules/ppcp-onboarding/src/OnboardingModule.php
@@ -13,6 +13,7 @@ use WooCommerce\PayPalCommerce\Onboarding\Endpoint\UpdateSignupLinksEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Assets\OnboardingAssets;
 use WooCommerce\PayPalCommerce\Onboarding\Endpoint\LoginSellerEndpoint;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingRenderer;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -48,7 +49,8 @@ class OnboardingModule implements ServiceModule, ExtendingModule, ExecutableModu
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
 			getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
-		) ) {
+		) || SettingsModule::should_use_the_old_ui()
+		) {
 
 			$asset_loader = $c->get( 'onboarding.assets' );
 			/**

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const config = ppcpSwitchSettingsUi;
+    const button = document.querySelector('.button.button-settings-switch-ui');
+
+    if ( ! typeof config || !button) {
+        return;
+    }
+
+    button.addEventListener('click', () => {
+        fetch(config.endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                nonce: config.nonce,
+            }),
+        })
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then((data) => {
+                window.location.reload();
+            })
+            .catch((error) => {
+                console.error('Error:', error);
+            });
+    });
+});

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Settings;
 
 use WooCommerce\PayPalCommerce\Settings\Endpoint\ConnectManualRestEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Endpoint\SwitchSettingsUiEndpoint;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\OnboardingRestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
@@ -108,5 +109,11 @@ return array(
 		$eligible_countries = $container->get( 'settings.casual-selling.supported-countries' );
 
 		return in_array( $country, $eligible_countries, true );
+	},
+	'settings.switch-ui.endpoint'                => static function ( ContainerInterface $container ) : SwitchSettingsUiEndpoint {
+		return new SwitchSettingsUiEndpoint(
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'button.request-data' ),
+		);
 	},
 );

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -110,7 +110,7 @@ return array(
 
 		return in_array( $country, $eligible_countries, true );
 	},
-	'settings.switch-ui.endpoint'                => static function ( ContainerInterface $container ) : SwitchSettingsUiEndpoint {
+	'settings.switch-ui.endpoint'                 => static function ( ContainerInterface $container ) : SwitchSettingsUiEndpoint {
 		return new SwitchSettingsUiEndpoint(
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'button.request-data' ),

--- a/modules/ppcp-settings/src/Endpoint/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SwitchSettingsUiEndpoint.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * The settings UI switching Endpoint.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Endpoint
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Endpoint;
+
+use Exception;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+
+/**
+ * Class SwitchSettingsUiEndpoint
+ */
+class SwitchSettingsUiEndpoint {
+
+	use RequestTrait;
+
+	public const ENDPOINT = 'ppcp-settings-switch-ui';
+	public const OPTION_NAME_SHOULD_USE_OLD_UI  = 'woocommerce_ppcp-settings-should-use-old-ui';
+
+	/**
+	 * The RequestData.
+	 *
+	 * @var RequestData
+	 */
+	protected RequestData $request_data;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	protected LoggerInterface $logger;
+
+	/**
+	 * SwitchSettingsUiEndpoint constructor.
+	 *
+	 * @param LoggerInterface          $logger The logger.
+	 * @param RequestData              $request_data The Request data.
+	 */
+	public function __construct(
+		LoggerInterface $logger,
+		RequestData $request_data
+	) {
+		$this->logger             = $logger;
+		$this->request_data       = $request_data;
+	}
+
+	/**
+	 * Handles the request.
+	 */
+	public function handle_request(): void {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( 'Not an admin.', 403 );
+			return;
+		}
+
+		try {
+			$this->request_data->read_request( $this->nonce() );
+			update_option( self::OPTION_NAME_SHOULD_USE_OLD_UI, false );
+
+			wp_send_json_success();
+		} catch ( Exception $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 500 );
+		}
+	}
+
+	/**
+	 * The nonce.
+	 *
+	 * @return string
+	 */
+	public static function nonce(): string {
+		return self::ENDPOINT;
+	}
+}

--- a/modules/ppcp-settings/src/Endpoint/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SwitchSettingsUiEndpoint.php
@@ -21,8 +21,8 @@ class SwitchSettingsUiEndpoint {
 
 	use RequestTrait;
 
-	public const ENDPOINT = 'ppcp-settings-switch-ui';
-	public const OPTION_NAME_SHOULD_USE_OLD_UI  = 'woocommerce_ppcp-settings-should-use-old-ui';
+	public const ENDPOINT                      = 'ppcp-settings-switch-ui';
+	public const OPTION_NAME_SHOULD_USE_OLD_UI = 'woocommerce_ppcp-settings-should-use-old-ui';
 
 	/**
 	 * The RequestData.
@@ -41,15 +41,15 @@ class SwitchSettingsUiEndpoint {
 	/**
 	 * SwitchSettingsUiEndpoint constructor.
 	 *
-	 * @param LoggerInterface          $logger The logger.
-	 * @param RequestData              $request_data The Request data.
+	 * @param LoggerInterface $logger The logger.
+	 * @param RequestData     $request_data The Request data.
 	 */
 	public function __construct(
 		LoggerInterface $logger,
 		RequestData $request_data
 	) {
-		$this->logger             = $logger;
-		$this->request_data       = $request_data;
+		$this->logger       = $logger;
+		$this->request_data = $request_data;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SwitchSettingsUiEndpoint.php
@@ -11,15 +11,12 @@ namespace WooCommerce\PayPalCommerce\Settings\Endpoint;
 
 use Exception;
 use Psr\Log\LoggerInterface;
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
 
 /**
  * Class SwitchSettingsUiEndpoint
  */
 class SwitchSettingsUiEndpoint {
-
-	use RequestTrait;
 
 	public const ENDPOINT                      = 'ppcp-settings-switch-ui';
 	public const OPTION_NAME_SHOULD_USE_OLD_UI = 'woocommerce_ppcp-settings-should-use-old-ui';

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -29,7 +29,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	public static function should_use_the_old_ui(): bool {
 		return apply_filters(
 			'woocommerce_paypal_payments_should_use_the_old_ui',
-			( bool ) get_option(SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI) === true
+			(bool) get_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI ) === true
 		);
 	}
 
@@ -56,7 +56,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			add_action(
 				'admin_enqueue_scripts',
 				static function () use ( $container ) {
-					$module_url = $container->get('settings.url');
+					$module_url        = $container->get( 'settings.url' );
 					$script_asset_file = require dirname( realpath( __FILE__ ) ?: '', 2 ) . '/assets/switchSettingsUi.asset.php';
 
 					wp_register_script(

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -29,7 +29,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	public static function should_use_the_old_ui(): bool {
 		return apply_filters(
 			'woocommerce_paypal_payments_should_use_the_old_ui',
-			get_option(SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI) === '1'
+			( bool ) get_option(SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI) === true
 		);
 	}
 
@@ -45,14 +45,12 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 */
 	public function run( ContainerInterface $container ) : bool {
 		if ( self::should_use_the_old_ui() ) {
-			add_action(
+			add_filter(
 				'woocommerce_paypal_payments_inside_settings_page_header',
-				static function () : void {
-					echo sprintf(
-						'<a href="#" class="button button-settings-switch-ui">%s</a>',
-						esc_html__( 'Switch to new settings UI', 'woocommerce-paypal-payments' )
-					);
-				}
+				static fn() : string => sprintf(
+					'<a href="#" class="button button-settings-switch-ui">%s</a>',
+					esc_html__( 'Switch to new settings UI', 'woocommerce-paypal-payments' )
+				)
 			);
 
 			add_action(

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -56,7 +56,13 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			add_action(
 				'admin_enqueue_scripts',
 				static function () use ( $container ) {
-					$module_url        = $container->get( 'settings.url' );
+					$module_url = $container->get( 'settings.url' );
+
+					/**
+					 * Require resolves.
+					 *
+					 * @psalm-suppress UnresolvableInclude
+					 */
 					$script_asset_file = require dirname( realpath( __FILE__ ) ?: '', 2 ) . '/assets/switchSettingsUi.asset.php';
 
 					wp_register_script(

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -33,9 +33,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * {@inheritDoc}
 	 */
 	public function services() : array {
-		if ( self::should_use_the_old_ui() ) {
-			return array();
-		}
 		return require __DIR__ . '/../services.php';
 	}
 
@@ -51,6 +48,30 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 						'<a href="#" class="button" onclick="javascript:void(0);">%s</a>',
 						esc_html__( 'Switch to new settings UI', 'woocommerce-paypal-payments' )
 					);
+				}
+			);
+
+			add_action(
+				'admin_enqueue_scripts',
+				static function () use ( $container ) {
+					$module_url = $container->get('settings.url');
+					$script_asset_file = require dirname( realpath( __FILE__ ) ?: '', 2 ) . '/assets/switchSettingsUi.asset.php';
+
+					wp_register_script(
+						'ppcp-switch-settings-ui',
+						untrailingslashit( $module_url ) . '/assets/switchSettingsUi.js',
+						$script_asset_file['dependencies'],
+						$script_asset_file['version'],
+						true
+					);
+
+					wp_localize_script(
+						'ppcp-switch-settings-ui',
+						'PayPalCommerceGatewayOrderTrackingInfo',
+						array()
+					);
+
+					wp_enqueue_script( 'ppcp-switch-settings-ui' );
 				}
 			);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -23,9 +23,19 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	use ModuleClassNameIdTrait;
 
 	/**
+	 * Returns whether the old settings UI should be loaded.
+	 */
+	public static function should_use_the_old_ui(): bool {
+		return apply_filters( 'woocommerce_paypal_payments_should_use_the_old_ui', false );
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function services() : array {
+		if ( self::should_use_the_old_ui() ) {
+			return array();
+		}
 		return require __DIR__ . '/../services.php';
 	}
 
@@ -33,6 +43,20 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * {@inheritDoc}
 	 */
 	public function run( ContainerInterface $container ) : bool {
+		if ( self::should_use_the_old_ui() ) {
+			add_action(
+				'woocommerce_paypal_payments_inside_settings_page_header',
+				static function () : void {
+					echo sprintf(
+						'<a href="#" class="button" onclick="javascript:void(0);">%s</a>',
+						esc_html__( 'Switch to new settings UI', 'woocommerce-paypal-payments' )
+					);
+				}
+			);
+
+			return true;
+		}
+
 		add_action(
 			'admin_enqueue_scripts',
 			/**

--- a/modules/ppcp-settings/webpack.config.js
+++ b/modules/ppcp-settings/webpack.config.js
@@ -7,6 +7,7 @@ module.exports = {
 	...{
 		entry: {
 			index: path.resolve( process.cwd(), 'resources/js', 'index.js' ),
+            switchSettingsUi: path.resolve( process.cwd(), 'resources/js', 'switchSettingsUi.js' ),
 			style: path.resolve( process.cwd(), 'resources/css', 'style.scss' ),
 		},
 	},

--- a/modules/ppcp-uninstall/services.php
+++ b/modules/ppcp-uninstall/services.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Uninstall;
 
 use WooCommerce\PayPalCommerce\ApiClient\Repository\PayPalRequestIdRepository;
+use WooCommerce\PayPalCommerce\Settings\Endpoint\SwitchSettingsUiEndpoint;
 use WooCommerce\PayPalCommerce\Uninstall\Assets\ClearDatabaseAssets;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
@@ -34,6 +35,7 @@ return array(
 			WebhookSimulation::OPTION_ID,
 			WebhookRegistrar::KEY,
 			'ppcp_payment_tokens_migration_initialized',
+			SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI,
 		);
 	},
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -24,6 +24,7 @@ use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Onboarding\Environment;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\RenderReauthorizeAction;
 use WooCommerce\PayPalCommerce\WcGateway\Assets\VoidButtonAssets;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CaptureCardPayment;
@@ -2067,6 +2068,6 @@ return array(
 	},
 
 	'wcgateway.settings.admin-settings-enabled'            => static function( ContainerInterface $container ): bool {
-		return $container->has( 'settings.url' );
+		return $container->has( 'settings.url' ) && ! SettingsModule::should_use_the_old_ui();
 	},
 );

--- a/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
@@ -76,7 +76,7 @@ class HeaderRenderer {
 						. __( 'Submit a bug', 'woocommerce-paypal-payments' ) .
 					'</a>
 				</span>
-				' . do_action( 'woocommerce_paypal_payments_inside_settings_page_header' ) . '
+				' . apply_filters( 'woocommerce_paypal_payments_inside_settings_page_header', '' ) . '
 			</div>
 
 			<div class="ppcp-notice-wrapper"></div>

--- a/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
@@ -76,6 +76,7 @@ class HeaderRenderer {
 						. __( 'Submit a bug', 'woocommerce-paypal-payments' ) .
 					'</a>
 				</span>
+				' . do_action( 'woocommerce_paypal_payments_inside_settings_page_header' ) . '
 			</div>
 
 			<div class="ppcp-notice-wrapper"></div>


### PR DESCRIPTION
# Issue Description

Users must be able to switch between the old settings and the new settings

# PR Description

- The button is placed on old settings screen and only when the feature flag is enabled.
- The button is placed above the navigation tabs, styled as “Documentation“ & “Get help“ buttons.
- The filter is added to be used to switch back to new UI, although it can be used to switch to the old UI.
- Once clicked:
  - The option is stored in database and used to check the above filter param.
  - The page is reloaded with appropriate UI based on the option/filter value
