### PR TITLE
UX Legacy Migration: phase 1 opt in via banner (4854)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -438,26 +438,26 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.30.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -498,7 +498,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -514,7 +514,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "wikimedia/composer-merge-plugin",
@@ -545,10 +545,10 @@
             },
             "type": "composer-plugin",
             "extra": {
+                "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin",
                 "branch-alias": {
                     "dev-master": "2.x-dev"
-                },
-                "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin"
+                }
             },
             "autoload": {
                 "psr-4": {
@@ -788,20 +788,20 @@
         },
         {
             "name": "antecedent/patchwork",
-            "version": "2.1.28",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/antecedent/patchwork.git",
-                "reference": "6b30aff81ebadf0f2feb9268d3e08385cebcc08d"
+                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/6b30aff81ebadf0f2feb9268d3e08385cebcc08d",
-                "reference": "6b30aff81ebadf0f2feb9268d3e08385cebcc08d",
+                "url": "https://api.github.com/repos/antecedent/patchwork/zipball/1bf183a3e1bd094f231a2128b9ecc5363c269245",
+                "reference": "1bf183a3e1bd094f231a2128b9ecc5363c269245",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
                 "phpunit/phpunit": ">=4"
@@ -830,22 +830,22 @@
             ],
             "support": {
                 "issues": "https://github.com/antecedent/patchwork/issues",
-                "source": "https://github.com/antecedent/patchwork/tree/2.1.28"
+                "source": "https://github.com/antecedent/patchwork/tree/2.2.1"
             },
-            "time": "2024-02-06T09:26:11+00:00"
+            "time": "2024-12-11T10:19:54+00:00"
         },
         {
             "name": "brain/monkey",
-            "version": "2.6.1",
+            "version": "2.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/BrainMonkey.git",
-                "reference": "a31c84515bb0d49be9310f52ef1733980ea8ffbb"
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/a31c84515bb0d49be9310f52ef1733980ea8ffbb",
-                "reference": "a31c84515bb0d49be9310f52ef1733980ea8ffbb",
+                "url": "https://api.github.com/repos/Brain-WP/BrainMonkey/zipball/d95a9d895352c30f47604ad1b825ab8fa9d1a373",
+                "reference": "d95a9d895352c30f47604ad1b825ab8fa9d1a373",
                 "shasum": ""
             },
             "require": {
@@ -861,8 +861,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-version/1": "1.x-dev",
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.x-dev",
+                    "dev-version/1": "1.x-dev"
                 }
             },
             "autoload": {
@@ -902,7 +902,7 @@
                 "issues": "https://github.com/Brain-WP/BrainMonkey/issues",
                 "source": "https://github.com/Brain-WP/BrainMonkey"
             },
-            "time": "2021-11-11T15:53:55+00:00"
+            "time": "2024-08-29T20:15:04+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -979,16 +979,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "63aaeac21d7e775ff9bc9d45021e1745c97521c4"
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/63aaeac21d7e775ff9bc9d45021e1745c97521c4",
-                "reference": "63aaeac21d7e775ff9bc9d45021e1745c97521c4",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
                 "shasum": ""
             },
             "require": {
@@ -998,19 +998,19 @@
                 "phpstan/phpstan": "<1.11.10"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.11.10",
-                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
                 "phpunit/phpunit": "^8 || ^9"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                },
                 "phpstan": {
                     "includes": [
                         "extension.neon"
                     ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -1038,7 +1038,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.1"
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
             },
             "funding": [
                 {
@@ -1054,28 +1054,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-27T18:44:43+00:00"
+            "time": "2024-11-12T16:29:46+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.4.2",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6"
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c51258e759afdb17f1fd1fe83bc12baaef6309d6",
-                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6",
+                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.4",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
             },
             "type": "library",
             "extra": {
@@ -1119,7 +1119,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.2"
+                "source": "https://github.com/composer/semver/tree/3.4.3"
             },
             "funding": [
                 {
@@ -1135,7 +1135,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-12T11:35:52+00:00"
+            "time": "2024-09-19T14:15:21+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1432,29 +1432,30 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.3",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
+                "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -1462,7 +1463,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                    "Doctrine\\Deprecations\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1473,9 +1474,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
-            "time": "2024-01-30T19:34:25+00:00"
+            "time": "2025-04-07T20:06:18+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1594,16 +1595,16 @@
         },
         {
             "name": "felixfbecker/language-server-protocol",
-            "version": "v1.5.2",
+            "version": "v1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/felixfbecker/php-language-server-protocol.git",
-                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842"
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/6e82196ffd7c62f7794d778ca52b69feec9f2842",
-                "reference": "6e82196ffd7c62f7794d778ca52b69feec9f2842",
+                "url": "https://api.github.com/repos/felixfbecker/php-language-server-protocol/zipball/a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
+                "reference": "a9e113dbc7d849e35b8776da39edaf4313b7b6c9",
                 "shasum": ""
             },
             "require": {
@@ -1644,9 +1645,9 @@
             ],
             "support": {
                 "issues": "https://github.com/felixfbecker/php-language-server-protocol/issues",
-                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.2"
+                "source": "https://github.com/felixfbecker/php-language-server-protocol/tree/v1.5.3"
             },
-            "time": "2022-03-02T22:36:06+00:00"
+            "time": "2024-04-30T00:40:11+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -1712,20 +1713,20 @@
         },
         {
             "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
+                "reference": "f8b1c0173b22fa6ec77a81fe63e5b01eba7e6487",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3|^7.0|^8.0"
+                "php": "^7.4|^8.0"
             },
             "replace": {
                 "cordoval/hamcrest-php": "*",
@@ -1733,8 +1734,8 @@
                 "kodova/hamcrest-php": "*"
             },
             "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+                "phpunit/php-file-iterator": "^1.4 || ^2.0 || ^3.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -1757,9 +1758,9 @@
             ],
             "support": {
                 "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
-            "time": "2020-07-09T08:09:16+00:00"
+            "time": "2025-04-30T06:54:44+00:00"
         },
         {
             "name": "inpsyde/composer-assets-compiler",
@@ -1792,10 +1793,10 @@
             "extra": {
                 "class": "Inpsyde\\AssetsCompiler\\Composer\\Plugin",
                 "branch-alias": {
-                    "dev-master": "2.x-dev",
                     "dev-v1.x": "1.x-dev",
                     "dev-v2.x": "2.x-dev",
-                    "dev-v3.x": "3.x-dev"
+                    "dev-v3.x": "3.x-dev",
+                    "dev-master": "2.x-dev"
                 }
             },
             "autoload": {
@@ -1828,31 +1829,34 @@
         },
         {
             "name": "inpsyde/modularity",
-            "version": "1.10.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/inpsyde/modularity.git",
-                "reference": "2119d0e32706741a3c6dc0a85d908ec19ebf142e"
+                "reference": "e1ca1c81b7b663355906b586525d21ac5d46bc65"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/inpsyde/modularity/zipball/2119d0e32706741a3c6dc0a85d908ec19ebf142e",
-                "reference": "2119d0e32706741a3c6dc0a85d908ec19ebf142e",
+                "url": "https://api.github.com/repos/inpsyde/modularity/zipball/e1ca1c81b7b663355906b586525d21ac5d46bc65",
+                "reference": "e1ca1c81b7b663355906b586525d21ac5d46bc65",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": ">=7.4 <8.4",
+                "php": ">=7.4",
                 "psr/container": "^1.1.0 || ^2"
             },
             "require-dev": {
                 "brain/monkey": "^2.6.1",
-                "inpsyde/php-coding-standards": "^2@dev",
-                "inpsyde/wp-stubs-versions": "dev-latest",
+                "inpsyde/wp-stubs-versions": "6.7",
                 "mikey179/vfsstream": "^v1.6.11",
+                "phpstan/phpstan": "^2.1.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpstan/phpstan-mockery": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0.4",
                 "phpunit/phpunit": "^9.6.19",
-                "roots/wordpress-no-content": "@dev",
-                "vimeo/psalm": "^5.24.0"
+                "swissspidy/phpstan-no-private": "^v1.0.0",
+                "syde/phpcs": "^1.0.0"
             },
             "type": "library",
             "extra": {
@@ -1871,18 +1875,18 @@
             ],
             "authors": [
                 {
-                    "name": "Inpsyde GmbH",
-                    "email": "hello@inpsyde.com",
-                    "homepage": "https://inpsyde.com/",
+                    "name": "Syde GmbH",
+                    "email": "hello@syde.com",
+                    "homepage": "https://syde.com/",
                     "role": "Company"
                 }
             ],
             "description": "Modular PSR-11 implementation for WordPress plugins, themes or libraries.",
             "support": {
                 "issues": "https://github.com/inpsyde/modularity/issues",
-                "source": "https://github.com/inpsyde/modularity/tree/1.10.0"
+                "source": "https://github.com/inpsyde/modularity/tree/1.12.0"
             },
-            "time": "2024-09-03T10:42:50+00:00"
+            "time": "2025-05-09T12:13:17+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -1969,16 +1973,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -2017,7 +2021,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -2025,20 +2029,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.4.1",
+            "version": "v4.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "132c75c7dd83e45353ebb9c6c9f591952995bbf0"
+                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/132c75c7dd83e45353ebb9c6c9f591952995bbf0",
-                "reference": "132c75c7dd83e45353ebb9c6c9f591952995bbf0",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
+                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
                 "shasum": ""
             },
             "require": {
@@ -2074,22 +2078,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.4.1"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
             },
-            "time": "2024-01-31T06:18:54+00:00"
+            "time": "2024-09-08T10:13:13+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.1",
+            "version": "v4.19.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
                 "shasum": ""
             },
             "require": {
@@ -2098,7 +2102,7 @@
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -2130,9 +2134,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
             },
