### PR TITLE
“Save changes” is grey and unclickable when switching from Sandbox to Live

### DIFF
--- a/modules/ppcp-onboarding/resources/js/onboarding.js
+++ b/modules/ppcp-onboarding/resources/js/onboarding.js
@@ -345,6 +345,10 @@ window.ppcp_onboarding_productionCallback = function ( ...args ) {
 
 	const sandboxSwitchElement = document.querySelector( '#ppcp-sandbox_on' );
 
+    sandboxSwitchElement?.addEventListener( 'click', () => {
+        document.querySelector( '.woocommerce-save-button' )?.removeAttribute( 'disabled' );
+    });
+
 	const validate = () => {
 		const selectors = sandboxSwitchElement.checked
 			? sandboxCredentialElementsSelectors


### PR DESCRIPTION
Removed "disabled" from save button when the sandbox checkbox is changed.