### PR TITLE
Add capture pre-conditions for card payment source (4461)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -307,9 +307,12 @@ class OrderEndpoint {
 	 * @throws RuntimeException If the request fails.
 	 */
 	public function capture( Order $order ): Order {
+		do_action( 'woocommerce_paypal_payments_before_capture_order', $order );
+
 		if ( $order->status()->is( OrderStatus::COMPLETED ) ) {
 			return $order;
 		}
+
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $order->id() . '/capture';
 		$args   = array(

--- a/modules/ppcp-api-client/src/Entity/CardAuthenticationResult.php
+++ b/modules/ppcp-api-client/src/Entity/CardAuthenticationResult.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The CardauthenticationResult object
+ * The CardAuthenticationResult object
  *
  * @package WooCommerce\PayPalCommerce\ApiClient\Entity
  */

--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\CardFields;
 
 use WooCommerce\PayPalCommerce\CardFields\Helper\CardFieldsApplies;
+use WooCommerce\PayPalCommerce\CardFields\Service\CardCaptureValidator;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
@@ -74,5 +75,8 @@ return array(
 				'NO',
 			)
 		);
+	},
+	'card-fields.service.card-capture-validator'       => static function ( ContainerInterface $container ) : CardCaptureValidator {
+		return new CardCaptureValidator();
 	},
 );

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\CardFields;
 
 use DomainException;
 use Psr\Log\LoggerInterface;
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\CardFields\Service\CardCaptureValidator;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
@@ -185,7 +186,19 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 					$logger = $c->get( 'woocommerce.logger.woocommerce' );
 					assert( $logger instanceof LoggerInterface );
 
-					$logger->warning( "Could not capture order {$order->id()}." );
+					$logger->warning( "Could not capture order {$order->id()}" );
+
+					// Deletes WC order if it exists in PayPal order.
+					$wc_order_id = (int)$order->purchase_units()[0]->custom_id();
+					if( $wc_order_id ) {
+						$wc_order = wc_get_order( $wc_order_id );
+						if ( $wc_order instanceof WC_Order ) {
+							$result = $this->is_hpos_enabled() ? $wc_order->delete(true) : wp_delete_post($wc_order_id, true);
+							if($result) {
+								$logger->info( "Deleting failed WC order #$wc_order_id" );
+							}
+						}
+					}
 
 					throw new DomainException( esc_html__( 'Could not capture the PayPal order.', 'woocommerce-paypal-payments' ) );
 				}
@@ -193,5 +206,23 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 		);
 
 		return true;
+	}
+
+	/**
+	 * Check if HPOS is enabled.
+	 *
+	 * @return bool True if HPOS is enabled, false otherwise.
+	 */
+	private function is_hpos_enabled(): bool {
+		if ( ! class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) ) {
+			return false;
+		}
+
+		// Check if the method exists to avoid errors on older WooCommerce versions
+		if ( method_exists( \Automattic\WooCommerce\Utilities\OrderUtil::class, 'custom_orders_table_usage_is_enabled' ) ) {
+			return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
+		}
+
+		return false;
 	}
 }

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -173,7 +173,7 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 			2
 		);
 
-		// Ensures either order status or 3DS approval for card payment source is valid.
+		// Validates if an order with card payment source can be captured.
 		add_action(
 			'woocommerce_paypal_payments_before_capture_order',
 			function( Order $order ) use ( $c ) {

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -173,7 +173,7 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 			2
 		);
 
-		// Ensures either order status or 3DS approval for card payment source is correct.
+		// Ensures either order status or 3DS approval for card payment source is valid.
 		add_action(
 			'woocommerce_paypal_payments_before_capture_order',
 			function( Order $order ) use ( $c ) {

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\CardFields;
 
+use DomainException;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\CardFields\Service\CardCaptureValidator;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -168,6 +171,19 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 			},
 			10,
 			2
+		);
+
+		// Ensures either order status or 3DS approval for card payment source is correct.
+		add_action(
+			'woocommerce_paypal_payments_before_capture_order',
+			function( Order $order ) use ( $c ) {
+				$validator = $c->get( 'card-fields.service.card-capture-validator' );
+				assert( $validator instanceof CardCaptureValidator );
+
+				if ( ! $validator->is_valid( $order ) ) {
+					throw new DomainException( 'Could not capture the order' );
+				}
+			}
 		);
 
 		return true;

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -188,18 +188,6 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 
 					$logger->warning( "Could not capture order {$order->id()}" );
 
-					// Deletes WC order if it exists in PayPal order.
-					$wc_order_id = (int)$order->purchase_units()[0]->custom_id();
-					if( $wc_order_id ) {
-						$wc_order = wc_get_order( $wc_order_id );
-						if ( $wc_order instanceof WC_Order ) {
-							$result = $this->is_hpos_enabled() ? $wc_order->delete(true) : wp_delete_post($wc_order_id, true);
-							if($result) {
-								$logger->info( "Deleting failed WC order #$wc_order_id" );
-							}
-						}
-					}
-
 					throw new DomainException( esc_html__( 'Could not capture the PayPal order.', 'woocommerce-paypal-payments' ) );
 				}
 			}

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -11,7 +11,6 @@ namespace WooCommerce\PayPalCommerce\CardFields;
 
 use DomainException;
 use Psr\Log\LoggerInterface;
