### PR TITLE
option with BN code not created in branded-only mode (4470)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -156,22 +156,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				&& update_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI, 'yes' )
 		);
 
-		/**
-		 * This hook is fired when the plugin is installed or updated.
-		 */
-		add_action(
-			'woocommerce_paypal_payments_gateway_migrate',
-			static function () use ( $container ) {
-				$partner_attribution = $container->get( 'api.helper.partner-attribution' );
-				assert( $partner_attribution instanceof PartnerAttribution );
-
-				$general_settings = $container->get( 'settings.data.general' );
-				assert( $general_settings instanceof GeneralSettings );
-
-				$partner_attribution->initialize_bn_code( $general_settings->get_installation_path() );
-			}
-		);
-
 		$this->apply_branded_only_limitations( $container );
 
 		add_action(
@@ -705,7 +689,15 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$path_repository = $container->get( 'settings.service.branded-experience.path-repository' );
 		assert( $path_repository instanceof PathRepository );
 
+		$partner_attribution = $container->get( 'api.helper.partner-attribution' );
+		assert( $partner_attribution instanceof PartnerAttribution );
+
+		$general_settings = $container->get( 'settings.data.general' );
+		assert( $general_settings instanceof GeneralSettings );
+
 		$path_repository->persist();
+
+		$partner_attribution->initialize_bn_code( $general_settings->get_installation_path() );
 	}
 
 	/**


### PR DESCRIPTION
The option that controls the BN code in branded-only mode is not created.

### Steps To Reproduce
- set up plugin in branded-only mode
- navigate to any (classic) page with PayPal button
- type `PayPalCommerceGateway` in the browser console

Observe BN code is Woo_PPCP:

![image-20250404-073228](https://github.com/user-attachments/assets/0061d2e7-e7ea-4e3f-93d7-35e21ad408ff)
