### PR TITLE
Learn More link for PayInThree, UK (4208)

### DIFF
--- a/modules/ppcp-settings/resources/js/utils/countryInfoLinks.js
+++ b/modules/ppcp-settings/resources/js/utils/countryInfoLinks.js
@@ -24,7 +24,7 @@ export const learnMoreLinks = {
 			'https://www.paypal.com/uk/business/paypal-business-fees',
 		PayPalCheckout:
 			'https://www.paypal.com/uk/business/accept-payments/checkout',
-		PayLater:
+		PayInThree:
 			'https://www.paypal.com/uk/business/accept-payments/checkout/installments',
 	},
 	FR: {


### PR DESCRIPTION
### Description

Adds the missing "Learn More" link of the "Pay in 3" item for UK onboarding

#### Screenshot of the item
The "Learn More" link is missing in the marked section
![image](https://github.com/user-attachments/assets/4249173f-0256-4bf2-9ec8-9e757ce0b0df)
