### PR TITLE
Change hardcoded address match and postal match to matched details on cvv response

### DIFF
--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -108,12 +108,12 @@ class FraudProcessorResponse {
 			'3' => __( '3: The merchant did not provide AVS information. Not processed.', 'woocommerce-paypal-payments' ),
 			'4' => __( '4: Address not checked, or acquirer had no response. Service not available.', 'woocommerce-paypal-payments' ),
 		);
+
 		/**
-		 * Translators: %s is fraud AVS code
-		 *
 		 * @psalm-suppress PossiblyNullArrayOffset
 		 * @psalm-suppress PossiblyNullArgument
 		 */
+		/* translators: %s is fraud AVS code */
 		return $messages[ $this->avs_code() ] ?? sprintf( __( '%s: Error', 'woocommerce-paypal-payments' ), $this->avs_code() );
 	}
 
@@ -145,12 +145,12 @@ class FraudProcessorResponse {
 			'3' => __( '3: Merchant has indicated that CVV2 is not present on card', 'woocommerce-paypal-payments' ),
 			'4' => __( '4: Service not available', 'woocommerce-paypal-payments' ),
 		);
+
 		/**
-		 * Translators: %s is fraud CVV2 code
-		 *
 		 * @psalm-suppress PossiblyNullArrayOffset
 		 * @psalm-suppress PossiblyNullArgument
 		 */
+		/* translators: %s is fraud CVV2 code */
 		return $messages[ $this->cvv_code() ] ?? sprintf( __( '%s: Error', 'woocommerce-paypal-payments' ), $this->cvv_code() );
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -108,7 +108,12 @@ class FraudProcessorResponse {
 			'3' => __( '3: The merchant did not provide AVS information. Not processed.', 'woocommerce-paypal-payments' ),
 			'4' => __( '4: Address not checked, or acquirer had no response. Service not available.', 'woocommerce-paypal-payments' ),
 		);
-		/* translators: %s is fraud AVS code */
+		/**
+		 * Translators: %s is fraud AVS code
+		 *
+		 * @psalm-suppress PossiblyNullArrayOffset
+		 * @psalm-suppress PossiblyNullArgument
+		 */
 		return $messages[ $this->avs_code() ] ?? sprintf( __( '%s: Error', 'woocommerce-paypal-payments' ), $this->avs_code() );
 	}
 
@@ -140,7 +145,12 @@ class FraudProcessorResponse {
 			'3' => __( '3: Merchant has indicated that CVV2 is not present on card', 'woocommerce-paypal-payments' ),
 			'4' => __( '4: Service not available', 'woocommerce-paypal-payments' ),
 		);
-		/* translators: %s is fraud CVV2 code */
+		/**
+		 * Translators: %s is fraud CVV2 code
+		 *
+		 * @psalm-suppress PossiblyNullArrayOffset
+		 * @psalm-suppress PossiblyNullArgument
+		 */
 		return $messages[ $this->cvv_code() ] ?? sprintf( __( '%s: Error', 'woocommerce-paypal-payments' ), $this->cvv_code() );
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -110,6 +110,8 @@ class FraudProcessorResponse {
 		);
 
 		/**
+		 * Psalm suppress
+		 *
 		 * @psalm-suppress PossiblyNullArrayOffset
 		 * @psalm-suppress PossiblyNullArgument
 		 */
@@ -147,6 +149,8 @@ class FraudProcessorResponse {
 		);
 
 		/**
+		 * Psalm suppress
+		 *
 		 * @psalm-suppress PossiblyNullArrayOffset
 		 * @psalm-suppress PossiblyNullArgument
 		 */

