### PR TITLE
New Settings UI: Validate advanced options client ID (3958)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_button.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_button.scss
@@ -5,7 +5,7 @@ button.components-button, a.components-button {
 		}
 
 		&:disabled {
-			color: $color-white;
+			color: $color-gray-700;
 		}
 
 		border-radius: 50px;

--- a/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
@@ -26,6 +26,12 @@
 		border: none;
 	}
 
+	.client-id-error {
+		color: #cc1818;
+		margin: -16px 0 24px;
+		@include font(11, 16, 450);
+	}
+
 	.onboarding-advanced-options {
 		max-width: 800px;
 	}

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/AdvancedOptionsForm.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/AdvancedOptionsForm.js
@@ -30,7 +30,7 @@ const AdvancedOptionsForm = ( { setCompleted } ) => {
 	const refClientSecret = useRef( null );
 
 	const isValidClientId = useMemo( () => {
-		return clientId ? /^A[\w-]{79}$/.test( clientId ) : true;
+		return /^A[\w-]{79}$/.test( clientId );
 	}, [ clientId ] );
 
 	const isFormValid = useMemo( () => {


### PR DESCRIPTION
### Description

Add extra validation logic to make sure that the advanced options client ID field matches the provided regex, otherwise show an inline error message.

### Steps to Test

1. Enable the new Settings UI.
2. Start the PayPal onboarding process.
3. Inside the "Welcome to PayPal Payments" step, scroll down and click on "See advanced options".
4. Verify that the "Connect Account" button is disabled by default.
5. Verify that the "Connect Account" button remains disabled until both "Live Client ID" and "Live Secret Key" have correct values.
6. Verify that "Live Client ID" will display an inline error message that says "Please enter a valid Client ID" when the entered value doesn't match the provided regex.
7. Verify that the error message goes away when entering a correct client ID, e.g. "AQ85ce4QdFoaNqh5iG9kQMYBFwDzOhqkPcbpq1S7Te5ImQPkQpotd4-AeB_T6aISKJ0YOIgQU8kzusIN"

### Screenshots


![WooCommerce-settings-‹-WooCommerce-PayPal-Payments-—-WordPress-11-29-2024_11_50_AM](https://github.com/user-attachments/assets/4ad844ad-d39e-4d65-9481-19c994005819)


