### PR TITLE
Connect the PayPal settings with the frontend (4212)

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -161,7 +161,9 @@ return array(
 			new SettingsMap(
 				$container->get( 'settings.data.settings' ),
 				array(
-					'disable_cards' => 'disabled_cards',
+					'disable_cards'   => 'disabled_cards',
+					'brand_name'      => 'brand_name',
+					'soft_descriptor' => 'soft_descriptor',
 				)
 			),
 			new SettingsMap(

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Compat;
 use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
 use WooCommerce\PayPalCommerce\Compat\Settings\SettingsMap;
 use WooCommerce\PayPalCommerce\Compat\Settings\SettingsMapHelper;
+use WooCommerce\PayPalCommerce\Compat\Settings\SettingsTabMapHelper;
 use WooCommerce\PayPalCommerce\Compat\Settings\StylingSettingsMapHelper;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
@@ -133,6 +134,9 @@ return array(
 		$styling_settings_map_helper = $container->get( 'compat.settings.styling_map_helper' );
 		assert( $styling_settings_map_helper instanceof StylingSettingsMapHelper );
 
+		$settings_tab_map_helper = $container->get( 'compat.settings.settings_tab_map_helper' );
+		assert( $settings_tab_map_helper instanceof SettingsTabMapHelper );
+
 		return array(
 			new SettingsMap(
 				$container->get( 'settings.data.general' ),
@@ -160,11 +164,7 @@ return array(
 			),
 			new SettingsMap(
 				$container->get( 'settings.data.settings' ),
-				array(
-					'disable_cards'   => 'disabled_cards',
-					'brand_name'      => 'brand_name',
-					'soft_descriptor' => 'soft_descriptor',
-				)
+				$settings_tab_map_helper->map()
 			),
 			new SettingsMap(
 				$container->get( 'settings.data.styling' ),
@@ -185,10 +185,14 @@ return array(
 	'compat.settings.settings_map_helper'            => static function( ContainerInterface $container ) : SettingsMapHelper {
 		return new SettingsMapHelper(
 			$container->get( 'compat.setting.new-to-old-map' ),
-			$container->get( 'compat.settings.styling_map_helper' )
+			$container->get( 'compat.settings.styling_map_helper' ),
+			$container->get( 'compat.settings.settings_tab_map_helper' )
 		);
 	},
 	'compat.settings.styling_map_helper'             => static function() : StylingSettingsMapHelper {
 		return new StylingSettingsMapHelper();
+	},
+	'compat.settings.settings_tab_map_helper'        => static function() : SettingsTabMapHelper {
+		return new SettingsTabMapHelper();
 	},
 );

--- a/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Compat\Settings;
 
 use RuntimeException;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
 
 /**
@@ -50,16 +51,29 @@ class SettingsMapHelper {
 	protected StylingSettingsMapHelper $styling_settings_map_helper;
 
 	/**
+	 * A helper for mapping the old/new settings tab settings.
+	 *
+	 * @var SettingsTabMapHelper
+	 */
+	protected SettingsTabMapHelper $settings_tab_map_helper;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param SettingsMap[]            $settings_map A list of settings maps containing key definitions.
 	 * @param StylingSettingsMapHelper $styling_settings_map_helper A helper for mapping the old/new styling settings.
+	 * @param SettingsTabMapHelper     $settings_tab_map_helper A helper for mapping the old/new settings tab settings.
 	 * @throws RuntimeException When an old key has multiple mappings.
 	 */
-	public function __construct( array $settings_map, StylingSettingsMapHelper $styling_settings_map_helper ) {
+	public function __construct(
+		array $settings_map,
+		StylingSettingsMapHelper $styling_settings_map_helper,
+		SettingsTabMapHelper $settings_tab_map_helper
+	) {
 		$this->validate_settings_map( $settings_map );
 		$this->settings_map                = $settings_map;
 		$this->styling_settings_map_helper = $styling_settings_map_helper;
+		$this->settings_tab_map_helper     = $settings_tab_map_helper;
 	}
 
 	/**
@@ -135,6 +149,10 @@ class SettingsMapHelper {
 		switch ( true ) {
 			case $model instanceof StylingSettings:
 				return $this->styling_settings_map_helper->mapped_value( $old_key, $this->model_cache[ $model_id ] );
+
+			case $model instanceof SettingsModel:
+				return $this->settings_tab_map_helper->mapped_value( $old_key, $this->model_cache[ $model_id ] );
+
 			default:
 				return $this->model_cache[ $model_id ][ $new_key ] ?? null;
 		}

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * A helper for mapping the old/new settings tab settings.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat\Settings
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat\Settings;
+
+use WooCommerce\PayPalCommerce\ApiClient\Helper\PurchaseUnitSanitizer;
+use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
+
+/**
+ * A map of old to new styling settings.
+ *
+ * @psalm-import-type newSettingsKey from SettingsMap
+ * @psalm-import-type oldSettingsKey from SettingsMap
+ */
+class SettingsTabMapHelper {
+
+	use ContextTrait;
+
+	/**
+	 * Maps old setting keys to new setting keys.
+	 *
+	 * @psalm-return array<oldSettingsKey, newSettingsKey>
+	 */
+	public function map(): array {
+		return array(
+			'disable_cards'              => 'disabled_cards',
+			'brand_name'                 => 'brand_name',
+			'soft_descriptor'            => 'soft_descriptor',
+			'subtotal_mismatch_behavior' => 'subtotal_adjustment',
+		);
+	}
+
+	/**
+	 * Retrieves the value of a mapped key from the new settings.
+	 *
+	 * @param string $old_key The key from the legacy settings.
+	 * @param array<string, scalar|array> $settings_model The new settings model data as an array.
+	 * @return mixed The value of the mapped setting, (null if not found).
+	 */
+	public function mapped_value( string $old_key, array $settings_model ) {
+		$settings_map = $this->map();
+		$new_key      = $settings_map[ $old_key ] ?? false;
+		switch ( $old_key ) {
+			case 'subtotal_mismatch_behavior':
+				return $this->mapped_mismatch_behavior_value( $settings_model );
+
+			default:
+				return $settings_model[ $new_key ] ?? null;
+		}
+	}
+
+	/**
+	 * Retrieves the mapped mismatch_behavior value from the new settings.
+	 *
+	 * @param array<string, scalar|array> $settings_model The new settings model data as an array.
+	 * @return 'extra_line'|'ditch'|null The mapped mismatch_behavior value.
+	 */
+	protected function mapped_mismatch_behavior_value( array $settings_model ): ?string {
+		$subtotal_adjustment = $settings_model[ 'subtotal_adjustment' ] ?? false;
+
+		if ( ! $subtotal_adjustment ) {
+			return null;
+		}
+
+		return $subtotal_adjustment === 'correction' ? PurchaseUnitSanitizer::MODE_EXTRA_LINE : PurchaseUnitSanitizer::MODE_DITCH;
+	}
+}

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -36,6 +36,7 @@ class SettingsTabMapHelper {
 			'payee_preferred'            => 'instant_payments_only',
 			'subtotal_mismatch_behavior' => 'subtotal_adjustment',
 			'landing_page'               => 'landing_page',
+			'smart_button_language'      => 'button_language',
 		);
 	}
 

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -39,7 +39,7 @@ class SettingsTabMapHelper {
 	/**
 	 * Retrieves the value of a mapped key from the new settings.
 	 *
-	 * @param string $old_key                             The key from the legacy settings.
+	 * @param string                      $old_key The key from the legacy settings.
 	 * @param array<string, scalar|array> $settings_model The new settings model data as an array.
 	 * @return mixed The value of the mapped setting, (null if not found).
 	 */

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat\Settings;
 
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ApplicationContext;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PurchaseUnitSanitizer;
 use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
 
@@ -32,7 +33,9 @@ class SettingsTabMapHelper {
 			'disable_cards'              => 'disabled_cards',
 			'brand_name'                 => 'brand_name',
 			'soft_descriptor'            => 'soft_descriptor',
+			'payee_preferred'            => 'instant_payments_only',
 			'subtotal_mismatch_behavior' => 'subtotal_adjustment',
+			'landing_page'               => 'landing_page',
 		);
 	}
 
@@ -50,16 +53,19 @@ class SettingsTabMapHelper {
 			case 'subtotal_mismatch_behavior':
 				return $this->mapped_mismatch_behavior_value( $settings_model );
 
+			case 'landing_page':
+				return $this->mapped_landing_page_value( $settings_model );
+
 			default:
 				return $settings_model[ $new_key ] ?? null;
 		}
 	}
 
 	/**
-	 * Retrieves the mapped mismatch_behavior value from the new settings.
+	 * Retrieves the mapped value for the 'mismatch_behavior' from the new settings.
 	 *
 	 * @param array<string, scalar|array> $settings_model The new settings model data as an array.
-	 * @return 'extra_line'|'ditch'|null The mapped mismatch_behavior value.
+	 * @return 'extra_line'|'ditch'|null The mapped 'mismatch_behavior' setting value.
 	 */
 	protected function mapped_mismatch_behavior_value( array $settings_model ): ?string {
 		$subtotal_adjustment = $settings_model['subtotal_adjustment'] ?? false;
@@ -69,5 +75,26 @@ class SettingsTabMapHelper {
 		}
 
 		return $subtotal_adjustment === 'correction' ? PurchaseUnitSanitizer::MODE_EXTRA_LINE : PurchaseUnitSanitizer::MODE_DITCH;
+	}
+
+	/**
+	 * Retrieves the mapped value for the 'landing_page' from the new settings.
+	 *
+	 * @param array<string, scalar|array> $settings_model The new settings model data as an array.
+	 * @return 'LOGIN'|'BILLING'|'NO_PREFERENCE'|null The mapped 'landing_page' setting value.
+	 */
+	protected function mapped_landing_page_value( array $settings_model ): ?string {
+		$landing_page = $settings_model['landing_page'] ?? false;
+
+		if ( ! $landing_page ) {
+			return null;
+		}
+
+		return $landing_page === 'login'
+			? ApplicationContext::LANDING_PAGE_LOGIN
+			: ( $landing_page === 'guest_checkout'
+				? ApplicationContext::LANDING_PAGE_BILLING
+				: ApplicationContext::LANDING_PAGE_NO_PREFERENCE
+			);
 	}
 }

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -62,7 +62,7 @@ class SettingsTabMapHelper {
 	 * @return 'extra_line'|'ditch'|null The mapped mismatch_behavior value.
 	 */
 	protected function mapped_mismatch_behavior_value( array $settings_model ): ?string {
-		$subtotal_adjustment = $settings_model[ 'subtotal_adjustment' ] ?? false;
+		$subtotal_adjustment = $settings_model['subtotal_adjustment'] ?? false;
 
 		if ( ! $subtotal_adjustment ) {
 			return null;

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -39,7 +39,7 @@ class SettingsTabMapHelper {
 	/**
 	 * Retrieves the value of a mapped key from the new settings.
 	 *
-	 * @param string $old_key The key from the legacy settings.
+	 * @param string $old_key                             The key from the legacy settings.
 	 * @param array<string, scalar|array> $settings_model The new settings model data as an array.
 	 * @return mixed The value of the mapped setting, (null if not found).
 	 */

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
@@ -142,10 +142,10 @@ const PaypalSettings = () => {
 };
 
 const languagesExample = [
-	{ value: 'en', label: 'English' },
-	{ value: 'de', label: 'German' },
-	{ value: 'es', label: 'Spanish' },
-	{ value: 'it', label: 'Italian' },
+	{ value: 'en_US', label: 'English' },
+	{ value: 'de_DE', label: 'German' },
+	{ value: 'es_ES', label: 'Spanish' },
+	{ value: 'it_IT', label: 'Italian' },
 ];
 
 const subtotalAdjustmentChoices = [

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -73,7 +73,7 @@ class SettingsModel extends AbstractDataModel {
 			// Enum-type string values.
 			'subtotal_adjustment'    => 'skip_details', // Options: [correction|no_details].
 			'landing_page'           => 'any',          // Options: [any|login|guest_checkout].
-			'button_language'        => '',             // empty or a 2-letter language code.
+			'button_language'        => '',             // empty or a language locale code.
 
 			// Boolean flags.
 			'authorize_only'         => false,


### PR DESCRIPTION
## Issue Description

The “PayPal settings“ from the new UI’s settings tab is not currently connected with the frontend

<img width="919" alt="Screenshot 2025-02-12 at 15 36 26" src="https://github.com/user-attachments/assets/366dcee7-2840-4a59-bc69-28983e3fe832" />

## PR Description

This PR will connect the "PayPal Settings" section from the settings tab to frontend by mapping the following fields

- Subtotal mismatch fallback
- Instant payments only (This one is not saved in DB yet)
- Brand name
- Soft Descriptor
- PayPal landing page
- Button Language