### PR TITLE
New UI - On Goole Pay popup no shipping methods visible when Pay Now is enabled (4976)

### DIFF
--- a/modules/ppcp-blocks/resources/js/paypal-config.js
+++ b/modules/ppcp-blocks/resources/js/paypal-config.js
@@ -99,7 +99,7 @@ export const handleApprove = async (
 			order = json.data;
 		}
 
-		const shippingAddress = order.purchase_units?.[ 0 ]?.shipping?.address;
+		const shippingAddress = order?.purchase_units?.[ 0 ]?.shipping?.address;
 		if ( shippingAddress ) {
 			const addresses = paypalOrderToWcAddresses( order );
 

--- a/modules/ppcp-button/src/Endpoint/ChangeCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ChangeCartEndpoint.php
@@ -102,4 +102,34 @@ class ChangeCartEndpoint extends AbstractCartEndpoint {
 		$pu = $this->purchase_unit_factory->from_wc_cart();
 		return array( $pu->to_array() );
 	}
+
+	/**
+	 * Adds products to cart with shipping data preservation.
+	 *
+	 * @param array $products Array of products to be added to cart.
+	 * @return bool
+	 * @throws Exception Add to cart methods throw an exception on fail.
+	 */
+	protected function add_products( array $products ): bool {
+		// Preserve shipping data before emptying cart.
+		$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
+
+		$this->cart->empty_cart( false );
+
+		try {
+			$this->cart_products->add_products( $products );
+
+			if ( $chosen_shipping_methods ) {
+				WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
+
+				$this->cart->calculate_shipping();
+				$this->cart->calculate_fees();
+				$this->cart->calculate_totals();
+			}
+		} catch ( Exception $e ) {
+			$this->handle_error();
+		}
+
+		return true;
+	}
 }

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -190,7 +190,8 @@ return array(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'settings.environment' ),
 			$container->get( 'wcgateway.settings.status' ),
