### PR TITLE
Always enable the new settings module (4998)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -33,6 +33,7 @@ return function ( string $root_dir ): iterable {
 		( require "$modules_dir/ppcp-blocks/module.php" )(),
 		( require "$modules_dir/ppcp-paypal-subscriptions/module.php" )(),
 		( require "$modules_dir/ppcp-local-alternative-payment-methods/module.php" )(),
+		( require "$modules_dir/ppcp-settings/module.php" )(),
 	);
 	// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
 
@@ -89,13 +90,6 @@ return function ( string $root_dir ): iterable {
 	) ) {
 		$modules[] = ( require "$modules_dir/ppcp-axo/module.php" )();
 		$modules[] = ( require "$modules_dir/ppcp-axo-block/module.php" )();
-	}
-
-	if ( apply_filters(
-		'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
-		true
-	) ) {
-		$modules[] = ( require "$modules_dir/ppcp-settings/module.php" )();
 	}
 
 	return $modules;

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -75,7 +75,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		if ( ! apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
-			getenv('PCP_SETTINGS_ENABLED') !== '1'
+			getenv( 'PCP_SETTINGS_ENABLED' ) !== '1'
 		) ) {
 			return true;
 		}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -66,20 +66,29 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * Returns whether the old settings UI should be loaded.
 	 */
 	public static function should_use_the_old_ui() : bool {
-		// New merchants should never see the #legacy-ui.
-		$show_new_ux = '1' === get_option( 'woocommerce-ppcp-is-new-merchant' );
+		/**
+		 * Determine if the new Settings UI is disabled via feature flag.
+		 *
+		 * This is the highest-priority check: if the `woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled` filter
+		 * is used to disable the new UI, it will override all other conditions.
+		 */
+		if ( ! apply_filters(
+			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
+			'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
+			getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
+		) ) {
+			return true;
+		}
 
-		if ( $show_new_ux ) {
+		// New merchants always see the new UI if the filter above is not used.
+		if ( '1' === get_option( 'woocommerce-ppcp-is-new-merchant' ) ) {
 			return false;
 		}
 
-		// Existing merchants can opt-in to see the new UI.
-		$opt_out_choice = 'yes' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI );
+		// Existing merchants can opt out via DB option.
+		$opt_out = 'yes' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI );
 
-		return apply_filters(
-			'woocommerce_paypal_payments_should_use_the_old_ui',
-			$opt_out_choice
-		);
+		return apply_filters( 'woocommerce_paypal_payments_should_use_the_old_ui', $opt_out );
 	}
 
 	/**

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -75,7 +75,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		if ( ! apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
-			getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
+			getenv('PCP_SETTINGS_ENABLED') !== '1'
 		) ) {
 			return true;
 		}


### PR DESCRIPTION
## Issue Description

When attempting to disable the new PayPal Payments settings UI using the `woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled` filter (e.g., via the "Disable new UI" plugin), a **fatal error occurs** 

`PHP Fatal error: Uncaught class@anonymous: Service with ID settings.data.settings not found.`

Originates from `/modules/ppcp-axo/src/AxoModule.php:82`

This happens because several modules (e.g., AXO) **rely on services from the new settings module**, which is disabled when the feature flag is set to false. The code assumes the settings module is always active, resulting in fatal errors when it's not.

**Impact**:
* Fatal error blocks access to the site when disabling the new settings UI via the filter.
* Affects users still relying on the filter or shared plugins/workarounds.

## PR Description

This PR makes sure the new settings module is always enabled. The filter is still can be used to switch to the old UI.