### PR TITLE
Remove redundant authorize call in subscription renewal handler (1575)

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -516,7 +516,7 @@ class RenewalHandler {
 		$this->add_paypal_meta( $wc_order, $order, $this->environment );
 
 		if ( $order->intent() === 'AUTHORIZE' ) {
-			$order = $this->order_endpoint->authorize( $order );
+			// No authorize call needed - vault tokens auto-authorize during order creation.
 			$wc_order->update_meta_data( AuthorizedPaymentsProcessor::CAPTURED_META_KEY, 'false' );
 		}
 


### PR DESCRIPTION
The vaulted subscription renewal handler was attempting to authorize orders when the intent was set to "AUTHORIZE". This resulted in `ORDER_ALREADY_AUTHORIZED` errors because PayPal orders created with tokens as a payment source are authorized automatically, with the authorization returned in the order creation response.

This PR removes the redundant authorize call while maintaining the `AuthorizedPaymentsProcessor::CAPTURED_META_KEY` meta update call, which is necessary for the manual renewal action to be displayed.

This change will only affect vaulted subscription renewals. Since these renewals always use tokens as the payment source, no explicit authorization call is required.