### PR TITLE
PayPal button for vaulting subscription in block cart page does not work (4346)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/paypal.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal.js
@@ -67,27 +67,6 @@ export const PayPalComponent = ( {
 		? `${ config.id }-${ fundingSource }`
 		: config.id;
 
-	/**
-	 * The block cart displays express checkout buttons. Those buttons are handled by the
-	 * PAYPAL_GATEWAY_ID method on the server ("PayPal Smart Buttons").
-	 *
-	 * A possible bug in WooCommerce does not use the correct payment method ID for the express
-	 * payment buttons inside the cart, but sends the ID of the _first_ active payment method.
-	 *
-	 * This function uses an internal WooCommerce dispatcher method to set the correct method ID.
-	 */
-	const enforcePaymentMethodForCart = () => {
-		// Do nothing, unless we're handling block cart express payment buttons.
-		if ( 'cart-block' !== config.scriptData.context ) {
-			return;
-		}
-
-		// Set the active payment method to PAYPAL_GATEWAY_ID.
-		wp.data
-			.dispatch( 'wc/store/payment' )
-			.__internalSetActivePaymentMethod( PAYPAL_GATEWAY_ID, {} );
-	};
-
 	useEffect( () => {
 		// fill the form if in continuation (for product or mini-cart buttons)
 		if ( continuationFilled || ! config.scriptData.continuation?.order ) {
@@ -339,7 +318,6 @@ export const PayPalComponent = ( {
 						shouldskipFinalConfirmation,
 						getCheckoutRedirectUrl,
 						setGotoContinuationOnError,
-						enforcePaymentMethodForCart,
 						onSubmit,
 						onError,
 						onClose
@@ -439,7 +417,6 @@ export const PayPalComponent = ( {
 						shouldskipFinalConfirmation,
 						getCheckoutRedirectUrl,
 						setGotoContinuationOnError,
-						enforcePaymentMethodForCart,
 						onSubmit,
 						onError,
 						onClose
@@ -476,7 +453,6 @@ export const PayPalComponent = ( {
 					shouldskipFinalConfirmation,
 					getCheckoutRedirectUrl,
 					setGotoContinuationOnError,
-					enforcePaymentMethodForCart,
 					onSubmit,
 					onError,
 					onClose

--- a/modules/ppcp-blocks/resources/js/paypal-config.js
+++ b/modules/ppcp-blocks/resources/js/paypal-config.js
@@ -61,7 +61,6 @@ export const handleApprove = async (
 	shouldskipFinalConfirmation,
 	getCheckoutRedirectUrl,
 	setGotoContinuationOnError,
-	enforcePaymentMethodForCart,
 	onSubmit,
 	onError,
 	onClose
@@ -132,7 +131,6 @@ export const handleApprove = async (
 			location.href = getCheckoutRedirectUrl();
 		} else {
 			setGotoContinuationOnError( true );
-			enforcePaymentMethodForCart();
 			onSubmit();
 		}
 	} catch ( err ) {
@@ -171,7 +169,6 @@ export const handleApproveSubscription = async (
 	shouldskipFinalConfirmation,
 	getCheckoutRedirectUrl,
 	setGotoContinuationOnError,
-	enforcePaymentMethodForCart,
 	onSubmit,
 	onError,
 	onClose
@@ -242,7 +239,6 @@ export const handleApproveSubscription = async (
 			location.href = getCheckoutRedirectUrl();
 		} else {
 			setGotoContinuationOnError( true );
-			enforcePaymentMethodForCart();
 			onSubmit();
 		}
 	} catch ( err ) {


### PR DESCRIPTION
This PR removes `enforcePaymentMethodForCart` method which was introduced to fix an issue in WC where the first button was used in blocks cart. 

### Steps to reproduce
- On a fresh WP install, install and activate WC and WC Subscriptions
- Install and activate last package from trunk
- As WC US merchant onboard as business, subscriptions product and Custom card fields
    - TIP: onboard as live till the last screen, then go back and onboard as sandbox merchant, the live onboarding info you selected is going to used here.
- Ensure “Save PayPal and Venmo” is enabled in Settings / Common settings / Save payment methods
- Create a WC Subscriptions product
- Add product to cart and visit blocks cart page
- Click PayPal button

“No payment method provided.“ error is displayed in the screen:
![Captura de pantalla 2025-03-13 a las 16 35 42](https://github.com/user-attachments/assets/a1fde5d9-b0dc-4232-99a7-2e5f8d5e01dd)
