### PR TITLE
Fastlane: Add Classic Checkout card design to Block Checkout (4996)

### DIFF
--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -50,7 +50,6 @@ $fast-transition-duration: 0.5s;
 		position: relative;
 		box-sizing: border-box;
 		aspect-ratio: 1.586;
-		font-family: monospace;
 		margin: 1em 0;
 		border-radius: 10px;
 		width: 100%;
@@ -70,6 +69,7 @@ $fast-transition-duration: 0.5s;
 			text-shadow: 0 -1px 1px #fff, 0 1px 1px rgba(0, 0, 0, .2666666667);
 			color: #666;
 			text-align: center;
+			font-family: monospace;
 		}
 
 		&-logo {
@@ -81,8 +81,8 @@ $fast-transition-duration: 0.5s;
 
 		&-expiry {
 			text-align: right;
-			font-size: 12px;
-			padding-right: 33px;
+			font-size: 14px;
+			padding-right: 32px;
 		}
 
 		&-name {
@@ -90,6 +90,7 @@ $fast-transition-duration: 0.5s;
 			position: absolute;
 			left: 24px;
 			bottom: 20px;
+			line-height: 1em;
 		}
 	}
 

--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -42,40 +42,55 @@ $fast-transition-duration: 0.5s;
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		max-width: 300px;
+		max-width: 340px;
 		width: 100%;
 	}
 
 	&__content {
+		position: relative;
 		box-sizing: border-box;
 		aspect-ratio: 1.586;
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		border: 1px solid $border-color;
-		font-size: 0.875em;
 		font-family: monospace;
-		padding: 1em;
 		margin: 1em 0;
-		border-radius: 4px;
+		border-radius: 10px;
 		width: 100%;
+		box-shadow: 0 3px 10px -3px rgba(0, 0, 0, .2666666667);
+		background-image: linear-gradient(60deg, rgba(0, 0, 0, 0.0666666667), rgba(204, 204, 204, 0.0666666667) 65%, rgba(255, 255, 255, 0.4) 68%, rgba(255, 255, 255, 0));
+		border: 2px solid #ccc;
+		background-color: #f6f6f6;
 	}
 
 	&__meta {
-		@include flex-space-between;
 		width: 100%;
+		text-align: left;
 
 		&-digits {
-			letter-spacing: 2px;
+			margin-top: 76px;
+			font-size: 24px;
+			text-shadow: 0 -1px 1px #fff, 0 1px 1px rgba(0, 0, 0, .2666666667);
+			color: #666;
+			text-align: center;
 		}
 
-		&:last-child {
-			align-self: flex-end;
+		&-logo {
+			position: absolute;
+			right: 32px;
+			top: 32px;
+			height: 40px;
 		}
-	}
 
-	&__watermark {
-		align-self: flex-end;
+		&-expiry {
+			text-align: right;
+			font-size: 12px;
+			padding-right: 33px;
+		}
+
+		&-name {
+			text-transform: uppercase;
+			position: absolute;
+			left: 24px;
+			bottom: 20px;
+		}
 	}
 
 	&__edit {

--- a/modules/ppcp-axo-block/resources/js/components/Card/Card.js
+++ b/modules/ppcp-axo-block/resources/js/components/Card/Card.js
@@ -59,15 +59,6 @@ const Card = ( { fastlaneSdk, showWatermark = true } ) => {
 						</div>
 					</div>
 				</div>
-				<div className="wc-block-checkout-axo-block-card__watermark">
-					{ showWatermark && (
-						<Watermark
-							fastlaneSdk={ fastlaneSdk }
-							name="wc-block-checkout-axo-card-watermark"
-							includeAdditionalInfo={ false }
-						/>
-					) }
-				</div>
 			</div>
 		</div>
 	);

--- a/modules/ppcp-axo-block/resources/js/components/Card/Card.js
+++ b/modules/ppcp-axo-block/resources/js/components/Card/Card.js
@@ -45,14 +45,18 @@ const Card = ( { fastlaneSdk, showWatermark = true } ) => {
 			<div className="wc-block-checkout-axo-block-card__inner">
 				<div className="wc-block-checkout-axo-block-card__content">
 					<div className="wc-block-checkout-axo-block-card__meta">
-						<span className="wc-block-checkout-axo-block-card__meta-digits">
+						<div className="wc-block-checkout-axo-block-card__meta-logo">
+							{ cardLogo }
+						</div>
+						<div className="wc-block-checkout-axo-block-card__meta-digits">
 							{ `**** **** **** ${ lastDigits }` }
-						</span>
-						{ cardLogo }
-					</div>
-					<div className="wc-block-checkout-axo-block-card__meta">
-						<span>{ name }</span>
-						<span>{ formattedExpiry }</span>{ ' ' }
+						</div>
+						<div className="wc-block-checkout-axo-block-card__meta-expiry">
+							{ formattedExpiry }
+						</div>
+						<div className="wc-block-checkout-axo-block-card__meta-name">
+							{ name }
+						</div>
 					</div>
 				</div>
 				<div className="wc-block-checkout-axo-block-card__watermark">


### PR DESCRIPTION
## Issue Description

We need Fastlane credit card placeholder to look nice on Classic and Block Checkout.
The Classic Checkout has a more modern card place holder design in Ryan flow:

<img width="1083" height="840" alt="image-20250710-170015" src="https://github.com/user-attachments/assets/8c05fbfe-a2e4-48b0-b6ab-fe8f2f37b93b" />

The Block Checkout has an older design:

<img width="1424" height="1067" alt="image-20250710-170018" src="https://github.com/user-attachments/assets/318864a9-aa63-480b-a09f-018764a3954b" />

## PR Description

This PR adjusts the styles and structure of block to match the design of Classic checkout
