### PR TITLE
Release 3.0.4-rc1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 3.0.4 - xxxx-xx-xx =
+* Fix - Onboarding screen blank when WooPayments plugin is active #3312
+
 = 3.0.3 - 2025-04-08 =
 * Fix - BN code was set before the installation path was initialized #3309
 * Fix - Things to do next referenced Apple Pay while in branded-only mode #3308

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
@@ -65,8 +65,9 @@ export const getSteps = ( flags ) => {
 		( step ) => flags.canUseCasualSelling || step.id !== 'business',
 		// Skip payment methods screen.
 		( step ) =>
-			! flags.shouldSkipPaymentMethods &&
-			! ( ownBrandOnly && isCasualSeller && step.id === 'methods' ), // personal user in branded-only mode.
+			step.id !== 'methods' ||
+			( ! flags.shouldSkipPaymentMethods &&
+				! ( ownBrandOnly && isCasualSeller ) ),
 	] );
 
 	const totalStepsCount = steps.length;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/index.js
@@ -10,6 +10,15 @@ const OnboardingScreen = () => {
 	const Steps = getSteps( flags );
 	const currentStep = getCurrentStep( step, Steps );
 
+	if ( ! currentStep?.StepComponent ) {
+		console.error( 'Invalid Onboarding State', {
+			step,
+			flags,
+			Steps,
+			currentStep,
+		} );
+	}
+
 	const handleNext = () => setStep( currentStep.nextStep );
 	const handlePrev = () => setStep( currentStep.prevStep );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: paypal, woocommerce, automattic, syde
 Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 6.5
-Tested up to: 6.7
+Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 3.0.3
+Stable tag: 3.0.4
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,9 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 6. Main settings screen.
 
 == Changelog ==
+
+= 3.0.4 - xxxx-xx-xx =
+* Fix - Onboarding screen blank when WooPayments plugin is active #3312
 
 = 3.0.3 - 2025-04-08 =
 * Fix - BN code was set before the installation path was initialized #3309

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     3.0.3
+ * Version:     3.0.4
  * Author:      PayPal
  * Author URI:  https://paypal.com/
  * License:     GPL-2.0
@@ -27,7 +27,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2025-04-04' );
+define( 'PAYPAL_INTEGRATION_DATE', '2025-04-23' );
 define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );


### PR DESCRIPTION
[3.0.3](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/3.0.3) plus:
* Fix - Onboarding screen blank when WooPayments plugin is active #3312