### PR TITLE
Improve styling for the pay later configurator (PCP-4237)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/screens/settings/_tab-paylater-configurator.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/settings/_tab-paylater-configurator.scss
@@ -47,6 +47,10 @@
 				width: 3rem;
 			}
 		}
+
+		.css-1s8clkf.etu8a6w2 {
+			width: 374px;
+		}
 	}
 
 	&__subheader, #configurator-controlPanelSubHeader {


### PR DESCRIPTION
## Issue Description

The 2nd and 1st options of the Pay Later Messaging configurator looks a bit broken

<img width="725" alt="Screenshot 2025-02-18 at 18 38 43" src="https://github.com/user-attachments/assets/6e7ae953-c506-4b2e-8034-959a29ba5b35" />

## PR Description

Fixes the previews for all the options to have a same width

<img width="1153" alt="Screenshot 2025-02-18 at 18 49 12" src="https://github.com/user-attachments/assets/eff16cc7-f911-46cd-996a-f5621954d1e5" />
