### PR TITLE
Add PR preview via WordPress Playground (5039)

### DIFF
--- a/.github/scripts/playground-comment.js
+++ b/.github/scripts/playground-comment.js
@@ -1,0 +1,113 @@
+const generateWordpressPlaygroundBlueprint = (runId, prNumber, artifactName) => {
+    const defaultSchema = {
+        landingPage: '/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway',
+        preferredVersions: {
+            php: '8.0',
+            wp: 'latest',
+        },
+        phpExtensionBundles: ['kitchen-sink'],
+        features: { networking: true },
+        steps: [
+            {
+                step: 'installPlugin',
+                pluginData: {
+                    resource: 'wordpress.org/plugins',
+                    slug: 'woocommerce'
+                },
+                options: {
+                    activate: true
+                }
+            },
+            {
+                step: 'installPlugin',
+                pluginZipFile: {
+                    resource: 'url',
+                    url: `https://playground.wordpress.net/plugin-proxy.php?org=woocommerce&repo=woocommerce-paypal-payments&workflow=PR%20Playground%20Demo&artifact=${artifactName}&pr=${prNumber}`,
+                },
+                options: {
+                    activate: true,
+                },
+            },
+            {
+                step: 'setSiteOptions',
+                options: {
+                    woocommerce_onboarding_profile: {
+                        skipped: true,
+                    },
+                },
+            },
+            {
+                step: 'login',
+                username: 'admin',
+                password: 'password',
+            },
+        ],
+        plugins: [],
+    };
+    return defaultSchema;
+};
+
+async function run({ github, context, core }) {
+    try {
+        const commentInfo = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+        };
+
+        // Validate required environment variables
+        if (!process.env.PLUGIN_VERSION || !process.env.ARTIFACT_NAME) {
+            core.setFailed('Missing required environment variables: PLUGIN_VERSION or ARTIFACT_NAME');
+            return;
+        }
+
+        // Comments are only added after the first successful build.
+        // The caller should check for existing comments before calling this function.
+
+        const defaultSchema = generateWordpressPlaygroundBlueprint(
+            context.runId,
+            context.issue.number,
+            process.env.ARTIFACT_NAME
+        );
+
+        const url = `https://playground.wordpress.net/#${JSON.stringify(defaultSchema)}`;
+
+        const body = `## Test using WordPress Playground
+The changes in this pull request can be previewed and tested using a [WordPress Playground](https://developer.wordpress.org/playground/) instance.
+[WordPress Playground](https://developer.wordpress.org/playground/) is an experimental project that creates a full WordPress instance entirely within the browser.
+
+**🔗 [Test this pull request with WordPress Playground](${url})**
+
+### What's included:
+- ✅ WordPress (latest)
+- ✅ WooCommerce (latest)
+- ✅ PayPal Payments plugin v${process.env.PLUGIN_VERSION} (built from this PR)
+
+### Login credentials:
+- **Username:** \`admin\`
+- **Password:** \`password\`
+
+### Plugin Details:
+- **Version:** ${process.env.PLUGIN_VERSION}
+- **Commit:** ${context.payload.pull_request.head.sha}
+- **Artifact:** ${process.env.ARTIFACT_NAME}
+
+> 💡 The demo environment resets each time you refresh. Perfect for testing!
+>
+> ⚠️ This URL is valid for 30 days from when this comment was last updated. You can refresh it by pushing a new commit.
+
+---
+<sub>🤖 Auto-generated for commit ${context.payload.pull_request.head.sha}</sub>`;
+
+        // Create the comment
+        commentInfo.body = body;
+        await github.rest.issues.createComment(commentInfo);
+
+        core.info('Successfully created playground comment on PR');
+
+    } catch (error) {
+        core.setFailed(`Failed to create playground comment: ${error.message}`);
+    }
+}
+
+module.exports = { run };

--- a/.github/scripts/playground-comment.js
+++ b/.github/scripts/playground-comment.js
@@ -78,8 +78,13 @@ async function run({ github, context, core }) {
             return;
         }
 
