### PR TITLE
Write tests for payload structure (4805)

### DIFF
--- a/tests/PHPUnit/ApiClient/Entity/ExperienceContextTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/ExperienceContextTest.php
@@ -19,7 +19,8 @@ class ExperienceContextTest extends TestCase
 			->with_landing_page('NO_PREFERENCE')
 			->with_shipping_preference('NO_SHIPPING')
 			->with_user_action('CONTINUE')
-			->with_payment_method_preference('UNRESTRICTED');
+			->with_payment_method_preference('UNRESTRICTED')
+			->with_contact_preference('NO_CONTACT_INFO');
 
 		$this->assertEmpty($empty->to_array());
 
@@ -32,6 +33,7 @@ class ExperienceContextTest extends TestCase
 			'shipping_preference' => 'NO_SHIPPING',
 			'user_action' => 'CONTINUE',
 			'payment_method_preference' => 'UNRESTRICTED',
+			'contact_preference' => 'NO_CONTACT_INFO',
 		], $result->to_array());
     }
 }

--- a/tests/PHPUnit/ApiClient/Factory/ContactPreferenceFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ContactPreferenceFactoryTest.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
+
+class ContactPreferenceFactoryTest extends TestCase
+{
+	/**
+	 * @dataProvider forStateData
+	 */
+	public function testFromState(
+		string $paymentSourceKey,
+		bool $isContactModuleActive,
+		bool $isEligibleForContactModule,
+		?string $expectedResult
+	) {
+		$md = $this->createMerchantDetails($isEligibleForContactModule);
+
+		$testee = new ContactPreferenceFactory($isContactModuleActive, $md);
+
+		$result = $testee->from_state($paymentSourceKey);
+
+		self::assertEquals($expectedResult, $result);
+	}
+
+	public function forStateData()
+	{
+		// Ensure UPDATE_CONTACT response for paypal and venmo.
+		yield [
+			'paypal',
+			true,
+			true,
+			ExperienceContext::CONTACT_PREFERENCE_UPDATE_CONTACT_INFO
+		];
+		yield [
+			'venmo',
+			true,
+			true,
+			ExperienceContext::CONTACT_PREFERENCE_UPDATE_CONTACT_INFO
+		];
+
+		// Ensure NO_CONTACT response when not eligible or feature is disabled.
+		yield [
+			'paypal',
+			false,
+			true,
+			ExperienceContext::CONTACT_PREFERENCE_NO_CONTACT_INFO
+		];
+		yield [
+			'paypal',
+			true,
+			false,
+			ExperienceContext::CONTACT_PREFERENCE_NO_CONTACT_INFO
+		];
+		yield [
+			'paypal',
+			false,
+			false,
+			ExperienceContext::CONTACT_PREFERENCE_NO_CONTACT_INFO
+		];
+
+		// Ensure NULL response when using an unsupported payment-source.
+		yield [
+			'oxxo',
+			true,
+			true,
+			null
+		];
+		yield [
+			'oxxo',
+			false,
+			true,
+			null
+		];
+
+		yield [
+			'oxxo',
+			false,
+			false,
+			null
+		];
+	}
+
+	private function createMerchantDetails($isEligible): MerchantDetails {
+		$md = Mockery::mock(MerchantDetails::class);
+		$md->shouldReceive('is_eligible_for')->andReturn($isEligible);
+		return $md;
+	}
+}

--- a/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
@@ -196,4 +196,27 @@ class ExperienceContextBuilderTest extends TestCase
 			ExperienceContext::PAYMENT_METHOD_IMMEDIATE_PAYMENT_REQUIRED,
 		];
 	}
+
+	/**
+	 * @dataProvider contactPreferenceDataProvider
+	 */
+	public function testContactPreference($preference) {
+		$result = $this->sut
+			->with_contact_preference($preference)
+			->build();
+
+		self::assertEquals([
+			'contact_preference' => $preference,
+		], $result->to_array());
+	}
+
+	public function contactPreferenceDataProvider()
+	{
+		yield [
+			ExperienceContext::CONTACT_PREFERENCE_NO_CONTACT_INFO,
+		];
+		yield [
+			ExperienceContext::CONTACT_PREFERENCE_UPDATE_CONTACT_INFO,
+		];
+	}
 }


### PR DESCRIPTION
_Extends PR #3456_

### Description

Adds new unit tests to confirm the "experience_context" payload is correctly assembled based on relevant settings.

### New test cases

Class | method | Notes
---|---|---
`ExperienceContext` | `with_contact_preference()` | The specified value is part of the `to_array()` response
`ExperienceContextBuilder` | `with_contact_preference()` |  The specified value is part of the `build()` response
`ContactPreferenceFactory` | `from_state()` | Payment sources `paypal` and `venmo` always add a contact-preference value
`ContactPreferenceFactory` | `from_state()` | Other payment sources set the contact-preference to `null`
`ContactPreferenceFactory` | `from_state()` | The `MerchantDetails::is_eligible_for()` check impacts the contact preference
`ContactPreferenceFactory` | `from_state()` | The new setting value (present in the new UI) impacts the contact preference