### PR TITLE
Fix send only country banner (4375)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Navigation.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Navigation.js
@@ -16,9 +16,9 @@ const NOTIFICATION_ANIMATION_DURATION = 300;
 
 const SettingsNavigation = ( {
 	canSave = true,
-	tabs,
-	activePanel,
-	setActivePanel,
+	tabs = [],
+	activePanel = '',
+	setActivePanel = () => {},
 } ) => {
 	const { persistAll } = useStoreManager();
 

--- a/modules/ppcp-settings/resources/js/data/common/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/common/hooks.js
@@ -212,6 +212,7 @@ export const useMerchant = () => {
 			clientSecret: merchant.clientSecret ?? '',
 			isBusinessSeller: 'business' === merchant.sellerType,
 			isCasualSeller: 'personal' === merchant.sellerType,
+			isSendOnlyCountry: merchant.isSendOnlyCountry ?? false,
 		} ),
 		// the merchant object is stable, so a new memo is only generated when a merchant prop changes.
 		[ merchant ]


### PR DESCRIPTION
This PR solves the problem:  When a “Send only” country is confitgured, then the plugin cannot be used.
The param with that information got lost in refactorings and now we also consider the navigation without tabs.

