### PR TITLE
Fix the unresponsive product editing screen for variable products (PayPal Subscriptions API error) (4465)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/resources/js/paypal-subscription.js
+++ b/modules/ppcp-paypal-subscriptions/resources/js/paypal-subscription.js
@@ -1,8 +1,6 @@
-import { __ } from '@wordpress/i18n';
 document.addEventListener( 'DOMContentLoaded', () => {
-
 	const disableFields = ( productId ) => {
-        const variations = document.querySelector( '.woocommerce_variations' );
+		const variations = document.querySelector( '.woocommerce_variations' );
 		if ( variations ) {
 			const children = variations.children;
 			for ( let i = 0; i < children.length; i++ ) {
@@ -70,156 +68,232 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		soldIndividually.setAttribute( 'disabled', 'disabled' );
 	};
 
-    const checkSubscriptionPeriodsInterval = (period, period_interval, price, linkBtn) => {
-        if (
-            ( period === 'year' && parseInt( period_interval ) > 1 ) ||
-            ( period === 'month' && parseInt( period_interval ) > 12 ) ||
-            ( period === 'week' && parseInt( period_interval ) > 52 ) ||
-            ( period === 'day' && parseInt( period_interval ) > 356 ) ||
-            ( ! price || parseInt( price ) <= 0 )
-        ) {
-            linkBtn.disabled = true;
-            linkBtn.checked = false;
-            if (! price || parseInt( price ) <= 0 ) {
-                linkBtn.setAttribute('title', __( 'Prices must be above zero for PayPal Subscriptions!', 'woocommerce-paypal-subscriptions' ) );
-            } else {
-                linkBtn.setAttribute('title', __( 'Not allowed period interval combination for PayPal Subscriptions!', 'woocommerce-paypal-subscriptions' ) );
-            }
+	const checkSubscriptionPeriodsInterval = (
+		period,
+		period_interval,
+		price,
+		linkBtn
+	) => {
+		if ( ! linkBtn ) {
+			return;
+		}
 
-        } else {
-            linkBtn.disabled = false;
-            linkBtn.removeAttribute('title');
-        }
-    }
+		if (
+			( period === 'year' && parseInt( period_interval ) > 1 ) ||
+			( period === 'month' && parseInt( period_interval ) > 12 ) ||
+			( period === 'week' && parseInt( period_interval ) > 52 ) ||
+			( period === 'day' && parseInt( period_interval ) > 356 ) ||
+			! price ||
+			parseInt( price ) <= 0
+		) {
+			linkBtn.disabled = true;
+			linkBtn.checked = false;
+			if ( ! price || parseInt( price ) <= 0 ) {
+				linkBtn.setAttribute(
+					'title',
+					PayPalCommerceGatewayPayPalSubscriptionProducts.i18n
+						.prices_must_be_above_zero
+				);
+			} else {
+				linkBtn.setAttribute(
+					'title',
+					PayPalCommerceGatewayPayPalSubscriptionProducts.i18n
+						.not_allowed_period_interval
+				);
+			}
+		} else {
+			linkBtn.disabled = false;
+			linkBtn.removeAttribute( 'title' );
+		}
+	};
 
 	const setupProducts = () => {
-        jQuery( '.wc_input_subscription_period' ).on( 'change', (e) => {
-            const linkBtn = e.target.parentElement.parentElement.parentElement.parentElement.querySelector('input[name="_ppcp_enable_subscription_product"]');
-            const period_interval = e.target.parentElement.querySelector('select.wc_input_subscription_period_interval')?.value;
-            const period = e.target.value;
-            const price = e.target.parentElement.querySelector('input.wc_input_subscription_price')?.value;
+		jQuery( '.wc_input_subscription_period' ).on( 'change', ( e ) => {
+			const linkBtn =
+				e.target.parentElement.parentElement.parentElement.parentElement.querySelector(
+					'input[name="_ppcp_enable_subscription_product"]'
+				);
+			if ( linkBtn ) {
+				const period_interval = e.target.parentElement.querySelector(
+					'select.wc_input_subscription_period_interval'
+				)?.value;
+				const period = e.target.value;
+				const price = e.target.parentElement.querySelector(
+					'input.wc_input_subscription_price'
+				)?.value;
 
-            checkSubscriptionPeriodsInterval(period, period_interval, price, linkBtn);
-        });
+				checkSubscriptionPeriodsInterval(
+					period,
+					period_interval,
+					price,
+					linkBtn
+				);
+			}
+		} );
 
-        jQuery( '.wc_input_subscription_period_interval' ).on( 'change', (e) => {
-            const linkBtn = e.target.parentElement.parentElement.parentElement.parentElement.querySelector('input[name="_ppcp_enable_subscription_product"]');
-            const period_interval = e.target.value;
-            const period = e.target.parentElement.querySelector('select.wc_input_subscription_period')?.value;
-            const price = e.target.parentElement.querySelector('input.wc_input_subscription_price')?.value;
+		jQuery( '.wc_input_subscription_period_interval' ).on(
+			'change',
+			( e ) => {
+				const linkBtn =
+					e.target.parentElement.parentElement.parentElement.parentElement.querySelector(
+						'input[name="_ppcp_enable_subscription_product"]'
+					);
+				if ( linkBtn ) {
+					const period_interval = e.target.value;
+					const period = e.target.parentElement.querySelector(
+						'select.wc_input_subscription_period'
+					)?.value;
+					const price = e.target.parentElement.querySelector(
+						'input.wc_input_subscription_price'
+					)?.value;
 
-            checkSubscriptionPeriodsInterval(period, period_interval, price, linkBtn);
-        });
+					checkSubscriptionPeriodsInterval(
+						period,
+						period_interval,
+						price,
+						linkBtn
+					);
+				}
+			}
+		);
 
-        jQuery( '.wc_input_subscription_price' ).on( 'change', (e) => {
-            const linkBtn = e.target.parentElement.parentElement.parentElement.parentElement.querySelector('input[name="_ppcp_enable_subscription_product"]');
-            const period_interval = e.target.parentElement.querySelector('select.wc_input_subscription_period_interval')?.value;
-            const period = e.target.parentElement.querySelector('select.wc_input_subscription_period')?.value;
-            const price = e.target.value;
+		jQuery( '.wc_input_subscription_price' ).on( 'change', ( e ) => {
+			const linkBtn =
+				e.target.parentElement.parentElement.parentElement.parentElement.querySelector(
+					'input[name="_ppcp_enable_subscription_product"]'
+				);
+			if ( linkBtn ) {
+				const period_interval = e.target.parentElement.querySelector(
+					'select.wc_input_subscription_period_interval'
+				)?.value;
+				const period = e.target.parentElement.querySelector(
+					'select.wc_input_subscription_period'
+				)?.value;
+				const price = e.target.value;
 
-            checkSubscriptionPeriodsInterval(period, period_interval, price, linkBtn);
-        });
+				checkSubscriptionPeriodsInterval(
+					period,
+					period_interval,
+					price,
+					linkBtn
+				);
+			}
+		} );
 
-        jQuery( '.wc_input_subscription_price' ).trigger( 'change' );
+		jQuery( '.wc_input_subscription_price' ).trigger( 'change' );
 
-        let variationProductIds = [ PayPalCommerceGatewayPayPalSubscriptionProducts.product_id ];
-        const variationsInput =  document.querySelectorAll( '.variable_post_id' );
-        for ( let i = 0; i < variationsInput.length; i++ ) {
-            variationProductIds.push( variationsInput[ i ].value );
-        }
+		const variationProductIds = [
+			PayPalCommerceGatewayPayPalSubscriptionProducts.product_id,
+		];
+		const variationsInput =
+			document.querySelectorAll( '.variable_post_id' );
+		for ( let i = 0; i < variationsInput.length; i++ ) {
+			variationProductIds.push( variationsInput[ i ].value );
+		}
 
-        variationProductIds?.forEach(
-			( productId ) => {
-                const linkBtn = document.getElementById(
-                    `ppcp_enable_subscription_product-${ productId }`
-                );
+		variationProductIds?.forEach( ( productId ) => {
+			const linkBtn = document.getElementById(
+				`ppcp_enable_subscription_product-${ productId }`
+			);
+			if ( linkBtn ) {
 				if ( linkBtn.checked && linkBtn.value === 'yes' ) {
 					disableFields( productId );
 				}
-                linkBtn?.addEventListener( 'click', ( event ) => {
-                    const unlinkBtnP = document.getElementById(
-                        `ppcp-enable-subscription-${ productId }`
-                    );
-                    const titleP = document.getElementById(
-                        `ppcp_subscription_plan_name_p-${ productId }`
-                    );
-                    if (event.target.checked === true) {
-                        if ( unlinkBtnP ) {
-                            unlinkBtnP.style.display = 'none';
-                        }
-                        if ( titleP ) {
-                            titleP.style.display = 'block';
-                        }
-                    } else {
-                        if ( unlinkBtnP ) {
-                            unlinkBtnP.style.display = 'block';
-                        }
-                        if ( titleP ) {
-                            titleP.style.display = 'none';
-                        }
-                    }
-                });
-
-                const unlinkBtn = document.getElementById(
-                    `ppcp-unlink-sub-plan-${ productId }`
-                );
-				unlinkBtn?.addEventListener( 'click', ( event ) => {
-					event.preventDefault();
-					unlinkBtn.disabled = true;
-					const spinner = document.getElementById(
-						`spinner-unlink-plan-${ productId }`
+				linkBtn.addEventListener( 'click', ( event ) => {
+					const unlinkBtnP = document.getElementById(
+						`ppcp-enable-subscription-${ productId }`
 					);
-					spinner.style.display = 'inline-block';
+					const titleP = document.getElementById(
+						`ppcp_subscription_plan_name_p-${ productId }`
+					);
+					if ( event.target.checked === true ) {
+						if ( unlinkBtnP ) {
+							unlinkBtnP.style.display = 'none';
+						}
+						if ( titleP ) {
+							titleP.style.display = 'block';
+						}
+					} else {
+						if ( unlinkBtnP ) {
+							unlinkBtnP.style.display = 'block';
+						}
+						if ( titleP ) {
+							titleP.style.display = 'none';
+						}
+					}
+				} );
+			}
 
-					fetch( PayPalCommerceGatewayPayPalSubscriptionProducts.ajax.deactivate_plan.endpoint, {
+			const unlinkBtn = document.getElementById(
+				`ppcp-unlink-sub-plan-${ productId }`
+			);
+			unlinkBtn?.addEventListener( 'click', ( event ) => {
+				event.preventDefault();
+				unlinkBtn.disabled = true;
+				const spinner = document.getElementById(
+					`spinner-unlink-plan-${ productId }`
+				);
+				spinner.style.display = 'inline-block';
+
+				fetch(
+					PayPalCommerceGatewayPayPalSubscriptionProducts.ajax
+						.deactivate_plan.endpoint,
+					{
 						method: 'POST',
 						headers: {
 							'Content-Type': 'application/json',
 						},
 						credentials: 'same-origin',
 						body: JSON.stringify( {
-							nonce: PayPalCommerceGatewayPayPalSubscriptionProducts.ajax.deactivate_plan.nonce,
+							nonce: PayPalCommerceGatewayPayPalSubscriptionProducts
+								.ajax.deactivate_plan.nonce,
 							plan_id: linkBtn.dataset.subsPlan,
 							product_id: productId,
 						} ),
+					}
+				)
+					.then( function ( res ) {
+						return res.json();
 					} )
-						.then( function ( res ) {
-							return res.json();
-						} )
-						.then( function ( data ) {
-							if ( ! data.success ) {
-								unlinkBtn.disabled = false;
-								spinner.style.display = 'none';
-								console.error( data );
-								throw Error( data.data.message );
-							}
+					.then( function ( data ) {
+						if ( ! data.success ) {
+							unlinkBtn.disabled = false;
+							spinner.style.display = 'none';
+							console.error( data );
+							throw Error( data.data.message );
+						}
 
-							const enableSubscription = document.getElementById(
-								'ppcp-enable-subscription-' + data.data.product_id
+						const enableSubscription = document.getElementById(
+							'ppcp-enable-subscription-' + data.data.product_id
+						);
+						const product = document.getElementById(
+							'pcpp-product-' + data.data.product_id
+						);
+						const plan = document.getElementById(
+							'pcpp-plan-' + data.data.product_id
+						);
+						enableSubscription.style.display = 'none';
+						product.style.display = 'none';
+						plan.style.display = 'none';
+
+						const enable_subscription_product =
+							document.getElementById(
+								'ppcp_enable_subscription_product-' +
+									data.data.product_id
 							);
-							const product =	document.getElementById( 'pcpp-product-' + data.data.product_id );
-							const plan = document.getElementById( 'pcpp-plan-' + data.data.product_id );
-							enableSubscription.style.display = 'none';
-							product.style.display = 'none';
-							plan.style.display = 'none';
+						enable_subscription_product.disabled = true;
 
-							const enable_subscription_product =
-								document.getElementById(
-									'ppcp_enable_subscription_product-' + data.data.product_id
-								);
-							enable_subscription_product.disabled = true;
+						const planUnlinked = document.getElementById(
+							'pcpp-plan-unlinked-' + data.data.product_id
+						);
+						planUnlinked.style.display = 'block';
 
-							const planUnlinked =
-								document.getElementById( 'pcpp-plan-unlinked-' + data.data.product_id );
-							planUnlinked.style.display = 'block';
-
-							setTimeout( () => {
-								location.reload();
-							}, 1000 );
-						} );
-				} );
-			}
-		);
+						setTimeout( () => {
+							location.reload();
+						}, 1000 );
+					} );
+			} );
+		} );
 	};
 
 	setupProducts();

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -581,6 +581,10 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 							),
 						),
 						'product_id' => $product->get_id(),
+						'i18n'       => array(
+							'prices_must_be_above_zero' => __( 'Prices must be above zero for PayPal Subscriptions!', 'woocommerce-paypal-payments' ),
+							'not_allowed_period_interval' => __( 'Not allowed period interval combination for PayPal Subscriptions!', 'woocommerce-paypal-payments' ),
+						),
 					)
 				);
 			}


### PR DESCRIPTION
### Description

This PR will fix the issue where the product editing screen becomes unresponsive when the PayPal Subscriptions API is enabled and users attempt to edit variable products.

### Solution
1. Added null checks for `linkBtn` in the `checkSubscriptionPeriodsInterval` function and all event handlers
2. Moved hardcoded translation strings to the server side via `wp_localize_script`


### Steps to Test
1. Set subscription mode to "PayPal Subscriptions API" (old UI)
2. Edit a variable product with multiple variations
3. Verify the variations load correctly and can be modified without the UI freezing
4. Ensure subscription-related functionality still works for subscription products
