### PR TITLE
Use get_id instead of get_order_number on setting custom_id

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -466,7 +466,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 						continue;
 					}
 
-					$custom_id    = $wc_order->get_order_number();
+					$custom_id    = $wc_order->get_id();
 					$invoice_id   = $this->prefix . $wc_order->get_order_number();
 					$create_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order );
 

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -466,7 +466,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 						continue;
 					}
 
-					$custom_id    = $wc_order->get_id();
+					$custom_id    = (string) $wc_order->get_id();
 					$invoice_id   = $this->prefix . $wc_order->get_order_number();
 					$create_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order );
 


### PR DESCRIPTION
Filtering "woocommerce_order_number" to customise the invoice_id seems to be unstable unless the get_order_number function is also used to generate the custom_id in /modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php:469

### References
When a PurchaseUnit is created in PurchaseUnitFactory, the WC_Order method get_id() is used in /modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php:128

This topic is also mentioned here:
https://github.com/woocommerce/woocommerce-paypal-payments/pull/365