### PR TITLE
Create a helper for mapping the payment methods (4273)

### DIFF
--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -104,6 +104,6 @@ class DisabledFundingSources {
 			$disable_funding = $all_sources;
 		}
 
-		return $disable_funding;
+		return apply_filters( 'woocommerce_paypal_payments_disabled_funding_sources', $disable_funding );
 	}
 }

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Compat;
 
 use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
 use WooCommerce\PayPalCommerce\Compat\Settings\GeneralSettingsMapHelper;
+use WooCommerce\PayPalCommerce\Compat\Settings\PaymentMethodSettingsMapHelper;
 use WooCommerce\PayPalCommerce\Compat\Settings\SettingsMap;
 use WooCommerce\PayPalCommerce\Compat\Settings\SettingsMapHelper;
 use WooCommerce\PayPalCommerce\Compat\Settings\SettingsTabMapHelper;
@@ -145,6 +146,9 @@ return array(
 		$general_map_helper = $container->get( 'compat.settings.general_map_helper' );
 		assert( $general_map_helper instanceof GeneralSettingsMapHelper );
 
+		$payment_methods_map_helper = $container->get( 'compat.settings.payment_methods_map_helper' );
+		assert( $payment_methods_map_helper instanceof PaymentMethodSettingsMapHelper );
+
 		return array(
 			new SettingsMap(
 				$container->get( 'settings.data.general' ),
@@ -182,6 +186,10 @@ return array(
 				$container->get( 'settings.data.payment' ),
 				array()
 			),
+			new SettingsMap(
+				$container->get( 'settings.data.payment' ),
+				$payment_methods_map_helper->map()
+			),
 		);
 	},
 	'compat.settings.settings_map_helper'            => static function( ContainerInterface $container ) : SettingsMapHelper {
@@ -191,6 +199,7 @@ return array(
 			$container->get( 'compat.settings.settings_tab_map_helper' ),
 			$container->get( 'compat.settings.subscription_map_helper' ),
 			$container->get( 'compat.settings.general_map_helper' ),
+			$container->get( 'compat.settings.payment_methods_map_helper' ),
 			$container->get( 'wcgateway.settings.admin-settings-enabled' )
 		);
 	},
@@ -205,5 +214,8 @@ return array(
 	},
 	'compat.settings.general_map_helper'             => static function() : GeneralSettingsMapHelper {
 		return new GeneralSettingsMapHelper();
+	},
+	'compat.settings.payment_methods_map_helper'     => static function() : PaymentMethodSettingsMapHelper {
+		return new PaymentMethodSettingsMapHelper();
 	},
 );

--- a/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * A helper for mapping the old/new payment method settings.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat\Settings
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat\Settings;
+
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+
+/**
+ * A map of old to new payment method settings.
+ *
+ * @psalm-import-type newSettingsKey from SettingsMap
+ * @psalm-import-type oldSettingsKey from SettingsMap
+ */
+class PaymentMethodSettingsMapHelper {
+
+	/**
+	 * Maps old setting keys to new payment method settings names.
+	 *
+	 * @psalm-return array<oldSettingsKey, newSettingsKey>
+	 */
+	public function map(): array {
+		return array(
+			'dcc_enabled' => 'acdc',
+			'axo_enabled' => 'axo',
+		);
+	}
+
+	/**
+	 * Retrieves the value of a mapped key from the new settings.
+	 *
+	 * @param string          $old_key The key from the legacy settings.
+	 * @param PaymentSettings $payment_settings The payment settings model.
+	 *
+	 * @return mixed The value of the mapped setting, (null if not found).
+	 */
+	public function mapped_value( string $old_key, PaymentSettings $payment_settings ): ?bool {
+
+		$payment_method = $this->map()[ $old_key ] ?? false;
+
+		if ( ! $payment_method ) {
+			return null;
+		}
+
+		return $payment_settings->is_method_enabled( $payment_method );
+	}
+}

--- a/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
@@ -9,7 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat\Settings;
 
-use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 
 /**
  * A map of old to new payment method settings.
@@ -26,20 +27,18 @@ class PaymentMethodSettingsMapHelper {
 	 */
 	public function map(): array {
 		return array(
-			'dcc_enabled' => 'acdc',
-			'axo_enabled' => 'axo',
+			'dcc_enabled' => CreditCardGateway::ID,
+			'axo_enabled' => AxoGateway::ID,
 		);
 	}
 
 	/**
 	 * Retrieves the value of a mapped key from the new settings.
 	 *
-	 * @param string          $old_key The key from the legacy settings.
-	 * @param PaymentSettings $payment_settings The payment settings model.
-	 *
+	 * @param string $old_key The key from the legacy settings.
 	 * @return mixed The value of the mapped setting, (null if not found).
 	 */
