### PR TITLE
plugin queries variations when button/messaging is disabled on single product page

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1910,7 +1910,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 
 		$in_stock = $product->is_in_stock();
 
-		if ( $product->is_type( 'variable' ) ) {
+		if ( ! $in_stock && $product->is_type( 'variable' ) ) {
 			/**
 			 * The method is defined in WC_Product_Variable class.
 			 *


### PR DESCRIPTION
Removed the additional query over variations when "variable product" is in stock.

- The variable product is in stock when one variation is in stock.
- The check on all variations must only run when sock management is active on variations and variable product with out of stock

So it will improve the performance because it only queries all variations on edge cases.

The HTML div problem was already solved.


