### PR TITLE
Brand name: Default to WP site title (4164)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-
+import { useSelect } from '@wordpress/data';
 import {
 	ControlRadioGroup,
 	ControlToggleButton,
@@ -25,7 +25,8 @@ const PaypalSettings = () => {
 		buttonLanguage,
 		setButtonLanguage,
 	} = SettingsHooks.useSettings();
-
+	const siteData = useSelect( ( select ) => select( 'core' ).getSite(), [] );
+	const siteTitle = siteData?.title;
 	return (
 		<Accordion
 			className="ppcp--paypal-settings"
@@ -77,10 +78,10 @@ const PaypalSettings = () => {
 				<ControlTextInput
 					value={ brandName }
 					onChange={ setBrandName }
-					placeholder={ __(
-						'Brand name',
-						'woocommerce-paypal-payments'
-					) }
+					placeholder={
+						siteTitle ||
+						__( 'Brand name', 'woocommerce-paypal-payments' )
+					}
 				/>
 			</SettingsBlock>
 

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -112,8 +112,8 @@ class SettingsModel extends AbstractDataModel {
 	 * @return string The brand name.
 	 */
 	public function get_brand_name() : string {
-		return $this->data['brand_name'];
-	}
+	return !empty($this->data['brand_name']) ? $this->data['brand_name'] : get_bloginfo('name');
+}
 
 	/**
 	 * Sets the brand name.

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -111,9 +111,10 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return string The brand name.
 	 */
-	public function get_brand_name() : string {
-	return !empty($this->data['brand_name']) ? $this->data['brand_name'] : get_bloginfo('name');
-}
+	public function get_brand_name(): string
+	{
+		return ! empty( $this->data['brand_name'] ) ? $this->data['brand_name'] : get_bloginfo( 'name' );
+	}
 
 	/**
 	 * Sets the brand name.

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -111,8 +111,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return string The brand name.
 	 */
-	public function get_brand_name(): string
-	{
+	public function get_brand_name(): string {
 		return ! empty( $this->data['brand_name'] ) ? $this->data['brand_name'] : get_bloginfo( 'name' );
 	}
 


### PR DESCRIPTION
In the legacy UI, the initial default value for the “brand name” was the WP site title.
Apply this default to the new UI - if the brand name is left empty, it should default to the site title