### PR TITLE
Non acdc country vietnam (4488)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalApmProductStatus.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalApmProductStatus.php
@@ -64,8 +64,11 @@ class LocalApmProductStatus extends ProductStatus {
 	protected function check_active_state( SellerStatus $seller_status ) : bool {
 		$has_capability = false;
 
-		foreach ( $seller_status->products() as $product ) {
-			if ( $product->name() === 'PAYMENT_METHODS' ) {
+		foreach ( $seller_status->capabilities() as $capability ) {
+			if ( 'ACTIVE' !== $capability->status() ) {
+				continue;
+			}
+			if ( 'PAYPAL_CHECKOUT_ALTERNATIVE_PAYMENT_METHODS' === $capability->name() ) {
 				$has_capability = true;
 				break;
 			}

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/PaymentFlow.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/PaymentFlow.js
@@ -42,10 +42,7 @@ const PaymentFlow = ( {
 			/>
 		);
 	}
-	let description = optionalDescription;
-	if ( ! useAcdc ) {
-		description = '';
-	}
+const description = useAcdc ? optionalDescription : '';
 	return (
 		<div className="ppcp-r-welcome-docs__wrapper">
 			<DefaultMethodsSection

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/PaymentFlow.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/PaymentFlow.js
@@ -42,7 +42,10 @@ const PaymentFlow = ( {
 			/>
 		);
 	}
-
+	let description = optionalDescription;
+	if ( ! useAcdc ) {
+		description = '';
+	}
 	return (
 		<div className="ppcp-r-welcome-docs__wrapper">
 			<DefaultMethodsSection
@@ -53,7 +56,7 @@ const PaymentFlow = ( {
 
 			<OptionalMethodsSection
 				title={ optionalTitle }
-				description={ optionalDescription }
+				description={ description }
 				methods={ optionalMethods }
 				learnMoreConfig={ learnMoreConfig }
 			/>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
@@ -12,10 +12,11 @@ const StepPaymentMethods = () => {
 		OnboardingHooks.useOptionalPaymentMethods();
 	const { ownBrandOnly } = CommonHooks.useWooSettings();
 	const { isCasualSeller } = OnboardingHooks.useBusiness();
+	const { canUseCardPayments } = OnboardingHooks.useFlags();
 
 	const optionalMethodTitle = useMemo( () => {
-		// The BCDC flow does not show a title.
-		if ( isCasualSeller ) {
+		// The BCDC flow does not show a title. !acdc does not show a title.
+		if ( isCasualSeller || ! canUseCardPayments ) {
 			return null;
 		}
 
@@ -23,7 +24,7 @@ const StepPaymentMethods = () => {
 			'Available with additional application',
 			'woocommerce-paypal-payments'
 		);
-	}, [ isCasualSeller ] );
+	}, [ isCasualSeller, canUseCardPayments ] );
 
 	const methodChoices = [
 		{
@@ -32,13 +33,16 @@ const StepPaymentMethods = () => {
 			description: <OptionalMethodDescription />,
 		},
 		{
-			title: ownBrandOnly ? __(
-				'No thanks, I prefer to use a different provider for local payment methods',
-				'woocommerce-paypal-payments'
-			) : __(
-				'No thanks, I prefer to use a different provider for processing credit cards, digital wallets, and local payment methods',
-				'woocommerce-paypal-payments'
-			),
+			title:
+				ownBrandOnly || ! canUseCardPayments
+					? __(
+							'No thanks, I prefer to use a different provider for local payment methods',
+							'woocommerce-paypal-payments'
+					  )
+					: __(
+							'No thanks, I prefer to use a different provider for processing credit cards, digital wallets, and local payment methods',
+							'woocommerce-paypal-payments'
+					  ),
 			value: false,
 		},
 	];

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -59,11 +59,7 @@ const TabPaymentMethods = () => {
 		merchant.isBusinessSeller &&
 		canUseCardPayments;
 
-	const showApms =
-		methods.apm.length > 0 &&
-		merchant.isBusinessSeller &&
-		canUseCardPayments;
-
+	const showApms = methods.apm.length > 0 && merchant.isBusinessSeller;
 	return (
 		<div className="ppcp-r-payment-methods">
 			<PaymentMethodCard

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -412,15 +412,10 @@ return array(
 			)
 		);
 
-		$is_business = $container->get( 'settings.data.general' )->is_business_seller();
-		$is_acdc = $container->get( 'settings.service.merchant_capabilities' )['acdc'] ?? false;
-		$bcdc_enabled = $is_business && $is_acdc;
-
 		return new PaymentMethodsDefinition(
 			$container->get( 'settings.data.payment' ),
 			$container->get( 'settings.data.general' ),
-			$axo_notices,
-			$bcdc_enabled
+			$axo_notices
 		);
 	},
 	'settings.data.definition.method_dependencies'        => static function ( ContainerInterface $container ) : PaymentMethodsDependenciesDefinition {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -401,10 +401,15 @@ return array(
 			)
 		);
 
+		$is_business = $container->get( 'settings.data.general' )->is_business_seller();
+		$is_acdc = $container->get( 'settings.service.merchant_capabilities' )['acdc'] ?? false;
+		$bcdc_enabled = $is_business && $is_acdc;
+
 		return new PaymentMethodsDefinition(
 			$container->get( 'settings.data.payment' ),
 			$container->get( 'settings.data.general' ),
-			$axo_notices
+			$axo_notices,
+			$bcdc_enabled
 		);
 	},
 	'settings.data.definition.method_dependencies'        => static function ( ContainerInterface $container ) : PaymentMethodsDependenciesDefinition {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -566,7 +566,7 @@ return array(
 		$merchant_capabilities = array(
 			'save_paypal' => $capabilities['save_paypal'], // Save PayPal and Venmo eligibility.
 			'acdc'        => $capabilities['acdc'] && ! $gateways['card-button'], // Advanced credit and debit cards eligibility.
-			'apm'         => $capabilities['acdc'] && ! $gateways['card-button'], // Alternative payment methods eligibility.
+			'apm'         => ! $gateways['card-button'], // Alternative payment methods eligibility.
 			'google_pay'  => $capabilities['acdc'] && $capabilities['google_pay'], // Google Pay eligibility.
 			'apple_pay'   => $capabilities['acdc'] && $capabilities['apple_pay'], // Apple Pay eligibility.
 			'pay_later'   => $capabilities['acdc'] && ! $gateways['card-button'], // Pay Later eligibility.

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -64,20 +64,30 @@ class PaymentMethodsDefinition {
 	private ?array $wc_gateways = null;
 
 	/**
+	 * Whether the BCDC is enabled.
+	 *
+	 * @var bool
+	 */
+	private bool $bcdc_enabled;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param PaymentSettings $settings              Payment methods data model.
 	 * @param GeneralSettings $general_settings      General plugin settings model.
 	 * @param array           $axo_conflicts_notices Conflicts notices for Axo.
+	 * @param bool            $bcdc_enabled          Whether the BCDC is enabled.
 	 */
 	public function __construct(
 		PaymentSettings $settings,
 		GeneralSettings $general_settings,
-		array $axo_conflicts_notices = array()
+		array $axo_conflicts_notices = array(),
+		$bcdc_enabled = false
 	) {
 		$this->settings              = $settings;
 		$this->general_settings      = $general_settings;
 		$this->axo_conflicts_notices = $axo_conflicts_notices;
+		$this->bcdc_enabled          = $bcdc_enabled;
 	}
 
 	/**
@@ -137,10 +147,13 @@ class PaymentMethodsDefinition {
 
 		$gateway_title       = $gateway ? $gateway->get_title() : $title;
 		$gateway_description = $gateway ? $gateway->get_description() : $description;
-
+		$enabled = $this->settings->is_method_enabled( $gateway_id );
+		if ( $gateway_id === CardButtonGateway::ID ) {
+			$enabled = $this->bcdc_enabled;
+		}
 		$config = array(
 			'id'              => $gateway_id,
-			'enabled'         => $this->settings->is_method_enabled( $gateway_id ),
+			'enabled'         => $enabled,
 			'title'           => str_replace( '&amp;', '&', $gateway_title ),
 			'description'     => $gateway_description,
 			'icon'            => $icon,

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -73,8 +73,7 @@ class PaymentMethodsDefinition {
 	public function __construct(
 		PaymentSettings $settings,
 		GeneralSettings $general_settings,
-		array $axo_conflicts_notices = array(),
-		$bcdc_enabled = false
+		array $axo_conflicts_notices = array()
 	) {
 		$this->settings              = $settings;
 		$this->general_settings      = $general_settings;
@@ -138,8 +137,8 @@ class PaymentMethodsDefinition {
 
 		$gateway_title       = $gateway ? $gateway->get_title() : $title;
 		$gateway_description = $gateway ? $gateway->get_description() : $description;
-		$enabled = $this->settings->is_method_enabled( $gateway_id );
-		$config = array(
+		$enabled             = $this->settings->is_method_enabled( $gateway_id );
+		$config              = array(
 			'id'              => $gateway_id,
 			'enabled'         => $enabled,
 			'title'           => str_replace( '&amp;', '&', $gateway_title ),

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -64,19 +64,11 @@ class PaymentMethodsDefinition {
 	private ?array $wc_gateways = null;
 
 	/**
-	 * Whether the BCDC is enabled.
-	 *
-	 * @var bool
-	 */
-	private bool $bcdc_enabled;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param PaymentSettings $settings              Payment methods data model.
 	 * @param GeneralSettings $general_settings      General plugin settings model.
 	 * @param array           $axo_conflicts_notices Conflicts notices for Axo.
-	 * @param bool            $bcdc_enabled          Whether the BCDC is enabled.
 	 */
 	public function __construct(
 		PaymentSettings $settings,
@@ -87,7 +79,6 @@ class PaymentMethodsDefinition {
 		$this->settings              = $settings;
 		$this->general_settings      = $general_settings;
 		$this->axo_conflicts_notices = $axo_conflicts_notices;
-		$this->bcdc_enabled          = $bcdc_enabled;
 	}
 
 	/**
@@ -148,9 +139,6 @@ class PaymentMethodsDefinition {
 		$gateway_title       = $gateway ? $gateway->get_title() : $title;
 		$gateway_description = $gateway ? $gateway->get_description() : $description;
 		$enabled = $this->settings->is_method_enabled( $gateway_id );
-		if ( $gateway_id === CardButtonGateway::ID ) {
-			$enabled = $this->bcdc_enabled;
-		}
 		$config = array(
 			'id'              => $gateway_id,
 			'enabled'         => $enabled,

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -420,19 +420,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				if ( $dcc_product_status->is_active() && $card_fields_eligible ) {
 					unset( $payment_methods[ CardButtonGateway::ID ] );
 				} else {
-					// For non-ACDC regions unset ACDC, local APMs and set BCDC.
+					// For non-ACDC regions unset ACDC.
 					unset( $payment_methods[ CreditCardGateway::ID ] );
-					unset( $payment_methods['pay-later'] );
-					unset( $payment_methods[ BancontactGateway::ID ] );
-					unset( $payment_methods[ BlikGateway::ID ] );
-					unset( $payment_methods[ EPSGateway::ID ] );
-					unset( $payment_methods[ IDealGateway::ID ] );
-					unset( $payment_methods[ MyBankGateway::ID ] );
-					unset( $payment_methods[ P24Gateway::ID ] );
-					unset( $payment_methods[ TrustlyGateway::ID ] );
-					unset( $payment_methods[ MultibancoGateway::ID ] );
-					unset( $payment_methods[ PayUponInvoiceGateway::ID ] );
-					unset( $payment_methods[ OXXO::ID ] );
 				}
 
 				// Unset Venmo when store location is not United States.


### PR DESCRIPTION
This PR changes some wording for non ACDC users

- Welcome Screen: Remove wording for BCDC that indicates "with additional application" 
- On Payment Selection screen (onboarding wizard), And !ACDC, Then remove "Available with additional application" wording. Also change the "No thanks..." to refer only to credit and debit cards. Remove digital wallets and local payment methods from the sentence.

The second part of this PR decouples APM from ACDC and so the AMP are showing in non ACDC countries if elegible, The Pay Later card shows (disabled), and BCDC is enabled for ACDC && business merchants in non-ACDC countries. 

<img width="1037" alt="Captura de pantalla 2025-04-30 a las 8 34 03" src="https://github.com/user-attachments/assets/01ac7342-bf79-4beb-9f9f-9652d396ee61" />
