### PR TITLE
Legacy UI - Mexico - Notice on frontend when wp debugging is enabled  (4972)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
@@ -332,7 +332,9 @@ class CardPaymentsConfiguration {
 	public function is_bcdc_enabled() : bool {
 		if ( 'MX' === $this->store_country ) {
 			$bcdc_setting = get_option( 'woocommerce_ppcp-card-button-gateway_settings' );
-			return 'yes' === $bcdc_setting['enabled'];
+			$enabled      = $bcdc_setting['enabled'] ?? '';
+
+			return 'yes' === $enabled;
 		}
 
 		return $this->is_enabled() && ! $this->use_acdc();


### PR DESCRIPTION
### Steps To Reproduce
- Onboard as Mexico merchant in legacy UI
- Enable WP debugging
- Navigate to shop 
- Observe notice: `Try to access array offset on value of type bool`

This PR fixes the issue by setting empty `string` if given setting is `null`.