### PR TITLE
QA Implement vaulting functionality for new UI

### DIFF
--- a/tests/qa/resources/cards.ts
+++ b/tests/qa/resources/cards.ts
@@ -1,17 +1,22 @@
 const visa: WooCommerce.CreditCard = {
-	// card_number: '4005519200000004',
 	card_number: '4444333322221111',
-	// card_number: '4111111111111111',
 	expiration_date: '12/30',
 	card_cvv: '029',
-	card_type: 'VISA',
+	card_type: 'Visa',
+};
+
+const visa2: WooCommerce.CreditCard = {
+	card_number: '4012000077777777',
+	expiration_date: '12/30',
+	card_cvv: '123',
+	card_type: 'Visa',
 };
 
 const visa3ds: WooCommerce.CreditCard = {
 	card_number: '4020024518402084',
 	expiration_date: '01/30',
 	card_cvv: '123',
-	card_type: 'VISA',
+	card_type: 'Visa',
 	code_3ds: '1234',
 };
 
@@ -19,20 +24,21 @@ const mastercard: WooCommerce.CreditCard = {
 	card_number: '2223000048400011',
 	expiration_date: '12/30',
 	card_cvv: '456',
-	card_type: 'Master',
+	card_type: 'Mastercard',
 };
 
 const declined: WooCommerce.CreditCard = {
 	card_number: '4032037524607534',
 	expiration_date: '09/30',
 	card_cvv: '340',
-	card_type: 'VISA',
+	card_type: 'Visa',
 };
 
 export const cards: {
 	[ key: string ]: WooCommerce.CreditCard;
 } = {
 	visa,
+	visa2,
 	visa3ds,
 	mastercard,
 	declined,

--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -5,6 +5,8 @@ export type PayPalAccount = {
 
 export type ShopOrder = WooCommerce.ShopOrder & {
 	title?: string;
+	payment?: Pcp.Payment;
+	merchant?: Pcp.Merchant;
 };
 
 export type ShopRefund = ShopOrder & {
@@ -15,15 +17,9 @@ export type ShopRefund = ShopOrder & {
 };
 
 export namespace PayPal {
-	export type PaymentStatus =
-		| 'REFUNDED'
-		| 'PARTIALLY_REFUNDED'
-		| string; // TODO: complete the type
+	export type PaymentStatus = 'REFUNDED' | 'PARTIALLY_REFUNDED' | string; // TODO: complete the type
 
-	export type OrderStatus =
-		| 'COMPLETED'
-		| 'PENDING_APPROVAL'
-		| string; // TODO: complete the type
+	export type OrderStatus = 'COMPLETED' | 'PENDING_APPROVAL' | string; // TODO: complete the type
 }
 
 export namespace Pcp {

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-checkout.data.ts
@@ -1,11 +1,16 @@
 /**
  * Internal dependencies
  */
-import { payments, orders, customers, guests, ShopOrder } from '../../../../resources';
+import {
+	payments,
+	orders,
+	customers,
+	guests,
+	ShopOrder,
+} from '../../../../resources';
 
 const customer = customers.usa;
 const guest = guests.usa;
-
 
 export const acdcCheckout: ShopOrder[] = [
 	{

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-classic-checkout.data.ts
@@ -1,7 +1,13 @@
 /**
  * Internal dependencies
  */
-import { payments, orders, customers, guests, ShopOrder } from '../../../../resources';
+import {
+	payments,
+	orders,
+	customers,
+	guests,
+	ShopOrder,
+} from '../../../../resources';
 
 const customer = customers.usa;
 const guest = guests.usa;

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-pay-by-link.data.ts
@@ -1,7 +1,13 @@
 /**
  * Internal dependencies
  */
-import { customers, guests, payments, orders, ShopOrder } from '../../../../resources';
+import {
+	customers,
+	guests,
+	payments,
+	orders,
+	ShopOrder,
+} from '../../../../resources';
 
 const customer = customers.usa;
 const guest = guests.usa;

--- a/tests/qa/tests/05-transactions/transaction-usa-classic.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-usa-classic.spec.ts
@@ -95,13 +95,17 @@ test.describe( () => {
 // ACDC 3DS
 test.describe( () => {
 	test.beforeAll( async ( { pcpApi } ) => {
-		await pcpApi.updatePcpPaymentMethods( { threeDSecure: 'always-3d-secure' } );
+		await pcpApi.updatePcpPaymentMethods( {
+			threeDSecure: 'always-3d-secure',
+		} );
 	} );
 
 	transactionsOnClassicCheckout( acdcClassicCheckout3ds );
 
 	test.afterAll( async ( { pcpApi } ) => {
-		await pcpApi.updatePcpPaymentMethods( { threeDSecure: 'no-3d-secure' } );
+		await pcpApi.updatePcpPaymentMethods( {
+			threeDSecure: 'no-3d-secure',
+		} );
 	} );
 } );
 

--- a/tests/qa/tests/05-transactions/transaction-usa.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-usa.spec.ts
@@ -84,14 +84,18 @@ test.describe( () => {
 // ACDC 3DS
 test.describe( () => {
 	test.beforeAll( async ( { pcpApi } ) => {
-		await pcpApi.updatePcpPaymentMethods( { threeDSecure: 'always-3d-secure' } );
+		await pcpApi.updatePcpPaymentMethods( {
+			threeDSecure: 'always-3d-secure',
+		} );
 	} );
 
 	transactionsOnCheckout( acdcCheckout3ds );
 	transactionsOnPayByLink( acdcPayByLink3ds );
 
 	test.afterAll( async ( { pcpApi } ) => {
-		await pcpApi.updatePcpPaymentMethods( { threeDSecure: 'no-3d-secure' } );
+		await pcpApi.updatePcpPaymentMethods( {
+			threeDSecure: 'no-3d-secure',
+		} );
 	} );
 } );
 

--- a/tests/qa/tests/06-refund/_test-data/paypal/refund-paypal.data.ts
+++ b/tests/qa/tests/06-refund/_test-data/paypal/refund-paypal.data.ts
@@ -1,7 +1,13 @@
 /**
  * Internal dependencies
  */
-import { payments, orders, ShopRefund, customers, guests } from '../../../../resources';
+import {
+	payments,
+	orders,
+	ShopRefund,
+	customers,
+	guests,
+} from '../../../../resources';
 
 const { payPal } = payments;
 const customer = customers.usa;

--- a/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
+++ b/tests/qa/tests/06-refund/_test-scenarios/refund.scenario.ts
@@ -31,7 +31,7 @@ export const testRefund = ( testsData: ShopRefund[] ) => {
 				const refundAvailable = total.order;
 				const refundAmount = getAmountPercentage(
 					refundAvailable,
-					testData.refundPercentage,
+					testData.refundPercentage
 				);
 
 				// Precondition
@@ -40,7 +40,7 @@ export const testRefund = ( testsData: ShopRefund[] ) => {
 					order = await utils.payForApiOrder(
 						order.id,
 						order.order_key,
-						testData,
+						testData
 					);
 				} else {
 					order = await utils.completeOrderOnCheckout( testData );
@@ -59,7 +59,9 @@ export const testRefund = ( testsData: ShopRefund[] ) => {
 				).toHaveText( `-${ formatMoney( 0, testData.currency ) }` );
 				await expect(
 					wooCommerceOrderEdit.totalAvailableToRefund()
-				).toHaveText( formatMoney( Number( refundAvailable ), testData.currency ) );
+				).toHaveText(
+					formatMoney( Number( refundAvailable ), testData.currency )
+				);
 
 				// Make refund
 				await wooCommerceOrderEdit.makePayPalRefund( refundAmount );
@@ -70,7 +72,10 @@ export const testRefund = ( testsData: ShopRefund[] ) => {
 					wooCommerceOrderEdit.refundNumber()
 				).toContainText( `Refund #` );
 				await expect( wooCommerceOrderEdit.refundAmount() ).toHaveText(
-					`-${ formatMoney( Number( refundAmount ), testData.currency ) }`
+					`-${ formatMoney(
+						Number( refundAmount ),
+						testData.currency
+					) }`
 				);
 
 				// Assert via API WooCommerce Order refund status and presence of refunds
@@ -83,7 +88,7 @@ export const testRefund = ( testsData: ShopRefund[] ) => {
 				// Assert via API the refund status of PayPal payment
 				const payPalPayment = await payPalApi.getCapturedPayment(
 					order.transaction_id,
-					testData.merchant,
+					testData.merchant
 				);
 				await expect( payPalPayment.status ).toEqual(
 					testData.refundPaymentStatus
@@ -100,7 +105,7 @@ export const testRefund = ( testsData: ShopRefund[] ) => {
 				const payPalRefundId = payPalRefunds[ 0 ];
 				const payPalRefund = await payPalApi.getRefund(
 					payPalRefundId,
-					testData.merchant,
+					testData.merchant
 				);
 				await expect( payPalRefund.status ).toEqual( 'COMPLETED' );
 

--- a/tests/qa/tests/07-vaulting/README.md
+++ b/tests/qa/tests/07-vaulting/README.md
@@ -1,0 +1,87 @@
+
+# Vaulting automated tests
+
+## Tests data
+
+### My Account tests
+
+- Payment details (type `Pcp.Payment`)
+- Registered customer (type `WooCommerce.CreateCustomer`)
+
+### Transaction tests
+
+- Default order (type `ShopOrder`) by registered customer.
+- Payment details (type `Pcp.Payment`)
+	- Additional flag `saveToAccount: boolean`. Always true for PayPal (should be always saved if vaulting is enabled). For ACDC, depending on test case, can be true or false resulting in saved or not saved card for the customer.
+	- Additional flag `isVaulted: boolean` - to use vaulted payment method in `PayPalUi.makePayment` method.
+- Registered customer (type `WooCommerce.CreateCustomer`)
+
+## Preconditions
+
+- `beforeAll` hook to setup store (USA, USD, default taxes, etc.) and plugin settings (install PCP, reset DB, connect merchant, enable APMs and vaulting settings).
+- Second `beforeAll` hook to recreate the customer before the test case and restore his storage state.
+- Optionally, depending on scenario, inside of the test - save payment method (for vaulted PayPal account session needs to be preserved).
+
+## Main test scenarios
+
+### My Account
+
+- PCP-0000 | Vaulting - My Account - Payment Methods - PayPal - Save payment method
+- PCP-0000 | Vaulting - My Account - Payment Methods - ACDC - Save payment method
+- PCP-0000 | Vaulting - My Account - Payment Methods - PayPal - Delete payment method
+- PCP-0000 | Vaulting - My Account - Payment Methods - ACDC - Delete payment method
+- PCP-0000 | Vaulting - My Account - Payment Methods - PayPal - Unable to save additional account
+- PCP-0000 | Vaulting - My Account - Payment Methods - ACDC - Save additional card
+- PCP-0000 | Vaulting - My Account - Payment Methods - PayPal - Make default **(not yet automated)**
+- PCP-0000 | Vaulting - My Account - Payment Methods - ACDC - Make default **(not yet automated)**
+
+Approximate scenario for "Save payment method":
+
+1. Assert customer has no saved payment method.
+
+2. Save payment method via My Account > Payment methods > Add payment method.
+
+3. Assert payment method has been saved.
+
+### Classic checkout
+
+> Note: same for Checkout, Pay for Order.
+
+- PCP-0000 | Vaulting - Transaction - Classic checkout - PayPal - Save payment method
+- PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Do not save payment method
+- PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Save payment method
+- PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved, not saving it
+- PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved, saving it
+- PCP-0000 | Vaulting - Transaction - Classic checkout - PayPal - Pay with saved payment method
+- PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Pay with saved payment method
+
+#### Approximate scenario for "Save payment method":
+
+	1. Assert customer has no saved payment method.
+
+	2. Add product to cart and perform a transaction.
+
+	3. Assert payment method has been saved. Depends on specified `saveToAccount` flag.
+
+#### Approximate scenario for "Pay with saved payment method":
+
+	1. Save payment method via My Account.
+
+	2. Add product to cart and perform a transaction, asserting the display of vaulted pyment method.
+
+	3. Assert details on Order Received page.
+
+	4. Get order and payment details via PayPal API and assert data has been transferred correctly (PayPal account or card number).
+
+	5. Assert details on WooCommerce Order Edit page (order status, PayPal fees, payout, etc.)
+
+### Classic cart
+
+> Note: same for Cart, Product, (Minicart?).
+
+- PCP-0000 | Vaulting - Transaction - Classic cart - PayPal - Save payment method
+- PCP-0000 | Vaulting - Transaction - Classic cart - PayPal - Pay with saved payment method
+
+Approximate scenarios are similar to Classic checout section.
+
+> Note: Only for PayPal, since ACDC is only available on checkout pages.

--- a/tests/qa/tests/07-vaulting/_test-data/index.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/index.ts
@@ -1,0 +1,4 @@
+export * from './vaulting-checkout.data';
+export * from './vaulting-classic-cart.data';
+export * from './vaulting-classic-checkout.data';
+export * from './vaulting-pay-by-link.data';

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-checkout.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-checkout.data.ts
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import { customers, orders, payments, ShopOrder } from '../../../resources';
+
+const customer = customers.usa;
+
+const savePaymentMethodData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Checkout - PayPal - Save payment method',
+		...orders.default,
+		payment: {
+			...payments.payPal,
+			saveToAccount: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Checkout - ACDC - Save payment method',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Checkout - ACDC - Do not save payment method',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: false,
+		},
+		customer,
+	},
+];
+
+const acdcAdditionalCardData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Checkout - ACDC - Pay with card other then saved and do not save it',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: false,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Checkout - ACDC - Pay with card other then saved and save it',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: true,
+		},
+		customer,
+	},
+];
+
+const vaultedPaymentMethodData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Checkout - PayPal - Pay with vaulted account',
+		...orders.default,
+		payment: {
+			...payments.payPal,
+			isVaulted: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Checkout - ACDC - Pay with saved card',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			isVaulted: true,
+		},
+		customer,
+	},
+];
+
+export const vaultingCheckout = {
+	savePaymentMethodData,
+	acdcAdditionalCardData,
+	vaultedPaymentMethodData,
+};

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-cart.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-cart.data.ts
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import { customers, orders, payments, ShopOrder } from '../../../resources';
+
+const customer = customers.usa;
+
+const savePaymentMethodData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic cart - PayPal - Save payment method',
+		...orders.default,
+		payment: {
+			...payments.payPal,
+			saveToAccount: true,
+		},
+		customer,
+	},
+];
+
+const vaultedPaymentMethodData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic cart - PayPal - Pay with vaulted account',
+		...orders.default,
+		payment: {
+			...payments.payPal,
+			isVaulted: true,
+		},
+		customer,
+	},
+];
+
+export const vaultingClassicCart = {
+	savePaymentMethodData,
+	vaultedPaymentMethodData,
+};

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-checkout.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-checkout.data.ts
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import { customers, orders, payments, ShopOrder } from '../../../resources';
+
+const customer = customers.usa;
+
+const savePaymentMethodData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - PayPal - Save payment method',
+		...orders.default,
+		payment: {
+			...payments.payPal,
+			saveToAccount: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Save payment method',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Do not save payment method',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: false,
+		},
+		customer,
+	},
+];
+
+const acdcAdditionalCardData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved and do not save it',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: false,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved and save it',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: true,
+		},
+		customer,
+	},
+];
+
+const vaultedPaymentMethodData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - PayPal - Pay with vaulted account',
+		...orders.default,
+		payment: {
+			...payments.payPal,
+			isVaulted: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Pay with saved card',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			isVaulted: true,
+		},
+		customer,
+	},
+];
+
+export const vaultingClassicCheckout = {
+	savePaymentMethodData,
+	acdcAdditionalCardData,
+	vaultedPaymentMethodData,
+};

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-pay-by-link.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-pay-by-link.data.ts
@@ -1,0 +1,84 @@
+/**
+ * Internal dependencies
+ */
+import { customers, orders, payments, ShopOrder } from '../../../resources';
+
+const customer = customers.usa;
+
+const savePaymentMethodData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - PayPal - Save payment method',
+		...orders.default,
+		payment: {
+			...payments.payPal,
+			saveToAccount: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Save payment method',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Do not save payment method',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: false,
+		},
+		customer,
+	},
+];
+
+const acdcAdditionalCardData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Pay with card other then saved and do not save it',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: false,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Pay with card other then saved and save it',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			saveToAccount: true,
+		},
+		customer,
+	},
+];
+
+const vaultedPaymentMethodData: ShopOrder[] = [
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - PayPal - Pay with vaulted account',
+		...orders.default,
+		payment: {
+			...payments.payPal,
+			isVaulted: true,
+		},
+		customer,
+	},
+	{
+		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Pay with saved card',
+		...orders.default,
+		payment: {
+			...payments.acdc,
+			isVaulted: true,
+		},
+		customer,
+	},
+];
+
+export const vaultingPayByLink = {
+	savePaymentMethodData,
+	acdcAdditionalCardData,
+	vaultedPaymentMethodData,
+};

