### PR TITLE
Fix PHP notices related to settings-mapping (4028)

### DIFF
--- a/modules/ppcp-compat/src/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/SettingsMapHelper.php
@@ -9,6 +9,8 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
+use RuntimeException;
+
 /**
  * A helper class to manage the transition between legacy and new settings.
  *
@@ -42,10 +44,33 @@ class SettingsMapHelper {
 	/**
 	 * Constructor.
 	 *
+	 * @throws RuntimeException When an old key has multiple mappings.
+	 *
 	 * @param SettingsMap[] $settings_map A list of settings maps containing key definitions.
 	 */
 	public function __construct( array $settings_map ) {
+		$this->validate_settings_map( $settings_map );
 		$this->settings_map = $settings_map;
+	}
+
+	/**
+	 * Validates the settings map for duplicate keys.
+	 *
+	 * @throws RuntimeException When an old key has multiple mappings.
+	 *
+	 * @param SettingsMap[] $settings_map The settings map to validate.
+	 */
+	protected function validate_settings_map( array $settings_map ) : void {
+		$seen_keys = array();
+
+		foreach ( $settings_map as $settings_map_instance ) {
+			foreach ( $settings_map_instance->get_map() as $old_key => $new_key ) {
+				if ( isset( $seen_keys[ $old_key ] ) ) {
+					throw new RuntimeException( "Duplicate mapping for legacy key '$old_key'." );
+				}
+				$seen_keys[ $old_key ] = true;
+			}
+		}
 	}
 
 	/**

--- a/modules/ppcp-compat/src/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/SettingsMapHelper.php
@@ -10,12 +10,16 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Compat;
 
 /**
- * A helper for mapping the new/old settings.
+ * A helper class to manage the transition between legacy and new settings.
+ *
+ * This utility provides mapping from old setting keys to new ones and retrieves
+ * their corresponding values from the appropriate models. The class uses lazy
+ * loading and caching to optimize performance during runtime.
  */
 class SettingsMapHelper {
 
 	/**
-	 * A list of mapped settings.
+	 * A list of settings maps containing mapping definitions.
 	 *
 	 * @var SettingsMap[]
 	 */
@@ -24,18 +28,18 @@ class SettingsMapHelper {
 	/**
 	 * Constructor.
 	 *
-	 * @param SettingsMap[] $settings_map A list of mapped settings.
+	 * @param SettingsMap[] $settings_map A list of settings maps containing key definitions.
 	 */
 	public function __construct( array $settings_map ) {
 		$this->settings_map = $settings_map;
 	}
 
 	/**
-	 * Retrieves the mapped value from the new settings.
+	 * Retrieves the value of a mapped key from the new settings.
 	 *
 	 * @param string $old_key The key from the legacy settings.
 	 *
-	 * @return ?mixed the mapped value or Null if it doesn't exist.
+	 * @return mixed|null The value of the mapped setting, or null if not found.
 	 */
 	public function mapped_value( string $old_key ) {
 		if ( ! $this->has_mapped_key( $old_key ) ) {
@@ -55,11 +59,11 @@ class SettingsMapHelper {
 	}
 
 	/**
-	 * Checks if the given key exists in the new settings.
+	 * Determines if a given legacy key exists in the new settings.
 	 *
 	 * @param string $old_key The key from the legacy settings.
 	 *
-	 * @return bool true if the given key exists in the new settings, otherwise false.
+	 * @return bool True if the key exists in the new settings, false otherwise.
 	 */
 	public function has_mapped_key( string $old_key ) : bool {
 		foreach ( $this->settings_map as $settings_map ) {

--- a/modules/ppcp-compat/src/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/SettingsMapHelper.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce\Compat
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
@@ -33,17 +33,19 @@ class SettingsMapHelper {
 	/**
 	 * Retrieves the mapped value from the new settings.
 	 *
-	 * @param string $key The key.
+	 * @param string $old_key The key from the legacy settings.
+	 *
 	 * @return ?mixed the mapped value or Null if it doesn't exist.
 	 */
-	public function mapped_value( string $key ) {
-		if ( ! $this->has_mapped_key( $key ) ) {
+	public function mapped_value( string $old_key ) {
+		if ( ! $this->has_mapped_key( $old_key ) ) {
 			return null;
 		}
 
 		foreach ( $this->settings_map as $settings_map ) {
-			$mapped_key   = array_search( $key, $settings_map->get_map(), true );
+			$mapped_key   = array_search( $old_key, $settings_map->get_map(), true );
 			$new_settings = $settings_map->get_model()->to_array();
+
 			if ( ! empty( $new_settings[ $mapped_key ] ) ) {
 				return $new_settings[ $mapped_key ];
 			}
@@ -55,12 +57,13 @@ class SettingsMapHelper {
 	/**
 	 * Checks if the given key exists in the new settings.
 	 *
-	 * @param string $key The key.
+	 * @param string $old_key The key from the legacy settings.
+	 *
 	 * @return bool true if the given key exists in the new settings, otherwise false.
 	 */
-	public function has_mapped_key( string $key ) : bool {
+	public function has_mapped_key( string $old_key ) : bool {
 		foreach ( $this->settings_map as $settings_map ) {
-			if ( in_array( $key, $settings_map->get_map(), true ) ) {
+			if ( in_array( $old_key, $settings_map->get_map(), true ) ) {
 				return true;
 			}
 		}

--- a/modules/ppcp-compat/src/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/SettingsMapHelper.php
@@ -44,9 +44,8 @@ class SettingsMapHelper {
 	/**
 	 * Constructor.
 	 *
-	 * @throws RuntimeException When an old key has multiple mappings.
-	 *
 	 * @param SettingsMap[] $settings_map A list of settings maps containing key definitions.
+	 * @throws RuntimeException When an old key has multiple mappings.
 	 */
 	public function __construct( array $settings_map ) {
 		$this->validate_settings_map( $settings_map );
@@ -56,9 +55,8 @@ class SettingsMapHelper {
 	/**
 	 * Validates the settings map for duplicate keys.
 	 *
-	 * @throws RuntimeException When an old key has multiple mappings.
-	 *
 	 * @param SettingsMap[] $settings_map The settings map to validate.
+	 * @throws RuntimeException When an old key has multiple mappings.
 	 */
 	protected function validate_settings_map( array $settings_map ) : void {
 		$seen_keys = array();

--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -104,7 +104,7 @@ class Settings implements ContainerInterface {
 	 *
 	 * @return mixed
 	 */
-	public function get( string $id ) {
+	public function get( $id ) {
 		if ( ! $this->has( $id ) ) {
 			throw new NotFoundException();
 		}
@@ -119,7 +119,7 @@ class Settings implements ContainerInterface {
 	 *
 	 * @return bool
 	 */
-	public function has( string $id ) : bool {
+	public function has( string $id ) {
 		if ( $this->settings_map_helper->has_mapped_key( $id ) ) {
 			return true;
 		}
@@ -135,7 +135,7 @@ class Settings implements ContainerInterface {
 	 * @param string $id    The value identifier.
 	 * @param mixed  $value The value.
 	 */
-	public function set( string $id, $value ) : void {
+	public function set( $id, $value ) {
 		$this->load();
 		$this->settings[ $id ] = $value;
 	}
@@ -143,18 +143,18 @@ class Settings implements ContainerInterface {
 	/**
 	 * Stores the settings to the database.
 	 */
-	public function persist() : bool {
+	public function persist() {
 		return update_option( self::KEY, $this->settings );
 	}
 
 	/**
 	 * Loads the settings.
 	 *
-	 * @return void
+	 * @return bool
 	 */
-	private function load() : void {
+	private function load() : bool {
 		if ( $this->settings ) {
-			return;
+			return false;
 		}
 		$this->settings = get_option( self::KEY, array() );
 
@@ -186,5 +186,6 @@ class Settings implements ContainerInterface {
 			$this->settings[ $key ] = $value;
 		}
 
+		return true;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce\WcGateway\Settings
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Settings;
 
@@ -18,44 +18,46 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
  */
 class Settings implements ContainerInterface {
 
-	const KEY               = 'woocommerce-ppcp-settings';
+	const KEY = 'woocommerce-ppcp-settings';
+
 	const CONNECTION_TAB_ID = 'ppcp-connection';
-	const PAY_LATER_TAB_ID  = 'ppcp-pay-later';
+
+	const PAY_LATER_TAB_ID = 'ppcp-pay-later';
 
 	/**
 	 * The settings.
 	 *
 	 * @var array
 	 */
-	private $settings = array();
+	private array $settings = array();
 
 	/**
 	 * The list of selected default button locations.
 	 *
 	 * @var string[]
 	 */
-	protected $default_button_locations;
+	protected array $default_button_locations;
 
 	/**
 	 * The list of selected default pay later button locations.
 	 *
 	 * @var string[]
 	 */
-	protected $default_pay_later_button_locations;
+	protected array $default_pay_later_button_locations;
 
 	/**
 	 * The list of selected default pay later messaging locations.
 	 *
 	 * @var string[]
 	 */
-	protected $default_pay_later_messaging_locations;
+	protected array $default_pay_later_messaging_locations;
 
 	/**
 	 * The default ACDC gateway title.
 	 *
 	 * @var string
 	 */
-	protected $default_dcc_gateway_title;
+	protected string $default_dcc_gateway_title;
 
 	/**
 	 * A helper for mapping the new/old settings.
@@ -67,11 +69,17 @@ class Settings implements ContainerInterface {
 	/**
 	 * Settings constructor.
 	 *
-	 * @param string[]          $default_button_locations The list of selected default button locations.
-	 * @param string            $default_dcc_gateway_title The default ACDC gateway title.
-	 * @param string[]          $default_pay_later_button_locations The list of selected default pay later button locations.
-	 * @param string[]          $default_pay_later_messaging_locations The list of selected default pay later messaging locations.
-	 * @param SettingsMapHelper $settings_map_helper A helper for mapping the new/old settings.
+	 * @param string[]          $default_button_locations              The list of selected default
+	 *                                                                 button locations.
+	 * @param string            $default_dcc_gateway_title             The default ACDC gateway
+	 *                                                                 title.
+	 * @param string[]          $default_pay_later_button_locations    The list of selected default
+	 *                                                                 pay later button locations.
+	 * @param string[]          $default_pay_later_messaging_locations The list of selected default
+	 *                                                                 pay later messaging
+	 *                                                                 locations.
+	 * @param SettingsMapHelper $settings_map_helper                   A helper for mapping the
+	 *                                                                 new/old settings.
 	 */
 	public function __construct(
 		array $default_button_locations,
@@ -90,12 +98,13 @@ class Settings implements ContainerInterface {
 	/**
 	 * Returns the value for an id.
 	 *
-	 * @param string $id The value identificator.
+	 * @throws NotFoundException When nothing was found.
+	 *
+	 * @param string $id The value identifier.
 	 *
 	 * @return mixed
-	 * @throws NotFoundException When nothing was found.
 	 */
-	public function get( $id ) {
+	public function get( string $id ) {
 		if ( ! $this->has( $id ) ) {
 			throw new NotFoundException();
 		}
@@ -106,26 +115,27 @@ class Settings implements ContainerInterface {
 	/**
 	 * Whether a value exists.
 	 *
-	 * @param string $id The value identificator.
+	 * @param string $id The value identifier.
 	 *
 	 * @return bool
 	 */
-	public function has( $id ) {
+	public function has( string $id ) : bool {
 		if ( $this->settings_map_helper->has_mapped_key( $id ) ) {
 			return true;
 		}
 
 		$this->load();
+
 		return array_key_exists( $id, $this->settings );
 	}
 
 	/**
 	 * Sets a value.
 	 *
-	 * @param string $id The value identificator.
+	 * @param string $id    The value identifier.
 	 * @param mixed  $value The value.
 	 */
-	public function set( $id, $value ) {
+	public function set( string $id, $value ) : void {
 		$this->load();
 		$this->settings[ $id ] = $value;
 	}
@@ -133,18 +143,18 @@ class Settings implements ContainerInterface {
 	/**
 	 * Stores the settings to the database.
 	 */
-	public function persist() {
+	public function persist() : bool {
 		return update_option( self::KEY, $this->settings );
 	}
 
 	/**
 	 * Loads the settings.
 	 *
-	 * @return bool
+	 * @return void
 	 */
-	private function load(): bool {
+	private function load() : void {
 		if ( $this->settings ) {
-			return false;
+			return;
 		}
 		$this->settings = get_option( self::KEY, array() );
 
@@ -175,6 +185,6 @@ class Settings implements ContainerInterface {
 			}
 			$this->settings[ $key ] = $value;
 		}
-		return true;
+
 	}
 }


### PR DESCRIPTION
### Description

Several improvements for the `SettingsMapHelper` 

- Prevent PHP notice about accessing undefined array-keys
- Add caching mechanism to avoid repeat loops - which becomes more important as we map more settings