### PR TITLE
Fix fatal error in PayLaterConfigurator (4103)

### DIFF
--- a/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
+++ b/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
@@ -70,9 +70,15 @@ class PayLaterConfiguratorModule implements ServiceModule, ExtendingModule, Exec
 				$current_page_id     = $c->get( 'wcgateway.current-ppcp-settings-page-id' );
 				$is_wc_settings_page = $c->get( 'wcgateway.is-wc-settings-page' );
 				$messaging_locations = $c->get( 'paylater-configurator.messaging-locations' );
-				$onboarding_profile  = $c->get( 'settings.data.onboarding' );
 
-				self::add_paylater_update_notice( $messaging_locations, $is_wc_settings_page, $current_page_id, $onboarding_profile );
+				if ( $c->has( 'settings.data.onboarding' ) &&
+					$c->get( 'settings.data.onboarding' )->get_completed() === true ) {
+						self::add_paylater_update_notice(
+							$messaging_locations,
+							$is_wc_settings_page,
+							$current_page_id
+						);
+				}
 
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
@@ -162,19 +168,13 @@ class PayLaterConfiguratorModule implements ServiceModule, ExtendingModule, Exec
 	 * The notice appears on any PayPal-Settings page, except for the Pay-Later settings page,
 	 * when no Pay-Later messaging is used yet.
 	 *
-	 * @param array             $message_locations   PayLater messaging locations.
-	 * @param bool              $is_settings_page    Whether the current page is a WC settings page.
-	 * @param string            $current_page_id     ID of current settings page tab.
-	 * @param OnboardingProfile $onboarding_profile  Onboarding profile.
+	 * @param array  $message_locations   PayLater messaging locations.
+	 * @param bool   $is_settings_page    Whether the current page is a WC settings page.
+	 * @param string $current_page_id     ID of current settings page tab.
 	 *
 	 * @return void
 	 */
-	private static function add_paylater_update_notice( array $message_locations, bool $is_settings_page, string $current_page_id, OnboardingProfile $onboarding_profile ) : void {
-		// Don't display the notice if the user has not completed the onboarding process.
-		if ( $onboarding_profile->get_completed() !== true ) {
-			return;
-		}
-
+	private static function add_paylater_update_notice( array $message_locations, bool $is_settings_page, string $current_page_id ) : void {
 		// The message must be registered on any WC-Settings page, except for the Pay Later page.
 		if ( ! $is_settings_page || Settings::PAY_LATER_TAB_ID === $current_page_id ) {
 			return;

--- a/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
+++ b/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
@@ -9,11 +9,9 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\PayLaterConfigurator;
 
-use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\Endpoint\GetConfig;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\Endpoint\SaveConfig;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\Factory\ConfigFactory;
-use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -71,14 +69,11 @@ class PayLaterConfiguratorModule implements ServiceModule, ExtendingModule, Exec
 				$is_wc_settings_page = $c->get( 'wcgateway.is-wc-settings-page' );
 				$messaging_locations = $c->get( 'paylater-configurator.messaging-locations' );
 
-				if ( $c->has( 'settings.data.onboarding' ) &&
-					$c->get( 'settings.data.onboarding' )->get_completed() === true ) {
-						self::add_paylater_update_notice(
-							$messaging_locations,
-							$is_wc_settings_page,
-							$current_page_id
-						);
-				}
+				self::add_paylater_update_notice(
+					$messaging_locations,
+					$is_wc_settings_page,
+					$current_page_id
+				);
 
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );


### PR DESCRIPTION
This PR fixes a fatal error in the `PayLaterConfiguratorModule` caused by the unavailability of the `settings.data.onboarding` service in legacy mode.