### PR TITLE
Fix post onboarding payment methods frontend/backend sync (4340)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
@@ -6,8 +6,13 @@ import useSettingDependencyState from '../../../../../hooks/useSettingDependency
 import PaymentDependencyMessage from './PaymentDependencyMessage';
 import SettingDependencyMessage from './SettingDependencyMessage';
 import SpinnerOverlay from '../../../../ReusableComponents/SpinnerOverlay';
-import { PaymentHooks, SettingsHooks } from '../../../../../data';
+import {
+	PaymentHooks,
+	SettingsHooks,
+	OnboardingHooks,
+} from '../../../../../data';
 import { useNavigation } from '../../../../../hooks/useNavigation';
+import usePaymentGatewayRefresh from '../../../../../hooks/usePaymentGatewayRefresh';
 
 /**
  * Renders a payment method card with dependency handling
@@ -36,6 +41,10 @@ const PaymentMethodCard = ( {
 	const { isReady: isPaymentStoreReady } = PaymentHooks.useStore();
 	const { isReady: isSettingsStoreReady } = SettingsHooks.useStore();
 	const { handleHighlightFromUrl } = useNavigation();
+	const { gatewaysRefreshed } = OnboardingHooks.useGatewayRefresh();
+
+	// Re-fetch payment gateway data to hide methods based on exclusion conditions.
+	usePaymentGatewayRefresh();
 
 	const paymentDependencies = usePaymentDependencyState(
 		methods,
@@ -50,7 +59,11 @@ const PaymentMethodCard = ( {
 		}
 	}, [ handleHighlightFromUrl, isPaymentStoreReady, isSettingsStoreReady ] );
 
-	if ( ! isPaymentStoreReady || ! isSettingsStoreReady ) {
+	if (
+		! isPaymentStoreReady ||
+		! isSettingsStoreReady ||
+		! gatewaysRefreshed
+	) {
 		return <SpinnerOverlay asModal={ true } />;
 	}
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabOverview.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabOverview.js
@@ -3,11 +3,15 @@ import Features from '../Components/Overview/Features/Features';
 import Help from '../Components/Overview/Help/Help';
 import { TodosHooks, CommonHooks, FeaturesHooks } from '../../../../data';
 import SpinnerOverlay from '../../../ReusableComponents/SpinnerOverlay';
+import usePaymentGatewaySync from '../../../../hooks/usePaymentGatewaySync';
 
 const TabOverview = () => {
 	const { isReady: areTodosReady } = TodosHooks.useTodos();
 	const { isReady: merchantIsReady } = CommonHooks.useMerchantInfo();
 	const { isReady: featuresIsReady } = FeaturesHooks.useFeatures();
+
+	// Enable payment gateways after onboarding based on relevant flags.
+	usePaymentGatewaySync();
 
 	if ( ! areTodosReady || ! merchantIsReady || ! featuresIsReady ) {
 		return <SpinnerOverlay asModal={ true } />;

--- a/modules/ppcp-settings/resources/js/data/onboarding/action-types.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/action-types.js
@@ -12,4 +12,8 @@ export default {
 	SET_PERSISTENT: 'ppcp/onboarding/SET_PERSISTENT',
 	RESET: 'ppcp/onboarding/RESET',
 	HYDRATE: 'ppcp/onboarding/HYDRATE',
+
+	// Gateway sync flag
+	SYNC_GATEWAYS: 'ppcp/onboarding/SYNC_GATEWAYS',
+	REFRESH_GATEWAYS: 'ppcp/onboarding/REFRESH_GATEWAYS',
 };

--- a/modules/ppcp-settings/resources/js/data/onboarding/actions.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/actions.js
@@ -127,7 +127,7 @@ export const updateGatewaysRefreshed = ( refreshed = true ) =>
  */
 export function syncGateways() {
 	return async ( { dispatch } ) => {
-		dispatch( { type: ACTION_TYPES.SYNC_GATEWAYS } );
+		dispatch( setPersistent( 'gatewaysSynced', true ) );
 		await dispatch( persist() );
 		return { success: true };
 	};
@@ -135,7 +135,7 @@ export function syncGateways() {
 
 export function refreshGateways() {
 	return async ( { dispatch } ) => {
-		dispatch( { type: ACTION_TYPES.REFRESH_GATEWAYS } );
+		dispatch( setPersistent( 'gatewaysRefreshed', true ) );
 		await dispatch( persist() );
 		return { success: true };
 	};

--- a/modules/ppcp-settings/resources/js/data/onboarding/actions.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/actions.js
@@ -100,3 +100,43 @@ export function refresh() {
 		select.persistentData();
 	};
 }
+
+/**
+ * Persistent. Updates the gateway synced status.
+ *
+ * @param {boolean} synced The sync status to set
+ * @return {Action} The action.
+ */
+export const updateGatewaysSynced = ( synced = true ) =>
+	setPersistent( 'gatewaysSynced', synced );
+
+/**
+ * Persistent. Updates the gateway refreshed status.
+ *
+ * @param {boolean} refreshed The refreshed status to set
+ * @return {Action} The action.
+ */
+export const updateGatewaysRefreshed = ( refreshed = true ) =>
+	setPersistent( 'gatewaysRefreshed', refreshed );
+
+/**
+ * Action creator to sync payment gateways.
+ * This will both update the state and persist it.
+ *
+ * @return {Function} The thunk function.
+ */
+export function syncGateways() {
+	return async ( { dispatch } ) => {
+		dispatch( { type: ACTION_TYPES.SYNC_GATEWAYS } );
+		await dispatch( persist() );
+		return { success: true };
+	};
+}
+
+export function refreshGateways() {
+	return async ( { dispatch } ) => {
+		dispatch( { type: ACTION_TYPES.REFRESH_GATEWAYS } );
+		await dispatch( persist() );
+		return { success: true };
+	};
+}

--- a/modules/ppcp-settings/resources/js/data/onboarding/actions.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/actions.js
@@ -128,7 +128,7 @@ export const updateGatewaysRefreshed = ( refreshed = true ) =>
 export function syncGateways() {
 	return async ( { dispatch } ) => {
 		dispatch( setPersistent( 'gatewaysSynced', true ) );
-		await dispatch( persist() );
+		await dispatch.persist();
 		return { success: true };
 	};
 }
@@ -136,7 +136,7 @@ export function syncGateways() {
 export function refreshGateways() {
 	return async ( { dispatch } ) => {
 		dispatch( setPersistent( 'gatewaysRefreshed', true ) );
-		await dispatch( persist() );
+		await dispatch.persist();
 		return { success: true };
 	};
 }

--- a/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
@@ -12,10 +12,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { createHooksForStore } from '../utils';
 import { PRODUCT_TYPES } from './configuration';
 import { STORE_NAME } from './constants';
+import ACTION_TYPES from './action-types';
 
 const useHooks = () => {
 	const { useTransient, usePersistent } = createHooksForStore( STORE_NAME );
-	const { persist } = useDispatch( STORE_NAME );
+	const { persist, dispatch } = useDispatch( STORE_NAME );
 
 	// Read-only flags and derived state.
 	const flags = useSelect( ( select ) => select( STORE_NAME ).flags(), [] );
@@ -36,6 +37,12 @@ const useHooks = () => {
 		'areOptionalPaymentMethodsEnabled'
 	);
 	const [ products, setProducts ] = usePersistent( 'products' );
+	// Add the setter for gatewaysSynced
+	const [ gatewaysSynced, setGatewaysSynced ] =
+		usePersistent( 'gatewaysSynced' );
+
+	const [ gatewaysRefreshed, setGatewaysRefreshed ] =
+		usePersistent( 'gatewaysRefreshed' );
 
 	const savePersistent = async ( setter, value ) => {
 		setter( value );
@@ -75,6 +82,26 @@ const useHooks = () => {
 				Object.values( PRODUCT_TYPES ).includes( item )
 			);
 			return savePersistent( setProducts, validProducts );
+		},
+		gatewaysSynced,
+		setGatewaysSynced: ( value ) => {
+			return savePersistent( setGatewaysSynced, value );
+		},
+		syncGateways: async () => {
+			await savePersistent( setGatewaysSynced, true );
+			dispatch( {
+				type: ACTION_TYPES.SYNC_GATEWAYS,
+			} );
+		},
+		gatewaysRefreshed,
+		setGatewaysRefreshed: ( value ) => {
+			return savePersistent( setGatewaysRefreshed, value );
+		},
+		refreshGateways: async () => {
+			await savePersistent( setGatewaysRefreshed, true );
+			dispatch( {
+				type: ACTION_TYPES.REFRESH_GATEWAYS,
+			} );
 		},
 	};
 };
@@ -144,4 +171,14 @@ export const useDetermineProducts = () => {
 export const useFlags = () => {
 	const { flags } = useHooks();
 	return flags;
+};
+
+export const useGatewaySync = () => {
+	const { gatewaysSynced, syncGateways } = useHooks();
+	return { gatewaysSynced, syncGateways };
+};
+
+export const useGatewayRefresh = () => {
+	const { gatewaysRefreshed, refreshGateways } = useHooks();
+	return { gatewaysRefreshed, refreshGateways };
 };

--- a/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/reducer.js
@@ -35,6 +35,8 @@ const defaultPersistent = Object.freeze( {
 	isCasualSeller: null, // null value will uncheck both options in the UI.
 	areOptionalPaymentMethodsEnabled: null,
 	products: [],
+	gatewaysSynced: false,
+	gatewaysRefreshed: false,
 } );
 
 // Reducer logic.
@@ -76,6 +78,14 @@ const onboardingReducer = createReducer( defaultTransient, defaultPersistent, {
 		}
 
 		return newState;
+	},
+
+	[ ACTION_TYPES.SYNC_GATEWAYS ]: ( state ) => {
+		return changePersistent( state, { gatewaysSynced: true } );
+	},
+
+	[ ACTION_TYPES.REFRESH_GATEWAYS ]: ( state ) => {
+		return changePersistent( state, { gatewaysRefreshed: true } );
 	},
 } );
 

--- a/modules/ppcp-settings/resources/js/hooks/usePaymentGatewayRefresh.js
+++ b/modules/ppcp-settings/resources/js/hooks/usePaymentGatewayRefresh.js
@@ -1,0 +1,111 @@
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+import { STORE_NAME as PAYMENT_STORE_NAME } from '../data/payment';
+import { OnboardingHooks } from '../data';
+import { STORE_NAME as ONBOARDING_STORE_NAME } from '../data/onboarding';
+/**
+ * Custom hook for refreshing payment gateway data
+ *
+ * @return {Object} Refresh API including the refresh function and state
+ */
+export const usePaymentGatewayRefresh = () => {
+	const paymentDispatch = useDispatch( PAYMENT_STORE_NAME );
+	const { gatewaysRefreshed } = OnboardingHooks.useGatewayRefresh();
+	const { gatewaysSynced } = OnboardingHooks.useGatewaySync();
+	const { refreshGateways } = useDispatch( ONBOARDING_STORE_NAME );
+	const { hydrate, refresh, reset } = paymentDispatch;
+	const [ refreshCompleted, setRefreshCompleted ] = useState( false );
+	const [ isRefreshing, setIsRefreshing ] = useState( false );
+	const [ refreshError, setRefreshError ] = useState( null );
+	// Only refresh if gateways are synced (post-onboarding payment method toggling happened & Redux data loaded correctly).
+	const isReadyToRefresh = gatewaysSynced;
+
+	/**
+	 * Refreshes payment gateway data
+	 *
+	 * @return {Promise<boolean|Object>} True when completed successfully, or object with error details
+	 */
+	const refreshPaymentGateways = useCallback( async () => {
+		if ( isRefreshing ) {
+			return {
+				success: false,
+				skipped: true,
+				reason: 'already-refreshing',
+			};
+		}
+		if ( ! isReadyToRefresh ) {
+			return { success: false, skipped: true, reason: 'not-ready' };
+		}
+		setIsRefreshing( true );
+		setRefreshError( null );
+		try {
+			// Reset payment store if available.
+			if ( typeof reset === 'function' ) {
+				await reset();
+			}
+			// Fetch payment data.
+			const response = await apiFetch( {
+				path: `/wc/v3/wc_paypal/payment`,
+				method: 'GET',
+			} );
+			// Update store with fetched data.
+			hydrate( response );
+			// Refresh payment store if available.
+			if ( typeof refresh === 'function' ) {
+				await refresh();
+			}
+			// Update gateways_refreshed flag in database.
+			await apiFetch( {
+				path: '/wc/v3/wc_paypal/onboarding/refresh-gateways',
+				method: 'POST',
+			} );
+			// Update Redux state to mark gateways as refreshed.
+			await refreshGateways();
+			setRefreshCompleted( true );
+			return { success: true };
+		} catch ( error ) {
+			setRefreshError( error );
+			return { success: false, error };
+		} finally {
+			setIsRefreshing( false );
+		}
+	}, [
+		isRefreshing,
+		isReadyToRefresh,
+		reset,
+		hydrate,
+		refresh,
+		refreshGateways,
+	] );
+
+	// Auto-trigger refresh when conditions are met.
+	useEffect( () => {
+		if (
+			isReadyToRefresh &&
+			! gatewaysRefreshed &&
+			! isRefreshing &&
+			! refreshCompleted
+		) {
+			refreshPaymentGateways().catch( ( error ) => {
+				// Error handling is managed through state.
+			} );
+		}
+	}, [
+		isReadyToRefresh,
+		gatewaysRefreshed,
+		isRefreshing,
+		refreshCompleted,
+		refreshPaymentGateways,
+	] );
+
+	return {
+		refreshPaymentGateways,
+		refreshCompleted,
+		isRefreshing,
+		refreshError,
+		gatewaysRefreshed: gatewaysRefreshed || refreshCompleted,
+	};
+};
+
+export default usePaymentGatewayRefresh;

--- a/modules/ppcp-settings/resources/js/hooks/usePaymentGatewayRefresh.js
+++ b/modules/ppcp-settings/resources/js/hooks/usePaymentGatewayRefresh.js
@@ -4,21 +4,24 @@ import apiFetch from '@wordpress/api-fetch';
 import { STORE_NAME as PAYMENT_STORE_NAME } from '../data/payment';
 import { OnboardingHooks } from '../data';
 import { STORE_NAME as ONBOARDING_STORE_NAME } from '../data/onboarding';
+
 /**
- * Custom hook for refreshing payment gateway data
+ * Custom hook for refreshing payment gateway data.
  *
  * @return {Object} Refresh API including the refresh function and state
  */
 export const usePaymentGatewayRefresh = () => {
 	const paymentDispatch = useDispatch( PAYMENT_STORE_NAME );
+	const onboardingDispatch = useDispatch( ONBOARDING_STORE_NAME );
 	const { gatewaysRefreshed } = OnboardingHooks.useGatewayRefresh();
 	const { gatewaysSynced } = OnboardingHooks.useGatewaySync();
-	const { refreshGateways } = useDispatch( ONBOARDING_STORE_NAME );
+	const { refreshGateways } = onboardingDispatch;
 	const { hydrate, refresh, reset } = paymentDispatch;
+
 	const [ refreshCompleted, setRefreshCompleted ] = useState( false );
 	const [ isRefreshing, setIsRefreshing ] = useState( false );
 	const [ refreshError, setRefreshError ] = useState( null );
-	// Only refresh if gateways are synced (post-onboarding payment method toggling happened & Redux data loaded correctly).
+	// Only refresh if gateways are synced.
 	const isReadyToRefresh = gatewaysSynced;
 
 	/**
@@ -34,34 +37,41 @@ export const usePaymentGatewayRefresh = () => {
 				reason: 'already-refreshing',
 			};
 		}
+
 		if ( ! isReadyToRefresh ) {
-			return { success: false, skipped: true, reason: 'not-ready' };
+			return {
+				success: false,
+				skipped: true,
+				reason: 'not-ready',
+			};
 		}
+
 		setIsRefreshing( true );
 		setRefreshError( null );
+
 		try {
 			// Reset payment store if available.
 			if ( typeof reset === 'function' ) {
 				await reset();
 			}
+
 			// Fetch payment data.
 			const response = await apiFetch( {
 				path: `/wc/v3/wc_paypal/payment`,
 				method: 'GET',
 			} );
-			// Update store with fetched data.
+
+			// Update store with data.
 			hydrate( response );
+
 			// Refresh payment store if available.
 			if ( typeof refresh === 'function' ) {
 				await refresh();
 			}
-			// Update gateways_refreshed flag in database.
-			await apiFetch( {
-				path: '/wc/v3/wc_paypal/onboarding/refresh-gateways',
-				method: 'POST',
-			} );
+
 			// Update Redux state to mark gateways as refreshed.
-			await refreshGateways();
+			const result = await refreshGateways();
+
 			setRefreshCompleted( true );
 			return { success: true };
 		} catch ( error ) {
@@ -87,8 +97,8 @@ export const usePaymentGatewayRefresh = () => {
 			! isRefreshing &&
 			! refreshCompleted
 		) {
-			refreshPaymentGateways().catch( ( error ) => {
-				// Error handling is managed through state.
+			refreshPaymentGateways().catch( () => {
+				// Silent catch to prevent unhandled promise rejections.
 			} );
 		}
 	}, [

--- a/modules/ppcp-settings/resources/js/hooks/usePaymentGatewaySync.js
+++ b/modules/ppcp-settings/resources/js/hooks/usePaymentGatewaySync.js
@@ -1,26 +1,28 @@
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
 import { OnboardingHooks, CommonHooks } from '../data';
 import { STORE_NAME as ONBOARDING_STORE_NAME } from '../data/onboarding';
+
 /**
  * Custom hook for handling gateway synchronization
  *
  * @return {boolean} Whether gateway sync is completed
  */
 export const usePaymentGatewaySync = () => {
-	// Get sync state from Redux
 	const { gatewaysSynced } = OnboardingHooks.useGatewaySync();
-	const { syncGateways } = useDispatch( ONBOARDING_STORE_NAME );
-	// Get required state
+
+	const onboardingDispatch = useDispatch( ONBOARDING_STORE_NAME );
+	const { syncGateways } = onboardingDispatch;
+
 	const { isReady: onboardingIsReady, completed: onboardingCompleted } =
 		OnboardingHooks.useSteps();
 	const { isReady: merchantIsReady } = CommonHooks.useStore();
-	// Define sync state hooks
+
 	const [ isSyncing, setIsSyncing ] = useState( false );
 	const [ syncCompleted, setSyncCompleted ] = useState( false );
 	const [ syncError, setSyncError ] = useState( null );
-	// Use a ref to track if we've initiated a sync during this session
+
+	// Use a ref to track if we've initiated a sync during this session.
 	const syncAttemptedRef = useRef( false );
 
 	/**
@@ -32,19 +34,20 @@ export const usePaymentGatewaySync = () => {
 		if ( isSyncing ) {
 			return { success: false, skipped: true };
 		}
+
 		setIsSyncing( true );
 		setSyncError( null );
+
 		try {
-			await apiFetch( {
-				path: '/wc/v3/wc_paypal/onboarding/sync-gateways',
-				method: 'POST',
-			} );
 			const result = await syncGateways();
+
 			if ( result.success ) {
+				// Add a small delay to ensure UI updates properly.
 				await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
 				setSyncCompleted( true );
 				return { success: true };
 			}
+
 			throw new Error( result.message || 'Failed to sync gateways' );
 		} catch ( error ) {
 			setSyncError( error );
@@ -52,6 +55,7 @@ export const usePaymentGatewaySync = () => {
 			setTimeout( () => {
 				syncAttemptedRef.current = false;
 			}, 5000 );
+
 			return { success: false, error };
 		} finally {
 			setIsSyncing( false );
@@ -64,6 +68,7 @@ export const usePaymentGatewaySync = () => {
 		if ( ! onboardingIsReady || ! merchantIsReady || gatewaysSynced ) {
 			return;
 		}
+
 		// Only attempt sync if not already syncing and no previous attempt.
 		if ( ! isSyncing && ! syncAttemptedRef.current ) {
 			syncAttemptedRef.current = true;

--- a/modules/ppcp-settings/resources/js/hooks/usePaymentGatewaySync.js
+++ b/modules/ppcp-settings/resources/js/hooks/usePaymentGatewaySync.js
@@ -1,0 +1,84 @@
+import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+import { OnboardingHooks, CommonHooks } from '../data';
+import { STORE_NAME as ONBOARDING_STORE_NAME } from '../data/onboarding';
+/**
+ * Custom hook for handling gateway synchronization
+ *
+ * @return {boolean} Whether gateway sync is completed
+ */
+export const usePaymentGatewaySync = () => {
+	// Get sync state from Redux
+	const { gatewaysSynced } = OnboardingHooks.useGatewaySync();
+	const { syncGateways } = useDispatch( ONBOARDING_STORE_NAME );
+	// Get required state
+	const { isReady: onboardingIsReady, completed: onboardingCompleted } =
+		OnboardingHooks.useSteps();
+	const { isReady: merchantIsReady } = CommonHooks.useStore();
+	// Define sync state hooks
+	const [ isSyncing, setIsSyncing ] = useState( false );
+	const [ syncCompleted, setSyncCompleted ] = useState( false );
+	const [ syncError, setSyncError ] = useState( null );
+	// Use a ref to track if we've initiated a sync during this session
+	const syncAttemptedRef = useRef( false );
+
+	/**
+	 * Handles the gateway synchronization
+	 *
+	 * @return {Promise<Object>} Result of the sync operation
+	 */
+	const handleSync = useCallback( async () => {
+		if ( isSyncing ) {
+			return { success: false, skipped: true };
+		}
+		setIsSyncing( true );
+		setSyncError( null );
+		try {
+			await apiFetch( {
+				path: '/wc/v3/wc_paypal/onboarding/sync-gateways',
+				method: 'POST',
+			} );
+			const result = await syncGateways();
+			if ( result.success ) {
+				await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+				setSyncCompleted( true );
+				return { success: true };
+			}
+			throw new Error( result.message || 'Failed to sync gateways' );
+		} catch ( error ) {
+			setSyncError( error );
+			// After an error, allow retry after 5 seconds.
+			setTimeout( () => {
+				syncAttemptedRef.current = false;
+			}, 5000 );
+			return { success: false, error };
+		} finally {
+			setIsSyncing( false );
+		}
+	}, [ isSyncing, syncGateways ] );
+
+	// Automatically sync when conditions are met.
+	useEffect( () => {
+		// Skip if required conditions aren't met.
+		if ( ! onboardingIsReady || ! merchantIsReady || gatewaysSynced ) {
+			return;
+		}
+		// Only attempt sync if not already syncing and no previous attempt.
+		if ( ! isSyncing && ! syncAttemptedRef.current ) {
+			syncAttemptedRef.current = true;
+			handleSync();
+		}
+	}, [
+		onboardingIsReady,
+		merchantIsReady,
+		onboardingCompleted,
+		gatewaysSynced,
+		isSyncing,
+		handleSync,
+	] );
+
+	return gatewaysSynced;
+};
+
+export default usePaymentGatewaySync;

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -74,7 +74,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	protected function get_defaults() : array {
+	protected function get_defaults(): array {
 		return array(
 			'completed'            => false,
 			'step'                 => 0,
@@ -82,6 +82,8 @@ class OnboardingProfile extends AbstractDataModel {
 			'accept_card_payments' => null,
 			'products'             => array(),
 			'setup_done'           => false,
+			'gateways_synced'      => false,
+			'gateways_refreshed'   => false,
 		);
 	}
 
@@ -202,5 +204,41 @@ class OnboardingProfile extends AbstractDataModel {
 	 */
 	public function set_setup_done( bool $done ) : void {
 		$this->data['setup_done'] = $done;
+	}
+
+	/**
+	 * Get whether gateways have been synced.
+	 *
+	 * @return bool
+	 */
+	public function is_gateways_synced(): bool {
+		return $this->data['gateways_synced'] ?? false;
+	}
+
+	/**
+	 * Set whether gateways have been synced.
+	 *
+	 * @param bool $synced Whether gateways have been synced.
+	 */
+	public function set_gateways_synced( bool $synced ): void {
+		$this->data['gateways_synced'] = $synced;
+	}
+
+	/**
+	 * Get whether gateways have been refreshed.
+	 *
+	 * @return bool
+	 */
+	public function is_gateways_refreshed(): bool {
+		return $this->data['gateways_refreshed'] ?? false;
+	}
+
+	/**
+	 * Set whether gateways have been refreshed.
+	 *
+	 * @param bool $refreshed Whether gateways have been refreshed.
+	 */
+	public function set_gateways_refreshed( bool $refreshed ): void {
+		$this->data['gateways_refreshed'] = $refreshed;
 	}
 }

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -222,6 +222,11 @@ class OnboardingProfile extends AbstractDataModel {
 	 */
 	public function set_gateways_synced( bool $synced ): void {
 		$this->data['gateways_synced'] = $synced;
+
+		// If enabling the flag, trigger the action.
+		if ( $synced ) {
+			do_action( 'woocommerce_paypal_payments_sync_gateways' );
+		}
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -60,6 +60,14 @@ class OnboardingRestEndpoint extends RestEndpoint {
 		'products'             => array(
 			'js_name' => 'products',
 		),
+		'gateways_synced'      => array(
+			'js_name'  => 'gatewaysSynced',
+			'sanitize' => 'to_boolean',
+		),
+		'gateways_refreshed'   => array(
+			'js_name'  => 'gatewaysRefreshed',
+			'sanitize' => 'to_boolean',
+		),
 	);
 
 	/**
@@ -134,6 +142,32 @@ class OnboardingRestEndpoint extends RestEndpoint {
 				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
+
+		/**
+		 * POST /wp-json/wc/v3/wc_paypal/onboarding/sync-gateways
+		 */
+		register_rest_route(
+			static::NAMESPACE,
+			'/' . $this->rest_base . '/sync-gateways',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'sync_gateways' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+
+		/**
+		 * POST /wp-json/wc/v3/wc_paypal/onboarding/refresh-gateways
+		 */
+		register_rest_route(
+			static::NAMESPACE,
+			'/' . $this->rest_base . '/refresh-gateways',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'refresh_gateways' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
 	}
 
 	/**
@@ -177,5 +211,50 @@ class OnboardingRestEndpoint extends RestEndpoint {
 		$this->profile->save();
 
 		return $this->get_details();
+	}
+
+	/**
+	 * Synchronize gateway settings based on onboarding choices.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response.
+	 */
+	public function sync_gateways( WP_REST_Request $request ) : WP_REST_Response {
+		// Execute the sync action
+		do_action( 'woocommerce_paypal_payments_sync_gateways' );
+
+		// Update gateways_synced in the profile.
+		$data                    = $this->profile->to_array();
+		$data['gateways_synced'] = true;
+		$this->profile->from_array( $data );
+		$this->profile->save();
+
+		return $this->return_success(
+			array(
+				'success' => true,
+				'message' => 'Payment gateways synchronized successfully.',
+			)
+		);
+	}
+
+	/**
+	 * Refresh gateway settings.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response The response.
+	 */
+	public function refresh_gateways( WP_REST_Request $request ) : WP_REST_Response {
+		// Update gateways_refreshed in the profile.
+		$data                       = $this->profile->to_array();
+		$data['gateways_refreshed'] = true;
+		$this->profile->from_array( $data );
+		$this->profile->save();
+
+		return $this->return_success(
+			array(
+				'success' => true,
+				'message' => 'Payment gateways refreshed successfully.',
+			)
+		);
 	}
 }

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -142,32 +142,6 @@ class OnboardingRestEndpoint extends RestEndpoint {
 				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
-
-		/**
-		 * POST /wp-json/wc/v3/wc_paypal/onboarding/sync-gateways
-		 */
-		register_rest_route(
-			static::NAMESPACE,
-			'/' . $this->rest_base . '/sync-gateways',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'sync_gateways' ),
-				'permission_callback' => array( $this, 'check_permission' ),
-			)
-		);
-
-		/**
-		 * POST /wp-json/wc/v3/wc_paypal/onboarding/refresh-gateways
-		 */
-		register_rest_route(
-			static::NAMESPACE,
-			'/' . $this->rest_base . '/refresh-gateways',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'refresh_gateways' ),
-				'permission_callback' => array( $this, 'check_permission' ),
-			)
-		);
 	}
 
 	/**
@@ -211,47 +185,5 @@ class OnboardingRestEndpoint extends RestEndpoint {
 		$this->profile->save();
 
 		return $this->get_details();
-	}
-
-	/**
-	 * Synchronize gateway settings based on onboarding choices.
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response The response.
-	 */
-	public function sync_gateways( WP_REST_Request $request ) : WP_REST_Response {
-		/**
-		 * Execute the sync action.
-		 */
-		do_action( 'woocommerce_paypal_payments_sync_gateways' );
-		// Update gateways_synced in the profile.
-		$this->profile->set_gateways_synced( true );
-		$this->profile->save();
-
-		return $this->return_success(
-			array(
-				'success' => true,
-				'message' => 'Payment gateways synchronized successfully.',
-			)
-		);
-	}
-
-	/**
-	 * Refresh gateway settings.
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response The response.
-	 */
-	public function refresh_gateways( WP_REST_Request $request ) : WP_REST_Response {
-		// Update gateways_refreshed in the profile.
-		$this->profile->set_gateways_refreshed( true );
-		$this->profile->save();
-
-		return $this->return_success(
-			array(
-				'success' => true,
-				'message' => 'Payment gateways refreshed successfully.',
-			)
-		);
 	}
 }

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -220,7 +220,9 @@ class OnboardingRestEndpoint extends RestEndpoint {
 	 * @return WP_REST_Response The response.
 	 */
 	public function sync_gateways( WP_REST_Request $request ) : WP_REST_Response {
-		// Execute the sync action
+		/**
+		 * Execute the sync action.
+		 */
 		do_action( 'woocommerce_paypal_payments_sync_gateways' );
 
 		// Update gateways_synced in the profile.

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -224,11 +224,8 @@ class OnboardingRestEndpoint extends RestEndpoint {
 		 * Execute the sync action.
 		 */
 		do_action( 'woocommerce_paypal_payments_sync_gateways' );
-
 		// Update gateways_synced in the profile.
-		$data                    = $this->profile->to_array();
-		$data['gateways_synced'] = true;
-		$this->profile->from_array( $data );
+		$this->profile->set_gateways_synced( true );
 		$this->profile->save();
 
 		return $this->return_success(
@@ -247,9 +244,7 @@ class OnboardingRestEndpoint extends RestEndpoint {
 	 */
 	public function refresh_gateways( WP_REST_Request $request ) : WP_REST_Response {
 		// Update gateways_refreshed in the profile.
-		$data                       = $this->profile->to_array();
-		$data['gateways_refreshed'] = true;
-		$this->profile->from_array( $data );
+		$this->profile->set_gateways_refreshed( true );
 		$this->profile->save();
 
 		return $this->return_success(

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -204,15 +204,6 @@ class SettingsDataManager {
 	}
 
 	/**
-	 * Initialize hooks for gateway synchronization.
-	 *
-	 * @return void
-	 */
-	public function init_hooks() : void {
-		add_action( 'woocommerce_paypal_payments_sync_gateways', array( $this, 'sync_gateway_settings' ) );
-	}
-
-	/**
 	 * Synchronize gateway settings with merchant onboarding choices.
 	 *
 	 * @return void
@@ -236,7 +227,7 @@ class SettingsDataManager {
 	 * @param ConfigurationFlagsDTO $flags Shop configuration flags.
 	 * @return void
 	 */
-	public function toggle_payment_gateways( ConfigurationFlagsDTO $flags ) : void {
+	protected function toggle_payment_gateways( ConfigurationFlagsDTO $flags ) : void {
 		// First, disable all payment methods.
 		$methods_paypal = $this->methods_definition->group_paypal_methods();
 		$methods_cards  = $this->methods_definition->group_card_methods();

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -193,9 +193,6 @@ class SettingsDataManager {
 	 * @return void
 	 */
 	protected function apply_configuration( ConfigurationFlagsDTO $flags ) : void {
-		// Apply defaults for the "Payment Methods" tab.
-		$this->toggle_payment_gateways( $flags );
-
 		// Apply defaults for the "Settings" tab.
 		$this->apply_payment_settings( $flags );
 
@@ -207,13 +204,39 @@ class SettingsDataManager {
 	}
 
 	/**
+	 * Initialize hooks for gateway synchronization.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() : void {
+		add_action( 'woocommerce_paypal_payments_sync_gateways', array( $this, 'sync_gateway_settings' ) );
+	}
+
+	/**
+	 * Synchronize gateway settings with merchant onboarding choices.
+	 *
+	 * @return void
+	 */
+	public function sync_gateway_settings() : void {
+		$flags = new ConfigurationFlagsDTO();
+
+		$profile_data = $this->onboarding_profile->to_array();
+
+		$flags->is_business_seller = ! ( $profile_data['is_casual_seller'] ?? false );
+		$flags->use_card_payments  = $profile_data['accept_card_payments'] ?? false;
+		$flags->use_subscriptions  = in_array( 'SUBSCRIPTIONS', $profile_data['products'] ?? array(), true );
+
+		$this->toggle_payment_gateways( $flags );
+	}
+
+	/**
 	 * Enables or disables payment gateways depending on the provided
 	 * configuration flags.
 	 *
 	 * @param ConfigurationFlagsDTO $flags Shop configuration flags.
 	 * @return void
 	 */
-	protected function toggle_payment_gateways( ConfigurationFlagsDTO $flags ) : void {
+	public function toggle_payment_gateways( ConfigurationFlagsDTO $flags ) : void {
 		// First, disable all payment methods.
 		$methods_paypal = $this->methods_definition->group_paypal_methods();
 		$methods_cards  = $this->methods_definition->group_card_methods();
@@ -249,6 +272,14 @@ class SettingsDataManager {
 				$this->payment_methods->toggle_method_state( $method['id'], true );
 			}
 		}
+
+		/**
+		 * Allow plugins to modify payment gateway states before saving.
+		 *
+		 * @param PaymentSettings $payment_methods The payment methods object.
+		 * @param ConfigurationFlagsDTO $flags Configuration flags that determine which gateways to enable.
+		 */
+		do_action( 'woocommerce_paypal_payments_toggle_payment_gateways', $this->payment_methods, $flags );
 
 		$this->payment_methods->save();
 	}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -611,7 +611,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		// Enable Fastlane after onboarding if the store is compatible.
 		add_action(
 			'woocommerce_paypal_payments_toggle_payment_gateways',
-			function( $payment_methods, $flags ) use ( $container ) {
+			function( PaymentSettings $payment_methods, ConfigurationFlagsDTO $flags ) use ( $container ) {
 				if ( $flags->is_business_seller && $flags->use_card_payments ) {
 					$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
 					assert( $compatibility_checker instanceof CompatibilityChecker );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -627,11 +627,11 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		// Toggle payment gateways after onboarding based on flags.
 		add_action(
-			'init',
-			function() use ( $container ) {
+			'woocommerce_paypal_payments_sync_gateways',
+			static function() use ( $container ) {
 				$settings_data_manager = $container->get( 'settings.service.data-manager' );
 				assert( $settings_data_manager instanceof SettingsDataManager );
-				$settings_data_manager->init_hooks();
+				$settings_data_manager->sync_gateway_settings();
 			}
 		);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -303,6 +303,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 				$onboarding_profile->set_completed( false );
 				$onboarding_profile->set_step( 0 );
+				$onboarding_profile->set_gateways_synced( false );
+				$onboarding_profile->set_gateways_refreshed( false );
 				$onboarding_profile->save();
 
 				// Reset dismissed and completed on click todos.
@@ -608,19 +610,28 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		// Enable Fastlane after onboarding if the store is compatible.
 		add_action(
-			'woocommerce_paypal_payments_apply_default_configuration',
-			static function () use ( $container ) {
-				$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
-				assert( $compatibility_checker instanceof CompatibilityChecker );
+			'woocommerce_paypal_payments_toggle_payment_gateways',
+			function( $payment_methods, $flags ) use ( $container ) {
+				if ( $flags->is_business_seller && $flags->use_card_payments ) {
+					$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
+					assert( $compatibility_checker instanceof CompatibilityChecker );
 
-				$payment_settings = $container->get( 'settings.data.payment' );
-				assert( $payment_settings instanceof PaymentSettings );
-
-				if ( $compatibility_checker->is_fastlane_compatible() ) {
-					$payment_settings->toggle_method_state( AxoGateway::ID, true );
+					if ( $compatibility_checker->is_fastlane_compatible() ) {
+						$payment_methods->toggle_method_state( AxoGateway::ID, true );
+					}
 				}
+			},
+			10,
+			2
+		);
 
-				$payment_settings->save();
+		// Toggle payment gateways after onboarding based on flags.
+		add_action(
+			'init',
+			function() use ( $container ) {
+				$settings_data_manager = $container->get( 'settings.service.data-manager' );
+				assert( $settings_data_manager instanceof SettingsDataManager );
+				$settings_data_manager->init_hooks();
 			}
 		);
 


### PR DESCRIPTION
### Description

This PR will address an issue where payment methods are not properly synchronized between the frontend and backend after completing the onboarding process. When a merchant completes the onboarding flow, certain payment methods that should be enabled based on their selections (like ACDC) are not being activated in the new Settings UI.

The core issues are:
1. ACDC as a gateway gets registered too late for us to toggle it during page load.
2. No mechanism to refresh payment gateway data after onboarding flags get set. This causes issues hiding payment gateways based on country/currency/misc exclusion rules.


## Changes

- This PR will add state tracking flags (`gateways_synced` and `gateways_refreshed`) to the onboarding profile
- <strike>Create new REST endpoints for gateway synchronization and refreshing</strike>
- Implement custom hooks `usePaymentGatewaySync` and `usePaymentGatewayRefresh` to handle the synchronization process
- Add proper Redux actions and state management for tracking gateway sync status
- Modify the payment method card component to wait for gateway refresh before rendering
- Move the payment gateway synchronization to be initialized from the Overview tab after onboarding


## Steps to Test

1. Complete a fresh PayPal onboarding process
2. Ensure you selected to accept card payments during onboarding 
3. Navigate to PayPal settings > Payment methods tab
4. Verify that all eligible payment methods (based on onboarding selections) are properly enabled
5. Ensure the payment method card UI correctly reflects the enabled/disabled state of each method
6. Disconnect and repeat the process and verify that everything is working as expected
