### PR TITLE
Fix the flags for ACDC and BCDC when onboarding with subscriptions (4294)

### DIFF
--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -88,7 +88,8 @@ class PartnerReferralsData {
 		);
 
 		if ( true === $use_subscriptions ) {
-			$capabilities[] = 'PAYPAL_WALLET_VAULTING_ADVANCED';
+			$capabilities[]         = 'PAYPAL_WALLET_VAULTING_ADVANCED';
+			$first_party_features[] = 'BILLING_AGREEMENT';
 		}
 
 		// Backwards compatibility. Keep those features in the legacy UI (null-value).

--- a/modules/ppcp-settings/resources/js/data/onboarding/selectors.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/selectors.js
@@ -67,6 +67,14 @@ export const determineProductsAndCaps = ( state ) => {
 		 * The store uses the Express-checkout product.
 		 */
 		apiModules.push( PAYPAL_PRODUCTS.BCDC );
+
+		if ( products?.includes( PRODUCT_TYPES.SUBSCRIPTIONS ) ) {
+			options.useSubscriptions = true;
+		}
+
+		if ( canUseVaulting ) {
+			apiModules.push( PAYPAL_PRODUCTS.VAULTING );
+		}
 	} else if ( isCasualSeller ) {
 		/**
 		 * Branch 2: Merchant has no business.

--- a/tests/PHPUnit/ApiClient/Repository/PartnerReferralsDataTest.php
+++ b/tests/PHPUnit/ApiClient/Repository/PartnerReferralsDataTest.php
@@ -203,6 +203,10 @@ class PartnerReferralsDataTest extends TestCase {
 
 		$expected['partner_config_override']['show_add_credit_card'] = $expected_changes['show_add_credit_card'];
 
+		if ( $has_subscriptions ) {
+			$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'BILLING_AGREEMENT';
+		}
+
 		if ( $expected_changes['has_vault_features'] ) {
 			$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'FUTURE_PAYMENT';
 			$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'VAULT';


### PR DESCRIPTION
## Issue Description

This issue fixes incorrect issue for ACDC and No Cards.

**Business → Subscriptions → ACDC**
`Issue: operations.api_integration_preference.rest_api_integration.first_party_details.features` is still missing `BILLING_AGREEMENT` [as described](https://developer.paypal.com/docs/multiparty/checkout/save-payment-methods/onboarding/merchant/#onboard-merchants).

**Business → Subscriptions → No Cards**
Issue: Missing `VAULT` & `BILLING_AGREEMENT` in [features](https://developer.paypal.com/docs/multiparty/checkout/save-payment-methods/onboarding/merchant/#onboard-merchants).
Missing `ADVANCED_VAULTING` in products
Missing
```
"capabilities": [
    "PAYPAL_WALLET_VAULTING_ADVANCED"
  ]
```

## PR Description

Includes subscriptions flag and `ADVANCED_VAULTING` for BCDC onboarding
Includes `BILLING_AGREEMENT` when onboarding with subscriptions
