### PR TITLE
Update paypal_credit setting title and description

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabPaymentMethods.js
@@ -111,9 +111,9 @@ const paymentMethodsPayPalCheckout = [
 	},
 	{
 		id: 'paypal_credit',
-		title: __( 'PayPal Credit', 'woocommerce-paypal-payments' ),
+		title: __( 'Pay Later', 'woocommerce-paypal-payments' ),
 		description: __(
-			'Get paid in full at checkout while giving your customers the option to pay interest free if paid within 6 months on orders over $99.',
+			'Get paid in full at checkout while giving your customers the flexibility to pay in installments over time with no late fees.',
 			'woocommerce-paypal-payments'
 		),
 		icon: 'payment-method-paypal',


### PR DESCRIPTION
This PR updates de title to "Pay Later" and the description of the `paypal_credit` setting