### PR TITLE
Subscriptions product without reference transactions but with ACDC  (4252)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
@@ -40,6 +40,7 @@ const SavePaymentMethods = () => {
 				) }
 				value={ savePaypalAndVenmo }
 				onChange={ setSavePaypalAndVenmo }
+				disabled={ ! savePaypalAndVenmo }
 			/>
 
 			<ControlToggleButton

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
@@ -3,6 +3,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import SettingsBlock from '../../../../../ReusableComponents/SettingsBlock';
 import { ControlToggleButton } from '../../../../../ReusableComponents/Controls';
 import { SettingsHooks } from '../../../../../../data';
+import { useMerchantInfo } from '../../../../../../data/common/hooks';
 
 const SavePaymentMethods = () => {
 	const {
@@ -11,6 +12,8 @@ const SavePaymentMethods = () => {
 		saveCardDetails,
 		setSaveCardDetails,
 	} = SettingsHooks.useSettings();
+
+	const { features } = useMerchantInfo();
 
 	return (
 		<SettingsBlock
@@ -38,9 +41,13 @@ const SavePaymentMethods = () => {
 					'https://woocommerce.com/document/woocommerce-paypal-payments/#pay-later',
 					'https://woocommerce.com/document/woocommerce-paypal-payments/#alternative-payment-methods'
 				) }
-				value={ savePaypalAndVenmo }
+				value={
+					features.save_paypal_and_venmo.enabled
+						? savePaypalAndVenmo
+						: false
+				}
 				onChange={ setSavePaypalAndVenmo }
-				disabled={ ! savePaypalAndVenmo }
+				disabled={ ! features.save_paypal_and_venmo.enabled }
 			/>
 
 			<ControlToggleButton


### PR DESCRIPTION
This is the use case where a customer says they want subscriptions, but does not get approved for reference transactions. But does get approved for ACDC. 

In this case, they can still vault credit cards, so that toggle should default on. But, the PayPal and Venmo is off (and cannot be toggled on).

This PR implements uncheck and disable “Save PayPal and Venmo” toggle when merchant is not approved for reference transactions (`save_paypal_and_venmo` enabled false).

### How to test
- Onboard with a merchant with subscription product, without reference transactions but with ACDC 
- Go to Settings screen and ensure that "Save PayPal and Venmo" toggle in Common settings / Save payment methods is unchecked and disabled.