### PR TITLE
QA Add ACDC tests

### DIFF
--- a/tests/qa/resources/cards.ts
+++ b/tests/qa/resources/cards.ts
@@ -1,6 +1,6 @@
 const visa: WooCommerce.CreditCard = {
-	card_number: '4005519200000004',
-	// card_number: '4444333322221111',
+	// card_number: '4005519200000004',
+	card_number: '4444333322221111',
 	// card_number: '4111111111111111',
 	expiration_date: '12/30',
 	card_cvv: '029',
@@ -9,7 +9,7 @@ const visa: WooCommerce.CreditCard = {
 
 const visa3ds: WooCommerce.CreditCard = {
 	card_number: '4020024518402084',
-	expiration_date: '01/25',
+	expiration_date: '01/30',
 	card_cvv: '123',
 	card_type: 'VISA',
 	code_3ds: '1234',
@@ -24,7 +24,7 @@ const mastercard: WooCommerce.CreditCard = {
 
 const declined: WooCommerce.CreditCard = {
 	card_number: '4032037524607534',
-	expiration_date: '09/25',
+	expiration_date: '09/30',
 	card_cvv: '340',
 	card_type: 'VISA',
 };

--- a/tests/qa/resources/pcp-gateways.ts
+++ b/tests/qa/resources/pcp-gateways.ts
@@ -64,7 +64,6 @@ const acdc: Pcp.Gateway = {
 
 const acdc3ds: Pcp.Gateway = {
 	...acdc,
-	shortcut: 'acdc3ds',
 	threeDSecure: 'always-3d-secure',
 };
 

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-checkout.data.ts
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import { payments, orders, customers, guests, ShopOrder } from '../../../../resources';
+
+const customer = customers.usa;
+const guest = guests.usa;
+
+
+export const acdcCheckout: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-3217
+		title: 'PCP-3217 | Transaction - Checkout - ACDC - Default order',
+		...orders.default,
+		payment: payments.acdc,
+		customer: guest,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-3224
+		title: 'PCP-3224 | Transaction - Checkout - ACDC - Order by customer',
+		...orders.default,
+		payment: payments.acdc,
+		customer,
+	},
+];
+
+export const acdcCheckoutExcludingTax: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-3221
+		title: 'PCP-3221 | Transaction - Checkout - ACDC - Order with price excluding tax',
+		...orders.excludingTax,
+		payment: payments.acdc,
+		customer: guest,
+	},
+];
+
+export const acdcCheckoutIntentAuthorized: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-3228
+		title: 'PCP-3228 | Transaction - Checkout - ACDC - Order with Intent Authorized',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			isAuthorized: true,
+		},
+		orderStatus: 'on-hold',
+		customer: guest,
+	},
+];
+
+export const acdcCheckout3ds: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1135
+		title: 'PCP-1135 | Transaction - Checkout - ACDC - Order with Always trigger 3D secure',
+		...orders.default,
+		payment: payments.acdc3ds,
+		customer: guest,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-3225
+		title: 'PCP-3225 | Transaction - Checkout - ACDC - Order paid with card requiring 3DS',
+		...orders.default,
+		payment: payments.acdc3ds,
+		customer,
+	},
+];

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-classic-checkout.data.ts
@@ -1,0 +1,64 @@
+/**
+ * Internal dependencies
+ */
+import { payments, orders, customers, guests, ShopOrder } from '../../../../resources';
+
+const customer = customers.usa;
+const guest = guests.usa;
+
+export const acdcClassicCheckout: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1202
+		title: 'PCP-1202 | Transaction - Classic checkout - ACDC - Default order',
+		...orders.default,
+		payment: payments.acdc,
+		customer: guest,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-2743
+		title: 'PCP-2743 | Transaction - Classic checkout - ACDC - Order by customer',
+		...orders.default,
+		payment: payments.acdc,
+		customer,
+	},
+];
+
+export const acdcClassicCheckoutExcludingTax: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1259
+		title: 'PCP-1259 | Transaction - Classic checkout - ACDC - Order with price excluding tax',
+		...orders.excludingTax,
+		payment: payments.acdc,
+	},
+];
+
+export const acdcClassicCheckoutIntentAuthorized: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/
+		title: 'PCP-0000 | Transaction - Classic checkout - ACDC - Order with Intent Authorized',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			isAuthorized: true,
+		},
+		orderStatus: 'on-hold',
+		customer: guest,
+	},
+];
+
+export const acdcClassicCheckout3ds: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/
+		title: 'PCP-0000 | Transaction - Classic checkout - ACDC - Contingency for 3D Secure = Always trigger 3D secure',
+		...orders.default,
+		payment: payments.acdc3ds,
+		customer: guest,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1209
+		title: 'PCP-1209 | Transaction - Classic checkout - ACDC - Order paid with card requiring 3DS',
+		...orders.default,
+		payment: payments.acdc3ds,
+		customer: guest,
+	},
+];

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-pay-by-link.data.ts
@@ -1,0 +1,65 @@
+/**
+ * Internal dependencies
+ */
+import { customers, guests, payments, orders, ShopOrder } from '../../../../resources';
+
+const customer = customers.usa;
+const guest = guests.usa;
+
+export const acdcPayByLink: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1327
+		title: 'PCP-1327 | Transaction - Pay by link - ACDC - Guest - Default order',
+		...orders.default,
+		payment: payments.acdc,
+		customer: guest,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1326
+		title: 'PCP-1326 | Transaction - Pay by link - ACDC - Customer - Default order',
+		...orders.default,
+		payment: payments.acdc,
+		customer,
+	},
+];
+
+export const acdcPayByLinkExcludingTax: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/
+		title: 'PCP-0000 | Transaction - Pay by link - ACDC - Order with price excluding tax',
+		...orders.excludingTax,
+		payment: payments.acdc,
+		customer: guest,
+	},
+];
+
+export const acdcPayByLinkIntentAuthorized: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/
+		title: 'PCP-0000 | Transaction - Pay by link - ACDC - Order with Intent Authorized',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			isAuthorized: true,
+		},
+		orderStatus: 'on-hold',
+		customer: guest,
+	},
+];
+
+export const acdcPayByLink3ds: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/
+		title: 'PCP-0000 | Transaction - Pay by link - ACDC - Contingency for 3D Secure = Always trigger 3D secure',
+		...orders.default,
+		payment: payments.acdc3ds,
+		customer: guest,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/
+		title: 'PCP-0000 | Transaction - Pay by link - ACDC - Order paid with card requiring 3DS',
+		...orders.default,
+		payment: payments.acdc3ds,
+		customer: guest,
+	},
+];

