### PR TITLE
Conflict with EasyShip Plugin: Shipping Methods Not Displayed

### DIFF
--- a/modules/ppcp-axo-block/services.php
+++ b/modules/ppcp-axo-block/services.php
@@ -39,8 +39,7 @@ return array(
 			$container->get( 'onboarding.environment' ),
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'axo.payment_method_selected_map' ),
-			$container->get( 'axo.supported-country-card-type-matrix' ),
-			$container->get( 'axo.shipping-wc-enabled-locations' )
+			$container->get( 'axo.supported-country-card-type-matrix' )
 		);
 	},
 );

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -94,13 +94,6 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	private $supported_country_card_type_matrix;
 
 	/**
-	 * The list of WooCommerce enabled shipping locations.
-	 *
-	 * @var array
-	 */
-	private array $enabled_shipping_locations;
-
-	/**
 	 * AdvancedCardPaymentMethod constructor.
 	 *
 	 * @param string                        $module_url The URL of this module.
@@ -113,7 +106,6 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	 * @param string                        $wcgateway_module_url The WcGateway module URL.
 	 * @param array                         $payment_method_selected_map Mapping of payment methods to the PayPal Insights 'payment_method_selected' types.
 	 * @param array                         $supported_country_card_type_matrix The supported country card type matrix for Axo.
-	 * @param array                         $enabled_shipping_locations The list of WooCommerce enabled shipping locations.
 	 */
 	public function __construct(
 	string $module_url,
@@ -125,8 +117,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	Environment $environment,
 	string $wcgateway_module_url,
 	array $payment_method_selected_map,
-	array $supported_country_card_type_matrix,
-	array $enabled_shipping_locations
+	array $supported_country_card_type_matrix
 	) {
 		$this->name                               = AxoGateway::ID;
 		$this->module_url                         = $module_url;
@@ -139,7 +130,6 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 		$this->wcgateway_module_url               = $wcgateway_module_url;
 		$this->payment_method_selected_map        = $payment_method_selected_map;
 		$this->supported_country_card_type_matrix = $supported_country_card_type_matrix;
-		$this->enabled_shipping_locations         = $enabled_shipping_locations;
 	}
 	/**
 	 * {@inheritDoc}
@@ -237,7 +227,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 			),
 			'allowed_cards'              => $this->supported_country_card_type_matrix,
 			'disable_cards'              => $this->settings->has( 'disable_cards' ) ? (array) $this->settings->get( 'disable_cards' ) : array(),
-			'enabled_shipping_locations' => $this->enabled_shipping_locations,
+			'enabled_shipping_locations' => apply_filters( 'woocommerce_paypal_payments_axo_shipping_wc_enabled_locations', array() ),
 			'style_options'              => array(
 				'root'  => array(
 					'backgroundColor' => $this->settings->has( 'axo_style_root_bg_color' ) ? $this->settings->get( 'axo_style_root_bg_color' ) : '',

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -70,8 +70,7 @@ return array(
 			$container->get( 'api.shop.currency.getter' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'wcgateway.url' ),
-			$container->get( 'axo.supported-country-card-type-matrix' ),
-			$container->get( 'axo.shipping-wc-enabled-locations' )
+			$container->get( 'axo.supported-country-card-type-matrix' )
 		);
 	},
 
@@ -329,33 +328,23 @@ return array(
 		);
 	},
 
-	'axo.shipping-wc-enabled-locations'      => static function ( ContainerInterface $container ): array {
+	'axo.shipping-wc-enabled-locations'      => static function ( ContainerInterface $container ) {
 		$default_zone = new \WC_Shipping_Zone( 0 );
 
-		$is_method_enabled = fn( \WC_Shipping_Method $method): bool => $method->enabled === 'yes';
-
-		$is_default_zone_enabled = ! empty(
-			array_filter(
-				$default_zone->get_shipping_methods(),
-				$is_method_enabled
-			)
-		);
-
-		if ( $is_default_zone_enabled ) {
+		if ( ! empty( $default_zone->get_shipping_methods( true ) ) ) {
 			return array();
 		}
 
 		$shipping_zones = \WC_Shipping_Zones::get_zones();
-
 		$get_zone_locations = fn( \WC_Shipping_Zone $zone): array =>
-		! empty( array_filter( $zone->get_shipping_methods(), $is_method_enabled ) )
+		! empty( $zone->get_shipping_methods( true ) )
 			? array_map(
 				fn( object $location): string => $location->code,
 				$zone->get_zone_locations()
 			)
 			: array();
 
-		$enabled_locations = array_unique(
+		return array_unique(
 			array_merge(
 				...array_map(
 					$get_zone_locations,
@@ -367,7 +356,5 @@ return array(
 				)
 			)
 		);
-
-		return $enabled_locations;
 	},
 );

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -99,12 +99,6 @@ class AxoManager {
 	 * @var array
 	 */
 	private array $supported_country_card_type_matrix;
-	/**
-	 * The list of WooCommerce enabled shipping locations.
-	 *
-	 * @var array
-	 */
-	private array $enabled_shipping_locations;
 
 	/**
 	 * AxoManager constructor.
@@ -120,7 +114,6 @@ class AxoManager {
 	 * @param LoggerInterface $logger The logger.
 	 * @param string          $wcgateway_module_url The WcGateway module URL.
 	 * @param array           $supported_country_card_type_matrix The supported country card type matrix for Axo.
-	 * @param array           $enabled_shipping_locations The list of WooCommerce enabled shipping locations.
 	 */
 	public function __construct(
 		string $module_url,
@@ -133,8 +126,7 @@ class AxoManager {
 		CurrencyGetter $currency,
 		LoggerInterface $logger,
 		string $wcgateway_module_url,
-		array $supported_country_card_type_matrix,
-		array $enabled_shipping_locations
+		array $supported_country_card_type_matrix
 	) {
 
 		$this->module_url                         = $module_url;
@@ -147,7 +139,6 @@ class AxoManager {
 		$this->currency                           = $currency;
 		$this->logger                             = $logger;
 		$this->wcgateway_module_url               = $wcgateway_module_url;
-		$this->enabled_shipping_locations         = $enabled_shipping_locations;
 		$this->supported_country_card_type_matrix = $supported_country_card_type_matrix;
 	}
 
@@ -203,7 +194,7 @@ class AxoManager {
 				return $data; } )( $this->insights_data ),
 			'allowed_cards'              => $this->supported_country_card_type_matrix,
 			'disable_cards'              => $this->settings->has( 'disable_cards' ) ? (array) $this->settings->get( 'disable_cards' ) : array(),
-			'enabled_shipping_locations' => $this->enabled_shipping_locations,
+			'enabled_shipping_locations' => apply_filters( 'woocommerce_paypal_payments_axo_shipping_wc_enabled_locations', array() ),
 			'style_options'              => array(
 				'root'  => array(
 					'backgroundColor' => $this->settings->has( 'axo_style_root_bg_color' ) ? $this->settings->get( 'axo_style_root_bg_color' ) : '',

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -230,6 +230,16 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				);
 
 				/**
+				 * Late loading locations because of trouble with some shipping plugins
+				 */
+				add_filter(
+					'woocommerce_paypal_payments_axo_shipping_wc_enabled_locations',
+					function ( array $locations ) use ( $c ): array {
+						return array_merge( $locations, $c->get( 'axo.shipping-wc-enabled-locations' ) );
+					}
+				);
+
+				/**
 				 * Param types removed to avoid third-party issues.
 				 *
 				 * @psalm-suppress MissingClosureParamType


### PR DESCRIPTION

See: #2807 

Load service for getting shipping information with a filter so that it is only loaded if needed and later.