### PR TITLE
Block checkout - Address form is missing after payment on Product and Cart pages (4557)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/paypal.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal.js
@@ -98,7 +98,7 @@ export const PayPalComponent = ( {
 
 		// this useEffect should run only once, but adding this in case of some kind of full re-rendering
 		setContinuationFilled( true );
-	}, [ shippingData, continuationFilled ] );
+	}, [ shippingData.needsShipping, continuationFilled ] );
 
 	const getCheckoutRedirectUrl = () => {
 		const checkoutUrl = new URL( config.scriptData.redirect );


### PR DESCRIPTION
Due to a infinite updates error in React, the address component is not rendered, this PR fixes that by using the proper `useEffect` dependecy.

### Steps To Reproduce
- In the dashboard → WooCommerce → Settings → Advanced select Block cart and Block checkout pages as default.
- On frontend navigate to the product and pay for it with PayPal or Pay Later.
- Check the address fields on Block checkout page.