### PR TITLE
Limit length of Soft Descriptor (4165)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Controls/SoftdescriptorInput.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Controls/SoftdescriptorInput.js
@@ -1,0 +1,19 @@
+import ControlTextInput from './ControlTextInput';
+
+const SoftDescriptorInput = ( { value, onChange, placeholder } ) => {
+	const handleChange = ( newValue ) => {
+		if ( newValue.length <= 22 ) {
+			onChange( newValue );
+		}
+	};
+
+	return (
+		<ControlTextInput
+			value={ value }
+			onChange={ handleChange }
+			placeholder={ placeholder }
+		/>
+	);
+};
+
+export default SoftDescriptorInput;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
@@ -9,6 +9,7 @@ import {
 import SettingsBlock from '../../../../../ReusableComponents/SettingsBlock';
 import Accordion from '../../../../../ReusableComponents/AccordionSection';
 import { SettingsHooks } from '../../../../../../data';
+import SoftDescriptorInput from '../../../../../ReusableComponents/Controls/SoftdescriptorInput';
 
 const PaypalSettings = () => {
 	const {
@@ -91,7 +92,7 @@ const PaypalSettings = () => {
 					'woocommerce-paypal-payments'
 				) }
 			>
-				<ControlTextInput
+				<SoftDescriptorInput
 					value={ softDescriptor }
 					onChange={ setSoftDescriptor }
 					placeholder={ __(

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -139,7 +139,8 @@ class SettingsModel extends AbstractDataModel {
 	 * @param string $descriptor The soft descriptor to set.
 	 */
 	public function set_soft_descriptor( string $descriptor ) : void {
-		$this->data['soft_descriptor'] = $this->sanitizer->sanitize_text( $descriptor );
+		$trimmed_descriptor = substr( $descriptor, 0, 22 );
+		$this->data['soft_descriptor'] = $this->sanitizer->sanitize_text( $trimmed_descriptor );
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -140,7 +140,7 @@ class SettingsModel extends AbstractDataModel {
 	 */
 	public function set_soft_descriptor( string $descriptor ) : void {
 		$descriptor = $this->sanitizer->sanitize_text( $descriptor );
-		$descriptor = preg_replace( '/[^a-zA-Z0-9\-*. ]/', '', $descriptor );
+		$descriptor = preg_replace( '/[^a-zA-Z0-9\-*. ]/', '', $descriptor ) ?? '';
 		$this->data['soft_descriptor'] = substr( $descriptor, 0, 22 );
 	}
 

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -139,8 +139,9 @@ class SettingsModel extends AbstractDataModel {
 	 * @param string $descriptor The soft descriptor to set.
 	 */
 	public function set_soft_descriptor( string $descriptor ) : void {
-		$trimmed_descriptor = substr( $descriptor, 0, 22 );
-		$this->data['soft_descriptor'] = $this->sanitizer->sanitize_text( $trimmed_descriptor );
+		$descriptor = $this->sanitizer->sanitize_text( $descriptor );
+		$descriptor = preg_replace( '/[^a-zA-Z0-9\-*. ]/', '', $descriptor );
+		$this->data['soft_descriptor'] = substr( $descriptor, 0, 22 );
 	}
 
 	/**


### PR DESCRIPTION
This PR limits the length of the `soft descriptor` option in ExpertSettings->PayPal Settings to 22 characters, both in frontend and backend