### PR TITLE
Prevent subscription price override for non-subscription products (4988)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/resources/js/paypal-subscription.js
+++ b/modules/ppcp-paypal-subscriptions/resources/js/paypal-subscription.js
@@ -180,7 +180,18 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			}
 		} );
 
-		jQuery( '.wc_input_subscription_price' ).trigger( 'change' );
+		const $productType = jQuery( '#product-type' );
+		const $subscriptionInput = jQuery( '.wc_input_subscription_price' );
+
+		if (
+			$productType.length &&
+			$subscriptionInput.length &&
+			[ 'subscription', 'variable-subscription' ].includes(
+				$productType.val()
+			)
+		) {
+			$subscriptionInput.trigger( 'change' );
+		}
 
 		const variationProductIds = [
 			PayPalCommerceGatewayPayPalSubscriptionProducts.product_id,


### PR DESCRIPTION
## Issue Description

When WooCommerce Square, WooCommerce PayPal Payments, and WooCommerce Subscriptions are all active and configured, editing a product causes the price to disappear after page load.
This appears to be caused by a script in the PayPal Payments plugin triggering a subscription-specific price update.
[This line](https://github.com/woocommerce/woocommerce-paypal-payments/blob/80d7da4df3ea1afcba4de4362833d797e8f2987e/modules/ppcp-paypal-subscriptions/resources/js/paypal-subscription.js#L183) causes the Subscriptions plugin to overwrite the regular price with the subscription price.
If the product is not a subscription, and no subscription price is set, this results in the price field being blanked out.
The Square plugin likely triggers the chain of events that results in this script firing.

## PR Description

This PR prevents issue where non-subscription products have their regular price cleared, which was likely triggered indirectly by the Square plugin.
Ensures `.trigger('change')` on `.wc_input_subscription_price` is only called
when the selected product type is 'subscription' or 'variable-subscription'.

Prevents issue where non-subscription products have their regular price cleared,
which was likely triggered indirectly by the Square plugin.

