### PR TITLE
WC Subscriptions Next Payment date not updating when processing a renewal order (4070)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-paypal-subscriptions/src/RenewalHandler.php
@@ -49,6 +49,8 @@ class RenewalHandler {
 	public function process( array $subscriptions, string $transaction_id ): void {
 		foreach ( $subscriptions as $subscription ) {
 			if ( $this->is_for_renewal_order( $subscription ) ) {
+				$subscription->update_status( 'on-hold' );
+
 				$renewal_order = wcs_create_renewal_order( $subscription );
 				if ( is_a( $renewal_order, WC_Order::class ) ) {
 					$this->logger->info(


### PR DESCRIPTION
### Steps to Reproduce

- Go to “Standard Payments” tab and set “Subscriptions Mode” to “PayPal Subscriptions”
- Create and connect a WC Subscriptions product with an every day renewal (24 hours)
- Purchase the subscription
- After ~24 hours notice that Next Payment date is not updating

This PR update subscription status to `on-hold` before creating the renewal order via `wcs_create_renewal_order( $subscription )`, by doing so it will handle updating the next payment date when the subscription transitions from on-hold to active.