### PR TITLE
Add French Territories to Expanded Checkout

### DIFF
--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -219,6 +219,11 @@ return array(
 				'SE', // Sweden
 				'US', // United States
 				'GB', // United Kingdom
+				'YT', // Mayotte
+				'RE', // Reunion
+				'GP', // Guadelope
+				'GF', // French Guiana
+				'MQ', // Martinique
 			)
 			// phpcs:enable Squiz.Commenting.InlineComment
 		);

--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -74,6 +74,11 @@ return array(
 				'GB',
 				'US',
 				'NO',
+				'YT',
+				'RE',
+				'GP',
+				'GF',
+				'MQ'
 			)
 		);
 	},

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -132,6 +132,11 @@ return array(
 				'SE', // Sweden
 				'US', // United States
 				'GB', // United Kingdom
+				'YT', // Mayotte
+				'RE', // Reunion
+				'GP', // Guadelope
+				'GF', // French Guiana
+				'MQ', // Martinique
 			)
 			// phpcs:enable Squiz.Commenting.InlineComment
 		);

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -398,7 +398,6 @@ return array(
 			'ML',
 			'MH',
 			'MR',
-			'YT',
 			'FM',
 			'MN',
 			'ME',


### PR DESCRIPTION
**Issue**: French territories Mayotte, Reunion, Guadelope, French Guiana, and Martinique have been approved for Expanded Checkout.

**Slack Thread**: https://pyplexternal.slack.com/archives/CUNAX990E/p1748029157896819

---

### Description

Removed Mayotte from "Send Only" list and added all territories to Expanded Checkout, Apple Pay, and Google Pay eligibility lists.

### Steps to Test

1. Change store country to one of the territories
2. Go to Welcome Screen. Verify that the region shows Expanded checkout.
3. Onboard sandbox and confirm ACDC, Google Pay, and Apple Pay are available.

### Documentation

If documentation lists region eligibility, these countries will need to be added.

### Changelog Entry

1. Mayotte removed from Send Only country list.
2. Mayotte, Reunion, Guadelope, French Guiana, and Martinique have been added to Expanded Checkout list.
3. Mayotte, Reunion, Guadelope, French Guiana, and Martinique have been added to Apple Pay eligibility list.
4. Mayotte, Reunion, Guadelope, French Guiana, and Martinique have been added to Google Pay eligibility list.