--- a/tests/qa/tests/07-vaulting/_test-scenarios/index.ts
+++ b/tests/qa/tests/07-vaulting/_test-scenarios/index.ts
@@ -1,0 +1,4 @@
+export * from './vaulting-checkout.scenario';
+export * from './vaulting-classic-cart.scenario';
+export * from './vaulting-classic-checkout.scenario';
+export * from './vaulting-pay-by-link.scenario';

--- a/tests/qa/tests/07-vaulting/_test-scenarios/vaulting-checkout.scenario.ts
+++ b/tests/qa/tests/07-vaulting/_test-scenarios/vaulting-checkout.scenario.ts
@@ -1,0 +1,193 @@
+/**
+ * Internal dependencies
+ */
+import { cards, payments, ShopOrder } from '../../../resources';
+import { annotateVisitor, expect, test } from '../../../utils';
+
+const testSavePaymentMethod = ( testOrder: ShopOrder ) => {
+	const { title, payment, products, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				utils,
+				customerPaymentMethods,
+				checkout,
+				orderReceived,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				await expect(
+					customerPaymentMethods.noSavedMethodsMessage()
+				).toBeVisible();
+
+				// Make tested order (testOrder.payment.saveToAccount = true):
+				await utils.fillVisitorsCart( products );
+				await checkout.makeOrder( testOrder );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				await customerPaymentMethods.visit();
+				if ( payment.saveToAccount === true ) {
+					await customerPaymentMethods.assertIsSavedPaymentMethod(
+						payment
+					);
+				} else {
+					await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+						payment
+					);
+				}
+
+				await utils.fillVisitorsCart( products );
+				await checkout.visit();
+				if ( payment.saveToAccount === true ) {
+					await checkout.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+						payment
+					);
+				} else {
+					await checkout.payPalUi.assertVaultedPaymentMethodIsNotDisplayed(
+						payment
+					);
+				}
+			}
+		);
+	} );
+};
+
+const testAcdcAdditionalCard = ( testOrder: ShopOrder ) => {
+	const { title, payment, products, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				utils,
+				customerPaymentMethods,
+				checkout,
+				orderReceived,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				// Save initial card (not tested one)
+				await customerPaymentMethods.savePaymentMethod( {
+					...payments.acdc,
+					card: cards.visa2,
+				} );
+				// Assert tested card is not present in My Account
+				await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+					payment
+				);
+
+				// Make tested order (testOrder.payment.saveToAccount = true):
+				await utils.fillVisitorsCart( products );
+				await checkout.makeOrder( testOrder );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				await customerPaymentMethods.visit();
+				if ( payment.saveToAccount === true ) {
+					await customerPaymentMethods.assertIsSavedPaymentMethod(
+						payment
+					);
+				} else {
+					await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+						payment
+					);
+				}
+
+				await utils.fillVisitorsCart( products );
+				await checkout.visit();
+				if ( payment.saveToAccount === true ) {
+					await checkout.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+						payment
+					);
+				} else {
+					await checkout.payPalUi.assertVaultedPaymentMethodIsNotDisplayed(
+						payment
+					);
+				}
+			}
+		);
+	} );
+};
+
+const testVaultedPaymentMethod = ( testOrder: ShopOrder ) => {
+	const { title, payment, products, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				utils,
+				customerPaymentMethods,
+				checkout,
+				wooCommerceApi,
+				orderReceived,
+				payPalApi,
+				wooCommerceOrderEdit,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				await customerPaymentMethods.savePaymentMethod( payment );
+
+				// Make tested order:
+				await utils.fillVisitorsCart( products );
+
+				await checkout.makeOrder( testOrder );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				const orderId = await orderReceived.getOrderNumber();
+				const orderJson = await wooCommerceApi.getOrder( orderId );
+
+				const pcpData = {
+					transactionId: orderJson.transaction_id,
+					payPalFee: await payPalApi.getFee(
+						orderJson.transaction_id,
+						testOrder
+					),
+					payPalPayout: await payPalApi.getPayout(
+						orderJson.transaction_id,
+						testOrder
+					),
+				};
+
+				await payPalApi.assertOrder( orderJson, testOrder );
+				await payPalApi.assertPayment(
+					orderJson.transaction_id,
+					testOrder
+				);
+				await wooCommerceOrderEdit.assertOrderDetails(
+					orderId,
+					testOrder,
+					pcpData
+				);
+			}
+		);
+	} );
+};
+
+export const testVaultingCheckout = {
+	testSavePaymentMethod,
+	testAcdcAdditionalCard,
+	testVaultedPaymentMethod,
+};

