### PR TITLE
Fix payment_source usage

### DIFF
--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Applepay;
 
 use WC_Payment_Gateway;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
 use WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Applepay\Assets\PropertiesDictionary;
@@ -196,6 +197,31 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 				return $features;
 			}
+		);
+
+		add_filter(
+			'ppcp_create_order_request_body_data',
+			static function ( array $data, string $payment_method, array $request ) use ( $c ) : array {
+
+				if ( $payment_method !== ApplePayGateway::ID ) {
+					return $data;
+				}
+
+				$experience_context_builder = $c->get( 'wcgateway.builder.experience-context' );
+				assert( $experience_context_builder instanceof ExperienceContextBuilder );
+
+				$data['payment_source'] = array(
+					'apple_pay' => array(
+						'experience_context' => $experience_context_builder
+							->with_endpoint_return_urls()
+							->build()->to_array(),
+					),
+				);
+
+				return $data;
+			},
+			10,
+			3
 		);
 
 		return true;

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -441,8 +441,13 @@ class CreateOrderEndpoint implements EndpointInterface {
 			}
 		}
 
+		$payment_source_key = 'paypal';
+		if ( in_array( $funding_source, array( 'venmo' ), true ) ) {
+			$payment_source_key = $funding_source;
+		}
+
 		$payment_source = new PaymentSource(
-			'paypal',
+			$payment_source_key,
 			(object) array(
 				'experience_context' => $this->experience_context_builder
 					->with_default_paypal_config( $shipping_preference, $action )

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -393,50 +393,6 @@ class CreateOrderEndpoint implements EndpointInterface {
 	}
 
 	/**
-	 * Once the checkout has been validated we execute this method.
-	 *
-	 * @param array     $data The data.
-	 * @param \WP_Error $errors The errors, which occurred.
-	 *
-	 * @return array
-	 * @throws Exception On Error.
-	 */
-	public function after_checkout_validation( array $data, \WP_Error $errors ): array {
-		if ( ! $errors->errors ) {
-			try {
-				$order = $this->create_paypal_order();
-			} catch ( Exception $exception ) {
-				$this->logger->error( 'Order creation failed: ' . $exception->getMessage() );
-				throw $exception;
-			}
-
-			/**
-			 * In case we are onboarded and everything is fine with the \WC_Order
-			 * we want this order to be created. We will intercept it and leave it
-			 * in the "Pending payment" status though, which than later will change
-			 * during the "onApprove"-JS callback or the webhook listener.
-			 */
-			if ( ! $this->early_order_handler->should_create_early_order() ) {
-				wp_send_json_success( $this->make_response( $order ) );
-			}
-			$this->early_order_handler->register_for_order( $order );
-			return $data;
-		}
-
-		$this->logger->error( 'Checkout validation failed: ' . $errors->get_error_message() );
-
-		wp_send_json_error(
-			array(
-				'name'    => '',
-				'message' => $errors->get_error_message(),
-				'code'    => (int) $errors->get_error_code(),
-				'details' => array(),
-			)
-		);
-		return $data;
-	}
-
-	/**
 	 * Creates the order in the PayPal, uses data from WC order if provided.
 	 *
 	 * @param \WC_Order|null $wc_order WC order to get data from.

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\CardFields;
 use DomainException;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
 use WooCommerce\PayPalCommerce\CardFields\Service\CardCaptureValidator;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
@@ -150,6 +151,15 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
+				$experience_context_builder = $c->get( 'wcgateway.builder.experience-context' );
+				assert( $experience_context_builder instanceof ExperienceContextBuilder );
+
+				$payment_source_data = array(
+					'experience_context' => $experience_context_builder
+						->with_endpoint_return_urls()
+						->build()->to_array(),
+				);
+
 				$three_d_secure_contingency =
 					$settings->has( '3d_secure_contingency' )
 						? apply_filters( 'woocommerce_paypal_payments_three_d_secure_contingency', $settings->get( '3d_secure_contingency' ) )
@@ -159,14 +169,14 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 					$three_d_secure_contingency === 'SCA_ALWAYS'
 					|| $three_d_secure_contingency === 'SCA_WHEN_REQUIRED'
 				) {
-					$data['payment_source']['card'] = array(
-						'attributes' => array(
-							'verification' => array(
-								'method' => $three_d_secure_contingency,
-							),
+					$payment_source_data['attributes'] = array(
+						'verification' => array(
+							'method' => $three_d_secure_contingency,
 						),
 					);
 				}
+
+				$data['payment_source'] = array( 'card' => $payment_source_data );
 
 				return $data;
 			},

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Googlepay;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use WC_Payment_Gateway;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint;
@@ -261,6 +262,15 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
+				$experience_context_builder = $c->get( 'wcgateway.builder.experience-context' );
+				assert( $experience_context_builder instanceof ExperienceContextBuilder );
+
+				$payment_source_data = array(
+					'experience_context' => $experience_context_builder
+						->with_endpoint_return_urls()
+						->build()->to_array(),
+				);
+
 				$three_d_secure_contingency =
 					$settings->has( '3d_secure_contingency' )
 						? apply_filters( 'woocommerce_paypal_payments_three_d_secure_contingency', $settings->get( '3d_secure_contingency' ) )
@@ -270,14 +280,14 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 					$three_d_secure_contingency === 'SCA_ALWAYS'
 					|| $three_d_secure_contingency === 'SCA_WHEN_REQUIRED'
 				) {
-					$data['payment_source']['google_pay'] = array(
-						'attributes' => array(
-							'verification' => array(
-								'method' => $three_d_secure_contingency,
-							),
+					$payment_source_data['attributes'] = array(
+						'verification' => array(
+							'method' => $three_d_secure_contingency,
 						),
 					);
 				}
+
+				$data['payment_source'] = array( 'google_pay' => $payment_source_data );
 
 				return $data;
 			},

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -115,73 +115,67 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 					function ( array $data, string $payment_method, array $request_data ) use ( $c ): array {
 						$settings = $c->get( 'wcgateway.settings' );
 						assert( $settings instanceof Settings );
+
+						$new_attributes = array(
+							'vault' => array(
+								'store_in_vault' => 'ON_SUCCESS',
+							),
+						);
+
+						$target_customer_id = get_user_meta( get_current_user_id(), '_ppcp_target_customer_id', true );
+						if ( ! $target_customer_id ) {
+							$target_customer_id = get_user_meta( get_current_user_id(), 'ppcp_customer_id', true );
+						}
+						if ( $target_customer_id ) {
+							$new_attributes['customer'] = array(
+								'id' => $target_customer_id,
+							);
+						}
+
+						$funding_source = (string) ( $request_data['funding_source'] ?? '' );
+
 						if ( $payment_method === CreditCardGateway::ID ) {
 							if ( ! $settings->has( 'vault_enabled_dcc' ) || ! $settings->get( 'vault_enabled_dcc' ) ) {
 								return $data;
 							}
 
 							$save_payment_method = $request_data['save_payment_method'] ?? false;
-							if ( $save_payment_method ) {
-								$data['payment_source'] = array(
-									'card' => array(
-										'attributes' => array(
-											'vault' => array(
-												'store_in_vault' => 'ON_SUCCESS',
-											),
-										),
-									),
-								);
-
-								$target_customer_id = get_user_meta( get_current_user_id(), '_ppcp_target_customer_id', true );
-								if ( ! $target_customer_id ) {
-									$target_customer_id = get_user_meta( get_current_user_id(), 'ppcp_customer_id', true );
-								}
-
-								if ( $target_customer_id ) {
-									$data['payment_source']['card']['attributes']['customer'] = array(
-										'id' => $target_customer_id,
-									);
-								}
+							if ( ! $save_payment_method ) {
+								return $data;
 							}
-						}
-
-						if ( $payment_method === PayPalGateway::ID ) {
+						} elseif ( $payment_method === PayPalGateway::ID ) {
 							if ( ! $settings->has( 'vault_enabled' ) || ! $settings->get( 'vault_enabled' ) ) {
 								return $data;
 							}
 
-							$funding_source = $request_data['funding_source'] ?? null;
-
-							if ( $funding_source && $funding_source === 'venmo' ) {
-								$data['payment_source'] = array(
-									'venmo' => array(
-										'attributes' => array(
-											'vault' => array(
-												'store_in_vault' => 'ON_SUCCESS',
-												'usage_type' => 'MERCHANT',
-												'permit_multiple_payment_tokens' => apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', false ),
-											),
-										),
-									),
-								);
-							} else {
-								$data['payment_source'] = array(
-									'paypal' => array(
-										'attributes' => array(
-											'vault' => array(
-												'store_in_vault' => 'ON_SUCCESS',
-												'usage_type' => 'MERCHANT',
-												'permit_multiple_payment_tokens' => apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', false ),
-											),
-										),
-									),
-								);
+							if ( ! in_array( $funding_source, array( 'paypal', 'venmo' ), true ) ) {
+								return $data;
 							}
+
+							$new_attributes['vault']['usage_type']                     = 'MERCHANT';
+							$new_attributes['vault']['permit_multiple_payment_tokens'] = apply_filters( 'woocommerce_paypal_payments_permit_multiple_payment_tokens', false );
+						} else {
+							return $data;
 						}
+
+						$payment_source = (array) ( $data['payment_source'] ?? array() );
+						$key            = array_key_first( $payment_source );
+						if ( ! is_string( $key ) || empty( $key ) ) {
+							$key = $payment_method;
+							if ( $payment_method === PayPalGateway::ID && $funding_source ) {
+								$key = $funding_source;
+							}
+							$payment_source[ $key ] = array();
+						}
+						$payment_source[ $key ]               = (array) $payment_source[ $key ];
+						$attributes                           = (array) ( $payment_source[ $key ]['attributes'] ?? array() );
+						$payment_source[ $key ]['attributes'] = array_merge( $attributes, $new_attributes );
+
+						$data['payment_source'] = $payment_source;
 
 						return $data;
 					},
-					10,
+					20,
 					3
 				);
 

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -164,20 +164,6 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 										),
 									),
 								);
-							} elseif ( $funding_source && $funding_source === 'apple_pay' ) {
-								$data['payment_source'] = array(
-									'apple_pay' => array(
-										'stored_credential' => array(
-											'payment_initiator' => 'CUSTOMER',
-											'payment_type' => 'RECURRING',
-										),
-										'attributes' => array(
-											'vault' => array(
-												'store_in_vault' => 'ON_SUCCESS',
-											),
-										),
-									),
-								);
 							} else {
 								$data['payment_source'] = array(
 									'paypal' => array(


### PR DESCRIPTION
Fixed vaulting after #3431, also fixed the request for the Venmo button and Apple Pay, Google Pay (they were sending `paypal` in the `payment_source` and/or overwriting it incorrectly).

For payment source overwriting there is one annoying thing, for the `PaymentSource` class we create it as an `object` while in other places we need it as an array. I think ideally it should be arrays everywhere, but there are too many places, so I guess just remember to cast it into array when using it in places like `ppcp_create_order_request_body_data`.

The vaulting code is a bit refactored and improved, now trying to send `customer.id` for all methods, not just ACDC. Currently it handles the ACDC gateway and PayPal/Venmo. Not sure if we should also add Apple Pay and Google Pay. They were missing before this PR too, there was code for Apple Pay but only for the old button inside the PayPal gateway (possibly a mistake/forgot to update?).

And also while refactoring I removed the `after_checkout_validation` method which seems to be unused for several years.
Previously it was used in this filter
https://github.com/woocommerce/woocommerce-paypal-payments/blob/f2f3633df4d2ca7644ec0a30ba7f90aa152fe411/modules/ppcp-button/src/Endpoint/class-createorderendpoint.php#L356-L361