### PR TITLE
Hide the price notice when no badges are visible (4000)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/WelcomeDocs.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/WelcomeDocs.js
@@ -1,7 +1,8 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import AcdcFlow from './AcdcFlow';
 import BcdcFlow from './BcdcFlow';
-import { Button } from '@wordpress/components';
+import { countryPriceInfo } from '../../../utils/countryPriceInfo';
+import { pricesBasedDescription } from './pricesBasedDescription';
 
 const WelcomeDocs = ( {
 	useAcdc,
@@ -10,15 +11,6 @@ const WelcomeDocs = ( {
 	storeCountry,
 	storeCurrency,
 } ) => {
-	const pricesBasedDescription = sprintf(
-		// translators: %s: Link to PayPal REST application guide
-		__(
-			'<sup>1</sup>Prices based on domestic transactions as of October 25th, 2024. <a target="_blank" href="%s">Click here</a> for full pricing details.',
-			'woocommerce-paypal-payments'
-		),
-		'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-	);
-
 	return (
 		<div className="ppcp-r-welcome-docs">
 			<h2 className="ppcp-r-welcome-docs__title">
@@ -41,10 +33,14 @@ const WelcomeDocs = ( {
 					storeCurrency={ storeCurrency }
 				/>
 			) }
-			<p
-				className="ppcp-r-optional-payment-methods__description"
-				dangerouslySetInnerHTML={ { __html: pricesBasedDescription } }
-			></p>
+			{ storeCountry in countryPriceInfo && (
+				<p
+					className="ppcp-r-optional-payment-methods__description"
+					dangerouslySetInnerHTML={ {
+						__html: pricesBasedDescription,
+					} }
+				></p>
+			) }
 		</div>
 	);
 };

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/pricesBasedDescription.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/WelcomeDocs/pricesBasedDescription.js
@@ -1,0 +1,10 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+export const pricesBasedDescription = sprintf(
+	// translators: %s: Link to PayPal REST application guide
+	__(
+		'<sup>1</sup>Prices based on domestic transactions as of October 25th, 2024. <a target="_blank" href="%s">Click here</a> for full pricing details.',
+		'woocommerce-paypal-payments'
+	),
+	'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
+);

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/StepPaymentMethods.js
@@ -1,10 +1,12 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 import OnboardingHeader from '../../ReusableComponents/OnboardingHeader';
 import SelectBoxWrapper from '../../ReusableComponents/SelectBoxWrapper';
 import SelectBox from '../../ReusableComponents/SelectBox';
 import { CommonHooks, OnboardingHooks } from '../../../data';
 import OptionalPaymentMethods from '../../ReusableComponents/OptionalPaymentMethods/OptionalPaymentMethods';
+import { pricesBasedDescription } from '../../ReusableComponents/WelcomeDocs/pricesBasedDescription';
+import { countryPriceInfo } from '../../../utils/countryPriceInfo';
 
 const OPM_RADIO_GROUP_NAME = 'optional-payment-methods';
 
@@ -15,15 +17,6 @@ const StepPaymentMethods = ( {} ) => {
 	} = OnboardingHooks.useOptionalPaymentMethods();
 
 	const { storeCountry, storeCurrency } = CommonHooks.useWooSettings();
-
-	const pricesBasedDescription = sprintf(
-		// translators: %s: Link to PayPal REST application guide
-		__(
-			'<sup>1</sup>Prices based on domestic transactions as of October 25th, 2024. <a target="_blank" href="%s">Click here</a> for full pricing details.',
-			'woocommerce-paypal-payments'
-		),
-		'https://woocommerce.com/document/woocommerce-paypal-payments/#manual-credential-input '
-	);
 
 	return (
 		<div className="ppcp-r-page-optional-payment-methods">
@@ -67,12 +60,14 @@ const StepPaymentMethods = ( {} ) => {
 						type="radio"
 					></SelectBox>
 				</SelectBoxWrapper>
-				<p
-					className="ppcp-r-optional-payment-methods__description"
-					dangerouslySetInnerHTML={ {
-						__html: pricesBasedDescription,
-					} }
-				></p>
+				{ storeCountry in countryPriceInfo && (
+					<p
+						className="ppcp-r-optional-payment-methods__description"
+						dangerouslySetInnerHTML={ {
+							__html: pricesBasedDescription,
+						} }
+					></p>
+				) }
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Step 1 (welcome) and 4 (optional payment methods) contains badges with country & currency relevant pricing details. When using a store country that is not defined, the badges are hidden.

When those badges are not displayed, the footer remark must be hidden as well:
<img width="1124" alt="image-20241204-110333" src="https://github.com/user-attachments/assets/c22ef67b-5d64-4404-a107-6da7d0262820">

### Steps to reproduce
- Set the WooCommerce store country to something like Algeria, Brazil, or China
- Check that in steps 1 and 4 price notice is hidden