### PR TITLE
Standard Card Button not disaplayed in standalone gateway when free trial subscription is in the cart

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -362,4 +362,19 @@ class CardButtonGateway extends \WC_Payment_Gateway {
 	protected function settings_renderer(): SettingsRenderer {
 		return $this->settings_renderer;
 	}
+
+	/**
+	 * Determines if the Gateway is available for use.
+	 *
+	 * @return bool
+	 */
+	public function is_available(): bool {
+		$is_available = parent::is_available();
+
+		if ( $is_available && $this->is_free_trial_cart() ) {
+			$is_available = false;
+		}
+
+		return $is_available;
+	}
 }


### PR DESCRIPTION
Not display "Button Gateway" when only a free trial product is in the cart