### PR TITLE
Remove hardcoded update bcdc gateway enabled option

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -628,8 +628,6 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 					$standard_card_button['enabled'] = 'no';
 					update_option( 'woocommerce_ppcp-card-button-gateway_settings', $standard_card_button );
 				}
-				$standard_card_button['enabled'] = 'yes';
-				update_option( 'woocommerce_ppcp-card-button-gateway_settings', $standard_card_button );
 
 				$dcc_applies = $container->get( 'api.helpers.dccapplies' );
 				assert( $dcc_applies instanceof DccApplies );


### PR DESCRIPTION
While debugging BCDC a hardcoded update enabled option was added which ended up in trunk. This PR removes it.