### PR TITLE
Fix Dynamic Property Deprecation Warnings in PHP8 (5180)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/Shipping.php
+++ b/modules/ppcp-api-client/src/Entity/Shipping.php
@@ -55,8 +55,8 @@ class Shipping {
 	 * @param ShippingOption[] $options       Shipping methods.
 	 */
 	public function __construct(
-		string $name = null,
-		Address $address = null,
+		?string $name = null,
+		?Address $address = null,
 		?string $email_address = null,
 		?Phone $phone_number = null,
 		array $options = array()

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -187,6 +187,62 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	protected $logger;
 
 	/**
+	 * ID of the class extending the settings API. Used in option names.
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * Supported features such as 'default_credit_card_form', 'refunds'.
+	 *
+	 * @var array
+	 */
+	public $supports;
+
+	/**
+	 * Gateway title.
+	 *
+	 * @var string
+	 */
+	public $method_title;
+
+	/**
+	 * Gateway description.
+	 *
+	 * @var string
+	 */
+	public $method_description;
+
+	/**
+	 * Payment method title for the frontend.
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * Payment method description for the frontend.
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * Form option fields.
+	 *
+	 * @var array
+	 */
+	public $form_fields;
+
+	/**
+	 * Yes or no based on whether the method is enabled.
+	 *
+	 * @var string
+	 */
+	public $enabled;
+
+	/**
 	 * CreditCardGateway constructor.
 	 *
 	 * @param SettingsRenderer          $settings_renderer           The Settings Renderer.

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -198,21 +198,21 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 *
 	 * @var array
 	 */
-	public $supports;
+	public $supports = array( 'products' );
 
 	/**
 	 * Gateway title.
 	 *
 	 * @var string
 	 */
-	public $method_title;
+	public $method_title = '';
 
 	/**
 	 * Gateway description.
 	 *
 	 * @var string
 	 */
-	public $method_description;
+	public $method_description = '';
 
 	/**
 	 * Payment method title for the frontend.
@@ -233,14 +233,14 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 *
 	 * @var array
 	 */
-	public $form_fields;
+	public $form_fields = array();
 
 	/**
 	 * Yes or no based on whether the method is enabled.
 	 *
 	 * @var string
 	 */
-	public $enabled;
+	public $enabled = 'yes';
 
 	/**
 	 * CreditCardGateway constructor.

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
@@ -98,14 +98,14 @@ class OXXOGateway extends WC_Payment_Gateway {
 	 *
 	 * @var string
 	 */
-	public $method_title;
+	public $method_title = '';
 
 	/**
 	 * Gateway description.
 	 *
 	 * @var string
 	 */
-	public $method_description;
+	public $method_description = '';
 
 	/**
 	 * Payment method title for the frontend.
@@ -126,7 +126,7 @@ class OXXOGateway extends WC_Payment_Gateway {
 	 *
 	 * @var array
 	 */
-	public $form_fields;
+	public $form_fields = array();
 
 	/**
 	 * Icon for the gateway.

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXOGateway.php
@@ -87,6 +87,55 @@ class OXXOGateway extends WC_Payment_Gateway {
 	protected ExperienceContextBuilder $experience_context_builder;
 
 	/**
+	 * ID of the class extending the settings API. Used in option names.
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * Gateway title.
+	 *
+	 * @var string
+	 */
+	public $method_title;
+
+	/**
+	 * Gateway description.
+	 *
+	 * @var string
+	 */
+	public $method_description;
+
+	/**
+	 * Payment method title for the frontend.
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * Payment method description for the frontend.
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * Form option fields.
+	 *
+	 * @var array
+	 */
+	public $form_fields;
+
+	/**
+	 * Icon for the gateway.
+	 *
+	 * @var string
+	 */
+	public $icon;
+
+	/**
 	 * OXXOGateway constructor.
 	 *
 	 * @param OrderEndpoint             $order_endpoint The order endpoint.

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -213,6 +213,69 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	private $admin_settings_enabled;
 
 	/**
+	 * ID of the class extending the settings API. Used in option names.
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * Gateway title.
+	 *
+	 * @var string
+	 */
+	public $method_title;
+
+	/**
+	 * Gateway description.
+	 *
+	 * @var string
+	 */
+	public $method_description;
+
+	/**
+	 * Payment method title for the frontend.
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * Payment method description for the frontend.
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * Form option fields.
+	 *
+	 * @var array
+	 */
+	public $form_fields;
+
+	/**
+	 * Icon for the gateway.
+	 *
+	 * @var string
+	 */
+	public $icon;
+
+	/**
+	 * Supported features such as 'default_credit_card_form', 'refunds'.
+	 *
+	 * @var array
+	 */
+	public $supports;
+
+	/**
+	 * Set if the place order button should be renamed on selection.
+	 *
+	 * @var string
+	 */
+	public $order_button_text;
+
+	/**
 	 * PayPalGateway constructor.
 	 *
 	 * @param SettingsRenderer         $settings_renderer The Settings Renderer.

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -224,14 +224,14 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 *
 	 * @var string
 	 */
-	public $method_title;
+	public $method_title = '';
 
 	/**
 	 * Gateway description.
 	 *
 	 * @var string
 	 */
-	public $method_description;
+	public $method_description = '';
 
 	/**
 	 * Payment method title for the frontend.
@@ -252,7 +252,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 *
 	 * @var array
 	 */
-	public $form_fields;
+	public $form_fields = array();
 
 	/**
 	 * Icon for the gateway.
@@ -266,7 +266,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 *
 	 * @var array
 	 */
-	public $supports;
+	public $supports = array( 'products' );
 
 	/**
 	 * Set if the place order button should be renamed on selection.

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -114,14 +114,14 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	 *
 	 * @var string
 	 */
-	public $method_title;
+	public $method_title = '';
 
 	/**
 	 * Gateway description.
 	 *
 	 * @var string
 	 */
-	public $method_description;
+	public $method_description = '';
 
 	/**
 	 * Payment method title for the frontend.
@@ -142,7 +142,7 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	 *
 	 * @var array
 	 */
-	public $form_fields;
+	public $form_fields = array();
 
 	/**
 	 * Icon for the gateway.
@@ -156,7 +156,7 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	 *
 	 * @var array
 	 */
-	public $supports;
+	public $supports = array( 'products' );
 
 	/**
 	 * PayUponInvoiceGateway constructor.

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoiceGateway.php
@@ -103,6 +103,62 @@ class PayUponInvoiceGateway extends WC_Payment_Gateway {
 	private $module_url;
 
 	/**
+	 * ID of the class extending the settings API. Used in option names.
+	 *
+	 * @var string
+	 */
+	public $id;
+
+	/**
+	 * Gateway title.
+	 *
+	 * @var string
+	 */
+	public $method_title;
+
+	/**
+	 * Gateway description.
+	 *
+	 * @var string
+	 */
+	public $method_description;
+
+	/**
+	 * Payment method title for the frontend.
+	 *
+	 * @var string
+	 */
+	public $title;
+
+	/**
+	 * Payment method description for the frontend.
+	 *
+	 * @var string
+	 */
+	public $description;
+
+	/**
+	 * Form option fields.
+	 *
+	 * @var array
+	 */
+	public $form_fields;
+
+	/**
+	 * Icon for the gateway.
+	 *
+	 * @var string
+	 */
+	public $icon;
+
+	/**
+	 * Supported features such as 'default_credit_card_form', 'refunds'.
+	 *
+	 * @var array
+	 */
+	public $supports;
+
+	/**
 	 * PayUponInvoiceGateway constructor.
 	 *
 	 * @param PayUponInvoiceOrderEndpoint $order_endpoint The order endpoint.

--- a/tests/PHPUnit/ApiClient/Endpoint/PaymentTokenEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/PaymentTokenEndpointTest.php
@@ -30,6 +30,7 @@ class PaymentTokenEndpointTest extends TestCase
     private $customer_repository;
 	private $request_id_repository;
     private $sut;
+	private $logger;
 
     public function setUp(): void
     {

--- a/tests/PHPUnit/ModularTestCase.php
+++ b/tests/PHPUnit/ModularTestCase.php
@@ -74,6 +74,8 @@ class ModularTestCase extends TestCase
 		$module = new class ($overriddenServices) implements ServiceModule, ExecutableModule {
 			use ModuleClassNameIdTrait;
 
+			private $services;
+
 			public function __construct(array $services) {
 				$this->services = $services;
 			}

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -5,6 +5,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 
 use Mockery\MockInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
@@ -45,6 +46,8 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 	private $config;
 	private $captureId = '123qwe';
 	private $testee;
+	private $subscription_helper;
+	private $amount_factory;
 
 	public function setUp(): void {
 		parent::setUp();

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -5,7 +5,6 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
 
 
 use Mockery\MockInterface;
-use PHPUnit\Framework\MockObject\MockObject;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;


### PR DESCRIPTION
### Description

This PR eliminates code warnings when running the project with PHP8.  Specifically the warnings discovered when running PHPUNIT in the project.

1. **Set properties and default values as in WC_Payment_Gateway**
    - Added properties with their default values in several gateway classes to match `WC_Payment_Gateway` class specification. Properties like `$supports``$method_title``$method_description``$enabled` and `$form_fields` now have appropriate default values. 

2. **Fix deprecation messages in modules**
    - In api-client module: Fixed parameter type hinting with nullable types (`?string` instead of `string = null`)
    - In tests: Added missing property declaration

### Steps to Test

1. Check out this PR
2. Run PHPUNIT with PHP8
3. No warnings or deprecation messages appear
4. Run PHPUNIT with PHP7 
5. No warnings or deprecation messages appear

### Screenshots

https://github.com/user-attachments/assets/7ec3ed04-fb64-4a5c-99d3-34196ffd2895

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->
