### PR TITLE
Update Shipping entity to include contact fields (email, phone) (4808)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/Shipping.php
+++ b/modules/ppcp-api-client/src/Entity/Shipping.php
@@ -29,6 +29,16 @@ class Shipping {
 	private $address;
 
 	/**
+	 * Custom contact email address, usually added via the Contact Module.
+	 */
+	private ?string $email_address = null;
+
+	/**
+	 * Custom contact phone number, usually added via the Contact Module.
+	 */
+	private ?Phone $phone_number = null;
+
+	/**
 	 * Shipping methods.
 	 *
 	 * @var ShippingOption[]
@@ -38,14 +48,18 @@ class Shipping {
 	/**
 	 * Shipping constructor.
 	 *
-	 * @param string           $name The name.
-	 * @param Address          $address The address.
-	 * @param ShippingOption[] $options Shipping methods.
+	 * @param string           $name          The name.
+	 * @param Address          $address       The address.
+	 * @param string|null      $email_address Contact email.
+	 * @param Phone|null       $phone_number  Contact phone.
+	 * @param ShippingOption[] $options       Shipping methods.
 	 */
-	public function __construct( string $name, Address $address, array $options = array() ) {
-		$this->name    = $name;
-		$this->address = $address;
-		$this->options = $options;
+	public function __construct( string $name, Address $address, string $email_address = null, Phone $phone_number = null, array $options = array() ) {
+		$this->name          = $name;
+		$this->address       = $address;
+		$this->email_address = $email_address;
+		$this->phone_number  = $phone_number;
+		$this->options       = $options;
 	}
 
 	/**
@@ -64,6 +78,24 @@ class Shipping {
 	 */
 	public function address(): Address {
 		return $this->address;
+	}
+
+	/**
+	 * Returns the contact email address, or null.
+	 *
+	 * @return null|string
+	 */
+	public function email_address() : ?string {
+		return $this->email_address;
+	}
+
+	/**
+	 * Returns the contact phone number, or null.
+	 *
+	 * @return null|Phone
+	 */
+	public function phone_number() : ?Phone {
+		return $this->phone_number;
 	}
 
 	/**
@@ -87,6 +119,17 @@ class Shipping {
 			),
 			'address' => $this->address()->to_array(),
 		);
+
+		$contact_email = $this->email_address();
+		$contact_phone = $this->phone_number();
+
+		if ( $contact_email ) {
+			$result['email_address'] = $contact_email;
+		}
+		if ( $contact_phone ) {
+			$result['phone_number'] = $contact_phone->to_array();
+		}
+
 		if ( $this->options ) {
 			$result['options'] = array_map(
 				function ( ShippingOption $opt ): array {

--- a/modules/ppcp-api-client/src/Factory/ShippingFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ShippingFactory.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\ShippingOption;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Phone;
 
 /**
  * Class ShippingFactory
@@ -60,9 +60,12 @@ class ShippingFactory {
 			$customer->get_shipping_last_name()
 		);
 		$address = $this->address_factory->from_wc_customer( $customer );
+
 		return new Shipping(
 			$full_name,
 			$address,
+			null,
+			null,
 			$with_shipping_options ? $this->shipping_option_factory->from_wc_cart() : array()
 		);
 	}
@@ -77,6 +80,7 @@ class ShippingFactory {
 	public function from_wc_order( \WC_Order $order ): Shipping {
 		$full_name = $order->get_formatted_shipping_full_name();
 		$address   = $this->address_factory->from_wc_order( $order );
+
 		return new Shipping(
 			$full_name,
 			$address
@@ -102,14 +106,27 @@ class ShippingFactory {
 				__( 'No address was given for shipping.', 'woocommerce-paypal-payments' )
 			);
 		}
-		$address = $this->address_factory->from_paypal_response( $data->address );
+		$contact_phone = null;
+		$contact_email = null;
+		$address       = $this->address_factory->from_paypal_response( $data->address );
+
 		$options = array_map(
 			array( $this->shipping_option_factory, 'from_paypal_response' ),
 			$data->options ?? array()
 		);
+
+		if ( isset( $data->phone_number->national_number ) ) {
+			$contact_phone = new Phone( $data->phone_number->national_number );
+		}
+		if ( isset( $data->email_address ) ) {
+			$contact_email = $data->email_address;
+		}
+
 		return new Shipping(
 			$data->name->full_name,
 			$address,
+			$contact_email,
+			$contact_phone,
 			$options
 		);
 	}


### PR DESCRIPTION
_This PR extends #3457_

### Description

Extend the `Shipping` class to contain the two optional properties `email_address` and `phone_number`

Those properties are populated from the API's response object `purchase_units[].shipping`, so they depend on the presence of the shipping address in the order data