### PR TITLE
Add methods prop to enable button (4105)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
@@ -36,7 +36,8 @@ const ALL_STEPS = [
 		id: 'methods',
 		title: __( 'Choose checkout options', 'woocommerce-paypal-payments' ),
 		StepComponent: StepPaymentMethods,
-		canProceed: () => true,
+		canProceed: ( { methods } ) =>
+			methods.areOptionalPaymentMethodsEnabled !== null,
 	},
 	{
 		id: 'complete',

--- a/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
@@ -136,10 +136,12 @@ export const useSteps = () => {
 export const useNavigationState = () => {
 	const products = useProducts();
 	const business = useBusiness();
+	const methods = useOptionalPaymentMethods();
 
 	return {
 		products,
 		business,
+		methods,
 	};
 };
 


### PR DESCRIPTION
This PR solves the problem where the button to continue was enabled despite no selection was made in the methods step during onboarding. 
The fix adds a methods.areOptionalPaymentMethodsEnabled prop to the steps to check if canProceed, and so enable or disable the button. 