### PR TITLE
Welcome screen lists "all major credit/debit cards, Apple Pay, Google Pay," in branded-only mode (4445)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
@@ -29,7 +29,7 @@ const StepWelcome = ( { setStep, currentStep } ) => {
 					'woocommerce-paypal-payments'
 			  )
 			: __(
-					'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, and more.',
+					'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, and more.',
 					'woocommerce-paypal-payments'
 			  );
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
@@ -22,15 +22,16 @@ const StepWelcome = ( { setStep, currentStep } ) => {
 		ownBrandOnly
 	);
 
-	const onboardingHeaderDescription = canUseCardPayments
-		? __(
-				'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, Apple Pay, Google Pay, and more.',
-				'woocommerce-paypal-payments'
-		  )
-		: __(
-				'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, and more.',
-				'woocommerce-paypal-payments'
-		  );
+	const onboardingHeaderDescription =
+		! canUseCardPayments || ownBrandOnly
+			? __(
+					'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, and more.',
+					'woocommerce-paypal-payments'
+			  )
+			: __(
+					'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, Apple Pay, Google Pay, and more.',
+					'woocommerce-paypal-payments'
+			  );
 
 	return (
 		<div className="ppcp-r-page-welcome">

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
@@ -23,13 +23,13 @@ const StepWelcome = ( { setStep, currentStep } ) => {
 	);
 
 	const onboardingHeaderDescription =
-		! canUseCardPayments || ownBrandOnly
+		canUseCardPayments && ! ownBrandOnly
 			? __(
-					'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, and more.',
+					'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, Apple Pay, Google Pay, and more.',
 					'woocommerce-paypal-payments'
 			  )
 			: __(
-					'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, Apple Pay, Google Pay, and more.',
+					'Your all-in-one integration for PayPal checkout solutions that enable buyers to pay via PayPal, Pay Later, all major credit/debit cards, and more.',
 					'woocommerce-paypal-payments'
 			  );
 


### PR DESCRIPTION
With this PR in branded-only mode, the description hides the mention to Google or Apple as it does not apply