### PR TITLE
Disable the mini-cart location by default (4442)

### DIFF
--- a/modules/ppcp-settings/src/Data/StylingSettings.php
+++ b/modules/ppcp-settings/src/Data/StylingSettings.php
@@ -56,7 +56,7 @@ class StylingSettings extends AbstractDataModel {
 			'cart'             => new LocationStylingDTO( 'cart' ),
 			'classic_checkout' => new LocationStylingDTO( 'classic_checkout' ),
 			'express_checkout' => new LocationStylingDTO( 'express_checkout' ),
-			'mini_cart'        => new LocationStylingDTO( 'mini_cart' ),
+			'mini_cart'        => new LocationStylingDTO( 'mini_cart', false ),
 			'product'          => new LocationStylingDTO( 'product' ),
 		);
 	}

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -330,7 +330,7 @@ class SettingsDataManager {
 			'cart'             => new LocationStylingDTO( 'cart', true, $methods_full ),
 			'classic_checkout' => new LocationStylingDTO( 'classic_checkout', true, $methods_full ),
 			'express_checkout' => new LocationStylingDTO( 'express_checkout', true, $methods_full ),
-			'mini_cart'        => new LocationStylingDTO( 'mini_cart', true, $methods_full ),
+			'mini_cart'        => new LocationStylingDTO( 'mini_cart', false, $methods_full ),
 			'product'          => new LocationStylingDTO( 'product', true, $methods_own ),
 		);
 


### PR DESCRIPTION
## Issue Description

When setting up PayPal Payments plugin for the first time with the new UI, then the Mini Cart button is enabled by default
Note: The Mini Cart button location should be disabled in the default configuration.

**Acceptance Criteria**
GIVEN the PayPal Payments plugin is installed and in factory settings
WHEN the PayPal account was connected
THEN the Mini Cart button location is disabled by default

## PR Description

The PR sets the default value for the `enabled` property to be `false`