### PR TITLE
No ACDC eligibility: Hide "Online Card Payments" (4197, 4148)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -3,7 +3,7 @@ import { useCallback } from '@wordpress/element';
 
 import SettingsCard from '../../../ReusableComponents/SettingsCard';
 import { PaymentMethodsBlock } from '../../../ReusableComponents/SettingsBlocks';
-import { PaymentHooks } from '../../../../data';
+import { CommonHooks, PaymentHooks } from '../../../../data';
 import { useActiveModal } from '../../../../data/common/hooks';
 import Modal from '../Components/Payment/Modal';
 
@@ -45,6 +45,8 @@ const TabPaymentMethods = () => {
 		[ changePaymentSettings, setActiveModal, setPersistent ]
 	);
 
+	const merchant = CommonHooks.useMerchant();
+
 	return (
 		<div className="ppcp-r-payment-methods">
 			<PaymentMethodCard
@@ -58,20 +60,22 @@ const TabPaymentMethods = () => {
 				methods={ methods.paypal }
 				onTriggerModal={ setActiveModal }
 			/>
-			<PaymentMethodCard
-				id="ppcp-card-payments-card"
-				title={ __(
-					'Online Card Payments',
-					'woocommerce-paypal-payments'
-				) }
-				description={ __(
-					'Select your preferred card payment options for efficient payment processing.',
-					'woocommerce-paypal-payments'
-				) }
-				icon="icon-checkout-online-methods.svg"
-				methods={ methods.cardPayment }
-				onTriggerModal={ setActiveModal }
-			/>
+			{ merchant.isBusinessSeller && (
+				<PaymentMethodCard
+					id="ppcp-card-payments-card"
+					title={ __(
+						'Online Card Payments',
+						'woocommerce-paypal-payments'
+					) }
+					description={ __(
+						'Select your preferred card payment options for efficient payment processing.',
+						'woocommerce-paypal-payments'
+					) }
+					icon="icon-checkout-online-methods.svg"
+					methods={ methods.cardPayment }
+					onTriggerModal={ setActiveModal }
+				/>
+			) }
 			<PaymentMethodCard
 				id="ppcp-alternative-payments-card"
 				title={ __(

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -3,7 +3,7 @@ import { useCallback } from '@wordpress/element';
 
 import SettingsCard from '../../../ReusableComponents/SettingsCard';
 import { PaymentMethodsBlock } from '../../../ReusableComponents/SettingsBlocks';
-import { CommonHooks, PaymentHooks } from '../../../../data';
+import { CommonHooks, OnboardingHooks, PaymentHooks } from '../../../../data';
 import { useActiveModal } from '../../../../data/common/hooks';
 import Modal from '../Components/Payment/Modal';
 
@@ -46,6 +46,7 @@ const TabPaymentMethods = () => {
 	);
 
 	const merchant = CommonHooks.useMerchant();
+	const { canUseCardPayments } = OnboardingHooks.useFlags();
 
 	return (
 		<div className="ppcp-r-payment-methods">
@@ -60,7 +61,7 @@ const TabPaymentMethods = () => {
 				methods={ methods.paypal }
 				onTriggerModal={ setActiveModal }
 			/>
-			{ merchant.isBusinessSeller && (
+			{ merchant.isBusinessSeller && canUseCardPayments && (
 				<PaymentMethodCard
 					id="ppcp-card-payments-card"
 					title={ __(

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -308,8 +308,9 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$dcc_applies = $container->get( 'api.helpers.dccapplies' );
 				assert( $dcc_applies instanceof DCCApplies );
 
-				// Unset BCDC if merchant is eligible for ACDC.
-				if ( $dcc_product_status->is_active() && ! $container->get( 'wcgateway.settings.allow_card_button_gateway' ) ) {
+				// Unset BCDC if merchant is eligible for ACDC and country is eligible for card fields.
+				$card_fields_eligible = $container->get( 'card-fields.eligible' );
+				if ( $dcc_product_status->is_active() && $card_fields_eligible ) {
 					unset( $payment_methods[ CardButtonGateway::ID ] );
 				}
 
@@ -366,6 +367,9 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					return $methods;
 				}
 
+				$card_button_gateway = $container->get( 'wcgateway.card-button-gateway' );
+				assert( $card_button_gateway instanceof CardButtonGateway );
+
 				$googlepay_gateway = $container->get( 'googlepay.wc-gateway' );
 				assert( $googlepay_gateway instanceof WC_Payment_Gateway );
 
@@ -375,6 +379,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$axo_gateway = $container->get( 'axo.gateway' );
 				assert( $axo_gateway instanceof WC_Payment_Gateway );
 
+				$methods[] = $card_button_gateway;
 				$methods[] = $googlepay_gateway;
 				$methods[] = $applepay_gateway;
 				$methods[] = $axo_gateway;
@@ -399,6 +404,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			10,
 			2
 		);
+
+		add_filter( 'woocommerce_paypal_payments_card_button_gateway_should_register_gateway', '__return_true' );
 
 		add_filter(
 			'woocommerce_paypal_payments_credit_card_gateway_form_fields',

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -648,7 +648,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 					$methods[] = $container->get( 'wcgateway.credit-card-gateway' );
 				}
 
-				if ( $paypal_gateway_enabled && $container->get( 'wcgateway.settings.allow_card_button_gateway' ) ) {
+				if ( $paypal_gateway_enabled && apply_filters( 'woocommerce_paypal_payments_card_button_gateway_should_register_gateway', $container->get( 'wcgateway.settings.allow_card_button_gateway' ) ) ) {
 					$methods[] = $container->get( 'wcgateway.card-button-gateway' );
 				}
 


### PR DESCRIPTION
When signed in with a personal account, the “Online Card Payments” section should be completely hidden.

![CleanShot 2025-02-07 at 17 43 41@2x-20250207-164439](https://github.com/user-attachments/assets/300ebede-c8ab-4b2c-ae61-27549a616a2f)

This PR uses custom hook `useMerchant` to get the type of merchant account, then conditionally renders the component based on that value.

It also ensures correct visibility for BCDC, ACDC, Apple and Google Pay based on store country.