### PR TITLE
Add Mexico-specific logic for BCDC (4254)

### DIFF
--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -346,7 +346,8 @@ return array(
 		return new DisabledFundingSources(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'wcgateway.all-funding-sources' ),
-			$container->get( 'wcgateway.configuration.card-configuration' )
+			$container->get( 'wcgateway.configuration.card-configuration' ),
+			$container->get( 'settings.data.general' )->get_merchant_country()
 		);
 	},
 	'button.is-logged-in'                         => static function ( ContainerInterface $container ): bool {

--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -154,7 +154,7 @@ class DisabledFundingSources {
 	 * @return array
 	 */
 	private function apply_context_rules( array $disable_funding ) : array {
-		if ( 'MX' === $this->merchant_country && $this->dcc_configuration->is_bcdc_enabled() ) {
+		if ( 'MX' === $this->merchant_country && $this->dcc_configuration->is_bcdc_enabled() && is_checkout() ) {
 			return $disable_funding;
 		}
 

--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -13,6 +13,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CartCheckoutDetector;
 
 /**
  * Class DisabledFundingSources
@@ -154,7 +155,7 @@ class DisabledFundingSources {
 	 * @return array
 	 */
 	private function apply_context_rules( array $disable_funding ) : array {
-		if ( 'MX' === $this->merchant_country && $this->dcc_configuration->is_bcdc_enabled() && is_checkout() ) {
+		if ( 'MX' === $this->merchant_country && $this->dcc_configuration->is_bcdc_enabled() && CartCheckoutDetector::has_classic_checkout() && is_checkout() ) {
 			return $disable_funding;
 		}
 

--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -43,16 +43,25 @@ class DisabledFundingSources {
 	private CardPaymentsConfiguration $dcc_configuration;
 
 	/**
+	 * Merchant Country
+	 *
+	 * @var string
+	 */
+	private string $merchant_country;
+
+	/**
 	 * DisabledFundingSources constructor.
 	 *
 	 * @param Settings                  $settings            The settings.
 	 * @param array                     $all_funding_sources All existing funding sources.
 	 * @param CardPaymentsConfiguration $dcc_configuration   DCC gateway configuration.
+	 * @param string                    $merchant_country     Merchant country.
 	 */
-	public function __construct( Settings $settings, array $all_funding_sources, CardPaymentsConfiguration $dcc_configuration ) {
+	public function __construct( Settings $settings, array $all_funding_sources, CardPaymentsConfiguration $dcc_configuration, string $merchant_country ) {
 		$this->settings            = $settings;
 		$this->all_funding_sources = $all_funding_sources;
 		$this->dcc_configuration   = $dcc_configuration;
+		$this->merchant_country    = $merchant_country;
 	}
 
 	/**
@@ -145,11 +154,13 @@ class DisabledFundingSources {
 	 * @return array
 	 */
 	private function apply_context_rules( array $disable_funding ) : array {
+		if ( 'MX' === $this->merchant_country && $this->dcc_configuration->is_bcdc_enabled() ) {
+			return $disable_funding;
+		}
+
 		if ( ! is_checkout() || $this->dcc_configuration->use_acdc() ) {
 			// Non-checkout pages, or ACDC capability: Don't load card button.
 			$disable_funding[] = 'card';
-
-			return $disable_funding;
 		}
 
 		return $disable_funding;

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -575,16 +575,16 @@ return array(
 			'acdc'                        => $features['advanced_credit_and_debit_cards']['enabled'] ?? false,
 			'save_paypal'                 => $features['save_paypal_and_venmo']['enabled'] ?? false,
 			'alternative_payment_methods' => $features['alternative_payment_methods']['enabled'] ?? false,
-			'installments' => $features['installments']['enabled'] ?? false,
+			'installments'                => $features['installments']['enabled'] ?? false,
 		);
 
 		$merchant_capabilities = array(
-			'save_paypal' => $capabilities['save_paypal'], // Save PayPal and Venmo eligibility.
-			'acdc'        => $capabilities['acdc'], // Advanced credit and debit cards eligibility.
-			'apm'         => $capabilities['alternative_payment_methods'], // Alternative payment methods eligibility.
-			'google_pay'  => $capabilities['acdc'] && $capabilities['google_pay'], // Google Pay eligibility.
-			'apple_pay'   => $capabilities['acdc'] && $capabilities['apple_pay'], // Apple Pay eligibility.
-			'pay_later'   => $capabilities['acdc'] && ! $gateways['card-button'], // Pay Later eligibility.
+			'save_paypal'  => $capabilities['save_paypal'], // Save PayPal and Venmo eligibility.
+			'acdc'         => $capabilities['acdc'], // Advanced credit and debit cards eligibility.
+			'apm'          => $capabilities['alternative_payment_methods'], // Alternative payment methods eligibility.
+			'google_pay'   => $capabilities['acdc'] && $capabilities['google_pay'], // Google Pay eligibility.
+			'apple_pay'    => $capabilities['acdc'] && $capabilities['apple_pay'], // Apple Pay eligibility.
+			'pay_later'    => $capabilities['acdc'] && ! $gateways['card-button'], // Pay Later eligibility.
 			'installments' => $capabilities['installments'], // Installments eligibility.
 		);
 		return new FeaturesDefinition(

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1404,7 +1404,8 @@ return array(
 			$container->get( 'settings.connection-state' ),
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'api.helpers.dccapplies' ),
-			$container->get( 'wcgateway.helper.dcc-product-status' )
+			$container->get( 'wcgateway.helper.dcc-product-status' ),
+			$container->get( 'settings.data.general' )
 		);
 	},
 

--- a/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\Axo\Helper\PropertiesDictionary;
@@ -68,6 +69,13 @@ class CardPaymentsConfiguration {
 	 * @var DCCProductStatus
 	 */
 	private DCCProductStatus $dcc_status;
+
+	/**
+	 * General Settings
+	 *
+	 * @var GeneralSettings
+	 */
+	private GeneralSettings $general_settings;
 
 	/**
 	 * This classes lazily resolves settings on first access. This flag indicates
@@ -134,17 +142,20 @@ class CardPaymentsConfiguration {
 	 * @param Settings         $settings         Plugin settings instance.
 	 * @param DccApplies       $dcc_applies      DCC eligibility helper.
 	 * @param DCCProductStatus $dcc_status        Manages the Seller status.
+	 * @param GeneralSettings  $general_settings General settings instance.
 	 */
 	public function __construct(
 		ConnectionState $connection_state,
 		Settings $settings,
 		DccApplies $dcc_applies,
-		DCCProductStatus $dcc_status
+		DCCProductStatus $dcc_status,
+		GeneralSettings $general_settings
 	) {
 		$this->connection_state = $connection_state;
 		$this->settings         = $settings;
 		$this->dcc_applies      = $dcc_applies;
 		$this->dcc_status       = $dcc_status;
+		$this->general_settings = $general_settings;
 
 		$this->is_resolved = false;
 	}
@@ -319,6 +330,11 @@ class CardPaymentsConfiguration {
 	 * @return bool
 	 */
 	public function is_bcdc_enabled() : bool {
+		if ( 'MX' === $this->general_settings->get_merchant_country() ) {
+			$bcdc_setting = get_option( 'woocommerce_ppcp-card-button-gateway_settings' );
+			return 'yes' === $bcdc_setting['enabled'];
+		}
+
 		return $this->is_enabled() && ! $this->use_acdc();
 	}
 

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -38,6 +38,7 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->setWcPaymentGateways();
 
 		when('is_checkout')->justReturn(true);
+		when('wc_get_page_id')->justReturn(123);
 
 		$this->assertEquals(['card'], $sut->sources('checkout-block'));
 	}
@@ -56,6 +57,7 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->setWcPaymentGateways();
 
 		when('is_checkout')->justReturn(false);
+		when('wc_get_page_id')->justReturn(123);
 
 		$this->assertEquals(['card'], $sut->sources('checkout'));
 	}
@@ -79,6 +81,7 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->setWcPaymentGateways();
 
 		when('is_checkout')->justReturn(true);
+		when('wc_get_page_id')->justReturn(123);
 
 		$this->assertEquals(['card', 'foo'], $sut->sources('checkout-block'));
 	}
@@ -98,6 +101,7 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->setWcPaymentGateways();
 
 		when('is_checkout')->justReturn(true);
+		when('wc_get_page_id')->justReturn(123);
 
 		// For Mexico with BCDC enabled, card should not be in disabled funding sources
 		$this->assertEquals([], $sut->sources('checkout-block'));
@@ -118,6 +122,7 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->setWcPaymentGateways();
 
 		when('is_checkout')->justReturn(true);
+		when('wc_get_page_id')->justReturn(123);
 
 		// For Mexico with BCDC disabled, card should be in disabled funding sources
 		$this->assertEquals(['card'], $sut->sources('checkout-block'));
@@ -138,6 +143,7 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->setWcPaymentGateways();
 
 		when('is_checkout')->justReturn(true);
+		when('wc_get_page_id')->justReturn(123);
 
 		// For non-Mexico countries, existing logic applies
 		$this->assertEquals(['card'], $sut->sources('checkout-block'));

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -32,7 +32,7 @@ class DisabledFundingSourcesTest extends TestCase
 	{
 		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
 		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
-		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration);
+		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration, 'US');
 
 		$this->setExpectations();
 		$this->setWcPaymentGateways();
@@ -50,7 +50,7 @@ class DisabledFundingSourcesTest extends TestCase
 	{
 		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
 		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
-		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration);
+		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration, 'US');
 
 		$this->setExpectations();
 		$this->setWcPaymentGateways();
@@ -71,7 +71,8 @@ class DisabledFundingSourcesTest extends TestCase
 				'paypal' => 'PayPal',
 				'foo' => 'Bar',
 			],
-			$this->dcc_configuration
+			$this->dcc_configuration,
+			'US'
 		);
 
 		$this->setExpectations();
@@ -80,6 +81,66 @@ class DisabledFundingSourcesTest extends TestCase
 		when('is_checkout')->justReturn(true);
 
 		$this->assertEquals(['card', 'foo'], $sut->sources('checkout-block'));
+	}
+
+	/**
+	 * Test Mexico-specific logic: BCDC enabled should not disable card funding
+	 */
+	public function test_mexico_bcdc_enabled_does_not_disable_card_funding()
+	{
+		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
+
+		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration, 'MX');
+
+		$this->setExpectations();
+		$this->setWcPaymentGateways();
+
+		when('is_checkout')->justReturn(true);
+
+		// For Mexico with BCDC enabled, card should not be in disabled funding sources
+		$this->assertEquals([], $sut->sources('checkout-block'));
+	}
+
+	/**
+	 * Test Mexico-specific logic: BCDC disabled should disable card funding
+	 */
+	public function test_mexico_bcdc_disabled_disables_card_funding()
+	{
+		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
+
+		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration, 'MX');
+
+		$this->setExpectations();
+		$this->setWcPaymentGateways();
+
+		when('is_checkout')->justReturn(true);
+
+		// For Mexico with BCDC disabled, card should be in disabled funding sources
+		$this->assertEquals(['card'], $sut->sources('checkout-block'));
+	}
+
+	/**
+	 * Test non-Mexico country behavior remains unchanged
+	 */
+	public function test_non_mexico_country_behavior_unchanged()
+	{
+		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		// BCDC method should not be called for non-Mexico countries
+
+		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration, 'CA');
+
+		$this->setExpectations();
+		$this->setWcPaymentGateways();
+
+		when('is_checkout')->justReturn(true);
+
+		// For non-Mexico countries, existing logic applies
+		$this->assertEquals(['card'], $sut->sources('checkout-block'));
 	}
 
 	private function setExpectations(

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -36,9 +36,9 @@ class DisabledFundingSourcesTest extends TestCase
 
 		$this->setExpectations();
 		$this->setWcPaymentGateways();
+		$this->setWooCommerceFunctionMocks();
 
 		when('is_checkout')->justReturn(true);
-		when('wc_get_page_id')->justReturn(123);
 
 		$this->assertEquals(['card'], $sut->sources('checkout-block'));
 	}
