### PR TITLE
Reset BN code on plugin uninstall (4858)

### DIFF
--- a/modules/ppcp-api-client/src/Helper/PartnerAttribution.php
+++ b/modules/ppcp-api-client/src/Helper/PartnerAttribution.php
@@ -58,20 +58,22 @@ class PartnerAttribution {
 	}
 
 	/**
-	 * Initializes the BN Code if not already set.
-	 *
-	 * This method ensures that the BN Code is only stored once during the initial setup.
+	 * Initializes or updates the BN Code.
 	 *
 	 * @param string $installation_path The installation path used to determine the BN Code.
+	 * @param bool   $force_update Whether to force an update of the BN code if it already exists.
 	 */
-	public function initialize_bn_code( string $installation_path ) : void {
+	public function initialize_bn_code( string $installation_path, bool $force_update = false ) : void {
 		$selected_bn_code = $this->bn_codes[ $installation_path ] ?? '';
-
-		if ( ! $selected_bn_code || get_option( $this->bn_code_option_name ) ) {
+		if ( ! $selected_bn_code ) {
 			return;
 		}
 
-		// This option is permanent and should not change.
+		$existing_bn_code = get_option( $this->bn_code_option_name );
+		if ( $existing_bn_code && ! $force_update ) {
+			return;
+		}
+
 		update_option( $this->bn_code_option_name, $selected_bn_code );
 	}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -31,6 +31,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\RestEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Enum\InstallationPathEnum;
 use WooCommerce\PayPalCommerce\Settings\Handler\ConnectionListener;
 use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\PathRepository;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
@@ -637,6 +638,25 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				assert( $settings_model instanceof SettingsModel );
 
 				return ! $settings_model->get_save_paypal_and_venmo();
+			}
+		);
+
+		// Migration code to update BN code of merchants that are on whitelabel mode (own_brand_only false) to use the whitelabel BN code (direct).
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate_on_update',
+			static function() use ( $container ) {
+				$general_settings = $container->get( 'settings.data.general' );
+				assert( $general_settings instanceof GeneralSettings );
+
+				$partner_attribution = $container->get( 'api.helper.partner-attribution' );
+				assert( $partner_attribution instanceof PartnerAttribution );
+
+				$own_brand_only    = $general_settings->own_brand_only();
+				$installation_path = $general_settings->get_installation_path();
+
+				if ( ! $own_brand_only && $installation_path !== InstallationPathEnum::DIRECT ) {
+					$partner_attribution->initialize_bn_code( InstallationPathEnum::DIRECT, true );
+				}
 			}
 		);
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -96,6 +96,8 @@ function clear_plugin_branding( ContainerInterface $container ) : void {
 	 */
 	delete_option( 'woocommerce_paypal_branded' );
 
+	delete_option( 'ppcp_bn_code' );
+
 	try {
 		$general_settings = $container->get( 'settings.data.general' );
 		assert( $general_settings instanceof GeneralSettings );


### PR DESCRIPTION
Currently, the plugin stores a permanent BN code which depends on the “installation path”. Initially, this BN code was supposed to be permanent and never change after the first onboarding.

The corrected requirement is:
- When the plugin is uninstalled, we need to reset the BN code
- Add migration code to update BN code of merchants that are on whitelabel mode to use the whitelabel BN code.

The original problem is, that PayPal starts seeing ACDC payments made with the branded only BN code, which is a combination that must not happen.

Relevant functions
- GeneralSettings::own_brand_only() – get the current installation path
- PartnerAttribution::initialize_bn_code() – this flag must be reset on uninstallation