### PR TITLE
When Apple Pay is enabled empty space for Apple Pay button is showing on all pages  (3957)

### DIFF
--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -105,7 +105,8 @@ registerExpressPaymentMethod( {
 	content: <ApplePayComponent isEditing={ false } />,
 	edit: <ApplePayComponent isEditing={ true } />,
 	ariaLabel: buttonData.title,
-	canMakePayment: () => buttonData.enabled,
+	canMakePayment: () =>
+		buttonData.enabled && window.ApplePaySession?.canMakePayments(),
 	supports: {
 		features,
 		style: [ 'height', 'borderRadius' ],


### PR DESCRIPTION
### Steps to reproduce
- Enable Apple Pay
- Enable Express Checkout and Mini Cart in Styling button location
- Navigate to block Checkout with non-Apple device
→ observe empty Apple Pay button div:

<img width="906" height="262" alt="f2353af9-94dd-49c6-8547-322f07eb5b23" src="https://github.com/user-attachments/assets/b1e63c1d-b69b-49cf-9799-fa67f966c436" />

This PR adds a condition into `registerExpressPaymentMethod` `canMakePayment`  to display button only if Apple session and can make payments are available.