### PR TITLE
Fallback functionality from new to old settings ( 3903 )

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -131,7 +131,6 @@ return array(
 			new SettingsMap(
 				$container->get( 'settings.data.common' ),
 				array(
-					'use_sandbox'   => 'sandbox_on',
 					'client_id'     => 'client_id',
 					'client_secret' => 'client_secret',
 				)

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -9,9 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
-use WooCommerce\PayPalCommerce\Settings\Data\CommonSettings;
-use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
-use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
 
@@ -127,7 +124,7 @@ return array(
 	'compat.setting.new-to-old-map'                  => function( ContainerInterface $container ) : array {
 		return array(
 			new SettingsMap(
-				$container->get( CommonSettings::class ),
+				$container->get( 'settings.data.common' ),
 				array(
 					'use_sandbox'   => 'sandbox_on',
 					'client_id'     => 'client_id',
@@ -135,7 +132,7 @@ return array(
 				)
 			),
 			new SettingsMap(
-				$container->get( GeneralSettings::class ),
+				$container->get( 'settings.data.general' ),
 				array(
 					'is_sandbox'             => 'sandbox_on',
 					'live_client_id'         => 'client_id_production',
@@ -149,7 +146,7 @@ return array(
 				)
 			),
 			new SettingsMap(
-				$container->get( OnboardingProfile::class ),
+				$container->get( 'settings.data.onboarding' ),
 				array(
 					'is_casual_seller'                     => null,
 					'are_optional_payment_methods_enabled' => true,

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -150,14 +150,6 @@ return array(
 					'sandbox_merchant_email' => 'merchant_email_sandbox',
 				)
 			),
-			new SettingsMap(
-				$container->get( 'settings.data.onboarding' ),
-				array(
-					'is_casual_seller'                     => '',
-					'are_optional_payment_methods_enabled' => '',
-					'products'                             => '',
-				)
-			),
 		);
 	},
 	'compat.settings.settings_map_helper'            => static function( ContainerInterface $container ) : SettingsMapHelper {

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
+use WooCommerce\PayPalCommerce\Settings\Data\CommonSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
 
@@ -114,5 +117,48 @@ return array(
 			$container->get( 'compat.wc_shipping_tax.is_supported_plugin_version_active' ),
 			$container->get( 'api.bearer' )
 		);
+	},
+
+	/**
+	 * Configuration for the new/old settings map.
+	 *
+	 * @returns SettingsMap[]
+	 */
+	'compat.setting.new-to-old-map'                  => function( ContainerInterface $container ) : array {
+		return array(
+			new SettingsMap(
+				$container->get( CommonSettings::class ),
+				array(
+					'use_sandbox'   => 'sandbox_on',
+					'client_id'     => 'client_id',
+					'client_secret' => 'client_secret',
+				)
+			),
+			new SettingsMap(
+				$container->get( GeneralSettings::class ),
+				array(
+					'is_sandbox'             => 'sandbox_on',
+					'live_client_id'         => 'client_id_production',
+					'live_client_secret'     => 'client_secret_production',
+					'live_merchant_id'       => 'merchant_id_production',
+					'live_merchant_email'    => 'merchant_email_production',
+					'sandbox_client_id'      => 'client_id_sandbox',
+					'sandbox_client_secret'  => 'client_secret_sandbox',
+					'sandbox_merchant_id'    => 'merchant_id_sandbox',
+					'sandbox_merchant_email' => 'merchant_email_sandbox',
+				)
+			),
+			new SettingsMap(
+				$container->get( OnboardingProfile::class ),
+				array(
+					'is_casual_seller'                     => null,
+					'are_optional_payment_methods_enabled' => true,
+					'products'                             => array(),
+				)
+			),
+		);
+	},
+	'compat.settings.settings_map_helper'            => static function( ContainerInterface $container ) : SettingsMapHelper {
+		return new SettingsMapHelper( $container->get( 'compat.setting.new-to-old-map' ) );
 	},
 );

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -153,9 +153,9 @@ return array(
 			new SettingsMap(
 				$container->get( 'settings.data.onboarding' ),
 				array(
-					'is_casual_seller'                     => null,
-					'are_optional_payment_methods_enabled' => true,
-					'products'                             => array(),
+					'is_casual_seller'                     => '',
+					'are_optional_payment_methods_enabled' => '',
+					'products'                             => '',
 				)
 			),
 		);

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -122,6 +122,11 @@ return array(
 	 * @returns SettingsMap[]
 	 */
 	'compat.setting.new-to-old-map'                  => function( ContainerInterface $container ) : array {
+		$are_new_settings_enabled = $container->get( 'wcgateway.settings.admin-settings-enabled' );
+		if ( ! $are_new_settings_enabled ) {
+			return array();
+		}
+
 		return array(
 			new SettingsMap(
 				$container->get( 'settings.data.common' ),

--- a/modules/ppcp-compat/src/SettingsMap.php
+++ b/modules/ppcp-compat/src/SettingsMap.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * A map of new to old settings.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+use WooCommerce\PayPalCommerce\Settings\Data\AbstractDataModel;
+
+/**
+ * A map of new to old settings.
+ *
+ * @psalm-type newSettingsKey = string
+ * @psalm-type oldSettingsKey = string
+ */
+class SettingsMap {
+	/**
+	 * The new settings model.
+	 *
+	 * @var AbstractDataModel
+	 */
+	private AbstractDataModel $model;
+
+	/**
+	 * The map of the new setting key to the old setting keys.
+	 *
+	 * @var array<newSettingsKey, oldSettingsKey>
+	 */
+	private array $map;
+
+	/**
+	 * The constructor.
+	 *
+	 * @param AbstractDataModel                     $model The new settings model.
+	 * @param array<newSettingsKey, oldSettingsKey> $map The map of the new setting key to the old setting keys.
+	 */
+	public function __construct( AbstractDataModel $model, array $map ) {
+		$this->model = $model;
+		$this->map   = $map;
+	}
+
+	/**
+	 * The model.
+	 *
+	 * @return AbstractDataModel
+	 */
+	public function get_model(): AbstractDataModel {
+		return $this->model;
+	}
+
+	/**
+	 * The map of the new setting key to the old setting keys.
+	 *
+	 * @return array<newSettingsKey, oldSettingsKey>
+	 */
+	public function get_map(): array {
+		return $this->map;
+	}
+}

--- a/modules/ppcp-compat/src/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/SettingsMapHelper.php
@@ -44,8 +44,12 @@ class SettingsMapHelper {
 		foreach ( $this->settings_map as $settings_map ) {
 			$mapped_key   = array_search( $key, $settings_map->get_map(), true );
 			$new_settings = $settings_map->get_model()->to_array();
-			return $new_settings[ $mapped_key ] ?? null;
+			if ( ! empty( $new_settings[ $mapped_key ] ) ) {
+				return $new_settings[ $mapped_key ];
+			}
 		}
+
+		return null;
 	}
 
 	/**

--- a/modules/ppcp-compat/src/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/SettingsMapHelper.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * A helper for mapping the new/old settings.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+/**
+ * A helper for mapping the new/old settings.
+ */
+class SettingsMapHelper {
+
+	/**
+	 * A list of mapped settings.
+	 *
+	 * @var SettingsMap[]
+	 */
+	protected array $settings_map;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SettingsMap[] $settings_map A list of mapped settings.
+	 */
+	public function __construct( array $settings_map ) {
+		$this->settings_map = $settings_map;
+	}
+
+	/**
+	 * Retrieves the mapped value from the new settings.
+	 *
+	 * @param string $key The key.
+	 * @return ?mixed the mapped value or Null if it doesn't exist.
+	 */
+	public function mapped_value( string $key ) {
+		if ( ! $this->has_mapped_key( $key ) ) {
+			return null;
+		}
+
+		foreach ( $this->settings_map as $settings_map ) {
+			$mapped_key   = array_search( $key, $settings_map->get_map(), true );
+			$new_settings = $settings_map->get_model()->to_array();
+			return $new_settings[ $mapped_key ] ?? null;
+		}
+	}
+
+	/**
+	 * Checks if the given key exists in the new settings.
+	 *
+	 * @param string $key The key.
+	 * @return bool true if the given key exists in the new settings, otherwise false.
+	 */
+	public function has_mapped_key( string $key ) : bool {
+		foreach ( $this->settings_map as $settings_map ) {
+			if ( in_array( $key, $settings_map->get_map(), true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -64,11 +64,11 @@ class OnboardingProfile extends AbstractDataModel {
 	 */
 	protected function get_defaults() : array {
 		return array(
-			'completed'        => false,
-			'step'             => 0,
-			'is_casual_seller' => null,
+			'completed'                            => false,
+			'step'                                 => 0,
+			'is_casual_seller'                     => null,
 			'are_optional_payment_methods_enabled' => true,
-			'products'         => array(),
+			'products'                             => array(),
 		);
 	}
 

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -41,15 +41,15 @@ class OnboardingRestEndpoint extends RestEndpoint {
 	 * @var array
 	 */
 	private array $field_map = array(
-		'completed'        => array(
+		'completed'                            => array(
 			'js_name'  => 'completed',
 			'sanitize' => 'to_boolean',
 		),
-		'step'             => array(
+		'step'                                 => array(
 			'js_name'  => 'step',
 			'sanitize' => 'to_number',
 		),
-		'is_casual_seller' => array(
+		'is_casual_seller'                     => array(
 			'js_name'  => 'isCasualSeller',
 			'sanitize' => 'to_boolean',
 		),
@@ -57,7 +57,7 @@ class OnboardingRestEndpoint extends RestEndpoint {
 			'js_name'  => 'areOptionalPaymentMethodsEnabled',
 			'sanitize' => 'to_boolean',
 		),
-		'products'         => array(
+		'products'                             => array(
 			'js_name' => 'products',
 		),
 	);

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -338,7 +338,7 @@ return array(
 				$container->get( 'wcgateway.settings.dcc-gateway-title.default' ),
 				$container->get( 'wcgateway.settings.pay-later.default-button-locations' ),
 				$container->get( 'wcgateway.settings.pay-later.default-messaging-locations' ),
-				$container->get ( 'compat.settings.settings_map_helper' )
+				$container->get( 'compat.settings.settings_map_helper' )
 			);
 		}
 	),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -337,7 +337,8 @@ return array(
 				$container->get( 'wcgateway.button.default-locations' ),
 				$container->get( 'wcgateway.settings.dcc-gateway-title.default' ),
 				$container->get( 'wcgateway.settings.pay-later.default-button-locations' ),
-				$container->get( 'wcgateway.settings.pay-later.default-messaging-locations' )
+				$container->get( 'wcgateway.settings.pay-later.default-messaging-locations' ),
+				$container->get ( 'compat.settings.settings_map_helper' )
 			);
 		}
 	),

--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
+use WooCommerce\PayPalCommerce\Compat\SettingsMapHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
@@ -57,23 +58,33 @@ class Settings implements ContainerInterface {
 	protected $default_dcc_gateway_title;
 
 	/**
+	 * A helper for mapping the new/old settings.
+	 *
+	 * @var SettingsMapHelper
+	 */
+	protected SettingsMapHelper $settings_map_helper;
+
+	/**
 	 * Settings constructor.
 	 *
-	 * @param string[] $default_button_locations The list of selected default button locations.
-	 * @param string   $default_dcc_gateway_title The default ACDC gateway title.
-	 * @param string[] $default_pay_later_button_locations The list of selected default pay later button locations.
-	 * @param string[] $default_pay_later_messaging_locations The list of selected default pay later messaging locations.
+	 * @param string[]          $default_button_locations The list of selected default button locations.
+	 * @param string            $default_dcc_gateway_title The default ACDC gateway title.
+	 * @param string[]          $default_pay_later_button_locations The list of selected default pay later button locations.
+	 * @param string[]          $default_pay_later_messaging_locations The list of selected default pay later messaging locations.
+	 * @param SettingsMapHelper $settings_map_helper A helper for mapping the new/old settings.
 	 */
 	public function __construct(
 		array $default_button_locations,
 		string $default_dcc_gateway_title,
 		array $default_pay_later_button_locations,
-		array $default_pay_later_messaging_locations
+		array $default_pay_later_messaging_locations,
+		SettingsMapHelper $settings_map_helper
 	) {
 		$this->default_button_locations              = $default_button_locations;
 		$this->default_dcc_gateway_title             = $default_dcc_gateway_title;
 		$this->default_pay_later_button_locations    = $default_pay_later_button_locations;
 		$this->default_pay_later_messaging_locations = $default_pay_later_messaging_locations;
+		$this->settings_map_helper                   = $settings_map_helper;
 	}
 
 	/**
@@ -88,7 +99,8 @@ class Settings implements ContainerInterface {
 		if ( ! $this->has( $id ) ) {
 			throw new NotFoundException();
 		}
-		return $this->settings[ $id ];
+
+		return $this->settings_map_helper->mapped_value( $id ) ?? $this->settings[ $id ];
 	}
 
 	/**
@@ -99,6 +111,10 @@ class Settings implements ContainerInterface {
 	 * @return bool
 	 */
 	public function has( $id ) {
+		if ( $this->settings_map_helper->has_mapped_key( $id ) ) {
+			return true;
+		}
+
 		$this->load();
 		return array_key_exists( $id, $this->settings );
 	}

--- a/tests/e2e/PHPUnit/SettingsTest.php
+++ b/tests/e2e/PHPUnit/SettingsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace WooCommerce\PayPalCommerce\Tests\E2e;
+
+use WooCommerce\PayPalCommerce\Compat\SettingsMap;
+use WooCommerce\PayPalCommerce\Compat\SettingsMapHelper;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Settings\Data\AbstractDataModel;
+
+class SettingsTest extends TestCase {
+	private Settings $settings;
+
+	protected function setUp(): void {
+		$commonSettingsModel = $this->createMock(AbstractDataModel::class);
+		$commonSettingsModel->method('to_array')->willReturn([
+			'use_sandbox'   => 'yes',
+			'client_id'     => 'abc123',
+			'client_secret' => 'secret123',
+		]);
+
+		$generalSettingsModel = $this->createMock(AbstractDataModel::class);
+		$generalSettingsModel->method('to_array')->willReturn([
+			'is_sandbox'             => 'no',
+			'live_client_id'         => 'live_id_123',
+			'live_client_secret'     => 'live_secret_123',
+		]);
+
+		$settingsMap = [
+			new SettingsMap(
+				$commonSettingsModel,
+				[
+					'client_id'     => 'client_id',
+					'client_secret' => 'client_secret',
+				]
+			),
+			new SettingsMap(
+				$generalSettingsModel,
+				[
+					'is_sandbox'             => 'sandbox_on',
+					'live_client_id'         => 'client_id_production',
+					'live_client_secret'     => 'client_secret_production',
+				]
+			),
+		];
+
+		$settingsMapHelper = new SettingsMapHelper($settingsMap);
+
+		$this->settings = new Settings(
+			['cart', 'checkout'],
+			'PayPal Credit Gateway',
+			['checkout'],
+			['cart'],
+			$settingsMapHelper
+		);
+	}
+
+	public function testGetMappedValue() {
+		$value = $this->settings->get('sandbox_on');
+
+		$this->assertEquals('no', $value);
+	}
+
+	public function testGetThrowsNotFoundExceptionForInvalidKey() {
+		$this->expectException(NotFoundException::class);
+
+		$this->settings->get('invalid_key');
+	}
+}
+


### PR DESCRIPTION
# Issue Description

We need to have a fallback functionality from new to old settings:

- First try to use the new setting value
- If the new setting value does not exist, fall back to the old setting value


# PR Description

 Implements the new to old setting values fallback functionality.

-  A new configuration service is added with mapping of the new to old setting key
   - If the new settings module is not enabled will just return an empty `array`
- A helper class is created which allows:
  - To check if the given old setting's key map/equivalent exists in the new settings
  - Get the value of the new setting by provided old setting's key