### PR TITLE
Add missing useCallback import (4944)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classNames from 'classnames';
 import { OpenSignup } from '../../../ReusableComponents/Icons';


### PR DESCRIPTION
This PR will fix the `Uncaught ReferenceError: useCallback is not defined` error, breaking the last step of the onboarding process.