-use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\CardFields\Service\CardCaptureValidator;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
@@ -188,29 +187,16 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 
 					$logger->warning( "Could not capture order {$order->id()}" );
 
+					if ( apply_filters( 'woocommerce_paypal_payments_force_delete_wc_order_on_failed_capture', true ) ) {
+						// Add delete order flag in WC session to force delete on process payment failure handler.
+						WC()->session->set( 'ppcp_delete_wc_order_on_payment_failure', true );
+					}
+
 					throw new DomainException( esc_html__( 'Could not capture the PayPal order.', 'woocommerce-paypal-payments' ) );
 				}
 			}
 		);
 
 		return true;
-	}
-
-	/**
-	 * Check if HPOS is enabled.
-	 *
-	 * @return bool True if HPOS is enabled, false otherwise.
-	 */
-	private function is_hpos_enabled(): bool {
-		if ( ! class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) ) {
-			return false;
-		}
-
-		// Check if the method exists to avoid errors on older WooCommerce versions
-		if ( method_exists( \Automattic\WooCommerce\Utilities\OrderUtil::class, 'custom_orders_table_usage_is_enabled' ) ) {
-			return \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled();
-		}
-
-		return false;
 	}
 }

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\CardFields;
 
 use DomainException;
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\CardFields\Service\CardCaptureValidator;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
@@ -181,7 +182,12 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 				assert( $validator instanceof CardCaptureValidator );
 
 				if ( ! $validator->is_valid( $order ) ) {
-					throw new DomainException( 'Could not capture the order' );
+					$logger = $c->get( 'woocommerce.logger.woocommerce' );
+					assert( $logger instanceof LoggerInterface );
+
+					$logger->warning( "Could not capture order {$order->id()}." );
+
+					throw new DomainException( esc_html__( 'Could not capture the PayPal order.', 'woocommerce-paypal-payments' ) );
 				}
 			}
 		);

--- a/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
+++ b/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
@@ -31,18 +31,20 @@ class CardCaptureValidator {
 		}
 
 		$payment_source = $order->payment_source();
