### PR TITLE
Revert delete select item

### DIFF
--- a/modules/ppcp-settings/src/Service/ScriptDataHandler.php
+++ b/modules/ppcp-settings/src/Service/ScriptDataHandler.php
@@ -148,10 +148,6 @@ class ScriptDataHandler {
 		$is_pay_later_configurator_available = $this->paylater_is_available;
 		$disabled_cards_choices              = array(
 			array(
-				'value' => '',
-				'label' => _x( 'Select', 'Name of credit card', 'woocommerce-paypal-payments' ),
-			),
-			array(
 				'value' => 'visa',
 				'label' => _x( 'Visa', 'Name of credit card', 'woocommerce-paypal-payments' ),
 			),


### PR DESCRIPTION
When resolving merge conflicts in #3342, deleting `select` item was not included, this PR fixes that by removing it and therefore will not be included as value in the select.