### PR TITLE
Implement country-based feature availability check (4800)

### DIFF
--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
 
 return array(
 	'api.paypal-host'                    => function( ContainerInterface $container ) : string {
@@ -102,7 +103,11 @@ return array(
 
 		return $state->get_environment();
 	},
+	'settings.merchant-details'          => static function ( ContainerInterface $container ) : MerchantDetails {
+		$woo_country = $container->get( 'api.shop.country' );
 
+		return new MerchantDetails( $woo_country, $woo_country );
+	},
 	'onboarding.assets'                  => function( ContainerInterface $container ) : OnboardingAssets {
 		$state                 = $container->get( 'onboarding.state' );
 		$login_seller_endpoint = $container->get( 'onboarding.endpoint.login-seller' );

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -71,6 +71,7 @@ use WooCommerce\PayPalCommerce\PayLaterConfigurator\Endpoint\SaveConfig;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 use WooCommerce\PayPalCommerce\Settings\Service\InternalRestService;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
 
 return array(
 	'settings.url'                                        => static function ( ContainerInterface $container ) : string {
@@ -604,6 +605,7 @@ return array(
 		assert( $messages_apply instanceof MessagesApply );
 		$pay_later_eligible = $messages_apply->for_country();
 
+		// TODO: Variable "merchant_country" contains "shop-country". Which is correct?
 		$merchant_country = $container->get( 'api.shop.country' );
 		$ineligible_countries = array( 'RU', 'BR', 'JP' );
 		$apm_eligible = ! in_array( $merchant_country, $ineligible_countries, true );
@@ -662,5 +664,14 @@ return array(
 			$container->get( 'settings.service.branded-experience.activation-detector' ),
 			$container->get( 'settings.data.general' )
 		);
+	},
+	'settings.merchant-details'                           => static function ( ContainerInterface $container ) : MerchantDetails {
+		$data = $container->get( 'settings.data.general' );
+		assert( $data instanceof GeneralSettings );
+
+		$merchant_country = $data->get_merchant_country();
+		$woo_data         = $data->get_woo_settings();
+
+		return new MerchantDetails( $merchant_country, $woo_data['country'] );
 	},
 );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -86,6 +86,7 @@ use WooCommerce\PayPalCommerce\Axo\Helper\PropertiesDictionary;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
 
 return array(
 	'wcgateway.paypal-gateway'                             => static function ( ContainerInterface $container ): PayPalGateway {
@@ -2104,13 +2105,16 @@ return array(
 		/**
 		 * Decides, whether the current merchant is eligible to use the
 		 * "Contact Module" feature on this site.
-		 *
-		 * This check will change later:
-		 * - For the start, a feature flag will decide if the contact module can be accessed.
-		 * - Later, we will extend this check to also verify merchant details, like country.
 		 */
-		return static function () use ( $feature_enabled ) {
-			return $feature_enabled;
+		return static function () use ( $feature_enabled, $container ) {
+			if ( ! $feature_enabled ) {
+				return false;
+			}
+
+			$details = $container->get( 'settings.merchant-details' );
+			assert( $details instanceof MerchantDetails );
+
+			return 'US' === $details->get_merchant_country();
 		};
 	},
 	/**

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2109,7 +2109,9 @@ return array(
 		 * - For the start, a feature flag will decide if the contact module can be accessed.
 		 * - Later, we will extend this check to also verify merchant details, like country.
 		 */
-		return static fn() => $feature_enabled;
+		return static function () use ( $feature_enabled ) {
+			return $feature_enabled;
+		};
 	},
 	/**
 	 * Returns a prefix for the site, ensuring the same site always gets the same prefix (unless the URL changes).

--- a/modules/ppcp-wc-gateway/src/Helper/MerchantDetails.php
+++ b/modules/ppcp-wc-gateway/src/Helper/MerchantDetails.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Provides a central information source for details about the current PayPal merchant.
+ *
+ * @package WooCommerce\PayPalCommerce\WcGateway\Helper
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+/**
+ * Main information source about merchant details.
+ */
+class MerchantDetails {
+	/**
+	 * The merchant's country according to PayPal, which might be different from
+	 * the WooCommerce country.
+	 *
+	 * #legacy-ui uses the Woo store country for this.
+	 *
+	 * @var string
+	 */
+	private string $merchant_country;
+
+	/**
+	 * The WooCommerce store country.
+	 *
+	 * @var string
+	 */
+	private string $store_country;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $merchant_country Initial merchant country.
+	 * @param string $store_country    Initial store country.
+	 */
+	public function __construct( string $merchant_country, string $store_country ) {
+		$this->merchant_country = $merchant_country;
+		$this->store_country    = $store_country;
+	}
+
+	/**
+	 * Returns the merchant's country. This country is used by PayPal to decide
+	 * which features the merchant can access.
+	 *
+	 * This country is provided by PayPal and defines the operating country of
+	 * the merchant.
+	 *
+	 * @return string
+	 */
+	public function get_merchant_country() : string {
+		return $this->merchant_country;
+	}
+
+	/**
+	 * The WooCommerce store's country, which could be different from the
+	 * merchant's country in some cases. This country is used by WooCommerce.
+	 *
+	 * @return string
+	 */
+	public function get_shop_country() : string {
+		return $this->store_country;
+	}
+}


### PR DESCRIPTION
_This PR extends #3447_

### Description

Extends the Contact Module feature flag with a second condition:

The feature is only available, if the merchant country is "US"

#### Technical Change

The PR introduces a new class named `MerchantDetails` which provides access to the country.

This class is a first implementation that should eventually in two ways:
1. Replace using the service in many places `api.shop.country`
2. Provide more information, especially eligibility checks (e.g. merging `FeaturesEligibilityService` into this)