-		if ( $payment_source && $payment_source->name() !== 'card' ) {
-			return true;
-		}
+		if ( $payment_source ) {
+			if ( $payment_source->name() !== 'card' ) {
+				return true;
+			}
 
-		/**
-		 * The LiabilityShift response determines how you might proceed with authentication.
-		 *
-		 * @link https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/response-parameters/
-		 */
-		$liability_shift = $payment_source->properties()->authentication_result->liability_shift ?? '';
-		if ( in_array( $liability_shift, array( 'POSSIBLE', 'YES' ), true ) ) {
-			return true;
+			/**
+			 * The LiabilityShift response determines how you might proceed with authentication.
+			 *
+			 * @link https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/response-parameters/
+			 */
+			$liability_shift = $payment_source->properties()->authentication_result->liability_shift ?? '';
+			if ( in_array( $liability_shift, array( 'POSSIBLE', 'YES' ), true ) ) {
+				return true;
+			}
 		}
 
 		return false;

--- a/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
+++ b/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
@@ -25,13 +25,23 @@ class CardCaptureValidator {
 	 * @return bool
 	 */
 	public function is_valid( Order $order ): bool {
+		$order_status = $order->status();
+		if ( $order_status->name() === OrderStatus::APPROVED ) {
+			return true;
+		}
+
 		$payment_source = $order->payment_source();
 		if ( $payment_source && $payment_source->name() !== 'card' ) {
 			return true;
 		}
 
-		$order_status = $order->status();
-		if ( $order_status->name() === OrderStatus::APPROVED ) {
+		/**
+		 * The LiabilityShift response determines how you might proceed with authentication.
+		 *
+		 * @link https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/response-parameters/
+		 */
+		$liability_shift = $payment_source->properties()->authentication_result->liability_shift ?? '';
+		if ( in_array( $liability_shift, array( 'POSSIBLE', 'YES' ), true ) ) {
 			return true;
 		}
 

--- a/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
+++ b/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
@@ -37,7 +37,7 @@ class CardCaptureValidator {
 			}
 
 			/**
-			 * The LiabilityShift response determines how you might proceed with authentication.
+			 * LiabilityShift determines how to proceed with authentication.
 			 *
 			 * @link https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/response-parameters/
 			 */

--- a/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
+++ b/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Service for checking if an order with card payment source can be captured.
+ *
+ * @package WooCommerce\PayPalCommerce\CardFields\Service
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\CardFields\Service;
+
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+
+/**
+ * CardCaptureValidator constructor.
+ */
+class CardCaptureValidator {
+
+	/**
+	 * Checks whether an order is valid for capture.
+	 *
+	 * @param Order $order PayPal order.
+	 *
+	 * @return bool
+	 */
+	public function is_valid( Order $order ): bool {
+		$payment_source = $order->payment_source();
+		if ( $payment_source && $payment_source->name() !== 'card' ) {
+			return true;
+		}
+
+		$order_status = $order->status();
+		if ( $order_status->name() === OrderStatus::APPROVED ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
+++ b/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
@@ -13,7 +13,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 
 /**
- * CardCaptureValidator constructor.
+ * CardCaptureValidator class.
  */
 class CardCaptureValidator {
 
@@ -31,22 +31,21 @@ class CardCaptureValidator {
 		}
 
 		$payment_source = $order->payment_source();
-		if ( $payment_source ) {
-			if ( $payment_source->name() !== 'card' ) {
-				return true;
-			}
-
-			/**
-			 * LiabilityShift determines how to proceed with authentication.
-			 *
-			 * @link https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/response-parameters/
-			 */
-			$liability_shift = $payment_source->properties()->authentication_result->liability_shift ?? '';
-			if ( in_array( $liability_shift, array( 'POSSIBLE', 'YES' ), true ) ) {
-				return true;
-			}
+		if ( ! $payment_source ) {
+			return false;
 		}
 
-		return false;
+		if ( $payment_source->name() !== 'card' ) {
+			return true;
+		}
+
+		/**
+		 * LiabilityShift determines how to proceed with authentication.
+		 *
+		 * @link https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/response-parameters/
+		 */
+		$liability_shift = $payment_source->properties()->authentication_result->liability_shift ?? '';
+
+		return in_array( $liability_shift, array( 'POSSIBLE', 'YES' ), true );
 	}
 }

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -538,7 +538,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 						),
 						'product_id' => $product->get_id(),
 						'i18n'       => array(
-							'prices_must_be_above_zero' => __( 'Prices must be above zero for PayPal Subscriptions!', 'woocommerce-paypal-payments' ),
+							'prices_must_be_above_zero'   => __( 'Prices must be above zero for PayPal Subscriptions!', 'woocommerce-paypal-payments' ),
 							'not_allowed_period_interval' => __( 'Not allowed period interval combination for PayPal Subscriptions!', 'woocommerce-paypal-payments' ),
 						),
 					)

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -544,8 +544,6 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 					$error
 				)
 			);
-		} catch ( DomainException $error ) {
-			return $this->handle_payment_failure( $wc_order, $error, true );
 		} catch ( Exception $error ) {
 			return $this->handle_payment_failure( $wc_order, $error );
 		}

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
+use DomainException;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WC_Order;
@@ -543,7 +544,10 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 					$error
 				)
 			);
