### PR TITLE
Phase 2: Settings Migration - Change banner text

### DIFF
--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -7,14 +7,6 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		'.ppcp-notice-wrapper:not(.inline) a.settings-switch-ui'
 	);
 
-	console.log( 'Config:', config );
-	console.log( 'Button found:', button );
-	console.log( 'Link found:', link );
-	console.log(
-		'All links with settings-switch-ui:',
-		document.querySelectorAll( '.settings-switch-ui' )
-	);
-
 	if ( typeof config === 'undefined' || ( ! button && ! link ) ) {
 		return;
 	}

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -20,7 +20,6 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	}
 
 	const handleClick = ( event ) => {
-		console.log( 'here' );
 		event.preventDefault();
 
 		const confirmed = confirm( config.confirmMessage );

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -3,13 +3,24 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	const button = document.querySelector(
 		'.button.button-settings-switch-ui'
 	);
-	const link = document.querySelector( 'a.settings-switch-ui' );
+	const link = document.querySelector(
+		'.ppcp-notice-wrapper:not(.inline) a.settings-switch-ui'
+	);
+
+	console.log( 'Config:', config );
+	console.log( 'Button found:', button );
+	console.log( 'Link found:', link );
+	console.log(
+		'All links with settings-switch-ui:',
+		document.querySelectorAll( '.settings-switch-ui' )
+	);
 
 	if ( typeof config === 'undefined' || ( ! button && ! link ) ) {
 		return;
 	}
 
 	const handleClick = ( event ) => {
+		console.log( 'here' );
 		event.preventDefault();
 
 		const confirmed = confirm( config.confirmMessage );
@@ -45,7 +56,10 @@ document.addEventListener( 'DOMContentLoaded', () => {
 		button.addEventListener( 'click', handleClick );
 	}
 
-	if ( link ) {
-		link.addEventListener( 'click', handleClick );
-	}
+	document.addEventListener( 'click', ( event ) => {
+		const linkElement = event.target.closest( 'a.settings-switch-ui' );
+		if ( linkElement ) {
+			handleClick( event );
+		}
+	} );
 } );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -107,7 +107,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				'woocommerce_paypal_payments_inside_settings_page_header',
 				static fn() : string => sprintf(
 					'<button type="button" class="button button-settings-switch-ui" aria-describedby="switch-ui-desc">%s</button><span id="switch-ui-desc" class="screen-reader-text">%s</span>',
-					esc_html__( 'Switch to new settings UI', 'woocommerce-paypal-payments' ),
+					esc_html__( 'Switch to New Settings', 'woocommerce-paypal-payments' ),
 					esc_html__( 'This action will permanently switch to the new settings interface and cannot be undone', 'woocommerce-paypal-payments' )
 				)
 			);

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -128,7 +128,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					$message = sprintf(
 					// translators: %1$s is the URL for the startup guide.
 						__(
-							'🎉 <strong>Discover the new PayPal Payments settings!</strong> Enjoy a cleaner, faster interface. Check out the <a href="%1$s" target="_blank">Startup Guide</a>, then click <a href="#" class="settings-switch-ui" role="button" aria-describedby="switch-ui-desc"><strong>Switch to New Settings</strong></a> to activate it.',
+							'<strong>📢 Important: New PayPal Payments settings UI becoming default in October!</strong><br>We\'ve redesigned the settings for better performance and usability. Starting late October, this improved design will be the default for all WooCommerce installations to enjoy faster navigation, cleaner organization, and improved performance. Check out the <a href="%1$s" target="_blank">Startup Guide</a>, then click <a href="#" class="settings-switch-ui" role="button" aria-describedby="switch-ui-desc"><strong>Switch to New Settings</strong></a> to activate it.',
 							'woocommerce-paypal-payments'
 						),
 						'https://woocommerce.com/document/woocommerce-paypal-payments/paypal-payments-startup-guide/'


### PR DESCRIPTION
## Issue Description

## Update 3.0.0 launched the new UI for new plugin setups.
We now need to implement mechanisms for existing users to be served the new UI as well.

### Requirements:
**Phase 1**
* Merchants on the legacy UX see a banner at the top of all admin panel pages advising that there is a new UX available.

**Phase 2 (Phase 1 + 6 weeks)**
* Banner text changes slightly to:
📢 Important: New PayPal Payments settings UI becoming default in October!
We've redesigned the settings for better performance and usability. Starting late October, this improved design will be the default for all WooCommerce installations to enjoy faster navigation, cleaner organization, and improved performance. Check out the [Startup Guide](https://woocommerce.com/document/woocommerce-paypal-payments/paypal-payments-startup-guide/), then click [Switch to New Settings](https://migrate.link/) to activate it.

**Phase 3 (Phase 2 + 6 weeks)**
* All legacy UX will migrate to new UX.

---

## PR Description
This PR implements **Phase 2** of the migration plan, updating the banner message to include the October timeline and improved messaging about the upcoming default UI change.

<img width="1544" height="171" alt="Screenshot 2025-08-14 at 18 54 02" src="https://github.com/user-attachments/assets/3493a024-be2b-488a-ab1b-fd3097398c5c" />