### PR TITLE
Fix contacts race condition in block

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -56,6 +56,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	public const THREE_D_AUTH_RESULT_META_KEY  = '_ppcp_paypal_3DS_auth_result';
 	public const FRAUD_RESULT_META_KEY         = '_ppcp_paypal_fraud_result';
 
+	// Used by the Contact Module integration.
+	public const CONTACT_EMAIL_META_KEY = '_ppcp_paypal_contact_email';
+	public const CONTACT_PHONE_META_KEY = '_ppcp_paypal_contact_phone';
+
 	// Used by the Contact Module integration to store the original details.
 	public const ORIGINAL_EMAIL_META_KEY = '_ppcp_paypal_billing_email';
 	public const ORIGINAL_PHONE_META_KEY = '_ppcp_paypal_billing_phone';

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -81,12 +81,16 @@ trait OrderMetaTrait {
 		$contact_email = $shipping_details->email_address();
 		$contact_phone = $shipping_details->phone_number();
 
+		$added = false;
+
 		if ( $contact_email && is_email( $contact_email ) ) {
 			$billing_email = $wc_order->get_billing_email();
 
 			if ( $billing_email && $billing_email !== $contact_email ) {
 				$wc_order->update_meta_data( PayPalGateway::CONTACT_EMAIL_META_KEY, $contact_email );
 				$wc_order->update_meta_data( PayPalGateway::ORIGINAL_EMAIL_META_KEY, $billing_email );
+
+				$added = true;
 			}
 		}
 
@@ -97,7 +101,13 @@ trait OrderMetaTrait {
 			if ( $billing_phone && $billing_phone !== $contact_phone_number ) {
 				$wc_order->update_meta_data( PayPalGateway::CONTACT_PHONE_META_KEY, $contact_phone_number );
 				$wc_order->update_meta_data( PayPalGateway::ORIGINAL_PHONE_META_KEY, $billing_phone );
+
+				$added = true;
 			}
+		}
+
+		if ( $added ) {
+			do_action( 'woocommerce_paypal_payments_contacts_added', $wc_order, $order );
 		}
 	}
 

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -66,16 +66,10 @@ trait OrderMetaTrait {
 	}
 
 	/**
-	 * Swaps out the billing details with the custom contact details provided by PayPal via the
-	 * "Contact Module" integration.
-	 *
-	 * The contact module can provide a custom email and phone number via the shipping details;
-	 * Though it's part of the shipping object, these two properties are intended to be treated
-	 * as primary contact details.
+	 * Adds the custom contact details provided by PayPal via the "Contact Module" integration.
 	 *
 	 * @param WC_Order $wc_order The WooCommerce order to update.
 	 * @param Order    $order    The PayPal order which provides the details.
-	 * @return void
 	 */
 	private function add_contact_details_to_wc_order( WC_Order $wc_order, Order $order ) : void {
 		$shipping_details = $this->get_shipping_details( $order );
@@ -91,10 +85,9 @@ trait OrderMetaTrait {
 			$billing_email = $wc_order->get_billing_email();
 
 			if ( $billing_email && $billing_email !== $contact_email ) {
+				$wc_order->update_meta_data( PayPalGateway::CONTACT_EMAIL_META_KEY, $contact_email );
 				$wc_order->update_meta_data( PayPalGateway::ORIGINAL_EMAIL_META_KEY, $billing_email );
 			}
-
-			$wc_order->set_billing_email( $contact_email );
 		}
 
 		if ( $contact_phone ) {
@@ -102,10 +95,9 @@ trait OrderMetaTrait {
 			$contact_phone_number = $contact_phone->national_number();
 
 			if ( $billing_phone && $billing_phone !== $contact_phone_number ) {
+				$wc_order->update_meta_data( PayPalGateway::CONTACT_PHONE_META_KEY, $contact_phone_number );
 				$wc_order->update_meta_data( PayPalGateway::ORIGINAL_PHONE_META_KEY, $billing_phone );
 			}
-
-			$wc_order->set_billing_phone( $contact_phone_number );
 		}
 	}
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -92,6 +92,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	public function run( ContainerInterface $c ): bool {
 		$this->register_payment_gateways( $c );
 		$this->register_order_functionality( $c );
+		$this->register_contact_handlers();
 		$this->register_columns( $c );
 		$this->register_checkout_paypal_address_preset( $c );
 		$this->register_wc_tasks( $c );
@@ -1009,6 +1010,33 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		}
 
 		return false === strpos( $order->get_payment_method_title(), '(via PayPal)' );
+	}
+
+	/**
+	 * Overwrite WC order email/phone.
+	 *
+	 * The contact module can provide a custom email and phone number.
+	 * These two properties are intended to be treated as primary contact details.
+	 */
+	private function register_contact_handlers(): void {
+		$set_order_contacts = function ( WC_Order $wc_order ): void {
+			$email = $wc_order->get_meta( PayPalGateway::CONTACT_EMAIL_META_KEY );
+			$phone = $wc_order->get_meta( PayPalGateway::CONTACT_PHONE_META_KEY );
+
+			if ( $email && is_string( $email ) ) {
+				$wc_order->set_billing_email( $email );
+			}
+			if ( $phone && is_string( $phone ) ) {
+				$wc_order->set_billing_phone( $phone );
+			}
+		};
+
+		add_action(
+			'woocommerce_paypal_payments_contacts_added',
+			function ( WC_Order $wc_order ) use ( $set_order_contacts ): void {
+				$set_order_contacts( $wc_order );
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -1037,6 +1037,16 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$set_order_contacts( $wc_order );
 			}
 		);
+		// There is a race condition in express block checkout, the contacts set in woocommerce_paypal_payments_contacts_added
+		// may get reverted by another ajax WC request. So we set them again after that.
+		add_action(
+			'woocommerce_store_api_cart_update_order_from_request',
+			function ( WC_Order $wc_order ) use ( $set_order_contacts ): void {
+				// This hook fires for all methods, but we do not do anything if the meta is not set
+				// so probably no need to add additional checks.
+				$set_order_contacts( $wc_order );
+			}
+		);
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -1023,7 +1023,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			$email = $wc_order->get_meta( PayPalGateway::CONTACT_EMAIL_META_KEY );
 			$phone = $wc_order->get_meta( PayPalGateway::CONTACT_PHONE_META_KEY );
 
-			if ( $email && is_string( $email ) ) {
+			if ( $email && is_email( $email ) ) {
 				$wc_order->set_billing_email( $email );
 			}
 			if ( $phone && is_string( $phone ) ) {


### PR DESCRIPTION
There was a race condition in express block checkout when setting a custom contact email/phone in the popup, 
they were reverted in the next order save call in another WC request. Not sure why since it's tricky to debug, I guess WC does not have any sync here, so if the second request loads the order data before my save it will have the old data and it will be detected as new changes.

<img src="https://github.com/user-attachments/assets/1e572d8c-3993-469e-93bd-d7f6e262d036" height="250">

So now setting the contacts again in the `woocommerce_store_api_cart_update_order_from_request` hook which is fired after that second save. The contacts are initially saved into the order meta to be able to retrieve them later without an API request. Also there is now `woocommerce_paypal_payments_contacts_added` hook, it is used for setting the contacts in other cases instead of directly in `add_paypal_meta` to avoid code duplication.
