### PR TITLE
Fix context.repo undefined error in the Playground workflow

### DIFF
--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -144,6 +144,7 @@ jobs:
             const updatedContext = {
               ...context,
               issue: {
+                ...context.issue,
                 number: parseInt(pr_number, 10)
               }
             };


### PR DESCRIPTION
This PR will fix the context.repo undefined error in the Playground workflow