### PR TITLE
Pay Later messaging component active with Configure button when "Save PayPal and Venmo" is active (4351)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -556,7 +556,8 @@ return array(
 		return new FeaturesDefinition(
 			$container->get( 'settings.service.features_eligibilities' ),
 			$container->get( 'settings.data.general' ),
-			$merchant_capabilities
+			$merchant_capabilities,
+			$container->get( 'settings.data.settings' )
 		);
 	},
 	'settings.service.features_eligibilities'      => static function( ContainerInterface $container ): FeaturesEligibilityService {

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Settings\Data\Definition;
 
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Service\FeaturesEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 
@@ -43,20 +44,30 @@ class FeaturesDefinition {
 	protected array $merchant_capabilities;
 
 	/**
+	 * The plugin settings.
+	 *
+	 * @var SettingsModel
+	 */
+	protected SettingsModel $plugin_settings;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param FeaturesEligibilityService $eligibilities The features eligibility service.
 	 * @param GeneralSettings            $settings The general settings service.
 	 * @param array                      $merchant_capabilities The merchant capabilities.
+	 * @param SettingsModel              $plugin_settings The plugin settings.
 	 */
 	public function __construct(
 		FeaturesEligibilityService $eligibilities,
 		GeneralSettings $settings,
-		array $merchant_capabilities
+		array $merchant_capabilities,
+		SettingsModel $plugin_settings
 	) {
 		$this->eligibilities         = $eligibilities;
 		$this->settings              = $settings;
 		$this->merchant_capabilities = $merchant_capabilities;
+		$this->plugin_settings       = $plugin_settings;
 	}
 
 	/**
@@ -82,7 +93,7 @@ class FeaturesDefinition {
 	 * @return array[] The array of all available features.
 	 */
 	public function all_available_features(): array {
-		$paylater_countries = array(
+		$paylater_countries    = array(
 			'UK',
 			'ES',
 			'IT',
@@ -91,8 +102,9 @@ class FeaturesDefinition {
 			'DE',
 			'AU',
 		);
-		$store_country      = $this->settings->get_woo_settings()['country'];
-		$country_location   = in_array( $store_country, $paylater_countries, true ) ? strtolower( $store_country ) : 'us';
+		$store_country         = $this->settings->get_woo_settings()['country'];
+		$country_location      = in_array( $store_country, $paylater_countries, true ) ? strtolower( $store_country ) : 'us';
+		$save_paypal_and_venmo = $this->plugin_settings->get_save_paypal_and_venmo();
 
 		return array(
 			'save_paypal_and_venmo'           => array(
@@ -104,8 +116,8 @@ class FeaturesDefinition {
 						'type'     => 'secondary',
 						'text'     => __( 'Configure', 'woocommerce-paypal-payments' ),
 						'action'   => array(
-							'type' => 'tab',
-							'tab'  => 'settings',
+							'type'    => 'tab',
+							'tab'     => 'settings',
 							'section' => 'ppcp-save-paypal-and-venmo',
 						),
 						'showWhen' => 'enabled',
@@ -288,7 +300,7 @@ class FeaturesDefinition {
 					'Let customers know they can buy now and pay later with PayPal. Adding this messaging can boost conversion rates and increase cart sizes by 39%¹, with no extra cost to you—plus, you get paid up front.',
 					'woocommerce-paypal-payments'
 				),
-				'enabled'     => $this->merchant_capabilities['pay_later'],
+				'enabled'     => $this->merchant_capabilities['pay_later'] && ! $save_paypal_and_venmo,
 				'buttons'     => array(
 					array(
 						'type'     => 'secondary',


### PR DESCRIPTION
Despite using PayPal Vaulting, in the Overview tab the Pay Later Messaging component is visible and says Active.

This PR removes Active badge and Configure button form Pay Later feature item when setting Save PayPal and Venmo is enabled.
