### PR TITLE
Updating GitHub upload action due deprecation

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,7 +50,7 @@ jobs:
       if: github.event.inputs.filePrefix
 
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.FILENAME }}
         path: dist/


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

GitHub will be closing down `actions/upload` v1 and v2 on January 30th, 2025. We need to update it to version 4, at least, to keep things working.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

Code review. Check if the GitHub checks are still working with the new versions.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Dev - Updates GitHub actions/upload to v4 due deprecation.
