### PR TITLE
Fix product subscription unlink functionality

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -681,7 +681,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			'<label for="ppcp_enable_subscription_product-' . esc_attr( (string) $product->get_id() ) . '" style="' . esc_attr( $style ) . '">',
 			'</label>'
 		);
-		$plan_id = isset( $subscription_plan['id'] ) ?? '';
+		$plan_id = $subscription_plan['id'] ?? '';
 		echo '<input type="checkbox" id="ppcp_enable_subscription_product-' . esc_attr( (string) $product->get_id() ) . '" data-subs-plan="' . esc_attr( (string) $plan_id ) . '" name="_ppcp_enable_subscription_product" value="yes" ' . checked( $enable_subscription_product, 'yes', false ) . '/>';
 		echo sprintf(
 		// translators: %1$s and %2$s are label open and close tags.


### PR DESCRIPTION
The problem was caused by an incorrect implementation of the null coalescing operator, which was returning a bool instead of the actual plan ID when rendering the template, therefore calls to the PayPal `/v1/billing/plans/{id}/deactivate` endpoint were failing because the provided plan ID was invalid. 

This PR fixes it by adjusting the code to return the actual subscription ID.