### PR TITLE
Axo: Ensure the Insights script is only loaded when Fastlane is enabled (3963)

### DIFF
--- a/modules/ppcp-axo-block/src/AxoBlockModule.php
+++ b/modules/ppcp-axo-block/src/AxoBlockModule.php
@@ -144,8 +144,8 @@ class AxoBlockModule implements ServiceModule, ExtendingModule, ExecutableModule
 		if ( $is_axo_enabled ) {
 			add_action(
 				'wp_enqueue_scripts',
-				function () use ($c) {
-					$this->enqueue_paypal_insights_script($c);
+				function () use ( $c ) {
+					$this->enqueue_paypal_insights_script( $c );
 				}
 			);
 		}

--- a/modules/ppcp-axo-block/src/AxoBlockModule.php
+++ b/modules/ppcp-axo-block/src/AxoBlockModule.php
@@ -22,6 +22,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCGatewayConfiguration;
 
 /**
  * Class AxoBlockModule
@@ -135,12 +136,19 @@ class AxoBlockModule implements ServiceModule, ExtendingModule, ExecutableModule
 		);
 
 		// Enqueue the PayPal Insights script.
-		add_action(
-			'wp_enqueue_scripts',
-			function () use ( $c ) {
-				$this->enqueue_paypal_insights_script( $c );
-			}
-		);
+		$dcc_configuration = $c->get( 'wcgateway.configuration.dcc' );
+		assert( $dcc_configuration instanceof DCCGatewayConfiguration );
+
+		$is_axo_enabled = $dcc_configuration->use_fastlane();
+
+		if ( $is_axo_enabled ) {
+			add_action(
+				'wp_enqueue_scripts',
+				function () use ($c) {
+					$this->enqueue_paypal_insights_script($c);
+				}
+			);
+		}
 
 		return true;
 	}


### PR DESCRIPTION
### Description
This PR makes the Insights script load only when Fastlane is eligible for loading (is enabled and the country config is correct).

### Steps to test

1. Disable Fastlane.
2. Ensure the `PayPalInsightsLoader.js` script is not being loaded on the Block Checkout.

### Screenshots

N/A