### PR TITLE
fix: check variation stock for all variable products (5173)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1928,7 +1928,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 
 		$in_stock = $product->is_in_stock();
 
-		if ( ! $in_stock && $product->is_type( 'variable' ) ) {
+		if ( $product->is_type( 'variable' ) ) {
 			/**
 			 * The method is defined in WC_Product_Variable class.
 			 *


### PR DESCRIPTION
## Issue Description
PayPal payment buttons (PayPal, Google Pay, Apple Pay) were incorrectly displaying on variable products that had no valid or priced variations. This occurred because the stock check logic only examined individual variations when the parent variable product was marked as "out of stock", but variable products without proper variation configuration often remain marked as "in stock" at the parent level.

**Steps to Reproduce:**
1. Create a variable product in WooCommerce
2. Do not add prices or proper configuration to any variations
3. Navigate to the shop page and click on the product
4. **Issue**: PayPal payment buttons are visible and appear clickable
5. **Expected**: Buttons should be hidden since no variations are actually purchasable

## PR Description
This PR fixes the product support validation logic for variable products by ensuring variation availability is always checked, regardless of the parent product's stock status.