### PR TITLE
Subscriptions migrated from PPEC to PPC fails on renewal

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -94,28 +94,6 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		$this->legacy_ui_card_payment_mapping( $c );
 
-		// Short-circuit RenewalHandler::get_token_for_customer() to use a Billing Agreement ID for PPEC orders.
-		add_filter('woocommerce_paypal_payments_subscriptions_get_token_for_customer', function ($token, $customer, $order ) {
-			if ( PPECHelper::PPEC_GATEWAY_ID === $order->get_payment_method() && wcs_order_contains_renewal( $order ) ) {
-				$subscriptions = wcs_get_subscriptions_for_renewal_order($order);
-
-				if (!empty($subscriptions)) {
-					$subscription = reset($subscriptions); // Get first subscription.
-					$parent_order = $subscription->get_parent();
-
-					if ($parent_order) {
-						$billing_agreement_id = $parent_order->get_meta('_ppec_billing_agreement_id', true);
-
-						if ($billing_agreement_id) {
-							$token = new PaymentToken($billing_agreement_id, new stdClass(), 'BILLING_AGREEMENT');
-						}
-					}
-				}
-			}
-
-			return $token;
-		}, 10, 3);
-
 		return true;
 	}
 

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -10,12 +10,9 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Compat;
 
 use Exception;
-use stdClass;
 use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Product;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
-use WooCommerce\PayPalCommerce\Compat\PPEC\PPECHelper;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -10,9 +10,12 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Compat;
 
 use Exception;
+use stdClass;
 use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Product;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentToken;
+use WooCommerce\PayPalCommerce\Compat\PPEC\PPECHelper;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -90,6 +93,28 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		add_action( 'woocommerce_paypal_payments_gateway_migrate', static fn() => delete_transient( 'ppcp_has_ppec_subscriptions' ) );
 
 		$this->legacy_ui_card_payment_mapping( $c );
+
+		// Short-circuit RenewalHandler::get_token_for_customer() to use a Billing Agreement ID for PPEC orders.
+		add_filter('woocommerce_paypal_payments_subscriptions_get_token_for_customer', function ($token, $customer, $order ) {
+			if ( PPECHelper::PPEC_GATEWAY_ID === $order->get_payment_method() && wcs_order_contains_renewal( $order ) ) {
+				$subscriptions = wcs_get_subscriptions_for_renewal_order($order);
+
+				if (!empty($subscriptions)) {
+					$subscription = reset($subscriptions); // Get first subscription.
+					$parent_order = $subscription->get_parent();
+
+					if ($parent_order) {
+						$billing_agreement_id = $parent_order->get_meta('_ppec_billing_agreement_id', true);
+
+						if ($billing_agreement_id) {
+							$token = new PaymentToken($billing_agreement_id, new stdClass(), 'BILLING_AGREEMENT');
+						}
+					}
+				}
+			}
+
+			return $token;
+		}, 10, 3);
 
 		return true;
 	}

