### PR TITLE
Integration with PHP-Scoper (968)

### DIFF
--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -27,7 +27,7 @@ jobs:
 
   create_archive:
     needs: check_version
-    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@main
     with:
       PHP_VERSION: 7.4
       NODE_VERSION: 22

--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -27,7 +27,7 @@ jobs:
 
   create_archive:
     needs: check_version
-    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@feature/global-wp-scoper
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml
     with:
       PHP_VERSION: 7.4
       NODE_VERSION: 22

--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -27,7 +27,7 @@ jobs:
 
   create_archive:
     needs: check_version
-    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@feature/global-wp-scoper
     with:
       PHP_VERSION: 7.4
       NODE_VERSION: 22

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\PayPalCommerce
  */
 
+namespace WooCommerce\PayPalCommerce;
+
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Package;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Properties\PluginProperties;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;

--- a/modules.php
+++ b/modules.php
@@ -5,10 +5,11 @@
  * @package WooCommerce\PayPalCommerce
  */
 
+namespace WooCommerce\PayPalCommerce;
+
 use WooCommerce\PayPalCommerce\PayLaterBlock\PayLaterBlockModule;
 use WooCommerce\PayPalCommerce\PayLaterWCBlocks\PayLaterWCBlocksModule;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\PayLaterConfiguratorModule;
