### PR TITLE
Prevent navigation on incomplete steps (4243)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepBusiness.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepBusiness.js
@@ -22,8 +22,13 @@ const StepBusiness = ( {} ) => {
 	);
 
 	useEffect( () => {
+		if ( ! businessChoice ) {
+			return;
+		}
+
 		setIsCasualSeller( BUSINESS_TYPES.CASUAL_SELLER === businessChoice );
 	}, [ businessChoice, setIsCasualSeller ] );
+
 	const { canUseSubscriptions } = OnboardingHooks.useFlags();
 	const businessChoices = [
 		{

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
@@ -36,8 +36,7 @@ const ALL_STEPS = [
 		id: 'methods',
 		title: __( 'Choose checkout options', 'woocommerce-paypal-payments' ),
 		StepComponent: StepPaymentMethods,
-		canProceed: ( { methods } ) =>
-			methods.areOptionalPaymentMethodsEnabled !== null,
+		canProceed: ( { methods } ) => methods.optionalMethods !== null,
 	},
 	{
 		id: 'complete',


### PR DESCRIPTION
### Description

Keeps the "Continue" button in the onboarding wizard disabled on Step 2 and 4 while no option was selected.

**Sample of bug on Step 2:**
![image](https://github.com/user-attachments/assets/66c4dd0d-3389-4799-a1bc-3388aa5d116d)
