### PR TITLE
Fix empty description handling and logo display for PayPal gateway (4999)

### DIFF
--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -260,7 +260,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 					'src' => $this->gateway->icon,
 				),
 			),
-			'description'                 => $this->gateway->description,
+			'description'                 => $this->gateway->get_description(),
 			'smartButtonsEnabled'         => $smart_buttons_enabled,
 			'placeOrderEnabled'           => $place_order_enabled,
 			'fundingSource'               => $this->session_handler->funding_source(),

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -254,8 +254,8 @@ class CreateOrderEndpoint implements EndpointInterface {
 		$this->pay_now_contexts                      = $pay_now_contexts;
 		$this->handle_shipping_in_paypal             = $handle_shipping_in_paypal;
 		$this->server_side_shipping_callback_enabled = $server_side_shipping_callback_enabled;
-		$this->funding_sources_without_redirect = $funding_sources_without_redirect;
-		$this->logger                           = $logger;
+		$this->funding_sources_without_redirect      = $funding_sources_without_redirect;
+		$this->logger                                = $logger;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -136,7 +136,7 @@ class PaymentMethodsDefinition {
 		$gateway = $this->wc_gateways[ $gateway_id ] ?? null;
 
 		$gateway_title       = $gateway ? $gateway->get_title() : $title;
-		$gateway_description = $gateway ? $gateway->get_description() : $description;
+		$gateway_description = $gateway->settings['description'] ?? $description;
 		$enabled             = $this->settings->is_method_enabled( $gateway_id );
 		$config              = array(
 			'id'              => $gateway_id,
@@ -159,7 +159,7 @@ class PaymentMethodsDefinition {
 					),
 					'checkoutPageDescription' => array(
 						'type'    => 'text',
-						'default' => $gateway ? $gateway->get_description() : '',
+						'default' => $gateway_description,
 						'label'   => __( 'Checkout page description', 'woocommerce-paypal-payments' ),
 					),
 				),

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -527,6 +527,17 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			2
 		);
 
+		add_filter(
+			'woocommerce_paypal_payments_paypal_gateway_icon',
+			function ( string $icon_url ) use ( $container ) {
+				$payment_settings = $container->get( 'settings.data.payment' );
+				assert( $payment_settings instanceof PaymentSettings );
+
+				// If "Show logo" is disabled, return an empty string to hide the icon.
+				return $payment_settings->get_paypal_show_logo() ? $icon_url : '';
+			}
+		);
+
 		add_filter( 'woocommerce_paypal_payments_card_button_gateway_should_register_gateway', '__return_true' );
 
 		add_filter(

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -352,6 +352,21 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	}
 
 	/**
+	 * Return the gateway's description.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		$gateway_settings = get_option( $this->get_option_key(), array() );
+
+		if ( array_key_exists( 'description', $gateway_settings ) ) {
+			return $gateway_settings['description'];
+		}
+
+		return $this->description;
+	}
+
+	/**
 	 * Whether the Gateway needs to be setup.
 	 *
 	 * @return bool


### PR DESCRIPTION
### Summary

This PR will fix the issue where the PayPal gateway was not handling empty descriptions correctly (reverting to defaults) and the `Show logo` toggle was not functioning properly.

### Screenshots

#### Before

|Settings|Checkout|
|-|-|
|<img width="1539" height="855" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/9f5d77bb-c1ca-4ab8-82f3-fd2610cd9243" />|<img width="1300" height="891" alt="Classic_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/8c313d69-610d-49ba-a6a7-53b3f2644c4c" />|

#### After

|Settings|Checkout|
|-|-|
|<img width="1539" height="855" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/9f5d77bb-c1ca-4ab8-82f3-fd2610cd9243" />|<img width="1335" height="832" alt="Classic_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/57e9c22b-49eb-41be-b00e-d0c62169a4dc" />|

### Testing Steps
1. Enable PayPal.
2. In PayPal gateway settings.
3. Set the `Checkout Page Description` field to be empty.
4. Untoggle the `Show logo` option.
5. Navigate to Checkout page (Classic & Block).
6. Confirm there's no gateway description displayed for PayPal and no logo is present.