### PR TITLE
Update selector for hiding express checkout (4406)

### DIFF
--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -101,7 +101,7 @@ $fast-transition-duration: 0.5s;
 }
 
 // 3. Express Payment Block
-.wp-block-woocommerce-checkout-express-payment-block {
+.wc-block-components-express-payment--checkout, .wp-block-woocommerce-checkout-express-payment-block {
 	transition: opacity $transition-duration ease-in,
 	scale $transition-duration ease-in,
 	display $transition-duration ease-in;

--- a/modules/ppcp-axo-block/resources/js/helpers/classnamesManager.js
+++ b/modules/ppcp-axo-block/resources/js/helpers/classnamesManager.js
@@ -10,7 +10,7 @@ import { STORE_NAME } from '../stores/axoStore';
  */
 export const setupAuthenticationClassToggle = () => {
 	const targetSelector =
-		'.wp-block-woocommerce-checkout-express-payment-block';
+		'.wc-block-components-express-payment--checkout, .wp-block-woocommerce-checkout-express-payment-block';
 	const authClass = 'wc-block-axo-is-authenticated';
 
 	const updateAuthenticationClass = () => {


### PR DESCRIPTION
Updated the selectors for hiding express checkout in Fastlane, since it changed in WC 9.4.0.