### PR TITLE
Store shipping contact info in order metadata (4809)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -44,17 +44,17 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 	use ProcessPaymentTrait, FreeTrialHandlerTrait, GatewaySettingsRendererTrait, OrderMetaTrait, TransactionIdHandlingTrait, PaymentsStatusHandlingTrait;
 
-	const ID                            = 'ppcp-gateway';
-	const INTENT_META_KEY               = '_ppcp_paypal_intent';
-	const ORDER_ID_META_KEY             = '_ppcp_paypal_order_id';
-	const ORDER_PAYMENT_MODE_META_KEY   = '_ppcp_paypal_payment_mode';
-	const ORDER_PAYMENT_SOURCE_META_KEY = '_ppcp_paypal_payment_source';
-	const ORDER_PAYER_EMAIL_META_KEY    = '_ppcp_paypal_payer_email';
-	const FEES_META_KEY                 = '_ppcp_paypal_fees';
-	const REFUND_FEES_META_KEY          = '_ppcp_paypal_refund_fees';
-	const REFUNDS_META_KEY              = '_ppcp_refunds';
-	const THREE_D_AUTH_RESULT_META_KEY  = '_ppcp_paypal_3DS_auth_result';
-	const FRAUD_RESULT_META_KEY         = '_ppcp_paypal_fraud_result';
+	public const ID                            = 'ppcp-gateway';
+	public const INTENT_META_KEY               = '_ppcp_paypal_intent';
+	public const ORDER_ID_META_KEY             = '_ppcp_paypal_order_id';
+	public const ORDER_PAYMENT_MODE_META_KEY   = '_ppcp_paypal_payment_mode';
+	public const ORDER_PAYMENT_SOURCE_META_KEY = '_ppcp_paypal_payment_source';
+	public const ORDER_PAYER_EMAIL_META_KEY    = '_ppcp_paypal_payer_email';
+	public const FEES_META_KEY                 = '_ppcp_paypal_fees';
+	public const REFUND_FEES_META_KEY          = '_ppcp_paypal_refund_fees';
+	public const REFUNDS_META_KEY              = '_ppcp_refunds';
+	public const THREE_D_AUTH_RESULT_META_KEY  = '_ppcp_paypal_3DS_auth_result';
+	public const FRAUD_RESULT_META_KEY         = '_ppcp_paypal_fraud_result';
 
 	/**
 	 * List of payment sources for which we are expected to store the payer email in the WC Order metadata.

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -55,6 +55,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	public const REFUNDS_META_KEY              = '_ppcp_refunds';
 	public const THREE_D_AUTH_RESULT_META_KEY  = '_ppcp_paypal_3DS_auth_result';
 	public const FRAUD_RESULT_META_KEY         = '_ppcp_paypal_fraud_result';
+	public const CONTACT_EMAIL_META_KEY        = '_ppcp_paypal_contact_email';
+	public const CONTACT_PHONE_META_KEY        = '_ppcp_paypal_contact_phone';
 
 	/**
 	 * List of payment sources for which we are expected to store the payer email in the WC Order metadata.

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderTransient;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
 
 /**
  * Trait OrderMetaTrait.
@@ -57,9 +58,53 @@ trait OrderMetaTrait {
 			}
 		}
 
+		$this->add_contact_details_to_wc_order( $wc_order, $order );
+
 		$wc_order->save();
 
 		do_action( 'woocommerce_paypal_payments_woocommerce_order_created', $wc_order, $order );
+	}
+
+	/**
+	 * Add order-meta entries with custom contact details
+	 *
+	 * @param WC_Order $wc_order The WooCommerce order to update.
+	 * @param Order    $order    The PayPal order which provides the details.
+	 * @return void
+	 */
+	private function add_contact_details_to_wc_order( WC_Order $wc_order, Order $order ) : void {
+		$shipping_details = $this->get_shipping_details( $order );
+
+		if ( ! $shipping_details ) {
+			return;
+		}
+
+		$contact_email = $shipping_details->email_address();
+		$contact_phone = $shipping_details->phone_number();
+
+		if ( $contact_email ) {
+			$wc_order->update_meta_data( PayPalGateway::CONTACT_EMAIL_META_KEY, $contact_email );
+		}
+		if ( $contact_phone ) {
+			$wc_order->update_meta_data( PayPalGateway::CONTACT_PHONE_META_KEY, $contact_phone->national_number() );
+		}
+	}
+
+	/**
+	 * Returns the shipping address details for the order.
+	 *
+	 * @param Order $order The PayPal order that contains potential shipping information.
+	 * @return ?Shipping The shipping details, or null if none present.
+	 */
+	private function get_shipping_details( Order $order ) : ?Shipping {
+		foreach ( $order->purchase_units() as $unit ) {
+			$shipping = $unit->shipping();
+			if ( $shipping ) {
+				return $shipping;
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
+++ b/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
@@ -24,8 +24,6 @@ use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
 use WooCommerce\PayPalCommerce\Vaulting\VaultedCreditCardHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
-use function Brain\Monkey\Functions\expect;
-use function Brain\Monkey\Functions\when;
 
 class VaultedCreditCardHandlerTest extends TestCase
 {
@@ -123,6 +121,7 @@ class VaultedCreditCardHandlerTest extends TestCase
 		$capture->shouldReceive('status')->andReturn($captureStatus);
 		$payments->shouldReceive('captures')->andReturn([$capture]);
 		$purchaseUnit->shouldReceive('payments')->andReturn($payments);
+		$purchaseUnit->shouldReceive('shipping')->andReturn(null);
 
 		$this->orderEndpoint->shouldReceive('create')
 			->with([$purchaseUnit], 'some_preference', $payer, '', array(), $requestPaymentSource)

--- a/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
@@ -9,7 +9,6 @@ use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
@@ -111,6 +110,7 @@ private $testee;
 		$order->shouldReceive('intent');
 		$order->shouldReceive('payment_source');
 		$order->shouldReceive('payer');
+		$order->shouldReceive('purchase_units')->andReturn([]);
 
 		$this->orderEndpoint
 			->shouldReceive('create')

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -23,13 +23,11 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderHelper;
 use WooCommerce\PayPalCommerce\Button\Helper\ThreeDSecure;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
-use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Container\ReadOnlyContainer;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use Mockery;
-use function Brain\Monkey\Functions\when;
 
 class OrderProcessorTest extends TestCase
 {
@@ -59,6 +57,8 @@ class OrderProcessorTest extends TestCase
         $purchaseUnit = Mockery::mock(PurchaseUnit::class);
         $purchaseUnit->shouldReceive('payments')
             ->andReturn($payments);
+	    $purchaseUnit->shouldReceive('shipping')
+		    ->andReturn(null);
 
         $wcOrder = Mockery::mock(\WC_Order::class);
 		$wcOrder->expects('get_items')->andReturn([]);
@@ -213,6 +213,8 @@ class OrderProcessorTest extends TestCase
         $purchaseUnit = Mockery::mock(PurchaseUnit::class);
         $purchaseUnit->shouldReceive('payments')
             ->andReturn($payments);
+        $purchaseUnit->shouldReceive('shipping')
+	        ->andReturn(null);
 
         $wcOrder = Mockery::mock(\WC_Order::class);
 		$wcOrder->expects('get_items')->andReturn([]);
@@ -348,7 +350,9 @@ class OrderProcessorTest extends TestCase
 
         $purchaseUnit = Mockery::mock(PurchaseUnit::class);
         $purchaseUnit->shouldReceive('payments')
-            ->andReturn($payments);
+            ->andReturn($payments);;
+	    $purchaseUnit->shouldReceive('shipping')
+		    ->andReturn(null);
 
         $wcOrder = Mockery::mock(\WC_Order::class);
 


### PR DESCRIPTION
_This PR extends #3463_

### Description

When the new email/phone properties are present in in the `Shipping` object, the values are stored to the DB as order-meta values during order processing.

Two new optional order-meta fields added:
- `_ppcp_paypal_contact_email`
- `_ppcp_paypal_contact_phone`
