### PR TITLE
Hide the payment methods screen for personal user in branded-only mode (4443)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 
+import { CommonHooks, OnboardingHooks } from '../../../../data';
 import StepWelcome from './StepWelcome';
 import StepBusiness from './StepBusiness';
 import StepProducts from './StepProducts';
@@ -56,11 +57,16 @@ const filterSteps = ( steps, conditions ) => {
 };
 
 export const getSteps = ( flags ) => {
+	const { ownBrandOnly } = CommonHooks.useWooSettings();
+	const { isCasualSeller } = OnboardingHooks.useBusiness();
+
 	const steps = filterSteps( ALL_STEPS, [
 		// Casual selling: Unlock the "Personal Account" choice.
 		( step ) => flags.canUseCasualSelling || step.id !== 'business',
 		// Skip payment methods screen.
-		( step ) => ! flags.shouldSkipPaymentMethods || step.id !== 'methods',
+		( step ) =>
+			! flags.shouldSkipPaymentMethods &&
+			! ( ownBrandOnly && isCasualSeller && step.id === 'methods' ), // personal user in branded-only mode.
 	] );
 
 	const totalStepsCount = steps.length;

--- a/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/hooks.js
@@ -162,10 +162,15 @@ export const useNavigationState = () => {
 	};
 };
 
-export const useDetermineProducts = () => {
-	return useSelect( ( select ) => {
-		return select( STORE_NAME ).determineProductsAndCaps();
-	}, [] );
+export const useDetermineProducts = ( ownBrandOnly ) => {
+	return useSelect(
+		( select ) => {
+			return select( STORE_NAME ).determineProductsAndCaps(
+				ownBrandOnly
+			);
+		},
+		[ ownBrandOnly ]
+	);
 };
 
 export const useFlags = () => {

--- a/modules/ppcp-settings/resources/js/data/onboarding/selectors.js
+++ b/modules/ppcp-settings/resources/js/data/onboarding/selectors.js
@@ -33,10 +33,11 @@ export const flags = ( state ) => {
  * This selector does not return state-values, but uses the state to derive the products-array
  * that should be returned.
  *
- * @param {{}} state
+ * @param {{}}      state
+ * @param {boolean} ownBrandOnly
  * @return {{products:string[], options:{}}} The ISU products, based on choices made in the onboarding wizard.
  */
-export const determineProductsAndCaps = ( state ) => {
+export const determineProductsAndCaps = ( state, ownBrandOnly ) => {
 	/**
 	 * An array of product-names that are used to build an onboarding URL via the
 	 * PartnerReferrals API. To avoid confusion with the "products" property from the
@@ -58,8 +59,12 @@ export const determineProductsAndCaps = ( state ) => {
 	const { isCasualSeller, areOptionalPaymentMethodsEnabled, products } =
 		persistentData( state );
 	const { canUseVaulting, canUseCardPayments } = flags( state );
+	const isBrandedCasualSeller = isCasualSeller && ownBrandOnly;
+
 	const cardPaymentsEligibleAndSelected =
-		canUseCardPayments && areOptionalPaymentMethodsEnabled;
+		canUseCardPayments &&
+		areOptionalPaymentMethodsEnabled &&
+		! isBrandedCasualSeller;
 
 	if ( ! cardPaymentsEligibleAndSelected ) {
 		/**

--- a/modules/ppcp-settings/resources/js/hooks/useHandleConnections.js
+++ b/modules/ppcp-settings/resources/js/hooks/useHandleConnections.js
@@ -31,7 +31,9 @@ export const useHandleOnboardingButton = ( isSandbox ) => {
 	const { onboardingUrl } = isSandbox
 		? CommonHooks.useSandbox()
 		: CommonHooks.useProduction();
-	const { products, options } = OnboardingHooks.useDetermineProducts();
+	const { ownBrandOnly } = CommonHooks.useWooSettings();
+	const { products, options } =
+		OnboardingHooks.useDetermineProducts( ownBrandOnly );
 	const { startActivity } = CommonHooks.useBusyState();
 	const { authenticateWithOAuth } = CommonHooks.useAuthentication();
 	const [ onboardingUrlState, setOnboardingUrl ] = useState( '' );


### PR DESCRIPTION
## Issue description

When in branded-only mode, selecting a personal account results in step 4 being displayed like this:

![image-20250327-175036](https://github.com/user-attachments/assets/1dad1ced-3dd2-46e5-9651-9eb24cd12713)

The “Add Credit and Debit Cards” step should not be displayed for personal users in branded-only mode

**Steps To Reproduce**

- install plugin
- navigate to welcome screen
- enable branded-only mode with `ppcpDebugger.simulateBrandedOnly(true)`
- start onboarding
- select personal account
- observe the “Add Credit and Debit Cards” step being displayed

## PR Description

This PR hides the payment methods screen for personal user in branded-only mode