-        // Comments are only added after the first successful build.
-        // The caller should check for existing comments before calling this function.
+        // Check for existing playground comment to update instead of creating duplicate
+        const comments = await github.rest.issues.listComments(commentInfo);
+
+        const existingComment = comments.data.find(comment =>
+            comment.user.type === 'Bot' &&
+            comment.body.includes('Test using WordPress Playground')
+        );
 
         const defaultSchema = generateWordpressPlaygroundBlueprint(
             context.runId,
@@ -111,19 +116,36 @@ The changes in this pull request can be previewed and tested using a [WordPress 
 
 > 💡 The demo environment resets each time you refresh. Perfect for testing!
 >
-> ⚠️ This URL is valid for 30 days from when this comment was last updated. You can refresh it by pushing a new commit.
+> 🔄 This link updates automatically with each new commit to the PR.
+>
+> ⚠️ This URL is valid for 30 days from when this comment was last updated.
 
 ---
-<sub>🤖 Auto-generated for commit ${context.payload.pull_request.head.sha}</sub>`;
+<sub>🤖 Auto-generated for commit ${context.payload.pull_request.head.sha} • Last updated: ${new Date().toISOString()}</sub>`;
 
-        // Create the comment
-        commentInfo.body = body;
-        await github.rest.issues.createComment(commentInfo);
+        if (existingComment) {
+            // Update existing comment
+            await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body: body
+            });
 
-        core.info('Successfully created playground comment on PR');
+            core.info(`Successfully updated existing playground comment #${existingComment.id} on PR #${context.issue.number}`);
+        } else {
+            // Create new comment
+            await github.rest.issues.createComment({
+                ...commentInfo,
+                body: body
+            });
+
+            core.info(`Successfully created new playground comment on PR #${context.issue.number}`);
+        }
 
     } catch (error) {
-        core.setFailed(`Failed to create playground comment: ${error.message}`);
+        core.setFailed(`Failed to create/update playground comment: ${error.message}`);
+        core.error(`Error details: ${error.stack}`);
     }
 }
 

--- a/.github/scripts/playground-comment.js
+++ b/.github/scripts/playground-comment.js
@@ -49,7 +49,15 @@ const generateWordpressPlaygroundBlueprint = (runId, prNumber, artifactName) => 
                 },
             },
 
-            // Step 4: Set up admin user login
+            // Step 4: Enable Coming Soon mode
+            {
+                step: 'setSiteOptions',
+                options: {
+                    woocommerce_coming_soon: 'yes',
+                },
+            },
+
+            // Step 5: Set up admin user login
             {
                 step: 'login',
                 username: 'admin',

--- a/.github/scripts/playground-comment.js
+++ b/.github/scripts/playground-comment.js
@@ -1,13 +1,21 @@
 const generateWordpressPlaygroundBlueprint = (runId, prNumber, artifactName) => {
     const defaultSchema = {
-        landingPage: '/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway',
+        landingPage: '/wp-admin/admin.php?page=wc-settings&tab=advanced&section=blueprint&activate-multi=true',
+
         preferredVersions: {
             php: '8.0',
             wp: 'latest',
         },
+
         phpExtensionBundles: ['kitchen-sink'],
-        features: { networking: true },
+
+        // Enable networking for API calls and external connections
+        features: {
+            networking: true
+        },
+
         steps: [
+            // Step 1: Install and activate WooCommerce
             {
                 step: 'installPlugin',
                 pluginData: {
@@ -18,6 +26,8 @@ const generateWordpressPlaygroundBlueprint = (runId, prNumber, artifactName) => 
                     activate: true
                 }
             },
+
+            // Step 2: Install PayPal Payments plugin from PR artifact
             {
                 step: 'installPlugin',
                 pluginZipFile: {
@@ -28,6 +38,8 @@ const generateWordpressPlaygroundBlueprint = (runId, prNumber, artifactName) => 
                     activate: true,
                 },
             },
+
+            // Step 3: Skip WooCommerce onboarding wizard
             {
                 step: 'setSiteOptions',
                 options: {
@@ -36,14 +48,19 @@ const generateWordpressPlaygroundBlueprint = (runId, prNumber, artifactName) => 
                     },
                 },
             },
+
+            // Step 4: Set up admin user login
             {
                 step: 'login',
                 username: 'admin',
                 password: 'password',
             },
         ],
+
+        // Initialize empty plugins array (can be extended later)
         plugins: [],
     };
+
     return defaultSchema;
 };
 

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -30,7 +30,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  create_archive:
+  prepare_version:
     runs-on: ubuntu-latest
     # Only run for the main repository, not forks, and allow push events on PCP-5039 branches
     if: >
