### PR TITLE
[dev] Pin Github actions to full-commit SHA

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
 
     name: PHP ${{ matrix.php-versions }} WC ${{ matrix.wc-versions }}
     steps:
-    - uses: ddev/github-action-setup-ddev@v1
+    - uses: ddev/github-action-setup-ddev@1c7ef18595da42355373cb6d9417a6f44d758b93 # v1
       with:
         autostart: false
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ jobs:
 
     name: PHP ${{ matrix.php-versions }} WC ${{ matrix.wc-versions }}
     steps:
-    - uses: ddev/github-action-setup-ddev@1c7ef18595da42355373cb6d9417a6f44d758b93 # v1
+    - uses: ddev/github-action-setup-ddev@1c7ef18595da42355373cb6d9417a6f44d758b93 # v1.10.1
       with:
         autostart: false
 

--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -27,7 +27,7 @@ jobs:
 
   create_archive:
     needs: check_version
-    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@a9af34f34e95cbe18703198c7e972e97ebcd7473
     with:
       PHP_VERSION: 7.4
       NODE_VERSION: 22

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
       with:
         php-version: 7.4
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
       with:
         php-version: ${{ matrix.php-versions }}
 
@@ -22,7 +22,7 @@ jobs:
       run: composer validate
 
     - name: Install dependencies
-      uses: ramsey/composer-install@v1
+      uses: ramsey/composer-install@994bb194a4fefcf39449ccf0f7766a4318f1ac76 # v1
       with:
         composer-options: "--prefer-dist"
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -22,7 +22,7 @@ jobs:
       run: composer validate
 
     - name: Install dependencies
-      uses: ramsey/composer-install@994bb194a4fefcf39449ccf0f7766a4318f1ac76 # v1
+      uses: ramsey/composer-install@a7320a0581dcd0432930c48a0e7ced67e6ec17e8 # v1.3.0
       with:
         composer-options: "--prefer-dist"
 

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Check spelling
         id: spelling
-        uses: crate-ci/typos@v1.30.2
+        uses: crate-ci/typos@7bc041cbb7ca9167c9e0e4ccbb26f48eb0f9d4e0 # v1.30.2
         with:
           # Path to config file
           config: .github/workflows-config/typos.toml


### PR DESCRIPTION
### Description

Closes [QAO-42](https://linear.app/a8c/issue/QAO-42/pin-github-actions-to-full-commit-shas-for-immutability)
Contributes to [QAO-22](https://linear.app/a8c/issue/QAO-22), [QAO-23](https://linear.app/a8c/issue/QAO-23)

Pins Github actions to full commit SHAs as immutable references.
Skipped all official GitHub actions.  
No version updates - used the latest commit in the tag that was already used.

### Steps to Test

CI should pass.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

CI updates
