### PR TITLE
Fix copy of the "Disabled Cards" field (4196)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/OtherSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/OtherSettings.js
@@ -25,7 +25,7 @@ const OtherSettings = () => {
 					'woocommerce-paypal-payments'
 				) }
 				description={ __(
-					"If left blank, PayPal and other buttons will present in the user's detected language. Enter a language here to force all buttons to display in that language.",
+					'By default, all possible credit cards will be accepted. Card types added here will be rejected at checkout.',
 					'woocommerce-paypal-payments'
 				) }
 			>
@@ -34,6 +34,10 @@ const OtherSettings = () => {
 					value={ disabledCards }
 					onChange={ setDisabledCards }
 					isMulti={ true }
+					placeholder={ __(
+						'Show all cards',
+						'woocommerce-paypal-payments'
+					) }
 				/>
 			</SettingsBlock>
 		</Accordion>


### PR DESCRIPTION
The field has a new description and the placeholder shows "Show all cards" 

<img width="862" alt="Captura de pantalla 2025-02-10 a las 9 46 03" src="https://github.com/user-attachments/assets/778fa562-9a51-4945-9f14-28f977ed8d18" />
