### PR TITLE
Phase 2: Settings Migration - Add Woo Inbox item (5166)

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -13,6 +13,9 @@ use Exception;
 use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Product;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -90,6 +93,64 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		add_action( 'woocommerce_paypal_payments_gateway_migrate', static fn() => delete_transient( 'ppcp_has_ppec_subscriptions' ) );
 
 		$this->legacy_ui_card_payment_mapping( $c );
+
+		/**
+		 * Automatically enable Pay Later messaging for eligible stores during plugin update.
+		 *
+		 * This action runs during plugin updates to automatically enable Pay Later messaging for stores
+		 * that meet the following criteria:
+		 * - Feature flag 'paylater_messaging_force_enabled' is enabled (default: true, can be disabled via filter)
+		 * - Pay Later messaging is available for the store's country
+		 * - The "Stay updated" checkbox is enabled (checked in either old or new UI)
+		 *
+		 * The "Stay updated" setting is retrieved differently based on the UI version:
+		 * - Legacy UI: Retrieved from wcgateway.settings
+		 * - New UI: Retrieved from settings.data.settings model
+		 *
+		 * When all conditions are met, this will:
+		 * - Enable Pay Later messaging
+		 * - Add default messaging locations (product, cart, checkout) to existing selections
+		 *
+		 * @todo Remove this auto-enablement logic after the next release
+		 *
+		 * @hook woocommerce_paypal_payments_gateway_migrate_on_update
+		 */
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate_on_update',
+			static function() use ( $c ) {
+				if ( ! apply_filters(
+				// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+					'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
+					true
+				) ) {
+					return;
+				}
+
+				$messages_apply = $c->get( 'button.helper.messages-apply' );
+				assert( $messages_apply instanceof MessagesApply );
+
+				$settings_model = $c->get( 'settings.data.settings' );
+				assert( $settings_model instanceof SettingsModel );
+
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				$stay_updated = SettingsModule::should_use_the_old_ui()
+					? $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' )
+					: $settings_model->get_stay_updated();
+
+				if ( ! $messages_apply->for_country() || ! $stay_updated ) {
+					return;
+				}
+
+				$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
+
+				$settings->set( 'pay_later_messaging_enabled', true );
+				$settings->set( 'pay_later_messaging_locations', array_merge( $selected_locations, array( 'product', 'cart', 'checkout' ) ) );
+
+				$settings->persist();
+			}
+		);
 
 		return true;
 	}

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -146,7 +146,10 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
 
 				$settings->set( 'pay_later_messaging_enabled', true );
