### PR TITLE
Onboarding fails in some browsers (4223)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
@@ -32,7 +32,6 @@ const ButtonOrPlaceholder = ( {
 
 	if ( href ) {
 		buttonProps.href = href;
-		buttonProps.target = 'PPFrame';
 		buttonProps[ 'data-paypal-button' ] = 'true';
 		buttonProps[ 'data-paypal-onboard-button' ] = 'true';
 	}


### PR DESCRIPTION
This PR fixes sandbox onboarding for Firefox on Mac by removing the target attribute
