### PR TITLE
3.0.7-rc1 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,21 @@
 *** Changelog ***
 
+= 3.0.7 - xxxx-xx-xx =
+* Enhancement - Deprecate `application_context` in favor of `experience_context` object #3431
+ **NOTE**: If you were extending/modifying the `application_context` object programmatically, you may need to update your code to utilize `experience_context` for your customizations. 
+* Enhancement - Add Contact Module feature
+* Enhancement - Add WooCommerce Tracks integration
+* Enhancement - Onboarding notification for Firefox browser #3433
+* Enhancement - Reset BN code on plugin uninstall #3471
+* Enhancement - Add "Stay updated with PayPal" option in the old and new settings UI #3430
+* Enhancement - Add French Territories to the supported ACDC countries list #3438
+* Enhancement - Auto-enable logging during onboarding #3369
+* Fix - DUPLICATE_INVOICE_ID in Sandbox due to missing invoice prefix #3435
+* Fix - Subscription product could not be unlinked from PayPal Subscription #3429
+* Fix - PayPal button greyed out on single product page for variable products with >2 attributes #3395
+* Fix - APMs automatically enabled despite selecting "No, ..." during onboarding #3362
+* Fix - Ditch items logic does not work when using saved card payment #3476
+
 = 3.0.6 - 2025-05-27 =
 * Enhancement - Implement 3D secure check for Google Pay #3163
 * Enhancement - Add options for "Disable Credit Cards" and "Language" #3226

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "description": "WooCommerce PayPal Payments",
   "repository": "https://github.com/woocommerce/woocommerce-paypal-payments",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 6.5
 Tested up to: 6.8
 Requires PHP: 7.4
-Stable tag: 3.0.6
+Stable tag: 3.0.7
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -155,6 +155,22 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 6. Main settings screen.
 
 == Changelog ==
+
+= 3.0.7 - xxxx-xx-xx =
+* Enhancement - Deprecate `application_context` in favor of `experience_context` object #3431
+ **NOTE**: If you were extending/modifying the `application_context` object programmatically, you may need to update your code to utilize `experience_context` for your customizations. 
+* Enhancement - Add Contact Module feature
+* Enhancement - Add WooCommerce Tracks integration
+* Enhancement - Onboarding notification for Firefox browser #3433
+* Enhancement - Reset BN code on plugin uninstall #3471
+* Enhancement - Add "Stay updated with PayPal" option in the old and new settings UI #3430
+* Enhancement - Add French Territories to the supported ACDC countries list #3438
+* Enhancement - Auto-enable logging during onboarding #3369
+* Fix - DUPLICATE_INVOICE_ID in Sandbox due to missing invoice prefix #3435
+* Fix - Subscription product could not be unlinked from PayPal Subscription #3429
+* Fix - PayPal button greyed out on single product page for variable products with >2 attributes #3395
+* Fix - APMs automatically enabled despite selecting "No, ..." during onboarding #3362
+* Fix - Ditch items logic does not work when using saved card payment #3476
 
 = 3.0.6 - 2025-05-27 =
 * Enhancement - Implement 3D secure check for Google Pay #3163

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayPal Payments
  * Plugin URI:  https://woocommerce.com/products/woocommerce-paypal-payments/
  * Description: PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
- * Version:     3.0.6
+ * Version:     3.0.7
  * Author:      PayPal
  * Author URI:  https://paypal.com/
  * License:     GPL-2.0
@@ -11,7 +11,7 @@
  * Requires Plugins: woocommerce
  * Requires at least: 6.5
  * WC requires at least: 9.6
- * WC tested up to: 9.8
+ * WC tested up to: 9.9
  * Text Domain: woocommerce-paypal-payments
  *
  * @package WooCommerce\PayPalCommerce
@@ -27,7 +27,7 @@ define( 'PAYPAL_API_URL', 'https://api-m.paypal.com' );
 define( 'PAYPAL_URL', 'https://www.paypal.com' );
 define( 'PAYPAL_SANDBOX_API_URL', 'https://api-m.sandbox.paypal.com' );
 define( 'PAYPAL_SANDBOX_URL', 'https://www.sandbox.paypal.com' );
-define( 'PAYPAL_INTEGRATION_DATE', '2025-05-14' );
+define( 'PAYPAL_INTEGRATION_DATE', '2025-06-25' );
 define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 ! defined( 'CONNECT_WOO_CLIENT_ID' ) && define( 'CONNECT_WOO_CLIENT_ID', 'AcCAsWta_JTL__OfpjspNyH7c1GGHH332fLwonA5CwX4Y10mhybRZmHLA0GdRbwKwjQIhpDQy0pluX_P' );


### PR DESCRIPTION
* Enhancement - Deprecate `application_context` in favor of `experience_context` object #3431
 **NOTE**: If you were extending/modifying the `application_context` object programmatically, you may need to update your code to utilize `experience_context` for your customizations. 
* Enhancement - Add Contact Module feature
* Enhancement - Add WooCommerce Tracks integration
* Enhancement - Onboarding notification for Firefox browser #3433
* Enhancement - Reset BN code on plugin uninstall #3471
* Enhancement - Add "Stay updated with PayPal" option in the old and new settings UI #3430
* Enhancement - Add French Territories to the supported ACDC countries list #3438
* Enhancement - Auto-enable logging during onboarding #3369
* Fix - DUPLICATE_INVOICE_ID in Sandbox due to missing invoice prefix #3435
* Fix - Subscription product could not be unlinked from PayPal Subscription #3429
* Fix - PayPal button greyed out on single product page for variable products with >2 attributes #3395
* Fix - APMs automatically enabled despite selecting "No, ..." during onboarding #3362
* Fix - Ditch items logic does not work when using saved card payment #3476