### PR TITLE
Fix 'Ignoring unknown key' console warnings when modifying payment gateway state (4501)

### DIFF
--- a/modules/ppcp-settings/resources/js/data/payment/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/payment/reducer.js
@@ -70,7 +70,6 @@ const reducer = createReducer( defaultTransient, defaultPersistent, {
 		}
 
 		return changePersistent( state, {
-			...state,
 			[ methodId ]: { ...oldProps, ...payload.props },
 		} );
 	},


### PR DESCRIPTION
### Description

This PR will fix the console warnings that appear when modifying enabled state for payment methods.

The issue was in the `CHANGE_PAYMENT_SETTING` reducer handler which was incorrectly passing the entire state object to `changePersistent()`, including transient properties not defined in `defaultPersistent`.

Modified the reducer to only pass the relevant payment method properties to `changePersistent()`, which eliminates the warnings.

### Screenshot

<img width="691" alt="warning" src="https://github.com/user-attachments/assets/20aee6b2-8c08-418f-8886-1779763fe0cc" />

