### PR TITLE
Adjust onboarding notice based on Woo guidelines

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2022,6 +2022,49 @@ return array(
 		return new TaskRegistrar();
 	},
 
+	'wcgateway.settings.wc-tasks.pay-later-task-config'    => static function( ContainerInterface $container ): array {
+		$section_id = PayPalGateway::ID;
+		$pay_later_tab_id = Settings::PAY_LATER_TAB_ID;
+
+		if ( $container->has( 'paylater-configurator.is-available' ) && $container->get( 'paylater-configurator.is-available' ) ) {
+			return array(
+				array(
+					'id'           => 'pay-later-messaging-task',
+					'title'        => __( 'Configure PayPal Pay Later messaging', 'woocommerce-paypal-payments' ),
+					'description'  => __( 'Decide where you want dynamic Pay Later messaging to show up and how you want it to look on your site.', 'woocommerce-paypal-payments' ),
+					'redirect_url' => admin_url( "admin.php?page=wc-settings&tab=checkout&section={$section_id}&ppcp-tab={$pay_later_tab_id}" ),
+				),
+			);
+		}
+
+		return array();
+	},
+
+	'wcgateway.settings.wc-tasks.connect-task-config'      => static function( ContainerInterface $container ): array {
+		$is_connected = $container->get( 'settings.flag.is-connected' );
+		$is_current_country_send_only = $container->get( 'wcgateway.is-send-only-country' );
+
+		if ( ! $is_connected && ! $is_current_country_send_only ) {
+			return array(
+				array(
+					'id'           => 'connect-to-paypal-task',
+					'title'        => __( 'Connect PayPal to complete setup', 'woocommerce-paypal-payments' ),
+					'description'  => __( 'PayPal Payments is almost ready. To get started, connect your account with the Activate PayPal Payments button.', 'woocommerce-paypal-payments' ),
+					'redirect_url' => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=' . Settings::CONNECTION_TAB_ID ),
+				),
+			);
+		}
+
+		return array();
+	},
+
+	'wcgateway.settings.wc-tasks.task-config-services'     => static function(): array {
+		return array(
+			'wcgateway.settings.wc-tasks.pay-later-task-config',
+			'wcgateway.settings.wc-tasks.connect-task-config',
+		);
+	},
+
 	/**
 	 * A configuration for simple redirect wc tasks.
 	 *
@@ -2033,18 +2076,14 @@ return array(
 	 * }>
 	 */
 	'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' => static function( ContainerInterface $container ): array {
-		$section_id       = PayPalGateway::ID;
-		$pay_later_tab_id = Settings::PAY_LATER_TAB_ID;
-
 		$list_of_config = array();
+		$task_config_services = $container->get( 'wcgateway.settings.wc-tasks.task-config-services' );
 
-		if ( $container->has( 'paylater-configurator.is-available' ) && $container->get( 'paylater-configurator.is-available' ) ) {
-			$list_of_config[] = array(
-				'id'           => 'pay-later-messaging-task',
-				'title'        => __( 'Configure PayPal Pay Later messaging', 'woocommerce-paypal-payments' ),
-				'description'  => __( 'Decide where you want dynamic Pay Later messaging to show up and how you want it to look on your site.', 'woocommerce-paypal-payments' ),
-				'redirect_url' => admin_url( "admin.php?page=wc-settings&tab=checkout&section={$section_id}&ppcp-tab={$pay_later_tab_id}" ),
-			);
+		foreach ( $task_config_services as $service_id ) {
+			if ( $container->has( $service_id ) ) {
+				$task_config = $container->get( $service_id );
+				$list_of_config = array_merge( $list_of_config, $task_config );
+			}
 		}
 
 		return $list_of_config;

--- a/modules/ppcp-wc-gateway/src/Notice/ConnectAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/ConnectAdminNotice.php
@@ -69,12 +69,22 @@ class ConnectAdminNotice {
 		$message = sprintf(
 			/* translators: %1$s the gateway name. */
 			__(
-				'PayPal Payments is almost ready. To get started, connect your account with the <b>Activate PayPal</b> button <a href="%1$s">on the Account Setup page</a>.',
+				'PayPal Payments is almost ready. To get started, connect your account with the <b>Activate PayPal Payments</b> button <a href="%1$s">on the Account Setup page</a>.',
 				'woocommerce-paypal-payments'
 			),
 			admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=' . Settings::CONNECTION_TAB_ID )
 		);
 		return new Message( $message, 'warning' );
+	}
+
+	/**
+	 * Returns whether the current page is plugins.php.
+	 *
+	 * @return bool
+	 */
+	private function is_current_page_plugins_page(): bool {
+		global $pagenow;
+		return isset( $pagenow ) && $pagenow === 'plugins.php';
 	}
 
 	/**
@@ -87,6 +97,8 @@ class ConnectAdminNotice {
 	 * @return bool
 	 */
 	protected function should_display(): bool {
-		return ! $this->is_connected && ! $this->is_current_country_send_only;
+		return $this->is_current_page_plugins_page()
+			&& ! $this->is_connected
+			&& ! $this->is_current_country_send_only;
 	}
 }


### PR DESCRIPTION
This PR takes care of adjusting the “Activate PayPal Payments” notice so it is displayed only on the plugins.php page and adds a task to the “Things to do next” list to meet Woo's merchant onboarding guidelines.