### PR TITLE
Todos: Update the eligibility conditions for the Subscription todo (4177)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -307,7 +307,8 @@ return array(
 	'settings.data.definition.todos'              => static function ( ContainerInterface $container ) : TodosDefinition {
 		return new TodosDefinition(
 			$container->get( 'settings.service.todos_eligibilities' ),
-			$container->get( 'settings.data.general' )
+			$container->get( 'settings.data.general' ),
+			$container->get( 'wc-subscriptions.helper' )
 		);
 	},
 	'settings.data.definition.methods'            => static function ( ContainerInterface $container ) : PaymentMethodsDefinition {
@@ -360,18 +361,18 @@ return array(
 			$capabilities['acdc'] && ! $gateways['axo'],                                              // Enable Fastlane.
 			$capabilities['acdc'] && ! $gateways['card-button'],                                      // Enable Credit and Debit Cards on your checkout.
 			$is_pay_later_messaging_enabled_for_any_location,                                         // Enable Pay Later messaging.
-			! $is_pay_later_messaging_enabled_for_any_location && ! $pay_later_statuses['product'],   // Add Pay Later messaging (Product page).
-			! $is_pay_later_messaging_enabled_for_any_location && ! $pay_later_statuses['cart'],      // Add Pay Later messaging (Cart).
+			! $is_pay_later_messaging_enabled_for_any_location && ! $pay_later_statuses['product'],    // Add Pay Later messaging (Product page).
+			! $is_pay_later_messaging_enabled_for_any_location && ! $pay_later_statuses['cart'],          // Add Pay Later messaging (Cart).
 			! $is_pay_later_messaging_enabled_for_any_location && ! $pay_later_statuses['checkout'],  // Add Pay Later messaging (Checkout).
-			true,                                                                                     // Configure a PayPal Subscription.
-			true,                                                                                     // Add PayPal buttons.
-			true,                                                                                     // Register Domain for Apple Pay.
-			$capabilities['acdc'] && ! ( $capabilities['apple_pay'] && $capabilities['google_pay'] ), // Add digital wallets to your account.
+			$container->has( 'save-payment-methods.eligible' ) && ! $container->get( 'save-payment-methods.eligible' ) && $container->has( 'wc-subscriptions.helper' ) && $container->get( 'wc-subscriptions.helper' )
+					->plugin_is_active(),                                                                                   // Configure a PayPal Subscription.
+			true,                                                                                      // Add PayPal buttons.
+			$capabilities['apple_pay'],                                                                                     // Register Domain for Apple Pay.
+			$capabilities['acdc'] && ! ( $capabilities['apple_pay'] && $capabilities['google_pay'] ),   // Add digital wallets to your account.
 			$capabilities['acdc'] && ! $capabilities['apple_pay'],                                    // Add Apple Pay to your account.
-			$capabilities['acdc'] && ! $capabilities['google_pay'],                                   // Add Google Pay to your account.
-			true,                                                                                     // Configure a PayPal Subscription.
-			$capabilities['apple_pay'] && ! $gateways['apple_pay'],                                   // Enable Apple Pay.
-			$capabilities['google_pay'] && ! $gateways['google_pay'], // Enable Google Pay.
+			$capabilities['acdc'] && ! $capabilities['google_pay'],                                  // Add Google Pay to your account.
+			$capabilities['apple_pay'] && ! $gateways['apple_pay'],                              // Enable Apple Pay.
+			$capabilities['google_pay'] && ! $gateways['google_pay'],                           // Enable Google Pay.
 		);
 	},
 );

--- a/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Settings\Data\Definition;
 
 use WooCommerce\PayPalCommerce\Settings\Service\TodosEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
  * Class TodosDefinition