@@ -53,23 +53,33 @@ jobs:
           echo "plugin_version=$PR_VERSION" >> $GITHUB_OUTPUT
           echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
 
-      - name: Build plugin archive
-        uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@a9af34f34e95cbe18703198c7e972e97ebcd7473
-        with:
-          PHP_VERSION: 7.4
-          NODE_VERSION: 22
-          PLUGIN_MAIN_FILE: ./woocommerce-paypal-payments.php
-          PLUGIN_VERSION: ${{ steps.version.outputs.plugin_version }}
-          PLUGIN_FOLDER_NAME: woocommerce-paypal-payments
-          ARCHIVE_NAME: ${{ steps.version.outputs.artifact_name }}
-          COMPILE_ASSETS_ARGS: "-vv --env=root"
+  build_plugin:
+    needs: prepare_version
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@a9af34f34e95cbe18703198c7e972e97ebcd7473
+    with:
+      PHP_VERSION: 7.4
+      NODE_VERSION: 22
+      PLUGIN_MAIN_FILE: ./woocommerce-paypal-payments.php
+      PLUGIN_VERSION: ${{ needs.prepare_version.outputs.plugin_version }}
+      PLUGIN_FOLDER_NAME: woocommerce-paypal-payments
+      ARCHIVE_NAME: ${{ needs.prepare_version.outputs.artifact_name }}
+      COMPILE_ASSETS_ARGS: "-vv --env=root"
+
+  create_archive:
+    runs-on: ubuntu-latest
+    needs: [prepare_version, build_plugin]
+    outputs:
+      artifact_name: ${{ needs.prepare_version.outputs.artifact_name }}
+      plugin_version: ${{ needs.prepare_version.outputs.plugin_version }}
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Save PR details
         run: |
           mkdir -p ./pr
           echo "${{ github.event.pull_request.number || '0' }}" > ./pr/NR
-          echo "${{ steps.version.outputs.plugin_version }}" > ./pr/VERSION
-          echo "${{ steps.version.outputs.artifact_name }}" > ./pr/ARTIFACT
+          echo "${{ needs.prepare_version.outputs.plugin_version }}" > ./pr/VERSION
+          echo "${{ needs.prepare_version.outputs.artifact_name }}" > ./pr/ARTIFACT
 
       - name: Upload PR number
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -3,6 +3,11 @@ name: PR Playground Demo
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'assets/**'
+      - 'package.json'
+      - 'composer.json'
   workflow_run:
     workflows: ["PR Playground Demo"]
     types:

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -9,15 +9,11 @@ on:
       - "package.json"
       - "composer.json"
   push:
-    branches:
-      - "PCP-5039-*"
     paths:
       - "src/**"
       - "assets/**"
       - "package.json"
       - "composer.json"
-      - ".github/workflows/pr-playground-demo.yml"
-      - ".github/scripts/playground-comment.js"
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -30,11 +26,8 @@ permissions: {}
 jobs:
   prepare_version:
     runs-on: ubuntu-latest
-    # Only run for the main repository, not forks, and allow push events on PCP-5039 branches
-    if: >
-      github.repository == 'woocommerce/woocommerce-paypal-payments' &&
-      (github.event_name == 'pull_request' ||
-       (github.event_name == 'push' && startsWith(github.ref_name, 'PCP-5039-')))
+    # Only run for the main repository, not forks
+    if: github.repository == 'woocommerce/woocommerce-paypal-payments' && github.event_name == 'pull_request'
     outputs:
       artifact_name: ${{ steps.version.outputs.artifact_name }}
       plugin_version: ${{ steps.version.outputs.plugin_version }}
