### PR TITLE
Error during initialization: TypeError: window[this.namespace].Applepay is not a function (4275)

### DIFF
--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -1018,6 +1018,10 @@ class ApplePayButton implements ButtonInterface {
 	 * @return void
 	 */
 	public function enqueue(): void {
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		wp_register_script(
 			'wc-ppcp-applepay',
 			untrailingslashit( $this->module_url ) . '/assets/js/boot.js',


### PR DESCRIPTION
There is this error in frontend (ex. in Single Product page) even if Apple Pay is disabled in Payment Methods screen:

![Captura de pantalla 2025-02-28 a las 16 13 09](https://github.com/user-attachments/assets/7b2b1757-2447-4ba5-bf9f-74ee48aea852)

This PR ensures that scripts are loaded only if the payment method is enabled. 
