### PR TITLE
Show other payment methods if isn't eligible for WooPayments (4419)

### DIFF
--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Data;
 
+use Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions\DefaultPaymentGateways;
 use RuntimeException;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
@@ -306,6 +307,13 @@ class GeneralSettings extends AbstractDataModel {
 	 * @return bool
 	 */
 	public function own_brand_only() : bool {
+		/**
+		 * If the current store is not eligible for WooPayments, we have to also show the other payment methods.
+		 */
+		if ( ! in_array( $this->woo_settings['country'], DefaultPaymentGateways::get_wcpay_countries(), true ) ) {
+			return false;
+		}
+
 		// Temporary dev/test mode.
 		$simulate_cookie = sanitize_key( wp_unslash( $_COOKIE['simulate-branded-only'] ?? '' ) );
 


### PR DESCRIPTION
## Issue Description

When the merchant country [does not support WooPayments](https://woocommerce.com/document/woopayments/compatibility/countries/), but the installation path is “Core Profiler” we need to apply a hybrid approach:

- The custom BN Code must be used regardless of the WooPayments availability.
- However, all other restrictions (onboarding, settings, front end) do not apply

 Short: When WooPayments is unavailable, the merchant gets the “unbranded experience” except for the custom BN codes on API level (for PayPal reporting)

 ## PR Description
 
 This PR will add a check: If the current store is not eligible for WooPayments, we have to also show the other payment methods.