### PR TITLE
Simplify the new UI check for the onboarding.js file (4384)

### DIFF
--- a/modules/ppcp-onboarding/src/OnboardingModule.php
+++ b/modules/ppcp-onboarding/src/OnboardingModule.php
@@ -55,9 +55,9 @@ class OnboardingModule implements ServiceModule, ExtendingModule, ExecutableModu
 						'1' === get_option( 'woocommerce-ppcp-is-new-merchant' )
 						|| getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
 					)
-				)
+				) {
 					return;
-
+				}
 
 				$asset_loader = $c->get( 'onboarding.assets' );
 				assert( $asset_loader instanceof OnboardingAssets );

--- a/modules/ppcp-onboarding/src/OnboardingModule.php
+++ b/modules/ppcp-onboarding/src/OnboardingModule.php
@@ -48,9 +48,15 @@ class OnboardingModule implements ServiceModule, ExtendingModule, ExecutableModu
 		add_action(
 			'admin_enqueue_scripts',
 			function() use ( $c ) {
-				if ( ! SettingsModule::should_use_the_old_ui() ) {
+				if (
+					apply_filters(
+						'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
+						'1' === get_option( 'woocommerce-ppcp-is-new-merchant' )
+						|| getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
+					)
+				)
 					return;
-				}
+
 
 				$asset_loader = $c->get( 'onboarding.assets' );
 				assert( $asset_loader instanceof OnboardingAssets );

--- a/modules/ppcp-onboarding/src/OnboardingModule.php
+++ b/modules/ppcp-onboarding/src/OnboardingModule.php
@@ -50,6 +50,7 @@ class OnboardingModule implements ServiceModule, ExtendingModule, ExecutableModu
 			function() use ( $c ) {
 				if (
 					apply_filters(
+					// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 						'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
 						'1' === get_option( 'woocommerce-ppcp-is-new-merchant' )
 						|| getenv( 'PCP_SETTINGS_ENABLED' ) === '1'

--- a/modules/ppcp-onboarding/src/OnboardingModule.php
+++ b/modules/ppcp-onboarding/src/OnboardingModule.php
@@ -48,13 +48,7 @@ class OnboardingModule implements ServiceModule, ExtendingModule, ExecutableModu
 		add_action(
 			'admin_enqueue_scripts',
 			function() use ( $c ) {
-				if (
-					apply_filters(
-					// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
-						'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
-						getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
-					) && ! SettingsModule::should_use_the_old_ui()
-				) {
+				if ( ! SettingsModule::should_use_the_old_ui() ) {
 					return;
 				}
 


### PR DESCRIPTION
### Description
This PR will simplify the conditional check in the `OnboardingModule.php` file for when to enqueue scripts.

This will remove the `Uncaught TypeError: Cannot set properties of null (setting 'checked')` error from the console when the new UI is loaded.