@@ -46,7 +39,7 @@ jobs:
         run: |
           BASE_VERSION=$(sed -nE '/Version:/s/.* ([0-9.]+).*/\1/p' woocommerce-paypal-payments.php)
           VERSUFFIX="${GITHUB_RUN_ID}-g$(git rev-parse --short HEAD)"
-          PR_VERSION="${BASE_VERSION}-pr${{ github.event.pull_request.number || '0' }}-${VERSUFFIX}"
+          PR_VERSION="${BASE_VERSION}-pr${{ github.event.pull_request.number }}-${VERSUFFIX}"
           ARTIFACT_NAME="woocommerce-paypal-payments-${PR_VERSION}"
           echo "plugin_version=$PR_VERSION" >> $GITHUB_OUTPUT
           echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
@@ -75,7 +68,7 @@ jobs:
       - name: Save PR details
         run: |
           mkdir -p ./pr
-          echo "${{ github.event.pull_request.number || '0' }}" > ./pr/NR
+          echo "${{ github.event.pull_request.number }}" > ./pr/NR
           echo "${{ needs.prepare_version.outputs.plugin_version }}" > ./pr/VERSION
           echo "${{ needs.prepare_version.outputs.artifact_name }}" > ./pr/ARTIFACT
 
@@ -92,11 +85,8 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    # Only run for pull requests in the main repository, or push events to PCP-5039 branches
-    if: >
-      github.repository == 'woocommerce/woocommerce-paypal-payments' &&
-      (github.event_name == 'pull_request' ||
-       (github.event_name == 'push' && startsWith(github.ref_name, 'PCP-5039-')))
+    # Only run for pull requests in the main repository
+    if: github.repository == 'woocommerce/woocommerce-paypal-payments' && github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
 
@@ -138,9 +128,7 @@ jobs:
           script: |
             const fs = require('fs');
 
-            // For testing, always use PR #3574
-            const issue_number = 3574;
-
+            const pr_number = fs.readFileSync('./NR', 'utf8').trim();
             const plugin_version = fs.readFileSync('./VERSION', 'utf8').trim();
             const artifact_name = fs.readFileSync('./ARTIFACT', 'utf8').trim();
 
@@ -151,22 +139,11 @@ jobs:
             process.env.PLUGIN_VERSION = plugin_version;
             process.env.ARTIFACT_NAME = artifact_name;
 