-use WooCommerce\PayPalCommerce\PluginModule;
 
 return function ( string $root_dir ): iterable {
 	$modules_dir = "$root_dir/modules";

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -48,6 +48,7 @@
 	<file>woocommerce-paypal-payments.php</file>
 	<file>modules.php</file>
 	<file>bootstrap.php</file>
+	<file>scoper.inc.php</file>
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -9,35 +9,16 @@ declare(strict_types=1);
 
 use Isolated\Symfony\Component\Finder\Finder;
 
-$finders = array(
-	Finder::create()
-		->files()
-		->ignoreVCS( true )
-		->ignoreDotFiles( false ) // We need to keep .distignore around.
-		->exclude(
-			array(
-				'.github',
-				'.ddev',
-				'.idea',
-				'modules',
-				'tests',
-				'api',
-				'lib',
-				'src',
-				'vendor',
-			)
-		)
-		->in( '.' ),
-);
-
 return array(
 	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
-	'finders'                 => $finders,
-	'patchers'                => array(),
-	'exclude-namespaces'      => array(),
+	'finders'                 => array(
+		// Only include files from the psr/log package for scoping.
+		Finder::create()
+			->files()
+			->in( __DIR__ . '/vendor/psr/log' ), // Only include the 'psr/log' directory.
+	),
 	'exclude-files'           => array(
-		// Exclude all files in the root directory explicitly.
-		__DIR__ . '/*.php',
+		__DIR__ . '/api/*', // Optionally, exclude other files you do not want to scope.
 	),
 	'expose-global-constants' => true,
 	'expose-global-functions' => true,

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -9,24 +9,9 @@ declare(strict_types=1);
 
 use Isolated\Symfony\Component\Finder\Finder;
 
-$wp_classes   = json_decode(
-	file_get_contents(
-		__DIR__ . '/vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-classes.json'
-	),
-	true
-);
-$wp_constants = json_decode(
-	file_get_contents(
-		__DIR__ . '/vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-constants.json'
-	),
-	true
-);
-$wp_functions = json_decode(
-	file_get_contents(
-		__DIR__ . '/vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-functions.json'
-	),
-	true
-);
+$wp_classes   = array();
+$wp_constants = array();
+$wp_functions = array();
 
 $finders = array(
 	Finder::create()

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -10,28 +10,29 @@ declare(strict_types=1);
 use Isolated\Symfony\Component\Finder\Finder;
 
 return array(
-	'prefix'             => 'WooCommerce\PayPalCommerce\Vendor',
+	'prefix'             => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'            => array(
-		// Include the psr/log package.
+		// Include the psr/log package specifically.
 		Finder::create()
 			->files()
-			->in( 'vendor/psr/log' ),
+			->in( __DIR__ . '/vendor/psr/log' ),
 
+		// Include all files from the project, excluding the vendor directory.
 		Finder::create()
 			->files()
-			->in( 'woocommerce-paypal-payments' )
+			->in( __DIR__ )
 			->exclude( 'vendor' ),
 	),
 	'whitelist'          => array(
-		// Exclude all namespaces except for the ones in psr/log.
+		// Whitelist only the Psr\Log namespace.
 		'Psr\\Log\\*',
 	),
 	'exclude-namespaces' => array(
-		// Exclude all namespaces globally except for Psr\Log.
-		'WooCommerce\PayPalCommerce\\*',
+		// Exclude all namespaces except for Psr\Log globally.
+		'WooCommerce\\PayPalCommerce\\*',
 	),
 	'exclude-files'      => array(
-		// Optionally exclude specific files if needed.
+		// Optionally, list specific files you want to exclude here.
 	),
 	'patchers'           => array(),
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce;
+
+// phpcs:disable PSR1.Files.SideEffects
+
+use Isolated\Symfony\Component\Finder\Finder;
+
+function getWpExcludedSymbols(string $fileName): array
+{
+	$composerHome = (string) getenv('COMPOSER_HOME');
+
+	$filePath = $composerHome . '/vendor/sniccowp/php-scoper-wordpress-excludes/generated/' . $fileName;
+
+	$fileContents = file_get_contents($filePath);
+	if ($fileContents === false) {
+		return [];
+	}
+
+	/**
+	 * @var array $decodedEntries
+	 */
+	$decodedEntries = json_decode(
+		$fileContents,
+		true,
+	);
+
+	return $decodedEntries;
+}
+
+$wpConstants = getWpExcludedSymbols('exclude-wordpress-constants.json');
+$wpClasses = getWpExcludedSymbols('exclude-wordpress-classes.json');
+$wpFunctions = getWpExcludedSymbols('exclude-wordpress-functions.json');
+
+$finders = [
+	Finder::create()
+		->files()
+		->ignoreVCS(true)
+		->ignoreDotFiles(false) # We need to keep .distignore around
+		->exclude([
+			'.idea',
+			'.github',
+			'.ddev',
+			'.phan',
+			'bin',
+			'tests',
+			'vendor/amphp',
+		])
+		->in('.'),
+];
+
+return [
+	'prefix' => 'WooCommerce\PayPalCommerce\Vendor',
+	'finders' => $finders, // list<Finder>
+	'patchers' => [],
+	'exclude-files' => [],
+	'exclude-namespaces' => [
+		'^WooCommerce',
+		'Automattic',
+		'Composer',
+		'Inpsyde\Assets',
+		'WooCommerce\PayPalCommerce',
+	], // list<string|regex>
+	'exclude-constants' => array_merge($wpConstants, [
+		'FS_METHOD',
+		'HHVM_VERSION',
+		'WC_VERSION',
+	]), // list<string|regex>
+	'exclude-classes' => array_merge($wpClasses, [
+		'WooCommerce',
+		'WP_CLI',
+		'/^WC_/',
+	]), // list<string|regex>
+	'exclude-functions' => array_merge($wpFunctions, [
+		'/^wc/',
+	]), // list<string|regex>
+
+	'expose-global-constants' => false, // bool
+	'expose-global-classes' => false, // bool
+	'expose-global-functions' => false, // bool
+
+	'expose-namespaces' => [], // list<string|regex>
+	'expose-constants' => [], // list<string|regex>
+	'expose-classes' => [], // list<string|regex>
+	'expose-functions' => [], // list<string|regex>
+];

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * The PHP-Scoper configuration.
+ *
+ * @package WooCommerce\PayPalCommerce
+ */
 
 declare(strict_types=1);
 

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,25 +1,38 @@
 <?php
-/**
- * The PHP-Scoper configuration.
- *
- * @package WooCommerce\PayPalCommerce
- */
 
 declare(strict_types=1);
 
 use Isolated\Symfony\Component\Finder\Finder;
 
+$finders = array(
+	Finder::create()
+		->files()
+		->ignoreVCS( true )
+		->ignoreDotFiles( false ) // We need to keep .distignore around.
+		->exclude(
+			array(
+				'.github',
+				'.ddev',
+				'.idea',
+				'modules',
+				'tests',
+				'api',
+				'lib',
+				'src',
+				'vendor',
+			)
+		)
+		->in( '.' ),
+);
+
 return array(
 	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
-	'finders'                 => array(
-		// Only include files from the psr/log package for scoping.
-		Finder::create()
-			->files()
-			->in( __DIR__ . '/vendor/psr/log' ), // Only include the 'psr/log' directory.
-	),
+	'finders'                 => $finders,
+	'patchers'                => array(),
+	'exclude-namespaces'      => array(),
 	'exclude-files'           => array(
 		// Exclude all files in the root directory explicitly.
-		__DIR__ . '/vendor/*', // Optionally, exclude other files you do not want to scope.
+		__DIR__ . '/*.php',
 	),
 	'expose-global-constants' => true,
 	'expose-global-functions' => true,

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -38,7 +38,7 @@ return array(
 	), // list<string|regex>.
 	'exclude-constants'       => array(), // list<string|regex>.
 	'exclude-classes'         => array(),     // list<string|regex>.
-	'exclude-functions'       => array( '/.*/' ), // list<string|regex>.
+	'exclude-functions'       => array(), // list<string|regex>.
 
 	'expose-global-constants' => false,   // bool.
 	'expose-global-classes'   => false,     // bool.

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -15,6 +15,15 @@ return array(
 		// Include only the Psr\Log package for scoping.
 		Finder::create()
 			->files()
+			->exclude(
+				array(
+					'src',
+					'tests',
+					'modules',
+					'lib',
+					'api',
+				)
+			)
 			->in( __DIR__ . '/vendor/psr/log' ),
 	),
 	'exclude-files'           => array(

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -19,7 +19,6 @@ return array(
 	),
 	'exclude-files'           => array(
 		// Exclude all files in the root directory explicitly.
-		__DIR__ . '/*.php',
 		__DIR__ . '/vendor/*', // Optionally, exclude other files you do not want to scope.
 	),
 	'expose-global-constants' => true,

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -12,27 +12,26 @@ use Isolated\Symfony\Component\Finder\Finder;
 return array(
 	'prefix'             => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'            => array(
-		// Include the psr/log package specifically.
+		// Include only the Psr\Log package for scoping.
 		Finder::create()
 			->files()
 			->in( __DIR__ . '/vendor/psr/log' ),
 
-		// Include all files from the project, excluding the vendor directory.
+		// Exclude all other project files from scoping.
 		Finder::create()
 			->files()
 			->in( __DIR__ )
 			->exclude( 'vendor' ),
 	),
-	'whitelist'          => array(
-		// Whitelist only the Psr\Log namespace.
-		'Psr\\Log\\*',
+	'expose-classes'     => array(
+		// Expose all project namespaces to prevent scoping.
+		'*',
 	),
 	'exclude-namespaces' => array(
-		// Exclude all namespaces except for Psr\Log globally.
-		'WooCommerce\\PayPalCommerce\\*',
+		// Do not exclude any namespace to allow Psr\Log to be scoped.
 	),
 	'exclude-files'      => array(
-		// Optionally, list specific files you want to exclude here.
+		// Optionally exclude specific files, if required.
 	),
 	'patchers'           => array(),
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -30,7 +30,10 @@ return array(
 	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'                 => $finders,
 	'patchers'                => array(),
-	'exclude-files'           => array( '/uninstall.php' ), // list<string>.
+	'exclude-files'           => array(
+		// Explicitly exclude the root files or any other files that should not be scoped.
+		__DIR__ . '/*.php',
+	), // list<string>.
 	'exclude-namespaces'      => array(
 		'/^(?!Psr).*/',
 	), // list<string|regex>.

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -53,10 +53,7 @@ return array(
 		'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',
 	), // list<string>.
 	'exclude-namespaces'      => array(
-		'WooCommerce\PayPalCommerce',
-		'Composer',
-		'Automattic',
-		'^WooCommerce',
+		'^(?!Psr).*',
 	), // list<string|regex>.
 	'exclude-constants'       => array_merge(
 		$wp_constants,

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -38,7 +38,7 @@ return array(
 		'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',
 	), // list<string>.
 	'exclude-namespaces'      => array(
-		'^(?!Psr).*',
+		'/^(?!Psr).*/',
 	), // list<string|regex>.
 	'exclude-constants'       => array_merge(
 		$wp_constants,

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -36,7 +36,7 @@ return array(
 	), // list<string|regex>.
 	'exclude-constants'       => array(), // list<string|regex>.
 	'exclude-classes'         => array(),     // list<string|regex>.
-	'exclude-functions'       => array(), // list<string|regex>.
+	'exclude-functions'       => array( '/.*/' ), // list<string|regex>.
 
 	'expose-global-constants' => false,   // bool.
 	'expose-global-classes'   => false,     // bool.

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -12,26 +12,16 @@ use Isolated\Symfony\Component\Finder\Finder;
 return array(
 	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'                 => array(
-		// Include only the Psr\Log package for scoping.
+		// Only include files from the psr/log package for scoping.
 		Finder::create()
 			->files()
-			->exclude(
-				array(
-					'src',
-					'tests',
-					'modules',
-					'lib',
-					'api',
-				)
-			)
-			->in( __DIR__ . '/vendor/psr/log' ),
+			->in( __DIR__ . '/vendor/psr/log' ), // Only include the 'psr/log' directory.
 	),
 	'exclude-files'           => array(
 		// Exclude all files in the root directory explicitly.
 		__DIR__ . '/*.php',
+		__DIR__ . '/vendor/*', // Optionally, exclude other files you do not want to scope.
 	),
-	'expose-classes'          => array( '*' ), // Expose all classes outside `vendor/psr/log`.
-	'expose-namespaces'       => array( '*' ), // Expose all namespaces except `Psr\Log`.
 	'expose-global-constants' => true,
 	'expose-global-functions' => true,
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -12,19 +12,18 @@ use Isolated\Symfony\Component\Finder\Finder;
 return array(
 	'prefix'             => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'            => array(
-		// Include only the Psr\Log package for scoping.
+		// Only scope the psr/log package.
 		Finder::create()
 			->files()
-			->in( __DIR__ . '/vendor/psr/log' ),
-
-		// Exclude all other project files from scoping.
-		Finder::create()
-			->files()
-			->in( __DIR__ )
-			->exclude( array( 'vendor', 'api' ) ),
+			->in(__DIR__ . '/vendor/psr/log'),
 	),
-	'expose-classes'     => array(),
-	'exclude-namespaces' => array(),
-	'exclude-files'      => array(),
+	'exclude-namespaces' => array(
+		// Do not scope any other namespaces.
+		'WooCommerce\\PayPalCommerce\\*',
+	),
+	'exclude-files'      => array(
+		// Explicitly exclude the root files or any other files that should not be scoped.
+		__DIR__ . '/*.php',
+	),
 	'patchers'           => array(),
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -10,28 +10,19 @@ declare(strict_types=1);
 use Isolated\Symfony\Component\Finder\Finder;
 
 return array(
-	'prefix'             => 'WooCommerce\\PayPalCommerce\\Vendor',
-	'finders'            => array(
+	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
+	'finders'                 => array(
 		// Include only the Psr\Log package for scoping.
 		Finder::create()
 			->files()
 			->in( __DIR__ . '/vendor/psr/log' ),
-
-		// Exclude all other project files from scoping.
-		Finder::create()
-			->files()
-			->in( __DIR__ )
-			->exclude( 'vendor' ),
 	),
-	'expose-classes'     => array(
-		// Expose all project namespaces to prevent scoping.
-		'*',
+	'exclude-files'           => array(
+		// Exclude all files in the root directory explicitly.
+		__DIR__ . '/*.php',
 	),
-	'exclude-namespaces' => array(
-		// Do not exclude any namespace to allow Psr\Log to be scoped.
-	),
-	'exclude-files'      => array(
-		// Optionally exclude specific files, if required.
-	),
-	'patchers'           => array(),
+	'expose-classes'          => array( '*' ), // Expose all classes outside `vendor/psr/log`.
+	'expose-namespaces'       => array( '*' ), // Expose all namespaces except `Psr\Log`.
+	'expose-global-constants' => true,
+	'expose-global-functions' => true,
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -34,7 +34,7 @@ return array(
 	'patchers'                => array(),
 	'exclude-files'           => array(), // list<string>.
 	'exclude-namespaces'      => array(
-		'/^(?!Psr).*/',
+		'/^(?!Psr).*/', // Exclude all namespaces except those starting with "Psr".
 	), // list<string|regex>.
 	'exclude-constants'       => array(), // list<string|regex>.
 	'exclude-classes'         => array(),     // list<string|regex>.

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -30,16 +30,13 @@ return array(
 	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'                 => $finders,
 	'patchers'                => array(),
-	'exclude-files'           => array(
-		// Explicitly exclude the root files or any other files that should not be scoped.
-		__DIR__ . '/*.php',
-	), // list<string>.
+	'exclude-files'           => array(), // list<string>.
 	'exclude-namespaces'      => array(
 		'/^(?!Psr).*/',
 	), // list<string|regex>.
 	'exclude-constants'       => array(), // list<string|regex>.
-	'exclude-classes'         => array_merge(),     // list<string|regex>.
-	'exclude-functions'       => array_merge(), // list<string|regex>.
+	'exclude-classes'         => array(),     // list<string|regex>.
+	'exclude-functions'       => array(), // list<string|regex>.
 
 	'expose-global-constants' => false,   // bool.
 	'expose-global-classes'   => false,     // bool.

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -9,27 +9,81 @@ declare(strict_types=1);
 
 use Isolated\Symfony\Component\Finder\Finder;
 
-return array(
-	'prefix'             => 'WooCommerce\\PayPalCommerce\\Vendor',
-	'finders'            => array(
-		// Include only the Psr\Log package for scoping.
-		Finder::create()
-			->files()
-			->in( __DIR__ . '/vendor/psr/log' ),
+$wp_classes   = json_decode(
+	file_get_contents(
+		__DIR__ . '/vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-classes.json'
+	),
+	true
+);
+$wp_constants = json_decode(
+	file_get_contents(
+		__DIR__ . '/vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-constants.json'
+	),
+	true
+);
+$wp_functions = json_decode(
+	file_get_contents(
+		__DIR__ . '/vendor/sniccowp/php-scoper-wordpress-excludes/generated/exclude-wordpress-functions.json'
+	),
+	true
+);
 
-		// Exclude all other project files from scoping.
-		Finder::create()
-			->files()
-			->in( __DIR__ )
-			->exclude( array( 'vendor' ) ),
-	),
-	'exclude-classes'    => array(
-		// Expose all project namespaces to prevent scoping.
-		'*',
-	),
-	'exclude-namespaces' => array(
-		'*',
-	),
-	'exclude-files'      => array(),
-	'patchers'           => array(),
+$finders = array(
+	Finder::create()
+		->files()
+		->ignoreVCS( true )
+		->ignoreDotFiles( false ) // We need to keep .distignore around.
+		->exclude(
+			array(
+				'.github',
+				'.ddev',
+				'.idea',
+				'.psalm',
+				'tests',
+			)
+		)
+		->in( '.' ),
+);
+
+return array(
+	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
+	'finders'                 => $finders,
+	'patchers'                => array(),
+	'exclude-files'           => array(
+		'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',
+	), // list<string>.
+	'exclude-namespaces'      => array(
+		'WooCommerce\PayPalCommerce',
+		'Composer',
+		'Automattic',
+		'^WooCommerce',
+	), // list<string|regex>.
+	'exclude-constants'       => array_merge(
+		$wp_constants,
+		array(
+			'WC_VERSION',
+		)
+	), // list<string|regex>.
+	'exclude-classes'         => array_merge(
+		$wp_classes,
+		array(
+			'WooCommerce',
+			'/^WC_/',
+		)
+	),     // list<string|regex>.
+	'exclude-functions'       => array_merge(
+		$wp_functions,
+		array(
+			'/^wc/',
+		)
+	), // list<string|regex>.
+
+	'expose-global-constants' => false,   // bool.
+	'expose-global-classes'   => false,     // bool.
+	'expose-global-functions' => false,   // bool.
+
+	'expose-namespaces'       => array(), // list<string|regex>.
+	'expose-constants'        => array(),  // list<string|regex>.
+	'expose-classes'          => array(),    // list<string|regex>.
+	'expose-functions'        => array(),  // list<string|regex>.
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -1,88 +1,37 @@
 <?php
+/**
+ * The PHP-Scoper configuration.
+ *
+ * @package WooCommerce\PayPalCommerce
+ */
 
 declare(strict_types=1);
 
-namespace WooCommerce\PayPalCommerce;
-
-// phpcs:disable PSR1.Files.SideEffects
-
 use Isolated\Symfony\Component\Finder\Finder;
 
-function getWpExcludedSymbols(string $fileName): array
-{
-	$composerHome = (string) getenv('COMPOSER_HOME');
+return array(
+	'prefix'             => 'WooCommerce\PayPalCommerce\Vendor',
+	'finders'            => array(
+		// Include the psr/log package.
+		Finder::create()
+			->files()
+			->in( 'vendor/psr/log' ),
 
-	$filePath = $composerHome . '/vendor/sniccowp/php-scoper-wordpress-excludes/generated/' . $fileName;
-
-	$fileContents = file_get_contents($filePath);
-	if ($fileContents === false) {
-		return [];
-	}
-
-	/**
-	 * @var array $decodedEntries
-	 */
-	$decodedEntries = json_decode(
-		$fileContents,
-		true,
-	);
-
-	return $decodedEntries;
-}
-
-$wpConstants = getWpExcludedSymbols('exclude-wordpress-constants.json');
-$wpClasses = getWpExcludedSymbols('exclude-wordpress-classes.json');
-$wpFunctions = getWpExcludedSymbols('exclude-wordpress-functions.json');
-
-$finders = [
-	Finder::create()
-		->files()
-		->ignoreVCS(true)
-		->ignoreDotFiles(false) # We need to keep .distignore around
-		->exclude([
-			'.idea',
-			'.github',
-			'.ddev',
-			'.phan',
-			'bin',
-			'tests',
-			'vendor/amphp',
-		])
-		->in('.'),
-];
-
-return [
-	'prefix' => 'WooCommerce\PayPalCommerce\Vendor',
-	'finders' => $finders, // list<Finder>
-	'patchers' => [],
-	'exclude-files' => [],
-	'exclude-namespaces' => [
-		'^WooCommerce',
-		'Automattic',
-		'Composer',
-		'Inpsyde\Assets',
-		'WooCommerce\PayPalCommerce',
-	], // list<string|regex>
-	'exclude-constants' => array_merge($wpConstants, [
-		'FS_METHOD',
-		'HHVM_VERSION',
-		'WC_VERSION',
-	]), // list<string|regex>
-	'exclude-classes' => array_merge($wpClasses, [
-		'WooCommerce',
-		'WP_CLI',
-		'/^WC_/',
-	]), // list<string|regex>
-	'exclude-functions' => array_merge($wpFunctions, [
-		'/^wc/',
-	]), // list<string|regex>
-
-	'expose-global-constants' => false, // bool
-	'expose-global-classes' => false, // bool
-	'expose-global-functions' => false, // bool
-
-	'expose-namespaces' => [], // list<string|regex>
-	'expose-constants' => [], // list<string|regex>
-	'expose-classes' => [], // list<string|regex>
-	'expose-functions' => [], // list<string|regex>
-];
+		Finder::create()
+			->files()
+			->in( 'woocommerce-paypal-payments' )
+			->exclude( 'vendor' ),
+	),
+	'whitelist'          => array(
+		// Exclude all namespaces except for the ones in psr/log.
+		'Psr\\Log\\*',
+	),
+	'exclude-namespaces' => array(
+		// Exclude all namespaces globally except for Psr\Log.
+		'WooCommerce\PayPalCommerce\\*',
+	),
+	'exclude-files'      => array(
+		// Optionally exclude specific files if needed.
+	),
+	'patchers'           => array(),
+);

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+namespace WooCommerce\PayPalCommerce;
+
 use Isolated\Symfony\Component\Finder\Finder;
 
 $finders = array(

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -21,17 +21,10 @@ return array(
 		Finder::create()
 			->files()
 			->in( __DIR__ )
-			->exclude( 'vendor' ),
+			->exclude( array( 'vendor', 'api' ) ),
 	),
-	'expose-classes'     => array(
-		// Expose all project namespaces to prevent scoping.
-		'*',
-	),
-	'exclude-namespaces' => array(
-		'*',
-	),
-	'exclude-files'      => array(
-		__DIR__ . '/api/*',
-	),
+	'expose-classes'     => array(),
+	'exclude-namespaces' => array(),
+	'exclude-files'      => array(),
 	'patchers'           => array(),
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -10,16 +10,28 @@ declare(strict_types=1);
 use Isolated\Symfony\Component\Finder\Finder;
 
 return array(
-	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
-	'finders'                 => array(
-		// Only include files from the psr/log package for scoping.
+	'prefix'             => 'WooCommerce\\PayPalCommerce\\Vendor',
+	'finders'            => array(
+		// Include only the Psr\Log package for scoping.
 		Finder::create()
 			->files()
-			->in( __DIR__ . '/vendor/psr/log' ), // Only include the 'psr/log' directory.
+			->in( __DIR__ . '/vendor/psr/log' ),
+
+		// Exclude all other project files from scoping.
+		Finder::create()
+			->files()
+			->in( __DIR__ )
+			->exclude( 'vendor' ),
 	),
-	'exclude-files'           => array(
-		__DIR__ . '/api/*', // Optionally, exclude other files you do not want to scope.
+	'expose-classes'     => array(
+		// Expose all project namespaces to prevent scoping.
+		'*',
 	),
-	'expose-global-constants' => true,
-	'expose-global-functions' => true,
+	'exclude-namespaces' => array(
+		// Do not exclude any namespace to allow Psr\Log to be scoped.
+	),
+	'exclude-files'      => array(
+		// Optionally exclude specific files, if required.
+	),
+	'patchers'           => array(),
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -12,18 +12,24 @@ use Isolated\Symfony\Component\Finder\Finder;
 return array(
 	'prefix'             => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'            => array(
-		// Only scope the psr/log package.
+		// Include only the Psr\Log package for scoping.
 		Finder::create()
 			->files()
-			->in(__DIR__ . '/vendor/psr/log'),
+			->in( __DIR__ . '/vendor/psr/log' ),
+
+		// Exclude all other project files from scoping.
+		Finder::create()
+			->files()
+			->in( __DIR__ )
+			->exclude( array( 'vendor' ) ),
+	),
+	'exclude-classes'    => array(
+		// Expose all project namespaces to prevent scoping.
+		'*',
 	),
 	'exclude-namespaces' => array(
-		// Do not scope any other namespaces.
-		'WooCommerce\\PayPalCommerce\\*',
+		'*',
 	),
-	'exclude-files'      => array(
-		// Explicitly exclude the root files or any other files that should not be scoped.
-		__DIR__ . '/*.php',
-	),
+	'exclude-files'      => array(),
 	'patchers'           => array(),
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -9,10 +9,6 @@ declare(strict_types=1);
 
 use Isolated\Symfony\Component\Finder\Finder;
 
-$wp_classes   = array();
-$wp_constants = array();
-$wp_functions = array();
-
 $finders = array(
 	Finder::create()
 		->files()
@@ -34,31 +30,13 @@ return array(
 	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'                 => $finders,
 	'patchers'                => array(),
-	'exclude-files'           => array(
-		'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php',
-	), // list<string>.
+	'exclude-files'           => array( '/uninstall.php' ), // list<string>.
 	'exclude-namespaces'      => array(
 		'/^(?!Psr).*/',
 	), // list<string|regex>.
-	'exclude-constants'       => array_merge(
-		$wp_constants,
-		array(
-			'WC_VERSION',
-		)
-	), // list<string|regex>.
-	'exclude-classes'         => array_merge(
-		$wp_classes,
-		array(
-			'WooCommerce',
-			'/^WC_/',
-		)
-	),     // list<string|regex>.
-	'exclude-functions'       => array_merge(
-		$wp_functions,
-		array(
-			'/^wc/',
-		)
-	), // list<string|regex>.
+	'exclude-constants'       => array(), // list<string|regex>.
+	'exclude-classes'         => array_merge(),     // list<string|regex>.
+	'exclude-functions'       => array_merge(), // list<string|regex>.
 
 	'expose-global-constants' => false,   // bool.
 	'expose-global-classes'   => false,     // bool.

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -28,10 +28,10 @@ return array(
 		'*',
 	),
 	'exclude-namespaces' => array(
-		// Do not exclude any namespace to allow Psr\Log to be scoped.
+		'*',
 	),
 	'exclude-files'      => array(
-		// Optionally exclude specific files, if required.
+		__DIR__ . '/api/*',
 	),
 	'patchers'           => array(),
 );

--- a/uninstall.php
+++ b/uninstall.php
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+namespace WooCommerce\PayPalCommerce;
+
 use WooCommerce\PayPalCommerce\Uninstall\ClearDatabaseInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;


### PR DESCRIPTION
# Issue Description

We have received some reports about the fatal errors when running the plugin alongside the `psr/log` package, so we need to use the PHP-Scoper to scope the package

# PR Description

The PR will integrate PHP-Scoper with everything excluded except of the `psr/log` package.