### PR TITLE
Update the option when clearing the DB (4279)

### DIFF
--- a/modules/ppcp-uninstall/src/UninstallModule.php
+++ b/modules/ppcp-uninstall/src/UninstallModule.php
@@ -100,6 +100,8 @@ class UninstallModule implements ServiceModule, ExtendingModule, ExecutableModul
 					$clear_db->clear_scheduled_actions( $scheduled_action_names );
 					$clear_db->clear_actions( $action_names );
 
+					update_option( 'woocommerce-ppcp-is-new-merchant', '1' );
+
 					wp_send_json_success();
 					return true;
 				} catch ( Exception $error ) {


### PR DESCRIPTION
## Issue Description

Existing merchant upgrades to new package and then disconnects via "Clear now" button, currently legacy UI is shown while new UI should be shown instead

## PR Description

When clearing the DB from the old settings UI the `'woocommerce-ppcp-is-new-merchant'` option is updated to '1'