### PR TITLE
Fix QIT warnings

### DIFF
--- a/modules/ppcp-admin-notices/src/Renderer/Renderer.php
+++ b/modules/ppcp-admin-notices/src/Renderer/Renderer.php
@@ -80,7 +80,7 @@ class Renderer implements RendererInterface {
 
 			printf(
 				'<div class="notice notice-%s %s" %s%s><p>%s</p></div>',
-				$message->type(),
+				esc_attr( $message->type() ),
 				( $message->is_dismissible() ) ? 'is-dismissible' : '',
 				( $message->wrapper() ? sprintf( 'data-ppcp-wrapper="%s"', esc_attr( $message->wrapper() ) ) : '' ),
 				// Use `empty()` in condition, to avoid false phpcs warning.

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -444,9 +444,7 @@ class OrderEndpoint {
 		}
 		$response = $this->request( $url, $args );
 		if ( is_wp_error( $response ) ) {
-			$error = new RuntimeException(
-				__( 'Could not retrieve order.', 'woocommerce-paypal-payments' )
-			);
+			$error = new RuntimeException( 'Could not retrieve order.' );
 			$this->logger->warning( $error->getMessage() );
 
 			throw $error;
@@ -456,7 +454,7 @@ class OrderEndpoint {
 
 		if ( 404 === $status_code || empty( $response['body'] ) ) {
 			$error = new RuntimeException(
-				__( 'Could not retrieve order.', 'woocommerce-paypal-payments' ),
+				'Could not retrieve order.',
 				404
 			);
 			$this->logger->warning(

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -176,10 +176,10 @@ class OrderEndpoint {
 	public function create(
 		array $items,
 		string $shipping_preference,
-		Payer $payer = null,
+		?Payer $payer = null,
 		string $payment_method = '',
 		array $request_data = array(),
-		PaymentSource $payment_source = null
+		?PaymentSource $payment_source = null
 	): Order {
 		$bearer = $this->bearer->bearer();
 		$data   = array(

--- a/modules/ppcp-api-client/src/Endpoint/WebhookEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/WebhookEndpoint.php
@@ -113,9 +113,7 @@ class WebhookEndpoint {
 		$response = $this->request( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
-			throw new RuntimeException(
-				__( 'Not able to create a webhook.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Not able to create a webhook.' );
 		}
 
 		$json        = json_decode( $response['body'] );
@@ -151,9 +149,7 @@ class WebhookEndpoint {
 		$response = $this->request( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
-			throw new RuntimeException(
-				__( 'Not able to load webhooks list.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Not able to load webhooks list.' );
 		}
 
 		$json        = json_decode( $response['body'] );
@@ -195,9 +191,7 @@ class WebhookEndpoint {
 		$response = $this->request( $url, $args );
 
 		if ( $response instanceof WP_Error ) {
-			throw new RuntimeException(
-				__( 'Not able to delete the webhook.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Not able to delete the webhook.' );
 		}
 
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
@@ -250,9 +244,7 @@ class WebhookEndpoint {
 		$response = $this->request( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
-			throw new RuntimeException(
-				__( 'Not able to simulate webhook.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Not able to simulate webhook.' );
 		}
 		$json        = json_decode( $response['body'] );
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
@@ -312,9 +304,7 @@ class WebhookEndpoint {
 		);
 		$response = $this->request( $url, $args );
 		if ( is_wp_error( $response ) ) {
-			$error = new RuntimeException(
-				__( 'Not able to verify webhook event.', 'woocommerce-paypal-payments' )
-			);
+			$error = new RuntimeException( 'Not able to verify webhook event.' );
 			$this->logger->log(
 				'warning',
 				$error->getMessage(),
@@ -340,9 +330,7 @@ class WebhookEndpoint {
 	public function verify_current_request_for_webhook( Webhook $webhook ): bool {
 
 		if ( ! $webhook->id() ) {
-			$error = new RuntimeException(
-				__( 'Not a valid webhook to verify.', 'woocommerce-paypal-payments' )
-			);
+			$error = new RuntimeException( 'Not a valid webhook to verify.' );
 			$this->logger->log( 'warning', $error->getMessage(), array( 'webhook' => $webhook ) );
 			throw $error;
 		}
@@ -369,11 +357,7 @@ class WebhookEndpoint {
 
 			$error = new RuntimeException(
 				sprintf(
-					// translators: %s is the headers key.
-					__(
-						'Not a valid webhook event. Header %s is missing',
-						'woocommerce-paypal-payments'
-					),
+					'Not a valid webhook event. Header %s is missing',
 					$key
 				)
 			);

--- a/modules/ppcp-api-client/src/Entity/Amount.php
+++ b/modules/ppcp-api-client/src/Entity/Amount.php
@@ -41,7 +41,7 @@ class Amount {
 	 * @param Money                $money The money.
 	 * @param AmountBreakdown|null $breakdown The breakdown.
 	 */
-	public function __construct( Money $money, AmountBreakdown $breakdown = null ) {
+	public function __construct( Money $money, ?AmountBreakdown $breakdown = null ) {
 		$this->money     = $money;
 		$this->breakdown = $breakdown;
 	}

--- a/modules/ppcp-api-client/src/Entity/AuthorizationStatus.php
+++ b/modules/ppcp-api-client/src/Entity/AuthorizationStatus.php
@@ -62,8 +62,7 @@ class AuthorizationStatus {
 		if ( ! in_array( $status, self::VALID_STATUS, true ) ) {
 			throw new RuntimeException(
 				sprintf(
-					// translators: %s is the current status.
-					__( '%s is not a valid status', 'woocommerce-paypal-payments' ),
+					'%s is not a valid status',
 					$status
 				)
 			);

--- a/modules/ppcp-api-client/src/Entity/Item.php
+++ b/modules/ppcp-api-client/src/Entity/Item.php
@@ -114,13 +114,13 @@ class Item {
 		Money $unit_amount,
 		int $quantity,
 		string $description = '',
-		Money $tax = null,
+		?Money $tax = null,
 		string $sku = '',
 		string $category = 'PHYSICAL_GOODS',
 		string $url = '',
 		string $image_url = '',
 		float $tax_rate = 0,
-		string $cart_item_key = null
+		?string $cart_item_key = null
 	) {
 
 		$this->name          = $name;

--- a/modules/ppcp-api-client/src/Entity/Order.php
+++ b/modules/ppcp-api-client/src/Entity/Order.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
 
+use DateTime;
+
 /**
  * Class Order
  */
@@ -25,7 +27,7 @@ class Order {
 	/**
 	 * The create time.
 	 *
-	 * @var \DateTime|null
+	 * @var DateTime|null
 	 */
 	private $create_time;
 
@@ -60,7 +62,7 @@ class Order {
 	/**
 	 * The update time.
 	 *
-	 * @var \DateTime|null
+	 * @var DateTime|null
 	 */
 	private $update_time;
 
@@ -86,18 +88,18 @@ class Order {
 	 * @param PaymentSource|null $payment_source The payment source.
 	 * @param Payer|null         $payer The payer.
 	 * @param string             $intent The intent.
-	 * @param \DateTime|null     $create_time The create time.
-	 * @param \DateTime|null     $update_time The update time.
+	 * @param DateTime|null      $create_time The create time.
+	 * @param DateTime|null      $update_time The update time.
 	 */
 	public function __construct(
 		string $id,
 		array $purchase_units,
 		OrderStatus $order_status,
-		PaymentSource $payment_source = null,
-		Payer $payer = null,
+		?PaymentSource $payment_source = null,
+		?Payer $payer = null,
 		string $intent = 'CAPTURE',
-		\DateTime $create_time = null,
-		\DateTime $update_time = null,
+		?DateTime $create_time = null,
+		?DateTime $update_time = null,
 		$links = null
 	) {
 
@@ -124,7 +126,7 @@ class Order {
 	/**
 	 * Returns the create time.
 	 *
-	 * @return \DateTime|null
+	 * @return DateTime|null
 	 */
 	public function create_time() {
 		return $this->create_time;
@@ -133,7 +135,7 @@ class Order {
 	/**
 	 * Returns the update time.
 	 *
-	 * @return \DateTime|null
+	 * @return DateTime|null
 	 */
 	public function update_time() {
 		return $this->update_time;

--- a/modules/ppcp-api-client/src/Entity/OrderStatus.php
+++ b/modules/ppcp-api-client/src/Entity/OrderStatus.php
@@ -51,8 +51,7 @@ class OrderStatus {
 		if ( ! in_array( $status, self::VALID_STATUS, true ) ) {
 			throw new RuntimeException(
 				sprintf(
-					// translators: %s is the current status.
-					__( '%s is not a valid status', 'woocommerce-paypal-payments' ),
+					'%s is not a valid status',
 					$status
 				)
 			);

--- a/modules/ppcp-api-client/src/Entity/Payer.php
+++ b/modules/ppcp-api-client/src/Entity/Payer.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
 
+use DateTime;
+
 /**
  * Class Payer
  * The customer who sends the money.
@@ -39,7 +41,7 @@ class Payer {
 	/**
 	 * The birth date.
 	 *
-	 * @var \DateTime|null
+	 * @var DateTime|null
 	 */
 	private $birthdate;
 
@@ -71,7 +73,7 @@ class Payer {
 	 * @param string             $email_address The email.
 	 * @param string             $payer_id The payer id.
 	 * @param Address|null       $address The address.
-	 * @param \DateTime|null     $birthdate The birth date.
+	 * @param DateTime|null      $birthdate The birth date.
 	 * @param PhoneWithType|null $phone The phone.
 	 * @param PayerTaxInfo|null  $tax_info The tax info.
 	 */
@@ -79,10 +81,10 @@ class Payer {
 		?PayerName $name,
 		string $email_address,
 		string $payer_id,
-		Address $address = null,
-		\DateTime $birthdate = null,
-		PhoneWithType $phone = null,
-		PayerTaxInfo $tax_info = null
+		?Address $address = null,
+		?DateTime $birthdate = null,
+		?PhoneWithType $phone = null,
+		?PayerTaxInfo $tax_info = null
 	) {
 
 		$this->name          = $name;
@@ -133,7 +135,7 @@ class Payer {
 	/**
 	 * Returns the birth date.
 	 *
-	 * @return \DateTime|null
+	 * @return DateTime|null
 	 */
 	public function birthdate() {
 		return $this->birthdate;

--- a/modules/ppcp-api-client/src/Entity/PayerTaxInfo.php
+++ b/modules/ppcp-api-client/src/Entity/PayerTaxInfo.php
@@ -51,8 +51,7 @@ class PayerTaxInfo {
 		if ( ! in_array( $type, self::VALID_TYPES, true ) ) {
 			throw new RuntimeException(
 				sprintf(
-				// translators: %s is the current type.
-					__( '%s is not a valid tax type.', 'woocommerce-paypal-payments' ),
+					'%s is not a valid tax type.',
 					$type
 				)
 			);

--- a/modules/ppcp-api-client/src/Entity/PaymentToken.php
+++ b/modules/ppcp-api-client/src/Entity/PaymentToken.php
@@ -50,9 +50,7 @@ class PaymentToken {
 	 */
 	public function __construct( string $id, stdClass $source, string $type = self::TYPE_PAYMENT_METHOD_TOKEN ) {
 		if ( ! in_array( $type, self::get_valid_types(), true ) ) {
-			throw new RuntimeException(
-				__( 'Not a valid payment source type.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Not a valid payment source type.' );
 		}
 		$this->id     = $id;
 		$this->type   = $type;

--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -109,13 +109,13 @@ class PurchaseUnit {
 	public function __construct(
 		Amount $amount,
 		array $items = array(),
-		Shipping $shipping = null,
+		?Shipping $shipping = null,
 		string $reference_id = 'default',
 		string $description = '',
 		string $custom_id = '',
 		string $invoice_id = '',
 		string $soft_descriptor = '',
-		Payments $payments = null
+		?Payments $payments = null
 	) {
 
 		$this->amount       = $amount;

--- a/modules/ppcp-api-client/src/Entity/RefundCapture.php
+++ b/modules/ppcp-api-client/src/Entity/RefundCapture.php
@@ -54,7 +54,7 @@ class RefundCapture {
 		Capture $capture,
 		string $invoice_id,
 		string $note_to_payer = '',
-		Amount $amount = null
+		?Amount $amount = null
 	) {
 		$this->capture       = $capture;
 		$this->invoice_id    = $invoice_id;

--- a/modules/ppcp-api-client/src/Entity/Shipping.php
+++ b/modules/ppcp-api-client/src/Entity/Shipping.php
@@ -54,7 +54,13 @@ class Shipping {
 	 * @param Phone|null       $phone_number  Contact phone.
 	 * @param ShippingOption[] $options       Shipping methods.
 	 */
-	public function __construct( string $name, Address $address, string $email_address = null, Phone $phone_number = null, array $options = array() ) {
+	public function __construct(
+		string $name,
+		Address $address,
+		?string $email_address = null,
+		?Phone $phone_number = null,
+		array $options = array()
+	) {
 		$this->name          = $name;
 		$this->address       = $address;
 		$this->email_address = $email_address;

--- a/modules/ppcp-api-client/src/Exception/PayPalApiException.php
+++ b/modules/ppcp-api-client/src/Exception/PayPalApiException.php
@@ -36,9 +36,9 @@ class PayPalApiException extends RuntimeException {
 	 * @param stdClass|null $response The JSON object.
 	 * @param int           $status_code The HTTP status code.
 	 */
-	public function __construct( stdClass $response = null, int $status_code = 0 ) {
+	public function __construct( ?stdClass $response = null, int $status_code = 0 ) {
 		if ( is_null( $response ) ) {
-			$response = new \stdClass();
+			$response = new stdClass();
 		}
 		if ( ! isset( $response->message ) ) {
 			$response->message = sprintf(
@@ -63,7 +63,7 @@ class PayPalApiException extends RuntimeException {
 		/**
 		 * The JSON response object.
 		 *
-		 * @var \stdClass $response
+		 * @var stdClass $response
 		 */
 		$this->response    = $response;
 		$this->status_code = $status_code;

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -245,8 +245,7 @@ class AmountFactory {
 			if ( ! isset( $item->value ) || ! is_numeric( $item->value ) ) {
 				throw new RuntimeException(
 					sprintf(
-					// translators: %s is the current breakdown key.
-						__( 'No value given for breakdown %s', 'woocommerce-paypal-payments' ),
+						'No value given for breakdown %s',
 						$key
 					)
 				);
@@ -254,8 +253,7 @@ class AmountFactory {
 			if ( ! isset( $item->currency_code ) ) {
 				throw new RuntimeException(
 					sprintf(
-					// translators: %s is the current breakdown key.
-						__( 'No currency given for breakdown %s', 'woocommerce-paypal-payments' ),
+						'No currency given for breakdown %s',
 						$key
 					)
 				);

--- a/modules/ppcp-api-client/src/Factory/AuthorizationFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AuthorizationFactory.php
@@ -45,15 +45,11 @@ class AuthorizationFactory {
 	 */
 	public function from_paypal_response( \stdClass $data ): Authorization {
 		if ( ! isset( $data->id ) ) {
-			throw new RuntimeException(
-				__( 'Does not contain an id.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Does not contain an id.' );
 		}
 
 		if ( ! isset( $data->status ) ) {
-			throw new RuntimeException(
-				__( 'Does not contain status.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Does not contain status.' );
 		}
 
 		$reason = $data->status_details->reason ?? null;

--- a/modules/ppcp-api-client/src/Factory/CaptureFactory.php
+++ b/modules/ppcp-api-client/src/Factory/CaptureFactory.php
@@ -78,7 +78,7 @@ class CaptureFactory {
 
 		$amount = $this->amount_factory->from_paypal_response( $data->amount );
 		if ( null === $amount ) {
-			throw new RuntimeException( __( 'Invalid capture amount data.', 'woocommerce-paypal-payments' ) );
+			throw new RuntimeException( 'Invalid capture amount data.' );
 		}
 
 		return new Capture(

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -179,19 +179,13 @@ class ItemFactory {
 	 */
 	public function from_paypal_response( \stdClass $data ): Item {
 		if ( ! isset( $data->name ) ) {
-			throw new RuntimeException(
-				__( 'No name for item given', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No name for item given' );
 		}
 		if ( ! isset( $data->quantity ) || ! is_numeric( $data->quantity ) ) {
-			throw new RuntimeException(
-				__( 'No quantity for item given', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No quantity for item given' );
 		}
 		if ( ! isset( $data->unit_amount->value ) || ! isset( $data->unit_amount->currency_code ) ) {
-			throw new RuntimeException(
-				__( 'No money values for item given', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No money values for item given' );
 		}
 
 		$unit_amount = new Money( (float) $data->unit_amount->value, $data->unit_amount->currency_code );

--- a/modules/ppcp-api-client/src/Factory/OrderFactory.php
+++ b/modules/ppcp-api-client/src/Factory/OrderFactory.php
@@ -114,9 +114,7 @@ class OrderFactory {
 	 */
 	private function validate_order_id( \stdClass $order_data ): void {
 		if ( ! isset( $order_data->id ) ) {
-			throw new RuntimeException(
-				__( 'Order does not contain an id.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Order does not contain an id.' );
 		}
 	}
 

--- a/modules/ppcp-api-client/src/Factory/PaymentTokenFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PaymentTokenFactory.php
@@ -27,9 +27,7 @@ class PaymentTokenFactory {
 	 */
 	public function from_paypal_response( $data ): PaymentToken {
 		if ( ! isset( $data->id ) ) {
-			throw new RuntimeException(
-				__( 'No id for payment token given', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No id for payment token given' );
 		}
 
 		return new PaymentToken(

--- a/modules/ppcp-api-client/src/Factory/PlanFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PlanFactory.php
@@ -57,24 +57,16 @@ class PlanFactory {
 	 */
 	public function from_paypal_response( stdClass $data ): Plan {
 		if ( ! isset( $data->id ) ) {
-			throw new RuntimeException(
-				__( 'No id for given plan', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No id for given plan' );
 		}
 		if ( ! isset( $data->name ) ) {
-			throw new RuntimeException(
-				__( 'No name for plan given', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No name for plan given' );
 		}
 		if ( ! isset( $data->product_id ) ) {
-			throw new RuntimeException(
-				__( 'No product id for given plan', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No product id for given plan' );
 		}
 		if ( ! isset( $data->billing_cycles ) ) {
-			throw new RuntimeException(
-				__( 'No billing cycles for given plan', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No billing cycles for given plan' );
 		}
 
 		$billing_cycles = array();

--- a/modules/ppcp-api-client/src/Factory/ProductFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ProductFactory.php
@@ -28,14 +28,10 @@ class ProductFactory {
 	 */
 	public function from_paypal_response( stdClass $data ): Product {
 		if ( ! isset( $data->id ) ) {
-			throw new RuntimeException(
-				__( 'No id for product given', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No id for product given' );
 		}
 		if ( ! isset( $data->name ) ) {
-			throw new RuntimeException(
-				__( 'No name for product given', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No name for product given' );
 		}
 
 		return new Product(

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -224,9 +224,7 @@ class PurchaseUnitFactory {
 	 */
 	public function from_paypal_response( \stdClass $data ): ?PurchaseUnit {
 		if ( ! isset( $data->reference_id ) || ! is_string( $data->reference_id ) ) {
-			throw new RuntimeException(
-				__( 'No reference ID given.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No reference ID given.' );
 		}
 
 		$amount_data = $data->amount ?? null;

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -88,7 +88,7 @@ class PurchaseUnitFactory {
 		PaymentsFactory $payments_factory,
 		string $prefix = 'WC-',
 		string $soft_descriptor = '',
-		PurchaseUnitSanitizer $sanitizer = null
+		?PurchaseUnitSanitizer $sanitizer = null
 	) {
 
 		$this->amount_factory   = $amount_factory;

--- a/modules/ppcp-api-client/src/Factory/RefundFactory.php
+++ b/modules/ppcp-api-client/src/Factory/RefundFactory.php
@@ -77,7 +77,7 @@ class RefundFactory {
 
 		$amount = $this->amount_factory->from_paypal_response( $data->amount );
 		if ( null === $amount ) {
-			throw new RuntimeException( __( 'Invalid refund amount data.', 'woocommerce-paypal-payments' ) );
+			throw new RuntimeException( 'Invalid refund amount data.' );
 		}
 
 		return new Refund(

--- a/modules/ppcp-api-client/src/Factory/ReturnUrlFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ReturnUrlFactory.php
@@ -36,9 +36,7 @@ class ReturnUrlFactory {
 					}
 				}
 
-				throw new RuntimeException(
-					__( 'Product URL is required but not provided in the request data.', 'woocommerce-paypal-payments' )
-				);
+				throw new RuntimeException( 'Product URL is required but not provided in the request data.' );
 			case 'pay-now':
 				if ( ! empty( $request_data['order_id'] ) ) {
 					$order = wc_get_order( $request_data['order_id'] );
@@ -47,9 +45,7 @@ class ReturnUrlFactory {
 					}
 				}
 
-				throw new RuntimeException(
-					__( 'The order ID is invalid.', 'woocommerce-paypal-payments' )
-				);
+				throw new RuntimeException( 'The order ID is invalid.' );
 			default:
 				return wc_get_checkout_url();
 		}

--- a/modules/ppcp-api-client/src/Factory/ShippingFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ShippingFactory.php
@@ -97,14 +97,10 @@ class ShippingFactory {
 	 */
 	public function from_paypal_response( \stdClass $data ): Shipping {
 		if ( ! isset( $data->name->full_name ) ) {
-			throw new RuntimeException(
-				__( 'No name was given for shipping.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No name was given for shipping.' );
 		}
 		if ( ! isset( $data->address ) ) {
-			throw new RuntimeException(
-				__( 'No address was given for shipping.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No address was given for shipping.' );
 		}
 		$contact_phone = null;
 		$contact_email = null;

--- a/modules/ppcp-api-client/src/Factory/WebhookEventFactory.php
+++ b/modules/ppcp-api-client/src/Factory/WebhookEventFactory.php
@@ -40,14 +40,10 @@ class WebhookEventFactory {
 	 */
 	public function from_paypal_response( $data ): WebhookEvent {
 		if ( ! isset( $data->id ) ) {
-			throw new RuntimeException(
-				__( 'ID for webhook event not found.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'ID for webhook event not found.' );
 		}
 		if ( ! isset( $data->event_type ) ) {
-			throw new RuntimeException(
-				__( 'Event type for webhook event not found.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Event type for webhook event not found.' );
 		}
 
 		$create_time = ( isset( $data->create_time ) ) ?

--- a/modules/ppcp-api-client/src/Factory/WebhookFactory.php
+++ b/modules/ppcp-api-client/src/Factory/WebhookFactory.php
@@ -59,19 +59,13 @@ class WebhookFactory {
 	 */
 	public function from_paypal_response( $data ): Webhook {
 		if ( ! isset( $data->id ) ) {
-			throw new RuntimeException(
-				__( 'No id for webhook given.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No id for webhook given.' );
 		}
 		if ( ! isset( $data->url ) ) {
-			throw new RuntimeException(
-				__( 'No URL for webhook given.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No URL for webhook given.' );
 		}
 		if ( ! isset( $data->event_types ) ) {
-			throw new RuntimeException(
-				__( 'No event types for webhook given.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No event types for webhook given.' );
 		}
 
 		return new Webhook(

--- a/modules/ppcp-api-client/src/Helper/ProductStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatus.php
@@ -114,7 +114,7 @@ abstract class ProductStatus {
 	 * @param Settings|null $settings See description in {@see self::clear()}.
 	 * @return void
 	 */
-	abstract protected function clear_state( Settings $settings = null ) : void;
+	abstract protected function clear_state( ?Settings $settings = null ) : void;
 
 	/**
 	 * Whether the merchant has access to the feature.
@@ -199,7 +199,7 @@ abstract class ProductStatus {
 	 * @param Settings|null $settings The settings object.
 	 * @return void
 	 */
-	public function clear( Settings $settings = null ) : void {
+	public function clear( ?Settings $settings = null ) : void {
 		$this->is_eligible         = null;
 		$this->has_request_failure = false;
 

--- a/modules/ppcp-api-client/src/Helper/PurchaseUnitSanitizer.php
+++ b/modules/ppcp-api-client/src/Helper/PurchaseUnitSanitizer.php
@@ -81,7 +81,7 @@ class PurchaseUnitSanitizer {
 	 * @param string|null $mode The mismatch handling mode, ditch or extra_line.
 	 * @param string|null $extra_line_name The name of the extra line.
 	 */
-	public function __construct( string $mode = null, string $extra_line_name = null ) {
+	public function __construct( ?string $mode = null, ?string $extra_line_name = null ) {
 
 		if ( ! in_array( $mode, self::VALID_MODES, true ) ) {
 			$mode = self::MODE_DITCH;

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -54,7 +54,12 @@ class PartnerReferralsData {
 	 * @param bool     $use_card_payments If the merchant wants to process credit card payments.
 	 * @return array
 	 */
-	public function data( array $products = array(), string $onboarding_token = '', bool $use_subscriptions = null, bool $use_card_payments = true ) : array {
+	public function data(
+		array $products = array(),
+		string $onboarding_token = '',
+		?bool $use_subscriptions = null,
+		bool $use_card_payments = true
+	) : array {
 		$in_acdc_country = $this->dcc_applies->for_country_currency();
 
 		if ( ! $products ) {

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -241,7 +241,8 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 			$validation_string = $this->validation_string( $is_sandbox );
 			nocache_headers();
 			header( 'Content-Type: text/plain', true, 200 );
-			echo $validation_string;// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $validation_string;
 			exit;
 		}
 	}

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -55,7 +55,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function( Settings $settings = null ) use ( $c ): void {
+			function( ?Settings $settings = null ) use ( $c ): void {
 				$apm_status = $c->get( 'applepay.apple-product-status' );
 				assert( $apm_status instanceof AppleProductStatus );
 				$apm_status->clear( $settings );

--- a/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
@@ -160,7 +160,7 @@ class ApplePayDataObjectHttp {
 	 * @return void
 	 */
 	public function validation_data(): void {
-		$data = filter_input( INPUT_POST, 'validation', FILTER_VALIDATE_BOOL );
+		$data = filter_input( INPUT_POST, 'validation', FILTER_VALIDATE_BOOLEAN );
 		if ( ! $data ) {
 			return;
 		}

--- a/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
+++ b/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
@@ -101,7 +101,7 @@ class AppleProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ) : void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -264,9 +264,9 @@ class AxoGateway extends WC_Payment_Gateway {
 			);
 		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$axo_nonce = wc_clean( wp_unslash( $_POST['axo_nonce'] ?? '' ) );
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification
+
+		$axo_nonce   = wc_clean( wp_unslash( $_POST['axo_nonce'] ?? '' ) );
 		$token_param = wc_clean( wp_unslash( $_GET['token'] ?? '' ) );
 
 		if ( empty( $axo_nonce ) && ! empty( $token_param ) ) {
@@ -274,7 +274,6 @@ class AxoGateway extends WC_Payment_Gateway {
 		}
 
 		try {
-			// phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$fastlane_member = wc_clean( wp_unslash( $_POST['fastlane_member'] ?? '' ) );
 			if ( $fastlane_member ) {
 				$payment_method_title = __( 'Debit & Credit Cards (via Fastlane by PayPal)', 'woocommerce-paypal-payments' );
@@ -341,6 +340,7 @@ class AxoGateway extends WC_Payment_Gateway {
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $wc_order ),
 		);
+		// phpcs:enable WordPress.Security.NonceVerification
 	}
 
 	/**

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1926,8 +1926,10 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			$variations = $product->get_available_variations( 'objects' );
 			$in_stock   = $this->has_in_stock_variation( $variations );
 		}
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$enable_button = ! $product->is_type( array( 'external', 'grouped' ) ) && $in_stock &&
 			! ( ( $product->is_type( 'subscription' ) || $product->is_type( 'variable-subscription' ) ) && ! empty( $_GET['switch-subscription'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		/**
 		 * Allows to filter if PayPal buttons/messages can be rendered for the given product.

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -810,7 +810,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	 * @param string      $gateway_id The gateway ID, like 'ppcp-gateway'.
 	 * @param string|null $action_name The action name to be called.
 	 */
-	public function button_renderer( string $gateway_id, string $action_name = null ) {
+	public function button_renderer( string $gateway_id, ?string $action_name = null ) {
 
 		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 
@@ -1968,7 +1968,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	 * @param array       $context_data The context data for this filter.
 	 * @return bool
 	 */
-	public function is_button_disabled( string $context = null, array $context_data = array() ): bool {
+	public function is_button_disabled( ?string $context = null, array $context_data = array() ): bool {
 		if ( null === $context ) {
 			$context = $this->context();
 		}

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -173,9 +173,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 		try {
 			$data = $this->request_data->read_request( self::nonce() );
 			if ( ! isset( $data['order_id'] ) ) {
-				throw new RuntimeException(
-					__( 'No order id given', 'woocommerce-paypal-payments' )
-				);
+				throw new RuntimeException( 'No order id given' );
 			}
 
 			$order = $this->api_endpoint->order( $data['order_id'] );

--- a/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
@@ -111,9 +111,7 @@ class ApproveSubscriptionEndpoint implements EndpointInterface {
 	public function handle_request(): bool {
 		$data = $this->request_data->read_request( $this->nonce() );
 		if ( ! isset( $data['order_id'] ) ) {
-			throw new RuntimeException(
-				__( 'No order id given', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'No order id given' );
 		}
 
 		$order = $this->order_endpoint->order( $data['order_id'] );

--- a/modules/ppcp-button/src/Endpoint/CartScriptParamsEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CartScriptParamsEndpoint.php
@@ -76,7 +76,8 @@ class CartScriptParamsEndpoint implements EndpointInterface {
 				wc_maybe_define_constant( 'WOOCOMMERCE_CART', true );
 			}
 
-			$include_shipping = (bool) wc_clean( wp_unslash( $_GET['shipping'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$include_shipping = (bool) wc_clean( wp_unslash( $_GET['shipping'] ?? '' ) );
 
 			$script_data = $this->smart_button->script_data();
 			if ( ! $script_data ) {

--- a/modules/ppcp-button/src/Endpoint/CartScriptParamsEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CartScriptParamsEndpoint.php
@@ -155,7 +155,9 @@ class CartScriptParamsEndpoint implements EndpointInterface {
 				'description' => html_entity_decode(
 					wp_strip_all_tags(
 						wc_price( (float) $rate->get_cost(), array( 'currency' => get_woocommerce_currency() ) )
-					)
+					),
+					ENT_QUOTES,
+					'UTF-8'
 				),
 			);
 		}

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -254,8 +254,8 @@ class CreateOrderEndpoint implements EndpointInterface {
 		$this->pay_now_contexts                      = $pay_now_contexts;
 		$this->handle_shipping_in_paypal             = $handle_shipping_in_paypal;
 		$this->server_side_shipping_callback_enabled = $server_side_shipping_callback_enabled;
-		$this->funding_sources_without_redirect = $funding_sources_without_redirect;
-		$this->logger                           = $logger;
+		$this->funding_sources_without_redirect      = $funding_sources_without_redirect;
+		$this->logger                                = $logger;
 	}
 
 	/**

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -13,6 +13,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use stdClass;
 use Throwable;
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
@@ -282,7 +283,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 			$wc_order                  = null;
 			if ( 'pay-now' === $data['context'] ) {
 				$wc_order = wc_get_order( (int) $data['order_id'] );
-				if ( ! is_a( $wc_order, \WC_Order::class ) ) {
+				if ( ! is_a( $wc_order, WC_Order::class ) ) {
 					wp_send_json_error(
 						array(
 							'name'    => 'order-not-found',
@@ -359,7 +360,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 				$this->early_order_handler->register_for_order( $order );
 			}
 
-			if ( 'pay-now' === $data['context'] && is_a( $wc_order, \WC_Order::class ) ) {
+			if ( 'pay-now' === $data['context'] && is_a( $wc_order, WC_Order::class ) ) {
 				$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 				$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
 
@@ -418,9 +419,9 @@ class CreateOrderEndpoint implements EndpointInterface {
 	/**
 	 * Creates the order in the PayPal, uses data from WC order if provided.
 	 *
-	 * @param \WC_Order|null $wc_order WC order to get data from.
-	 * @param string         $payment_method WC payment method.
-	 * @param array          $data Request data.
+	 * @param WC_Order|null $wc_order WC order to get data from.
+	 * @param string        $payment_method WC payment method.
+	 * @param array         $data Request data.
 	 *
 	 * @return Order Created PayPal order.
 	 *
@@ -429,7 +430,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 	 *
 	 * phpcs:disable Squiz.Commenting.FunctionCommentThrowTag.WrongNumber
 	 */
-	private function create_paypal_order( \WC_Order $wc_order = null, string $payment_method = '', array $data = array() ): Order {
+	private function create_paypal_order( ?WC_Order $wc_order = null, string $payment_method = '', array $data = array() ): Order {
 		assert( $this->purchase_unit instanceof PurchaseUnit );
 
 		$funding_source = $this->parsed_request_data['funding_source'] ?? '';
@@ -540,12 +541,12 @@ class CreateOrderEndpoint implements EndpointInterface {
 	/**
 	 * Returns the Payer entity based on the request data.
 	 *
-	 * @param array          $data The request data.
-	 * @param \WC_Order|null $wc_order The order.
+	 * @param array         $data The request data.
+	 * @param WC_Order|null $wc_order The order.
 	 *
 	 * @return Payer|null
 	 */
-	private function payer( array $data, \WC_Order $wc_order = null ) {
+	private function payer( array $data, ?WC_Order $wc_order = null ) {
 		if ( 'pay-now' === $data['context'] ) {
 			$payer = $this->payer_factory->from_wc_order( $wc_order );
 			return $payer;

--- a/modules/ppcp-button/src/Endpoint/RequestData.php
+++ b/modules/ppcp-button/src/Endpoint/RequestData.php
@@ -47,9 +47,7 @@ class RequestData {
 			|| ! wp_verify_nonce( $json['nonce'], $nonce )
 		) {
 			remove_filter( 'nonce_user_logged_out', array( $this, 'nonce_fix' ), 100 );
-			throw new RuntimeException(
-				__( 'Could not validate nonce.', 'woocommerce-paypal-payments' )
-			);
+			throw new RuntimeException( 'Could not validate nonce.' );
 		}
 		$this->dequeue_nonce_fix();
 

--- a/modules/ppcp-button/src/Helper/ContextTrait.php
+++ b/modules/ppcp-button/src/Helper/ContextTrait.php
@@ -301,8 +301,9 @@ trait ContextTrait {
 	 * @return bool
 	 */
 	private function is_subscription_change_payment_method_page(): bool {
-		if ( isset( $_GET['change_payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return wcs_is_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( isset( $_GET['change_payment_method'] ) ) {
+			return wcs_is_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) );
 		}
 
 		return false;
@@ -325,12 +326,14 @@ trait ContextTrait {
 	 * @return bool
 	 */
 	protected function is_wc_settings_payments_tab(): bool {
-		if ( ! is_admin() || isset( $_GET['section'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( ! is_admin() || isset( $_GET['section'] ) ) {
 			return false;
 		}
 
-		$page = wc_clean( wp_unslash( $_GET['page'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification
-		$tab  = wc_clean( wp_unslash( $_GET['tab'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		$page = wc_clean( wp_unslash( $_GET['page'] ?? '' ) );
+		$tab  = wc_clean( wp_unslash( $_GET['tab'] ?? '' ) );
+		// phpcs:enable WordPress.Security.NonceVerification
 
 		return $page === 'wc-settings' && $tab === 'checkout';
 	}

--- a/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
+++ b/modules/ppcp-button/src/Helper/EarlyOrderHandler.php
@@ -78,7 +78,7 @@ class EarlyOrderHandler {
 	 *
 	 * @return int|null
 	 */
-	public function determine_wc_order_id( int $value = null ) {
+	public function determine_wc_order_id( ?int $value = null ) {
 
 		if ( ! isset( $_REQUEST['ppcp-resume-order'] ) ) {
 			return $value;

--- a/modules/ppcp-compat/src/AdminContextTrait.php
+++ b/modules/ppcp-compat/src/AdminContextTrait.php
@@ -20,7 +20,8 @@ trait AdminContextTrait {
 	 * @return bool
 	 */
 	private function is_paypal_order_edit_page(): bool {
-		$post_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$post_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) );
 		if ( ! $post_id ) {
 			return false;
 		}

--- a/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
+++ b/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
@@ -150,6 +150,8 @@ class SubscriptionsHandler {
 			return true;
 		}
 
+		// phpcs:disable WordPress.Security.NonceVerification
+
 		// Checks that require Subscriptions.
 		if ( class_exists( \WC_Subscriptions::class ) ) {
 			// My Account > Subscriptions > (Subscription).
@@ -160,15 +162,15 @@ class SubscriptionsHandler {
 			}
 
 			// Changing payment method?
-			if ( is_wc_endpoint_url( 'order-pay' ) && isset( $_GET['change_payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( is_wc_endpoint_url( 'order-pay' ) && isset( $_GET['change_payment_method'] ) ) {
 				$subscription = wcs_get_subscription( absint( get_query_var( 'order-pay' ) ) );
 
 				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
 			}
 
 			// Early renew (via modal).
-			if ( isset( $_GET['process_early_renewal'], $_GET['subscription_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				$subscription = wcs_get_subscription( absint( $_GET['subscription_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( isset( $_GET['process_early_renewal'], $_GET['subscription_id'] ) ) {
+				$subscription = wcs_get_subscription( absint( $_GET['subscription_id'] ) );
 
 				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
 			}
@@ -185,7 +187,6 @@ class SubscriptionsHandler {
 		}
 
 		// Are we editing an order or subscription tied to PPEC?
-		// phpcs:ignore WordPress.Security.NonceVerification
 		$order_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? $_POST['post_ID'] ?? '' ) );
 		if ( $order_id ) {
 			$order = wc_get_order( $order_id );
@@ -199,9 +200,7 @@ class SubscriptionsHandler {
 		 * @psalm-suppress UndefinedClass
 		 */
 		$post_type_or_page = class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled()
-			// phpcs:ignore WordPress.Security.NonceVerification
 			? wc_clean( wp_unslash( $_GET['page'] ?? '' ) )
-			// phpcs:ignore WordPress.Security.NonceVerification
 			: wc_clean( wp_unslash( $_GET['post_type'] ?? $_POST['post_type'] ?? '' ) );
 		if ( $post_type_or_page === 'shop_subscription' || $post_type_or_page === 'wc-orders--shop_subscription' ) {
 			return true;

--- a/modules/ppcp-googlepay/src/Endpoint/UpdatePaymentDataEndpoint.php
+++ b/modules/ppcp-googlepay/src/Endpoint/UpdatePaymentDataEndpoint.php
@@ -145,7 +145,9 @@ class UpdatePaymentDataEndpoint {
 				'description' => html_entity_decode(
 					wp_strip_all_tags(
 						wc_price( (float) $rate->get_cost(), array( 'currency' => get_woocommerce_currency() ) )
-					)
+					),
+					ENT_QUOTES,
+					'UTF-8'
 				),
 				'cost'        => $rate->get_cost(),
 			);

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -53,7 +53,7 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function( Settings $settings = null ) use ( $c ): void {
+			function( ?Settings $settings = null ) use ( $c ): void {
 				$apm_status = $c->get( 'googlepay.helpers.apm-product-status' );
 				assert( $apm_status instanceof ApmProductStatus );
 				$apm_status->clear( $settings );

--- a/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
@@ -101,7 +101,7 @@ class ApmProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ) : void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalApmProductStatus.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalApmProductStatus.php
@@ -86,7 +86,7 @@ class LocalApmProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ) : void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-onboarding/src/Render/OnboardingRenderer.php
+++ b/modules/ppcp-onboarding/src/Render/OnboardingRenderer.php
@@ -81,7 +81,7 @@ class OnboardingRenderer {
 		PartnerReferrals $sandbox_partner_referrals,
 		PartnerReferralsData $partner_referrals_data,
 		Cache $cache,
-		LoggerInterface $logger = null
+		?LoggerInterface $logger = null
 	) {
 		$this->settings                     = $settings;
 		$this->production_partner_referrals = $production_partner_referrals;

--- a/modules/ppcp-order-tracking/src/TrackingAvailabilityTrait.php
+++ b/modules/ppcp-order-tracking/src/TrackingAvailabilityTrait.php
@@ -24,7 +24,8 @@ trait TrackingAvailabilityTrait {
 	 * @return bool
 	 */
 	protected function is_tracking_enabled( Bearer $bearer ): bool {
-		$post_id = (int) wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$post_id = (int) wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? '' ) );
 		if ( ! $post_id ) {
 			return false;
 		}

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -167,6 +167,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 					return;
 				}
 
+				// phpcs:ignore WordPress.Security.NonceVerification
 				$nonce = wc_clean( wp_unslash( $_POST['_wcsnonce'] ?? '' ) );
 				if (
 					$subscriptions_mode !== 'subscriptions_api'
@@ -250,6 +251,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function( $variation_id ) use ( $c ) {
+				// phpcs:ignore WordPress.Security.NonceVerification
 				$wcsnonce_save_variations = wc_clean( wp_unslash( $_POST['_wcsnonce_save_variations'] ?? '' ) );
 
 				if (

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -285,7 +285,8 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 								? apply_filters( 'woocommerce_paypal_payments_three_d_secure_contingency', $settings->get( '3d_secure_contingency' ) )
 								: '';
 
-							$change_payment_method = wc_clean( wp_unslash( $_GET['change_payment_method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification
+							// phpcs:ignore WordPress.Security.NonceVerification
+							$change_payment_method = wc_clean( wp_unslash( $_GET['change_payment_method'] ?? '' ) );
 
 							wp_localize_script(
 								'ppcp-add-payment-method',

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -236,7 +236,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @param string|null $three_d_secure The 3D Secure setting ('no-3d-secure', 'only-required-3d-secure', 'always-3d-secure').
 	 * @return string The corresponding API enum string ('NO_3D_SECURE', 'SCA_WHEN_REQUIRED', 'SCA_ALWAYS').
 	 */
-	public function get_three_d_secure_enum( string $three_d_secure = null ): string {
+	public function get_three_d_secure_enum( ?string $three_d_secure = null ): string {
 		// If no value is provided, use the current setting.
 		if ( $three_d_secure === null ) {
 			$three_d_secure = $this->get_three_d_secure();

--- a/modules/ppcp-settings/src/Handler/ConnectionListener.php
+++ b/modules/ppcp-settings/src/Handler/ConnectionListener.php
@@ -105,7 +105,7 @@ class ConnectionListener {
 		OnboardingUrlManager $url_manager,
 		AuthenticationManager $authentication_manager,
 		RedirectorInterface $redirector,
-		LoggerInterface $logger = null
+		?LoggerInterface $logger = null
 	) {
 		$this->settings_page_id       = $settings_page_id;
 		$this->url_manager            = $url_manager;

--- a/modules/ppcp-settings/src/Service/DataSanitizer.php
+++ b/modules/ppcp-settings/src/Service/DataSanitizer.php
@@ -23,7 +23,7 @@ class DataSanitizer {
 	 * @param ?string $location Name of the location.
 	 * @return LocationStylingDTO Styling data.
 	 */
-	public function sanitize_location_style( $data, string $location = null ) : LocationStylingDTO {
+	public function sanitize_location_style( $data, ?string $location = null ) : LocationStylingDTO {
 		if ( $data instanceof LocationStylingDTO ) {
 			if ( $location ) {
 				$data->location = $location;

--- a/modules/ppcp-settings/src/Service/OnboardingUrlManager.php
+++ b/modules/ppcp-settings/src/Service/OnboardingUrlManager.php
@@ -47,7 +47,7 @@ class OnboardingUrlManager {
 	 * @param Cache            $cache  Cache instance for onboarding token.
 	 * @param ?LoggerInterface $logger The logger, for debugging purposes.
 	 */
-	public function __construct( Cache $cache, LoggerInterface $logger = null ) {
+	public function __construct( Cache $cache, ?LoggerInterface $logger = null ) {
 		$this->cache  = $cache;
 		$this->logger = $logger ?: new NullLogger();
 	}

--- a/modules/ppcp-settings/src/Service/ScriptDataHandler.php
+++ b/modules/ppcp-settings/src/Service/ScriptDataHandler.php
@@ -121,7 +121,7 @@ class ScriptDataHandler {
 			true
 		);
 
-		wp_enqueue_script( 'ppcp-admin-settings', '', array( 'wp-i18n' ), $script_asset_file['version'] );
+		wp_enqueue_script( 'ppcp-admin-settings', '', array( 'wp-i18n' ), $script_asset_file['version'], true );
 		wp_set_script_translations(
 			'ppcp-admin-settings',
 			'woocommerce-paypal-payments',

--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -85,6 +85,8 @@ class StatusReportModule implements ServiceModule, ExtendingModule, ExecutableMo
 
 				$subscription_mode_options = $c->get( 'wcgateway.settings.fields.subscriptions_mode_options' );
 
+				// Feature flag convention.
+				// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
 				$items = array(
 					array(
 						'label'          => esc_html__( 'Onboarded', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-vaulting/src/PaymentTokenHelper.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenHelper.php
@@ -24,7 +24,7 @@ class PaymentTokenHelper {
 	 * @param ?string            $class_name Class name of the token.
 	 * @return bool
 	 */
-	public function token_exist( array $wc_tokens, string $token_id, string $class_name = null ): bool {
+	public function token_exist( array $wc_tokens, string $token_id, ?string $class_name = null ): bool {
 		foreach ( $wc_tokens as $wc_token ) {
 			if ( $wc_token->get_token() === $token_id ) {
 				if ( null !== $class_name ) {

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -207,6 +207,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 						return;
 					}
 
+					// phpcs:ignore WordPress.Security.NonceVerification
 					$wpnonce         = wc_clean( wp_unslash( $_REQUEST['_wpnonce'] ?? '' ) );
 					$token_id_string = (string) $token_id;
 					$action          = 'delete-payment-method-' . $token_id_string;

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -247,9 +247,8 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	 */
 	public function process_payment( $order_id ) {
 		$wc_order = wc_get_order( $order_id );
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		// phpcs:disable WordPress.Security.NonceVerification
 		$birth_date = wc_clean( wp_unslash( $_POST['billing_birth_date'] ?? '' ) );
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$pay_for_order = wc_clean( wp_unslash( $_GET['pay_for_order'] ?? '' ) );
 		if ( 'true' === $pay_for_order ) {
 			if ( ! $this->checkout_helper->validate_birth_date( $birth_date ) ) {
@@ -261,7 +260,7 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 		}
 
 		$phone_number = wc_clean( wp_unslash( $_POST['billing_phone'] ?? '' ) );
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
+		// phpcs:enable WordPress.Security.NonceVerification
 		if ( $phone_number ) {
 			$wc_order->set_billing_phone( $phone_number );
 			$wc_order->save();

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -60,7 +60,7 @@ trait ProcessPaymentTrait {
 	 * @param string|null   $url The redirect URL.
 	 * @return array The data that can be returned by the gateway process_payment method.
 	 */
-	protected function handle_payment_success( ?WC_Order $wc_order, string $url = null ): array {
+	protected function handle_payment_success( ?WC_Order $wc_order, ?string $url = null ): array {
 		if ( ! $url ) {
 			$url = $this->get_return_url( $wc_order );
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -126,7 +126,7 @@ class DCCProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( Settings $settings = null ): void {
+	protected function clear_state( ?Settings $settings = null ): void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/DisplayManager.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DisplayManager.php
@@ -46,7 +46,7 @@ class DisplayManager {
 	 * @param string|null $key The rule key.
 	 * @return DisplayRule
 	 */
-	public function rule( string $key = null ): DisplayRule {
+	public function rule( ?string $key = null ): DisplayRule {
 		if ( null === $key ) {
 			$key = '_rule_' . ( (string) count( $this->rules ) );
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/InstallmentsProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/InstallmentsProductStatus.php
@@ -98,7 +98,7 @@ class InstallmentsProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ) : void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -111,7 +111,7 @@ class PayUponInvoiceProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ) : void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -33,7 +33,7 @@ trait OrderMetaTrait {
 		WC_Order $wc_order,
 		Order $order,
 		Environment $environment,
-		OrderTransient $order_transient = null
+		?OrderTransient $order_transient = null
 	): void {
 		$wc_order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, $order->id() );
 		$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );

--- a/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
@@ -107,7 +107,7 @@ class RefundProcessor {
 	 *
 	 * @phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag.Missing
 	 */
-	public function process( WC_Order $wc_order, float $amount = null, string $reason = '' ) : bool {
+	public function process( WC_Order $wc_order, ?float $amount = null, string $reason = '' ) : bool {
 		try {
 			$payment_gateways = WC()->payment_gateways()->payment_gateways();
 			if ( ! isset( $payment_gateways[ $wc_order->get_payment_method() ] ) || ! $payment_gateways[ $wc_order->get_payment_method() ]->supports( 'refunds' ) ) {

--- a/modules/ppcp-wc-gateway/src/Processor/TransactionIdHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/TransactionIdHandlingTrait.php
@@ -31,7 +31,7 @@ trait TransactionIdHandlingTrait {
 	public function update_transaction_id(
 		string $transaction_id,
 		WC_Order $wc_order,
-		LoggerInterface $logger = null
+		?LoggerInterface $logger = null
 	): bool {
 		try {
 			$wc_order->set_transaction_id( $transaction_id );

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -207,7 +207,7 @@ class SettingsListener {
 		string $partner_merchant_id_production,
 		string $partner_merchant_id_sandbox,
 		ReferenceTransactionStatus $reference_transaction_status,
-		LoggerInterface $logger = null,
+		?LoggerInterface $logger,
 		Cache $client_credentials_cache,
 		Cache $reference_transaction_status_cache
 	) {

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -475,7 +475,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function( Settings $settings = null ) use ( $c ): void {
+			function( ?Settings $settings = null ) use ( $c ): void {
 
 				// Clear DCC Product status.
 				$dcc_product_status = $c->get( 'wcgateway.helper.dcc-product-status' );


### PR DESCRIPTION
Fixed some QIT warnings, such as

- replace `FILTER_VALIDATE_BOOL` (8.0+) with `FILTER_VALIDATE_BOOLEAN`
- specify `html_entity_decode` options explicitly
- always use `?Type` in parameters when `Type $foo = null`
- remove translation of exceptions (when does not make much sense to display in UI, too technical etc.)
- move/replace `phpcs:ignore` lines when they become in a wrong place after Scoper (when end of the line or inside an expression)