### PR TITLE
Fix PHP notice about "_load_textdomain_just_in_time" (4250)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -233,7 +233,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 	 * @return bool
 	 */
 	private function should_add_local_apm_gateways( ContainerInterface $container ) : bool {
-		// Merchant onboarding must be completed.
+		// APMs are only available after merchant onboarding is completed.
 		$is_connected = $container->get( 'settings.flag.is-connected' );
 		if ( ! $is_connected ) {
 			/**
@@ -243,13 +243,8 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 			 * During the authentication process (which happens via a REST call)
 			 * the gateways need to be present, so they can be correctly
 			 * pre-configured for new merchants.
-			 *
-			 * TODO is there a cleaner solution for this?
 			 */
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' );
-
-			return str_contains( $request_uri, '/wp-json/wc/' );
+			return $this->is_rest_request();
 		}
 
 		// The general plugin functionality must be enabled.
@@ -262,5 +257,17 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 		// Register APM gateways, when the relevant setting is active.
 		return $settings->has( 'allow_local_apm_gateways' )
 			&& $settings->get( 'allow_local_apm_gateways' ) === true;
+	}
+
+	/**
+	 * Checks, whether the current request is trying to access a WooCommerce REST endpoint.
+	 *
+	 * @return bool True, if the request path matches the WC-Rest namespace.
+	 */
+	private function is_rest_request(): bool {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' );
+
+		return str_contains( $request_uri, '/wp-json/wc/' );
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -42,10 +42,24 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 	/**
 	 * {@inheritDoc}
 	 */
-	public function run( ContainerInterface $c ): bool {
+	public function run( ContainerInterface $c ) : bool {
+		add_action( 'after_setup_theme', fn() => $this->run_with_translations( $c ) );
+
+		return true;
+	}
+
+	/**
+	 * Set up WP hooks that depend on translation features.
+	 * Runs after the theme setup, when translations are available, which is fired
+	 * before the `init` hook, which usually contains most of the logic.
+	 *
+	 * @param ContainerInterface $c The DI container.
+	 * @return void
+	 */
+	private function run_with_translations( ContainerInterface $c ) : void {
 		// When Local APMs are disabled, none of the following hooks are needed.
 		if ( ! $this->should_add_local_apm_gateways( $c ) ) {
-			return true;
+			return;
 		}
 
 		/**
@@ -193,8 +207,6 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 			10,
 			2
 		);
-
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
### Description

Slightly delays registration of some hooks that depends on the `wcgateway.settings` service, as that service has some i10n dependencies.