### PR TITLE
Fix three_d_secure check logic and prevent the undefined array key warning (4968)

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -289,7 +289,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				$data_settings    = get_option( 'woocommerce-ppcp-data-settings' ) ?: array();
 
 				// Skip if payment settings don't have the setting but data settings do.
-				if ( ! isset( $payment_settings['three_d_secure'] ) && isset( $data_settings['three_d_secure'] ) ) {
+				if ( ! isset( $payment_settings['three_d_secure'] ) || isset( $data_settings['three_d_secure'] ) ) {
 					return;
 				}
 


### PR DESCRIPTION
### Description

This PR will fix the `Warning: Undefined array key "three_d_secure" in /var/www/html/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-compat/src/CompatModule.php on line 243 ` warning.