### PR TITLE
Invoice prefix repeatable number causes an error on frontend (4793)

### DIFF
--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -78,7 +78,7 @@ return array(
 				'RE',
 				'GP',
 				'GF',
-				'MQ'
+				'MQ',
 			)
 		);
 	},

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -120,9 +120,12 @@ return array(
 		return new PaymentSettings();
 	},
 	'settings.data.settings'                              => static function ( ContainerInterface $container ) : SettingsModel {
+		$environment = $container->get( 'settings.environment' );
+		assert( $environment instanceof Environment );
+
 		return new SettingsModel(
 			$container->get( 'settings.service.sanitizer' ),
-			$container->has( 'wcgateway.settings.invoice-prefix' ) ? $container->get( 'wcgateway.settings.invoice-prefix' ) : ''
+			$environment->is_sandbox() ? $container->get( 'wcgateway.settings.invoice-prefix-random' ) : $container->get( 'wcgateway.settings.invoice-prefix' )
 		);
 	},
 	'settings.data.paylater-messaging'                    => static function ( ContainerInterface $container ) : array {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -121,7 +121,8 @@ return array(
 	},
 	'settings.data.settings'                              => static function ( ContainerInterface $container ) : SettingsModel {
 		return new SettingsModel(
-			$container->get( 'settings.service.sanitizer' )
+			$container->get( 'settings.service.sanitizer' ),
+			$container->has( 'wcgateway.settings.invoice-prefix' ) ? $container->get( 'wcgateway.settings.invoice-prefix' ) : ''
 		);
 	},
 	'settings.data.paylater-messaging'                    => static function ( ContainerInterface $container ) : array {

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -48,13 +48,23 @@ class SettingsModel extends AbstractDataModel {
 	protected DataSanitizer $sanitizer;
 
 	/**
+	 * Invoice prefix.
+	 *
+	 * @var string
+	 */
+	private string $invoice_prefix;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param DataSanitizer $sanitizer Data sanitizer service.
+	 * @param string        $invoice_prefix Invoice prefix.
 	 * @throws RuntimeException If the OPTION_KEY is not defined in the child class.
 	 */
-	public function __construct( DataSanitizer $sanitizer ) {
-		$this->sanitizer = $sanitizer;
+	public function __construct( DataSanitizer $sanitizer, string $invoice_prefix ) {
+		$this->sanitizer      = $sanitizer;
+		$this->invoice_prefix = $invoice_prefix;
+
 		parent::__construct();
 	}
 
@@ -66,7 +76,7 @@ class SettingsModel extends AbstractDataModel {
 	protected function get_defaults() : array {
 		return array(
 			// Free-form string values.
-			'invoice_prefix'         => '',
+			'invoice_prefix'         => $this->invoice_prefix,
 			'brand_name'             => '',
 			'soft_descriptor'        => '',
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2095,9 +2095,21 @@ return array(
 	},
 
 	/**
-	 * Returns random 6 characters length alphanumeric prefix, followed by a hyphen.
+	 * Returns a prefix for the site, ensuring the same site always gets the same prefix (unless the URL changes).
 	 */
 	'wcgateway.settings.invoice-prefix'                    => static function( ContainerInterface $container ): string {
-		return wp_generate_password(6, false) . '-';
+		$site_url = get_site_url( get_current_blog_id() );
+		$hash     = md5( $site_url );
+		$letters  = preg_replace( '~\d~', '', $hash ) ?? '';
+		$prefix   = substr( $letters, 0, 6 );
+
+		return $prefix ? $prefix . '-' : '';
+	},
+
+	/**
+	 * Returns random 6 characters length alphanumeric prefix, followed by a hyphen.
+	 */
+	'wcgateway.settings.invoice-prefix-random'             => static function( ContainerInterface $container ): string {
+		return wp_generate_password( 6, false ) . '-';
 	},
 );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2106,9 +2106,15 @@ return array(
 	},
 
 	/**
-	 * Returns random 6 characters length alphanumeric prefix, followed by a hyphen.
+	 * Returns random 6 characters length alphabetic prefix, followed by a hyphen.
 	 */
 	'wcgateway.settings.invoice-prefix-random'             => static function( ContainerInterface $container ): string {
-		return wp_generate_password( 6, false ) . '-';
+		$characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+		$prefix = '';
+		for ( $i = 0; $i < 6; $i++ ) {
+			$prefix .= $characters[ wp_rand( 0, strlen( $characters ) - 1 ) ];
+		}
+
+		return $prefix . '-';
 	},
 );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2093,4 +2093,16 @@ return array(
 	'wcgateway.settings.admin-settings-enabled'            => static function( ContainerInterface $container ): bool {
 		return $container->has( 'settings.url' ) && ! SettingsModule::should_use_the_old_ui();
 	},
+
+	/**
+	 * Returns a prefix for the site, ensuring the same site always gets the same prefix (unless the URL changes).
+	 */
+	'wcgateway.settings.invoice-prefix'                    => static function( ContainerInterface $container ): string {
+		$site_url = get_site_url( get_current_blog_id() );
+		$hash     = md5( $site_url );
+		$letters  = preg_replace( '~\d~', '', $hash ) ?? '';
+		$prefix   = substr( $letters, 0, 6 );
+
+		return $prefix ? $prefix . '-' : '';
+	},
 );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2095,14 +2095,9 @@ return array(
 	},
 
 	/**
-	 * Returns a prefix for the site, ensuring the same site always gets the same prefix (unless the URL changes).
+	 * Returns random 6 characters length alphanumeric prefix, followed by a hyphen.
 	 */
 	'wcgateway.settings.invoice-prefix'                    => static function( ContainerInterface $container ): string {
-		$site_url = get_site_url( get_current_blog_id() );
-		$hash     = md5( $site_url );
-		$letters  = preg_replace( '~\d~', '', $hash ) ?? '';
-		$prefix   = substr( $letters, 0, 6 );
-
-		return $prefix ? $prefix . '-' : '';
+		return wp_generate_password(6, false) . '-';
 	},
 );

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -510,13 +510,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'custom_attributes' => array(
 				'pattern' => '[a-zA-Z_\\-]+',
 			),
-			'default'           => ( static function (): string {
-				$site_url = get_site_url( get_current_blog_id() );
-				$hash = md5( $site_url );
-				$letters = preg_replace( '~\d~', '', $hash ) ?? '';
-				$prefix = substr( $letters, 0, 6 );
-				return $prefix ? $prefix . '-' : '';
-			} )(),
+			'default'           => $container->get( 'wcgateway.settings.invoice-prefix' ),
 			'screens'           => array(
 				State::STATE_START,
 				State::STATE_ONBOARDED,
@@ -539,7 +533,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'requirements' => array(),
 			'gateway'      => Settings::CONNECTION_TAB_ID,
 		),
-		'stay_updated'                               => array(
+		'stay_updated'                                  => array(
 			'title'        => __( 'Stay Updated', 'woocommerce-paypal-payments' ),
 			'type'         => 'checkbox',
 			'desc_tip'     => true,

--- a/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Fields/connection-tab-fields.php
@@ -49,6 +49,9 @@ return function ( ContainerInterface $container, array $fields ): array {
 	$onboarding_send_only_notice_renderer = $container->get( 'onboarding.render-send-only-notice' );
 	assert( $onboarding_send_only_notice_renderer instanceof OnboardingSendOnlyNoticeRenderer );
 
+	$environment = $container->get( 'settings.environment' );
+	assert( $environment instanceof Environment );
+
 	$is_send_only_country           = $container->get( 'wcgateway.is-send-only-country' );
 	$onboarding_elements_class      = $is_send_only_country ? 'hide' : 'ppcp-onboarding-element';
 	$send_only_country_notice_class = $is_send_only_country ? 'ppcp-onboarding-element' : 'hide';
@@ -510,7 +513,7 @@ return function ( ContainerInterface $container, array $fields ): array {
 			'custom_attributes' => array(
 				'pattern' => '[a-zA-Z_\\-]+',
 			),
-			'default'           => $container->get( 'wcgateway.settings.invoice-prefix' ),
+			'default'           => $environment->is_sandbox() ? $container->get( 'wcgateway.settings.invoice-prefix-random' ) : $container->get( 'wcgateway.settings.invoice-prefix' ),
 			'screens'           => array(
 				State::STATE_START,
 				State::STATE_ONBOARDED,


### PR DESCRIPTION
This issue relates to a problem with the invoice prefix functionality. When sending an existing invoice ID to PayPal, it's causing `DUPLICATE_INVOICE_ID` error on the frontend of the website. 

### How to reproduce
- Create a new business account on PayPal developer portal
- Onboard merchant
- Create and purchase a product using PayPal payment
   - Check WC order ID
- Log as merchant in PayPal sandbox
   - Go to last transaction and check Invoice ID value
- Reset WordPress installation including the database and onboard merchant again
   - This is important as WC order ID will start with the same value as before
- Create and purchase a product using PayPal payment
- `DUPLICATE_INVOICE_ID` Error is displayed

This PR fixes 2 issues:
1. In new settings UI invoice prefix was not sent to PayPal, only the WC order ID.
2. When reseting WordPress and onboard existing merchant with existing transactions DUPLICATE_INVOICE_ID is thrown when sending the same invoice ID to PayPal.

As `DUPLICATE_INVOICE_ID` issue affects mostly sandbox environments while developing, this PR only adds the random invoice prefix on sandbox and uses the same logic as before (prefix is generate based on site URL) for live environments.

