### PR TITLE
Add "Keep updated with PayPal" option in the old and new settings UI

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/KeepUpdated.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/KeepUpdated.js
@@ -1,0 +1,28 @@
+import { __ } from '@wordpress/i18n';
+
+import { ControlToggleButton } from '../../../../../ReusableComponents/Controls';
+import { SettingsHooks } from '../../../../../../data';
+import SettingsBlock from '../../../../../ReusableComponents/SettingsBlock';
+
+const KeepUpdated = () => {
+	const { keepUpdated, setKeepUpdated } = SettingsHooks.useSettings();
+
+	return (
+		<SettingsBlock className="ppcp--pay-now-experience">
+			<ControlToggleButton
+				label={ __(
+					'Keep updated with PayPal',
+					'woocommerce-paypal-payments'
+				) }
+				description={ __(
+					'Receive updates on PayPal features, promotions, and news.',
+					'woocommerce-paypal-payments'
+				) }
+				onChange={ setKeepUpdated }
+				value={ keepUpdated }
+			/>
+		</SettingsBlock>
+	);
+};
+
+export default KeepUpdated;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/StayUpdated.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/StayUpdated.js
@@ -4,25 +4,22 @@ import { ControlToggleButton } from '../../../../../ReusableComponents/Controls'
 import { SettingsHooks } from '../../../../../../data';
 import SettingsBlock from '../../../../../ReusableComponents/SettingsBlock';
 
