### PR TITLE
Connect Common settings with the frontend (4211)

### DIFF
--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -39,7 +39,7 @@ class SettingsTabMapHelper {
 			'smart_button_language'      => 'button_language',
 			'prefix'                     => 'invoice_prefix',
 			'intent'                     => '',
-			'vault_enabled'              => 'save_paypal_and_venmo',
+			'vault_enabled_dcc'          => 'save_card_details',
 		);
 	}
 

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -64,6 +64,9 @@ class SettingsTabMapHelper {
 			case 'intent':
 				return $this->mapped_intent_value( $settings_model );
 
+			case 'blocks_final_review_enabled':
+				return $this->mapped_pay_now_value( $settings_model );
+
 			default:
 				return $settings_model[ $new_key ] ?? null;
 		}
@@ -121,5 +124,21 @@ class SettingsTabMapHelper {
 		}
 
 		return $authorize_only ? 'AUTHORIZE' : 'CAPTURE';
+	}
+
+	/**
+	 * Retrieves the mapped value for the "Pay Now Experience" from the new settings.
+	 *
+	 * @param array<string, scalar|array> $settings_model The new settings model data as an array.
+	 * @return bool|null The mapped 'Pay Now Experience' setting value.
+	 */
+	protected function mapped_pay_now_value( array $settings_model ): ?bool {
+		$enable_pay_now = $settings_model['enable_pay_now'] ?? null;
+
+		if ( is_null( $enable_pay_now ) ) {
+			return null;
+		}
+
+		return ! $enable_pay_now;
 	}
 }

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -39,6 +39,7 @@ class SettingsTabMapHelper {
 			'smart_button_language'      => 'button_language',
 			'prefix'                     => 'invoice_prefix',
 			'intent'                     => '',
+			'vault_enabled'              => 'save_paypal_and_venmo',
 		);
 	}
 

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -37,7 +37,8 @@ class SettingsTabMapHelper {
 			'subtotal_mismatch_behavior' => 'subtotal_adjustment',
 			'landing_page'               => 'landing_page',
 			'smart_button_language'      => 'button_language',
-			'prefix'      				 => 'invoice_prefix',
+			'prefix'                     => 'invoice_prefix',
+			'intent'                     => '',
 		);
 	}
 
@@ -57,6 +58,9 @@ class SettingsTabMapHelper {
 
 			case 'landing_page':
 				return $this->mapped_landing_page_value( $settings_model );
+
+			case 'intent':
+				return $this->mapped_intent_value( $settings_model );
 
 			default:
 				return $settings_model[ $new_key ] ?? null;
@@ -98,5 +102,22 @@ class SettingsTabMapHelper {
 				? ApplicationContext::LANDING_PAGE_BILLING
 				: ApplicationContext::LANDING_PAGE_NO_PREFERENCE
 			);
+	}
+
+	/**
+	 * Retrieves the mapped value for the order intent from the new settings.
+	 *
+	 * @param array<string, scalar|array> $settings_model The new settings model data as an array.
+	 * @return 'AUTHORIZE'|'CAPTURE'|null The mapped 'intent' setting value.
+	 */
+	protected function mapped_intent_value( array $settings_model ): ?string {
+		$authorize_only         = $settings_model['authorize_only'] ?? null;
+		$capture_virtual_orders = $settings_model['capture_virtual_orders'] ?? null;
+
+		if ( is_null( $authorize_only ) && is_null( $capture_virtual_orders ) ) {
+			return null;
+		}
+
+		return $authorize_only ? 'AUTHORIZE' : 'CAPTURE';
 	}
 }

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -37,6 +37,7 @@ class SettingsTabMapHelper {
 			'subtotal_mismatch_behavior' => 'subtotal_adjustment',
 			'landing_page'               => 'landing_page',
 			'smart_button_language'      => 'button_language',
+			'prefix'      				 => 'invoice_prefix',
 		);
 	}
 

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -30,16 +30,17 @@ class SettingsTabMapHelper {
 	 */
 	public function map(): array {
 		return array(
-			'disable_cards'              => 'disabled_cards',
-			'brand_name'                 => 'brand_name',
-			'soft_descriptor'            => 'soft_descriptor',
-			'payee_preferred'            => 'instant_payments_only',
-			'subtotal_mismatch_behavior' => 'subtotal_adjustment',
-			'landing_page'               => 'landing_page',
-			'smart_button_language'      => 'button_language',
-			'prefix'                     => 'invoice_prefix',
-			'intent'                     => '',
-			'vault_enabled_dcc'          => 'save_card_details',
+			'disable_cards'               => 'disabled_cards',
+			'brand_name'                  => 'brand_name',
+			'soft_descriptor'             => 'soft_descriptor',
+			'payee_preferred'             => 'instant_payments_only',
+			'subtotal_mismatch_behavior'  => 'subtotal_adjustment',
+			'landing_page'                => 'landing_page',
+			'smart_button_language'       => 'button_language',
+			'prefix'                      => 'invoice_prefix',
+			'intent'                      => '',
+			'vault_enabled_dcc'           => 'save_card_details',
+			'blocks_final_review_enabled' => 'enable_pay_now',
 		);
 	}
 


### PR DESCRIPTION
## Issue Description

The “PayPal settings“ from the new UI’s settings tab is not currently connected with the frontend

<img width="1066" alt="Screenshot 2025-02-12 at 15 33 52" src="https://github.com/user-attachments/assets/2c5412bb-abd0-49b7-b986-760c9c12702a" />

## PR Description

This PR will connect the "Common Settings" section from the settings tab to frontend by mapping the following fields

- Invoice Prefix
- Order Intent
- Save payment methods
- Pay Now Experience