-				$settings->set( 'pay_later_messaging_locations', array_merge( $selected_locations, array( 'product', 'cart', 'checkout' ) ) );
+				$settings->set(
+					'pay_later_messaging_locations',
+					array_unique( array_merge( $selected_locations, array( 'product', 'cart', 'checkout' ) ) )
+				);
 
 				$settings->persist();
 			}

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/StayUpdated.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/StayUpdated.js
@@ -10,6 +10,7 @@ const StayUpdated = () => {
 	return (
 		<SettingsBlock className="ppcp--pay-now-experience">
 			<ControlToggleButton
+				id="ppcp-stay-updated"
 				label={ __( 'Stay Updated', 'woocommerce-paypal-payments' ) }
 				description={ __(
 					'Get the latest PayPal features and capabilities as they are released. When the extension is updated, new features, payment methods, styling options, and more will automatically update.',

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -40,11 +40,13 @@ document.addEventListener( 'DOMContentLoaded', () => {
 	document.addEventListener( 'click', ( event ) => {
 		if (
 			event.target.closest( '.button.button-settings-switch-ui' ) ||
-			event.target.closest( '.ppcp-notice-wrapper:not(.inline) a.settings-switch-ui' ) ||
+			event.target.closest(
+				'.ppcp-notice-wrapper:not(.inline) a.settings-switch-ui'
+			) ||
 			event.target.closest( 'a[name="settings-switch-ui"]' ) ||
 			event.target
 				.closest( '.woocommerce-inbox-note__action-button' )
-				.textContent.includes( 'Switch to New Settings' )
+				?.textContent.includes( 'Switch to New Settings' )
 		) {
 			handleClick( event );
 		}

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -42,7 +42,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			event.target.closest( '.button.button-settings-switch-ui' ) ||
 			event.target.closest( 'a.settings-switch-ui' ) ||
 			event.target.closest( 'a[name="settings-switch-ui"]' ) ||
-			event.target.closest( '.woocommerce-inbox-note__action-button' )
+			event.target
+				.closest( '.woocommerce-inbox-note__action-button' )
+				.textContent.includes( 'Switch to New Settings' )
 		) {
 			handleClick( event );
 		}

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -1,11 +1,7 @@
 document.addEventListener( 'DOMContentLoaded', () => {
 	const config = ppcpSwitchSettingsUi;
-	const button = document.querySelector(
-		'.button.button-settings-switch-ui'
-	);
-	const link = document.querySelector( 'a.settings-switch-ui' );
 
-	if ( typeof config === 'undefined' || ( ! button && ! link ) ) {
+	if ( typeof config === 'undefined' ) {
 		return;
 	}
 
@@ -34,18 +30,21 @@ document.addEventListener( 'DOMContentLoaded', () => {
 				return response.json();
 			} )
 			.then( ( data ) => {
-				window.location.reload();
+				window.location.href = config.settingsUrl;
 			} )
 			.catch( ( error ) => {
 				console.error( 'Error:', error );
 			} );
 	};
 
-	if ( button ) {
-		button.addEventListener( 'click', handleClick );
-	}
-
-	if ( link ) {
-		link.addEventListener( 'click', handleClick );
-	}
+	document.addEventListener( 'click', ( event ) => {
+		if (
+			event.target.closest( '.button.button-settings-switch-ui' ) ||
+			event.target.closest( 'a.settings-switch-ui' ) ||
+			event.target.closest( 'a[name="settings-switch-ui"]' ) ||
+			event.target.closest( '.woocommerce-inbox-note__action-button' )
+		) {
+			handleClick( event );
+		}
+	} );
 } );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -165,6 +165,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 								'Are you sure you want to switch to the new settings interface?This action cannot be undone.',
 								'woocommerce-paypal-payments'
 							),
+							'settingsUrl'    => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
 						)
 					);
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2185,7 +2185,6 @@ return array(
 			'https://woocommerce.com/document/woocommerce-paypal-payments/paypal-payments-startup-guide/'
 		);
 
-
 		return array(
 			$inbox_note_factory->create_note(
 				__( 'PayPal Working Capital', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -21,11 +21,13 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Axo\Helper\PropertiesDictionary;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesDisclaimers;
 use WooCommerce\PayPalCommerce\Common\Pattern\SingletonDecorator;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\FeesRenderer;
@@ -2168,13 +2170,36 @@ return array(
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
+		$settings_model = $container->get( 'settings.data.settings' );
+		assert( $settings_model instanceof SettingsModel );
+
+		$messages_apply = $container->get( 'button.helper.messages-apply' );
+		assert( $messages_apply instanceof MessagesApply );
+
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
 			getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
 		);
 
-		$is_working_capital_eligible = $container->get( 'api.shop.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
+		$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
+		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
+			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
+			true
+		);
+
+		$stay_updated = SettingsModule::should_use_the_old_ui()
+			? $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' )
+			: $settings_model->get_stay_updated();
+
+		$stay_updated_field_link = SettingsModule::should_use_the_old_ui()
+			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#ppcp-stay_updated_field' )
+			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&panel=settings#ppcp-stay-updated' );
+
+		$paylater_messaging_tab_link = SettingsModule::should_use_the_old_ui()
+			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' )
+			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&panel=pay-later-messaging' );
+
 
 		$message = sprintf(
 		// translators: %1$s is the URL for the startup guide.
@@ -2192,7 +2217,7 @@ return array(
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-working-capital-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
-				$is_working_capital_feature_flag_enabled && $is_working_capital_eligible,
+				$is_working_capital_feature_flag_enabled && $container->get( 'api.shop.country' ) === 'US' && $stay_updated,
 				new InboxNoteAction(
 					'apply_now',
 					__( 'Apply now', 'woocommerce-paypal-payments' ),
@@ -2212,6 +2237,28 @@ return array(
 					'switch_to_new_settings',
 					__( 'Switch to New Settings', 'woocommerce-paypal-payments' ),
 					admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+					Note::E_WC_ADMIN_NOTE_UNACTIONED,
+					true
+				)
+			),
+			$inbox_note_factory->create_note(
+				__( 'Pay Later messaging now optimizing conversions', 'woocommerce-paypal-payments' ),
+				sprintf(
+				// translators: %1$s is the URL for Pay Later messaging documentation.
+					__(
+						'PayPal Pay Later messages are now displaying on your store through your <a href="%1$s">Stay Updated</a> preference, helping customers see flexible payment options. Merchants typically see 20-40% higher conversion rates with these purchase incentives. The messages appear contextually near prices, not as ads. You control this completely—disable anytime if your conversion metrics don\'t improve.',
+						'woocommerce-paypal-payments'
+					),
+					$stay_updated_field_link
+				),
+				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
+				'ppcp-settings-paylater-messaging-force-enabled-inbox-note',
+				Note::E_WC_ADMIN_NOTE_UNACTIONED,
+				$is_paylater_messaging_force_enabled_feature_flag_enabled && $messages_apply->for_country() && $stay_updated,
+				new InboxNoteAction(
+					'review_pay_later_settings',
+					__( 'Review Pay Later settings', 'woocommerce-paypal-payments' ),
+					$paylater_messaging_tab_link,
 					Note::E_WC_ADMIN_NOTE_UNACTIONED,
 					true
 				)

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2200,7 +2200,6 @@ return array(
 			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' )
 			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&panel=pay-later-messaging' );
 
-
 		$message = sprintf(
 		// translators: %1$s is the URL for the startup guide.
 			__(

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2161,9 +2161,30 @@ return array(
 	 *
 	 * @returns InboxNoteInterface[]
 	 */
-	'wcgateway.settings.inbox-notes'                    => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.inbox-notes'                       => static function( ContainerInterface $container ): array {
 		$inbox_note_factory = $container->get( 'wcgateway.settings.inbox-note-factory' );
 		assert( $inbox_note_factory instanceof InboxNoteFactory );
+
+		$settings = $container->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+
+		$is_working_capital_feature_flag_enabled = apply_filters(
+		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
+			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
+			getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
+		);
+
+		$is_working_capital_eligible = $container->get( 'api.shop.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
+
+		$message = sprintf(
+		// translators: %1$s is the URL for the startup guide.
+			__(
+				'We\'ve redesigned the settings for better performance and usability. Starting late October, this improved design will be the default for all WooCommerce installations to enjoy faster navigation, cleaner organization, and improved performance. Check out the <a href="%1$s" target="_blank">Startup Guide</a>, then click <a href="#" name="settings-switch-ui"><strong>Switch to New Settings</strong></a> to activate it.',
+				'woocommerce-paypal-payments'
+			),
+			'https://woocommerce.com/document/woocommerce-paypal-payments/paypal-payments-startup-guide/'
+		);
+
 
 		return array(
 			$inbox_note_factory->create_note(
@@ -2172,10 +2193,26 @@ return array(
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-working-capital-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
+				$is_working_capital_feature_flag_enabled && $is_working_capital_eligible,
 				new InboxNoteAction(
 					'apply_now',
 					__( 'Apply now', 'woocommerce-paypal-payments' ),
 					'http://example.com/',
+					Note::E_WC_ADMIN_NOTE_UNACTIONED,
+					true
+				)
+			),
+			$inbox_note_factory->create_note(
+				__( '📢 Important: New PayPal Payments settings UI becoming default in October!', 'woocommerce-paypal-payments' ),
+				$message,
+				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
+				'ppcp-settings-migration-inbox-note',
+				Note::E_WC_ADMIN_NOTE_UNACTIONED,
+				SettingsModule::should_use_the_old_ui(),
+				new InboxNoteAction(
+					'switch_to_new_settings',
+					__( 'Switch to New Settings', 'woocommerce-paypal-payments' ),
+					admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
 					Note::E_WC_ADMIN_NOTE_UNACTIONED,
 					true
 				)

--- a/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNote.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNote.php
@@ -17,6 +17,7 @@ class InboxNote implements InboxNoteInterface {
 	protected string $type;
 	protected string $name;
 	protected string $status;
+	protected bool $is_enabled;
 	protected InboxNoteActionInterface $action;
 
 	public function __construct(
@@ -25,14 +26,16 @@ class InboxNote implements InboxNoteInterface {
 		string $type,
 		string $name,
 		string $status,
+		bool $is_enabled,
 		InboxNoteActionInterface $action
 	) {
-		$this->title   = $title;
-		$this->content = $content;
-		$this->type    = $type;
-		$this->name    = $name;
-		$this->status  = $status;
-		$this->action  = $action;
+		$this->title      = $title;
+		$this->content    = $content;
+		$this->type       = $type;
+		$this->name       = $name;
+		$this->status     = $status;
+		$this->is_enabled = $is_enabled;
+		$this->action     = $action;
 	}
 
 	public function title(): string {
@@ -53,6 +56,10 @@ class InboxNote implements InboxNoteInterface {
 
 	public function status(): string {
 		return $this->status;
+	}
+
+	public function is_enabled(): bool {
+		return $this->is_enabled;
 	}
 
 	public function action(): InboxNoteActionInterface {

--- a/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteFactory.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteFactory.php
@@ -18,8 +18,9 @@ class InboxNoteFactory {
 		string $type,
 		string $name,
 		string $status,
+		bool $is_enabled,
 		InboxNoteActionInterface $action
 	): InboxNoteInterface {
-		return new InboxNote( $title, $content, $type, $name, $status, $action );
+		return new InboxNote( $title, $content, $type, $name, $status, $is_enabled, $action );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteInterface.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteInterface.php
@@ -16,5 +16,6 @@ interface InboxNoteInterface {
 	public function type(): string;
 	public function name(): string;
 	public function status(): string;
+	public function is_enabled(): bool;
 	public function action(): InboxNoteActionInterface;
 }

--- a/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
@@ -29,6 +29,11 @@ class InboxNoteRegistrar {
 
 	public function register(): void {
 		foreach ( $this->inbox_notes as $inbox_note ) {
+			if ( ! $inbox_note->is_enabled() ) {
+				$this->unregister( $inbox_note->name() );
+				continue;
+			}
+
 			$inbox_note_name = $inbox_note->name();
 
 			if ( Notes::get_note_by_name( $inbox_note_name ) ) {
@@ -54,6 +59,19 @@ class InboxNoteRegistrar {
 			);
 
 			$note->save();
+		}
+	}
+
+	public function unregister( string $inbox_note_name ): void {
+		$data_store        = Notes::load_data_store();
+		$existing_note_ids = $data_store->get_notes_with_name( $inbox_note_name );
+
+		foreach ( $existing_note_ids as $note_id ) {
+			$note = Notes::get_note( $note_id );
+
+			if ( $note ) {
+				$data_store->delete( $note );
+			}
 		}
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
@@ -9,8 +9,6 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcInboxNotes;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\Notes;
-use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
-use Exception;
 use WpOop\WordPress\Plugin\PluginInterface;
 
 /**
@@ -31,18 +29,17 @@ class InboxNoteRegistrar {
 
 	public function register(): void {
 		foreach ( $this->inbox_notes as $inbox_note ) {
+			$inbox_note_name = $inbox_note->name();
+			$existing_note   = Notes::get_note_by_name( $inbox_note_name );
+
 			if ( ! $inbox_note->is_enabled() ) {
-				try {
-					$this->unregister( $inbox_note->name() );
-				} catch ( Exception $exeption ) {
-					continue;
+				if ( $existing_note instanceof Note ) {
+					Notes::delete_note( $existing_note );
 				}
 				continue;
 			}
 
-			$inbox_note_name = $inbox_note->name();
-
-			if ( Notes::get_note_by_name( $inbox_note_name ) ) {
+			if ( $existing_note ) {
 				continue;
 			}
 
@@ -65,23 +62,6 @@ class InboxNoteRegistrar {
 			);
 
 			$note->save();
-		}
-	}
-
-	/**
-	 * @throws NotesUnavailableException If unable to unregister the note.
-	 */
-	public function unregister( string $inbox_note_name ): void {
-		$data_store        = Notes::load_data_store();
-		$existing_note_ids = $data_store->get_notes_with_name( $inbox_note_name );
-
-		foreach ( $existing_note_ids as $note_id ) {
-			$note = Notes::get_note( $note_id );
-
-			if ( $note ) {
-				/** @psalm-suppress PossiblyInvalidArgument */
-				$data_store->delete( $note );
-			}
 		}
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
@@ -9,6 +9,8 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Settings\WcInboxNotes;
 
 use Automattic\WooCommerce\Admin\Notes\Note;
 use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\NotesUnavailableException;
+use Exception;
 use WpOop\WordPress\Plugin\PluginInterface;
 
 /**
@@ -30,7 +32,11 @@ class InboxNoteRegistrar {
 	public function register(): void {
 		foreach ( $this->inbox_notes as $inbox_note ) {
 			if ( ! $inbox_note->is_enabled() ) {
-				$this->unregister( $inbox_note->name() );
+				try {
+					$this->unregister( $inbox_note->name() );
+				} catch ( Exception $exeption ) {
+					continue;
+				}
 				continue;
 			}
 
@@ -62,6 +68,9 @@ class InboxNoteRegistrar {
 		}
 	}
 
+	/**
+	 * @throws NotesUnavailableException If unable to unregister the note.
+	 */
 	public function unregister( string $inbox_note_name ): void {
 		$data_store        = Notes::load_data_store();
 		$existing_note_ids = $data_store->get_notes_with_name( $inbox_note_name );

--- a/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
@@ -79,6 +79,7 @@ class InboxNoteRegistrar {
 			$note = Notes::get_note( $note_id );
 
 			if ( $note ) {
+				/** @psalm-suppress PossiblyInvalidArgument */
 				$data_store->delete( $note );
 			}
 		}

--- a/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/Settings/WcInboxNotes/InboxNoteRegistrar.php
@@ -34,7 +34,8 @@ class InboxNoteRegistrar {
 
 			if ( ! $inbox_note->is_enabled() ) {
 				if ( $existing_note instanceof Note ) {
-					Notes::delete_note( $existing_note );
+					$data_store = Notes::load_data_store();
+					$data_store->delete( $existing_note );
 				}
 				continue;
 			}

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -966,26 +966,13 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		add_action(
 			'admin_init',
 			static function () use ( $container ): void {
-				$settings = $container->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
-
-				$is_working_capital_feature_flag_enabled = apply_filters(
-				// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
-					'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
-					getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
-				);
-
-				$is_working_capital_eligible = $container->get( 'api.shop.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
-
-				if ( ! $is_working_capital_feature_flag_enabled || ! $is_working_capital_eligible ) {
-					return;
-				}
-
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );
 				assert( $logger instanceof LoggerInterface );
+
+				$inbox_note_registrar = $container->get( 'wcgateway.settings.inbox-note-registrar' );
+				assert( $inbox_note_registrar instanceof InboxNoteRegistrar );
+
 				try {
-					$inbox_note_registrar = $container->get( 'wcgateway.settings.inbox-note-registrar' );
-					assert( $inbox_note_registrar instanceof InboxNoteRegistrar );
 					$inbox_note_registrar->register();
 				} catch ( Exception $exception ) {
 					$logger->error( 'Failed to add note to the WooCommerce inbox section. ' . $exception->getMessage() );


### PR DESCRIPTION
## Issue Description

To inform users about the upcoming settings migration, we already display a notice in our settings page, and additionally want to add a WC Home Inbox item

## PR Description

This PR:

- Adds a logic to dynamically and separately enable/disable the inbox notes
- If the condition is not met, then the previously added note will be deleted
- Adds new Woo Inbox note, which also allows to migrate settings.

<img width="759" height="326" alt="Screenshot 2025-08-18 at 16 15 12" src="https://github.com/user-attachments/assets/e6bc046c-6260-4166-b1f7-2afda4ce653d" />