-            "time": "2024-03-17T08:10:35+00:00"
+            "time": "2024-09-29T15:01:53+00:00"
         },
         {
             "name": "openlss/lib-array2xml",
@@ -2532,21 +2536,22 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.5",
+            "version": "2.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082"
+                "reference": "5bfbbfbabb3df2b9a83e601de9153e4a7111962c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
-                "reference": "01c1ff2704a58e46f0cb1ca9d06aee07b3589082",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/5bfbbfbabb3df2b9a83e601de9153e4a7111962c",
+                "reference": "5bfbbfbabb3df2b9a83e601de9153e4a7111962c",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
             },
             "require-dev": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
@@ -2596,9 +2601,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-04-24T21:37:59+00:00"
+            "time": "2025-05-12T16:38:37+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2655,16 +2664,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.4.1",
+            "version": "5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c"
+                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
-                "reference": "9d07b3f7fdcf5efec5d1609cba3c19c5ea2bdc9c",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/92dde6a5919e34835c506ac8c523ef095a95ed62",
+                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62",
                 "shasum": ""
             },
             "require": {
@@ -2673,17 +2682,17 @@
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
                 "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.5",
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpstan": "^1.8",
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "vimeo/psalm": "^5.13"
+                "psalm/phar": "^5.26"
             },
             "type": "library",
             "extra": {
@@ -2713,29 +2722,29 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.4.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.2"
             },
-            "time": "2024-05-21T05:55:05+00:00"
+            "time": "2025-04-13T19:20:35+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.8.2",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "153ae662783729388a584b4361f2545e4d841e3c"
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/153ae662783729388a584b4361f2545e4d841e3c",
-                "reference": "153ae662783729388a584b4361f2545e4d841e3c",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
                 "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.13"
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
@@ -2771,9 +2780,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.8.2"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
             },
-            "time": "2024-02-23T11:10:43+00:00"
+            "time": "2024-11-09T15:12:26+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -2852,30 +2861,30 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.30.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "5ceb0e384997db59f38774bf79c2a6134252c08f"
+                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/5ceb0e384997db59f38774bf79c2a6134252c08f",
-                "reference": "5ceb0e384997db59f38774bf79c2a6134252c08f",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
+                "reference": "9b30d6fd026b2c132b3985ce6b23bec09ab3aa68",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^5.3.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
                 "symfony/process": "^5.2"
             },
             "type": "library",
@@ -2893,9 +2902,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.30.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.1.0"
             },
