### PR TITLE
Set default option for Subtotal Mismatch (4353)

### DIFF
--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -71,7 +71,7 @@ class SettingsModel extends AbstractDataModel {
 			'soft_descriptor'        => '',
 
 			// Enum-type string values.
-			'subtotal_adjustment'    => 'skip_details', // Options: [correction|no_details].
+			'subtotal_adjustment'    => 'correction', // Options: [correction|no_details].
 			'landing_page'           => 'any',          // Options: [any|login|guest_checkout].
 			'button_language'        => '',             // empty or a language locale code.
 


### PR DESCRIPTION
## Issue Description

There's no default in Settings -> PayPal Settings -> Subtotal Mismatch. Please set default to Add a Correction

## PR Description

Sets the default value for Subtotal Mismatch