### PR TITLE
Fix the "New UI active" status report, add "Branded only" status report (4941)

### DIFF
--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Compat\PPEC\PPECHelper;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -100,12 +101,7 @@ class StatusReportModule implements ServiceModule, ExtendingModule, ExecutableMo
 						'label'          => esc_html__( 'New UI active', 'woocommerce-paypal-payments' ),
 						'exported_label' => 'New UI active',
 						'description'    => esc_html__( 'Indicates whether the new Settings UI is enabled.', 'woocommerce-paypal-payments' ),
-						'value'          => $this->bool_to_html(
-							apply_filters(
-								'woocommerce.feature-flags.woocommerce_paypal_payments.settings_enabled',
-								'1' === get_option( 'woocommerce-ppcp-is-new-merchant' ) || getenv( 'PCP_SETTINGS_ENABLED' ) === '1'
-							)
-						),
+						'value'          => $this->bool_to_html( ! SettingsModule::should_use_the_old_ui() ),
 					),
 					array(
 						'label'          => esc_html__( 'Shop country code', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Compat\PPEC\PPECHelper;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
@@ -86,6 +87,9 @@ class StatusReportModule implements ServiceModule, ExtendingModule, ExecutableMo
 
 				$subscription_mode_options = $c->get( 'wcgateway.settings.fields.subscriptions_mode_options' );
 
+				/* @var GeneralSettings $general_settings General plugin settings. */
+				$general_settings = $c->get( 'settings.data.general' );
+
 				// Feature flag convention.
 				// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
 				$items = array(
@@ -96,6 +100,12 @@ class StatusReportModule implements ServiceModule, ExtendingModule, ExecutableMo
 						'value'          => $this->bool_to_html(
 							$this->onboarded( $bearer, $is_connected )
 						),
+					),
+					array(
+						'label'          => esc_html__( 'Branded only', 'woocommerce-paypal-payments' ),
+						'exported_label' => 'Branded only',
+						'description'    => esc_html__( 'Whether the plugin is in Branded only mode or not.', 'woocommerce-paypal-payments' ),
+						'value'          => $this->bool_to_html( $general_settings->own_brand_only() ),
 					),
 					array(
 						'label'          => esc_html__( 'New UI active', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
## Issue Description

The PayPal Payments section in the system report should include an indicator for whether the plugin is in Branded only mode or not.
Additionally the "New UI active“ is not showing correctly anymore, so this needs to be fixed.

## PR Description

- “New UI active“ is fixed. Now we rely on `SettingsModule::should_use_the_old_ui()` [method](https://github.com/woocommerce/woocommerce-paypal-payments/blob/ba8b42068a4b2c2901c5ca4ef261943c71d383a4/modules/ppcp-settings/src/SettingsModule.php#L68) to determine whether the new UI is being used.
- Added status report for the "Branded only"