### PR TITLE
Add modules to paths being tracked for WordPress Playground Demo

### DIFF
--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "src/**"
       - "assets/**"
+      - "modules/**"
       - "package.json"
       - "composer.json"
   push:


### PR DESCRIPTION
This PR will tweak the tracked paths for the WordPress Playground Demo workflow 