### PR TITLE
Fastlane gateway visible on Pay for Order page (4428)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -349,25 +349,25 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			}
 		);
 
-	// Remove Fastlane on the Pay for Order page.
-	add_filter(
-    		'woocommerce_available_payment_gateways',
+		// Remove Fastlane on the Pay for Order page.
+		add_filter(
+			'woocommerce_available_payment_gateways',
 			/**
 			 * Param types removed to avoid third-party issues.
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-    		static function ( $methods ) {
-        		if ( ! is_array( $methods ) || ! is_wc_endpoint_url( 'order-pay' ) ) {
-            		return $methods;
-        	}
-        
-        	// Remove Fastlane if present.
-        	unset( $methods[AxoGateway::ID] );
-        
-        	return $methods;
-    	}
-	);
+			static function ( $methods ) {
+				if ( ! is_array( $methods ) || ! is_wc_endpoint_url( 'order-pay' ) ) {
+					return $methods;
+				}
+
+				// Remove Fastlane if present.
+				unset( $methods[ AxoGateway::ID ] );
+
+				return $methods;
+			}
+		);
 
 		return true;
 	}

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -349,35 +349,25 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			}
 		);
 
-		// we need to remove Fastlane when we are in order pay page
-		add_filter(
-			'woocommerce_available_payment_gateways',
+	// Remove Fastlane on the Pay for Order page.
+	add_filter(
+    		'woocommerce_available_payment_gateways',
 			/**
 			 * Param types removed to avoid third-party issues.
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			static function ( $methods ) use ( $c ) : array {
-				if ( ! is_array( $methods ) ) {
-					return $methods;
-				}
-
-				if (! is_wc_endpoint_url( 'order-pay' )) {
-					return $methods;
-				}
-
-
-				foreach ( $methods as $key => $method ) {
-					if ( $method && $method->id === 'ppcp-axo-gateway' ) {
-						unset( $methods[ $key ] );
-						break;
-					}
-				}
-
-
-				return $methods;
-			}
-		);
+    		static function ( $methods ) {
+        		if ( ! is_array( $methods ) || ! is_wc_endpoint_url( 'order-pay' ) ) {
+            		return $methods;
+        	}
+        
+        	// Remove Fastlane if present.
+        	unset( $methods[AxoGateway::ID] );
+        
+        	return $methods;
+    	}
+	);
 
 		return true;
 	}

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -349,6 +349,36 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			}
 		);
 
+		// we need to remove Fastlane when we are in order pay page
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			static function ( $methods ) use ( $c ) : array {
+				if ( ! is_array( $methods ) ) {
+					return $methods;
+				}
+
+				if (! is_wc_endpoint_url( 'order-pay' )) {
+					return $methods;
+				}
+
+
+				foreach ( $methods as $key => $method ) {
+					if ( $method && $method->id === 'ppcp-axo-gateway' ) {
+						unset( $methods[ $key ] );
+						break;
+					}
+				}
+
+
+				return $methods;
+			}
+		);
+
 		return true;
 	}
 

--- a/modules/ppcp-button/src/Helper/ThreeDSecure.php
+++ b/modules/ppcp-button/src/Helper/ThreeDSecure.php
@@ -20,7 +20,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\CardAuthenticationResultFactory
 class ThreeDSecure {
 
 	const NO_DECISION = 0;
-	const PROCEED    = 1;
+	const PROCEED     = 1;
 	const REJECT      = 2;
 	const RETRY       = 3;
 


### PR DESCRIPTION
We need to remove the Fastlane gateway from the list later and then the `order-pay` endpoint returns true when we are in that page. 