-		} catch ( Exception $error ) {
+		} catch ( DomainException $error ) {
+			return $this->handle_payment_failure( $wc_order, $error, true );
+		}
+		catch ( Exception $error ) {
 			return $this->handle_payment_failure( $wc_order, $error );
 		}
 	}

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -546,8 +546,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			);
 		} catch ( DomainException $error ) {
 			return $this->handle_payment_failure( $wc_order, $error, true );
-		}
-		catch ( Exception $error ) {
+		} catch ( Exception $error ) {
 			return $this->handle_payment_failure( $wc_order, $error );
 		}
 	}

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -24,7 +24,7 @@ trait ProcessPaymentTrait {
 	 *
 	 * @param WC_Order|null $wc_order The order.
 	 * @param Exception     $error The error causing the failure.
-	 * @param bool         $delete_order Whether to delete the order.
+	 * @param bool          $delete_order Whether to delete the order.
 	 * @return array The data that can be returned by the gateway process_payment method.
 	 */
 	protected function handle_payment_failure( ?WC_Order $wc_order, Exception $error, bool $delete_order = false ): array {
@@ -36,7 +36,7 @@ trait ProcessPaymentTrait {
 				$this->format_exception( $error )
 			);
 
-			if($delete_order) {
+			if ( $delete_order ) {
 				$wc_order->delete( true );
 			}
 		}

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -35,7 +35,7 @@ trait ProcessPaymentTrait {
 				$this->format_exception( $error )
 			);
 
-			if ( WC()->session->get( 'ppcp_delete_wc_order_on_payment_failure' ) ) {
+			if ( WC()->session->get( 'ppcp_delete_wc_order_on_payment_failure' ) ?? false ) {
 				$wc_order->delete( true );
 			}
 		}

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -24,10 +24,9 @@ trait ProcessPaymentTrait {
 	 *
 	 * @param WC_Order|null $wc_order The order.
 	 * @param Exception     $error The error causing the failure.
-	 * @param bool          $delete_order Whether to delete the order.
 	 * @return array The data that can be returned by the gateway process_payment method.
 	 */
-	protected function handle_payment_failure( ?WC_Order $wc_order, Exception $error, bool $delete_order = false ): array {
+	protected function handle_payment_failure( ?WC_Order $wc_order, Exception $error ): array {
 		$this->logger->error( 'Payment failed: ' . $this->format_exception( $error ) );
 
 		if ( $wc_order ) {
@@ -36,13 +35,14 @@ trait ProcessPaymentTrait {
 				$this->format_exception( $error )
 			);
 
-			if ( $delete_order ) {
+			if ( WC()->session->get( 'ppcp_delete_wc_order_on_payment_failure' ) ) {
 				$wc_order->delete( true );
 			}
 		}
 
 		$this->session_handler->destroy_session_data();
 		WC()->session->set( 'ppcp_subscription_id', '' );
+		WC()->session->set( 'ppcp_delete_wc_order_on_payment_failure', false );
 
 		wc_add_notice( $error->getMessage(), 'error' );
 

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -24,9 +24,10 @@ trait ProcessPaymentTrait {
 	 *
 	 * @param WC_Order|null $wc_order The order.
 	 * @param Exception     $error The error causing the failure.
+	 * @param bool         $delete_order Whether to delete the order.
 	 * @return array The data that can be returned by the gateway process_payment method.
 	 */
-	protected function handle_payment_failure( ?WC_Order $wc_order, Exception $error ): array {
+	protected function handle_payment_failure( ?WC_Order $wc_order, Exception $error, bool $delete_order = false ): array {
 		$this->logger->error( 'Payment failed: ' . $this->format_exception( $error ) );
 
 		if ( $wc_order ) {
@@ -34,6 +35,10 @@ trait ProcessPaymentTrait {
 				'failed',
 				$this->format_exception( $error )
 			);
+
+			if($delete_order) {
+				$wc_order->delete( true );
+			}
 		}
 
 		$this->session_handler->destroy_session_data();

--- a/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
+++ b/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\CardFields\Service;
 
@@ -11,31 +11,54 @@ use WooCommerce\PayPalCommerce\TestCase;
 
 class CardCaptureValidatorTest extends TestCase {
 
-	public function test_is_valid_when_payment_source_is_not_card() {
-		$validator = new CardCaptureValidator();
-
-		$order = Mockery::mock(Order::class);
-		$paymentSource = Mockery::mock(PaymentSource::class);
-
-		$order->shouldReceive('payment_source')->andReturn($paymentSource);
-		$paymentSource->shouldReceive('name')->andReturn('foo');
-
-		$this->assertTrue($validator->is_valid($order));
-	}
-
 	public function test_is_valid_if_order_status_is_approved() {
 		$validator = new CardCaptureValidator();
 
-		$order = Mockery::mock(Order::class);
-		$paymentSource = Mockery::mock(PaymentSource::class);
-		$orderStatus = Mockery::mock(OrderStatus::class);
+		$order       = Mockery::mock( Order::class );
+		$orderStatus = Mockery::mock( OrderStatus::class );
 
-		$order->shouldReceive('payment_source')->andReturn($paymentSource);
-		$paymentSource->shouldReceive('name')->andReturn('card');
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::APPROVED );
 
-		$order->shouldReceive('status')->andReturn($orderStatus);
-		$orderStatus->shouldReceive('name')->andReturn($orderStatus::APPROVED);
+		$this->assertTrue( $validator->is_valid( $order ) );
+	}
 
-		$this->assertTrue($validator->is_valid($order));
+	public function test_is_valid_when_payment_source_is_not_card() {
+		$validator = new CardCaptureValidator();
+
+		$order         = Mockery::mock( Order::class );
+		$orderStatus   = Mockery::mock( OrderStatus::class );
+		$paymentSource = Mockery::mock( PaymentSource::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
+
+		$order->shouldReceive( 'payment_source' )->andReturn( $paymentSource );
+		$paymentSource->shouldReceive( 'name' )->andReturn( 'foo' );
+
+		$this->assertTrue( $validator->is_valid( $order ) );
+	}
+
+	public function test_is_valid_if_authentication_result_passes_3ds_approval() {
+		$validator = new CardCaptureValidator();
+
+		$order         = Mockery::mock( Order::class );
+		$orderStatus   = Mockery::mock( OrderStatus::class );
+		$paymentSource = Mockery::mock( PaymentSource::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
+
+		$order->shouldReceive( 'payment_source' )->andReturn( $paymentSource );
+		$paymentSource->shouldReceive( 'name' )->andReturn( 'card' );
+
+		$paymentSource->shouldReceive( 'properties' )->andReturn( (object) [
+			'authentication_result' => (object) [
+				'liability_shift' => 'POSSIBLE',
+			]
+		] );
+
+		$this->assertTrue( $validator->is_valid( $order ) );
+
 	}
 }

--- a/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
+++ b/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\CardFields\Service;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
+use WooCommerce\PayPalCommerce\TestCase;
+
+class CardCaptureValidatorTest extends TestCase {
+
+	public function test_is_valid_when_payment_source_is_not_card() {
+		$validator = new CardCaptureValidator();
+
+		$order = Mockery::mock(Order::class);
+		$paymentSource = Mockery::mock(PaymentSource::class);
+
+		$order->shouldReceive('payment_source')->andReturn($paymentSource);
+		$paymentSource->shouldReceive('name')->andReturn('foo');
+
+		$this->assertTrue($validator->is_valid($order));
+	}
+
+	public function test_is_valid_if_order_status_is_approved() {
+		$validator = new CardCaptureValidator();
+
+		$order = Mockery::mock(Order::class);
+		$paymentSource = Mockery::mock(PaymentSource::class);
+		$orderStatus = Mockery::mock(OrderStatus::class);
+
+		$order->shouldReceive('payment_source')->andReturn($paymentSource);
+		$paymentSource->shouldReceive('name')->andReturn('card');
+
+		$order->shouldReceive('status')->andReturn($orderStatus);
+		$orderStatus->shouldReceive('name')->andReturn($orderStatus::APPROVED);
+
+		$this->assertTrue($validator->is_valid($order));
+	}
+}

--- a/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
+++ b/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
@@ -11,7 +11,7 @@ use WooCommerce\PayPalCommerce\TestCase;
 
 class CardCaptureValidatorTest extends TestCase {
 
-	public function test_is_valid_if_order_status_is_approved() {
+	public function test_is_valid_when_order_status_is_approved() {
 		$validator = new CardCaptureValidator();
 
 		$order       = Mockery::mock( Order::class );
@@ -39,7 +39,7 @@ class CardCaptureValidatorTest extends TestCase {
 		$this->assertTrue( $validator->is_valid( $order ) );
 	}
 
-	public function test_is_valid_if_authentication_result_passes_3ds_approval() {
+	public function test_is_valid_when_authentication_result_passes_3ds_approval() {
 		$validator = new CardCaptureValidator();
 
 		$order         = Mockery::mock( Order::class );
@@ -48,7 +48,6 @@ class CardCaptureValidatorTest extends TestCase {
 
 		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
 		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
-
 		$order->shouldReceive( 'payment_source' )->andReturn( $paymentSource );
 		$paymentSource->shouldReceive( 'name' )->andReturn( 'card' );
 
@@ -59,6 +58,5 @@ class CardCaptureValidatorTest extends TestCase {
 		] );
 
 		$this->assertTrue( $validator->is_valid( $order ) );
-
 	}
 }


### PR DESCRIPTION
For non-3DS ACDC transactions, after a successful JSSDK call to confirm-payment-source endpoint, further GET calls register order status as `APPROVED`. It does look like that in the case of 3DS, the order status remains as `CREATED`.

In order to prevent capturing orders with the wrong status or without 3DS approval this PR adds the following pre-conditions:

- When `payment_source` = `card`.
    - .capture call only if status = `APPROVED`
    - OR `authentication_result` object is present and passes 3DS approval logic.

If these conditions doesn’t match then we’ll throw an exception which would prevent the `.capture` endpoint to be called.

### What this PR does
- Add new `CardCaptureValidator` class that implements the validation logic
- Add new action `woocommerce_paypal_payments_before_capture_order` to validate orders before capture
- Forces deletion of WC order on failed capture with a filter to disable it
- Add unit tests to ensure capture card validation works correctly across different scenarios