### PR TITLE
ACDC card fields not loading when smart buttons are disabled - classic checkout (3916)

### DIFF
--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -143,10 +143,15 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
-			function( array $components ) {
-				$components[] = 'buttons';
+			function( array $components, string $context ) {
+				if ( str_ends_with( $context, '-block' ) ) {
+					$components[] = 'buttons';
+				}
+
 				return $components;
-			}
+			},
+			10,
+			2
 		);
 		return true;
 	}

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -324,6 +324,10 @@ const bootstrap = () => {
 	messagesBootstrap.init();
 
 	apmButtonsInit( PayPalCommerceGateway );
+
+	if ( ! renderer.useSmartButtons ) {
+		buttonsSpinner.unblock();
+	}
 };
 
 document.addEventListener( 'DOMContentLoaded', () => {

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstap.js
@@ -211,6 +211,7 @@ class CheckoutBootstap {
 		const isFreeTrial = PayPalCommerceGateway.is_free_trial_cart;
 		const hasVaultedPaypal =
 			PayPalCommerceGateway.vaulted_paypal_email !== '';
+		const useSmartButtons = this.renderer.useSmartButtons ?? true;
 
 		const paypalButtonWrappers = {
 			...Object.entries( PayPalCommerceGateway.separate_buttons ).reduce(
@@ -225,7 +226,8 @@ class CheckoutBootstap {
 			this.standardOrderButtonSelector,
 			( isPaypal && isFreeTrial && hasVaultedPaypal ) ||
 				isNotOurGateway ||
-				isSavedCard,
+				isSavedCard ||
+				( isPaypal && ! useSmartButtons ),
 			'ppcp-hidden'
 		);
 		setVisible( '.ppcp-vaulted-paypal-details', isPaypal );

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -7,6 +7,7 @@ import {
 	handleShippingOptionsChange,
 	handleShippingAddressChange,
 } from '../Helper/ShippingHandler.js';
+import { PaymentContext } from '../Helper/CheckoutMethodState';
 
 class Renderer {
 	constructor(
@@ -35,6 +36,10 @@ class Renderer {
 	 * @return {boolean} True, if smart buttons are present on the page.
 	 */
 	get useSmartButtons() {
+		if ( PaymentContext.Preview === this.defaultSettings?.context ) {
+			return true;
+		}
+
 		const components = this.defaultSettings?.url_params?.components || '';
 
 		return components.split( ',' ).includes( 'buttons' );

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -56,12 +56,14 @@ class Renderer {
 			Object.keys( enabledSeparateGateways ).length !== 0;
 
 		if ( ! hasEnabledSeparateGateways ) {
-			this.renderButtons(
-				settings.button.wrapper,
-				settings.button.style,
-				contextConfig,
-				hasEnabledSeparateGateways
-			);
+			if ( this.useSmartButtons ) {
+				this.renderButtons(
+					settings.button.wrapper,
+					settings.button.style,
+					contextConfig,
+					hasEnabledSeparateGateways
+				);
+			}
 		} else {
 			// render each button separately
 			for ( const fundingSource of paypal

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -28,6 +28,18 @@ class Renderer {
 		this.reloadEventName = 'ppcp-reload-buttons';
 	}
 
+	/**
+	 * Determine is PayPal smart buttons are used by inspecting the existing plugin configuration:
+	 * If the url-param "components" contains a "buttons" element, smart buttons are enabled.
+	 *
+	 * @return {boolean} True, if smart buttons are present on the page.
+	 */
+	get useSmartButtons() {
+		const components = this.defaultSettings?.url_params?.components || '';
+
+		return components.split( ',' ).includes( 'buttons' );
+	}
+
 	render(
 		contextConfig,
 		settingsOverride = {},

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -160,7 +160,7 @@ class Renderer {
 			// Check the condition and add the handler if needed
 			if ( this.shouldEnableShippingCallback() ) {
 				options.onShippingOptionsChange = ( data, actions ) => {
-                    let shippingOptionsChange =
+					const shippingOptionsChange =
 					! this.isVenmoButtonClickedWhenVaultingIsEnabled(
 						venmoButtonClicked
 					)
@@ -171,10 +171,10 @@ class Renderer {
 						  )
 						: null;
 
-                    return shippingOptionsChange
+					return shippingOptionsChange;
 				};
 				options.onShippingAddressChange = ( data, actions ) => {
-                    let shippingAddressChange =
+					const shippingAddressChange =
 					! this.isVenmoButtonClickedWhenVaultingIsEnabled(
 						venmoButtonClicked
 					)
@@ -185,7 +185,7 @@ class Renderer {
 						  )
 						: null;
 
-                    return shippingAddressChange
+					return shippingAddressChange;
 				};
 			}
 
@@ -247,8 +247,13 @@ class Renderer {
 	};
 
     shouldEnableShippingCallback = () => {
-        let needShipping = this.defaultSettings.needShipping || this.defaultSettings.context === 'product'
-        return this.defaultSettings.should_handle_shipping_in_paypal && needShipping
+		const needShipping =
+			this.defaultSettings.needShipping ||
+			this.defaultSettings.context === 'product';
+		return (
+			this.defaultSettings.should_handle_shipping_in_paypal &&
+			needShipping
+		);
     };
 
 	isAlreadyRendered( wrapper, fundingSource ) {

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1594,10 +1594,15 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 		 *
 		 * @internal Matches filter name in APM extension.
 		 *
-		 * @param array $components The array of components already registered.
+		 * @param array  $components The array of components already registered.
+		 * @param string $context    The SmartButton context.
 		 */
 		return array_unique(
-			(array) apply_filters( 'woocommerce_paypal_payments_sdk_components_hook', $components )
+			(array) apply_filters(
+				'woocommerce_paypal_payments_sdk_components_hook',
+				$components,
+				$this->context()
+			)
 		);
 	}
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1596,7 +1596,9 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 		 *
 		 * @param array $components The array of components already registered.
 		 */
-		return apply_filters( 'woocommerce_paypal_payments_sdk_components_hook', $components );
+		return array_unique(
+			(array) apply_filters( 'woocommerce_paypal_payments_sdk_components_hook', $components )
+		);
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
+++ b/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
@@ -11,6 +11,7 @@ import {
 	isVisible,
 } from '../../../ppcp-button/resources/js/modules/Helper/Hiding';
 import widgetBuilder from '../../../ppcp-button/resources/js/modules/Renderer/WidgetBuilder';
+import { PaymentContext } from '../../../ppcp-button/resources/js/modules/Helper/CheckoutMethodState';
 
 document.addEventListener( 'DOMContentLoaded', () => {
 	function disableAll( nodeList ) {
@@ -134,7 +135,12 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	function createButtonPreview( settingsCallback ) {
 		const render = ( settings ) => {
-			const { button, separate_buttons } = settings;
+			const previewSettings = {
+				context: PaymentContext.Preview,
+				...settings,
+			};
+
+			const { button, separate_buttons } = previewSettings;
 			const wrapperSelector = (
 				Object.values( separate_buttons )[ 0 ] ?? button
 			)?.wrapper;
@@ -147,7 +153,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 			const renderer = new Renderer(
 				null,
-				settings,
+				previewSettings,
 				( data, actions ) => actions.reject(),
 				null
 			);
@@ -156,7 +162,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				renderer.render( {} );
 				jQuery( document ).trigger(
 					'ppcp_paypal_render_preview',
-					settings
+					previewSettings
 				);
 			} catch ( err ) {
 				console.error( err );

--- a/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
+++ b/modules/ppcp-wc-gateway/resources/js/gateway-settings.js
@@ -134,11 +134,12 @@ document.addEventListener( 'DOMContentLoaded', () => {
 
 	function createButtonPreview( settingsCallback ) {
 		const render = ( settings ) => {
-			const wrapperSelector =
-				Object.values( settings.separate_buttons ).length > 0
-					? Object.values( settings.separate_buttons )[ 0 ].wrapper
-					: settings.button.wrapper;
+			const { button, separate_buttons } = settings;
+			const wrapperSelector = (
+				Object.values( separate_buttons )[ 0 ] ?? button
+			)?.wrapper;
 			const wrapper = document.querySelector( wrapperSelector );
+
 			if ( ! wrapper ) {
 				return;
 			}


### PR DESCRIPTION
### Description

This PR allows using the Advanced card processing (ACDC) features on pages that do not use the PayPal Smart Buttons.

Before this change, the ACDC logic was coupled with the presence of smart buttons. After this change, the smart button JS library is still required by ACDC, but most of the initialization logic has become conditional.

### Screenshots

| Before | After |
|---|---|
| ![2024-11-27_16-09-15](https://github.com/user-attachments/assets/a716e3c2-d67a-4b95-a2d9-1190cb0f6bfc) | ![2024-11-27_16-09-27](https://github.com/user-attachments/assets/1b956c23-0722-477c-8f4d-606aeaad4e02) |