### PR TITLE
Hide Payment Methods screen when WooPayments is active (4167)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
@@ -59,8 +59,8 @@ export const getSteps = ( flags ) => {
 	const steps = filterSteps( ALL_STEPS, [
 		// Casual selling: Unlock the "Personal Account" choice.
 		( step ) => flags.canUseCasualSelling || step.id !== 'business',
-		// Hide methods screen when WooPayments is active.
-		( step ) => ! flags.isWooPaymentsActive || step.id !== 'methods',
+		// Skip payment methods screen.
+		( step ) => ! flags.shouldSkipPaymentMethods || step.id !== 'methods',
 	] );
 
 	const totalStepsCount = steps.length;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
@@ -59,6 +59,8 @@ export const getSteps = ( flags ) => {
 	const steps = filterSteps( ALL_STEPS, [
 		// Casual selling: Unlock the "Personal Account" choice.
 		( step ) => flags.canUseCasualSelling || step.id !== 'business',
+		// Hide methods screen when WooPayments is active.
+		( step ) => ! flags.isWooPaymentsActive || step.id !== 'methods',
 	] );
 
 	const totalStepsCount = steps.length;

--- a/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
@@ -23,6 +23,7 @@ const defaultTransient = Object.freeze( {
 		canUseVaulting: false,
 		canUseCardPayments: false,
 		canUseSubscriptions: false,
+		isWooPaymentsActive: false,
 	} ),
 } );
 

