### PR TITLE
Can not save payments if subscriptions is not selected when onboarding (4679)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,8 @@
 * Fix - BCDC not enabled by default when cards selected during onboarding #3366
 * Fix - Block checkout - Address form missing after payment on Product and Cart pages #3371
 * Fix - Payments with Debit & Credit Cards failing #3376
+* Fix - PayPalGateway::process_payment on completed order leads to order failure #3374
+* Fix - Can not save payments if subscriptions is not selected when onboarding #3408
 
 = 3.0.5 - 2025-04-23 =
 * Fix - Onboarding screen blank when WooPayments plugin is active #3312

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -87,27 +87,17 @@ class PartnerReferralsData {
 			'TRACKING_SHIPMENT_READWRITE',
 		);
 
-		if ( true === $use_subscriptions ) {
-			if ( $this->dcc_applies->for_country_currency() ) {
-				$capabilities[] = 'PAYPAL_WALLET_VAULTING_ADVANCED';
-			}
-
-			$first_party_features[] = 'BILLING_AGREEMENT';
+		if ( $this->dcc_applies->for_country_currency() ) {
+			$capabilities[] = 'PAYPAL_WALLET_VAULTING_ADVANCED';
 		}
+
+		$first_party_features[] = 'BILLING_AGREEMENT';
 
 		// Backwards compatibility. Keep those features in the #legacy-ui (null-value).
 		// Move this into the previous condition, once legacy code is removed.
 		if ( false !== $use_subscriptions ) {
 			$first_party_features[] = 'FUTURE_PAYMENT';
 			$first_party_features[] = 'VAULT';
-		}
-
-		if ( false === $use_subscriptions ) {
-			// Only use "ADVANCED_VAULTING" product for onboarding with subscriptions.
-			$products = array_filter(
-				$products,
-				static fn( $product ) => $product !== 'ADVANCED_VAULTING'
-			);
 		}
 
 		$payload = array(

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -55,9 +55,11 @@ class PartnerReferralsData {
 	 * @return array
 	 */
 	public function data( array $products = array(), string $onboarding_token = '', bool $use_subscriptions = null, bool $use_card_payments = true ) : array {
+		$in_acdc_country = $this->dcc_applies->for_country_currency();
+
 		if ( ! $products ) {
 			$products = array(
-				$this->dcc_applies->for_country_currency() ? 'PPCP' : 'EXPRESS_CHECKOUT',
+				$in_acdc_country ? 'PPCP' : 'EXPRESS_CHECKOUT',
 			);
 		}
 
@@ -87,7 +89,7 @@ class PartnerReferralsData {
 			'TRACKING_SHIPMENT_READWRITE',
 		);
 
-		if ( $this->dcc_applies->for_country_currency() ) {
+		if ( $in_acdc_country ) {
 			$capabilities[] = 'PAYPAL_WALLET_VAULTING_ADVANCED';
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -178,6 +178,8 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - BCDC not enabled by default when cards selected during onboarding #3366
 * Fix - Block checkout - Address form missing after payment on Product and Cart pages #3371
 * Fix - Payments with Debit & Credit Cards failing #3376
+* Fix - PayPalGateway::process_payment on completed order leads to order failure #3374
+* Fix - Can not save payments if subscriptions is not selected when onboarding #3408
 
 = 3.0.5 - 2025-04-23 =
 * Fix - Onboarding screen blank when WooPayments plugin is active #3312

--- a/tests/PHPUnit/ApiClient/Repository/PartnerReferralsDataTest.php
+++ b/tests/PHPUnit/ApiClient/Repository/PartnerReferralsDataTest.php
@@ -206,20 +206,23 @@ class PartnerReferralsDataTest extends TestCase {
 	 * core params present in the legacy and new UI.
 	 */
 	public function testDataStructure() : void {
+		$this->dccApplies->shouldReceive('for_country_currency')->andReturn(true);
+
 		/**
 		 * Undefined subscription: Keep vaulting in first-party, but don't add the capability.
 		 */
 		$result = $this->testee->data( [ 'PPCP' ], self::TOKEN );
-		$this->dccApplies->shouldNotHaveReceived( 'for_country_currency' );
 
 		$expected = $this->getBaseExpectedArray();
 
 		$expected['products'] = [ 'PPCP' ];
 
+		$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'BILLING_AGREEMENT';
 		$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'FUTURE_PAYMENT';
 		$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'VAULT';
 
-		$this->assertArrayNotHasKey( 'capabilities', $expected );
+		$expected['capabilities'][] = 'PAYPAL_WALLET_VAULTING_ADVANCED';
+
 		$this->assertEquals( $expected, $result );
 	}
 

--- a/tests/PHPUnit/ApiClient/Repository/PartnerReferralsDataTest.php
+++ b/tests/PHPUnit/ApiClient/Repository/PartnerReferralsDataTest.php
@@ -127,6 +127,7 @@ class PartnerReferralsDataTest extends TestCase {
 				true,  // With cards?
 				true,  // ACDC eligible?
 				[
+					'capabilities'         => [ 'PAYPAL_WALLET_VAULTING_ADVANCED' ],
 					'show_add_credit_card' => true,
 					'has_vault_features'   => false,
 				],
@@ -136,6 +137,7 @@ class PartnerReferralsDataTest extends TestCase {
 				false, // With cards?
 				true,  // ACDC eligible?
 				[
+					'capabilities'         => [ 'PAYPAL_WALLET_VAULTING_ADVANCED' ],
 					'show_add_credit_card' => false,
 					'has_vault_features'   => false,
 				],
@@ -249,9 +251,7 @@ class PartnerReferralsDataTest extends TestCase {
 
 		$expected['partner_config_override']['show_add_credit_card'] = $expected_changes['show_add_credit_card'];
 
-		if ( $has_subscriptions ) {
-			$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'BILLING_AGREEMENT';
-		}
+		$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'BILLING_AGREEMENT';
 
 		if ( $expected_changes['has_vault_features'] ) {
 			$expected['operations'][0]['api_integration_preference']['rest_api_integration']['first_party_details']['features'][] = 'FUTURE_PAYMENT';

--- a/tests/PHPUnit/ApiClient/Repository/PartnerReferralsDataTest.php
+++ b/tests/PHPUnit/ApiClient/Repository/PartnerReferralsDataTest.php
@@ -97,11 +97,12 @@ class PartnerReferralsDataTest extends TestCase {
 	/**
 	 * Data provider for testing flag combinations.
 	 *
-	 * @return array[] Test cases with [has_subscriptions, has_cards, is_acdc_eligible, expected_changes]
+	 * @return array[] Test cases with [has_subscriptions, has_cards, is_acdc_eligible,
+	 *                 expected_changes]
 	 */
 	public function flagCombinationsProvider() : array {
 		return [
-			'with subscriptions and cards, ACDC eligible' => [
+			'with subscriptions and cards, ACDC eligible'        => [
 				true,  // With subscription?
 				true,  // With cards?
 				true,  // ACDC eligible?
@@ -111,7 +112,7 @@ class PartnerReferralsDataTest extends TestCase {
 					'has_vault_features'   => true,
 				],
 			],
-			'with subscriptions, no cards, ACDC eligible' => [
+			'with subscriptions, no cards, ACDC eligible'        => [
 				true,  // With subscription?
 				false, // With cards?
 				true,  // ACDC eligible?
@@ -121,7 +122,7 @@ class PartnerReferralsDataTest extends TestCase {
 					'has_vault_features'   => true,
 				],
 			],
-			'no subscriptions, with cards, ACDC eligible' => [
+			'no subscriptions, with cards, ACDC eligible'        => [
 				false, // With subscription?
 				true,  // With cards?
 				true,  // ACDC eligible?
@@ -130,7 +131,7 @@ class PartnerReferralsDataTest extends TestCase {
 					'has_vault_features'   => false,
 				],
 			],
-			'no subscriptions, no cards, ACDC eligible' => [
+			'no subscriptions, no cards, ACDC eligible'          => [
 				false, // With subscription?
 				false, // With cards?
 				true,  // ACDC eligible?
@@ -166,7 +167,7 @@ class PartnerReferralsDataTest extends TestCase {
 					'has_vault_features'   => false,
 				],
 			],
-			'no subscriptions, no cards, ACDC is not eligible' => [
+			'no subscriptions, no cards, ACDC is not eligible'   => [
 				false, // With subscription?
 				false, // With cards?
 				false, // ACDC eligible?
@@ -206,7 +207,7 @@ class PartnerReferralsDataTest extends TestCase {
 	 * core params present in the legacy and new UI.
 	 */
 	public function testDataStructure() : void {
-		$this->dccApplies->shouldReceive('for_country_currency')->andReturn(true);
+		$this->dccApplies->shouldReceive( 'for_country_currency' )->andReturn( true );
 
 		/**
 		 * Undefined subscription: Keep vaulting in first-party, but don't add the capability.
@@ -233,7 +234,7 @@ class PartnerReferralsDataTest extends TestCase {
 	 * @dataProvider flagCombinationsProvider
 	 */
 	public function testDataStructureWithFlags( bool $has_subscriptions, bool $has_cards, bool $is_acdc_eligible, array $expected_changes ) : void {
-		$this->dccApplies->shouldReceive('for_country_currency')->andReturn($is_acdc_eligible);
+		$this->dccApplies->shouldReceive( 'for_country_currency' )->andReturn( $is_acdc_eligible );
 
 		$result   = $this->testee->data( [ 'PPCP' ], self::TOKEN, $has_subscriptions, $has_cards );
 		$expected = $this->getBaseExpectedArray();


### PR DESCRIPTION
Customer can not save payment if merchant does not select subscriptions when onboarding. 

### Steps To Reproduce
- Onboard without subscription
- Go to setting tab and enable saving cards
- Navigate to checkout page, enter number of card and click to save card
- Observe error: “Unfortunately, your credit card details are not valid.“

### Expected behavior
No mater what the merchant selected when onboarding, if the merchant has the capability, save cards should work in any case when selected in settings. 

This PR ensures vaulting capabilities are sent to PayPal when onboarding.