### PR TITLE
Auto-enable Pay Later messaging for eligible stores on update (5158)

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -13,6 +13,9 @@ use Exception;
 use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Product;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -90,6 +93,64 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		add_action( 'woocommerce_paypal_payments_gateway_migrate', static fn() => delete_transient( 'ppcp_has_ppec_subscriptions' ) );
 
 		$this->legacy_ui_card_payment_mapping( $c );
+
+		/**
+		 * Automatically enable Pay Later messaging for eligible stores during plugin update.
+		 *
+		 * This action runs during plugin updates to automatically enable Pay Later messaging for stores
+		 * that meet the following criteria:
+		 * - Feature flag 'paylater_messaging_force_enabled' is enabled (default: true, can be disabled via filter)
+		 * - Pay Later messaging is available for the store's country
+		 * - The "Stay updated" checkbox is enabled (checked in either old or new UI)
+		 *
+		 * The "Stay updated" setting is retrieved differently based on the UI version:
+		 * - Legacy UI: Retrieved from wcgateway.settings
+		 * - New UI: Retrieved from settings.data.settings model
+		 *
+		 * When all conditions are met, this will:
+		 * - Enable Pay Later messaging
+		 * - Add default messaging locations (product, cart, checkout) to existing selections
+		 *
+		 * @todo Remove this auto-enablement logic after the next release
+		 *
+		 * @hook woocommerce_paypal_payments_gateway_migrate_on_update
+		 */
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate_on_update',
+			static function() use ( $c ) {
+				if ( ! apply_filters(
+				// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+					'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
+					true
+				) ) {
+					return;
+				}
+
+				$messages_apply = $c->get( 'button.helper.messages-apply' );
+				assert( $messages_apply instanceof MessagesApply );
+
+				$settings_model = $c->get( 'settings.data.settings' );
+				assert( $settings_model instanceof SettingsModel );
+
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				$stay_updated = SettingsModule::should_use_the_old_ui()
+					? $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' )
+					: $settings_model->get_stay_updated();
+
+				if ( ! $messages_apply->for_country() || ! $stay_updated ) {
+					return;
+				}
+
+				$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
+
+				$settings->set( 'pay_later_messaging_enabled', true );
+				$settings->set( 'pay_later_messaging_locations', array_merge( $selected_locations, array( 'product', 'cart', 'checkout' ) ) );
+
+				$settings->persist();
+			}
+		);
 
 		return true;
 	}

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/StayUpdated.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/StayUpdated.js
@@ -10,6 +10,7 @@ const StayUpdated = () => {
 	return (
 		<SettingsBlock className="ppcp--pay-now-experience">
 			<ControlToggleButton
+				id="ppcp-stay-updated"
 				label={ __( 'Stay Updated', 'woocommerce-paypal-payments' ) }
 				description={ __(
 					'Get the latest PayPal features and capabilities as they are released. When the extension is updated, new features, payment methods, styling options, and more will automatically update.',

--- a/modules/ppcp-settings/resources/js/switchSettingsUi.js
+++ b/modules/ppcp-settings/resources/js/switchSettingsUi.js
@@ -42,7 +42,9 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			event.target.closest( '.button.button-settings-switch-ui' ) ||
 			event.target.closest( 'a.settings-switch-ui' ) ||
 			event.target.closest( 'a[name="settings-switch-ui"]' ) ||
-			event.target.closest( '.woocommerce-inbox-note__action-button' )
+			event.target
+				.closest( '.woocommerce-inbox-note__action-button' )
+				.textContent.includes( 'Switch to New Settings' )
 		) {
 			handleClick( event );
 		}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -21,11 +21,13 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Axo\Helper\PropertiesDictionary;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesDisclaimers;
 use WooCommerce\PayPalCommerce\Common\Pattern\SingletonDecorator;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Onboarding\State;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\FeesRenderer;
@@ -2168,13 +2170,36 @@ return array(
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
+		$settings_model = $container->get( 'settings.data.settings' );
+		assert( $settings_model instanceof SettingsModel );
+
+		$messages_apply = $container->get( 'button.helper.messages-apply' );
+		assert( $messages_apply instanceof MessagesApply );
+
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
 			getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
 		);
 
-		$is_working_capital_eligible = $container->get( 'api.shop.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
+		$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
+		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
+			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
+			true
+		);
+
+		$stay_updated = SettingsModule::should_use_the_old_ui()
+			? $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' )
+			: $settings_model->get_stay_updated();
+
+		$stay_updated_field_link = SettingsModule::should_use_the_old_ui()
+			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#ppcp-stay_updated_field' )
+			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&panel=settings#ppcp-stay-updated' );
+
+		$paylater_messaging_tab_link = SettingsModule::should_use_the_old_ui()
+			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' )
+			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&panel=pay-later-messaging' );
+
 
 		$message = sprintf(
 		// translators: %1$s is the URL for the startup guide.
@@ -2192,7 +2217,7 @@ return array(
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-working-capital-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
-				$is_working_capital_feature_flag_enabled && $is_working_capital_eligible,
+				$is_working_capital_feature_flag_enabled && $container->get( 'api.shop.country' ) === 'US' && $stay_updated,
 				new InboxNoteAction(
 					'apply_now',
 					__( 'Apply now', 'woocommerce-paypal-payments' ),
@@ -2212,6 +2237,28 @@ return array(
 					'switch_to_new_settings',
 					__( 'Switch to New Settings', 'woocommerce-paypal-payments' ),
 					admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+					Note::E_WC_ADMIN_NOTE_UNACTIONED,
+					true
+				)
+			),
+			$inbox_note_factory->create_note(
+				__( 'Pay Later messaging now optimizing conversions', 'woocommerce-paypal-payments' ),
+				sprintf(
+				// translators: %1$s is the URL for Pay Later messaging documentation.
+					__(
+						'PayPal Pay Later messages are now displaying on your store through your <a href="%1$s">Stay Updated</a> preference, helping customers see flexible payment options. Merchants typically see 20-40% higher conversion rates with these purchase incentives. The messages appear contextually near prices, not as ads. You control this completely—disable anytime if your conversion metrics don\'t improve.',
+						'woocommerce-paypal-payments'
+					),
+					$stay_updated_field_link
+				),
+				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
+				'ppcp-settings-paylater-messaging-force-enabled-inbox-note',
+				Note::E_WC_ADMIN_NOTE_UNACTIONED,
+				$is_paylater_messaging_force_enabled_feature_flag_enabled && $messages_apply->for_country() && $stay_updated,
+				new InboxNoteAction(
+					'review_pay_later_settings',
+					__( 'Review Pay Later settings', 'woocommerce-paypal-payments' ),
+					$paylater_messaging_tab_link,
 					Note::E_WC_ADMIN_NOTE_UNACTIONED,
 					true
 				)

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2200,7 +2200,6 @@ return array(
 			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' )
 			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&panel=pay-later-messaging' );
 
-
 		$message = sprintf(
 		// translators: %1$s is the URL for the startup guide.
 			__(


### PR DESCRIPTION
## Issue Description

This PR implements automatic enablement of Pay Later messaging for stores that have opted into automatic feature updates.
A few updates ago, the "Stay Updated" checkbox was introduced and automatically checked for all users. Since then, users have had the opportunity to uncheck it, but the vast majority of users still have it enabled. This indicates user consent for automatic feature enablement.

### PR Description

**Automatic Enablement Logic:**
- Triggers during plugin updates via `woocommerce_paypal_payments_gateway_migrate_on_update` hook
- Only enables Pay Later messaging for stores that meet ALL criteria:
  - "Stay Updated" checkbox is enabled (works with both legacy and new UI)
  - Pay Later messaging is available for the store's country
  - Feature flag allows enablement (can be disabled via filter)

**User Notification:**
- Creates WooCommerce inbox notification to inform users of the automatic change

### Technical Notes
- Includes feature flag for emergency disable capability
- Handles both legacy and new UI settings retrieval