### PR TITLE
Add filter to disable feature (4801)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2114,7 +2114,16 @@ return array(
 			$details = $container->get( 'settings.merchant-details' );
 			assert( $details instanceof MerchantDetails );
 
-			return 'US' === $details->get_merchant_country();
+			$enable_contact_module = 'US' === $details->get_merchant_country();
+
+			/**
+			 * The contact module is enabled for US-based merchants by default.
+			 * This filter provides the official way to opt-out of using it on this store.
+			 */
+			return (bool) apply_filters(
+				'woocommerce_paypal_payments_contact_module_enabled',
+				$enable_contact_module
+			);
 		};
 	},
 	/**


### PR DESCRIPTION
_Extends #3449_

### Description

Add a WP filter to programmatically control the contact module eligibility.

- When the filter returns `false`, the contact module is disabled on the site and the toggle disappears from the new settings UI (even for US merchants).
- When the filter returns `true`, the contact module is enabled on this site and the toggle in the new UI is displayed.

Note that _enabling_ the feature for ineligible merchants is possibly ignored by the PayPal API. The filter can be used to reliably opt-out of the feature, while potentially not providing any benefits for merchants in unsupported countries.

### Steps to Test

Add one of the two code snippets below to a mu-plugins file

#### Snippet to Disable

```php 
<?php
add_filter(
  'woocommerce_paypal_payments_contact_module_enabled',
  '__return_false'
);
```

#### Snippet to Enable

```php
<?php
add_filter(
  'woocommerce_paypal_payments_contact_module_enabled',
  '__return_true'
);
``` 

