### PR TITLE
Manual Connection Error (4286)

### DIFF
--- a/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
@@ -9,11 +9,11 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Endpoint;
 
+use Exception;
 use WP_REST_Server;
 use WP_REST_Response;
 use WP_REST_Request;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
-use WooCommerce\PayPalCommerce\Settings\Service\InternalRestService;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 
 /**
@@ -257,9 +257,17 @@ class CommonRestEndpoint extends RestEndpoint {
 	 * @return WP_REST_Response Seller details, provided by PayPal's API.
 	 */
 	public function get_seller_account_info() : WP_REST_Response {
-		$seller_status = $this->partners_endpoint->seller_status();
+		try {
+			$seller_status = $this->partners_endpoint->seller_status();
 
-		return $this->return_success( array( 'country' => $seller_status->country() ) );
+			$seller_data = array(
+				'country' => $seller_status->country(),
+			);
+
+			return $this->return_success( $seller_data );
+		} catch ( Exception $ex ) {
+			return $this->return_error( $ex->getMessage() );
+		}
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -449,20 +449,20 @@ class AuthenticationManager {
 			$response = $this->rest_service->get_response( $endpoint );
 
 			if ( ! $response['success'] ) {
-				$this->logger->warning( 'Failed to load merchant details!', $response );
+				$this->enrichment_failed( 'Server failed to provide data', $response );
 
 				return;
 			}
 
 			$details = $response['data'];
 		} catch ( Throwable $exception ) {
-			$this->logger->warning( 'Could not determine merchant country: ' . $exception->getMessage() );
+			$this->enrichment_failed( $exception->getMessage() );
 
 			return;
 		}
 
 		if ( ! isset( $details['country'] ) ) {
-			$this->logger->warning( 'Missing country in merchant details' );
+			$this->enrichment_failed( 'Missing country in merchant details' );
 
 			return;
 		}
@@ -476,6 +476,26 @@ class AuthenticationManager {
 		// Persist the changes.
 		$this->common_settings->set_merchant_data( $connection );
 		$this->common_settings->save();
+	}
+
+	/**
+	 * When the `enrich_merchant_details()` call fails, this method might
+	 * set up a cron task to retry the attempt after some time.
+	 *
+	 * @param string $reason  Reason for the failure, will be logged.
+	 * @param mixed  $details Optional. Additional details to log.
+	 * @return void
+	 */
+	private function enrichment_failed( string $reason, $details = null ) : void {
+		$this->logger->warning(
+			'Failed to enrich merchant details: ' . $reason,
+			array(
+				'reason'  => $reason,
+				'details' => $details,
+			)
+		);
+
+		// TODO: Schedule a cron task to retry the enrichment, e.g. with wp_schedule_single_event().
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -446,9 +446,24 @@ class AuthenticationManager {
 
 		try {
 			$endpoint = CommonRestEndpoint::seller_account_route( true );
-			$details  = $this->rest_service->get_response( $endpoint );
+			$response = $this->rest_service->get_response( $endpoint );
+
+			if ( ! $response['success'] ) {
+				$this->logger->warning( 'Failed to load merchant details!', $response );
+
+				return;
+			}
+
+			$details = $response['data'];
 		} catch ( Throwable $exception ) {
 			$this->logger->warning( 'Could not determine merchant country: ' . $exception->getMessage() );
+
+			return;
+		}
+
+		if ( ! isset( $details['country'] ) ) {
+			$this->logger->warning( 'Missing country in merchant details' );
+
 			return;
 		}
 

--- a/modules/ppcp-settings/src/Service/InternalRestService.php
+++ b/modules/ppcp-settings/src/Service/InternalRestService.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Settings\Service;
 
 use Throwable;
+use RuntimeException;
 use Psr\Log\LoggerInterface;
 use WP_Http_Cookie;
 
@@ -48,6 +49,7 @@ class InternalRestService {
 	 *
 	 * @param string $endpoint The endpoint for which the token is generated.
 	 * @return mixed The REST response.
+	 * @throws RuntimeException In case the remote request fails, an exception is thrown.
 	 */
 	public function get_response( string $endpoint ) {
 		$rest_url     = rest_url( $endpoint );
@@ -69,9 +71,11 @@ class InternalRestService {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			$this->logger->error( 'Internal REST error', array( 'response' => $response ) );
+			// Error: The wp_remote_request() call failed (timeout or similar).
+			$error = new RuntimeException( 'Internal REST error' );
+			$this->logger->error( $error->getMessage(), array( 'response' => $response ) );
 
-			return array();
+			throw $error;
 		}
 
 		$body = wp_remote_retrieve_body( $response );
@@ -79,26 +83,22 @@ class InternalRestService {
 		try {
 			$json = json_decode( $body, true, 512, JSON_THROW_ON_ERROR );
 		} catch ( Throwable $exception ) {
+			// Error: The returned body-string is not valid JSON.
+			$error = new RuntimeException( 'Internal REST error: Invalid JSON response' );
 			$this->logger->error(
-				'Internal REST error: Invalid JSON response',
+				$error->getMessage(),
 				array(
 					'error'         => $exception->getMessage(),
 					'response_body' => $body,
 				)
 			);
 
-			return array();
+			throw $error;
 		}
 
-		if ( ! $json || empty( $json['success'] ) ) {
-			$this->logger->error( 'Internal REST error: Invalid response', array( 'json' => $json ) );
+		$this->logger->info( 'Internal REST success!', array( 'json' => $json ) );
 
-			return array();
-		}
-
-		$this->logger->info( 'Internal REST success', array( 'data' => $json['data'] ) );
-
-		return $json['data'];
+		return $json;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -171,6 +171,19 @@ class SettingsDataManager {
 
 		$this->onboarding_profile->set_setup_done( true );
 		$this->onboarding_profile->save();
+
+		/**
+		 * Fires after the core merchant configuration was applied.
+		 *
+		 * This action indicates that a merchant completed the onboarding wizard.
+		 * The flags contain several choices which the merchant took during the
+		 * onboarding wizard, and provide additional context on which defaults
+		 * should be applied for the new merchant.
+		 *
+		 * Other modules or integrations can use this hook to initialize
+		 * additional plugin settings on first merchant login.
+		 */
+		do_action( 'woocommerce_paypal_payments_apply_default_configuration', $flags );
 	}
 
 	/**


### PR DESCRIPTION
### Description

Adds additional error handling to improve onboarding stability for manual connection.

This PR addresses a rare edge case that we encountered:

- PayPal API returned an error when attempting to fetch additional seller-details
- Those details are not critical for onboarding (currently, only includes the seller-country)
- Since the plugin caches this API response for 24 hours, onboarding was completely blocked for one day

This PR adds error handling to (a) log the error and then (b) continue as usual, without knowing the exact seller country

**Next steps**

In a future PR, we want to add a cron schedule on failure, that retries to populate the merchant country from the API after 24 hours.