-            // Create context for the script
-            const mockContext = {
+            const updatedContext = {
               ...context,
-              repo: {
-                owner: context.repo.owner,
-                repo: context.repo.repo
-              },
-              issue: { number: issue_number },
-              runId: context.runId,
-              payload: {
-                pull_request: {
-                  head: {
-                    sha: context.sha
-                  }
-                }
+              issue: {
+                number: parseInt(pr_number, 10)
               }
             };
 
-            await script.run({ github, context: mockContext, core });
+            await script.run({ github, context: updatedContext, core });

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Unzip PR details
         run: unzip pr-details.zip
 
-      - name: Comment on PR with WordPress Playground link
+      - name: Create or update PR playground comment
         uses: actions/github-script@v7
         with:
           script: |
@@ -117,21 +117,6 @@ jobs:
             const issue_number = Number(fs.readFileSync('./NR'));
             const plugin_version = fs.readFileSync('./VERSION', 'utf8').trim();
             const artifact_name = fs.readFileSync('./ARTIFACT', 'utf8').trim();
-
-            // Check for existing comment to avoid duplicates
-            const commentInfo = {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number,
-            };
-
-            const comments = (await github.rest.issues.listComments(commentInfo)).data;
-
-            for (const currentComment of comments) {
-              if (currentComment.user.type === 'Bot' && currentComment.body.includes('Test using WordPress Playground')) {
-                return;
-              }
-            }
 
             // Load the comment script
             const script = require('./.github/scripts/playground-comment.js');

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -62,18 +62,96 @@ jobs:
           name: pr-details
           path: pr/
 
-  # Placeholder for playground_demo job - will be implemented in Task 2
-  # playground_demo:
-  #   name: Comment on PR with Playground details
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     issues: write
-  #     pull-requests: write
-  #   if: >
-  #     github.repository == 'woocommerce/woocommerce-paypal-payments' &&
-  #     github.event_name == 'workflow_run' &&
-  #     github.event.workflow_run.event == 'pull_request' &&
-  #     github.event.workflow_run.conclusion == 'success'
-  #   steps:
-  #     - name: Placeholder
-  #       run: echo "Playground demo job will be implemented in Task 2"
+  playground_demo:
+    name: Comment on PR with Playground details
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    # Only run on workflow_run events from successful builds, and only for the main repo
+    if: >
+      github.repository == 'woocommerce/woocommerce-paypal-payments' &&
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download PR details artifact
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name === 'pr-details'
+            })[0];
+
+            if (!matchArtifact) {
+              core.setFailed('No pr-details artifact found!');
+              return;
+            }
+
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr-details.zip', Buffer.from(download.data));
+
+      - name: Unzip PR details
+        run: unzip pr-details.zip
+
+      - name: Comment on PR with WordPress Playground link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const issue_number = Number(fs.readFileSync('./NR'));
+            const plugin_version = fs.readFileSync('./VERSION', 'utf8').trim();
+            const artifact_name = fs.readFileSync('./ARTIFACT', 'utf8').trim();
+
+            // Check for existing comment to avoid duplicates
+            const commentInfo = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+            };
+
+            const comments = (await github.rest.issues.listComments(commentInfo)).data;
+
+            for (const currentComment of comments) {
+              if (currentComment.user.type === 'Bot' && currentComment.body.includes('Test using WordPress Playground')) {
+                return;
+              }
+            }
+
+            // Load the comment script
+            const script = require('./.github/scripts/playground-comment.js');
+
+            // Set environment variables for the script
+            process.env.PLUGIN_VERSION = plugin_version;
+            process.env.ARTIFACT_NAME = artifact_name;
+
+            // Create a mock context for the script
+            const mockContext = {
+              ...context,
+              issue: { number: issue_number },
+              runId: ${{ github.event.workflow_run.id }},
+              payload: {
+                pull_request: {
+                  head: {
+                    sha: '${{ github.event.workflow_run.head_sha }}'
+                  }
+                }
+              }
+            };
+
+            await script.run({ github, context: mockContext, core });

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -90,10 +90,11 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    # Only run for pull requests in the main repository
+    # Only run for pull requests in the main repository, or push events to PCP-5039 branches
     if: >
       github.repository == 'woocommerce/woocommerce-paypal-payments' &&
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'push' && startsWith(github.ref_name, 'PCP-5039-')))
     steps:
       - uses: actions/checkout@v4
 
@@ -134,7 +135,10 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const issue_number = Number(fs.readFileSync('./NR'));
+
+            // For testing, always use PR #3574
+            const issue_number = 3574;
+
             const plugin_version = fs.readFileSync('./VERSION', 'utf8').trim();
             const artifact_name = fs.readFileSync('./ARTIFACT', 'utf8').trim();
 
@@ -160,58 +164,3 @@ jobs:
             };
 
             await script.run({ github, context: mockContext, core });
