### PR TITLE
Add a logic to deactivate the plugin when Woo is not active (4780)

### DIFF
--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -95,9 +95,13 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 					),
 					wp_kses(
 						sprintf(
-						// translators: %s is a link to WooCommerce.com.
-							esc_html__( 'WooCommerce PayPal Payments requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-paypal-payments' ),
-							'<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>'
+						// translators: %s is a link to install WooCommerce.
+							esc_html__( 'WooCommerce PayPal Payments requires WooCommerce to be installed and active. %s', 'woocommerce-paypal-payments' ),
+							sprintf(
+								'<a href="%s">%s</a>',
+								esc_url( network_admin_url( 'plugin-install.php?tab=plugin-information&plugin=woocommerce' ) ),
+								esc_html__( 'You can download WooCommerce here.', 'woocommerce-paypal-payments' )
+							)
 						),
 						array(
 							'a' => array(

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -146,6 +146,11 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 		'plugins_loaded',
 		function () {
 			init();
+
+			if ( ! is_woocommerce_activated() ) {
+				return;
+			}
+
 			add_action(
 				'init',
 				function () {

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -86,12 +86,27 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 		$root_dir = __DIR__;
 
 		if ( ! is_woocommerce_activated() ) {
-			add_action(
-				'admin_notices',
-				function() {
-					/* translators: 1. URL link. */
-					echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'WooCommerce PayPal Payments requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-paypal-payments' ), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
-				}
+			show_admin_notice_and_deactivate(
+				static fn() => printf(
+					'<div class="notice notice-error"><span class="notice-title">%1$s</span><p>%2$s</p></div>',
+					esc_html__(
+						'The plugin WooCommerce PayPal Payments has been deactivated',
+						'woocommerce-paypal-payments'
+					),
+					wp_kses(
+						sprintf(
+						// translators: %s is a link to WooCommerce.com.
+							esc_html__( 'WooCommerce PayPal Payments requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-paypal-payments' ),
+							'<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>'
+						),
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array(),
+							),
+						)
+					)
+				)
 			);
 
 			return;

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -112,11 +112,15 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 			return;
 		}
 		if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
-			add_action(
-				'admin_notices',
-				function() {
-					echo '<div class="error"><p>' . esc_html__( 'WooCommerce PayPal Payments requires PHP 7.4 or above.', 'woocommerce-paypal-payments' ), '</p></div>';
-				}
+			show_admin_notice_and_deactivate(
+				static fn() => printf(
+					'<div class="notice notice-error"><span class="notice-title">%1$s</span><p>%2$s</p></div>',
+					esc_html__(
+						'The plugin WooCommerce PayPal Payments has been deactivated',
+						'woocommerce-paypal-payments'
+					),
+					esc_html__( 'WooCommerce PayPal Payments requires PHP 7.4 or above.', 'woocommerce-paypal-payments' )
+				)
 			);
 
 			return;

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -44,6 +44,42 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 	}
 
 	/**
+	 * Displays an admin notice and optionally deactivates the current plugin.
+	 *
+	 * This function registers a callback to display administrative notices on both
+	 * single-site and network admin areas. It's typically used to show error messages
+	 * when plugin requirements are not met, followed by automatic plugin deactivation.
+	 *
+	 * @param callable $notice_callback The callback function that outputs the admin notice HTML.
+	 *                                  Should echo/print the notice markup directly.
+	 * @param bool     $auto_deactivate Optional. Whether to automatically deactivate the plugin
+	 *                                  after displaying the notice. Default true.
+	 *
+	 * @return void
+	 */
+	function show_admin_notice_and_deactivate( callable $notice_callback, bool $auto_deactivate = true ): void {
+		if ( ! is_callable( $notice_callback ) ) {
+			return;
+		}
+
+		$admin_notice_hooks = array( 'admin_notices', 'network_admin_notices' );
+
+		foreach ( $admin_notice_hooks as $hook ) {
+			add_action(
+				$hook,
+				static function () use ( $notice_callback, $auto_deactivate ) {
+					$notice_callback();
+
+					if ( $auto_deactivate ) {
+						deactivate_plugins( plugin_basename( __FILE__ ) );
+						unset( $_GET['activate'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+					}
+				}
+			);
+		}
+	}
+
+	/**
 	 * Initialize the plugin and its modules.
 	 */
 	function init(): void {


### PR DESCRIPTION
## Issue Description

When WooCommerce plugin is disabled but PayPal Payments is a active, the site crashes with message sometimes.

```
Fatal error: Uncaught LogicException: No PPCP container, probably called too early when the plugin is not initialized yet.
```

###Steps To Reproduce

- set up Multisite
- install WooCommerce & PayPal Payments
- network activate WooCommerce
- navigate to the main site and activate PayPal Payments on the site
- network deactivate WooCommerce
- navigate to main site
- → observe fatal error

## PR Description

Added a logic to deactivate the plugin when Woo is not active