### PR TITLE
Remove the specified gateway when the button is disabled (4520)

### DIFF
--- a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
@@ -319,7 +319,7 @@ class StylingSettingsMapHelper {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			static function ( $methods ) use ( $button_name, $current_context ) {
+			static function ( $methods ) use ( $button_name, $current_context ): array {
 				if ( $current_context !== 'classic_checkout' ) {
 					return $methods;
 				}

--- a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
@@ -305,7 +305,6 @@ class StylingSettingsMapHelper {
 			}
 		}
 
-
 		/**
 		 * Filters the available payment gateways to remove the specified gateway (e.g., Google Pay or Apple Pay)
 		 * when the button is disabled for the current location (e.g., classic checkout) in the styling settings.

--- a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php
@@ -305,26 +305,29 @@ class StylingSettingsMapHelper {
 			}
 		}
 
-		if ( $current_context === 'classic_checkout' ) {
+
+		/**
+		 * Filters the available payment gateways to remove the specified gateway (e.g., Google Pay or Apple Pay)
+		 * when the button is disabled for the current location (e.g., classic checkout) in the styling settings.
+		 * This is necessary because WooCommerce automatically includes the gateway when it is enabled,
+		 * even if the button is hidden via settings.
+		 */
+		add_filter(
+			'woocommerce_available_payment_gateways',
 			/**
-			 * Outputs an inline CSS style that hides the Google Pay gateway (on Classic Checkout)
-			 * In case if the button is disabled from the styling settings but the gateway itself is enabled.
+			 * Param types removed to avoid third-party issues.
 			 *
-			 * @return void
+			 * @psalm-suppress MissingClosureParamType
 			 */
-			add_action(
-				'woocommerce_paypal_payments_checkout_button_render',
-				static function (): void {
-					?>
-					<style data-hide-gateway='<?php echo esc_attr( GooglePayGateway::ID ); ?>'>
-						.wc_payment_method.payment_method_ppcp-googlepay {
-							display: none;
-						}
-					</style>
-					<?php
+			static function ( $methods ) use ( $button_name, $current_context ) {
+				if ( $current_context !== 'classic_checkout' ) {
+					return $methods;
 				}
-			);
-		}
+
+				unset( $methods[ $button_name ] );
+				return $methods;
+			}
+		);
 
 		return 0;
 	}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -248,7 +248,7 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	public function process_payment( $order_id ) {
 		$wc_order = wc_get_order( $order_id );
 		// phpcs:disable WordPress.Security.NonceVerification
-		$birth_date = wc_clean( wp_unslash( $_POST['billing_birth_date'] ?? '' ) );
+		$birth_date    = wc_clean( wp_unslash( $_POST['billing_birth_date'] ?? '' ) );
 		$pay_for_order = wc_clean( wp_unslash( $_GET['pay_for_order'] ?? '' ) );
 		if ( 'true' === $pay_for_order ) {
 			if ( ! $this->checkout_helper->validate_birth_date( $birth_date ) ) {


### PR DESCRIPTION
 ## Issue Description
 
The separate Apple Pay gateway appears in some cases on the Classic Checkout when it’s not supposed to. The button is usually not displayed in these cases.

**Steps To Reproduce**

- Onboard with merchant eligible for acdc
- Navigate to shop
- Add product to cart
- Navigate to classic checkout

## PR Description
 
A Filter is added to remove the available payment gateways (e.g., Google Pay or Apple Pay) when the button is disabled for the current location (e.g., classic checkout) in the styling settings.
This is necessary because WooCommerce automatically includes the gateway when it is enabled, even if the button is hidden via settings.

