### PR TITLE
Add tests for PLM configurator

### DIFF
--- a/tests/qa/tests/02-dashboard-ui/_test-data/pay-later-messaging.data.ts
+++ b/tests/qa/tests/02-dashboard-ui/_test-data/pay-later-messaging.data.ts
@@ -38,10 +38,7 @@ const bannerColors: Pcp.Admin.Plm.BannerColor[] = [
 	'White',
 	'White (no border)',
 ];
-const bannerSizes: Pcp.Admin.Plm.BannerSize[] = [
-	'20 x 1',
-	'8 x 1'
-];
+const bannerSizes: Pcp.Admin.Plm.BannerSize[] = [ '20 x 1', '8 x 1' ];
 
 /**
  * Builds data combinations for pages with payment buttons (Procuct, Cart, Checkout) in the following format:

--- a/tests/qa/tests/02-dashboard-ui/_test-data/pay-later-messaging.data.ts
+++ b/tests/qa/tests/02-dashboard-ui/_test-data/pay-later-messaging.data.ts
@@ -1,0 +1,132 @@
+/**
+ * Internal dependencies
+ */
+import { Pcp } from '../../../resources';
+
+const checkoutLocations: Pcp.Admin.Plm.Location[] = [
+	'Product page',
+	'Cart',
+	'Checkout',
+];
+const logoTypes: Pcp.Admin.Plm.LogoType[] = [
+	'Full Logo',
+	'Monogram',
+	'Inline',
+	'Message only',
+];
+const textColors: Pcp.Admin.Plm.TextColor[] = [
+	'Black / Blue logo',
+	'White / White logo',
+	'Monochrome',
+	'Black / Gray logo',
+];
+const logoPositions: Pcp.Admin.Plm.LogoPosition[] = [
+	'Left',
+	'Right',
+	'Top'
+];
+const textSizes: Pcp.Admin.Plm.TextSize[] = [
+	'Small',
+	'Medium',
+	'Large'
+];
+
+const bannerLocations: Pcp.Admin.Plm.Location[] = [ 'Home', 'Shop' ];
+const bannerColors: Pcp.Admin.Plm.BannerColor[] = [
+	'Blue',
+	'Black',
+	'White',
+	'White (no border)',
+];
+const bannerSizes: Pcp.Admin.Plm.BannerSize[] = [
+	'20 x 1',
+	'8 x 1'
+];
+
+/**
+ * Builds data combinations for pages with payment buttons (Procuct, Cart, Checkout) in the following format:
+ * {
+ *     "Product page": {
+ *         location: "Product page",
+ *         settings: {
+ *             "logoType": "Full Logo",
+ *             "textColor": "Black / Blue logo",
+ *             "logoPosition": "Left",
+ *             "textSize": "Small",
+ *         }
+ *     },
+ *     ...
+ * }
+ */
+const checkoutLocationTests = Object.fromEntries(
+	checkoutLocations.map( ( location ) => [
+		location,
+		{
+			location,
+			settings: logoTypes
+				.map( ( logoType ) => {
+					const settings = {
+						logoType,
+						textColor: 'Black / Blue logo', // Default, replaced later
+						logoPosition: 'Left' as Pcp.Admin.Plm.LogoPosition,
+						textSize: 'Medium' as Pcp.Admin.Plm.TextSize,
+					};
+
+					if ( logoType === 'Full Logo' ) {
+						return textColors.flatMap( ( textColor ) =>
+							logoPositions.flatMap( ( logoPosition ) =>
+								textSizes.map( ( textSize ) => ( {
+									...settings,
+									textColor,
+									logoPosition,
+									textSize,
+								} ) )
+							)
+						);
+					}
+
+					return textColors.flatMap( ( textColor ) =>
+						textSizes.map( ( textSize ) => ( {
+							...settings,
+							textColor,
+							textSize,
+						} ) )
+					);
+				} )
+				.flat(),
+		},
+	] )
+);
+
+/**
+ * Builds data combinations for pages with banners (Home, Shop) in the following format:
+ * {
+ *     "Home": {
+ *         location: "Home",
+ *         settings: {
+ *             "bannerColor": "Blue",
+ *             "bannerSize": "20 x 1",
+ *         }
+ *     },
+ *     ...
+ * }
+ */
+const bannerLocationTests = Object.fromEntries(
+	bannerLocations.map( ( location ) => [
+		location,
+		{
+			location,
+			settings: bannerColors.flatMap( ( bannerColor ) =>
+				bannerSizes.map( ( bannerSize ) => ( {
+					bannerColor,
+					bannerSize,
+				} ) )
+			),
+		},
+	] )
+);
+
+export const payLaterMessagingData = {
+	checkoutLocationSettings: checkoutLocationTests,
+	bannerLocationSettings: bannerLocationTests,
+};

