### PR TITLE
Update the logic to show the subscription box even when the plugin is disabled (4248)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepProducts.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepProducts.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 
 import { OptionSelector } from '../../../ReusableComponents/Fields';
@@ -14,23 +14,24 @@ const StepProducts = () => {
 
 	useEffect( () => {
 		const initChoices = () => {
-			if ( optionState === canUseSubscriptions ) {
-				return;
-			}
-
-			let choices = productChoicesFull;
-
-			// Remove subscription details, if not available.
-			if ( ! canUseSubscriptions ) {
-				choices = choices.filter(
-					( { value } ) => value !== PRODUCT_TYPES.SUBSCRIPTIONS
-				);
-				setProducts(
-					products.filter(
-						( value ) => value !== PRODUCT_TYPES.SUBSCRIPTIONS
-					)
-				);
-			}
+			const choices = productChoicesFull.map( ( choice ) => {
+				if (
+					choice.value === PRODUCT_TYPES.SUBSCRIPTIONS &&
+					! canUseSubscriptions
+				) {
+					return {
+						...choice,
+						isDisabled: true,
+						contents: (
+							<DetailsSubscriptions
+								showLink={ true }
+								showNotice={ isCasualSeller }
+							/>
+						),
+					};
+				}
+				return choice;
+			} );
 
 			setProductChoices( choices );
 			setOptionState( canUseSubscriptions );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepProducts.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepProducts.js
@@ -131,15 +131,18 @@ const DetailsPhysical = () => (
 const DetailsSubscriptions = ( { showLink, showNotice } ) => (
 	<>
 		{ showLink && (
-			<a
-				target="__blank"
-				href="https://woocommerce.com/document/woocommerce-paypal-payments/#subscriptions-faq"
-			>
-				{ __(
-					'WooCommerce Subscriptions',
-					'woocommerce-paypal-payments'
-				) }
-			</a>
+			<p
+				dangerouslySetInnerHTML={ {
+					__html: sprintf(
+						/* translators: %s is the URL to the WooCommerce Subscriptions product page */
+						__(
+							'* To use subscriptions, you must have <a target="_blank" href="%s">WooCommerce Subscriptions</a> enabled.',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/products/woocommerce-subscriptions/'
+					),
+				} }
+			/>
 		) }
 		{ showNotice && (
 			<p>


### PR DESCRIPTION
## Issue Description

If WooCommerce Subscriptions extension is not installed, we need to show the "Subscriptions" box for Business accounts, but disabled and advise that you must have "WooCommerce Subscriptions" enabled and link to the product page of the extension.

## PR Description

- The Subscription box should be visible even if the plugin is not activated.
   - It should be disabled.
 - Adjust the description of the box if the subscription plugin is not activated