### PR TITLE
Add Contact Module setting to new settings UI (4799)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlock.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlock.js
@@ -10,7 +10,12 @@ const SettingsBlock = ( {
 	description,
 	horizontalLayout = false,
 	separatorAndGap = true,
+	visible = true,
 } ) => {
+	if ( ! visible ) {
+		return null;
+	}
+
 	const blockClassName = classNames( 'ppcp-r-settings-block', className, {
 		'ppcp--no-gap': ! separatorAndGap,
 		'ppcp--horizontal': horizontalLayout,

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
@@ -11,7 +11,7 @@ import Accordion from '../../../../../ReusableComponents/AccordionSection';
 import { SettingsHooks } from '../../../../../../data';
 import SoftDescriptorInput from '../../../../../ReusableComponents/Controls/SoftdescriptorInput';
 
-const PaypalSettings = () => {
+const PaypalSettings = ( { hasContactModule } ) => {
 	const {
 		savePaypalAndVenmo,
 		setSavePaypalAndVenmo,
@@ -31,6 +31,7 @@ const PaypalSettings = () => {
 	const siteData = useSelect( ( select ) => select( 'core' ).getSite(), [] );
 	const siteTitle = siteData?.title;
 	const buttonLanguageChoices = window.ppcpSettings.buttonLanguageChoices;
+
 	return (
 		<Accordion
 			className="ppcp--paypal-settings"
@@ -72,7 +73,7 @@ const PaypalSettings = () => {
 				/>
 			</SettingsBlock>
 
-			<SettingsBlock>
+			<SettingsBlock visible={ hasContactModule }>
 				<ControlToggleButton
 					label={ __(
 						'Custom Shipping Contact',

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
@@ -15,6 +15,8 @@ const PaypalSettings = () => {
 	const {
 		savePaypalAndVenmo,
 		setSavePaypalAndVenmo,
+		contactModule,
+		setContactModule,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
 		brandName,
@@ -67,6 +69,21 @@ const PaypalSettings = () => {
 					) }
 					value={ savePaypalAndVenmo }
 					onChange={ setSavePaypalAndVenmo }
+				/>
+			</SettingsBlock>
+
+			<SettingsBlock>
+				<ControlToggleButton
+					label={ __(
+						'Custom Shipping Contact',
+						'woocommerce-paypal-payments'
+					) }
+					description={ __(
+						'If enabled, customers can provide a custom shipping email and phone number when paying via PayPal. Order updates are delivered to the custom shipping email, and not to the billing email.',
+						'woocommerce-paypal-payments'
+					) }
+					value={ contactModule }
+					onChange={ setContactModule }
 				/>
 			</SettingsBlock>
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/ExpertSettings.js
@@ -8,7 +8,7 @@ import Troubleshooting from './Blocks/Troubleshooting';
 import PaypalSettings from './Blocks/PaypalSettings';
 import OtherSettings from './Blocks/OtherSettings';
 
-const ExpertSettings = ( { ownBradOnly } ) => {
+const ExpertSettings = ( { ownBradOnly, hasContactModule } ) => {
 	return (
 		<SettingsCard
 			icon="icon-settings-expert.svg"
@@ -33,7 +33,7 @@ const ExpertSettings = ( { ownBradOnly } ) => {
 				</Content>
 
 				<Content>
-					<PaypalSettings />
+					<PaypalSettings hasContactModule={ hasContactModule } />
 				</Content>
 
 				{ ownBradOnly || (

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabSettings.js
@@ -7,6 +7,7 @@ import { CommonHooks, SettingsHooks } from '../../../../data';
 const TabSettings = () => {
 	const { ownBrandOnly } = CommonHooks.useWooSettings();
 	const { isReady } = SettingsHooks.useStore();
+	const { features } = CommonHooks.useMerchantInfo();
 
 	if ( ! isReady ) {
 		return <SpinnerOverlay asModal={ true } />;
@@ -16,7 +17,10 @@ const TabSettings = () => {
 		<div className="ppcp-r-settings">
 			<ConnectionStatus />
 			<CommonSettings ownBradOnly={ ownBrandOnly } />
-			<ExpertSettings ownBradOnly={ ownBrandOnly } />
+			<ExpertSettings
+				ownBradOnly={ ownBrandOnly }
+				hasContactModule={ features?.contact_module?.enabled }
+			/>
 		</div>
 	);
 };

--- a/modules/ppcp-settings/resources/js/data/settings/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/settings/hooks.js
@@ -36,7 +36,20 @@ const useStoreData = () => {
 	);
 };
 
-const useHooks = () => {
+export const useStore = () => {
+	const { select, dispatch, useTransient } = useStoreData();
+	const { persist, refresh } = dispatch;
+	const [ isReady ] = useTransient( 'isReady' );
+
+	// Load persistent data from REST if not done yet.
+	if ( ! isReady ) {
+		select.persistentData();
+	}
+
+	return { persist, refresh, isReady };
+};
+
+export const useSettings = () => {
 	const { usePersistent } = useStoreData();
 
 	// Persistent accessors.
@@ -67,83 +80,6 @@ const useHooks = () => {
 
 	const [ disabledCards, setDisabledCards ] =
 		usePersistent( 'disabledCards' );
-
-	return {
-		invoicePrefix,
-		setInvoicePrefix,
-		authorizeOnly,
-		setAuthorizeOnly,
-		captureVirtualOnlyOrders,
-		setCaptureVirtualOnlyOrders,
-		savePaypalAndVenmo,
-		setSavePaypalAndVenmo,
-		saveCardDetails,
-		setSaveCardDetails,
-		payNowExperience,
-		setPayNowExperience,
-		logging,
-		setLogging,
-		stayUpdated,
-		setStayUpdated,
-		subtotalAdjustment,
-		setSubtotalAdjustment,
-		brandName,
-		setBrandName,
-		softDescriptor,
-		setSoftDescriptor,
-		landingPage,
-		setLandingPage,
-		buttonLanguage,
-		setButtonLanguage,
-		disabledCards,
-		setDisabledCards,
-	};
-};
-
-export const useStore = () => {
-	const { select, dispatch, useTransient } = useStoreData();
-	const { persist, refresh } = dispatch;
-	const [ isReady ] = useTransient( 'isReady' );
-
-	// Load persistent data from REST if not done yet.
-	if ( ! isReady ) {
-		select.persistentData();
-	}
-
-	return { persist, refresh, isReady };
-};
-
-export const useSettings = () => {
-	const {
-		invoicePrefix,
-		setInvoicePrefix,
-		authorizeOnly,
-		setAuthorizeOnly,
-		captureVirtualOnlyOrders,
-		setCaptureVirtualOnlyOrders,
-		savePaypalAndVenmo,
-		setSavePaypalAndVenmo,
-		saveCardDetails,
-		setSaveCardDetails,
-		payNowExperience,
-		setPayNowExperience,
-		logging,
-		setLogging,
-		stayUpdated,
-		setStayUpdated,
-		subtotalAdjustment,
-		setSubtotalAdjustment,
-		brandName,
-		setBrandName,
-		softDescriptor,
-		setSoftDescriptor,
-		landingPage,
-		setLandingPage,
-		buttonLanguage,
-		setButtonLanguage,
-		disabledCards,
-		setDisabledCards,
-	} = useHooks();
 
 	return {
 		invoicePrefix,

--- a/modules/ppcp-settings/resources/js/data/settings/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/settings/hooks.js
@@ -71,6 +71,9 @@ export const useSettings = () => {
 		usePersistent( 'captureVirtualOrders' );
 	const [ savePaypalAndVenmo, setSavePaypalAndVenmo ] =
 		usePersistent( 'savePaypalAndVenmo' );
+	const [ contactModule, setContactModule ] = usePersistent(
+		'enableContactModule'
+	);
 	const [ saveCardDetails, setSaveCardDetails ] =
 		usePersistent( 'saveCardDetails' );
 	const [ payNowExperience, setPayNowExperience ] =
@@ -90,6 +93,8 @@ export const useSettings = () => {
 		setCaptureVirtualOnlyOrders,
 		savePaypalAndVenmo,
 		setSavePaypalAndVenmo,
+		contactModule,
+		setContactModule,
 		saveCardDetails,
 		setSaveCardDetails,
 		payNowExperience,

--- a/modules/ppcp-settings/resources/js/data/settings/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/settings/reducer.js
@@ -39,6 +39,7 @@ const defaultPersistent = Object.freeze( {
 	authorizeOnly: false, // Whether to only authorize payments initially
 	captureVirtualOrders: false, // Auto-capture virtual-only orders
 	savePaypalAndVenmo: false, // Enable PayPal & Venmo vaulting
+	enableContactModule: false, // Enable the "Custom Shipping Contact" feature
 	saveCardDetails: false, // Enable card vaulting
 	enablePayNow: false, // Enable Pay Now experience
 	enableLogging: false, // Enable debug logging

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -79,6 +79,7 @@ class SettingsModel extends AbstractDataModel {
 			'authorize_only'         => false,
 			'capture_virtual_orders' => false,
 			'save_paypal_and_venmo'  => false,
+			'enable_contact_module'  => false,
 			'save_card_details'      => false,
 			'enable_pay_now'         => false,
 			'enable_logging'         => false,
@@ -252,6 +253,24 @@ class SettingsModel extends AbstractDataModel {
 	 */
 	public function set_save_paypal_and_venmo( bool $save ) : void {
 		$this->data['save_paypal_and_venmo'] = $this->sanitizer->sanitize_bool( $save );
+	}
+
+	/**
+	 * Gets the custom-shipping-contact flag ("Contact Module").
+	 *
+	 * @return bool True if the contact module feature is enabled, false otherwise.
+	 */
+	public function get_enable_contact_module() : bool {
+		return $this->data['enable_contact_module'];
+	}
+
+	/**
+	 * Sets the custom-shipping-contact flag ("Contact Module").
+	 *
+	 * @param bool $save Whether to use the contact module feature.
+	 */
+	public function set_enable_contact_module( bool $save ) : void {
+		$this->data['enable_contact_module'] = $this->sanitizer->sanitize_bool( $save );
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
@@ -74,6 +74,10 @@ class SettingsRestEndpoint extends RestEndpoint {
 			'js_name'  => 'savePaypalAndVenmo',
 			'sanitize' => 'to_boolean',
 		),
+		'enable_contact_module'  => array(
+			'js_name'  => 'enableContactModule',
+			'sanitize' => 'to_boolean',
+		),
 		'save_card_details'      => array(
 			'js_name'  => 'saveCardDetails',
 			'sanitize' => 'to_boolean',

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1921,6 +1921,7 @@ return array(
 		assert( $settings instanceof Settings );
 
 		if ( apply_filters(
+			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
 			getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
 		) ) {
@@ -2095,6 +2096,7 @@ return array(
 
 	'wcgateway.contact-module.eligibility.check'           => static function ( ContainerInterface $container ): callable {
 		$feature_enabled = (bool) apply_filters(
+			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.contact_module_enabled',
 			getenv( 'PCP_CONTACT_MODULE_ENABLED' ) === '1'
 		);

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2092,4 +2092,21 @@ return array(
 	'wcgateway.settings.admin-settings-enabled'            => static function( ContainerInterface $container ): bool {
 		return $container->has( 'settings.url' ) && ! SettingsModule::should_use_the_old_ui();
 	},
+
+	'wcgateway.contact-module.eligibility.check'           => static function ( ContainerInterface $container ): callable {
+		$feature_enabled = (bool) apply_filters(
+			'woocommerce.feature-flags.woocommerce_paypal_payments.contact_module_enabled',
+			getenv( 'PCP_CONTACT_MODULE_ENABLED' ) === '1'
+		);
+
+		/**
+		 * Decides, whether the current merchant is eligible to use the
+		 * "Contact Module" feature on this site.
+		 *
+		 * This check will change later:
+		 * - For the start, a feature flag will decide if the contact module can be accessed.
+		 * - Later, we will extend this check to also verify merchant details, like country.
+		 */
+		return static fn() => $feature_enabled;
+	},
 );

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -573,6 +573,9 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$installments_product_status = $c->get( 'wcgateway.installments-product-status' );
 				assert( $installments_product_status instanceof InstallmentsProductStatus );
 
+				$contact_module_check = $c->get( 'wcgateway.contact-module.eligibility.check' );
+				assert( is_callable( $contact_module_check ) );
+
 				$features['save_paypal_and_venmo'] = array(
 					'enabled' => $billing_agreements_endpoint->reference_transaction_enabled(),
 				);
@@ -590,6 +593,10 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 				$features['installments'] = array(
 					'enabled' => $installments_product_status->is_active(),
+				);
+
+				$features['contact_module'] = array(
+					'enabled' => $contact_module_check(),
 				);
 
 				return $features;


### PR DESCRIPTION
### Description

Added a new toggle option to the "Settings" tab in the new UI admin page.
- The toggle is gated by a new feature flag
- When the feature flag is active, the toggle appears in the "PayPal Settings" accordion
- Default value is currently set to false/off
- No logic is attached to the toggle - it's saved to the DB without doing anything else

#### Feature flag

How to activate the feature flag:
- Set env variable `PCP_CONTACT_MODULE_ENABLED` to "1"
- Return true via WP filter `woocommerce.feature-flags.woocommerce_paypal_payments.contact_module_enabled`


### Steps to Test

1. Activate the feature flag / ensure to use the new UI
2. Go to "WooCommerce → Settings → Payments → PayPal"
2. Navigate to tab "Settings", open the accordion "PayPal Settings"
3. The new toggle appears below the toggle "Instant payments only"

### Screenshots

<img width="1017" alt="image" src="https://github.com/user-attachments/assets/d8e020c0-1307-41a9-93c1-c8b6db291536" />
