### PR TITLE
Add shipping-related filters to avoid MISSING_%field_name% errors

### DIFF
--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -289,6 +289,23 @@ class PurchaseUnitFactory {
 	 */
 	private function shipping_needed( Item ...$items ): bool {
 
+		/**
+		 * If you are returning false from this filter, do not forget to also set
+		 * shipping_preference to 'NO_SHIPPING', otherwise PayPal will return an error.
+		 *
+		 * @see ShippingPreferenceFactory::from_state() for
+		 *      the 'woocommerce_paypal_payments_shipping_preference' filter.
+		 */
+		$shipping_needed = apply_filters(
+			'woocommerce_paypal_payments_shipping_needed',
+			null,
+			$items
+		);
+
+		if ( is_bool( $shipping_needed ) ) {
+			return $shipping_needed;
+		}
+
 		foreach ( $items as $item ) {
 			if ( $item->category() !== Item::DIGITAL_GOODS ) {
 				return true;

--- a/modules/ppcp-api-client/src/Factory/ShippingPreferenceFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ShippingPreferenceFactory.php
@@ -33,6 +33,29 @@ class ShippingPreferenceFactory {
 		?WC_Cart $cart = null,
 		string $funding_source = ''
 	): string {
+		/**
+		 *  If you are using this filter to set 'NO_SHIPPING', you may also want to disable sending
+		 *  shipping fields completely.
+		 *
+		 * @see PurchaseUnitFactory::shipping_needed() for
+		 *  the woocommerce_paypal_payments_shipping_needed filter.
+		 *
+		 * @see ExperienceContext for SHIPPING_PREFERENCE_* constants.
+		 * @see https://developer.paypal.com/serversdk/php/models/enumerations/shipping-preference/
+		 */
+		$shipping_preference = apply_filters(
+			'woocommerce_paypal_payments_shipping_preference',
+			null,
+			$purchase_unit,
+			$context,
+			$cart,
+			$funding_source
+		);
+
+		if ( is_string( $shipping_preference ) ) {
+			return $shipping_preference;
+		}
+
 		$contains_physical_goods = $purchase_unit->contains_physical_goods();
 		if ( ! $contains_physical_goods ) {
 			return ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING;


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Ticket**: PCP-4220, also PCP-1546 and PCP-952.

---

### Description

Two filters added:
`woocommerce_paypal_payments_shipping_preference` and `woocommerce_paypal_payments_shipping_preference`.

There was a problem with disabled shipping fields. If in any way some required shipping field is disabled, PayPal returned an error (e.g. MISSING_SHIPPING_ADDRESS or MISSING SHIPPING_CITY). This happened because `shipping_preference` was set to `SET_PROVIDED_ADDRESS`, which made PayPal expect shipping fields.

It was decided not to make changes in how the plugin behaves, but to add filters to let merchants deal with this problem if they manipulate checkout fields.

Example code to fix MISSING_* error:
```php
//Disable PayPal expectaion for shipping fields.
add_filter('woocommerce_paypal_payments_shipping_preference', fn() => 'NO_SHIPPING');

//Prevent sending shipping fields from order and cart
add_filter('woocommerce_paypal_payments_shipping_needed', '__return_false');
```
I'm attaching the same code as a plugin.
[paypal_disable_shipping.zip](https://github.com/user-attachments/files/21687900/paypal_disable_shipping.zip)



### Steps to Test
1. Install and activate the [Flexible Checkout Fields](https://wordpress.org/plugins/flexible-checkout-fields/) plugin.
2. Go to the Flexible Checkout Fields plugin settings, select the Shipping sub tab and disable  Street Address field (see screenshot).
3. Make sure shipping is enabled.
4. Go to the classic checkout with any physical product in cart and complete checkout using Pay with PayPal button.
5. Observe an error MISSING_SHIPPING_ADDRESS.
6. Install and activate plugin attached to this PR.
7. Go to the classic checkout and try to pay again, the error shouldn't happen anymore.

<img width="2560" height="967" alt="flexible-checkout-fields-disable-shipping-address" src="https://github.com/user-attachments/assets/b3486ddc-d35a-4d63-b55b-384d3ae392d2" />

To merchants, who has this error we might recommend the snippet above, but not the plugin. We would need to add author and other details before providing it.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

Added filters for fixing `MISSING_%field_name%` checkout error when some shipping fields are missing.