### PR TITLE
Disable the mapping If the new settings module is not enabled (4269)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -92,7 +92,7 @@ return function ( string $root_dir ): iterable {
 	}
 
 	$show_new_ux    = '1' === get_option( 'woocommerce-ppcp-is-new-merchant' );
-	$preview_new_ux = '0' !== getenv( 'PCP_SETTINGS_ENABLED' );
+	$preview_new_ux = '1' === getenv( 'PCP_SETTINGS_ENABLED' );
 
 	if ( apply_filters(
 		'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -190,7 +190,8 @@ return array(
 			$container->get( 'compat.settings.styling_map_helper' ),
 			$container->get( 'compat.settings.settings_tab_map_helper' ),
 			$container->get( 'compat.settings.subscription_map_helper' ),
-			$container->get( 'compat.settings.general_map_helper' )
+			$container->get( 'compat.settings.general_map_helper' ),
+			$container->get( 'wcgateway.settings.admin-settings-enabled' )
 		);
 	},
 	'compat.settings.styling_map_helper'             => static function() : StylingSettingsMapHelper {

--- a/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
@@ -75,6 +75,13 @@ class SettingsMapHelper {
 	protected GeneralSettingsMapHelper $general_settings_map_helper;
 
 	/**
+	 * Whether the new settings module is enabled.
+	 *
+	 * @var bool
+	 */
+	protected bool $new_settings_module_enabled;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param SettingsMap[]                 $settings_map A list of settings maps containing key definitions.
@@ -82,6 +89,7 @@ class SettingsMapHelper {
 	 * @param SettingsTabMapHelper          $settings_tab_map_helper A helper for mapping the old/new settings tab settings.
 	 * @param SubscriptionSettingsMapHelper $subscription_map_helper A helper for mapping old and new subscription settings.
 	 * @param GeneralSettingsMapHelper      $general_settings_map_helper A helper for mapping old and new general settings.
+	 * @param bool                          $new_settings_module_enabled Whether the new settings module is enabled.
 	 * @throws RuntimeException When an old key has multiple mappings.
 	 */
 	public function __construct(
@@ -89,7 +97,8 @@ class SettingsMapHelper {
 		StylingSettingsMapHelper $styling_settings_map_helper,
 		SettingsTabMapHelper $settings_tab_map_helper,
 		SubscriptionSettingsMapHelper $subscription_map_helper,
-		GeneralSettingsMapHelper $general_settings_map_helper
+		GeneralSettingsMapHelper $general_settings_map_helper,
+		bool $new_settings_module_enabled
 	) {
 		$this->validate_settings_map( $settings_map );
 		$this->settings_map                = $settings_map;
@@ -97,6 +106,7 @@ class SettingsMapHelper {
 		$this->settings_tab_map_helper     = $settings_tab_map_helper;
 		$this->subscription_map_helper     = $subscription_map_helper;
 		$this->general_settings_map_helper = $general_settings_map_helper;
+		$this->new_settings_module_enabled = $new_settings_module_enabled;
 	}
 
 	/**
@@ -126,6 +136,10 @@ class SettingsMapHelper {
 	 * @return mixed|null The value of the mapped setting, or null if not found.
 	 */
 	public function mapped_value( string $old_key ) {
+		if ( ! $this->new_settings_module_enabled ) {
+			return null;
+		}
+
 		$this->ensure_map_initialized();
 		if ( ! isset( $this->key_to_model[ $old_key ] ) ) {
 			return null;
@@ -149,6 +163,10 @@ class SettingsMapHelper {
 	 * @return bool True if the key exists in the new settings, false otherwise.
 	 */
 	public function has_mapped_key( string $old_key ) : bool {
+		if ( ! $this->new_settings_module_enabled ) {
+			return false;
+		}
+
 		$this->ensure_map_initialized();
 
 		return isset( $this->key_to_model[ $old_key ] );


### PR DESCRIPTION
## Issue Description

For existing merchants (new settings ui module is disabled) we should not execute any settings mapping logic, this will prevent issues for existing merchants which should notice nothing about new settings ui when upgrading the plugin.

## PR Description

The PR will add a check if the new settings module is enabled, if not, the mapping functions will return `null`, therefor the [old settings class](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-wc-gateway/src/Settings/Settings.php) will be [forced](https://github.com/woocommerce/woocommerce-paypal-payments/blob/4e000e2ae9295d31276520544524a6b7d1bb36b0/modules/ppcp-wc-gateway/src/Settings/Settings.php#L112) to use the values of old settings and not the mapped ones.

Additionally instead of `$preview_new_ux = '0' !== getenv( 'PCP_SETTINGS_ENABLED' );` we should use `$preview_new_ux = '1' === getenv( 'PCP_SETTINGS_ENABLED' );` becuase the module will be always enabled unless you set `PCP_SETTINGS_ENABLED = '0'` but by default the `PCP_SETTINGS_ENABLED` is `false` because it doesn’t exist.<!-- Source of this Pull Request. Remove any that are not applicable. 