-
-  # =============================================================================
-  # TEMPORARY TESTING JOB - REMOVE AFTER TESTING COMPLETE
-  # =============================================================================
-
-  temporary_comment_testing:
-    name: "[TEMP] Test Comment on PR #3574"
-    runs-on: ubuntu-latest
-    needs: create_archive
-    permissions:
-      issues: write
-      pull-requests: write
-    # TEMPORARY: Only for testing workflow development on PCP-5039 branches
-    if: >
-      github.repository == 'woocommerce/woocommerce-paypal-payments' &&
-      github.event_name == 'push' &&
-      startsWith(github.ref_name, 'PCP-5039-') &&
-      needs.create_archive.result == 'success'
-
-    steps:
-      - name: "[TEMP] Checkout for testing"
-        uses: actions/checkout@v4
-
-      - name: "[TEMP] Test comment on PR #3574"
-        uses: actions/github-script@v7
-        env:
-          PLUGIN_VERSION: ${{ needs.create_archive.outputs.plugin_version }}
-          ARTIFACT_NAME: ${{ needs.create_archive.outputs.artifact_name }}
-        with:
-          script: |
-            console.log("🧪 TEMPORARY TESTING: Testing comment on PR #3574");
-
-            const script = require('./.github/scripts/playground-comment.js');
-
-            // Direct context for PR #3574
-            const mockContext = {
-              ...context,
-              issue: { number: 3574 },
-              runId: context.runId,
-              payload: {
-                pull_request: {
-                  head: {
-                    sha: '${{ github.sha }}'
-                  }
-                }
-              }
-            };
-
-            console.log("🧪 TEMPORARY TESTING: Posting comment to PR #3574");
-            await script.run({ github, context: mockContext, core });
-            console.log("🧪 TEMPORARY TESTING: Comment posted successfully");
-
-  # =============================================================================
-  # END TEMPORARY TESTING SECTION
-  # =============================================================================

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -4,22 +4,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'src/**'
-      - 'assets/**'
-      - 'package.json'
-      - 'composer.json'
-  workflow_run:
-    workflows: ["PR Playground Demo"]
-    types:
-      - completed
+      - "src/**"
+      - "assets/**"
+      - "package.json"
+      - "composer.json"
   push:
     branches:
-      - 'PCP-5039-*'
+      - "PCP-5039-*"
     paths:
-      - 'src/**'
-      - 'assets/**'
-      - 'package.json'
-      - 'composer.json'
+      - "src/**"
+      - "assets/**"
+      - "package.json"
+      - "composer.json"
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -90,15 +86,14 @@ jobs:
   playground_demo:
     name: Comment on PR with Playground details
     runs-on: ubuntu-latest
+    needs: create_archive
     permissions:
       issues: write
       pull-requests: write
-    # Only run on workflow_run events from successful builds, and only for the main repo
+    # Only run for pull requests in the main repository
     if: >
       github.repository == 'woocommerce/woocommerce-paypal-payments' &&
-      github.event_name == 'workflow_run' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
 
@@ -109,7 +104,7 @@ jobs:
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
+              run_id: context.runId,
             });
 
             const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
@@ -150,15 +145,15 @@ jobs:
             process.env.PLUGIN_VERSION = plugin_version;
             process.env.ARTIFACT_NAME = artifact_name;
 
-            // Create a mock context for the script
+            // Create context for the script
             const mockContext = {
               ...context,
               issue: { number: issue_number },
-              runId: ${{ github.event.workflow_run.id }},
+              runId: context.runId,
               payload: {
                 pull_request: {
                   head: {
-                    sha: '${{ github.event.workflow_run.head_sha }}'
+                    sha: context.sha
                   }
                 }
               }

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -12,6 +12,14 @@ on:
     workflows: ["PR Playground Demo"]
     types:
       - completed
+  push:
+    branches:
+      - 'PCP-5039-*'
+    paths:
+      - 'src/**'
+      - 'assets/**'
+      - 'package.json'
+      - 'composer.json'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -24,8 +32,11 @@ permissions: {}
 jobs:
   create_archive:
     runs-on: ubuntu-latest
-    # Only run for the main repository, not forks
-    if: github.repository == 'woocommerce/woocommerce-paypal-payments' && github.event_name == 'pull_request'
+    # Only run for the main repository, not forks, and allow push events on PCP-5039 branches
+    if: >
+      github.repository == 'woocommerce/woocommerce-paypal-payments' &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'push' && startsWith(github.ref_name, 'PCP-5039-')))
     outputs:
       artifact_name: ${{ steps.version.outputs.artifact_name }}
       plugin_version: ${{ steps.version.outputs.plugin_version }}