--- a/tests/qa/tests/02-dashboard-ui/pay-later-messaging-configurator.spec.ts
+++ b/tests/qa/tests/02-dashboard-ui/pay-later-messaging-configurator.spec.ts
@@ -1,0 +1,373 @@
+/**
+ * Internal dependencies
+ */
+import {
+	expect,
+	getTestResultsFromFile,
+	PayPalUI,
+	PcpPayLaterMessaging,
+	saveTestResultsToFile,
+	test,
+} from '../../utils';
+import { merchants, storeConfigDefault, products, Pcp } from '../../resources';
+import { payLaterMessagingData } from './_test-data/pay-later-messaging.data';
+
+const TEST_RESULTS_FILE = 'plm-test-results.json';
+
+/**
+ * Adds settings values to test name.
+ *
+ * @param  baseName
+ * @param  settings
+ * @param  settings.logoType
+ * @param  settings.textColor
+ * @param  settings.logoPosition
+ * @param  settings.textSize
+ * @param  settings.bannerColor
+ * @param  settings.bannerSize
+ * @return { string } Example: (PCP-000) PLM - Product page - Full Logo - Black / Gray logo - Left - Small
+ */
+const buildTestName = (
+	baseName: string,
+	settings: {
+		logoType?: Pcp.Admin.Plm.LogoType;
+		textColor?: Pcp.Admin.Plm.TextColor;
+		logoPosition?: Pcp.Admin.Plm.LogoPosition;
+		textSize?: Pcp.Admin.Plm.TextSize;
+		bannerColor?: Pcp.Admin.Plm.BannerColor;
+		bannerSize?: Pcp.Admin.Plm.BannerSize;
+	}
+): string => {
+	const {
+		logoType,
+		textColor,
+		logoPosition,
+		textSize,
+		bannerColor,
+		bannerSize,
+	} = settings;
+	let snapshotName = baseName;
+
+	if ( logoType ) {
+		snapshotName += ` - ${ logoType }`;
+	}
+
+	if ( textColor ) {
+		snapshotName += ` - ${ textColor }`;
+	}
+
+	if ( logoPosition && logoType === 'Full Logo' ) {
+		snapshotName += ` - ${ logoPosition }`;
+	}
+
+	if ( textSize ) {
+		snapshotName += ` - ${ textSize }`;
+	}
+
+	if ( bannerColor ) {
+		snapshotName += ` - ${ bannerColor }`;
+	}
+
+	if ( bannerSize ) {
+		snapshotName += ` - ${ bannerSize }`;
+	}
+
+	return snapshotName;
+};
+
+/**
+ * Takes percy snapshot for each preview variant (text, desktop, mobile + light/dark):
+ * - Switches previews
+ * - Switches Light/Dark modes
+ * - Takes snapshot
+ *
+ * @param pcpPayLaterMessaging
+ * @param snapshotName
+ */
+const takePreviewSnapshots = async (
+	pcpPayLaterMessaging: PcpPayLaterMessaging,
+	snapshotName: string
+) => {
+	for ( const layout of [ 'Text', 'Desktop', 'Mobile' ] ) {
+		if ( layout === 'Text' ) {
+			await pcpPayLaterMessaging.previewTextButton().click();
+		}
+		if ( layout === 'Desktop' ) {
+			await pcpPayLaterMessaging.previewDesktopButton().click();
+		}
+		if ( layout === 'Mobile' ) {
+			await pcpPayLaterMessaging.previewMobileButton().click();
+		}
+		for ( const togglePosition of [ 'Dark', 'Light' ] ) {
+			const isDark = togglePosition === 'Dark';
+			const previewSnapshotName = `${ snapshotName } - ${ layout } - Preview - ${ togglePosition }`;
+			await pcpPayLaterMessaging.setDarkModeToggleState( isDark );
+			await pcpPayLaterMessaging.snapshotPlmConfigurator(
+				previewSnapshotName
+			);
+		}
+		break;
+	}
+};
+
+/**
+ * - Asserts Pay Later Messaging container is visible.
+ * - Compares actual PLM container screenshot to expected.
+ *
+ * @param ppui
+ * @param snapshotName
+ */
+const snapshotPlmContainer = async ( ppui: PayPalUI, snapshotName: string ) => {
+	await expect( ppui.payLaterMessageContainer() ).toBeVisible();
+	await ppui.page.waitForTimeout( 500 );
+	expect(
+		await ppui
+			.payLaterMessageContainer()
+			.screenshot( { animations: 'disabled' } )
+	).toMatchSnapshot( snapshotName );
+};
+
+test.beforeAll( async ( { utils } ) => {
+	await utils.configureStore( storeConfigDefault );
+	await utils.installAndActivatePcp();
+	await utils.resetPcpDb();
+	await utils.configurePcp( {
+		merchant: merchants.usa,
+	} );
+} );
+
+test.describe( () => {
+	const productPlm =
+		payLaterMessagingData.checkoutLocationSettings[ 'Product page' ];
+
+	for ( const settings of productPlm.settings ) {
+		test(
+			buildTestName( `(PCP-0001) PLM - Product page`, settings ),
+			async ( { pcpPayLaterMessaging, product, ppui }, testInfo ) => {
+				const snapshotName = testInfo.title;
+				const { location } = productPlm;
+				await pcpPayLaterMessaging.visit();
+				await pcpPayLaterMessaging.enableMessagingForLocation(
+					location
+				);
+				await pcpPayLaterMessaging.updateLocationSettings(
+					location,
+					settings
+				);
+				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.saveChanges();
+				await pcpPayLaterMessaging.page.reload();
+				await pcpPayLaterMessaging.expandAccordionSection( location );
+				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.snapshotPlmConfigurator(
+					`${ snapshotName } - After save.png`
+				);
+
+				await product.visit( products.simple10.slug );
+				await snapshotPlmContainer(
+					ppui,
+					`${ snapshotName } - Frontend.png`
+				);
+			}
+		);
+	}
+
+	const cartPlm = payLaterMessagingData.checkoutLocationSettings.Cart;
+
+	for ( const settings of cartPlm.settings ) {
+		test(
+			buildTestName( `(PCP-0002) PLM - Cart`, settings ),
+			async (
+				{ utils, pcpPayLaterMessaging, cart, classicCart, ppui },
+				testInfo
+			) => {
+				const snapshotName = testInfo.title;
+				const { location } = cartPlm;
+				await utils.fillVisitorsCart( [ products.simple10 ] );
+
+				await pcpPayLaterMessaging.visit();
+				await pcpPayLaterMessaging.enableMessagingForLocation(
+					location
+				);
+				await pcpPayLaterMessaging.updateLocationSettings(
+					location,
+					settings
+				);
+				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.saveChanges();
+				await pcpPayLaterMessaging.page.reload();
+				await pcpPayLaterMessaging.expandAccordionSection( location );
+				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.snapshotPlmConfigurator(
+					`${ snapshotName } - After save.png`
+				);
+				// Block cart
+				await cart.visit();
+				await snapshotPlmContainer(
+					ppui,
+					`${ snapshotName } - Frontend - Block cart.png`
+				);
+				// Classic cart
+				await classicCart.visit();
+				await snapshotPlmContainer(
+					ppui,
+					`${ snapshotName } - Frontend - Classic cart.png`
+				);
+			}
+		);
+	}
+
+	const checkoutPlm = payLaterMessagingData.checkoutLocationSettings.Checkout;
+
+	for ( const settings of checkoutPlm.settings ) {
+		test(
+			buildTestName( `(PCP-0003) PLM - Checkout`, settings ),
+			async (
+				{
+					utils,
+					pcpPayLaterMessaging,
+					checkout,
+					classicCheckout,
+					ppui,
+				},
+				testInfo
+			) => {
+				const snapshotName = testInfo.title;
+				const { location } = checkoutPlm;
+				await utils.fillVisitorsCart( [ products.simple10 ] );
+
+				await pcpPayLaterMessaging.visit();
+				await pcpPayLaterMessaging.enableMessagingForLocation(
+					location
+				);
+				await pcpPayLaterMessaging.updateLocationSettings(
+					location,
+					settings
+				);
+				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.saveChanges();
+				await pcpPayLaterMessaging.page.reload();
+				await pcpPayLaterMessaging.expandAccordionSection( location );
+				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.snapshotPlmConfigurator(
+					`${ snapshotName } - After save.png`
+				);
+				// Block checkout
+				await checkout.visit();
+				await snapshotPlmContainer(
+					ppui,
+					`${ snapshotName } - Frontend - Block checkout.png`
+				);
+				// Classic checkout
+				await classicCheckout.visit();
+				await snapshotPlmContainer(
+					ppui,
+					`${ snapshotName } - Frontend - Classic checkout.png`
+				);
+			}
+		);
+	}
+
+	const homePlm = payLaterMessagingData.bannerLocationSettings.Home;
+
+	for ( const settings of homePlm.settings ) {
+		test(
+			buildTestName( `(PCP-0004) PLM - Home`, settings ),
+			async (
+				{
+					pcpPayLaterMessaging,
+					ppui, // PayPal UI
+				},
+				testInfo
+			) => {
+				test.setTimeout( 10 * 60 * 1000 );
+				const snapshotName = testInfo.title;
+				const { location } = homePlm;
+				await pcpPayLaterMessaging.visit();
+				await pcpPayLaterMessaging.enableMessagingForLocation(
+					location
+				);
+				await pcpPayLaterMessaging.updateLocationSettings(
+					location,
+					settings
+				);
+				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.saveChanges();
+				await pcpPayLaterMessaging.page.reload();
+				await pcpPayLaterMessaging.expandAccordionSection( location );
+				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.snapshotPlmConfigurator(
+					`${ snapshotName } - After save.png`
+				);
+
+				await ppui.page.goto( '/' );
+				await snapshotPlmContainer(
+					ppui,
+					`${ snapshotName } - Frontend.png`
+				);
+			}
+		);
+	}
+
+	const shopPlm = payLaterMessagingData.bannerLocationSettings.Shop;
+
+	for ( const settings of shopPlm.settings ) {
+		test(
+			buildTestName( `(PCP-0005) PLM - Shop`, settings ),
+			async ( { pcpPayLaterMessaging, shop, ppui }, testInfo ) => {
+				const snapshotName = testInfo.title;
+				const { location } = shopPlm;
+				await pcpPayLaterMessaging.visit();
+				await pcpPayLaterMessaging.enableMessagingForLocation(
+					location
+				);
+				await pcpPayLaterMessaging.updateLocationSettings(
+					location,
+					settings
+				);
+				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.saveChanges();
+				await pcpPayLaterMessaging.page.reload();
+				await pcpPayLaterMessaging.expandAccordionSection( location );
+				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
+				await pcpPayLaterMessaging.snapshotPlmConfigurator(
+					`${ snapshotName } - After save.png`
+				);
+
+				await shop.visit();
+				await snapshotPlmContainer(
+					ppui,
+					`${ snapshotName } - Frontend.png`
+				);
+			}
+		);
+	}
+
+	test.afterEach( async ( {}, testInfo ) => {
+		saveTestResultsToFile(
+			testInfo.title,
+			testInfo.status,
+			TEST_RESULTS_FILE
+		);
+	} );
+} );
+
+test( 'PCP-0001 | Pay Later Messaging - Customize on Product page', async () => {
+	getTestResultsFromFile( 'PCP-0001', TEST_RESULTS_FILE );
+} );
+
+test( 'PCP-0002 | Pay Later Messaging - Customize on Cart (block and classic)', async () => {
+	getTestResultsFromFile( 'PCP-0002', TEST_RESULTS_FILE );
+} );
+
+test( 'PCP-0003 | Pay Later Messaging - Customize on Checkout (block and classic', async () => {
+	getTestResultsFromFile( 'PCP-0003', TEST_RESULTS_FILE );
+} );
+
+test( 'PCP-0004 | Pay Later Messaging - Customize on Home page', async () => {
+	getTestResultsFromFile( 'PCP-0004', TEST_RESULTS_FILE );
+} );
+
+test( 'PCP-0005 | Pay Later Messaging - Customize on Shop page', async () => {
+	getTestResultsFromFile( 'PCP-0005', TEST_RESULTS_FILE );
+} );