@@ -35,17 +36,27 @@ class TodosDefinition {
 	protected GeneralSettings $settings;
 
 	/**
+	 * The subscription helper.
+	 *
+	 * @var SubscriptionHelper
+	 */
+	protected SubscriptionHelper $subscription_helper;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param TodosEligibilityService $eligibilities The todos eligibility service.
 	 * @param GeneralSettings         $settings The general settings service.
+	 * @param SubscriptionHelper      $subscription_helper The subscription helper.
 	 */
 	public function __construct(
 		TodosEligibilityService $eligibilities,
-		GeneralSettings $settings
+		GeneralSettings $settings,
+		SubscriptionHelper $subscription_helper
 	) {
-		$this->eligibilities = $eligibilities;
-		$this->settings      = $settings;
+		$this->eligibilities       = $eligibilities;
+		$this->settings            = $settings;
+		$this->subscription_helper = $subscription_helper;
 	}
 
 	/**
@@ -126,8 +137,11 @@ class TodosDefinition {
 				'description' => __( 'Connect a subscriptions-type product from WooCommerce with PayPal', 'woocommerce-paypal-payments' ),
 				'isEligible'  => $eligibility_checks['configure_paypal_subscription'],
 				'action'      => array(
-					'type' => 'external',
-					'url'  => admin_url( 'edit.php?post_type=product&product_type=subscription' ),
+					'type'            => 'external',
+					'url'             => $this->subscription_helper->has_subscription_products()
+						? admin_url( 'edit.php?post_type=product&product_type=subscription' )  // If subscription products exist, go to the subscriptions products archive page.
+						: admin_url( 'post-new.php?post_type=product' ), // If there are no subscriptions products, go to create one.
+					'completeOnClick' => true,
 				),
 				'priority'    => 5,
 			),

--- a/modules/ppcp-settings/src/Service/TodosEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/TodosEligibilityService.php
@@ -102,13 +102,6 @@ class TodosEligibilityService {
 	private bool $is_paypal_buttons_eligible;
 
 	/**
-	 * Whether PayPal subscription configuration is eligible.
-	 *
-	 * @var bool
-	 */
-	private bool $is_add_subscription_eligible;
-
-	/**
 	 * Whether enabling Apple Pay is eligible.
 	 *
 	 * @var bool
@@ -137,7 +130,6 @@ class TodosEligibilityService {
 	 * @param bool $is_digital_wallet_eligible          Whether digital wallet features are eligible.
 	 * @param bool $is_apple_pay_eligible               Whether Apple Pay is eligible.
 	 * @param bool $is_google_pay_eligible              Whether Google Pay is eligible.
-	 * @param bool $is_add_subscription_eligible        Whether PayPal subscription configuration is eligible.
 	 * @param bool $is_enable_apple_pay_eligible        Whether enabling Apple Pay is eligible.
 	 * @param bool $is_enable_google_pay_eligible       Whether enabling Google Pay is eligible.
 	 */
@@ -154,7 +146,6 @@ class TodosEligibilityService {
 		bool $is_digital_wallet_eligible,
 		bool $is_apple_pay_eligible,
 		bool $is_google_pay_eligible,
-		bool $is_add_subscription_eligible,
 		bool $is_enable_apple_pay_eligible,
 		bool $is_enable_google_pay_eligible
 	) {
@@ -170,7 +161,6 @@ class TodosEligibilityService {
 		$this->is_digital_wallet_eligible               = $is_digital_wallet_eligible;
 		$this->is_apple_pay_eligible                    = $is_apple_pay_eligible;
 		$this->is_google_pay_eligible                   = $is_google_pay_eligible;
-		$this->is_add_subscription_eligible             = $is_add_subscription_eligible;
 		$this->is_enable_apple_pay_eligible             = $is_enable_apple_pay_eligible;
 		$this->is_enable_google_pay_eligible            = $is_enable_google_pay_eligible;
 	}

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -21,6 +21,7 @@ use WCS_Manual_Renewal_Manager;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WP_Query;
 
 /**
  * Class SubscriptionHelper
@@ -341,5 +342,31 @@ class SubscriptionHelper {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Checks if any subscription products exist.
+	 *
+	 * @return bool
+	 */
+	public function has_subscription_products(): bool {
+		// Query for subscription products.
+		$args = array(
+			'post_type'      => 'product',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'product_type',
+					'field'    => 'slug',
+					'terms'    => 'subscription',
+				),
+			),
+		);
+
+		$subscription_products = new WP_Query( $args );
+
+		return $subscription_products->have_posts();
 	}
 }


### PR DESCRIPTION
### Description

This PR will update the logic for the "Configure a PayPal Subscription" todo item:

- The item is eligible if the merchant has the WooCommerce Subscriptions plugin active, but is not eligible for vaulting.
- Furthermore, the action URL will be dynamic:
  - If subscription products exist, direct to the subscription products archive page
  - If no subscription products exist, direct to create a new product
- Remove unnecessary eligibility checks for subscription configuration
- Add helper method has_subscription_products() to determine if any subscription products exist

Additionally, it will also fix the logic for the `Register Domain for Apple Pay` item.