### PR TITLE
Add modules to push paths being tracked for WordPress Playground Demo

### DIFF
--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - "src/**"
       - "assets/**"
+      - "modules/**"
       - "package.json"
       - "composer.json"
 


### PR DESCRIPTION
This PR will tweak the tracked push paths for the WordPress Playground Demo workflow