### PR TITLE
Check if the "extended" section exists before adding items

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php
@@ -21,9 +21,14 @@ class TaskRegistrar implements TaskRegistrarInterface {
 	 *
 	 * @throws RuntimeException If problem registering.
 	 */
-	public function register( array $tasks ): void {
+	public function register( string $list_id, array $tasks ): void {
+		$task_lists = TaskLists::get_lists();
+		if ( ! isset( $task_lists[ $list_id ] ) ) {
+			return;
+		}
+
 		foreach ( $tasks as $task ) {
-			$added_task = TaskLists::add_task( 'extended', $task );
+			$added_task = TaskLists::add_task( $list_id, $task );
 			if ( $added_task instanceof WP_Error ) {
 				throw new RuntimeException( $added_task->get_error_message() );
 			}

--- a/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrarInterface.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrarInterface.php
@@ -15,11 +15,12 @@ use RuntimeException;
 interface TaskRegistrarInterface {
 
 	/**
-	 * Registers the tasks inside "Things to do next" WC section.
+	 * Registers the tasks inside the section with given list ID.
 	 *
+	 * @param string $list_id The list ID.
 	 * @param Task[] $tasks The list of tasks.
 	 * @return void
 	 * @throws RuntimeException If problem registering.
 	 */
-	public function register( array $tasks ): void;
+	public function register( string $list_id, array $tasks ): void;
 }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway;
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -867,10 +868,16 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );
 				assert( $logger instanceof LoggerInterface );
 				try {
+					$task_lists = TaskLists::get_lists();
+					if ( ! isset( $task_lists['extended'] ) ) {
+						return;
+					}
+
 					$simple_redirect_tasks = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-tasks' );
 					if ( empty( $simple_redirect_tasks ) ) {
 						return;
 					}
+
 					$task_registrar = $container->get( 'wcgateway.settings.wc-tasks.task-registrar' );
 					assert( $task_registrar instanceof TaskRegistrarInterface );
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway;
 
-use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -868,11 +867,6 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );
 				assert( $logger instanceof LoggerInterface );
 				try {
-					$task_lists = TaskLists::get_lists();
-					if ( ! isset( $task_lists['extended'] ) ) {
-						return;
-					}
-
 					$simple_redirect_tasks = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-tasks' );
 					if ( empty( $simple_redirect_tasks ) ) {
 						return;
@@ -881,7 +875,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 					$task_registrar = $container->get( 'wcgateway.settings.wc-tasks.task-registrar' );
 					assert( $task_registrar instanceof TaskRegistrarInterface );
 
-					$task_registrar->register( $simple_redirect_tasks );
+					$task_registrar->register( 'extended', $simple_redirect_tasks );
 				} catch ( Exception $exception ) {
 					$logger->error( "Failed to create a task in the 'Things to do next' section of WC. " . $exception->getMessage() );
 				}


### PR DESCRIPTION
# Issue Description

ERROR Failed to create a task in the 'Things to do next' section of WC

# PR Description

The message Task list ID does not exist is fired from [here](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-wc-gateway/src/Settings/WcTasks/Registrar/TaskRegistrar.php#L26) , when WC tries to add the task to an “extended“ section, which is actually the “What To Do“ next section. So it looks like the “extended“ section doesn’t exist for the user somehow.

The PR adds a simple check to see if the “extended“ list exists before adding our items