### PR TITLE
Improve the loading experience for the new UI (4429)

### DIFF
--- a/modules/ppcp-button/src/Helper/ThreeDSecure.php
+++ b/modules/ppcp-button/src/Helper/ThreeDSecure.php
@@ -20,7 +20,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\CardAuthenticationResultFactory
 class ThreeDSecure {
 
 	const NO_DECISION = 0;
-	const PROCEED    = 1;
+	const PROCEED     = 1;
 	const REJECT      = 2;
 	const RETRY       = 3;
 

--- a/modules/ppcp-settings/resources/css/components/_app.scss
+++ b/modules/ppcp-settings/resources/css/components/_app.scss
@@ -3,13 +3,6 @@
  */
 
 .ppcp-r-app.loading {
-	height: 400px;
-	width: 400px;
-	position: absolute;
-	left: 50%;
-	transform: translate(-50%, 0);
-	text-align: center;
-
 	.ppcp-r-spinner-overlay {
 		display: flex;
 		flex-direction: column;

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_spinner-overlay.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_spinner-overlay.scss
@@ -1,5 +1,4 @@
 .ppcp-r-spinner-overlay {
-	background: var(--spinner-overlay-color);
 	position: absolute;
 	width: 100%;
 	height: 100%;
@@ -13,8 +12,6 @@
 		left: 50%;
 		transform: translate(-50%, -50%);
 		margin: 0;
-		width: var(--spinner-size);
-		height: var(--spinner-size);
 	}
 
 	.ppcp--spinner-message {
@@ -29,7 +26,6 @@
 		position: fixed;
 		width: var(--spinner-overlay-width);
 		height: var(--spinner-overlay-height);
-		box-shadow: var(--spinner-overlay-box-shadow);
 		left: 50%;
 		top: 50%;
 		transform: translate(-50%, -50%);

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -592,7 +592,7 @@ return array(
 	'settings.service.gateway-redirect'                   => static function (): GatewayRedirectService {
 		return new GatewayRedirectService();
 	},
-	'settings.services.loading-screen-service'     => static function ( ContainerInterface $container ) : LoadingScreenService {
+	'settings.services.loading-screen-service'            => static function ( ContainerInterface $container ) : LoadingScreenService {
 		return new LoadingScreenService();
 	},
 	/**

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -49,6 +49,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\AuthenticationManager;
 use WooCommerce\PayPalCommerce\Settings\Service\ConnectionUrlGenerator;
 use WooCommerce\PayPalCommerce\Settings\Service\FeaturesEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
+use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
 use WooCommerce\PayPalCommerce\Settings\Service\OnboardingUrlManager;
 use WooCommerce\PayPalCommerce\Settings\Service\TodosEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\TodosSortingAndFilteringService;
@@ -587,6 +588,9 @@ return array(
 	},
 	'settings.service.gateway-redirect'            => static function (): GatewayRedirectService {
 		return new GatewayRedirectService();
+	},
+	'settings.services.loading-screen-service'     => static function ( ContainerInterface $container ) : LoadingScreenService {
+		return new LoadingScreenService();
 	},
 	/**
 	 * Returns a list of all payment gateway IDs created by this plugin.

--- a/modules/ppcp-settings/src/Service/GatewayRedirectService.php
+++ b/modules/ppcp-settings/src/Service/GatewayRedirectService.php
@@ -85,14 +85,9 @@ class GatewayRedirectService {
 
 		// Get current URL parameters.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		// The sanitize_get_param method handles unslashing and sanitization internally.
-		$page    = isset( $_GET['page'] ) ? $this->sanitize_get_param( $_GET['page'] ) : '';
-		$tab     = isset( $_GET['tab'] ) ? $this->sanitize_get_param( $_GET['tab'] ) : '';
-		$section = isset( $_GET['section'] ) ? $this->sanitize_get_param( $_GET['section'] ) : '';
-		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$page    = isset( $_GET['page'] ) ? wc_clean( wp_unslash( $_GET['page'] ) ) : '';
+		$tab     = isset( $_GET['tab'] ) ? wc_clean( wp_unslash( $_GET['tab'] ) ) : '';
+		$section = isset( $_GET['section'] ) ? wc_clean( wp_unslash( $_GET['section'] ) ) : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Check if we're on a WooCommerce settings page and checkout tab.
@@ -112,18 +107,5 @@ class GatewayRedirectService {
 			wp_safe_redirect( $redirect_url );
 			exit;
 		}
-	}
-
-	/**
-	 * Sanitizes a GET parameter that could be string or array.
-	 *
-	 * @param mixed $param The parameter to sanitize.
-	 * @return string The sanitized parameter.
-	 */
-	private function sanitize_get_param( $param ): string {
-		if ( is_array( $param ) ) {
-			return '';
-		}
-		return sanitize_text_field( wp_unslash( $param ) );
 	}
 }

--- a/modules/ppcp-settings/src/Service/LoadingScreenService.php
+++ b/modules/ppcp-settings/src/Service/LoadingScreenService.php
@@ -63,29 +63,11 @@ class LoadingScreenService {
 	 */
 	private function is_ppcp_settings_page(): bool {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		// The sanitize_get_param method handles unslashing and sanitization internally.
-		$page    = $this->sanitize_get_param( $_GET['page'] ?? '' );
-		$tab     = $this->sanitize_get_param( $_GET['tab'] ?? '' );
-		$section = $this->sanitize_get_param( $_GET['section'] ?? '' );
-		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$page    = wc_clean( wp_unslash( $_GET['page'] ?? '' ) );
+		$tab     = wc_clean( wp_unslash( $_GET['tab'] ?? '' ) );
+		$section = wc_clean( wp_unslash( $_GET['section'] ?? '' ) );
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		return $page === 'wc-settings' && $tab === 'checkout' && $section === 'ppcp-gateway';
-	}
-
-	/**
-	 * Sanitizes a GET parameter that could be string or array.
-	 *
-	 * @param mixed $param The parameter to sanitize.
-	 * @return string The sanitized parameter.
-	 */
-	private function sanitize_get_param( $param ): string {
-		if ( is_array( $param ) ) {
-			return '';
-		}
-		return sanitize_text_field( wp_unslash( $param ) );
 	}
 }

--- a/modules/ppcp-settings/src/Service/LoadingScreenService.php
+++ b/modules/ppcp-settings/src/Service/LoadingScreenService.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Provides loading screen handling logic for PayPal settings page.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Settings\Service;
+
+/**
+ * LoadingScreenService class. Handles the display of loading screen for the PayPal settings page.
+ */
+class LoadingScreenService {
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		add_action(
+			'admin_head',
+			array( $this, 'add_settings_loading_screen' )
+		);
+	}
+
+	/**
+	 * Add CSS to permanently hide specific WooCommerce elements on the PayPal settings page.
+	 *
+	 * @return void
+	 */
+	public function add_settings_loading_screen(): void {
+		// Only run on the specific WooCommerce PayPal settings page.
+		if ( ! $this->is_ppcp_settings_page() ) {
+			return;
+		}
+
+		?>
+		<style>
+			/* Permanently hide these WooCommerce elements. */
+			.woocommerce form#mainform > *:not(#ppcp-settings-container),
+			#woocommerce-embedded-root {
+				display: none;
+			}
+
+			#wpcontent #wpbody {
+				margin-top: 0;
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Check if we're on the PayPal checkout settings page.
+	 *
+	 * @return bool True if we're on the PayPal settings page
+	 */
+	private function is_ppcp_settings_page(): bool {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		// The sanitize_get_param method handles unslashing and sanitization internally.
+		$page    = $this->sanitize_get_param( $_GET['page'] ?? '' );
+		$tab     = $this->sanitize_get_param( $_GET['tab'] ?? '' );
+		$section = $this->sanitize_get_param( $_GET['section'] ?? '' );
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return $page === 'wc-settings' && $tab === 'checkout' && $section === 'ppcp-gateway';
+	}
+
+	/**
+	 * Sanitizes a GET parameter that could be string or array.
+	 *
+	 * @param mixed $param The parameter to sanitize.
+	 * @return string The sanitized parameter.
+	 */
+	private function sanitize_get_param( $param ): string {
+		if ( is_array( $param ) ) {
+			return '';
+		}
+		return sanitize_text_field( wp_unslash( $param ) );
+	}
+}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -175,7 +175,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
-		// Supress WooCommerce Settings UI elements via CSS to improve the loading experience.
+		// Suppress WooCommerce Settings UI elements via CSS to improve the loading experience.
 		$loading_screen_service = $container->get( 'settings.services.loading-screen-service' );
 		assert( $loading_screen_service instanceof LoadingScreenService );
 		$loading_screen_service->register();

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -147,6 +147,15 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		}
 
 		/**
+		 * This hook is fired when the plugin is updated.
+		 */
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate_on_update',
+			static fn() => ! get_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI )
+				&& update_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI, 'yes' )
+		);
+
+		/**
 		 * This hook is fired when the plugin is installed or updated.
 		 */
 		add_action(

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -29,6 +29,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\RestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Handler\ConnectionListener;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
+use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
@@ -143,6 +144,11 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 			return true;
 		}
+
+		// Add the loading screen.
+		$loading_screen_service = $container->get( 'settings.services.loading-screen-service' );
+		assert( $loading_screen_service instanceof LoadingScreenService );
+		$loading_screen_service->register();
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',


### PR DESCRIPTION
### Description

This PR will remove the jumpiness of the spinner screen while loading the new Settings UI.

### Screenshots

|Before|After|
|-|-|
|![loading before](https://github.com/user-attachments/assets/062d9a53-a542-403a-8181-500922bd8c7d)|![loading after](https://github.com/user-attachments/assets/bbcd7b04-80f0-4af3-bc56-3ea6d68e507e)|
