### PR TITLE
Connect the "Other payment method settings" with the frontend (4213)

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -159,6 +159,12 @@ return array(
 				)
 			),
 			new SettingsMap(
+				$container->get( 'settings.data.settings' ),
+				array(
+					'disable_cards' => 'disabled_cards',
+				)
+			),
+			new SettingsMap(
 				$container->get( 'settings.data.styling' ),
 				/**
 				 * The `StylingSettings` class stores settings as `LocationStylingDTO` objects.


### PR DESCRIPTION
## Issue Description

The “PayPal settings“ from the new UI’s settings tab is not currently connected with the frontend

<img width="1030" alt="Screenshot 2025-02-12 at 15 39 05" src="https://github.com/user-attachments/assets/b1fa5ec0-3cde-466f-996d-2410bb17a7c1" />

## PR Description

The PR maps the "Disable specific credit cards" setting with the old one, which allows to use the new setting value on frontend