### PR TITLE
Sync `activePanel` with the URL on Initial Load (4149)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/App.js
+++ b/modules/ppcp-settings/resources/js/Components/App.js
@@ -6,6 +6,7 @@ import SpinnerOverlay from './ReusableComponents/SpinnerOverlay';
 import SendOnlyMessage from './Screens/SendOnlyMessage';
 import OnboardingScreen from './Screens/Onboarding';
 import SettingsScreen from './Screens/Settings';
+import { getQuery } from '../utils/navigation';
 
 const SettingsApp = () => {
 	const { isReady: onboardingIsReady, completed: onboardingCompleted } =
@@ -31,7 +32,9 @@ const SettingsApp = () => {
 		loading: ! onboardingIsReady,
 	} );
 
-	const [ activePanel, setActivePanel ] = useState( 'overview' );
+	const defaultPanel = 'overview';
+	const [ activePanel, setActivePanel ] = useState( defaultPanel );
+	useEffect( () => setActivePanel( getQuery().panel || defaultPanel ), [] );
 
 	const Content = useMemo( () => {
 		if ( ! onboardingIsReady || ! merchantIsReady ) {

--- a/modules/ppcp-settings/resources/js/Components/App.js
+++ b/modules/ppcp-settings/resources/js/Components/App.js
@@ -32,9 +32,9 @@ const SettingsApp = () => {
 		loading: ! onboardingIsReady,
 	} );
 
-	const defaultPanel = 'overview';
-	const [ activePanel, setActivePanel ] = useState( defaultPanel );
-	useEffect( () => setActivePanel( getQuery().panel || defaultPanel ), [] );
+	const [ activePanel, setActivePanel ] = useState(
+		getQuery().panel || 'overview'
+	);
 
 	const Content = useMemo( () => {
 		if ( ! onboardingIsReady || ! merchantIsReady ) {


### PR DESCRIPTION
## Issue Description

Currently when reloading the settings screen, the “Overview” tab is automatically opened while the previously open tab should stay visible.

## PR Description

The issue is that while updating the URL with the active panel (`updateQueryString`), we're not initializing the `activePanel` state from the URL when the app loads. Since `activePanel` is initialized to 'overview' in `App.js`, it doesn't check the URL on refresh.

The PR will solve the problem by syncing the `activePanel` with the URL on reload