### PR TITLE
Add French Territories to the DCC supporting countries List (4735)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -682,6 +682,11 @@ return array(
 				'GB' => $default_currencies,
 				'US' => $default_currencies,
 				'NO' => $default_currencies,
+				'YT' => $default_currencies,
+				'RE' => $default_currencies,
+				'GP' => $default_currencies,
+				'GF' => $default_currencies,
+				'MQ' => $default_currencies,
 			)
 		);
 	},

--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -78,7 +78,7 @@ return array(
 				'RE',
 				'GP',
 				'GF',
-				'MQ'
+				'MQ',
 			)
 		);
 	},

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -78,6 +78,11 @@ return array(
 				'SE',
 				'GB',
 				'US',
+				'YT',
+				'RE',
+				'GP',
+				'GF',
+				'MQ',
 			)
 		);
 	},


### PR DESCRIPTION
### Description
This PR complements #3412 by adding French Territories (Mayotte, Reunion, Guadelope, French Guiana, and Martinique) to the DCC and save payment methods eligible lists.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Connect PayPal account to the plugin
2. Go to 'WooCommerce > Settings > General'
3. Set the store location to any French Territories (Mayotte, Reunion, Guadelope, French Guiana, and Martinique)
4. Navigate to PayPal Payments settings and observe the presence of Advanced Card Processing

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry
1. Mayotte, Reunion, Guadelope, French Guiana, and Martinique have been added to DCC list.
2. Mayotte, Reunion, Guadelope, French Guiana, and Martinique have been added to Vaulting list.
