### PR TITLE
Skip "Payment Methods" step for branded-only + BCDC and casual sellers (4425)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/index.js
@@ -64,10 +64,19 @@ export const getSteps = ( flags ) => {
 		// Casual selling: Unlock the "Personal Account" choice.
 		( step ) => flags.canUseCasualSelling || step.id !== 'business',
 		// Skip payment methods screen.
-		( step ) =>
-			step.id !== 'methods' ||
-			( ! flags.shouldSkipPaymentMethods &&
-				! ( ownBrandOnly && isCasualSeller ) ),
+		( step ) => {
+			if ( step.id !== 'methods' ) {
+				return true;
+			}
+
+			const isBrandedBCDC = ownBrandOnly && ! flags.canUseCardPayments;
+			const shouldSkip =
+				flags.shouldSkipPaymentMethods ||
+				isCasualSeller ||
+				isBrandedBCDC;
+
+			return ! shouldSkip;
+		},
 	] );
 
 	const totalStepsCount = steps.length;


### PR DESCRIPTION
## Issue Description

In branded-only mode with BCDC country (or casual seller): Skip step 4 “optional payment methods” should be skipped

**Acceptance Criteria (Gherkin)**

**Scenario: Branded only install path in non-ACDC country**
**GIVEN** the plugin was installed via Payments tab (branded only) in a non-ACDC WC store location
**WHEN** the PCP onboarding wizard is started and business account selected
**THEN**  the step (asking for optional payment methods/credit cards) should be skipped

**Scenario: Personal seller onboarding**
**GIVEN** the plugin was installed via [w.org](http://w.org/) plugin repo in a non-ACDC WC store location
**WHEN** the PCP onboarding wizard is started and personal account selected
**THEN** the step (asking for optional payment methods/credit cards) should be skipped

## PR Description

This PR updates the onboarding step logic to **skip the "Optional Payment Methods" step** (`step.id === 'methods'`) in the following cases:  

- When the seller is in **branded-only mode** and **BCDC country** (`!canUseCardPayments`)  
- OR when the seller is a **casual seller**  
