### PR TITLE
✨ Disable the browser warning on page reload

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Onboarding.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Onboarding.js
@@ -3,12 +3,27 @@ import { OnboardingHooks } from '../../../data';
 
 import { getSteps, getCurrentStep } from './availableSteps';
 import Navigation from './Components/Navigation';
+import { useEffect } from '@wordpress/element';
 
 const Onboarding = () => {
 	const { step, setStep, setCompleted, flags } = OnboardingHooks.useSteps();
 
 	const Steps = getSteps( flags );
 	const currentStep = getCurrentStep( step, Steps );
+
+	// Disable the "Changes you made might not be saved" browser warning.
+	useEffect( () => {
+		const suppressBeforeUnload = ( event ) => {
+			event.stopImmediatePropagation();
+			return undefined;
+		};
+
+		window.addEventListener( 'beforeunload', suppressBeforeUnload );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', suppressBeforeUnload );
+		};
+	}, [] );
 
 	const handleNext = () => setStep( currentStep.nextStep );
 	const handlePrev = () => setStep( currentStep.prevStep );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings.js
@@ -1,25 +1,9 @@
-import { useEffect } from '@wordpress/element';
-
 import { OnboardingHooks } from '../../data';
 import Onboarding from './Onboarding/Onboarding';
 import SettingsScreen from './SettingsScreen';
 
 const Settings = () => {
 	const onboardingProgress = OnboardingHooks.useSteps();
-
-	// Disable the "Changes you made might not be saved" browser warning.
-	useEffect( () => {
-		const suppressBeforeUnload = ( event ) => {
-			event.stopImmediatePropagation();
-			return undefined;
-		};
-
-		window.addEventListener( 'beforeunload', suppressBeforeUnload );
-
-		return () => {
-			window.removeEventListener( 'beforeunload', suppressBeforeUnload );
-		};
-	}, [] );
 
 	if ( ! onboardingProgress.isReady ) {
 		// TODO: Use better loading state indicator.

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings.js
@@ -1,9 +1,25 @@
+import { useEffect } from '@wordpress/element';
+
 import { OnboardingHooks } from '../../data';
 import Onboarding from './Onboarding/Onboarding';
 import SettingsScreen from './SettingsScreen';
 
 const Settings = () => {
 	const onboardingProgress = OnboardingHooks.useSteps();
+
+	// Disable the "Changes you made might not be saved" browser warning.
+	useEffect( () => {
+		const suppressBeforeUnload = ( event ) => {
+			event.stopImmediatePropagation();
+			return undefined;
+		};
+
+		window.addEventListener( 'beforeunload', suppressBeforeUnload );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', suppressBeforeUnload );
+		};
+	}, [] );
 
 	if ( ! onboardingProgress.isReady ) {
 		// TODO: Use better loading state indicator.


### PR DESCRIPTION
### Description

Disables the browser warning "Changes you made might not be saved", which was displayed when reloading the settings page, or navigating back to WooCommerce settings or any other page.

This warning is not needed, as our React app saves settings in real-time