### PR TITLE
Override email recipient with shipping contact (4810)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -55,8 +55,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	public const REFUNDS_META_KEY              = '_ppcp_refunds';
 	public const THREE_D_AUTH_RESULT_META_KEY  = '_ppcp_paypal_3DS_auth_result';
 	public const FRAUD_RESULT_META_KEY         = '_ppcp_paypal_fraud_result';
-	public const CONTACT_EMAIL_META_KEY        = '_ppcp_paypal_contact_email';
-	public const CONTACT_PHONE_META_KEY        = '_ppcp_paypal_contact_phone';
+
+	// Used by the Contact Module integration to store the original details.
+	public const ORIGINAL_EMAIL_META_KEY = '_ppcp_paypal_billing_email';
+	public const ORIGINAL_PHONE_META_KEY = '_ppcp_paypal_billing_phone';
 
 	/**
 	 * List of payment sources for which we are expected to store the payer email in the WC Order metadata.

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -66,7 +66,12 @@ trait OrderMetaTrait {
 	}
 
 	/**
-	 * Add order-meta entries with custom contact details
+	 * Swaps out the billing details with the custom contact details provided by PayPal via the
+	 * "Contact Module" integration.
+	 *
+	 * The contact module can provide a custom email and phone number via the shipping details;
+	 * Though it's part of the shipping object, these two properties are intended to be treated
+	 * as primary contact details.
 	 *
 	 * @param WC_Order $wc_order The WooCommerce order to update.
 	 * @param Order    $order    The PayPal order which provides the details.
@@ -83,9 +88,18 @@ trait OrderMetaTrait {
 		$contact_phone = $shipping_details->phone_number();
 
 		if ( $contact_email ) {
+			$billing_email = $wc_order->get_billing_email();
+			$wc_order->update_meta_data( PayPalGateway::ORIGINAL_EMAIL_META_KEY, $billing_email );
+
 			$wc_order->set_billing_email( $contact_email );
 		}
+
 		if ( $contact_phone ) {
+			$billing_phone = $wc_order->get_billing_phone();
+			if ( $billing_phone ) {
+				$wc_order->update_meta_data( PayPalGateway::ORIGINAL_PHONE_META_KEY, $billing_phone );
+			}
+
 			$wc_order->set_billing_phone( $contact_phone->national_number() );
 		}
 	}

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -87,20 +87,25 @@ trait OrderMetaTrait {
 		$contact_email = $shipping_details->email_address();
 		$contact_phone = $shipping_details->phone_number();
 
-		if ( $contact_email ) {
+		if ( $contact_email && is_email( $contact_email ) ) {
 			$billing_email = $wc_order->get_billing_email();
-			$wc_order->update_meta_data( PayPalGateway::ORIGINAL_EMAIL_META_KEY, $billing_email );
+
+			if ( $billing_email && $billing_email !== $contact_email ) {
+				$wc_order->update_meta_data( PayPalGateway::ORIGINAL_EMAIL_META_KEY, $billing_email );
+			}
 
 			$wc_order->set_billing_email( $contact_email );
 		}
 
 		if ( $contact_phone ) {
-			$billing_phone = $wc_order->get_billing_phone();
-			if ( $billing_phone ) {
+			$billing_phone        = $wc_order->get_billing_phone();
+			$contact_phone_number = $contact_phone->national_number();
+
+			if ( $billing_phone && $billing_phone !== $contact_phone_number ) {
 				$wc_order->update_meta_data( PayPalGateway::ORIGINAL_PHONE_META_KEY, $billing_phone );
 			}
 
-			$wc_order->set_billing_phone( $contact_phone->national_number() );
+			$wc_order->set_billing_phone( $contact_phone_number );
 		}
 	}
 

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -83,10 +83,10 @@ trait OrderMetaTrait {
 		$contact_phone = $shipping_details->phone_number();
 
 		if ( $contact_email ) {
-			$wc_order->update_meta_data( PayPalGateway::CONTACT_EMAIL_META_KEY, $contact_email );
+			$wc_order->set_billing_email( $contact_email );
 		}
 		if ( $contact_phone ) {
-			$wc_order->update_meta_data( PayPalGateway::CONTACT_PHONE_META_KEY, $contact_phone->national_number() );
+			$wc_order->set_billing_phone( $contact_phone->national_number() );
 		}
 	}
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -1015,24 +1015,22 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		}
 
 		if ( 'shipping' === $section ) {
-			$contact_email = $theorder->get_meta( PayPalGateway::CONTACT_EMAIL_META_KEY ) ?: '';
-			$contact_phone = $theorder->get_meta( PayPalGateway::CONTACT_PHONE_META_KEY ) ?: '';
+			$contact_email = $theorder->get_meta( PayPalGateway::ORIGINAL_EMAIL_META_KEY ) ?: '';
+			$contact_phone = $theorder->get_meta( PayPalGateway::ORIGINAL_PHONE_META_KEY ) ?: '';
 
 			if ( $contact_phone ) {
 				$fields['phone'] = array(
-					'label'             => __( 'Phone', 'woocommerce-paypal-payments' ),
-					'value'             => $contact_phone,
-					'wrapper_class'     => 'form-field-wide',
-					'custom_attributes' => array( 'disabled' => 'disabled' ),
+					'label'         => __( 'Phone', 'woocommerce-paypal-payments' ),
+					'value'         => $contact_phone,
+					'wrapper_class' => 'form-field-wide',
 				);
 			}
 
 			if ( $contact_email ) {
 				$fields['email'] = array(
-					'label'             => __( 'Email address', 'woocommerce-paypal-payments' ),
-					'value'             => $contact_email,
-					'wrapper_class'     => 'form-field-wide',
-					'custom_attributes' => array( 'disabled' => 'disabled' ),
+					'label'         => __( 'Email address', 'woocommerce-paypal-payments' ),
+					'value'         => $contact_email,
+					'wrapper_class' => 'form-field-wide',
 				);
 			}
 		}
@@ -1055,8 +1053,8 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			return;
 		}
 
-		$contact_email = $order->get_meta( PayPalGateway::CONTACT_EMAIL_META_KEY ) ?: '';
-		$contact_phone = $order->get_meta( PayPalGateway::CONTACT_PHONE_META_KEY ) ?: '';
+		$contact_email = $order->get_meta( PayPalGateway::ORIGINAL_EMAIL_META_KEY ) ?: '';
+		$contact_phone = $order->get_meta( PayPalGateway::ORIGINAL_PHONE_META_KEY ) ?: '';
 		if ( ! $contact_email && ! $contact_phone ) {
 			return;
 		}


### PR DESCRIPTION
_This PR extends #3465_

### Description

Swaps out the order's billing details (email and phone) with contact details provided by the contact module.

At the same time, the original billing details are preserved as custom order-meta entries that are visible in the order details page to the shop owner.

A "side effect" of this PR is that all customer-facing emails are sent to the custom contact address which