### PR TITLE
create new settings tab for messaging configurator (4099)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabPayLaterMessaging.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Overview/TabPayLaterMessaging.js
@@ -1,0 +1,5 @@
+const TabPayLaterMessaging = () => {
+	return <div className="ppcp-r-pay-later-messaging"></div>;
+};
+
+export default TabPayLaterMessaging;

--- a/modules/ppcp-settings/resources/js/Components/Screens/tabs.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/tabs.js
@@ -3,6 +3,7 @@ import TabOverview from './Overview/TabOverview';
 import TabPaymentMethods from './Overview/TabPaymentMethods';
 import TabSettings from './Overview/TabSettings';
 import TabStyling from './Overview/TabStyling';
+import TabPayLaterMessaging from './Overview/TabPayLaterMessaging';
 
 export const getSettingsTabs = () => {
 	const tabs = [];
@@ -29,6 +30,12 @@ export const getSettingsTabs = () => {
 		name: 'styling',
 		title: __( 'Styling', 'woocommerce-paypal-payments' ),
 		component: <TabStyling />,
+	} );
+
+	tabs.push( {
+		name: 'pay-later-messaging',
+		title: __( 'Pay Later Messaging', 'woocommerce-paypal-payments' ),
+		component: <TabPayLaterMessaging />,
 	} );
 
 	return tabs;

--- a/modules/ppcp-settings/resources/js/utils/tabSelector.js
+++ b/modules/ppcp-settings/resources/js/utils/tabSelector.js
@@ -4,6 +4,7 @@ export const TAB_IDS = {
 	PAYMENT_METHODS: 'tab-panel-0-payment-methods',
 	SETTINGS: 'tab-panel-0-settings',
 	STYLING: 'tab-panel-0-styling',
+	PAY_LATER_MESSAGING: 'tab-panel-0-pay-later-messaging',
 };
 
 /**


### PR DESCRIPTION
# Issue Description

On the right side of the Styling tab, we need a new tab called: **Pay Later messaging**.
This tab should host the Pay Later messaging configurator component

# PR Description

<img width="1027" alt="Screenshot 2025-01-13 at 14 16 18" src="https://github.com/user-attachments/assets/13323075-fb77-4671-a7e8-9a7600988f25" />

The PR will create an empty tab for Pay Later messaging configurator.