### PR TITLE
Support for creating an order containing bundled product (4437)

### DIFF
--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -133,6 +133,17 @@ class WooCommerceOrderCreator {
 			$item->set_product_id( $product_id );
 			$item->set_quantity( $quantity );
 
+			if ( isset( $cart_item['bundled_by'] ) ) {
+				$item->add_meta_data( '_bundled_by', $cart_item['bundled_by'], true );
+			}
+			if ( isset( $cart_item['bundled_item_id'] ) ) {
+				$item->add_meta_data( '_bundled_item_id', $cart_item['bundled_item_id'], true );
+			}
+			if ( isset( $cart_item['key'] ) ) {
+				$item->add_meta_data( '_bundle_cart_key', $cart_item['key'], true );
+			}
+
+
 			if ( $variation_id ) {
 				$item->set_variation_id( $variation_id );
 				$item->set_variation( $variation_attributes );
@@ -143,14 +154,13 @@ class WooCommerceOrderCreator {
 				return;
 			}
 
-			$subtotal = wc_get_price_excluding_tax( $product, array( 'qty' => $quantity ) );
-			$subtotal = apply_filters( 'woocommerce_paypal_payments_shipping_callback_cart_line_item_total', $subtotal, $cart_item );
+			$subtotal = apply_filters( 'woocommerce_paypal_payments_shipping_callback_cart_line_item_total', $cart_item['line_subtotal'], $cart_item );
 
 			$item->set_name( $product->get_name() );
 			$item->set_subtotal( $subtotal );
-			$item->set_total( $subtotal );
+			$item->set_total( $cart_item['line_total'] );
 
-			$this->configure_taxes( $product, $item, $subtotal );
+			$this->configure_taxes( $product, $item, $item->get_total() );
 
 			$product_id = $product->get_id();
 

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -143,7 +143,6 @@ class WooCommerceOrderCreator {
 				$item->add_meta_data( '_bundle_cart_key', $cart_item['key'], true );
 			}
 
-
 			if ( $variation_id ) {
 				$item->set_variation_id( $variation_id );
 				$item->set_variation( $variation_attributes );


### PR DESCRIPTION
## Issue Description

When placing an order using the Express Cart button on the cart page, bundled products are not treated as a single grouped item. Instead, each product in the bundle is processed as a separate line item, leading to incorrect totals.

In contrast, when the same bundle is purchased using the Express Checkout button on the checkout page, everything works as expected — the bundle is handled as a grouped product, and the total is correct.

## PR Description

This PR adds support for creating an order containing bundled products.