### PR TITLE
OAuth login often fails in new UI (4582)

### DIFF
--- a/modules/ppcp-settings/src/DTO/OAuthConnectionDTO.php
+++ b/modules/ppcp-settings/src/DTO/OAuthConnectionDTO.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Data transfer object. Hold the one-time connection details for the OAuth authentication flow.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\DTO;
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\DTO;
+
+/**
+ * DTO that holds OAuth connection details, that are used to retrieve a
+ * permanent client ID/secret later.
+ *
+ * Intentionally has no internal logic, sanitation or validation.
+ */
+class OAuthConnectionDTO {
+	/**
+	 * Whether this connection is a sandbox account.
+	 *
+	 * @var bool
+	 */
+	public bool $is_sandbox = false;
+
+	/**
+	 * The shared authentication ID.
+	 *
+	 * @var string
+	 */
+	public string $shared_id = '';
+
+	/**
+	 * The authentication token.
+	 *
+	 * @var string
+	 */
+	public string $auth_token = '';
+
+	/**
+	 * Timestamp when the OAuth details were generated.
+	 *
+	 * @var int
+	 */
+	public int $timestamp = 0;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param bool   $is_sandbox Whether this connection is a sandbox account.
+	 * @param string $shared_id  The shared oauth ID.
+	 * @param string $auth_token The authentication token.
+	 * @param int    $timestamp  Optional. When the credentials were generated.
+	 */
+	public function __construct(
+		bool $is_sandbox,
+		string $shared_id,
+		string $auth_token,
+		int $timestamp = 0
+	) {
+		$this->is_sandbox = $is_sandbox;
+		$this->shared_id  = $shared_id;
+		$this->auth_token = $auth_token;
+		$this->timestamp  = 0 === $timestamp ? time() : $timestamp;
+	}
+}

