### PR TITLE
Remove branded-only flag when uninstalling PayPal Payments (4454)

### DIFF
--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -41,6 +41,13 @@ class GeneralSettings extends AbstractDataModel {
 	protected array $woo_settings = array();
 
 	/**
+	 * Contexts in which the installation path can be reset.
+	 */
+	private const ALLOWED_RESET_REASONS = array(
+		'plugin_uninstall',
+	);
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $country              WooCommerce store country.
@@ -298,6 +305,22 @@ class GeneralSettings extends AbstractDataModel {
 	 */
 	public function get_installation_path() : string {
 		return $this->data['wc_installation_path'] ?? InstallationPathEnum::DIRECT;
+	}
+
+	/**
+	 * Resets the installation path to empty string. This method should only be called
+	 * during specific circumstances like plugin uninstallation.
+	 *
+	 * @param string $reason The reason for resetting the path, must be an allowed value.
+	 * @return bool Whether the reset was successful.
+	 */
+	public function reset_installation_path( string $reason ) : bool {
+		if ( ! in_array( $reason, self::ALLOWED_RESET_REASONS, true ) ) {
+			return false;
+		}
+
+		$this->data['wc_installation_path'] = '';
+		return true;
 	}
 
 	/**

--- a/uninstall.php
+++ b/uninstall.php
@@ -42,6 +42,7 @@ require $main_plugin_file;
 		$settings = $app_container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
+		// TODO: This is a flag only present in the #legacy-ui. Should we change this to a filter, or remove the DB reset code?
 		$should_clear_db = $settings->has( 'uninstall_clear_db_on_uninstall' ) && $settings->get( 'uninstall_clear_db_on_uninstall' );
 		if ( ! $should_clear_db ) {
 			return;

--- a/uninstall.php
+++ b/uninstall.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce;
 
@@ -17,16 +17,16 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die( 'Direct access not allowed.' );
 }
 
-$root_dir = __DIR__;
+$root_dir         = __DIR__;
 $main_plugin_file = "{$root_dir}/woocommerce-paypal-payments.php";
 
-if ( !file_exists( $main_plugin_file ) ) {
-    return;
+if ( ! file_exists( $main_plugin_file ) ) {
+	return;
 }
 
 require $main_plugin_file;
 
-( static function (string $root_dir): void {
+( static function ( string $root_dir ) : void {
 
 	$autoload_filepath = "{$root_dir}/vendor/autoload.php";
 	if ( file_exists( $autoload_filepath ) && ! class_exists( '\WooCommerce\PayPalCommerce\PluginModule' ) ) {
@@ -74,4 +74,4 @@ require $main_plugin_file;
 			}
 		);
 	}
-} )($root_dir);
+} )( $root_dir );

--- a/uninstall.php
+++ b/uninstall.php
@@ -11,7 +11,9 @@ namespace WooCommerce\PayPalCommerce;
 
 use WooCommerce\PayPalCommerce\Uninstall\ClearDatabaseInterface;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\NotFoundExceptionInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die( 'Direct access not allowed.' );
@@ -38,6 +40,8 @@ require $main_plugin_file;
 
 		$app_container = $bootstrap( $root_dir );
 		assert( $app_container instanceof ContainerInterface );
+
+		clear_plugin_branding( $app_container );
 
 		$settings = $app_container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
@@ -76,3 +80,24 @@ require $main_plugin_file;
 		);
 	}
 } )( $root_dir );
+
+/**
+ * Clears plugin branding by resetting the installation path flag.
+ *
+ * @param ContainerInterface $container The plugin's DI container.
+ * @return void
+ */
+function clear_plugin_branding( ContainerInterface $container ) : void {
+	try {
+		$general_settings = $container->get( 'wcgateway.settings.general_settings' );
+		assert( $general_settings instanceof GeneralSettings );
+
+		if ( $general_settings->reset_installation_path( 'plugin_uninstall' ) ) {
+			$general_settings->save();
+		}
+	} catch ( NotFoundExceptionInterface $e ) {
+		// The container does not exist or did not return a GeneralSettings instance.
+		// In any case: A failure can be ignored, as it means we cannot reset anything.
+		return;
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -88,6 +88,14 @@ require $main_plugin_file;
  * @return void
  */
 function clear_plugin_branding( ContainerInterface $container ) : void {
+	/*
+	 * This flag is set by WooCommerce when the plugin is installed via their
+	 * Settings page. We remove it here, as uninstalling the plugin should
+	 * open up the possibility of installing it from a different source in
+	 * "white label" mode.
+	 */
+	delete_option( 'woocommerce_paypal_branded' );
+
 	try {
 		$general_settings = $container->get( 'wcgateway.settings.general_settings' );
 		assert( $general_settings instanceof GeneralSettings );


### PR DESCRIPTION
### Description

During plugin uninstallation two flags are cleared from the DB:

1. Our plugin's `installation_path`: This flag effectively triggers the branded-only-experience.
2. WooCommerce's `woocommerce_paypal_branded`: The "installation_path" is defined based on this flag. If this flag would stay in the DB, the plugin would always enter the branded-only mode during next installation, regardless of the actual installation path. Setting this flag on every relevant installation action is a requirement WooCommerce must implement.
