### PR TITLE
Add Fastlane support for AU/AUD (5058)

### DIFF
--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -432,9 +432,9 @@ return array(
 	'axo.au.enabled'                         => static function ( ContainerInterface $container ): bool {
 		// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
 		/**
-		 * Filter to determine if Fastlane Australia should be enabled.
+		 * Filter to determine if Fastlane AU should be enabled.
 		 *
-		 * @param bool $enabled Whether Fastlane Australia is enabled.
+		 * @param bool $enabled Whether Fastlane AU is enabled.
 		 */
 		return apply_filters(
 			'woocommerce.feature-flags.woocommerce_paypal_payments.axo_au_enabled',

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -432,7 +432,7 @@ return array(
 	'axo.au.enabled'                         => static function ( ContainerInterface $container ): bool {
 		// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
 		/**
-		 * Filter to determine if Fastlane Australia with 3D Secure should be enabled.
+		 * Filter to determine if Fastlane Australia should be enabled.
 		 *
 		 * @param bool $enabled Whether Fastlane Australia is enabled.
 		 */

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -170,6 +170,10 @@ return array(
 			$matrix['GB'] = array( 'GBP' );
 		}
 
+		if ( $container->get( 'axo.au.enabled' ) ) {
+			$matrix['AU'] = array( 'AUD' );
+		}
+
 		/**
 		 * Returns which countries and currency combinations can be used for AXO.
 		 */
@@ -203,6 +207,14 @@ return array(
 				'MASTERCARD',
 				'AMEX',
 				'DISCOVER',
+			);
+		}
+
+		if ( $container->get( 'axo.au.enabled' ) ) {
+			$matrix['AU'] = array(
+				'VISA',
+				'MASTERCARD',
+				'AMEX',
 			);
 		}
 
@@ -414,6 +426,19 @@ return array(
 		return apply_filters(
 			'woocommerce.feature-flags.woocommerce_paypal_payments.axo_uk_enabled',
 			getenv( 'PCP_AXO_UK_ENABLED' ) !== '0'
+		);
+		// phpcs:enable WordPress.NamingConventions.ValidHookName.UseUnderscores
+	},
+	'axo.au.enabled'                         => static function ( ContainerInterface $container ): bool {
+		// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
+		/**
+		 * Filter to determine if Fastlane AU with 3D Secure should be enabled.
+		 *
+		 * @param bool $enabled Whether Fastlane AU is enabled.
+		 */
+		return apply_filters(
+			'woocommerce.feature-flags.woocommerce_paypal_payments.axo_au_enabled',
+			getenv( 'PCP_AXO_AU_ENABLED' ) !== '0'
 		);
 		// phpcs:enable WordPress.NamingConventions.ValidHookName.UseUnderscores
 	},

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -432,9 +432,9 @@ return array(
 	'axo.au.enabled'                         => static function ( ContainerInterface $container ): bool {
 		// phpcs:disable WordPress.NamingConventions.ValidHookName.UseUnderscores
 		/**
-		 * Filter to determine if Fastlane AU with 3D Secure should be enabled.
+		 * Filter to determine if Fastlane Australia with 3D Secure should be enabled.
 		 *
-		 * @param bool $enabled Whether Fastlane AU is enabled.
+		 * @param bool $enabled Whether Fastlane Australia is enabled.
 		 */
 		return apply_filters(
 			'woocommerce.feature-flags.woocommerce_paypal_payments.axo_au_enabled',

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2161,7 +2161,7 @@ return array(
 	 *
 	 * @returns InboxNoteInterface[]
 	 */
-	'wcgateway.settings.inbox-notes'                    => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.inbox-notes'                       => static function( ContainerInterface $container ): array {
 		$inbox_note_factory = $container->get( 'wcgateway.settings.inbox-note-factory' );
 		assert( $inbox_note_factory instanceof InboxNoteFactory );
 


### PR DESCRIPTION
### Description

This PR will add Fastlane support for Australia with `AUD` currency.

The changes include:
- Adding AU/AUD to the supported country-currency matrix
- Enabling Visa, Mastercard, and Amex card types
- Adding a feature flag (`axo.au.enabled`) to control the Australia Fastlane functionality