### PR TITLE
Remove the "Debit & Credit Card" option from button previews

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabStyling.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabStyling.js
@@ -321,6 +321,7 @@ const SectionButtonPreview = ( { locationSettings } ) => {
 				clientId: 'test',
 				merchantId: 'QTQX5NP6N9WZU',
 				components: 'buttons,googlepay',
+				'disable-funding': 'card',
 				'buyer-country': 'US',
 				currency: 'USD',
 			} }

--- a/modules/ppcp-settings/resources/js/data/settings/tab-styling-data.js
+++ b/modules/ppcp-settings/resources/js/data/settings/tab-styling-data.js
@@ -58,10 +58,6 @@ export const paymentMethodOptions = [
 		label: __( 'Pay Later', 'woocommerce-paypal-payments' ),
 	},
 	{
-		value: 'card',
-		label: __( 'Debit or Credit Card', 'woocommerce-paypal-payments' ),
-	},
-	{
 		value: 'googlepay',
 		label: __( 'Google Pay', 'woocommerce-paypal-payments' ),
 	},


### PR DESCRIPTION
# Issue Description

The "Debit & Credit Card" option should be removed from all locations in a preview
![image-20241203-165828](https://github.com/user-attachments/assets/b9db7c96-313f-4ec5-bc34-bc776f8faf18)


# PR Description

Removes the "Debit & Credit Card" option from button previews
<img width="1077" alt="Screenshot 2024-12-09 at 17 11 49" src="https://github.com/user-attachments/assets/4dd83a3c-b55f-403b-ac28-b443c0062db4">
