### PR TITLE
Settings UI: Add spinner when waiting for all components to be ready (4205)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabOverview.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabOverview.js
@@ -16,6 +16,7 @@ import { useTodos } from '../../../../data/todos/hooks';
 import { useMerchantInfo } from '../../../../data/common/hooks';
 import { STORE_NAME as COMMON_STORE_NAME } from '../../../../data/common';
 import { STORE_NAME as TODOS_STORE_NAME } from '../../../../data/todos';
+import { CommonHooks, TodosHooks } from '../../../../data';
 
 import { getFeatures } from '../Components/Overview/features-config';
 
@@ -23,8 +24,16 @@ import {
 	NOTIFICATION_ERROR,
 	NOTIFICATION_SUCCESS,
 } from '../../../ReusableComponents/Icons';
+import SpinnerOverlay from '../../../ReusableComponents/SpinnerOverlay';
 
 const TabOverview = () => {
+	const { isReady: areTodosReady } = TodosHooks.useTodos();
+	const { isReady: merchantIsReady } = CommonHooks.useMerchantInfo();
+
+	if ( ! areTodosReady || ! merchantIsReady ) {
+		return <SpinnerOverlay asModal={ true } />;
+	}
+
 	return (
 		<div className="ppcp-r-tab-overview">
 			<OverviewTodos />


### PR DESCRIPTION
### Description

This PR will add a loading spinner overlay while waiting for todos and merchant info components to be fully loaded in the Overview tab (prevents content jumping).