--- a/tests/qa/tests/07-vaulting/_test-scenarios/vaulting-classic-cart.scenario.ts
+++ b/tests/qa/tests/07-vaulting/_test-scenarios/vaulting-classic-cart.scenario.ts
@@ -1,0 +1,128 @@
+/**
+ * Internal dependencies
+ */
+import { cards, payments, ShopOrder } from '../../../resources';
+import { annotateVisitor, expect, test } from '../../../utils';
+
+const testSavePaymentMethod = ( testOrder: ShopOrder ) => {
+	const { title, payment, products, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				utils,
+				customerPaymentMethods,
+				classicCart,
+				orderReceived,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				await expect(
+					customerPaymentMethods.noSavedMethodsMessage()
+				).toBeVisible();
+
+				// Make tested order (testOrder.payment.saveToAccount = true):
+				await utils.fillVisitorsCart( products );
+				await classicCart.makeOrder( testOrder );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				await customerPaymentMethods.visit();
+				if ( payment.saveToAccount === true ) {
+					await customerPaymentMethods.assertIsSavedPaymentMethod(
+						payment
+					);
+				} else {
+					await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+						payment
+					);
+				}
+
+				await utils.fillVisitorsCart( products );
+				await classicCart.visit();
+				if ( payment.saveToAccount === true ) {
+					await classicCart.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+						payment
+					);
+				} else {
+					await classicCart.payPalUi.assertVaultedPaymentMethodIsNotDisplayed(
+						payment
+					);
+				}
+			}
+		);
+	} );
+};
+
+const testVaultedPaymentMethod = ( testOrder: ShopOrder ) => {
+	const { title, payment, products, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				utils,
+				customerPaymentMethods,
+				classicCart,
+				wooCommerceApi,
+				orderReceived,
+				payPalApi,
+				wooCommerceOrderEdit,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				await customerPaymentMethods.savePaymentMethod( payment );
+
+				// Make tested order:
+				await utils.fillVisitorsCart( products );
+				await classicCart.makeOrder( testOrder );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				const orderId = await orderReceived.getOrderNumber();
+				const orderJson = await wooCommerceApi.getOrder( orderId );
+
+				const pcpData = {
+					transactionId: orderJson.transaction_id,
+					payPalFee: await payPalApi.getFee(
+						orderJson.transaction_id,
+						testOrder
+					),
+					payPalPayout: await payPalApi.getPayout(
+						orderJson.transaction_id,
+						testOrder
+					),
+				};
+
+				await payPalApi.assertOrder( orderJson, testOrder );
+				await payPalApi.assertPayment(
+					orderJson.transaction_id,
+					testOrder
+				);
+				await wooCommerceOrderEdit.assertOrderDetails(
+					orderId,
+					testOrder,
+					pcpData
+				);
+			}
+		);
+	} );
+};
+
+export const testVaultingClassicCart = {
+	testSavePaymentMethod,
+	testVaultedPaymentMethod,
+};

--- a/tests/qa/tests/07-vaulting/_test-scenarios/vaulting-classic-checkout.scenario.ts
+++ b/tests/qa/tests/07-vaulting/_test-scenarios/vaulting-classic-checkout.scenario.ts
@@ -1,0 +1,193 @@
+/**
+ * Internal dependencies
+ */
+import { cards, payments, ShopOrder } from '../../../resources';
+import { annotateVisitor, expect, test } from '../../../utils';
+
+const testSavePaymentMethod = ( testOrder: ShopOrder ) => {
+	const { title, payment, products, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				utils,
+				customerPaymentMethods,
+				classicCheckout,
+				orderReceived,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				await expect(
+					customerPaymentMethods.noSavedMethodsMessage()
+				).toBeVisible();
+
+				// Make tested order (testOrder.payment.saveToAccount = true):
+				await utils.fillVisitorsCart( products );
+				await classicCheckout.makeOrder( testOrder );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				await customerPaymentMethods.visit();
+				if ( payment.saveToAccount === true ) {
+					await customerPaymentMethods.assertIsSavedPaymentMethod(
+						payment
+					);
+				} else {
+					await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+						payment
+					);
+				}
+
+				await utils.fillVisitorsCart( products );
+				await classicCheckout.visit();
+				if ( payment.saveToAccount === true ) {
+					await classicCheckout.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+						payment
+					);
+				} else {
+					await classicCheckout.payPalUi.assertVaultedPaymentMethodIsNotDisplayed(
+						payment
+					);
+				}
+			}
+		);
+	} );
+};
+
+const testAcdcAdditionalCard = ( testOrder: ShopOrder ) => {
+	const { title, payment, products, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				utils,
+				customerPaymentMethods,
+				classicCheckout,
+				orderReceived,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				// Save initial card (not tested one)
+				await customerPaymentMethods.savePaymentMethod( {
+					...payments.acdc,
+					card: cards.visa2,
+				} );
+				// Assert tested card is not present in My Account
+				await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+					payment
+				);
+
+				// Make tested order (testOrder.payment.saveToAccount = true):
+				await utils.fillVisitorsCart( products );
+				await classicCheckout.makeOrder( testOrder );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				await customerPaymentMethods.visit();
+				if ( payment.saveToAccount === true ) {
+					await customerPaymentMethods.assertIsSavedPaymentMethod(
+						payment
+					);
+				} else {
+					await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+						payment
+					);
+				}
+
+				await utils.fillVisitorsCart( products );
+				await classicCheckout.visit();
+				if ( payment.saveToAccount === true ) {
+					await classicCheckout.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+						payment
+					);
+				} else {
+					await classicCheckout.payPalUi.assertVaultedPaymentMethodIsNotDisplayed(
+						payment
+					);
+				}
+			}
+		);
+	} );
+};
+
+const testVaultedPaymentMethod = ( testOrder: ShopOrder ) => {
+	const { title, payment, products, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				utils,
+				customerPaymentMethods,
+				classicCheckout,
+				wooCommerceApi,
+				orderReceived,
+				payPalApi,
+				wooCommerceOrderEdit,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				await customerPaymentMethods.savePaymentMethod( payment );
+
+				// Make tested order:
+				await utils.fillVisitorsCart( products );
+
+				await classicCheckout.makeOrder( testOrder );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				const orderId = await orderReceived.getOrderNumber();
+				const orderJson = await wooCommerceApi.getOrder( orderId );
+
+				const pcpData = {
+					transactionId: orderJson.transaction_id,
+					payPalFee: await payPalApi.getFee(
+						orderJson.transaction_id,
+						testOrder
+					),
+					payPalPayout: await payPalApi.getPayout(
+						orderJson.transaction_id,
+						testOrder
+					),
+				};
+
+				await payPalApi.assertOrder( orderJson, testOrder );
+				await payPalApi.assertPayment(
+					orderJson.transaction_id,
+					testOrder
+				);
+				await wooCommerceOrderEdit.assertOrderDetails(
+					orderId,
+					testOrder,
+					pcpData
+				);
+			}
+		);
+	} );
+};
+
+export const testVaultingClassicCheckout = {
+	testSavePaymentMethod,
+	testAcdcAdditionalCard,
+	testVaultedPaymentMethod,
+};

