### PR TITLE
Fix BCDC onboarding for Mexico merchants (4141)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/hooks/usePaymentConfig.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/hooks/usePaymentConfig.js
@@ -116,16 +116,16 @@ const COUNTRY_CONFIGS = {
 	MX: {
 		extendedMethods: [
 			{
-				name: 'CardFields',
-				Component: CardFields,
+				name: 'CreditDebitCards',
+				Component: CreditDebitCards,
 				isOwnBrand: false,
-				isAcdc: true,
+				isAcdc: false,
 			},
 			{
 				name: 'APMs',
 				Component: AlternativePaymentMethods,
 				isOwnBrand: true,
-				isAcdc: true,
+				isAcdc: false,
 			},
 		],
 	},


### PR DESCRIPTION
### Description

This PR will fix the BCDC visibility during the onboarding of a Mexico merchant.

### Screenshots

|Before|After|
|-|-|
|<img width="595" alt="mx_before" src="https://github.com/user-attachments/assets/d81c7b73-25e8-408b-aa91-45b842667ce8" />|<img width="595" alt="mx_after" src="https://github.com/user-attachments/assets/281ec5f2-67b6-4095-9206-c54d65758066" />|

### Testing

- Set the WooCommerce merchant to: Mexico / Mexican Peso
- Go through the onboarding and verify BCDC is being displayed correctly