### PR TITLE
Exclude the `Stringable` interface from being scoped (4380)

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -46,6 +46,6 @@ return array(
 
 	'expose-namespaces'       => array(), // list<string|regex>.
 	'expose-constants'        => array(),  // list<string|regex>.
-	'expose-classes'          => array(),    // list<string|regex>.
+	'expose-classes'          => array( 'Stringable' ),    // list<string|regex>.
 	'expose-functions'        => array(),  // list<string|regex>.
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -37,7 +37,7 @@ return array(
 		'/^(?!Psr).*/', // Exclude all namespaces except those starting with "Psr".
 	), // list<string|regex>.
 	'exclude-constants'       => array(), // list<string|regex>.
-	'exclude-classes'         => array(),     // list<string|regex>.
+	'exclude-classes'         => array( 'Stringable' ),     // list<string|regex>.
 	'exclude-functions'       => array(), // list<string|regex>.
 
 	'expose-global-constants' => false,   // bool.
@@ -46,6 +46,6 @@ return array(
 
 	'expose-namespaces'       => array(), // list<string|regex>.
 	'expose-constants'        => array(),  // list<string|regex>.
-	'expose-classes'          => array( 'Stringable' ),    // list<string|regex>.
+	'expose-classes'          => array(),    // list<string|regex>.
 	'expose-functions'        => array(),  // list<string|regex>.
 );

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -32,20 +32,20 @@ return array(
 	'prefix'                  => 'WooCommerce\\PayPalCommerce\\Vendor',
 	'finders'                 => $finders,
 	'patchers'                => array(),
-	'exclude-files'           => array(), // list<string>.
+	'exclude-files'           => array( 'vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php' ), // list<string>.
 	'exclude-namespaces'      => array(
 		'/^(?!Psr).*/', // Exclude all namespaces except those starting with "Psr".
 	), // list<string|regex>.
 	'exclude-constants'       => array(), // list<string|regex>.
-	'exclude-classes'         => array( 'Stringable' ),     // list<string|regex>.
+	'exclude-classes'         => array(), // list<string|regex>.
 	'exclude-functions'       => array(), // list<string|regex>.
 
 	'expose-global-constants' => false,   // bool.
-	'expose-global-classes'   => false,     // bool.
+	'expose-global-classes'   => false,   // bool.
 	'expose-global-functions' => false,   // bool.
 
 	'expose-namespaces'       => array(), // list<string|regex>.
-	'expose-constants'        => array(),  // list<string|regex>.
-	'expose-classes'          => array(),    // list<string|regex>.
-	'expose-functions'        => array(),  // list<string|regex>.
+	'expose-constants'        => array(), // list<string|regex>.
+	'expose-classes'          => array(), // list<string|regex>.
+	'expose-functions'        => array(), // list<string|regex>.
 );


### PR DESCRIPTION
## Issue Description

Some users with enabled `WP_DEBUG_DISPLAY` reported these warnings after updating to 3.0.0:

```
Warning: Class 'WooCommerce\PayPalCommerce\Vendor\Stringable' not found in
/home2/cultutp2/public_html/wp-content/plugins/woocommerce-paypal-payments/vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php
on line 20
```

## PR Description

The problem happens because of the Scoping of `Stringable` ([PHP 8 Polyfill](https://github.com/symfony/polyfill-php80) Conflict)

- The file defines a fallback Stringable interface for `PHP < 8.0`.
- PHP-Scoper prefixed it as `WooCommerce\PayPalCommerce\Vendor\Stringable`.
- However, the `class_alias('WooCommerce\PayPalCommerce\Vendor\Stringable', 'Stringable', false);` line may not be executing properly, causing the alias to fail.


The PR fixes the problem by adding the `vendor/symfony/polyfill-php80/Resources/stubs/Stringable.php` file in the excluded list of files