### PR TITLE
OXXO payment gateway requires ORDER_COMPLETE_ON_PAYMENT_APPROVAL processing_instruction (4967)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -585,9 +585,6 @@ class OrderEndpoint {
 		$data = array(
 			'payment_source'         => $payment_source,
 			'processing_instruction' => 'ORDER_COMPLETE_ON_PAYMENT_APPROVAL',
-			'application_context'    => array(
-				'locale' => 'es-MX',
-			),
 		);
 
 		$args = array(

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
@@ -192,15 +192,19 @@ class OXXOGateway extends WC_Payment_Gateway {
 				'country_code'       => $wc_order->get_billing_country(),
 				'experience_context' => $this->experience_context_builder
 					->with_default_paypal_config( $shipping_preference )
-					->build()->to_array(),
+					->build()
+					->with_locale( 'en-MX' )
+					->to_array(),
 			);
 
 			$order = $this->order_endpoint->create(
 				array( $purchase_unit ),
 				$shipping_preference,
 				null,
-				'',
-				array(),
+				self::ID,
+				array(
+					'processing_instruction' => 'ORDER_COMPLETE_ON_PAYMENT_APPROVAL',
+				),
 				new PaymentSource(
 					'oxxo',
 					(object) $payment_source_data

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -25,6 +25,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Assets\VoidButtonAssets;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\RefreshFeatureStatusEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ShippingCallbackEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\VoidOrderEndpoint;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXOGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\InstallmentsProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Notice\SendOnlyCountryNotice;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\CreditCardOrderInfoHandlingTrait;
@@ -585,6 +586,25 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 				$endpoint->register();
 			}
+		);
+
+		// Add processing instruction request data for OXXO payment.
+		add_filter(
+			'ppcp_create_order_request_body_data',
+			static function ( array $data, string $payment_method, array $request ) use ( $c ) : array {
+				if ( $payment_method !== OXXOGateway::ID ) {
+					return $data;
+				}
+
+				$processing_instruction = $request['processing_instruction'] ?? '';
+				if ( $processing_instruction ) {
+					$data['processing_instruction'] = $processing_instruction;
+				}
+
+				return $data;
+			},
+			10,
+			3
 		);
 
 		return true;

--- a/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
@@ -122,7 +122,7 @@ private $testee;
 				[$purchaseUnit],
 				$shippingPreference,
 				null,
-				'ppcp-oxxo-gateway',
+				OXXOGateway::ID,
 				['processing_instruction' => 'ORDER_COMPLETE_ON_PAYMENT_APPROVAL'],
 				Mockery::any()
 			)

--- a/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/OXXO/OXXOGatewayTest.php
@@ -70,6 +70,10 @@ private $testee;
 			->shouldReceive('build')
 			->andReturn($experienceContext);
 		$experienceContext
+			->shouldReceive('with_locale')
+			->with('en-MX')
+			->andReturn($experienceContext);
+		$experienceContext
 			->shouldReceive('to_array')
 			->andReturn(['foo' => 'bar']);
 	}
@@ -114,7 +118,14 @@ private $testee;
 
 		$this->orderEndpoint
 			->shouldReceive('create')
-			->with([$purchaseUnit], $shippingPreference, null, '', [], Mockery::any())
+			->with(
+				[$purchaseUnit],
+				$shippingPreference,
+				null,
+				'ppcp-oxxo-gateway',
+				['processing_instruction' => 'ORDER_COMPLETE_ON_PAYMENT_APPROVAL'],
+				Mockery::any()
+			)
 			->andReturn($order);
 
 		$this->wcOrder


### PR DESCRIPTION
When OXXO is used for payment, the transaction is not completed.

### Steps To Reproduce
— Store country is Mexico and currency is MXN
- Add product to the cart and navigate to classic checkout
- Fill out the form and select OXXO payment and place the order.

This PR fixes the issue by removing `application_context` from `OrderEndpoint.php::confirm_payment_source` and adding `processing_instruction` and `locale` to `OXXO/OXXOGateway::process_payment`.