### PR TITLE
Unset the payment methods only if it belongs to our plugin (4349)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -10,7 +10,18 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Settings;
 
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BlikGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\EPSGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\IDealGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MultibancoGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MyBankGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
 use WooCommerce\PayPalCommerce\Settings\Ajax\SwitchSettingsUiEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDependenciesDefinition;
@@ -46,6 +57,11 @@ use WooCommerce\PayPalCommerce\Settings\Service\DataSanitizer;
 use WooCommerce\PayPalCommerce\Settings\Service\SettingsDataManager;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDefinition;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\Factory\ConfigFactory;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\Endpoint\SaveConfig;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
@@ -569,5 +585,30 @@ return array(
 	},
 	'settings.service.gateway-redirect'            => static function (): GatewayRedirectService {
 		return new GatewayRedirectService();
+	},
+	/**
+	 * Returns a list of all payment gateway IDs created by this plugin.
+	 *
+	 * @returns string[] The list of all gateway IDs.
+	 */
+	'settings.config.all-gateway-ids'              => static function (): array {
+		return array(
+			PayPalGateway::ID,
+			CardButtonGateway::ID,
+			CreditCardGateway::ID,
+			AxoGateway::ID,
+			ApplePayGateway::ID,
+			GooglePayGateway::ID,
+			BancontactGateway::ID,
+			BlikGateway::ID,
+			EPSGateway::ID,
+			IDealGateway::ID,
+			MyBankGateway::ID,
+			P24Gateway::ID,
+			TrustlyGateway::ID,
+			MultibancoGateway::ID,
+			PayUponInvoiceGateway::ID,
+			OXXO::ID,
+		);
 	},
 );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MyBankGateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
 use WooCommerce\PayPalCommerce\Settings\Ajax\SwitchSettingsUiEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDefinition;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\RestEndpoint;
@@ -449,12 +450,16 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$methods[] = $axo_gateway;
 
 				$is_payments_page = $container->get( 'wcgateway.is-wc-payments-page' );
+				$all_gateway_ids = $container->get( 'settings.config.all-gateway-ids' );
 
 				if ( $is_payments_page ) {
 					$methods = array_filter(
 						$methods,
-						function ( $method ): bool {
-							if ( ! is_object( $method ) || $method->id === PayPalGateway::ID ) {
+						function ( $method ) use( $all_gateway_ids ): bool {
+							if ( ! is_object( $method )
+								|| $method->id === PayPalGateway::ID
+								|| in_array( $method->id, $all_gateway_ids, true )
+							) {
 								return true;
 							}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -450,12 +450,12 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$methods[] = $axo_gateway;
 
 				$is_payments_page = $container->get( 'wcgateway.is-wc-payments-page' );
-				$all_gateway_ids = $container->get( 'settings.config.all-gateway-ids' );
+				$all_gateway_ids  = $container->get( 'settings.config.all-gateway-ids' );
 
 				if ( $is_payments_page ) {
 					$methods = array_filter(
 						$methods,
-						function ( $method ) use( $all_gateway_ids ): bool {
+						function ( $method ) use ( $all_gateway_ids ): bool {
 							if ( ! is_object( $method )
 								|| $method->id === PayPalGateway::ID
 								|| in_array( $method->id, $all_gateway_ids, true )

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -458,7 +458,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 						function ( $method ) use ( $all_gateway_ids ): bool {
 							if ( ! is_object( $method )
 								|| $method->id === PayPalGateway::ID
-								|| in_array( $method->id, $all_gateway_ids, true )
+								|| ! in_array( $method->id, $all_gateway_ids, true )
 							) {
 								return true;
 							}


### PR DESCRIPTION
## Issue Description

When the new PCP settings UI is active together with the Braintree plugin (official Woo extension), the Payments tab in WooCommerce settings throws a fatal error

## PR Description

- Creates a service to list all the gateway IDs registered with our plugin
- Unsets the payment methods only if it belongs to our plugin