### PR TITLE
Add "Things to do next" item after settings migration (5009)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -417,7 +417,8 @@ $services = array(
 	'settings.data.definition.todos'                      => static function ( ContainerInterface $container ) : TodosDefinition {
 		return new TodosDefinition(
 			$container->get( 'settings.service.todos_eligibilities' ),
-			$container->get( 'settings.data.general' )
+			$container->get( 'settings.data.general' ),
+			$container->get( 'settings.data.todos' )
 		);
 	},
 	'settings.data.definition.methods'                    => static function ( ContainerInterface $container ) : PaymentMethodsDefinition {

--- a/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
@@ -24,6 +24,7 @@ class SwitchSettingsUiEndpoint {
 
 	public const ENDPOINT                      = 'ppcp-settings-switch-ui';
 	public const OPTION_NAME_SHOULD_USE_OLD_UI = 'woocommerce_ppcp-settings-should-use-old-ui';
+	public const OPTION_NAME_MIGRATION_IS_DONE = 'woocommerce_ppcp-settings-migration-is-done';
 
 	protected RequestData $request_data;
 	protected LoggerInterface $logger;
@@ -70,6 +71,8 @@ class SwitchSettingsUiEndpoint {
 			$this->onboarding_profile->save();
 
 			$this->settings_data_migration->migrate();
+
+			update_option( self::OPTION_NAME_MIGRATION_IS_DONE, 'yes' );
 			wp_send_json_success();
 		} catch ( Exception $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 500 );

--- a/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
+++ b/modules/ppcp-settings/src/Ajax/SwitchSettingsUiEndpoint.php
@@ -72,7 +72,7 @@ class SwitchSettingsUiEndpoint {
 
 			$this->settings_data_migration->migrate();
 
-			update_option( self::OPTION_NAME_MIGRATION_IS_DONE, 'yes' );
+			update_option( self::OPTION_NAME_MIGRATION_IS_DONE, true );
 			wp_send_json_success();
 		} catch ( Exception $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 500 );

--- a/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Settings\Data\Definition;
 
+use WooCommerce\PayPalCommerce\Settings\Ajax\SwitchSettingsUiEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
 use WooCommerce\PayPalCommerce\Settings\Service\TodosEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 
@@ -34,18 +36,23 @@ class TodosDefinition {
 	 */
 	protected GeneralSettings $settings;
 
+	protected TodosModel $todos;
+
 	/**
 	 * Constructor.
 	 *
 	 * @param TodosEligibilityService $eligibilities The todos eligibility service.
 	 * @param GeneralSettings         $settings The general settings service.
+	 * @param TodosModel              $todos The todos model instance.
 	 */
 	public function __construct(
 		TodosEligibilityService $eligibilities,
-		GeneralSettings $settings
+		GeneralSettings $settings,
+		TodosModel $todos
 	) {
 		$this->eligibilities = $eligibilities;
 		$this->settings      = $settings;
+		$this->todos         = $todos;
 	}
 
 	/**
@@ -56,7 +63,7 @@ class TodosDefinition {
 	public function get(): array {
 		$eligibility_checks = $this->eligibilities->get_eligibility_checks();
 
-		return array(
+		$todo_items = array(
 			'enable_fastlane'                      => array(
 				'title'       => __( 'Enable Fastlane', 'woocommerce-paypal-payments' ),
 				'description' => __( 'Accelerate your guest checkout with Fastlane by PayPal', 'woocommerce-paypal-payments' ),
@@ -228,5 +235,63 @@ class TodosDefinition {
 				'priority'    => 13,
 			),
 		);
+
+		$todo_items['check_settings_after_migration'] = array(
+			'title'       => __( "You're now using the new PayPal Payments interface!", 'woocommerce-paypal-payments' ),
+			'description' => __( 'Complete the items below to ensure your payment configuration is optimized for your store.', 'woocommerce-paypal-payments' ),
+			'isEligible'  => fn(): bool => $this->is_settings_migration_done() && ! $this->are_all_todos_completed( $todo_items ),
+			'action'      => array(
+				'type' => 'tab',
+				'tab'  => 'overview',
+			),
+			'priority'    => 0,
+		);
+
+		return $todo_items;
 	}
+
+	/**
+	 * Checks whether the settings migration to the new UI has been completed.
+	 *
+	 * @return bool True if the migration is marked as done, false otherwise.
+	 */
+	protected function is_settings_migration_done(): bool {
+		return 'yes' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_MIGRATION_IS_DONE );
+	}
+
+	/**
+	 * Determines whether all todos have been completed or dismissed appropriately.
+	 *
+	 * A to-do is considered completed if:
+	 * - It's eligible (based on the callable `isEligible`), AND
+	 * - It is either:
+	 *     - A "completeOnClick" type and is present in the completed list, OR
+	 *     - Not a "completeOnClick" type and is present in the dismissed list.
+	 *
+	 * @param array $todos The array of to-do definitions.
+	 * @return bool True if all to-dos are completed or dismissed as expected, false otherwise.
+	 */
+	protected function are_all_todos_completed( array $todos ): bool {
+		$dismissed = $this->todos->get_dismissed_todos();
+		$completed = $this->todos->get_completed_onclick_todos();
+
+		foreach ( $todos as $id => $todo ) {
+			if ( ! is_callable( $todo['isEligible'] ) || ! call_user_func( $todo['isEligible'] ) ) {
+				continue;
+			}
+
+			$is_click_to_complete = $todo['action']['completeOnClick'] ?? false;
+
+			if ( $is_click_to_complete && ! in_array( $id, $completed, true ) ) {
+				return false;
+			}
+
+			if ( ! $is_click_to_complete && ! in_array( $id, $dismissed, true ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 }

--- a/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
@@ -256,7 +256,7 @@ class TodosDefinition {
 	 * @return bool True if the migration is marked as done, false otherwise.
 	 */
 	protected function is_settings_migration_done(): bool {
-		return 'yes' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_MIGRATION_IS_DONE );
+		return '1' === get_option( SwitchSettingsUiEndpoint::OPTION_NAME_MIGRATION_IS_DONE );
 	}
 
 	/**

--- a/modules/ppcp-uninstall/services.php
+++ b/modules/ppcp-uninstall/services.php
@@ -36,6 +36,7 @@ return array(
 			WebhookRegistrar::KEY,
 			'ppcp_payment_tokens_migration_initialized',
 			SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI,
+			SwitchSettingsUiEndpoint::OPTION_NAME_MIGRATION_IS_DONE,
 		);
 	},
 


### PR DESCRIPTION
## Issue Description

**Add "Things to do next" item after settings migration to encourage users to check their configuration**

**Description:** 
After users migrate from the old UI to the new UI using the migration button, we need to add a prominent action item in the "Things to do next" section to guide them through configuration verification.

**Requirements:**
* Add a new action item to the "Things to do next" section that appears immediately after successful migration
* The action item should be the first/top item users see post-migration
* Action item text: "**You're now using the new PayPal Payments interface!** Complete the items below to ensure your payment configuration is optimized for your store."

**Context:** 
The "Things to do next" section is a dedicated area in the plugin that serves as the primary user guidance interface. Since this is the first thing users see after migration, it's the ideal place to prompt configuration review.

**Technical Notes:**
* Should trigger only after successful migration from old to new UI
* May need to track migration completion status to show this item appropriately → automatically complete the item when all other items are completed

**Acceptance Criteria:**
* Action item appears in "Things to do next" section after migration completion
* Item is positioned as the top priority task
* Text matches the specified wording exactly
* Item is only shown for users who have just completed migration (not for all users)

## PR Description

This PR Adds "Things to do next" item after settings migration as described above.
It saves the `'woocommerce_ppcp-settings-migration-is-done'` option in DB when settings migration is completed and then uses it to the new todo item