### PR TITLE
Broken PayPal Subscriptions payment in blocks and classic cart (4982, 4943, 4981)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Helper/Address.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Address.js
@@ -81,14 +81,14 @@ export const paypalShippingToWc = ( shipping ) => {
 export const paypalPayerToWc = ( payer ) => {
 	const firstName = payer?.name?.given_name ?? '';
 	const lastName = payer?.name?.surname ?? '';
-    const phone = payer?.phone?.phone_number?.national_number ?? '';
+	const phone = payer?.phone?.phone_number?.national_number ?? '';
 	const address = payer.address ? paypalAddressToWc( payer.address ) : {};
 	return {
 		...address,
 		first_name: firstName,
 		last_name: lastName,
 		email: payer.email_address,
-        phone: phone
+		phone,
 	};
 };
 
@@ -115,7 +115,7 @@ export const paypalSubscriberToWc = ( subscriber ) => {
  * @return {Object}
  */
 export const paypalOrderToWcShippingAddress = ( order ) => {
-	const shipping = order.purchase_units[ 0 ].shipping;
+	const shipping = order.purchase_units?.[ 0 ]?.shipping;
 	if ( ! shipping ) {
 		return {};
 	}

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
@@ -8,14 +8,14 @@ class CartActionHandler {
 		this.errorHandler = errorHandler;
 	}
 
-	subscriptionsConfiguration( subscription_plan_id ) {
+	subscriptionsConfiguration( subscriptionPlanId ) {
 		return {
 			createSubscription: ( data, actions ) => {
 				return actions.subscription.create( {
-					plan_id: subscription_plan_id,
+					plan_id: subscriptionPlanId,
 				} );
 			},
-			onApprove: ( data, actions ) => {
+			onApprove: ( data ) => {
 				fetch( this.config.ajax.approve_subscription.endpoint, {
 					method: 'POST',
 					credentials: 'same-origin',
@@ -24,7 +24,7 @@ class CartActionHandler {
 						order_id: data.orderID,
 						subscription_id: data.subscriptionID,
 						should_create_wc_order:
-							! context.config.vaultingEnabled ||
+							! this.config.vaultingEnabled ||
 							data.paymentSource !== 'venmo',
 					} ),
 				} )
@@ -33,7 +33,6 @@ class CartActionHandler {
 					} )
 					.then( ( data ) => {
 						if ( ! data.success ) {
-							console.log( data );
 							throw Error( data.data.message );
 						}
 
@@ -41,7 +40,7 @@ class CartActionHandler {
 
 						location.href = orderReceivedUrl
 							? orderReceivedUrl
-							: context.config.redirect;
+							: this.config.redirect;
 					} );
 			},
 			onError: ( err ) => {
@@ -51,7 +50,7 @@ class CartActionHandler {
 	}
 
 	configuration() {
-		const createOrder = ( data, actions ) => {
+		const createOrder = () => {
 			const payer = payerData();
 			const bnCode =
 				typeof this.config.bn_codes[ this.config.context ] !==
@@ -89,7 +88,7 @@ class CartActionHandler {
 		return {
 			createOrder,
 			onApprove: onApprove( this, this.errorHandler ),
-			onError: ( error ) => {
+			onError: () => {
 				this.errorHandler.genericError();
 			},
 		};

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -89,8 +89,9 @@ class WooCommerceOrderCreator {
 		}
 
 		try {
-			$payer    = $order->payer();
-			$shipping = $order->purchase_units()[0]->shipping();
+			$payer          = $order->payer();
+			$purchase_units = $order->purchase_units();
+			$shipping       = ! empty( $purchase_units ) ? $purchase_units[0]->shipping() : null;
 
 			$this->configure_payment_source( $wc_order );
 			$this->configure_customer( $wc_order );

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -501,9 +501,10 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 				if ( ! is_string( $hook ) || wcs_is_manual_renewal_enabled() ) {
 					return;
 				}
+
 				$settings          = $c->get( 'wcgateway.settings' );
 				$subscription_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
-				if ( $hook !== 'post.php' && $hook !== 'post-new.php' && $subscription_mode !== 'subscriptions_api' ) {
+				if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) || $subscription_mode !== 'subscriptions_api' ) {
 					return;
 				}
 


### PR DESCRIPTION
### Steps To Reproduce
- Onboard as US business merchant with Subscriptions and without ACDC
- Disable “Save PayPal and Venmo” and “Save Credit and Debit Cards“
- Create a subscription product and connect it to PayPal
- Add product to cart and try to pay in the following pages: classic cart, blocks cart and checkout

This PR fixes JS and PHP errors related to undefined array access in PayPal subscription handling. The main issues were:
- context is not defined error in `CartActionHandler.js` causing subscription creation failures
- "Undefined offset: 0" PHP notice in `WooCommerceOrderCreator.php`
- "Cannot read properties of undefined (reading '0')" JavaScript error in `Address.js`

It also fixes a wrong condition that loaded `paypal-subscription.js` file not only in admin product screen but in multiple non related screens.
