### PR TITLE
Uncaught type error cannot read properties of null reading checked (4280)

### DIFF
--- a/modules/ppcp-onboarding/resources/js/onboarding.js
+++ b/modules/ppcp-onboarding/resources/js/onboarding.js
@@ -326,9 +326,9 @@ window.ppcp_onboarding_productionCallback = function ( ...args ) {
 
 		isDisconnecting = true;
 
-        const saveButton = document.querySelector( '.woocommerce-save-button' );
-        saveButton.removeAttribute( 'disabled' );
-        saveButton.click();
+		const saveButton = document.querySelector( '.woocommerce-save-button' );
+		saveButton.removeAttribute( 'disabled' );
+		saveButton.click();
 	};
 
 	// Prevent the message about unsaved checkbox/radiobutton when reloading the page.
@@ -345,9 +345,11 @@ window.ppcp_onboarding_productionCallback = function ( ...args ) {
 
 	const sandboxSwitchElement = document.querySelector( '#ppcp-sandbox_on' );
 
-    sandboxSwitchElement?.addEventListener( 'click', () => {
-        document.querySelector( '.woocommerce-save-button' )?.removeAttribute( 'disabled' );
-    });
+	sandboxSwitchElement?.addEventListener( 'click', () => {
+		document
+			.querySelector( '.woocommerce-save-button' )
+			?.removeAttribute( 'disabled' );
+	} );
 
 	const validate = () => {
 		const selectors = sandboxSwitchElement.checked
@@ -389,7 +391,8 @@ window.ppcp_onboarding_productionCallback = function ( ...args ) {
 
 	const isSandboxInBackend =
 		PayPalCommerceGatewayOnboarding.current_env === 'sandbox';
-	if ( sandboxSwitchElement.checked !== isSandboxInBackend ) {
+
+	if ( sandboxSwitchElement?.checked !== isSandboxInBackend ) {
 		sandboxSwitchElement.checked = isSandboxInBackend;
 	}
 

--- a/modules/ppcp-settings/resources/js/data/payment/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/payment/reducer.js
@@ -44,6 +44,7 @@ const defaultPersistent = Object.freeze( {
 	threeDSecure: 'no-3d-secure',
 	fastlaneCardholderName: false,
 	fastlaneDisplayWatermark: false,
+	__meta: false,
 } );
 
 // Reducer logic.


### PR DESCRIPTION
this Pr solves 2 errors, an error when `isSandboxInBackend` was null. Now we check before accessing. And a warning when in the payment method store we are passing a _meta key that was not declared in the allowed ones. 