### PR TITLE
Cache the reference transaction disabled value (4857)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php
@@ -135,12 +135,12 @@ class BillingAgreementsEndpoint {
 				);
 			} finally {
 				$this->is_request_logging_enabled = true;
-				set_transient( 'ppcp_reference_transaction_enabled', true, MONTH_IN_SECONDS );
 			}
 
+			set_transient( 'ppcp_reference_transaction_enabled', true, MONTH_IN_SECONDS );
 			return true;
 		} catch ( Exception $exception ) {
-			delete_transient( 'ppcp_reference_transaction_enabled' );
+			set_transient( 'ppcp_reference_transaction_enabled', false, HOUR_IN_SECONDS );
 			return false;
 		}
 	}


### PR DESCRIPTION
The [reference_transaction_enabled](https://github.com/woocommerce/woocommerce-paypal-payments/blob/8d8508618594bf9ec36c4eb283fe95a5744f651b/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php#L122) method attempts to check if Reference Transactions are enabled for the PayPal account by making a call to [create_token()](https://github.com/woocommerce/woocommerce-paypal-payments/blob/8d8508618594bf9ec36c4eb283fe95a5744f651b/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php#L73)  (Which is called only [once](https://github.com/woocommerce/woocommerce-paypal-payments/blob/8d8508618594bf9ec36c4eb283fe95a5744f651b/modules/ppcp-api-client/src/Endpoint/BillingAgreementsEndpoint.php#L131) in the codebase ) and caching the result with a transient:

1. On success, sets the transient to cache the result.
2. On failure, deletes the transient and returns false.

and If `create_token()` throws an exception, `set_transient()` never runs. This means the failure case is not cached, and the function maybe gets called again and again, causing API spam.