### PR TITLE
Clean AppSwitch hash params on Pay for Order page (5031)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForPayNow.js
@@ -4,11 +4,18 @@ import {
 } from '../Helper/CheckoutMethodState';
 import Spinner from '../Helper/Spinner';
 
+import resumeFlowHelper from '../Helper/ResumeFlowHelper';
+
 const onApprove = ( context, errorHandler ) => {
 	return ( data, actions ) => {
 		const spinner = Spinner.fullPage();
 		spinner.block();
 		errorHandler.clear();
+		// Pay Now submits via form (not AJAX), so we can't detect payment errors.
+		// Preemptively remove hash params to prevent reload issues.
+		if ( resumeFlowHelper.isResumeFlow() ) {
+			resumeFlowHelper.cleanHashParams();
+		}
 
 		return fetch( context.config.ajax.approve_order.endpoint, {
 			method: 'POST',


### PR DESCRIPTION
Unlike other contexts, the Pay for Order page does not process the payment over AJAX, it uses a regular form submission.

When there is an error during payment processing on this page, there is no way to notify that to the frontend before or after the page is reloaded. Since the AppSwitch hash params are still present in the URL upon reload, the AppSwitch flow is triggered again, causing an infinite reload loop.

To fix this, this PR adds code to preemptively remove the hash params from the URL on the onApprove callback, before the payment is processed.