### PR TITLE
Display only Credit Cards for Personal merchants in Onboarding flow (4295)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
@@ -59,29 +59,18 @@ const StepPaymentMethods = () => {
 export default StepPaymentMethods;
 
 const PaymentStepTitle = () => {
-	const { storeCountry } = CommonHooks.useWooSettings();
-
-	if ( 'US' === storeCountry ) {
-		return __(
-			'Add Expanded Checkout for More Ways to Pay',
-			'woocommerce-paypal-payments'
-		);
-	}
-
-	return __(
-		'Add optional payment methods to your Checkout',
-		'woocommerce-paypal-payments'
-	);
+	return __( 'Add Credit and Debit Cards', 'woocommerce-paypal-payments' );
 };
 
 const OptionalMethodDescription = () => {
+	const { isCasualSeller } = OnboardingHooks.useBusiness();
 	const { storeCountry, storeCurrency } = CommonHooks.useWooSettings();
 	const { canUseCardPayments } = OnboardingHooks.useFlags();
 
 	return (
 		<PaymentFlow
 			onlyOptional={ true }
-			useAcdc={ canUseCardPayments }
+			useAcdc={ ! isCasualSeller && canUseCardPayments }
 			isFastlane={ true }
 			isPayLater={ true }
 			storeCountry={ storeCountry }


### PR DESCRIPTION
### Description

This PR will update the onboarding screen to show _only_ credit card payment options for **personal** merchants.

It also renames the Payment Methods step title to: `Add Credit and Debit Cards`

### Screenshot

<img width="1085" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/033ef92f-0d4f-4b46-89c1-aa97385c32fb" />