--- a/modules/ppcp-settings/src/Endpoint/AuthenticationRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/AuthenticationRestEndpoint.php
@@ -204,17 +204,9 @@ class AuthenticationRestEndpoint extends RestEndpoint {
 		$auth_code   = $request->get_param( 'authCode' );
 		$use_sandbox = $request->get_param( 'useSandbox' );
 
-		try {
-			$this->authentication_manager->validate_id_and_auth_code( $shared_id, $auth_code );
-			$this->authentication_manager->authenticate_via_oauth( $use_sandbox, $shared_id, $auth_code );
-		} catch ( Exception $exception ) {
-			return $this->return_error( $exception->getMessage() );
-		}
+		$this->authentication_manager->remember_oauth_connection_details( $shared_id, $auth_code, $use_sandbox );
 
-		$account  = $this->authentication_manager->get_account_details();
-		$response = $this->sanitize_for_javascript( $this->response_map, $account );
-
-		return $this->return_success( $response );
+		return $this->return_success( true );
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Handler/ConnectionListener.php
+++ b/modules/ppcp-settings/src/Handler/ConnectionListener.php
@@ -156,7 +156,7 @@ class ConnectionListener {
 		$this->logger->info( 'Found OAuth merchant data in request', $data );
 
 		try {
-			$this->authentication_manager->finish_oauth_authentication( $data );
+			$this->authentication_manager->handle_oauth_authentication( $data );
 			$this->mark_token_as_processed( $token );
 		} catch ( \Exception $e ) {
 			$this->logger->error( 'Failed to complete authentication: ' . $e->getMessage() );

--- a/modules/ppcp-settings/src/Handler/ConnectionListener.php
+++ b/modules/ppcp-settings/src/Handler/ConnectionListener.php
@@ -29,6 +29,17 @@ use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
  */
 class ConnectionListener {
 	/**
+	 * Token processing states
+	 */
+	private const TOKEN_STATE_PROCESSING = 'processing';
+	private const TOKEN_STATE_PROCESSED  = 'processed';
+
+	/**
+	 * Transient key for storing token state.
+	 */
+	private const TOKEN_STATE_TRANSIENT = 'ppcp_auth_token_state';
+
+	/**
 	 * ID of the current settings page; empty if not on a PayPal settings page.
 	 *
 	 * @var string
@@ -133,34 +144,65 @@ class ConnectionListener {
 	 * @return void
 	 */
 	private function process_oauth_token( string $token ) : void {
-		// The request contains OAuth details: To avoid abuse we'll slow down the processing.
-		sleep( 2 );
-
 		if ( ! $token ) {
 			return;
 		}
 
+		$log_token = ( (string) substr( $token, 0, 2 ) ) . '...' . ( (string) substr( $token, - 6 ) );
+
 		if ( $this->was_token_processed( $token ) ) {
+			/*
+			 * Token already processed:
+			 * Do nothing as the DB already contains the full connection details.
+			 */
+			$this->logger->info( 'Token already processed, continuing silently', array( 'token' => $log_token ) );
+
 			return;
 		}
 
+		if ( $this->is_token_processing( $token ) ) {
+			/*
+			 * Authentication token is currently processed (in another request):
+			 * Briefly wait and then retry this request, basically waiting for
+			 * the above "was_processed" condition to become true.
+			 */
+			$this->logger->info( 'Token is currently being processed, waiting and retrying', array( 'token' => $log_token ) );
+			sleep( 1 );
+
+			// Get the current URL.
+			$current_url = add_query_arg( null, null );
+
+			// Add time to the query parameter to prevent browser cache issues.
+			$current_url = add_query_arg( 'retry', microtime( true ), $current_url );
+
+			wp_safe_redirect( $current_url );
+			exit;
+		}
+
 		if ( ! $this->url_manager->validate_token_and_delete( $token, $this->user_id ) ) {
+			$this->logger->error( 'Token validation failed', array( 'token' => $log_token ) );
+
 			return;
 		}
 
 		$data = $this->extract_data();
 		if ( ! $data ) {
+			$this->logger->error( 'Failed to extract merchant data from request' );
+
 			return;
 		}
 
 		$this->logger->info( 'Found OAuth merchant data in request', $data );
 
 		try {
+			$this->set_token_state( $token, self::TOKEN_STATE_PROCESSING );
+
 			$this->authentication_manager->handle_oauth_authentication( $data );
-			$this->mark_token_as_processed( $token );
 		} catch ( \Exception $e ) {
 			$this->logger->error( 'Failed to complete authentication: ' . $e->getMessage() );
 		}
+
+		$this->set_token_state( $token, self::TOKEN_STATE_PROCESSED );
 	}
 
 	/**
@@ -194,29 +236,57 @@ class ConnectionListener {
 	}
 
 	/**
-	 * Checks if the provided authentication token is new or has been used before.
+	 * Sets the state for a token.
 	 *
-	 * This check catches an issue where we receive the same authentication token twice,
-	 * which does not impact the login flow but creates noise in the logs.
-	 *
-	 * @param string $token The authentication token to check.
-	 * @return bool True if the token was already processed.
+	 * @param string $token The token to set state for.
+	 * @param string $state The state to set.
+	 * @return void
 	 */
-	private function was_token_processed( string $token ) : bool {
-		$prev_token = get_transient( 'ppcp_previous_auth_token' );
+	private function set_token_state( string $token, string $state ) : void {
+		$data = array(
+			'token' => $token,
+			'state' => $state,
+		);
 
-		return $prev_token && $prev_token === $token;
+		// 10 second expiration will block the page for max 10 seconds.
+		set_transient( self::TOKEN_STATE_TRANSIENT, $data, 10 );
 	}
 
 	/**
-	 * Stores the processed authentication token so we can prevent double-processing
-	 * of already verified token.
+	 * Gets the current state of a token.
 	 *
-	 * @param string $token The processed authentication token.
-	 * @return void
+	 * @param string $token The token to check.
+	 * @return string The current state of the token, or empty string if the token doesn't match.
 	 */
-	private function mark_token_as_processed( string $token ) : void {
-		set_transient( 'ppcp_previous_auth_token', $token, 60 );
+	private function get_token_state( string $token ) : string {
+		$data = get_transient( self::TOKEN_STATE_TRANSIENT );
+
+		if ( empty( $data ) || ! is_array( $data ) || empty( $data['token'] ) || empty( $data['state'] ) ) {
+			return '';
+		}
+
+		// Only return the state if the token matches.
+		return ( $data['token'] === $token ) ? $data['state'] : '';
+	}
+
+	/**
+	 * Checks if the token is currently being processed.
+	 *
+	 * @param string $token The token to check.
+	 * @return bool True if the token is currently being processed, false otherwise.
+	 */
+	private function is_token_processing( string $token ) : bool {
+		return $this->get_token_state( $token ) === self::TOKEN_STATE_PROCESSING;
+	}
+
+	/**
+	 * Checks if the token has been fully processed.
+	 *
+	 * @param string $token The token to check.
+	 * @return bool True if the token has been processed, false otherwise.
+	 */
+	private function was_token_processed( string $token ) : bool {
+		return $this->get_token_state( $token ) === self::TOKEN_STATE_PROCESSED;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -9,12 +9,9 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service;
 
-use JsonException;
 use Throwable;
-use Exception;
+use JsonException;
 use Psr\Log\LoggerInterface;
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\LoginSeller;
@@ -303,7 +300,7 @@ class AuthenticationManager {
 	 * @return void
 	 * @throws RuntimeException When invalid shared ID or auth provided.
 	 */
-	public function validate_id_and_auth_code( string $shared_id, string $auth_code ) : void {
+	private function validate_id_and_auth_code( string $shared_id, string $auth_code ) : void {
 		if ( empty( $shared_id ) ) {
 			throw new RuntimeException( 'No onboarding ID provided.' );
 		}
@@ -322,10 +319,10 @@ class AuthenticationManager {
 	 * @param bool   $use_sandbox Whether to use the sandbox mode.
 	 * @param string $shared_id   The OAuth client ID.
 	 * @param string $auth_code   The OAuth authorization code.
-	 * @return void
+	 * @return MerchantConnectionDTO A DTO containing the connection details.
 	 * @throws RuntimeException When failed to retrieve payee.
 	 */
-	public function authenticate_via_oauth( bool $use_sandbox, string $shared_id, string $auth_code ) : void {
+	private function authenticate_via_oauth( bool $use_sandbox, string $shared_id, string $auth_code ) : MerchantConnectionDTO {
 		$this->logger->info(
 			'Attempting OAuth login to PayPal...',
 			array(

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -24,6 +24,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\EnvironmentConfig;
 use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
+use WooCommerce\PayPalCommerce\Settings\DTO\OAuthConnectionDTO;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
 use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
@@ -33,6 +34,12 @@ use WooCommerce\PayPalCommerce\Settings\Endpoint\CommonRestEndpoint;
  * Class that manages the connection to PayPal.
  */
 class AuthenticationManager {
+
+	/**
+	 * Option name used to store the OAuth connection details.
+	 */
+	private const OAUTH_OPTION_NAME = 'ppcp_oauth_connection_details';
+
 	/**
 	 * Data model that stores the connection details.
 	 *
@@ -219,6 +226,35 @@ class AuthenticationManager {
 		);
 
 		$this->update_connection_details( $connection );
+	}
+
+	/**
+	 * Stores the OAuth details in the DB.
+	 *
+	 * Those details are used in another request to complete the OAuth login process.
+	 *
+	 * @param string $shared_id   The shared onboarding ID.
+	 * @param string $auth_code   The authorization code.
+	 * @param bool   $use_sandbox Whether it's a sandbox or production account.
+	 * @return void
+	 */
+	public function remember_oauth_connection_details( string $shared_id, string $auth_code, bool $use_sandbox ) : void {
+		$this->logger->info(
+			'Storing one-time OAuth credentials...',
+			array(
+				'shared_id'   => $shared_id,
+				'auth_code'   => $auth_code,
+				'use_sandbox' => $use_sandbox,
+			)
+		);
+
+		$oauth_connection = new OAuthConnectionDTO(
+			$use_sandbox,
+			$shared_id,
+			$auth_code
+		);
+
+		update_option( self::OAUTH_OPTION_NAME, $oauth_connection, false );
 	}
 
 

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Settings\Service;
 
 use JsonException;
 use Throwable;
+use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
@@ -257,6 +258,36 @@ class AuthenticationManager {
 		update_option( self::OAUTH_OPTION_NAME, $oauth_connection, false );
 	}
 
+	/**
+	 * Remove the temporary oauth credentials from the DB.
+	 *
+	 * @return void
+	 */
+	private function remove_oauth_connection_details() : void {
+		delete_option( self::OAUTH_OPTION_NAME );
+	}
+
+	/**
+	 * Returns the previously remembered oauth details.
+	 *
+	 * @return OAuthConnectionDTO The stored oauth credentials.
+	 * @throws RuntimeException When no stored credentials are found, or they have expired.
+	 */
+	private function retrieve_oauth_connection_details() : OAuthConnectionDTO {
+		$oauth_data = get_option( self::OAUTH_OPTION_NAME );
+
+		if ( ! $oauth_data instanceof OAuthConnectionDTO ) {
+			throw new RuntimeException( 'No stored OAuth credentials found' );
+		}
+
+		// Check for expiration (credentials expire after 1 hour).
+		if ( time() - $oauth_data->timestamp > 3600 ) {
+			$this->remove_oauth_connection_details();
+			throw new RuntimeException( 'Stored OAuth credentials have expired' );
+		}
+
+		return $oauth_data;
+	}
 
 	/**
 	 * Checks if the provided ID and auth-code have a valid format.
@@ -319,29 +350,44 @@ class AuthenticationManager {
 		$connection->client_secret = $credentials['client_secret'];
 		$connection->merchant_id   = $credentials['merchant_id'];
 
-		$this->update_connection_details( $connection );
+		return $connection;
 	}
 
 	/**
-	 * Verifies the merchant details in the final OAuth redirect and extracts
-	 * missing credentials from the URL.
+	 * Handles the full OAuth authentication flow.
+	 *
+	 * 1. Verify that the provided request contains required details.
+	 * 2. Retrieve the oauth-connection details and validate them.
+	 * 3. Convert the oauth-connection details into a permanent id/secret.
+	 * 4. Complete the authentication by storing all details in the DB.
 	 *
 	 * @param array $request_data Array of request parameters to process.
 	 * @return void
 	 *
 	 * @throws RuntimeException Missing or invalid credentials.
 	 */
-	public function finish_oauth_authentication( array $request_data ) : void {
+	public function handle_oauth_authentication( array $request_data ) : void {
 		$merchant_id    = $request_data['merchant_id'] ?? '';
 		$merchant_email = $request_data['merchant_email'] ?? '';
 		$seller_type    = $request_data['seller_type'] ?? '';
 
+		// 1. Verify the request details.
 		if ( empty( $merchant_id ) || empty( $merchant_email ) ) {
 			throw new RuntimeException( 'Missing merchant ID or email in request' );
 		}
 
-		$connection = $this->common_settings->get_merchant_data();
+		// 2. Retrieve and validate the oauth connection.
+		$oauth_connection = $this->retrieve_oauth_connection_details();
+		$this->validate_id_and_auth_code( $oauth_connection->shared_id, $oauth_connection->auth_token );
 
+		// 3. Trade oauth connection details to permanent client credentials.
+		$connection = $this->authenticate_via_oauth(
+			$oauth_connection->is_sandbox,
+			$oauth_connection->shared_id,
+			$oauth_connection->auth_token
+		);
+
+		// 4. Complete the authentication checks and persist details.
 		if ( $connection->merchant_id && $connection->merchant_id !== $merchant_id ) {
 			throw new RuntimeException( 'Unexpected merchant ID in request' );
 		}
@@ -352,6 +398,8 @@ class AuthenticationManager {
 		if ( SellerTypeEnum::is_valid( $seller_type ) ) {
 			$connection->seller_type = $seller_type;
 		}
+
+		$this->remove_oauth_connection_details();
 
 		$this->update_connection_details( $connection );
 	}

--- a/modules/ppcp-settings/src/Service/OnboardingUrlManager.php
+++ b/modules/ppcp-settings/src/Service/OnboardingUrlManager.php
@@ -87,13 +87,6 @@ class OnboardingUrlManager {
 			return true;
 		}
 
-		if ( OnboardingUrl::validate_previous_token( $this->cache, $token, $user_id ) ) {
-			// TODO: Do we need this here? Previous logic was to reload the page without doing anything in this case.
-			$this->logger->info( 'Validated previous token, silently redirecting: ' . $log_token );
-
-			return true;
-		}
-
 		$this->logger->error( 'Failed to validate onboarding ppcpToken: ' . $log_token );
 
 		return false;


### PR DESCRIPTION
### Description

This PR refactores the OAuth process in two ways:

#### I) Solve timing issues between REST and redirect

The initial REST call only stores the auth_code and ID, without attempting to resolve them directly. This ensures that the REST call finishes very fast.

The following page reload fetches the code/id from the DB and performs the API requests which were initially handled in the Ajax call. This consolidates the full authentication logic to the same HTTP request.

#### II) Handling concurrent page loads

After finishing the login popup, PayPal often starts TWO page reloads. While the first (detached) request handles the authentication correctly, the second request (which happens in the browser) would previously run into a “token already used” situation and display the login screen again.

A new state was introduced to mark the token as “currently processing” (max lifetime 10 seconds). When any follow-up request encounter this “currently processing” state, they will pause for 1 second and do a simple page reload, waiting for the authentication request to complete.