### PR TITLE
Conditionally check/uncheck the Order Intent (4207)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Controls/ControlToggleButton.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Controls/ControlToggleButton.js
@@ -1,7 +1,13 @@
 import { ToggleControl } from '@wordpress/components';
 import { Action, Description } from '../Elements';
 
-const ControlToggleButton = ( { label, description, value, onChange } ) => (
+const ControlToggleButton = ( {
+	label,
+	description,
+	value,
+	onChange,
+	disabled = false,
+} ) => (
 	<Action>
 		<ToggleControl
 			className="ppcp--control-toggle"
@@ -12,6 +18,7 @@ const ControlToggleButton = ( { label, description, value, onChange } ) => (
 			help={
 				description ? <Description>{ description }</Description> : null
 			}
+			disabled={ disabled }
 		/>
 	</Action>
 );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/OrderIntent.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/OrderIntent.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
 
 import { ControlToggleButton } from '../../../../../ReusableComponents/Controls';
 import SettingsBlock from '../../../../../ReusableComponents/SettingsBlock';
@@ -11,6 +12,12 @@ const OrderIntent = () => {
 		captureVirtualOnlyOrders,
 		setCaptureVirtualOnlyOrders,
 	} = SettingsHooks.useSettings();
+
+	useEffect( () => {
+		if ( ! authorizeOnly && captureVirtualOnlyOrders ) {
+			setCaptureVirtualOnlyOrders( false );
+		}
+	}, [ authorizeOnly ] );
 
 	return (
 		<SettingsBlock
@@ -34,6 +41,7 @@ const OrderIntent = () => {
 				) }
 				onChange={ setCaptureVirtualOnlyOrders }
 				value={ captureVirtualOnlyOrders }
+				disabled={ ! authorizeOnly }
 			/>
 		</SettingsBlock>
 	);


### PR DESCRIPTION
## Issue Description

When the "Authorize Only" intent is unchecked we should disable the "Capture Virtual-Only Orders" checkbox.

<img width="852" alt="image" src="https://github.com/user-attachments/assets/fe7a168c-6801-4708-9777-e3755e615e17" />

## PR Description

- When the "Authorize Only" intent is unchecked the "Capture Virtual-Only Orders" checkbox is disabled.
- When both intents are checked and then the user disables the "Authorize Only" checkbox then the "Capture Virtual-Only Orders" checkbox is disabled and unchecked.
- The `disabled` option is added to the `ControlToggleButton` component, which by default is set to `false`
