### PR TITLE
Dequeue the ppcp-paypal-subscription on the new UI admin page (4423)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -244,6 +244,9 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					'ppcpSettings',
 					$script_data
 				);
+
+				// Dequeue the PayPal Subscription script.
+				wp_dequeue_script( 'ppcp-paypal-subscription' );
 			}
 		);
 


### PR DESCRIPTION
### Description

This PR will dequeue the `ppcp-paypal-subscription` script on the new UI page.

It will resolve the `Uncaught ReferenceError: PayPalCommerceGatewayPayPalSubscriptionProducts is not defined` console error.