### PR TITLE
Remove SEPA icons from onboarding (4017)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/AcdcOptionalPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/AcdcOptionalPaymentMethods.js
@@ -145,7 +145,7 @@ const AcdcOptionalPaymentMethods = ( {
 						'woocommerce-paypal-payments'
 					) }
 					imageBadge={ [
-						'icon-button-sepa.svg',
+						// 'icon-button-sepa.svg',
 						'icon-button-ideal.svg',
 						'icon-button-blik.svg',
 						'icon-button-bancontact.svg',
@@ -211,7 +211,7 @@ const AcdcOptionalPaymentMethods = ( {
 					'woocommerce-paypal-payments'
 				) }
 				imageBadge={ [
-					'icon-button-sepa.svg',
+					// 'icon-button-sepa.svg',
 					'icon-button-ideal.svg',
 					'icon-button-blik.svg',
 					'icon-button-bancontact.svg',


### PR DESCRIPTION
### Description

Removes two left-over SEPA icons that should not be displayed yet