--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -44,7 +44,7 @@ class FraudProcessorResponse {
 	 *
 	 * @return string
 	 */
-	public function avs_code(): ?string {
+	public function avs_code(): string {
 		return $this->avs_code;
 	}
 
@@ -53,7 +53,7 @@ class FraudProcessorResponse {
 	 *
 	 * @return string
 	 */
-	public function cvv_code(): ?string {
+	public function cvv_code(): string {
 		return $this->cvv2_code;
 	}
 

--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -17,32 +17,32 @@ class FraudProcessorResponse {
 	/**
 	 * The AVS response code.
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	protected $avs_code;
+	protected string $avs_code;
 
 	/**
 	 * The CVV response code.
 	 *
-	 * @var string|null
+	 * @var string
 	 */
-	protected $cvv_code;
+	protected string $cvv2_code;
 
 	/**
 	 * FraudProcessorResponse constructor.
 	 *
 	 * @param string|null $avs_code The AVS response code.
-	 * @param string|null $cvv_code The CVV response code.
+	 * @param string|null $cvv2_code The CVV response code.
 	 */
-	public function __construct( ?string $avs_code, ?string $cvv_code ) {
-		$this->avs_code = $avs_code;
-		$this->cvv_code = $cvv_code;
+	public function __construct( ?string $avs_code, ?string $cvv2_code ) {
+		$this->avs_code  = (string) $avs_code;
+		$this->cvv2_code = (string) $cvv2_code;
 	}
 
 	/**
 	 * Returns the AVS response code.
 	 *
-	 * @return string|null
+	 * @return string
 	 */
 	public function avs_code(): ?string {
 		return $this->avs_code;
@@ -51,10 +51,10 @@ class FraudProcessorResponse {
 	/**
 	 * Returns the CVV response code.
 	 *
-	 * @return string|null
+	 * @return string
 	 */
 	public function cvv_code(): ?string {
-		return $this->cvv_code;
+		return $this->cvv2_code;
 	}
 
 	/**
@@ -64,11 +64,83 @@ class FraudProcessorResponse {
 	 */
 	public function to_array(): array {
 		return array(
-			'avs_code'      => $this->avs_code() ?: '',
-			'address_match' => $this->avs_code() === 'M' ? 'Y' : 'N',
-			'postal_match'  => $this->avs_code() === 'M' ? 'Y' : 'N',
-			'cvv_match'     => $this->cvv_code() === 'M' ? 'Y' : 'N',
+			'avs_code'  => $this->avs_code(),
+			'cvv2_code' => $this->cvv_code(),
 		);
 	}
 
+	/**
+	 * Retrieves the AVS (Address Verification System) code messages based on the AVS response code.
+	 *
+	 * Provides human-readable descriptions for various AVS response codes
+	 * and returns the corresponding message for the given code.
+	 *
+	 * @return string The AVS response code message. If the code is not found, an error message is returned.
+	 */
+	public function get_avs_code_messages(): string {
+		if ( $this->avs_code() ) {
+			return '';
+		}
+		$messages = array(
+			/* Visa, Mastercard, Discover, American Express */
+			'A' => __( 'A: Address - Address only (no ZIP code)', 'woocommerce-paypal-payments' ),
+			'B' => __( 'B: International "A" - Address only (no ZIP code)', 'woocommerce-paypal-payments' ),
+			'C' => __( 'C: International "N" - None. The transaction is declined.', 'woocommerce-paypal-payments' ),
+			'D' => __( 'D: International "X" - Address and Postal Code', 'woocommerce-paypal-payments' ),
+			'E' => __( 'E: Not allowed for MOTO (Internet/Phone) transactions - Not applicable. The transaction is declined.', 'woocommerce-paypal-payments' ),
+			'F' => __( 'F: UK-specific "X" - Address and Postal Code', 'woocommerce-paypal-payments' ),
+			'G' => __( 'G: Global Unavailable - Not applicable', 'woocommerce-paypal-payments' ),
+			'I' => __( 'I: International Unavailable - Not applicable', 'woocommerce-paypal-payments' ),
+			'M' => __( 'M: Address - Address and Postal Code', 'woocommerce-paypal-payments' ),
+			'N' => __( 'N: No - None. The transaction is declined.', 'woocommerce-paypal-payments' ),
+			'P' => __( 'P: Postal (International "Z") - Postal Code only (no Address)', 'woocommerce-paypal-payments' ),
+			'R' => __( 'R: Retry - Not applicable', 'woocommerce-paypal-payments' ),
+			'S' => __( 'S: Service not Supported - Not applicable', 'woocommerce-paypal-payments' ),
+			'U' => __( 'U: Unavailable / Address not checked, or acquirer had no response. Service not available.', 'woocommerce-paypal-payments' ),
+			'W' => __( 'W: Whole ZIP - Nine-digit ZIP code (no Address)', 'woocommerce-paypal-payments' ),
+			'X' => __( 'X: Exact match - Address and nine-digit ZIP code)', 'woocommerce-paypal-payments' ),
+			'Y' => __( 'Y: Yes - Address and five-digit ZIP', 'woocommerce-paypal-payments' ),
+			'Z' => __( 'Z: ZIP - Five-digit ZIP code (no Address)', 'woocommerce-paypal-payments' ),
+			/* Maestro */
+			'0' => __( '0: All the address information matched.', 'woocommerce-paypal-payments' ),
+			'1' => __( '1: None of the address information matched. The transaction is declined.', 'woocommerce-paypal-payments' ),
+			'2' => __( '2: Part of the address information matched.', 'woocommerce-paypal-payments' ),
+			'3' => __( '3: The merchant did not provide AVS information. Not processed.', 'woocommerce-paypal-payments' ),
+			'4' => __( '4: Address not checked, or acquirer had no response. Service not available.', 'woocommerce-paypal-payments' ),
+		);
+		/* translators: %s is fraud AVS code */
+		return $messages[ $this->avs_code() ] ?? sprintf( __( '%s: Error', 'woocommerce-paypal-payments' ), $this->avs_code() );
+	}
+
+	/**
+	 * Retrieves the CVV2 code message based on the CVV code provided.
+	 *
+	 * This method maps CVV response codes to their corresponding descriptive messages.
+	 *
+	 * @return string The descriptive message corresponding to the CVV2 code, or a formatted error message if the code is unrecognized.
+	 */
+	public function get_cvv2_code_messages(): string {
+		if ( $this->cvv_code() ) {
+			return '';
+		}
+		$messages = array(
+			/* Visa, Mastercard, Discover, American Express */
+			'E' => __( 'E: Error - Unrecognized or Unknown response', 'woocommerce-paypal-payments' ),
+			'I' => __( 'I: Invalid or Null', 'woocommerce-paypal-payments' ),
+			'M' => __( 'M: Match or CSC', 'woocommerce-paypal-payments' ),
+			'N' => __( 'N: No match', 'woocommerce-paypal-payments' ),
+			'P' => __( 'P: Not processed', 'woocommerce-paypal-payments' ),
+			'S' => __( 'S: Service not supported', 'woocommerce-paypal-payments' ),
+			'U' => __( 'U: Unknown - Issuer is not certified', 'woocommerce-paypal-payments' ),
+			'X' => __( 'X: No response / Service not available', 'woocommerce-paypal-payments' ),
+			/* Maestro */
+			'0' => __( '0: Matched CVV2', 'woocommerce-paypal-payments' ),
+			'1' => __( '1: No match', 'woocommerce-paypal-payments' ),
+			'2' => __( '2: The merchant has not implemented CVV2 code handling', 'woocommerce-paypal-payments' ),
+			'3' => __( '3: Merchant has indicated that CVV2 is not present on card', 'woocommerce-paypal-payments' ),
+			'4' => __( '4: Service not available', 'woocommerce-paypal-payments' ),
+		);
+		/* translators: %s is fraud CVV2 code */
+		return $messages[ $this->cvv_code() ] ?? sprintf( __( '%s: Error', 'woocommerce-paypal-payments' ), $this->cvv_code() );
+	}
 }

--- a/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
@@ -99,13 +99,12 @@ trait CreditCardOrderInfoHandlingTrait {
 		$card_brand       = $payment_source->properties()->brand ?? __( 'N/A', 'woocommerce-paypal-payments' );
 		$card_last_digits = $payment_source->properties()->last_digits ?? __( 'N/A', 'woocommerce-paypal-payments' );
 
-		$response_order_note_title = __( 'Card decline errors', 'woocommerce-paypal-payments' );
+		$response_order_note_title = __( 'PayPal Advanced Card Processing Verification:', 'woocommerce-paypal-payments' );
 		/* translators: %1$s is AVS order note title, %2$s is AVS order note result markup */
 		$response_order_note_format        = __( '%1$s %2$s', 'woocommerce-paypal-payments' );
 		$response_order_note_result_format = '<ul class="ppcp_avs_cvv_result">
             <li>%1$s</li>
             <li>%2$s</li>
-            <li>%3$s</li>
             <li>%3$s</li>
         </ul>';
 		$response_order_note_result        = sprintf(
@@ -113,9 +112,9 @@ trait CreditCardOrderInfoHandlingTrait {
 			/* translators: %1$s is card brand and %2$s card last 4 digits */
 			sprintf( __( 'Card: %1$s (%2$s)', 'woocommerce-paypal-payments' ), $card_brand, $card_last_digits ),
 			/* translators: %s is fraud AVS message */
-			sprintf( __( 'AVS: %s', 'woocommerce-paypal-payments' ), $fraud->get_avs_code_messages() ),
+			sprintf( __( 'AVS: %s', 'woocommerce-paypal-payments' ), $fraud->get_avs_code_message() ),
 			/* translators: %s is fraud CVV message */
-			sprintf( __( 'CVV: %s', 'woocommerce-paypal-payments' ), $fraud->get_cvv2_code_messages() ),
+			sprintf( __( 'CVV: %s', 'woocommerce-paypal-payments' ), $fraud->get_cvv2_code_message() ),
 		);
 		$response_order_note = sprintf(
 			$response_order_note_format,

--- a/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
@@ -96,52 +96,36 @@ trait CreditCardOrderInfoHandlingTrait {
 			return;
 		}
 
-		$fraud_responses  = $fraud->to_array();
 		$card_brand       = $payment_source->properties()->brand ?? __( 'N/A', 'woocommerce-paypal-payments' );
 		$card_last_digits = $payment_source->properties()->last_digits ?? __( 'N/A', 'woocommerce-paypal-payments' );
 
-		$avs_response_order_note_title = __( 'Address Verification Result', 'woocommerce-paypal-payments' );
+		$response_order_note_title = __( 'Card decline errors', 'woocommerce-paypal-payments' );
 		/* translators: %1$s is AVS order note title, %2$s is AVS order note result markup */
-		$avs_response_order_note_format        = __( '%1$s %2$s', 'woocommerce-paypal-payments' );
-		$avs_response_order_note_result_format = '<ul class="ppcp_avs_result">
-                                                                <li>%1$s</li>
-                                                                <ul class="ppcp_avs_result_inner">
-                                                                    <li>%2$s</li>
-                                                                    <li>%3$s</li>
-                                                                </ul>
-                                                                <li>%4$s</li>
-                                                                <li>%5$s</li>
-                                                            </ul>';
-		$avs_response_order_note_result        = sprintf(
-			$avs_response_order_note_result_format,
-			/* translators: %s is fraud AVS code */
-			sprintf( __( 'AVS: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['avs_code'] ) ),
-			/* translators: %s is fraud AVS address match */
-			sprintf( __( 'Address Match: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['address_match'] ) ),
-			/* translators: %s is fraud AVS postal match */
-			sprintf( __( 'Postal Match: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['postal_match'] ) ),
-			/* translators: %s is card brand */
-			sprintf( __( 'Card Brand: %s', 'woocommerce-paypal-payments' ), esc_html( $card_brand ) ),
-			/* translators: %s card last digits */
-			sprintf( __( 'Card Last Digits: %s', 'woocommerce-paypal-payments' ), esc_html( $card_last_digits ) )
+		$response_order_note_format        = __( '%1$s %2$s', 'woocommerce-paypal-payments' );
+		$response_order_note_result_format = '<ul class="ppcp_avs_cvv_result">
+            <li>%1$s</li>
+            <li>%2$s</li>
+            <li>%3$s</li>
+            <li>%3$s</li>
+        </ul>';
+		$response_order_note_result        = sprintf(
+			$response_order_note_result_format,
+			/* translators: %1$s is card brand and %2$s card last 4 digits */
+			sprintf( __( 'Card: %1$s (%2$s)', 'woocommerce-paypal-payments' ), $card_brand, $card_last_digits ),
+			/* translators: %s is fraud AVS message */
+			sprintf( __( 'AVS: %s', 'woocommerce-paypal-payments' ), $fraud->get_avs_code_messages() ),
+			/* translators: %s is fraud CVV message */
+			sprintf( __( 'CVV: %s', 'woocommerce-paypal-payments' ), $fraud->get_cvv2_code_messages() ),
 		);
-		$avs_response_order_note = sprintf(
-			$avs_response_order_note_format,
-			esc_html( $avs_response_order_note_title ),
-			wp_kses_post( $avs_response_order_note_result )
+		$response_order_note = sprintf(
+			$response_order_note_format,
+			esc_html( $response_order_note_title ),
+			wp_kses_post( $response_order_note_result )
 		);
-		$wc_order->add_order_note( $avs_response_order_note );
-
-		$cvv_response_order_note_format = '<ul class="ppcp_cvv_result"><li>%1$s</li></ul>';
-		$cvv_response_order_note        = sprintf(
-			$cvv_response_order_note_format,
-			/* translators: %s is fraud CVV match */
-			sprintf( __( 'CVV2 Match: %s', 'woocommerce-paypal-payments' ), esc_html( $fraud_responses['cvv_match'] ) )
-		);
-		$wc_order->add_order_note( $cvv_response_order_note );
+		$wc_order->add_order_note( $response_order_note );
 
 		$meta_details = array_merge(
-			$fraud_responses,
+			$fraud->to_array(),
 			array(
 				'card_brand'       => $card_brand,
 				'card_last_digits' => $card_last_digits,


### PR DESCRIPTION
The order node displays now a detailed message from card verification. 
2. Order node removed and included in the other.