### PR TITLE
Align to the left and under the arrow

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_settings-wrapper.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_settings-wrapper.scss
@@ -1,7 +1,6 @@
 .ppcp-r {
 	&-container {
 		max-width: var(--max-container-width, none);
-		margin-left: auto;
 		margin-right: auto;
 	}
 

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_tab-navigation.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_tab-navigation.scss
@@ -3,8 +3,8 @@
 	--wp-admin-border-width-focus: 3px;
 
 	max-width: var(--max-container-width);
-	margin: 0 auto;
 	transition: max-width 0.2s;
+	padding:0 35px;
 
 	.components-tab-panel__tabs {
 		box-shadow: 0 -1px 0 0 $color-gray-400 inset;


### PR DESCRIPTION
After the changes the page should look like this:
<img width="1292" alt="Captura de pantalla 2025-01-27 a las 11 54 08" src="https://github.com/user-attachments/assets/55de9436-7346-4447-9527-84f76788e038" />
