### PR TITLE
qa - uk payinthree instead of paylater

### DIFF
--- a/tests/qa/tests/02-dashboard-ui/visual-default-ui.spec.ts
+++ b/tests/qa/tests/02-dashboard-ui/visual-default-ui.spec.ts
@@ -101,13 +101,13 @@ test.describe.serial( () => {
 		percy,
 		wooCommerceApi,
 	}, testInfo ) => {
-		await pcpOnboarding.visit();
-		await pcpOnboarding.gotoInitialOnboardingPage();
 		await wooCommerceApi.updateGeneralSettings( {
 			woocommerce_default_country: 'GB',
 			woocommerce_currency: 'GBP',
 		} );
-		await pcpOnboarding.page.reload();
+		await pcpOnboarding.visit();
+		await pcpOnboarding.gotoInitialOnboardingPage();
+		
 		await percy.takeSnapshot( testInfo.title, percyConfig );
 	} );
 } );

--- a/tests/qa/tests/02-dashboard-ui/visual-default-ui.spec.ts
+++ b/tests/qa/tests/02-dashboard-ui/visual-default-ui.spec.ts
@@ -95,6 +95,21 @@ test.describe.serial( () => {
 		await pcpOnboarding.enableManuallyConnect();
 		await percy.takeSnapshot( testInfo.title, percyConfig );
 	} );
+
+	test.only( 'PCP-0000 | Settings - UK - Onboarding - Default UI (acdc, paylater) - Default UI @percy', async ( {
+		pcpOnboarding,
+		percy,
+		wooCommerceApi,
+	}, testInfo ) => {
+		await pcpOnboarding.visit();
+		await pcpOnboarding.gotoInitialOnboardingPage();
+		await wooCommerceApi.updateGeneralSettings( {
+			woocommerce_default_country: 'GB',
+			woocommerce_currency: 'GBP',
+		} );
+		await pcpOnboarding.page.reload();
+		await percy.takeSnapshot( testInfo.title, percyConfig );
+	} );
 } );
 
 test( 'PCP-0000 | Settings - Badge values per country @percy', async ( {


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #

**Ticket**:

**Slack Thread**:

---

### Description

**Test for the first onboarding screen for the UK added. Verifies that the first screen displays Pay in 3 instead of Pay Later**

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Go to '…'
2. Click on '…'
3. Scroll down to …'

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Closes # .
