### PR TITLE
Store and use the Merchant country from PayPal (4155)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
@@ -160,7 +160,7 @@ class PartnersEndpoint {
 
 		$this->failure_registry->clear_failures( FailureRegistry::SELLER_STATUS_KEY );
 
-		$status = $this->seller_status_factory->from_paypal_reponse( $json );
+		$status = $this->seller_status_factory->from_paypal_response( $json );
 		return $status;
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/SellerStatus.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatus.php
@@ -81,8 +81,12 @@ class SellerStatus {
 		return $this->capabilities;
 	}
 
+	public function country() : string {
+		return $this->country;
+	}
+
 	/**
-	 * Returns the enitity as array.
+	 * Returns the entity as array.
 	 *
 	 * @return array
 	 */

--- a/modules/ppcp-api-client/src/Entity/SellerStatus.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatus.php
@@ -29,14 +29,22 @@ class SellerStatus {
 	private $capabilities;
 
 	/**
+	 * Merchant country on PayPal.
+	 *
+	 * @var string
+	 */
+	private $country;
+
+	/**
 	 * SellerStatus constructor.
 	 *
 	 * @param SellerStatusProduct[]    $products The products.
 	 * @param SellerStatusCapability[] $capabilities The capabilities.
+	 * @param string                   $country Merchant country on PayPal.
 	 *
 	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
-	public function __construct( array $products, array $capabilities ) {
+	public function __construct( array $products, array $capabilities, string $country = '' ) {
 		foreach ( $products as $key => $product ) {
 			if ( is_a( $product, SellerStatusProduct::class ) ) {
 				continue;
@@ -52,6 +60,7 @@ class SellerStatus {
 
 		$this->products     = $products;
 		$this->capabilities = $capabilities;
+		$this->country      = $country;
 	}
 
 	/**
@@ -95,6 +104,7 @@ class SellerStatus {
 		return array(
 			'products'     => $products,
 			'capabilities' => $capabilities,
+			'country'      => $this->country,
 		);
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/SellerStatus.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatus.php
@@ -81,6 +81,11 @@ class SellerStatus {
 		return $this->capabilities;
 	}
 
+	/**
+	 * Returns merchant's country on PayPal.
+	 *
+	 * @return string
+	 */
 	public function country() : string {
 		return $this->country;
 	}

--- a/modules/ppcp-api-client/src/Entity/SellerStatus.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatus.php
@@ -33,7 +33,7 @@ class SellerStatus {
 	 *
 	 * @var string
 	 */
-	private $country;
+	private string $country;
 
 	/**
 	 * SellerStatus constructor.

--- a/modules/ppcp-api-client/src/Factory/SellerStatusFactory.php
+++ b/modules/ppcp-api-client/src/Factory/SellerStatusFactory.php
@@ -25,7 +25,7 @@ class SellerStatusFactory {
 	 *
 	 * @return SellerStatus
 	 */
-	public function from_paypal_reponse( \stdClass $json ) : SellerStatus {
+	public function from_paypal_response( \stdClass $json ) : SellerStatus {
 		$products = array_map(
 			function( $json ) : SellerStatusProduct {
 				$product = new SellerStatusProduct(
@@ -49,6 +49,6 @@ class SellerStatusFactory {
 			isset( $json->capabilities ) ? (array) $json->capabilities : array()
 		);
 
-		return new SellerStatus( $products, $capabilities );
+		return new SellerStatus( $products, $capabilities, $json->country ?? '' );
 	}
 }

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -308,7 +308,8 @@ return array(
 			$container->get( 'api.env.endpoint.login-seller' ),
 			$container->get( 'api.repository.partner-referrals-data' ),
 			$container->get( 'settings.connection-state' ),
-			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'api.endpoint.partners' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 	'settings.service.sanitizer'                  => static function ( ContainerInterface $container ) : DataSanitizer {

--- a/modules/ppcp-settings/src/DTO/MerchantConnectionDTO.php
+++ b/modules/ppcp-settings/src/DTO/MerchantConnectionDTO.php
@@ -53,6 +53,13 @@ class MerchantConnectionDTO {
 	public string $merchant_email = '';
 
 	/**
+	 * Merchant's country.
+	 *
+	 * @var string
+	 */
+	public string $merchant_country = '';
+
+	/**
 	 * Whether the merchant is a business or personal account.
 	 * Possible values: ['business'|'personal'|'unknown']
 	 *
@@ -68,6 +75,7 @@ class MerchantConnectionDTO {
 	 * @param string $client_secret  API client secret.
 	 * @param string $merchant_id    PayPal's 13-character merchant ID.
 	 * @param string $merchant_email Email address of the merchant account.
+	 * @param string $merchant_country Merchant's country.
 	 * @param string $seller_type    Whether the merchant is a business or personal account.
 	 */
 	public function __construct(
@@ -76,13 +84,15 @@ class MerchantConnectionDTO {
 		string $client_secret,
 		string $merchant_id,
 		string $merchant_email,
+		string $merchant_country,
 		string $seller_type = SellerTypeEnum::UNKNOWN
 	) {
-		$this->is_sandbox     = $is_sandbox;
-		$this->client_id      = $client_id;
-		$this->client_secret  = $client_secret;
-		$this->merchant_id    = $merchant_id;
-		$this->merchant_email = $merchant_email;
-		$this->seller_type    = $seller_type;
+		$this->is_sandbox       = $is_sandbox;
+		$this->client_id        = $client_id;
+		$this->client_secret    = $client_secret;
+		$this->merchant_id      = $merchant_id;
+		$this->merchant_email   = $merchant_email;
+		$this->merchant_country = $merchant_country;
+		$this->seller_type      = $seller_type;
 	}
 }

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -74,6 +74,7 @@ class GeneralSettings extends AbstractDataModel {
 			'sandbox_merchant'      => false,
 			'merchant_id'           => '',
 			'merchant_email'        => '',
+			'merchant_country'      => '',
 			'client_id'             => '',
 			'client_secret'         => '',
 			'seller_type'           => 'unknown',
@@ -138,6 +139,7 @@ class GeneralSettings extends AbstractDataModel {
 		$this->data['sandbox_merchant']   = $connection->is_sandbox;
 		$this->data['merchant_id']        = sanitize_text_field( $connection->merchant_id );
 		$this->data['merchant_email']     = sanitize_email( $connection->merchant_email );
+		$this->data['merchant_country']   = sanitize_text_field( $connection->merchant_country );
 		$this->data['client_id']          = sanitize_text_field( $connection->client_id );
 		$this->data['client_secret']      = sanitize_text_field( $connection->client_secret );
 		$this->data['seller_type']        = sanitize_text_field( $connection->seller_type );
@@ -156,6 +158,7 @@ class GeneralSettings extends AbstractDataModel {
 			$this->data['client_secret'],
 			$this->data['merchant_id'],
 			$this->data['merchant_email'],
+			$this->data['merchant_country'],
 			$this->data['seller_type']
 		);
 	}
@@ -171,6 +174,7 @@ class GeneralSettings extends AbstractDataModel {
 		$this->data['sandbox_merchant']   = $defaults['sandbox_merchant'];
 		$this->data['merchant_id']        = $defaults['merchant_id'];
 		$this->data['merchant_email']     = $defaults['merchant_email'];
+		$this->data['merchant_country']   = $defaults['merchant_country'];
 		$this->data['client_id']          = $defaults['client_id'];
 		$this->data['client_secret']      = $defaults['client_secret'];
 		$this->data['seller_type']        = $defaults['seller_type'];
@@ -238,5 +242,14 @@ class GeneralSettings extends AbstractDataModel {
 	 */
 	public function get_merchant_email() : string {
 		return $this->data['merchant_email'];
+	}
+
+	/**
+	 * Gets the currently connected merchant's country.
+	 *
+	 * @return string
+	 */
+	public function get_merchant_country() : string {
+		return $this->data['merchant_country'];
 	}
 }

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -12,6 +12,8 @@ namespace WooCommerce\PayPalCommerce\Settings\Service;
 use JsonException;
 use Throwable;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\LoginSeller;
@@ -73,6 +75,13 @@ class AuthenticationManager {
 	private ConnectionState $connection_state;
 
 	/**
+	 * Partners endpoint.
+	 *
+	 * @var PartnersEndpoint
+	 */
+	private PartnersEndpoint $partners_endpoint;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param GeneralSettings      $common_settings  Data model that stores the connection details.
@@ -80,6 +89,7 @@ class AuthenticationManager {
 	 * @param EnvironmentConfig    $login_endpoint   API handler to fetch merchant credentials.
 	 * @param PartnerReferralsData $referrals_data   Partner referrals data.
 	 * @param ConnectionState      $connection_state Connection state manager.
+	 * @param PartnersEndpoint     $partners_endpoint Partners endpoint.
 	 * @param ?LoggerInterface     $logger           Logging instance.
 	 */
 	public function __construct(
@@ -88,14 +98,16 @@ class AuthenticationManager {
 		EnvironmentConfig $login_endpoint,
 		PartnerReferralsData $referrals_data,
 		ConnectionState $connection_state,
+		PartnersEndpoint $partners_endpoint,
 		?LoggerInterface $logger = null
 	) {
-		$this->common_settings  = $common_settings;
-		$this->connection_host  = $connection_host;
-		$this->login_endpoint   = $login_endpoint;
-		$this->referrals_data   = $referrals_data;
-		$this->connection_state = $connection_state;
-		$this->logger           = $logger ?: new NullLogger();
+		$this->common_settings   = $common_settings;
+		$this->connection_host   = $connection_host;
+		$this->login_endpoint    = $login_endpoint;
+		$this->referrals_data    = $referrals_data;
+		$this->connection_state  = $connection_state;
+		$this->partners_endpoint = $partners_endpoint;
+		$this->logger            = $logger ?: new NullLogger();
 	}
 
 	/**
@@ -196,12 +208,19 @@ class AuthenticationManager {
 
 		$payee = $this->request_payee( $client_id, $client_secret, $use_sandbox );
 
+		try {
+			$seller_status = $this->partners_endpoint->seller_status();
+		} catch ( PayPalApiException $exception ) {
+			$seller_status = null;
+		}
+
 		$connection = new MerchantConnectionDTO(
 			$use_sandbox,
 			$client_id,
 			$client_secret,
 			$payee['merchant_id'],
 			$payee['email_address'],
+			! is_null( $seller_status ) ? $seller_status->country() : '',
 			SellerTypeEnum::BUSINESS
 		);
 
@@ -267,10 +286,17 @@ class AuthenticationManager {
 		 */
 		$connection = $this->common_settings->get_merchant_data();
 
-		$connection->is_sandbox    = $use_sandbox;
-		$connection->client_id     = $credentials['client_id'];
-		$connection->client_secret = $credentials['client_secret'];
-		$connection->merchant_id   = $credentials['merchant_id'];
+		try {
+			$seller_status = $this->partners_endpoint->seller_status();
+		} catch ( PayPalApiException $exception ) {
+			$seller_status = null;
+		}
+
+		$connection->is_sandbox       = $use_sandbox;
+		$connection->client_id        = $credentials['client_id'];
+		$connection->client_secret    = $credentials['client_secret'];
+		$connection->merchant_id      = $credentials['merchant_id'];
+		$connection->merchant_country = ! is_null( $seller_status ) ? $seller_status->country() : '';
 
 		$this->update_connection_details( $connection );
 	}
@@ -305,6 +331,13 @@ class AuthenticationManager {
 		if ( SellerTypeEnum::is_valid( $seller_type ) ) {
 			$connection->seller_type = $seller_type;
 		}
+
+		try {
+			$seller_status = $this->partners_endpoint->seller_status();
+		} catch ( PayPalApiException $exception ) {
+			$seller_status = null;
+		}
+		$connection->merchant_country = ! is_null( $seller_status ) ? $seller_status->country() : '';
 
 		$this->update_connection_details( $connection );
 	}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -304,16 +304,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 				$flags = new ConfigurationFlagsDTO();
 
-				$partners_endpoint = $container->get( 'api.endpoint.partners' );
-				assert( $partners_endpoint instanceof PartnersEndpoint );
-
-				try {
-					$seller_status = $partners_endpoint->seller_status();
-				} catch ( PayPalApiException $exception ) {
-					$seller_status = null;
-				}
-
-				$flags->country_code       = ! is_null( $seller_status ) ? $seller_status->country() : 'US';
+				$flags->country_code       = $general_settings->get_merchant_country();
 				$flags->is_business_seller = $general_settings->is_business_seller();
 				$flags->use_card_payments  = $onboarding_profile->get_accept_card_payments();
 				$flags->use_subscriptions  = in_array( ProductChoicesEnum::SUBSCRIPTIONS, $onboarding_profile->get_products(), true );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Settings;
 
 use WC_Payment_Gateway;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
@@ -302,8 +303,12 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 				$flags = new ConfigurationFlagsDTO();
 
-				// TODO: Get the merchant country from PayPal here!
-				$flags->country_code       = 'US';
+				$partners_endpoint = $container->get( 'api.endpoint.partners' );
+				assert( $partners_endpoint instanceof PartnersEndpoint );
+
+				$seller_status = $partners_endpoint->seller_status();
+
+				$flags->country_code       = $seller_status->country() ?: 'US';
 				$flags->is_business_seller = $general_settings->is_business_seller();
 				$flags->use_card_payments  = $onboarding_profile->get_accept_card_payments();
 				$flags->use_subscriptions  = in_array( ProductChoicesEnum::SUBSCRIPTIONS, $onboarding_profile->get_products(), true );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Settings;
 
 use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
@@ -306,9 +307,13 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$partners_endpoint = $container->get( 'api.endpoint.partners' );
 				assert( $partners_endpoint instanceof PartnersEndpoint );
 
-				$seller_status = $partners_endpoint->seller_status();
+				try {
+					$seller_status = $partners_endpoint->seller_status();
+				} catch ( PayPalApiException $exception ) {
+					$seller_status = null;
+				}
 
-				$flags->country_code       = $seller_status->country() ?: 'US';
+				$flags->country_code       = ! is_null( $seller_status ) ? $seller_status->country() : 'US';
 				$flags->is_business_seller = $general_settings->is_business_seller();
 				$flags->use_card_payments  = $onboarding_profile->get_accept_card_payments();
 				$flags->use_subscriptions  = in_array( ProductChoicesEnum::SUBSCRIPTIONS, $onboarding_profile->get_products(), true );


### PR DESCRIPTION
This PR gets the `country` parameter from `v1.customer.partners.*.merchant-integrations.*` response and set its value to `country_code` flag for new merchants. 

### Acceptance Criteria
- After onboarding, check the available features and payment methods
- Update the WooCommerce country to something else (e.g. Zimbabwe) and confirm that all Features and payment methods are still available.