### PR TITLE
Disable Specific credit cards shows Select as possible value (4506)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/OtherSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/OtherSettings.js
@@ -47,7 +47,6 @@ const OtherSettings = () => {
 export default OtherSettings;
 
 const disabledCardChoices = [
-	{ value: '', label: __( 'Select', 'woocommerce-paypal-payments' ) },
 	{
 		value: 'mastercard',
 		label: __( 'Mastercard', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
Remove select from selector options in disable specific cards settings. 