### PR TITLE
Correct heading in onboarding step 4 in branded-only mode (4444)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
@@ -10,6 +10,7 @@ import PaymentFlow from '../Components/PaymentFlow';
 const StepPaymentMethods = () => {
 	const { optionalMethods, setOptionalMethods } =
 		OnboardingHooks.useOptionalPaymentMethods();
+	const { ownBrandOnly } = CommonHooks.useWooSettings();
 	const { isCasualSeller } = OnboardingHooks.useBusiness();
 
 	const optionalMethodTitle = useMemo( () => {
@@ -41,7 +42,9 @@ const StepPaymentMethods = () => {
 
 	return (
 		<div className="ppcp-r-page-optional-payment-methods">
-			<OnboardingHeader title={ <PaymentStepTitle /> } />
+			<OnboardingHeader
+				title={ <PaymentStepTitle isBrandedOnly={ ownBrandOnly } /> }
+			/>
 			<div className="ppcp-r-inner-container">
 				<OptionSelector
 					multiSelect={ false }
@@ -58,7 +61,13 @@ const StepPaymentMethods = () => {
 
 export default StepPaymentMethods;
 
-const PaymentStepTitle = () => {
+const PaymentStepTitle = ( ownBrandOnly ) => {
+	if ( ownBrandOnly.isBrandedOnly ) {
+		return __(
+			'Add Expanded Checkout for more ways to pay',
+			'woocommerce-paypal-payments'
+		);
+	}
 	return __( 'Add Credit and Debit Cards', 'woocommerce-paypal-payments' );
 };
 


### PR DESCRIPTION
With this PR the payment title in onboarding, step 4 changes depending on `ownBrandOnly.isBrandedOnly`