### PR TITLE
Display migration notice only on PayPal Payments settings pages (5001)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -111,7 +111,11 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			 */
 			add_filter(
 				Repository::NOTICES_FILTER,
-				static function ( array $notices ): array {
+				static function ( array $notices ) use ( $container ): array {
+					if ( ! $container->get( 'wcgateway.is-ppcp-settings-page' ) ) {
+						return $notices;
+					}
+
 					$message = sprintf(
 					// translators: %1$s is the URL for the startup guide.
 						__(


### PR DESCRIPTION
## Issue Description

The migration notice is currently displayed in all pages of the `wp-admin`.
This notice should only appear on the PayPal Payments-related settings pages.

## PR Description

This PR adds a check for displaying the migration notice only on PayPal Payments settings pages.

