### PR TITLE
PayPal button greyed out on single product page for variable products with 2+ attributes with the old UI.  (4449)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.js
@@ -162,12 +162,16 @@ class SingleProductBootstrap {
 			},
 		]
 			.map( ( f ) => f() )
-            .sort((a, b) => {
-                if (parseInt(a.replace(/\D/g, '')) < parseInt(b.replace(/\D/g, '')) ) {
-                    return 1;
-                }
-                return -1;
-            })
+			.filter( ( val ) => val !== null && val !== undefined )
+			.sort( ( a, b ) => {
+				if (
+					parseInt( a.replace( /\D/g, '' ) ) <
+					parseInt( b.replace( /\D/g, '' ) )
+				) {
+					return 1;
+				}
+				return -1;
+			} )
 			.find( ( val ) => val );
 
 		if ( typeof priceText === 'undefined' ) {


### PR DESCRIPTION
Added a filter to remove null and undefined values before sorting price elements,
preventing "TypeError: a is null" errors when comparing prices. This ensures the
sort function only operates on valid price strings.


