### PR TITLE
Add a "Disconnect" button (4139)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ConnectionStatus.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ConnectionStatus.js
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import SettingsCard from '../../../../ReusableComponents/SettingsCard';
 import { CommonHooks } from '../../../../../data';
 import ConnectionStatusBadge from './Parts/ConnectionStatusBadge';
+import DisconnectButton from './Parts/DisconnectButton';
 import SettingsBlock from '../../../../ReusableComponents/SettingsBlock';
 import { ControlStaticValue } from '../../../../ReusableComponents/Controls';
 
@@ -13,10 +14,7 @@ const ConnectionStatus = () => {
 		<SettingsCard
 			className="ppcp-connection-details ppcp--value-list"
 			title={ __( 'Connection status', 'woocommerce-paypal-payments' ) }
-			description={ __(
-				'Your PayPal account connection details',
-				'woocommerce-paypal-payments'
-			) }
+			description={ <ConnectionDescription /> }
 		>
 			<SettingsBlock>
 				<ControlStaticValue
@@ -48,3 +46,15 @@ const ConnectionStatus = () => {
 };
 
 export default ConnectionStatus;
+
+const ConnectionDescription = () => {
+	return (
+		<>
+			{ __(
+				'Your PayPal account connection details.',
+				'woocommerce-paypal-payments'
+			) }
+			<DisconnectButton />
+		</>
+	);
+};

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/DisconnectButton.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Parts/DisconnectButton.js
@@ -1,0 +1,73 @@
+import { __ } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+import { useCallback, useState } from '@wordpress/element';
+
+import { CommonHooks } from '../../../../../../data';
+import { HStack } from '../../../../../ReusableComponents/Stack';
+
+const DisconnectButton = () => {
+	const [ isOpen, setIsOpen ] = useState( false );
+	const { disconnectMerchant } = CommonHooks.useDisconnectMerchant();
+
+	const handleOpen = useCallback( () => {
+		setIsOpen( true );
+	}, [] );
+
+	const handleCancel = useCallback( () => {
+		setIsOpen( false );
+	}, [] );
+
+	const handleConfirm = useCallback( async () => {
+		await disconnectMerchant();
+		window.location.reload();
+	}, [ disconnectMerchant ] );
+
+	const confirmationTitle = __(
+		'Disconnect from PayPal?',
+		'woocommerce-paypal-payments'
+	);
+
+	return (
+		<>
+			<Button
+				variant="tertiary"
+				isDestructive={ true }
+				onClick={ handleOpen }
+			>
+				{ __( 'Disconnect', 'woocommerce-paypal-payments' ) }
+			</Button>
+
+			{ isOpen && (
+				<Modal
+					size="small"
+					title={ confirmationTitle }
+					onRequestClose={ handleCancel }
+				>
+					<p>
+						{ __(
+							'Disconnecting your account will restart the connection wizard. Are you sure you want to disconnect from your PayPal account?',
+							'woocommerce-paypal-payments'
+						) }
+					</p>
+					<HStack>
+						<Button variant="tertiary" onClick={ handleCancel }>
+							{ __( 'Cancel', 'woocommerce-paypal-payments' ) }
+						</Button>
+						<Button
+							variant="primary"
+							isDestructive={ true }
+							onClick={ handleConfirm }
+						>
+							{ __(
+								'Disconnect',
+								'woocommerce-paypal-payments'
+							) }
+						</Button>
+					</HStack>
+				</Modal>
+			) }
+		</>
+	);
+};
+
+export default DisconnectButton;

--- a/modules/ppcp-settings/resources/js/data/common/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/common/hooks.js
@@ -23,6 +23,7 @@ const useHooks = () => {
 		authenticateWithOAuth,
 		startWebhookSimulation,
 		checkWebhookSimulationState,
+		disconnectMerchant,
 	} = useDispatch( STORE_NAME );
 
 	// Transient accessors.
@@ -78,6 +79,7 @@ const useHooks = () => {
 		productionOnboardingUrl,
 		authenticateWithCredentials,
 		authenticateWithOAuth,
+		disconnectMerchant,
 		merchant,
 		wooSettings,
 		features,
@@ -113,6 +115,11 @@ export const useAuthentication = () => {
 		authenticateWithCredentials,
 		authenticateWithOAuth,
 	};
+};
+
+export const useDisconnectMerchant = () => {
+	const { disconnectMerchant } = useHooks();
+	return { disconnectMerchant };
 };
 
 export const useWooSettings = () => {

--- a/modules/ppcp-settings/resources/js/data/common/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/common/hooks.js
@@ -23,7 +23,6 @@ const useHooks = () => {
 		authenticateWithOAuth,
 		startWebhookSimulation,
 		checkWebhookSimulationState,
-		disconnectMerchant,
 	} = useDispatch( STORE_NAME );
 
 	// Transient accessors.
@@ -79,7 +78,6 @@ const useHooks = () => {
 		productionOnboardingUrl,
 		authenticateWithCredentials,
 		authenticateWithOAuth,
-		disconnectMerchant,
 		merchant,
 		wooSettings,
 		features,
@@ -118,7 +116,7 @@ export const useAuthentication = () => {
 };
 
 export const useDisconnectMerchant = () => {
-	const { disconnectMerchant } = useHooks();
+	const { disconnectMerchant } = useDispatch( STORE_NAME );
 	return { disconnectMerchant };
 };
 


### PR DESCRIPTION
### Description

Introduces a new "Disconnect" button in the Settings tab that allows merchants to disconnect the WooCommerce store from PayPal again.

Disconnecting will restart the onboarding wizard

![CleanShot 2025-02-04 at 18 59 57](https://github.com/user-attachments/assets/5e6c8f45-cf3b-4546-ab1d-bf6635c1731c)
