### PR TITLE
Remove WooPayments menu item on PayPal Payments settings pages (4049)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/screens/_fullscreen.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_fullscreen.scss
@@ -11,6 +11,7 @@ body:has(.ppcp-r-container--onboarding) {
 	.nav-tab-wrapper.woo-nav-tab-wrapper,
 	.woocommerce-layout__header,
 	.wrap.woocommerce form > h2,
+	#mainform .subsubsub,
 	#screen-meta-links {
 		display: none !important;
 		visibility: hidden;


### PR DESCRIPTION
### Description

> Alternative to #2956 

Hides submenus in the Payments tab, when the new PayPal Settings UI is loaded.

Some plugins, such as [WooPayments](https://es.wordpress.org/plugins/woocommerce-payments/), may add extra sections to the checkout tab. Those extra sections are output as submenu-links at the beginning of the Payments tab.

This solution uses CSS to hide the submenu item