### PR TITLE
Fix new settings UI in WC 9.9+

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_welcome-docs.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_welcome-docs.scss
@@ -5,7 +5,7 @@
 .ppcp-r-welcome-docs__title {
 	text-align: center;
 	@include font(20, 28, 700);
-	margin: 32px 0 32px 0;
+	margin: 32px 0 32px 0 !important;
 }
 
 .ppcp-r-welcome-docs__wrapper {

--- a/modules/ppcp-settings/resources/css/components/screens/_fullscreen.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_fullscreen.scss
@@ -2,6 +2,11 @@ body:has(.ppcp-r-container--settings),
 body:has(.ppcp-r-container--onboarding) {
 	background-color: var(--ppcp-color-app-bg) !important;
 
+	// WC 9.9+.
+	#mainform {
+		background-color: var(--ppcp-color-app-bg) !important;
+	}
+
 	.woocommerce-layout,
 	#woocommerce-layout__primary {
 		padding: 0 !important;

--- a/modules/ppcp-settings/resources/css/components/screens/_fullscreen.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_fullscreen.scss
@@ -3,7 +3,8 @@ body:has(.ppcp-r-container--onboarding) {
 	background-color: var(--ppcp-color-app-bg) !important;
 
 	// WC 9.9+.
-	#mainform {
+	#mainform,
+	#wpcontent {
 		background-color: var(--ppcp-color-app-bg) !important;
 	}
 


### PR DESCRIPTION
The CSS changes in WC 9.9 affected our UI.

So in this PR

- setting the white background in `#mainform`, not just `body`
- added `!important` for the welcome screen h2 title margin, to avoid `margin: 0` from `body.woocommerce_page_wc-settings #mainform h2`, not sure if there is a better way