### PR TITLE
Automatically expand bcdc form fields upon selection when gateway is separated

### DIFF
--- a/modules/ppcp-button/package.json
+++ b/modules/ppcp-button/package.json
@@ -11,7 +11,7 @@
         "Edge >= 14"
     ],
     "dependencies": {
-        "@paypal/paypal-js": "^6.0.0",
+        "@paypal/paypal-js": "^8.1.2",
         "core-js": "^3.39",
         "deepmerge": "^4.3",
         "formdata-polyfill": "^4.0.10"

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -189,8 +189,8 @@ class Renderer {
 				};
 			}
 
-            if (hasEnabledSeparateGateways && options.fundingSource === 'card') {
-                options.style.expandCardForm = true;
+            if ( hasEnabledSeparateGateways && options.fundingSource === 'card' ) {
+                options.expandCardForm = true;
             }
 
 			return options;

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -7,7 +7,7 @@ import {
 	handleShippingOptionsChange,
 	handleShippingAddressChange,
 } from '../Helper/ShippingHandler.js';
-import {getCurrentPaymentMethod, PaymentContext} from '../Helper/CheckoutMethodState';
+import { PaymentContext } from '../Helper/CheckoutMethodState';
 
 class Renderer {
 	constructor(

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -7,7 +7,7 @@ import {
 	handleShippingOptionsChange,
 	handleShippingAddressChange,
 } from '../Helper/ShippingHandler.js';
-import { PaymentContext } from '../Helper/CheckoutMethodState';
+import {getCurrentPaymentMethod, PaymentContext} from '../Helper/CheckoutMethodState';
 
 class Renderer {
 	constructor(
@@ -188,6 +188,10 @@ class Renderer {
 					return shippingAddressChange;
 				};
 			}
+
+            if (hasEnabledSeparateGateways && options.fundingSource === 'card') {
+                options.style.expandCardForm = true;
+            }
 
 			return options;
 		};

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -294,7 +294,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 			if ( $this->early_validation_enabled
 				&& $this->form
 				&& 'checkout' === $data['context']
-				&& in_array( $payment_method, array( PayPalGateway::ID, CardButtonGateway::ID, CreditCardGateway::ID ), true )
+				&& in_array( $payment_method, array( PayPalGateway::ID, CreditCardGateway::ID ), true )
 			) {
 				$this->validate_form( $this->form );
 			}

--- a/modules/ppcp-button/webpack.config.js
+++ b/modules/ppcp-button/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = {
         path: path.resolve(__dirname, 'assets/'),
         filename: 'js/[name].js',
     },
+    watchOptions: {
+        ignored: /node_modules/
+    },
     module: {
         rules: [{
             test: /\.js?$/,

--- a/modules/ppcp-button/yarn.lock
+++ b/modules/ppcp-button/yarn.lock
@@ -935,10 +935,10 @@
     "@parcel/watcher-win32-ia32" "2.5.0"
     "@parcel/watcher-win32-x64" "2.5.0"
 
-"@paypal/paypal-js@^6.0.0":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@paypal/paypal-js/-/paypal-js-6.0.1.tgz#5d68d5863a5176383fee9424bc944231668fcffd"
-  integrity sha512-bvYetmkg2GEC6onsUJQx1E9hdAJWff2bS3IPeiZ9Sh9U7h26/fIgMKm240cq/908sbSoDjHys75XXd8at9OpQA==
+"@paypal/paypal-js@^8.1.2":
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/@paypal/paypal-js/-/paypal-js-8.1.2.tgz#3b6199e1c9e3b2a3e444309e0d0ff63556e3ef86"
+  integrity sha512-EKshGSWRxLWU1NyPB9P1TiOkPajVmpTo5I9HuZKoSv8y2uk0XIskXqMkAJ/Y9qAg9iJyP102Jb/atX63tTy24w==
   dependencies:
     promise-polyfill "^8.3.0"
 


### PR DESCRIPTION
Add the expanding option to the buttons when separated.
Removed card GW from early validation to get the fields shown.