### PR TITLE
Store account type during onboarding (4204)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ConnectionStatus.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ConnectionStatus.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
 
 import SettingsCard from '../../../../ReusableComponents/SettingsCard';
 import { CommonHooks } from '../../../../../data';
@@ -8,11 +9,15 @@ import SettingsBlock from '../../../../ReusableComponents/SettingsBlock';
 import { ControlStaticValue } from '../../../../ReusableComponents/Controls';
 
 const ConnectionStatus = () => {
-	const { merchant } = CommonHooks.useMerchantInfo();
+	const merchant = CommonHooks.useMerchant();
+	const className = classNames( 'ppcp-connection-details ppcp--value-list', {
+		'ppcp--type-business': merchant.isBusinessSeller,
+		'ppcp--type-casual': merchant.isCasualSeller,
+	} );
 
 	return (
 		<SettingsCard
-			className="ppcp-connection-details ppcp--value-list"
+			className={ className }
 			title={ __( 'Connection status', 'woocommerce-paypal-payments' ) }
 			description={ <ConnectionDescription /> }
 		>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
@@ -5,6 +5,7 @@ import { getSettingsTabs } from './Tabs';
 const SettingsScreen = ( { activePanel, setActivePanel } ) => {
 	const tabs = getSettingsTabs();
 	const { Component } = tabs.find( ( tab ) => tab.name === activePanel );
+
 	return (
 		<>
 			<SettingsNavigation

--- a/modules/ppcp-settings/resources/js/data/common/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/common/hooks.js
@@ -144,7 +144,8 @@ export const useWebhooks = () => {
 };
 
 export const useMerchantInfo = () => {
-	const { isReady, merchant, features } = useHooks();
+	const { isReady, features } = useHooks();
+	const merchant = useMerchant();
 	const { refreshMerchantData } = useDispatch( STORE_NAME );
 
 	const verifyLoginStatus = useCallback( async () => {
@@ -163,6 +164,22 @@ export const useMerchantInfo = () => {
 		merchant, // Merchant details
 		features, // Eligible merchant features
 		verifyLoginStatus, // Callback
+	};
+};
+
+// Read-only access to the sanitized merchant details.
+export const useMerchant = () => {
+	const { merchant } = useHooks();
+
+	return {
+		isConnected: merchant.isConnected ?? false,
+		isSandbox: merchant.isSandbox ?? true,
+		id: merchant.id ?? '',
+		email: merchant.email ?? '',
+		clientId: merchant.clientId ?? '',
+		clientSecret: merchant.clientSecret ?? '',
+		isBusinessSeller: 'business' === merchant.sellerType,
+		isCasualSeller: 'personal' === merchant.sellerType,
 	};
 };
 

--- a/modules/ppcp-settings/resources/js/data/common/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/common/hooks.js
@@ -8,7 +8,7 @@
  */
 
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 
 import { createHooksForStore } from '../utils';
 import { STORE_NAME } from './constants';
@@ -35,10 +35,6 @@ const useHooks = () => {
 	const [ isSandboxMode, setSandboxMode ] = usePersistent( 'useSandbox' );
 	const [ isManualConnectionMode, setManualConnectionMode ] = usePersistent(
 		'useManualConnection'
-	);
-	const merchant = useSelect(
-		( select ) => select( STORE_NAME ).merchant(),
-		[]
 	);
 
 	// Read-only properties.
@@ -78,7 +74,6 @@ const useHooks = () => {
 		productionOnboardingUrl,
 		authenticateWithCredentials,
 		authenticateWithOAuth,
-		merchant,
 		wooSettings,
 		features,
 		webhooks,
@@ -169,18 +164,25 @@ export const useMerchantInfo = () => {
 
 // Read-only access to the sanitized merchant details.
 export const useMerchant = () => {
-	const { merchant } = useHooks();
+	const merchant = useSelect(
+		( select ) => select( STORE_NAME ).merchant(),
+		[]
+	);
 
-	return {
-		isConnected: merchant.isConnected ?? false,
-		isSandbox: merchant.isSandbox ?? true,
-		id: merchant.id ?? '',
-		email: merchant.email ?? '',
-		clientId: merchant.clientId ?? '',
-		clientSecret: merchant.clientSecret ?? '',
-		isBusinessSeller: 'business' === merchant.sellerType,
-		isCasualSeller: 'personal' === merchant.sellerType,
-	};
+	return useMemo(
+		() => ( {
+			isConnected: merchant.isConnected ?? false,
+			isSandbox: merchant.isSandbox ?? true,
+			id: merchant.id ?? '',
+			email: merchant.email ?? '',
+			clientId: merchant.clientId ?? '',
+			clientSecret: merchant.clientSecret ?? '',
+			isBusinessSeller: 'business' === merchant.sellerType,
+			isCasualSeller: 'personal' === merchant.sellerType,
+		} ),
+		// the merchant object is stable, so a new memo is only generated when a merchant prop changes.
+		[ merchant ]
+	);
 };
 
 export const useActiveModal = () => {

--- a/modules/ppcp-settings/resources/js/data/common/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/common/reducer.js
@@ -26,6 +26,7 @@ const defaultTransient = Object.freeze( {
 		email: '',
 		clientId: '',
 		clientSecret: '',
+		sellerType: 'unknown',
 	} ),
 
 	wooSettings: Object.freeze( {

--- a/modules/ppcp-settings/src/DTO/MerchantConnectionDTO.php
+++ b/modules/ppcp-settings/src/DTO/MerchantConnectionDTO.php
@@ -51,6 +51,14 @@ class MerchantConnectionDTO {
 	public string $merchant_email = '';
 
 	/**
+	 * Whether the merchant is a business or personal account.
+	 * Possible values: ['business'|'personal'|'unknown']
+	 *
+	 * @var string
+	 */
+	public string $seller_type = 'unknown';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param bool   $is_sandbox     Whether this connection is a sandbox account.
@@ -58,18 +66,21 @@ class MerchantConnectionDTO {
 	 * @param string $client_secret  API client secret.
 	 * @param string $merchant_id    PayPal's 13-character merchant ID.
 	 * @param string $merchant_email Email address of the merchant account.
+	 * @param string $seller_type    Whether the merchant is a business or personal account.
 	 */
 	public function __construct(
 		bool $is_sandbox,
 		string $client_id,
 		string $client_secret,
 		string $merchant_id,
-		string $merchant_email
+		string $merchant_email,
+		string $seller_type = 'unknown'
 	) {
 		$this->is_sandbox     = $is_sandbox;
 		$this->client_id      = $client_id;
 		$this->client_secret  = $client_secret;
 		$this->merchant_id    = $merchant_id;
 		$this->merchant_email = $merchant_email;
+		$this->seller_type    = $seller_type;
 	}
 }

--- a/modules/ppcp-settings/src/DTO/MerchantConnectionDTO.php
+++ b/modules/ppcp-settings/src/DTO/MerchantConnectionDTO.php
@@ -9,6 +9,8 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\DTO;
 
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
+
 /**
  * DTO that collects all details of a "merchant connection".
  *
@@ -56,7 +58,7 @@ class MerchantConnectionDTO {
 	 *
 	 * @var string
 	 */
-	public string $seller_type = 'unknown';
+	public string $seller_type = SellerTypeEnum::UNKNOWN;
 
 	/**
 	 * Constructor.
@@ -74,7 +76,7 @@ class MerchantConnectionDTO {
 		string $client_secret,
 		string $merchant_id,
 		string $merchant_email,
-		string $seller_type = 'unknown'
+		string $seller_type = SellerTypeEnum::UNKNOWN
 	) {
 		$this->is_sandbox     = $is_sandbox;
 		$this->client_id      = $client_id;

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Settings\Data;
 
 use RuntimeException;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
 
 /**
  * Class GeneralSettings
@@ -195,6 +196,30 @@ class GeneralSettings extends AbstractDataModel {
 			&& $this->data['merchant_id']
 			&& $this->data['client_id']
 			&& $this->data['client_secret'];
+	}
+
+	/**
+	 * Whether the merchant uses a business account.
+	 *
+	 * Note: It's possible that the seller type is unknown, and both methods,
+	 * `is_casual_seller()` and `is_business_seller()` return false.
+	 *
+	 * @return bool
+	 */
+	public function is_business_seller() : bool {
+		return SellerTypeEnum::BUSINESS === $this->data['seller_type'];
+	}
+
+	/**
+	 * Whether the merchant is a casual seller using a personal account.
+	 *
+	 * Note: It's possible that the seller type is unknown, and both methods,
+	 * `is_casual_seller()` and `is_business_seller()` return false.
+	 *
+	 * @return bool
+	 */
+	public function is_casual_seller() : bool {
+		return SellerTypeEnum::PERSONAL === $this->data['seller_type'];
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -75,6 +75,7 @@ class GeneralSettings extends AbstractDataModel {
 			'merchant_email'        => '',
 			'client_id'             => '',
 			'client_secret'         => '',
+			'seller_type'           => 'unknown',
 		);
 	}
 
@@ -138,6 +139,7 @@ class GeneralSettings extends AbstractDataModel {
 		$this->data['merchant_email']     = sanitize_email( $connection->merchant_email );
 		$this->data['client_id']          = sanitize_text_field( $connection->client_id );
 		$this->data['client_secret']      = sanitize_text_field( $connection->client_secret );
+		$this->data['seller_type']        = sanitize_text_field( $connection->seller_type );
 		$this->data['merchant_connected'] = $this->is_merchant_connected();
 	}
 
@@ -152,7 +154,8 @@ class GeneralSettings extends AbstractDataModel {
 			$this->data['client_id'],
 			$this->data['client_secret'],
 			$this->data['merchant_id'],
-			$this->data['merchant_email']
+			$this->data['merchant_email'],
+			$this->data['seller_type']
 		);
 	}
 
@@ -169,6 +172,7 @@ class GeneralSettings extends AbstractDataModel {
 		$this->data['merchant_email']     = $defaults['merchant_email'];
 		$this->data['client_id']          = $defaults['client_id'];
 		$this->data['client_secret']      = $defaults['client_secret'];
+		$this->data['seller_type']        = $defaults['seller_type'];
 		$this->data['merchant_connected'] = false;
 	}
 

--- a/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
@@ -73,6 +73,9 @@ class CommonRestEndpoint extends RestEndpoint {
 		'merchant_email'       => array(
 			'js_name' => 'email',
 		),
+		'seller_type'          => array(
+			'js_name' => 'sellerType',
+		),
 		'client_id'            => array(
 			'js_name' => 'clientId',
 		),

--- a/modules/ppcp-settings/src/Enum/SellerTypeEnum.php
+++ b/modules/ppcp-settings/src/Enum/SellerTypeEnum.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Defines possible values for the merchant's `seller_type` property.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Enum
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Enum;
+
+/**
+ * Enum for the merchant's `seller_type` property.
+ */
+class SellerTypeEnum {
+	/**
+	 * Seller is a business, signed in with a business account.
+	 */
+	public const BUSINESS = 'business';
+
+	/**
+	 * Casual seller, authenticated with a personal account.
+	 */
+	public const PERSONAL = 'personal';
+
+	/**
+	 * Initial status, before the seller authenticated, or if detection failed.
+	 */
+	public const UNKNOWN = 'unknown';
+
+	/**
+	 * Get all valid seller types.
+	 *
+	 * @return array List of all valid seller_types.
+	 */
+	public static function get_valid_values() : array {
+		return array(
+			self::BUSINESS,
+			self::PERSONAL,
+			self::UNKNOWN,
+		);
+	}
+
+	/**
+	 * Check if a given type is valid.
+	 *
+	 * @param string $type The value to validate.
+	 * @return bool True, if the value is a valid seller_type.
+	 */
+	public static function is_valid( string $type ) : bool {
+		return in_array( $type, self::get_valid_values(), true );
+	}
+}

--- a/modules/ppcp-settings/src/Handler/ConnectionListener.php
+++ b/modules/ppcp-settings/src/Handler/ConnectionListener.php
@@ -17,6 +17,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\OnboardingUrlManager;
 use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\Http\RedirectorInterface;
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
 
 /**
  * Provides a listener that handles merchant-connection requests.
@@ -177,6 +178,7 @@ class ConnectionListener {
 
 		$merchant_id    = $this->get_merchant_id_from_request( $request );
 		$merchant_email = $this->get_merchant_email_from_request( $request );
+		$seller_type    = $this->get_seller_type_from_request( $request );
 
 		if ( ! $merchant_id || ! $merchant_email ) {
 			return array();
@@ -185,6 +187,7 @@ class ConnectionListener {
 		return array(
 			'merchant_id'    => $merchant_id,
 			'merchant_email' => $merchant_email,
+			'seller_type'    => $seller_type,
 		);
 	}
 
@@ -226,7 +229,7 @@ class ConnectionListener {
 	 *
 	 * Note that the email is provided via the argument "merchantId", which
 	 * looks incorrect at first, but PayPal uses the email address as merchant
-	 * IDm and offers a more anonymous ID via the "merchantIdInPayPal" argument.
+	 * ID, and offers a more anonymous ID via the "merchantIdInPayPal" argument.
 	 *
 	 * @param array $request Full request details.
 	 *
@@ -234,6 +237,40 @@ class ConnectionListener {
 	 */
 	private function get_merchant_email_from_request( array $request ) : string {
 		return $this->sanitize_merchant_email( $request['merchantId'] ?? '' );
+	}
+
+	/**
+	 * Returns the sanitized seller type, based on the incoming request.
+	 *
+	 * PayPal reports this via an `accountStatus` GET parameter, which can have
+	 * the value "BUSINESS_ACCOUNT", or "???". This method translates the GET
+	 * parameter into a SellerTypeEnum value.
+	 *
+	 * @param array $request Full request details.
+	 *
+	 * @return string A valid SellerTypeEnum value.
+	 */
+	private function get_seller_type_from_request( array $request ) : string {
+		$account_status = $request['accountStatus'] ?? '';
+
+		if ( 'BUSINESS_ACCOUNT' === $account_status ) {
+			return SellerTypeEnum::BUSINESS;
+		}
+
+		if ( ! $account_status ) {
+			/**
+			 * We assume that a valid authentication request that has no
+			 * accountStatus property must be a personal account.
+			 *
+			 * This logic is not officially documented, but was discovered
+			 * by trial-and-error.
+			 */
+			return SellerTypeEnum::PERSONAL;
+		}
+
+		$this->logger->info( 'Request with unknown accountStatus: ' . $account_status );
+
+		return SellerTypeEnum::UNKNOWN;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\EnvironmentConfig;
 use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
 
 /**
  * Class that manages the connection to PayPal.
@@ -186,7 +187,8 @@ class AuthenticationManager {
 			$client_id,
 			$client_secret,
 			$payee['merchant_id'],
-			$payee['email_address']
+			$payee['email_address'],
+			SellerTypeEnum::BUSINESS
 		);
 
 		$this->update_connection_details( $connection );

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -245,9 +245,11 @@ class AuthenticationManager {
 		$credentials = $this->get_credentials( $shared_id, $auth_code, $use_sandbox );
 
 		/**
-		 * The merchant's email is set by `ConnectionListener`. That listener
+		 * Some details are set by `ConnectionListener`. That listener
 		 * is invoked during the page reload, once the user clicks the blue
 		 * "Return to Store" button in PayPal's login popup.
+		 *
+		 * It sets: merchant_email, seller_type.
 		 */
 		$connection = $this->common_settings->get_merchant_data();
 
@@ -269,8 +271,9 @@ class AuthenticationManager {
 	 * @throws RuntimeException Missing or invalid credentials.
 	 */
 	public function finish_oauth_authentication( array $request_data ) : void {
-		$merchant_id    = $request_data['merchant_id'];
-		$merchant_email = $request_data['merchant_email'];
+		$merchant_id    = $request_data['merchant_id'] ?? '';
+		$merchant_email = $request_data['merchant_email'] ?? '';
+		$seller_type    = $request_data['seller_type'] ?? '';
 
 		if ( empty( $merchant_id ) || empty( $merchant_email ) ) {
 			throw new RuntimeException( 'Missing merchant ID or email in request' );
@@ -284,6 +287,10 @@ class AuthenticationManager {
 
 		$connection->merchant_id    = $merchant_id;
 		$connection->merchant_email = $merchant_email;
+
+		if ( SellerTypeEnum::is_valid( $seller_type ) ) {
+			$connection->seller_type = $seller_type;
+		}
 
 		$this->update_connection_details( $connection );
 	}

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -28,7 +28,7 @@
 		<directory name="modules" />
 		<file name="bootstrap.php" />
 		<file name="woocommerce-paypal-payments.php" />
-		<ignoreFiles>
+		<ignoreFiles allowMissingFiles="true">
 			<directory name="node_modules"/>
 			<directory name="modules/*/node_modules"/>
 		</ignoreFiles>


### PR DESCRIPTION
### Description

Detects the account-type (business or personal) during authentication, at the end of the onboarding flow, and stores it in the database.

### Usage

**In PHP**

```php
$data = $container->get( 'settings.data.general' );

if ( $data->is_business_seller() ) {
  // This is a business account.
} elseif ( $data.>is_casual_seller() ) {
  // This is a personal account.
} else {
  // Neither business nor casual: We do not know the type.
}
```

**In React**

```js
import { CommonHooks } from '../../../data';

// ...

const merchant = CommonHooks.useMerchant();

if ( merchant.isBusinessSeller ) {
  // Confirmed business seller account.
} else if ( merchant.isCasualSeller ) {
  // Confirmed casual seller account.
} else {
  // Unknown account type
}
```