### PR TITLE
Release 2.9.5-rc1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,23 @@
 *** Changelog ***
 
+= 2.9.5 - xxxx-xx-xx =
+Fix - Early translation loading triggers `Function _load_textdomain_just_in_time was called incorrectly.` notice #2816
+Fix - ACDC card fields not loading and payment not successful when Classic Checkout Smart Button Location disabled #2852
+Fix - ACDC gateway does not appear for guests when is Fastlane enabled and a subscription product is in the cart #2745
+Fix - "Voide authorization" button does not appear for Apple Pay/Google Pay orders when payment buttons are separated #2752
+Fix - Additional payment tokens saved with new customer_id #2820
+Fix - Vaulted payment method may not be displayed in PayPal button for return buyer #2809
+Fix - Conflict with EasyShip plugin due to shipping methods loading too early #2845
+Fix - Restore accidentally removed ACDC currencies #2838
+Enhancement - Native gateway icon for PayPal & Pay upon Invoice gateways #2712
+Enhancement - Allow disabling specific card types for Fastlane #2704
+Enhancement - Fastlane Insights SDK implementation for block Checkout #2737
+Enhancement - Hide split local APMs in Payments settings tab when PayPal is not enabled #2703
+Enhancement - Do not load split local APMs on Checkout when PayPal is not enabled #2792
+Enhancement - Add support for Button Options in the Block Checkout for Apple Pay & Google Pay buttons #2797 #2772
+Enhancement - Disable “Add payment method” button while saving ACDC payment #2794
+Enhancement - Sanitize soft_descriptor field #2846 #2854
+
 = 2.9.4 - 2024-11-11 =
 * Fix - Apple Pay button preview missing in Standard payment and Advanced Processing tabs #2755
 * Fix - Set "Sold individually" only for subscription connected to PayPal #2710

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: woocommerce, automattic, syde
 Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 6.3
-Tested up to: 6.6
+Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 2.9.4
+Stable tag: 2.9.5
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -178,6 +178,24 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 6. Main settings screen.
 
 == Changelog ==
+
+= 2.9.5 - xxxx-xx-xx =
+Fix - Early translation loading triggers `Function _load_textdomain_just_in_time was called incorrectly.` notice #2816
+Fix - ACDC card fields not loading and payment not successful when Classic Checkout Smart Button Location disabled #2852
+Fix - ACDC gateway does not appear for guests when is Fastlane enabled and a subscription product is in the cart #2745
+Fix - "Voide authorization" button does not appear for Apple Pay/Google Pay orders when payment buttons are separated #2752
+Fix - Additional payment tokens saved with new customer_id #2820
+Fix - Vaulted payment method may not be displayed in PayPal button for return buyer #2809
+Fix - Conflict with EasyShip plugin due to shipping methods loading too early #2845
+Fix - Restore accidentally removed ACDC currencies #2838
+Enhancement - Native gateway icon for PayPal & Pay upon Invoice gateways #2712
+Enhancement - Allow disabling specific card types for Fastlane #2704
+Enhancement - Fastlane Insights SDK implementation for block Checkout #2737
+Enhancement - Hide split local APMs in Payments settings tab when PayPal is not enabled #2703
+Enhancement - Do not load split local APMs on Checkout when PayPal is not enabled #2792
+Enhancement - Add support for Button Options in the Block Checkout for Apple Pay & Google Pay buttons #2797 #2772
+Enhancement - Disable “Add payment method” button while saving ACDC payment #2794
+Enhancement - Sanitize soft_descriptor field #2846 #2854
 
 = 2.9.4 - 2024-11-11 =
 * Fix - Apple Pay button preview missing in Standard payment and Advanced Processing tabs #2755

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,14 +3,14 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     2.9.4
+ * Version:     2.9.5
  * Author:      WooCommerce
  * Author URI:  https://woocommerce.com/
  * License:     GPL-2.0
  * Requires PHP: 7.4
  * Requires Plugins: woocommerce
  * WC requires at least: 6.9
- * WC tested up to: 9.3
+ * WC tested up to: 9.4
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce
@@ -26,7 +26,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2024-11-05' );
+define( 'PAYPAL_INTEGRATION_DATE', '2024-12-02' );
 define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );


### PR DESCRIPTION
Fix - Early translation loading triggers `Function _load_textdomain_just_in_time was called incorrectly.` notice #2816
Fix - ACDC card fields not loading and payment not successful when Classic Checkout Smart Button Location disabled #2852
Fix - ACDC gateway does not appear for guests when is Fastlane enabled and a subscription product is in the cart #2745
Fix - "Voide authorization" button does not appear for Apple Pay/Google Pay orders when payment buttons are separated #2752
Fix - Additional payment tokens saved with new customer_id #2820
Fix - Vaulted payment method may not be displayed in PayPal button for return buyer #2809
Fix - Conflict with EasyShip plugin due to shipping methods loading too early #2845
Fix - Restore accidentally removed ACDC currencies #2838
Enhancement - Native gateway icon for PayPal & Pay upon Invoice gateways #2712
Enhancement - Allow disabling specific card types for Fastlane #2704
Enhancement - Fastlane Insights SDK implementation for block Checkout #2737
Enhancement - Hide split local APMs in Payments settings tab when PayPal is not enabled #2703
Enhancement - Do not load split local APMs on Checkout when PayPal is not enabled #2792
Enhancement - Add support for Button Options in the Block Checkout for Apple Pay & Google Pay buttons #2797 #2772
Enhancement - Disable “Add payment method” button while saving ACDC payment #2794
Enhancement - Sanitize soft_descriptor field #2846 #2854