### PR TITLE
Rename "apply" labels in features tab to "sign up"

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Overview/features-config.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Overview/features-config.js
@@ -27,7 +27,7 @@ export const getFeatures = ( setActiveModal ) => {
 				},
 				{
 					type: 'secondary',
-					text: __( 'Apply', 'woocommerce-paypal-payments' ),
+					text: __( 'Sign up', 'woocommerce-paypal-payments' ),
 					urls: {
 						sandbox:
 							'https://www.sandbox.paypal.com/bizsignup/entry?product=ADVANCED_VAULTING',
@@ -74,7 +74,7 @@ export const getFeatures = ( setActiveModal ) => {
 				},
 				{
 					type: 'secondary',
-					text: __( 'Apply', 'woocommerce-paypal-payments' ),
+					text: __( 'Sign up', 'woocommerce-paypal-payments' ),
 					urls: {
 						sandbox:
 							'https://www.sandbox.paypal.com/bizsignup/entry?product=ppcp',
@@ -116,7 +116,7 @@ export const getFeatures = ( setActiveModal ) => {
 				},
 				{
 					type: 'secondary',
-					text: __( 'Apply', 'woocommerce-paypal-payments' ),
+					text: __( 'Sign up', 'woocommerce-paypal-payments' ),
 					url: 'https://developer.paypal.com/docs/checkout/apm/',
 					showWhen: 'disabled',
 					class: 'small-button',
@@ -153,7 +153,7 @@ export const getFeatures = ( setActiveModal ) => {
 				},
 				{
 					type: 'secondary',
-					text: __( 'Apply', 'woocommerce-paypal-payments' ),
+					text: __( 'Sign up', 'woocommerce-paypal-payments' ),
 					urls: {
 						sandbox:
 							'https://www.sandbox.paypal.com/bizsignup/add-product?product=payment_methods&capabilities=GOOGLE_PAY',
@@ -214,7 +214,7 @@ export const getFeatures = ( setActiveModal ) => {
 				},
 				{
 					type: 'secondary',
-					text: __( 'Apply', 'woocommerce-paypal-payments' ),
+					text: __( 'Sign up', 'woocommerce-paypal-payments' ),
 					urls: {
 						sandbox:
 							'https://www.sandbox.paypal.com/bizsignup/add-product?product=payment_methods&capabilities=APPLE_PAY',
@@ -258,7 +258,7 @@ export const getFeatures = ( setActiveModal ) => {
 				},
 				{
 					type: 'secondary',
-					text: __( 'Apply', 'woocommerce-paypal-payments' ),
+					text: __( 'Sign up', 'woocommerce-paypal-payments' ),
 					urls: {
 						sandbox: '#',
 						live: '#',


### PR DESCRIPTION
Merging this PR will change the secondary labels in the features part of the Overview tab from "Apply" to "Sign up"

<img width="796" alt="Captura de pantalla 2025-02-04 a las 11 32 09" src="https://github.com/user-attachments/assets/3a24bd67-fcc2-4171-bbb7-137dc3421d2b" />
