### PR TITLE
Display original billing data in order details (4902)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
@@ -76,11 +76,11 @@ const PaypalSettings = ( { hasContactModule } ) => {
 			<SettingsBlock visible={ hasContactModule }>
 				<ControlToggleButton
 					label={ __(
-						'Custom Shipping Contact',
+						'Contact selection on payment',
 						'woocommerce-paypal-payments'
 					) }
 					description={ __(
-						'If enabled, customers can provide a custom shipping email and phone number when paying via PayPal. Order updates are delivered to the custom shipping email, and not to the billing email.',
+						'Allow customers to choose an alternative email and phone number from their PayPal contacts during payment. Order confirmations and tracking updates are sent to the selected contacts instead of checkout details. Perfect for gift orders.',
 						'woocommerce-paypal-payments'
 					) }
 					value={ contactModule }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -1044,10 +1044,10 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		?>
 		<div class="ppcp-original-contact-data address" style="clear:both">
 			<h3>
-				<?php esc_html_e( 'Other Contact', 'woocommerce-paypal-payments' ); ?>
+				<?php esc_html_e( 'Other', 'woocommerce-paypal-payments' ); ?>
 				<span
-					class="woocommerce-help-tip" tabindex="0"
-					data-tip="<?php esc_attr_e( 'Contact details entered by the customer, which were replaced by PayPal during order creation', 'woocommerce-paypal-payments' ); ?>"
+					class="woocommerce-help-tip alignright" tabindex="0"
+					data-tip="<?php esc_attr_e( 'The customer entered these contact details during checkout, but provided different details in the PayPal popup. These details are kept for reference only.', 'woocommerce-paypal-payments' ); ?>"
 				></span>
 			</h3>
 			<?php if ( ! empty( $contact_email ) ) : ?>

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -499,7 +499,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		 */
 		add_filter(
 			'woocommerce_admin_billing_fields',
-			fn( $fields ) => $this->insert_custom_order_fields( 'billing', $fields )
+			fn( $fields ) => $this->insert_custom_fields_into_order_details( $fields )
 		);
 
 		/**
@@ -979,20 +979,19 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	/**
 	 * Inserts custom fields into the order-detail view.
 	 *
-	 * @param string $section Whether to insert fields to 'billing' or 'shipping'.
-	 * @param mixed  $fields  The field-list provided by WooCommerce, should be an array.
+	 * @param mixed $fields The field-list provided by WooCommerce, should be an array.
 	 * @return array|mixed The filtered field list.
 	 *
 	 * @psalm-suppress MissingClosureParamType
 	 */
-	private function insert_custom_order_fields( string $section, $fields ) {
+	private function insert_custom_fields_into_order_details( $fields ) {
 		global $theorder;
 
 		if ( ! is_array( $fields ) ) {
 			return $fields;
 		}
 
-		if ( ! $theorder instanceof WC_Order ) {
+		if ( ! $this->is_order_paid_by_paypal( $theorder ) ) {
 			return $fields;
 		}
 
@@ -1005,48 +1004,12 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		$email = $theorder->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ?: '';
 
-		// Relevant for 'billing' and 'shipping' sections, as a missing email indicates no PayPal payment.
-		if ( ! $email ) {
-			return $fields;
-		}
-
-		// Is payment source is paypal exclude all non paypal funding sources.
-		$payment_source           = $theorder->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) ?: '';
-		$is_paypal_funding_source = ( strpos( $theorder->get_payment_method_title(), '(via PayPal)' ) === false );
-
-		if ( $payment_source === 'paypal' && ! $is_paypal_funding_source ) {
-			return $fields;
-		}
-
-		if ( 'billing' === $section ) {
-			$fields['paypal_email'] = array(
-				'label'             => __( 'PayPal email address', 'woocommerce-paypal-payments' ),
-				'value'             => $email,
-				'wrapper_class'     => 'form-field-wide',
-				'custom_attributes' => array( 'disabled' => 'disabled' ),
-			);
-		}
-
-		if ( 'shipping' === $section ) {
-			$contact_email = $theorder->get_meta( PayPalGateway::ORIGINAL_EMAIL_META_KEY ) ?: '';
-			$contact_phone = $theorder->get_meta( PayPalGateway::ORIGINAL_PHONE_META_KEY ) ?: '';
-
-			if ( $contact_phone ) {
-				$fields['phone'] = array(
-					'label'         => __( 'Phone', 'woocommerce-paypal-payments' ),
-					'value'         => $contact_phone,
-					'wrapper_class' => 'form-field-wide',
-				);
-			}
-
-			if ( $contact_email ) {
-				$fields['email'] = array(
-					'label'         => __( 'Email address', 'woocommerce-paypal-payments' ),
-					'value'         => $contact_email,
-					'wrapper_class' => 'form-field-wide',
-				);
-			}
-		}
+		$fields['paypal_email'] = array(
+			'label'             => __( 'PayPal email address', 'woocommerce-paypal-payments' ),
+			'value'             => $email,
+			'wrapper_class'     => 'form-field-wide',
+			'custom_attributes' => array( 'disabled' => 'disabled' ),
+		);
 
 		return $fields;
 	}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -507,9 +507,9 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		 *
 		 * @psalm-suppress MissingClosureParamType
 		 */
-		add_filter(
-			'woocommerce_admin_shipping_fields',
-			fn( $fields ) => $this->insert_custom_order_fields( 'shipping', $fields )
+		add_action(
+			'woocommerce_admin_order_data_after_shipping_address',
+			fn( $order ) => $this->display_original_contact_in_order_details( $order )
 		);
 
 		add_action(
@@ -952,6 +952,31 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	}
 
 	/**
+	 * Checks, if the provided argument is a WC_Order which was paid directly by PayPal.
+	 *
+	 * Only considers direct PayPal payments, and returns false for orders that were paid "via"
+	 * PayPal, like wallets (Google Pay, ...) or local APMs.
+	 *
+	 * @param WC_Order|mixed $order The order to verify.
+	 * @return bool True, if it's a valid order that was paid via PayPal.
+	 */
+	private function is_order_paid_by_paypal( $order ) : bool {
+		if ( ! $order instanceof WC_Order ) {
+			return false;
+		}
+
+		if ( ! $order->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) ) {
+			return false;
+		}
+
+		if ( 'paypal' !== $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) ) {
+			return false;
+		}
+
+		return false === strpos( $order->get_payment_method_title(), '(via PayPal)' );
+	}
+
+	/**
 	 * Inserts custom fields into the order-detail view.
 	 *
 	 * @param string $section Whether to insert fields to 'billing' or 'shipping'.
@@ -1024,5 +1049,61 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		}
 
 		return $fields;
+	}
+
+	/**
+	 * Displays a custom section in the order details page with the original contact details entered
+	 * during checkout.
+	 *
+	 * When the Contact module is active, those contact details are replaced with details provided
+	 * by PayPal; this section shows the (unused) details which the user originally entered.
+	 *
+	 * @param WC_Order|mixed $order The order which is rendered.
+	 * @return void
+	 */
+	private function display_original_contact_in_order_details( $order ) : void {
+		if ( ! $this->is_order_paid_by_paypal( $order ) ) {
+			return;
+		}
+
+		if ( ! apply_filters( 'woocommerce_paypal_payments_order_details_show_original_contact', true ) ) {
+			return;
+		}
+
+		assert( $order instanceof WC_Order );
+		$contact_email = $order->get_meta( PayPalGateway::ORIGINAL_EMAIL_META_KEY );
+		$contact_phone = $order->get_meta( PayPalGateway::ORIGINAL_PHONE_META_KEY );
+
+		if ( ! $contact_email && ! $contact_phone ) {
+			return;
+		}
+
+		?>
+		<div class="ppcp-original-contact-data address" style="clear:both">
+			<h3>
+				<?php esc_html_e( 'Other Contact', 'woocommerce-paypal-payments' ); ?>
+				<span
+					class="woocommerce-help-tip" tabindex="0"
+					data-tip="<?php esc_attr_e( 'Contact details entered by the customer, which were replaced by PayPal during order creation', 'woocommerce-paypal-payments' ); ?>"
+				></span>
+			</h3>
+			<?php if ( ! empty( $contact_email ) ) : ?>
+				<p>
+					<strong>
+						<?php esc_html_e( 'Email address', 'woocommerce-paypal-payments' ); ?>:
+					</strong>
+					<a href="<?php echo esc_url( 'mailto:' . $contact_email ); ?>"><?php echo esc_html( $contact_email ); ?></a>
+				</p>
+			<?php endif; ?>
+			<?php if ( ! empty( $contact_phone ) ) : ?>
+				<p>
+					<strong>
+						<?php esc_html_e( 'Phone', 'woocommerce-paypal-payments' ); ?>:
+					</strong>
+					<?php echo wc_make_phone_clickable( $contact_phone ); ?>
+				</p>
+			<?php endif; ?>
+		</div>
+		<?php
 	}
 }


### PR DESCRIPTION
_This PR extends #3467_

### Description

Some updates to the admin UI, for merchants:

- Improved the display of original contact information in the order-details page
- Removed unused code from previous commits
- Refined the setting label and description

### Screenshots

**Order confirmation page**
![CleanShot 2025-06-20 at 15 03 23@2x](https://github.com/user-attachments/assets/7386a84b-4a31-4960-9c52-f6d3ee9f2ed3)

**Plugin settings**
![CleanShot 2025-06-20 at 15 49 45@2x](https://github.com/user-attachments/assets/f9096cfa-2bb1-4142-9942-8401e59f1b76)
