### PR TITLE
Configure buttons in Features section does not work as expected (4285)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Overview/Features/FeatureItem.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Overview/Features/FeatureItem.js
@@ -3,7 +3,8 @@ import { FeatureSettingsBlock } from '../../../../../ReusableComponents/Settings
 import { Content } from '../../../../../ReusableComponents/Elements';
 import { TITLE_BADGE_POSITIVE } from '../../../../../ReusableComponents/TitleBadge';
 import { selectTab, TAB_IDS } from '../../../../../../utils/tabSelector';
-import { setActiveModal } from '../../../../../../data/common/actions';
+import { useDispatch } from '@wordpress/data';
+import { STORE_NAME as COMMON_STORE_NAME } from '../../../../../../data/common';
 
 const FeatureItem = ( {
 	isBusy,
@@ -14,6 +15,7 @@ const FeatureItem = ( {
 	enabled,
 	notes,
 } ) => {
+	const { setActiveModal } = useDispatch( COMMON_STORE_NAME );
 	const getButtonUrl = ( button ) => {
 		if ( button.urls ) {
 			return isSandbox ? button.urls.sandbox : button.urls.live;
@@ -30,9 +32,11 @@ const FeatureItem = ( {
 	);
 	const handleClick = async ( feature ) => {
 		if ( feature.action?.type === 'tab' ) {
+			const highlight = Boolean( feature.action?.highlight );
 			const tabId = TAB_IDS[ feature.action.tab.toUpperCase() ];
-			await selectTab( tabId, feature.action.section );
+			await selectTab( tabId, feature.action.section, highlight );
 		}
+
 		if ( feature.action?.modal ) {
 			setActiveModal( feature.action.modal );
 		}

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -106,6 +106,7 @@ class FeaturesDefinition {
 						'action'   => array(
 							'type' => 'tab',
 							'tab'  => 'settings',
+							'section' => 'ppcp-save-paypal-and-venmo',
 						),
 						'showWhen' => 'enabled',
 						'class'    => 'small-button',
@@ -207,7 +208,7 @@ class FeaturesDefinition {
 						'action'   => array(
 							'type'      => 'tab',
 							'tab'       => 'payment_methods',
-							'section'   => 'ppcp-card-payments-card',
+							'section'   => 'ppcp-googlepay',
 							'highlight' => 'ppcp-googlepay',
 							'modal'     => 'ppcp-googlepay',
 						),


### PR DESCRIPTION
This PR solves: 
- In latest package from trunk, Configure buttons does not open the modal for ACDC, Google and Apple Pay.
- And also as part of this fix, ensure the “Save PayPal and Venmo“ configure button points to the correct element position (Save PayPal and Venmo toggle) when clicked.