@@ -37,7 +48,7 @@ jobs:
         run: |
           BASE_VERSION=$(sed -nE '/Version:/s/.* ([0-9.]+).*/\1/p' woocommerce-paypal-payments.php)
           VERSUFFIX="${GITHUB_RUN_ID}-g$(git rev-parse --short HEAD)"
-          PR_VERSION="${BASE_VERSION}-pr${{ github.event.pull_request.number }}-${VERSUFFIX}"
+          PR_VERSION="${BASE_VERSION}-pr${{ github.event.pull_request.number || '0' }}-${VERSUFFIX}"
           ARTIFACT_NAME="woocommerce-paypal-payments-${PR_VERSION}"
           echo "plugin_version=$PR_VERSION" >> $GITHUB_OUTPUT
           echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
@@ -53,11 +64,10 @@ jobs:
           ARCHIVE_NAME: ${{ steps.version.outputs.artifact_name }}
           COMPILE_ASSETS_ARGS: "-vv --env=root"
 
-      # Store PR number for the workflow_run job
-      - name: Save PR number
+      - name: Save PR details
         run: |
           mkdir -p ./pr
-          echo "${{ github.event.number }}" > ./pr/NR
+          echo "${{ github.event.pull_request.number || '0' }}" > ./pr/NR
           echo "${{ steps.version.outputs.plugin_version }}" > ./pr/VERSION
           echo "${{ steps.version.outputs.artifact_name }}" > ./pr/ARTIFACT
 
@@ -145,3 +155,58 @@ jobs:
             };
 
             await script.run({ github, context: mockContext, core });
+
+  # =============================================================================
+  # TEMPORARY TESTING JOB - REMOVE AFTER TESTING COMPLETE
+  # =============================================================================
+
+  temporary_comment_testing:
+    name: "[TEMP] Test Comment on PR #3574"
+    runs-on: ubuntu-latest
+    needs: create_archive
+    permissions:
+      issues: write
+      pull-requests: write
+    # TEMPORARY: Only for testing workflow development on PCP-5039 branches
+    if: >
+      github.repository == 'woocommerce/woocommerce-paypal-payments' &&
+      github.event_name == 'push' &&
+      startsWith(github.ref_name, 'PCP-5039-') &&
+      needs.create_archive.result == 'success'
+
+    steps:
+      - name: "[TEMP] Checkout for testing"
+        uses: actions/checkout@v4
+
+      - name: "[TEMP] Test comment on PR #3574"
+        uses: actions/github-script@v7
+        env:
+          PLUGIN_VERSION: ${{ needs.create_archive.outputs.plugin_version }}
+          ARTIFACT_NAME: ${{ needs.create_archive.outputs.artifact_name }}
+        with:
+          script: |
+            console.log("🧪 TEMPORARY TESTING: Testing comment on PR #3574");
+
+            const script = require('./.github/scripts/playground-comment.js');
+
+            // Direct context for PR #3574
+            const mockContext = {
+              ...context,
+              issue: { number: 3574 },
+              runId: context.runId,
+              payload: {
+                pull_request: {
+                  head: {
+                    sha: '${{ github.sha }}'
+                  }
+                }
+              }
+            };
+
+            console.log("🧪 TEMPORARY TESTING: Posting comment to PR #3574");
+            await script.run({ github, context: mockContext, core });
+            console.log("🧪 TEMPORARY TESTING: Comment posted successfully");
+
+  # =============================================================================
+  # END TEMPORARY TESTING SECTION
+  # =============================================================================

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -12,12 +12,12 @@ on:
     branches:
       - "PCP-5039-*"
     paths:
