### PR TITLE
APM - Trustly - Can not pay with Trustly - Error message "A required field / parameter is missing." is showing on frontend (4118)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/TrustlyGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/TrustlyGateway.php
@@ -141,6 +141,7 @@ class TrustlyGateway extends WC_Payment_Gateway {
 				'trustly' => array(
 					'country_code' => $wc_order->get_billing_country(),
 					'name'         => $wc_order->get_billing_first_name() . ' ' . $wc_order->get_billing_last_name(),
+					'email'        => $wc_order->get_billing_email(),
 				),
 			),
 			'processing_instruction' => 'ORDER_COMPLETE_ON_PAYMENT_APPROVAL',


### PR DESCRIPTION
Fix pay with trustly