### PR TITLE
Onboarding: Notification for Firefox users (4619)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_elements.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_elements.scss
@@ -69,3 +69,23 @@
 		margin-top: var(--block-action-gap, 16px);
 	}
 }
+
+.ppcp--notice {
+	display: block;
+	padding: 10px;
+	margin: 10px 0;
+	line-height: 1.5714285714;
+	font-size: 0.8125rem;
+	background: var(--notice-background);
+	color: var(--notice-text);
+
+	&.type--info {
+		--notice-background: var(--color-success-background);
+		--notice-text: var(--color-success-text);
+	}
+
+	&.type--error {
+		--notice-background: var(--color-failure-background);
+		--notice-text: var(--color-failure-text);
+	}
+}

--- a/modules/ppcp-settings/resources/css/components/screens/_onboarding.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_onboarding.scss
@@ -12,6 +12,10 @@
 
 	.ppcp-r-inner-container {
 		max-width: var(--max-width-onboarding-content);
+
+		&.ppcp--wide {
+			--max-width-onboarding-content: none;
+		}
 	}
 
 	.ppcp-r-payment-method--separator {

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Elements/Notice.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Elements/Notice.js
@@ -1,0 +1,17 @@
+import classNames from 'classnames';
+
+const Notice = ( { children, type = 'info', className = '' } ) => {
+	if ( ! children ) {
+		return null;
+	}
+
+	const elementClasses = classNames(
+		'ppcp--notice',
+		`type--${ type }`,
+		className
+	);
+
+	return <span className={ elementClasses }>{ children }</span>;
+};
+
+export default Notice;

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Elements/index.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Elements/index.js
@@ -9,6 +9,7 @@ export { default as ContentWrapper } from './ContentWrapper';
 export { default as Description } from './Description';
 export { default as Header } from './Header';
 export { default as LearnMore } from './LearnMore';
+export { default as Notice } from './Notice';
 export { default as Separator } from './Separator';
 export { default as Title } from './Title';
 export { default as TitleExtra } from './TitleExtra';

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
@@ -7,6 +7,13 @@ import { useHandleOnboardingButton } from '../../../../hooks/useHandleConnection
 import BusyStateWrapper from '../../../ReusableComponents/BusyStateWrapper';
 import { Notice } from '../../../ReusableComponents/Elements';
 
+const useIsFirefox = () => {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	return window.navigator.userAgent.toLowerCase().indexOf( 'firefox' ) > -1;
+};
+
 /**
  * Button component that outputs a placeholder button when no onboardingUrl is present yet - the
  * placeholder button looks identical to the working button, but has no href, target, or
@@ -26,9 +33,7 @@ const ButtonOrPlaceholder = ( {
 	href,
 	children,
 } ) => {
-	const isFirefox =
-		typeof window !== 'undefined' &&
-		window.navigator.userAgent.toLowerCase().indexOf( 'firefox' ) > -1;
+	const isFirefox = useIsFirefox();
 
 	const buttonProps = {
 		className,

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
@@ -1,9 +1,11 @@
 import { Button } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { OpenSignup } from '../../../ReusableComponents/Icons';
 import { useHandleOnboardingButton } from '../../../../hooks/useHandleConnections';
 import BusyStateWrapper from '../../../ReusableComponents/BusyStateWrapper';
+import { Notice } from '../../../ReusableComponents/Elements';
 
 /**
  * Button component that outputs a placeholder button when no onboardingUrl is present yet - the
@@ -24,6 +26,10 @@ const ButtonOrPlaceholder = ( {
 	href,
 	children,
 } ) => {
+	const isFirefox =
+		typeof window !== 'undefined' &&
+		window.navigator.userAgent.toLowerCase().indexOf( 'firefox' ) > -1;
+
 	const buttonProps = {
 		className,
 		variant,
@@ -34,6 +40,20 @@ const ButtonOrPlaceholder = ( {
 		buttonProps.href = href;
 		buttonProps[ 'data-paypal-button' ] = 'true';
 		buttonProps[ 'data-paypal-onboard-button' ] = 'true';
+	}
+
+	if ( isFirefox ) {
+		return (
+			<>
+				<Button { ...buttonProps }>{ children }</Button>
+				<Notice type={ 'error' }>
+					{ __(
+						'This button may not work in Firefox. Please use another browser, like Chrome, to complete this step.',
+						'woocommerce-paypal-payments'
+					) }
+				</Notice>
+			</>
+		);
 	}
 
 	return <Button { ...buttonProps }>{ children }</Button>;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepCompleteSetup.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepCompleteSetup.js
@@ -16,7 +16,7 @@ const StepCompleteSetup = () => {
 					'woocommerce-paypal-payments'
 				) }
 			/>
-			<div className="ppcp-r-inner-container">
+			<div className="ppcp-r-inner-container ppcp--wide">
 				<div className="ppcp-r-onboarding-header__description">
 					<ConnectionButton
 						title={ __(


### PR DESCRIPTION
### Description

As Firefox behaves different than all other browsers when it comes to loading scripts after page load, the onboarding buttons in the new UI are usually not working in that browser.

The issue is limited to the final "Login" button, which opens the PayPal oAuth popup - all other features do work in Firefox. As a first step to lower the onboarding frustration of Firefox users, we experiment with a new notification that is rendered below the login button in Firefox:

```txt
This button may not work in Firefox. Please use another browser, like Chrome, to complete this step.
```

This new message is displayed in two places:

1. Onboarding wizard, first step (in the "Sandbox" toggle section)
2. Onboarding wizard, last step

### Steps to Test

Requirements to test the notification:
1. Ensure the new settings UI is active
3. The current site is disconnected from PayPal, i.e. the onboarding wizard is active

Test the notification:
1. Use **Firefox** to open the onboarding wizard
2. Expand the "Advanced options" at the bottom of step 1
4. Enable the "Sandbox" toggle
5. Verify that the message is displayed (compare to screenshot below)
6. Follow the same steps in **Chrome**, **Safari**, or **Edge** and confirm there is no message

### Screenshot
![CleanShot 2025-05-30 at 17 40 14](https://github.com/user-attachments/assets/e93a6128-5d29-431c-a162-ebce06164474)