--- a/tests/qa/tests/07-vaulting/_test-scenarios/vaulting-pay-by-link.scenario.ts
+++ b/tests/qa/tests/07-vaulting/_test-scenarios/vaulting-pay-by-link.scenario.ts
@@ -1,0 +1,196 @@
+/**
+ * Internal dependencies
+ */
+import { cards, payments, ShopOrder } from '../../../resources';
+import { annotateVisitor, expect, test } from '../../../utils';
+
+const testSavePaymentMethod = ( testOrder: ShopOrder ) => {
+	const { title, payment, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				wooCommerceUtils,
+				customerPaymentMethods,
+				payForOrder,
+				orderReceived,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				await expect(
+					customerPaymentMethods.noSavedMethodsMessage()
+				).toBeVisible();
+
+				// Make tested order (testOrder.payment.saveToAccount = true):
+				let order = await wooCommerceUtils.createApiOrder( testOrder );
+				await payForOrder.makeOrder( testOrder, order );
+				// Expect Order Received page to be loaded
+				await orderReceived.assertOrderDetails( testOrder );
+
+				await customerPaymentMethods.visit();
+				if ( payment.saveToAccount === true ) {
+					await customerPaymentMethods.assertIsSavedPaymentMethod(
+						payment
+					);
+				} else {
+					await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+						payment
+					);
+				}
+
+				order = await wooCommerceUtils.createApiOrder( testOrder );
+				await payForOrder.visit( order.id, order.order_key );
+				if ( payment.saveToAccount === true ) {
+					await payForOrder.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+						payment
+					);
+				} else {
+					await payForOrder.payPalUi.assertVaultedPaymentMethodIsNotDisplayed(
+						payment
+					);
+				}
+			}
+		);
+	} );
+};
+
+const testAcdcAdditionalCard = ( testOrder: ShopOrder ) => {
+	const { title, payment, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				wooCommerceUtils,
+				customerPaymentMethods,
+				payForOrder,
+				orderReceived,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				// Save initial card (not tested one)
+				await customerPaymentMethods.savePaymentMethod( {
+					...payments.acdc,
+					card: cards.visa2,
+				} );
+				// Assert tested card is not present in My Account
+				await customerPaymentMethods.assertUrl();
+				await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+					payment
+				);
+
+				// Make tested order (testOrder.payment.saveToAccount = true):
+				let order = await wooCommerceUtils.createApiOrder( testOrder );
+				await payForOrder.makeOrder( testOrder, order );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				await customerPaymentMethods.visit();
+				if ( payment.saveToAccount === true ) {
+					await customerPaymentMethods.assertIsSavedPaymentMethod(
+						payment
+					);
+				} else {
+					await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+						payment
+					);
+				}
+
+				order = await wooCommerceUtils.createApiOrder( testOrder );
+				await payForOrder.visit( order.id, order.order_key );
+				if ( payment.saveToAccount === true ) {
+					await payForOrder.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+						payment
+					);
+				} else {
+					await payForOrder.payPalUi.assertVaultedPaymentMethodIsNotDisplayed(
+						payment
+					);
+				}
+			}
+		);
+	} );
+};
+
+const testVaultedPaymentMethod = ( testOrder: ShopOrder ) => {
+	const { title, payment, customer } = testOrder;
+
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			title,
+			annotateVisitor( customer ),
+			async ( {
+				wooCommerceUtils,
+				customerPaymentMethods,
+				payForOrder,
+				wooCommerceApi,
+				orderReceived,
+				payPalApi,
+				wooCommerceOrderEdit,
+			} ) => {
+				// Preconditions
+				await customerPaymentMethods.visit();
+				await customerPaymentMethods.savePaymentMethod( payment );
+
+				// Make tested order:
+				const order = await wooCommerceUtils.createApiOrder(
+					testOrder
+				);
+				await payForOrder.makeOrder( testOrder, order );
+				await orderReceived.assertOrderDetails( testOrder );
+
+				const orderId = await orderReceived.getOrderNumber();
+				const orderJson = await wooCommerceApi.getOrder( orderId );
+
+				const pcpData = {
+					transactionId: orderJson.transaction_id,
+					payPalFee: await payPalApi.getFee(
+						orderJson.transaction_id,
+						testOrder
+					),
+					payPalPayout: await payPalApi.getPayout(
+						orderJson.transaction_id,
+						testOrder
+					),
+				};
+
+				await payPalApi.assertOrder( orderJson, testOrder );
+				await payPalApi.assertPayment(
+					orderJson.transaction_id,
+					testOrder
+				);
+				await wooCommerceOrderEdit.assertOrderDetails(
+					orderId,
+					testOrder,
+					pcpData
+				);
+			}
+		);
+	} );
+};
+
+export const testVaultingPayByLink = {
+	testSavePaymentMethod,
+	testAcdcAdditionalCard,
+	testVaultedPaymentMethod,
+};

--- a/tests/qa/tests/07-vaulting/vaulting-checkout.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-checkout.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import { merchants, storeConfigUsa } from '../../resources';
+import { vaultingCheckout } from './_test-data';
+import { testVaultingCheckout } from './_test-scenarios';
+
+const {
+	savePaymentMethodData,
+	acdcAdditionalCardData,
+	vaultedPaymentMethodData,
+} = vaultingCheckout;
+
+const {
+	testSavePaymentMethod,
+	testAcdcAdditionalCard,
+	testVaultedPaymentMethod,
+} = testVaultingCheckout;
+
+test.beforeAll( async ( { utils, pcpApi } ) => {
+	await utils.configureStore( {
+		...storeConfigUsa,
+		classicPages: true,
+	} );
+	await utils.installAndActivatePcp();
+	await pcpApi.resetDb();
+	await pcpApi.connectMerchant(
+		merchants.usa.client_id,
+		merchants.usa.client_secret,
+		{
+			isCasualSeller: false,
+			areOptionalPaymentMethodsEnabled: true,
+		}
+	);
+	await pcpApi.updatePcpSettings( {
+		savePaypalAndVenmo: true,
+		saveCardDetails: true,
+	} );
+} );
+
+for ( const testData of savePaymentMethodData ) {
+	testSavePaymentMethod( testData );
+}
+
+for ( const testData of acdcAdditionalCardData ) {
+	testAcdcAdditionalCard( testData );
+}
+
+for ( const testData of vaultedPaymentMethodData ) {
+	testVaultedPaymentMethod( testData );
+}

--- a/tests/qa/tests/07-vaulting/vaulting-classic-cart.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-classic-cart.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import { merchants, storeConfigUsa } from '../../resources';
+import { vaultingClassicCart } from './_test-data';
+import { testVaultingClassicCart } from './_test-scenarios';
+
+const { savePaymentMethodData, vaultedPaymentMethodData } = vaultingClassicCart;
+
+const { testSavePaymentMethod, testVaultedPaymentMethod } =
+	testVaultingClassicCart;
+
+test.beforeAll( async ( { utils, pcpApi } ) => {
+	await utils.configureStore( {
+		...storeConfigUsa,
+		classicPages: true,
+	} );
+	await utils.installAndActivatePcp();
+	await pcpApi.resetDb();
+	await pcpApi.connectMerchant(
+		merchants.usa.client_id,
+		merchants.usa.client_secret,
+		{
+			isCasualSeller: false,
+			areOptionalPaymentMethodsEnabled: true,
+		}
+	);
+	await pcpApi.updatePcpSettings( {
+		savePaypalAndVenmo: true,
+		saveCardDetails: true,
+	} );
+} );
+
+for ( const testData of savePaymentMethodData ) {
+	testSavePaymentMethod( testData );
+}
+
+for ( const testData of vaultedPaymentMethodData ) {
+	testVaultedPaymentMethod( testData );
+}

--- a/tests/qa/tests/07-vaulting/vaulting-classic-checkout.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-classic-checkout.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import { merchants, storeConfigUsa } from '../../resources';
+import { vaultingClassicCheckout } from './_test-data';
+import { testVaultingClassicCheckout } from './_test-scenarios';
+
+const {
+	savePaymentMethodData,
+	acdcAdditionalCardData,
+	vaultedPaymentMethodData,
+} = vaultingClassicCheckout;
+
+const {
+	testSavePaymentMethod,
+	testAcdcAdditionalCard,
+	testVaultedPaymentMethod,
+} = testVaultingClassicCheckout;
+
+test.beforeAll( async ( { utils, pcpApi } ) => {
+	await utils.configureStore( {
+		...storeConfigUsa,
+		classicPages: true,
+	} );
+	await utils.installAndActivatePcp();
+	await pcpApi.resetDb();
+	await pcpApi.connectMerchant(
+		merchants.usa.client_id,
+		merchants.usa.client_secret,
+		{
+			isCasualSeller: false,
+			areOptionalPaymentMethodsEnabled: true,
+		}
+	);
+	await pcpApi.updatePcpSettings( {
+		savePaypalAndVenmo: true,
+		saveCardDetails: true,
+	} );
+} );
+
+for ( const testData of savePaymentMethodData ) {
+	testSavePaymentMethod( testData );
+}
+
+for ( const testData of acdcAdditionalCardData ) {
+	testAcdcAdditionalCard( testData );
+}
+
+for ( const testData of vaultedPaymentMethodData ) {
+	testVaultedPaymentMethod( testData );
+}