--- a/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
+++ b/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
@@ -76,7 +76,7 @@ class SubscriptionsHandler {
 	 * @return array
 	 */
 	public function add_mock_ppec_gateway( $gateways ) {
-		if ( ! isset( $gateways[ PPECHelper::PPEC_GATEWAY_ID ] ) && $this->should_mock_ppec_gateway() ) {
+		if ( ! isset( $gateways[ PPECHelper::PPEC_GATEWAY_ID ] ) ) {
 			$gateways[ PPECHelper::PPEC_GATEWAY_ID ] = $this->mock_gateway;
 		}
 
@@ -145,80 +145,5 @@ class SubscriptionsHandler {
 		}
 
 		return $token;
-	}
-
-	/**
-	 * Checks whether the mock PPEC gateway should be used or not.
-	 *
-	 * @return bool
-	 */
-	private function should_mock_ppec_gateway() {
-		// Are we processing a renewal?
-		if ( doing_action( 'woocommerce_scheduled_subscription_payment' ) ) {
-			return true;
-		}
-
-		// My Account > Subscriptions.
-		if ( is_wc_endpoint_url( 'subscriptions' ) ) {
-			return true;
-		}
-
-		// phpcs:disable WordPress.Security.NonceVerification
-
-		// Checks that require Subscriptions.
-		if ( class_exists( \WC_Subscriptions::class ) ) {
-			// My Account > Subscriptions > (Subscription).
-			if ( wcs_is_view_subscription_page() ) {
-				$subscription = wcs_get_subscription( absint( get_query_var( 'view-subscription' ) ) );
-
-				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
-			}
-
-			// Changing payment method?
-			if ( is_wc_endpoint_url( 'order-pay' ) && isset( $_GET['change_payment_method'] ) ) {
-				$subscription = wcs_get_subscription( absint( get_query_var( 'order-pay' ) ) );
-
-				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
-			}
-
-			// Early renew (via modal).
-			if ( isset( $_GET['process_early_renewal'], $_GET['subscription_id'] ) ) {
-				$subscription = wcs_get_subscription( absint( $_GET['subscription_id'] ) );
-
-				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
-			}
-		}
-
-		// Admin-only from here onwards.
-		if ( ! is_admin() ) {
-			return false;
-		}
-
-		// Are we saving metadata for a subscription?
-		if ( doing_action( 'woocommerce_process_shop_order_meta' ) ) {
-			return true;
-		}
-
-		// Are we editing an order or subscription tied to PPEC?
-		$order_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? $_POST['post_ID'] ?? '' ) );
-		if ( $order_id ) {
-			$order = wc_get_order( $order_id );
-			return ( $order && PPECHelper::PPEC_GATEWAY_ID === $order->get_payment_method() );
-		}
-
-		// Are we on the WC > Subscriptions screen?
-		/**
-		 * Class exist in WooCommerce.
-		 *
-		 * @psalm-suppress UndefinedClass
-		 */
-		$post_type_or_page = class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled()
-			? wc_clean( wp_unslash( $_GET['page'] ?? '' ) )
-			: wc_clean( wp_unslash( $_GET['post_type'] ?? $_POST['post_type'] ?? '' ) );
-		if ( $post_type_or_page === 'shop_subscription' || $post_type_or_page === 'wc-orders--shop_subscription' ) {
-			return true;
-		}
-
-		return false;
 	}
 }

--- a/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
+++ b/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
@@ -125,9 +125,22 @@ class SubscriptionsHandler {
 	public function use_billing_agreement_as_token( $token, $customer, $order ) {
 		if ( PPECHelper::PPEC_GATEWAY_ID === $order->get_payment_method() && wcs_order_contains_renewal( $order ) ) {
 			$billing_agreement_id = $order->get_meta( '_ppec_billing_agreement_id', true );
-
 			if ( $billing_agreement_id ) {
-				$token = new PaymentToken( $billing_agreement_id, new stdClass(), 'BILLING_AGREEMENT' );
+				return new PaymentToken( $billing_agreement_id, new stdClass(), 'BILLING_AGREEMENT' );
+			}
+
+			$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
+			if ( ! empty( $subscriptions ) ) {
+				$subscription = reset( $subscriptions ); // Get first subscription.
+				$parent_order = $subscription->get_parent();
+
+				if ( $parent_order ) {
+					$billing_agreement_id = $parent_order->get_meta( '_ppec_billing_agreement_id', true );
+
+					if ( $billing_agreement_id ) {
+						return new PaymentToken( $billing_agreement_id, new stdClass(), 'BILLING_AGREEMENT' );
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
When subscriptions originally purchased using the legacy PayPal Checkout gateway (PPEC) are migrated to PayPal Payments (PPC) fails on renewal.

### Steps To Reproduce
- Disable the PayPal Payments plugin (PPC).
- Enable WooCommerce PayPal Checkout Gateway (PPEC).
- Purchase a subscription product using PPEC.
- Disable PPEC and re-enable PPC.
- Confirm the subscription now shows paypal legacy as the gateway (expected behavior).
- Note the subscription post ID.
- In Tools → Scheduled Actions, locate the renewal action for that subscription and run action.

### Possible Cause
[should_mock_ppec_gateway](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php#L79) is executed before renewal action is triggered and therefore woocommerce_scheduled_subscription_payment [doing action](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php#L144) is always false. 

Because should_mock_ppec_gateway is false mocked PPEC gateway is not added and renewal triggered by action scheduler fails.

### Suggested Solution
Remove should_mock_ppec_gateway condition so PPCE mock gateway is added no matter the context when the site has existing PPEC subscriptions and PPEC plugin is not active.  

By doing so  woocommerce_scheduled_subscription_payment action check works as expected as PPCE mock gateway is available.


