### PR TITLE
Ratepay Payment Option Not Available for Unassembled Product Bundles (4503) 

### DIFF
--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -109,7 +109,15 @@ class PayUponInvoiceHelper {
 					$product_id = $item['variation_id'];
 				}
 				$product = wc_get_product( $product_id );
-				if ( $product && ! $this->checkout_helper->is_physical_product( $product ) ) {
+				if ( $product
+					/**
+					 * Allows filtering product validation for PUI.
+					 */
+					&& ! apply_filters(
+						'woocommerce_paypal_payments_is_valid_product_for_pui',
+						$this->checkout_helper->is_physical_product( $product ),
+						$product
+					) ) {
 					return false;
 				}
 			}


### PR DESCRIPTION
This PR adds a new filter `woocommerce_paypal_payments_is_valid_product_for_pui` to set product validation for PUI.

It will allow fix PayPal button not show issues like in "Unassembled Product Bundles" plugin, as it allows modify the conditions to render the PayPal button.

Here is the basic usage of the filter, in this case returning `true`, so PayPal buttons are rendered.
```php
add_filter('woocommerce_paypal_payments_is_valid_product_for_pui', '__return_true');
```

The filter has the WC product as second parameter in case you need to add more logic, for example:
```php
add_filter('woocommerce_paypal_payments_is_valid_product_for_pui', function ($is_valid, $product) {
    if ($product->get_id() === 42 ) {
        return true;
    }

    return $is_valid;
}, 10, 2);
```