### PR TITLE
Add PLM default UI test

### DIFF
--- a/tests/qa/playwright.config.ts
+++ b/tests/qa/playwright.config.ts
@@ -23,6 +23,8 @@ export default defineConfig( {
 	retries: process.env.CI ? 2 : 0,
 	/* Opt out of parallel tests on CI. */
 	workers: process.env.CI ? 1 : 1,
+	/* The base directory, relative to the config file, for snapshot files created with toMatchSnapshot */
+	snapshotDir: './snapshots',
 	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
 	reporter: process.env.CI
 		? [
@@ -41,7 +43,7 @@ export default defineConfig( {
 		  ]
 		: [
 				[ 'list' ],
-				// [ 'html', { outputFolder: 'playwright-report' } ],
+				[ 'html', { outputFolder: 'playwright-report' } ],
 				[
 					'@inpsyde/playwright-utils/build/integration/jira/xray-reporter.js',
 					{

--- a/tests/qa/tests/02-dashboard-ui/pay-later-messaging-default-ui.spec.ts
+++ b/tests/qa/tests/02-dashboard-ui/pay-later-messaging-default-ui.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Internal dependencies
+ */
+import { expect, test } from '../../utils';
+import { merchants, storeConfigDefault, products } from '../../resources';
+
+test.beforeAll( async ( { utils } ) => {
+	await utils.configureStore( storeConfigDefault );
+	await utils.installAndActivatePcp();
+	await utils.resetPcpDb();
+	await utils.configurePcp( {
+		merchant: merchants.usa,
+	} );
+} );
+
+test( 'PCP-0000 | Settings - Pay Later Messaging - Default UI', async ( {
+	utils,
+	ppui,
+	pcpPayLaterMessaging,
+	shop,
+	product,
+	cart,
+	classicCart,
+	checkout,
+	classicCheckout,
+}, testInfo ) => {
+	const snapshotName = testInfo.title;
+	await utils.fillVisitorsCart( [ products.simple10 ] );
+
+	await pcpPayLaterMessaging.visit();
+	await pcpPayLaterMessaging.waitForLoadingMaskRemoved();
+	await pcpPayLaterMessaging.snapshotPlmConfigurator(
+		`${ snapshotName } - Initial view`
+	);
+
+	await pcpPayLaterMessaging.expandAccordionSection( 'Product page' );
+	await pcpPayLaterMessaging.snapshotPlmConfigurator(
+		`${ snapshotName } - Product page config`
+	);
+
+	await pcpPayLaterMessaging.expandAccordionSection( 'Cart' );
+	await pcpPayLaterMessaging.snapshotPlmConfigurator(
+		`${ snapshotName } - Cart config`
+	);
+
+	await pcpPayLaterMessaging.expandAccordionSection( 'Checkout' );
+	await pcpPayLaterMessaging.snapshotPlmConfigurator(
+		`${ snapshotName } - Checkout config`
+	);
+
+	await pcpPayLaterMessaging.expandAccordionSection( 'Home' );
+	await pcpPayLaterMessaging.snapshotPlmConfigurator(
+		`${ snapshotName } - Home config`
+	);
+
+	await pcpPayLaterMessaging.expandAccordionSection( 'Shop' );
+	await pcpPayLaterMessaging.snapshotPlmConfigurator(
+		`${ snapshotName } - Shop config`
+	);
+
+	await product.visit( products.simple10.slug );
+	await expect( product.ppui.payLaterMessageContainer() ).toBeVisible();
+
+	await cart.visit();
+	await expect( cart.ppui.payLaterMessageContainer() ).toBeVisible();
+
+	await classicCart.visit();
+	await expect( classicCart.ppui.payLaterMessageContainer() ).toBeVisible();
+
+	await checkout.visit();
+	await expect( checkout.ppui.payLaterMessageContainer() ).toBeVisible();
+
+	await classicCheckout.visit();
+	await expect(
+		classicCheckout.ppui.payLaterMessageContainer()
+	).toBeVisible();
+
+	await shop.visit();
+	await expect( shop.ppui.payLaterMessageContainer() ).not.toBeVisible();
+
+	await ppui.page.goto( '/' ); // home page
+	await expect( ppui.payLaterMessageContainer() ).not.toBeVisible();
+} );


### PR DESCRIPTION
### Description

- Added test "Settings - Pay Later Messaging - Default UI" which combined functional and visual testing (playwright screenshots).
- Added `./snapshots/` dir to `playwright.config` as a default path for playwright screenshots.
