### PR TITLE
Release 3.0.2-rc1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,16 @@
 *** Changelog ***
 
+= 3.0.2 - xxxx-xx-xx =
+* Enhancement - Check the branded-only flag when settings-UI is loaded the first time #3278
+* Enhancement - Implement a Cache-Flush API #3276
+* Enhancement - Disable the mini-cart location by default #3284
+* Fix - Welcome screen lists "all major credit/debit cards, Apple Pay, Google Pay," in branded-only mode #3281
+* Fix - Correct heading in onboarding step 4 in branded-only mode #3282
+* Fix - Hide the payment methods screen for personal user in branded-only mode #3286
+* Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
+* Fix - Settings UI: Fix Feature button links #3285
+* Fix - Create mapping for the 3d_secure_contingency setting. (4410) #3262
+
 = 3.0.1 - 2025-03-26 =
 * Enhancement - Include Fastlane meta on homepage #3151
 * Enhancement - Include Branded-only plugin configuration for certain installation paths 

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@
 * Fix - Hide the payment methods screen for personal user in branded-only mode #3286
 * Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
 * Fix - Settings UI: Fix Feature button links #3285
-* Fix - Create mapping for the 3d_secure_contingency setting. (4410) #3262
+* Fix - Create mapping for the 3d_secure_contingency setting #3262
 
 = 3.0.1 - 2025-03-26 =
 * Enhancement - Include Fastlane meta on homepage #3151

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 6.5
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 3.0.1
+Stable tag: 3.0.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,17 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 6. Main settings screen.
 
 == Changelog ==
+
+= 3.0.2 - xxxx-xx-xx =
+* Enhancement - Check the branded-only flag when settings-UI is loaded the first time #3278
+* Enhancement - Implement a Cache-Flush API #3276
+* Enhancement - Disable the mini-cart location by default #3284
+* Fix - Welcome screen lists "all major credit/debit cards, Apple Pay, Google Pay," in branded-only mode #3281
+* Fix - Correct heading in onboarding step 4 in branded-only mode #3282
+* Fix - Hide the payment methods screen for personal user in branded-only mode #3286
+* Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
+* Fix - Settings UI: Fix Feature button links #3285
+* Fix - Create mapping for the 3d_secure_contingency setting. (4410) #3262
 
 = 3.0.1 - 2025-03-26 =
 * Enhancement - Include Fastlane meta on homepage #3151

--- a/readme.txt
+++ b/readme.txt
@@ -165,7 +165,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Hide the payment methods screen for personal user in branded-only mode #3286
 * Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
 * Fix - Settings UI: Fix Feature button links #3285
-* Fix - Create mapping for the 3d_secure_contingency setting. (4410) #3262
+* Fix - Create mapping for the 3d_secure_contingency setting #3262
 
 = 3.0.1 - 2025-03-26 =
 * Enhancement - Include Fastlane meta on homepage #3151

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     3.0.1
+ * Version:     3.0.2
  * Author:      PayPal
  * Author URI:  https://paypal.com/
  * License:     GPL-2.0
@@ -27,7 +27,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2025-03-25' );
+define( 'PAYPAL_INTEGRATION_DATE', '2025-03-31' );
 define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );


### PR DESCRIPTION
* Enhancement - Check the branded-only flag when settings-UI is loaded the first time #3278
* Enhancement - Implement a Cache-Flush API #3276
* Enhancement - Disable the mini-cart location by default #3284
* Fix - Welcome screen lists "all major credit/debit cards, Apple Pay, Google Pay," in branded-only mode #3281
* Fix - Correct heading in onboarding step 4 in branded-only mode #3282
* Fix - Hide the payment methods screen for personal user in branded-only mode #3286
* Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
* Fix - Settings UI: Fix Feature button links #3285
* Fix - Create mapping for the 3d_secure_contingency setting. (4410) #3262