@@ -55,9 +55,9 @@ class DisabledFundingSourcesTest extends TestCase
 
 		$this->setExpectations();
 		$this->setWcPaymentGateways();
+		$this->setWooCommerceFunctionMocks();
 
 		when('is_checkout')->justReturn(false);
-		when('wc_get_page_id')->justReturn(123);
 
 		$this->assertEquals(['card'], $sut->sources('checkout'));
 	}
@@ -79,9 +79,9 @@ class DisabledFundingSourcesTest extends TestCase
 
 		$this->setExpectations();
 		$this->setWcPaymentGateways();
+		$this->setWooCommerceFunctionMocks();
 
 		when('is_checkout')->justReturn(true);
-		when('wc_get_page_id')->justReturn(123);
 
 		$this->assertEquals(['card', 'foo'], $sut->sources('checkout-block'));
 	}
@@ -92,16 +92,16 @@ class DisabledFundingSourcesTest extends TestCase
 	public function test_mexico_bcdc_enabled_does_not_disable_card_funding()
 	{
 		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(false); // Changed to false
 		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
 
 		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration, 'MX');
 
 		$this->setExpectations();
 		$this->setWcPaymentGateways();
+		$this->setWooCommerceFunctionMocks();
 
 		when('is_checkout')->justReturn(true);