--- a/tests/qa/tests/05-transactions/_test-data/acdc/index.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/index.ts
@@ -1,0 +1,3 @@
+export * from './acdc-checkout.data';
+export * from './acdc-classic-checkout.data';
+export * from './acdc-pay-by-link.data';

--- a/tests/qa/tests/05-transactions/transaction-usa-classic.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-usa-classic.spec.ts
@@ -24,6 +24,12 @@ import {
 	payPalClassicCheckout,
 	payPalClassicCheckoutIntentAuthorized,
 } from './_test-data/paypal';
+import {
+	acdcClassicCheckout,
+	acdcClassicCheckoutIntentAuthorized,
+	acdcClassicCheckoutExcludingTax,
+	acdcClassicCheckout3ds,
+} from './_test-data/acdc';
 import { fastlaneClassicCheckout } from './_test-data/fastlane';
 
 const { payPal, venmo, acdc, fastlane } = gateways;
@@ -48,6 +54,7 @@ test.beforeAll( async ( { utils, pcpApi } ) => {
 } );
 
 transactionsOnClassicCheckout( payPalClassicCheckout );
+transactionsOnClassicCheckout( acdcClassicCheckout );
 
 /**
  * Venmo is eligible only for USA/USD
@@ -64,6 +71,7 @@ test.describe( () => {
 	} );
 
 	transactionsOnClassicCheckout( payPalCheckoutExcludingTax );
+	transactionsOnClassicCheckout( acdcClassicCheckoutExcludingTax );
 
 	test.afterAll( async ( { wooCommerceUtils } ) => {
 		await wooCommerceUtils.setTaxes( taxSettings.including );
@@ -77,9 +85,23 @@ test.describe( () => {
 	} );
 
 	transactionsOnClassicCheckout( payPalClassicCheckoutIntentAuthorized );
+	transactionsOnClassicCheckout( acdcClassicCheckoutIntentAuthorized );
 
 	test.afterAll( async ( { pcpApi } ) => {
 		await pcpApi.updatePcpSettings( { authorizeOnly: false } );
+	} );
+} );
+
+// ACDC 3DS
+test.describe( () => {
+	test.beforeAll( async ( { pcpApi } ) => {
+		await pcpApi.updatePcpPaymentMethods( { threeDSecure: 'always-3d-secure' } );
+	} );
+
+	transactionsOnClassicCheckout( acdcClassicCheckout3ds );
+
+	test.afterAll( async ( { pcpApi } ) => {
+		await pcpApi.updatePcpPaymentMethods( { threeDSecure: 'no-3d-secure' } );
 	} );
 } );
 

--- a/tests/qa/tests/05-transactions/transaction-usa.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-usa.spec.ts
@@ -8,12 +8,25 @@ import {
 	gateways,
 	taxSettings,
 } from '../../resources';
-import { transactionsOnCheckout } from './_test-scenarios';
+import {
+	transactionsOnCheckout,
+	transactionsOnPayByLink,
+} from './_test-scenarios';
 import {
 	payPalCheckout,
 	payPalCheckoutExcludingTax,
 	payPalCheckoutIntentAuthorized,
 } from './_test-data/paypal';
+import {
+	acdcCheckout,
+	acdcCheckoutExcludingTax,
+	acdcCheckoutIntentAuthorized,
+	acdcCheckout3ds,
+	acdcPayByLink,
+	acdcPayByLink3ds,
+	acdcPayByLinkExcludingTax,
+	acdcPayByLinkIntentAuthorized,
+} from './_test-data/acdc';
 import { fastlaneCheckout } from './_test-data/fastlane';
 
 const { payPal, venmo, acdc, fastlane } = gateways;
@@ -35,6 +48,8 @@ test.beforeAll( async ( { utils, pcpApi } ) => {
 } );
 
 transactionsOnCheckout( payPalCheckout );
+transactionsOnCheckout( acdcCheckout );
+transactionsOnPayByLink( acdcPayByLink );
 
 // Excluding Tax
 test.describe( () => {
@@ -43,6 +58,8 @@ test.describe( () => {
 	} );
 
 	transactionsOnCheckout( payPalCheckoutExcludingTax );
+	transactionsOnCheckout( acdcCheckoutExcludingTax );
+	transactionsOnPayByLink( acdcPayByLinkExcludingTax );
 
 	test.afterAll( async ( { wooCommerceUtils } ) => {
 		await wooCommerceUtils.setTaxes( taxSettings.including );
@@ -56,9 +73,25 @@ test.describe( () => {
 	} );
 
 	transactionsOnCheckout( payPalCheckoutIntentAuthorized );
+	transactionsOnCheckout( acdcCheckoutIntentAuthorized );
+	transactionsOnPayByLink( acdcPayByLinkIntentAuthorized );
 
 	test.afterAll( async ( { pcpApi } ) => {
 		await pcpApi.updatePcpSettings( { authorizeOnly: false } );
+	} );
+} );
+
+// ACDC 3DS
+test.describe( () => {
+	test.beforeAll( async ( { pcpApi } ) => {
+		await pcpApi.updatePcpPaymentMethods( { threeDSecure: 'always-3d-secure' } );
+	} );
+
+	transactionsOnCheckout( acdcCheckout3ds );
+	transactionsOnPayByLink( acdcPayByLink3ds );
+
+	test.afterAll( async ( { pcpApi } ) => {
+		await pcpApi.updatePcpPaymentMethods( { threeDSecure: 'no-3d-secure' } );
 	} );
 } );
 

--- a/tests/qa/utils/frontend/checkout.ts
+++ b/tests/qa/utils/frontend/checkout.ts
@@ -53,9 +53,8 @@ export class Checkout extends CheckoutBase {
 			// Fill billing details
 			await this.fillCheckoutForm( customer );
 		}
-
+		
 		// Select shipping or initial shipment (for subscriptions) option:
-		await this.selectShippingMethod( shipping.settings.title );
 		await this.selectShippingMethod( shipping.settings.title );
 
 		// Make payment with tested method

--- a/tests/qa/utils/frontend/paypal-ui-classic.ts
+++ b/tests/qa/utils/frontend/paypal-ui-classic.ts
@@ -65,15 +65,15 @@ export class PayPalUiClassic extends PayPalUi {
 	acdcGatewayText = () =>
 		this.page.locator( '.payment_method_ppcp-credit-card-gateway>label' );
 
-	cardNumberInput = () =>
+	acdcCardNumberInput = () =>
 		this.page
 			.frameLocator( 'iframe[title="paypal_card_number_field"]' )
 			.locator( 'input.card-field-number ' );
-	cardExpirationInput = () =>
+	acdcCardExpirationInput = () =>
 		this.page
 			.frameLocator( 'iframe[title="paypal_card_expiry_field"]' )
 			.locator( 'input.card-field-expiry' );
-	cardCVVInput = () =>
+	acdcCardCvvInput = () =>
 		this.page
 			.frameLocator( 'iframe[title="paypal_card_cvv_field"]' )
 			.locator( 'input.card-field-cvv' );
@@ -264,21 +264,6 @@ export class PayPalUiClassic extends PayPalUi {
 	acdcUseNewPaymentRadio = () =>
 		this.page.locator( '.woocommerce-SavedPaymentMethods-new > input' );
 
-	threeDSFrame1 = () =>
-		this.page
-			.frameLocator( '.paypal-checkout-sandbox-iframe' )
-			.frameLocator( '[name^="__zoid__three_domain_secure__"]' );
-	threeDSFrame2 = () =>
-		this.threeDSFrame1()
-			.frameLocator( '#threedsIframeV2' )
-			.frameLocator( '[id^="cardinal-stepUpIframe-"]' );
-	threeDSAcceptCookiesButton = () =>
-		this.threeDSFrame1().locator( '#acceptAllButton' );
-	threeDSOtpInput = () =>
-		this.threeDSFrame2().locator( 'input[name="challengeDataEntry"]' );
-	threeDSSubmitButton = () =>
-		this.threeDSFrame2().locator( 'input.primary[type="submit"]' );
-
 	payUponInvoiceBirthDateInput = () =>
 		this.page.locator( '#billing_birth_date' );
 	payUponInvoiceGatewayTitle = () =>
@@ -323,41 +308,6 @@ export class PayPalUiClassic extends PayPalUi {
 	// Actions
 
 	/**
-	 * Completes payment with ACDC (vaulting disabled)
-	 *
-	 * @param payment
-	 * @param merchant
-	 */
-	completeAcdcPayment = async (
-		payment: Pcp.Payment,
-		merchant: Pcp.Merchant
-	) => {
-		await expect( this.acdcGateway() ).toBeVisible();
-		await this.acdcGateway().click();
-
-		//if some cards are already stored then "Use a new payment method" radio should be checked
-		if ( await this.acdcUseNewPaymentRadio().isVisible() ) {
-			await this.acdcUseNewPaymentRadio().check();
-		}
-
-		await this.cardNumberInput().fill( payment.card.card_number );
-		// trick to properly fill expiration date input
-		await this.cardExpirationInput().click();
-		for ( const char of payment.card.expiration_date ) {
-			await this.page.keyboard.type( char );
-			await this.page.waitForTimeout( 250 );
-		}
-		await this.cardCVVInput().fill( payment.card.card_cvv );
-
-		if ( payment.saveToAccount ) {
-			await this.acdcSaveToAccountCheckbox().check();
-		}
-
-		await this.submitOrder();
-		await this.replacePayPalAuthToken( merchant );
-	};
-
-	/**
 	 * Completes payment with ACDC (vaulting enabled)
 	 *
 	 * @param payment
@@ -372,23 +322,6 @@ export class PayPalUiClassic extends PayPalUi {
 		await this.acdcSavedCardByNumber( payment.card.card_number ).click();
 		await this.submitOrder();
 		await this.replacePayPalAuthToken( merchant );
-	};
-
-	/**
-	 * Completes payment with ACDC 3D-Secure (vaulting disabled)
-	 *
-	 * @param payment
-	 * @param merchant
-	 */
-	completeAcdc3dsPayment = async (
-		payment: Pcp.Payment,
-		merchant: Pcp.Merchant
-	) => {
-		await this.completeAcdcPayment( payment, merchant );
-		// PayPal change: Manual 3DS input is not required any more
-		// await this.threeDSAcceptCookiesButton().click();
-		// await this.threeDSOtpInput().fill( payment.card.code_3ds );
-		// await this.threeDSSubmitButton().click();
 	};
 
 	/**
@@ -468,10 +401,10 @@ export class PayPalUiClassic extends PayPalUi {
 	addCardPaymentMethod = async ( payment: Pcp.Payment ) => {
 		await expect( this.debitCreditCardsGateway() ).toBeVisible();
 		await this.debitCreditCardsGateway().click();
-		await this.cardNumberInput().fill( payment.card.card_number );
-		await this.cardExpirationInput().click();
+		await this.acdcCardNumberInput().fill( payment.card.card_number );
+		await this.acdcCardExpirationInput().click();
 		await this.page.keyboard.type( payment.card.expiration_date );
-		await this.cardCVVInput().fill( payment.card.card_cvv );
+		await this.acdcCardCvvInput().fill( payment.card.card_cvv );
 		await this.addPaymentMethodButton().click();
 	};
 

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -24,6 +24,11 @@ export class PayPalUi {
 	}
 
 	// Locators
+	paymentOptionsContainers = () =>
+		this.page
+			.locator( '#payment-method' )
+			.locator( '.wc-block-components-radio-control-accordion-option' );
+
 	placeOrderButton = () =>
 		this.page.getByRole( 'button', { name: 'Place order' } );
 	payForOrderButton = () =>
@@ -104,6 +109,44 @@ export class PayPalUi {
 	fastlaneOtp3Input = () => this.page.locator( '#otp3-input' );
 	fastlaneOtp4Input = () => this.page.locator( '#otp4-input' );
 	fastlaneOtp5Input = () => this.page.locator( '#otp5-input' );
+	
+	acdcGateway = () => this.page.locator(
+		'#radio-control-wc-payment-method-options-ppcp-credit-card-gateway'
+	);
+	acdcContainer = () => this.paymentOptionsContainers().filter( {
+		has: this.acdcGateway()
+	} );
+	acdcCardholderNameInput = () =>
+		this.acdcContainer()
+			.frameLocator( '[id^="zoid-paypal-card-name-field"] iframe[name^="__zoid__paypal_card_name_field__"]' )
+			.locator( 'input.card-field-name' );
+	acdcCardNumberInput = () =>
+		this.acdcContainer()
+			.frameLocator( '[id^="zoid-paypal-card-number-field"] iframe[name^="__zoid__paypal_card_number_field__"]' )
+			.locator( 'input.card-field-number' );
+	acdcCardExpirationInput = () =>
+		this.acdcContainer()
+			.frameLocator( '[id^="zoid-paypal-card-expiry-field"] iframe[name^="__zoid__paypal_card_expiry_field__"]' )
+			.locator( 'input.card-field-expiry' );
+	acdcCardCvvInput = () =>
+		this.acdcContainer()
+			.frameLocator( '[id^="zoid-paypal-card-cvv-field"] iframe[name^="__zoid__paypal_card_cvv_field__"]' )
+			.locator( 'input.card-field-cvv' );
+
+	threeDSFrame1 = () =>
+		this.page
+			.frameLocator( '.paypal-checkout-sandbox-iframe' )
+			.frameLocator( '[name^="__zoid__three_domain_secure__"]' );
+	threeDSFrame2 = () =>
+		this.threeDSFrame1()
+			.frameLocator( '#threedsIframeV2' )
+			.frameLocator( '[id^="cardinal-stepUpIframe-"]' );
+	threeDSAcceptCookiesButton = () =>
+		this.threeDSFrame1().locator( '#acceptAllButton' );
+	threeDSOtpInput = () =>
+		this.threeDSFrame2().locator( 'input[name="challengeDataEntry"]' );
+	threeDSSubmitButton = () =>
+		this.threeDSFrame2().locator( 'input.primary[type="submit"]' );
 
 	// Actions
 
@@ -294,6 +337,69 @@ export class PayPalUi {
 	};
 
 	/**
+	 * Completes payment with ACDC (vaulting disabled)
+	 *
+	 * @param payment
+	 * @param merchant
+	 */
+	completeAcdcPayment = async (
+		payment: Pcp.Payment,
+		merchant: Pcp.Merchant
+	) => {
+		const { card, saveToAccount } = payment;
+		await expect( this.acdcGateway() ).toBeVisible();
+		await this.acdcGateway().click();
+
+		// TODO: implement tests
+		// //if some cards are already stored then "Use a new payment method" radio should be checked
+		// if ( await this.acdcUseNewPaymentRadio().isVisible() ) {
+		// 	await this.acdcUseNewPaymentRadio().check();
+		// }
+
+		// On block checkout the Cardholder Name input is present
+		// Needed to assert payment via PayPal API
+		// await this.acdcCardholderNameInput().fill( card.card_holder );
+			
+		await this.acdcCardNumberInput().fill( card.card_number );
+		// trick to properly fill expiration date input
+		await this.acdcCardExpirationInput().click();
+		for ( const char of card.expiration_date ) {
+			await this.page.keyboard.type( char );
+			await this.page.waitForTimeout( 200 );
+		}
+		await this.acdcCardCvvInput().fill( card.card_cvv );
+
+		// TODO: implement tests
+		// if ( saveToAccount ) {
+		// 	await this.acdcSaveToAccountCheckbox().check();
+		// }
+
+		await this.submitOrder();
+		await this.replacePayPalAuthToken( merchant );
+	};
+
+	/**
+	 * Completes payment with ACDC 3D-Secure (vaulting disabled)
+	 *
+	 * @param payment
+	 * @param merchant
+	 */
+	completeAcdc3dsPayment = async (
+		payment: Pcp.Payment,
+		merchant: Pcp.Merchant
+	) => {
+		await this.completeAcdcPayment( payment, merchant );
+		// TODO: report misbehavior
+		// PayPal change: Manual 3DS input is not required any more
+		// await this.threeDSAcceptCookiesButton().click();
+		// await this.threeDSOtpInput().fill( payment.card.code_3ds );
+		// await this.threeDSSubmitButton().click();
+	};
+
+	completeAcdcVaultedPayment = async ( ...args ) =>
+		console.log( `TODO: completeAcdc3dsPayment for block pages` );
+
+	/**
 	 * Asserts Fastlane input field and button
 	 * Inputs fastlane email and clicks Continue
 	 *
@@ -348,15 +454,6 @@ export class PayPalUi {
 		await this.page.waitForTimeout( 1000 );
 		await this.submitOrder();
 	};
-
-	completeAcdc3dsPayment = async ( ...args ) =>
-		console.log( `TODO: completeAcdc3dsPayment for block pages` );
-
-	completeAcdcVaultedPayment = async ( ...args ) =>
-		console.log( `TODO: completeAcdc3dsPayment for block pages` );
-
-	completeAcdcPayment = async ( ...args ) =>
-		console.log( `TODO: completeAcdcPayment for block pages` );
 
 	completeOXXOPayment = async ( ...args ) =>
 		console.log( `TODO: completeOXXOPayment for block pages` );

--- a/tests/qa/utils/paypal-api.ts
+++ b/tests/qa/utils/paypal-api.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { APIRequestContext, expect } from '@playwright/test';
-import { createAuthHeader } from '@inpsyde/playwright-utils/build';
+import { createAuthHeader, getLast4CardDigits } from '@inpsyde/playwright-utils/build';
 /**
  * Internal dependencies
  */
