### PR TITLE
Unsuccessfully payment with acdc when country store set for France territories (4958)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -783,6 +783,11 @@ return array(
 					'amex'       => array( 'JPY' ),
 					'jcb'        => array( 'JPY' ),
 				),
+				'YT' => $mastercard_visa_amex, // Mayotte.
+				'RE' => $mastercard_visa_amex, // Reunion.
+				'GP' => $mastercard_visa_amex, // Guadelope.
+				'GF' => $mastercard_visa_amex, // French Guiana.
+				'MQ' => $mastercard_visa_amex, // Martinique.
 			)
 		);
 	},


### PR DESCRIPTION
### Steps to reproduce
- Connect PayPal account to the plugin
- Go to 'WooCommerce > Settings > General'
- Set the store location to any French Territories (Mayotte, Reunion, Guadelope, French Guiana, and Martinique)
- Navigate to PayPal Payments settings and observe the presence of Advanced Card Processing
- Navigate to shop, add product to cart, navigate to classic checkout (or block)
- Select acdc, add card data and try to pay
- Observe errors

This PR adds French Territories to the country card matrix.