### PR TITLE
Disable the card button if BCDC is disabled (4989)

### DIFF
--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -159,7 +159,7 @@ class DisabledFundingSources {
 			return $disable_funding;
 		}
 
-		if ( ! is_checkout() || $this->dcc_configuration->use_acdc() ) {
+		if ( ! is_checkout() || $this->dcc_configuration->use_acdc() || ! $this->dcc_configuration->is_bcdc_enabled() ) {
 			// Non-checkout pages, or ACDC capability: Don't load card button.
 			$disable_funding[] = 'card';
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
@@ -330,7 +330,7 @@ class CardPaymentsConfiguration {
 	 * @return bool
 	 */
 	public function is_bcdc_enabled() : bool {
-		if ( 'MX' === $this->store_country ) {
+		if ( 'MX' === $this->store_country || ! $this->use_acdc() ) {
 			$bcdc_setting = get_option( 'woocommerce_ppcp-card-button-gateway_settings' );
 			$enabled      = $bcdc_setting['enabled'] ?? '';
 


### PR DESCRIPTION
## Issue Description

In the latest version of the PayPal Payments plugin UI, disabling Credit and Debit Card payments in the plugin settings does not remove the black PayPal card button from the checkout page.

**Steps to reproduce:**

- Set the country in WooCommerce settings to Venezuela 
- Go to the PayPal plugin settings.
- Disable the Credit and Debit Card payment option.
- Visit the checkout page.

## PR Description

- Adds a [Check for Card button gateway enabled](https://github.com/woocommerce/woocommerce-paypal-payments/commit/13f8a63e8ff44d9a7702ce3c4111ddbd4fdb6c10)
- [Disables the card button if BCDC is disabled](https://github.com/woocommerce/woocommerce-paypal-payments/commit/fadd2f5b40f21f7f98ae5781ed87fa5436930c95)