-		when('wc_get_page_id')->justReturn(123);
 
 		// For Mexico with BCDC enabled, card should not be in disabled funding sources
 		$this->assertEquals([], $sut->sources('checkout-block'));
@@ -113,16 +113,16 @@ class DisabledFundingSourcesTest extends TestCase
 	public function test_mexico_bcdc_disabled_disables_card_funding()
 	{
 		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true); // This should cause card to be disabled
 		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
 
 		$sut = new DisabledFundingSources($this->settings, [], $this->dcc_configuration, 'MX');
 
 		$this->setExpectations();
 		$this->setWcPaymentGateways();
+		$this->setWooCommerceFunctionMocks();
 
 		when('is_checkout')->justReturn(true);
-		when('wc_get_page_id')->justReturn(123);
 
 		// For Mexico with BCDC disabled, card should be in disabled funding sources
 		$this->assertEquals(['card'], $sut->sources('checkout-block'));
@@ -141,9 +141,9 @@ class DisabledFundingSourcesTest extends TestCase
 
 		$this->setExpectations();
 		$this->setWcPaymentGateways();
+		$this->setWooCommerceFunctionMocks();
 
 		when('is_checkout')->justReturn(true);
-		when('wc_get_page_id')->justReturn(123);
 
 		// For non-Mexico countries, existing logic applies
 		$this->assertEquals(['card'], $sut->sources('checkout-block'));
