### PR TITLE
Branded Only: Adjust React Settings (4417)

### DIFF
--- a/modules/ppcp-api-client/src/Helper/PartnerAttribution.php
+++ b/modules/ppcp-api-client/src/Helper/PartnerAttribution.php
@@ -64,13 +64,14 @@ class PartnerAttribution {
 	 *
 	 * @param string $installation_path The installation path used to determine the BN Code.
 	 */
-	public function initialize_bn_code( string $installation_path ): void {
-		$selected_bn_code = $this->bn_codes[ $installation_path ] ?? false;
+	public function initialize_bn_code( string $installation_path ) : void {
+		$selected_bn_code = $this->bn_codes[ $installation_path ] ?? '';
 
-		if ( get_option( $this->bn_code_option_name ) || ! $selected_bn_code ) {
+		if ( ! $selected_bn_code || get_option( $this->bn_code_option_name ) ) {
 			return;
 		}
 
+		// This option is permanent and should not change.
 		update_option( $this->bn_code_option_name, $selected_bn_code );
 	}
 
@@ -79,10 +80,10 @@ class PartnerAttribution {
 	 *
 	 * @return string The stored BN Code, or the default value if no path is detected.
 	 */
-	public function get_bn_code(): string {
-		$bn_code = get_option( $this->bn_code_option_name, $this->default_bn_code ) ?? $this->default_bn_code;
+	public function get_bn_code() : string {
+		$bn_code = (string) ( get_option( $this->bn_code_option_name, $this->default_bn_code ) ?? $this->default_bn_code );
 
-		if ( ! in_array( $bn_code, $this->bn_codes, true ) && $bn_code !== $this->default_bn_code ) {
+		if ( ! in_array( $bn_code, $this->bn_codes, true ) ) {
 			return $this->default_bn_code;
 		}
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
@@ -5,7 +5,7 @@ import { ControlToggleButton } from '../../../../../ReusableComponents/Controls'
 import { SettingsHooks } from '../../../../../../data';
 import { useMerchantInfo } from '../../../../../../data/common/hooks';
 
-const SavePaymentMethods = () => {
+const SavePaymentMethods = ( { ownBradOnly } ) => {
 	const {
 		savePaypalAndVenmo,
 		setSavePaypalAndVenmo,
@@ -50,18 +50,21 @@ const SavePaymentMethods = () => {
 				disabled={ ! features.save_paypal_and_venmo.enabled }
 			/>
 
-			<ControlToggleButton
-				label={ __(
-					'Save Credit and Debit Cards',
-					'woocommerce-paypal-payments'
-				) }
-				description={ __(
-					"Securely store your customer's credit card.",
-					'woocommerce-paypal-payments'
-				) }
-				onChange={ setSaveCardDetails }
-				value={ saveCardDetails }
-			/>
+			{ ownBradOnly || (
+				// Credit card settings are only available in "white label" mode.
+				<ControlToggleButton
+					label={ __(
+						'Save Credit and Debit Cards',
+						'woocommerce-paypal-payments'
+					) }
+					description={ __(
+						"Securely store your customer's credit card.",
+						'woocommerce-paypal-payments'
+					) }
+					onChange={ setSaveCardDetails }
+					value={ saveCardDetails }
+				/>
+			) }
 		</SettingsBlock>
 	);
 };

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/CommonSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/CommonSettings.js
@@ -6,7 +6,7 @@ import SavePaymentMethods from './Blocks/SavePaymentMethods';
 import InvoicePrefix from './Blocks/InvoicePrefix';
 import PayNowExperience from './Blocks/PayNowExperience';
 
-const CommonSettings = () => (
+const CommonSettings = ( { ownBradOnly } ) => (
 	<SettingsCard
 		icon="icon-settings-common.svg"
 		title={ __( 'Common settings', 'woocommerce-paypal-payments' ) }
@@ -18,7 +18,7 @@ const CommonSettings = () => (
 	>
 		<InvoicePrefix />
 		<OrderIntent />
-		<SavePaymentMethods />
+		<SavePaymentMethods ownBradOnly={ ownBradOnly } />
 		<PayNowExperience />
 	</SettingsCard>
 );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
@@ -9,9 +9,6 @@ import PaypalSettings from './Blocks/PaypalSettings';
 import OtherSettings from './Blocks/OtherSettings';
 
 const ExpertSettings = () => {
-	const settings = {}; // dummy object
-	const updateFormValue = () => {}; // dummy function
-
 	return (
 		<SettingsCard
 			icon="icon-settings-expert.svg"
@@ -22,38 +19,25 @@ const ExpertSettings = () => {
 				'woocommerce-paypal-payments'
 			) }
 			actionProps={ {
-				callback: updateFormValue,
 				key: 'payNowExperience',
 			} }
 			contentContainer={ false }
 		>
 			<ContentWrapper>
 				{ /*<Content>
-					<ConnectionDetails
-						updateFormValue={ updateFormValue }
-						settings={ settings }
-					/>
+					<ConnectionDetails />
 				</Content>*/ }
 
 				<Content>
-					<Troubleshooting
-						updateFormValue={ updateFormValue }
-						settings={ settings }
-					/>
+					<Troubleshooting />
 				</Content>
 
 				<Content>
-					<PaypalSettings
-						updateFormValue={ updateFormValue }
-						settings={ settings }
-					/>
+					<PaypalSettings />
 				</Content>
 
 				<Content>
-					<OtherSettings
-						updateFormValue={ updateFormValue }
-						settings={ settings }
-					/>
+					<OtherSettings />
 				</Content>
 			</ContentWrapper>
 		</SettingsCard>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
@@ -8,7 +8,7 @@ import Troubleshooting from './Blocks/Troubleshooting';
 import PaypalSettings from './Blocks/PaypalSettings';
 import OtherSettings from './Blocks/OtherSettings';
 
-const ExpertSettings = () => {
+const ExpertSettings = ( { ownBradOnly } ) => {
 	return (
 		<SettingsCard
 			icon="icon-settings-expert.svg"
@@ -36,9 +36,12 @@ const ExpertSettings = () => {
 					<PaypalSettings />
 				</Content>
 
-				<Content>
-					<OtherSettings />
-				</Content>
+				{ ownBradOnly || (
+					// The "other settings" accordion is only relevant in white-label mode.
+					<Content>
+						<OtherSettings />
+					</Content>
+				) }
 			</ContentWrapper>
 		</SettingsCard>
 	);

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -54,6 +54,13 @@ const TabPaymentMethods = () => {
 	const merchant = CommonHooks.useMerchant();
 	const { canUseCardPayments } = OnboardingHooks.useFlags();
 
+	const showCardPayments =
+		methods.cardPayment.length > 0 &&
+		merchant.isBusinessSeller &&
+		canUseCardPayments;
+
+	const showApms = methods.apm.length > 0;
+
 	return (
 		<div className="ppcp-r-payment-methods">
 			<PaymentMethodCard
@@ -68,7 +75,8 @@ const TabPaymentMethods = () => {
 				onTriggerModal={ setActiveModal }
 				methodsMap={ methodsMap }
 			/>
-			{ merchant.isBusinessSeller && canUseCardPayments && (
+
+			{ showCardPayments && (
 				<PaymentMethodCard
 					id="ppcp-card-payments-card"
 					title={ __(
@@ -85,21 +93,24 @@ const TabPaymentMethods = () => {
 					methodsMap={ methodsMap }
 				/>
 			) }
-			<PaymentMethodCard
-				id="ppcp-alternative-payments-card"
-				title={ __(
-					'Alternative Payment Methods',
-					'woocommerce-paypal-payments'
-				) }
-				description={ __(
-					'With alternative payment methods, customers across the globe can pay with their bank accounts and other local payment methods.',
-					'woocommerce-paypal-payments'
-				) }
-				icon="icon-checkout-alternative-methods.svg"
-				methods={ methods.apm }
-				onTriggerModal={ setActiveModal }
-				methodsMap={ methodsMap }
-			/>
+
+			{ showApms && (
+				<PaymentMethodCard
+					id="ppcp-alternative-payments-card"
+					title={ __(
+						'Alternative Payment Methods',
+						'woocommerce-paypal-payments'
+					) }
+					description={ __(
+						'With alternative payment methods, customers across the globe can pay with their bank accounts and other local payment methods.',
+						'woocommerce-paypal-payments'
+					) }
+					icon="icon-checkout-alternative-methods.svg"
+					methods={ methods.apm }
+					onTriggerModal={ setActiveModal }
+					methodsMap={ methodsMap }
+				/>
+			) }
 
 			{ activeModal && (
 				<Modal

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabSettings.js
@@ -2,9 +2,10 @@ import ConnectionStatus from '../Components/Settings/ConnectionStatus';
 import CommonSettings from '../Components/Settings/CommonSettings';
 import ExpertSettings from '../Components/Settings/ExpertSettings';
 import SpinnerOverlay from '../../../ReusableComponents/SpinnerOverlay';
-import { SettingsHooks } from '../../../../data';
+import { CommonHooks, SettingsHooks } from '../../../../data';
 
 const TabSettings = () => {
+	const { ownBrandOnly } = CommonHooks.useWooSettings();
 	const { isReady } = SettingsHooks.useStore();
 
 	if ( ! isReady ) {
@@ -14,8 +15,8 @@ const TabSettings = () => {
 	return (
 		<div className="ppcp-r-settings">
 			<ConnectionStatus />
-			<CommonSettings />
-			<ExpertSettings />
+			<CommonSettings ownBradOnly={ ownBrandOnly } />
+			<ExpertSettings ownBradOnly={ ownBrandOnly } />
 		</div>
 	);
 };

--- a/modules/ppcp-settings/resources/js/data/common/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/common/reducer.js
@@ -32,7 +32,16 @@ const defaultTransient = Object.freeze( {
 	wooSettings: Object.freeze( {
 		storeCountry: '',
 		storeCurrency: '',
-		installationPath: '',
+
+		/**
+		 * The "branded-only" experience is determined on server-side, based on the installation path.
+		 *
+		 * When true, the plugin must only display "PayPal's own brand" payment options
+		 * i.e. no card payments or Apple Pay/Google Pay.
+		 *
+		 * @type {boolean}
+		 */
+		ownBrandOnly: false,
 	} ),
 
 	features: Object.freeze( {

--- a/modules/ppcp-settings/resources/js/data/common/selectors.js
+++ b/modules/ppcp-settings/resources/js/data/common/selectors.js
@@ -44,7 +44,10 @@ export const wooSettings = ( state ) => {
 	const settings = getState( state ).wooSettings || EMPTY_OBJ;
 
 	// For development and testing. Remove this eventually!
-	const simulateBrandedOnly = localStorage.getItem( 'simulate-branded-only' );
+	const simulateBrandedOnly = document.cookie
+		.split( '; ' )
+		.find( ( row ) => row.startsWith( 'simulate-branded-only=' ) )
+		?.split( '=' )[ 1 ];
 
 	/**
 	 * The "own-brand-only" experience is determined on server-side, based on the installation path.

--- a/modules/ppcp-settings/resources/js/data/common/selectors.js
+++ b/modules/ppcp-settings/resources/js/data/common/selectors.js
@@ -43,10 +43,11 @@ export const features = ( state ) => {
 export const wooSettings = ( state ) => {
 	const settings = getState( state ).wooSettings || EMPTY_OBJ;
 
+	// For development and testing. Remove this eventually!
 	const simulateBrandedOnly = localStorage.getItem( 'simulate-branded-only' );
 
 	/**
-	 * The "branded only experience" is determined based on the installation path.
+	 * The "own-brand-only" experience is determined on server-side, based on the installation path.
 	 *
 	 * When true, the plugin must only display "PayPal's own brand" payment options
 	 * i.e. no card payments or Apple Pay/Google Pay.
@@ -54,9 +55,7 @@ export const wooSettings = ( state ) => {
 	 * @type {boolean}
 	 */
 	const ownBrandOnly =
-		'true' === simulateBrandedOnly || // For development and testing. Remove this eventually!
-		settings.installationPath === 'core-profile' ||
-		settings.installationPath === 'payment-settings';
+		'true' === simulateBrandedOnly || settings.ownBrandOnly;
 
 	return { ...settings, ownBrandOnly };
 };

--- a/modules/ppcp-settings/resources/js/data/debug.js
+++ b/modules/ppcp-settings/resources/js/data/debug.js
@@ -168,6 +168,16 @@ export const addDebugTools = ( context, modules ) => {
 		onboarding.persist();
 	};
 
+	/**
+	 * Sets a cookie to simulate the branded-only experience.
+	 * @param {boolean} value - Whether to simulate branded-only experience.
+	 */
+	debugApi.simulateBrandedOnly = ( value ) => {
+		const expirationDate = new Date( Date.now() + 3600000 ).toUTCString();
+		document.cookie = `simulate-branded-only=${ value }; expires=${ expirationDate }; path=/`;
+		window.location.reload();
+	};
+
 	// Expose original debug API.
 	Object.assign( context, debugApi );
 };

--- a/modules/ppcp-settings/resources/js/data/payment/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/payment/hooks.js
@@ -83,34 +83,22 @@ export const usePaymentMethods = () => {
 	const [ pui ] = usePersistent( 'ppcp-pay-upon-invoice-gateway' );
 	const [ oxxo ] = usePersistent( 'ppcp-oxxo-gateway' );
 
-	const payPalCheckout = [ paypal, venmo, payLater, creditCard ];
-	const onlineCardPayments = [
-		advancedCreditCard,
-		fastlane,
-		applePay,
-		googlePay,
-	];
-	const alternative = [
-		bancontact,
-		blik,
-		eps,
-		ideal,
-		mybank,
-		p24,
-		trustly,
-		multibanco,
-		pui,
-		oxxo,
-	];
-	const paymentMethods = [
+	const removeEmpty = ( list ) =>
+		list.filter( ( item ) => item && item.id?.length );
+
+	const payPalCheckout = removeEmpty( [
 		paypal,
 		venmo,
 		payLater,
 		creditCard,
+	] );
+	const onlineCardPayments = removeEmpty( [
 		advancedCreditCard,
 		fastlane,
 		applePay,
 		googlePay,
+	] );
+	const alternative = removeEmpty( [
 		bancontact,
 		blik,
 		eps,
@@ -121,6 +109,12 @@ export const usePaymentMethods = () => {
 		multibanco,
 		pui,
 		oxxo,
+	] );
+
+	const paymentMethods = [
+		...payPalCheckout,
+		...onlineCardPayments,
+		...alternative,
 	];
 
 	return {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -402,6 +402,7 @@ return array(
 
 		return new PaymentMethodsDefinition(
 			$container->get( 'settings.data.payment' ),
+			$container->get( 'settings.data.general' ),
 			$axo_notices
 		);
 	},

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MyBankGateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
@@ -41,6 +42,14 @@ class PaymentMethodsDefinition {
 	private PaymentSettings $settings;
 
 	/**
+	 * Data model for the general plugin settings, used to access flags like
+	 * "own brand only" to modify the payment method details.
+	 *
+	 * @var GeneralSettings
+	 */
+	private GeneralSettings $general_settings;
+
+	/**
 	 * Conflict notices for Axo gateway.
 	 *
 	 * @var array
@@ -57,14 +66,17 @@ class PaymentMethodsDefinition {
 	/**
 	 * Constructor.
 	 *
-	 * @param PaymentSettings $settings Payment methods data model.
+	 * @param PaymentSettings $settings              Payment methods data model.
+	 * @param GeneralSettings $general_settings      General plugin settings model.
 	 * @param array           $axo_conflicts_notices Conflicts notices for Axo.
 	 */
 	public function __construct(
 		PaymentSettings $settings,
+		GeneralSettings $general_settings,
 		array $axo_conflicts_notices = array()
 	) {
 		$this->settings              = $settings;
+		$this->general_settings      = $general_settings;
 		$this->axo_conflicts_notices = $axo_conflicts_notices;
 	}
 
@@ -94,6 +106,7 @@ class PaymentMethodsDefinition {
 				$method['warningMessages'] ?? array(),
 			);
 		}
+
 		return $result;
 	}
 
@@ -105,9 +118,11 @@ class PaymentMethodsDefinition {
 	 * @param string      $title                      Admin-side payment method title.
 	 * @param string      $description                Admin-side info about the payment method.
 	 * @param string      $icon                       Admin-side icon of the payment method.
-	 * @param array|false $fields                     Optional. Additional fields to display in the edit modal.
-	 *                                                Setting this to false omits all fields.
-	 * @param array       $warning_messages           Optional. Warning messages to display in the UI.
+	 * @param array|false $fields                     Optional. Additional fields to display in the
+	 *                                                edit modal. Setting this to false omits all
+	 *                                                fields.
+	 * @param array       $warning_messages           Optional. Warning messages to display in the
+	 *                                                UI.
 	 * @return array Payment method definition.
 	 */
 	private function build_method_definition(
@@ -115,7 +130,7 @@ class PaymentMethodsDefinition {
 		string $title,
 		string $description,
 		string $icon,
-			   $fields = array(),
+		$fields = array(),
 		array $warning_messages = array()
 	) : array {
 		$gateway = $this->wc_gateways[ $gateway_id ] ?? null;
@@ -197,13 +212,16 @@ class PaymentMethodsDefinition {
 				'icon'        => 'payment-method-paypal',
 				'fields'      => false,
 			),
-			array(
+		);
+
+		if ( ! $this->general_settings->own_brand_only() ) {
+			$group[] = array(
 				'id'          => CardButtonGateway::ID,
 				'title'       => __( 'Credit and debit card payments', 'woocommerce-paypal-payments' ),
 				'description' => __( "Accept all major credit and debit cards - even if your customer doesn't have a PayPal account . ", 'woocommerce-paypal-payments' ),
 				'icon'        => 'payment-method-cards',
-			),
-		);
+			);
+		}
 
 		return apply_filters( 'woocommerce_paypal_payments_gateway_group_paypal', $group );
 	}
@@ -214,8 +232,10 @@ class PaymentMethodsDefinition {
 	 * @return array
 	 */
 	public function group_card_methods() : array {
-		$group = array(
-			array(
+		$group = array();
+
+		if ( ! $this->general_settings->own_brand_only() ) {
+			$group[] = array(
 				'id'          => CreditCardGateway::ID,
 				'title'       => __( 'Advanced Credit and Debit Card Payments', 'woocommerce-paypal-payments' ),
 				'description' => __( "Present custom credit and debit card fields to your payers so they can pay with credit and debit cards using your site's branding.", 'woocommerce-paypal-payments' ),
@@ -254,8 +274,8 @@ class PaymentMethodsDefinition {
 						),
 					),
 				),
-			),
-			array(
+			);
+			$group[] = array(
 				'id'              => AxoGateway::ID,
 				'title'           => __( 'Fastlane by PayPal', 'woocommerce-paypal-payments' ),
 				'description'     => __( "Tap into the scale and trust of PayPal's customer network to recognize shoppers and make guest checkout more seamless than ever.", 'woocommerce-paypal-payments' ),
@@ -279,20 +299,20 @@ class PaymentMethodsDefinition {
 					),
 				),
 				'warningMessages' => $this->axo_conflicts_notices,
-			),
-			array(
+			);
+			$group[] = array(
 				'id'          => ApplePayGateway::ID,
 				'title'       => __( 'Apple Pay', 'woocommerce-paypal-payments' ),
 				'description' => __( 'Allow customers to pay via their Apple Pay digital wallet.', 'woocommerce-paypal-payments' ),
 				'icon'        => 'payment-method-apple-pay',
-			),
-			array(
+			);
+			$group[] = array(
 				'id'          => GooglePayGateway::ID,
 				'title'       => __( 'Google Pay', 'woocommerce-paypal-payments' ),
 				'description' => __( 'Allow customers to pay via their Google Pay digital wallet.', 'woocommerce-paypal-payments' ),
 				'icon'        => 'payment-method-google-pay',
-			),
-		);
+			);
+		}
 
 		return apply_filters( 'woocommerce_paypal_payments_gateway_group_cards', $group );
 	}

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -131,7 +131,7 @@ class GeneralSettings extends AbstractDataModel {
 	public function get_woo_settings() : array {
 		$settings = $this->woo_settings;
 
-		$settings['installation_path'] = $this->get_installation_path();
+		$settings['own_brand_only'] = $this->own_brand_only();
 
 		return $settings;
 	}

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -298,4 +298,19 @@ class GeneralSettings extends AbstractDataModel {
 	public function get_installation_path() : string {
 		return $this->data['installation_path'] ?? InstallationPathEnum::DIRECT;
 	}
+
+	/**
+	 * Whether the plugin is in the branded-experience mode and shows/enables only
+	 * payment methods that are PayPal's own brand.
+	 *
+	 * @return bool
+	 */
+	public function own_brand_only() : bool {
+		$brand_only_paths = array(
+			InstallationPathEnum::CORE_PROFILER,
+			InstallationPathEnum::PAYMENT_SETTINGS,
+		);
+
+		return in_array( $this->get_installation_path(), $brand_only_paths, true );
+	}
 }

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -306,6 +306,15 @@ class GeneralSettings extends AbstractDataModel {
 	 * @return bool
 	 */
 	public function own_brand_only() : bool {
+		// Temporary dev/test mode.
+		$simulate_cookie = sanitize_key( wp_unslash( $_COOKIE['simulate-branded-only'] ?? '' ) );
+
+		if ( $simulate_cookie === 'true' ) {
+			return true;
+		} elseif ( $simulate_cookie === 'false' ) {
+			return false;
+		}
+
 		$brand_only_paths = array(
 			InstallationPathEnum::CORE_PROFILER,
 			InstallationPathEnum::PAYMENT_SETTINGS,

--- a/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
@@ -108,11 +108,14 @@ class CommonRestEndpoint extends RestEndpoint {
 	 * @var array
 	 */
 	private array $woo_settings_map = array(
-		'country'  => array(
+		'country'        => array(
 			'js_name' => 'storeCountry',
 		),
-		'currency' => array(
+		'currency'       => array(
 			'js_name' => 'storeCurrency',
+		),
+		'own_brand_only' => array(
+			'js_name' => 'ownBrandOnly',
 		),
 	);
 


### PR DESCRIPTION
### Description

Prepares a server-side check to detect if the plugin should serve "own_brand_only", and implements a new React hook property to hide certain settings and payment methods in branded mode.

#### Detection in PHP

```php
$settings = $container->get( 'settings.data.general' ),

if ( $settings->own_brand_only() ) {
  // Disable all white-label features.
}
```

#### Detection in JS

```js
const { ownBrandOnly } = CommonHooks.useWooSettings();

if ( ownBrandOnly ) {
  // Hide all white-label features.
}
```

### Simulate branded-only

Since the detection is done on server-side, the previous `localStorage` test code does not work anymore. A new debug function sets a cookie (1-hour expiration) to simulate a specific mode:

```js
ppcpDebugger.simulateBrandedOnly(true)  // Simulate branded-only mode.
ppcpDebugger.simulateBrandedOnly(false) // Simulate white-label mode.
ppcpDebugger.simulateBrandedOnly(null)  // Revert to default logic (using the installation path).
```