### PR TITLE
Add supported currencies filter

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -613,29 +613,32 @@ return array(
 	 * The matrix which countries and currency combinations can be used for DCC.
 	 */
 	'api.dcc-supported-country-currency-matrix'      => static function ( ContainerInterface $container ) : array {
-		$default_currencies = array(
-			'AUD',
-			'BRL',
-			'CAD',
-			'CHF',
-			'CZK',
-			'DKK',
-			'EUR',
-			'HKD',
-			'GBP',
-			'HUF',
-			'ILS',
-			'JPY',
-			'MXN',
-			'NOK',
-			'NZD',
-			'PHP',
-			'PLN',
-			'SGD',
-			'SEK',
-			'THB',
-			'TWD',
-			'USD',
+		$default_currencies = apply_filters(
+			'woocommerce_paypal_payments_supported_country_currency_matrix',
+			array(
+				'AUD',
+				'BRL',
+				'CAD',
+				'CHF',
+				'CZK',
+				'DKK',
+				'EUR',
+				'HKD',
+				'GBP',
+				'HUF',
+				'ILS',
+				'JPY',
+				'MXN',
+				'NOK',
+				'NZD',
+				'PHP',
+				'PLN',
+				'SGD',
+				'SEK',
+				'THB',
+				'TWD',
+				'USD',
+			)
 		);
 
 		/**

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -614,7 +614,7 @@ return array(
 	 */
 	'api.dcc-supported-country-currency-matrix'      => static function ( ContainerInterface $container ) : array {
 		$default_currencies = apply_filters(
-			'woocommerce_paypal_payments_supported_country_currency_matrix',
+			'woocommerce_paypal_payments_default_currencies',
 			array(
 				'AUD',
 				'BRL',

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -614,7 +614,7 @@ return array(
 	 */
 	'api.dcc-supported-country-currency-matrix'      => static function ( ContainerInterface $container ) : array {
 		$default_currencies = apply_filters(
-			'woocommerce_paypal_payments_default_currencies',
+			'woocommerce_paypal_payments_supported_currencies',
 			array(
 				'AUD',
 				'BRL',


### PR DESCRIPTION
This PR adds `woocommerce_paypal_payments_supported_currencies` filter for [PayPal supported currencies](https://developer.paypal.com/docs/reports/reference/paypal-supported-currencies/).