### PR TITLE
Fix the mapping for the pay later button. (4341)

### DIFF
--- a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
@@ -27,7 +27,7 @@ class StylingSettingsMapHelper {
 
 	use ContextTrait;
 
-	protected const BUTTON_NAMES = array( GooglePayGateway::ID, ApplePayGateway::ID, 'pay-later' );
+	protected const BUTTON_NAMES = array( GooglePayGateway::ID, ApplePayGateway::ID );
 
 	/**
 	 * Maps old setting keys to new setting style names.

--- a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
@@ -95,7 +95,7 @@ class StylingSettingsMapHelper {
 				return $this->mapped_button_enabled_value( $styling_models, ApplePayGateway::ID );
 
 			case 'pay_later_button_enabled':
-				return $this->mapped_button_enabled_value( $styling_models, 'pay-later' );
+				return $this->mapped_pay_later_button_enabled_value( $styling_models, $payment_settings );
 
 			default:
 				foreach ( $this->locations_map() as $old_location_name => $new_location_name ) {

--- a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
@@ -255,6 +255,33 @@ class StylingSettingsMapHelper {
 	}
 
 	/**
+	 * Retrieves the mapped enabled or disabled PayLater button value from the new settings.
+	 *
+	 * @param LocationStylingDTO[]   $styling_models The list of location styling models.
+	 * @param AbstractDataModel|null $payment_settings The payment settings model.
+	 * @return int|null The enabled (1) or disabled (0) state or null if it should fall back to old settings value.
+	 */
+	protected function mapped_pay_later_button_enabled_value( array $styling_models, ?AbstractDataModel $payment_settings ): ?int {
+
+		if ( ! $payment_settings instanceof PaymentSettings ) {
+			return null;
+		}
+
+		$locations_to_context_map = $this->current_context_to_new_button_location_map();
+		$current_context          = $locations_to_context_map[ $this->context() ] ?? '';
+
+		foreach ( $styling_models as $model ) {
+			if ( $model->enabled && $model->location === $current_context ) {
+				if ( in_array( 'pay-later', $model->methods, true ) && $payment_settings->get_paylater_enabled() ) {
+					return 1;
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	/**
 	 * Retrieves the mapped enabled or disabled button value from the new settings.
 	 *
 	 * @param LocationStylingDTO[] $styling_models The list of location styling models.


### PR DESCRIPTION
## Issue Description

Front End Issue - The "PayLater" is added in the disable-funding array even though backend has it enabled.

## PR Description

Fixes the problem by introducing a separate mapping method for the PayLater button:
- Whether it is enabled from styling tab settings.
- Whether it is enabled from payment methods tab.
