### PR TITLE
Settings UI: Enable Fastlane Watermark by default after onboarding for compatible stores (4457)

### DIFF
--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -234,6 +234,9 @@ class SettingsDataManager {
 		$methods_apm    = $this->methods_definition->group_apms();
 		$all_methods    = array_merge( $methods_paypal, $methods_cards, $methods_apm );
 
+		// Enable the Fastlane watermark by default.
+		$this->payment_methods->set_fastlane_display_watermark( true );
+
 		foreach ( $all_methods as $method ) {
 			$this->payment_methods->toggle_method_state( $method['id'], false );
 		}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -617,7 +617,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 					if ( $compatibility_checker->is_fastlane_compatible() ) {
 						$payment_methods->toggle_method_state( AxoGateway::ID, true );
-						$payment_methods->set_fastlane_display_watermark( true );
 					}
 				}
 			},

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -617,6 +617,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 					if ( $compatibility_checker->is_fastlane_compatible() ) {
 						$payment_methods->toggle_method_state( AxoGateway::ID, true );
+						$payment_methods->set_fastlane_display_watermark( true );
 					}
 				}
 			},


### PR DESCRIPTION
### Description
This PR will enable the `Display Fastlane Watermark` setting by default for new store setups when the store is determined to be Fastlane-compatible.

### Steps to Test
1. Onboard with a merchant that is eligible for Fastlane and the store meets Fastlane compatibility requirements (country/currency)
2. Navigate to the new Settings UI
3. Open the Payment Methods tab and verify that `Display Fastlane Watermark` is enabled

### Screenshot

<img width="1048" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/c36d0ba8-a142-4c6c-ac3f-3cdb40d8fcae" />
