### PR TITLE
Phone Number not saved in WC order when using Pay Now experience (4257)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Helper/Address.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Address.js
@@ -81,12 +81,14 @@ export const paypalShippingToWc = ( shipping ) => {
 export const paypalPayerToWc = ( payer ) => {
 	const firstName = payer?.name?.given_name ?? '';
 	const lastName = payer?.name?.surname ?? '';
+    const phone = payer?.phone?.phone_number?.national_number ?? '';
 	const address = payer.address ? paypalAddressToWc( payer.address ) : {};
 	return {
 		...address,
 		first_name: firstName,
 		last_name: lastName,
 		email: payer.email_address,
+        phone: phone
 	};
 };
 

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -201,6 +201,7 @@ class WooCommerceOrderCreator {
 		if ( $payer ) {
 			$address    = $payer->address();
 			$payer_name = $payer->name();
+			$payer_phone = $payer->phone();
 
 			$wc_email    = null;
 			$wc_customer = WC()->customer;
@@ -220,6 +221,7 @@ class WooCommerceOrderCreator {
 				'state'      => $address ? $address->admin_area_1() : '',
 				'postcode'   => $address ? $address->postal_code() : '',
 				'country'    => $address ? $address->country_code() : '',
+				'phone'      => $payer_phone ? $payer_phone->phone()->national_number() : ''
 			);
 		}
 

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -199,8 +199,8 @@ class WooCommerceOrderCreator {
 		$shipping_options = null;
 
 		if ( $payer ) {
-			$address    = $payer->address();
-			$payer_name = $payer->name();
+			$address     = $payer->address();
+			$payer_name  = $payer->name();
 			$payer_phone = $payer->phone();
 
 			$wc_email    = null;
@@ -221,7 +221,7 @@ class WooCommerceOrderCreator {
 				'state'      => $address ? $address->admin_area_1() : '',
 				'postcode'   => $address ? $address->postal_code() : '',
 				'country'    => $address ? $address->country_code() : '',
-				'phone'      => $payer_phone ? $payer_phone->phone()->national_number() : ''
+				'phone'      => $payer_phone ? $payer_phone->phone()->national_number() : '',
 			);
 		}
 


### PR DESCRIPTION
- Add phone number from Payer to block checkout
- Add phone number from Payer to check out without confirmation