### PR TITLE
Display shipping contact display in order-details page (4807)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -499,44 +499,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		 */
 		add_filter(
 			'woocommerce_admin_billing_fields',
-			function ( $fields ) {
-				global $theorder;
-
-				if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_paypal_email', true ) ) {
-					return $fields;
-				}
-
-				if ( ! is_array( $fields ) ) {
-					return $fields;
-				}
-
-				if ( ! $theorder instanceof WC_Order ) {
-					return $fields;
-				}
-
-				$email = $theorder->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ?: '';
-
-				if ( ! $email ) {
-					return $fields;
-				}
-
-				// Is payment source is paypal exclude all non paypal funding sources.
-				$payment_source           = $theorder->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) ?: '';
-				$is_paypal_funding_source = ( strpos( $theorder->get_payment_method_title(), '(via PayPal)' ) === false );
-
-				if ( $payment_source === 'paypal' && ! $is_paypal_funding_source ) {
-					return $fields;
-				}
-
-				$fields['paypal_email'] = array(
-					'label'             => __( 'PayPal email address', 'woocommerce-paypal-payments' ),
-					'value'             => $email,
-					'wrapper_class'     => 'form-field-wide',
-					'custom_attributes' => array( 'disabled' => 'disabled' ),
-				);
-
-				return $fields;
-			}
+			fn( $fields ) => $this->insert_custom_order_fields( $fields )
 		);
 
 		add_action(
@@ -976,5 +939,50 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$endpoint->handle_request();
 			}
 		);
+	}
+
+	/**
+	 * @param mixed $fields The field-list provided by WooCommerce, should be an array.
+	 * @return array|mixed The filtered field list.
+	 *
+	 * @psalm-suppress MissingClosureParamType
+	 */
+	private function insert_custom_order_fields  ( $fields) {
+		global $theorder;
+
+		if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_paypal_email', true ) ) {
+			return $fields;
+		}
+
+		if ( ! is_array( $fields ) ) {
+			return $fields;
+		}
+
+		if ( ! $theorder instanceof WC_Order ) {
+			return $fields;
+		}
+
+		$email = $theorder->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ?: '';
+
+		if ( ! $email ) {
+			return $fields;
+		}
+
+		// Is payment source is paypal exclude all non paypal funding sources.
+		$payment_source           = $theorder->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) ?: '';
+		$is_paypal_funding_source = ( strpos( $theorder->get_payment_method_title(), '(via PayPal)' ) === false );
+
+		if ( $payment_source === 'paypal' && ! $is_paypal_funding_source ) {
+			return $fields;
+		}
+
+		$fields['paypal_email'] = array(
+			'label'             => __( 'PayPal email address', 'woocommerce-paypal-payments' ),
+			'value'             => $email,
+			'wrapper_class'     => 'form-field-wide',
+			'custom_attributes' => array( 'disabled' => 'disabled' ),
+		);
+
+		return $fields;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -499,7 +499,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		 */
 		add_filter(
 			'woocommerce_admin_billing_fields',
-			fn( $fields ) => $this->insert_custom_order_fields( $fields )
+			fn( $fields ) => $this->insert_custom_order_fields( 'billing', $fields )
 		);
 
 		add_action(
@@ -942,23 +942,26 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	}
 
 	/**
-	 * @param mixed $fields The field-list provided by WooCommerce, should be an array.
+	 * Inserts custom fields into the order-detail view.
+	 *
+	 * @param string $section Whether to insert fields to 'billing' or 'shipping'.
+	 * @param mixed  $fields  The field-list provided by WooCommerce, should be an array.
 	 * @return array|mixed The filtered field list.
 	 *
 	 * @psalm-suppress MissingClosureParamType
 	 */
-	private function insert_custom_order_fields  ( $fields) {
+	private function insert_custom_order_fields( string $section, $fields ) {
 		global $theorder;
-
-		if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_paypal_email', true ) ) {
-			return $fields;
-		}
 
 		if ( ! is_array( $fields ) ) {
 			return $fields;
 		}
 
 		if ( ! $theorder instanceof WC_Order ) {
+			return $fields;
+		}
+
+		if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_paypal_email', true ) ) {
 			return $fields;
 		}
 
@@ -976,12 +979,14 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			return $fields;
 		}
 
-		$fields['paypal_email'] = array(
-			'label'             => __( 'PayPal email address', 'woocommerce-paypal-payments' ),
-			'value'             => $email,
-			'wrapper_class'     => 'form-field-wide',
-			'custom_attributes' => array( 'disabled' => 'disabled' ),
-		);
+		if ( 'billing' === $section ) {
+			$fields['paypal_email'] = array(
+				'label'             => __( 'PayPal email address', 'woocommerce-paypal-payments' ),
+				'value'             => $email,
+				'wrapper_class'     => 'form-field-wide',
+				'custom_attributes' => array( 'disabled' => 'disabled' ),
+			);
+		}
 
 		return $fields;
 	}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -502,6 +502,16 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			fn( $fields ) => $this->insert_custom_order_fields( 'billing', $fields )
 		);
 