--- a/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Internal dependencies
+ */
+import { annotateVisitor, expect, test } from '../../utils';
+import {
+	merchants,
+	storeConfigUsa,
+	customers,
+	payments,
+	cards,
+	products,
+} from '../../resources';
+
+const customer = customers.usa;
+const { payPal, acdc } = payments;
+const acdc2 = { ...acdc, card: cards.visa2 };
+
+test.beforeAll( async ( { utils, pcpApi } ) => {
+	await utils.configureStore( {
+		...storeConfigUsa,
+		classicPages: true,
+	} );
+	await utils.installAndActivatePcp();
+	await pcpApi.resetDb();
+	await pcpApi.connectMerchant(
+		merchants.usa.client_id,
+		merchants.usa.client_secret,
+		{
+			isCasualSeller: false,
+			areOptionalPaymentMethodsEnabled: true,
+		}
+	);
+	await pcpApi.updatePcpSettings( {
+		savePaypalAndVenmo: true,
+		saveCardDetails: true,
+	} );
+} );
+
+const savePaymentMethodData = [
+	{
+		testKey: 'PCP-0000',
+		payment: payPal,
+	},
+	{
+		testKey: 'PCP-0000',
+		payment: acdc,
+	},
+];
+
+for ( const testData of savePaymentMethodData ) {
+	const { testKey, payment } = testData;
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			`${ testKey } | Vaulting - My Account - Payment Methods - ${ payment.gateway.title } - Save payment method`,
+			annotateVisitor( customer ),
+			async ( { utils, customerPaymentMethods, classicCheckout } ) => {
+				await customerPaymentMethods.visit();
+				await expect(
+					customerPaymentMethods.noSavedMethodsMessage()
+				).toBeVisible();
+
+				await customerPaymentMethods.savePaymentMethod( payment );
+
+				await customerPaymentMethods.assertUrl();
+				await customerPaymentMethods.assertIsSavedPaymentMethod(
+					payment
+				);
+
+				await utils.fillVisitorsCart( [ products.simple10 ] );
+				await classicCheckout.visit();
+				await classicCheckout.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+					payment
+				);
+			}
+		);
+	} );
+}
+
+const deletePaymentMethodData = [
+	{
+		testKey: 'PCP-0000',
+		payment: payPal,
+	},
+	{
+		testKey: 'PCP-0000',
+		payment: acdc,
+	},
+];
+
+for ( const testData of deletePaymentMethodData ) {
+	const { testKey, payment } = testData;
+	test.describe( () => {
+		// Restore customer and his storage state to remove vaulted payment methods.
+		// Placed in beforeAll for each test to be able to use storate state in a test.
+		test.beforeAll( async ( { utils } ) => {
+			await utils.restoreCustomer( customer );
+		} );
+
+		test(
+			`${ testKey } | Vaulting - My Account - Payment Methods - ${ payment.gateway.title } - Delete saved payment method`,
+			annotateVisitor( customer ),
+			async ( { utils, customerPaymentMethods, classicCheckout } ) => {
+				await customerPaymentMethods.visit();
+				await expect(
+					customerPaymentMethods.noSavedMethodsMessage()
+				).toBeVisible();
+
+				await customerPaymentMethods.savePaymentMethod( payment );
+
+				const savedPaymentMethodText =
+					await customerPaymentMethods.getSavedPaymentMethodText(
+						payment
+					);
+
+				await customerPaymentMethods
+					.deletePaymentMethodButton( savedPaymentMethodText )
+					.click();
+				await customerPaymentMethods.page.waitForLoadState();
+
+				await customerPaymentMethods.assertUrl();
+				await expect(
+					customerPaymentMethods.paymentMethodDeletedMessage()
+				).toBeVisible();
+				await expect(
+					customerPaymentMethods.noSavedMethodsMessage()
+				).toBeVisible();
+				await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+					payment
+				);
+
+				await utils.fillVisitorsCart( [ products.simple10 ] );
+				await classicCheckout.visit();
+				await classicCheckout.payPalUi.assertVaultedPaymentMethodIsNotDisplayed(
+					payment
+				);
+			}
+		);
+	} );
+}
+
+test.describe( () => {
+	// Restore customer and his storage state to remove vaulted payment methods.
+	// Placed in beforeAll for each test to be able to use storate state in a test.
+	test.beforeAll( async ( { utils } ) => {
+		await utils.restoreCustomer( customer );
+	} );
+
+	test(
+		'PCP-0000 | Vaulting - My Account - Payment Methods - PayPal - Unable to save additional account',
+		annotateVisitor( customer ),
+		async ( { customerPaymentMethods } ) => {
+			// Preconditions
+			await customerPaymentMethods.visit();
+			// Save initial card (not tested)
+			await customerPaymentMethods.savePaymentMethod( payPal );
+			// Assert tested card is not present in My Account
+			await customerPaymentMethods.assertIsSavedPaymentMethod( payPal );
+			await customerPaymentMethods.addPaymentMethodButton().click();
+			await customerPaymentMethods.page.waitForLoadState();
+			await expect(
+				customerPaymentMethods.payPalUi.payPalGateway()
+			).not.toBeVisible();
+			await expect(
+				customerPaymentMethods.payPalUi.payPalButton()
+			).not.toBeVisible();
+		}
+	);
+} );
+
+test.describe( () => {
+	// Restore customer and his storage state to remove vaulted payment methods.
+	// Placed in beforeAll for each test to be able to use storate state in a test.
+	test.beforeAll( async ( { utils } ) => {
+		await utils.restoreCustomer( customer );
+	} );
+
+	test(
+		'PCP-0000 | Vaulting - My Account - Payment Methods - ACDC - Save additional card',
+		annotateVisitor( customer ),
+		async ( { utils, customerPaymentMethods, classicCheckout } ) => {
+			// Preconditions
+			await customerPaymentMethods.visit();
+			// Save initial card (not tested one)
+			await customerPaymentMethods.savePaymentMethod( acdc );
+			// Assert tested card is not present in My Account
+			await customerPaymentMethods.assertIsSavedPaymentMethod( acdc );
+			await customerPaymentMethods.assertIsNotSavedPaymentMethod( acdc2 );
+
+			await customerPaymentMethods.savePaymentMethod( acdc2 );
+
+			await customerPaymentMethods.assertUrl();
+			await customerPaymentMethods.assertIsSavedPaymentMethod( acdc );
+			await customerPaymentMethods.assertIsSavedPaymentMethod( acdc2 );
+
+			await utils.fillVisitorsCart( [ products.simple10 ] );
+			await classicCheckout.visit();
+			await classicCheckout.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+				acdc
+			);
+			await classicCheckout.payPalUi.assertVaultedPaymentMethodIsDisplayed(
+				acdc2
+			);
+		}
+	);
+} );

--- a/tests/qa/tests/07-vaulting/vaulting-pay-by-link.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-pay-by-link.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import { merchants, storeConfigUsa } from '../../resources';
+import { vaultingPayByLink } from './_test-data';
+import { testVaultingPayByLink } from './_test-scenarios';
+
+const {
+	savePaymentMethodData,
+	acdcAdditionalCardData,
+	vaultedPaymentMethodData,
+} = vaultingPayByLink;
+
+const {
+	testSavePaymentMethod,
+	testAcdcAdditionalCard,
+	testVaultedPaymentMethod,
+} = testVaultingPayByLink;
+
+test.beforeAll( async ( { utils, pcpApi } ) => {
+	await utils.configureStore( {
+		...storeConfigUsa,
+		classicPages: false,
+	} );
+	await utils.installAndActivatePcp();
+	await pcpApi.resetDb();
+	await pcpApi.connectMerchant(
+		merchants.usa.client_id,
+		merchants.usa.client_secret,
+		{
+			isCasualSeller: false,
+			areOptionalPaymentMethodsEnabled: true,
+		}
+	);
+	await pcpApi.updatePcpSettings( {
+		savePaypalAndVenmo: true,
+		saveCardDetails: true,
+	} );
+} );
+
+for ( const testData of savePaymentMethodData ) {
+	testSavePaymentMethod( testData );
+}
+
+for ( const testData of acdcAdditionalCardData ) {
+	testAcdcAdditionalCard( testData );
+}
+
+for ( const testData of vaultedPaymentMethodData ) {
+	testVaultedPaymentMethod( testData );
+}

--- a/tests/qa/tests/_setup/woocommerce.setup.ts
+++ b/tests/qa/tests/_setup/woocommerce.setup.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { updateDotenv } from '@inpsyde/playwright-utils/build';
+/**
  * Internal dependencies
  */
 import { test as setup } from '../../utils';
@@ -14,10 +18,8 @@ import {
 	subscriptionsPlugin,
 	disableWcSetupWizard,
 } from '../../resources';
