### PR TITLE
Fix undefined properties error in checkout block (5027)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Helper/Address.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Address.js
@@ -27,7 +27,7 @@ export const paypalAddressToWc = ( address ) => {
 		admin_area_2: 'city',
 		postal_code: 'postcode',
 	};
-	if ( address.city ) {
+	if ( address?.city ) {
 		// address not from API, such as onShippingChange
 		map = {
 			country_code: 'country',
@@ -38,7 +38,7 @@ export const paypalAddressToWc = ( address ) => {
 	}
 	const result = {};
 	Object.entries( map ).forEach( ( [ paypalKey, wcKey ] ) => {
-		if ( address[ paypalKey ] ) {
+		if ( address?.[ paypalKey ] ) {
 			result[ wcKey ] = address[ paypalKey ];
 		}
 	} );


### PR DESCRIPTION
The PayPal address may be empty in some cases, such as with virtual products. There were no undefined property checks in the address helpers, which was causing errors in the checkout block.

This PR fixes that by adding optional chaining to the address properties.