### PR TITLE
Ensure Fraudnet is always enabled when the new settings module is active (4238)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1854,6 +1854,13 @@ return array(
 		$settings      = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
+		if ( apply_filters(
+			'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
+			getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
+		) ) {
+			return true;
+		}
+
 		return $settings->has( 'fraudnet_enabled' ) && $settings->get( 'fraudnet_enabled' );
 	},
 	'wcgateway.fraudnet-assets'                            => function( ContainerInterface $container ) : FraudNetAssets {


### PR DESCRIPTION
## Issue Description

In the new UI  we do not have a checkbox to toggle “FraudNet”, and every merchant that uses the new UI will automatically opt-into using FraudNet validation.

## PR Description

When the new settings module is enabled the PR will force the "is-enabled" FraudNet service to always return `true`.