@@ -228,7 +228,7 @@ export class PayPalApi {
 		wooCommerceOrderJson: WooCommerce.Order,
 		shopOrder: WooCommerce.ShopOrder
 	) => {
-		const fundingSource = shopOrder.payment.gateway.shortcut;
+		const gatewayShortcut = shopOrder.payment.gateway.shortcut;
 		const payPalOrderId = await this.getOrderIdFromWooCommerce(
 			wooCommerceOrderJson
 		);
@@ -239,7 +239,7 @@ export class PayPalApi {
 			shopOrder.merchant
 		);
 
-		if ( fundingSource !== 'oxxo' ) {
+		if ( gatewayShortcut !== 'oxxo' ) {
 			const payPalPaymentId = await this.getPaymentIdFromOrder(
 				payPalOrder,
 				shopOrder.payment
@@ -254,7 +254,7 @@ export class PayPalApi {
 			: 'CAPTURE';
 		await expect( payPalOrder.intent ).toEqual( expectedIntent );
 
-		switch ( fundingSource ) {
+		switch ( gatewayShortcut ) {
 			case 'oxxo':
 				await expect( payPalOrder.status ).toEqual( 'COMPLETED' );
 				await expect( payPalOrder.payment_source ).toHaveProperty(
@@ -271,8 +271,8 @@ export class PayPalApi {
 				await expect( payPalOrder.payment_source ).toHaveProperty(
 					'card'
 				);
-				await expect( payPalOrder.payment_source.card.name ).toEqual(
-					`${ shopOrder.customer.first_name } ${ shopOrder.customer.last_name }`
+				await expect( payPalOrder.payment_source.card.last_digits ).toEqual(
+					getLast4CardDigits( shopOrder.payment.card.card_number )
 				);
 				break;
 


### PR DESCRIPTION
### Description

Add ACDC tests for new UI:

- Unify locators and makePayment for block and classic checkout.
- Add ACDC test data.
- Fix assertion in PayPalApi to satisfy both block and classic checkouts.
- Fix cards data.
- Fix ACDC 3DS gateway data.