### PR TITLE
Remove `action_scheduler_before_execute` code (4350)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -663,35 +663,6 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			2
 		);
 
-		add_action(
-			'action_scheduler_before_execute',
-			/**
-			 * Param types removed to avoid third-party issues.
-			 *
-			 * @psalm-suppress MissingClosureParamType
-			 */
-			function( $action_id ) {
-				/**
-				 * Class exist in WooCommerce.
-				 *
-				 * @psalm-suppress UndefinedClass
-				 */
-				$store  = ActionScheduler_Store::instance();
-				$action = $store->fetch_action( $action_id );
-
-				$subscription_id = $action->get_args()['subscription_id'] ?? null;
-				if ( $subscription_id ) {
-					$subscription = wcs_get_subscription( $subscription_id );
-					if ( is_a( $subscription, WC_Subscription::class ) ) {
-						$paypal_subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
-						if ( $paypal_subscription_id ) {
-							as_unschedule_action( $action->get_hook(), $action->get_args() );
-						}
-					}
-				}
-			}
-		);
-
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #3218.

This PR removes `action_scheduler_before_execute` code, this code is not needed anymore because `gateway_scheduled_payments` support was added for subscriptions that handles renewals via PayPal Subscriptions API. By adding this support automatic renewals are not triggered by WC Subscriptions plugin.