### PR TITLE
Axo: Make the state address data optional to fix non US-CA compatibility (5012)

### DIFF
--- a/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.js
+++ b/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.js
@@ -121,7 +121,7 @@ export const populateWooFields = (
 		address_1: address.addressLine1,
 		address_2: address.addressLine2 || '',
 		city: address.adminArea2,
-		state: address.adminArea1,
+		state: address.adminArea1 || '',
 		postcode: address.postalCode,
 		country: address.countryCode,
 		phone: phoneNumber.nationalNumber,

--- a/modules/ppcp-axo-block/resources/js/hooks/useShippingAddressChange.js
+++ b/modules/ppcp-axo-block/resources/js/hooks/useShippingAddressChange.js
@@ -32,7 +32,7 @@ export const useShippingAddressChange = ( fastlaneSdk, setShippingAddress ) => {
 					address_1: address.addressLine1,
 					address_2: address.addressLine2 || '',
 					city: address.adminArea2,
-					state: address.adminArea1,
+					state: address.adminArea1 || '',
 					postcode: address.postalCode,
 					country: address.countryCode,
 					phone: phoneNumber.nationalNumber,

--- a/modules/ppcp-axo/resources/js/Views/ShippingView.js
+++ b/modules/ppcp-axo/resources/js/Views/ShippingView.js
@@ -44,7 +44,7 @@ class ShippingView {
 						? this.states[ countryCode ][ stateCode ]
 						: stateCode;
 
-				if ( this.hasEmptyValues( data, stateName ) ) {
+				if ( this.hasEmptyValues( data ) ) {
 					return `
                         <div style="margin-bottom: 20px;">
                             <div class="axo-checkout-header-section">
@@ -71,9 +71,9 @@ class ShippingView {
 						) }</div>
                         <div>${ data.value( 'street1' ) }</div>
                         <div>${ data.value( 'street2' ) }</div>
-                        <div>${ data.value(
-							'city'
-						) }, ${ stateName } ${ data.value( 'postCode' ) }</div>
+                        <div>${ data.value( 'city' ) }${
+							stateName ? ', ' + stateName : ''
+						} ${ data.value( 'postCode' ) }</div>
                         <div>${ valueOfSelect(
 							'#billing_country',
 							countryCode
@@ -158,14 +158,13 @@ class ShippingView {
 		} );
 	}
 
-	hasEmptyValues( data, stateName ) {
+	hasEmptyValues( data ) {
 		return (
 			! data.value( 'email' ) ||
 			! data.value( 'firstName' ) ||
 			! data.value( 'lastName' ) ||
 			! data.value( 'street1' ) ||
-			! data.value( 'city' ) ||
-			! stateName
+			! data.value( 'city' )
 		);
 	}
 


### PR DESCRIPTION
### Summary
This PR will fix the issue where shipping addresses were failing to display and validate correctly for countries that don't include state data.

The original issue was caused by the state data being required to update/display the shipping address, but German addresses (and other countries) returned from PayPal don't include state data.

### Screenshots

#### Classic Checkout

|Before|After|
|-|-|
|<img width="1055" height="756" alt="Classic_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/e177ce1b-1723-4e37-9d27-4bc5c2d2b866" />|<img width="1071" height="837" alt="Classic_Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/32806672-f3e2-42fa-a487-a33efff342ea" />|

#### Block Checkout

|Before|After|
|-|-|
|<img width="1216" height="849" alt="Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/3dd209b9-3a4e-4c56-9a67-fe0bb95c1cf0" />|<img width="1226" height="833" alt="Checkout_–_WooCommerce_PayPal_Payments" src="https://github.com/user-attachments/assets/5dc1920d-1c03-4e63-a2f9-92a7e75574a8" />|

### Testing Steps
1. Create a test order using a Fastlane Profile account
2. Select a German shipping address
4. Verify that the form validates successfully and displays the German address correctly both in Classic and Block checkouts