--- a/tests/qa/tests/02-dashboard-ui/pay-later-messaging-configurator.spec.ts
+++ b/tests/qa/tests/02-dashboard-ui/pay-later-messaging-configurator.spec.ts
@@ -17,7 +17,7 @@ const TEST_RESULTS_FILE = 'plm-test-results.json';
 /**
  * Adds settings values to test name.
  *
- * @param  baseName
+ * @param  baseTitle
  * @param  settings
  * @param  settings.logoType
  * @param  settings.textColor
@@ -27,8 +27,8 @@ const TEST_RESULTS_FILE = 'plm-test-results.json';
  * @param  settings.bannerSize
  * @return { string } Example: (PCP-000) PLM - Product page - Full Logo - Black / Gray logo - Left - Small
  */
-const buildTestName = (
-	baseName: string,
+const completeTestTitle = (
+	baseTitle: string,
 	settings: {
 		logoType?: Pcp.Admin.Plm.LogoType;
 		textColor?: Pcp.Admin.Plm.TextColor;
@@ -46,33 +46,33 @@ const buildTestName = (
 		bannerColor,
 		bannerSize,
 	} = settings;
-	let snapshotName = baseName;
+	let title = baseTitle;
 
 	if ( logoType ) {
-		snapshotName += ` - ${ logoType }`;
+		title += ` - ${ logoType }`;
 	}
 
 	if ( textColor ) {
-		snapshotName += ` - ${ textColor }`;
+		title += ` - ${ textColor }`;
 	}
 
 	if ( logoPosition && logoType === 'Full Logo' ) {
-		snapshotName += ` - ${ logoPosition }`;
+		title += ` - ${ logoPosition }`;
 	}
 
 	if ( textSize ) {
-		snapshotName += ` - ${ textSize }`;
+		title += ` - ${ textSize }`;
 	}
 
 	if ( bannerColor ) {
-		snapshotName += ` - ${ bannerColor }`;
+		title += ` - ${ bannerColor }`;
 	}
 
 	if ( bannerSize ) {
-		snapshotName += ` - ${ bannerSize }`;
+		title += ` - ${ bannerSize }`;
 	}
 
-	return snapshotName;
+	return title;
 };
 
 /**
@@ -127,22 +127,22 @@ const snapshotPlmContainer = async ( ppui: PayPalUI, snapshotName: string ) => {
 	).toMatchSnapshot( snapshotName );
 };
 
-test.beforeAll( async ( { utils } ) => {
-	await utils.configureStore( storeConfigDefault );
-	await utils.installAndActivatePcp();
-	await utils.resetPcpDb();
-	await utils.configurePcp( {
-		merchant: merchants.usa,
+test.describe( 'Subtests', () => {
+	test.beforeAll( async ( { utils } ) => {
+		await utils.configureStore( storeConfigDefault );
+		await utils.installAndActivatePcp();
+		await utils.resetPcpDb();
+		await utils.configurePcp( {
+			merchant: merchants.usa,
+		} );
 	} );
-} );
 
-test.describe( () => {
 	const productPlm =
 		payLaterMessagingData.checkoutLocationSettings[ 'Product page' ];
 
 	for ( const settings of productPlm.settings ) {
 		test(
-			buildTestName( `(PCP-0001) PLM - Product page`, settings ),
+			completeTestTitle( `(PCP-0001) PLM - Product page`, settings ),
 			async ( { pcpPayLaterMessaging, product, ppui }, testInfo ) => {
 				const snapshotName = testInfo.title;
 				const { location } = productPlm;
@@ -176,7 +176,7 @@ test.describe( () => {
 
 	for ( const settings of cartPlm.settings ) {
 		test(
-			buildTestName( `(PCP-0002) PLM - Cart`, settings ),
+			completeTestTitle( `(PCP-0002) PLM - Cart`, settings ),
 			async (
 				{ utils, pcpPayLaterMessaging, cart, classicCart, ppui },
 				testInfo
@@ -221,7 +221,7 @@ test.describe( () => {
 
 	for ( const settings of checkoutPlm.settings ) {
 		test(
-			buildTestName( `(PCP-0003) PLM - Checkout`, settings ),
+			completeTestTitle( `(PCP-0003) PLM - Checkout`, settings ),
 			async (
 				{
 					utils,
@@ -272,7 +272,7 @@ test.describe( () => {
 
 	for ( const settings of homePlm.settings ) {
 		test(
-			buildTestName( `(PCP-0004) PLM - Home`, settings ),
+			completeTestTitle( `(PCP-0004) PLM - Home`, settings ),
 			async (
 				{
 					pcpPayLaterMessaging,
@@ -313,7 +313,7 @@ test.describe( () => {
 
 	for ( const settings of shopPlm.settings ) {
 		test(
-			buildTestName( `(PCP-0005) PLM - Shop`, settings ),
+			completeTestTitle( `(PCP-0005) PLM - Shop`, settings ),
 			async ( { pcpPayLaterMessaging, shop, ppui }, testInfo ) => {
 				const snapshotName = testInfo.title;
 				const { location } = shopPlm;

--- a/tests/qa/utils/admin/pcp-pay-later-messaging.ts
+++ b/tests/qa/utils/admin/pcp-pay-later-messaging.ts
@@ -332,7 +332,7 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 			.soft(
 				await this.configContainer().screenshot( {
 					animations: 'disabled',
-					style: '.ppcp-r-navigation-container { display: none; }',
+					style: '#wpadminbar, .ppcp-r-navigation-container { display: none; }',
 				} )
 			)
 			.toMatchSnapshot( snapshotName, { threshold: 0.8 } );

--- a/tests/qa/utils/helpers.ts
+++ b/tests/qa/utils/helpers.ts
@@ -1,4 +1,16 @@
 /**
+ * External dependencies
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+/**
+ * Internal dependencies
+ */
+import { expect } from './test';
+
+const TEST_RESULTS_DIR = join( process.cwd(), 'test-results' ); // Root 'test-results/' dir
+
+/**
  * Sets annotation about tested customer
  * If tested customer is registered (has non-empty username),
  * then his billing.country will be added to annotation for example: customer-germany
@@ -254,3 +266,88 @@ export function generateRandomString( length: number ): string {
 	}
 	return result;
 }
+
+/**
+ * Saves test result and writes to a JSON file.
+ * Is used for complex scenarios when one resulting test includes many subtests.
+ * - Expects testKey in following format: (PCP-0005)
+ * - Saves result in following format:
+ *     {
+ *         "PCP-0004": { status: "failed", errors: [ ""(PCP-0004) PLM - Home - Black" ] },
+ *         "PCP-0005": { status: "failed", errors: [ ""(PCP-0005) PLM - Shop - Black", "(PCP-0005) PLM - Shop - Blue" ] },
+ *     }
+ * - Subtests can have same testKeys but the titles should differ.
+ *
+ * @param testTitle
+ * @param testStatus
+ * @param filename
+ */
+export const saveTestResultsToFile = (
+	testTitle: string,
+	testStatus: string,
+	filename: string = 'test-results.json'
+) => {
+	const resultsFile = join( TEST_RESULTS_DIR, filename );
+
+	// Ensure directory exists
+	if ( ! existsSync( TEST_RESULTS_DIR ) ) {
+		mkdirSync( TEST_RESULTS_DIR, { recursive: true } );
+	}
+
+	// Read existing results or initialize empty object
+	const results = existsSync( resultsFile )
+		? JSON.parse( readFileSync( resultsFile, 'utf-8' ) )
+		: {};
+
+	const match = testTitle.match( /\((.*?)\)/ );
+	if ( ! match ) return;
+
+	const testKey = match[ 1 ]; // Extract test key
+
+	if ( ! results[ testKey ] ) {
+		results[ testKey ] = { status: 'passed', errors: [] };
+	}
+
+	if ( testStatus !== 'passed' ) {
+		results[ testKey ].status = 'failed';
+		results[ testKey ].errors.push( testTitle );
+	}
+
+	// Write updated results to file
+	writeFileSync( resultsFile, JSON.stringify( results, null, 2 ), 'utf-8' );
+};
+
+/**
+ * Reads test results from a JSON file and validates test status.
+ * Is used for complex scenarios when one resulting test includes many subtests.
+ * - Reads subtest(s) results by testKey.
+ * - Passes/fails test accordinf to "status".
+ * - Outputs "errors" if any.
+ *
+ * @param testKey
+ * @param filename
+ */
+export const getTestResultsFromFile = (
+	testKey: string,
+	filename: string = 'test-results.json'
+) => {
+	const resultsFile = join( TEST_RESULTS_DIR, filename );
+
+	if ( ! existsSync( resultsFile ) ) {
+		throw new Error( `Test results file '${ filename }' not found.` );
+	}
+
+	const results = JSON.parse( readFileSync( resultsFile, 'utf-8' ) );
+	const { status, errors } = results[ testKey ] || {
+		status: 'skipped',
+		errors: [],
+	};
+
+	expect.soft( status ).toBe( 'passed' );
+
+	if ( errors.length > 0 ) {
+		for ( const error of errors ) {
+			expect.soft( error ).toBe( '' );
+		}
+	}
+};


### PR DESCRIPTION
### Description

Added tests for PLM configurator:

- Added test data file - `pay-later-messaging.data.ts`.

- Add separate subtests for each data variation - allows to process each variation as a separate playwright test:
    (PCP-0001) PLM - Product page - Full Logo - Black / Blue logo - Left - Small
    (PCP-0001) PLM - Product page - Full Logo - Black / Blue logo - Left - Medium
    (PCP-0001) PLM - Product page - Full Logo - Black / Blue logo - Left - Large
    ...........
    
- Add resulting tests according to Xray - allows to not multiply testcases in Xray but to import subtests results as one resulting test:
    PCP-0001 | Pay Later Messaging - Customize on Product page
    PCP-0002 | Pay Later Messaging - Customize on Cart (block and classic)
    PCP-0003 | Pay Later Messaging - Customize on Checkout (block and classic
    PCP-0004 | Pay Later Messaging - Customize on Home page
    PCP-0005 | Pay Later Messaging - Customize on Shop page
    
- Add `saveTestResultsToFile`, `getTestResultsFromFile` helper methods to save and retreive results of subtests.