### PR TITLE
Settings UI: Tighten up the payment methods footer and modal styling (4222)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_payment-method-item.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_payment-method-item.scss
@@ -63,6 +63,10 @@
 			&:hover {
 				transform: rotate(45deg);
 			}
+
+			&.components-button {
+				height: auto;
+			}
 		}
 
 		.ppcp--method-icon {
@@ -79,6 +83,7 @@
 			justify-content: space-between;
 			align-items: center;
 			margin-top: auto;
+			min-height: 24px;
 		}
 	}
 }

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_payment-method-modal.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_payment-method-modal.scss
@@ -73,7 +73,6 @@
 		gap: 8px;
 
 		&--save {
-			margin-top: -4px;
 			align-items: flex-end;
 		}
 
@@ -87,7 +86,7 @@
 	&__field-rows {
 		display: flex;
 		flex-direction: column;
-		gap: 24px;
+		gap: 18px;
 
 		&--acdc {
 			gap: 18px;
@@ -98,17 +97,9 @@
 		}
 
 		.components-radio-control {
-			.components-flex {
-				gap: 18px;
-			}
-
 			label {
 				@include font(14, 20, 400);
 				color: $color-black;
-			}
-
-			&__option {
-				gap: 18px;
 			}
 
 			&__input {

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/Modal.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/Modal.js
@@ -100,14 +100,16 @@ const Modal = ( { method, setModalIsVisible, onSave } ) => {
 			case 'radio':
 				return (
 					<>
-						<strong className="ppcp-r-modal__content-title">
-							{ field.label }
-						</strong>
-						{ field.description && (
-							<p className="ppcp-r-modal__description">
-								{ field.description }
-							</p>
-						) }
+						<div className="ppcp-r-modal__field-row">
+							<strong className="ppcp-r-modal__content-title">
+								{ field.label }
+							</strong>
+							{ field.description && (
+								<span className="ppcp-r-modal__field-description">
+									{ field.description }
+								</span>
+							) }
+						</div>
 						<div className="ppcp-r-modal__field-row">
 							<RadioControl
 								selected={ settings[ key ] }


### PR DESCRIPTION
### Description

This PR will improve the UI consistency and styling of payment methods.

- Adjust the spacing and alignment of the payment method card icons
- Standardize gap sizes between elements in the modal
 
### Screenshots

|Before|After|
|-|-|
|<img width="1014" alt="before_payment_methods" src="https://github.com/user-attachments/assets/2f0194d7-fe24-4317-bc28-7dbd0dbbd943" />|<img width="1069" alt="after_payment_method" src="https://github.com/user-attachments/assets/1fdfc358-ef4d-4789-aedc-807e0054c316" />|


|Before|After|
|-|-|
|<img width="454" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/bf57623b-cad3-4e47-bbc4-8f3cdaf654d9" />|<img width="439" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/d00c0dce-c62b-4e6e-9d5a-0ea26e7c97de" />|
