### PR TITLE
New Settings UI: Set Optional Payment Methods default to null (3978)

### DIFF
--- a/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
@@ -27,7 +27,7 @@ const defaultPersistent = {
 	completed: false,
 	step: 0,
 	isCasualSeller: null, // null value will uncheck both options in the UI.
-	areOptionalPaymentMethodsEnabled: true,
+	areOptionalPaymentMethodsEnabled: null,
 	products: [],
 };
 

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -67,7 +67,7 @@ class OnboardingProfile extends AbstractDataModel {
 			'completed'                            => false,
 			'step'                                 => 0,
 			'is_casual_seller'                     => null,
-			'are_optional_payment_methods_enabled' => true,
+			'are_optional_payment_methods_enabled' => null,
 			'products'                             => array(),
 		);
 	}


### PR DESCRIPTION
### Description

Set the default value of the Optional Payment Methods step to null, so no option is checked by default.

### Steps to Test

1. Enable the new Settings UI.
2. Start the PayPal onboarding process.
3. Verify that no option is selected by default on the "Optional Payment Methods" step.