### PR TITLE
Create mapping for the `3d_secure_contingency` setting. (4410)

### DIFF
--- a/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Compat\Settings;
 
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\AbstractDataModel;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 
 /**
@@ -36,26 +38,39 @@ class PaymentMethodSettingsMapHelper {
 	 */
 	public function map(): array {
 		return array(
-			'dcc_enabled' => CreditCardGateway::ID,
-			'axo_enabled' => AxoGateway::ID,
+			'dcc_enabled'           => CreditCardGateway::ID,
+			'axo_enabled'           => AxoGateway::ID,
+			'3d_secure_contingency' => 'three_d_secure',
 		);
 	}
 
 	/**
 	 * Retrieves the value of a mapped key from the new settings.
 	 *
-	 * @param string $old_key The key from the legacy settings.
+	 * @param string                 $old_key The key from the legacy settings.
+	 * @param AbstractDataModel|null $payment_settings The payment settings model.
 	 * @return mixed The value of the mapped setting, (null if not found).
 	 */
-	public function mapped_value( string $old_key ): ?bool {
+	public function mapped_value( string $old_key, ?AbstractDataModel $payment_settings ) {
+		switch ( $old_key ) {
+			case '3d_secure_contingency':
+				if ( is_null( $payment_settings ) ) {
+					return null;
+				}
 
-		$payment_method = $this->map()[ $old_key ] ?? false;
+				assert( $payment_settings instanceof PaymentSettings );
+				$selected_three_d_secure = $payment_settings->get_three_d_secure();
+				return self::THREE_D_SECURE_VALUES_MAP[ $selected_three_d_secure ] ?? null;
 
-		if ( ! $payment_method ) {
-			return null;
+			default:
+				$payment_method = $this->map()[ $old_key ] ?? false;
+
+				if ( ! $payment_method ) {
+					return null;
+				}
+
+				return $this->is_gateway_enabled( $payment_method );
 		}
-
-		return $this->is_gateway_enabled( $payment_method );
 	}
 
 	/**

--- a/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/PaymentMethodSettingsMapHelper.php
@@ -21,6 +21,15 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 class PaymentMethodSettingsMapHelper {
 
 	/**
+	 * A map of new to old 3d secure values.
+	 */
+	protected const THREE_D_SECURE_VALUES_MAP = array(
+		'no-3d-secure'            => 'NO_3D_SECURE',
+		'only-required-3d-secure' => 'SCA_WHEN_REQUIRED',
+		'always-3d-secure'        => 'SCA_ALWAYS',
+	);
+
+	/**
 	 * Maps old setting keys to new payment method settings names.
 	 *
 	 * @psalm-return array<oldSettingsKey, newSettingsKey>

--- a/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
@@ -214,7 +214,7 @@ class SettingsMapHelper {
 				: $this->settings_tab_map_helper->mapped_value( $old_key, $this->model_cache[ $model_id ] );
 
 			case $model instanceof PaymentSettings:
-				return $this->payment_method_settings_map_helper->mapped_value( $old_key );
+				return $this->payment_method_settings_map_helper->mapped_value( $old_key, $this->get_payment_settings_model() );
 
 			default:
 				return $this->model_cache[ $model_id ][ $new_key ] ?? null;


### PR DESCRIPTION
## Issue Description

The ACDC payment method has an option to change the 3DS level via the payment method modal, which currently is not mapped, i.e. changing it from the new settings UI has no effect on the front-end.

Mapping:
- New setting: `PaymentSettings::get_three_d_secure()`
- Should be mapped to `Settings::get( '3d_secure_contingency' )`

Expected values

The `3d_secure_contingency` setting must return a string, which must be one of the following values:

- "NO_3D_SECURE" (default)
- "SCA_ALWAYS"
- "SCA_WHEN_REQUIRED"

## PR Description

This PR adds mapping for the `3d_secure_contingency` setting.