-            "time": "2024-08-29T09:54:52+00:00"
+            "time": "2025-02-19T13:28:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3218,16 +3227,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.20",
+            "version": "9.6.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "49d7820565836236411f5dc002d16dd689cde42f"
+                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/49d7820565836236411f5dc002d16dd689cde42f",
-                "reference": "49d7820565836236411f5dc002d16dd689cde42f",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
+                "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
                 "shasum": ""
             },
             "require": {
@@ -3238,11 +3247,11 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.0",
+                "myclabs/deep-copy": "^1.13.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.31",
+                "phpunit/php-code-coverage": "^9.2.32",
                 "phpunit/php-file-iterator": "^3.0.6",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.4",
@@ -3301,7 +3310,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.23"
             },
             "funding": [
                 {
@@ -3313,11 +3322,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-10T11:45:39+00:00"
+            "time": "2025-05-02T06:40:34+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -4284,16 +4301,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.10.2",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017"
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/86e5f5dd9a840c46810ebe5ff1885581c42a3017",
-                "reference": "86e5f5dd9a840c46810ebe5ff1885581c42a3017",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/5b5e3821314f947dd040c70f7992a64eac89025c",
+                "reference": "5b5e3821314f947dd040c70f7992a64eac89025c",
                 "shasum": ""
             },
             "require": {
@@ -4358,22 +4375,26 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-07-21T23:26:44+00:00"
+            "time": "2025-06-17T22:17:01+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.43",
+            "version": "v5.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e86f8554de667c16dde8aeb89a3990cfde924df9"
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e86f8554de667c16dde8aeb89a3990cfde924df9",
-                "reference": "e86f8554de667c16dde8aeb89a3990cfde924df9",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
                 "shasum": ""
             },
             "require": {
@@ -4443,7 +4464,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.43"
+                "source": "https://github.com/symfony/console/tree/v5.4.47"
             },
             "funding": [
                 {
@@ -4459,20 +4480,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T16:31:56+00:00"
+            "time": "2024-11-06T11:30:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.3",
+            "version": "v2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "80d075412b557d41002320b96a096ca65aa2c98d"
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/80d075412b557d41002320b96a096ca65aa2c98d",
-                "reference": "80d075412b557d41002320b96a096ca65aa2c98d",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
                 "shasum": ""
             },
             "require": {
@@ -4480,12 +4501,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -4510,7 +4531,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.3"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
             },
             "funding": [
                 {
@@ -4526,24 +4547,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-24T14:02:46+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.30.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-ctype": "*"
@@ -4554,8 +4575,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -4589,7 +4610,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4605,24 +4626,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.30.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a"
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/64647a7c30b2283f5d49b874d84a18fc22054b7a",
-                "reference": "64647a7c30b2283f5d49b874d84a18fc22054b7a",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -4630,8 +4651,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -4667,7 +4688,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4683,24 +4704,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.30.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb"
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/a95281b0be0d9ab48050ebd988b967875cdb9fdb",
-                "reference": "a95281b0be0d9ab48050ebd988b967875cdb9fdb",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "suggest": {
                 "ext-intl": "For best performance"
@@ -4708,8 +4729,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -4748,7 +4769,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4764,24 +4785,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.30.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-iconv": "*",
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -4792,8 +4814,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -4828,7 +4850,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4844,30 +4866,30 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-19T12:30:46+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.30.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1"
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/ec444d3f3f6505bb28d11afa41e75faadebc10a1",
-                "reference": "ec444d3f3f6505bb28d11afa41e75faadebc10a1",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -4904,7 +4926,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -4920,20 +4942,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.3",
+            "version": "v2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "a2329596ddc8fd568900e3fc76cba42489ecc7f3"
+                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a2329596ddc8fd568900e3fc76cba42489ecc7f3",
-                "reference": "a2329596ddc8fd568900e3fc76cba42489ecc7f3",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f37b419f7aea2e9abf10abd261832cace12e3300",
+                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300",
                 "shasum": ""
             },
             "require": {
@@ -4949,12 +4971,12 @@
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
                 "branch-alias": {
                     "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -4987,7 +5009,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.3"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.4"
             },
             "funding": [
                 {
@@ -5003,20 +5025,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-21T15:04:16+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.43",
+            "version": "v5.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "8be1d484951ff5ca995eaf8edcbcb8b9a5888450"
+                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/8be1d484951ff5ca995eaf8edcbcb8b9a5888450",
-                "reference": "8be1d484951ff5ca995eaf8edcbcb8b9a5888450",
+                "url": "https://api.github.com/repos/symfony/string/zipball/136ca7d72f72b599f2631aca474a4f8e26719799",
+                "reference": "136ca7d72f72b599f2631aca474a4f8e26719799",
                 "shasum": ""
             },
             "require": {
@@ -5073,7 +5095,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.43"
+                "source": "https://github.com/symfony/string/tree/v5.4.47"
             },
             "funding": [
                 {
@@ -5089,7 +5111,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-01T10:24:28+00:00"
+            "time": "2024-11-10T20:33:58+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5213,10 +5235,10 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev",
-                    "dev-3.x": "3.x-dev",
+                    "dev-1.x": "1.x-dev",
                     "dev-2.x": "2.x-dev",
-                    "dev-1.x": "1.x-dev"
+                    "dev-3.x": "3.x-dev",
+                    "dev-master": "4.x-dev"
                 }
             },
             "autoload": {
@@ -5251,16 +5273,16 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "a59a13791077fe3d44f90e7133eb68e7d22eaff2"
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/a59a13791077fe3d44f90e7133eb68e7d22eaff2",
-                "reference": "a59a13791077fe3d44f90e7133eb68e7d22eaff2",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
+                "reference": "24ac4c74f91ee2c193fa1aaa5c249cb0822809af",
                 "shasum": ""
             },
             "require": {
@@ -5319,7 +5341,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.1"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.2"
             },
             "funding": [
                 {
@@ -5331,7 +5353,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:52:34+00:00"
+            "time": "2025-04-30T23:37:27+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -5541,8 +5563,8 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "php-stubs/woocommerce-stubs": 0,
-        "php-stubs/wordpress-stubs": 0
+        "php-stubs/wordpress-stubs": 0,
+        "php-stubs/woocommerce-stubs": 0
     },
     "prefer-stable": true,
     "prefer-lowest": false,
@@ -5550,7 +5572,7 @@
         "php": "^7.4 | ^8.0",
         "ext-json": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
     },

--- a/modules.php
+++ b/modules.php
@@ -10,6 +10,7 @@ namespace WooCommerce\PayPalCommerce;
 use WooCommerce\PayPalCommerce\PayLaterBlock\PayLaterBlockModule;
 use WooCommerce\PayPalCommerce\PayLaterWCBlocks\PayLaterWCBlocksModule;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\PayLaterConfiguratorModule;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 
 return function ( string $root_dir ): iterable {
 	$modules_dir = "$root_dir/modules";
@@ -91,15 +92,7 @@ return function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-axo-block/module.php" )();
 	}
 
-	$show_new_ux    = '1' === get_option( 'woocommerce-ppcp-is-new-merchant' );
-	$preview_new_ux = '1' === getenv( 'PCP_SETTINGS_ENABLED' );
-
-	if ( apply_filters(
-		'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
-		$show_new_ux || $preview_new_ux
-	) ) {
-		$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
-	}
+	$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
 
 	return $modules;
 };

--- a/modules.php
+++ b/modules.php
@@ -10,7 +10,6 @@ namespace WooCommerce\PayPalCommerce;
 use WooCommerce\PayPalCommerce\PayLaterBlock\PayLaterBlockModule;
 use WooCommerce\PayPalCommerce\PayLaterWCBlocks\PayLaterWCBlocksModule;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\PayLaterConfiguratorModule;
-use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 
 return function ( string $root_dir ): iterable {
 	$modules_dir = "$root_dir/modules";
@@ -92,7 +91,12 @@ return function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-axo-block/module.php" )();
 	}
 
-	$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
+	if ( apply_filters(
+		'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
+		true
+	) ) {
+		$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
+	}
 
 	return $modules;
 };

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -28,7 +28,7 @@ class SettingsTabMapHelper {
 	 *
 	 * @var array<string, string>
 	 */
-	protected const THREE_D_SECURE_VALUES_MAP = array(
+	public const THREE_D_SECURE_VALUES_MAP = array(
 		'no-3d-secure'            => 'NO_3D_SECURE',
 		'only-required-3d-secure' => 'SCA_WHEN_REQUIRED',
 		'always-3d-secure'        => 'SCA_ALWAYS',
@@ -54,7 +54,7 @@ class SettingsTabMapHelper {
 			'blocks_final_review_enabled' => 'enable_pay_now',
 			'logging_enabled'             => 'enable_logging',
 			'vault_enabled'               => 'save_paypal_and_venmo',
-			'3d_secure_contingency'       => 'threeDSecure',
+			'3d_secure_contingency'       => 'three_d_secure',
 		);
 	}
 
@@ -96,7 +96,7 @@ class SettingsTabMapHelper {
 	 * @return string|null The mapped '3d_secure_contingency' setting value.
 	 */
 	protected function mapped_3d_secure_value( array $settings_model ): ?string {
-		$three_d_secure = $settings_model['threeDSecure'] ?? null;
+		$three_d_secure = $settings_model['three_d_secure'] ?? null;
 
 		if ( ! is_string( $three_d_secure ) ) {
 			return null;

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -3,12 +3,21 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const button = document.querySelector(
 		'.button.button-settings-switch-ui'
 	);
+	const link = document.querySelector( 'a.settings-switch-ui' );
 
-	if ( ! typeof config || ! button ) {
+	if ( ! typeof config || ( ! button && ! link ) ) {
 		return;
 	}
 
-	button.addEventListener( 'click', () => {
+	const handleClick = ( event ) => {
+		event.preventDefault();
+
+		const confirmed = confirm( config.confirmMessage );
+
+		if ( ! confirmed ) {
+			return;
+		}
+
 		fetch( config.endpoint, {
 			method: 'POST',
 			headers: {
@@ -30,5 +39,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			.catch( ( error ) => {
 				console.error( 'Error:', error );
 			} );
-	} );
+	};
+
+	if ( button ) {
+		button.addEventListener( 'click', handleClick );
+	}
+
+	if ( link ) {
+		link.addEventListener( 'click', handleClick );
+	}
 } );

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -5,7 +5,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	);
 	const link = document.querySelector( 'a.settings-switch-ui' );
 
-	if ( ! typeof config || ( ! button && ! link ) ) {
+	if ( typeof config === 'undefined' || ( ! button && ! link ) ) {
 		return;
 	}
 

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -78,7 +78,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 use WooCommerce\PayPalCommerce\Settings\Service\InternalRestService;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
 
-$services =  array(
+$services = array(
 	'settings.url'                                        => static function ( ContainerInterface $container ) : string {
 		/**
 		 * The path cannot be false.
@@ -371,27 +371,27 @@ $services =  array(
 		$partner_attribution = $container->get( 'api.helper.partner-attribution' );
 		return new ScriptDataHandler( $settings, $settings_url, $paylater_is_available, $store_country, $merchant_id, $button_language_choices, $partner_attribution );
 	},
-	'settings.service.data-migration'                    => static fn( ContainerInterface $c ): MigrationManager => new MigrationManager(
+	'settings.service.data-migration'                     => static fn( ContainerInterface $c ): MigrationManager => new MigrationManager(
 		$c->get( 'settings.service.data-migration.general-settings' ),
 		$c->get( 'settings.service.data-migration.settings-tab' ),
 		$c->get( 'settings.service.data-migration.styling' ),
 		$c->get( 'settings.service.data-migration.payment-settings' ),
 	),
-	'settings.service.data-migration.settings-tab'       => static fn( ContainerInterface $c ): SettingsTabMigration => new SettingsTabMigration(
+	'settings.service.data-migration.settings-tab'        => static fn( ContainerInterface $c ): SettingsTabMigration => new SettingsTabMigration(
 		$c->get( 'wcgateway.settings' ),
 		$c->get( 'settings.data.settings' ),
 		$c->get( 'compat.settings.settings_tab_map_helper' ),
 	),
-	'settings.service.data-migration.styling'       => static fn( ContainerInterface $c ): StylingSettingsMigration => new StylingSettingsMigration(
+	'settings.service.data-migration.styling'             => static fn( ContainerInterface $c ): StylingSettingsMigration => new StylingSettingsMigration(
 		$c->get( 'wcgateway.settings' ),
 		$c->get( 'settings.data.styling' ),
 	),
-	'settings.service.data-migration.payment-settings'       => static fn( ContainerInterface $c ): PaymentSettingsMigration => new PaymentSettingsMigration(
+	'settings.service.data-migration.payment-settings'    => static fn( ContainerInterface $c ): PaymentSettingsMigration => new PaymentSettingsMigration(
 		$c->get( 'wcgateway.settings' ),
 		$c->get( 'settings.data.payment' ),
 		$c->get( 'ppcp-local-apms.payment-methods' ),
 	),
-	'settings.service.data-migration.general-settings'       => static fn( ContainerInterface $c ): GeneralSettingsMigration => new GeneralSettingsMigration(
+	'settings.service.data-migration.general-settings'    => static fn( ContainerInterface $c ): GeneralSettingsMigration => new GeneralSettingsMigration(
 		$c->get( 'wcgateway.settings' ),
 		$c->get( 'settings.data.general' ),
 		$c->get( 'api.endpoint.partners' ),

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -52,6 +52,11 @@ use WooCommerce\PayPalCommerce\Settings\Service\ConnectionUrlGenerator;
 use WooCommerce\PayPalCommerce\Settings\Service\FeaturesEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\GeneralSettingsMigration;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\SettingsTabMigration;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\StylingSettingsMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\OnboardingUrlManager;
 use WooCommerce\PayPalCommerce\Settings\Service\ScriptDataHandler;
 use WooCommerce\PayPalCommerce\Settings\Service\TodosEligibilityService;
@@ -72,7 +77,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 use WooCommerce\PayPalCommerce\Settings\Service\InternalRestService;
 
-return array(
+$services =  array(
 	'settings.url'                                        => static function ( ContainerInterface $container ) : string {
 		/**
 		 * The path cannot be false.
@@ -146,20 +151,6 @@ return array(
 			'read' => $pay_later_config,
 			'save' => $save_config,
 		);
-	},
-	/**
-	 * Merchant connection details, which includes the connection status
-	 * (onboarding/connected) and connection-aware environment checks.
-	 * This is the preferred solution to check environment and connection state.
-	 */
-	'settings.connection-state'                           => static function ( ContainerInterface $container ) : ConnectionState {
-		$data = $container->get( 'settings.data.general' );
-		assert( $data instanceof GeneralSettings );
-
-		$is_connected = $data->is_merchant_connected();
-		$environment  = new Environment( $data->is_sandbox_merchant() );
-
-		return new ConnectionState( $is_connected, $environment );
 	},
 	/**
 	 * Returns details about the connected environment (production/sandbox).
@@ -379,14 +370,38 @@ return array(
 		$partner_attribution = $container->get( 'api.helper.partner-attribution' );
 		return new ScriptDataHandler( $settings, $settings_url, $paylater_is_available, $store_country, $merchant_id, $button_language_choices, $partner_attribution );
 	},
-	'settings.ajax.switch_ui'                             => static function ( ContainerInterface $container ) : SwitchSettingsUiEndpoint {
-		return new SwitchSettingsUiEndpoint(
-			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'button.request-data' ),
-			$container->get( 'settings.data.onboarding' ),
-			$container->get( 'api.merchant_id' ) !== ''
-		);
-	},
+	'settings.service.data-migration'                    => static fn( ContainerInterface $c ): MigrationManager => new MigrationManager(
+		$c->get( 'settings.service.data-migration.general-settings' ),
+		$c->get( 'settings.service.data-migration.settings-tab' ),
+		$c->get( 'settings.service.data-migration.styling' ),
+		$c->get( 'settings.service.data-migration.payment-settings' ),
+	),
+	'settings.service.data-migration.settings-tab'       => static fn( ContainerInterface $c ): SettingsTabMigration => new SettingsTabMigration(
+		$c->get( 'wcgateway.settings' ),
+		$c->get( 'settings.data.settings' ),
+		$c->get( 'compat.settings.settings_tab_map_helper' ),
+	),
+	'settings.service.data-migration.styling'       => static fn( ContainerInterface $c ): StylingSettingsMigration => new StylingSettingsMigration(
+		$c->get( 'wcgateway.settings' ),
+		$c->get( 'settings.data.styling' ),
+	),
+	'settings.service.data-migration.payment-settings'       => static fn( ContainerInterface $c ): PaymentSettingsMigration => new PaymentSettingsMigration(
+		$c->get( 'wcgateway.settings' ),
+		$c->get( 'settings.data.payment' ),
+		$c->get( 'ppcp-local-apms.payment-methods' ),
+	),
+	'settings.service.data-migration.general-settings'       => static fn( ContainerInterface $c ): GeneralSettingsMigration => new GeneralSettingsMigration(
+		$c->get( 'wcgateway.settings' ),
+		$c->get( 'settings.data.general' ),
+		$c->get( 'api.endpoint.partners' ),
+	),
+	'settings.ajax.switch_ui'                             => static fn ( ContainerInterface $c ): SwitchSettingsUiEndpoint => new SwitchSettingsUiEndpoint(
+		$c->get( 'woocommerce.logger.woocommerce' ),
+		$c->get( 'button.request-data' ),
+		$c->get( 'settings.data.onboarding' ),
+		$c->get( 'settings.service.data-migration' ),
+		$c->get( 'api.merchant_id' ) !== ''
+	),
 	'settings.rest.todos'                                 => static function ( ContainerInterface $container ) : TodosRestEndpoint {
 		return new TodosRestEndpoint(
 			$container->get( 'settings.data.todos' ),
@@ -664,3 +679,22 @@ return array(
 		);
 	},
 );
+
+if ( ! SettingsModule::should_use_the_old_ui() ) {
+	/**
+	 * Merchant connection details, which includes the connection status
+	 * (onboarding/connected) and connection-aware environment checks.
+	 * This is the preferred solution to check environment and connection state.
+	 */
+	$services['settings.connection-state'] = static function ( ContainerInterface $container ) : ConnectionState {
+		$data = $container->get( 'settings.data.general' );
+		assert( $data instanceof GeneralSettings );
+
+		$is_connected = $data->is_merchant_connected();
+		$environment  = new Environment( $data->is_sandbox_merchant() );
+
+		return new ConnectionState( $is_connected, $environment );
+	};
+}
+
+return $services;

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -52,7 +52,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\ConnectionUrlGenerator;
 use WooCommerce\PayPalCommerce\Settings\Service\FeaturesEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
-use WooCommerce\PayPalCommerce\Settings\Service\Migration\GeneralSettingsMigration;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\SettingsMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\SettingsTabMigration;
@@ -391,7 +391,7 @@ $services = array(
 		$c->get( 'settings.data.payment' ),
 		$c->get( 'ppcp-local-apms.payment-methods' ),
 	),
-	'settings.service.data-migration.general-settings'    => static fn( ContainerInterface $c ): GeneralSettingsMigration => new GeneralSettingsMigration(
+	'settings.service.data-migration.general-settings'    => static fn( ContainerInterface $c ): SettingsMigration => new SettingsMigration(
 		$c->get( 'wcgateway.settings' ),
 		$c->get( 'settings.data.general' ),
 		$c->get( 'api.endpoint.partners' ),

--- a/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
@@ -13,6 +13,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
 
 /**
  * Class SwitchSettingsUiEndpoint
@@ -24,26 +25,10 @@ class SwitchSettingsUiEndpoint {
 	public const ENDPOINT                      = 'ppcp-settings-switch-ui';
 	public const OPTION_NAME_SHOULD_USE_OLD_UI = 'woocommerce_ppcp-settings-should-use-old-ui';
 
-	/**
-	 * The RequestData.
-	 *
-	 * @var RequestData
-	 */
 	protected RequestData $request_data;
-
-	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
 	protected LoggerInterface $logger;
-
-	/**
-	 * The Onboarding profile.
-	 *
-	 * @var OnboardingProfile
-	 */
 	protected OnboardingProfile $onboarding_profile;
+	protected MigrationManager $settings_data_migration;
 
 	/**
 	 * True if the merchant is onboarded, otherwise false.
@@ -52,24 +37,18 @@ class SwitchSettingsUiEndpoint {
 	 */
 	protected bool $is_onboarded;
 
-	/**
-	 * SwitchSettingsUiEndpoint constructor.
-	 *
-	 * @param LoggerInterface   $logger The logger.
-	 * @param RequestData       $request_data The Request data.
-	 * @param OnboardingProfile $onboarding_profile The Onboarding profile.
-	 * @param bool              $is_onboarded True if the merchant is onboarded, otherwise false.
-	 */
 	public function __construct(
 		LoggerInterface $logger,
 		RequestData $request_data,
 		OnboardingProfile $onboarding_profile,
+		MigrationManager $settings_data_migration,
 		bool $is_onboarded
 	) {
-		$this->logger             = $logger;
-		$this->request_data       = $request_data;
-		$this->onboarding_profile = $onboarding_profile;
-		$this->is_onboarded       = $is_onboarded;
+		$this->logger                  = $logger;
+		$this->request_data            = $request_data;
+		$this->onboarding_profile      = $onboarding_profile;
+		$this->settings_data_migration = $settings_data_migration;
+		$this->is_onboarded            = $is_onboarded;
 	}
 
 	/**
@@ -81,18 +60,23 @@ class SwitchSettingsUiEndpoint {
 			return;
 		}
 
+		update_option( MigrationManager::OPTION_NAME_IS_MIGRATION_RUNNING, true );
+
 		try {
 			$this->request_data->read_request( $this->nonce() );
 			update_option( self::OPTION_NAME_SHOULD_USE_OLD_UI, 'no' );
 
-			if ( $this->is_onboarded ) {
-				$this->onboarding_profile->set_completed( true );
-				$this->onboarding_profile->save();
-			}
+			$this->onboarding_profile->set_completed( true );
+			$this->onboarding_profile->set_gateways_synced( true );
+			$this->onboarding_profile->save();
 
+			$this->settings_data_migration->migrate();
+
+			delete_option(MigrationManager::OPTION_NAME_IS_MIGRATION_RUNNING);
 			wp_send_json_success();
 		} catch ( Exception $error ) {
-			wp_send_json_error( array( 'message' => $error->getMessage() ), 500 );
+			delete_option(MigrationManager::OPTION_NAME_IS_MIGRATION_RUNNING);
+			wp_send_json_error(array('message' => $error->getMessage()), 500);
 		}
 	}
 

--- a/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
@@ -65,13 +65,13 @@ class SwitchSettingsUiEndpoint {
 			update_option( self::OPTION_NAME_SHOULD_USE_OLD_UI, 'no' );
 
 			$this->onboarding_profile->set_completed( true );
-			$this->onboarding_profile->set_gateways_refreshed(true);
+			$this->onboarding_profile->set_gateways_refreshed( true );
 			$this->onboarding_profile->save();
 
 			$this->settings_data_migration->migrate();
 			wp_send_json_success();
 		} catch ( Exception $error ) {
-			wp_send_json_error(array('message' => $error->getMessage()), 500);
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 500 );
 		}
 	}
 

--- a/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
@@ -60,22 +60,17 @@ class SwitchSettingsUiEndpoint {
 			return;
 		}
 
-		update_option( MigrationManager::OPTION_NAME_IS_MIGRATION_RUNNING, true );
-
 		try {
 			$this->request_data->read_request( $this->nonce() );
 			update_option( self::OPTION_NAME_SHOULD_USE_OLD_UI, 'no' );
 
 			$this->onboarding_profile->set_completed( true );
-			$this->onboarding_profile->set_gateways_synced( true );
+			$this->onboarding_profile->set_gateways_refreshed(true);
 			$this->onboarding_profile->save();
 
 			$this->settings_data_migration->migrate();
-
-			delete_option(MigrationManager::OPTION_NAME_IS_MIGRATION_RUNNING);
 			wp_send_json_success();
 		} catch ( Exception $error ) {
-			delete_option(MigrationManager::OPTION_NAME_IS_MIGRATION_RUNNING);
 			wp_send_json_error(array('message' => $error->getMessage()), 500);
 		}
 	}

--- a/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
@@ -66,6 +66,7 @@ class SwitchSettingsUiEndpoint {
 
 			$this->onboarding_profile->set_completed( true );
 			$this->onboarding_profile->set_gateways_refreshed( true );
+			$this->onboarding_profile->set_gateways_synced( true );
 			$this->onboarding_profile->save();
 
 			$this->settings_data_migration->migrate();

--- a/modules/ppcp-settings/src/Service/Migration/GeneralSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/GeneralSettingsMigration.php
@@ -32,8 +32,8 @@ class GeneralSettingsMigration {
 		GeneralSettings $general_settings,
 		PartnersEndpoint $partners_endpoint
 	) {
-		$this->settings = $settings;
-		$this->general_settings   = $general_settings;
+		$this->settings          = $settings;
+		$this->general_settings  = $general_settings;
 		$this->partners_endpoint = $partners_endpoint;
 	}
 
@@ -43,9 +43,9 @@ class GeneralSettingsMigration {
 	 * @return void
 	 */
 	public function migrate(): void {
-		if ( !$this->settings->has( 'client_id' )
-		|| !$this->settings->has( 'client_secret' )
-		|| !$this->settings->has( 'merchant_id' ) ) {
+		if ( ! $this->settings->has( 'client_id' )
+		|| ! $this->settings->has( 'client_secret' )
+		|| ! $this->settings->has( 'merchant_id' ) ) {
 			return;
 		}
 
@@ -72,29 +72,28 @@ class GeneralSettingsMigration {
 	 * @param SellerStatus $seller_status
 	 * @return 'business' | 'unknown' The merchant account type (SellerTypeEnum constant).
 	 */
-	protected function merchant_account_type(SellerStatus $seller_status): string
-	{
-		if ($this->has_capability_active($seller_status, 'COMMERCIAL_ENTITY')) {
+	protected function merchant_account_type( SellerStatus $seller_status ): string {
+		if ( $this->has_capability_active( $seller_status, 'COMMERCIAL_ENTITY' ) ) {
 			return SellerTypeEnum::BUSINESS;
 		}
 
-		$business_capabilities = [
+		$business_capabilities = array(
 			'CUSTOM_CARD_PROCESSING',
 			'CARD_PROCESSING_VIRTUAL_TERMINAL',
 			'FRAUD_TOOL_ACCESS',
 			'PAY_UPON_INVOICE',
-			'SEND_INVOICE'
-		];
+			'SEND_INVOICE',
+		);
 
-		foreach ($business_capabilities as $capability) {
-			if ($this->has_capability_active($seller_status, $capability)) {
+		foreach ( $business_capabilities as $capability ) {
+			if ( $this->has_capability_active( $seller_status, $capability ) ) {
 				return SellerTypeEnum::BUSINESS;
 			}
 		}
 
-		foreach ($seller_status->products() as $product) {
-			if ($product->name() === 'PPCP_CUSTOM' &&
-				$product->vetting_status() === 'SUBSCRIBED') {
+		foreach ( $seller_status->products() as $product ) {
+			if ( $product->name() === 'PPCP_CUSTOM' &&
+				$product->vetting_status() === 'SUBSCRIBED' ) {
 				return SellerTypeEnum::BUSINESS;
 			}
 		}
@@ -109,11 +108,10 @@ class GeneralSettingsMigration {
 	 * @param string       $capability_name
 	 * @return bool True if the capability is active, false otherwise.
 	 */
-	private function has_capability_active(SellerStatus $seller_status, string $capability_name): bool
-	{
-		foreach ($seller_status->capabilities() as $capability) {
-			if ($capability->name() === $capability_name &&
-				$capability->status() === 'ACTIVE') {
+	private function has_capability_active( SellerStatus $seller_status, string $capability_name ): bool {
+		foreach ( $seller_status->capabilities() as $capability ) {
+			if ( $capability->name() === $capability_name &&
+				$capability->status() === 'ACTIVE' ) {
 				return true;
 			}
 		}

--- a/modules/ppcp-settings/src/Service/Migration/GeneralSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/GeneralSettingsMigration.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Handles migration of general PayPal settings from legacy format to new structure.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service\Migration
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
+
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+/**
+ * Class GeneralSettingsMigration
+ *
+ * Handles migration of general plugin settings.
+ */
+class GeneralSettingsMigration {
+
+	protected Settings $settings;
+	protected GeneralSettings $general_settings;
+	protected PartnersEndpoint $partners_endpoint;
+
+	public function __construct(
+		Settings $settings,
+		GeneralSettings $general_settings,
+		PartnersEndpoint $partners_endpoint
+	) {
+		$this->settings = $settings;
+		$this->general_settings   = $general_settings;
+		$this->partners_endpoint = $partners_endpoint;
+	}
+
+	/**
+	 * Migrates legacy connection settings to new data structure.
+	 *
+	 * @return void
+	 */
+	public function migrate(): void {
+		if ( !$this->settings->has( 'client_id' )
+		|| !$this->settings->has( 'client_secret' )
+		|| !$this->settings->has( 'merchant_id' ) ) {
+			return;
+		}
+
+		$connection = new MerchantConnectionDTO(
+			$this->settings->has( 'sandbox_on' ) && $this->settings->get( 'sandbox_on' ),
+			$this->settings->get( 'client_id' ),
+			$this->settings->get( 'client_secret' ),
+			$this->settings->get( 'merchant_id' ),
+			$this->settings->has( 'merchant_email' ) ? $this->settings->get( 'merchant_email' ) : '',
+			$this->partners_endpoint->seller_status()->country(),
+			$this->merchant_account_type( $this->partners_endpoint->seller_status() )
+		);
+
+		$this->general_settings->set_merchant_data( $connection );
+		$this->general_settings->save();
+	}
+
+	/**
+	 * Determines the merchant account type based on seller status capabilities.
+	 *
+	 * Analyzes PayPal seller capabilities to determine if the account is a business
+	 * account or falls back to unknown.
+	 *
+	 * @param SellerStatus $seller_status
+	 * @return 'business' | 'unknown' The merchant account type (SellerTypeEnum constant).
+	 */
+	protected function merchant_account_type(SellerStatus $seller_status): string
+	{
+		if ($this->has_capability_active($seller_status, 'COMMERCIAL_ENTITY')) {
+			return SellerTypeEnum::BUSINESS;
+		}
+
+		$business_capabilities = [
+			'CUSTOM_CARD_PROCESSING',
+			'CARD_PROCESSING_VIRTUAL_TERMINAL',
+			'FRAUD_TOOL_ACCESS',
+			'PAY_UPON_INVOICE',
+			'SEND_INVOICE'
+		];
+
+		foreach ($business_capabilities as $capability) {
+			if ($this->has_capability_active($seller_status, $capability)) {
+				return SellerTypeEnum::BUSINESS;
+			}
+		}
+
+		foreach ($seller_status->products() as $product) {
+			if ($product->name() === 'PPCP_CUSTOM' &&
+				$product->vetting_status() === 'SUBSCRIBED') {
+				return SellerTypeEnum::BUSINESS;
+			}
+		}
+
+		return SellerTypeEnum::UNKNOWN;
+	}
+
+	/**
+	 * Checks if a specific capability is active for the seller.
+	 *
+	 * @param SellerStatus $seller_status
+	 * @param string       $capability_name
+	 * @return bool True if the capability is active, false otherwise.
+	 */
+	private function has_capability_active(SellerStatus $seller_status, string $capability_name): bool
+	{
+		foreach ($seller_status->capabilities() as $capability) {
+			if ($capability->name() === $capability_name &&
+				$capability->status() === 'ACTIVE') {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Provides functionality for settings migration management.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service\Migration
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
+
+/**
+ * Class MigrationManager
+ *
+ * Manages migration operations for plugin settings.
+ */
+class MigrationManager {
+
+	public const OPTION_NAME_IS_MIGRATION_RUNNING = 'woocommerce_ppcp-settings-is-migration-running';
+
+	protected GeneralSettingsMigration $general_settings_migration;
+	protected SettingsTabMigration $settings_tab_migration;
+	protected StylingSettingsMigration $styling_settings_migration;
+	protected PaymentSettingsMigration $payment_settings_migration;
+
+	public function __construct(
+		GeneralSettingsMigration $general_settings_migration,
+		SettingsTabMigration $settings_tab_migration,
+		StylingSettingsMigration $styling_settings_migration,
+		PaymentSettingsMigration $payment_settings_migration
+	) {
+		$this->general_settings_migration = $general_settings_migration;
+		$this->settings_tab_migration = $settings_tab_migration;
+		$this->styling_settings_migration = $styling_settings_migration;
+		$this->payment_settings_migration = $payment_settings_migration;
+	}
+
+	/**
+	 * Executes migration for all settings areas/tabs.
+	 *
+	 * @return void
+	 */
+	public function migrate(): void {
+		$this->general_settings_migration->migrate();
+		$this->settings_tab_migration->migrate();
+		$this->styling_settings_migration->migrate();
+		$this->payment_settings_migration->migrate();
+	}
+}

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -28,7 +28,7 @@ class MigrationManager {
 		PaymentSettingsMigration $payment_settings_migration
 	) {
 		$this->general_settings_migration = $general_settings_migration;
-		$this->settings_tab_migration = $settings_tab_migration;
+		$this->settings_tab_migration     = $settings_tab_migration;
 		$this->styling_settings_migration = $styling_settings_migration;
 		$this->payment_settings_migration = $payment_settings_migration;
 	}

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -16,8 +16,6 @@ namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
  */
 class MigrationManager {
 
-	public const OPTION_NAME_IS_MIGRATION_RUNNING = 'woocommerce_ppcp-settings-is-migration-running';
-
 	protected GeneralSettingsMigration $general_settings_migration;
 	protected SettingsTabMigration $settings_tab_migration;
 	protected StylingSettingsMigration $styling_settings_migration;

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -14,15 +14,15 @@ namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
  *
  * Manages migration operations for plugin settings.
  */
-class MigrationManager {
+class MigrationManager implements SettingsMigrationInterface {
 
-	protected GeneralSettingsMigration $general_settings_migration;
+	protected SettingsMigration $general_settings_migration;
 	protected SettingsTabMigration $settings_tab_migration;
 	protected StylingSettingsMigration $styling_settings_migration;
 	protected PaymentSettingsMigration $payment_settings_migration;
 
 	public function __construct(
-		GeneralSettingsMigration $general_settings_migration,
+		SettingsMigration $general_settings_migration,
 		SettingsTabMigration $settings_tab_migration,
 		StylingSettingsMigration $styling_settings_migration,
 		PaymentSettingsMigration $payment_settings_migration
@@ -33,11 +33,6 @@ class MigrationManager {
 		$this->payment_settings_migration = $payment_settings_migration;
 	}
 
-	/**
-	 * Executes migration for all settings areas/tabs.
-	 *
-	 * @return void
-	 */
 	public function migrate(): void {
 		$this->general_settings_migration->migrate();
 		$this->settings_tab_migration->migrate();

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Handles migration of payment settings from legacy format to new structure.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service\Migration
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
+
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+/**
+ * Class PaymentSettingsMigration
+ *
+ * Handles migration of payment settings.
+ */
+class PaymentSettingsMigration {
+
+	protected Settings $settings;
+	protected PaymentSettings $payment_settings;
+
+	/**
+	 * The list of local apm methods.
+	 *
+	 * @var array<string, array>
+	 */
+	protected array $local_apms;
+
+	public function __construct(
+		Settings $settings,
+		PaymentSettings $payment_settings,
+		array $local_apms
+	) {
+		$this->settings = $settings;
+		$this->payment_settings   = $payment_settings;
+		$this->local_apms = $local_apms;
+	}
+
+	/**
+	 * Migrates legacy payment settings to new data structure.
+	 *
+	 * @return void
+	 */
+	public function migrate(): void {
+		if ( $this->settings->has('disable_funding') ) {
+			$disable_funding = $this->settings->get('disable_funding');
+			if ( ! in_array('venmo', $disable_funding, true) ) {
+				$this->payment_settings->toggle_method_state( 'venmo', true );
+			}
+
+			foreach ( $this->local_apms as $apm ) {
+				if ( ! in_array($apm['id'], $disable_funding, true) ) {
+					$this->payment_settings->toggle_method_state( $apm['id'], true );
+				}
+			}
+		}
+
+		foreach ( $this->map() as $old_key => $method_name ) {
+			if ( $this->settings->has( $old_key ) && $this->settings->get( $old_key ) ) {
+				$this->payment_settings->toggle_method_state( $method_name, true );
+			}
+		}
+
+		$this->payment_settings->save();
+	}
+
+	/**
+	 * Maps old setting keys to new payment method settings names.
+	 *
+	 * @return array<string, string>
+	 */
+	protected function map(): array {
+		return array(
+			'dcc_enabled'              => CreditCardGateway::ID,
+			'axo_enabled'              => AxoGateway::ID,
+			'applepay_button_enabled'  => ApplePayGateway::ID,
+			'googlepay_button_enabled' => GooglePayGateway::ID,
+			'pay_later_button_enabled' => 'pay-later',
+		);
+	}
+}

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -38,9 +38,9 @@ class PaymentSettingsMigration {
 		PaymentSettings $payment_settings,
 		array $local_apms
 	) {
-		$this->settings = $settings;
-		$this->payment_settings   = $payment_settings;
-		$this->local_apms = $local_apms;
+		$this->settings         = $settings;
+		$this->payment_settings = $payment_settings;
+		$this->local_apms       = $local_apms;
 	}
 
 	/**
@@ -49,14 +49,14 @@ class PaymentSettingsMigration {
 	 * @return void
 	 */
 	public function migrate(): void {
-		if ( $this->settings->has('disable_funding') ) {
-			$disable_funding = $this->settings->get('disable_funding');
-			if ( ! in_array('venmo', $disable_funding, true) ) {
+		if ( $this->settings->has( 'disable_funding' ) ) {
+			$disable_funding = $this->settings->get( 'disable_funding' );
+			if ( ! in_array( 'venmo', $disable_funding, true ) ) {
 				$this->payment_settings->toggle_method_state( 'venmo', true );
 			}
 
 			foreach ( $this->local_apms as $apm ) {
-				if ( ! in_array($apm['id'], $disable_funding, true) ) {
+				if ( ! in_array( $apm['id'], $disable_funding, true ) ) {
 					$this->payment_settings->toggle_method_state( $apm['id'], true );
 				}
 			}

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -21,7 +21,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  *
  * Handles migration of payment settings.
  */
-class PaymentSettingsMigration {
+class PaymentSettingsMigration implements SettingsMigrationInterface {
 
 	protected Settings $settings;
 	protected PaymentSettings $payment_settings;
@@ -43,11 +43,6 @@ class PaymentSettingsMigration {
 		$this->local_apms       = $local_apms;
 	}
 
-	/**
-	 * Migrates legacy payment settings to new data structure.
-	 *
-	 * @return void
-	 */
 	public function migrate(): void {
 		if ( $this->settings->has( 'disable_funding' ) ) {
 			$disable_funding = $this->settings->get( 'disable_funding' );
@@ -72,7 +67,7 @@ class PaymentSettingsMigration {
 	}
 
 	/**
-	 * Maps old setting keys to new payment method settings names.
+	 * Maps old setting keys to new payment method names.
 	 *
 	 * @return array<string, string>
 	 */

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -47,7 +47,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		$allow_local_apm_gateways = $this->settings->has( 'allow_local_apm_gateways' ) && $this->settings->get( 'allow_local_apm_gateways' );
 
 		if ( $this->settings->has( 'disable_funding' ) ) {
-			$disable_funding = $this->settings->get( 'disable_funding' );
+			$disable_funding = (array) $this->settings->get( 'disable_funding' );
 			if ( ! in_array( 'venmo', $disable_funding, true ) ) {
 				$this->payment_settings->toggle_method_state( 'venmo', true );
 			}

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -44,15 +44,19 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	}
 
 	public function migrate(): void {
+		$allow_local_apm_gateways = $this->settings->has( 'allow_local_apm_gateways' ) && $this->settings->get( 'allow_local_apm_gateways' );
+
 		if ( $this->settings->has( 'disable_funding' ) ) {
 			$disable_funding = $this->settings->get( 'disable_funding' );
 			if ( ! in_array( 'venmo', $disable_funding, true ) ) {
 				$this->payment_settings->toggle_method_state( 'venmo', true );
 			}
 
-			foreach ( $this->local_apms as $apm ) {
-				if ( ! in_array( $apm['id'], $disable_funding, true ) ) {
-					$this->payment_settings->toggle_method_state( $apm['id'], true );
+			if ( ! $allow_local_apm_gateways ) {
+				foreach ( $this->local_apms as $apm ) {
+					if ( ! in_array( $apm['id'], $disable_funding, true ) ) {
+						$this->payment_settings->toggle_method_state( $apm['id'], true );
+					}
 				}
 			}
 		}

--- a/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Handles migration of general PayPal settings from legacy format to new structure.
+ * Handles migration of general settings from legacy format to new structure.
  *
  * @package WooCommerce\PayPalCommerce\Settings\Service\Migration
  */
@@ -21,7 +21,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  *
  * Handles migration of general plugin settings.
  */
-class GeneralSettingsMigration {
+class SettingsMigration implements SettingsMigrationInterface {
 
 	protected Settings $settings;
 	protected GeneralSettings $general_settings;
@@ -37,11 +37,6 @@ class GeneralSettingsMigration {
 		$this->partners_endpoint = $partners_endpoint;
 	}
 
-	/**
-	 * Migrates legacy connection settings to new data structure.
-	 *
-	 * @return void
-	 */
 	public function migrate(): void {
 		if ( ! $this->settings->has( 'client_id' )
 		|| ! $this->settings->has( 'client_secret' )

--- a/modules/ppcp-settings/src/Service/Migration/SettingsMigrationInterface.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsMigrationInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Interface for settings migration classes.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service\Migration
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
+
+/**
+ * Interface SettingsMigrationInterface
+ *
+ * Defines the contract for all settings migration classes.
+ */
+interface SettingsMigrationInterface {
+	/**
+	 * Migrates legacy settings to new data structure.
+	 *
+	 * @return void
+	 */
+	public function migrate(): void;
+}

--- a/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Handles migration of settings tab settings from legacy format to new structure.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service\Migration
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
+
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\PurchaseUnitSanitizer;
+use WooCommerce\PayPalCommerce\Compat\Settings\SettingsTabMapHelper;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+/**
+ * Class SettingsTabMigration
+ *
+ * Handles migration of settings tab settings.
+ */
+class SettingsTabMigration {
+
+	protected Settings $settings;
+	protected SettingsModel $settings_tab;
+	protected SettingsTabMapHelper $settings_tab_map_helper;
+
+	public function __construct(
+		Settings $settings,
+		SettingsModel $settings_tab,
+		SettingsTabMapHelper $settings_tab_map_helper
+	) {
+		$this->settings = $settings;
+		$this->settings_tab   = $settings_tab;
+		$this->settings_tab_map_helper = $settings_tab_map_helper;
+	}
+
+	/**
+	 * Migrates legacy settings tab settings to new data structure.
+	 *
+	 * @return void
+	 */
+	public function migrate(): void {
+		$data = array();
+
+		foreach ($this->settings_tab_map_helper->map() as $old_key => $new_key) {
+			if ( ! $this->settings->has( $old_key ) ) {
+				continue;
+			}
+
+			switch ( $old_key ) {
+				case 'subtotal_mismatch_behavior':
+					$value = $this->settings->get( $old_key );
+					$data[$new_key] = $value === PurchaseUnitSanitizer::MODE_EXTRA_LINE ? 'correction' : 'no_details';
+					break;
+				case 'landing_page':
+					$value = $this->settings->get( $old_key );
+					$data[$new_key] = $value === ExperienceContext::LANDING_PAGE_LOGIN
+						? 'login'
+						: ( $value === ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT
+							? 'guest_checkout'
+							: 'any'
+						);
+					break;
+				case 'intent':
+					$value = $this->settings->get( $old_key );
+					$data['authorize_only']         = $value === 'AUTHORIZE';
+					$data['capture_virtual_orders'] = $value === 'CAPTURE';
+					break;
+				case 'blocks_final_review_enabled':
+					$data[$new_key] = ! $this->settings->get( $old_key );
+					break;
+				default:
+					$data[$new_key] = $this->settings->get( $old_key );
+			}
+		}
+
+		$this->settings_tab->from_array($data);
+		$this->settings_tab->save();
+	}
+}

--- a/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
@@ -31,8 +31,8 @@ class SettingsTabMigration {
 		SettingsModel $settings_tab,
 		SettingsTabMapHelper $settings_tab_map_helper
 	) {
-		$this->settings = $settings;
-		$this->settings_tab   = $settings_tab;
+		$this->settings                = $settings;
+		$this->settings_tab            = $settings_tab;
 		$this->settings_tab_map_helper = $settings_tab_map_helper;
 	}
 
@@ -44,19 +44,19 @@ class SettingsTabMigration {
 	public function migrate(): void {
 		$data = array();
 
-		foreach ($this->settings_tab_map_helper->map() as $old_key => $new_key) {
+		foreach ( $this->settings_tab_map_helper->map() as $old_key => $new_key ) {
 			if ( ! $this->settings->has( $old_key ) ) {
 				continue;
 			}
 
 			switch ( $old_key ) {
 				case 'subtotal_mismatch_behavior':
-					$value = $this->settings->get( $old_key );
-					$data[$new_key] = $value === PurchaseUnitSanitizer::MODE_EXTRA_LINE ? 'correction' : 'no_details';
+					$value            = $this->settings->get( $old_key );
+					$data[ $new_key ] = $value === PurchaseUnitSanitizer::MODE_EXTRA_LINE ? 'correction' : 'no_details';
 					break;
 				case 'landing_page':
-					$value = $this->settings->get( $old_key );
-					$data[$new_key] = $value === ExperienceContext::LANDING_PAGE_LOGIN
+					$value            = $this->settings->get( $old_key );
+					$data[ $new_key ] = $value === ExperienceContext::LANDING_PAGE_LOGIN
 						? 'login'
 						: ( $value === ExperienceContext::LANDING_PAGE_GUEST_CHECKOUT
 							? 'guest_checkout'
@@ -64,19 +64,19 @@ class SettingsTabMigration {
 						);
 					break;
 				case 'intent':
-					$value = $this->settings->get( $old_key );
+					$value                          = $this->settings->get( $old_key );
 					$data['authorize_only']         = $value === 'AUTHORIZE';
 					$data['capture_virtual_orders'] = $value === 'CAPTURE';
 					break;
 				case 'blocks_final_review_enabled':
-					$data[$new_key] = ! $this->settings->get( $old_key );
+					$data[ $new_key ] = ! $this->settings->get( $old_key );
 					break;
 				default:
-					$data[$new_key] = $this->settings->get( $old_key );
+					$data[ $new_key ] = $this->settings->get( $old_key );
 			}
 		}
 
-		$this->settings_tab->from_array($data);
+		$this->settings_tab->from_array( $data );
 		$this->settings_tab->save();
 	}
 }

--- a/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
@@ -20,7 +20,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  *
  * Handles migration of settings tab settings.
  */
-class SettingsTabMigration {
+class SettingsTabMigration implements SettingsMigrationInterface {
 
 	protected Settings $settings;
 	protected SettingsModel $settings_tab;
@@ -36,11 +36,6 @@ class SettingsTabMigration {
 		$this->settings_tab_map_helper = $settings_tab_map_helper;
 	}
 
-	/**
-	 * Migrates legacy settings tab settings to new data structure.
-	 *
-	 * @return void
-	 */
 	public function migrate(): void {
 		$data = array();
 

--- a/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
@@ -60,11 +60,16 @@ class SettingsTabMigration implements SettingsMigrationInterface {
 					break;
 				case 'intent':
 					$value                          = $this->settings->get( $old_key );
-					$data['authorize_only']         = $value === 'AUTHORIZE';
-					$data['capture_virtual_orders'] = $value === 'CAPTURE';
+					$data['authorize_only']         = $value === 'authorize';
+					$data['capture_virtual_orders'] = $value === 'capture';
 					break;
 				case 'blocks_final_review_enabled':
 					$data[ $new_key ] = ! $this->settings->get( $old_key );
+					break;
+				case '3d_secure_contingency':
+					$value                    = $this->settings->get( $old_key );
+					$old_to_new_3d_secure_map = array_flip( SettingsTabMapHelper::THREE_D_SECURE_VALUES_MAP );
+					$data[ $new_key ]         = $old_to_new_3d_secure_map[ $value ] ?? 'NO_3D_SECURE';
 					break;
 				default:
 					$data[ $new_key ] = $this->settings->get( $old_key );

--- a/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
@@ -26,9 +26,9 @@ class StylingSettingsMigration {
 	protected Settings $settings;
 	protected StylingSettings $styling_settings;
 
-	public function __construct( Settings $settings,  StylingSettings $styling_settings ) {
-		$this->settings = $settings;
-		$this->styling_settings   = $styling_settings;
+	public function __construct( Settings $settings, StylingSettings $styling_settings ) {
+		$this->settings         = $settings;
+		$this->styling_settings = $styling_settings;
 	}
 
 	/**
@@ -39,12 +39,12 @@ class StylingSettingsMigration {
 	public function migrate(): void {
 		$location_styles = array();
 
-		$styling_per_location = $this->settings->has('smart_button_enable_styling_per_location') && $this->settings->get('smart_button_enable_styling_per_location');
+		$styling_per_location = $this->settings->has( 'smart_button_enable_styling_per_location' ) && $this->settings->get( 'smart_button_enable_styling_per_location' );
 
 		foreach ( $this->locations_map() as $old_location => $new_location ) {
 			$context = $styling_per_location ? $old_location : 'general';
 
-			$location_styles[$new_location] = new LocationStylingDTO(
+			$location_styles[ $new_location ] = new LocationStylingDTO(
 				$new_location,
 				$this->is_button_enabled_for_location( $old_location, 'smart' ),
 				$this->enabled_methods( $old_location ),
@@ -70,15 +70,15 @@ class StylingSettingsMigration {
 	 * @return string[] The list of enabled payment method IDs.
 	 */
 	protected function enabled_methods( string $location ): array {
-		$methods = array(PayPalGateway::ID);
+		$methods = array( PayPalGateway::ID );
 
 		if ( $this->is_button_enabled_for_location( $location, 'pay_later' ) ) {
 			$methods[] = 'pay-later';
 		}
 
-		if ( $this->settings->has('disable_funding') ) {
-			$disable_funding = $this->settings->get('disable_funding');
-			if ( ! in_array('venmo', $disable_funding, true) ) {
+		if ( $this->settings->has( 'disable_funding' ) ) {
+			$disable_funding = $this->settings->get( 'disable_funding' );
+			if ( ! in_array( 'venmo', $disable_funding, true ) ) {
 				$methods[] = 'venmo';
 			}
 		}

--- a/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
@@ -48,10 +48,10 @@ class StylingSettingsMigration {
 				$new_location,
 				$this->is_button_enabled_for_location( $old_location, 'smart' ),
 				$this->enabled_methods( $old_location ),
-				$this->style_for_context( 'shape', $context ) ?? 'rect',
-				$this->style_for_context( 'label', $context ) ?? 'pay',
-				$this->style_for_context( 'color', $context ) ?? 'gold',
-				$this->style_for_context( 'layout', $context ) ?? 'vertical',
+				(string) ( $this->style_for_context( 'shape', $context ) ?? 'rect' ),
+				(string) ( $this->style_for_context( 'label', $context ) ?? 'pay' ),
+				(string) ( $this->style_for_context( 'color', $context ) ?? 'gold' ),
+				(string) ( $this->style_for_context( 'layout', $context ) ?? 'vertical' ),
 				(bool) ( $this->style_for_context( 'tagline', $context ) ?? false )
 			);
 		}
@@ -139,7 +139,7 @@ class StylingSettingsMigration {
 	 *
 	 * @param string $style    The name of the style property ('shape', 'label', 'color', etc.).
 	 * @param string $location The location name ('cart', 'checkout', etc.).
-	 * @return string|int|null The style value or null if not found.
+	 * @return string|bool|null The style value or null if not found.
 	 */
 	private function style_for_context( string $style, string $location ) {
 		if ( $location === 'cart' ) {
@@ -155,7 +155,7 @@ class StylingSettingsMigration {
 	 * Retrieves a style property value from legacy settings.
 	 *
 	 * @param string $key The style property key in the settings.
-	 * @return string|int|null The style value or null if not found.
+	 * @return string|bool|null The style value or null if not found.
 	 */
 	private function get_style_value( string $key ) {
 		if ( ! $this->settings->has( $key ) ) {

--- a/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Handles migration of styling settings from legacy format to new structure.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service\Migration
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
+
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+
+/**
+ * Class StylingSettingsMigration
+ *
+ * Handles migration of styling settings.
+ */
+class StylingSettingsMigration {
+
+	protected Settings $settings;
+	protected StylingSettings $styling_settings;
+
+	public function __construct( Settings $settings,  StylingSettings $styling_settings ) {
+		$this->settings = $settings;
+		$this->styling_settings   = $styling_settings;
+	}
+
+	/**
+	 * Migrates legacy styling settings to new data structure.
+	 *
+	 * @return void
+	 */
+	public function migrate(): void {
+		$location_styles = array();
+
+		$styling_per_location = $this->settings->has('smart_button_enable_styling_per_location') && $this->settings->get('smart_button_enable_styling_per_location');
+
+		foreach ( $this->locations_map() as $old_location => $new_location ) {
+			$context = $styling_per_location ? $old_location : 'general';
+
+			$location_styles[$new_location] = new LocationStylingDTO(
+				$new_location,
+				$this->is_button_enabled_for_location( $old_location, 'smart' ),
+				$this->enabled_methods( $old_location ),
+				$this->style_for_context( 'shape', $context ) ?? 'rect',
+				$this->style_for_context( 'label', $context ) ?? 'pay',
+				$this->style_for_context( 'color', $context ) ?? 'gold',
+				$this->style_for_context( 'layout', $context ) ?? 'vertical',
+				(bool) ( $this->style_for_context( 'tagline', $context ) ?? false )
+			);
+		}
+
+		$this->styling_settings->from_array( $location_styles );
+		$this->styling_settings->save();
+	}
+
+	/**
+	 * Determines which payment methods are enabled for a specific location.
+	 *
+	 * Checks legacy settings to determine which payment methods (PayPal, Pay Later,
+	 * Venmo, Apple Pay, Google Pay) should be enabled for the given location.
+	 *
+	 * @param string $location The location name ('cart', 'checkout', etc.).
+	 * @return string[] The list of enabled payment method IDs.
+	 */
+	protected function enabled_methods( string $location ): array {
+		$methods = array(PayPalGateway::ID);
+
+		if ( $this->is_button_enabled_for_location( $location, 'pay_later' ) ) {
+			$methods[] = 'pay-later';
+		}
+
+		if ( $this->settings->has('disable_funding') ) {
+			$disable_funding = $this->settings->get('disable_funding');
+			if ( ! in_array('venmo', $disable_funding, true) ) {
+				$methods[] = 'venmo';
+			}
+		}
+
+		if ( $this->settings->has( 'applepay_button_enabled' ) && $this->settings->get( 'applepay_button_enabled' ) ) {
+			$methods[] = ApplePayGateway::ID;
+		}
+
+		if ( $this->settings->has( 'googlepay_button_enabled' ) && $this->settings->get( 'googlepay_button_enabled' ) ) {
+			$methods[] = GooglePayGateway::ID;
+		}
+
+		return $methods;
+	}
+
+	/**
+	 * Checks if a specific button type is enabled for a given location.
+	 *
+	 * @param string $location The location name ('cart', 'checkout', etc.).
+	 * @param string $type     The button type ('smart', 'pay_later', etc.).
+	 * @return bool True if the button is enabled for the location, false otherwise.
+	 */
+	protected function is_button_enabled_for_location( string $location, string $type ): bool {
+		$key = "{$type}_button_locations";
+		if ( ! $this->settings->has( $key ) ) {
+			return false;
+		}
+
+		$enabled_locations = $this->settings->get( $key );
+
+		if ( $location === 'cart' ) {
+			return in_array( $location, $enabled_locations, true ) || in_array( 'cart-block', $enabled_locations, true );
+		}
+
+		return in_array( $location, $enabled_locations, true );
+	}
+
+	/**
+	 * Returns a mapping of old button location names to new settings location names.
+	 *
+	 * @return string[] The mapping of old location names to new location names.
+	 */
+	protected function locations_map(): array {
+		return array(
+			'product'                => 'product',
+			'cart'                   => 'cart',
+			'checkout'               => 'classic_checkout',
+			'mini-cart'              => 'mini_cart',
+			'checkout-block-express' => 'express_checkout',
+		);
+	}
+
+	/**
+	 * Determines the style value for a given property in a given context.
+	 *
+	 * Looks up style values with context-specific fallbacks. For cart context,
+	 * also checks cart-block variants.
+	 *
+	 * @param string $style    The name of the style property ('shape', 'label', 'color', etc.).
+	 * @param string $location The location name ('cart', 'checkout', etc.).
+	 * @return string|int|null The style value or null if not found.
+	 */
+	private function style_for_context( string $style, string $location ) {
+		if ( $location === 'cart' ) {
+			return $this->get_style_value( "button_{$location}_{$style}" )
+				?? $this->get_style_value( "button_cart-block_{$style}" );
+		}
+
+		return $this->get_style_value( "button_{$location}_{$style}" )
+			?? $this->get_style_value( "button_{$style}" );
+	}
+
+	/**
+	 * Retrieves a style property value from legacy settings.
+	 *
+	 * @param string $key The style property key in the settings.
+	 * @return string|int|null The style value or null if not found.
+	 */
+	private function get_style_value( string $key ) {
+		if ( ! $this->settings->has( $key ) ) {
+			return null;
+		}
+		return $this->settings->get( $key );
+	}
+}

--- a/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
@@ -21,7 +21,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  *
  * Handles migration of styling settings.
  */
-class StylingSettingsMigration {
+class StylingSettingsMigration implements SettingsMigrationInterface {
 
 	protected Settings $settings;
 	protected StylingSettings $styling_settings;
@@ -31,11 +31,6 @@ class StylingSettingsMigration {
 		$this->styling_settings = $styling_settings;
 	}
 
-	/**
-	 * Migrates legacy styling settings to new data structure.
-	 *
-	 * @return void
-	 */
 	public function migrate(): void {
 		$location_styles = array();
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -35,6 +35,7 @@ use WooCommerce\PayPalCommerce\Settings\Handler\ConnectionListener;
 use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\PathRepository;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
@@ -70,7 +71,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		}
 
 		// Existing merchants can opt-in to see the new UI.
-		$opt_out_choice = 'yes' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI );
+		$opt_out_choice = 'yes' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI );;
 
 		return apply_filters(
 			'woocommerce_paypal_payments_should_use_the_old_ui',
@@ -135,15 +136,14 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				}
 			);
 
-			$endpoint = $container->get( 'settings.ajax.switch_ui' ) ? $container->get( 'settings.ajax.switch_ui' ) : null;
-			assert( $endpoint instanceof SwitchSettingsUiEndpoint );
-
 			add_action(
 				'wc_ajax_' . SwitchSettingsUiEndpoint::ENDPOINT,
-				array(
-					$endpoint,
-					'handle_request',
-				)
+				static function () use ($container): void {
+					$endpoint = $container->get( 'settings.ajax.switch_ui' ) ? $container->get( 'settings.ajax.switch_ui' ) : null;
+					assert( $endpoint instanceof SwitchSettingsUiEndpoint );
+
+					$endpoint->handle_request();
+				}
 			);
 
 			return true;

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -72,7 +72,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		}
 
 		// Existing merchants can opt-in to see the new UI.
-		$opt_out_choice = 'yes' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI );;
+		$opt_out_choice = 'yes' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI );
 
 		return apply_filters(
 			'woocommerce_paypal_payments_should_use_the_old_ui',
@@ -139,7 +139,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 			add_action(
 				'wc_ajax_' . SwitchSettingsUiEndpoint::ENDPOINT,
-				static function () use ($container): void {
+				static function () use ( $container ): void {
 					$endpoint = $container->get( 'settings.ajax.switch_ui' ) ? $container->get( 'settings.ajax.switch_ui' ) : null;
 					assert( $endpoint instanceof SwitchSettingsUiEndpoint );
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -149,8 +149,12 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 						'ppcp-switch-settings-ui',
 						'ppcpSwitchSettingsUi',
 						array(
-							'endpoint' => \WC_AJAX::get_endpoint( SwitchSettingsUiEndpoint::ENDPOINT ),
-							'nonce'    => wp_create_nonce( SwitchSettingsUiEndpoint::nonce() ),
+							'endpoint'       => \WC_AJAX::get_endpoint( SwitchSettingsUiEndpoint::ENDPOINT ),
+							'nonce'          => wp_create_nonce( SwitchSettingsUiEndpoint::nonce() ),
+							'confirmMessage' => __(
+								'Are you sure you want to switch to the new settings interface?This action cannot be undone.',
+								'woocommerce-paypal-payments'
+							),
 						)
 					);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -11,6 +11,8 @@ namespace WooCommerce\PayPalCommerce\Settings;
 
 use WC_Payment_Gateway;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
+use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
@@ -98,6 +100,29 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					'<a href="#" class="button button-settings-switch-ui">%s</a>',
 					esc_html__( 'Switch to new settings UI', 'woocommerce-paypal-payments' )
 				)
+			);
+
+			/**
+			 * Adds new settings discovery notice.
+			 *
+			 * @param Message[] $notices
+			 * @return Message[]
+			 */
+			add_filter(
+				Repository::NOTICES_FILTER,
+				static function ( array $notices ): array {
+					$message = sprintf(
+					// translators: %1$s is the URL for the startup guide.
+						__(
+							'🎉 <strong>Discover the new PayPal Payments settings!</strong> Enjoy a cleaner, faster interface. Check out the <a href="%1$s" target="_blank">Startup Guide</a>, then click <a class="settings-switch-ui" href=""><strong>Switch to New Settings</strong></a> to activate it.',
+							'woocommerce-paypal-payments'
+						),
+						'https://woocommerce.com/document/woocommerce-paypal-payments/paypal-payments-startup-guide/'
+					);
+
+					$notices[] = new Message( $message, 'info', false, 'ppcp-notice-wrapper' );
+					return $notices;
+				}
 			);
 
 			add_action(

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -97,8 +97,9 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			add_filter(
 				'woocommerce_paypal_payments_inside_settings_page_header',
 				static fn() : string => sprintf(
-					'<a href="#" class="button button-settings-switch-ui">%s</a>',
-					esc_html__( 'Switch to new settings UI', 'woocommerce-paypal-payments' )
+					'<button type="button" class="button button-settings-switch-ui" aria-describedby="switch-ui-desc">%s</button><span id="switch-ui-desc" class="screen-reader-text">%s</span>',
+					esc_html__( 'Switch to new settings UI', 'woocommerce-paypal-payments' ),
+					esc_html__( 'This action will permanently switch to the new settings interface and cannot be undone', 'woocommerce-paypal-payments' )
 				)
 			);
 
@@ -114,7 +115,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					$message = sprintf(
 					// translators: %1$s is the URL for the startup guide.
 						__(
-							'🎉 <strong>Discover the new PayPal Payments settings!</strong> Enjoy a cleaner, faster interface. Check out the <a href="%1$s" target="_blank">Startup Guide</a>, then click <a class="settings-switch-ui" href=""><strong>Switch to New Settings</strong></a> to activate it.',
+							'🎉 <strong>Discover the new PayPal Payments settings!</strong> Enjoy a cleaner, faster interface. Check out the <a href="%1$s" target="_blank">Startup Guide</a>, then click <a href="#" class="settings-switch-ui" role="button" aria-describedby="switch-ui-desc"><strong>Switch to New Settings</strong></a> to activate it.',
 							'woocommerce-paypal-payments'
 						),
 						'https://woocommerce.com/document/woocommerce-paypal-payments/paypal-payments-startup-guide/'

--- a/tests/PHPUnit/ModularTestCase.php
+++ b/tests/PHPUnit/ModularTestCase.php
@@ -32,6 +32,8 @@ class ModularTestCase extends TestCase
         when('WC')->justReturn((object) [
         	'session' => null,
 		]);
+	    when('is_admin')->justReturn(true);
+	    when('sanitize_key')->returnArg();
 
 		global $wpdb;
 		$wpdb = \Mockery::mock(\stdClass::class);

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -11,5 +11,6 @@ require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway_CC.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Ajax.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Checkout.php';
 require_once TESTS_ROOT_DIR . '/stubs/Task.php';
+require_once TESTS_ROOT_DIR . '/stubs/DefaultPaymentGateways.php';
 
 Hamcrest\Util::registerGlobalFunctions();

--- a/tests/stubs/DefaultPaymentGateways.php
+++ b/tests/stubs/DefaultPaymentGateways.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Automattic\WooCommerce\Admin\Features\PaymentGatewaySuggestions;
+
+class DefaultPaymentGateways
+{
+	public static function get_all(): array
+	{
+		return [];
+	}
+
+	public static function get_wcpay_countries(): array
+	{
+		return ['US', 'CA', 'GB', 'AU', 'DE', 'FR'];
+	}
+}


### PR DESCRIPTION
## Issue Description
Update 3.0.0 launched the new UI for fresh plugin installations. We now need to implement mechanisms for existing users to migrate to the new UI.

**Phase 1 Requirements:**
Merchants using the legacy UX will see a banner on all admin panel pages with:
- **Learn more link** - directing to new experience documentation  
- **"Switch to New Settings" button** - for merchant opt-in migration

**Implementation Goals:**
- Detect if merchant is using legacy UX
- Display migration banner on admin panel pages
- Handle migration button click to save preference and reload with new UI

## Solution Overview
This PR implements:

1. **Legacy UX Detection** - Check if user should see old vs new interface
2. **Admin Banner Display** - Show migration notice on relevant admin pages
3. **Confirmation Flow** - Warn users that migration cannot be undone
4. **Migration Handler** - Process user opt-in and switch to new UI

## Technical Implementation
- Added banner notice with translatable text and proper links
- Implemented JavaScript handler for migration button with confirmation
- Created migration endpoint to save settings with the new models

## Testing
**Scenario: Old settings UI active**

**GIVEN** the old settings UI is active
**WHEN** the PayPal Payments settings page is visited
**THEN** a dismissable banner is visible, which prompts the user to activate the new UI
**AND** a button is visible that enables the new UI