--- a/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
@@ -23,7 +23,7 @@ const defaultTransient = Object.freeze( {
 		canUseVaulting: false,
 		canUseCardPayments: false,
 		canUseSubscriptions: false,
-		isWooPaymentsActive: false,
+		shouldSkipPaymentMethods: false,
 	} ),
 } );
 

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -68,18 +68,14 @@ return array(
 		$can_use_card_payments  = $container->has( 'card-fields.eligible' ) && $container->get( 'card-fields.eligible' );
 		$can_use_subscriptions  = $container->has( 'wc-subscriptions.helper' ) && $container->get( 'wc-subscriptions.helper' )
 				->plugin_is_active();
-
-		// Card payments are disabled for this plugin when WooPayments is active.
-		// TODO: Move this condition to the card-fields.eligible service?
-		if ( class_exists( '\WC_Payments' ) ) {
-			$can_use_card_payments = false;
-		}
+		$is_woopayments_active = class_exists( '\WC_Payments' );
 
 		return new OnboardingProfile(
 			$can_use_casual_selling,
 			$can_use_vaulting,
 			$can_use_card_payments,
-			$can_use_subscriptions
+			$can_use_subscriptions,
+			$is_woopayments_active
 		);
 	},
 	'settings.data.general'                        => static function ( ContainerInterface $container ) : GeneralSettings {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -68,14 +68,14 @@ return array(
 		$can_use_card_payments  = $container->has( 'card-fields.eligible' ) && $container->get( 'card-fields.eligible' );
 		$can_use_subscriptions  = $container->has( 'wc-subscriptions.helper' ) && $container->get( 'wc-subscriptions.helper' )
 				->plugin_is_active();
-		$is_woopayments_active = class_exists( '\WC_Payments' );
+		$should_skip_payment_methods = class_exists( '\WC_Payments' );
 
 		return new OnboardingProfile(
 			$can_use_casual_selling,
 			$can_use_vaulting,
 			$can_use_card_payments,
 			$can_use_subscriptions,
-			$is_woopayments_active
+			$should_skip_payment_methods
 		);
 	},
 	'settings.data.general'                        => static function ( ContainerInterface $container ) : GeneralSettings {

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -43,6 +43,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 * @param bool $can_use_vaulting       Whether vaulting is enabled in the store's country.
 	 * @param bool $can_use_card_payments  Whether credit card payments are possible.
 	 * @param bool $can_use_subscriptions  Whether WC Subscriptions plugin is active.
+	 * @param bool $is_woopayments_active  Whether WooPayments plugin is active.
 	 *
 	 * @throws RuntimeException If the OPTION_KEY is not defined in the child class.
 	 */
@@ -50,7 +51,8 @@ class OnboardingProfile extends AbstractDataModel {
 		bool $can_use_casual_selling = false,
 		bool $can_use_vaulting = false,
 		bool $can_use_card_payments = false,
-		bool $can_use_subscriptions = false
+		bool $can_use_subscriptions = false,
+		bool $is_woopayments_active = false
 	) {
 		parent::__construct();
 
@@ -58,6 +60,7 @@ class OnboardingProfile extends AbstractDataModel {
 		$this->flags['can_use_vaulting']       = $can_use_vaulting;
 		$this->flags['can_use_card_payments']  = $can_use_card_payments;
 		$this->flags['can_use_subscriptions']  = $can_use_subscriptions;
+		$this->flags['is_woopayments_active']  = $is_woopayments_active;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -43,7 +43,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 * @param bool $can_use_vaulting       Whether vaulting is enabled in the store's country.
 	 * @param bool $can_use_card_payments  Whether credit card payments are possible.
 	 * @param bool $can_use_subscriptions  Whether WC Subscriptions plugin is active.
-	 * @param bool $is_woopayments_active  Whether WooPayments plugin is active.
+	 * @param bool $should_skip_payment_methods  Whether it should skip payment methods screen.
 	 *
 	 * @throws RuntimeException If the OPTION_KEY is not defined in the child class.
 	 */
@@ -52,15 +52,15 @@ class OnboardingProfile extends AbstractDataModel {
 		bool $can_use_vaulting = false,
 		bool $can_use_card_payments = false,
 		bool $can_use_subscriptions = false,
-		bool $is_woopayments_active = false
+		bool $should_skip_payment_methods = false
 	) {
 		parent::__construct();
 
-		$this->flags['can_use_casual_selling'] = $can_use_casual_selling;
-		$this->flags['can_use_vaulting']       = $can_use_vaulting;
-		$this->flags['can_use_card_payments']  = $can_use_card_payments;
-		$this->flags['can_use_subscriptions']  = $can_use_subscriptions;
-		$this->flags['is_woopayments_active']  = $is_woopayments_active;
+		$this->flags['can_use_casual_selling']      = $can_use_casual_selling;
+		$this->flags['can_use_vaulting']            = $can_use_vaulting;
+		$this->flags['can_use_card_payments']       = $can_use_card_payments;
+		$this->flags['can_use_subscriptions']       = $can_use_subscriptions;
+		$this->flags['should_skip_payment_methods'] = $should_skip_payment_methods;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -80,6 +80,9 @@ class OnboardingRestEndpoint extends RestEndpoint {
 		'can_use_subscriptions'  => array(
 			'js_name' => 'canUseSubscriptions',
 		),
+		'is_woopayments_active'  => array(
+			'js_name' => 'isWooPaymentsActive',
+		),
 	);
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -68,20 +68,20 @@ class OnboardingRestEndpoint extends RestEndpoint {
 	 * @var array
 	 */
 	private array $flag_map = array(
-		'can_use_casual_selling' => array(
+		'can_use_casual_selling'      => array(
 			'js_name' => 'canUseCasualSelling',
 		),
-		'can_use_vaulting'       => array(
+		'can_use_vaulting'            => array(
 			'js_name' => 'canUseVaulting',
 		),
-		'can_use_card_payments'  => array(
+		'can_use_card_payments'       => array(
 			'js_name' => 'canUseCardPayments',
 		),
-		'can_use_subscriptions'  => array(
+		'can_use_subscriptions'       => array(
 			'js_name' => 'canUseSubscriptions',
 		),
-		'is_woopayments_active'  => array(
-			'js_name' => 'isWooPaymentsActive',
+		'should_skip_payment_methods' => array(
+			'js_name' => 'shouldSkipPaymentMethods',
 		),
 	);
 


### PR DESCRIPTION
When a WordPress site has an active installation of the WooPayments plugin, the ACDC feature is disabled for the merchant (regardless of the region) and the site will fall back to a restricted BCDC onboarding flow.

This PR adds a new "WooPayments plugin active" flag that is used to conditionally display the onboarding payment methods screen.

### How to test
- Activate WooPayments plugin
- Check that payment methods screen does not appear in live onboarding flow:

![Captura de pantalla 2025-02-25 a las 11 36 44](https://github.com/user-attachments/assets/71a6e389-6aaa-4873-8d04-70096b58a299)
