### PR TITLE
Error: _load_textdomain_just_in_time Called Incorrectly When Running Docker Compose (PCP-4227)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -458,9 +458,14 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		);
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			\WP_CLI::add_command(
-				'pcp settings',
-				$c->get( 'wcgateway.cli.settings.command' )
+			add_action(
+				'init',
+				function() use ( $c ) {
+					\WP_CLI::add_command(
+						'pcp settings',
+						$c->get( 'wcgateway.cli.settings.command' )
+					);
+				}
 			);
 		}
 


### PR DESCRIPTION
Fix text domain depreciation warning on using WP-CLI command