### PR TITLE
Hide duplicate "Pay Later" for UK merchants (4169)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/hooks/usePaymentConfig.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/hooks/usePaymentConfig.js
@@ -113,7 +113,6 @@ const countrySpecificConfigs = {
 	GB: {
 		includedMethods: [
 			{ name: 'PayWithPayPal', Component: PayWithPayPal },
-			{ name: 'PayLater', Component: PayLater },
 			{ name: 'PayInThree', Component: PayInThree },
 		],
 	},


### PR DESCRIPTION
### Description

Hides the duplicate "Pay Later" item on the first screen