### PR TITLE
Apple Pay does not update shipping method or address changes on Classic Checkout (4484)

### DIFF
--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -334,11 +334,21 @@ class ApplePayButton extends PaymentButton {
 		this.checkEligibility();
 	}
 
-	reinit() {
+	async reinit() {
 		// Missing (invalid) configuration indicates, that the first `init()` call did not happen yet.
 		if ( ! this.validateConfiguration( true ) ) {
 			return;
 		}
+
+		// Ensures transaction info is updated in Apple Pay session when cart or checkout update events are triggered.
+		await this.contextHandler
+			.transactionInfo()
+			.then( ( transactionInfo ) => {
+				this.transactionInfo = transactionInfo;
+			} )
+			.catch( ( error ) => {
+				console.error( 'Failed to get transaction info:', error );
+			} );
 
 		super.reinit();
 

--- a/modules/ppcp-applepay/resources/js/ApplepayButton.js
+++ b/modules/ppcp-applepay/resources/js/ApplepayButton.js
@@ -340,7 +340,7 @@ class ApplePayButton extends PaymentButton {
 			return;
 		}
 
-		// Ensures transaction info is updated in Apple Pay session when cart or checkout update events are triggered.
+		// Ensures transaction info is updated when cart or checkout update events are triggered.
 		await this.contextHandler
 			.transactionInfo()
 			.then( ( transactionInfo ) => {


### PR DESCRIPTION
When using Apple Pay on the classic checkout page, any changes made to the shipping method or shipping address are not reflected in the Apple Pay popup. The total shown is based on the values present when the page initially loaded.

### Steps To Reproduce
- Load the Classic Checkout page with a default shipping method and address.
- Change the shipping method or shipping address.
- Click the Apple Pay / button without refreshing the page.
- The Apple Pay popup shows the old total, not the updated one.

This PR adds a transaction info call when cart or checkout update event is triggered which ensures transaction data is updated correctly before being transaction data is updated before is sent to the Apple Pay session.