### PR TITLE
Enabling Save PayPal does not disable Pay Later messaging (4450)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -466,6 +466,10 @@ class SmartButton implements SmartButtonInterface {
 	 * @return bool
 	 */
 	private function render_message_wrapper_registrar(): bool {
+		if ( ! apply_filters( 'woocommerce_paypal_payments_should_render_pay_later_messaging', true ) ) {
+			return false;
+		}
+
 		if ( ! $this->settings_status->is_pay_later_messaging_enabled() || ! $this->settings_status->has_pay_later_messaging_locations() ) {
 			return false;
 		}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -639,10 +639,10 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		assert( $gateway_redirect_service instanceof GatewayRedirectService );
 		$gateway_redirect_service->register();
 
-		// Do not render Pay Later messaging if "Save PayPal and Venmo" setting is enabled.
+		// Do not render Pay Later messaging if the "Save PayPal and Venmo" setting is enabled.
 		add_filter(
 			'woocommerce_paypal_payments_should_render_pay_later_messaging',
-			function() use ( $container ) {
+			static function() use ( $container ): bool {
 				$settings_model = $container->get( 'settings.data.settings' );
 				assert( $settings_model instanceof SettingsModel );
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -646,11 +646,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$settings_model = $container->get( 'settings.data.settings' );
 				assert( $settings_model instanceof SettingsModel );
 
-				if ( $settings_model->get_save_paypal_and_venmo() ) {
-					return false;
-				}
-
-				return true;
+				return ! $settings_model->get_save_paypal_and_venmo();
 			}
 		);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -25,6 +25,7 @@ use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
 use WooCommerce\PayPalCommerce\Settings\Ajax\SwitchSettingsUiEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\RestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Handler\ConnectionListener;
@@ -637,6 +638,21 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$gateway_redirect_service = $container->get( 'settings.service.gateway-redirect' );
 		assert( $gateway_redirect_service instanceof GatewayRedirectService );
 		$gateway_redirect_service->register();
+
+		// Do not render Pay Later messaging if "Save PayPal and Venmo" setting is enabled.
+		add_filter(
+			'woocommerce_paypal_payments_should_render_pay_later_messaging',
+			function() use ( $container ) {
+				$settings_model = $container->get( 'settings.data.settings' );
+				assert( $settings_model instanceof SettingsModel );
+
+				if ( $settings_model->get_save_paypal_and_venmo() ) {
+					return false;
+				}
+
+				return true;
+			}
+		);
 
 		return true;
 	}


### PR DESCRIPTION
When enabling “Save PayPal and Venmo” in Settings it disables Pay Later button correctly, however it does not disable Pay Later messaging in frontend pages.

This PR adds a new `woocommerce_paypal_payments_should_render_pay_later_messaging` filter that allows skip the render of Pay Later messaging. Then the filter is used in the new Settings module which does not render Pay Later messaging if "Save PayPal and Venmo" setting is enabled.