### PR TITLE
Remove the Firefox onboarding notice (4995)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
@@ -8,13 +8,6 @@ import { OnboardingHooks } from '../../../../data/onboarding/hooks';
 import BusyStateWrapper from '../../../ReusableComponents/BusyStateWrapper';
 import { Notice } from '../../../ReusableComponents/Elements';
 
-const useIsFirefox = () => {
-	if ( typeof window === 'undefined' ) {
-		return false;
-	}
-	return window.navigator.userAgent.toLowerCase().indexOf( 'firefox' ) > -1;
-};
-
 /**
  * Button component that outputs a placeholder button when no onboardingUrl is present yet - the
  * placeholder button looks identical to the working button, but has no href, target, or
@@ -36,8 +29,6 @@ const ButtonOrPlaceholder = ( {
 	children,
 	onClick,
 } ) => {
-	const isFirefox = useIsFirefox();
-
 	const buttonProps = {
 		className,
 		variant,
@@ -49,20 +40,6 @@ const ButtonOrPlaceholder = ( {
 		buttonProps.href = href;
 		buttonProps[ 'data-paypal-button' ] = 'true';
 		buttonProps[ 'data-paypal-onboard-button' ] = 'true';
-	}
-
-	if ( isFirefox ) {
-		return (
-			<>
-				<Button { ...buttonProps }>{ children }</Button>
-				<Notice type={ 'error' }>
-					{ __(
-						'This button may not work in Firefox. Please use another browser, like Chrome, to complete this step.',
-						'woocommerce-paypal-payments'
-					) }
-				</Notice>
-			</>
-		);
 	}
 
 	return <Button { ...buttonProps }>{ children }</Button>;


### PR DESCRIPTION
## Issue Description

The notice saying that the onboarding buttons may not work with Firefox should be removed now.

## PR Description

Removes the notice about onboarding buttons not compatible with Firefox