### PR TITLE
Do not validate ACDC card brand keys locally but via Confirm Payment Source API

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/Orders.php
+++ b/modules/ppcp-api-client/src/Endpoint/Orders.php
@@ -118,13 +118,13 @@ class Orders {
 	 *
 	 * @link https://developer.paypal.com/docs/api/orders/v2/#orders_confirm
 	 *
-	 * @param array  $request_body The request body.
 	 * @param string $id PayPal order ID.
-	 * @return array
+	 * @param array  $request_body The request body.
+	 * @return \stdClass
 	 * @throws RuntimeException If something went wrong with the request.
 	 * @throws PayPalApiException If something went wrong with the PayPal API request.
 	 */
-	public function confirm_payment_source( array $request_body, string $id ): array {
+	public function confirm_payment_source( string $id, array $request_body ): \stdClass {
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $id . '/confirm-payment-source';
 
@@ -133,6 +133,7 @@ class Orders {
 			'headers' => array(
 				'Authorization'     => 'Bearer ' . $bearer->token(),
 				'Content-Type'      => 'application/json',
+				'Prefer'            => 'return=representation',
 				'PayPal-Request-Id' => uniqid( 'ppcp-', true ),
 			),
 			'body'    => wp_json_encode( $request_body ),
@@ -143,22 +144,21 @@ class Orders {
 			throw new RuntimeException( $response->get_error_message() );
 		}
 
+		$json        = json_decode( $response['body'] );
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( $status_code !== 200 ) {
-			$body = json_decode( $response['body'] );
-
-			$message = $body->details[0]->description ?? '';
+			$message = $json->details[0]->description ?? '';
 			if ( $message ) {
 				throw new RuntimeException( $message );
 			}
 
 			throw new PayPalApiException(
-				$body,
+				$json,
 				$status_code
 			);
 		}
 
-		return $response;
+		return $json;
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Entity/PaymentSource.php
+++ b/modules/ppcp-api-client/src/Entity/PaymentSource.php
@@ -58,4 +58,10 @@ class PaymentSource {
 	public function properties(): object {
 		return $this->properties;
 	}
+
+	public function to_array(): array {
+		return array(
+			$this->name => (array) $this->properties
+		);
+	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/MultibancoGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/MultibancoGateway.php
@@ -169,11 +169,10 @@ class MultibancoGateway extends WC_Payment_Gateway {
 				),
 			);
 
-			$response = $this->orders_endpoint->confirm_payment_source( $request_body, $body->id );
-			$body     = json_decode( $response['body'] );
+			$response = $this->orders_endpoint->confirm_payment_source( $body->id, $request_body );
 
 			$payer_action = '';
-			foreach ( $body->links as $link ) {
+			foreach ( $response->links as $link ) {
 				if ( $link->rel === 'payer-action' ) {
 					$payer_action = $link->href;
 				}

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
@@ -186,7 +186,15 @@ class OXXOGateway extends WC_Payment_Gateway {
 					'country_code' => $wc_order->get_billing_country(),
 				),
 			);
-			$payment_method = $this->order_endpoint->confirm_payment_source( $order->id(), $payment_source );
+			$request_body   = array(
+				'payment_source'         => $payment_source,
+				'processing_instruction' => 'ORDER_COMPLETE_ON_PAYMENT_APPROVAL',
+				'application_context'    => array(
+					'locale' => 'es-MX',
+				),
+			);
+
+			$payment_method = $this->order_endpoint->confirm_payment_source( $order->id(), $request_body );
 			foreach ( $payment_method->links as $link ) {
 				if ( $link->rel === 'payer-action' ) {
 					$payer_action = $link->href;


### PR DESCRIPTION
Streamline the call off confirm_payment_source() and reference implementation for future investigation.