-			$container->get( 'woocommerce.logger.woocommerce' )
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->has('settings.data.settings') ? $container->get('settings.data.settings') : null
 		);
 	},
 

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -191,7 +191,7 @@ return array(
 			$container->get( 'settings.environment' ),
 			$container->get( 'wcgateway.settings.status' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->has('settings.data.settings') ? $container->get('settings.data.settings') : null
+			$container->has( 'settings.data.settings' ) ? $container->get( 'settings.data.settings' ) : null
 		);
 	},
 

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -135,7 +135,7 @@ class Button implements ButtonInterface {
 		$this->environment         = $environment;
 		$this->settings_status     = $settings_status;
 		$this->logger              = $logger;
-		$this->new_settings = $new_settings;
+		$this->new_settings        = $new_settings;
 	}
 
 	/**
@@ -546,11 +546,11 @@ class Button implements ButtonInterface {
 	 * Check if new settings model exist and if so check enable pay now setting,
 	 * if none of the above is true, check legacy settings for shipping enabled.
 	 *
-	 * @return bool
-	 * @throws NotFoundException
+	 * @return bool Whether shipping should be used or not.
+	 * @throws NotFoundException If the settings are not found.
 	 */
 	private function should_use_shipping(): bool {
-		if(! is_null($this->new_settings) && $this->new_settings->get_enable_pay_now() === true) {
+		if ( ! is_null( $this->new_settings ) && $this->new_settings->get_enable_pay_now() === true ) {
 			return true;
 		}
 

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
 use WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
@@ -94,6 +95,11 @@ class Button implements ButtonInterface {
 	private $subscription_helper;
 
 	/**
+	 * @var SettingsModel|null New settings UI model.
+	 */
+	private ?SettingsModel $new_settings;
+
+	/**
 	 * SmartButton constructor.
 	 *
 	 * @param string             $module_url The URL to the module.
@@ -101,10 +107,11 @@ class Button implements ButtonInterface {
 	 * @param string             $version The assets version.
 	 * @param SessionHandler     $session_handler The Session handler.
 	 * @param SubscriptionHelper $subscription_helper The subscription helper.
-	 * @param Settings           $settings The Settings.
+	 * @param Settings           $settings The legacy settings.
 	 * @param Environment        $environment The environment object.
 	 * @param SettingsStatus     $settings_status The Settings status helper.
 	 * @param LoggerInterface    $logger The logger.
+	 * @param SettingsModel|null $new_settings The new settings model.
 	 */
 	public function __construct(
 		string $module_url,
@@ -115,7 +122,8 @@ class Button implements ButtonInterface {
 		Settings $settings,
 		Environment $environment,
 		SettingsStatus $settings_status,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		SettingsModel $new_settings = null
 	) {
 
 		$this->module_url          = $module_url;
@@ -127,6 +135,7 @@ class Button implements ButtonInterface {
 		$this->environment         = $environment;
 		$this->settings_status     = $settings_status;
 		$this->logger              = $logger;
+		$this->new_settings = $new_settings;
 	}
 
 	/**
@@ -445,9 +454,10 @@ class Button implements ButtonInterface {
 	 * The configuration for the smart buttons.
 	 *
 	 * @return array
+	 * @throws NotFoundException If the settings are not found.
 	 */
 	public function script_data(): array {
-		$use_shipping_form = $this->settings->has( 'googlepay_button_shipping_enabled' ) && $this->settings->get( 'googlepay_button_shipping_enabled' );
+		$use_shipping_form = $this->should_use_shipping();
 
 		// On the product page, only show the shipping form for physical products.
 		$context = $this->context();
@@ -530,5 +540,20 @@ class Button implements ButtonInterface {
 	 */
 	private function wc_countries(): WC_Countries {
 		return new WC_Countries();
+	}
+
+	/**
+	 * Check if new settings model exist and if so check enable pay now setting,
+	 * if none of the above is true, check legacy settings for shipping enabled.
+	 *
+	 * @return bool
+	 * @throws NotFoundException
+	 */
+	private function should_use_shipping(): bool {
+		if(! is_null($this->new_settings) && $this->new_settings->get_enable_pay_now() === true) {
+			return true;
+		}
+
+		return $this->settings->has( 'googlepay_button_shipping_enabled' ) && $this->settings->get( 'googlepay_button_shipping_enabled' );
 	}
 }

--- a/tests/PHPUnit/Button/Endpoint/ChangeCartEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/ChangeCartEndpointTest.php
@@ -84,6 +84,18 @@ class ChangeCartEndpointTest extends TestCase
             ->with(ChangeCartEndpoint::nonce())
             ->andReturn($data);
 
+        // Mock WC session for shipping data preservation
+        $session = Mockery::mock(\WC_Session::class);
+        $session->shouldReceive('get')
+            ->with('chosen_shipping_methods')
+            ->andReturn(null);
+        $session->shouldReceive('set')
+            ->with('chosen_shipping_methods', Mockery::any());
+
+        $wc = Mockery::mock();
+        $wc->session = $session;
+        expect('WC')->andReturn($wc);
+
 		$pu = Mockery::mock(PurchaseUnit::class);
 		$pu
 			->shouldReceive('to_array')


### PR DESCRIPTION
Shipping callback currently does not work for Google Pay in new settings UI.

### Steps to reproduce
- Define for example free shipping and flat rate methods
- Navigate to shop, click on product, click on Google Pay
  - Observe shipping methods are not showing in Google Pay modal

### Expected behavior
When the “Pay Now Experience” setting is enabled, then both PayPal and Google Pay should have the shipping callback functionality automatically enabled.

### Possible cause
It seems the problem of non displaying shipping methods in Google Pay modal is caused by `this.buttonConfig.shipping?.enabled` returning false in [requiresShipping](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-googlepay/resources/js/GooglepayButton.js#L220).

`this.buttonConfig.shipping?.enabled` get its value from setting [googlepay_button_shipping_enabled](https://github.com/woocommerce/woocommerce-paypal-payments/blob/trunk/modules/ppcp-googlepay/extensions.php#L222) which defaults to `no`.

In new setting UI we do not have this setting in the UI and therefore it’s not possible to change its value.

### Suggested solution
`requiresShipping` should get the value from "Pay Now Experience" setting for new settings UI while still using the `googlepay_button_shipping_enabled` value for legacy UI.