### PR TITLE
Auto-enable logging during onboarding (4591)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1501,16 +1501,26 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'wcgateway.logging.is-enabled'                         => function ( ContainerInterface $container ) : bool {
+	'wcgateway.logging.is-enabled'                         => static function ( ContainerInterface $container ) : bool {
 		$settings = $container->get( 'wcgateway.settings' );
+
+		// Check if logging was enabled in plugin settings.
+		$is_enabled = $settings->has( 'logging_enabled' ) && $settings->get( 'logging_enabled' );
+
+		// If not enabled, check if plugin is in onboarding mode.
+		if ( ! $is_enabled ) {
+			$state = $container->get( 'settings.connection-state' );
+			assert( $state instanceof ConnectionState );
+
+			$is_enabled = $state->is_onboarding();
+		}
 
 		/**
 		 * Whether the logging of the plugin errors/events is enabled.
+		 *
+		 * @param bool $is_enabled Whether the logging is enabled.
 		 */
-		return apply_filters(
-			'woocommerce_paypal_payments_is_logging_enabled',
-			$settings->has( 'logging_enabled' ) && $settings->get( 'logging_enabled' )
-		);
+		return apply_filters( 'woocommerce_paypal_payments_is_logging_enabled', $is_enabled );
 	},
 
 	'wcgateway.use-place-order-button'                     => function ( ContainerInterface $container ) : bool {


### PR DESCRIPTION
### Description

Changes the default state of the logging-module to be enabled while the merchant did not complete the onboarding wizard.

- This change affect the default state for legacy, and the new UI
- Since the merchant has no access to the plugin settings, the logger can only be disabled via the WP filter
- The filter `woocommerce_paypal_payments_is_logging_enabled` still has the final decision over the logger state

### Steps to Test

In the new UI:

1. Disconnect using the "Start over" toggle to completely reset all settings
    - This step will disable the logger, prior to this PR
2. On the first page of the onboarding wizard, expand the "Advanced options" and enable the "Sandbox" toggle
    - This action triggers an API call to the PayPal servers, which is logged
3. Navigate to "WooCommerce → Settings → Logs" and verify the PayPal API call is logged