### PR TITLE
New Settings UI: Adjust features button styling (4023)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/screens/_settings.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_settings.scss
@@ -101,6 +101,8 @@
 		span {
 			font-weight: 500;
 		}
+
+		margin-top:24px;
 	}
 }
 

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlocks/FeatureSettingsBlock.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlocks/FeatureSettingsBlock.js
@@ -37,6 +37,7 @@ const FeatureSettingsBlock = ( { title, description, ...props } ) => {
 				<div className="ppcp-r-feature-item__buttons">
 					{ props.actionProps?.buttons.map( ( button ) => (
 						<Button
+							className={ button.class ? button.class : '' }
 							href={ button.url }
 							key={ button.text }
 							variant={ button.type }

--- a/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabOverview.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabOverview.js
@@ -177,6 +177,7 @@ const featuresDefault = [
 		buttons: [
 			{
 				type: 'secondary',
+				class: 'small-button',
 				text: __( 'Configure', 'woocommerce-paypal-payments' ),
 				url: '#',
 			},
@@ -200,6 +201,7 @@ const featuresDefault = [
 		buttons: [
 			{
 				type: 'secondary',
+				class: 'small-button',
 				text: __( 'Configure', 'woocommerce-paypal-payments' ),
 				url: '#',
 			},
@@ -223,6 +225,7 @@ const featuresDefault = [
 		buttons: [
 			{
 				type: 'secondary',
+				class: 'small-button',
 				text: __( 'Apply', 'woocommerce-paypal-payments' ),
 				url: '#',
 			},
@@ -243,6 +246,7 @@ const featuresDefault = [
 		buttons: [
 			{
 				type: 'secondary',
+				class: 'small-button',
 				text: __( 'Configure', 'woocommerce-paypal-payments' ),
 				url: '#',
 			},
@@ -251,9 +255,6 @@ const featuresDefault = [
 				text: __( 'Learn more', 'woocommerce-paypal-payments' ),
 				url: '#',
 			},
-		],
-		notes: [
-			__( '¹PayPal Q2 Earnings-2021.', 'woocommerce-paypal-payments' ),
 		],
 	},
 	{
@@ -266,6 +267,7 @@ const featuresDefault = [
 		buttons: [
 			{
 				type: 'secondary',
+				class: 'small-button',
 				text: __(
 					'Domain registration',
 					'woocommerce-paypal-payments'
@@ -289,6 +291,7 @@ const featuresDefault = [
 		buttons: [
 			{
 				type: 'secondary',
+				class: 'small-button',
 				text: __( 'Configure', 'woocommerce-paypal-payments' ),
 				url: '#',
 			},
@@ -297,6 +300,9 @@ const featuresDefault = [
 				text: __( 'Learn more', 'woocommerce-paypal-payments' ),
 				url: '#',
 			},
+		],
+		notes: [
+			__( '¹PayPal Q2 Earnings-2021.', 'woocommerce-paypal-payments' ),
 		],
 	},
 ];


### PR DESCRIPTION
### Description

This PR introduces a small change to adjust the style of the buttons within the overview tab to match the Figma design. 

### Steps to Test

1. Go to to the new settings UI "overview" tab.
2. Verify that the design of the secondary buttons (the ones that say "Enable" or "Configure") match the Figma design.

### Screenshots

![WooCommerce-settings-‹-WooCommerce-PayPal-Payments-—-WordPress-12-20-2024_01_52_PM](https://github.com/user-attachments/assets/637b791f-eb15-434c-b0b3-c5cc0639030b)