-      - 'src/**'
-      - 'assets/**'
-      - 'package.json'
-      - 'composer.json'
-      - '.github/workflows/pr-playground-demo.yml'
-      - '.github/scripts/playground-comment.js'
+      - "src/**"
+      - "assets/**"
+      - "package.json"
+      - "composer.json"
+      - ".github/workflows/pr-playground-demo.yml"
+      - ".github/scripts/playground-comment.js"
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -154,6 +154,10 @@ jobs:
             // Create context for the script
             const mockContext = {
               ...context,
+              repo: {
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              },
               issue: { number: issue_number },
               runId: context.runId,
               payload: {

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -12,10 +12,12 @@ on:
     branches:
       - "PCP-5039-*"
     paths:
-      - "src/**"
-      - "assets/**"
-      - "package.json"
-      - "composer.json"
+      - 'src/**'
+      - 'assets/**'
+      - 'package.json'
+      - 'composer.json'
+      - '.github/workflows/pr-playground-demo.yml'
+      - '.github/scripts/playground-comment.js'
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -1,0 +1,79 @@
+name: PR Playground Demo
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_run:
+    workflows: ["PR Playground Demo"]
+    types:
+      - completed
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+permissions: {}
+
+jobs:
+  create_archive:
+    runs-on: ubuntu-latest
+    # Only run for the main repository, not forks
+    if: github.repository == 'woocommerce/woocommerce-paypal-payments' && github.event_name == 'pull_request'
+    outputs:
+      artifact_name: ${{ steps.version.outputs.artifact_name }}
+      plugin_version: ${{ steps.version.outputs.plugin_version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set plugin version and artifact name
+        id: version
+        run: |
+          BASE_VERSION=$(sed -nE '/Version:/s/.* ([0-9.]+).*/\1/p' woocommerce-paypal-payments.php)
+          VERSUFFIX="${GITHUB_RUN_ID}-g$(git rev-parse --short HEAD)"
+          PR_VERSION="${BASE_VERSION}-pr${{ github.event.pull_request.number }}-${VERSUFFIX}"
+          ARTIFACT_NAME="woocommerce-paypal-payments-${PR_VERSION}"
+          echo "plugin_version=$PR_VERSION" >> $GITHUB_OUTPUT
+          echo "artifact_name=$ARTIFACT_NAME" >> $GITHUB_OUTPUT
+
+      - name: Build plugin archive
+        uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@a9af34f34e95cbe18703198c7e972e97ebcd7473
+        with:
+          PHP_VERSION: 7.4
+          NODE_VERSION: 22
+          PLUGIN_MAIN_FILE: ./woocommerce-paypal-payments.php
+          PLUGIN_VERSION: ${{ steps.version.outputs.plugin_version }}
+          PLUGIN_FOLDER_NAME: woocommerce-paypal-payments
+          ARCHIVE_NAME: ${{ steps.version.outputs.artifact_name }}
+          COMPILE_ASSETS_ARGS: "-vv --env=root"
+
+      # Store PR number for the workflow_run job
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo "${{ github.event.number }}" > ./pr/NR
+          echo "${{ steps.version.outputs.plugin_version }}" > ./pr/VERSION
+          echo "${{ steps.version.outputs.artifact_name }}" > ./pr/ARTIFACT
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-details
+          path: pr/
+
+  # Placeholder for playground_demo job - will be implemented in Task 2
+  # playground_demo:
+  #   name: Comment on PR with Playground details
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     issues: write
+  #     pull-requests: write
+  #   if: >
+  #     github.repository == 'woocommerce/woocommerce-paypal-payments' &&
+  #     github.event_name == 'workflow_run' &&
+  #     github.event.workflow_run.event == 'pull_request' &&
+  #     github.event.workflow_run.conclusion == 'success'
+  #   steps:
+  #     - name: Placeholder
+  #       run: echo "Playground demo job will be implemented in Task 2"


### PR DESCRIPTION
### Description

This PR will add automated WordPress Playground integration for pull request testing.

When a PR is opened or updated, a GitHub Action will build the plugin and post a comment with a one-click link to test changes in a live WordPress environment.

### What's included:
- **GitHub workflow** that builds plugin artifacts on PR events
- **Comment script** that generates WordPress Playground blueprints 
- **Auto-update functionality** to refresh links when PRs are updated
- **Security measures** to prevent execution on forks

### How it works:
1. PR opened/updated → workflow builds plugin artifact
2. Bot comments with Playground link containing WordPress + WooCommerce + plugin from PR
3. Link auto-updates with new commits