### PR TITLE
Save transaction status in order meta

### DIFF
--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -354,6 +354,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 			}
 
 			if ( 'pay-now' === $data['context'] && is_a( $wc_order, \WC_Order::class ) ) {
+				$wc_order->update_meta_data( PayPalGateway::ORDER_STATUS_META_KEY, $order->status()->name() );
 				$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 				$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
 

--- a/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
+++ b/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
@@ -154,11 +154,12 @@ class EarlyOrderHandler {
 		 */
 		WC()->session->set( 'order_awaiting_payment', $order_id );
 
-		/** @var \WC_Order $wc_order */
 		$wc_order = wc_get_order( $order_id );
-		$wc_order->update_meta_data( PayPalGateway::ORDER_STATUS_META_KEY, $order->status()->name() );
-		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
-		$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
+		if ( $wc_order instanceof \WC_Order ) {
+			$wc_order->update_meta_data( PayPalGateway::ORDER_STATUS_META_KEY, $order->status()->name() );
+			$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
+			$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
+		}
 
 		$payment_source      = $order->payment_source();
 		$payment_source_name = $payment_source ? $payment_source->name() : null;

--- a/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
+++ b/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
@@ -154,7 +154,9 @@ class EarlyOrderHandler {
 		 */
 		WC()->session->set( 'order_awaiting_payment', $order_id );
 
+		/** @var \WC_Order $wc_order */
 		$wc_order = wc_get_order( $order_id );
+		$wc_order->update_meta_data( PayPalGateway::ORDER_STATUS_META_KEY, $order->status()->name() );
 		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 		$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
 

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -470,6 +470,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 					}
 
 					$order = $this->order_endpoint->order( $create_order->id );
+					$wc_order->update_meta_data( PayPalGateway::ORDER_STATUS_META_KEY, $order->status()->name() );
 					$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
 					$wc_order->add_payment_token( $token );
 

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -47,6 +47,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	public const ID                            = 'ppcp-gateway';
 	public const INTENT_META_KEY               = '_ppcp_paypal_intent';
 	public const ORDER_ID_META_KEY             = '_ppcp_paypal_order_id';
+	public const ORDER_STATUS_META_KEY         = '_ppcp_paypal_order_status';
 	public const ORDER_PAYMENT_MODE_META_KEY   = '_ppcp_paypal_payment_mode';
 	public const ORDER_PAYMENT_SOURCE_META_KEY = '_ppcp_paypal_payment_source';
 	public const ORDER_PAYER_EMAIL_META_KEY    = '_ppcp_paypal_payer_email';

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -35,6 +35,7 @@ trait OrderMetaTrait {
 		Environment $environment,
 		OrderTransient $order_transient = null
 	): void {
+		$wc_order->update_meta_data( PayPalGateway::ORDER_STATUS_META_KEY, $order->status()->name() );
 		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 		$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
 		$wc_order->update_meta_data(

--- a/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
+++ b/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
@@ -109,6 +109,7 @@ class VaultedCreditCardHandlerTest extends TestCase
 
 		$orderStatus = Mockery::mock(OrderStatus::class);
 		$orderStatus->shouldReceive('is')->andReturn(true);
+		$orderStatus->shouldReceive('name')->andReturn('AUTHORIZED');
 		$order->shouldReceive('status')->andReturn($orderStatus);
 
 		$order->shouldReceive('purchase_units')->andReturn([$purchaseUnit]);

--- a/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
@@ -9,6 +9,8 @@ use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
@@ -109,11 +111,16 @@ private $testee;
 				]
 			]);
 
+		$orderStatus = Mockery::mock(OrderStatus::class);
+		$orderStatus->shouldReceive('is')->andReturn(true);
+		$orderStatus->shouldReceive('name')->andReturn('AUTHORIZED');
+
 		$order = Mockery::mock(Order::class);
 		$order->shouldReceive('id')->andReturn('1');
 		$order->shouldReceive('intent');
 		$order->shouldReceive('payment_source');
 		$order->shouldReceive('payer');
+		$order->shouldReceive('status')->andReturn($orderStatus);
 		$order->shouldReceive('purchase_units')->andReturn([]);
 
 		$this->orderEndpoint

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -79,8 +79,9 @@ class OrderProcessorTest extends TestCase
 		    ->shouldReceive('is')
 		    ->with(OrderStatus::COMPLETED)
 		    ->andReturn(true);
+		$orderStatus->shouldReceive('name')->andReturn(OrderStatus::COMPLETED);
 
-        $orderId = 'abc';
+		$orderId = 'abc';
         $orderIntent = 'AUTHORIZE';
 
         $currentOrder = Mockery::mock(Order::class);
@@ -183,6 +184,12 @@ class OrderProcessorTest extends TestCase
                 PayPalGateway::INTENT_META_KEY,
                 $orderIntent
             );
+		$wcOrder
+			->expects('update_meta_data')
+			->with(
+				PayPalGateway::ORDER_STATUS_META_KEY,
+				OrderStatus::COMPLETED
+			);
         $wcOrder
             ->expects('update_status')
             ->with('on-hold', 'Awaiting payment.');
@@ -231,7 +238,8 @@ class OrderProcessorTest extends TestCase
             ->shouldReceive('is')
             ->with(OrderStatus::COMPLETED)
             ->andReturn(true);
-        $orderId = 'abc';
+		$orderStatus->shouldReceive('name')->andReturn(OrderStatus::COMPLETED);
+		$orderId = 'abc';
         $orderIntent = 'CAPTURE';
         $currentOrder = Mockery::mock(Order::class);
         $currentOrder
@@ -324,6 +332,12 @@ class OrderProcessorTest extends TestCase
             );
         $wcOrder->expects('update_meta_data')
             ->with(PayPalGateway::ORDER_PAYMENT_MODE_META_KEY, 'live');
+		$wcOrder
+			->expects('update_meta_data')
+			->with(
+				PayPalGateway::ORDER_STATUS_META_KEY,
+				OrderStatus::COMPLETED
+			);
         $wcOrder->expects('set_transaction_id')
             ->with($transactionId);
         $wcOrder
@@ -374,8 +388,9 @@ class OrderProcessorTest extends TestCase
 		$orderStatus
 			->expects('is')
 			->with(OrderStatus::CREATED)
-			->andReturn(false);
-        $orderId = 'abc';
+			->andReturn(true);
+		$orderStatus->shouldReceive('name')->andReturn(OrderStatus::CREATED);
+		$orderId = 'abc';
         $orderIntent = 'CAPTURE';
         $currentOrder = Mockery::mock(Order::class);
         $currentOrder
@@ -450,6 +465,12 @@ class OrderProcessorTest extends TestCase
                 PayPalGateway::INTENT_META_KEY,
                 $orderIntent
             );
+		$wcOrder
+			->expects('update_meta_data')
+			->with(
+				PayPalGateway::ORDER_STATUS_META_KEY,
+				OrderStatus::CREATED
+			);
 		$wcOrder->shouldReceive('save');
 
 		$order_helper->shouldReceive('contains_physical_goods')->andReturn(true);


### PR DESCRIPTION
This PR adds a new `_ppcp_paypal_order_status` meta key to orders, which stores the PayPal order status.