### PR TITLE
New Settings UI: Conditionally show "Subscriptions" option in Product Types step (3977)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepProducts.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepProducts.js
@@ -9,6 +9,7 @@ const PRODUCTS_CHECKBOX_GROUP_NAME = 'products';
 
 const StepProducts = () => {
 	const { products, setProducts } = OnboardingHooks.useProducts();
+	const { canUseSubscriptions } = OnboardingHooks.useFlags();
 
 	return (
 		<div className="ppcp-r-page-products">
@@ -86,31 +87,33 @@ const StepProducts = () => {
 							</li>
 						</ul>
 					</SelectBox>
-					<SelectBox
-						title={ __(
-							'Subscriptions',
-							'woocommerce-paypal-payments'
-						) }
-						description={ __(
-							'Recurring payments for either physical goods or services.',
-							'woocommerce-paypal-payments'
-						) }
-						name={ PRODUCTS_CHECKBOX_GROUP_NAME }
-						value={ PRODUCT_TYPES.SUBSCRIPTIONS }
-						changeCallback={ setProducts }
-						currentValue={ products }
-						type="checkbox"
-					>
-						<a
-							target="__blank"
-							href="https://woocommerce.com/document/woocommerce-paypal-payments/#subscriptions-faq"
-						>
-							{ __(
-								'WooCommerce Subscriptions',
+					{ canUseSubscriptions && (
+						<SelectBox
+							title={ __(
+								'Subscriptions',
 								'woocommerce-paypal-payments'
 							) }
-						</a>
-					</SelectBox>
+							description={ __(
+								'Recurring payments for either physical goods or services.',
+								'woocommerce-paypal-payments'
+							) }
+							name={ PRODUCTS_CHECKBOX_GROUP_NAME }
+							value={ PRODUCT_TYPES.SUBSCRIPTIONS }
+							changeCallback={ setProducts }
+							currentValue={ products }
+							type="checkbox"
+						>
+							<a
+								target="__blank"
+								href="https://woocommerce.com/document/woocommerce-paypal-payments/#subscriptions-faq"
+							>
+								{ __(
+									'WooCommerce Subscriptions',
+									'woocommerce-paypal-payments'
+								) }
+							</a>
+						</SelectBox>
+					) }
 				</SelectBoxWrapper>
 			</div>
 		</div>

--- a/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
@@ -123,3 +123,8 @@ export const useNavigationState = () => {
 		business,
 	};
 };
+
+export const useFlags = () => {
+	const { flags } = useHooks();
+	return flags;
+};

--- a/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
@@ -20,6 +20,7 @@ const defaultTransient = {
 		canUseCasualSelling: false,
 		canUseVaulting: false,
 		canUseCardPayments: false,
+		canUseSubscriptions: false,
 	},
 };
 

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -37,6 +37,7 @@ return array(
 		$can_use_casual_selling = $container->get( 'settings.casual-selling.eligible' );
 		$can_use_vaulting       = $container->has( 'save-payment-methods.eligible' ) && $container->get( 'save-payment-methods.eligible' );
 		$can_use_card_payments  = $container->has( 'card-fields.eligible' ) && $container->get( 'card-fields.eligible' );
+		$can_use_subscriptions = $container->has( 'wc-subscriptions.helper' ) && $container->get( 'wc-subscriptions.helper' )->plugin_is_active();
 
 		// Card payments are disabled for this plugin when WooPayments is active.
 		// TODO: Move this condition to the card-fields.eligible service?
@@ -47,7 +48,8 @@ return array(
 		return new OnboardingProfile(
 			$can_use_casual_selling,
 			$can_use_vaulting,
-			$can_use_card_payments
+			$can_use_card_payments,
+			$can_use_subscriptions
 		);
 	},
 	'settings.data.general'                       => static function ( ContainerInterface $container ) : GeneralSettings {

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -48,13 +48,15 @@ class OnboardingProfile extends AbstractDataModel {
 	public function __construct(
 		bool $can_use_casual_selling = false,
 		bool $can_use_vaulting = false,
-		bool $can_use_card_payments = false
+		bool $can_use_card_payments = false,
+		bool $can_use_subscriptions = false
 	) {
 		parent::__construct();
 
 		$this->flags['can_use_casual_selling'] = $can_use_casual_selling;
 		$this->flags['can_use_vaulting']       = $can_use_vaulting;
 		$this->flags['can_use_card_payments']  = $can_use_card_payments;
+		$this->flags['can_use_subscriptions'] = $can_use_subscriptions;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -42,6 +42,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 * @param bool $can_use_casual_selling Whether casual selling is enabled in the store's country.
 	 * @param bool $can_use_vaulting       Whether vaulting is enabled in the store's country.
 	 * @param bool $can_use_card_payments  Whether credit card payments are possible.
+	 * @param bool $can_use_subscriptions  Whether WC Subscriptions plugin is active.
 	 *
 	 * @throws RuntimeException If the OPTION_KEY is not defined in the child class.
 	 */
@@ -56,7 +57,7 @@ class OnboardingProfile extends AbstractDataModel {
 		$this->flags['can_use_casual_selling'] = $can_use_casual_selling;
 		$this->flags['can_use_vaulting']       = $can_use_vaulting;
 		$this->flags['can_use_card_payments']  = $can_use_card_payments;
-		$this->flags['can_use_subscriptions'] = $can_use_subscriptions;
+		$this->flags['can_use_subscriptions']  = $can_use_subscriptions;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -77,6 +77,9 @@ class OnboardingRestEndpoint extends RestEndpoint {
 		'can_use_card_payments'  => array(
 			'js_name' => 'canUseCardPayments',
 		),
+		'can_use_subscriptions'  => array(
+			'js_name' => 'canUseSubscriptions',
+		),
 	);
 
 	/**


### PR DESCRIPTION
### Description

Show the "Subscriptions" option in the Product Types step only if the WooCommerce Subscriptions plugin is enabled.

### Steps to Test

1. Enable the new Settings UI.
2. Start the PayPal onboarding process.
3. Verify that the WooCommerce Subscriptions plugin is not enabled.
4. Verify that there is no "Subscriptions" option in the "Tell us about the products you sell" step.
5. Enable WooCommerce Subscriptions
6. Verify that the "Subscriptions" option now appears.