### PR TITLE
Prevent early is_enabled check for Apple Pay button in new UI (4711)

### DIFF
--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -94,21 +94,23 @@ if (
 	features.push( 'subscriptions' );
 }
 
-registerExpressPaymentMethod( {
-	name: buttonData.id,
-	title: `PayPal - ${ buttonData.title }`,
-	description: __(
-		'Eligible users will see the PayPal button.',
-		'woocommerce-paypal-payments'
-	),
-	label: <div dangerouslySetInnerHTML={ { __html: buttonData.title } } />,
-	content: <ApplePayComponent isEditing={ false } />,
-	edit: <ApplePayComponent isEditing={ true } />,
-	ariaLabel: buttonData.title,
-	canMakePayment: () =>
-		buttonData.enabled && window.ApplePaySession?.canMakePayments(),
-	supports: {
-		features,
-		style: [ 'height', 'borderRadius' ],
-	},
-} );
+if ( buttonConfig?.is_enabled ) {
+	registerExpressPaymentMethod( {
+		name: buttonData.id,
+		title: `PayPal - ${ buttonData.title }`,
+		description: __(
+			'Eligible users will see the PayPal button.',
+			'woocommerce-paypal-payments'
+		),
+		label: <div dangerouslySetInnerHTML={ { __html: buttonData.title } } />,
+		content: <ApplePayComponent isEditing={ false } />,
+		edit: <ApplePayComponent isEditing={ true } />,
+		ariaLabel: buttonData.title,
+		canMakePayment: () =>
+			buttonData.enabled && window.ApplePaySession?.canMakePayments(),
+		supports: {
+			features,
+			style: [ 'height', 'borderRadius' ],
+		},
+	} );
+}

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\Applepay\Assets\PropertiesDictionary;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Applepay\Helper\AvailabilityNotice;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
@@ -93,15 +94,17 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 					return;
 				}
 
-				if ( $apple_payment_method->is_enabled() ) {
-					$module->load_assets( $c, $apple_payment_method );
-					$module->handle_validation_file( $c, $apple_payment_method );
-					$module->render_buttons( $c, $apple_payment_method );
-					$apple_payment_method->bootstrap_ajax_request();
-				}
-
 				$module->load_admin_assets( $c, $apple_payment_method );
 				$module->load_block_editor_assets( $c, $apple_payment_method );
+
+				if ( SettingsModule::should_use_the_old_ui() && ! $apple_payment_method->is_enabled() ) {
+					return;
+				}
+
+				$module->load_assets( $c, $apple_payment_method );
+				$module->handle_validation_file( $c, $apple_payment_method );
+				$module->render_buttons( $c, $apple_payment_method );
+				$apple_payment_method->bootstrap_ajax_request();
 			},
 			1
 		);
@@ -255,13 +258,13 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 	 * @return void
 	 */
 	public function load_assets( ContainerInterface $c, ApplePayButton $button ): void {
-		if ( ! $button->is_enabled() ) {
-			return;
-		}
 
 		add_action(
 			'wp_enqueue_scripts',
 			function () use ( $c, $button ) {
+				if ( ! $button->is_enabled() ) {
+					return;
+				}
 				$smart_button = $c->get( 'button.smart-button' );
 				assert( $smart_button instanceof SmartButtonInterface );
 				if ( $smart_button->should_load_ppcp_script() ) {
@@ -282,6 +285,9 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 		add_action(
 			'enqueue_block_editor_assets',
 			function () use ( $c, $button ) {
+				if ( ! $button->is_enabled() ) {
+					return;
+				}
 				$button->enqueue_admin_styles();
 			}
 		);
@@ -362,9 +368,6 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 	 * @return void
 	 */
 	public function render_buttons( ContainerInterface $c, ApplePayButton $button ): void {
-		if ( ! $button->is_enabled() ) {
-			return;
-		}
 
 		add_action(
 			'wp',
@@ -372,7 +375,12 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 				if ( is_admin() ) {
 					return;
 				}
+
 				$button = $c->get( 'applepay.button' );
+
+				if ( ! $button->is_enabled() ) {
+					return;
+				}
 
 				/**
 				 * The Button.
@@ -392,9 +400,6 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 	 * @return void
 	 */
 	public function handle_validation_file( ContainerInterface $c, ApplePayButton $button ): void {
-		if ( ! $button->is_enabled() ) {
-			return;
-		}
 		$env = $c->get( 'settings.environment' );
 		assert( $env instanceof Environment );
 		$is_sandbox = $env->current_environment_is( Environment::SANDBOX );


### PR DESCRIPTION
This PR prevents early `is_enabled()` checks for the Apple Pay button in the new UI.

In the new UI, the Apple Pay button availability is determined by several factors like the current context, not a global setting. The `is_enabled()` check depends on context functions (like `is_cart()`), which return false too early during block registration.

This issue and solution are the same as described in this PR: https://github.com/woocommerce/woocommerce-paypal-payments/pull/3566