### PR TITLE
Branded-Only: Remove hint for credit cards/wallets from payment method screen (4458)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
@@ -32,7 +32,10 @@ const StepPaymentMethods = () => {
 			description: <OptionalMethodDescription />,
 		},
 		{
-			title: __(
+			title: ownBrandOnly ? __(
+				'No thanks, I prefer to use a different provider for local payment methods',
+				'woocommerce-paypal-payments'
+			) : __(
 				'No thanks, I prefer to use a different provider for processing credit cards, digital wallets, and local payment methods',
 				'woocommerce-paypal-payments'
 			),


### PR DESCRIPTION
### Description

Small change that removes the reference to "Credit cards" and "wallets" from the payment methods screen of the onboarding wizard.