### PR TITLE
Fix Google Pay button enabled state on variable product pages (5169)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
@@ -897,7 +897,7 @@ export default class PaymentButton {
 				}
 			);
 
-			// ✅ Ensure initial state is synced on page load
+			// Ensure initial state is synced on page load
 			this.syncProductButtonsState();
 		}
 	}

--- a/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/PaymentButton.js
@@ -896,6 +896,9 @@ export default class PaymentButton {
 					this.syncProductButtonsState();
 				}
 			);
+
+			// ✅ Ensure initial state is synced on page load
+			this.syncProductButtonsState();
 		}
 	}
 


### PR DESCRIPTION
## Issue Description

Google Pay button is clickable for variable products even before selecting the variations

**Steps to reproduce (before fix)**

- Create a variable product.
- Navigate to the shop and open the product page.
- Notice Google Pay button is clickable before variation selection.
- Reload the page.
- Notice Google Pay button is now disabled until a variation is selected.

## PR Description

This PR fixes an issue where the Google Pay button on variable product pages appeared clickable before a variation was selected. After reloading the page, the button behaved as expected, remaining disabled until a variation was chosen.

**Root cause**

The button’s enabled/disabled state was only synced after `ppcp-shown`, `ppcp-hidden`, `ppcp-enabled`, or `ppcp-disabled` events were triggered.
On initial page load, no event had fired yet, leaving the Google Pay button enabled by default.

**Fix**

Call `this.syncProductButtonsState()` immediately after binding the event listeners in `initEventListeners()`.
This ensures the Google Pay button state is synced with the PayPal button right away on page load.