### PR TITLE
New Settings UI: Add optional payment methods step (3912) (3913)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_badge-box.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_badge-box.scss
@@ -18,7 +18,7 @@
 			}
 		}
 
-		&-image-badge {
+		.ppcp-r-badge-box__title-text:not(:empty) + .ppcp-r-badge-box__title-image-badge {
 			margin-left: 7px;
 
 			img {

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_separator.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_separator.scss
@@ -10,7 +10,7 @@
 	}
 
 	&__line {
-		background-color: $color-gray-600;
+		background-color: $color-gray-400;
 		height: 1px;
 	}
 

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_welcome-docs.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_welcome-docs.scss
@@ -7,16 +7,6 @@
 		margin: 0 0 32px 0;
 	}
 
-	&__description {
-		text-align: center;
-		@include font(14, 22, 400);
-		font-style: italic;
-
-		a {
-			color: $color-gray-700;
-		}
-	}
-
 	&__wrapper {
 		padding: 8px;
 		margin: 0 0 48px 0;

--- a/modules/ppcp-settings/resources/css/components/screens/_onboarding.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_onboarding.scss
@@ -1,6 +1,7 @@
 @import './onboarding/step-welcome';
 @import './onboarding/step-business';
 @import './onboarding/step-products';
+@import './onboarding/step-payment-methods';
 
 .ppcp-r-tabs.onboarding,
 .ppcp-r-container--onboarding {

--- a/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-payment-methods.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-payment-methods.scss
@@ -1,0 +1,38 @@
+.ppcp-r-page-optional-payment-methods {
+	.ppcp-r-select-box:first-child {
+		.ppcp-r-select-box__title {
+			margin-bottom: 20px;
+		}
+	}
+}
+
+.ppcp-r-optional-payment-methods {
+	&__wrapper {
+		.ppcp-r-badge-box {
+			margin: 0 0 24px 0;
+			&:last-child {
+				margin: 0;
+			}
+		}
+
+		.ppcp-r-badge-box__description {
+			margin: 12px 0 0 0;
+			@include font(14, 20, 400);
+		}
+	}
+
+	&__description {
+		margin: 32px 0 0 0;
+		text-align: center;
+		@include font(14, 22, 400);
+		font-style: italic;
+
+		a {
+			color: $color-gray-700;
+		}
+	}
+
+	&__separator {
+		margin: 0 0 24px 0;
+	}
+}

--- a/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
@@ -16,13 +16,10 @@
 		text-align: center;
 	}
 
-	.ppcp-r-page-welcome-or-separator {
-		margin: 0 0 16px 0;
-	}
-
 	.components-base-control__field {
 		margin: 0 0 24px 0;
 	}
+
 	.ppcp-r-toggle-block__toggled-content > button{
 		@include small-button;
 		color: $color-white;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/OptionalPaymentMethods/AcdcOptionalPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/OptionalPaymentMethods/AcdcOptionalPaymentMethods.js
@@ -1,0 +1,271 @@
+import BadgeBox, { BADGE_BOX_TITLE_BIG } from '../BadgeBox';
+import { __, sprintf } from '@wordpress/i18n';
+import Separator from '../Separator';
+
+const AcdcOptionalPaymentMethods = ( {
+	isFastlane,
+	isPayLater,
+	storeCountry,
+} ) => {
+	if ( isFastlane && isPayLater && storeCountry === 'us' ) {
+		return (
+			<div className="ppcp-r-optional-payment-methods__wrapper">
+				<BadgeBox
+					title={ __(
+						'Custom Card Fields',
+						'woocommerce-paypal-payments'
+					) }
+					imageBadge={ [
+						'icon-button-visa.svg',
+						'icon-button-mastercard.svg',
+						'icon-button-amex.svg',
+						'icon-button-discover.svg',
+					] }
+					textBadge={ __(
+						'from 2.59% + $0.49 USD<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Style the credit card fields to match your own style. Includes advanced processing with risk management, 3D Secure, fraud protection options, and chargeback protection. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+				<Separator className="ppcp-r-optional-payment-methods__separator" />
+				<BadgeBox
+					title={ __(
+						'Digital Wallets',
+						'woocommerce-paypal-payments'
+					) }
+					imageBadge={ [
+						'icon-button-apple-pay.svg',
+						'icon-button-google-pay.svg',
+					] }
+					textBadge={ __(
+						'from 2.59% + $0.49 USD<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Accept Apple Pay on eligible devices and Google Pay through mobile and web. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+				<Separator className="ppcp-r-optional-payment-methods__separator" />
+				<BadgeBox
+					title={ __(
+						'Alternative Payment Methods',
+						'woocommerce-paypal-payments'
+					) }
+					imageBadge={ [
+						'icon-button-sepa.svg',
+						'icon-button-ideal.svg',
+						'icon-button-blik.svg',
+						'icon-button-bancontact.svg',
+					] }
+					textBadge={ __(
+						'from 3.49% + $0.49 USD<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Seamless payments for customers across the globe using their preferred payment methods. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+				<Separator className="ppcp-r-optional-payment-methods__separator" />
+				<BadgeBox
+					title={ __( '', 'woocommerce-paypal-payments' ) }
+					imageBadge={ [ 'icon-payment-method-fastlane-small.svg' ] }
+					textBadge={ __(
+						'from 2.59% + $0.49 USD<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Speed up guest checkout with Fatslane. Link a customer\'s email address to their payment details. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+			</div>
+		);
+	}
+
+	if ( isPayLater && storeCountry === 'uk' ) {
+		return (
+			<div className="ppcp-r-optional-payment-methods__wrapper">
+				<BadgeBox
+					title={ __(
+						'Custom Card Fields',
+						'woocommerce-paypal-payments'
+					) }
+					imageBadge={ [
+						'icon-button-visa.svg',
+						'icon-button-mastercard.svg',
+						'icon-button-amex.svg',
+						'icon-button-discover.svg',
+					] }
+					textBadge={ __(
+						'from 1.20% + £0.30 GBP<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Style the credit card fields to match your own style. Includes advanced processing with risk management, 3D Secure, fraud protection options, and chargeback protection. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+				<Separator className="ppcp-r-optional-payment-methods__separator" />
+				<BadgeBox
+					title={ __(
+						'Digital Wallets',
+						'woocommerce-paypal-payments'
+					) }
+					imageBadge={ [
+						'icon-button-apple-pay.svg',
+						'icon-button-google-pay.svg',
+					] }
+					textBadge={ __(
+						'from 1.20% + £0.30 GBP<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Accept Apple Pay on eligible devices and Google Pay through mobile and web. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+				<Separator className="ppcp-r-optional-payment-methods__separator" />
+				<BadgeBox
+					title={ __(
+						'Alternative Payment Methods',
+						'woocommerce-paypal-payments'
+					) }
+					imageBadge={ [
+						'icon-button-sepa.svg',
+						'icon-button-ideal.svg',
+						'icon-button-blik.svg',
+						'icon-button-bancontact.svg',
+					] }
+					textBadge={ __(
+						'from 1.20% + £0.30 GBP<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Seamless payments for customers across the globe using their preferred payment methods. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div className="ppcp-r-optional-payment-methods__wrapper">
+			<BadgeBox
+				title={ __(
+					'Optional payment methods',
+					'woocommerce-paypal-payments'
+				) }
+				titleType={ BADGE_BOX_TITLE_BIG }
+				description={ __(
+					'with additional application',
+					'woocommerce-paypal-payments'
+				) }
+			/>
+			<BadgeBox
+				title={ __(
+					'Custom Card Fields',
+					'woocommerce-paypal-payments'
+				) }
+				imageBadge={ [
+					'icon-button-visa.svg',
+					'icon-button-mastercard.svg',
+					'icon-button-amex.svg',
+					'icon-button-discover.svg',
+				] }
+				textBadge={ __(
+					'from 3.40% + €0.35 EUR<sup>1</sup>',
+					'woocommerce-paypal-payments'
+				) }
+				description={ sprintf(
+					// translators: %s: Link to PayPal REST application guide
+					__(
+						'Style the credit card fields to match your own style. Includes advanced processing with risk management, 3D Secure, fraud protection options, and chargeback protection. <a target="_blank" href="%s">Learn more</a>',
+						'woocommerce-paypal-payments'
+					),
+					'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+				) }
+			/>
+			<Separator className="ppcp-r-optional-payment-methods__separator" />
+			<BadgeBox
+				title={ __( 'Digital Wallets', 'woocommerce-paypal-payments' ) }
+				imageBadge={ [
+					'icon-button-apple-pay.svg',
+					'icon-button-google-pay.svg',
+				] }
+				textBadge={ __(
+					'from 3.40% + €0.35 EUR<sup>1</sup>',
+					'woocommerce-paypal-payments'
+				) }
+				description={ sprintf(
+					// translators: %s: Link to PayPal REST application guide
+					__(
+						'Accept Apple Pay on eligible devices and Google Pay through mobile and web. <a target="_blank" href="%s">Learn more</a>',
+						'woocommerce-paypal-payments'
+					),
+					'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+				) }
+			/>
+			<Separator className="ppcp-r-optional-payment-methods__separator" />
+			<BadgeBox
+				title={ __(
+					'Alternative Payment Methods',
+					'woocommerce-paypal-payments'
+				) }
+				imageBadge={ [
+					'icon-button-sepa.svg',
+					'icon-button-ideal.svg',
+					'icon-button-blik.svg',
+					'icon-button-bancontact.svg',
+				] }
+				textBadge={ __(
+					'from 3.40% + €0.35 EUR<sup>1</sup>',
+					'woocommerce-paypal-payments'
+				) }
+				description={ sprintf(
+					// translators: %s: Link to PayPal REST application guide
+					__(
+						'Seamless payments for customers across the globe using their preferred payment methods. <a target="_blank" href="%s">Learn more</a>',
+						'woocommerce-paypal-payments'
+					),
+					'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+				) }
+			/>
+		</div>
+	);
+};
+
+export default AcdcOptionalPaymentMethods;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/OptionalPaymentMethods/BcdcOptionalPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/OptionalPaymentMethods/BcdcOptionalPaymentMethods.js
@@ -1,0 +1,66 @@
+import BadgeBox from '../BadgeBox';
+import { __, sprintf } from '@wordpress/i18n';
+
+const BcdcOptionalPaymentMethods = ( { isPayLater, storeCountry } ) => {
+	if ( isPayLater && storeCountry === 'us' ) {
+		return (
+			<div className="ppcp-r-optional-payment-methods__wrapper">
+				<BadgeBox
+					title={ __(
+						'Credit and Debit Cards',
+						'woocommerce-paypal-payments'
+					) }
+					imageBadge={ [
+						'icon-button-visa.svg',
+						'icon-button-mastercard.svg',
+						'icon-button-amex.svg',
+						'icon-button-discover.svg',
+					] }
+					textBadge={ __(
+						'from 2.59% + $0.49 USD<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Process major credit and debit cards through PayPal’s card fields. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+			</div>
+		);
+	}
+
+	return (
+		<div className="ppcp-r-optional-payment-methods__wrapper">
+			<BadgeBox
+				title={ __(
+					'Credit and Debit Cards',
+					'woocommerce-paypal-payments'
+				) }
+				imageBadge={ [
+					'icon-button-visa.svg',
+					'icon-button-mastercard.svg',
+					'icon-button-amex.svg',
+					'icon-button-discover.svg',
+				] }
+				textBadge={ __(
+					'from 3.40% + €0.35 EUR<sup>1</sup>',
+					'woocommerce-paypal-payments'
+				) }
+				description={ sprintf(
+					// translators: %s: Link to PayPal REST application guide
+					__(
+						'Process major credit and debit cards through PayPal’s card fields. <a target="_blank" href="%s">Learn more</a>',
+						'woocommerce-paypal-payments'
+					),
+					'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+				) }
+			/>
+		</div>
+	);
+};
+
+export default BcdcOptionalPaymentMethods;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/OptionalPaymentMethods/OptionalPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/OptionalPaymentMethods/OptionalPaymentMethods.js
@@ -1,0 +1,28 @@
+import AcdcOptionalPaymentMethods from './AcdcOptionalPaymentMethods';
+import BcdcOptionalPaymentMethods from './BcdcOptionalPaymentMethods';
+
+const OptionalPaymentMethods = ( {
+	useAcdc,
+	isFastlane,
+	isPayLater,
+	storeCountry,
+} ) => {
+	return (
+		<div className="ppcp-r-optional-payment-methods">
+			{ useAcdc ? (
+				<AcdcOptionalPaymentMethods
+					isFastlane={ isFastlane }
+					isPayLater={ isPayLater }
+					storeCountry={ storeCountry }
+				/>
+			) : (
+				<BcdcOptionalPaymentMethods
+					isPayLater={ isPayLater }
+					storeCountry={ storeCountry }
+				/>
+			) }
+		</div>
+	);
+};
+
+export default OptionalPaymentMethods;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/AcdcFlow.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/AcdcFlow.js
@@ -1,327 +1,276 @@
-import BadgeBox, { BADGE_BOX_TITLE_BIG } from "../BadgeBox";
+import BadgeBox, { BADGE_BOX_TITLE_BIG } from '../BadgeBox';
 import { __, sprintf } from '@wordpress/i18n';
 import Separator from '../Separator';
+import OptionalPaymentMethods from '../OptionalPaymentMethods/OptionalPaymentMethods';
 
 const AcdcFlow = ( { isFastlane, isPayLater, storeCountry } ) => {
-    if (isFastlane && isPayLater && storeCountry === 'us') {
-        return (
-            <div className="ppcp-r-welcome-docs__wrapper">
-                <div className="ppcp-r-welcome-docs__col">
-                    <BadgeBox
-                        title={__('PayPal Checkout', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}
-                        textBadge={__('from 3.49% + $0.49 USD<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={__(
-                            'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
-                            'woocommerce-paypal-payments'
-                        )}
-                    />
-                    <BadgeBox
-                        title={__('Included in PayPal Checkout', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}/>
-                    <BadgeBox
-                        title={__('Pay with PayPal', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-paypal.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Pay Later', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-payment-method-paypal-small.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Venmo', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-venmo.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Automatically offer Venmo checkout to millions of active users. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Crypto', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-payment-method-crypto.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Let customers checkout with Crypto while you get paid in cash. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                </div>
-                <div className="ppcp-r-welcome-docs__col">
-                    <BadgeBox
-                        title={__('Optional payment methods', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}
-                        description={__('with additional application', 'woocommerce-paypal-payments')}
-                    />
-                    <BadgeBox
-                        title={__('Custom Card Fields', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-visa.svg', 'icon-button-mastercard.svg', 'icon-button-amex.svg', 'icon-button-discover.svg']}
-                        textBadge={__('from 2.59% + $0.49 USD<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Style the credit card fields to match your own style. Includes advanced processing with risk management, 3D Secure, fraud protection options, and chargeback protection. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Digital Wallets', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-apple-pay.svg', 'icon-button-google-pay.svg']}
-                        textBadge={__('from 2.59% + $0.49 USD<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Accept Apple Pay on eligible devices and Google Pay through mobile and web. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Alternative Payment Methods', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-sepa.svg', 'icon-button-ideal.svg', 'icon-button-blik.svg', 'icon-button-bancontact.svg']}
-                        textBadge={__('from 3.49% + $0.49 USD<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Seamless payments for customers across the globe using their preferred payment methods. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-payment-method-fastlane-small.svg']}
-                        textBadge={__('from 2.59% + $0.49 USD<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Speed up guest checkout with Fatslane. Link a customer\'s email address to their payment details. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                </div>
-            </div>
-        );
-    }
+	if ( isFastlane && isPayLater && storeCountry === 'us' ) {
+		return (
+			<div className="ppcp-r-welcome-docs__wrapper">
+				<div className="ppcp-r-welcome-docs__col">
+					<BadgeBox
+						title={ __(
+							'PayPal Checkout',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+						textBadge={ __(
+							'from 3.49% + $0.49 USD<sup>1</sup>',
+							'woocommerce-paypal-payments'
+						) }
+						description={ __(
+							'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
+							'woocommerce-paypal-payments'
+						) }
+					/>
+					<BadgeBox
+						title={ __(
+							'Included in PayPal Checkout',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+					/>
+					<BadgeBox
+						title={ __(
+							'Pay with PayPal',
+							'woocommerce-paypal-payments'
+						) }
+						imageBadge={ [ 'icon-button-paypal.svg' ] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+					<Separator className="ppcp-r-page-welcome-mode-separator" />
+					<BadgeBox
+						title={ __(
+							'Pay Later',
+							'woocommerce-paypal-payments'
+						) }
+						imageBadge={ [
+							'icon-payment-method-paypal-small.svg',
+						] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+					<Separator className="ppcp-r-page-welcome-mode-separator" />
+					<BadgeBox
+						title={ __( 'Venmo', 'woocommerce-paypal-payments' ) }
+						imageBadge={ [ 'icon-button-venmo.svg' ] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Automatically offer Venmo checkout to millions of active users. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+					<Separator className="ppcp-r-page-welcome-mode-separator" />
+					<BadgeBox
+						title={ __( 'Crypto', 'woocommerce-paypal-payments' ) }
+						imageBadge={ [ 'icon-payment-method-crypto.svg' ] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Let customers checkout with Crypto while you get paid in cash. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+				</div>
+				<div className="ppcp-r-welcome-docs__col">
+					<BadgeBox
+						title={ __(
+							'Optional payment methods',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+						description={ __(
+							'with additional application',
+							'woocommerce-paypal-payments'
+						) }
+					/>
+					<OptionalPaymentMethods
+						useAcdc={ true }
+						isFastlane={ isFastlane }
+						isPayLater={ isPayLater }
+						storeCountry={ storeCountry }
+					/>
+				</div>
+			</div>
+		);
+	}
 
-    if (isPayLater && storeCountry === 'uk') {
-        return (
-            <div className="ppcp-r-welcome-docs__wrapper">
-                <div className="ppcp-r-welcome-docs__col">
-                    <BadgeBox
-                        title={__('PayPal Checkout', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}
-                        textBadge={__('from 2.90% + £0.30 GBP<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={__(
-                            'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
-                            'woocommerce-paypal-payments'
-                        )}
-                    />
-                    <BadgeBox
-                        title={__('Included in PayPal Checkout', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}/>
-                    <BadgeBox
-                        title={__('Pay with PayPal', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-paypal.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Pay in 3', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-payment-method-paypal-small.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                </div>
-                <div className="ppcp-r-welcome-docs__col">
-                    <BadgeBox
-                        title={__('Optional payment methods', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}
-                        description={__('with additional application', 'woocommerce-paypal-payments')}
-                    />
-                    <BadgeBox
-                        title={__('Custom Card Fields', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-visa.svg', 'icon-button-mastercard.svg', 'icon-button-amex.svg', 'icon-button-discover.svg']}
-                        textBadge={__('from 1.20% + £0.30 GBP<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Style the credit card fields to match your own style. Includes advanced processing with risk management, 3D Secure, fraud protection options, and chargeback protection. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Digital Wallets', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-apple-pay.svg', 'icon-button-google-pay.svg']}
-                        textBadge={__('from 1.20% + £0.30 GBP<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Accept Apple Pay on eligible devices and Google Pay through mobile and web. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Alternative Payment Methods', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-sepa.svg', 'icon-button-ideal.svg', 'icon-button-blik.svg', 'icon-button-bancontact.svg']}
-                        textBadge={__('from 1.20% + £0.30 GBP<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Seamless payments for customers across the globe using their preferred payment methods. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                </div>
-            </div>
-        );
-    }
+	if ( isPayLater && storeCountry === 'uk' ) {
+		return (
+			<div className="ppcp-r-welcome-docs__wrapper">
+				<div className="ppcp-r-welcome-docs__col">
+					<BadgeBox
+						title={ __(
+							'PayPal Checkout',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+						textBadge={ __(
+							'from 2.90% + £0.30 GBP<sup>1</sup>',
+							'woocommerce-paypal-payments'
+						) }
+						description={ __(
+							'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
+							'woocommerce-paypal-payments'
+						) }
+					/>
+					<BadgeBox
+						title={ __(
+							'Included in PayPal Checkout',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+					/>
+					<BadgeBox
+						title={ __(
+							'Pay with PayPal',
+							'woocommerce-paypal-payments'
+						) }
+						imageBadge={ [ 'icon-button-paypal.svg' ] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+					<Separator className="ppcp-r-page-welcome-mode-separator" />
+					<BadgeBox
+						title={ __(
+							'Pay in 3',
+							'woocommerce-paypal-payments'
+						) }
+						imageBadge={ [
+							'icon-payment-method-paypal-small.svg',
+						] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+				</div>
+				<div className="ppcp-r-welcome-docs__col">
+					<BadgeBox
+						title={ __(
+							'Optional payment methods',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+						description={ __(
+							'with additional application',
+							'woocommerce-paypal-payments'
+						) }
+					/>
+					<OptionalPaymentMethods
+						useAcdc={ true }
+						isFastlane={ isFastlane }
+						isPayLater={ isPayLater }
+						storeCountry={ storeCountry }
+					/>
+				</div>
+			</div>
+		);
+	}
 
-    return (
-        <div className="ppcp-r-welcome-docs__wrapper">
-            <div className="ppcp-r-welcome-docs__col">
-                <BadgeBox
-                    title={__('PayPal Checkout', 'woocommerce-paypal-payments')}
-                    titleType={BADGE_BOX_TITLE_BIG}
-                    textBadge={__('from 3.40% + €0.35 EUR<sup>1</sup>', 'woocommerce-paypal-payments')}
-                    description={__(
-                        'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
-                        'woocommerce-paypal-payments'
-                    )}
-                />
-                <BadgeBox
-                    title={__('Included in PayPal Checkout', 'woocommerce-paypal-payments')}
-                    titleType={BADGE_BOX_TITLE_BIG}/>
-                <BadgeBox
-                    title={__('Pay with PayPal', 'woocommerce-paypal-payments')}
-                    imageBadge={['icon-button-paypal.svg']}
-                    description={sprintf(
-                        // translators: %s: Link to PayPal REST application guide
-                        __(
-                            'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
-                            'woocommerce-paypal-payments'
-                        ),
-                        'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                    )}
-                />
-                <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                <BadgeBox
-                    title={__('Pay Later', 'woocommerce-paypal-payments')}
-                    imageBadge={['icon-payment-method-paypal-small.svg']}
-                    description={sprintf(
-                        // translators: %s: Link to PayPal REST application guide
-                        __(
-                            'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
-                            'woocommerce-paypal-payments'
-                        ),
-                        'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                    )}
-                />
-            </div>
-            <div className="ppcp-r-welcome-docs__col">
-                <BadgeBox
-                    title={__('Optional payment methods', 'woocommerce-paypal-payments')}
-                    titleType={BADGE_BOX_TITLE_BIG}
-                    description={__('with additional application', 'woocommerce-paypal-payments')}
-                />
-                <BadgeBox
-                    title={__('Custom Card Fields', 'woocommerce-paypal-payments')}
-                    imageBadge={['icon-button-visa.svg', 'icon-button-mastercard.svg', 'icon-button-amex.svg', 'icon-button-discover.svg']}
-                    textBadge={__('from 3.40% + €0.35 EUR<sup>1</sup>', 'woocommerce-paypal-payments')}
-                    description={sprintf(
-                        // translators: %s: Link to PayPal REST application guide
-                        __(
-                            'Style the credit card fields to match your own style. Includes advanced processing with risk management, 3D Secure, fraud protection options, and chargeback protection. <a target="_blank" href="%s">Learn more</a>',
-                            'woocommerce-paypal-payments'
-                        ),
-                        'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                    )}
-                />
-                <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                <BadgeBox
-                    title={__('Digital Wallets', 'woocommerce-paypal-payments')}
-                    imageBadge={['icon-button-apple-pay.svg', 'icon-button-google-pay.svg']}
-                    textBadge={__('from 3.40% + €0.35 EUR<sup>1</sup>', 'woocommerce-paypal-payments')}
-                    description={sprintf(
-                        // translators: %s: Link to PayPal REST application guide
-                        __(
-                            'Accept Apple Pay on eligible devices and Google Pay through mobile and web. <a target="_blank" href="%s">Learn more</a>',
-                            'woocommerce-paypal-payments'
-                        ),
-                        'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                    )}
-                />
-                <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                <BadgeBox
-                    title={__('Alternative Payment Methods', 'woocommerce-paypal-payments')}
-                    imageBadge={['icon-button-sepa.svg', 'icon-button-ideal.svg', 'icon-button-blik.svg', 'icon-button-bancontact.svg']}
-                    textBadge={__('from 3.40% + €0.35 EUR<sup>1</sup>', 'woocommerce-paypal-payments')}
-                    description={sprintf(
-                        // translators: %s: Link to PayPal REST application guide
-                        __(
-                            'Seamless payments for customers across the globe using their preferred payment methods. <a target="_blank" href="%s">Learn more</a>',
-                            'woocommerce-paypal-payments'
-                        ),
-                        'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                    )}
-                />
-            </div>
-        </div>
-    );
+	return (
+		<div className="ppcp-r-welcome-docs__wrapper">
+			<div className="ppcp-r-welcome-docs__col">
+				<BadgeBox
+					title={ __(
+						'PayPal Checkout',
+						'woocommerce-paypal-payments'
+					) }
+					titleType={ BADGE_BOX_TITLE_BIG }
+					textBadge={ __(
+						'from 3.40% + €0.35 EUR<sup>1</sup>',
+						'woocommerce-paypal-payments'
+					) }
+					description={ __(
+						'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
+						'woocommerce-paypal-payments'
+					) }
+				/>
+				<BadgeBox
+					title={ __(
+						'Included in PayPal Checkout',
+						'woocommerce-paypal-payments'
+					) }
+					titleType={ BADGE_BOX_TITLE_BIG }
+				/>
+				<BadgeBox
+					title={ __(
+						'Pay with PayPal',
+						'woocommerce-paypal-payments'
+					) }
+					imageBadge={ [ 'icon-button-paypal.svg' ] }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+				<Separator className="ppcp-r-page-welcome-mode-separator" />
+				<BadgeBox
+					title={ __( 'Pay Later', 'woocommerce-paypal-payments' ) }
+					imageBadge={ [ 'icon-payment-method-paypal-small.svg' ] }
+					description={ sprintf(
+						// translators: %s: Link to PayPal REST application guide
+						__(
+							'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+					) }
+				/>
+			</div>
+			<div className="ppcp-r-welcome-docs__col">
+				<BadgeBox
+					title={ __(
+						'Optional payment methods',
+						'woocommerce-paypal-payments'
+					) }
+					titleType={ BADGE_BOX_TITLE_BIG }
+					description={ __(
+						'with additional application',
+						'woocommerce-paypal-payments'
+					) }
+				/>
+				<OptionalPaymentMethods
+					useAcdc={ true }
+					isFastlane={ isFastlane }
+					isPayLater={ isPayLater }
+					storeCountry={ storeCountry }
+				/>
+			</div>
+		</div>
+	);
 };
 
 export default AcdcFlow;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/BcdcFlow.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/BcdcFlow.js
@@ -1,160 +1,184 @@
-import BadgeBox, { BADGE_BOX_TITLE_BIG } from "../BadgeBox";
+import BadgeBox, { BADGE_BOX_TITLE_BIG } from '../BadgeBox';
 import { __, sprintf } from '@wordpress/i18n';
 import Separator from '../Separator';
+import OptionalPaymentMethods from '../OptionalPaymentMethods/OptionalPaymentMethods';
 
 const BcdcFlow = ( { isPayLater, storeCountry } ) => {
-    if (isPayLater && storeCountry === 'us') {
-        return (
-            <div className="ppcp-r-welcome-docs__wrapper">
-                <div className="ppcp-r-welcome-docs__col">
-                    <BadgeBox
-                        title={__('PayPal Checkout', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}
-                        textBadge={__('from 3.49% + $0.49 USD<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={__(
-                            'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
-                            'woocommerce-paypal-payments'
-                        )}
-                    />
-                    <BadgeBox
-                        title={__('Included in PayPal Checkout', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}/>
-                    <BadgeBox
-                        title={__('Pay with PayPal', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-paypal.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Pay Later', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-payment-method-paypal-small.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Venmo', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-venmo.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Automatically offer Venmo checkout to millions of active users. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                    <Separator className="ppcp-r-page-welcome-mode-separator"/>
-                    <BadgeBox
-                        title={__('Crypto', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-payment-method-crypto.svg']}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Let customers checkout with Crypto while you get paid in cash. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                </div>
-                <div className="ppcp-r-welcome-docs__col">
-                    <BadgeBox
-                        title={__('Optional payment methods', 'woocommerce-paypal-payments')}
-                        titleType={BADGE_BOX_TITLE_BIG}
-                        description={__('with additional application', 'woocommerce-paypal-payments')}
-                    />
-                    <BadgeBox
-                        title={__('Credit and Debit Cards', 'woocommerce-paypal-payments')}
-                        imageBadge={['icon-button-visa.svg', 'icon-button-mastercard.svg', 'icon-button-amex.svg', 'icon-button-discover.svg']}
-                        textBadge={__('from 2.59% + $0.49 USD<sup>1</sup>', 'woocommerce-paypal-payments')}
-                        description={sprintf(
-                            // translators: %s: Link to PayPal REST application guide
-                            __(
-                                'Process major credit and debit cards through PayPal’s card fields. <a target="_blank" href="%s">Learn more</a>',
-                                'woocommerce-paypal-payments'
-                            ),
-                            'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                        )}
-                    />
-                </div>
-            </div>
-        );
-    }
+	if ( isPayLater && storeCountry === 'us' ) {
+		return (
+			<div className="ppcp-r-welcome-docs__wrapper">
+				<div className="ppcp-r-welcome-docs__col">
+					<BadgeBox
+						title={ __(
+							'PayPal Checkout',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+						textBadge={ __(
+							'from 3.49% + $0.49 USD<sup>1</sup>',
+							'woocommerce-paypal-payments'
+						) }
+						description={ __(
+							'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
+							'woocommerce-paypal-payments'
+						) }
+					/>
+					<BadgeBox
+						title={ __(
+							'Included in PayPal Checkout',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+					/>
+					<BadgeBox
+						title={ __(
+							'Pay with PayPal',
+							'woocommerce-paypal-payments'
+						) }
+						imageBadge={ [ 'icon-button-paypal.svg' ] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+					<Separator className="ppcp-r-page-welcome-mode-separator" />
+					<BadgeBox
+						title={ __(
+							'Pay Later',
+							'woocommerce-paypal-payments'
+						) }
+						imageBadge={ [
+							'icon-payment-method-paypal-small.svg',
+						] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+					<Separator className="ppcp-r-page-welcome-mode-separator" />
+					<BadgeBox
+						title={ __( 'Venmo', 'woocommerce-paypal-payments' ) }
+						imageBadge={ [ 'icon-button-venmo.svg' ] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Automatically offer Venmo checkout to millions of active users. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+					<Separator className="ppcp-r-page-welcome-mode-separator" />
+					<BadgeBox
+						title={ __( 'Crypto', 'woocommerce-paypal-payments' ) }
+						imageBadge={ [ 'icon-payment-method-crypto.svg' ] }
+						description={ sprintf(
+							// translators: %s: Link to PayPal REST application guide
+							__(
+								'Let customers checkout with Crypto while you get paid in cash. <a target="_blank" href="%s">Learn more</a>',
+								'woocommerce-paypal-payments'
+							),
+							'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+						) }
+					/>
+				</div>
+				<div className="ppcp-r-welcome-docs__col">
+					<BadgeBox
+						title={ __(
+							'Optional payment methods',
+							'woocommerce-paypal-payments'
+						) }
+						titleType={ BADGE_BOX_TITLE_BIG }
+						description={ __(
+							'with additional application',
+							'woocommerce-paypal-payments'
+						) }
+					/>
+					<OptionalPaymentMethods
+						useAcdc={ false }
+						isFastlane={ false }
+						isPayLater={ isPayLater }
+						storeCountry={ storeCountry }
+					/>
+				</div>
+			</div>
+		);
+	}
 
-    return (
-        <div className="ppcp-r-welcome-docs__wrapper ppcp-r-welcome-docs__wrapper--one-col">
-            <BadgeBox
-                title={__('PayPal Checkout', 'woocommerce-paypal-payments')}
-                titleType={BADGE_BOX_TITLE_BIG}
-                textBadge={__('from 3.40% + €0.35 EUR<sup>1</sup>', 'woocommerce-paypal-payments')}
-                description={__(
-                    'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
-                    'woocommerce-paypal-payments'
-                )}
-            />
-            <BadgeBox
-                title={__('Included in PayPal Checkout', 'woocommerce-paypal-payments')}
-                titleType={BADGE_BOX_TITLE_BIG}/>
-            <BadgeBox
-                title={__('Pay with PayPal', 'woocommerce-paypal-payments')}
-                imageBadge={['icon-button-paypal.svg']}
-                description={sprintf(
-                    // translators: %s: Link to PayPal REST application guide
-                    __(
-                        'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
-                        'woocommerce-paypal-payments'
-                    ),
-                    'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                )}
-            />
-            <Separator className="ppcp-r-page-welcome-mode-separator"/>
-            <BadgeBox
-                title={__('Pay Later', 'woocommerce-paypal-payments')}
-                imageBadge={['icon-payment-method-paypal-small.svg']}
-                description={sprintf(
-                    // translators: %s: Link to PayPal REST application guide
-                    __(
-                        'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
-                        'woocommerce-paypal-payments'
-                    ),
-                    'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                )}
-            />
-            <Separator className="ppcp-r-page-welcome-mode-separator"/>
-            <BadgeBox
-                title={__('Optional payment methods', 'woocommerce-paypal-payments')}
-                titleType={BADGE_BOX_TITLE_BIG}
-                description={__('with additional application', 'woocommerce-paypal-payments')}
-            />
-            <BadgeBox
-                title={__('Credit and Debit Cards', 'woocommerce-paypal-payments')}
-                imageBadge={['icon-button-visa.svg', 'icon-button-mastercard.svg', 'icon-button-amex.svg', 'icon-button-discover.svg']}
-                textBadge={__('from 3.40% + €0.35 EUR<sup>1</sup>', 'woocommerce-paypal-payments')}
-                description={sprintf(
-                    // translators: %s: Link to PayPal REST application guide
-                    __(
-                        'Process major credit and debit cards through PayPal’s card fields. <a target="_blank" href="%s">Learn more</a>',
-                        'woocommerce-paypal-payments'
-                    ),
-                    'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-                )}
-            />
-        </div>
-    );
+	return (
+		<div className="ppcp-r-welcome-docs__wrapper ppcp-r-welcome-docs__wrapper--one-col">
+			<BadgeBox
+				title={ __( 'PayPal Checkout', 'woocommerce-paypal-payments' ) }
+				titleType={ BADGE_BOX_TITLE_BIG }
+				textBadge={ __(
+					'from 3.40% + €0.35 EUR<sup>1</sup>',
+					'woocommerce-paypal-payments'
+				) }
+				description={ __(
+					'Our all-in-one checkout solution lets you offer PayPal, Venmo, Pay Later options, and more to help maximise conversion',
+					'woocommerce-paypal-payments'
+				) }
+			/>
+			<BadgeBox
+				title={ __(
+					'Included in PayPal Checkout',
+					'woocommerce-paypal-payments'
+				) }
+				titleType={ BADGE_BOX_TITLE_BIG }
+			/>
+			<BadgeBox
+				title={ __( 'Pay with PayPal', 'woocommerce-paypal-payments' ) }
+				imageBadge={ [ 'icon-button-paypal.svg' ] }
+				description={ sprintf(
+					// translators: %s: Link to PayPal REST application guide
+					__(
+						'Our brand recognition helps give customers the confidence to buy. <a target="_blank" href="%s">Learn more</a>',
+						'woocommerce-paypal-payments'
+					),
+					'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+				) }
+			/>
+			<Separator className="ppcp-r-page-welcome-mode-separator" />
+			<BadgeBox
+				title={ __( 'Pay Later', 'woocommerce-paypal-payments' ) }
+				imageBadge={ [ 'icon-payment-method-paypal-small.svg' ] }
+				description={ sprintf(
+					// translators: %s: Link to PayPal REST application guide
+					__(
+						'Offer installment payment options and get paid upfront - at no extra cost to you. <a target="_blank" href="%s">Learn more</a>',
+						'woocommerce-paypal-payments'
+					),
+					'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+				) }
+			/>
+			<Separator className="ppcp-r-page-welcome-mode-separator" />
+			<BadgeBox
+				title={ __(
+					'Optional payment methods',
+					'woocommerce-paypal-payments'
+				) }
+				titleType={ BADGE_BOX_TITLE_BIG }
+				description={ __(
+					'with additional application',
+					'woocommerce-paypal-payments'
+				) }
+			/>
+			<OptionalPaymentMethods
+				useAcdc={ false }
+				isFastlane={ false }
+				isPayLater={ isPayLater }
+				storeCountry={ storeCountry }
+			/>
+		</div>
+	);
 };
 
 export default BcdcFlow;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/WelcomeDocs.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/WelcomeDocs.js
@@ -22,8 +22,8 @@ const WelcomeDocs = ( { useAcdc, isFastlane, isPayLater, storeCountry, storeCurr
                 <BcdcFlow isPayLater={ isPayLater } storeCountry={ storeCountry } />
             )}
             <p
-                className="ppcp-r-welcome-docs__description"
-                dangerouslySetInnerHTML={{__html: pricesBasedDescription,}}
+                className="ppcp-r-optional-payment-methods__description"
+                dangerouslySetInnerHTML={ { __html: pricesBasedDescription } }
             ></p>
         </div>
     );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepPaymentMethods.js
@@ -1,0 +1,78 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+import OnboardingHeader from '../../ReusableComponents/OnboardingHeader';
+import SelectBoxWrapper from '../../ReusableComponents/SelectBoxWrapper';
+import SelectBox from '../../ReusableComponents/SelectBox';
+import { OnboardingHooks } from '../../../data';
+import OptionalPaymentMethods from '../../ReusableComponents/OptionalPaymentMethods/OptionalPaymentMethods';
+
+const OPM_RADIO_GROUP_NAME = 'optional-payment-methods';
+
+const StepPaymentMethods = ( {} ) => {
+	const {
+		areOptionalPaymentMethodsEnabled,
+		setAreOptionalPaymentMethodsEnabled,
+	} = OnboardingHooks.useOptionalPaymentMethods();
+	const pricesBasedDescription = sprintf(
+		// translators: %s: Link to PayPal REST application guide
+		__(
+			'<sup>1</sup>Prices based on domestic transactions as of October 25th, 2024. <a target="_blank" href="%s">Click here</a> for full pricing details.',
+			'woocommerce-paypal-payments'
+		),
+		'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+	);
+
+	return (
+		<div className="ppcp-r-page-optional-payment-methods">
+			<OnboardingHeader
+				title={ __(
+					'Add optional payment methods to your Checkout',
+					'woocommerce-paypal-payments'
+				) }
+			/>
+			<div className="ppcp-r-inner-container">
+				<SelectBoxWrapper>
+					<SelectBox
+						title={ __(
+							'Available with additional application',
+							'woocommerce-paypal-payments'
+						) }
+						description={
+							<OptionalPaymentMethods
+								useAcdc={ true }
+								isFastlane={ true }
+								isPayLater={ true }
+								storeCountry={ 'us' }
+								storeCurrency={ 'usd' }
+							/>
+						}
+						name={ OPM_RADIO_GROUP_NAME }
+						value={ true }
+						changeCallback={ setAreOptionalPaymentMethodsEnabled }
+						currentValue={ areOptionalPaymentMethodsEnabled }
+						type="radio"
+					></SelectBox>
+					<SelectBox
+						title={ __(
+							'No thanks, I prefer to use a different provider for processing credit cards, digital wallets, and local payment methods',
+							'woocommerce-paypal-payments'
+						) }
+						name={ OPM_RADIO_GROUP_NAME }
+						value={ false }
+						changeCallback={ setAreOptionalPaymentMethodsEnabled }
+						currentValue={ areOptionalPaymentMethodsEnabled }
+						type="radio"
+					></SelectBox>
+				</SelectBoxWrapper>
+				<p
+					className="ppcp-r-optional-payment-methods__description"
+					dangerouslySetInnerHTML={ {
+						__html: pricesBasedDescription,
+					} }
+				></p>
+			</div>
+		</div>
+	);
+};
+
+export default StepPaymentMethods;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/availableSteps.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/availableSteps.js
@@ -1,6 +1,7 @@
 import StepWelcome from './StepWelcome';
 import StepBusiness from './StepBusiness';
 import StepProducts from './StepProducts';
+import StepPaymentMethods from './StepPaymentMethods';
 import StepCompleteSetup from './StepCompleteSetup';
 
 export const getSteps = ( flags ) => {
@@ -8,6 +9,7 @@ export const getSteps = ( flags ) => {
 		StepWelcome,
 		StepBusiness,
 		StepProducts,
+        StepPaymentMethods,
 		StepCompleteSetup,
 	];
 

--- a/modules/ppcp-settings/resources/js/data/onboarding/actions.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/actions.js
@@ -81,6 +81,19 @@ export const setIsCasualSeller = ( isCasualSeller ) => ( {
 } );
 
 /**
+ * Persistent. Sets the "areOptionalPaymentMethodsEnabled" value.
+ *
+ * @param {boolean} areOptionalPaymentMethodsEnabled
+ * @return {Action} The action.
+ */
+export const setAreOptionalPaymentMethodsEnabled = (
+	areOptionalPaymentMethodsEnabled
+) => ( {
+	type: ACTION_TYPES.SET_PERSISTENT,
+	payload: { areOptionalPaymentMethodsEnabled },
+} );
+
+/**
  * Persistent. Sets the "products" array.
  *
  * @param {string[]} products

--- a/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
@@ -25,8 +25,14 @@ const usePersistent = ( key ) =>
 	);
 
 const useHooks = () => {
-	const { persist, setStep, setCompleted, setIsCasualSeller, setProducts } =
-		useDispatch( STORE_NAME );
+	const {
+		persist,
+		setStep,
+		setCompleted,
+		setIsCasualSeller,
+		setAreOptionalPaymentMethodsEnabled,
+		setProducts,
+	} = useDispatch( STORE_NAME );
 
 	// Read-only flags.
 	const flags = useSelect( ( select ) => select( STORE_NAME ).flags(), [] );
@@ -38,6 +44,9 @@ const useHooks = () => {
 	const step = usePersistent( 'step' );
 	const completed = usePersistent( 'completed' );
 	const isCasualSeller = usePersistent( 'isCasualSeller' );
+	const areOptionalPaymentMethodsEnabled = usePersistent(
+		'areOptionalPaymentMethodsEnabled'
+	);
 	const products = usePersistent( 'products' );
 
 	const savePersistent = async ( setter, value ) => {
@@ -60,6 +69,10 @@ const useHooks = () => {
 		setIsCasualSeller: ( value ) => {
 			return savePersistent( setIsCasualSeller, value );
 		},
+		areOptionalPaymentMethodsEnabled,
+		setAreOptionalPaymentMethodsEnabled: ( value ) => {
+			return savePersistent( setAreOptionalPaymentMethodsEnabled, value );
+		},
 		products,
 		setProducts: ( activeProducts ) => {
 			const validProducts = activeProducts.filter( ( item ) =>
@@ -80,6 +93,18 @@ export const useProducts = () => {
 	const { products, setProducts } = useHooks();
 
 	return { products, setProducts };
+};
+
+export const useOptionalPaymentMethods = () => {
+	const {
+		areOptionalPaymentMethodsEnabled,
+		setAreOptionalPaymentMethodsEnabled,
+	} = useHooks();
+
+	return {
+		areOptionalPaymentMethodsEnabled,
+		setAreOptionalPaymentMethodsEnabled,
+	};
 };
 
 export const useSteps = () => {

--- a/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
@@ -27,6 +27,7 @@ const defaultPersistent = {
 	completed: false,
 	step: 0,
 	isCasualSeller: null, // null value will uncheck both options in the UI.
+	areOptionalPaymentMethodsEnabled: true,
 	products: [],
 };
 

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -67,6 +67,7 @@ class OnboardingProfile extends AbstractDataModel {
 			'completed'        => false,
 			'step'             => 0,
 			'is_casual_seller' => null,
+			'are_optional_payment_methods_enabled' => true,
 			'products'         => array(),
 		);
 	}
@@ -125,6 +126,15 @@ class OnboardingProfile extends AbstractDataModel {
 	 */
 	public function set_casual_seller( ?bool $casual_seller ) : void {
 		$this->data['is_casual_seller'] = $casual_seller;
+	}
+
+	/**
+	 * Sets the optional payment methods flag.
+	 *
+	 * @param bool|null $are_optional_payment_methods_enabled Whether the PayPal optional payment methods are enabled.
+	 */
+	public function set_are_optional_payment_methods_enabled( ?bool $are_optional_payment_methods_enabled ) : void {
+		$this->data['are_optional_payment_methods_enabled'] = $are_optional_payment_methods_enabled;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -53,6 +53,10 @@ class OnboardingRestEndpoint extends RestEndpoint {
 			'js_name'  => 'isCasualSeller',
 			'sanitize' => 'to_boolean',
 		),
+		'are_optional_payment_methods_enabled' => array(
+			'js_name'  => 'areOptionalPaymentMethodsEnabled',
+			'sanitize' => 'to_boolean',
+		),
 		'products'         => array(
 			'js_name' => 'products',
 		),


### PR DESCRIPTION
### Description

Add a new step to the onboarding wizard to enable/disable the optional payment methods.

### Steps to Test

1. Enable the new Settings UI
2. Start the PayPal onboarding process
3. Verify that there is a new step:  "Add optional payment methods to your Checkout"
4. Verify that the design aligns with the Figma design

### Documentation

One of the requirements of this task was that the second option of the new step would have a dynamic message depending on if the current flow is ACDC or BCDC.

We are waiting for more information regarding the API to fetch the data related to the ACDC/BCDC flows, so this requirement was not fulfilled as part of this PR.

### Screenshots

![WooCommerce-settings-‹-WooCommerce-PayPal-Payments-—-WordPress-11-25-2024_08_45_PM](https://github.com/user-attachments/assets/921b5af3-931b-474a-a8b8-adb31d4ed51a)


