### PR TITLE
Replace BILLING with GUEST_CHECKOUT for landing page

### DIFF
--- a/modules/ppcp-api-client/src/Entity/ExperienceContext.php
+++ b/modules/ppcp-api-client/src/Entity/ExperienceContext.php
@@ -175,6 +175,10 @@ class ExperienceContext {
 	 * @param string|null $new_value The value to set.
 	 */
 	public function with_landing_page( ?string $new_value ): ExperienceContext {
+		if ( $new_value && strtoupper( $new_value ) === 'BILLING' ) {
+			$new_value = self::LANDING_PAGE_GUEST_CHECKOUT;
+		}
+
 		$obj = clone $this;
 
 		$obj->landing_page = $new_value;


### PR DESCRIPTION
The `BILLING` value is no longer valid for `experience_context.landing_page` resulting in an `INVALID_PARAMETER_VALUE` error, now it needs to be `GUEST_CHECKOUT`.

I added a check in the `ExperienceContext` setter, this seems to be the simplest and most reliable solution in this case.