-	public function mapped_value( string $old_key, PaymentSettings $payment_settings ): ?bool {
+	public function mapped_value( string $old_key): ?bool {
 
 		$payment_method = $this->map()[ $old_key ] ?? false;
 
@@ -47,6 +46,19 @@ class PaymentMethodSettingsMapHelper {
 			return null;
 		}
 
-		return $payment_settings->is_method_enabled( $payment_method );
+		return $this->is_gateway_enabled( $payment_method );
+	}
+
+	/**
+	 * Checks if the payment gateway with the given name is enabled.
+	 *
+	 * @param string $gateway_name The gateway name.
+	 * @return bool True if the payment gateway with the given name is enabled, otherwise false.
+	 */
+	protected function is_gateway_enabled( string $gateway_name ): bool {
+		$gateway_settings = get_option( "woocommerce_{$gateway_name}_settings", [] );
+		$gateway_enabled  = $gateway_settings['enabled'] ?? false;
+
+		return $gateway_enabled === 'yes';
 	}
 }

--- a/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
@@ -38,7 +38,7 @@ class PaymentMethodSettingsMapHelper {
 	 * @param string $old_key The key from the legacy settings.
 	 * @return mixed The value of the mapped setting, (null if not found).
 	 */
-	public function mapped_value( string $old_key): ?bool {
+	public function mapped_value( string $old_key ): ?bool {
 
 		$payment_method = $this->map()[ $old_key ] ?? false;
 
@@ -56,7 +56,7 @@ class PaymentMethodSettingsMapHelper {
 	 * @return bool True if the payment gateway with the given name is enabled, otherwise false.
 	 */
 	protected function is_gateway_enabled( string $gateway_name ): bool {
-		$gateway_settings = get_option( "woocommerce_{$gateway_name}_settings", [] );
+		$gateway_settings = get_option( "woocommerce_{$gateway_name}_settings", array() );
 		$gateway_enabled  = $gateway_settings['enabled'] ?? false;
 
 		return $gateway_enabled === 'yes';

--- a/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
@@ -214,7 +214,7 @@ class SettingsMapHelper {
 				: $this->settings_tab_map_helper->mapped_value( $old_key, $this->model_cache[ $model_id ] );
 
 			case $model instanceof PaymentSettings:
-				return $this->payment_method_settings_map_helper->mapped_value( $old_key, $model );
+				return $this->payment_method_settings_map_helper->mapped_value( $old_key );
 
 			default:
 				return $this->model_cache[ $model_id ][ $new_key ] ?? null;

--- a/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
@@ -75,6 +75,13 @@ class SettingsMapHelper {
 	protected GeneralSettingsMapHelper $general_settings_map_helper;
 
 	/**
+	 * A helper for mapping old and new payment method settings.
+	 *
+	 * @var PaymentMethodSettingsMapHelper
+	 */
+	protected PaymentMethodSettingsMapHelper $payment_method_settings_map_helper;
+
+	/**
 	 * Whether the new settings module is enabled.
 	 *
 	 * @var bool
@@ -84,12 +91,13 @@ class SettingsMapHelper {
 	/**
 	 * Constructor.
 	 *
-	 * @param SettingsMap[]                 $settings_map A list of settings maps containing key definitions.
-	 * @param StylingSettingsMapHelper      $styling_settings_map_helper A helper for mapping the old/new styling settings.
-	 * @param SettingsTabMapHelper          $settings_tab_map_helper A helper for mapping the old/new settings tab settings.
-	 * @param SubscriptionSettingsMapHelper $subscription_map_helper A helper for mapping old and new subscription settings.
-	 * @param GeneralSettingsMapHelper      $general_settings_map_helper A helper for mapping old and new general settings.
-	 * @param bool                          $new_settings_module_enabled Whether the new settings module is enabled.
+	 * @param SettingsMap[]                  $settings_map A list of settings maps containing key definitions.
+	 * @param StylingSettingsMapHelper       $styling_settings_map_helper A helper for mapping the old/new styling settings.
+	 * @param SettingsTabMapHelper           $settings_tab_map_helper A helper for mapping the old/new settings tab settings.
+	 * @param SubscriptionSettingsMapHelper  $subscription_map_helper A helper for mapping old and new subscription settings.
+	 * @param GeneralSettingsMapHelper       $general_settings_map_helper A helper for mapping old and new general settings.
+	 * @param PaymentMethodSettingsMapHelper $payment_method_settings_map_helper A helper for mapping old and new payment method settings.
+	 * @param bool                           $new_settings_module_enabled Whether the new settings module is enabled.
 	 * @throws RuntimeException When an old key has multiple mappings.
 	 */
 	public function __construct(
@@ -98,15 +106,17 @@ class SettingsMapHelper {
 		SettingsTabMapHelper $settings_tab_map_helper,
 		SubscriptionSettingsMapHelper $subscription_map_helper,
 		GeneralSettingsMapHelper $general_settings_map_helper,
+		PaymentMethodSettingsMapHelper $payment_method_settings_map_helper,
 		bool $new_settings_module_enabled
 	) {
 		$this->validate_settings_map( $settings_map );
-		$this->settings_map                = $settings_map;
-		$this->styling_settings_map_helper = $styling_settings_map_helper;
-		$this->settings_tab_map_helper     = $settings_tab_map_helper;
-		$this->subscription_map_helper     = $subscription_map_helper;
-		$this->general_settings_map_helper = $general_settings_map_helper;
-		$this->new_settings_module_enabled = $new_settings_module_enabled;
+		$this->settings_map                       = $settings_map;
+		$this->styling_settings_map_helper        = $styling_settings_map_helper;
+		$this->settings_tab_map_helper            = $settings_tab_map_helper;
+		$this->subscription_map_helper            = $subscription_map_helper;
+		$this->general_settings_map_helper        = $general_settings_map_helper;
+		$this->payment_method_settings_map_helper = $payment_method_settings_map_helper;
+		$this->new_settings_module_enabled        = $new_settings_module_enabled;
 	}
 
 	/**
@@ -202,6 +212,9 @@ class SettingsMapHelper {
 				return $old_key === 'subscriptions_mode'
 				? $this->subscription_map_helper->mapped_value( $old_key, $this->model_cache[ $model_id ] )
 				: $this->settings_tab_map_helper->mapped_value( $old_key, $this->model_cache[ $model_id ] );
+
+			case $model instanceof PaymentSettings:
+				return $this->payment_method_settings_map_helper->mapped_value( $old_key, $model );
 
 			default:
 				return $this->model_cache[ $model_id ][ $new_key ] ?? null;

--- a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
@@ -89,13 +89,13 @@ class StylingSettingsMapHelper {
 				return $this->mapped_disabled_funding_value( $styling_models, $payment_settings );
 
 			case 'googlepay_button_enabled':
-				return $this->mapped_button_enabled_value( $styling_models, GooglePayGateway::ID, $payment_settings );
+				return $this->mapped_button_enabled_value( $styling_models, GooglePayGateway::ID );
 
 			case 'applepay_button_enabled':
-				return $this->mapped_button_enabled_value( $styling_models, ApplePayGateway::ID, $payment_settings );
+				return $this->mapped_button_enabled_value( $styling_models, ApplePayGateway::ID );
 
 			case 'pay_later_button_enabled':
-				return $this->mapped_button_enabled_value( $styling_models, 'pay-later', $payment_settings );
+				return $this->mapped_button_enabled_value( $styling_models, 'pay-later' );
 
 			default:
 				foreach ( $this->locations_map() as $old_location_name => $new_location_name ) {
@@ -257,28 +257,22 @@ class StylingSettingsMapHelper {
 	/**
 	 * Retrieves the mapped enabled or disabled button value from the new settings.
 	 *
-	 * @param LocationStylingDTO[]   $styling_models The list of location styling models.
-	 * @param string                 $button_name The button name (see {@link self::BUTTON_NAMES}).
-	 * @param AbstractDataModel|null $payment_settings The payment settings model.
+	 * @param LocationStylingDTO[] $styling_models The list of location styling models.
+	 * @param string               $button_name The button name (see {@link self::BUTTON_NAMES}).
 	 * @return int The enabled (1) or disabled (0) state.
 	 * @throws RuntimeException If an invalid button name is provided.
 	 */
-	protected function mapped_button_enabled_value( array $styling_models, string $button_name, ?AbstractDataModel $payment_settings ): ?int {
-		if ( is_null( $payment_settings ) ) {
-			return null;
-		}
-
+	protected function mapped_button_enabled_value( array $styling_models, string $button_name): ?int {
 		if ( ! in_array( $button_name, self::BUTTON_NAMES, true ) ) {
 			throw new RuntimeException( 'Wrong button name is provided.' );
 		}
 
 		$locations_to_context_map = $this->current_context_to_new_button_location_map();
 		$current_context          = $locations_to_context_map[ $this->context() ] ?? '';
-		assert( $payment_settings instanceof PaymentSettings );
 
 		foreach ( $styling_models as $model ) {
 			if ( $model->enabled && $model->location === $current_context ) {
-				if ( in_array( $button_name, $model->methods, true ) && $payment_settings->is_method_enabled( $button_name ) ) {
+				if ( in_array( $button_name, $model->methods, true ) && $this->is_gateway_enabled( $button_name ) ) {
 					return 1;
 				}
 			}
@@ -306,5 +300,18 @@ class StylingSettingsMapHelper {
 		}
 
 		return 0;
+	}
+
+	/**
+	 * Checks if the payment gateway with the given name is enabled.
+	 *
+	 * @param string $gateway_name The gateway name.
+	 * @return bool True if the payment gateway with the given name is enabled, otherwise false.
+	 */
+	protected function is_gateway_enabled( string $gateway_name ): bool {
+		$gateway_settings = get_option( "woocommerce_{$gateway_name}_settings", [] );
+		$gateway_enabled = $gateway_settings['enabled'] ?? false;
+
+		return $gateway_enabled === 'yes';
 	}
 }

--- a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
@@ -262,7 +262,7 @@ class StylingSettingsMapHelper {
 	 * @return int The enabled (1) or disabled (0) state.
 	 * @throws RuntimeException If an invalid button name is provided.
 	 */
-	protected function mapped_button_enabled_value( array $styling_models, string $button_name): ?int {
+	protected function mapped_button_enabled_value( array $styling_models, string $button_name ): ?int {
 		if ( ! in_array( $button_name, self::BUTTON_NAMES, true ) ) {
 			throw new RuntimeException( 'Wrong button name is provided.' );
 		}
@@ -309,8 +309,8 @@ class StylingSettingsMapHelper {
 	 * @return bool True if the payment gateway with the given name is enabled, otherwise false.
 	 */
 	protected function is_gateway_enabled( string $gateway_name ): bool {
-		$gateway_settings = get_option( "woocommerce_{$gateway_name}_settings", [] );
-		$gateway_enabled = $gateway_settings['enabled'] ?? false;
+		$gateway_settings = get_option( "woocommerce_{$gateway_name}_settings", array() );
+		$gateway_enabled  = $gateway_settings['enabled'] ?? false;
 
 		return $gateway_enabled === 'yes';
 	}

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -105,12 +105,6 @@ class PaymentSettings extends AbstractDataModel {
 				return $this->get_paylater_enabled();
 
 			default:
-				if (
-					! did_filter( 'woocommerce_payment_gateways' )
-					|| doing_filter( 'woocommerce_payment_gateways' )
-				) {
-					return true;
-				}
 				$gateway = $this->get_gateway( $method_id );
 
 				if ( $gateway ) {

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -520,6 +520,27 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			2
 		);
 
+		/**
+		 * Unsets the BCDC black button if merchant is eligible for ACDC.
+		 */
+		add_filter(
+			'woocommerce_paypal_payments_disabled_funding_sources',
+			static function ( $disable_funding ) use ( $container ) {
+				if ( ! is_array( $disable_funding ) || in_array( 'card', $disable_funding, true ) ) {
+					return $disable_funding;
+				}
+
+				$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
+				assert( $dcc_product_status instanceof DCCProductStatus );
+
+				if ( $dcc_product_status->is_active() ) {
+					$disable_funding[] = 'card';
+				}
+
+				return $disable_funding;
+			}
+		);
+
 		return true;
 	}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -525,6 +525,14 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		 */
 		add_filter(
 			'woocommerce_paypal_payments_disabled_funding_sources',
+			/**
+			 * Unsets the BCDC black button if merchant is eligible for ACDC.
+			 *
+			 * @param int[]|string[]|mixed $disable_funding The disabled funding sources.
+			 * @return int[]|string[]|mixed The disabled funding sources.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
 			static function ( $disable_funding ) use ( $container ) {
 				if ( ! is_array( $disable_funding ) || in_array( 'card', $disable_funding, true ) ) {
 					return $disable_funding;


### PR DESCRIPTION
## Issue Description

We need a way to perform some actions based on if the payment setting is enabled/disabled when using the new settings UI
Example issue we currently have: BCDC button is visible on classic checkout and on express checkout even when acdc is enabled (or disabled)

## PR Description

- Provides  a new helper for mapping the payment methods enabled or disabled state.
- Fixes infinite loop problem by directly checking from DB if the gateway is enabled (temporary solution until the migration).
- Maps the enabled or disabled state for ACDC and Fastlane
- Provides a filter to override the disabled funding sources.
- Unsets the black BCDC button if merchant is eligible for ACDC