### PR TITLE
Add Configure button for the Installments feature (4254)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@
 * Fix - Block checkout - Address form missing after payment on Product and Cart pages #3371
 * Fix - Payments with Debit & Credit Cards failing #3376
 * Fix - PayPalGateway::process_payment on completed order leads to order failure #3374
+* Fix - New settings UI background color impacted by WooCommerce 9.9+ #3407
 * Fix - Can not save payments if subscriptions is not selected when onboarding #3408
 
 = 3.0.5 - 2025-04-23 =

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -342,7 +342,7 @@ class FeaturesDefinition {
 						'url'      => 'https://www.paypal.com/businessmanage/preferences/installmentplan',
 						'showWhen' => 'disabled',
 						'class'    => 'small-button',
-					)
+					),
 				),
 			),
 		);

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -331,11 +331,18 @@ class FeaturesDefinition {
 				'buttons'     => array(
 					array(
 						'type'     => 'secondary',
+						'text'     => __( 'Configure', 'woocommerce-paypal-payments' ),
+						'url'      => 'https://www.paypal.com/businessmanage/preferences/installmentplan',
+						'showWhen' => 'enabled',
+						'class'    => 'small-button',
+					),
+					array(
+						'type'     => 'secondary',
 						'text'     => __( 'Sign up', 'woocommerce-paypal-payments' ),
 						'url'      => 'https://www.paypal.com/businessmanage/preferences/installmentplan',
 						'showWhen' => 'disabled',
 						'class'    => 'small-button',
-					),
+					)
 				),
 			),
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -181,6 +181,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 * Fix - Block checkout - Address form missing after payment on Product and Cart pages #3371
 * Fix - Payments with Debit & Credit Cards failing #3376
 * Fix - PayPalGateway::process_payment on completed order leads to order failure #3374
+* Fix - New settings UI background color impacted by WooCommerce 9.9+ #3407
 * Fix - Can not save payments if subscriptions is not selected when onboarding #3408
 
 = 3.0.5 - 2025-04-23 =


### PR DESCRIPTION
### Description

This PR will add a "Configure" button to the Installments feature for Mexico merchants.

### Screenshot

<img width="637" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/9059b4b1-4ead-4a3e-80df-f9671118e0e0" />

