### PR TITLE
Front-End: Disable White Label Features (4418)

### DIFF
--- a/modules/ppcp-api-client/src/Helper/PartnerAttribution.php
+++ b/modules/ppcp-api-client/src/Helper/PartnerAttribution.php
@@ -64,13 +64,14 @@ class PartnerAttribution {
 	 *
 	 * @param string $installation_path The installation path used to determine the BN Code.
 	 */
-	public function initialize_bn_code( string $installation_path ): void {
-		$selected_bn_code = $this->bn_codes[ $installation_path ] ?? false;
+	public function initialize_bn_code( string $installation_path ) : void {
+		$selected_bn_code = $this->bn_codes[ $installation_path ] ?? '';
 
-		if ( get_option( $this->bn_code_option_name ) || ! $selected_bn_code ) {
+		if ( ! $selected_bn_code || get_option( $this->bn_code_option_name ) ) {
 			return;
 		}
 
+		// This option is permanent and should not change.
 		update_option( $this->bn_code_option_name, $selected_bn_code );
 	}
 
@@ -79,10 +80,10 @@ class PartnerAttribution {
 	 *
 	 * @return string The stored BN Code, or the default value if no path is detected.
 	 */
-	public function get_bn_code(): string {
-		$bn_code = get_option( $this->bn_code_option_name, $this->default_bn_code ) ?? $this->default_bn_code;
+	public function get_bn_code() : string {
+		$bn_code = (string) ( get_option( $this->bn_code_option_name, $this->default_bn_code ) ?? $this->default_bn_code );
 
-		if ( ! in_array( $bn_code, $this->bn_codes, true ) && $bn_code !== $this->default_bn_code ) {
+		if ( ! in_array( $bn_code, $this->bn_codes, true ) ) {
 			return $this->default_bn_code;
 		}
 

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -27,7 +27,7 @@ return array(
 		$apm_applies = $container->get( 'applepay.helpers.apm-applies' );
 		assert( $apm_applies instanceof ApmApplies );
 
-		return $apm_applies->for_country() && $apm_applies->for_currency();
+		return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
 	},
 	'applepay.helpers.apm-applies'             => static function ( ContainerInterface $container ) : ApmApplies {
 		return new ApmApplies(

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -29,6 +29,14 @@ return array(
 
 		return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
 	},
+	'applepay.eligibility.check'               => static function ( ContainerInterface $container ): callable {
+		$apm_applies = $container->get( 'applepay.helpers.apm-applies' );
+		assert( $apm_applies instanceof ApmApplies );
+
+		return static function () use ( $apm_applies ) : bool {
+			return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
+		};
+	},
 	'applepay.helpers.apm-applies'             => static function ( ContainerInterface $container ) : ApmApplies {
 		return new ApmApplies(
 			$container->get( 'applepay.supported-countries' ),

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -23,11 +23,11 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
+	// @deprecated - use `applepay.eligibility.check` instead.
 	'applepay.eligible'                        => static function ( ContainerInterface $container ): bool {
-		$apm_applies = $container->get( 'applepay.helpers.apm-applies' );
-		assert( $apm_applies instanceof ApmApplies );
+		$eligibility_check = $container->get( 'applepay.eligibility.check' );
 
-		return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
+		return $eligibility_check();
 	},
 	'applepay.eligibility.check'               => static function ( ContainerInterface $container ): callable {
 		$apm_applies = $container->get( 'applepay.helpers.apm-applies' );

--- a/modules/ppcp-applepay/src/Helper/ApmApplies.php
+++ b/modules/ppcp-applepay/src/Helper/ApmApplies.php
@@ -83,4 +83,16 @@ class ApmApplies {
 		return in_array( $this->currency->get(), $this->allowed_currencies, true );
 	}
 
+	/**
+	 * Indicates, whether the current merchant is eligible for ApplePay. Always true,
+	 * but the filter allows other modules to disable ApplePay site-wide.
+	 *
+	 * @return bool
+	 */
+	public function for_merchant() : bool {
+		return apply_filters(
+			'woocommerce_paypal_payments_is_eligible_for_applepay',
+			true
+		);
+	}
 }

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -22,12 +22,11 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 
 return array(
 
-	// If AXO can be configured.
+	// @deprecated - use `axo.eligibility.check` instead.
 	'axo.eligible'                           => static function ( ContainerInterface $container ): bool {
-		$apm_applies = $container->get( 'axo.helpers.apm-applies' );
-		assert( $apm_applies instanceof ApmApplies );
+		$eligibility_check = $container->get( 'axo.eligibility.check' );
 
-		return $apm_applies->for_country_currency() && $apm_applies->for_merchant();
+		return $eligibility_check();
 	},
 	'axo.eligibility.check'                  => static function ( ContainerInterface $container ): callable {
 		$apm_applies = $container->get( 'axo.helpers.apm-applies' );

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -29,7 +29,14 @@ return array(
 
 		return $apm_applies->for_country_currency() && $apm_applies->for_merchant();
 	},
+	'axo.eligibility.check'                  => static function ( ContainerInterface $container ): callable {
+		$apm_applies = $container->get( 'axo.helpers.apm-applies' );
+		assert( $apm_applies instanceof ApmApplies );
 
+		return static function () use ( $apm_applies ) : bool {
+			return $apm_applies->for_country_currency() && $apm_applies->for_merchant();
+		};
+	},
 	'axo.helpers.apm-applies'                => static function ( ContainerInterface $container ) : ApmApplies {
 		return new ApmApplies(
 			$container->get( 'axo.supported-country-currency-matrix' ),

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -27,7 +27,7 @@ return array(
 		$apm_applies = $container->get( 'axo.helpers.apm-applies' );
 		assert( $apm_applies instanceof ApmApplies );
 
-		return $apm_applies->for_country_currency();
+		return $apm_applies->for_country_currency() && $apm_applies->for_merchant();
 	},
 
 	'axo.helpers.apm-applies'                => static function ( ContainerInterface $container ) : ApmApplies {

--- a/modules/ppcp-axo/src/Helper/ApmApplies.php
+++ b/modules/ppcp-axo/src/Helper/ApmApplies.php
@@ -66,4 +66,17 @@ class ApmApplies {
 		}
 		return in_array( $this->currency->get(), $this->allowed_country_currency_matrix[ $this->country ], true );
 	}
+
+	/**
+	 * Indicates, whether the current merchant is eligible for Fastlane. Always true,
+	 * but the filter allows other modules to disable Fastlane site-wide.
+	 *
+	 * @return bool
+	 */
+	public function for_merchant() : bool {
+		return apply_filters(
+			'woocommerce_paypal_payments_is_eligible_for_axo',
+			true
+		);
+	}
 }

--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -17,7 +17,7 @@ return array(
 		$save_payment_methods_applies = $container->get( 'card-fields.helpers.save-payment-methods-applies' );
 		assert( $save_payment_methods_applies instanceof CardFieldsApplies );
 
-		return $save_payment_methods_applies->for_country();
+		return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
 	},
 	'card-fields.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ) : CardFieldsApplies {
 		return new CardFieldsApplies(

--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -19,6 +19,14 @@ return array(
 
 		return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
 	},
+	'card-fields.eligibility.check'                    => static function ( ContainerInterface $container ): callable {
+		$save_payment_methods_applies = $container->get( 'card-fields.helpers.save-payment-methods-applies' );
+		assert( $save_payment_methods_applies instanceof CardFieldsApplies );
+
+		return static function () use ( $save_payment_methods_applies ) : bool {
+			return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
+		};
+	},
 	'card-fields.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ) : CardFieldsApplies {
 		return new CardFieldsApplies(
 			$container->get( 'card-fields.supported-country-matrix' ),

--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -13,11 +13,11 @@ use WooCommerce\PayPalCommerce\CardFields\Helper\CardFieldsApplies;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
+	// @deprecated - use `card-fields.eligibility.check` instead.
 	'card-fields.eligible'                             => static function ( ContainerInterface $container ): bool {
-		$save_payment_methods_applies = $container->get( 'card-fields.helpers.save-payment-methods-applies' );
-		assert( $save_payment_methods_applies instanceof CardFieldsApplies );
+		$eligibility_check = $container->get( 'card-fields.eligibility.check' );
 
-		return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
+		return $eligibility_check();
 	},
 	'card-fields.eligibility.check'                    => static function ( ContainerInterface $container ): callable {
 		$save_payment_methods_applies = $container->get( 'card-fields.helpers.save-payment-methods-applies' );

--- a/modules/ppcp-card-fields/src/Helper/CardFieldsApplies.php
+++ b/modules/ppcp-card-fields/src/Helper/CardFieldsApplies.php
@@ -50,4 +50,17 @@ class CardFieldsApplies {
 	public function for_country(): bool {
 		return in_array( $this->country, $this->allowed_country_matrix, true );
 	}
+
+	/**
+	 * Indicates, whether the current merchant is eligible for Card Fields. Always true,
+	 * but the filter allows other modules to disable Card Fields site-wide.
+	 *
+	 * @return bool
+	 */
+	public function for_merchant() : bool {
+		return apply_filters(
+			'woocommerce_paypal_payments_is_eligible_for_card_fields',
+			true
+		);
+	}
 }

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -28,7 +28,7 @@ return array(
 		$apm_applies = $container->get( 'googlepay.helpers.apm-applies' );
 		assert( $apm_applies instanceof ApmApplies );
 
-		return $apm_applies->for_country() && $apm_applies->for_currency();
+		return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
 	},
 
 	'googlepay.helpers.apm-applies'             => static function ( ContainerInterface $container ) : ApmApplies {

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -30,7 +30,14 @@ return array(
 
 		return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
 	},
+	'googlepay.eligibility.check'               => static function ( ContainerInterface $container ): callable {
+		$apm_applies = $container->get( 'googlepay.helpers.apm-applies' );
+		assert( $apm_applies instanceof ApmApplies );
 
+		return static function () use ( $apm_applies ) : bool {
+			return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
+		};
+	},
 	'googlepay.helpers.apm-applies'             => static function ( ContainerInterface $container ) : ApmApplies {
 		return new ApmApplies(
 			$container->get( 'googlepay.supported-countries' ),

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -23,12 +23,11 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
 
-	// If GooglePay can be configured.
+	// @deprecated - use `googlepay.eligibility.check` instead.
 	'googlepay.eligible'                        => static function ( ContainerInterface $container ): bool {
-		$apm_applies = $container->get( 'googlepay.helpers.apm-applies' );
-		assert( $apm_applies instanceof ApmApplies );
+		$eligibility_check = $container->get( 'googlepay.eligibility.check' );
 
-		return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
+		return $eligibility_check();
 	},
 	'googlepay.eligibility.check'               => static function ( ContainerInterface $container ): callable {
 		$apm_applies = $container->get( 'googlepay.helpers.apm-applies' );

--- a/modules/ppcp-googlepay/src/Helper/ApmApplies.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmApplies.php
@@ -83,4 +83,16 @@ class ApmApplies {
 		return in_array( $this->currency->get(), $this->allowed_currencies, true );
 	}
 
+	/**
+	 * Indicates, whether the current merchant is eligible for GooglePay. Always true,
+	 * but the filter allows other modules to disable GooglePay site-wide.
+	 *
+	 * @return bool
+	 */
+	public function for_merchant() : bool {
+		return apply_filters(
+			'woocommerce_paypal_payments_is_eligible_for_googlepay',
+			true
+		);
+	}
 }

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -16,11 +16,11 @@ use WooCommerce\PayPalCommerce\SavePaymentMethods\Helper\SavePaymentMethodsAppli
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
+	// @deprecated - use `save-payment-methods.eligibility.check` instead.
 	'save-payment-methods.eligible'                      => static function ( ContainerInterface $container ): bool {
-		$save_payment_methods_applies = $container->get( 'save-payment-methods.helpers.save-payment-methods-applies' );
-		assert( $save_payment_methods_applies instanceof SavePaymentMethodsApplies );
+		$eligibility_check = $container->get( 'save-payment-methods.eligibility.check' );
 
-		return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
+		return $eligibility_check();
 	},
 	'save-payment-methods.eligibility.check'             => static function ( ContainerInterface $container ): callable {
 		$save_payment_methods_applies = $container->get( 'save-payment-methods.helpers.save-payment-methods-applies' );

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -22,6 +22,14 @@ return array(
 
 		return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
 	},
+	'save-payment-methods.eligibility.check'             => static function ( ContainerInterface $container ): callable {
+		$save_payment_methods_applies = $container->get( 'save-payment-methods.helpers.save-payment-methods-applies' );
+		assert( $save_payment_methods_applies instanceof SavePaymentMethodsApplies );
+
+		return static function () use ( $save_payment_methods_applies ) : bool {
+			return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
+		};
+	},
 	'save-payment-methods.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ) : SavePaymentMethodsApplies {
 		return new SavePaymentMethodsApplies(
 			$container->get( 'save-payment-methods.supported-countries' ),

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -20,7 +20,7 @@ return array(
 		$save_payment_methods_applies = $container->get( 'save-payment-methods.helpers.save-payment-methods-applies' );
 		assert( $save_payment_methods_applies instanceof SavePaymentMethodsApplies );
 
-		return $save_payment_methods_applies->for_country();
+		return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
 	},
 	'save-payment-methods.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ) : SavePaymentMethodsApplies {
 		return new SavePaymentMethodsApplies(

--- a/modules/ppcp-save-payment-methods/src/Helper/SavePaymentMethodsApplies.php
+++ b/modules/ppcp-save-payment-methods/src/Helper/SavePaymentMethodsApplies.php
@@ -48,7 +48,19 @@ class SavePaymentMethodsApplies {
 	 * @return bool
 	 */
 	public function for_country(): bool {
-
 		return in_array( $this->country, $this->allowed_countries, true );
+	}
+
+	/**
+	 * Indicates, whether the current merchant is eligible for Save Payment Methods. Always true,
+	 * but the filter allows other modules to disable Save Payment Methods site-wide.
+	 *
+	 * @return bool
+	 */
+	public function for_merchant() : bool {
+		return apply_filters(
+			'woocommerce_paypal_payments_is_eligible_for_save_payment_methods',
+			true
+		);
 	}
 }

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
@@ -5,7 +5,7 @@ import { ControlToggleButton } from '../../../../../ReusableComponents/Controls'
 import { SettingsHooks } from '../../../../../../data';
 import { useMerchantInfo } from '../../../../../../data/common/hooks';
 
-const SavePaymentMethods = () => {
+const SavePaymentMethods = ( { ownBradOnly } ) => {
 	const {
 		savePaypalAndVenmo,
 		setSavePaypalAndVenmo,
@@ -50,18 +50,21 @@ const SavePaymentMethods = () => {
 				disabled={ ! features.save_paypal_and_venmo.enabled }
 			/>
 
-			<ControlToggleButton
-				label={ __(
-					'Save Credit and Debit Cards',
-					'woocommerce-paypal-payments'
-				) }
-				description={ __(
-					"Securely store your customer's credit card.",
-					'woocommerce-paypal-payments'
-				) }
-				onChange={ setSaveCardDetails }
-				value={ saveCardDetails }
-			/>
+			{ ownBradOnly || (
+				// Credit card settings are only available in "white label" mode.
+				<ControlToggleButton
+					label={ __(
+						'Save Credit and Debit Cards',
+						'woocommerce-paypal-payments'
+					) }
+					description={ __(
+						"Securely store your customer's credit card.",
+						'woocommerce-paypal-payments'
+					) }
+					onChange={ setSaveCardDetails }
+					value={ saveCardDetails }
+				/>
+			) }
 		</SettingsBlock>
 	);
 };

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/CommonSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/CommonSettings.js
@@ -6,7 +6,7 @@ import SavePaymentMethods from './Blocks/SavePaymentMethods';
 import InvoicePrefix from './Blocks/InvoicePrefix';
 import PayNowExperience from './Blocks/PayNowExperience';
 
-const CommonSettings = () => (
+const CommonSettings = ( { ownBradOnly } ) => (
 	<SettingsCard
 		icon="icon-settings-common.svg"
 		title={ __( 'Common settings', 'woocommerce-paypal-payments' ) }
@@ -18,7 +18,7 @@ const CommonSettings = () => (
 	>
 		<InvoicePrefix />
 		<OrderIntent />
-		<SavePaymentMethods />
+		<SavePaymentMethods ownBradOnly={ ownBradOnly } />
 		<PayNowExperience />
 	</SettingsCard>
 );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
@@ -9,9 +9,6 @@ import PaypalSettings from './Blocks/PaypalSettings';
 import OtherSettings from './Blocks/OtherSettings';
 
 const ExpertSettings = () => {
-	const settings = {}; // dummy object
-	const updateFormValue = () => {}; // dummy function
-
 	return (
 		<SettingsCard
 			icon="icon-settings-expert.svg"
@@ -22,38 +19,25 @@ const ExpertSettings = () => {
 				'woocommerce-paypal-payments'
 			) }
 			actionProps={ {
-				callback: updateFormValue,
 				key: 'payNowExperience',
 			} }
 			contentContainer={ false }
 		>
 			<ContentWrapper>
 				{ /*<Content>
-					<ConnectionDetails
-						updateFormValue={ updateFormValue }
-						settings={ settings }
-					/>
+					<ConnectionDetails />
 				</Content>*/ }
 
 				<Content>
-					<Troubleshooting
-						updateFormValue={ updateFormValue }
-						settings={ settings }
-					/>
+					<Troubleshooting />
 				</Content>
 
 				<Content>
-					<PaypalSettings
-						updateFormValue={ updateFormValue }
-						settings={ settings }
-					/>
+					<PaypalSettings />
 				</Content>
 
 				<Content>
-					<OtherSettings
-						updateFormValue={ updateFormValue }
-						settings={ settings }
-					/>
+					<OtherSettings />
 				</Content>
 			</ContentWrapper>
 		</SettingsCard>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
@@ -8,7 +8,7 @@ import Troubleshooting from './Blocks/Troubleshooting';
 import PaypalSettings from './Blocks/PaypalSettings';
 import OtherSettings from './Blocks/OtherSettings';
 
-const ExpertSettings = () => {
+const ExpertSettings = ( { ownBradOnly } ) => {
 	return (
 		<SettingsCard
 			icon="icon-settings-expert.svg"
@@ -36,9 +36,12 @@ const ExpertSettings = () => {
 					<PaypalSettings />
 				</Content>
 
-				<Content>
-					<OtherSettings />
-				</Content>
+				{ ownBradOnly || (
+					// The "other settings" accordion is only relevant in white-label mode.
+					<Content>
+						<OtherSettings />
+					</Content>
+				) }
 			</ContentWrapper>
 		</SettingsCard>
 	);

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -54,6 +54,13 @@ const TabPaymentMethods = () => {
 	const merchant = CommonHooks.useMerchant();
 	const { canUseCardPayments } = OnboardingHooks.useFlags();
 
+	const showCardPayments =
+		methods.cardPayment.length > 0 &&
+		merchant.isBusinessSeller &&
+		canUseCardPayments;
+
+	const showApms = methods.apm.length > 0;
+
 	return (
 		<div className="ppcp-r-payment-methods">
 			<PaymentMethodCard
@@ -68,7 +75,8 @@ const TabPaymentMethods = () => {
 				onTriggerModal={ setActiveModal }
 				methodsMap={ methodsMap }
 			/>
-			{ merchant.isBusinessSeller && canUseCardPayments && (
+
+			{ showCardPayments && (
 				<PaymentMethodCard
 					id="ppcp-card-payments-card"
 					title={ __(
@@ -85,21 +93,24 @@ const TabPaymentMethods = () => {
 					methodsMap={ methodsMap }
 				/>
 			) }
-			<PaymentMethodCard
-				id="ppcp-alternative-payments-card"
-				title={ __(
-					'Alternative Payment Methods',
-					'woocommerce-paypal-payments'
-				) }
-				description={ __(
-					'With alternative payment methods, customers across the globe can pay with their bank accounts and other local payment methods.',
-					'woocommerce-paypal-payments'
-				) }
-				icon="icon-checkout-alternative-methods.svg"
-				methods={ methods.apm }
-				onTriggerModal={ setActiveModal }
-				methodsMap={ methodsMap }
-			/>
+
+			{ showApms && (
+				<PaymentMethodCard
+					id="ppcp-alternative-payments-card"
+					title={ __(
+						'Alternative Payment Methods',
+						'woocommerce-paypal-payments'
+					) }
+					description={ __(
+						'With alternative payment methods, customers across the globe can pay with their bank accounts and other local payment methods.',
+						'woocommerce-paypal-payments'
+					) }
+					icon="icon-checkout-alternative-methods.svg"
+					methods={ methods.apm }
+					onTriggerModal={ setActiveModal }
+					methodsMap={ methodsMap }
+				/>
+			) }
 
 			{ activeModal && (
 				<Modal

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabSettings.js
@@ -2,9 +2,10 @@ import ConnectionStatus from '../Components/Settings/ConnectionStatus';
 import CommonSettings from '../Components/Settings/CommonSettings';
 import ExpertSettings from '../Components/Settings/ExpertSettings';
 import SpinnerOverlay from '../../../ReusableComponents/SpinnerOverlay';
-import { SettingsHooks } from '../../../../data';
+import { CommonHooks, SettingsHooks } from '../../../../data';
 
 const TabSettings = () => {
+	const { ownBrandOnly } = CommonHooks.useWooSettings();
 	const { isReady } = SettingsHooks.useStore();
 
 	if ( ! isReady ) {
@@ -14,8 +15,8 @@ const TabSettings = () => {
 	return (
 		<div className="ppcp-r-settings">
 			<ConnectionStatus />
-			<CommonSettings />
-			<ExpertSettings />
+			<CommonSettings ownBradOnly={ ownBrandOnly } />
+			<ExpertSettings ownBradOnly={ ownBrandOnly } />
 		</div>
 	);
 };

--- a/modules/ppcp-settings/resources/js/data/common/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/common/reducer.js
@@ -32,7 +32,16 @@ const defaultTransient = Object.freeze( {
 	wooSettings: Object.freeze( {
 		storeCountry: '',
 		storeCurrency: '',
-		installationPath: '',
+
+		/**
+		 * The "branded-only" experience is determined on server-side, based on the installation path.
+		 *
+		 * When true, the plugin must only display "PayPal's own brand" payment options
+		 * i.e. no card payments or Apple Pay/Google Pay.
+		 *
+		 * @type {boolean}
+		 */
+		ownBrandOnly: false,
 	} ),
 
 	features: Object.freeze( {

--- a/modules/ppcp-settings/resources/js/data/common/selectors.js
+++ b/modules/ppcp-settings/resources/js/data/common/selectors.js
@@ -44,7 +44,10 @@ export const wooSettings = ( state ) => {
 	const settings = getState( state ).wooSettings || EMPTY_OBJ;
 
 	// For development and testing. Remove this eventually!
-	const simulateBrandedOnly = localStorage.getItem( 'simulate-branded-only' );
+	const simulateBrandedOnly = document.cookie
+		.split( '; ' )
+		.find( ( row ) => row.startsWith( 'simulate-branded-only=' ) )
+		?.split( '=' )[ 1 ];
 
 	/**
 	 * The "own-brand-only" experience is determined on server-side, based on the installation path.

--- a/modules/ppcp-settings/resources/js/data/common/selectors.js
+++ b/modules/ppcp-settings/resources/js/data/common/selectors.js
@@ -43,10 +43,11 @@ export const features = ( state ) => {
 export const wooSettings = ( state ) => {
 	const settings = getState( state ).wooSettings || EMPTY_OBJ;
 
+	// For development and testing. Remove this eventually!
 	const simulateBrandedOnly = localStorage.getItem( 'simulate-branded-only' );
 
 	/**
-	 * The "branded only experience" is determined based on the installation path.
+	 * The "own-brand-only" experience is determined on server-side, based on the installation path.
 	 *
 	 * When true, the plugin must only display "PayPal's own brand" payment options
 	 * i.e. no card payments or Apple Pay/Google Pay.
@@ -54,9 +55,7 @@ export const wooSettings = ( state ) => {
 	 * @type {boolean}
 	 */
 	const ownBrandOnly =
-		'true' === simulateBrandedOnly || // For development and testing. Remove this eventually!
-		settings.installationPath === 'core-profile' ||
-		settings.installationPath === 'payment-settings';
+		'true' === simulateBrandedOnly || settings.ownBrandOnly;
 
 	return { ...settings, ownBrandOnly };
 };

--- a/modules/ppcp-settings/resources/js/data/debug.js
+++ b/modules/ppcp-settings/resources/js/data/debug.js
@@ -168,6 +168,16 @@ export const addDebugTools = ( context, modules ) => {
 		onboarding.persist();
 	};
 
+	/**
+	 * Sets a cookie to simulate the branded-only experience.
+	 * @param {boolean} value - Whether to simulate branded-only experience.
+	 */
+	debugApi.simulateBrandedOnly = ( value ) => {
+		const expirationDate = new Date( Date.now() + 3600000 ).toUTCString();
+		document.cookie = `simulate-branded-only=${ value }; expires=${ expirationDate }; path=/`;
+		window.location.reload();
+	};
+
 	// Expose original debug API.
 	Object.assign( context, debugApi );
 };

--- a/modules/ppcp-settings/resources/js/data/payment/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/payment/hooks.js
@@ -83,34 +83,22 @@ export const usePaymentMethods = () => {
 	const [ pui ] = usePersistent( 'ppcp-pay-upon-invoice-gateway' );
 	const [ oxxo ] = usePersistent( 'ppcp-oxxo-gateway' );
 
-	const payPalCheckout = [ paypal, venmo, payLater, creditCard ];
-	const onlineCardPayments = [
-		advancedCreditCard,
-		fastlane,
-		applePay,
-		googlePay,
-	];
-	const alternative = [
-		bancontact,
-		blik,
-		eps,
-		ideal,
-		mybank,
-		p24,
-		trustly,
-		multibanco,
-		pui,
-		oxxo,
-	];
-	const paymentMethods = [
+	const removeEmpty = ( list ) =>
+		list.filter( ( item ) => item && item.id?.length );
+
+	const payPalCheckout = removeEmpty( [
 		paypal,
 		venmo,
 		payLater,
 		creditCard,
+	] );
+	const onlineCardPayments = removeEmpty( [
 		advancedCreditCard,
 		fastlane,
 		applePay,
 		googlePay,
+	] );
+	const alternative = removeEmpty( [
 		bancontact,
 		blik,
 		eps,
@@ -121,6 +109,12 @@ export const usePaymentMethods = () => {
 		multibanco,
 		pui,
 		oxxo,
+	] );
+
+	const paymentMethods = [
+		...payPalCheckout,
+		...onlineCardPayments,
+		...alternative,
 	];
 
 	return {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -576,10 +576,10 @@ return array(
 
 		return new FeaturesEligibilityService(
 			$container->get( 'save-payment-methods.eligible' ), // Save PayPal and Venmo eligibility.
-			$container->get( 'card-fields.eligible' ), // Advanced credit and debit cards eligibility.
+			$container->get( 'card-fields.eligibility.check' ), // Advanced credit and debit cards eligibility.
 			$apm_eligible, // Alternative payment methods eligibility.
-			$container->get( 'googlepay.eligible' ), // Google Pay eligibility.
-			$container->get( 'applepay.eligible' ), // Apple Pay eligibility.
+			$container->get( 'googlepay.eligibility.check' ), // Google Pay eligibility.
+			$container->get( 'applepay.eligibility.check' ), // Apple Pay eligibility.
 			$pay_later_eligible, // Pay Later eligibility.
 		);
 	},

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -402,6 +402,7 @@ return array(
 
 		return new PaymentMethodsDefinition(
 			$container->get( 'settings.data.payment' ),
+			$container->get( 'settings.data.general' ),
 			$axo_notices
 		);
 	},

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MyBankGateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
@@ -41,6 +42,14 @@ class PaymentMethodsDefinition {
 	private PaymentSettings $settings;
 
 	/**
+	 * Data model for the general plugin settings, used to access flags like
+	 * "own brand only" to modify the payment method details.
+	 *
+	 * @var GeneralSettings
+	 */
+	private GeneralSettings $general_settings;
+
+	/**
 	 * Conflict notices for Axo gateway.
 	 *
 	 * @var array
@@ -57,14 +66,17 @@ class PaymentMethodsDefinition {
 	/**
 	 * Constructor.
 	 *
-	 * @param PaymentSettings $settings Payment methods data model.
+	 * @param PaymentSettings $settings              Payment methods data model.
+	 * @param GeneralSettings $general_settings      General plugin settings model.
 	 * @param array           $axo_conflicts_notices Conflicts notices for Axo.
 	 */
 	public function __construct(
 		PaymentSettings $settings,
+		GeneralSettings $general_settings,
 		array $axo_conflicts_notices = array()
 	) {
 		$this->settings              = $settings;
+		$this->general_settings      = $general_settings;
 		$this->axo_conflicts_notices = $axo_conflicts_notices;
 	}
 
@@ -94,6 +106,7 @@ class PaymentMethodsDefinition {
 				$method['warningMessages'] ?? array(),
 			);
 		}
+
 		return $result;
 	}
 
@@ -105,9 +118,11 @@ class PaymentMethodsDefinition {
 	 * @param string      $title                      Admin-side payment method title.
 	 * @param string      $description                Admin-side info about the payment method.
 	 * @param string      $icon                       Admin-side icon of the payment method.
-	 * @param array|false $fields                     Optional. Additional fields to display in the edit modal.
-	 *                                                Setting this to false omits all fields.
-	 * @param array       $warning_messages           Optional. Warning messages to display in the UI.
+	 * @param array|false $fields                     Optional. Additional fields to display in the
+	 *                                                edit modal. Setting this to false omits all
+	 *                                                fields.
+	 * @param array       $warning_messages           Optional. Warning messages to display in the
+	 *                                                UI.
 	 * @return array Payment method definition.
 	 */
 	private function build_method_definition(
@@ -115,7 +130,7 @@ class PaymentMethodsDefinition {
 		string $title,
 		string $description,
 		string $icon,
-			   $fields = array(),
+		$fields = array(),
 		array $warning_messages = array()
 	) : array {
 		$gateway = $this->wc_gateways[ $gateway_id ] ?? null;
@@ -197,13 +212,16 @@ class PaymentMethodsDefinition {
 				'icon'        => 'payment-method-paypal',
 				'fields'      => false,
 			),
-			array(
+		);
+
+		if ( ! $this->general_settings->own_brand_only() ) {
+			$group[] = array(
 				'id'          => CardButtonGateway::ID,
 				'title'       => __( 'Credit and debit card payments', 'woocommerce-paypal-payments' ),
 				'description' => __( "Accept all major credit and debit cards - even if your customer doesn't have a PayPal account . ", 'woocommerce-paypal-payments' ),
 				'icon'        => 'payment-method-cards',
-			),
-		);
+			);
+		}
 
 		return apply_filters( 'woocommerce_paypal_payments_gateway_group_paypal', $group );
 	}
@@ -214,8 +232,10 @@ class PaymentMethodsDefinition {
 	 * @return array
 	 */
 	public function group_card_methods() : array {
-		$group = array(
-			array(
+		$group = array();
+
+		if ( ! $this->general_settings->own_brand_only() ) {
+			$group[] = array(
 				'id'          => CreditCardGateway::ID,
 				'title'       => __( 'Advanced Credit and Debit Card Payments', 'woocommerce-paypal-payments' ),
 				'description' => __( "Present custom credit and debit card fields to your payers so they can pay with credit and debit cards using your site's branding.", 'woocommerce-paypal-payments' ),
@@ -254,8 +274,8 @@ class PaymentMethodsDefinition {
 						),
 					),
 				),
-			),
-			array(
+			);
+			$group[] = array(
 				'id'              => AxoGateway::ID,
 				'title'           => __( 'Fastlane by PayPal', 'woocommerce-paypal-payments' ),
 				'description'     => __( "Tap into the scale and trust of PayPal's customer network to recognize shoppers and make guest checkout more seamless than ever.", 'woocommerce-paypal-payments' ),
@@ -279,20 +299,20 @@ class PaymentMethodsDefinition {
 					),
 				),
 				'warningMessages' => $this->axo_conflicts_notices,
-			),
-			array(
+			);
+			$group[] = array(
 				'id'          => ApplePayGateway::ID,
 				'title'       => __( 'Apple Pay', 'woocommerce-paypal-payments' ),
 				'description' => __( 'Allow customers to pay via their Apple Pay digital wallet.', 'woocommerce-paypal-payments' ),
 				'icon'        => 'payment-method-apple-pay',
-			),
-			array(
+			);
+			$group[] = array(
 				'id'          => GooglePayGateway::ID,
 				'title'       => __( 'Google Pay', 'woocommerce-paypal-payments' ),
 				'description' => __( 'Allow customers to pay via their Google Pay digital wallet.', 'woocommerce-paypal-payments' ),
 				'icon'        => 'payment-method-google-pay',
-			),
-		);
+			);
+		}
 
 		return apply_filters( 'woocommerce_paypal_payments_gateway_group_cards', $group );
 	}

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -131,7 +131,7 @@ class GeneralSettings extends AbstractDataModel {
 	public function get_woo_settings() : array {
 		$settings = $this->woo_settings;
 
-		$settings['installation_path'] = $this->get_installation_path();
+		$settings['own_brand_only'] = $this->own_brand_only();
 
 		return $settings;
 	}

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -298,4 +298,19 @@ class GeneralSettings extends AbstractDataModel {
 	public function get_installation_path() : string {
 		return $this->data['installation_path'] ?? InstallationPathEnum::DIRECT;
 	}
+
+	/**
+	 * Whether the plugin is in the branded-experience mode and shows/enables only
+	 * payment methods that are PayPal's own brand.
+	 *
+	 * @return bool
+	 */
+	public function own_brand_only() : bool {
+		$brand_only_paths = array(
+			InstallationPathEnum::CORE_PROFILER,
+			InstallationPathEnum::PAYMENT_SETTINGS,
+		);
+
+		return in_array( $this->get_installation_path(), $brand_only_paths, true );
+	}
 }

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -306,6 +306,15 @@ class GeneralSettings extends AbstractDataModel {
 	 * @return bool
 	 */
 	public function own_brand_only() : bool {
+		// Temporary dev/test mode.
+		$simulate_cookie = sanitize_key( wp_unslash( $_COOKIE['simulate-branded-only'] ?? '' ) );
+
+		if ( $simulate_cookie === 'true' ) {
+			return true;
+		} elseif ( $simulate_cookie === 'false' ) {
+			return false;
+		}
+
 		$brand_only_paths = array(
 			InstallationPathEnum::CORE_PROFILER,
 			InstallationPathEnum::PAYMENT_SETTINGS,

--- a/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
@@ -108,11 +108,14 @@ class CommonRestEndpoint extends RestEndpoint {
 	 * @var array
 	 */
 	private array $woo_settings_map = array(
-		'country'  => array(
+		'country'        => array(
 			'js_name' => 'storeCountry',
 		),
-		'currency' => array(
+		'currency'       => array(
 			'js_name' => 'storeCurrency',
+		),
+		'own_brand_only' => array(
+			'js_name' => 'ownBrandOnly',
 		),
 	);
 

--- a/modules/ppcp-settings/src/Service/FeaturesEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/FeaturesEligibilityService.php
@@ -3,13 +3,13 @@
  * PayPal Commerce eligibility service for WooCommerce.
  *
  * This file contains the FeaturesEligibilityService class which manages eligibility checks
- * for various PayPal Commerce features including saving PayPal and Venmo, advanced credit and debit cards,
- * alternative payment methods, Google Pay, Apple Pay, and Pay Later.
+ * for various PayPal Commerce features including saving PayPal and Venmo, advanced credit and
+ * debit cards, alternative payment methods, Google Pay, Apple Pay, and Pay Later.
  *
  * @package WooCommerce\PayPalCommerce\Settings\Service
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service;
 
@@ -22,35 +22,35 @@ class FeaturesEligibilityService {
 	 *
 	 * @var bool
 	 */
-	private bool $is_save_paypal_and_venmo_eligible;
+	private bool $is_save_paypal_eligible;
 
 	/**
 	 * Whether advanced credit and debit cards are eligible.
 	 *
-	 * @var bool
+	 * @var callable
 	 */
-	private bool $is_advanced_credit_and_debit_cards_eligible;
+	private $check_acdc_eligible;
 
 	/**
 	 * Whether alternative payment methods are eligible.
 	 *
 	 * @var bool
 	 */
-	private bool $is_alternative_payment_methods_eligible;
+	private bool $is_apm_eligible;
 
 	/**
 	 * Whether Google Pay is eligible.
 	 *
-	 * @var bool
+	 * @var callable
 	 */
-	private bool $is_google_pay_eligible;
+	private $check_google_pay_eligible;
 
 	/**
 	 * Whether Apple Pay is eligible.
 	 *
-	 * @var bool
+	 * @var callable
 	 */
-	private bool $is_apple_pay_eligible;
+	private $check_apple_pay_eligible;
 
 	/**
 	 * Whether Pay Later is eligible.
@@ -62,27 +62,27 @@ class FeaturesEligibilityService {
 	/**
 	 * Constructor.
 	 *
-	 * @param bool $is_save_paypal_and_venmo_eligible            Whether saving PayPal and Venmo is eligible.
-	 * @param bool $is_advanced_credit_and_debit_cards_eligible  Whether advanced credit and debit cards are eligible.
-	 * @param bool $is_alternative_payment_methods_eligible      Whether alternative payment methods are eligible.
-	 * @param bool $is_google_pay_eligible                       Whether Google Pay is eligible.
-	 * @param bool $is_apple_pay_eligible                        Whether Apple Pay is eligible.
-	 * @param bool $is_pay_later_eligible                        Whether Pay Later is eligible.
+	 * @param bool     $is_save_paypal_eligible   If saving PayPal and Venmo is eligible.
+	 * @param callable $check_acdc_eligible       If advanced credit and debit cards are eligible.
+	 * @param bool     $is_apm_eligible           If alternative payment methods are eligible.
+	 * @param callable $check_google_pay_eligible If Google Pay is eligible.
+	 * @param callable $check_apple_pay_eligible  If Apple Pay is eligible.
+	 * @param bool     $is_pay_later_eligible     If Pay Later is eligible.
 	 */
 	public function __construct(
-		bool $is_save_paypal_and_venmo_eligible,
-		bool $is_advanced_credit_and_debit_cards_eligible,
-		bool $is_alternative_payment_methods_eligible,
-		bool $is_google_pay_eligible,
-		bool $is_apple_pay_eligible,
+		bool $is_save_paypal_eligible,
+		callable $check_acdc_eligible,
+		bool $is_apm_eligible,
+		callable $check_google_pay_eligible,
+		callable $check_apple_pay_eligible,
 		bool $is_pay_later_eligible
 	) {
-		$this->is_save_paypal_and_venmo_eligible           = $is_save_paypal_and_venmo_eligible;
-		$this->is_advanced_credit_and_debit_cards_eligible = $is_advanced_credit_and_debit_cards_eligible;
-		$this->is_alternative_payment_methods_eligible     = $is_alternative_payment_methods_eligible;
-		$this->is_google_pay_eligible                      = $is_google_pay_eligible;
-		$this->is_apple_pay_eligible                       = $is_apple_pay_eligible;
-		$this->is_pay_later_eligible                       = $is_pay_later_eligible;
+		$this->is_save_paypal_eligible   = $is_save_paypal_eligible;
+		$this->check_acdc_eligible       = $check_acdc_eligible;
+		$this->is_apm_eligible           = $is_apm_eligible;
+		$this->check_google_pay_eligible = $check_google_pay_eligible;
+		$this->check_apple_pay_eligible  = $check_apple_pay_eligible;
+		$this->is_pay_later_eligible     = $is_pay_later_eligible;
 	}
 
 	/**
@@ -90,13 +90,13 @@ class FeaturesEligibilityService {
 	 *
 	 * @return array<string, callable>
 	 */
-	public function get_eligibility_checks(): array {
+	public function get_eligibility_checks() : array {
 		return array(
-			'save_paypal_and_venmo'           => fn() => $this->is_save_paypal_and_venmo_eligible,
-			'advanced_credit_and_debit_cards' => fn() => $this->is_advanced_credit_and_debit_cards_eligible,
-			'alternative_payment_methods'     => fn() => $this->is_alternative_payment_methods_eligible,
-			'google_pay'                      => fn() => $this->is_google_pay_eligible,
-			'apple_pay'                       => fn() => $this->is_apple_pay_eligible,
+			'save_paypal_and_venmo'           => fn() => $this->is_save_paypal_eligible,
+			'advanced_credit_and_debit_cards' => $this->check_acdc_eligible,
+			'alternative_payment_methods'     => fn() => $this->is_apm_eligible,
+			'google_pay'                      => $this->check_google_pay_eligible,
+			'apple_pay'                       => $this->check_apple_pay_eligible,
 			'pay_later'                       => fn() => $this->is_pay_later_eligible,
 		);
 	}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -174,6 +174,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		$this->apply_branded_only_limitations( $container );
+
 		add_action(
 			'admin_enqueue_scripts',
 			/**
@@ -636,6 +638,30 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$gateway_redirect_service->register();
 
 		return true;
+	}
+
+	/**
+	 * Checks the branded-only state and applies relevant site-wide feature limitations, if needed.
+	 *
+	 * @param ContainerInterface $container The DI container provider.
+	 * @return void
+	 */
+	protected function apply_branded_only_limitations( ContainerInterface $container ) : void {
+		$settings = $container->get( 'settings.data.general' );
+		assert( $settings instanceof GeneralSettings );
+
+		if ( ! $settings->own_brand_only() ) {
+			return;
+		}
+
+		/**
+		 * In branded-only mode, we completely disable all white label features.
+		 */
+		add_filter( 'woocommerce_paypal_payments_is_eligible_for_applepay', '__return_false' );
+		add_filter( 'woocommerce_paypal_payments_is_eligible_for_googlepay', '__return_false' );
+		add_filter( 'woocommerce_paypal_payments_is_eligible_for_axo', '__return_false' );
+		add_filter( 'woocommerce_paypal_payments_is_eligible_for_save_payment_methods', '__return_false' );
+		add_filter( 'woocommerce_paypal_payments_is_eligible_for_card_fields', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
> Important: This PR extends from #3267 (not from trunk)

### Description

Introduces five new filters that are used to mark the following features as "not eligible" when branded only is active:

- Apple Pay
- Google Pay
- Card Payments
- Fastlane
- Save Payment Methods (tokenization)

#### Eligibility Check Services

Our code previously resolved the eligibility state directly on services initialization: The "service" was a static boolean flag.

A new set of callable services allow our modules to resolve the eligibility after the plugin was fully initialized, and all modules were set up. This allows modules to register relevant filter callbacks and make the eligibility checks more dynamic.

Sample of an old service:
```php
'applepay.eligible' => static function ( ContainerInterface $container ): bool {
    $apm_applies = $container->get( 'applepay.helpers.apm-applies' );
    assert( $apm_applies instanceof ApmApplies );

    return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
},
```


Sample of a new service, which provides full backwards compatibility:
```php
// New service, returns a callable.
'applepay.eligibility.check' => static function ( ContainerInterface $container ): callable {
    $apm_applies = $container->get( 'applepay.helpers.apm-applies' );
    assert( $apm_applies instanceof ApmApplies );

    return static function () use ( $apm_applies ) : bool {
        return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
    };
}

// usage sample / old service; deprecated but present for backwards compatibility.
'applepay.eligible'          => static function ( ContainerInterface $container ): bool {
    $eligibility_check = $container->get( 'applepay.eligibility.check' );

    return $eligibility_check();
}
```