-const KeepUpdated = () => {
-	const { keepUpdated, setKeepUpdated } = SettingsHooks.useSettings();
+const StayUpdated = () => {
+	const { stayUpdated, setStayUpdated } = SettingsHooks.useSettings();
 
 	return (
 		<SettingsBlock className="ppcp--pay-now-experience">
 			<ControlToggleButton
-				label={ __(
-					'Keep updated with PayPal',
-					'woocommerce-paypal-payments'
-				) }
+				label={ __( 'Stay Updated', 'woocommerce-paypal-payments' ) }
 				description={ __(
-					'Receive updates on PayPal features, promotions, and news.',
+					'Get the latest PayPal features and capabilities as they are released. When the extension is updated, new features, payment methods, styling options, and more will automatically update.',
 					'woocommerce-paypal-payments'
 				) }
-				onChange={ setKeepUpdated }
-				value={ keepUpdated }
+				onChange={ setStayUpdated }
+				value={ stayUpdated }
 			/>
 		</SettingsBlock>
 	);
 };
 
-export default KeepUpdated;
+export default StayUpdated;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/CommonSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/CommonSettings.js
@@ -5,6 +5,7 @@ import OrderIntent from './Blocks/OrderIntent';
 import SavePaymentMethods from './Blocks/SavePaymentMethods';
 import InvoicePrefix from './Blocks/InvoicePrefix';
 import PayNowExperience from './Blocks/PayNowExperience';
+import KeepUpdated from './Blocks/KeepUpdated';
 
 const CommonSettings = ( { ownBradOnly } ) => (
 	<SettingsCard
@@ -20,6 +21,7 @@ const CommonSettings = ( { ownBradOnly } ) => (
 		<OrderIntent />
 		<SavePaymentMethods ownBradOnly={ ownBradOnly } />
 		<PayNowExperience />
+		<KeepUpdated />
 	</SettingsCard>
 );
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/CommonSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/CommonSettings.js
@@ -5,7 +5,7 @@ import OrderIntent from './Blocks/OrderIntent';
 import SavePaymentMethods from './Blocks/SavePaymentMethods';
 import InvoicePrefix from './Blocks/InvoicePrefix';
 import PayNowExperience from './Blocks/PayNowExperience';
-import KeepUpdated from './Blocks/KeepUpdated';
+import StayUpdated from './Blocks/StayUpdated';
 
 const CommonSettings = ( { ownBradOnly } ) => (
 	<SettingsCard
@@ -21,7 +21,7 @@ const CommonSettings = ( { ownBradOnly } ) => (
 		<OrderIntent />
 		<SavePaymentMethods ownBradOnly={ ownBradOnly } />
 		<PayNowExperience />
-		<KeepUpdated />
+		<StayUpdated />
 	</SettingsCard>
 );
 

--- a/modules/ppcp-settings/resources/js/data/settings/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/settings/hooks.js
@@ -63,7 +63,7 @@ const useHooks = () => {
 	const [ payNowExperience, setPayNowExperience ] =
 		usePersistent( 'enablePayNow' );
 	const [ logging, setLogging ] = usePersistent( 'enableLogging' );
-	const [ keepUpdated, setKeepUpdated ] = usePersistent( 'keepUpdated' );
+	const [ stayUpdated, setStayUpdated ] = usePersistent( 'stayUpdated' );
 
 	const [ disabledCards, setDisabledCards ] =
 		usePersistent( 'disabledCards' );
@@ -83,8 +83,8 @@ const useHooks = () => {
 		setPayNowExperience,
 		logging,
 		setLogging,
-		keepUpdated,
-		setKeepUpdated,
+		stayUpdated,
+		setStayUpdated,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
 		brandName,
@@ -129,8 +129,8 @@ export const useSettings = () => {
 		setPayNowExperience,
 		logging,
 		setLogging,
-		keepUpdated,
-		setKeepUpdated,
+		stayUpdated,
+		setStayUpdated,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
 		brandName,
@@ -160,8 +160,8 @@ export const useSettings = () => {
 		setPayNowExperience,
 		logging,
 		setLogging,
-		keepUpdated,
-		setKeepUpdated,
+		stayUpdated,
+		setStayUpdated,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
 		brandName,

--- a/modules/ppcp-settings/resources/js/data/settings/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/settings/hooks.js
@@ -63,6 +63,7 @@ const useHooks = () => {
 	const [ payNowExperience, setPayNowExperience ] =
 		usePersistent( 'enablePayNow' );
 	const [ logging, setLogging ] = usePersistent( 'enableLogging' );
+	const [ keepUpdated, setKeepUpdated ] = usePersistent( 'keepUpdated' );
 
 	const [ disabledCards, setDisabledCards ] =
 		usePersistent( 'disabledCards' );
@@ -82,6 +83,8 @@ const useHooks = () => {
 		setPayNowExperience,
 		logging,
 		setLogging,
+		keepUpdated,
+		setKeepUpdated,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
 		brandName,
@@ -126,6 +129,8 @@ export const useSettings = () => {
 		setPayNowExperience,
 		logging,
 		setLogging,
+		keepUpdated,
+		setKeepUpdated,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
 		brandName,
@@ -155,6 +160,8 @@ export const useSettings = () => {
 		setPayNowExperience,
 		logging,
 		setLogging,
+		keepUpdated,
+		setKeepUpdated,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
 		brandName,

--- a/modules/ppcp-settings/resources/js/data/settings/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/settings/reducer.js
@@ -42,6 +42,7 @@ const defaultPersistent = Object.freeze( {
 	saveCardDetails: false, // Enable card vaulting
 	enablePayNow: false, // Enable Pay Now experience
 	enableLogging: false, // Enable debug logging
+	keepUpdated: false, // Enable to receive PayPal-related updates
 
 	// String arrays.
 	disabledCards: [], // Disabled credit card types

--- a/modules/ppcp-settings/resources/js/data/settings/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/settings/reducer.js
@@ -42,7 +42,7 @@ const defaultPersistent = Object.freeze( {
 	saveCardDetails: false, // Enable card vaulting
 	enablePayNow: false, // Enable Pay Now experience
 	enableLogging: false, // Enable debug logging
-	keepUpdated: false, // Enable to receive PayPal-related updates
+	stayUpdated: false, // Enable to get the latest PayPal features
 
 	// String arrays.
 	disabledCards: [], // Disabled credit card types

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -82,6 +82,7 @@ class SettingsModel extends AbstractDataModel {
 			'save_card_details'      => false,
 			'enable_pay_now'         => false,
 			'enable_logging'         => false,
+			'keep_updated'           => true,
 
 			// Array of string values.
 			'disabled_cards'         => array(),

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -82,7 +82,7 @@ class SettingsModel extends AbstractDataModel {
 			'save_card_details'      => false,
 			'enable_pay_now'         => false,
 			'enable_logging'         => false,
-			'keep_updated'           => true,
+			'stay_updated'           => true,
 
 			// Array of string values.
 			'disabled_cards'         => array(),

--- a/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
@@ -86,8 +86,8 @@ class SettingsRestEndpoint extends RestEndpoint {
 			'js_name'  => 'enableLogging',
 			'sanitize' => 'to_boolean',
 		),
-		'keep_updated'           => array(
-			'js_name'  => 'keepUpdated',
+		'stay_updated'           => array(
+			'js_name'  => 'stayUpdated',
 			'sanitize' => 'to_boolean',
 		),
 		'disabled_cards'         => array(

--- a/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
@@ -86,6 +86,10 @@ class SettingsRestEndpoint extends RestEndpoint {
 			'js_name'  => 'enableLogging',
 			'sanitize' => 'to_boolean',
 		),
+		'keep_updated'           => array(
+			'js_name'  => 'keepUpdated',
+			'sanitize' => 'to_boolean',
+		),
 		'disabled_cards'         => array(
 			'js_name' => 'disabledCards',
 		),

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -539,6 +539,20 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
+		'keep_updated'                               => array(
+			'title'        => __( 'Keep updated with PayPal', 'woocommerce-paypal-payments' ),
+			'type'         => 'checkbox',
+			'desc_tip'     => true,
+			'label'        => __( 'Keep updated with PayPal. ', 'woocommerce-paypal-payments' ),
+			'description'  => __( 'Receive updates on PayPal features, promotions, and news.', 'woocommerce-paypal-payments' ),
+			'default'      => true,
+			'screens'      => array(
+				State::STATE_START,
+				State::STATE_ONBOARDED,
+			),
+			'requirements' => array(),
+			'gateway'      => Settings::CONNECTION_TAB_ID,
+		),
 		'subtotal_mismatch_behavior'                    => array(
 			'title'             => __( 'Subtotal mismatch behavior', 'woocommerce-paypal-payments' ),
 			'type'              => 'select',

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -539,12 +539,12 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
-		'keep_updated'                               => array(
-			'title'        => __( 'Keep updated with PayPal', 'woocommerce-paypal-payments' ),
+		'stay_updated'                               => array(
+			'title'        => __( 'Stay Updated', 'woocommerce-paypal-payments' ),
 			'type'         => 'checkbox',
 			'desc_tip'     => true,
-			'label'        => __( 'Keep updated with PayPal. ', 'woocommerce-paypal-payments' ),
-			'description'  => __( 'Receive updates on PayPal features, promotions, and news.', 'woocommerce-paypal-payments' ),
+			'label'        => __( 'Update to the latest features when available. ', 'woocommerce-paypal-payments' ),
+			'description'  => __( 'Get the latest PayPal features and capabilities as they are released. When the extension is updated, new features, payment methods, styling options, and more will automatically update.', 'woocommerce-paypal-payments' ),
 			'default'      => true,
 			'screens'      => array(
 				State::STATE_START,


### PR DESCRIPTION
This PR adds a new checkbox/toggle in the old and new settings UI. 

The “Keep updated with PayPal” option will be enabled by default, and its only purpose at the moment is to let users opt out. Functionality connected to this option will be added in future releases.

Old settings UI:
![WooCommerce-settings-‹-WooCommerce-PayPal-Payments-—-WordPress-05-29-2025_01_41_PM](https://github.com/user-attachments/assets/4e5765c4-a714-4a3e-b81b-2fddb5b5e112)

New settings UI:
![WooCommerce-settings-‹-WooCommerce-PayPal-Payments-—-WordPress-05-29-2025_01_42_PM](https://github.com/user-attachments/assets/37fbd40f-1586-4202-923a-c8ed5f6444dd)
