### PR TITLE
Security Deposits Plugin Causing PayPal Button to Be Grayed Out on Product Page (4219)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstap.js
@@ -162,6 +162,12 @@ class SingleProductBootstap {
 			},
 		]
 			.map( ( f ) => f() )
+            .sort((a, b) => {
+                if (parseInt(a.replace(/\D/g, '')) < parseInt(b.replace(/\D/g, '')) ) {
+                    return 1;
+                }
+                return -1;
+            })
 			.find( ( val ) => val );
 
 		if ( typeof priceText === 'undefined' ) {


### PR DESCRIPTION
Improved detection if a price is given on the page, especially when multiple in dom