@@ -179,5 +179,19 @@ class DisabledFundingSourcesTest extends TestCase
 		$woocommerce->payment_gateways = $payment_gateways;
 		$payment_gateways->shouldReceive('get_available_payment_gateways')
 			->andReturn($paymentGateways);
+	}
+
+	/**
+	 * Set up common WooCommerce function mocks
+	 */
+	private function setWooCommerceFunctionMocks(): void
+	{
+		when('wc_get_page_id')->justReturn(123);
+		when('has_block')->justReturn(false);
+		when('get_post')->justReturn((object) [
+			'ID' => 123,
+			'post_content' => 'Mock post content',
+			'post_type' => 'page'
+		]);
 	}
 }


### PR DESCRIPTION
### Description

This PR will add Mexico-specific logic for BCDC. This ensures that when the merchant has ACDC capability but has BCDC enabled, the card button displays correctly in both Classic and Block checkouts.

### Screenshots

#### Classic Checkout

|Before|After|
|-|-|
|<img width="1047" alt="classic_checkout_before" src="https://github.com/user-attachments/assets/0a5ce84d-7de0-4dff-b4ef-594abdbde7df" />|<img width="1053" alt="Classic_Checkout_after" src="https://github.com/user-attachments/assets/6ecc34cc-23fb-4249-8e49-56eb07baf29a" />|