+		/**
+		 * Param types removed to avoid third-party issues.
+		 *
+		 * @psalm-suppress MissingClosureParamType
+		 */
+		add_filter(
+			'woocommerce_admin_shipping_fields',
+			fn( $fields ) => $this->insert_custom_order_fields( 'shipping', $fields )
+		);
+
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
 			function( string $installed_plugin_version ) use ( $c ) {
@@ -961,12 +971,16 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			return $fields;
 		}
 
+		/**
+		 * We use this filter to de-customize the order details - 'billing' and 'shipping' section.
+		 */
 		if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_paypal_email', true ) ) {
 			return $fields;
 		}
 
 		$email = $theorder->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ?: '';
 
+		// Relevant for 'billing' and 'shipping' sections, as a missing email indicates no PayPal payment.
 		if ( ! $email ) {
 			return $fields;
 		}
@@ -986,6 +1000,29 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				'wrapper_class'     => 'form-field-wide',
 				'custom_attributes' => array( 'disabled' => 'disabled' ),
 			);
+		}
+
+		if ( 'shipping' === $section ) {
+			$contact_email = $theorder->get_meta( PayPalGateway::CONTACT_EMAIL_META_KEY ) ?: '';
+			$contact_phone = $theorder->get_meta( PayPalGateway::CONTACT_PHONE_META_KEY ) ?: '';
+
+			if ( $contact_phone ) {
+				$fields['phone'] = array(
+					'label'             => __( 'Phone', 'woocommerce-paypal-payments' ),
+					'value'             => $contact_phone,
+					'wrapper_class'     => 'form-field-wide',
+					'custom_attributes' => array( 'disabled' => 'disabled' ),
+				);
+			}
+
+			if ( $contact_email ) {
+				$fields['email'] = array(
+					'label'             => __( 'Email address', 'woocommerce-paypal-payments' ),
+					'value'             => $contact_email,
+					'wrapper_class'     => 'form-field-wide',
+					'custom_attributes' => array( 'disabled' => 'disabled' ),
+				);
+			}
 		}
 
 		return $fields;

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -512,6 +512,18 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			fn( $fields ) => $this->insert_custom_order_fields( 'shipping', $fields )
 		);
 
+		/**
+		 * Param types removed to avoid third-party issues.
+		 *
+		 * @psalm-suppress MissingClosureParamType
+		 */
+		add_action(
+			'woocommerce_order_details_after_customer_address',
+			fn( $section, $order ) => $this->display_custom_order_details( $section, $order ),
+			10,
+			2
+		);
+
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
 			function( string $installed_plugin_version ) use ( $c ) {
@@ -1026,5 +1038,40 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		}
 
 		return $fields;
+	}
+
+	/**
+	 * Outputs custom contact details on the customer-facing order confirmation page.
+	 *
+	 * @param string|mixed   $section The order-detail section (billing/shipping).
+	 * @param WC_Order|mixed $order   The order object.
+	 * @return void
+	 */
+	private function display_custom_order_details( $section, $order ) : void {
+		if ( ! ( $order instanceof WC_Order ) ) {
+			return;
+		}
+		if ( 'shipping' !== $section ) {
+			return;
+		}
+
+		$contact_email = $order->get_meta( PayPalGateway::CONTACT_EMAIL_META_KEY ) ?: '';
+		$contact_phone = $order->get_meta( PayPalGateway::CONTACT_PHONE_META_KEY ) ?: '';
+		if ( ! $contact_email && ! $contact_phone ) {
+			return;
+		}
+
+		if ( $contact_phone ) {
+			printf(
+				'<p class="woocommerce-customer-details--phone">%s</p>',
+				esc_html( $contact_phone )
+			);
+		}
+		if ( $contact_email ) {
+			printf(
+				'<p class="woocommerce-customer-details--email">%s</p>',
+				esc_html( $contact_email )
+			);
+		}
 	}
 }


### PR DESCRIPTION
_This PR extends #3464_

### Description

Enhances the following pages to display the custom contact details:

1. Order details page. Displays the contact details to the admin
2. Order confirmation page. Displays the contact details to the customer.

### Screenshots

**Order details page** (admin)
![CleanShot 2025-06-18 at 17 30 42@2x](https://github.com/user-attachments/assets/6d2893a3-6e62-4939-92fa-2c7e5aba1275)

**Order confirmation** (customer facing)
![CleanShot 2025-06-18 at 17 28 55@2x](https://github.com/user-attachments/assets/5e4ec62c-15bb-41e1-93e8-2a36ec2854cb)
