### PR TITLE
Toggle the checkboxes when clicking anywhere inside the box

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/SelectBox.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/SelectBox.js
@@ -12,8 +12,31 @@ const SelectBox = ( props ) => {
 		boxClassName += ' selected';
 	}
 
+	const handleClick = () => {
+		if ( props.type === 'checkbox' ) {
+			let newValue;
+
+			if ( Array.isArray( props.currentValue ) ) {
+				if ( props.currentValue.includes( props.value ) ) {
+					newValue = props.currentValue.filter(
+						( optionValue ) => optionValue !== props.value
+					);
+				} else {
+					newValue = [ ...props.currentValue, props.value ];
+				}
+			} else {
+				newValue = ! props.currentValue;
+			}
+
+			props.changeCallback( newValue );
+		}
+	};
+
 	return (
-		<div className={ boxClassName }>
+		<div
+			className={ boxClassName }
+			onClick={ props.type === 'checkbox' ? handleClick : undefined }
+		>
 			{ props.type === 'radio' && (
 				<PayPalRdb
 					{ ...{
@@ -22,11 +45,7 @@ const SelectBox = ( props ) => {
 					} }
 				/>
 			) }
-			{ props.type === 'checkbox' && (
-				<PayPalCheckbox
-					{ ...props }
-				/>
-			) }
+			{ props.type === 'checkbox' && <PayPalCheckbox { ...props } /> }
 			<div className="ppcp-r-select-box__content">
 				<div className="ppcp-r-select-box__content-inner">
 					<span className="ppcp-r-select-box__title">


### PR DESCRIPTION
## Issue Description

Currently, to check a checkbox you need to explicitly click the checkbox.
Clicking anywhere inside the box should be sufficient to trigger the checkbox state - same as the UX for radio buttons

![5eed86c4-983b-4902-b093-3ef16f0f5df4](https://github.com/user-attachments/assets/13618951-b0ca-40e0-9453-4b82f80cf73a)

## PR Description

The PR adds functionality to toggle the checkboxes when clicking anywhere inside the box
