### PR TITLE
Only show active payment methods (PCP-4194)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Styling/Content/PaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Styling/Content/PaymentMethods.js
@@ -1,17 +1,29 @@
 import { __ } from '@wordpress/i18n';
 
-import { StylingHooks } from '../../../../../../data';
+import { PaymentHooks, StylingHooks } from '../../../../../../data';
 import { CheckboxStylingSection } from '../Layout';
 
 const SectionPaymentMethods = ( { location } ) => {
 	const { paymentMethods, setPaymentMethods, choices } =
 		StylingHooks.usePaymentMethodProps( location );
 
+	const methods = PaymentHooks.usePaymentMethods();
+	const methodIds = [];
+	methods.all.forEach( ( method ) => {
+		if ( method.enabled === true ) {
+			methodIds.push( method.id );
+		}
+	} );
+
+	const filteredChoices = choices.filter( ( choice ) => {
+		return methodIds.includes( choice.paymentMethod );
+	} );
+
 	return (
 		<CheckboxStylingSection
 			name="payment-methods"
 			title={ __( 'Payment Methods', 'woocommerce-paypal-payments' ) }
-			options={ choices }
+			options={ filteredChoices }
 			value={ paymentMethods }
 			onChange={ setPaymentMethods }
 		/>

--- a/modules/ppcp-settings/resources/js/data/styling/configuration.js
+++ b/modules/ppcp-settings/resources/js/data/styling/configuration.js
@@ -109,23 +109,28 @@ export const STYLING_PAYMENT_METHODS = {
 		label: __( 'PayPal', 'woocommerce-paypal-payments' ),
 		checked: true,
 		disabled: true,
+		paymentMethod: 'ppcp-gateway',
 	},
 	venmo: {
 		value: 'venmo',
 		label: __( 'Venmo', 'woocommerce-paypal-payments' ),
 		isFunding: true,
+		paymentMethod: 'venmo',
 	},
 	paylater: {
 		value: 'paylater',
 		label: __( 'Pay Later', 'woocommerce-paypal-payments' ),
 		isFunding: true,
+		paymentMethod: 'pay-later',
 	},
 	googlepay: {
 		value: 'googlepay',
 		label: __( 'Google Pay', 'woocommerce-paypal-payments' ),
+		paymentMethod: 'ppcp-googlepay',
 	},
 	applepay: {
 		value: 'applepay',
 		label: __( 'Apple Pay', 'woocommerce-paypal-payments' ),
+		paymentMethod: 'ppcp-applepay',
 	},
 };


### PR DESCRIPTION
This PR ensures that when a payment method item (ex. Google Pay...) is not checked in Payment Methods screen it should not be visible in Styling screen.