-/**
- * External dependencies
- */
-import { updateDotenv } from '@inpsyde/playwright-utils/build';
+
+const country = process.env.WC_DEFAULT_COUNTRY || 'usa';
 
 setup( 'Setup Permalinks', async ( { requestUtils } ) => {
 	await requestUtils.setPermalinks( '/%postname%/' );
@@ -163,7 +165,7 @@ setup( 'Setup WooCommerce email settings', async ( { wooCommerceApi } ) => {
 } );
 
 setup( 'Setup WooCommerce general settings', async ( { wooCommerceApi } ) => {
-	await wooCommerceApi.updateGeneralSettings( shopSettings.germany.general );
+	await wooCommerceApi.updateGeneralSettings( shopSettings[country].general );
 } );
 
 setup( 'Setup WooCommerce shipping', async ( { wooCommerceUtils } ) => {
@@ -175,7 +177,7 @@ setup( 'Setup WooCommerce taxes (included)', async ( { wooCommerceUtils } ) => {
 } );
 
 setup( 'Setup Registered Customer', async ( { wooCommerceUtils } ) => {
-	await wooCommerceUtils.createCustomer( customers.germany );
+	await wooCommerceUtils.createCustomer( customers[country] );
 } );
 
 setup( 'Setup Delete Previous Orders', async ( { wooCommerceApi } ) => {

--- a/tests/qa/utils/admin/woocommerce-order-edit.ts
+++ b/tests/qa/utils/admin/woocommerce-order-edit.ts
@@ -240,7 +240,7 @@ export class WooCommerceOrderEdit extends WooCommerceOrderEditBase {
 			payPalNetTotal,
 			currency,
 		} = data;
-		
+
 		await super.assertRefundData( data );
 
 		if ( payPalFee !== undefined ) {

--- a/tests/qa/utils/frontend/checkout.ts
+++ b/tests/qa/utils/frontend/checkout.ts
@@ -53,7 +53,7 @@ export class Checkout extends CheckoutBase {
 			// Fill billing details
 			await this.fillCheckoutForm( customer );
 		}
-		
+
 		// Select shipping or initial shipment (for subscriptions) option:
 		await this.selectShippingMethod( shipping.settings.title );
 

--- a/tests/qa/utils/frontend/classic-checkout.ts
+++ b/tests/qa/utils/frontend/classic-checkout.ts
@@ -43,7 +43,6 @@ export class ClassicCheckout extends ClassicCheckoutBase {
 
 		// Add coupons if needed
 		await this.applyCouponIfNeeded( coupons );
-		await this.applyCouponIfNeeded( coupons );
 
 		// Select shipping or initial shipment (for subscriptions) option:
 		if ( products.some( ( product ) => product.type === 'subscription' ) ) {

--- a/tests/qa/utils/frontend/customer-payment-methods.ts
+++ b/tests/qa/utils/frontend/customer-payment-methods.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { CustomerPaymentMethods as CustomerPaymentMethodsBase } from '@inpsyde/playwright-utils/build';
+import {
+	CustomerPaymentMethods as CustomerPaymentMethodsBase,
+	expect,
+	getLast4CardDigits,
+} from '@inpsyde/playwright-utils/build';
 /**
  * Internal dependencies
  */
@@ -17,28 +21,45 @@ export class CustomerPaymentMethods extends CustomerPaymentMethodsBase {
 	}
 
 	// Locators
+	paymentMethodDeletedMessage = () =>
+		// TODO: remove with playwright-utils version > 2.6.1
+		this.page.getByText( 'Payment method deleted.' );
 	noSavedMethodsMessage = () =>
+		// TODO: remove with playwright-utils version > 2.6.1
 		this.page.getByText( 'No saved methods found' );
+	addPaymentMethodButton = () =>
+		// TODO: remove with playwright-utils version > 2.6.1
+		this.page
+			.getByRole( 'link', { name: 'Add payment method' } )
+			.or(
+				this.page.getByRole( 'button', { name: 'Add payment method' } )
+			);
 
 	// Actions
-	isSavedPaymentMethod = async ( payment: Pcp.Payment ) => {
-		await this.visit();
+	getSavedPaymentMethodText = async ( payment: Pcp.Payment ) => {
+		switch ( payment.gateway.shortcut ) {
+			case 'paypal':
+				const payPalEmail = payment.payPalAccount.email;
+				const match = payPalEmail.replace( /.{2}-.{1}/, '' );
+				return new RegExp( `Paypal /.*${ match }`, 'i' );
 
+			case 'acdc':
+				const { card } = payment;
+				const last4Digits = getLast4CardDigits( card.card_number );
+				return `${ card.card_type } ending in ${ last4Digits }`;
+		}
+	};
+
+	isSavedPaymentMethod = async ( payment: Pcp.Payment ) => {
 		if ( await this.noSavedMethodsMessage().isVisible() ) {
 			return false;
 		}
-
-		switch ( payment.gateway.shortcut ) {
-			case 'paypal':
-				return await this.savedPaymentMethodRow(
-					`Paypal /`
-				).isVisible();
-
-			case 'card':
-				return await this.savedPaymentMethodRow(
-					payment.card?.card_number
-				).isVisible();
-		}
+		const paymentMethodText = await this.getSavedPaymentMethodText(
+			payment
+		);
+		return await this.savedPaymentMethodRow(
+			paymentMethodText
+		).isVisible();
 	};
 
 	/**
@@ -47,12 +68,65 @@ export class CustomerPaymentMethods extends CustomerPaymentMethodsBase {
 	 * @param payment
 	 */
 	savePaymentMethod = async ( payment: Pcp.Payment ) => {
-		if ( ! ( await this.isSavedPaymentMethod( payment ) ) ) {
-			await this.addPaymentMethodButton().click();
-			await this.page.waitForLoadState();
-			await this.payPalUi.savePaymentMethod( payment );
+		const { gateway, card, payPalAccount } = payment;
+
+		const addPaymentMethodButton = this.addPaymentMethodButton();
+		await expect( addPaymentMethodButton ).toBeVisible();
+		await addPaymentMethodButton.click();
+		await this.page.waitForLoadState();
+
+		switch ( gateway.shortcut ) {
+			case 'paypal':
+				await this.payPalUi.payPalGateway().click();
+				const popup = await this.payPalUi.openPayPalPupup();
+				await popup.savePayPalPaymentMethod( payPalAccount );
+				break;
+
+			case 'acdc':
+				await this.payPalUi.acdcGateway().click();
+				await this.payPalUi
+					.acdcCardNumberInput()
+					.fill( card.card_number );
+				// trick to properly fill expiration date input
+				await this.payPalUi.acdcCardExpirationInput().click();
+				for ( const char of card.expiration_date ) {
+					await this.page.keyboard.type( char );
+					await this.page.waitForTimeout( 200 );
+				}
+				await this.payPalUi.acdcCardCvvInput().fill( card.card_cvv );
+				await this.addPaymentMethodButton().click();
+				await this.page.waitForLoadState();
+				break;
 		}
 	};
 
 	// Assertions
+
+	/**
+	 * Asserts payment method row is visible
+	 *
+	 * @param payment
+	 */
+	assertIsSavedPaymentMethod = async ( payment: Pcp.Payment ) => {
+		const paymentMethodText = await this.getSavedPaymentMethodText(
+			payment
+		);
+		await expect(
+			this.savedPaymentMethodRow( paymentMethodText )
+		).toBeVisible();
+	};
+
+	/**
+	 * Asserts payment method row is not visible
+	 *
+	 * @param payment
+	 */
+	assertIsNotSavedPaymentMethod = async ( payment: Pcp.Payment ) => {
+		const paymentMethodText = await this.getSavedPaymentMethodText(
+			payment
+		);
+		await expect(
+			this.savedPaymentMethodRow( paymentMethodText )
+		).not.toBeVisible();
+	};
 }

--- a/tests/qa/utils/frontend/paypal-popup.ts
+++ b/tests/qa/utils/frontend/paypal-popup.ts
@@ -23,7 +23,10 @@ export class PayPalPopup {
 	passwordInput = () => this.popup.locator( '[name="login_password"]' );
 	nextButton = () => this.popup.locator( '#btnNext' );
 	loginButton = () => this.popup.locator( '#btnLogin' );
-	submitPaymentButton = () => this.popup.locator( '#payment-submit-btn' );
+	submitPaymentButton = () =>
+		this.popup
+			.locator( '#payment-submit-btn' )
+			.or( this.popup.getByTestId( 'submit-button-initial' ) );
 	payLaterSwitcher = () => this.popup.getByTestId( 'paylater-tab' );
 	payLaterRadio = () =>
 		this.popup.locator( 'label[for^="credit-offer"]' ).first();

--- a/tests/qa/utils/frontend/paypal-ui-classic.ts
+++ b/tests/qa/utils/frontend/paypal-ui-classic.ts
@@ -20,7 +20,8 @@ export class PayPalUiClassic extends PayPalUi {
 
 	payPalIframe = () =>
 		this.page.frameLocator(
-			'#ppc-button-ppcp-gateway iframe[name^="__zoid__paypal_buttons__"]'
+			// unified selector for My Account and checkout pages
+			'[id^="ppc-button-ppcp-gateway"] iframe[name^="__zoid__paypal_buttons__"]'
 		);
 	payPalButtonsClassicContainer = () =>
 		this.payPalIframe().locator( '#buttons-container' );
@@ -255,12 +256,12 @@ export class PayPalUiClassic extends PayPalUi {
 		this.page.locator( '#wc-ppcp-credit-card-gateway-new-payment-method' );
 	acdcSavedCards = () =>
 		this.page.locator( '.woocommerce-SavedPaymentMethods-token' );
-	acdcSavedCardByNumber = ( cardNumber ) =>
-		this.acdcSavedCards()
-			.filter( {
-				hasText: `ending in ${ getLast4CardDigits( cardNumber ) }`,
-			} )
-			.first();
+	acdcSavedCard = ( card: WooCommerce.CreditCard ) =>
+		this.acdcSavedCards().filter( {
+			hasText: `${ card.card_type } ending in ${ getLast4CardDigits(
+				card.card_number
+			) } (expires ${ card.expiration_date })`,
+		} );
 	acdcUseNewPaymentRadio = () =>
 		this.page.locator( '.woocommerce-SavedPaymentMethods-new > input' );
 
@@ -308,6 +309,45 @@ export class PayPalUiClassic extends PayPalUi {
 	// Actions
 
 	/**
+	 * Completes payment with ACDC
+	 *
+	 * @param payment
+	 * @param merchant
+	 */
+	completeAcdcPayment = async (
+		payment: Pcp.Payment,
+		merchant: Pcp.Merchant
+	) => {
+		const { card, saveToAccount, isVaulted } = payment;
+		await expect( this.acdcGateway() ).toBeVisible();
+		await this.acdcGateway().click();
+
+		//if some cards are already stored then "Use a new payment method" radio should be checked
+		if (
+			! isVaulted &&
+			( await this.acdcUseNewPaymentRadio().isVisible() )
+		) {
+			await this.acdcUseNewPaymentRadio().check();
+		}
+
+		await this.acdcCardNumberInput().fill( card.card_number );
+		// trick to properly fill expiration date input
+		await this.acdcCardExpirationInput().click();
+		for ( const char of card.expiration_date ) {
+			await this.page.keyboard.type( char );
+			await this.page.waitForTimeout( 200 );
+		}
+		await this.acdcCardCvvInput().fill( card.card_cvv );
+
+		if ( saveToAccount ) {
+			await this.acdcSaveToAccountCheckbox().check();
+		}
+
+		await this.submitOrder();
+		await this.replacePayPalAuthToken( merchant );
+	};
+
+	/**
 	 * Completes payment with ACDC (vaulting enabled)
 	 *
 	 * @param payment
@@ -319,7 +359,7 @@ export class PayPalUiClassic extends PayPalUi {
 	) => {
 		await expect( this.acdcGateway() ).toBeVisible();
 		await this.acdcGateway().click();
-		await this.acdcSavedCardByNumber( payment.card.card_number ).click();
+		await this.acdcSavedCard( payment.card ).click();
 		await this.submitOrder();
 		await this.replacePayPalAuthToken( merchant );
 	};
@@ -409,6 +449,56 @@ export class PayPalUiClassic extends PayPalUi {
 	};
 
 	// Assertions
+
+	/**
+	 * Asserts the saved payment method is visible
+	 *
+	 * @param payment
+	 */
+	assertVaultedPaymentMethodIsDisplayed = async ( payment: Pcp.Payment ) => {
+		switch ( payment.gateway.shortcut ) {
+			case 'paypal':
+				await this.payPalGateway().click();
+				await expect( this.payPalButton() ).toContainText( 'Pay Now' );
+				await expect( this.payPalButtonMoreOptions() ).toBeVisible();
+				break;
+
+			case 'acdc':
+				await this.acdcGateway().click();
+				await expect(
+					this.acdcSavedCard( payment.card )
+				).toBeVisible();
+				break;
+		}
+	};
+
+	/**
+	 * Asserts the saved payment method is not visible
+	 *
+	 * @param payment
+	 */
+	assertVaultedPaymentMethodIsNotDisplayed = async (
+		payment: Pcp.Payment
+	) => {
+		switch ( payment.gateway.shortcut ) {
+			case 'paypal':
+				await this.payPalGateway().click();
+				await expect( this.payPalButton() ).not.toContainText(
+					'Pay Now'
+				);
+				await expect(
+					this.payPalButtonMoreOptions()
+				).not.toBeVisible();
+				break;
+
+			case 'acdc':
+				await this.acdcGateway().click();
+				await expect(
+					this.acdcSavedCard( payment.card )
+				).not.toBeVisible();
+				break;
+		}
+	};
 
 	/**
 	 * - Asserts PayPal buttons classic container is visible.

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { Page } from '@playwright/test';
-import { expect } from '@inpsyde/playwright-utils/build';
+import { expect, getLast4CardDigits } from '@inpsyde/playwright-utils/build';
 /**
  * Internal dependencies
  */
@@ -61,8 +61,16 @@ export class PayPalUi {
 			)
 			.locator( `[data-funding-source="venmo"]` );
 
-	payPalButtonMoreOptions = () => this.page.locator( '.todo' );
-	payWithDifferentAccountButton = () => this.page.locator( '.todo' );
+	payPalGateway = () =>
+		this.page.locator(
+			'#radio-control-wc-payment-method-options-ppcp-gateway'
+		);
+	payPalButtonMoreOptions = () => this.page.locator( '.todo' ); // TODO
+	payWithDifferentAccountButton = () => this.page.locator( '.todo' ); // TODO
+	payPalVaultedGateway = () =>
+		this.paymentOptionsContainers().filter( {
+			hasText: 'Saved token for ppcp-gateway',
+		} );
 
 	payLaterMessageIframe = () =>
 		this.page.frameLocator( 'iframe[name^="__zoid__paypal_message__"]' );
@@ -109,29 +117,46 @@ export class PayPalUi {
 	fastlaneOtp3Input = () => this.page.locator( '#otp3-input' );
 	fastlaneOtp4Input = () => this.page.locator( '#otp4-input' );
 	fastlaneOtp5Input = () => this.page.locator( '#otp5-input' );
-	
-	acdcGateway = () => this.page.locator(
-		'#radio-control-wc-payment-method-options-ppcp-credit-card-gateway'
-	);
-	acdcContainer = () => this.paymentOptionsContainers().filter( {
-		has: this.acdcGateway()
-	} );
+
+	acdcGateway = () =>
+		this.page.locator(
+			'#radio-control-wc-payment-method-options-ppcp-credit-card-gateway'
+		);
+	acdcContainer = () =>
+		this.paymentOptionsContainers().filter( {
+			has: this.acdcGateway(),
+		} );
 	acdcCardholderNameInput = () =>
 		this.acdcContainer()
-			.frameLocator( '[id^="zoid-paypal-card-name-field"] iframe[name^="__zoid__paypal_card_name_field__"]' )
+			.frameLocator(
+				'[id^="zoid-paypal-card-name-field"] iframe[name^="__zoid__paypal_card_name_field__"]'
+			)
 			.locator( 'input.card-field-name' );
 	acdcCardNumberInput = () =>
 		this.acdcContainer()
-			.frameLocator( '[id^="zoid-paypal-card-number-field"] iframe[name^="__zoid__paypal_card_number_field__"]' )
+			.frameLocator(
+				'[id^="zoid-paypal-card-number-field"] iframe[name^="__zoid__paypal_card_number_field__"]'
+			)
 			.locator( 'input.card-field-number' );
 	acdcCardExpirationInput = () =>
 		this.acdcContainer()
-			.frameLocator( '[id^="zoid-paypal-card-expiry-field"] iframe[name^="__zoid__paypal_card_expiry_field__"]' )
+			.frameLocator(
+				'[id^="zoid-paypal-card-expiry-field"] iframe[name^="__zoid__paypal_card_expiry_field__"]'
+			)
 			.locator( 'input.card-field-expiry' );
 	acdcCardCvvInput = () =>
 		this.acdcContainer()
-			.frameLocator( '[id^="zoid-paypal-card-cvv-field"] iframe[name^="__zoid__paypal_card_cvv_field__"]' )
+			.frameLocator(
+				'[id^="zoid-paypal-card-cvv-field"] iframe[name^="__zoid__paypal_card_cvv_field__"]'
+			)
 			.locator( 'input.card-field-cvv' );
+	acdcSaveToAccountCheckbox = () => this.page.locator( '#save' );
+	acdcSavedCard = ( card: WooCommerce.CreditCard ) =>
+		this.paymentOptionsContainers().filter( {
+			hasText: `${ card.card_type } ending in ${ getLast4CardDigits(
+				card.card_number
+			) } (expires ${ card.expiration_date })`,
+		} );
 
 	threeDSFrame1 = () =>
 		this.page
@@ -151,52 +176,38 @@ export class PayPalUi {
 	// Actions
 
 	/**
-	 * Opens PayPal popup per given funding source options
-	 *
-	 * @param payment
+	 * Clicks PayPal button to open popup
 	 */
-	openPayPalGatewayPupup = async ( payment: Pcp.Payment ) => {
-		const { gateway } = payment;
-		const { shortcut } = gateway;
-
+	openPayPalPupup = async (): Promise< PayPalPopup > => {
 		const popupPromise = this.page.waitForEvent( 'popup' );
+		await expect( this.payPalButton() ).toBeVisible();
+		await this.payPalButton().click();
 
-		switch ( shortcut ) {
-			case 'paypal':
-				// pay with vaulted account (vaulting enabled)
-				if ( payment.isVaulted ) {
-					await expect( this.payPalButton() ).toBeVisible();
-					await this.payPalButton().click();
-					break;
-				}
-				// pay with account other than vaulted (vaulting enabled)
-				if ( payment.useNotVaultedAccount ) {
-					await expect(
-						this.payPalButtonMoreOptions()
-					).toBeVisible();
-					await this.payPalButtonMoreOptions().click();
+		const popup = await popupPromise;
+		await popup.waitForLoadState();
+		return new PayPalPopup( popup );
+	};
 
-					await expect(
-						this.payWithDifferentAccountButton()
-					).toBeVisible();
-					await this.payWithDifferentAccountButton().click();
-					break;
-				}
-				// pay with PayPal button (vaulting disabled)
-				await expect( this.payPalButton() ).toBeVisible();
-				await this.payPalButton().click();
-				break;
+	/**
+	 * Clicks Pay Later button to open popup
+	 */
+	openPayLaterPupup = async (): Promise< PayPalPopup > => {
+		const popupPromise = this.page.waitForEvent( 'popup' );
+		await expect( this.payLaterButton() ).toBeVisible();
+		await this.payLaterButton().click();
 
-			case 'paylater':
-				await expect( this.payLaterButton() ).toBeVisible();
-				await this.payLaterButton().click();
-				break;
+		const popup = await popupPromise;
+		await popup.waitForLoadState();
+		return new PayPalPopup( popup );
+	};
 
-			case 'venmo':
-				await expect( this.venmoButton() ).toBeVisible();
-				await this.venmoButton().click();
-				break;
-		}
+	/**
+	 * Clicks Venmo button to open popup
+	 */
+	openVenmoPupup = async (): Promise< PayPalPopup > => {
+		const popupPromise = this.page.waitForEvent( 'popup' );
+		await expect( this.venmoButton() ).toBeVisible();
+		await this.venmoButton().click();
 
 		const popup = await popupPromise;
 		await popup.waitForLoadState();
@@ -221,36 +232,38 @@ export class PayPalUi {
 		// Map to the tested method
 		switch ( shortcut ) {
 			case 'paypal':
-				// open expected PayPal popup
-				popup = await this.openPayPalGatewayPupup( payment );
 				// pay with vaulted account
 				if ( payment.isVaulted ) {
-					await popup.completePayPalVaultedPayment();
+					await expect( this.payPalButton() ).toBeVisible();
+					await this.assertVaultedPaymentMethodIsDisplayed( payment );
+					await this.payPalButton().click();
 					break;
 				}
-				// pay with PayPal (vaulting disabled)
-				// or account other than vaulted (vaulting enabled)
+				// open expected PayPal popup
+				popup = await this.openPayPalPupup();
+				// pay with given PayPal account
 				await popup.completePayPalPayment( payPalAccount );
 				break;
 
 			case 'paylater':
 				// open expected PayPal popup
-				popup = await this.openPayPalGatewayPupup( payment );
+				popup = await this.openPayLaterPupup();
 				await popup.completePayLaterPayment( payPalAccount );
 				break;
 
 			case 'venmo':
-				popup = await this.openPayPalGatewayPupup( payment );
+				popup = await this.openVenmoPupup();
 				await popup.completeVenmoPayment();
 				break;
 
 			case 'acdc':
-				if ( gateway.threeDSecure === 'always-3d-secure' ) {
-					await this.completeAcdc3dsPayment( payment, merchant );
+				if ( payment.isVaulted ) {
+					await this.assertVaultedPaymentMethodIsDisplayed( payment );
+					await this.completeAcdcVaultedPayment( payment, merchant );
 					break;
 				}
-				if ( payment.isVaulted ) {
-					await this.completeAcdcVaultedPayment( payment, merchant );
+				if ( gateway.threeDSecure === 'always-3d-secure' ) {
+					await this.completeAcdc3dsPayment( payment, merchant );
 					break;
 				}
 				await this.completeAcdcPayment( payment, merchant );
@@ -278,26 +291,6 @@ export class PayPalUi {
 
 			case 'fastlane':
 				await this.completeFastlanePayment( payment );
-				break;
-		}
-	};
-
-	/**
-	 * Adds payment method on My Account/Payment Methods page
-	 *
-	 * @param payment
-	 */
-	savePaymentMethod = async ( payment: Pcp.Payment ) => {
-		const { gateway, payPalAccount } = payment;
-		const { shortcut } = gateway;
-		switch ( shortcut ) {
-			case 'paypal':
-				const popup = await this.openPayPalGatewayPupup( payment );
-				await popup.savePayPalPaymentMethod( payPalAccount );
-				break;
-
-			case 'acdc':
-				await this.addCardPaymentMethod( payment );
 				break;
 		}
 	};
@@ -337,7 +330,7 @@ export class PayPalUi {
 	};
 
 	/**
-	 * Completes payment with ACDC (vaulting disabled)
+	 * Completes payment with ACDC
 	 *
 	 * @param payment
 	 * @param merchant
@@ -350,16 +343,10 @@ export class PayPalUi {
 		await expect( this.acdcGateway() ).toBeVisible();
 		await this.acdcGateway().click();
 
-		// TODO: implement tests
-		// //if some cards are already stored then "Use a new payment method" radio should be checked
-		// if ( await this.acdcUseNewPaymentRadio().isVisible() ) {
-		// 	await this.acdcUseNewPaymentRadio().check();
-		// }
-
 		// On block checkout the Cardholder Name input is present
 		// Needed to assert payment via PayPal API
 		// await this.acdcCardholderNameInput().fill( card.card_holder );
-			
+
 		await this.acdcCardNumberInput().fill( card.card_number );
 		// trick to properly fill expiration date input
 		await this.acdcCardExpirationInput().click();
@@ -369,10 +356,9 @@ export class PayPalUi {
 		}
 		await this.acdcCardCvvInput().fill( card.card_cvv );
 
-		// TODO: implement tests
-		// if ( saveToAccount ) {
-		// 	await this.acdcSaveToAccountCheckbox().check();
-		// }
+		if ( saveToAccount ) {
+			await this.acdcSaveToAccountCheckbox().check();
+		}
 
 		await this.submitOrder();
 		await this.replacePayPalAuthToken( merchant );
@@ -396,8 +382,22 @@ export class PayPalUi {
 		// await this.threeDSSubmitButton().click();
 	};
 
-	completeAcdcVaultedPayment = async ( ...args ) =>
-		console.log( `TODO: completeAcdc3dsPayment for block pages` );
+	/**
+	 * Completes payment with ACDC (vaulting enabled)
+	 *
+	 * @param payment
+	 * @param merchant
+	 */
+	completeAcdcVaultedPayment = async (
+		payment: Pcp.Payment,
+		merchant: Pcp.Merchant
+	) => {
+		const savedCardGateway = this.acdcSavedCard( payment.card );
+		await expect( savedCardGateway ).toBeVisible();
+		await savedCardGateway.click();
+		await this.submitOrder();
+		await this.replacePayPalAuthToken( merchant );
+	};
 
 	/**
 	 * Asserts Fastlane input field and button
@@ -469,10 +469,53 @@ export class PayPalUi {
 	completePayUponInvoicePayment = async ( ...args ) =>
 		console.log( `TODO: completePayUponInvoicePayment for block pages` );
 
-	addCardPaymentMethod = async ( ...args ) =>
-		console.log( `TODO: addCardPaymentMethod for block pages` );
-
 	// Assertions
+
+	/**
+	 * Asserts the saved payment method is visible
+	 *
+	 * @param payment
+	 */
+	assertVaultedPaymentMethodIsDisplayed = async ( payment: Pcp.Payment ) => {
+		switch ( payment.gateway.shortcut ) {
+			case 'paypal':
+				await expect( this.payPalButton() ).toContainText( 'Pay Now' );
+				await expect( this.payPalButtonMoreOptions() ).toBeVisible();
+				break;
+
+			case 'acdc':
+				await expect(
+					this.acdcSavedCard( payment.card )
+				).toBeVisible();
+				break;
+		}
+	};
+
+	/**
+	 * Asserts the saved payment method is not visible
+	 *
+	 * @param payment
+	 */
+	assertVaultedPaymentMethodIsNotDisplayed = async (
+		payment: Pcp.Payment
+	) => {
+		switch ( payment.gateway.shortcut ) {
+			case 'paypal':
+				await expect( this.payPalButton() ).not.toContainText(
+					'Pay Now'
+				);
+				await expect(
+					this.payPalButtonMoreOptions()
+				).not.toBeVisible();
+				break;
+
+			case 'acdc':
+				await expect(
+					this.acdcSavedCard( payment.card )
+				).not.toBeVisible();
+				break;
+		}
+	};
 
 	/**
 	 * - Asserts PayPal buttons block container is visible.

--- a/tests/qa/utils/paypal-api.ts
+++ b/tests/qa/utils/paypal-api.ts
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { APIRequestContext, expect } from '@playwright/test';
-import { createAuthHeader, getLast4CardDigits } from '@inpsyde/playwright-utils/build';
+import {
+	createAuthHeader,
+	getLast4CardDigits,
+} from '@inpsyde/playwright-utils/build';
 /**
  * Internal dependencies
  */
@@ -271,7 +274,9 @@ export class PayPalApi {
 				await expect( payPalOrder.payment_source ).toHaveProperty(
 					'card'
 				);
-				await expect( payPalOrder.payment_source.card.last_digits ).toEqual(
+				await expect(
+					payPalOrder.payment_source.card.last_digits
+				).toEqual(
 					getLast4CardDigits( shopOrder.payment.card.card_number )
 				);
 				break;

--- a/tests/qa/utils/pcp-api.ts
+++ b/tests/qa/utils/pcp-api.ts
@@ -23,10 +23,10 @@ export class PcpApi extends WooCommerceApiBase {
 
 	/**
 	 * Connects merchant via REST API.
-	 * 
-	 * @param clientId PayPal merchant's client ID
-	 * @param clientSecret PayPal merchant's client Isecret
-	 * @param useSandbox is sandbox mode enabled
+	 *
+	 * @param clientId          PayPal merchant's client ID
+	 * @param clientSecret      PayPal merchant's client Isecret
+	 * @param onboardingOptions
 	 */
 	connectMerchant = async (
 		clientId: string,
@@ -34,17 +34,13 @@ export class PcpApi extends WooCommerceApiBase {
 		onboardingOptions: Pcp.Api.OnboardingOptions = {
 			isCasualSeller: false,
 			products: [ 'physical', 'virtual' ],
-		},
+		}
 	) => {
 		// Preset onboarding options
-		await this.wcRequest(
-			'post',
-			'wc_paypal/onboarding',
-			{
-				...onboardingOptions,
-				_locale: 'user',
-			}
-		);
+		await this.wcRequest( 'post', 'wc_paypal/onboarding', {
+			...onboardingOptions,
+			_locale: 'user',
+		} );
 		// Merchant connection request
 		const response = await this.wcRequest(
 			'post',
@@ -61,8 +57,8 @@ export class PcpApi extends WooCommerceApiBase {
 
 	/**
 	 * Disconnects merchant via REST API with optional DB reset parameter.
-	 * 
-	 * @param reset 
+	 *
+	 * @param reset
 	 */
 	disconnectMerchant = async ( reset: boolean = false ) => {
 		const response = await this.wcRequest(
@@ -83,7 +79,7 @@ export class PcpApi extends WooCommerceApiBase {
 
 	/**
 	 * Updates Payment Methods tab via REST API.
-	 * 
+	 *
 	 * @example of data (all params are optional):
 	 * {
 	 * 		fastlaneCardholderName: false,
@@ -93,8 +89,8 @@ export class PcpApi extends WooCommerceApiBase {
 	 * 		"ppcp-gateway": { enabled: true },
 	 * 		"pay-later": { enabled: true },
 	 * 	}
-	 * 
-	 * @param data 
+	 *
+	 * @param data
 	 */
 	updatePcpPaymentMethods = async ( data: Pcp.Api.PaymentMethods ) => {
 		const response = await this.wcRequest( 'post', `wc_paypal/payment`, {
@@ -106,8 +102,8 @@ export class PcpApi extends WooCommerceApiBase {
 
 	/**
 	 * Updates Settings tab via REST API.
-	 * 
-	 * @param data 
+	 *
+	 * @param data
 	 */
 	updatePcpSettings = async ( data: Pcp.Api.Settings ) => {
 		const response = await this.wcRequest( 'post', `wc_paypal/settings`, {

--- a/tests/qa/utils/utils.ts
+++ b/tests/qa/utils/utils.ts
@@ -21,6 +21,7 @@ import {
 	subscriptionsPlugin,
 	wpDebuggingPlugin,
 	pcpPlugin,
+	ShopOrder,
 } from '../resources';
 import { getCustomerStorageStateName } from './helpers';
 
@@ -93,7 +94,7 @@ export class Utils {
 	payForApiOrder = async (
 		orderId: number,
 		orderKey: string,
-		order: WooCommerce.ShopOrder
+		order: ShopOrder
 	) => {
 		await this.payForOrder.visit( orderId, orderKey );
 		await this.payForOrder.payPalUi.makePayment( {
@@ -128,7 +129,7 @@ export class Utils {
 	 *
 	 * @param shopOrder
 	 */
-	completeOrderOnCheckout = async ( shopOrder: WooCommerce.ShopOrder ) => {
+	completeOrderOnCheckout = async ( shopOrder: ShopOrder ) => {
 		await this.fillVisitorsCart( shopOrder.products );
 
 		await this.checkout.makeOrder( shopOrder );
@@ -144,9 +145,7 @@ export class Utils {
 	 *
 	 * @param shopOrder
 	 */
-	completeOrderOnClassicCheckout = async (
-		shopOrder: WooCommerce.ShopOrder
-	) => {
+	completeOrderOnClassicCheckout = async ( shopOrder: ShopOrder ) => {
 		await this.fillVisitorsCart( shopOrder.products );
 		await this.classicCheckout.makeOrder( shopOrder );
 		const orderId = await this.orderReceived.getOrderNumber();


### PR DESCRIPTION
### Description

- Add second visa
- Fix types
- Split PayPalUi.openPayPalGatewayPupup into separate for PayPal, Pay Later, Venmo.
- Add vaulting functionality to PayPalUi.makePayment.
- Move savepaymentMethod from PayPalUi to CustomerPaymentMethods.
- Separate completeAcdcPayment method for PayPalUi and PayPalUiClassic.
- Implement PayPalUi.completeAcdcVaultedPayment method.
- Add assertions for not/display of vaulted payment methods to PayPalUi/Classic, CustomerPaymentMethods.
- Update locators.