### PR TITLE
Fix Google Pay transaction from block pages (5007)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Helper/Address.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Address.js
@@ -115,7 +115,7 @@ export const paypalSubscriberToWc = ( subscriber ) => {
  * @return {Object}
  */
 export const paypalOrderToWcShippingAddress = ( order ) => {
-	const shipping = order.purchase_units?.[ 0 ]?.shipping;
+	const shipping = order?.purchase_units?.[ 0 ]?.shipping;
 	if ( ! shipping ) {
 		return {};
 	}

--- a/modules/ppcp-blocks/resources/js/Helper/Address.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Address.js
@@ -145,7 +145,7 @@ export const paypalOrderToWcShippingAddress = ( order ) => {
 export const paypalOrderToWcAddresses = ( order ) => {
 	const shippingAddress = paypalOrderToWcShippingAddress( order );
 	let billingAddress = shippingAddress;
-	if ( order.payer ) {
+	if ( order?.payer ) {
 		billingAddress = paypalPayerToWc( order.payer );
 		// no billing address, such as if billing address retrieval is not allowed in the merchant account
 		if ( ! billingAddress.address_line_1 ) {


### PR DESCRIPTION
## Issue Description

On latest version of the plugin (3.0.7), the transaction with Google Pay isn't working on Express checkout and Block Cart due to an error.

**Steps To Reproduce**

-  Insatall and activate 3.0.7 or 3.0.8 beta-1
- Navigate to store
- Try to perform a transaction using Google Pay from: Express checkout or Block cart

## PR Description

This PR adds checks in JS to prevent errors.