### PR TITLE
Hardcoded flags in WelcomeDocs component (4130)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
@@ -12,7 +12,8 @@ import AdvancedOptionsForm from '../Components/AdvancedOptionsForm';
 
 const StepWelcome = ( { setStep, currentStep } ) => {
 	const { storeCountry } = CommonHooks.useWooSettings();
-	const { canUseCardPayments, canUseFastlane } = OnboardingHooks.useFlags();
+	const { canUseCardPayments, canUseFastlane, canUsePayLater } =
+		OnboardingHooks.useFlags();
 	const nonAcdcIcons = [ 'paypal', 'visa', 'mastercard', 'amex', 'discover' ];
 
 	return (
@@ -55,7 +56,7 @@ const StepWelcome = ( { setStep, currentStep } ) => {
 			<WelcomeDocs
 				useAcdc={ canUseCardPayments }
 				isFastlane={ canUseFastlane }
-				isPayLater={ true }
+				isPayLater={ canUsePayLater }
 				storeCountry={ storeCountry }
 			/>
 			<Separator text={ __( 'or', 'woocommerce-paypal-payments' ) } />

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
@@ -12,7 +12,7 @@ import AdvancedOptionsForm from '../Components/AdvancedOptionsForm';
 
 const StepWelcome = ( { setStep, currentStep } ) => {
 	const { storeCountry } = CommonHooks.useWooSettings();
-	const { canUseCardPayments } = OnboardingHooks.useFlags();
+	const { canUseCardPayments, canUseFastlane } = OnboardingHooks.useFlags();
 	const nonAcdcIcons = [ 'paypal', 'visa', 'mastercard', 'amex', 'discover' ];
 
 	return (
@@ -54,7 +54,7 @@ const StepWelcome = ( { setStep, currentStep } ) => {
 			<Separator className="ppcp-r-page-welcome-mode-separator" />
 			<WelcomeDocs
 				useAcdc={ canUseCardPayments }
-				isFastlane={ true }
+				isFastlane={ canUseFastlane }
 				isPayLater={ true }
 				storeCountry={ storeCountry }
 			/>

--- a/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
@@ -24,6 +24,7 @@ const defaultTransient = Object.freeze( {
 		canUseCardPayments: false,
 		canUseSubscriptions: false,
 		shouldSkipPaymentMethods: false,
+		canUseFastlane: false,
 	} ),
 } );
 

--- a/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
@@ -25,6 +25,7 @@ const defaultTransient = Object.freeze( {
 		canUseSubscriptions: false,
 		shouldSkipPaymentMethods: false,
 		canUseFastlane: false,
+		canUsePayLater: false,
 	} ),
 } );
 

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -70,6 +70,7 @@ return array(
 				->plugin_is_active();
 		$should_skip_payment_methods = class_exists( '\WC_Payments' );
 		$can_use_fastlane = $container->get( 'axo.eligible' );
+		$can_use_pay_later = $container->get( 'button.helper.messages-apply' );
 
 		return new OnboardingProfile(
 			$can_use_casual_selling,
@@ -77,7 +78,8 @@ return array(
 			$can_use_card_payments,
 			$can_use_subscriptions,
 			$should_skip_payment_methods,
-			$can_use_fastlane
+			$can_use_fastlane,
+			$can_use_pay_later->for_country()
 		);
 	},
 	'settings.data.general'                        => static function ( ContainerInterface $container ) : GeneralSettings {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -69,13 +69,15 @@ return array(
 		$can_use_subscriptions  = $container->has( 'wc-subscriptions.helper' ) && $container->get( 'wc-subscriptions.helper' )
 				->plugin_is_active();
 		$should_skip_payment_methods = class_exists( '\WC_Payments' );
+		$can_use_fastlane = $container->get( 'axo.eligible' );
 
 		return new OnboardingProfile(
 			$can_use_casual_selling,
 			$can_use_vaulting,
 			$can_use_card_payments,
 			$can_use_subscriptions,
-			$should_skip_payment_methods
+			$should_skip_payment_methods,
+			$can_use_fastlane
 		);
 	},
 	'settings.data.general'                        => static function ( ContainerInterface $container ) : GeneralSettings {

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -45,7 +45,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 * @param bool $can_use_subscriptions  Whether WC Subscriptions plugin is active.
 	 * @param bool $should_skip_payment_methods  Whether it should skip payment methods screen.
 	 * @param bool $can_use_fastlane  Whether it can use Fastlane or not.
-	 * @param bool $can_use_pay_later  Whether it can use PAy Later or not.
+	 * @param bool $can_use_pay_later  Whether it can use Pay Later or not.
 	 *
 	 * @throws RuntimeException If the OPTION_KEY is not defined in the child class.
 	 */

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -44,6 +44,8 @@ class OnboardingProfile extends AbstractDataModel {
 	 * @param bool $can_use_card_payments  Whether credit card payments are possible.
 	 * @param bool $can_use_subscriptions  Whether WC Subscriptions plugin is active.
 	 * @param bool $should_skip_payment_methods  Whether it should skip payment methods screen.
+	 * @param bool $can_use_fastlane  Whether it can use Fastlane or not.
+	 * @param bool $can_use_pay_later  Whether it can use PAy Later or not.
 	 *
 	 * @throws RuntimeException If the OPTION_KEY is not defined in the child class.
 	 */
@@ -53,7 +55,8 @@ class OnboardingProfile extends AbstractDataModel {
 		bool $can_use_card_payments = false,
 		bool $can_use_subscriptions = false,
 		bool $should_skip_payment_methods = false,
-		bool $can_use_fastlane = false
+		bool $can_use_fastlane = false,
+		bool $can_use_pay_later = false
 	) {
 		parent::__construct();
 
@@ -62,7 +65,8 @@ class OnboardingProfile extends AbstractDataModel {
 		$this->flags['can_use_card_payments']       = $can_use_card_payments;
 		$this->flags['can_use_subscriptions']       = $can_use_subscriptions;
 		$this->flags['should_skip_payment_methods'] = $should_skip_payment_methods;
-		$this->flags['can_use_fastlane'] = $can_use_fastlane;
+		$this->flags['can_use_fastlane']            = $can_use_fastlane;
+		$this->flags['can_use_pay_later']           = $can_use_pay_later;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -52,7 +52,8 @@ class OnboardingProfile extends AbstractDataModel {
 		bool $can_use_vaulting = false,
 		bool $can_use_card_payments = false,
 		bool $can_use_subscriptions = false,
-		bool $should_skip_payment_methods = false
+		bool $should_skip_payment_methods = false,
+		bool $can_use_fastlane = false
 	) {
 		parent::__construct();
 
@@ -61,6 +62,7 @@ class OnboardingProfile extends AbstractDataModel {
 		$this->flags['can_use_card_payments']       = $can_use_card_payments;
 		$this->flags['can_use_subscriptions']       = $can_use_subscriptions;
 		$this->flags['should_skip_payment_methods'] = $should_skip_payment_methods;
+		$this->flags['can_use_fastlane'] = $can_use_fastlane;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -83,8 +83,11 @@ class OnboardingRestEndpoint extends RestEndpoint {
 		'should_skip_payment_methods' => array(
 			'js_name' => 'shouldSkipPaymentMethods',
 		),
-		'can_use_fastlane' => array(
+		'can_use_fastlane'            => array(
 			'js_name' => 'canUseFastlane',
+		),
+		'can_use_pay_later'           => array(
+			'js_name' => 'canUsePayLater',
 		),
 	);
 

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -83,6 +83,9 @@ class OnboardingRestEndpoint extends RestEndpoint {
 		'should_skip_payment_methods' => array(
 			'js_name' => 'shouldSkipPaymentMethods',
 		),
+		'can_use_fastlane' => array(
+			'js_name' => 'canUseFastlane',
+		),
 	);
 
 	/**


### PR DESCRIPTION
In `StepWelcome.js` we use a `WelcomeDocs` component to display the available payment methods. This component has some hardcoded prop values.

```
<WelcomeDocs
    useAcdc={ canUseCardPayments }
    isFastlane={ true }   // ← resolve this
    isPayLater={ true }   // ← resolve this
    storeCountry={ storeCountry }
/>
```

This PR sets `isFastlane` and `isPayLater` values dynamically based on country availability.

### How to test
- WC store country US should display Fastlane icon
- Non US WC store countries should not display Fastlane icon

<img width="1025" alt="Captura de pantalla 2025-02-26 a las 15 50 59" src="https://github.com/user-attachments/assets/b7880f74-089a-4abe-a554-6ce3bb6ee583" />

- [Available](https://developer.paypal.com/docs/checkout/payment-methods/) WC store countries should display Pay Later icon
- Non available WC store countries should not display Pay Later icon

<img width="1020" alt="Captura de pantalla 2025-02-26 a las 15 49 53" src="https://github.com/user-attachments/assets/40a7eaec-7b58-4d48-abeb-c3ac783739ee" />
