### PR TITLE
Ditch items logic does not work when using saved card payment (4884)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,3 @@
+{
+  "enableAllProjectMcpServers": false
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,3 +1,0 @@
-{
-  "enableAllProjectMcpServers": false
-}

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -155,7 +155,7 @@ class CaptureCardPayment {
 			'intent'         => $intent,
 			'purchase_units' => array_map(
 				static function ( PurchaseUnit $item ): array {
-					return $item->to_array( true, false );
+					return $item->to_array();
 				},
 				$items
 			),

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -462,7 +462,12 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 				if ( $token->get_id() === (int) $card_payment_token_id ) {
 					$custom_id    = (string) $wc_order->get_id();
 					$invoice_id   = $this->prefix . $wc_order->get_order_number();
-					$create_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order );
+
+					try {
+						$create_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order );
+					} catch (RuntimeException $exception) {
+						$this->logger->error($exception->getMessage());
+					}
 
 					$order = $this->order_endpoint->order( $create_order->id );
 					$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -460,13 +460,13 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			$tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id() );
 			foreach ( $tokens as $token ) {
 				if ( $token->get_id() === (int) $card_payment_token_id ) {
-					$custom_id    = (string) $wc_order->get_id();
-					$invoice_id   = $this->prefix . $wc_order->get_order_number();
+					$custom_id  = (string) $wc_order->get_id();
+					$invoice_id = $this->prefix . $wc_order->get_order_number();
 
 					try {
 						$create_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order );
-					} catch (RuntimeException $exception) {
-						$this->logger->error($exception->getMessage());
+					} catch ( RuntimeException $exception ) {
+						$this->logger->error( $exception->getMessage() );
 					}
 
 					$order = $this->order_endpoint->order( $create_order->id );


### PR DESCRIPTION
The Subtotal mismatch fallback logic to prevent `ITEM_TOTAL_MISMATCH` error when creating the PayPal order was not executed when capturing the order using a vaulted card payment. This PR fixes it and handles the error adding a log entry when it fails.