### PR TITLE
ACDC payments for Subscription are failing at checkout for new users (4549)

### DIFF
--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\Settings\DTO\ConfigurationFlagsDTO;
 use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Settings\Enum\ProductChoicesEnum;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
@@ -215,7 +216,7 @@ class SettingsDataManager {
 
 		$flags->is_business_seller = ! ( $profile_data['is_casual_seller'] ?? false );
 		$flags->use_card_payments  = $profile_data['accept_card_payments'] ?? false;
-		$flags->use_subscriptions  = in_array( 'SUBSCRIPTIONS', $profile_data['products'] ?? array(), true );
+		$flags->use_subscriptions  = in_array( ProductChoicesEnum::SUBSCRIPTIONS, $profile_data['products'] ?? array(), true );
 
 		$this->toggle_payment_gateways( $flags );
 	}
@@ -259,8 +260,11 @@ class SettingsDataManager {
 				$this->payment_methods->toggle_method_state( ApplePayGateway::ID, true );
 				$this->payment_methods->toggle_method_state( GooglePayGateway::ID, true );
 
-				// Enable Pay Later for business sellers.
-				$this->payment_methods->toggle_method_state( 'pay-later', true );
+				// Enable Pay Later for business sellers if subscriptions were not selected.
+				// Selecting subscriptions automatically enables the "Save PayPal and Venmo" option, which is incompatible with Pay Later.
+				if ( ! $flags->use_subscriptions ) {
+					$this->payment_methods->toggle_method_state( 'pay-later', true );
+				}
 			}
 
 			// Enable all APM methods.


### PR DESCRIPTION
The problem seems caused by Pay Later enabled together with Vaulting at the same time in the JSSDK:

![Captura de pantalla 2025-04-30 a las 17 35 59](https://github.com/user-attachments/assets/9b1a7259-af02-43eb-99fb-b8bf2dc57dbc)

### How to reproduce
- Reset environment
- Activate WC, configure country as US
- Activate WC Subscriptions
- Activate PayPal plugin
- Onboard using US business merchant account
- Select “Business”, “Subscriptions” and “Available with additional application” when onboarding
- Once onboarded visit Payment Methods tab, notice how Pay Later is disabled but checkbox is checked:

![Captura de pantalla 2025-04-30 a las 17 49 43](https://github.com/user-attachments/assets/f49f9783-61ea-424b-b410-46864a23d17e)

This PR fixes `use_subscriptions` flag as it was using `SUBSCRIPTIONS` instead of `subscriptions` and therefore the condition always returned `false`.

Then uses `use_subscriptions` flag value to enable Pay Later when is not `true`.