### PR TITLE
Soft descriptor: Fix INVALID_STRING_LENGTH issue (3960)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -127,7 +127,7 @@ class PurchaseUnitFactory {
 		$description     = '';
 		$custom_id       = (string) $order->get_id();
 		$invoice_id      = $this->prefix . $order->get_order_number();
-		$soft_descriptor = $this->soft_descriptor;
+		$soft_descriptor = $this->sanitize_soft_descriptor( $this->soft_descriptor );
 
 		$purchase_unit = new PurchaseUnit(
 			$amount,
@@ -197,7 +197,7 @@ class PurchaseUnitFactory {
 			}
 		}
 		$invoice_id      = '';
-		$soft_descriptor = $this->soft_descriptor;
+		$soft_descriptor = $this->sanitize_soft_descriptor( $this->soft_descriptor );
 		$purchase_unit   = new PurchaseUnit(
 			$amount,
 			$items,
@@ -233,7 +233,7 @@ class PurchaseUnitFactory {
 		$description     = ( isset( $data->description ) ) ? $data->description : '';
 		$custom_id       = ( isset( $data->custom_id ) ) ? $data->custom_id : '';
 		$invoice_id      = ( isset( $data->invoice_id ) ) ? $data->invoice_id : '';
-		$soft_descriptor = ( isset( $data->soft_descriptor ) ) ? $data->soft_descriptor : $this->soft_descriptor;
+		$soft_descriptor = $this->sanitize_soft_descriptor( $data->soft_descriptor ?? $this->soft_descriptor );
 		$items           = array();
 		if ( isset( $data->items ) && is_array( $data->items ) ) {
 			$items = array_map(
@@ -315,5 +315,26 @@ class PurchaseUnitFactory {
 		if ( $this->sanitizer instanceof PurchaseUnitSanitizer ) {
 			$purchase_unit->set_sanitizer( $this->sanitizer );
 		}
+	}
+
+	/**
+	 * Sanitizes a soft descriptor, ensuring it is limited to 22 chars.
+	 *
+	 * The soft descriptor in the DB is escaped using `wp_kses_post()` which
+	 * escapes certain characters via `wp_kses_normalize_entities()`. This
+	 * helper method reverts those normalized entities back to UTF characters.
+	 *
+	 * @param string $soft_descriptor Soft descriptor to sanitize.
+	 *
+	 * @return string The sanitized soft descriptor.
+	 */
+	private function sanitize_soft_descriptor( string $soft_descriptor ) : string {
+		$decoded = html_entity_decode(
+			$soft_descriptor,
+			ENT_QUOTES | ENT_HTML5 | ENT_SUBSTITUTE,
+			'UTF-8'
+		);
+
+		return substr( $decoded, 0, 22 ) ?: '';
 	}
 }


### PR DESCRIPTION
### Description

This PR adds logic so decode the stored DB value for "Soft Descriptor" before passing it to a new `PurchaseUnit` instance.

Effectively, this change allows using the character "&" in the soft descriptor, which was encoded as "&amp;" before this change, adding 4 additional characters, which could lead to an INVALID_STRING_LENGTH error.

**Note**

The new validation logic is intentionally added to the `PurchaseUnitFactory`, to keep the change as localized as possible. Since `PurchaseUnit` instances are transmitted via API, the value they contain must adhere to API specs