### PR TITLE
QA - Update `pcp-pay-later-messaging` and respective types

### DIFF
--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -82,19 +82,52 @@ export namespace Pcp {
 		}
 
 		export namespace PayLaterMessaging {
-			export type LogoType = 'Full Logo' | ''; // TODO
+			export type Location =
+				| 'Product page'
+				| 'Cart'
+				| 'Checkout'
+				| 'Home'
+				| 'Shop';
 
-			export type LogoPosition = ''; // TODO
+			export type LogoType =
+				| 'Full Logo'
+				| 'Monogram'
+				| 'Inline'
+				| 'Message only';
 
-			export type TextColor = ''; // TODO
+			export type TextColor =
+				| 'Black / Blue logo'
+				| 'White / White logo'
+				| 'Monochrome'
+				| 'Black / Gray logo';
 
-			export type TextSize = ''; // TODO
+			export type LogoPosition =
+				| 'Left'
+				| 'Right'
+				| 'Top';
 
-			export type BannerColor = ''; // TODO
+			export type TextSize = 
+				| 'Small'
+				| 'Medium'
+				| 'Large';
 
-			export type BannerSize = ''; // TODO
+			export type BannerColor = 
+				| 'Blue'
+				| 'Black'
+				| 'White'
+				| 'White (no border)';
 
-			export type CheckoutPage = {
+			export type BannerSize = 
+				| '20 x 1'
+				| '8 x 1';
+
+			export type PreviewLayout =
+				| 'Text'
+				| 'Desktop'
+				| 'Mobile';
+
+			// Checkout locations - pages where checkout can be done with paypal (Products, Carts, Checkouts)
+			export type CheckoutLocation = {
 				enabled?: boolean;
 				logoType?: LogoType;
 				logoPosition?: LogoPosition;
@@ -102,7 +135,8 @@ export namespace Pcp {
 				textSize?: TextSize;
 			};
 
-			export type BannerPage = {
+			// Banner locations - pages where only banner is displayed (Home, Shop)
+			export type BannerLocation = {
 				enabled?: boolean;
 				bannerColor?: BannerColor;
 				bannerSize?: BannerSize;
@@ -110,12 +144,12 @@ export namespace Pcp {
 
 			export type Config = {
 				enabledDarkMode?: boolean;
-				product?: CheckoutPage;
-				cart?: CheckoutPage;
-				checkout?: CheckoutPage;
-				home?: BannerPage;
-				shop?: BannerPage;
-				enabledWooCommerceBlock?: boolean;
+				product?: CheckoutLocation;
+				cart?: CheckoutLocation;
+				checkout?: CheckoutLocation;
+				home?: BannerLocation;
+				shop?: BannerLocation;
+				enabledWooCommerceBlock?: boolean; // TODO: check for deprecation
 			};
 		}
 

--- a/tests/qa/utils/admin/pcp-pay-later-messaging.ts
+++ b/tests/qa/utils/admin/pcp-pay-later-messaging.ts
@@ -1,15 +1,160 @@
 /**
  * Internal dependencies
  */
+import { expect } from '../test';
 import { PcpAdminPage } from './pcp-admin-page';
 import urls from '../urls';
+import { Pcp } from 'resources';
 
 export class PcpPayLaterMessaging extends PcpAdminPage {
 	url = urls.admin.pcp.payLaterMessaging;
 
 	// Locators
+	configContainer = () =>
+		this.page.locator( '#messaging-configurator' );
+	accordionButton = ( location: Pcp.Admin.PayLaterMessaging.Location ) =>
+		this.page.getByRole( 'button', { name: location } );
+	accordionButtonSvgPath = ( location: Pcp.Admin.PayLaterMessaging.Location ) =>
+		this.accordionButton( location ).locator('svg path');
+	accordionContainer = ( location: Pcp.Admin.PayLaterMessaging.Location ) =>
+		this.page
+			.locator( 'div[accordionname="message-configs"]' )
+			.filter( { has: this.accordionButton( location ) } );
+	accordionCheckbox = ( location: Pcp.Admin.PayLaterMessaging.Location ) =>
+		this.accordionContainer( location )
+			.locator( 'div[data-id="checkbox"] label[for^="Checkbox"]' );
+	accordionCheckboxSvg = ( location: Pcp.Admin.PayLaterMessaging.Location ) =>
+		this.accordionCheckbox( location ).locator( 'svg' );
+
+	logoTypeCombobox = () =>
+		this.page.locator( 'button[aria-labelledby^="dropdownMenuButton_Logotype"]' );
+	textColorCombobox = () =>
+		this.page.locator( 'button[aria-labelledby^="dropdownMenuButton_Textcolor"]' );
+	logoPositionCombobox = () =>
+		this.page.locator( 'button[aria-labelledby^="dropdownMenuButton_Logoposition"]' );
+	textSizeCombobox = () =>
+		this.page.locator( 'button[aria-labelledby^="dropdownMenuButton_Textsize"]' );
+	bannerColorCombobox = () =>
+		this.page.locator( 'button[aria-labelledby^="dropdownMenuButton_Bannercolor"]' );
+	bannerSizeCombobox = () =>
+		this.page.locator( 'button[aria-labelledby^="dropdownMenuButton_Bannersize"]' );
+	comboboxOption = ( optionName: string ) =>
+		this.page.locator( 'li[id^="smenu_item_"]' ).filter( { hasText: optionName } );
+
+	previewIframe = () =>
+		this.page.frameLocator( '#configurator-previewSectionContainer iframe' );
+	previewMessageContainer = () =>
+		this.previewIframe().locator( '.message__container' );
+	previewTextButton = () =>
+		this.page.locator(
+			'svg path[d="M5 5a1 1 0 0 0 0 2h14a1 1 0 1 0 0-2H5zm-1 7a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1zm0 6a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1z"]'
+		);
+	previewDesktopButton = () =>
+		this.page.locator(
+			'svg path[d="M4 5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v11a1 1 0 0 1-1 1h-6v2h2.25a.75.75 0 0 1 0 1.5h-6.5a.75.75 0 0 1 0-1.5H11v-2H5a1 1 0 0 1-1-1V5zm2 9.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75z"]'
+		);
+	previewMobileButton = () =>
+		this.page.locator(
+			'svg path[d="M6 2a1 1 0 0 0-1 1v18a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V3a1 1 0 0 0-1-1H6zm6 18a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z"]'
+		);
+	darkModeToggle = () =>
+		this.page.locator( 'label[for="configurator-previewSectionDarkModeToggle"]' );
+	
 
 	// Actions
+
+	/**
+	 * Expands section of the accordion by provided location.
+	 * 
+	 * Simply clicking on a button doesn't work because there's no way to tell if section is expanded.
+	 * Unfortunately there's no other way to differentiate between collapsed and expanded section except svg path value.
+	 * 
+	 * @param {Pcp.Admin.PayLaterMessaging.Location} location 
+	 */
+	expandAccordionSection = async ( location: Pcp.Admin.PayLaterMessaging.Location ) => {
+		// Get the current path data
+		const pathData = await this.accordionButtonSvgPath( location ).getAttribute('d');
+
+		// Expected values (replace with correct ones if needed)
+		const collapsedPath = "M4.292 8.293a1 1 0 0 1 1.414 0L12 14.586l6.293-6.293a1 1 0 0 1 1.414 1.414L12.713 16.7a1.01 1.01 0 0 1-1.428 0L4.292 9.707a1 1 0 0 1 0-1.414z";
+		const expandedPath = "M4.293 15.703a1 1 0 0 0 1.414 0L12 9.41l6.293 6.293a1 1 0 0 0 1.414-1.414l-6.993-6.993a1.01 1.01 0 0 0-1.428 0l-6.993 6.993a1 1 0 0 0 0 1.414z";
+
+		if ( pathData === collapsedPath ) {
+			await this.accordionButton( location ).click();
+			await expect(
+				this.accordionButtonSvgPath( location )
+			).toHaveAttribute('d', expandedPath);
+		}
+	}
+
+	/**
+	 * Checks/unchecks checkbox for messaging for location.
+	 * 
+	 * @param location 
+	 * @param isEnabled 
+	 */
+	setMessagingCheckboxStateForLocation = async (
+		location: Pcp.Admin.PayLaterMessaging.Location,
+		isEnabled: boolean,
+	) => {
+		// Get the current 'color' property of SVG
+		const color = await this.accordionCheckboxSvg( location ).evaluate(
+			el => getComputedStyle( el ).color
+		);	
+		// Expected colors
+		const checkedColor = 'rgb(255, 255, 255)'; // White (checked)		
+		const isChecked = color === checkedColor;	
+		if ( isChecked !== isEnabled ) {
+			await this.accordionCheckbox( location ).click();
+		}
+	};
+
+	/**
+	 * Enables messaging for location.
+	 * 
+	 * @param location
+	 */
+	enableMessagingForLocation = async (
+		location: Pcp.Admin.PayLaterMessaging.Location
+	) => this.setMessagingCheckboxStateForLocation( location, true );
+
+	/**
+	 * Disables messaging for location.
+	 * 
+	 * @param location
+	 */
+	disableMessagingForLocation = async (
+		location: Pcp.Admin.PayLaterMessaging.Location
+	) => this.setMessagingCheckboxStateForLocation( location, false );
+	
+	/**
+	 * Toggles dark mode on/off.
+	 * 
+	 * @param isEnabled 
+	 */
+	setDarkModeToggleState = async ( isEnabled: boolean ) => {
+		const toggle = this.darkModeToggle();	
+		// Get the current 'color' property
+		const color = await toggle.evaluate(
+			el => getComputedStyle( el ).borderBottomColor
+		);	
+		// Expected colors
+		const uncheckedColor = 'rgb(146, 148, 150)'; // White (unchecked)		
+		const isChecked = color !== uncheckedColor;	
+		if ( isChecked !== isEnabled ) {
+			await toggle.click();
+		}
+	}
+
+	/**
+	 * Toggles dark mode on.
+	 */
+	enableDarkModeToggle = async () => this.setDarkModeToggleState( true );
+
+	/**
+	 * Toggles dark mode off.
+	 */
+	disableDarkModeToggle = async () => this.setDarkModeToggleState( false );
 
 	// Assertions
 }

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -336,14 +336,14 @@ export class PayPalUI {
 	payWithDifferentAccountButton = () =>
 		this.payPalMenuIframe().getByText( 'pay with a different account' );
 
-	submitOrder = async () => {
-		// on Pay for Order page the button name is Pay for order
-		if ( this.page.url().includes( 'pay_for_order' ) ) {
-			await this.payForOrderButton().click();
-		} else {
-			await this.placeOrderButton().click();
-		}
-	};
+	payLaterMessageIframe = () =>
+		this.page.frameLocator(
+			'iframe[name^="__zoid__paypal_message__"]'
+		);
+	payLaterMessageContainer = () =>
+		this.payLaterMessageIframe().locator( '.message__container' );
+	payLaterMessageTextPart = () =>
+		this.payLaterMessageContainer().getByText( 'Pay in 4 interest-free payments on' );
 
 	// Actions
 
@@ -785,6 +785,15 @@ export class PayPalUI {
 		await this.page.keyboard.type( payment.card.expiration_date );
 		await this.cardCVVInput().fill( payment.card.card_cvv );
 		await this.addPaymentMethodButton().click();
+	};
+
+	submitOrder = async () => {
+		// on Pay for Order page the button name is Pay for order
+		if ( this.page.url().includes( 'pay_for_order' ) ) {
+			await this.payForOrderButton().click();
+		} else {
+			await this.placeOrderButton().click();
+		}
 	};
 
 	// Assertions


### PR DESCRIPTION
### Description

Updates in `pcp-pay-later-messaging` and Pcp.Admin.PayLaterMessaging types:

- Add respective types in Pcp.Admin.PayLaterMessaging
- Add locators and methods to operate in Pay Later Messaging settings tab
- Add locators for Pay Later Messaging on frontend

Settings for Pay Later Messaging are using specific configurator coming from PayPal which has dynamic structure. It mainly contains only dynamic CSS properties, class and id names, svg, etc. This makes it quite hard to automate forcing to depend on unusual values like, for example, `svg path` properties.
