### PR TITLE
Fix BCDC not enabled by default when cards selected when onboarding (4488)

### DIFF
--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -265,6 +265,9 @@ class SettingsDataManager {
 				if ( ! $flags->use_subscriptions ) {
 					$this->payment_methods->toggle_method_state( 'pay-later', true );
 				}
+
+				// Enable BCDC for business sellers without ACDC.
+				$this->payment_methods->toggle_method_state( CardButtonGateway::ID, true );
 			}
 
 			// Enable all APM methods.


### PR DESCRIPTION
This PR fixes the case when merchant not eligible for advanced cards selects cards when onboarding, the BCDC item on Payment Methods tab is not enabled by default.