### PR TITLE
Add feature flag for AppSwitch (5010)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/paypal.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal.js
@@ -401,6 +401,7 @@ export const PayPalComponent = ( {
 	const shouldEnableAppSwitch = () => {
 		// AppSwitch should only be enabled in Pay Now flows with server side shipping callback.
 		return (
+			config.scriptData.appswitch.enabled &&
 			! config.scriptData.final_review_enabled &&
 			config.scriptData.server_side_shipping_callback.enabled
 		);

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -252,6 +252,7 @@ class Renderer {
 	shouldEnableAppSwitch = () => {
 		// AppSwitch should only be enabled in Pay Now flows with server side shipping callback.
 		return (
+			this.defaultSettings.appswitch.enabled &&
 			! this.defaultSettings.final_review_enabled &&
 			this.defaultSettings.server_side_shipping_callback.enabled
 		);

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -169,6 +169,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'button.handle-shipping-in-paypal' ),
 			$container->get( 'wcgateway.server-side-shipping-callback-enabled' ),
+			$container->get( 'wcgateway.appswitch-enabled' ),
 			$container->get( 'button.helper.disabled-funding-sources' ),
 			$container->get( 'wcgateway.configuration.card-configuration' ),
 			$container->get( 'api.helper.partner-attribution' ),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -260,6 +260,11 @@ class SmartButton implements SmartButtonInterface {
 	private bool $server_side_shipping_callback_enabled;
 
 	/**
+	 * Whether the AppSwitch is enabled (feature flag).
+	 */
+	private bool $appswitch_enabled;
+
+	/**
 	 * Whether the final review is enabled in blocks settings.
 	 */
 	private bool $final_review_enabled;
@@ -291,6 +296,7 @@ class SmartButton implements SmartButtonInterface {
 	 * @param LoggerInterface           $logger                            The logger.
 	 * @param bool                      $should_handle_shipping_in_paypal  Whether the shipping should be handled in PayPal.
 	 * @param bool                      $server_side_shipping_callback_enabled Whether the server-side shipping callback is enabled (feature flag).
+	 * @param bool                      $appswitch_enabled                 Whether the AppSwitch is enabled (feature flag).
 	 * @param DisabledFundingSources    $disabled_funding_sources          List of funding sources to be disabled.
 	 * @param CardPaymentsConfiguration $dcc_configuration                 The DCC Gateway Configuration.
 	 * @param PartnerAttribution        $partner_attribution The PayPal Partner Attribution Helper.
@@ -321,6 +327,7 @@ class SmartButton implements SmartButtonInterface {
 		LoggerInterface $logger,
 		bool $should_handle_shipping_in_paypal,
 		bool $server_side_shipping_callback_enabled,
+		bool $appswitch_enabled,
 		DisabledFundingSources $disabled_funding_sources,
 		CardPaymentsConfiguration $dcc_configuration,
 		PartnerAttribution $partner_attribution,
@@ -350,6 +357,7 @@ class SmartButton implements SmartButtonInterface {
 		$this->payment_tokens_endpoint               = $payment_tokens_endpoint;
 		$this->should_handle_shipping_in_paypal      = $should_handle_shipping_in_paypal;
 		$this->server_side_shipping_callback_enabled = $server_side_shipping_callback_enabled;
+		$this->appswitch_enabled                     = $appswitch_enabled;
 		$this->disabled_funding_sources              = $disabled_funding_sources;
 		$this->dcc_configuration                     = $dcc_configuration;
 		$this->partner_attribution                   = $partner_attribution;
@@ -1364,6 +1372,9 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'should_handle_shipping_in_paypal'        => $this->should_handle_shipping_in_paypal && ! $this->is_checkout(),
 			'server_side_shipping_callback'           => array(
 				'enabled' => $this->server_side_shipping_callback_enabled,
+			),
+			'appswitch'                               => array(
+				'enabled' => $this->appswitch_enabled,
 			),
 			'needShipping'                            => $this->need_shipping(),
 			'vaultingEnabled'                         => $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2265,4 +2265,12 @@ return array(
 			getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) === '1'
 		);
 	},
+
+	'wcgateway.appswitch-enabled'                          => static function( ContainerInterface $container ) : bool {
+		return apply_filters(
+			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+			'woocommerce.feature-flags.woocommerce_paypal_payments.appswitch_enabled',
+			getenv( 'PCP_APPSWITCH_ENABLED' ) === '1'
+		);
+	},
 );


### PR DESCRIPTION
This PR introduces a feature flag to conditionally enable AppSwitch, which is off by default.

It can be enabled by setting the env var `PCP_APPSWITCH_ENABLED=1` or by using the filter:

`add_filter( 'woocommerce.feature-flags.woocommerce_paypal_payments.appswitch_enabled', '__return_true' );`