### PR TITLE
Enable Fastlane by default for compatible setups (4292)

### DIFF
--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -12,7 +12,7 @@ namespace WooCommerce\PayPalCommerce\Axo;
 use WooCommerce\PayPalCommerce\Axo\Assets\AxoManager;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Axo\Helper\ApmApplies;
-use WooCommerce\PayPalCommerce\Axo\Helper\SettingsNoticeGenerator;
+use WooCommerce\PayPalCommerce\Axo\Helper\CompatibilityChecker;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -38,8 +38,8 @@ return array(
 		);
 	},
 
-	'axo.helpers.settings-notice-generator'  => static function ( ContainerInterface $container ) : SettingsNoticeGenerator {
-		return new SettingsNoticeGenerator( $container->get( 'axo.fastlane-incompatible-plugin-names' ) );
+	'axo.helpers.compatibility-checker'      => static function ( ContainerInterface $container ) : CompatibilityChecker {
+		return new CompatibilityChecker( $container->get( 'axo.fastlane-incompatible-plugin-names' ) );
 	},
 
 	// If AXO is configured and onboarded.
@@ -190,38 +190,38 @@ return array(
 		);
 	},
 	'axo.settings-conflict-notice'           => static function ( ContainerInterface $container ) : string {
-		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
-		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
+		$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
+		assert( $compatibility_checker instanceof CompatibilityChecker );
 
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
-		return $settings_notice_generator->generate_settings_conflict_notice( $settings );
+		return $compatibility_checker->generate_settings_conflict_notice( $settings );
 	},
 
 	'axo.checkout-config-notice'             => static function ( ContainerInterface $container ) : string {
-		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
-		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
+		$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
+		assert( $compatibility_checker instanceof CompatibilityChecker );
 
-		return $settings_notice_generator->generate_checkout_notice();
+		return $compatibility_checker->generate_checkout_notice();
 	},
 
 	'axo.checkout-config-notice.raw'         => static function ( ContainerInterface $container ) : string {
-		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
-		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
+		$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
+		assert( $compatibility_checker instanceof CompatibilityChecker );
 
-		return $settings_notice_generator->generate_checkout_notice( true );
+		return $compatibility_checker->generate_checkout_notice( true );
 	},
 
 	'axo.incompatible-plugins-notice'        => static function ( ContainerInterface $container ) : string {
-		$settings_notice_generator = $container->get( 'axo.helpers.settings-notice-generator' );
-		assert( $settings_notice_generator instanceof SettingsNoticeGenerator );
+		$settings_notice_generator = $container->get( 'axo.helpers.compatibility-checker' );
+		assert( $settings_notice_generator instanceof CompatibilityChecker );
 
 		return $settings_notice_generator->generate_incompatible_plugins_notice();
 	},
 
 	'axo.incompatible-plugins-notice.raw'    => static function ( ContainerInterface $container ) : string {
-		$settings_notice_generator = new SettingsNoticeGenerator(
+		$settings_notice_generator = new CompatibilityChecker(
 			$container->get( 'axo.fastlane-incompatible-plugin-names' )
 		);
 

--- a/modules/ppcp-axo/src/Helper/CompatibilityChecker.php
+++ b/modules/ppcp-axo/src/Helper/CompatibilityChecker.php
@@ -15,7 +15,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 
 /**
- * Class FastlaneCompatibilityChecker
+ * Class CompatibilityChecker
  */
 class CompatibilityChecker {
 	/**

--- a/modules/ppcp-axo/src/Helper/CompatibilityChecker.php
+++ b/modules/ppcp-axo/src/Helper/CompatibilityChecker.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Settings notice generator.
- * Generates the settings notices.
+ * Fastlane compatibility checker.
+ * Detects compatibility issues and generates relevant notices.
  *
  * @package WooCommerce\PayPalCommerce\Axo\Helper
  */
@@ -15,9 +15,9 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 
 /**
- * Class SettingsNoticeGenerator
+ * Class FastlaneCompatibilityChecker
  */
-class SettingsNoticeGenerator {
+class CompatibilityChecker {
 	/**
 	 * The list of Fastlane incompatible plugin names.
 	 *
@@ -26,12 +26,88 @@ class SettingsNoticeGenerator {
 	protected array $incompatible_plugin_names;
 
 	/**
-	 * SettingsNoticeGenerator constructor.
+	 * Stores the result of checkout compatibility checks.
+	 *
+	 * @var array
+	 */
+	protected array $checkout_compatibility;
+
+	/**
+	 * Stores whether DCC is enabled.
+	 *
+	 * @var bool|null
+	 */
+	protected ?bool $is_dcc_enabled = null;
+
+	/**
+	 * FastlaneCompatibilityChecker constructor.
 	 *
 	 * @param string[] $incompatible_plugin_names The list of Fastlane incompatible plugin names.
 	 */
 	public function __construct( array $incompatible_plugin_names ) {
 		$this->incompatible_plugin_names = $incompatible_plugin_names;
+		$this->checkout_compatibility    = array(
+			'has_elementor_checkout' => null,
+			'has_classic_checkout'   => null,
+			'has_block_checkout'     => null,
+		);
+	}
+
+	/**
+	 * Checks if the checkout uses Elementor.
+	 *
+	 * @return bool Whether the checkout uses Elementor.
+	 */
+	protected function has_elementor_checkout(): bool {
+		if ( $this->checkout_compatibility['has_elementor_checkout'] === null ) {
+			$this->checkout_compatibility['has_elementor_checkout'] = CartCheckoutDetector::has_elementor_checkout();
+		}
+
+		return $this->checkout_compatibility['has_elementor_checkout'];
+	}
+
+	/**
+	 * Checks if the checkout uses classic checkout.
+	 *
+	 * @return bool Whether the checkout uses classic checkout.
+	 */
+	protected function has_classic_checkout(): bool {
+		if ( $this->checkout_compatibility['has_classic_checkout'] === null ) {
+			$this->checkout_compatibility['has_classic_checkout'] = CartCheckoutDetector::has_classic_checkout();
+		}
+
+		return $this->checkout_compatibility['has_classic_checkout'];
+	}
+
+	/**
+	 * Checks if the checkout uses block checkout.
+	 *
+	 * @return bool Whether the checkout uses block checkout.
+	 */
+	protected function has_block_checkout(): bool {
+		if ( $this->checkout_compatibility['has_block_checkout'] === null ) {
+			$this->checkout_compatibility['has_block_checkout'] = CartCheckoutDetector::has_block_checkout();
+		}
+
+		return $this->checkout_compatibility['has_block_checkout'];
+	}
+
+	/**
+	 * Checks if DCC is enabled.
+	 *
+	 * @param Settings $settings The plugin settings container.
+	 * @return bool Whether DCC is enabled.
+	 */
+	protected function is_dcc_enabled( Settings $settings ): bool {
+		if ( $this->is_dcc_enabled === null ) {
+			try {
+				$this->is_dcc_enabled = $settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' );
+			} catch ( NotFoundException $ignored ) {
+				$this->is_dcc_enabled = false;
+			}
+		}
+
+		return $this->is_dcc_enabled;
 	}
 
 	/**
@@ -60,21 +136,53 @@ class SettingsNoticeGenerator {
 	}
 
 	/**
+	 * Check if there aren't any incompatibilities that would prevent Fastlane from working properly.
+	 *
+	 * @return bool Whether the setup is compatible.
+	 */
+	public function is_fastlane_compatible(): bool {
+		// Check for incompatible plugins.
+		if ( ! empty( $this->incompatible_plugin_names ) ) {
+			return false;
+		}
+
+		// Check for checkout page incompatibilities.
+		if ( $this->has_elementor_checkout() ) {
+			return false;
+		}
+
+		if ( ! $this->has_classic_checkout() && ! $this->has_block_checkout() ) {
+			return false;
+		}
+
+		// No incompatibilities found.
+		return true;
+	}
+
+	/**
 	 * Generates the checkout notice.
 	 *
 	 * @param bool $raw_message Whether to return raw message without HTML wrappers.
 	 * @return string
 	 */
 	public function generate_checkout_notice( bool $raw_message = false ): string {
+		$notice_content = '';
+
+		// Check for checkout incompatibilities.
+		$has_checkout_incompatibility = $this->has_elementor_checkout() ||
+			( ! $this->has_classic_checkout() && ! $this->has_block_checkout() );
+
+		if ( ! $has_checkout_incompatibility ) {
+			return '';
+		}
+
 		$checkout_page_link       = esc_url( get_edit_post_link( wc_get_page_id( 'checkout' ) ) ?? '' );
 		$block_checkout_docs_link = __(
 			'https://woocommerce.com/document/woocommerce-store-editing/customizing-cart-and-checkout/#using-the-cart-and-checkout-blocks',
 			'woocommerce-paypal-payments'
 		);
 
-		$notice_content = '';
-
-		if ( CartCheckoutDetector::has_elementor_checkout() ) {
+		if ( $this->has_elementor_checkout() ) {
 			$notice_content = sprintf(
 			/* translators: %1$s: URL to the Checkout edit page. %2$s: URL to the block checkout docs. */
 				__(
@@ -84,7 +192,7 @@ class SettingsNoticeGenerator {
 				esc_url( $checkout_page_link ),
 				esc_url( $block_checkout_docs_link )
 			);
-		} elseif ( ! CartCheckoutDetector::has_classic_checkout() && ! CartCheckoutDetector::has_block_checkout() ) {
+		} elseif ( ! $this->has_classic_checkout() && ! $this->has_block_checkout() ) {
 			$notice_content = sprintf(
 			/* translators: %1$s: URL to the Checkout edit page. %2$s: URL to the block checkout docs. */
 				__(
@@ -132,22 +240,14 @@ class SettingsNoticeGenerator {
 	 * @return string
 	 */
 	public function generate_settings_conflict_notice( Settings $settings, bool $raw_message = false ) : string {
-		$notice_content = '';
-		$is_dcc_enabled = false;
-
-		try {
-			$is_dcc_enabled = $settings->has( 'dcc_enabled' ) && $settings->get( 'dcc_enabled' );
-			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-		} catch ( NotFoundException $ignored ) {
-			// Never happens.
+		if ( $this->is_dcc_enabled( $settings ) ) {
+			return '';
 		}
 
-		if ( ! $is_dcc_enabled ) {
-			$notice_content = __(
-				'<span class="highlight">Warning:</span> To enable Fastlane and accelerate payments, the <strong>Advanced Card Processing</strong> payment method must also be enabled.',
-				'woocommerce-paypal-payments'
-			);
-		}
+		$notice_content = __(
+			'<span class="highlight">Warning:</span> To enable Fastlane and accelerate payments, the <strong>Advanced Card Processing</strong> payment method must also be enabled.',
+			'woocommerce-paypal-payments'
+		);
 
 		return $this->render_notice( $notice_content, true, $raw_message );
 	}

--- a/modules/ppcp-axo/src/Helper/CompatibilityChecker.php
+++ b/modules/ppcp-axo/src/Helper/CompatibilityChecker.php
@@ -40,7 +40,7 @@ class CompatibilityChecker {
 	protected ?bool $is_dcc_enabled = null;
 
 	/**
-	 * FastlaneCompatibilityChecker constructor.
+	 * CompatibilityChecker constructor.
 	 *
 	 * @param string[] $incompatible_plugin_names The list of Fastlane incompatible plugin names.
 	 */

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -9,11 +9,13 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings;
 
+use Mollie\Api\Resources\Payment;
 use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BlikGateway;
@@ -43,6 +45,8 @@ use WooCommerce\PayPalCommerce\Settings\Service\SettingsDataManager;
 use WooCommerce\PayPalCommerce\Settings\DTO\ConfigurationFlagsDTO;
 use WooCommerce\PayPalCommerce\Settings\Enum\ProductChoicesEnum;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Axo\Helper\CompatibilityChecker;
 
 /**
  * Class SettingsModule
@@ -575,6 +579,24 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				}
 
 				return $disable_funding;
+			}
+		);
+
+		// Enable Fastlane after onboarding if the store is compatible.
+		add_action(
+			'woocommerce_paypal_payments_apply_default_configuration',
+			static function () use ( $container ) {
+				$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
+				assert( $compatibility_checker instanceof CompatibilityChecker );
+
+				$payment_settings = $container->get( 'settings.data.payment' );
+				assert( $payment_settings instanceof PaymentSettings );
+
+				if ( $compatibility_checker->is_fastlane_compatible() ) {
+					$payment_settings->toggle_method_state( AxoGateway::ID, true );
+				}
+
+				$payment_settings->save();
 			}
 		);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -9,7 +9,6 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings;
 
-use Mollie\Api\Resources\Payment;
 use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;


### PR DESCRIPTION
### Description

This PR will add functionality to enable `Fastlane` after onboarding when the merchant's store setup is compatible.

### Significant changes

- Rename `SettingsNoticeGenerator` to `CompatibilityChecker` to better reflect its expanded role
- Add a compatibility check method `is_fastlane_compatible()` to determine if Fastlane can be safely enabled
- Hook into the `woocommerce_paypal_payments_apply_default_configuration` action to enable the Fastlane payment method
