### PR TITLE
Undefined array key "disable_funding" on new install (4228)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -120,7 +120,10 @@ class Settings implements ContainerInterface {
 	 * @return bool
 	 */
 	public function has( string $id ) {
-		if ( $this->settings_map_helper->has_mapped_key( $id ) ) {
+		if (
+			$this->settings_map_helper->has_mapped_key( $id )
+			&& ! is_null( $this->settings_map_helper->mapped_value( $id ) )
+		) {
 			return true;
 		}
 


### PR DESCRIPTION
## Issue Description

On a fresh install, after onboarding a business sandbox account using app client id and secret the error is thrown about Undefined array key "disable_funding"

## PR Description

The PR will ensure the [has](https://github.com/woocommerce/woocommerce-paypal-payments/blob/22ddf2597f42531f4159d9b4e2db0732473d0cf9/modules/ppcp-wc-gateway/src/Settings/Settings.php#L122) method returns `false` if the mapped value doesn't exist



