### PR TITLE
Add badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,10 @@
   </a>
 </p>
 
-[![PHP Version](https://img.shields.io/badge/PHP-7.4%2B-green)](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/woocommerce-paypal-payments.php#L10)
-[![WordPress Version](https://img.shields.io/badge/WordPress-6.5%2B-blue)](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/woocommerce-paypal-payments.php#L12)
-[![WooCommerce Version](https://img.shields.io/badge/WooCommerce-9.6%2B-purple)](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/woocommerce-paypal-payments.php#L13)
 [![License](https://img.shields.io/github/license/woocommerce/woocommerce-paypal-payments 'License')](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/LICENSE)
 [![GitHub Release](https://img.shields.io/github/v/release/woocommerce/woocommerce-paypal-payments)](https://github.com/woocommerce/woocommerce-paypal-payments/releases)
 [![GitHub Release Date](https://img.shields.io/github/release-date/woocommerce/woocommerce-paypal-payments)](https://github.com/woocommerce/woocommerce-paypal-payments/releases)
 [![WordPress.org downloads](https://img.shields.io/wordpress/plugin/dt/woocommerce-paypal-payments.svg 'WordPress.org downloads')](https://wordpress.org/plugins/woocommerce-paypal-payments/advanced/#plugin-download-history-stats)
-[![WordPress.org rating](https://img.shields.io/wordpress/plugin/r/woocommerce-paypal-payments.svg 'WordPress.org rating')](https://wordpress.org/support/plugin/woocommerce-paypal-payments/reviews/)
 [![Build Status](https://github.com/woocommerce/woocommerce-paypal-payments/actions/workflows/php.yml/badge.svg?branch=trunk 'Build Status')](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/.github/workflows/php.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/woocommerce/woocommerce-paypal-payments)
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@
   </a>
 </p>
 
-![PHP Version](https://img.shields.io/badge/PHP-7.4%2B-green)
-![WordPress Version](https://img.shields.io/badge/WordPress-6.5%2B-blue)
-![WooCommerce Version](https://img.shields.io/badge/WooCommerce-9.6%2B-purple)
-![GitHub Release](https://img.shields.io/github/v/release/woocommerce/woocommerce-paypal-payments)
-![GitHub Release Date](https://img.shields.io/github/release-date/woocommerce/woocommerce-paypal-payments)
+[![PHP Version](https://img.shields.io/badge/PHP-7.4%2B-green)](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/woocommerce-paypal-payments.php#L10)
+[![WordPress Version](https://img.shields.io/badge/WordPress-6.5%2B-blue)](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/woocommerce-paypal-payments.php#L12)
+[![WooCommerce Version](https://img.shields.io/badge/WooCommerce-9.6%2B-purple)](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/woocommerce-paypal-payments.php#L13)
+[![License](https://img.shields.io/github/license/woocommerce/woocommerce-paypal-payments 'License')](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/LICENSE)
+[![GitHub Release](https://img.shields.io/github/v/release/woocommerce/woocommerce-paypal-payments)](https://github.com/woocommerce/woocommerce-paypal-payments/releases)
+[![GitHub Release Date](https://img.shields.io/github/release-date/woocommerce/woocommerce-paypal-payments)](https://github.com/woocommerce/woocommerce-paypal-payments/releases)
+[![WordPress.org downloads](https://img.shields.io/wordpress/plugin/dt/woocommerce-paypal-payments.svg 'WordPress.org downloads')](https://wordpress.org/plugins/woocommerce-paypal-payments/advanced/#plugin-download-history-stats)
+[![WordPress.org rating](https://img.shields.io/wordpress/plugin/r/woocommerce-paypal-payments.svg 'WordPress.org rating')](https://wordpress.org/support/plugin/woocommerce-paypal-payments/reviews/)
 [![Build Status](https://github.com/woocommerce/woocommerce-paypal-payments/actions/workflows/integration.yml/badge.svg?branch=trunk 'Build Status')](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/.github/workflows/integration.yml)
-![WordPress.org downloads](https://img.shields.io/wordpress/plugin/dt/woocommerce-paypal-payments.svg 'WordPress.org downloads')
-
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/woocommerce/woocommerce-paypal-payments)
 
 # WooCommerce PayPal Payments

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![GitHub Release Date](https://img.shields.io/github/release-date/woocommerce/woocommerce-paypal-payments)](https://github.com/woocommerce/woocommerce-paypal-payments/releases)
 [![WordPress.org downloads](https://img.shields.io/wordpress/plugin/dt/woocommerce-paypal-payments.svg 'WordPress.org downloads')](https://wordpress.org/plugins/woocommerce-paypal-payments/advanced/#plugin-download-history-stats)
 [![WordPress.org rating](https://img.shields.io/wordpress/plugin/r/woocommerce-paypal-payments.svg 'WordPress.org rating')](https://wordpress.org/support/plugin/woocommerce-paypal-payments/reviews/)
-[![Build Status](https://github.com/woocommerce/woocommerce-paypal-payments/actions/workflows/integration.yml/badge.svg?branch=trunk 'Build Status')](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/.github/workflows/integration.yml)
+[![Build Status](https://github.com/woocommerce/woocommerce-paypal-payments/actions/workflows/php.yml/badge.svg?branch=trunk 'Build Status')](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/.github/workflows/php.yml)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/woocommerce/woocommerce-paypal-payments)
 
 # WooCommerce PayPal Payments

--- a/README.md
+++ b/README.md
@@ -1,12 +1,57 @@
+<!-- WooCommerce logo -->
+<p align="center">
+  <a href="https://woocommerce.com/products/woocommerce-paypal-payments/">
+    <img src="https://woocommerce.com/wp-content/themes/woo/images/logo-woocommerce@2x.png"
+         alt="WooCommerce logo">
+  </a>
+</p>
+
+<!-- PayPal logo -->
+<p align="center">
+  <a href="https://woocommerce.com/products/woocommerce-paypal-payments/">
+    <img src="https://paypal.inpsyde.com/wp-content/uploads/sites/43/2025/05/PayPal-Logo-RGB-Black.png"
+         alt="PayPal logo" height="130">
+  </a>
+</p>
+
+![PHP Version](https://img.shields.io/badge/PHP-7.4%2B-green)
+![WordPress Version](https://img.shields.io/badge/WordPress-6.5%2B-blue)
+![WooCommerce Version](https://img.shields.io/badge/WooCommerce-9.6%2B-purple)
+![GitHub Release](https://img.shields.io/github/v/release/woocommerce/woocommerce-paypal-payments)
+![GitHub Release Date](https://img.shields.io/github/release-date/woocommerce/woocommerce-paypal-payments)
+[![Build Status](https://github.com/woocommerce/woocommerce-paypal-payments/actions/workflows/integration.yml/badge.svg?branch=trunk 'Build Status')](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/.github/workflows/integration.yml)
+![WordPress.org downloads](https://img.shields.io/wordpress/plugin/dt/woocommerce-paypal-payments.svg 'WordPress.org downloads')
+
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/woocommerce/woocommerce-paypal-payments)
+
 # WooCommerce PayPal Payments
 
 PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
 
+## Features  
+  
+- **Multiple Payment Options**: PayPal, credit/debit cards, Pay Later, digital wallets (Apple Pay, Google Pay), and localized payment methods  
+- **Subscription Support**: Supports WooCommerce Subscriptions with PayPal Vaulting and PayPal Subscriptions  
+- **Customizable Experience**: Flexible button placement and styling options  
+- **Enhanced Security**: PCI compliance, 3D Secure, and fraud protection tools  
+- **Global Compliance**: Meets international standards (PSD2, SCA)  
+  
+## Documentation  
+  
+Visit our [official documentation](https://woocommerce.com/document/woocommerce-paypal-payments/) for detailed guides and setup instructions.
+
 ## Dependencies
 
 * PHP >= 7.4
-* WordPress >= 6.3
-* WooCommerce >= 6.9
+* WordPress >= 6.5
+* WooCommerce >= 9.6
+
+## Quick Installation  
+  
+1. Go to **Plugins > Add New** in your WordPress admin  
+2. Search for "WooCommerce PayPal Payments"  
+3. Click "Install Now" and then "Activate"  
+4. Go to **WooCommerce > Settings > Payments** to configure PayPal Payments
 
 ## Development
 
@@ -58,7 +103,7 @@ To set up the DDEV environment, follow these steps:
 3. `$ ddev orchestrate` to install WP/WC.
 4. Open https://wc-pp.ddev.site
 
-Use `$ ddev orchestrate -f` for reinstalattion (will destroy all site data).
+Use `$ ddev orchestrate -f` for reinstallation (will destroy all site data).
 You may also need `$ ddev restart` to apply the config changes.
 
 ### Running tests and other tasks in the DDEV environment


### PR DESCRIPTION
### Description

Adds informative badges to [README.md](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/README.md), including a DeepWiki badge for automatic doc updates, so key plugin details are visible at a glance.