### PR TITLE
Subscriptions requires a business account (4189)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Fields/OptionSelector.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Fields/OptionSelector.js
@@ -9,7 +9,13 @@ const OptionSelector = ( {
 } ) => (
 	<div className="ppcp-r-select-box-wrapper">
 		{ options.map(
-			( { value: itemValue, title, description, contents } ) => {
+			( {
+				value: itemValue,
+				title,
+				description,
+				contents,
+				isDisabled = false,
+			} ) => {
 				let isSelected;
 
 				if ( Array.isArray( value ) ) {
@@ -27,6 +33,7 @@ const OptionSelector = ( {
 						onChange={ onChange }
 						isMulti={ multiSelect }
 						isSelected={ isSelected }
+						isDisabled={ isDisabled }
 					>
 						{ contents }
 					</OptionItem>
@@ -46,13 +53,13 @@ const OptionItem = ( {
 	isMulti,
 	isSelected,
 	children,
+	isDisabled = false,
 } ) => {
 	const boxClassName = classNames( 'ppcp-r-select-box', {
 		'ppcp--selected': isSelected,
 		'ppcp--multiselect': isMulti,
 		'ppcp--no-title': ! itemTitle,
 	} );
-
 	return (
 		// eslint-disable-next-line jsx-a11y/label-has-associated-control -- label has a nested input control.
 		<label className={ boxClassName }>
@@ -61,6 +68,7 @@ const OptionItem = ( {
 				isRadio={ ! isMulti }
 				onChange={ onChange }
 				isSelected={ isSelected }
+				isDisabled={ isDisabled }
 			/>
 
 			<div className="ppcp--box-content">
@@ -80,7 +88,7 @@ const OptionItem = ( {
 	);
 };
 
-const InputField = ( { value, onChange, isRadio, isSelected } ) => {
+const InputField = ( { value, onChange, isRadio, isSelected, isDisabled } ) => {
 	if ( isRadio ) {
 		return (
 			<PayPalRdb
@@ -96,6 +104,7 @@ const InputField = ( { value, onChange, isRadio, isSelected } ) => {
 			value={ value }
 			onChange={ onChange }
 			checked={ isSelected }
+			disabled={ isDisabled }
 		/>
 	);
 };

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepBusiness.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepBusiness.js
@@ -24,6 +24,26 @@ const StepBusiness = ( {} ) => {
 	useEffect( () => {
 		setIsCasualSeller( BUSINESS_TYPES.CASUAL_SELLER === businessChoice );
 	}, [ businessChoice, setIsCasualSeller ] );
+	const { canUseSubscriptions } = OnboardingHooks.useFlags();
+	const businessChoices = [
+		{
+			value: BUSINESS_TYPES.BUSINESS,
+			title: __( 'Business', 'woocommerce-paypal-payments' ),
+			description: __(
+				'Recommended for individuals and organizations that primarily use PayPal to sell goods or services or receive donations, even if your business is not incorporated.',
+				'woocommerce-paypal-payments'
+			),
+		},
+		{
+			value: BUSINESS_TYPES.CASUAL_SELLER,
+			title: __( 'Personal Account', 'woocommerce-paypal-payments' ),
+			description: __(
+				'Ideal for those who primarily make purchases or send personal transactions to family and friends.',
+				'woocommerce-paypal-payments'
+			),
+			contents: canUseSubscriptions ? <DetailsAccountType /> : null,
+		},
+	];
 
 	return (
 		<div className="ppcp-r-page-business">
@@ -45,23 +65,13 @@ const StepBusiness = ( {} ) => {
 	);
 };
 
-const businessChoices = [
-	{
-		value: BUSINESS_TYPES.BUSINESS,
-		title: __( 'Business', 'woocommerce-paypal-payments' ),
-		description: __(
-			'Recommended for individuals and organizations that primarily use PayPal to sell goods or services or receive donations, even if your business is not incorporated.',
+const DetailsAccountType = () => (
+	<p>
+		{ __(
+			'* Business account is required for subscriptions.',
 			'woocommerce-paypal-payments'
-		),
-	},
-	{
-		value: BUSINESS_TYPES.CASUAL_SELLER,
-		title: __( 'Personal Account', 'woocommerce-paypal-payments' ),
-		description: __(
-			'Ideal for those who primarily make purchases or send personal transactions to family and friends.',
-			'woocommerce-paypal-payments'
-		),
-	},
-];
+		) }
+	</p>
+);
 
 export default StepBusiness;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepProducts.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepProducts.js
@@ -10,6 +10,7 @@ const StepProducts = () => {
 	const { canUseSubscriptions } = OnboardingHooks.useFlags();
 	const [ optionState, setOptionState ] = useState( null );
 	const [ productChoices, setProductChoices ] = useState( [] );
+	const { isCasualSeller } = OnboardingHooks.useBusiness();
 
 	useEffect( () => {
 		const initChoices = () => {
@@ -48,7 +49,36 @@ const StepProducts = () => {
 
 		setProducts( getNewValue() );
 	};
-
+	const productChoicesFull = [
+		{
+			value: PRODUCT_TYPES.VIRTUAL,
+			title: __( 'Virtual', 'woocommerce-paypal-payments' ),
+			description: __(
+				'Items do not require shipping.',
+				'woocommerce-paypal-payments'
+			),
+			contents: <DetailsVirtual />,
+		},
+		{
+			value: PRODUCT_TYPES.PHYSICAL,
+			title: __( 'Physical Goods', 'woocommerce-paypal-payments' ),
+			description: __(
+				'Items require shipping.',
+				'woocommerce-paypal-payments'
+			),
+			contents: <DetailsPhysical />,
+		},
+		{
+			value: PRODUCT_TYPES.SUBSCRIPTIONS,
+			title: __( 'Subscriptions', 'woocommerce-paypal-payments' ),
+			description: __(
+				'Recurring payments for either physical goods or services.',
+				'woocommerce-paypal-payments'
+			),
+			isDisabled: isCasualSeller,
+			contents: <DetailsSubscriptions showNotice={ isCasualSeller } />,
+		},
+	];
 	return (
 		<div className="ppcp-r-page-products">
 			<OnboardingHeader
@@ -87,41 +117,21 @@ const DetailsPhysical = () => (
 	</ul>
 );
 
-const DetailsSubscriptions = () => (
-	<a
-		target="__blank"
-		href="https://woocommerce.com/document/woocommerce-paypal-payments/#subscriptions-faq"
-	>
-		{ __( 'WooCommerce Subscriptions', 'woocommerce-paypal-payments' ) }
-	</a>
+const DetailsSubscriptions = ( { showNotice } ) => (
+	<>
+		<a
+			target="__blank"
+			href="https://woocommerce.com/document/woocommerce-paypal-payments/#subscriptions-faq"
+		>
+			{ __( 'WooCommerce Subscriptions', 'woocommerce-paypal-payments' ) }
+		</a>
+		{ showNotice && (
+			<p>
+				{ __(
+					'* Business account is required for subscriptions.',
+					'woocommerce-paypal-payments'
+				) }
+			</p>
+		) }
+	</>
 );
-
-const productChoicesFull = [
-	{
-		value: PRODUCT_TYPES.VIRTUAL,
-		title: __( 'Virtual', 'woocommerce-paypal-payments' ),
-		description: __(
-			'Items do not require shipping.',
-			'woocommerce-paypal-payments'
-		),
-		contents: <DetailsVirtual />,
-	},
-	{
-		value: PRODUCT_TYPES.PHYSICAL,
-		title: __( 'Physical Goods', 'woocommerce-paypal-payments' ),
-		description: __(
-			'Items require shipping.',
-			'woocommerce-paypal-payments'
-		),
-		contents: <DetailsPhysical />,
-	},
-	{
-		value: PRODUCT_TYPES.SUBSCRIPTIONS,
-		title: __( 'Subscriptions', 'woocommerce-paypal-payments' ),
-		description: __(
-			'Recurring payments for either physical goods or services.',
-			'woocommerce-paypal-payments'
-		),
-		contents: <DetailsSubscriptions />,
-	},
-];


### PR DESCRIPTION
- In new UX, in the Account Type screen, if user has WooCommerce Subscriptions active, please add a warning note to the Personal box: `Business account is required for subscriptions.`

- In new UX, if the Account Type is selected as Personal, then grey out the Subscriptions box with the same warning note.

<img width="674" alt="Captura de pantalla 2025-02-11 a las 14 19 24" src="https://github.com/user-attachments/assets/578b9b98-55d5-4995-9372-262150373ba0" />

<img width="641" alt="Captura de pantalla 2025-02-11 a las 14 19 47" src="https://github.com/user-attachments/assets/25e0a0f3-c9a0-4ab6-930f-06b6eb725f7c" />
