### PR TITLE
Unsuccessfully payment with Fastlane, error on console and broken env (3996)

### DIFF
--- a/modules/ppcp-axo-block/resources/js/plugins/PayPalInsightsLoader.js
+++ b/modules/ppcp-axo-block/resources/js/plugins/PayPalInsightsLoader.js
@@ -1,7 +1,6 @@
 import { registerPlugin } from '@wordpress/plugins';
 import { useEffect, useCallback, useState, useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
-import { PAYMENT_STORE_KEY } from '@woocommerce/block-data';
 import PayPalInsights from '../../../../ppcp-axo/resources/js/Insights/PayPalInsights';
 import { STORE_NAME } from '../stores/axoStore';
 import usePayPalCommerceGateway from '../hooks/usePayPalCommerceGateway';
@@ -149,6 +148,7 @@ const usePaymentMethodTracking = ( axoConfig, eventTracking ) => {
 	const isInitialMount = useRef( true );
 
 	const activePaymentMethod = useSelect( ( select ) => {
+		const { PAYMENT_STORE_KEY } = window.wc.wcBlocksData;
 		return select( PAYMENT_STORE_KEY )?.getActivePaymentMethod();
 	}, [] );
 


### PR DESCRIPTION
Unsuccessfully payment with Fastlane, error on console and broken env.

### Steps To Reproduce
- Navigate to shop as guest
- Add product to cart
- Open console
- Navigate to block checkout page
    - Observe error on console

![Screenshot 2024-12-03 at 09 44 51](https://github.com/user-attachments/assets/7da35c06-016a-4ebe-bf44-6529afb34816)

This PR fixes the error by getting `PAYMENT_STORE_KEY` from global `wc` variable instead of importing it.