### PR TITLE
PayPal button for WC Subscriptions product  (4283)

### DIFF
--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -42,6 +42,7 @@ class SettingsTabMapHelper {
 			'vault_enabled_dcc'           => 'save_card_details',
 			'blocks_final_review_enabled' => 'enable_pay_now',
 			'logging_enabled'             => 'enable_logging',
+			'vault_enabled'               => 'save_paypal_and_venmo',
 		);
 	}
 


### PR DESCRIPTION
Currently only classic checkout and cart shows the PayPal button for WC Subscription product.
Once buttons are shown, next step it ensure that subscription payment and renewal flows works.

This PR connects legacy `vault_enabled` to new `save_paypal_and_venmo` setting.

### How to test

**PayPal button display**

- On a fresh WP install, install and activate WC and WC Subscriptions
- Install and activate last package from trunk
- As WC US merchant onboard as business, subscriptions product and Custom card fields
    - TIP: onboard as live till the last screen, then go back and onboard as sandbox merchant, the live onboarding info you selected is going to used here.
- Ensure “Save PayPal and Venmo” is enabled in Settings / Common settings / Save payment methods
- Create a WC Subscriptions product
- Go to frontend and check:
    - Single Product: ensure PayPal button is displayed → PayPal button is shown
    - Cart: ensure PayPal button is displayed → PayPal button is shown
    - Checkout: ensure PayPal button is displayed in “Express Checkout” section → PayPal button is shown
    - Classic Cart: ensure PayPal button is displayed → PayPal button is shown
    - Classic Checkout: ensure PayPal button is displayed → PayPal button is shown