### PR TITLE
Block UI during onApprove callback (4712)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -158,7 +158,7 @@ class CheckoutActionHandler {
 		};
 		return {
 			createOrder,
-			onApprove: onApprove( this, this.errorHandler, this.spinner ),
+			onApprove: onApprove( this, this.errorHandler ),
 			onCancel: () => {
 				spinner.unblock();
 			},

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
@@ -2,9 +2,11 @@ import {
 	getCurrentPaymentMethod,
 	PaymentMethods,
 } from '../Helper/CheckoutMethodState';
+import Spinner from '../Helper/Spinner';
 
-const onApprove = ( context, errorHandler, spinner ) => {
+const onApprove = ( context, errorHandler ) => {
 	return ( data, actions ) => {
+		const spinner = Spinner.fullPage();
 		spinner.block();
 		errorHandler.clear();
 
@@ -24,7 +26,6 @@ const onApprove = ( context, errorHandler, spinner ) => {
 				return res.json();
 			} )
 			.then( ( data ) => {
-				spinner.unblock();
 				if ( ! data.success ) {
 					if ( data.data.code === 100 ) {
 						errorHandler.message( data.data.message );
@@ -49,6 +50,9 @@ const onApprove = ( context, errorHandler, spinner ) => {
 				}
 
 				document.querySelector( '#place_order' ).click();
+			} )
+			.finally( () => {
+				spinner.unblock();
 			} );
 	};
 };

--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
@@ -4,11 +4,18 @@ import {
 } from '../Helper/CheckoutMethodState';
 import Spinner from '../Helper/Spinner';
 
+import resumeFlowHelper from '../Helper/ResumeFlowHelper';
+
 const onApprove = ( context, errorHandler ) => {
 	return ( data, actions ) => {
 		const spinner = Spinner.fullPage();
 		spinner.block();
 		errorHandler.clear();
+		// Pay Now submits via form (not AJAX), so we can't detect payment errors.
+		// Preemptively remove hash params to prevent reload issues.
+		if ( resumeFlowHelper.isResumeFlow() ) {
+			resumeFlowHelper.cleanHashParams();
+		}
 
 		return fetch( context.config.ajax.approve_order.endpoint, {
 			method: 'POST',


### PR DESCRIPTION
When returning from AppSwitch, the `onApprove` callback takes a few seconds to finish processing. During this time, the user could click the PayPal button again or trigger other WooCommerce actions like "Proceed to Checkout", which disrupted the AppSwitch flow and caused unexpected issues reported by QA.

This PR addresses the problem by implementing the same approach used at checkout: blocking the entire UI while the payment is being processed. 

**Classic contexts:**

To address this in classic contexts, I've reused the `Spinner` class, triggering a full-page blocking overlay when the onApprove callback is triggered, and removing it in the `.finally` callback.

**Block contexts:**

Block contexts are trickier. Unblocking the spinner in the `.finally` callback of the `onApprove` method was too soon, since WooCommerce has its own async order processing in block contexts. This left a significant time window in which the user could perform actions like clicking "Proceed to Checkout".

To handle block contexts, I’ve set up a useEffect that tracks the value of `isFullPageSpinnerActive` and toggles the spinner when it changes. This allows the spinner to be enabled in the onApprove callback, remain active, and be removed only in exceptional circumstances such as checkout errors which are handled by WooCommerce events.