### PR TITLE
Release 3.0.2-rc2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,12 +4,15 @@
 * Enhancement - Check the branded-only flag when settings-UI is loaded the first time #3278
 * Enhancement - Implement a Cache-Flush API #3276
 * Enhancement - Disable the mini-cart location by default #3284
+* Enhancement - Remove branded-only flag when uninstalling PayPal Payments #3295
 * Fix - Welcome screen lists "all major credit/debit cards, Apple Pay, Google Pay," in branded-only mode #3281
 * Fix - Correct heading in onboarding step 4 in branded-only mode #3282
 * Fix - Hide the payment methods screen for personal user in branded-only mode #3286
 * Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
 * Fix - Settings UI: Fix Feature button links #3285
 * Fix - Create mapping for the 3d_secure_contingency setting #3262
+* Fix - Enable Fastlane Watermark by default in new settings UI #3296
+* Fix - Payment method screen is referencing credit cards, digital wallets in branded-only mode #3297
 
 = 3.0.1 - 2025-03-26 =
 * Enhancement - Include Fastlane meta on homepage #3151

--- a/readme.txt
+++ b/readme.txt
@@ -160,12 +160,15 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Enhancement - Check the branded-only flag when settings-UI is loaded the first time #3278
 * Enhancement - Implement a Cache-Flush API #3276
 * Enhancement - Disable the mini-cart location by default #3284
+* Enhancement - Remove branded-only flag when uninstalling PayPal Payments #3295
 * Fix - Welcome screen lists "all major credit/debit cards, Apple Pay, Google Pay," in branded-only mode #3281
 * Fix - Correct heading in onboarding step 4 in branded-only mode #3282
 * Fix - Hide the payment methods screen for personal user in branded-only mode #3286
 * Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
 * Fix - Settings UI: Fix Feature button links #3285
 * Fix - Create mapping for the 3d_secure_contingency setting #3262
+* Fix - Enable Fastlane Watermark by default in new settings UI #3296
+* Fix - Payment method screen is referencing credit cards, digital wallets in branded-only mode #3297
 
 = 3.0.1 - 2025-03-26 =
 * Enhancement - Include Fastlane meta on homepage #3151


### PR DESCRIPTION
[3.0.2-rc1](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/3.0.2-rc1) plus:
* Enhancement - Remove branded-only flag when uninstalling PayPal Payments #3295
* Fix - Enable Fastlane Watermark by default in new settings UI #3296
* Fix - Payment method screen is referencing credit cards, digital wallets in branded-only mode #3297