### PR TITLE
New Settings UI: Remove section links from PayPal settings page (4049)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -227,7 +227,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
-
 		/**
 		 * Removes the default WooCommerce action that displays extra section links in the checkout tab.
 		 * Prevents unwanted section links (e.g., from WooPayments) from appearing on the PayPal settings page.

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -227,6 +227,36 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		add_action(
+			'admin_init',
+			function() use ( $container ) {
+				global $wp_filter;
+
+				if ( ! $container->has( 'wcgateway.is-ppcp-settings-page' ) ||
+					$container->get( 'wcgateway.is-ppcp-settings-page' ) === false ) {
+					return;
+				}
+
+				if ( empty( $wp_filter['woocommerce_sections_checkout']->callbacks ) ) {
+					return;
+				}
+
+				foreach ( $wp_filter['woocommerce_sections_checkout']->callbacks as $priority => $callbacks ) {
+					foreach ( $callbacks as $callback_key => $callback_data ) {
+						$function = $callback_data['function'];
+
+						if (
+							is_array( $function )
+							&& is_object( $function[0] )
+							&& $function[1] === 'output_sections'
+							&& get_class( $function[0] ) === 'WC_Settings_Payment_Gateways'
+						) {
+							remove_action( 'woocommerce_sections_checkout', $function, $priority );
+						}
+					}
+				}}
+		);
+
 		return true;
 	}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -227,17 +227,25 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+
+		/**
+		 * Removes the default WooCommerce action that displays extra section links in the checkout tab.
+		 * Prevents unwanted section links (e.g., from WooPayments) from appearing on the PayPal settings page.
+		 *
+		 * @psalm-suppress TypeDoesNotContainType
+		 */
 		add_action(
 			'admin_init',
 			function() use ( $container ) {
-				global $wp_filter;
 
 				if ( ! $container->has( 'wcgateway.is-ppcp-settings-page' ) ||
 					$container->get( 'wcgateway.is-ppcp-settings-page' ) === false ) {
 					return;
 				}
 
-				if ( empty( $wp_filter['woocommerce_sections_checkout']->callbacks ) ) {
+				global $wp_filter;
+
+				if ( ! isset( $wp_filter['woocommerce_sections_checkout'] ) ) {
 					return;
 				}
 


### PR DESCRIPTION
### Description

Some plugins, such as [WooPayments](https://es.wordpress.org/plugins/woocommerce-payments/), may add extra sections to the checkout tab . By default, WooCommerce outputs the links to these sections at the beginning of the tab. 

To prevent these section links from displaying on the PayPal settings page, this PR takes care of removing the action responsible of echoing the links. 


### Steps to Test

1. Enable the new PayPal settings UI
2. [Install the WooCommerce Payments plugin](https://es.wordpress.org/plugins/woocommerce-payments/)
3. Go to the Payments tab inside the WooCommerce settings page.
4. Verify that there are 2 links at the top: "WooPayments" and "All payment methods".
5. Go to the PayPal settings section.
6. Verify that the 2 links are not displaying.

It might be worth moving the logic for removing an action based on its name to a separate function, which could be useful in future cases like this one, where we don't have access to a class instance to remove an action or filter directly.