### PR TITLE
Enable all/Disable all toggle next to Alternative Payment methods on Payment Methods tab (4481)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/BulkPaymentToggle.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/BulkPaymentToggle.js
@@ -1,0 +1,68 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Renders a link to enable/disable all payment methods in a group
+ *
+ * @param {Object}   props            - Component props
+ * @param {boolean}  props.isEnabled  - Whether all methods are currently enabled
+ * @param {Function} props.onToggle   - Callback when link is clicked
+ * @param {string}   props.label      - Custom label for the link
+ * @param {boolean}  props.isDisabled - Whether the link is disabled
+ * @param {string}   props.groupName  - Name of the payment method group
+ * @return {JSX.Element} The rendered component
+ */
+const BulkPaymentToggle = ( {
+	isEnabled = false,
+	onToggle,
+	label = '',
+	isDisabled = false,
+	groupName = '',
+} ) => {
+	let displayLabel;
+
+	if ( label ) {
+		// Use provided label if available
+		displayLabel = label;
+	} else {
+		const action = isEnabled
+			? __( 'Disable', 'woocommerce-paypal-payments' )
+			: __( 'Enable', 'woocommerce-paypal-payments' );
+
+		/* translators: %s: payment method group name */
+		const templateString = __(
+			'all %s Methods',
+			'woocommerce-paypal-payments'
+		);
+
+		displayLabel = sprintf(
+			/* translators: %1$s: action (Enable/Disable), %2$s: formatted string with payment method group name */
+			__( '%1$s %2$s', 'woocommerce-paypal-payments' ),
+			action,
+			sprintf( templateString, groupName )
+		);
+	}
+
+	return (
+		<div className="ppcp-bulk-action">
+			{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+			<a
+				href="#"
+				className={ `ppcp-bulk-action__link ${
+					isDisabled ? 'ppcp-bulk-action__link--disabled' : ''
+				}` }
+				onClick={ ( e ) => {
+					e.preventDefault();
+					if ( ! isDisabled ) {
+						onToggle();
+					}
+				} }
+				aria-disabled={ isDisabled }
+				role={ 'button' }
+			>
+				{ displayLabel }
+			</a>
+		</div>
+	);
+};
+
+export default BulkPaymentToggle;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/BulkPaymentToggle.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/BulkPaymentToggle.js
@@ -1,4 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 /**
  * Renders a link to enable/disable all payment methods in a group
@@ -43,24 +44,14 @@ const BulkPaymentToggle = ( {
 	}
 
 	return (
-		<div className="ppcp-bulk-action">
-			{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-			<a
-				href="#"
-				className={ `ppcp-bulk-action__link ${
-					isDisabled ? 'ppcp-bulk-action__link--disabled' : ''
-				}` }
-				onClick={ ( e ) => {
-					e.preventDefault();
-					if ( ! isDisabled ) {
-						onToggle();
-					}
-				} }
-				aria-disabled={ isDisabled }
-				role={ 'button' }
+		<div className="ppcp-bulk-toggle-payment-gateways">
+			<Button
+				variant="tertiary"
+				onClick={ onToggle }
+				disabled={ isDisabled }
 			>
 				{ displayLabel }
-			</a>
+			</Button>
 		</div>
 	);
 };

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
@@ -3,6 +3,8 @@ import SettingsCard from '../../../../ReusableComponents/SettingsCard';
 import { PaymentMethodsBlock } from '../../../../ReusableComponents/SettingsBlocks';
 import usePaymentDependencyState from '../../../../../hooks/usePaymentDependencyState';
 import useSettingDependencyState from '../../../../../hooks/useSettingDependencyState';
+import usePaymentMethodsToggle from '../../../../../hooks/usePaymentMethodsToggle';
+import BulkPaymentToggle from './BulkPaymentToggle';
 import PaymentDependencyMessage from './PaymentDependencyMessage';
 import SettingDependencyMessage from './SettingDependencyMessage';
 import SpinnerOverlay from '../../../../ReusableComponents/SpinnerOverlay';
@@ -26,6 +28,8 @@ import usePaymentGatewayRefresh from '../../../../../hooks/usePaymentGatewayRefr
  * @param {Object}   props.methodsMap     - Map of all payment methods by ID
  * @param {Function} props.onTriggerModal - Callback when a method is clicked
  * @param {boolean}  props.isDisabled     - Whether the entire card is disabled
+ * @param {boolean}  props.showBulkToggle - Whether to show the bulk toggle option
+ * @param {string}   props.groupName      - Name of the payment method group for the toggle label
  * @return {JSX.Element} The rendered component
  */
 const PaymentMethodCard = ( {
@@ -37,8 +41,11 @@ const PaymentMethodCard = ( {
 	methodsMap = {},
 	onTriggerModal,
 	isDisabled = false,
+	showBulkToggle = false,
+	groupName = '',
 } ) => {
-	const { isReady: isPaymentStoreReady } = PaymentHooks.useStore();
+	const { isReady: isPaymentStoreReady, changePaymentSettings } =
+		PaymentHooks.useStore();
 	const { isReady: isSettingsStoreReady } = SettingsHooks.useStore();
 	const { handleHighlightFromUrl } = useNavigation();
 	const { gatewaysRefreshed } = OnboardingHooks.useGatewayRefresh();
@@ -52,6 +59,17 @@ const PaymentMethodCard = ( {
 	);
 
 	const settingDependencies = useSettingDependencyState( methods );
+
+	// Initialize the bulk toggle functionality.
+	const { allEnabled, toggleAllMethods, methodCount } =
+		usePaymentMethodsToggle( {
+			methods,
+			methodsMap,
+			changePaymentSettings,
+			paymentDependencies,
+			settingDependencies,
+			additionalDeps: [ isDisabled, gatewaysRefreshed ],
+		} );
 
 	useEffect( () => {
 		if ( isPaymentStoreReady && isSettingsStoreReady ) {
@@ -67,51 +85,65 @@ const PaymentMethodCard = ( {
 		return <SpinnerOverlay asModal={ true } />;
 	}
 
+	// Process methods with dependencies
+	const processedMethods = methods.map( ( method ) => {
+		const paymentDependency = paymentDependencies?.[ method.id ];
+		const settingDependency = settingDependencies?.[ method.id ];
+
+		let dependencyMessage = null;
+		let isMethodDisabled = method.isDisabled || isDisabled;
+
+		if ( paymentDependency ) {
+			dependencyMessage = (
+				<PaymentDependencyMessage
+					parentId={ paymentDependency.parentId }
+					parentName={ paymentDependency.parentName }
+				/>
+			);
+			isMethodDisabled = true;
+		} else if ( settingDependency?.isDisabled ) {
+			dependencyMessage = (
+				<SettingDependencyMessage
+					settingId={ settingDependency.settingId }
+					requiredValue={ settingDependency.requiredValue }
+					methodId={ method.id }
+				/>
+			);
+			isMethodDisabled = true;
+		}
+
+		return {
+			...method,
+			isDisabled: isMethodDisabled,
+			disabledMessage: dependencyMessage,
+		};
+	} );
+
+	const descriptionWithToggle = showBulkToggle ? (
+		<div>
+			<p>{ description }</p>
+			<BulkPaymentToggle
+				isEnabled={ allEnabled }
+				onToggle={ toggleAllMethods }
+				isDisabled={ isDisabled || methodCount === 0 }
+				groupName={ groupName }
+				methodCount={ methodCount }
+			/>
+		</div>
+	) : (
+		description
+	);
+
 	return (
 		<SettingsCard
 			id={ id }
 			title={ title }
-			description={ description }
+			description={ descriptionWithToggle }
 			icon={ icon }
 			contentContainer={ false }
 		>
 			<PaymentMethodsBlock
-				paymentMethods={ methods.map( ( method ) => {
-					const paymentDependency =
-						paymentDependencies?.[ method.id ];
-					const settingDependency =
-						settingDependencies?.[ method.id ];
-
-					let dependencyMessage = null;
-					let isMethodDisabled = method.isDisabled || isDisabled;
-
-					if ( paymentDependency ) {
-						dependencyMessage = (
-							<PaymentDependencyMessage
-								parentId={ paymentDependency.parentId }
-								parentName={ paymentDependency.parentName }
-							/>
-						);
-						isMethodDisabled = true;
-					} else if ( settingDependency?.isDisabled ) {
-						dependencyMessage = (
-							<SettingDependencyMessage
-								settingId={ settingDependency.settingId }
-								requiredValue={
-									settingDependency.requiredValue
-								}
-								methodId={ method.id }
-							/>
-						);
-						isMethodDisabled = true;
-					}
-
-					return {
-						...method,
-						isDisabled: isMethodDisabled,
-						disabledMessage: dependencyMessage,
-					};
-				} ) }
+				paymentMethods={ processedMethods }
 				onTriggerModal={ onTriggerModal }
 			/>
 		</SettingsCard>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
@@ -85,7 +85,7 @@ const PaymentMethodCard = ( {
 		return <SpinnerOverlay asModal={ true } />;
 	}
 
-	// Process methods with dependencies
+	// Process methods with dependencies.
 	const processedMethods = methods.map( ( method ) => {
 		const paymentDependency = paymentDependencies?.[ method.id ];
 		const settingDependency = settingDependencies?.[ method.id ];

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
@@ -69,6 +69,7 @@ const PaymentMethodCard = ( {
 			paymentDependencies,
 			settingDependencies,
 			additionalDeps: [ isDisabled, gatewaysRefreshed ],
+			groupName,
 		} );
 
 	useEffect( () => {

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -112,6 +112,8 @@ const TabPaymentMethods = () => {
 					methods={ methods.apm }
 					onTriggerModal={ setActiveModal }
 					methodsMap={ methodsMap }
+					showBulkToggle={ methods.apm.length > 1 }
+					groupName="Alternative Payment"
 				/>
 			) }
 

--- a/modules/ppcp-settings/resources/js/hooks/usePaymentMethodsToggle.js
+++ b/modules/ppcp-settings/resources/js/hooks/usePaymentMethodsToggle.js
@@ -82,6 +82,22 @@ const usePaymentMethodsToggle = ( {
 		} );
 	}, [ availableMethods, changePaymentSettings, allEnabled ] );
 
+       // Announce the change to screen readers.
+       const actionText = newState 
+          ? __('enabled', 'woocommerce-paypal-payments') 
+          : __('disabled', 'woocommerce-paypal-payments');
+       
+       const groupText = groupName || __('payment', 'woocommerce-paypal-payments');
+       
+       const message = sprintf(
+          /* translators: %1$s: group name, %2$s: "enabled" or "disabled" */
+          __('All %1$s payment gateways have been %2$s.', 'woocommerce-paypal-payments'),
+          groupText,
+          actionText
+       );
+       
+       speak(message, 'assertive');
+
 	return {
 		allEnabled,
 		toggleAllMethods,

--- a/modules/ppcp-settings/resources/js/hooks/usePaymentMethodsToggle.js
+++ b/modules/ppcp-settings/resources/js/hooks/usePaymentMethodsToggle.js
@@ -72,7 +72,7 @@ const usePaymentMethodsToggle = ( {
 			return;
 		}
 
-		// Determine the new state - if all are enabled, disable them, otherwise enable all
+		// Determine the new state - if all are enabled, disable them, otherwise enable all.
 		const newState = ! allEnabled;
 
 		availableMethods.forEach( ( method ) => {

--- a/modules/ppcp-settings/resources/js/hooks/usePaymentMethodsToggle.js
+++ b/modules/ppcp-settings/resources/js/hooks/usePaymentMethodsToggle.js
@@ -1,4 +1,6 @@
 import { useState, useEffect, useCallback } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { speak } from '@wordpress/a11y';
 
 /**
  * Custom hook to manage bulk toggling of payment methods
@@ -10,6 +12,7 @@ import { useState, useEffect, useCallback } from '@wordpress/element';
  * @param {Object}   options.paymentDependencies   - Payment method dependencies (optional)
  * @param {Object}   options.settingDependencies   - Setting dependencies (optional)
  * @param {Array}    options.additionalDeps        - Additional dependencies to trigger recalculation (optional)
+ * @param {string}   options.groupName
  * @return {Object} Toggle state and handlers
  */
 const usePaymentMethodsToggle = ( {
@@ -19,6 +22,7 @@ const usePaymentMethodsToggle = ( {
 	paymentDependencies = {},
 	settingDependencies = {},
 	additionalDeps = [],
+	groupName = '',
 } ) => {
 	const [ allEnabled, setAllEnabled ] = useState( false );
 	const [ availableMethods, setAvailableMethods ] = useState( [] );
@@ -80,23 +84,26 @@ const usePaymentMethodsToggle = ( {
 				enabled: newState,
 			} );
 		} );
-	}, [ availableMethods, changePaymentSettings, allEnabled ] );
+		// Announce the change to screen readers.
+		const actionText = newState
+			? __( 'enabled', 'woocommerce-paypal-payments' )
+			: __( 'disabled', 'woocommerce-paypal-payments' );
 
-       // Announce the change to screen readers.
-       const actionText = newState 
-          ? __('enabled', 'woocommerce-paypal-payments') 
-          : __('disabled', 'woocommerce-paypal-payments');
-       
-       const groupText = groupName || __('payment', 'woocommerce-paypal-payments');
-       
-       const message = sprintf(
-          /* translators: %1$s: group name, %2$s: "enabled" or "disabled" */
-          __('All %1$s payment gateways have been %2$s.', 'woocommerce-paypal-payments'),
-          groupText,
-          actionText
-       );
-       
-       speak(message, 'assertive');
+		const groupText =
+			groupName || __( 'payment', 'woocommerce-paypal-payments' );
+
+		const message = sprintf(
+			/* translators: %1$s: group name, %2$s: "enabled" or "disabled" */
+			__(
+				'All %1$s payment gateways have been %2$s.',
+				'woocommerce-paypal-payments'
+			),
+			groupText,
+			actionText
+		);
+
+		speak( message, 'assertive' );
+	}, [ availableMethods, changePaymentSettings, allEnabled, groupName ] );
 
 	return {
 		allEnabled,

--- a/modules/ppcp-settings/resources/js/hooks/usePaymentMethodsToggle.js
+++ b/modules/ppcp-settings/resources/js/hooks/usePaymentMethodsToggle.js
@@ -1,0 +1,93 @@
+import { useState, useEffect, useCallback } from '@wordpress/element';
+
+/**
+ * Custom hook to manage bulk toggling of payment methods
+ *
+ * @param {Object}   options                       - Options for the hook
+ * @param {Array}    options.methods               - List of payment methods to control
+ * @param {Object}   options.methodsMap            - Map of all payment methods by ID
+ * @param {Function} options.changePaymentSettings - Function to update payment settings
+ * @param {Object}   options.paymentDependencies   - Payment method dependencies (optional)
+ * @param {Object}   options.settingDependencies   - Setting dependencies (optional)
+ * @param {Array}    options.additionalDeps        - Additional dependencies to trigger recalculation (optional)
+ * @return {Object} Toggle state and handlers
+ */
+const usePaymentMethodsToggle = ( {
+	methods = [],
+	methodsMap = {},
+	changePaymentSettings,
+	paymentDependencies = {},
+	settingDependencies = {},
+	additionalDeps = [],
+} ) => {
+	const [ allEnabled, setAllEnabled ] = useState( false );
+	const [ availableMethods, setAvailableMethods ] = useState( [] );
+	useEffect( () => {
+		if ( ! methods || methods.length === 0 ) {
+			setAllEnabled( false );
+			setAvailableMethods( [] );
+			return;
+		}
+
+		const available = methods.filter( ( method ) => {
+			if ( ! method || ! method.id ) {
+				return false;
+			}
+
+			const hasPaymentDependency =
+				paymentDependencies && paymentDependencies[ method.id ];
+
+			const hasSettingDependency =
+				settingDependencies && settingDependencies[ method.id ];
+
+			if (
+				hasPaymentDependency ||
+				hasSettingDependency ||
+				method.isDisabled
+			) {
+				return false;
+			}
+
+			return true;
+		} );
+
+		setAvailableMethods( available );
+
+		const areAllEnabled =
+			available.length > 0 &&
+			available.every( ( method ) => method.enabled === true );
+
+		setAllEnabled( areAllEnabled );
+	}, [
+		methods,
+		methodsMap,
+		paymentDependencies,
+		settingDependencies,
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		...additionalDeps,
+	] );
+
+	const toggleAllMethods = useCallback( () => {
+		if ( ! availableMethods.length || ! changePaymentSettings ) {
+			return;
+		}
+
+		// Determine the new state - if all are enabled, disable them, otherwise enable all
+		const newState = ! allEnabled;
+
+		availableMethods.forEach( ( method ) => {
+			changePaymentSettings( method.id, {
+				enabled: newState,
+			} );
+		} );
+	}, [ availableMethods, changePaymentSettings, allEnabled ] );
+
+	return {
+		allEnabled,
+		toggleAllMethods,
+		availableMethods,
+		methodCount: availableMethods.length,
+	};
+};
+
+export default usePaymentMethodsToggle;


### PR DESCRIPTION
## Description
This PR will add a toggle link next to Alternative Payment methods on Payment Methods tab to Enable all/Disable all of them.

The file `BulkPaymentToggle.js` defines a React functional component called `BulkPaymentToggle`. This component is responsible for rendering a link that allows users to enable or disable all payment methods in a group. 
### Functionality
1. **Label Generation**:
   - If a custom `label` is provided, it is used as the link's text.
   - If no `label` is provided, the component generates a label dynamically:
     - It determines the action (`Enable` or `Disable`) based on the `isEnabled` state.
     - It uses the `groupName` to create a descriptive label, such as "Enable all Credit Card Methods."

2. **Rendering**:
   - The component renders a `<div>` containing an `<a>` tag styled as a link.
   - The link has a class name that changes based on whether it is disabled (`ppcp-bulk-action__link--disabled`).
   - The `aria-disabled` attribute is set to reflect the `isDisabled` state for accessibility.

3. **Click Handling**:
   - When the link is clicked, the default browser behavior is prevented.
   - If the link is not disabled, the `onToggle` callback is executed.

The file `usePaymentMethodsToggle.js` contains a custom React hook designed to manage the toggling of payment methods in bulk. 

### Purpose
The hook provides a way to:
1. Determine which payment methods are available for toggling.
2. Check if all available methods are enabled.
3. Toggle all available methods on or off.


