### PR TITLE
Prevent early `is_enabled()` check for Google Pay button in new UI (5021)

### DIFF
--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -17,6 +17,7 @@ use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\AvailabilityNotice;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -149,9 +150,11 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				add_action(
 					'woocommerce_blocks_payment_method_type_registration',
 					function( PaymentMethodRegistry $payment_method_registry ) use ( $c, $button ): void {
-						if ( $button->is_enabled() ) {
-							$payment_method_registry->register( $c->get( 'googlepay.blocks-payment-method' ) );
+						if ( SettingsModule::should_use_the_old_ui() && ! $button->is_enabled() ) {
+							return;
 						}
+
+						$payment_method_registry->register( $c->get( 'googlepay.blocks-payment-method' ) );
 					}
 				);
 


### PR DESCRIPTION
## Issue Description

1. When Google Pay isn't selected in Styling->Products location then it will not be visible in Store -> Mini cart, as well. Despite the fact that, for mini cart location Google Pay will be selected.
2. When in Styling →  Mini cart location  "Enable payment methods in this location" will not be checked, then Google Pay will not be available for Store : Block cart, Express checkout, Product page.

### The Problem

In the **old UI**, we don’t have location-based settings for the Google Pay button. Instead, we rely on a single setting — `googlepay_button_enabled` — to enable or disable the button globally across all locations.

In the **new UI**, however, we support **location-based settings**, and we [map](https://github.com/woocommerce/woocommerce-paypal-payments/blob/9455a6855d823f746fffe5cd15b3bf142671ad4a/modules/ppcp-compat/src/Settings/StylingSettingsMapHelper.php#L292) the `googlepay_button_enabled` option individually for each location.

The issue arises because, during block registration, [we call](https://github.com/woocommerce/woocommerce-paypal-payments/blob/9455a6855d823f746fffe5cd15b3bf142671ad4a/modules/ppcp-googlepay/src/GooglepayModule.php#L152) `$button->is_enabled()`. This method uses ContextTrait to determine the current context. But inside the `woocommerce_blocks_payment_method_type_registration` hook, context-detection functions like `is_cart()` always return `false` , because this hook is triggered too early in the WordPress lifecycle, before those context functions are properly initialized.

As a result, the context defaults to` 'mini-cart'`, which is typically **disabled** by default. This leads to `$button->is_enabled()` returning `false`, and the Google Pay payment method is **not registered** in the block cart.

## PR Description

This PR prevents early `is_enabled()` check for Google Pay button in new UI.
In the new UI, the Google Pay button availability is determined by gateway enablement and location selection, not a global setting. The `is_enabled()` check depends on context functions (like `is_cart()`), which return `false` too early during block registration.
