### PR TITLE
Refactor PHPCS configuration to be compatible to PHP8 (5180)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "container-interop/service-provider": "^0.4.0",
         "dhii/containers": "^0.1.0-alpha1",
         "inpsyde/modularity": "^1.7",
-        "woocommerce/woocommerce-sniffs": "^0.1.0",
+        "woocommerce/woocommerce-sniffs": "^1.0.0",
         "phpunit/phpunit": "^7.0 | ^8.0 | ^9.0",
         "brain/monkey": "^2.4",
         "php-stubs/wordpress-stubs": "^5.0@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ca9c2c7864d2649617db6d3850382c5",
+    "content-hash": "fd277e5a82374078694b99b0e6aef07c",
     "packages": [
         {
             "name": "container-interop/service-provider",
@@ -1263,35 +1263,38 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
             "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
             },
             "autoload": {
                 "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1301,17 +1304,16 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -1331,10 +1333,29 @@
                 "tests"
             ],
             "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2022-02-04T12:51:07+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "dhii/collections-interface",
@@ -2816,6 +2837,181 @@
                 }
             ],
             "time": "2025-05-12T16:38:37+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "reference": "fa4b8d051e278072928e32d817456a7fdb57b6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-06-14T07:40:39+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
+                "reference": "f7eb16f2fa4237d5db9e8fed8050239bee17a9bd",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.0 || ^4.0"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-08-10T01:04:45+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -5737,74 +5933,77 @@
         },
         {
             "name": "woocommerce/woocommerce-sniffs",
-            "version": "0.1.3",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-sniffs.git",
-                "reference": "4576d54595614d689bc4436acff8baaece3c5bb0"
+                "reference": "3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/4576d54595614d689bc4436acff8baaece3c5bb0",
-                "reference": "4576d54595614d689bc4436acff8baaece3c5bb0",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8",
+                "reference": "3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
                 "php": ">=7.0",
                 "phpcompatibility/phpcompatibility-wp": "^2.1.0",
-                "wp-coding-standards/wpcs": "^2.3.0"
+                "wp-coding-standards/wpcs": "^3.0.0"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Claudio Sanches",
-                    "email": "claudio@automattic.com"
-                }
-            ],
             "description": "WooCommerce sniffs",
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "woocommerce",
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
-                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/0.1.3"
+                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/1.0.0"
             },
-            "time": "2022-02-17T15:34:51+00:00"
+            "time": "2023-09-29T13:52:33+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -5821,6 +6020,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -5828,14 +6028,20 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-07-24T20:08:31+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "php-stubs/wordpress-stubs": 0,
-        "php-stubs/woocommerce-stubs": 0
+        "php-stubs/woocommerce-stubs": 0,
+        "php-stubs/wordpress-stubs": 0
     },
     "prefer-stable": true,
     "prefer-lowest": false,
@@ -5843,7 +6049,7 @@
         "php": "^7.4 | ^8.0",
         "ext-json": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },

--- a/modules/ppcp-admin-notices/src/AdminNotices.php
+++ b/modules/ppcp-admin-notices/src/AdminNotices.php
@@ -49,7 +49,7 @@ class AdminNotices implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		add_action(
 			'admin_notices',
-			function() use ( $renderer ) {
+			function () use ( $renderer ) {
 				$renderer->render();
 			}
 		);
@@ -113,11 +113,10 @@ class AdminNotices implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		add_action(
 			'woocommerce_init',
-			function() {
+			function () {
 				if ( is_admin() && is_callable( array( WC(), 'is_wc_admin_active' ) ) && WC()->is_wc_admin_active() && class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 					MexicoInstallmentsNote::init();
 				}
-
 			}
 		);
 

--- a/modules/ppcp-admin-notices/src/Endpoint/MuteMessageEndpoint.php
+++ b/modules/ppcp-admin-notices/src/Endpoint/MuteMessageEndpoint.php
@@ -53,7 +53,7 @@ class MuteMessageEndpoint {
 	 *
 	 * @return string
 	 */
-	public static function nonce() : string {
+	public static function nonce(): string {
 		return self::ENDPOINT;
 	}
 
@@ -62,7 +62,7 @@ class MuteMessageEndpoint {
 	 *
 	 * @return void
 	 */
-	public function handle_request() : void {
+	public function handle_request(): void {
 		try {
 			$data = $this->request_data->read_request( $this->nonce() );
 		} catch ( RuntimeException $ex ) {

--- a/modules/ppcp-admin-notices/src/Entity/Message.php
+++ b/modules/ppcp-admin-notices/src/Entity/Message.php
@@ -62,7 +62,7 @@ class Message {
 	 *
 	 * @return string
 	 */
-	public function message() : string {
+	public function message(): string {
 		return $this->message;
 	}
 
@@ -71,7 +71,7 @@ class Message {
 	 *
 	 * @return string
 	 */
-	public function type() : string {
+	public function type(): string {
 		return $this->type;
 	}
 
@@ -80,7 +80,7 @@ class Message {
 	 *
 	 * @return bool
 	 */
-	public function is_dismissible() : bool {
+	public function is_dismissible(): bool {
 		return $this->dismissible;
 	}
 
@@ -89,7 +89,7 @@ class Message {
 	 *
 	 * @return string
 	 */
-	public function wrapper() : string {
+	public function wrapper(): string {
 		return $this->wrapper;
 	}
 
@@ -98,7 +98,7 @@ class Message {
 	 *
 	 * @return array
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		return array(
 			'type'        => $this->type,
 			'message'     => $this->message,
@@ -114,7 +114,7 @@ class Message {
 	 *
 	 * @return Message
 	 */
-	public static function from_array( array $data ) : Message {
+	public static function from_array( array $data ): Message {
 		return new Message(
 			(string) ( $data['message'] ?? '' ),
 			(string) ( $data['type'] ?? '' ),

--- a/modules/ppcp-admin-notices/src/Entity/PersistentMessage.php
+++ b/modules/ppcp-admin-notices/src/Entity/PersistentMessage.php
@@ -47,7 +47,7 @@ class PersistentMessage extends Message {
 	 *
 	 * @return string
 	 */
-	public function id( bool $with_db_prefix = false ) : string {
+	public function id( bool $with_db_prefix = false ): string {
 		if ( ! $this->message_id ) {
 			return '';
 		}
@@ -58,7 +58,7 @@ class PersistentMessage extends Message {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		$data       = parent::to_array();
 		$data['id'] = $this->message_id;
 
@@ -70,7 +70,7 @@ class PersistentMessage extends Message {
 	 *
 	 * @return PersistentMessage
 	 */
-	public static function from_array( array $data ) : Message {
+	public static function from_array( array $data ): Message {
 		return new PersistentMessage(
 			(string) ( $data['id'] ?? '' ),
 			(string) ( $data['message'] ?? '' ),
@@ -84,7 +84,7 @@ class PersistentMessage extends Message {
 	 *
 	 * @return bool
 	 */
-	public function is_muted() : bool {
+	public function is_muted(): bool {
 		$user_id = get_current_user_id();
 
 		if ( ! $this->message_id || ! $user_id ) {
@@ -99,7 +99,7 @@ class PersistentMessage extends Message {
 	 *
 	 * @return void
 	 */
-	public function mute() : void {
+	public function mute(): void {
 		$user_id = get_current_user_id();
 
 		if ( $this->message_id && $user_id && ! $this->is_muted() ) {
@@ -112,7 +112,7 @@ class PersistentMessage extends Message {
 	 *
 	 * @return void
 	 */
-	public static function clear_all() : void {
+	public static function clear_all(): void {
 		global $wpdb;
 
 		$wpdb->query(

--- a/modules/ppcp-admin-notices/src/Renderer/Renderer.php
+++ b/modules/ppcp-admin-notices/src/Renderer/Renderer.php
@@ -95,7 +95,7 @@ class Renderer implements RendererInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function enqueue_admin() : void {
+	public function enqueue_admin(): void {
 		if ( ! $this->can_mute_message ) {
 			return;
 		}
@@ -129,7 +129,7 @@ class Renderer implements RendererInterface {
 	 *
 	 * @return array
 	 */
-	protected function script_data_for_admin() : array {
+	protected function script_data_for_admin(): array {
 		$ajax_url = admin_url( 'admin-ajax.php' );
 
 		return array(

--- a/modules/ppcp-admin-notices/src/Renderer/RendererInterface.php
+++ b/modules/ppcp-admin-notices/src/Renderer/RendererInterface.php
@@ -26,5 +26,5 @@ interface RendererInterface {
 	 *
 	 * @return void
 	 */
-	public function enqueue_admin() : void;
+	public function enqueue_admin(): void;
 }

--- a/modules/ppcp-admin-notices/src/Repository/Repository.php
+++ b/modules/ppcp-admin-notices/src/Repository/Repository.php
@@ -25,7 +25,7 @@ class Repository implements RepositoryInterface {
 	 *
 	 * @return Message[]
 	 */
-	public function current_message() : array {
+	public function current_message(): array {
 		return array_filter(
 			/**
 			 * Returns the list of admin messages.
@@ -34,7 +34,7 @@ class Repository implements RepositoryInterface {
 				self::NOTICES_FILTER,
 				array()
 			),
-			function ( $element ) : bool {
+			function ( $element ): bool {
 				if ( $element instanceof PersistentMessage ) {
 					return ! $element->is_muted();
 				}
@@ -51,7 +51,7 @@ class Repository implements RepositoryInterface {
 	 *
 	 * @return void
 	 */
-	public function persist( Message $message ) : void {
+	public function persist( Message $message ): void {
 		$persisted_notices = get_option( self::PERSISTED_NOTICES_OPTION ) ?: array();
 
 		$persisted_notices[] = $message->to_array();
@@ -64,7 +64,7 @@ class Repository implements RepositoryInterface {
 	 *
 	 * @return array|Message[]
 	 */
-	public function get_persisted_and_clear() : array {
+	public function get_persisted_and_clear(): array {
 		$notices = array();
 
 		$persisted_data = get_option( self::PERSISTED_NOTICES_OPTION ) ?: array();

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -86,7 +86,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\EnvironmentConfig;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 return array(
-	'api.host'                                       => static function( ContainerInterface $container ) : string {
+	'api.host'                                       => static function ( ContainerInterface $container ): string {
 		$environment = $container->get( 'settings.environment' );
 		assert( $environment instanceof Environment );
 
@@ -96,25 +96,25 @@ return array(
 
 		return (string) $container->get( 'api.production-host' );
 	},
-	'api.paypal-host'                                => function( ContainerInterface $container ) : string {
+	'api.paypal-host'                                => function ( ContainerInterface $container ): string {
 		return PAYPAL_API_URL;
 	},
 	// It seems this 'api.paypal-website-url' key is always overridden in ppcp-onboarding/services.php.
-	'api.paypal-website-url'                         => function( ContainerInterface $container ) : string {
+	'api.paypal-website-url'                         => function ( ContainerInterface $container ): string {
 		return PAYPAL_URL;
 	},
-	'api.factory.paypal-checkout-url'                => function( ContainerInterface $container ) : callable {
+	'api.factory.paypal-checkout-url'                => function ( ContainerInterface $container ): callable {
 		return function ( string $id ) use ( $container ): string {
 			return $container->get( 'api.paypal-website-url' ) . '/checkoutnow?token=' . $id;
 		};
 	},
-	'api.partner_merchant_id'                        => static function () : string {
+	'api.partner_merchant_id'                        => static function (): string {
 		return '';
 	},
-	'api.merchant_email'                             => function () : string {
+	'api.merchant_email'                             => function (): string {
 		return '';
 	},
-	'api.merchant_id'                                => function () : string {
+	'api.merchant_id'                                => function (): string {
 		return '';
 	},
 	'api.key'                                        => static function (): string {
@@ -142,7 +142,7 @@ return array(
 			$container->get( 'wcgateway.settings' )
 		);
 	},
-	'api.endpoint.partners'                          => static function ( ContainerInterface $container ) : PartnersEndpoint {
+	'api.endpoint.partners'                          => static function ( ContainerInterface $container ): PartnersEndpoint {
 		return new PartnersEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
@@ -153,10 +153,10 @@ return array(
 			$container->get( 'api.helper.failure-registry' )
 		);
 	},
-	'api.factory.sellerstatus'                       => static function ( ContainerInterface $container ) : SellerStatusFactory {
+	'api.factory.sellerstatus'                       => static function ( ContainerInterface $container ): SellerStatusFactory {
 		return new SellerStatusFactory();
 	},
-	'api.endpoint.payment-token'                     => static function ( ContainerInterface $container ) : PaymentTokenEndpoint {
+	'api.endpoint.payment-token'                     => static function ( ContainerInterface $container ): PaymentTokenEndpoint {
 		return new PaymentTokenEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
@@ -166,14 +166,14 @@ return array(
 			$container->get( 'api.repository.customer' )
 		);
 	},
-	'api.endpoint.payment-tokens'                    => static function( ContainerInterface $container ) : PaymentTokensEndpoint {
+	'api.endpoint.payment-tokens'                    => static function ( ContainerInterface $container ): PaymentTokensEndpoint {
 		return new PaymentTokensEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.webhook'                           => static function ( ContainerInterface $container ) : WebhookEndpoint {
+	'api.endpoint.webhook'                           => static function ( ContainerInterface $container ): WebhookEndpoint {
 
 		return new WebhookEndpoint(
 			$container->get( 'api.host' ),
@@ -183,7 +183,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.partner-referrals'                 => static function ( ContainerInterface $container ) : PartnerReferrals {
+	'api.endpoint.partner-referrals'                 => static function ( ContainerInterface $container ): PartnerReferrals {
 
 		return new PartnerReferrals(
 			$container->get( 'api.host' ),
@@ -191,7 +191,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.partner-referrals-sandbox'         => static function ( ContainerInterface $container ) : PartnerReferrals {
+	'api.endpoint.partner-referrals-sandbox'         => static function ( ContainerInterface $container ): PartnerReferrals {
 
 		return new PartnerReferrals(
 			CONNECT_WOO_SANDBOX_URL,
@@ -199,7 +199,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.partner-referrals-production'      => static function ( ContainerInterface $container ) : PartnerReferrals {
+	'api.endpoint.partner-referrals-production'      => static function ( ContainerInterface $container ): PartnerReferrals {
 
 		return new PartnerReferrals(
 			CONNECT_WOO_URL,
@@ -207,7 +207,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.identity-token'                    => static function ( ContainerInterface $container ) : IdentityToken {
+	'api.endpoint.identity-token'                    => static function ( ContainerInterface $container ): IdentityToken {
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 		$settings = $container->get( 'wcgateway.settings' );
 		$customer_repository = $container->get( 'api.repository.customer' );
@@ -232,7 +232,7 @@ return array(
 			$logger
 		);
 	},
-	'api.endpoint.login-seller'                      => static function ( ContainerInterface $container ) : LoginSeller {
+	'api.endpoint.login-seller'                      => static function ( ContainerInterface $container ): LoginSeller {
 
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
 		return new LoginSeller(
@@ -287,7 +287,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.billing-plans'                     => static function( ContainerInterface $container ): BillingPlans {
+	'api.endpoint.billing-plans'                     => static function ( ContainerInterface $container ): BillingPlans {
 		return new BillingPlans(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
@@ -296,21 +296,21 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.billing-subscriptions'             => static function( ContainerInterface $container ): BillingSubscriptions {
+	'api.endpoint.billing-subscriptions'             => static function ( ContainerInterface $container ): BillingSubscriptions {
 		return new BillingSubscriptions(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.payment-method-tokens'             => static function( ContainerInterface $container ): PaymentMethodTokensEndpoint {
+	'api.endpoint.payment-method-tokens'             => static function ( ContainerInterface $container ): PaymentMethodTokensEndpoint {
 		return new PaymentMethodTokensEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.repository.partner-referrals-data'          => static function ( ContainerInterface $container ) : PartnerReferralsData {
+	'api.repository.partner-referrals-data'          => static function ( ContainerInterface $container ): PartnerReferralsData {
 
 		$dcc_applies    = $container->get( 'api.helpers.dccapplies' );
 		return new PartnerReferralsData( $dcc_applies );
@@ -320,11 +320,11 @@ return array(
 		$merchant_id    = $container->get( 'api.merchant_id' );
 		return new PayeeRepository( $merchant_email, $merchant_id );
 	},
-	'api.repository.customer'                        => static function( ContainerInterface $container ): CustomerRepository {
+	'api.repository.customer'                        => static function ( ContainerInterface $container ): CustomerRepository {
 		$prefix           = $container->get( 'api.prefix' );
 		return new CustomerRepository( $prefix );
 	},
-	'api.repository.order'                           => static function( ContainerInterface $container ): OrderRepository {
+	'api.repository.order'                           => static function ( ContainerInterface $container ): OrderRepository {
 		return new OrderRepository(
 			$container->get( 'api.endpoint.order' )
 		);
@@ -345,10 +345,10 @@ return array(
 			$container->get( 'settings.merchant-details' )
 		);
 	},
-	'api.factory.payment-token'                      => static function ( ContainerInterface $container ) : PaymentTokenFactory {
+	'api.factory.payment-token'                      => static function ( ContainerInterface $container ): PaymentTokenFactory {
 		return new PaymentTokenFactory();
 	},
-	'api.factory.payment-token-action-links'         => static function ( ContainerInterface $container ) : PaymentTokenActionLinksFactory {
+	'api.factory.payment-token-action-links'         => static function ( ContainerInterface $container ): PaymentTokenActionLinksFactory {
 		return new PaymentTokenActionLinksFactory();
 	},
 	'api.factory.webhook'                            => static function ( ContainerInterface $container ): WebhookFactory {
@@ -485,25 +485,25 @@ return array(
 	'api.factory.fraud-processor-response'           => static function ( ContainerInterface $container ): FraudProcessorResponseFactory {
 		return new FraudProcessorResponseFactory();
 	},
-	'api.factory.product'                            => static function( ContainerInterface $container ): ProductFactory {
+	'api.factory.product'                            => static function ( ContainerInterface $container ): ProductFactory {
 		return new ProductFactory();
 	},
-	'api.factory.billing-cycle'                      => static function( ContainerInterface $container ): BillingCycleFactory {
+	'api.factory.billing-cycle'                      => static function ( ContainerInterface $container ): BillingCycleFactory {
 		return new BillingCycleFactory( $container->get( 'api.shop.currency.getter' ) );
 	},
-	'api.factory.payment-preferences'                => static function( ContainerInterface $container ):PaymentPreferencesFactory {
+	'api.factory.payment-preferences'                => static function ( ContainerInterface $container ): PaymentPreferencesFactory {
 		return new PaymentPreferencesFactory( $container->get( 'api.shop.currency.getter' ) );
 	},
-	'api.factory.plan'                               => static function( ContainerInterface $container ): PlanFactory {
+	'api.factory.plan'                               => static function ( ContainerInterface $container ): PlanFactory {
 		return new PlanFactory(
 			$container->get( 'api.factory.billing-cycle' ),
 			$container->get( 'api.factory.payment-preferences' )
 		);
 	},
-	'api.factory.card-authentication-result-factory' => static function( ContainerInterface $container ): CardAuthenticationResultFactory {
+	'api.factory.card-authentication-result-factory' => static function ( ContainerInterface $container ): CardAuthenticationResultFactory {
 		return new CardAuthenticationResultFactory();
 	},
-	'api.helpers.dccapplies'                         => static function ( ContainerInterface $container ) : DccApplies {
+	'api.helpers.dccapplies'                         => static function ( ContainerInterface $container ): DccApplies {
 		return new DccApplies(
 			$container->get( 'api.dcc-supported-country-currency-matrix' ),
 			$container->get( 'api.dcc-supported-country-card-matrix' ),
@@ -512,21 +512,21 @@ return array(
 		);
 	},
 
-	'api.shop.currency.getter'                       => static function ( ContainerInterface $container ) : CurrencyGetter {
+	'api.shop.currency.getter'                       => static function ( ContainerInterface $container ): CurrencyGetter {
 		return new CurrencyGetter();
 	},
-	'api.shop.country'                               => static function ( ContainerInterface $container ) : string {
+	'api.shop.country'                               => static function ( ContainerInterface $container ): string {
 		$location = wc_get_base_location();
 		return $location['country'];
 	},
-	'api.shop.is-psd2-country'                       => static function ( ContainerInterface $container ) : bool {
+	'api.shop.is-psd2-country'                       => static function ( ContainerInterface $container ): bool {
 		return in_array(
 			$container->get( 'api.shop.country' ),
 			$container->get( 'api.psd2-countries' ),
 			true
 		);
 	},
-	'api.shop.is-currency-supported'                 => static function ( ContainerInterface $container ) : bool {
+	'api.shop.is-currency-supported'                 => static function ( ContainerInterface $container ): bool {
 		return in_array(
 			$container->get( 'api.shop.currency.getter' )->get(),
 			$container->get( 'api.supported-currencies' ),
@@ -593,7 +593,7 @@ return array(
 	 *
 	 * From https://developer.paypal.com/docs/reports/reference/paypal-supported-currencies/
 	 */
-	'api.supported-currencies'                       => static function ( ContainerInterface $container ) : array {
+	'api.supported-currencies'                       => static function ( ContainerInterface $container ): array {
 		return array(
 			'AUD',
 			'BRL',
@@ -626,7 +626,7 @@ return array(
 	/**
 	 * The matrix which countries and currency combinations can be used for DCC.
 	 */
-	'api.dcc-supported-country-currency-matrix'      => static function ( ContainerInterface $container ) : array {
+	'api.dcc-supported-country-currency-matrix'      => static function ( ContainerInterface $container ): array {
 		$default_currencies = apply_filters(
 			'woocommerce_paypal_payments_supported_currencies',
 			array(
@@ -712,7 +712,7 @@ return array(
 	/**
 	 * Which countries support which credit cards. Empty credit card arrays mean no restriction on currency.
 	 */
-	'api.dcc-supported-country-card-matrix'          => static function ( ContainerInterface $container ) : array {
+	'api.dcc-supported-country-card-matrix'          => static function ( ContainerInterface $container ): array {
 		$mastercard_visa_amex = array(
 			'mastercard' => array(),
 			'visa'       => array(),
@@ -793,7 +793,7 @@ return array(
 		);
 	},
 
-	'api.psd2-countries'                             => static function ( ContainerInterface $container ) : array {
+	'api.psd2-countries'                             => static function ( ContainerInterface $container ): array {
 		return array(
 			'AT',
 			'BE',
@@ -826,7 +826,7 @@ return array(
 		);
 	},
 
-	'api.paylater-countries'                         => static function ( ContainerInterface $container ) : array {
+	'api.paylater-countries'                         => static function ( ContainerInterface $container ): array {
 		return apply_filters(
 			'woocommerce_paypal_payments_supported_paylater_countries',
 			array(
@@ -840,20 +840,20 @@ return array(
 			)
 		);
 	},
-	'api.order-helper'                               => static function( ContainerInterface $container ): OrderHelper {
+	'api.order-helper'                               => static function ( ContainerInterface $container ): OrderHelper {
 		return new OrderHelper();
 	},
-	'api.helper.order-transient'                     => static function( ContainerInterface $container ): OrderTransient {
+	'api.helper.order-transient'                     => static function ( ContainerInterface $container ): OrderTransient {
 		$cache                   = $container->get( 'api.paypal-bearer-cache' );
 		$purchase_unit_sanitizer = $container->get( 'api.helper.purchase-unit-sanitizer' );
 		return new OrderTransient( $cache, $purchase_unit_sanitizer );
 	},
-	'api.helper.failure-registry'                    => static function( ContainerInterface $container ): FailureRegistry {
+	'api.helper.failure-registry'                    => static function ( ContainerInterface $container ): FailureRegistry {
 		$cache = new Cache( 'ppcp-paypal-api-status-cache' );
 		return new FailureRegistry( $cache );
 	},
 	'api.helper.purchase-unit-sanitizer'             => SingletonDecorator::make(
-		static function( ContainerInterface $container ): PurchaseUnitSanitizer {
+		static function ( ContainerInterface $container ): PurchaseUnitSanitizer {
 			$settings  = $container->get( 'wcgateway.settings' );
 			assert( $settings instanceof Settings );
 
@@ -862,24 +862,24 @@ return array(
 			return new PurchaseUnitSanitizer( $behavior, $line_name );
 		}
 	),
-	'api.client-credentials'                         => static function( ContainerInterface $container ): ClientCredentials {
+	'api.client-credentials'                         => static function ( ContainerInterface $container ): ClientCredentials {
 		return new ClientCredentials(
 			$container->get( 'wcgateway.settings' )
 		);
 	},
-	'api.paypal-bearer-cache'                        => static function( ContainerInterface $container ): Cache {
+	'api.paypal-bearer-cache'                        => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-bearer' );
 	},
-	'api.client-credentials-cache'                   => static function( ContainerInterface $container ): Cache {
+	'api.client-credentials-cache'                   => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-client-credentials-cache' );
 	},
-	'api.user-id-token-cache'                        => static function( ContainerInterface $container ): Cache {
+	'api.user-id-token-cache'                        => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-id-token-cache' );
 	},
-	'api.reference-transaction-status-cache'         => static function( ContainerInterface $container ): Cache {
+	'api.reference-transaction-status-cache'         => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-reference-transaction-status-cache' );
 	},
-	'api.user-id-token'                              => static function( ContainerInterface $container ): UserIdToken {
+	'api.user-id-token'                              => static function ( ContainerInterface $container ): UserIdToken {
 		return new UserIdToken(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
@@ -887,7 +887,7 @@ return array(
 			$container->get( 'api.user-id-token-cache' )
 		);
 	},
-	'api.sdk-client-token'                           => static function( ContainerInterface $container ): SdkClientToken {
+	'api.sdk-client-token'                           => static function ( ContainerInterface $container ): SdkClientToken {
 		return new SdkClientToken(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
@@ -895,39 +895,39 @@ return array(
 			$container->get( 'api.client-credentials-cache' )
 		);
 	},
-	'api.paypal-host-production'                     => static function( ContainerInterface $container ) : string {
+	'api.paypal-host-production'                     => static function ( ContainerInterface $container ): string {
 		return PAYPAL_API_URL;
 	},
-	'api.paypal-host-sandbox'                        => static function( ContainerInterface $container ) : string {
+	'api.paypal-host-sandbox'                        => static function ( ContainerInterface $container ): string {
 		return PAYPAL_SANDBOX_API_URL;
 	},
-	'api.paypal-website-url-production'              => static function( ContainerInterface $container ) : string {
+	'api.paypal-website-url-production'              => static function ( ContainerInterface $container ): string {
 		return PAYPAL_URL;
 	},
-	'api.paypal-website-url-sandbox'                 => static function( ContainerInterface $container ) : string {
+	'api.paypal-website-url-sandbox'                 => static function ( ContainerInterface $container ): string {
 		return PAYPAL_SANDBOX_URL;
 	},
-	'api.partner_merchant_id-production'             => static function( ContainerInterface $container ) : string {
+	'api.partner_merchant_id-production'             => static function ( ContainerInterface $container ): string {
 		return CONNECT_WOO_MERCHANT_ID;
 	},
-	'api.partner_merchant_id-sandbox'                => static function( ContainerInterface $container ) : string {
+	'api.partner_merchant_id-sandbox'                => static function ( ContainerInterface $container ): string {
 		return CONNECT_WOO_SANDBOX_MERCHANT_ID;
 	},
-	'api.endpoint.login-seller-production'           => static function ( ContainerInterface $container ) : LoginSeller {
+	'api.endpoint.login-seller-production'           => static function ( ContainerInterface $container ): LoginSeller {
 		return new LoginSeller(
 			$container->get( 'api.paypal-host-production' ),
 			$container->get( 'api.partner_merchant_id-production' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.endpoint.login-seller-sandbox'              => static function ( ContainerInterface $container ) : LoginSeller {
+	'api.endpoint.login-seller-sandbox'              => static function ( ContainerInterface $container ): LoginSeller {
 		return new LoginSeller(
 			$container->get( 'api.paypal-host-sandbox' ),
 			$container->get( 'api.partner_merchant_id-sandbox' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'api.env.paypal-host'                            => static function ( ContainerInterface $container ) : EnvironmentConfig {
+	'api.env.paypal-host'                            => static function ( ContainerInterface $container ): EnvironmentConfig {
 		/**
 		 * Environment specific API host names.
 		 *
@@ -939,7 +939,7 @@ return array(
 			$container->get( 'api.paypal-host-sandbox' )
 		);
 	},
-	'api.env.endpoint.login-seller'                  => static function ( ContainerInterface $container ) : EnvironmentConfig {
+	'api.env.endpoint.login-seller'                  => static function ( ContainerInterface $container ): EnvironmentConfig {
 		/**
 		 * Environment specific LoginSeller API instances.
 		 *
@@ -951,7 +951,7 @@ return array(
 			$container->get( 'api.endpoint.login-seller-sandbox' )
 		);
 	},
-	'api.env.endpoint.partner-referrals'             => static function ( ContainerInterface $container ) : EnvironmentConfig {
+	'api.env.endpoint.partner-referrals'             => static function ( ContainerInterface $container ): EnvironmentConfig {
 		/**
 		 * Environment specific PartnerReferrals API instances.
 		 *
@@ -981,7 +981,7 @@ return array(
 
 		return CONNECT_WOO_URL;
 	},
-	'api.helper.partner-attribution'                 => static function ( ContainerInterface $container ) : PartnerAttribution {
+	'api.helper.partner-attribution'                 => static function ( ContainerInterface $container ): PartnerAttribution {
 		return new PartnerAttribution(
 			'ppcp_bn_code',
 			array(

--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -66,7 +66,7 @@ class ApiModule implements ServiceModule, FactoryModule, ExtendingModule, Execut
 		);
 		add_filter(
 			'ppcp_create_order_request_body_data',
-			function( array $data ) use ( $c ) {
+			function ( array $data ) use ( $c ) {
 
 				foreach ( ( $data['purchase_units'] ?? array() ) as $purchase_unit_index => $purchase_unit ) {
 					foreach ( ( $purchase_unit['items'] ?? array() ) as $item_index => $item ) {

--- a/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
@@ -100,7 +100,7 @@ class PayPalBearer implements Bearer {
 	 * @throws RuntimeException When request fails.
 	 * @return Token
 	 */
-	public function bearer() : Token {
+	public function bearer(): Token {
 		try {
 			$bearer = Token::from_json( (string) $this->cache->get( self::CACHE_KEY ) );
 
@@ -115,7 +115,7 @@ class PayPalBearer implements Bearer {
 	 *
 	 * @return string The client ID from settings, or the key defined via constructor.
 	 */
-	private function get_key() : string {
+	private function get_key(): string {
 		if (
 			$this->settings
 			&& $this->settings->has( 'client_id' )
@@ -132,7 +132,7 @@ class PayPalBearer implements Bearer {
 	 *
 	 * @return string The client secret from settings, or the value defined via constructor.
 	 */
-	private function get_secret() : string {
+	private function get_secret(): string {
 		if (
 			$this->settings
 			&& $this->settings->has( 'client_secret' )
@@ -150,7 +150,7 @@ class PayPalBearer implements Bearer {
 	 * @throws RuntimeException When request fails.
 	 * @return Token
 	 */
-	private function newBearer() : Token {
+	private function newBearer(): Token {
 		$key    = $this->get_key();
 		$secret = $this->get_secret();
 		$url    = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials';

--- a/modules/ppcp-api-client/src/Endpoint/BillingSubscriptions.php
+++ b/modules/ppcp-api-client/src/Endpoint/BillingSubscriptions.php
@@ -65,7 +65,7 @@ class BillingSubscriptions {
 	 * @throws RuntimeException If the request fails.
 	 * @throws PayPalApiException If the request fails.
 	 */
-	public function suspend( string $id ):void {
+	public function suspend( string $id ): void {
 		$data = array(
 			'reason' => sprintf( 'Suspended by %s.', is_admin() ? 'merchant' : 'customer' ),
 		);
@@ -214,6 +214,4 @@ class BillingSubscriptions {
 
 		return $json;
 	}
-
-
 }

--- a/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
@@ -108,7 +108,7 @@ class PartnersEndpoint {
 	 * @return SellerStatus
 	 * @throws RuntimeException When request could not be fulfilled.
 	 */
-	public function seller_status() : SellerStatus {
+	public function seller_status(): SellerStatus {
 		$url      = trailingslashit( $this->host ) . 'v1/customer/partners/' . $this->partner_id . '/merchant-integrations/' . $this->merchant_id;
 		$bearer   = $this->bearer->bearer();
 		$args     = array(

--- a/modules/ppcp-api-client/src/Endpoint/PaymentsEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentsEndpoint.php
@@ -203,7 +203,7 @@ class PaymentsEndpoint {
 	 * @throws RuntimeException If the request fails.
 	 * @throws PayPalApiException If the request fails.
 	 */
-	public function reauthorize( string $authorization_id, ?Money $amount = null ) : string {
+	public function reauthorize( string $authorization_id, ?Money $amount = null ): string {
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/payments/authorizations/' . $authorization_id . '/reauthorize';
 
@@ -249,7 +249,7 @@ class PaymentsEndpoint {
 	 * @throws RuntimeException If the request fails.
 	 * @throws PayPalApiException If the request fails.
 	 */
-	public function refund( RefundCapture $refund ) : string {
+	public function refund( RefundCapture $refund ): string {
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/payments/captures/' . $refund->for_capture()->id() . '/refund';
 		$args   = array(
@@ -289,7 +289,7 @@ class PaymentsEndpoint {
 	 * @throws RuntimeException If the request fails.
 	 * @throws PayPalApiException If the request fails.
 	 */
-	public function void( Authorization $authorization ) : void {
+	public function void( Authorization $authorization ): void {
 		$bearer = $this->bearer->bearer();
 		$url    = trailingslashit( $this->host ) . 'v2/payments/authorizations/' . $authorization->id() . '/void';
 		$args   = array(

--- a/modules/ppcp-api-client/src/Endpoint/WebhookEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/WebhookEndpoint.php
@@ -348,7 +348,7 @@ class WebhookEndpoint {
 			if ( isset( $expected_headers[ $key ] ) ) {
 				$expected_headers[ $key ] = $header;
 			}
-		};
+		}
 
 		foreach ( $expected_headers as $key => $value ) {
 			if ( ! empty( $value ) ) {

--- a/modules/ppcp-api-client/src/Entity/Authorization.php
+++ b/modules/ppcp-api-client/src/Entity/Authorization.php
@@ -86,7 +86,7 @@ class Authorization {
 	 *
 	 * @return FraudProcessorResponse|null
 	 */
-	public function fraud_processor_response() : ?FraudProcessorResponse {
+	public function fraud_processor_response(): ?FraudProcessorResponse {
 		return $this->fraud_processor_response;
 	}
 

--- a/modules/ppcp-api-client/src/Entity/Capture.php
+++ b/modules/ppcp-api-client/src/Entity/Capture.php
@@ -120,7 +120,7 @@ class Capture {
 	 *
 	 * @return string
 	 */
-	public function id() : string {
+	public function id(): string {
 		return $this->id;
 	}
 
@@ -129,7 +129,7 @@ class Capture {
 	 *
 	 * @return CaptureStatus
 	 */
-	public function status() : CaptureStatus {
+	public function status(): CaptureStatus {
 		return $this->status;
 	}
 
@@ -138,7 +138,7 @@ class Capture {
 	 *
 	 * @return Amount
 	 */
-	public function amount() : Amount {
+	public function amount(): Amount {
 		return $this->amount;
 	}
 
@@ -147,7 +147,7 @@ class Capture {
 	 *
 	 * @return bool
 	 */
-	public function final_capture() : bool {
+	public function final_capture(): bool {
 		return $this->final_capture;
 	}
 
@@ -165,7 +165,7 @@ class Capture {
 	 *
 	 * @return string
 	 */
-	public function invoice_id() : string {
+	public function invoice_id(): string {
 		return $this->invoice_id;
 	}
 
@@ -174,7 +174,7 @@ class Capture {
 	 *
 	 * @return string
 	 */
-	public function custom_id() : string {
+	public function custom_id(): string {
 		return $this->custom_id;
 	}
 
@@ -183,7 +183,7 @@ class Capture {
 	 *
 	 * @return SellerReceivableBreakdown|null
 	 */
-	public function seller_receivable_breakdown() : ?SellerReceivableBreakdown {
+	public function seller_receivable_breakdown(): ?SellerReceivableBreakdown {
 		return $this->seller_receivable_breakdown;
 	}
 
@@ -192,7 +192,7 @@ class Capture {
 	 *
 	 * @return FraudProcessorResponse|null
 	 */
-	public function fraud_processor_response() : ?FraudProcessorResponse {
+	public function fraud_processor_response(): ?FraudProcessorResponse {
 		return $this->fraud_processor_response;
 	}
 
@@ -201,7 +201,7 @@ class Capture {
 	 *
 	 * @return array
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		$data    = array(
 			'id'                => $this->id(),
 			'status'            => $this->status()->name(),

--- a/modules/ppcp-api-client/src/Entity/Item.php
+++ b/modules/ppcp-api-client/src/Entity/Item.php
@@ -204,7 +204,7 @@ class Item {
 	 *
 	 * @return string
 	 */
-	public function url():string {
+	public function url(): string {
 		return $this->url;
 	}
 
@@ -213,7 +213,7 @@ class Item {
 	 *
 	 * @return string
 	 */
-	public function image_url():string {
+	public function image_url(): string {
 		return $this->validate_image_url() ? $this->image_url : '';
 	}
 
@@ -222,7 +222,7 @@ class Item {
 	 *
 	 * @return float
 	 */
-	public function tax_rate():float {
+	public function tax_rate(): float {
 		return round( (float) $this->tax_rate, 2 );
 	}
 
@@ -231,7 +231,7 @@ class Item {
 	 *
 	 * @return string|null
 	 */
-	public function cart_item_key():?string {
+	public function cart_item_key(): ?string {
 		return $this->cart_item_key;
 	}
 

--- a/modules/ppcp-api-client/src/Entity/PaymentPreferences.php
+++ b/modules/ppcp-api-client/src/Entity/PaymentPreferences.php
@@ -104,7 +104,7 @@ class PaymentPreferences {
 	 *
 	 * @return array
 	 */
-	public function to_array():array {
+	public function to_array(): array {
 		return array(
 			'setup_fee'                 => $this->setup_fee(),
 			'auto_bill_outstanding'     => $this->auto_bill_outstanding(),

--- a/modules/ppcp-api-client/src/Entity/PaymentToken.php
+++ b/modules/ppcp-api-client/src/Entity/PaymentToken.php
@@ -124,5 +124,4 @@ class PaymentToken {
 			)
 		);
 	}
-
 }

--- a/modules/ppcp-api-client/src/Entity/Plan.php
+++ b/modules/ppcp-api-client/src/Entity/Plan.php
@@ -141,7 +141,7 @@ class Plan {
 	 *
 	 * @return array
 	 */
-	public function to_array():array {
+	public function to_array(): array {
 		return array(
 			'id'                  => $this->id(),
 			'name'                => $this->name(),

--- a/modules/ppcp-api-client/src/Entity/Refund.php
+++ b/modules/ppcp-api-client/src/Entity/Refund.php
@@ -119,7 +119,7 @@ class Refund {
 	 *
 	 * @return string
 	 */
-	public function id() : string {
+	public function id(): string {
 		return $this->id;
 	}
 
@@ -128,7 +128,7 @@ class Refund {
 	 *
 	 * @return RefundStatus
 	 */
-	public function status() : RefundStatus {
+	public function status(): RefundStatus {
 		return $this->status;
 	}
 
@@ -137,7 +137,7 @@ class Refund {
 	 *
 	 * @return Amount
 	 */
-	public function amount() : Amount {
+	public function amount(): Amount {
 		return $this->amount;
 	}
 
@@ -146,7 +146,7 @@ class Refund {
 	 *
 	 * @return string
 	 */
-	public function invoice_id() : string {
+	public function invoice_id(): string {
 		return $this->invoice_id;
 	}
 
@@ -155,7 +155,7 @@ class Refund {
 	 *
 	 * @return string
 	 */
-	public function custom_id() : string {
+	public function custom_id(): string {
 		return $this->custom_id;
 	}
 
@@ -164,7 +164,7 @@ class Refund {
 	 *
 	 * @return SellerPayableBreakdown|null
 	 */
-	public function seller_payable_breakdown() : ?SellerPayableBreakdown {
+	public function seller_payable_breakdown(): ?SellerPayableBreakdown {
 		return $this->seller_payable_breakdown;
 	}
 
@@ -173,7 +173,7 @@ class Refund {
 	 *
 	 * @return string
 	 */
-	public function acquirer_reference_number() : string {
+	public function acquirer_reference_number(): string {
 		return $this->acquirer_reference_number;
 	}
 
@@ -182,7 +182,7 @@ class Refund {
 	 *
 	 * @return string
 	 */
-	public function note_to_payer() : string {
+	public function note_to_payer(): string {
 		return $this->note_to_payer;
 	}
 
@@ -191,7 +191,7 @@ class Refund {
 	 *
 	 * @return RefundPayer|null
 	 */
-	public function payer() : ?RefundPayer {
+	public function payer(): ?RefundPayer {
 		return $this->payer;
 	}
 
@@ -200,7 +200,7 @@ class Refund {
 	 *
 	 * @return array
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		$data    = array(
 			'id'                        => $this->id(),
 			'status'                    => $this->status()->name(),

--- a/modules/ppcp-api-client/src/Entity/RefundCapture.php
+++ b/modules/ppcp-api-client/src/Entity/RefundCapture.php
@@ -67,7 +67,7 @@ class RefundCapture {
 	 *
 	 * @return Capture
 	 */
-	public function for_capture() : Capture {
+	public function for_capture(): Capture {
 		return $this->capture;
 	}
 
@@ -76,7 +76,7 @@ class RefundCapture {
 	 *
 	 * @return string
 	 */
-	public function invoice_id() : string {
+	public function invoice_id(): string {
 		return $this->invoice_id;
 	}
 
@@ -85,7 +85,7 @@ class RefundCapture {
 	 *
 	 * @return string
 	 */
-	public function note_to_payer() : string {
+	public function note_to_payer(): string {
 		return $this->note_to_payer;
 	}
 
@@ -103,7 +103,7 @@ class RefundCapture {
 	 *
 	 * @return array
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		$data = array(
 			'invoice_id' => $this->invoice_id(),
 		);

--- a/modules/ppcp-api-client/src/Entity/SellerStatus.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatus.php
@@ -68,7 +68,7 @@ class SellerStatus {
 	 *
 	 * @return SellerStatusProduct[]
 	 */
-	public function products() : array {
+	public function products(): array {
 		return $this->products;
 	}
 
@@ -77,7 +77,7 @@ class SellerStatus {
 	 *
 	 * @return SellerStatusCapability[]
 	 */
-	public function capabilities() : array {
+	public function capabilities(): array {
 		return $this->capabilities;
 	}
 
@@ -86,7 +86,7 @@ class SellerStatus {
 	 *
 	 * @return string
 	 */
-	public function country() : string {
+	public function country(): string {
 		return $this->country;
 	}
 
@@ -95,16 +95,16 @@ class SellerStatus {
 	 *
 	 * @return array
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		$products = array_map(
-			function( SellerStatusProduct $product ) : array {
+			function ( SellerStatusProduct $product ): array {
 				return $product->to_array();
 			},
 			$this->products()
 		);
 
 		$capabilities = array_map(
-			function( SellerStatusCapability $capability ) : array {
+			function ( SellerStatusCapability $capability ): array {
 				return $capability->to_array();
 			},
 			$this->capabilities()

--- a/modules/ppcp-api-client/src/Entity/SellerStatusCapability.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatusCapability.php
@@ -49,7 +49,7 @@ class SellerStatusCapability {
 	 *
 	 * @return string
 	 */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
@@ -58,7 +58,7 @@ class SellerStatusCapability {
 	 *
 	 * @return string
 	 */
-	public function status() : string {
+	public function status(): string {
 		return $this->status;
 	}
 
@@ -67,11 +67,10 @@ class SellerStatusCapability {
 	 *
 	 * @return array
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		return array(
 			'name'   => $this->name(),
 			'status' => $this->status(),
 		);
 	}
-
 }

--- a/modules/ppcp-api-client/src/Entity/SellerStatusProduct.php
+++ b/modules/ppcp-api-client/src/Entity/SellerStatusProduct.php
@@ -69,7 +69,7 @@ class SellerStatusProduct {
 	 *
 	 * @return string
 	 */
-	public function name() : string {
+	public function name(): string {
 		return $this->name;
 	}
 
@@ -78,7 +78,7 @@ class SellerStatusProduct {
 	 *
 	 * @return string
 	 */
-	public function vetting_status() : string {
+	public function vetting_status(): string {
 		return $this->vetting_status;
 	}
 
@@ -87,7 +87,7 @@ class SellerStatusProduct {
 	 *
 	 * @return string[]
 	 */
-	public function capabilities() : array {
+	public function capabilities(): array {
 		return $this->capabilities;
 	}
 
@@ -96,13 +96,11 @@ class SellerStatusProduct {
 	 *
 	 * @return array
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		return array(
 			'name'           => $this->name(),
 			'vetting_status' => $this->vetting_status(),
 			'capabilities'   => $this->capabilities(),
 		);
 	}
-
-
 }

--- a/modules/ppcp-api-client/src/Entity/Shipping.php
+++ b/modules/ppcp-api-client/src/Entity/Shipping.php
@@ -91,7 +91,7 @@ class Shipping {
 	 *
 	 * @return null|string
 	 */
-	public function email_address() : ?string {
+	public function email_address(): ?string {
 		return $this->email_address;
 	}
 
@@ -100,7 +100,7 @@ class Shipping {
 	 *
 	 * @return null|Phone
 	 */
-	public function phone_number() : ?Phone {
+	public function phone_number(): ?Phone {
 		return $this->phone_number;
 	}
 

--- a/modules/ppcp-api-client/src/Factory/CaptureFactory.php
+++ b/modules/ppcp-api-client/src/Factory/CaptureFactory.php
@@ -66,7 +66,7 @@ class CaptureFactory {
 	 * @return Capture
 	 * @throws RuntimeException When capture amount data is invalid.
 	 */
-	public function from_paypal_response( \stdClass $data ) : Capture {
+	public function from_paypal_response( \stdClass $data ): Capture {
 		$reason                      = $data->status_details->reason ?? null;
 		$seller_receivable_breakdown = isset( $data->seller_receivable_breakdown ) ?
 			$this->seller_receivable_breakdown_factory->from_paypal_response( $data->seller_receivable_breakdown )

--- a/modules/ppcp-api-client/src/Factory/ContactPreferenceFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ContactPreferenceFactory.php
@@ -48,7 +48,7 @@ class ContactPreferenceFactory {
 	 * @param string $payment_source_key Name of the payment_source.
 	 * @return string|null
 	 */
-	public function from_state( string $payment_source_key ) : ?string {
+	public function from_state( string $payment_source_key ): ?string {
 		$payment_sources_with_contact = array( 'paypal', 'venmo' );
 
 		/**

--- a/modules/ppcp-api-client/src/Factory/ExperienceContextBuilder.php
+++ b/modules/ppcp-api-client/src/Factory/ExperienceContextBuilder.php
@@ -214,7 +214,7 @@ class ExperienceContextBuilder {
 	 *
 	 * @param string|null $preference The new preference to apply.
 	 */
-	public function with_contact_preference( ?string $preference = null ) : ExperienceContextBuilder {
+	public function with_contact_preference( ?string $preference = null ): ExperienceContextBuilder {
 		$builder = clone $this;
 
 		$builder->experience_context = $builder->experience_context

--- a/modules/ppcp-api-client/src/Factory/PatchCollectionFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PatchCollectionFactory.php
@@ -53,7 +53,7 @@ class PatchCollectionFactory {
 					$from,
 					static function ( PurchaseUnit $unit ) use ( $purchase_unit_to ): bool {
 						// Loose comparison needed to compare two objects.
-						// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+						// phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 						return $unit == $purchase_unit_to;
 					}
 				)

--- a/modules/ppcp-api-client/src/Factory/PaymentPreferencesFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PaymentPreferencesFactory.php
@@ -41,7 +41,7 @@ class PaymentPreferencesFactory {
 	 * @param WC_Product $product WC product.
 	 * @return PaymentPreferences
 	 */
-	public function from_wc_product( WC_Product $product ):PaymentPreferences {
+	public function from_wc_product( WC_Product $product ): PaymentPreferences {
 		return new PaymentPreferences(
 			array(
 				'value'         => $product->get_meta( '_subscription_sign_up_fee' ) ?: '0',

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -175,6 +175,7 @@ class PurchaseUnitFactory {
 
 		$shipping = null;
 		$customer = \WC()->customer;
+		/** @psalm-suppress RedundantConditionGivenDocblockType False positive. Ignored because $customer can be null as well. */
 		if ( $this->shipping_needed( ...array_values( $items ) ) && is_a( $customer, \WC_Customer::class ) ) {
 			$shipping         = $this->shipping_factory->from_wc_customer( \WC()->customer, $with_shipping_options );
 			$shipping_address = $shipping->address();

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -175,7 +175,7 @@ class PurchaseUnitFactory {
 
 		$shipping = null;
 		$customer = \WC()->customer;
-		if ( $this->shipping_needed( ... array_values( $items ) ) && is_a( $customer, \WC_Customer::class ) ) {
+		if ( $this->shipping_needed( ...array_values( $items ) ) && is_a( $customer, \WC_Customer::class ) ) {
 			$shipping         = $this->shipping_factory->from_wc_customer( \WC()->customer, $with_shipping_options );
 			$shipping_address = $shipping->address();
 			if (
@@ -254,7 +254,7 @@ class PurchaseUnitFactory {
 				$shipping = $this->shipping_factory->from_paypal_response( $data->shipping );
 			}
 		} catch ( RuntimeException $error ) {
-			;
+			$shipping = null;
 		}
 		$payments = null;
 		try {
@@ -262,7 +262,7 @@ class PurchaseUnitFactory {
 				$payments = $this->payments_factory->from_paypal_response( $data->payments );
 			}
 		} catch ( RuntimeException $error ) {
-			;
+			$payments = null;
 		}
 
 		$purchase_unit = new PurchaseUnit(
@@ -333,7 +333,7 @@ class PurchaseUnitFactory {
 	 *
 	 * @return string The sanitized soft descriptor.
 	 */
-	private function sanitize_soft_descriptor( string $soft_descriptor ) : string {
+	private function sanitize_soft_descriptor( string $soft_descriptor ): string {
 		$decoded   = html_entity_decode( $soft_descriptor, ENT_QUOTES, 'UTF-8' );
 		$sanitized = preg_replace( '/[^a-zA-Z0-9 *\-.]/', '', $decoded ) ?: '';
 
@@ -349,9 +349,9 @@ class PurchaseUnitFactory {
 	 * @return bool
 	 */
 	private function should_disable_shipping( array $items, ?Address $shipping_address ): bool {
-		return ! $this->shipping_needed( ... array_values( $items ) ) ||
-			   ! $shipping_address ||
-			   empty( $shipping_address->country_code() ) ||
-			   ( ! $shipping_address->postal_code() && ! $this->country_without_postal_code( $shipping_address->country_code() ) );
+		return ! $this->shipping_needed( ...array_values( $items ) ) ||
+				! $shipping_address ||
+				empty( $shipping_address->country_code() ) ||
+				( ! $shipping_address->postal_code() && ! $this->country_without_postal_code( $shipping_address->country_code() ) );
 	}
 }

--- a/modules/ppcp-api-client/src/Factory/RefundFactory.php
+++ b/modules/ppcp-api-client/src/Factory/RefundFactory.php
@@ -65,7 +65,7 @@ class RefundFactory {
 	 * @return Refund
 	 * @throws RuntimeException When refund amount data is invalid.
 	 */
-	public function from_paypal_response( \stdClass $data ) : Refund {
+	public function from_paypal_response( \stdClass $data ): Refund {
 		$reason                   = $data->status_details->reason ?? null;
 		$seller_payable_breakdown = isset( $data->seller_payable_breakdown ) ?
 			$this->seller_payable_breakdown_factory->from_paypal_response( $data->seller_payable_breakdown )

--- a/modules/ppcp-api-client/src/Factory/SellerStatusFactory.php
+++ b/modules/ppcp-api-client/src/Factory/SellerStatusFactory.php
@@ -25,9 +25,9 @@ class SellerStatusFactory {
 	 *
 	 * @return SellerStatus
 	 */
-	public function from_paypal_response( \stdClass $json ) : SellerStatus {
+	public function from_paypal_response( \stdClass $json ): SellerStatus {
 		$products = array_map(
-			function( $json ) : SellerStatusProduct {
+			function ( $json ): SellerStatusProduct {
 				$product = new SellerStatusProduct(
 					isset( $json->name ) ? (string) $json->name : '',
 					isset( $json->vetting_status ) ? (string) $json->vetting_status : '',
@@ -39,7 +39,7 @@ class SellerStatusFactory {
 		);
 
 		$capabilities = array_map(
-			function( $json ) : SellerStatusCapability {
+			function ( $json ): SellerStatusCapability {
 				$capability = new SellerStatusCapability(
 					isset( $json->name ) ? (string) $json->name : '',
 					isset( $json->status ) ? (string) $json->status : ''

--- a/modules/ppcp-api-client/src/Helper/Cache.php
+++ b/modules/ppcp-api-client/src/Helper/Cache.php
@@ -48,7 +48,7 @@ class Cache {
 	 *
 	 * @return bool
 	 */
-	public function has( string $key ) : bool {
+	public function has( string $key ): bool {
 		$value = $this->get( $key );
 
 		return false !== $value;
@@ -59,7 +59,7 @@ class Cache {
 	 *
 	 * @param string $key The key.
 	 */
-	public function delete( string $key ) : void {
+	public function delete( string $key ): void {
 		delete_transient( $this->prefix . $key );
 	}
 
@@ -72,7 +72,7 @@ class Cache {
 	 *
 	 * @return bool
 	 */
-	public function set( string $key, $value, int $expiration = 0 ) : bool {
+	public function set( string $key, $value, int $expiration = 0 ): bool {
 		return (bool) set_transient( $this->prefix . $key, $value, $expiration );
 	}
 
@@ -81,7 +81,7 @@ class Cache {
 	 *
 	 * @return void
 	 */
-	public function flush() : void {
+	public function flush(): void {
 		global $wpdb;
 
 		// Get a list of all transients with the relevant "group prefix" from the DB.

--- a/modules/ppcp-api-client/src/Helper/DccApplies.php
+++ b/modules/ppcp-api-client/src/Helper/DccApplies.php
@@ -94,7 +94,7 @@ class DccApplies {
 	 *
 	 * @return array
 	 */
-	public function valid_cards() : array {
+	public function valid_cards(): array {
 		$cards = array();
 		if ( ! isset( $this->country_card_matrix[ $this->country ] ) ) {
 			return $cards;
@@ -122,7 +122,7 @@ class DccApplies {
 	 *
 	 * @return bool
 	 */
-	public function can_process_card( string $card ) : bool {
+	public function can_process_card( string $card ): bool {
 		if ( ! isset( $this->country_card_matrix[ $this->country ] ) ) {
 			return false;
 		}

--- a/modules/ppcp-api-client/src/Helper/FailureRegistry.php
+++ b/modules/ppcp-api-client/src/Helper/FailureRegistry.php
@@ -90,5 +90,4 @@ class FailureRegistry {
 	private function cache_key( string $key ): string {
 		return implode( '_', array( self::CACHE_KEY, $key ) );
 	}
-
 }

--- a/modules/ppcp-api-client/src/Helper/OrderTransient.php
+++ b/modules/ppcp-api-client/src/Helper/OrderTransient.php
@@ -156,5 +156,4 @@ class OrderTransient {
 		}
 		return implode( '_', array( self::CACHE_KEY . $order->id() ) );
 	}
-
 }

--- a/modules/ppcp-api-client/src/Helper/PartnerAttribution.php
+++ b/modules/ppcp-api-client/src/Helper/PartnerAttribution.php
@@ -63,7 +63,7 @@ class PartnerAttribution {
 	 * @param string $installation_path The installation path used to determine the BN Code.
 	 * @param bool   $force_update Whether to force an update of the BN code if it already exists.
 	 */
-	public function initialize_bn_code( string $installation_path, bool $force_update = false ) : void {
+	public function initialize_bn_code( string $installation_path, bool $force_update = false ): void {
 		$selected_bn_code = $this->bn_codes[ $installation_path ] ?? '';
 		if ( ! $selected_bn_code ) {
 			return;
@@ -82,7 +82,7 @@ class PartnerAttribution {
 	 *
 	 * @return string The stored BN Code, or the default value if no path is detected.
 	 */
-	public function get_bn_code() : string {
+	public function get_bn_code(): string {
 		$bn_code = (string) ( get_option( $this->bn_code_option_name, $this->default_bn_code ) ?? $this->default_bn_code );
 
 		if ( ! in_array( $bn_code, $this->bn_codes, true ) ) {

--- a/modules/ppcp-api-client/src/Helper/ProductStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatus.php
@@ -93,7 +93,7 @@ abstract class ProductStatus {
 	 * @throws RuntimeException When the check failed.
 	 * @throws NotFoundException When a relevant service or setting was not found.
 	 */
-	abstract protected function check_local_state() : ?bool;
+	abstract protected function check_local_state(): ?bool;
 
 	/**
 	 * Inspects the API response of the SellerStatus to determine feature eligibility.
@@ -105,7 +105,7 @@ abstract class ProductStatus {
 	 * @return bool
 	 * @throws RuntimeException When the check failed.
 	 */
-	abstract protected function check_active_state( SellerStatus $seller_status ) : bool;
+	abstract protected function check_active_state( SellerStatus $seller_status ): bool;
 
 	/**
 	 * Clears the eligibility status from the local cache/DB to enforce a new
@@ -114,14 +114,14 @@ abstract class ProductStatus {
 	 * @param Settings|null $settings See description in {@see self::clear()}.
 	 * @return void
 	 */
-	abstract protected function clear_state( ?Settings $settings = null ) : void;
+	abstract protected function clear_state( ?Settings $settings = null ): void;
 
 	/**
 	 * Whether the merchant has access to the feature.
 	 *
 	 * @return bool
 	 */
-	public function is_active() : bool {
+	public function is_active(): bool {
 		if ( null !== $this->is_eligible ) {
 			return $this->is_eligible;
 		}
@@ -158,7 +158,7 @@ abstract class ProductStatus {
 	 * @return SellerStatus
 	 * @throws RuntimeException When the check failed.
 	 */
-	protected function get_seller_status_object() : SellerStatus {
+	protected function get_seller_status_object(): SellerStatus {
 		if ( null === self::$seller_status ) {
 			// Check API failure registry to prevent multiple failed API requests.
 			if ( $this->api_failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, MINUTE_IN_SECONDS ) ) {
@@ -177,7 +177,7 @@ abstract class ProductStatus {
 	 *
 	 * @return bool True, if we can use the merchant API endpoints.
 	 */
-	public function is_onboarded() : bool {
+	public function is_onboarded(): bool {
 		return $this->is_connected;
 	}
 
@@ -186,7 +186,7 @@ abstract class ProductStatus {
 	 *
 	 * @return bool
 	 */
-	public function has_request_failure() : bool {
+	public function has_request_failure(): bool {
 		return $this->has_request_failure;
 	}
 
@@ -199,7 +199,7 @@ abstract class ProductStatus {
 	 * @param Settings|null $settings The settings object.
 	 * @return void
 	 */
-	public function clear( ?Settings $settings = null ) : void {
+	public function clear( ?Settings $settings = null ): void {
 		$this->is_eligible         = null;
 		$this->has_request_failure = false;
 

--- a/modules/ppcp-api-client/src/Helper/PurchaseUnitSanitizer.php
+++ b/modules/ppcp-api-client/src/Helper/PurchaseUnitSanitizer.php
@@ -393,5 +393,4 @@ class PurchaseUnitSanitizer {
 	public function set_last_message( string $message ): void {
 		$this->last_message = $message;
 	}
-
 }

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -40,7 +40,7 @@ class PartnerReferralsData {
 	 *
 	 * @return string
 	 */
-	public function nonce() : string {
+	public function nonce(): string {
 		return 'a1233wtergfsdt4365tzrshgfbaewa36AGa1233wtergfsdt4365tzrshgfbaewa36AG';
 	}
 
@@ -59,7 +59,7 @@ class PartnerReferralsData {
 		string $onboarding_token = '',
 		?bool $use_subscriptions = null,
 		bool $use_card_payments = true
-	) : array {
+	): array {
 		$in_acdc_country = $this->dcc_applies->for_country_currency();
 
 		if ( ! $products ) {

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -33,11 +33,11 @@ return array(
 		$apm_applies = $container->get( 'applepay.helpers.apm-applies' );
 		assert( $apm_applies instanceof ApmApplies );
 
-		return static function () use ( $apm_applies ) : bool {
+		return static function () use ( $apm_applies ): bool {
 			return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
 		};
 	},
-	'applepay.helpers.apm-applies'             => static function ( ContainerInterface $container ) : ApmApplies {
+	'applepay.helpers.apm-applies'             => static function ( ContainerInterface $container ): ApmApplies {
 		return new ApmApplies(
 			$container->get( 'applepay.supported-countries' ),
 			$container->get( 'applepay.supported-currencies' ),
@@ -45,7 +45,7 @@ return array(
 			$container->get( 'api.shop.country' )
 		);
 	},
-	'applepay.status-cache'                    => static function( ContainerInterface $container ): Cache {
+	'applepay.status-cache'                    => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-apple-status-cache' );
 	},
 
@@ -82,7 +82,7 @@ return array(
 	},
 
 	'applepay.apple-product-status'            => SingletonDecorator::make(
-		static function( ContainerInterface $container ): AppleProductStatus {
+		static function ( ContainerInterface $container ): AppleProductStatus {
 			return new AppleProductStatus(
 				$container->get( 'wcgateway.settings' ),
 				$container->get( 'api.endpoint.partners' ),
@@ -169,7 +169,7 @@ return array(
 	/**
 	 * The list of which countries can be used for ApplePay.
 	 */
-	'applepay.supported-countries'             => static function ( ContainerInterface $container ) : array {
+	'applepay.supported-countries'             => static function ( ContainerInterface $container ): array {
 		/**
 		 * Returns which countries can be used for ApplePay.
 		 */
@@ -225,7 +225,7 @@ return array(
 	/**
 	 * The list of which currencies can be used for ApplePay.
 	 */
-	'applepay.supported-currencies'            => static function ( ContainerInterface $container ) : array {
+	'applepay.supported-currencies'            => static function ( ContainerInterface $container ): array {
 		/**
 		 * Returns which currencies can be used for ApplePay.
 		 */

--- a/modules/ppcp-applepay/src/ApplePayGateway.php
+++ b/modules/ppcp-applepay/src/ApplePayGateway.php
@@ -171,7 +171,7 @@ class ApplePayGateway extends WC_Payment_Gateway {
 	 *
 	 * @return array
 	 */
-	public function process_payment( $order_id ) : array {
+	public function process_payment( $order_id ): array {
 		$wc_order = wc_get_order( $order_id );
 		if ( ! is_a( $wc_order, WC_Order::class ) ) {
 			return $this->handle_payment_failure(
@@ -234,7 +234,7 @@ class ApplePayGateway extends WC_Payment_Gateway {
 	 *
 	 * @return boolean True or false based on success, or a WP_Error object.
 	 */
-	public function process_refund( $order_id, $amount = null, $reason = '' ) : bool {
+	public function process_refund( $order_id, $amount = null, $reason = '' ): bool {
 		$order = wc_get_order( $order_id );
 		if ( ! is_a( $order, WC_Order::class ) ) {
 			return false;
@@ -250,7 +250,7 @@ class ApplePayGateway extends WC_Payment_Gateway {
 	 *
 	 * @return string
 	 */
-	public function get_transaction_url( $order ) : string {
+	public function get_transaction_url( $order ): string {
 		$this->view_transaction_url = $this->transaction_url_provider->get_transaction_url_base( $order );
 
 		return parent::get_transaction_url( $order );

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -56,7 +56,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function( ?Settings $settings = null ) use ( $c ): void {
+			function ( ?Settings $settings = null ) use ( $c ): void {
 				$apm_status = $c->get( 'applepay.apple-product-status' );
 				assert( $apm_status instanceof AppleProductStatus );
 				$apm_status->clear( $settings );
@@ -174,7 +174,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_filter(
 			'woocommerce_paypal_payments_selected_button_locations',
-			function( array $locations, string $setting_name ): array {
+			function ( array $locations, string $setting_name ): array {
 				$gateway = WC()->payment_gateways()->payment_gateways()[ ApplePayGateway::ID ] ?? '';
 				if ( $gateway && $gateway->enabled === 'yes' && $setting_name === 'smart_button_locations' ) {
 					$locations[] = 'checkout';
@@ -188,7 +188,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_filter(
 			'woocommerce_paypal_payments_rest_common_merchant_features',
-			function( array $features ) use ( $c ): array {
+			function ( array $features ) use ( $c ): array {
 				$product_status = $c->get( 'applepay.apple-product-status' );
 				assert( $product_status instanceof AppleProductStatus );
 
@@ -204,7 +204,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_filter(
 			'ppcp_create_order_request_body_data',
-			static function ( array $data, string $payment_method, array $request ) use ( $c ) : array {
+			static function ( array $data, string $payment_method, array $request ) use ( $c ): array {
 
 				if ( $payment_method !== ApplePayGateway::ID ) {
 					return $data;
@@ -294,7 +294,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
-			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
+			function ( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				$payment_method_registry->register( $c->get( 'applepay.blocks-payment-method' ) );
 			}
 		);
@@ -329,7 +329,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 		// Adds ApplePay component to the backend button preview settings.
 		add_action(
 			'woocommerce_paypal_payments_admin_gateway_settings',
-			function( array $settings ) use ( $c ): array {
+			function ( array $settings ) use ( $c ): array {
 				if ( is_array( $settings['components'] ) ) {
 					$settings['components'][] = 'applepay';
 				}
@@ -412,7 +412,7 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 	 * @param bool $is_sandbox The environment for this merchant.
 	 * @return string
 	 */
-	public function validation_string( bool $is_sandbox ) : string {
+	public function validation_string( bool $is_sandbox ): string {
 		$sandbox_string = $this->sandbox_validation_string();
 		$live_string    = $this->live_validation_string();
 		return $is_sandbox ? $sandbox_string : $live_string;

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -26,7 +26,8 @@ use WooCommerce\PayPalCommerce\Button\Helper\ContextTrait;
  * Class ApplePayButton
  */
 class ApplePayButton implements ButtonInterface {
-	use RequestHandlerTrait, ContextTrait;
+	use RequestHandlerTrait;
+	use ContextTrait;
 
 	/**
 	 * The settings.
@@ -222,7 +223,6 @@ class ApplePayButton implements ButtonInterface {
 		return $options . '<li><label><input type="checkbox" id="ppcp-onboarding-apple" ' . $checked . ' data-onboarding-option="ppcp-onboarding-apple"> ' .
 			__( 'Onboard with ApplePay', 'woocommerce-paypal-payments' ) . '
 		</label></li>';
-
 	}
 
 	/**
@@ -445,7 +445,7 @@ class ApplePayButton implements ButtonInterface {
 			} else {
 				add_filter(
 					'woocommerce_payment_successful_result',
-					function ( array $result ) use ( $cart, $cart_item_key ) : array {
+					function ( array $result ) use ( $cart, $cart_item_key ): array {
 						$this->clear_current_cart( $cart, $cart_item_key );
 						$this->reload_cart( $cart );
 						return $result;
@@ -917,7 +917,7 @@ class ApplePayButton implements ButtonInterface {
 
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
-			function( array $components ) {
+			function ( array $components ) {
 				$components[] = 'applepay';
 				return $components;
 			}

--- a/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
@@ -361,7 +361,6 @@ class ApplePayDataObjectHttp {
 			}
 			$this->$key = $value;
 		}
-
 	}
 
 	/**
@@ -509,7 +508,7 @@ class ApplePayDataObjectHttp {
 	 * @param array $data The data.
 	 * @return void
 	 */
-	protected function update_simplified_contact( array $data ) : void {
+	protected function update_simplified_contact( array $data ): void {
 		$simplified_contact_info  = array_map( 'sanitize_text_field', $data );
 		$this->simplified_contact = $this->simplified_address(
 			$simplified_contact_info
@@ -727,7 +726,7 @@ class ApplePayDataObjectHttp {
 	 *
 	 * @return bool
 	 */
-	public function is_nonce_valid():bool {
+	public function is_nonce_valid(): bool {
 		$nonce = filter_input( INPUT_POST, 'woocommerce-process-checkout-nonce', FILTER_SANITIZE_SPECIAL_CHARS );
 		if ( ! $nonce ) {
 			return false;

--- a/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
+++ b/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
@@ -54,7 +54,7 @@ class AppleProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_local_state() : ?bool {
+	protected function check_local_state(): ?bool {
 		$status_override = apply_filters( 'woocommerce_paypal_payments_apple_pay_product_status', null );
 		if ( null !== $status_override ) {
 			return $status_override;
@@ -68,7 +68,7 @@ class AppleProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ) : bool {
+	protected function check_active_state( SellerStatus $seller_status ): bool {
 		// Check the seller status for the intended capability.
 		$has_capability = false;
 		foreach ( $seller_status->products() as $product ) {
@@ -101,7 +101,7 @@ class AppleProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ): void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php
+++ b/modules/ppcp-applepay/src/Assets/DataToAppleButtonScripts.php
@@ -49,7 +49,7 @@ class DataToAppleButtonScripts {
 	 *
 	 * @return array
 	 */
-	public function apple_pay_script_data() : array {
+	public function apple_pay_script_data(): array {
 		if ( is_product() ) {
 			return $this->data_for_product_page();
 		}
@@ -62,7 +62,7 @@ class DataToAppleButtonScripts {
 	 *
 	 * @return array
 	 */
-	public function apple_pay_script_data_for_admin() : array {
+	public function apple_pay_script_data_for_admin(): array {
 		return $this->data_for_admin_page();
 	}
 
@@ -73,7 +73,7 @@ class DataToAppleButtonScripts {
 	 *
 	 * @return array
 	 */
-	private function get_apple_pay_data( array $product = array() ) : array {
+	private function get_apple_pay_data( array $product = array() ): array {
 		// true: Use Apple Pay as distinct gateway.
 		// false: integrate it with the smart buttons.
 		$available_gateways    = WC()->payment_gateways->get_available_payment_gateways();
@@ -132,7 +132,7 @@ class DataToAppleButtonScripts {
 	 *
 	 * @return bool
 	 */
-	protected function check_if_need_shipping( WC_Product $product ) : bool {
+	protected function check_if_need_shipping( WC_Product $product ): bool {
 		if (
 			! wc_shipping_enabled()
 			|| 0 === wc_get_shipping_method_count(
@@ -154,7 +154,7 @@ class DataToAppleButtonScripts {
 	 *
 	 * @return array
 	 */
-	protected function data_for_product_page() : array {
+	protected function data_for_product_page(): array {
 		$product = wc_get_product( get_the_id() );
 		if ( ! $product ) {
 			return array();
@@ -185,7 +185,7 @@ class DataToAppleButtonScripts {
 	 *
 	 * @return array
 	 */
-	protected function data_for_cart_page() : array {
+	protected function data_for_cart_page(): array {
 		$cart = WC()->cart;
 		if ( ! $cart ) {
 			return array();
@@ -206,7 +206,7 @@ class DataToAppleButtonScripts {
 	 *
 	 * @return array
 	 */
-	protected function data_for_admin_page() : array {
+	protected function data_for_admin_page(): array {
 		$data = $this->get_apple_pay_data(
 			array(
 				'needShipping' => false,

--- a/modules/ppcp-applepay/src/Helper/ApmApplies.php
+++ b/modules/ppcp-applepay/src/Helper/ApmApplies.php
@@ -89,7 +89,7 @@ class ApmApplies {
 	 *
 	 * @return bool
 	 */
-	public function for_merchant() : bool {
+	public function for_merchant(): bool {
 		return apply_filters(
 			'woocommerce_paypal_payments_is_eligible_for_applepay',
 			true

--- a/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
+++ b/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
@@ -141,7 +141,6 @@ class AvailabilityNotice {
 		if ( ! $this->is_merchant_validated ) {
 			$this->add_merchant_not_validated_notice();
 		}
-
 	}
 
 	/**
@@ -287,5 +286,4 @@ class AvailabilityNotice {
 			}
 		);
 	}
-
 }

--- a/modules/ppcp-axo-block/module.php
+++ b/modules/ppcp-axo-block/module.php
@@ -9,6 +9,6 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AxoBlock;
 
-return static function () : AxoBlockModule {
+return static function (): AxoBlockModule {
 	return new AxoBlockModule();
 };

--- a/modules/ppcp-axo-block/services.php
+++ b/modules/ppcp-axo-block/services.php
@@ -14,13 +14,13 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
 	// If AXO Block is configured and onboarded.
-	'axoblock.available' => static function ( ContainerInterface $container ) : bool {
+	'axoblock.available' => static function ( ContainerInterface $container ): bool {
 		return true;
 	},
-	'axoblock.url'       => static function ( ContainerInterface $container ) : string {
+	'axoblock.url'       => static function ( ContainerInterface $container ): string {
 		return plugins_url( '/modules/ppcp-axo-block/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
-	'axoblock.method'    => static function ( ContainerInterface $container ) : AxoBlockPaymentMethod {
+	'axoblock.method'    => static function ( ContainerInterface $container ): AxoBlockPaymentMethod {
 		return new AxoBlockPaymentMethod(
 			$container->get( 'axoblock.url' ),
 			$container->get( 'ppcp.asset-version' ),

--- a/modules/ppcp-axo-block/src/AxoBlockModule.php
+++ b/modules/ppcp-axo-block/src/AxoBlockModule.php
@@ -74,7 +74,7 @@ class AxoBlockModule implements ServiceModule, ExtendingModule, ExecutableModule
 				 */
 				add_filter(
 					'woocommerce_paypal_payments_sdk_components_hook',
-					function( $components ) use ( $c ) {
+					function ( $components ) use ( $c ) {
 						if ( ! $c->has( 'axo.available' ) || ! $c->get( 'axo.available' ) ) {
 							return $components;
 						}
@@ -87,7 +87,7 @@ class AxoBlockModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
-			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
+			function ( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				/*
 				 * Only register the method if we are not in the admin or the customer is not logged in.
 				 */

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -109,16 +109,16 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	 * @param array                         $supported_country_card_type_matrix The supported country card type matrix for Axo.
 	 */
 	public function __construct(
-	string $module_url,
-	string $version,
-	WC_Payment_Gateway $gateway,
-	$smart_button,
-	Settings $settings,
-	CardPaymentsConfiguration $dcc_configuration,
-	Environment $environment,
-	string $wcgateway_module_url,
-	array $payment_method_selected_map,
-	array $supported_country_card_type_matrix
+		string $module_url,
+		string $version,
+		WC_Payment_Gateway $gateway,
+		$smart_button,
+		Settings $settings,
+		CardPaymentsConfiguration $dcc_configuration,
+		Environment $environment,
+		string $wcgateway_module_url,
+		array $payment_method_selected_map,
+		array $supported_country_card_type_matrix
 	) {
 		$this->name                               = AxoGateway::ID;
 		$this->module_url                         = $module_url;
@@ -141,14 +141,14 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function is_active() : bool {
+	public function is_active(): bool {
 		return $this->gateway->is_available();
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function get_payment_method_script_handles() : array {
+	public function get_payment_method_script_handles(): array {
 		$script_path       = 'assets/js/index.js';
 		$script_asset_path = trailingslashit( $this->module_url ) . 'assets/js/index.asset.php';
 		$script_asset      = file_exists( $script_asset_path )
@@ -199,7 +199,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 	 *
 	 * @return array
 	 */
-	private function script_data() : array {
+	private function script_data(): array {
 		if ( is_admin() ) {
 			return array();
 		}

--- a/modules/ppcp-axo/extensions.php
+++ b/modules/ppcp-axo/extensions.php
@@ -18,7 +18,7 @@ return array(
 
 	'wcgateway.settings.fields' => function ( array $fields, ContainerInterface $container ): array {
 
-		$insert_after = function( array $array, string $key, array $new ): array {
+		$insert_after = function ( array $array, string $key, array $new ): array {
 			$keys = array_keys( $array );
 			$index = array_search( $key, $keys, true );
 			$pos = false === $index ? count( $array ) : $index + 1;

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -34,11 +34,11 @@ return array(
 		$axo_applies = $container->get( 'axo.service.axo-applies' );
 		assert( $axo_applies instanceof AxoApplies );
 
-		return static function () use ( $axo_applies ) : bool {
+		return static function () use ( $axo_applies ): bool {
 			return $axo_applies->for_country_currency() && $axo_applies->for_merchant();
 		};
 	},
-	'axo.service.axo-applies'                => static function ( ContainerInterface $container ) : AxoApplies {
+	'axo.service.axo-applies'                => static function ( ContainerInterface $container ): AxoApplies {
 		return new AxoApplies(
 			$container->get( 'axo.supported-country-currency-matrix' ),
 			$container->get( 'api.shop.currency.getter' ),
@@ -48,7 +48,7 @@ return array(
 		);
 	},
 
-	'axo.helpers.compatibility-checker'      => static function ( ContainerInterface $container ) : CompatibilityChecker {
+	'axo.helpers.compatibility-checker'      => static function ( ContainerInterface $container ): CompatibilityChecker {
 		return new CompatibilityChecker(
 			$container->get( 'axo.fastlane-incompatible-plugin-names' ),
 			$container->get( 'wcgateway.configuration.card-configuration' )
@@ -154,7 +154,7 @@ return array(
 	/**
 	 * The matrix which countries and currency combinations can be used for AXO.
 	 */
-	'axo.supported-country-currency-matrix'  => static function ( ContainerInterface $container ) : array {
+	'axo.supported-country-currency-matrix'  => static function ( ContainerInterface $container ): array {
 		$matrix = array(
 			'US' => array(
 				'AUD',
@@ -185,7 +185,7 @@ return array(
 	/**
 	 * The matrix which countries and card type combinations can be used for AXO.
 	 */
-	'axo.supported-country-card-type-matrix' => static function ( ContainerInterface $container ) : array {
+	'axo.supported-country-card-type-matrix' => static function ( ContainerInterface $container ): array {
 		$matrix = array(
 			'US' => array(
 				'VISA',
@@ -226,42 +226,42 @@ return array(
 			$matrix
 		);
 	},
-	'axo.settings-conflict-notice'           => static function ( ContainerInterface $container ) : string {
+	'axo.settings-conflict-notice'           => static function ( ContainerInterface $container ): string {
 		$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
 		assert( $compatibility_checker instanceof CompatibilityChecker );
 
 		return $compatibility_checker->generate_settings_conflict_notice();
 	},
 
-	'axo.checkout-config-notice'             => static function ( ContainerInterface $container ) : string {
+	'axo.checkout-config-notice'             => static function ( ContainerInterface $container ): string {
 		$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
 		assert( $compatibility_checker instanceof CompatibilityChecker );
 
 		return $compatibility_checker->generate_checkout_notice();
 	},
 
-	'axo.checkout-config-notice.raw'         => static function ( ContainerInterface $container ) : string {
+	'axo.checkout-config-notice.raw'         => static function ( ContainerInterface $container ): string {
 		$compatibility_checker = $container->get( 'axo.helpers.compatibility-checker' );
 		assert( $compatibility_checker instanceof CompatibilityChecker );
 
 		return $compatibility_checker->generate_checkout_notice( true );
 	},
 
-	'axo.incompatible-plugins-notice'        => static function ( ContainerInterface $container ) : string {
+	'axo.incompatible-plugins-notice'        => static function ( ContainerInterface $container ): string {
 		$settings_notice_generator = $container->get( 'axo.helpers.compatibility-checker' );
 		assert( $settings_notice_generator instanceof CompatibilityChecker );
 
 		return $settings_notice_generator->generate_incompatible_plugins_notice();
 	},
 
-	'axo.incompatible-plugins-notice.raw'    => static function ( ContainerInterface $container ) : string {
+	'axo.incompatible-plugins-notice.raw'    => static function ( ContainerInterface $container ): string {
 		$settings_notice_generator = $container->get( 'axo.helpers.compatibility-checker' );
 		assert( $settings_notice_generator instanceof CompatibilityChecker );
 
 		return $settings_notice_generator->generate_incompatible_plugins_notice( true );
 	},
 
-	'axo.smart-button-location-notice'       => static function ( ContainerInterface $container ) : string {
+	'axo.smart-button-location-notice'       => static function ( ContainerInterface $container ): string {
 		$dcc_configuration = $container->get( 'wcgateway.configuration.card-configuration' );
 		assert( $dcc_configuration instanceof CardPaymentsConfiguration );
 
@@ -310,7 +310,7 @@ return array(
 	 *
 	 * @returns array<array{name: string, is_active: bool}>
 	 */
-	'axo.fastlane-incompatible-plugins'      => static function () : array {
+	'axo.fastlane-incompatible-plugins'      => static function (): array {
 		/**
 		 * Filters the list of Fastlane incompatible plugins.
 		 */
@@ -365,12 +365,12 @@ return array(
 		);
 	},
 
-	'axo.fastlane-incompatible-plugin-names' => static function ( ContainerInterface $container ) : array {
+	'axo.fastlane-incompatible-plugin-names' => static function ( ContainerInterface $container ): array {
 		$incompatible_plugins = $container->get( 'axo.fastlane-incompatible-plugins' );
 
 		$active_plugins_list = array_filter(
 			$incompatible_plugins,
-			function( array $plugin ): bool {
+			function ( array $plugin ): bool {
 				return (bool) $plugin['is_active'];
 			}
 		);
@@ -395,10 +395,10 @@ return array(
 		}
 
 		$shipping_zones = \WC_Shipping_Zones::get_zones();
-		$get_zone_locations = fn( \WC_Shipping_Zone $zone): array =>
+		$get_zone_locations = fn( \WC_Shipping_Zone $zone ): array =>
 		! empty( $zone->get_shipping_methods( true ) )
 			? array_map(
-				fn( object $location): string => $location->code,
+				fn( object $location ): string => $location->code,
 				$zone->get_zone_locations()
 			)
 			: array();
@@ -408,7 +408,7 @@ return array(
 				...array_map(
 					$get_zone_locations,
 					array_map(
-						fn( $zone): \WC_Shipping_Zone =>
+						fn( $zone ): \WC_Shipping_Zone =>
 						$zone instanceof \WC_Shipping_Zone ? $zone : new \WC_Shipping_Zone( $zone['id'] ),
 						$shipping_zones
 					)

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -190,7 +190,7 @@ class AxoManager {
 				'email' => 'render',
 			),
 			// The amount is not available when setting the insights data, so we need to merge it here.
-			'insights'                   => ( function( array $data ): array {
+			'insights'                   => ( function ( array $data ): array {
 				$data['amount']['value'] = WC()->cart->get_total( 'numeric' );
 				return $data; } )( $this->insights_data ),
 			'allowed_cards'              => $this->supported_country_card_type_matrix,
@@ -270,5 +270,4 @@ class AxoManager {
 			esc_html( $label )
 		);
 	}
-
 }

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -168,7 +168,7 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				$listener->filter_settings(
 					$dcc_configuration->use_fastlane(),
 					'smart_button_locations',
-					function( array $existing_setting_value ) {
+					function ( array $existing_setting_value ) {
 						$axo_forced_locations = array( 'cart-block', 'cart' );
 						return array_unique( array_merge( $existing_setting_value, $axo_forced_locations ) );
 					}
@@ -248,7 +248,7 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				 */
 				add_filter(
 					'woocommerce_paypal_payments_sdk_components_hook',
-					function( $components ) use ( $c ) {
+					function ( $components ) use ( $c ) {
 						$dcc_configuration = $c->get( 'wcgateway.configuration.card-configuration' );
 						assert( $dcc_configuration instanceof CardPaymentsConfiguration );
 

--- a/modules/ppcp-axo/src/Gateway/AxoGateway.php
+++ b/modules/ppcp-axo/src/Gateway/AxoGateway.php
@@ -40,7 +40,9 @@ use DomainException;
  * Class AXOGateway.
  */
 class AxoGateway extends WC_Payment_Gateway {
-	use OrderMetaTrait, GatewaySettingsRendererTrait, ProcessPaymentTrait;
+	use OrderMetaTrait;
+	use GatewaySettingsRendererTrait;
+	use ProcessPaymentTrait;
 
 	const ID = 'ppcp-axo-gateway';
 
@@ -351,7 +353,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 *
 	 * @return array
 	 */
-	protected function process_3ds_return( WC_Order $wc_order, string $token ) : array {
+	protected function process_3ds_return( WC_Order $wc_order, string $token ): array {
 		try {
 			$paypal_order = $this->order_endpoint->order( $token );
 
@@ -424,7 +426,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 * @param Order $order The PayPal order.
 	 * @return string The payer action URL or an empty string if not found.
 	 */
-	private function get_payer_action_url( Order $order ) : string {
+	private function get_payer_action_url( Order $order ): string {
 		$links = $order->links();
 
 		if ( ! $links ) {
@@ -448,7 +450,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 *
 	 * @return Order The PayPal order.
 	 */
-	protected function create_paypal_order( WC_Order $wc_order, string $payment_token ) : Order {
+	protected function create_paypal_order( WC_Order $wc_order, string $payment_token ): Order {
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 
 		$shipping_preference = $this->shipping_preference_factory->from_state(
@@ -559,7 +561,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 *
 	 * @return string
 	 */
-	public function get_transaction_url( $order ) : string {
+	public function get_transaction_url( $order ): string {
 		$this->view_transaction_url = $this->transaction_url_provider->get_transaction_url_base( $order );
 
 		return parent::get_transaction_url( $order );
@@ -593,7 +595,7 @@ class AxoGateway extends WC_Payment_Gateway {
 	 *
 	 * @return SettingsRenderer
 	 */
-	protected function settings_renderer() : SettingsRenderer {
+	protected function settings_renderer(): SettingsRenderer {
 		return $this->settings_renderer;
 	}
 }

--- a/modules/ppcp-axo/src/Helper/CompatibilityChecker.php
+++ b/modules/ppcp-axo/src/Helper/CompatibilityChecker.php
@@ -65,7 +65,7 @@ class CompatibilityChecker {
 	 *
 	 * @return bool Whether the checkout uses Elementor.
 	 */
-	protected function has_elementor_checkout() : bool {
+	protected function has_elementor_checkout(): bool {
 		if ( $this->checkout_compatibility['has_elementor_checkout'] === null ) {
 			$this->checkout_compatibility['has_elementor_checkout'] = CartCheckoutDetector::has_elementor_checkout();
 		}
@@ -78,7 +78,7 @@ class CompatibilityChecker {
 	 *
 	 * @return bool Whether the checkout uses classic checkout.
 	 */
-	protected function has_classic_checkout() : bool {
+	protected function has_classic_checkout(): bool {
 		if ( $this->checkout_compatibility['has_classic_checkout'] === null ) {
 			$this->checkout_compatibility['has_classic_checkout'] = CartCheckoutDetector::has_classic_checkout();
 		}
@@ -91,7 +91,7 @@ class CompatibilityChecker {
 	 *
 	 * @return bool Whether the checkout uses block checkout.
 	 */
-	protected function has_block_checkout() : bool {
+	protected function has_block_checkout(): bool {
 		if ( $this->checkout_compatibility['has_block_checkout'] === null ) {
 			$this->checkout_compatibility['has_block_checkout'] = CartCheckoutDetector::has_block_checkout();
 		}
@@ -109,7 +109,7 @@ class CompatibilityChecker {
 	 *
 	 * @return string The full HTML code of the notification, or an empty string, or raw message.
 	 */
-	private function render_notice( string $message, bool $is_error = false, bool $raw_message = false ) : string {
+	private function render_notice( string $message, bool $is_error = false, bool $raw_message = false ): string {
 		if ( ! $message ) {
 			return '';
 		}
@@ -131,7 +131,7 @@ class CompatibilityChecker {
 	 *
 	 * @return bool Whether the setup is compatible.
 	 */
-	public function is_fastlane_compatible() : bool {
+	public function is_fastlane_compatible(): bool {
 		// Check for incompatible plugins.
 		if ( ! empty( $this->incompatible_plugin_names ) ) {
 			return false;
@@ -156,7 +156,7 @@ class CompatibilityChecker {
 	 * @param bool $raw_message Whether to return raw message without HTML wrappers.
 	 * @return string
 	 */
-	public function generate_checkout_notice( bool $raw_message = false ) : string {
+	public function generate_checkout_notice( bool $raw_message = false ): string {
 		$notice_content = '';
 
 		// Check for checkout incompatibilities.
@@ -204,7 +204,7 @@ class CompatibilityChecker {
 	 * @param bool $raw_message Whether to return raw message without HTML wrappers.
 	 * @return string
 	 */
-	public function generate_incompatible_plugins_notice( bool $raw_message = false ) : string {
+	public function generate_incompatible_plugins_notice( bool $raw_message = false ): string {
 		if ( empty( $this->incompatible_plugin_names ) ) {
 			return '';
 		}
@@ -229,7 +229,7 @@ class CompatibilityChecker {
 	 * @param bool $raw_message Whether to return raw message without HTML wrappers.
 	 * @return string
 	 */
-	public function generate_settings_conflict_notice( bool $raw_message = false ) : string {
+	public function generate_settings_conflict_notice( bool $raw_message = false ): string {
 		if ( $this->dcc_configuration->is_enabled() ) {
 			return '';
 		}

--- a/modules/ppcp-axo/src/Helper/PropertiesDictionary.php
+++ b/modules/ppcp-axo/src/Helper/PropertiesDictionary.php
@@ -25,5 +25,4 @@ class PropertiesDictionary {
 			'no'  => __( 'No', 'woocommerce-paypal-payments' ),
 		);
 	}
-
 }

--- a/modules/ppcp-axo/src/Service/AxoApplies.php
+++ b/modules/ppcp-axo/src/Service/AxoApplies.php
@@ -80,7 +80,7 @@ class AxoApplies {
 	 *
 	 * @return bool
 	 */
-	public function for_merchant() : bool {
+	public function for_merchant(): bool {
 		return apply_filters(
 			'woocommerce_paypal_payments_is_eligible_for_axo',
 			true
@@ -94,11 +94,11 @@ class AxoApplies {
 	 */
 	public function should_render_fastlane(): bool {
 		return ! is_user_logged_in()
-			   && CartCheckoutDetector::has_classic_checkout()
-			   && $this->dcc_configuration->use_fastlane()
-			   && ! $this->is_excluded_endpoint()
-			   && is_checkout()
-			   && ! $this->subscription_helper->cart_contains_subscription();
+				&& CartCheckoutDetector::has_classic_checkout()
+				&& $this->dcc_configuration->use_fastlane()
+				&& ! $this->is_excluded_endpoint()
+				&& is_checkout()
+				&& ! $this->subscription_helper->cart_contains_subscription();
 	}
 
 	/**

--- a/modules/ppcp-blocks/extensions.php
+++ b/modules/ppcp-blocks/extensions.php
@@ -29,7 +29,7 @@ return array(
 	},
 
 	'wcgateway.settings.fields'                        => function ( array $fields, ContainerInterface $container ): array {
-		$insert_after = function( array $array, string $key, array $new ): array {
+		$insert_after = function ( array $array, string $key, array $new ): array {
 			$keys = array_keys( $array );
 			$index = array_search( $key, $keys, true );
 			$pos = false === $index ? count( $array ) : $index + 1;

--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -40,7 +40,7 @@ return array(
 			$container->get( 'wcgateway.all-funding-sources' ),
 		);
 	},
-	'blocks.advanced-card-method'          => static function( ContainerInterface $container ): AdvancedCardPaymentMethod {
+	'blocks.advanced-card-method'          => static function ( ContainerInterface $container ): AdvancedCardPaymentMethod {
 		return new AdvancedCardPaymentMethod(
 			$container->get( 'blocks.url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -69,7 +69,7 @@ return array(
 		);
 	},
 
-	'blocks.add-place-order-method'        => function ( ContainerInterface $container ) : bool {
+	'blocks.add-place-order-method'        => function ( ContainerInterface $container ): bool {
 		/**
 		 * Whether to create a non-express method with the standard "Place order" button redirecting to PayPal.
 		 */

--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -68,7 +68,7 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
-			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
+			function ( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				$payment_method_registry->register( $c->get( 'blocks.method' ) );
 
 				$settings = $c->get( 'wcgateway.settings' );
@@ -80,7 +80,7 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		woocommerce_store_api_register_payment_requirements(
 			array(
-				'data_callback' => function() use ( $c ): array {
+				'data_callback' => function () use ( $c ): array {
 					$smart_button = $c->get( 'button.smart-button' );
 					assert( $smart_button instanceof SmartButtonInterface );
 
@@ -143,7 +143,7 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
-			function( array $components, string $context ) {
+			function ( array $components, string $context ) {
 				if ( str_ends_with( $context, '-block' ) ) {
 					$components[] = 'buttons';
 				}

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -246,7 +246,7 @@ return array(
 			$logger
 		);
 	},
-	'button.helper.early-order-handler'           => static function ( ContainerInterface $container ) : EarlyOrderHandler {
+	'button.helper.early-order-handler'           => static function ( ContainerInterface $container ): EarlyOrderHandler {
 		return new EarlyOrderHandler(
 			$container->get( 'settings.flag.is-connected' ),
 			$container->get( 'wcgateway.order-processor' ),
@@ -279,7 +279,7 @@ return array(
 			$logger
 		);
 	},
-	'button.endpoint.approve-subscription'        => static function( ContainerInterface $container ): ApproveSubscriptionEndpoint {
+	'button.endpoint.approve-subscription'        => static function ( ContainerInterface $container ): ApproveSubscriptionEndpoint {
 		return new ApproveSubscriptionEndpoint(
 			$container->get( 'button.request-data' ),
 			$container->get( 'api.endpoint.order' ),
@@ -301,7 +301,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'button.endpoint.data-client-id'              => static function( ContainerInterface $container ) : DataClientIdEndpoint {
+	'button.endpoint.data-client-id'              => static function ( ContainerInterface $container ): DataClientIdEndpoint {
 		$request_data   = $container->get( 'button.request-data' );
 		$identity_token = $container->get( 'api.endpoint.identity-token' );
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
@@ -311,7 +311,7 @@ return array(
 			$logger
 		);
 	},
-	'button.endpoint.vault-paypal'                => static function( ContainerInterface $container ) : StartPayPalVaultingEndpoint {
+	'button.endpoint.vault-paypal'                => static function ( ContainerInterface $container ): StartPayPalVaultingEndpoint {
 		return new StartPayPalVaultingEndpoint(
 			$container->get( 'button.request-data' ),
 			$container->get( 'api.endpoint.payment-token' ),

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1911,7 +1911,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
 	protected function is_cart_price_total_zero(): bool {
-        // phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+        // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
 		return WC()->cart && WC()->cart->get_total( 'numeric' ) == 0;
 	}
 

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -63,7 +63,8 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
  */
 class SmartButton implements SmartButtonInterface {
 
-	use FreeTrialHandlerTrait, ContextTrait;
+	use FreeTrialHandlerTrait;
+	use ContextTrait;
 
 	/**
 	 * The Settings status helper.
@@ -438,7 +439,7 @@ class SmartButton implements SmartButtonInterface {
 		$subscription_helper = $this->subscription_helper;
 		add_filter(
 			'woocommerce_credit_card_form_fields',
-			function ( array $default_fields, $id ) use ( $subscription_helper ) : array {
+			function ( array $default_fields, $id ) use ( $subscription_helper ): array {
 				if (
 					CreditCardGateway::ID === $id
 					&& is_user_logged_in()
@@ -671,7 +672,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			$enabled_on_cart = $this->settings_status->is_smart_button_enabled_for_location( 'cart' );
 			add_action(
 				$this->proceed_to_checkout_button_renderer_hook(),
-				function() use ( $enabled_on_cart ) {
+				function () use ( $enabled_on_cart ) {
 					if ( ! is_cart() || ! $enabled_on_cart || $this->is_free_trial_cart() || $this->is_cart_price_total_zero() || isset( reset( WC()->cart->cart_contents )['subscription_switch'] ) ) {
 						return;
 					}
@@ -700,7 +701,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	/**
 	 * Determines whether the button component should be loaded.
 	 */
-	public function should_load_buttons() : bool {
+	public function should_load_buttons(): bool {
 		$pcp_gateway_enabled = $this->settings->has( 'enabled' ) && $this->settings->get( 'enabled' );
 		if ( ! $pcp_gateway_enabled ) {
 			return false;
@@ -726,7 +727,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	/**
 	 * Determines whether the Pay Later messages component should be loaded.
 	 */
-	public function should_load_messages() : bool {
+	public function should_load_messages(): bool {
 		$pcp_gateway_enabled = $this->settings->has( 'enabled' ) && $this->settings->get( 'enabled' );
 		if ( ! $pcp_gateway_enabled ) {
 			return false;
@@ -768,7 +769,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	/**
 	 * Whether DCC fields can be rendered.
 	 */
-	public function can_render_dcc() : bool {
+	public function can_render_dcc(): bool {
 		return $this->dcc_configuration->is_acdc_enabled()
 			&& in_array(
 				$this->context(),
@@ -1142,7 +1143,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	 *
 	 * @return bool True, if any cart item requires shipping.
 	 */
-	private function need_shipping() : bool {
+	private function need_shipping(): bool {
 		/**
 		 * Cart instance; might be null, esp. in customizer or in Block Editor.
 		 *
@@ -1599,7 +1600,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	 *
 	 * @return array
 	 */
-	private function bn_codes() : array {
+	private function bn_codes(): array {
 
 		$bn_code = $this->partner_attribution->get_bn_code();
 
@@ -2045,7 +2046,6 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	public function is_pay_later_button_enabled_for_location( string $location, array $context_data = array() ): bool {
 		return $this->is_pay_later_filter_enabled_for_location( $location, $context_data )
 			&& $this->settings_status->is_pay_later_button_enabled_for_location( $location );
-
 	}
 
 	/**
@@ -2178,7 +2178,6 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			},
 			11
 		);
-
 	}
 
 	/**

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -159,7 +159,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 	 *
 	 * @return string
 	 */
-	public static function nonce() : string {
+	public static function nonce(): string {
 		return self::ENDPOINT;
 	}
 
@@ -169,7 +169,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 	 * @return bool
 	 * @throws RuntimeException When order not found or handling failed.
 	 */
-	public function handle_request() : bool {
+	public function handle_request(): bool {
 		try {
 			$data = $this->request_data->read_request( self::nonce() );
 			if ( ! isset( $data['order_id'] ) ) {
@@ -266,7 +266,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 	 *
 	 * @return void
 	 */
-	protected function toggle_final_review_enabled_setting() : void {
+	protected function toggle_final_review_enabled_setting(): void {
 		// TODO new-ux: This flag must also be updated in the new settings.
 		$final_review_enabled_setting = $this->settings->has( 'blocks_final_review_enabled' ) && $this->settings->get( 'blocks_final_review_enabled' );
 		$this->settings->set( 'blocks_final_review_enabled', ! $final_review_enabled_setting );
@@ -285,7 +285,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 	 * @param Order $order The PayPal order to inspect.
 	 * @throws RuntimeException When the 3DS check was rejected.
 	 */
-	protected function verify_three_d_secure( Order $order ) : void {
+	protected function verify_three_d_secure( Order $order ): void {
 		$payment_source = $order->payment_source();
 
 		if ( ! $payment_source ) {

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -353,7 +353,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 				if (
 					! $this->early_order_handler->should_create_early_order()
 					|| $this->registration_needed
-					|| isset( $data['createaccount'] ) && '1' === $data['createaccount'] ) {
+					|| ( isset( $data['createaccount'] ) && '1' === $data['createaccount'] ) ) {
 					wp_send_json_success( $this->make_response( $order ) );
 				}
 

--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -172,11 +172,9 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 			// Removes shutdown actions to prevent persisting session, transients and save cookies.
 			remove_all_actions( 'shutdown' );
 			unset( WC()->cart );
-		} else {
+		} elseif ( null !== $this->real_cart ) {
 			// Restores cart, may lead to race conditions.
-			if ( null !== $this->real_cart ) {
-				WC()->cart = $this->real_cart;
-			}
+			WC()->cart = $this->real_cart;
 		}
 
 		unset( $this->cart );

--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -181,5 +181,4 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 
 		unset( $this->cart );
 	}
-
 }

--- a/modules/ppcp-button/src/Helper/CartProductsHelper.php
+++ b/modules/ppcp-button/src/Helper/CartProductsHelper.php
@@ -281,5 +281,4 @@ class CartProductsHelper {
 	public function cart_item_keys(): array {
 		return $this->cart_item_keys;
 	}
-
 }

--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -71,7 +71,7 @@ class DisabledFundingSources {
 	 * @param string $context The context.
 	 * @return string[] List of disabled sources
 	 */
-	public function sources( string $context ) : array {
+	public function sources( string $context ): array {
 		$block_contexts = array( 'checkout-block', 'cart-block' );
 		$flags          = array(
 			'context'          => $context,
@@ -104,7 +104,7 @@ class DisabledFundingSources {
 	 *
 	 * @return array
 	 */
-	private function get_sources_from_settings() : array {
+	private function get_sources_from_settings(): array {
 		try {
 			// Settings field present in the legacy UI.
 			$disabled_funding = $this->settings->get( 'disable_funding' );
@@ -133,7 +133,7 @@ class DisabledFundingSources {
 	 *
 	 * @return array
 	 */
-	private function get_sources_for_free_trial() : array {
+	private function get_sources_for_free_trial(): array {
 		// Disable all sources.
 		$disable_funding = array_keys( $this->all_funding_sources );
 
@@ -154,7 +154,7 @@ class DisabledFundingSources {
 	 * @param array $disable_funding The current disabled funding sources.
 	 * @return array
 	 */
-	private function apply_context_rules( array $disable_funding ) : array {
+	private function apply_context_rules( array $disable_funding ): array {
 		if ( 'MX' === $this->merchant_country && $this->dcc_configuration->is_bcdc_enabled() && CartCheckoutDetector::has_classic_checkout() && is_checkout() ) {
 			return $disable_funding;
 		}
@@ -173,7 +173,7 @@ class DisabledFundingSources {
 	 * @param array $disable_funding The current disabled funding sources.
 	 * @return array
 	 */
-	private function apply_block_checkout_rules( array $disable_funding ) : array {
+	private function apply_block_checkout_rules( array $disable_funding ): array {
 		/**
 		 * Block checkout only supports the following funding methods:
 		 * - PayPal
@@ -196,7 +196,7 @@ class DisabledFundingSources {
 	 * @param array $flags           Decision flags.
 	 * @return string[]
 	 */
-	private function sanitize_and_filter_sources( array $disable_funding, array $flags ) : array {
+	private function sanitize_and_filter_sources( array $disable_funding, array $flags ): array {
 		/**
 		 * Filters the final list of disabled funding sources.
 		 *

--- a/modules/ppcp-button/src/Helper/ThreeDSecure.php
+++ b/modules/ppcp-button/src/Helper/ThreeDSecure.php
@@ -61,7 +61,7 @@ class ThreeDSecure {
 	 *
 	 * @return int
 	 */
-	public function proceed_with_order( Order $order ) : int {
+	public function proceed_with_order( Order $order ): int {
 
 		do_action( 'woocommerce_paypal_payments_three_d_secure_before_check', $order );
 
@@ -120,7 +120,7 @@ class ThreeDSecure {
 	 * @param Order $order    The PayPal Order object.
 	 * @return int
 	 */
-	public function return_decision( int $decision, Order $order ) : int {
+	public function return_decision( int $decision, Order $order ): int {
 		$decision = apply_filters( 'woocommerce_paypal_payments_three_d_secure_decision', $decision, $order );
 		do_action( 'woocommerce_paypal_payments_three_d_secure_after_check', $order, $decision );
 
@@ -134,7 +134,7 @@ class ThreeDSecure {
 	 *
 	 * @return int
 	 */
-	private function no_liability_shift( AuthResult $result ) : int {
+	private function no_liability_shift( AuthResult $result ): int {
 		$enrollment     = $result->enrollment_status();
 		$authentication = $result->authentication_result();
 

--- a/modules/ppcp-button/src/Validation/CheckoutFormValidator.php
+++ b/modules/ppcp-button/src/Validation/CheckoutFormValidator.php
@@ -93,7 +93,7 @@ class CheckoutFormValidator extends WC_Checkout {
 		}
 
 		// Some plugins call wc_add_notice directly.
-		// We should retrieve such notices, and also clear them to avoid duplicates	later.
+		// We should retrieve such notices, and also clear them to avoid duplicates later.
 		// TODO: Normally WC converts the messages from validate_checkout into notices,
 		// maybe we should do the same for consistency, but it requires lots of changes in the way we handle/output errors.
 		$messages = array_merge(

--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -24,17 +24,17 @@ return array(
 		$save_payment_methods_applies = $container->get( 'card-fields.helpers.save-payment-methods-applies' );
 		assert( $save_payment_methods_applies instanceof CardFieldsApplies );
 
-		return static function () use ( $save_payment_methods_applies ) : bool {
+		return static function () use ( $save_payment_methods_applies ): bool {
 			return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
 		};
 	},
-	'card-fields.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ) : CardFieldsApplies {
+	'card-fields.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ): CardFieldsApplies {
 		return new CardFieldsApplies(
 			$container->get( 'card-fields.supported-country-matrix' ),
 			$container->get( 'api.shop.country' )
 		);
 	},
-	'card-fields.supported-country-matrix'             => static function ( ContainerInterface $container ) : array {
+	'card-fields.supported-country-matrix'             => static function ( ContainerInterface $container ): array {
 		return apply_filters(
 			'woocommerce_paypal_payments_card_fields_supported_country_matrix',
 			array(
@@ -82,7 +82,7 @@ return array(
 			)
 		);
 	},
-	'card-fields.service.card-capture-validator'       => static function ( ContainerInterface $container ) : CardCaptureValidator {
+	'card-fields.service.card-capture-validator'       => static function ( ContainerInterface $container ): CardCaptureValidator {
 		return new CardCaptureValidator();
 	},
 );

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -53,7 +53,7 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
-			static function( array $components ) use ( $c ) {
+			static function ( array $components ) use ( $c ) {
 				$dcc_config = $c->get( 'wcgateway.configuration.card-configuration' );
 				assert( $dcc_config instanceof CardPaymentsConfiguration );
 
@@ -104,7 +104,7 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 			 * @psalm-suppress MissingClosureReturnType
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $default_fields, $id ) use ( $c ) {
+			function ( $default_fields, $id ) use ( $c ) {
 				if ( ! $c->get( 'wcgateway.configuration.card-configuration' )->is_enabled() ) {
 					return $default_fields;
 				}
@@ -139,7 +139,7 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 
 		add_filter(
 			'ppcp_create_order_request_body_data',
-			function( array $data, string $payment_method ) use ( $c ): array {
+			function ( array $data, string $payment_method ) use ( $c ): array {
 				if ( ! $c->get( 'wcgateway.configuration.card-configuration' )->is_enabled() ) {
 					return $data;
 				}
@@ -187,7 +187,7 @@ class CardFieldsModule implements ServiceModule, ExtendingModule, ExecutableModu
 		// Validates if an order with card payment source can be captured.
 		add_action(
 			'woocommerce_paypal_payments_before_capture_order',
-			function( Order $order ) use ( $c ) {
+			function ( Order $order ) use ( $c ) {
 				$validator = $c->get( 'card-fields.service.card-capture-validator' );
 				assert( $validator instanceof CardCaptureValidator );
 

--- a/modules/ppcp-card-fields/src/Helper/CardFieldsApplies.php
+++ b/modules/ppcp-card-fields/src/Helper/CardFieldsApplies.php
@@ -57,7 +57,7 @@ class CardFieldsApplies {
 	 *
 	 * @return bool
 	 */
-	public function for_merchant() : bool {
+	public function for_merchant(): bool {
 		return apply_filters(
 			'woocommerce_paypal_payments_is_eligible_for_card_fields',
 			true

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -21,7 +21,7 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
 
-	'compat.ppec.mock-gateway'                       => static function( $container ) {
+	'compat.ppec.mock-gateway'                       => static function ( $container ) {
 		$settings = $container->get( 'wcgateway.settings' );
 		$title    = $settings->has( 'title' ) ? $settings->get( 'title' ) : __( 'PayPal', 'woocommerce-paypal-payments' );
 		$title    = sprintf(
@@ -40,13 +40,13 @@ return array(
 		return new PPEC\SubscriptionsHandler( $ppcp_renewal_handler, $gateway );
 	},
 
-	'compat.ppec.settings_importer'                  => static function( ContainerInterface $container ) : PPEC\SettingsImporter {
+	'compat.ppec.settings_importer'                  => static function ( ContainerInterface $container ): PPEC\SettingsImporter {
 		$settings = $container->get( 'wcgateway.settings' );
 
 		return new PPEC\SettingsImporter( $settings );
 	},
 
-	'compat.plugin-script-names'                     => static function( ContainerInterface $container ) : array {
+	'compat.plugin-script-names'                     => static function ( ContainerInterface $container ): array {
 		return array(
 			'ppcp-smart-button',
 			'ppcp-oxxo',
@@ -61,7 +61,7 @@ return array(
 		);
 	},
 
-	'compat.plugin-script-file-names'                => static function( ContainerInterface $container ) : array {
+	'compat.plugin-script-file-names'                => static function ( ContainerInterface $container ): array {
 		return array(
 			'button.js',
 			'gateway-settings.js',
@@ -104,7 +104,7 @@ return array(
 		return plugins_url( '/modules/ppcp-compat/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
 
-	'compat.assets'                                  => function( ContainerInterface $container ) : CompatAssets {
+	'compat.assets'                                  => function ( ContainerInterface $container ): CompatAssets {
 		return new CompatAssets(
 			$container->get( 'compat.module.url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -120,7 +120,7 @@ return array(
 	 *
 	 * @returns SettingsMap[]
 	 */
-	'compat.setting.new-to-old-map'                  => static function( ContainerInterface $container ) : array {
+	'compat.setting.new-to-old-map'                  => static function ( ContainerInterface $container ): array {
 		$are_new_settings_enabled = $container->get( 'wcgateway.settings.admin-settings-enabled' );
 		if ( ! $are_new_settings_enabled ) {
 			return array();
@@ -184,7 +184,7 @@ return array(
 			),
 		);
 	},
-	'compat.settings.settings_map_helper'            => static function( ContainerInterface $container ) : SettingsMapHelper {
+	'compat.settings.settings_map_helper'            => static function ( ContainerInterface $container ): SettingsMapHelper {
 		return new SettingsMapHelper(
 			$container->get( 'compat.setting.new-to-old-map' ),
 			$container->get( 'compat.settings.styling_map_helper' ),
@@ -195,19 +195,19 @@ return array(
 			$container->get( 'wcgateway.settings.admin-settings-enabled' )
 		);
 	},
-	'compat.settings.styling_map_helper'             => static function() : StylingSettingsMapHelper {
+	'compat.settings.styling_map_helper'             => static function (): StylingSettingsMapHelper {
 		return new StylingSettingsMapHelper();
 	},
-	'compat.settings.settings_tab_map_helper'        => static function() : SettingsTabMapHelper {
+	'compat.settings.settings_tab_map_helper'        => static function (): SettingsTabMapHelper {
 		return new SettingsTabMapHelper();
 	},
-	'compat.settings.subscription_map_helper'        => static function( ContainerInterface $container ) : SubscriptionSettingsMapHelper {
+	'compat.settings.subscription_map_helper'        => static function ( ContainerInterface $container ): SubscriptionSettingsMapHelper {
 		return new SubscriptionSettingsMapHelper( $container->get( 'wc-subscriptions.helper' ) );
 	},
-	'compat.settings.general_map_helper'             => static function() : GeneralSettingsMapHelper {
+	'compat.settings.general_map_helper'             => static function (): GeneralSettingsMapHelper {
 		return new GeneralSettingsMapHelper();
 	},
-	'compat.settings.payment_methods_map_helper'     => static function() : PaymentMethodSettingsMapHelper {
+	'compat.settings.payment_methods_map_helper'     => static function (): PaymentMethodSettingsMapHelper {
 		return new PaymentMethodSettingsMapHelper();
 	},
 );

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -55,7 +55,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		add_action(
 			'woocommerce_init',
-			function() use ( $c ) {
+			function () use ( $c ) {
 				$this->initialize_ppec_compat_layer( $c );
 				$this->initialize_tracking_compat_layer( $c );
 			}
@@ -63,7 +63,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		add_action(
 			'init',
-			function() use ( $c ) {
+			function () use ( $c ) {
 				$asset_loader = $c->get( 'compat.assets' );
 				assert( $asset_loader instanceof CompatAssets );
 
@@ -117,7 +117,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		 */
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
-			static function() use ( $c ) {
+			static function () use ( $c ) {
 				if ( ! apply_filters(
 				// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 					'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
@@ -176,7 +176,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		// Inbox note inviting merchant to disable PayPal Express Checkout.
 		add_action(
 			'woocommerce_init',
-			function() {
+			function () {
 				if ( is_admin() && is_callable( array( WC(), 'is_wc_admin_active' ) ) && WC()->is_wc_admin_active() && class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
 					PPEC\DeactivateNote::init();
 				}
@@ -377,7 +377,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 	protected function fix_page_builders(): void {
 		add_action(
 			'init',
-			function() {
+			function () {
 				if (
 					$this->is_block_theme_active()
 					|| $this->is_elementor_pro_active()
@@ -386,7 +386,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				) {
 					add_filter(
 						'woocommerce_paypal_payments_single_product_renderer_hook',
-						function(): string {
+						function (): string {
 							return 'woocommerce_after_add_to_cart_form';
 						},
 						5
@@ -443,7 +443,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 	protected function set_elementor_checkout_context(): void {
 		add_action(
 			'wp',
-			function() {
+			function () {
 				$page_id = get_the_ID();
 				if ( ! is_numeric( $page_id ) || ! CartCheckoutDetector::has_elementor_checkout( (int) $page_id ) ) {
 					return;
@@ -473,7 +473,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		// Siteground SG Optimize.
 		add_filter(
 			'sgo_js_minify_exclude',
-			function( array $scripts ) use ( $ppcp_script_names ) {
+			function ( array $scripts ) use ( $ppcp_script_names ) {
 				return array_merge( $scripts, $ppcp_script_names );
 			}
 		);
@@ -481,7 +481,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		// LiteSpeed Cache.
 		add_filter(
 			'litespeed_optimize_js_excludes',
-			function( array $excluded_js ) use ( $ppcp_script_file_names ) {
+			function ( array $excluded_js ) use ( $ppcp_script_file_names ) {
 				return array_merge( $excluded_js, $ppcp_script_file_names );
 			}
 		);
@@ -498,7 +498,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			 * @return bool Whether to do tag minification.
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( bool $do_tag_minification, string $script_tag, $file ) {
+			function ( bool $do_tag_minification, string $script_tag, $file ) {
 				if ( $file && strpos( $file, 'ppcp' ) !== false ) {
 					return false;
 				}
@@ -517,7 +517,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 	protected function initialize_nyp_compat_layer(): void {
 		add_filter(
 			'woocommerce_paypal_payments_shipping_callback_cart_line_item_total',
-			static function( string $total, array $cart_item ) {
+			static function ( string $total, array $cart_item ) {
 				if ( ! isset( $cart_item['nyp'] ) ) {
 					return $total;
 				}
@@ -596,7 +596,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 	 * @param ContainerInterface $container DI container instance.
 	 * @return void
 	 */
-	protected function legacy_ui_card_payment_mapping( ContainerInterface $container ) : void {
+	protected function legacy_ui_card_payment_mapping( ContainerInterface $container ): void {
 		$new_ui = $container->get( 'wcgateway.settings.admin-settings-enabled' );
 		if ( $new_ui ) {
 			return;
@@ -604,7 +604,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		add_filter(
 			'woocommerce_paypal_payments_is_acdc_active',
-			static function ( bool $is_acdc ) use ( $container ) : bool {
+			static function ( bool $is_acdc ) use ( $container ): bool {
 				$settings = $container->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 

--- a/modules/ppcp-compat/src/PPEC/DeactivateNote.php
+++ b/modules/ppcp-compat/src/PPEC/DeactivateNote.php
@@ -116,5 +116,4 @@ class DeactivateNote {
 			$note->save();
 		}
 	}
-
 }

--- a/modules/ppcp-compat/src/PPEC/MockGateway.php
+++ b/modules/ppcp-compat/src/PPEC/MockGateway.php
@@ -45,5 +45,4 @@ class MockGateway extends \WC_Payment_Gateway {
 		// Hide mock gateway, except on admin.
 		return is_admin();
 	}
-
 }

--- a/modules/ppcp-compat/src/PPEC/PPECHelper.php
+++ b/modules/ppcp-compat/src/PPEC/PPECHelper.php
@@ -117,5 +117,4 @@ class PPECHelper {
 			&& self::site_has_ppec_subscriptions()
 			&& apply_filters( 'woocommerce_paypal_payments_process_legacy_subscriptions', true );
 	}
-
 }

--- a/modules/ppcp-compat/src/PPEC/SettingsImporter.php
+++ b/modules/ppcp-compat/src/PPEC/SettingsImporter.php
@@ -231,5 +231,4 @@ class SettingsImporter {
 
 		return $result;
 	}
-
 }

--- a/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsMapHelper.php
@@ -125,7 +125,7 @@ class SettingsMapHelper {
 	 * @param SettingsMap[] $settings_map The settings map to validate.
 	 * @throws RuntimeException When an old key has multiple mappings.
 	 */
-	protected function validate_settings_map( array $settings_map ) : void {
+	protected function validate_settings_map( array $settings_map ): void {
 		$seen_keys = array();
 
 		foreach ( $settings_map as $settings_map_instance ) {
@@ -172,7 +172,7 @@ class SettingsMapHelper {
 	 *
 	 * @return bool True if the key exists in the new settings, false otherwise.
 	 */
-	public function has_mapped_key( string $old_key ) : bool {
+	public function has_mapped_key( string $old_key ): bool {
 		if ( ! $this->new_settings_module_enabled ) {
 			return false;
 		}
@@ -228,7 +228,7 @@ class SettingsMapHelper {
 	 *
 	 * @return void
 	 */
-	protected function ensure_map_initialized() : void {
+	protected function ensure_map_initialized(): void {
 		if ( $this->key_to_model === null ) {
 			$this->initialize_key_map();
 		}
@@ -242,7 +242,7 @@ class SettingsMapHelper {
 	 *
 	 * @return void
 	 */
-	protected function initialize_key_map() : void {
+	protected function initialize_key_map(): void {
 		$this->key_to_model = array();
 
 		foreach ( $this->settings_map as $settings_map_instance ) {
@@ -264,7 +264,7 @@ class SettingsMapHelper {
 	 *
 	 * @return AbstractDataModel|null
 	 */
-	protected function get_payment_settings_model() : ?AbstractDataModel {
+	protected function get_payment_settings_model(): ?AbstractDataModel {
 		foreach ( $this->settings_map as $settings_map_instance ) {
 			if ( $settings_map_instance->get_model() instanceof PaymentSettings ) {
 				return $settings_map_instance->get_model();

--- a/modules/ppcp-googlepay/extensions.php
+++ b/modules/ppcp-googlepay/extensions.php
@@ -31,7 +31,7 @@ return array(
 		$is_available = $container->get( 'googlepay.available' );
 		$is_referral  = $container->get( 'googlepay.is_referral' );
 
-		$insert_after = function( array $array, string $key, array $new ): array {
+		$insert_after = function ( array $array, string $key, array $new ): array {
 			$keys = array_keys( $array );
 			$index = array_search( $key, $keys, true );
 			$pos = false === $index ? count( $array ) : $index + 1;

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -33,11 +33,11 @@ return array(
 		$apm_applies = $container->get( 'googlepay.helpers.apm-applies' );
 		assert( $apm_applies instanceof ApmApplies );
 
-		return static function () use ( $apm_applies ) : bool {
+		return static function () use ( $apm_applies ): bool {
 			return $apm_applies->for_country() && $apm_applies->for_currency() && $apm_applies->for_merchant();
 		};
 	},
-	'googlepay.helpers.apm-applies'             => static function ( ContainerInterface $container ) : ApmApplies {
+	'googlepay.helpers.apm-applies'             => static function ( ContainerInterface $container ): ApmApplies {
 		return new ApmApplies(
 			$container->get( 'googlepay.supported-countries' ),
 			$container->get( 'googlepay.supported-currencies' ),
@@ -76,7 +76,7 @@ return array(
 	},
 
 	'googlepay.helpers.apm-product-status'      => SingletonDecorator::make(
-		static function( ContainerInterface $container ): ApmProductStatus {
+		static function ( ContainerInterface $container ): ApmProductStatus {
 			return new ApmProductStatus(
 				$container->get( 'wcgateway.settings' ),
 				$container->get( 'api.endpoint.partners' ),
@@ -89,7 +89,7 @@ return array(
 	/**
 	 * The list of which countries can be used for GooglePay.
 	 */
-	'googlepay.supported-countries'             => static function ( ContainerInterface $container ) : array {
+	'googlepay.supported-countries'             => static function ( ContainerInterface $container ): array {
 		/**
 		 * Returns which countries can be used for GooglePay.
 		 */
@@ -145,7 +145,7 @@ return array(
 	/**
 	 * The list of which currencies can be used for GooglePay.
 	 */
-	'googlepay.supported-currencies'            => static function ( ContainerInterface $container ) : array {
+	'googlepay.supported-currencies'            => static function ( ContainerInterface $container ): array {
 		/**
 		 * Returns which currencies can be used for GooglePay.
 		 */

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -275,7 +275,7 @@ class Button implements ButtonInterface {
 		 */
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
-			function( $components ) {
+			function ( $components ) {
 				$components[] = 'googlepay';
 				return $components;
 			}
@@ -369,7 +369,7 @@ class Button implements ButtonInterface {
 	 *
 	 * @return void
 	 */
-	protected function hide_gateway_until_eligible() : void {
+	protected function hide_gateway_until_eligible(): void {
 		?>
 		<style data-hide-gateway='<?php echo esc_attr( GooglePayGateway::ID ); ?>'>
 			.wc_payment_method.payment_method_ppcp-googlepay {

--- a/modules/ppcp-googlepay/src/Endpoint/UpdatePaymentDataEndpoint.php
+++ b/modules/ppcp-googlepay/src/Endpoint/UpdatePaymentDataEndpoint.php
@@ -219,5 +219,4 @@ class UpdatePaymentDataEndpoint {
 			WC()->session->set( 'chosen_shipping_methods', array( $rate_id ) );
 		}
 	}
-
 }

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -54,7 +54,7 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function( ?Settings $settings = null ) use ( $c ): void {
+			function ( ?Settings $settings = null ) use ( $c ): void {
 				$apm_status = $c->get( 'googlepay.helpers.apm-product-status' );
 				assert( $apm_status instanceof ApmProductStatus );
 				$apm_status->clear( $settings );
@@ -149,7 +149,7 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				// Registers buttons on blocks pages.
 				add_action(
 					'woocommerce_blocks_payment_method_type_registration',
-					function( PaymentMethodRegistry $payment_method_registry ) use ( $c, $button ): void {
+					function ( PaymentMethodRegistry $payment_method_registry ) use ( $c, $button ): void {
 						if ( SettingsModule::should_use_the_old_ui() && ! $button->is_enabled() ) {
 							return;
 						}
@@ -161,7 +161,7 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				// Adds GooglePay component to the backend button preview settings.
 				add_action(
 					'woocommerce_paypal_payments_admin_gateway_settings',
-					function( array $settings ) use ( $c ): array {
+					function ( array $settings ) use ( $c ): array {
 						if ( is_array( $settings['components'] ) ) {
 							$settings['components'][] = 'googlepay';
 						}
@@ -178,7 +178,6 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 						$endpoint->handle_request();
 					}
 				);
-
 			},
 			1
 		);
@@ -225,7 +224,7 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		add_filter(
 			'woocommerce_paypal_payments_selected_button_locations',
-			function( array $locations, string $setting_name ): array {
+			function ( array $locations, string $setting_name ): array {
 				$gateway = WC()->payment_gateways()->payment_gateways()[ GooglePayGateway::ID ] ?? '';
 				if ( $gateway && $gateway->enabled === 'yes' && $setting_name === 'smart_button_locations' ) {
 					$locations[] = 'checkout';
@@ -255,7 +254,7 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		add_filter(
 			'ppcp_create_order_request_body_data',
-			static function ( array $data, string $payment_method, array $request ) use ( $c ) : array {
+			static function ( array $data, string $payment_method, array $request ) use ( $c ): array {
 
 				$funding_source = $request['funding_source'] ?? '';
 				if ( $payment_method !== GooglePayGateway::ID && $funding_source !== 'googlepay' ) {

--- a/modules/ppcp-googlepay/src/Helper/ApmApplies.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmApplies.php
@@ -89,7 +89,7 @@ class ApmApplies {
 	 *
 	 * @return bool
 	 */
-	public function for_merchant() : bool {
+	public function for_merchant(): bool {
 		return apply_filters(
 			'woocommerce_paypal_payments_is_eligible_for_googlepay',
 			true

--- a/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
@@ -54,7 +54,7 @@ class ApmProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_local_state() : ?bool {
+	protected function check_local_state(): ?bool {
 		$status_override = apply_filters( 'woocommerce_paypal_payments_google_pay_product_status', null );
 		if ( null !== $status_override ) {
 			return $status_override;
@@ -68,7 +68,7 @@ class ApmProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ) : bool {
+	protected function check_active_state( SellerStatus $seller_status ): bool {
 		// Check the seller status for the intended capability.
 		$has_capability = false;
 		foreach ( $seller_status->products() as $product ) {
@@ -101,7 +101,7 @@ class ApmProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ): void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-googlepay/src/Helper/AvailabilityNotice.php
+++ b/modules/ppcp-googlepay/src/Helper/AvailabilityNotice.php
@@ -153,5 +153,4 @@ class AvailabilityNotice {
 			}
 		);
 	}
-
 }

--- a/modules/ppcp-local-alternative-payment-methods/services.php
+++ b/modules/ppcp-local-alternative-payment-methods/services.php
@@ -16,7 +16,7 @@ return array(
 	'ppcp-local-apms.url'                       => static function ( ContainerInterface $container ): string {
 		return plugins_url( '/modules/ppcp-local-alternative-payment-methods/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
-	'ppcp-local-apms.payment-methods'           => static function( ContainerInterface $container ): array {
+	'ppcp-local-apms.payment-methods'           => static function ( ContainerInterface $container ): array {
 		return array(
 			'bancontact' => array(
 				'id'         => BancontactGateway::ID,
@@ -140,56 +140,56 @@ return array(
 			$container->get( 'wcgateway.builder.experience-context' )
 		);
 	},
-	'ppcp-local-apms.bancontact.payment-method' => static function( ContainerInterface $container ): BancontactPaymentMethod {
+	'ppcp-local-apms.bancontact.payment-method' => static function ( ContainerInterface $container ): BancontactPaymentMethod {
 		return new BancontactPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.bancontact.wc-gateway' )
 		);
 	},
-	'ppcp-local-apms.blik.payment-method'       => static function( ContainerInterface $container ): BlikPaymentMethod {
+	'ppcp-local-apms.blik.payment-method'       => static function ( ContainerInterface $container ): BlikPaymentMethod {
 		return new BlikPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.blik.wc-gateway' )
 		);
 	},
-	'ppcp-local-apms.eps.payment-method'        => static function( ContainerInterface $container ): EPSPaymentMethod {
+	'ppcp-local-apms.eps.payment-method'        => static function ( ContainerInterface $container ): EPSPaymentMethod {
 		return new EPSPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.eps.wc-gateway' )
 		);
 	},
-	'ppcp-local-apms.ideal.payment-method'      => static function( ContainerInterface $container ): IDealPaymentMethod {
+	'ppcp-local-apms.ideal.payment-method'      => static function ( ContainerInterface $container ): IDealPaymentMethod {
 		return new IDealPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.ideal.wc-gateway' )
 		);
 	},
-	'ppcp-local-apms.mybank.payment-method'     => static function( ContainerInterface $container ): MyBankPaymentMethod {
+	'ppcp-local-apms.mybank.payment-method'     => static function ( ContainerInterface $container ): MyBankPaymentMethod {
 		return new MyBankPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.mybank.wc-gateway' )
 		);
 	},
-	'ppcp-local-apms.p24.payment-method'        => static function( ContainerInterface $container ): P24PaymentMethod {
+	'ppcp-local-apms.p24.payment-method'        => static function ( ContainerInterface $container ): P24PaymentMethod {
 		return new P24PaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.p24.wc-gateway' )
 		);
 	},
-	'ppcp-local-apms.trustly.payment-method'    => static function( ContainerInterface $container ): TrustlyPaymentMethod {
+	'ppcp-local-apms.trustly.payment-method'    => static function ( ContainerInterface $container ): TrustlyPaymentMethod {
 		return new TrustlyPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.trustly.wc-gateway' )
 		);
 	},
-	'ppcp-local-apms.multibanco.payment-method' => static function( ContainerInterface $container ): MultibancoPaymentMethod {
+	'ppcp-local-apms.multibanco.payment-method' => static function ( ContainerInterface $container ): MultibancoPaymentMethod {
 		return new MultibancoPaymentMethod(
 			$container->get( 'ppcp-local-apms.url' ),
 			$container->get( 'ppcp.asset-version' ),

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -28,21 +28,21 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 	/**
 	 * {@inheritDoc}
 	 */
-	public function services() : array {
+	public function services(): array {
 		return require __DIR__ . '/../services.php';
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function extensions() : array {
+	public function extensions(): array {
 		return require __DIR__ . '/../extensions.php';
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function run( ContainerInterface $c ) : bool {
+	public function run( ContainerInterface $c ): bool {
 		add_action( 'after_setup_theme', fn() => $this->run_with_translations( $c ) );
 
 		return true;
@@ -56,7 +56,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 	 * @param ContainerInterface $c The DI container.
 	 * @return void
 	 */
-	private function run_with_translations( ContainerInterface $c ) : void {
+	private function run_with_translations( ContainerInterface $c ): void {
 		// When Local APMs are disabled, none of the following hooks are needed.
 		if ( ! $this->should_add_local_apm_gateways( $c ) ) {
 			return;
@@ -131,7 +131,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 		 */
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
-			function( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
+			function ( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				$payment_methods = $c->get( 'ppcp-local-apms.payment-methods' );
 				foreach ( $payment_methods as $key => $value ) {
 					$payment_method_registry->register( $c->get( 'ppcp-local-apms.' . $key . '.payment-method' ) );
@@ -159,7 +159,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $order_id ) use ( $c ) {
+			function ( $order_id ) use ( $c ) {
 				$order = wc_get_order( $order_id );
 				if ( ! $order instanceof WC_Order ) {
 					return;
@@ -191,7 +191,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 
 		add_action(
 			'woocommerce_paypal_payments_payment_capture_completed_webhook_handler',
-			function( WC_Order $wc_order, string $order_id ) use ( $c ) {
+			function ( WC_Order $wc_order, string $order_id ) use ( $c ) {
 				$payment_methods = $c->get( 'ppcp-local-apms.payment-methods' );
 				if (
 				! $this->is_local_apm( $wc_order->get_payment_method(), $payment_methods )
@@ -232,7 +232,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 	 * @param ContainerInterface $container Container.
 	 * @return bool
 	 */
-	private function should_add_local_apm_gateways( ContainerInterface $container ) : bool {
+	private function should_add_local_apm_gateways( ContainerInterface $container ): bool {
 		// APMs are only available after merchant onboarding is completed.
 		$is_connected = $container->get( 'settings.flag.is-connected' );
 		if ( ! $is_connected ) {

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalApmProductStatus.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalApmProductStatus.php
@@ -52,7 +52,7 @@ class LocalApmProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_local_state() : ?bool {
+	protected function check_local_state(): ?bool {
 		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
 			return wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
 		}
@@ -61,7 +61,7 @@ class LocalApmProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ) : bool {
+	protected function check_active_state( SellerStatus $seller_status ): bool {
 		$has_capability = false;
 
 		foreach ( $seller_status->capabilities() as $capability ) {
@@ -86,7 +86,7 @@ class LocalApmProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ): void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-onboarding/services.php
+++ b/modules/ppcp-onboarding/services.php
@@ -24,7 +24,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
 
 return array(
-	'api.paypal-host'                    => function( ContainerInterface $container ) : string {
+	'api.paypal-host'                    => function ( ContainerInterface $container ): string {
 		$environment = $container->get( 'settings.environment' );
 		/**
 		 * The current environment.
@@ -35,18 +35,16 @@ return array(
 			return $container->get( 'api.paypal-host-sandbox' );
 		}
 		return $container->get( 'api.paypal-host-production' );
-
 	},
-	'api.paypal-website-url'             => function( ContainerInterface $container ) : string {
+	'api.paypal-website-url'             => function ( ContainerInterface $container ): string {
 		$environment = $container->get( 'settings.environment' );
 		assert( $environment instanceof Environment );
 		if ( $environment->current_environment_is( Environment::SANDBOX ) ) {
 			return $container->get( 'api.paypal-website-url-sandbox' );
 		}
 		return $container->get( 'api.paypal-website-url-production' );
-
 	},
-	'onboarding.state'                   => function( ContainerInterface $container ) : State {
+	'onboarding.state'                   => function ( ContainerInterface $container ): State {
 		$settings    = $container->get( 'wcgateway.settings' );
 		return new State( $settings );
 	},
@@ -55,7 +53,7 @@ return array(
 	 * (onboarding/connected) and connection-aware environment checks.
 	 * This is the preferred solution to check environment and connection state.
 	 */
-	'settings.connection-state'          => static function ( ContainerInterface $container ) : ConnectionState {
+	'settings.connection-state'          => static function ( ContainerInterface $container ): ConnectionState {
 		$state = $container->get( 'onboarding.state' );
 		assert( $state instanceof State );
 
@@ -74,7 +72,7 @@ return array(
 	 *
 	 * @deprecated Use 'settings.connection-state' instead.
 	 */
-	'settings.flag.is-connected'         => static function ( ContainerInterface $container ) : bool {
+	'settings.flag.is-connected'         => static function ( ContainerInterface $container ): bool {
 		$state = $container->get( 'settings.connection-state' );
 		assert( $state instanceof ConnectionState );
 
@@ -86,7 +84,7 @@ return array(
 	 *
 	 * @deprecated Use 'settings.connection-state' instead.
 	 */
-	'settings.flag.is-sandbox'           => static function ( ContainerInterface $container ) : bool {
+	'settings.flag.is-sandbox'           => static function ( ContainerInterface $container ): bool {
 		$state = $container->get( 'settings.connection-state' );
 		assert( $state instanceof ConnectionState );
 
@@ -97,19 +95,19 @@ return array(
 	 *
 	 * @deprecated Directly use 'settings.connection-state' instead of this.
 	 */
-	'settings.environment'               => function ( ContainerInterface $container ) : Environment {
+	'settings.environment'               => function ( ContainerInterface $container ): Environment {
 		$state = $container->get( 'settings.connection-state' );
 		assert( $state instanceof ConnectionState );
 
 		return $state->get_environment();
 	},
-	'settings.merchant-details'          => static function ( ContainerInterface $container ) : MerchantDetails {
+	'settings.merchant-details'          => static function ( ContainerInterface $container ): MerchantDetails {
 		$woo_country        = $container->get( 'api.shop.country' );
 		$eligibility_checks = $container->get( 'wcgateway.feature-eligibility.list' );
 
 		return new MerchantDetails( $woo_country, $woo_country, $eligibility_checks );
 	},
-	'onboarding.assets'                  => function( ContainerInterface $container ) : OnboardingAssets {
+	'onboarding.assets'                  => function ( ContainerInterface $container ): OnboardingAssets {
 		$state                 = $container->get( 'onboarding.state' );
 		$login_seller_endpoint = $container->get( 'onboarding.endpoint.login-seller' );
 		return new OnboardingAssets(
@@ -126,7 +124,7 @@ return array(
 		return plugins_url( '/modules/ppcp-onboarding/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
 
-	'onboarding.endpoint.login-seller'   => static function ( ContainerInterface $container ) : LoginSellerEndpoint {
+	'onboarding.endpoint.login-seller'   => static function ( ContainerInterface $container ): LoginSellerEndpoint {
 
 		$request_data            = $container->get( 'button.request-data' );
 		$login_seller_production = $container->get( 'api.endpoint.login-seller-production' );
@@ -146,7 +144,7 @@ return array(
 			new Cache( 'ppcp-client-credentials-cache' )
 		);
 	},
-	'onboarding.endpoint.pui'            => static function( ContainerInterface $container ) : UpdateSignupLinksEndpoint {
+	'onboarding.endpoint.pui'            => static function ( ContainerInterface $container ): UpdateSignupLinksEndpoint {
 		return new UpdateSignupLinksEndpoint(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'button.request-data' ),
@@ -156,7 +154,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'onboarding.signup-link-cache'       => static function( ContainerInterface $container ): Cache {
+	'onboarding.signup-link-cache'       => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-signup-link' );
 	},
 	'onboarding.signup-link-ids'         => static function ( ContainerInterface $container ): array {
@@ -167,12 +165,12 @@ return array(
 			'sandbox-express_checkout',
 		);
 	},
-	'onboarding.render-send-only-notice' => static function( ContainerInterface $container ) {
+	'onboarding.render-send-only-notice' => static function ( ContainerInterface $container ) {
 		return new OnboardingSendOnlyNoticeRenderer(
 			$container->get( 'wcgateway.send-only-message' )
 		);
 	},
-	'onboarding.render'                  => static function ( ContainerInterface $container ) : OnboardingRenderer {
+	'onboarding.render'                  => static function ( ContainerInterface $container ): OnboardingRenderer {
 		$partner_referrals         = $container->get( 'api.endpoint.partner-referrals-production' );
 		$partner_referrals_sandbox = $container->get( 'api.endpoint.partner-referrals-sandbox' );
 		$partner_referrals_data    = $container->get( 'api.repository.partner-referrals-data' );
@@ -188,14 +186,14 @@ return array(
 			$logger
 		);
 	},
-	'onboarding.render-options'          => static function ( ContainerInterface $container ) : OnboardingOptionsRenderer {
+	'onboarding.render-options'          => static function ( ContainerInterface $container ): OnboardingOptionsRenderer {
 		return new OnboardingOptionsRenderer(
 			$container->get( 'onboarding.url' ),
 			$container->get( 'api.shop.country' ),
 			$container->get( 'wcgateway.settings' )
 		);
 	},
-	'onboarding.rest'                    => static function( $container ) : OnboardingRESTController {
+	'onboarding.rest'                    => static function ( $container ): OnboardingRESTController {
 		return new OnboardingRESTController( $container );
 	},
 );

--- a/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
@@ -175,10 +175,8 @@ class LoginSellerEndpoint implements EndpointInterface {
 			}
 			if ( $accept_cards ) {
 				$funding_sources = array_diff( $funding_sources, array( 'card' ) );
-			} else {
-				if ( ! in_array( 'card', $funding_sources, true ) ) {
+			} elseif ( ! in_array( 'card', $funding_sources, true ) ) {
 					$funding_sources[] = 'card';
-				}
 			}
 			$this->settings->set( 'disable_funding', $funding_sources );
 

--- a/modules/ppcp-onboarding/src/Endpoint/UpdateSignupLinksEndpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/UpdateSignupLinksEndpoint.php
@@ -161,4 +161,3 @@ class UpdateSignupLinksEndpoint implements EndpointInterface {
 		return true;
 	}
 }
-

--- a/modules/ppcp-onboarding/src/Helper/OnboardingUrl.php
+++ b/modules/ppcp-onboarding/src/Helper/OnboardingUrl.php
@@ -396,5 +396,4 @@ class OnboardingUrl {
 			$this->previous_cache_ttl
 		);
 	}
-
 }

--- a/modules/ppcp-onboarding/src/OnboardingModule.php
+++ b/modules/ppcp-onboarding/src/OnboardingModule.php
@@ -47,7 +47,7 @@ class OnboardingModule implements ServiceModule, ExtendingModule, ExecutableModu
 
 		add_action(
 			'admin_enqueue_scripts',
-			function() use ( $c ) {
+			function () use ( $c ) {
 				if (
 					apply_filters(
 					// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores

--- a/modules/ppcp-onboarding/src/OnboardingRESTController.php
+++ b/modules/ppcp-onboarding/src/OnboardingRESTController.php
@@ -294,5 +294,4 @@ class OnboardingRESTController {
 
 		return $link;
 	}
-
 }

--- a/modules/ppcp-onboarding/src/State.php
+++ b/modules/ppcp-onboarding/src/State.php
@@ -77,7 +77,7 @@ class State {
 	 *
 	 * @return int
 	 */
-	public function sandbox_state() : int {
+	public function sandbox_state(): int {
 
 		return $this->state_by_keys(
 			array(
@@ -94,7 +94,7 @@ class State {
 	 *
 	 * @return int
 	 */
-	public function production_state() : int {
+	public function production_state(): int {
 
 		return $this->state_by_keys(
 			array(
@@ -112,7 +112,7 @@ class State {
 	 * @param int $state An onboarding state to translate.
 	 * @return string A string representing the state: "start" or "onboarded".
 	 */
-	public static function get_state_name( int $state ) : string {
+	public static function get_state_name( int $state ): string {
 		switch ( $state ) {
 			case self::STATE_START:
 				return 'start';
@@ -130,7 +130,7 @@ class State {
 	 *
 	 * @return int
 	 */
-	private function state_by_keys( array $onboarded_keys ) : int {
+	private function state_by_keys( array $onboarded_keys ): int {
 		foreach ( $onboarded_keys as $key ) {
 			if ( ! $this->settings->has( $key ) || ! $this->settings->get( $key ) ) {
 				return self::STATE_START;

--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -22,16 +22,16 @@ use WooCommerce\PayPalCommerce\OrderTracking\Assets\OrderEditPageAssets;
 use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 
 return array(
-	'order-tracking.assets'                           => function( ContainerInterface $container ) : OrderEditPageAssets {
+	'order-tracking.assets'                           => function ( ContainerInterface $container ): OrderEditPageAssets {
 		return new OrderEditPageAssets(
 			$container->get( 'order-tracking.module.url' ),
 			$container->get( 'ppcp.asset-version' )
 		);
 	},
-	'order-tracking.shipment.factory'                 => static function ( ContainerInterface $container ) : ShipmentFactoryInterface {
+	'order-tracking.shipment.factory'                 => static function ( ContainerInterface $container ): ShipmentFactoryInterface {
 		return new ShipmentFactory();
 	},
-	'order-tracking.endpoint.controller'              => static function ( ContainerInterface $container ) : OrderTrackingEndpoint {
+	'order-tracking.endpoint.controller'              => static function ( ContainerInterface $container ): OrderTrackingEndpoint {
 		return new OrderTrackingEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -41,7 +41,8 @@ use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
  */
 class OrderTrackingEndpoint {
 
-	use RequestTrait, TransactionIdHandlingTrait;
+	use RequestTrait;
+	use TransactionIdHandlingTrait;
 
 	const ENDPOINT = 'ppc-tracking-info';
 
@@ -171,7 +172,7 @@ class OrderTrackingEndpoint {
 	 *
 	 * @throws RuntimeException If problem adding.
 	 */
-	public function add_tracking_information( ShipmentInterface $shipment, int $order_id ) : void {
+	public function add_tracking_information( ShipmentInterface $shipment, int $order_id ): void {
 		$wc_order = wc_get_order( $order_id );
 		if ( ! $wc_order instanceof WC_Order ) {
 			return;
@@ -221,7 +222,7 @@ class OrderTrackingEndpoint {
 	 *
 	 * @throws RuntimeException If problem updating.
 	 */
-	public function update_tracking_information( ShipmentInterface $shipment, int $order_id ) : void {
+	public function update_tracking_information( ShipmentInterface $shipment, int $order_id ): void {
 		$host          = trailingslashit( $this->host );
 		$tracker_id    = $this->find_tracker_id( $shipment->capture_id(), $shipment->tracking_number() );
 		$url           = "{$host}v1/shipping/trackers/{$tracker_id}";
@@ -267,7 +268,7 @@ class OrderTrackingEndpoint {
 	 * @return ShipmentInterface|null The tracking information.
 	 * @throws RuntimeException If problem getting.
 	 */
-	public function get_tracking_information( int $wc_order_id, string $tracking_number ) : ?ShipmentInterface {
+	public function get_tracking_information( int $wc_order_id, string $tracking_number ): ?ShipmentInterface {
 		$wc_order = wc_get_order( $wc_order_id );
 		if ( ! $wc_order instanceof WC_Order ) {
 			return null;
@@ -316,7 +317,7 @@ class OrderTrackingEndpoint {
 	 * @return ShipmentInterface[] The list of shipments.
 	 * @throws RuntimeException If problem getting.
 	 */
-	public function list_tracking_information( int $wc_order_id ) : ?array {
+	public function list_tracking_information( int $wc_order_id ): ?array {
 		$wc_order = wc_get_order( $wc_order_id );
 		if ( ! $wc_order instanceof WC_Order ) {
 			return array();

--- a/modules/ppcp-order-tracking/src/Integration/DhlShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/DhlShipmentIntegration.php
@@ -69,7 +69,7 @@ class DhlShipmentIntegration implements Integration {
 	public function integrate(): void {
 		add_action(
 			'pr_save_dhl_label_tracking',
-			function( int $order_id, array $tracking_details ) {
+			function ( int $order_id, array $tracking_details ) {
 				try {
 					$wc_order = wc_get_order( $order_id );
 					if ( ! is_a( $wc_order, WC_Order::class ) ) {

--- a/modules/ppcp-order-tracking/src/Integration/GermanizedShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/GermanizedShipmentIntegration.php
@@ -72,7 +72,7 @@ class GermanizedShipmentIntegration implements Integration {
 
 		add_action(
 			'woocommerce_gzd_shipment_status_shipped',
-			function( int $shipment_id, Shipment $shipment ) {
+			function ( int $shipment_id, Shipment $shipment ) {
 				try {
 					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_gzd_tracking', true ) ) {
 						return;

--- a/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/ShipStationIntegration.php
@@ -75,7 +75,7 @@ class ShipStationIntegration implements Integration {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $wc_order, array $data ) {
+			function ( $wc_order, array $data ) {
 				try {
 					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_ship_station_tracking', true ) ) {
 						return;

--- a/modules/ppcp-order-tracking/src/Integration/ShipmentTrackingIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/ShipmentTrackingIntegration.php
@@ -72,7 +72,7 @@ class ShipmentTrackingIntegration implements Integration {
 
 		add_action(
 			'wp_ajax_wc_shipment_tracking_save_form',
-			function() {
+			function () {
 				try {
 					check_ajax_referer( 'create-tracking-item', 'security', true );
 
@@ -110,7 +110,7 @@ class ShipmentTrackingIntegration implements Integration {
 		 */
 		add_filter(
 			'woocommerce_rest_prepare_order_shipment_tracking',
-			function( WP_REST_Response $response, array $tracking_item, WP_REST_Request $request ): WP_REST_Response {
+			function ( WP_REST_Response $response, array $tracking_item, WP_REST_Request $request ): WP_REST_Response {
 				try {
 					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_wc_shipment_tracking', true ) ) {
 						return $response;

--- a/modules/ppcp-order-tracking/src/Integration/WcShippingTaxIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/WcShippingTaxIntegration.php
@@ -27,7 +27,8 @@ use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
  */
 class WcShippingTaxIntegration implements Integration {
 
-	use TrackingAvailabilityTrait, TransactionIdHandlingTrait;
+	use TrackingAvailabilityTrait;
+	use TransactionIdHandlingTrait;
 
 	/**
 	 * The shipment factory.
@@ -74,7 +75,7 @@ class WcShippingTaxIntegration implements Integration {
 
 		add_filter(
 			'rest_post_dispatch',
-			function( WP_HTTP_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_HTTP_Response {
+			function ( WP_HTTP_Response $response, WP_REST_Server $server, WP_REST_Request $request ): WP_HTTP_Response {
 				try {
 					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_wc_shipping_tax', true ) ) {
 						return $response;
@@ -122,7 +123,6 @@ class WcShippingTaxIntegration implements Integration {
 			10,
 			3
 		);
-
 	}
 
 	/**

--- a/modules/ppcp-order-tracking/src/Integration/YithShipmentIntegration.php
+++ b/modules/ppcp-order-tracking/src/Integration/YithShipmentIntegration.php
@@ -70,7 +70,7 @@ class YithShipmentIntegration implements Integration {
 
 		add_action(
 			'woocommerce_process_shop_order_meta',
-			function( int $order_id ) {
+			function ( int $order_id ) {
 				try {
 					if ( ! apply_filters( 'woocommerce_paypal_payments_sync_ywot_tracking', true ) ) {
 						return;

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -30,7 +30,8 @@ use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
  */
 class OrderTrackingModule implements ServiceModule, ExtendingModule, ExecutableModule {
 	use ModuleClassNameIdTrait;
-	use TrackingAvailabilityTrait, TransactionIdHandlingTrait;
+	use TrackingAvailabilityTrait;
+	use TransactionIdHandlingTrait;
 
 	public const PPCP_TRACKING_INFO_META_NAME = '_ppcp_paypal_tracking_info_meta_name';
 
@@ -58,7 +59,7 @@ class OrderTrackingModule implements ServiceModule, ExtendingModule, ExecutableM
 
 		add_action(
 			'wc_ajax_' . OrderTrackingEndpoint::ENDPOINT,
-			function() use ( $c ) {
+			function () use ( $c ) {
 				$c->get( 'order-tracking.endpoint.controller' )->handle_request();
 			}
 		);
@@ -68,7 +69,7 @@ class OrderTrackingModule implements ServiceModule, ExtendingModule, ExecutableM
 
 		add_action(
 			'init',
-			function() use ( $asset_loader, $c ) {
+			function () use ( $asset_loader, $c ) {
 				if ( ! $this->is_tracking_enabled( $c->get( 'api.bearer' ) ) ) {
 					return;
 				}
@@ -78,7 +79,7 @@ class OrderTrackingModule implements ServiceModule, ExtendingModule, ExecutableM
 		);
 		add_action(
 			'init',
-			function() use ( $asset_loader, $c ) {
+			function () use ( $asset_loader, $c ) {
 				if ( ! $this->is_tracking_enabled( $c->get( 'api.bearer' ) ) ) {
 					return;
 				}
@@ -98,7 +99,7 @@ class OrderTrackingModule implements ServiceModule, ExtendingModule, ExecutableM
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( string $post_type, $post_or_order_object ) use ( $c ) {
+			function ( string $post_type, $post_or_order_object ) use ( $c ) {
 				if ( ! $this->is_tracking_enabled( $c->get( 'api.bearer' ) ) ) {
 					return;
 				}

--- a/modules/ppcp-paylater-configurator/services.php
+++ b/modules/ppcp-paylater-configurator/services.php
@@ -37,7 +37,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'paylater-configurator.is-available'         => static function ( ContainerInterface $container ) : bool {
+	'paylater-configurator.is-available'         => static function ( ContainerInterface $container ): bool {
 		// Test, if Pay-Later is available; depends on the shop country and Vaulting status.
 		$messages_apply = $container->get( 'button.helper.messages-apply' );
 		assert( $messages_apply instanceof MessagesApply );
@@ -55,7 +55,7 @@ return array(
 		// Pay Later Messaging is available if vaulting is not enabled, the shop country is supported, and is eligible for ACDC.
 		return ! $vault_enabled && $messages_apply->for_country() && $dcc_product_status->is_active() && $card_fields_eligible;
 	},
-	'paylater-configurator.messaging-locations'  => static function ( ContainerInterface $container ) : array {
+	'paylater-configurator.messaging-locations'  => static function ( ContainerInterface $container ): array {
 		// Get an array of locations that display the Pay-Later message.
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );

--- a/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
+++ b/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
@@ -56,7 +56,7 @@ class PayLaterConfiguratorModule implements ServiceModule, ExtendingModule, Exec
 	/**
 	 * {@inheritDoc}
 	 */
-	public function run( ContainerInterface $c ) : bool {
+	public function run( ContainerInterface $c ): bool {
 
 		add_action(
 			'init',
@@ -171,7 +171,7 @@ class PayLaterConfiguratorModule implements ServiceModule, ExtendingModule, Exec
 	 *
 	 * @return void
 	 */
-	private static function add_paylater_update_notice( array $message_locations, bool $is_settings_page, string $current_page_id ) : void {
+	private static function add_paylater_update_notice( array $message_locations, bool $is_settings_page, string $current_page_id ): void {
 		// The message must be registered on any WC-Settings page, except for the Pay Later page.
 		if ( ! $is_settings_page || Settings::PAY_LATER_TAB_ID === $current_page_id ) {
 			return;
@@ -192,7 +192,7 @@ class PayLaterConfiguratorModule implements ServiceModule, ExtendingModule, Exec
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			static function ( $notices ) : array {
+			static function ( $notices ): array {
 				$settings_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' );
 
 				$message = sprintf(

--- a/modules/ppcp-paylater-wc-blocks/services.php
+++ b/modules/ppcp-paylater-wc-blocks/services.php
@@ -47,4 +47,3 @@ return array(
 		);
 	},
 );
-

--- a/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php
+++ b/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php
@@ -71,7 +71,7 @@ class PayLaterWCBlocksModule implements ServiceModule, ExtendingModule, Executab
 	 * @param string         $location The location to check.
 	 * @return bool true if the placement is enabled, otherwise false.
 	 */
-	public static function is_placement_enabled( SettingsStatus $settings_status, string $location ) : bool {
+	public static function is_placement_enabled( SettingsStatus $settings_status, string $location ): bool {
 		return self::is_block_enabled( $settings_status, $location );
 	}
 
@@ -80,7 +80,7 @@ class PayLaterWCBlocksModule implements ServiceModule, ExtendingModule, Executab
 	 *
 	 * @return bool true if the under cart totals placement is enabled, otherwise false.
 	 */
-	public function is_under_cart_totals_placement_enabled() : bool {
+	public function is_under_cart_totals_placement_enabled(): bool {
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_wc_blocks_cart_under_totals_enabled',

--- a/modules/ppcp-paypal-subscriptions/services.php
+++ b/modules/ppcp-paypal-subscriptions/services.php
@@ -18,7 +18,7 @@ return array(
 			$container->get( 'api.endpoint.billing-plans' )
 		);
 	},
-	'paypal-subscriptions.api-handler'              => static function( ContainerInterface $container ): SubscriptionsApiHandler {
+	'paypal-subscriptions.api-handler'              => static function ( ContainerInterface $container ): SubscriptionsApiHandler {
 		return new SubscriptionsApiHandler(
 			$container->get( 'api.endpoint.catalog-products' ),
 			$container->get( 'api.factory.product' ),

--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -157,7 +157,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $product_id ) use ( $c ) {
+			function ( $product_id ) use ( $c ) {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
@@ -250,7 +250,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $variation_id ) use ( $c ) {
+			function ( $variation_id ) use ( $c ) {
 				// phpcs:ignore WordPress.Security.NonceVerification
 				$wcsnonce_save_variations = wc_clean( wp_unslash( $_POST['_wcsnonce_save_variations'] ?? '' ) );
 
@@ -285,7 +285,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $id ) use ( $c ) {
+			function ( $id ) use ( $c ) {
 				$subscription = wcs_get_subscription( $id );
 				if ( $subscription === false ) {
 					return;
@@ -309,7 +309,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 		 */
 		add_action(
 			'woocommerce_subscription_status_updated',
-			function( WC_Subscription $subscription ) use ( $c ) {
+			function ( WC_Subscription $subscription ) use ( $c ) {
 				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
 				if ( ! $subscription_id ) {
 					return;
@@ -329,7 +329,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $subscription ) use ( $c ) {
+			function ( $subscription ) use ( $c ) {
 				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
 				if ( $subscription_id ) {
 					$environment = $c->get( 'settings.environment' );
@@ -353,7 +353,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $query, $query_vars ): array {
+			function ( $query, $query_vars ): array {
 				if ( ! empty( $query_vars['ppcp_subscription'] ) ) {
 					$query['meta_query'][] = array(
 						'key'   => 'ppcp_subscription',
@@ -374,7 +374,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $subscription ) use ( $c ) {
+			function ( $subscription ) use ( $c ) {
 				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
 				if ( $subscription_id ) {
 					$subscriptions_endpoint = $c->get( 'api.endpoint.billing-subscriptions' );
@@ -402,7 +402,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $subscription ) use ( $c ) {
+			function ( $subscription ) use ( $c ) {
 				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
 				if ( $subscription_id ) {
 					$subscriptions_endpoint = $c->get( 'api.endpoint.billing-subscriptions' );
@@ -425,7 +425,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 
 		add_action(
 			'woocommerce_product_options_general_product_data',
-			function() use ( $c ) {
+			function () use ( $c ) {
 				if ( wcs_is_manual_renewal_enabled() ) {
 					return;
 				}
@@ -465,7 +465,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $loop, $variation_data, $variation ) use ( $c ) {
+			function ( $loop, $variation_data, $variation ) use ( $c ) {
 				if ( wcs_is_manual_renewal_enabled() ) {
 					return;
 				}
@@ -499,7 +499,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $hook ) use ( $c ) {
+			function ( $hook ) use ( $c ) {
 				if ( ! is_string( $hook ) || wcs_is_manual_renewal_enabled() ) {
 					return;
 				}
@@ -551,7 +551,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 
 		add_action(
 			'wc_ajax_' . DeactivatePlanEndpoint::ENDPOINT,
-			function() use ( $c ) {
+			function () use ( $c ) {
 				$c->get( 'paypal-subscriptions.deactivate-plan-endpoint' )->handle_request();
 			}
 		);
@@ -563,7 +563,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( string $post_type, $post_or_order_object ) use ( $c ) {
+			function ( string $post_type, $post_or_order_object ) use ( $c ) {
 				if ( ! function_exists( 'wcs_get_subscription' ) ) {
 					return;
 				}
@@ -594,7 +594,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 				add_meta_box(
 					'ppcp_paypal_subscription',
 					__( 'PayPal Subscription', 'woocommerce-paypal-payments' ),
-					function() use ( $subscription_id, $host ) {
+					function () use ( $subscription_id, $host ) {
 						$url = trailingslashit( $host ) . 'billing/subscriptions/' . $subscription_id;
 						echo '<p>' . esc_html__( 'This subscription is linked to a PayPal Subscription, Cancel it to unlink.', 'woocommerce-paypal-payments' ) . '</p>';
 						echo '<p><strong>' . esc_html__( 'Subscription:', 'woocommerce-paypal-payments' ) . '</strong> <a href="' . esc_url( $url ) . '" target="_blank">' . esc_attr( $subscription_id ) . '</a></p>';
@@ -602,7 +602,6 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 					$post_type,
 					'side'
 				);
-
 			},
 			30,
 			2

--- a/modules/ppcp-paypal-subscriptions/src/SubscriptionsApiHandler.php
+++ b/modules/ppcp-paypal-subscriptions/src/SubscriptionsApiHandler.php
@@ -260,7 +260,7 @@ class SubscriptionsApiHandler {
 				1
 			) )->to_array();
 
-			$sequence++;
+			++$sequence;
 		}
 
 		$interval        = $product->get_meta( '_subscription_period' );

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -27,17 +27,17 @@ return array(
 		$save_payment_methods_applies = $container->get( 'save-payment-methods.helpers.save-payment-methods-applies' );
 		assert( $save_payment_methods_applies instanceof SavePaymentMethodsApplies );
 
-		return static function () use ( $save_payment_methods_applies ) : bool {
+		return static function () use ( $save_payment_methods_applies ): bool {
 			return $save_payment_methods_applies->for_country() && $save_payment_methods_applies->for_merchant();
 		};
 	},
-	'save-payment-methods.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ) : SavePaymentMethodsApplies {
+	'save-payment-methods.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ): SavePaymentMethodsApplies {
 		return new SavePaymentMethodsApplies(
 			$container->get( 'save-payment-methods.supported-countries' ),
 			$container->get( 'api.shop.country' )
 		);
 	},
-	'save-payment-methods.supported-countries'           => static function ( ContainerInterface $container ) : array {
+	'save-payment-methods.supported-countries'           => static function ( ContainerInterface $container ): array {
 		if ( has_filter( 'woocommerce_paypal_payments_save_payment_methods_supported_country_currency_matrix' ) ) {
 			_deprecated_hook( 'woocommerce_paypal_payments_save_payment_methods_supported_country_currency_matrix', '3.0.0', 'woocommerce_paypal_payments_save_payment_methods_supported_countries', esc_attr__( 'Please use the new Hook to filter countries for saved payments in PayPal Payments.', 'woocommerce-paypal-payments' ) );
 		}

--- a/modules/ppcp-save-payment-methods/src/Helper/SavePaymentMethodsApplies.php
+++ b/modules/ppcp-save-payment-methods/src/Helper/SavePaymentMethodsApplies.php
@@ -57,7 +57,7 @@ class SavePaymentMethodsApplies {
 	 *
 	 * @return bool
 	 */
-	public function for_merchant() : bool {
+	public function for_merchant(): bool {
 		return apply_filters(
 			'woocommerce_paypal_payments_is_eligible_for_save_payment_methods',
 			true

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -66,7 +66,7 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
-			function() use ( $c ) {
+			function () use ( $c ) {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
@@ -391,7 +391,7 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 
 				add_action(
 					'woocommerce_paypal_payments_before_delete_payment_token',
-					function( string $token_id ) use ( $c ) {
+					function ( string $token_id ) use ( $c ) {
 						try {
 							$endpoint = $c->get( 'api.endpoint.payment-tokens' );
 							assert( $endpoint instanceof PaymentTokensEndpoint );
@@ -413,7 +413,7 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 
 				add_filter(
 					'woocommerce_paypal_payments_credit_card_gateway_supports',
-					function( array $supports ) use ( $c ): array {
+					function ( array $supports ) use ( $c ): array {
 						$settings = $c->get( 'wcgateway.settings' );
 						assert( $settings instanceof ContainerInterface );
 
@@ -428,7 +428,7 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 
 				add_filter(
 					'woocommerce_paypal_payments_save_payment_methods_eligible',
-					function() {
+					function () {
 						return true;
 					}
 				);

--- a/modules/ppcp-saved-payment-checker/extensions.php
+++ b/modules/ppcp-saved-payment-checker/extensions.php
@@ -18,7 +18,7 @@ return array(
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 		assert( $subscription_helper instanceof SubscriptionHelper );
 
-		$insert_after = function( array $array, string $key, array $new ): array {
+		$insert_after = function ( array $array, string $key, array $new ): array {
 			$keys = array_keys( $array );
 			$index = array_search( $key, $keys, true );
 			$pos = false === $index ? count( $array ) : $index + 1;

--- a/modules/ppcp-saved-payment-checker/services.php
+++ b/modules/ppcp-saved-payment-checker/services.php
@@ -12,7 +12,7 @@ namespace WooCommerce\PayPalCommerce\SavedPaymentChecker;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
-	'saved-payment-checker.payment-token-checker' => function( ContainerInterface $container ) : PaymentTokenChecker {
+	'saved-payment-checker.payment-token-checker' => function ( ContainerInterface $container ): PaymentTokenChecker {
 		return new PaymentTokenChecker(
 			$container->get( 'vaulting.repository.payment-token' ),
 			$container->get( 'api.repository.order' ),

--- a/modules/ppcp-saved-payment-checker/src/PaymentTokenChecker.php
+++ b/modules/ppcp-saved-payment-checker/src/PaymentTokenChecker.php
@@ -120,7 +120,7 @@ class PaymentTokenChecker {
 	 * @param string $intent The intent from settings when order was created.
 	 * @return void
 	 */
-	public function check_and_update( int $order_id, int $customer_id, string $intent ):void {
+	public function check_and_update( int $order_id, int $customer_id, string $intent ): void {
 		$wc_order = wc_get_order( $order_id );
 		if ( ! is_a( $wc_order, WC_Order::class ) ) {
 			return;

--- a/modules/ppcp-saved-payment-checker/src/SavedPaymentCheckerModule.php
+++ b/modules/ppcp-saved-payment-checker/src/SavedPaymentCheckerModule.php
@@ -48,7 +48,7 @@ class SavedPaymentCheckerModule implements ServiceModule, ExtendingModule, Execu
 		 */
 		add_filter(
 			'woocommerce_paypal_payments_order_intent',
-			function( string $intent ) use ( $c ) {
+			function ( string $intent ) use ( $c ) {
 				$subscription_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscription_helper instanceof SubscriptionHelper );
 
@@ -65,7 +65,7 @@ class SavedPaymentCheckerModule implements ServiceModule, ExtendingModule, Execu
 		 */
 		add_action(
 			'woocommerce_paypal_payments_before_handle_payment_success',
-			function( WC_Order $wc_order ) use ( $c ) {
+			function ( WC_Order $wc_order ) use ( $c ) {
 				$subscription_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscription_helper instanceof SubscriptionHelper );
 
@@ -98,7 +98,7 @@ class SavedPaymentCheckerModule implements ServiceModule, ExtendingModule, Execu
 		 */
 		add_action(
 			'woocommerce_email_before_order_table',
-			function( WC_Order $order ) use ( $c ) {
+			function ( WC_Order $order ) use ( $c ) {
 				$subscription_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscription_helper instanceof SubscriptionHelper );
 				$logger = $c->get( 'woocommerce.logger.woocommerce' );
@@ -124,7 +124,7 @@ class SavedPaymentCheckerModule implements ServiceModule, ExtendingModule, Execu
 		 */
 		add_action(
 			'woocommerce_email_after_order_table',
-			function( WC_Order $order ) use ( $c ) {
+			function ( WC_Order $order ) use ( $c ) {
 				$subscription_helper = $c->get( 'wc-subscriptions.helper' );
 				assert( $subscription_helper instanceof SubscriptionHelper );
 				$logger = $c->get( 'woocommerce.logger.woocommerce' );

--- a/modules/ppcp-session/services.php
+++ b/modules/ppcp-session/services.php
@@ -14,16 +14,16 @@ use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 
 return array(
-	'session.handler'                 => function ( ContainerInterface $container ) : SessionHandler {
+	'session.handler'                 => function ( ContainerInterface $container ): SessionHandler {
 		return new SessionHandler();
 	},
-	'session.cancellation.view'       => function ( ContainerInterface $container ) : CancelView {
+	'session.cancellation.view'       => function ( ContainerInterface $container ): CancelView {
 		return new CancelView(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'wcgateway.funding-source.renderer' )
 		);
 	},
-	'session.cancellation.controller' => function ( ContainerInterface $container ) : CancelController {
+	'session.cancellation.controller' => function ( ContainerInterface $container ): CancelController {
 		return new CancelController(
 			$container->get( 'session.handler' ),
 			$container->get( 'session.cancellation.view' )

--- a/modules/ppcp-session/src/SessionHandler.php
+++ b/modules/ppcp-session/src/SessionHandler.php
@@ -109,7 +109,7 @@ class SessionHandler {
 	 *
 	 * @return string
 	 */
-	public function bn_code() : string {
+	public function bn_code(): string {
 		$this->load_session();
 
 		return $this->bn_code;
@@ -120,7 +120,7 @@ class SessionHandler {
 	 *
 	 * @param string $bn_code The new BN Code.
 	 */
-	public function replace_bn_code( string $bn_code ) : void {
+	public function replace_bn_code( string $bn_code ): void {
 		$this->load_session();
 
 		$this->bn_code = $bn_code;
@@ -157,7 +157,7 @@ class SessionHandler {
 	 *
 	 * @return int
 	 */
-	public function insufficient_funding_tries() : int {
+	public function insufficient_funding_tries(): int {
 		$this->load_session();
 
 		return $this->insufficient_funding_tries;
@@ -169,7 +169,7 @@ class SessionHandler {
 	public function increment_insufficient_funding_tries(): void {
 		$this->load_session();
 
-		$this->insufficient_funding_tries++;
+		++$this->insufficient_funding_tries;
 
 		$this->store_session();
 	}
@@ -179,7 +179,7 @@ class SessionHandler {
 	 *
 	 * @return SessionHandler
 	 */
-	public function destroy_session_data() : SessionHandler {
+	public function destroy_session_data(): SessionHandler {
 		$this->order                      = null;
 		$this->bn_code                    = '';
 		$this->insufficient_funding_tries = 0;

--- a/modules/ppcp-settings/module.php
+++ b/modules/ppcp-settings/module.php
@@ -9,6 +9,6 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings;
 
-return static function () : SettingsModule {
+return static function (): SettingsModule {
 	return new SettingsModule();
 };

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -79,10 +79,10 @@ use WooCommerce\PayPalCommerce\Settings\Service\InternalRestService;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
 
 $services = array(
-	'settings.url'                                        => static function ( ContainerInterface $container ) : string {
+	'settings.url'                                        => static function ( ContainerInterface $container ): string {
 		return plugins_url( '/modules/ppcp-settings/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
-	'settings.data.onboarding'                            => static function ( ContainerInterface $container ) : OnboardingProfile {
+	'settings.data.onboarding'                            => static function ( ContainerInterface $container ): OnboardingProfile {
 		$can_use_casual_selling = $container->get( 'settings.casual-selling.eligible' );
 		$can_use_vaulting       = $container->has( 'save-payment-methods.eligible' ) && $container->get( 'save-payment-methods.eligible' );
 		$can_use_card_payments  = $container->has( 'card-fields.eligible' ) && $container->get( 'card-fields.eligible' );
@@ -102,22 +102,22 @@ $services = array(
 			$can_use_pay_later->for_country()
 		);
 	},
-	'settings.data.general'                               => static function ( ContainerInterface $container ) : GeneralSettings {
+	'settings.data.general'                               => static function ( ContainerInterface $container ): GeneralSettings {
 		return new GeneralSettings(
 			$container->get( 'api.shop.country' ),
 			$container->get( 'api.shop.currency.getter' )->get(),
 			$container->get( 'wcgateway.is-send-only-country' )
 		);
 	},
-	'settings.data.styling'                               => static function ( ContainerInterface $container ) : StylingSettings {
+	'settings.data.styling'                               => static function ( ContainerInterface $container ): StylingSettings {
 		return new StylingSettings(
 			$container->get( 'settings.service.sanitizer' )
 		);
 	},
-	'settings.data.payment'                               => static function ( ContainerInterface $container ) : PaymentSettings {
+	'settings.data.payment'                               => static function ( ContainerInterface $container ): PaymentSettings {
 		return new PaymentSettings();
 	},
-	'settings.data.settings'                              => static function ( ContainerInterface $container ) : SettingsModel {
+	'settings.data.settings'                              => static function ( ContainerInterface $container ): SettingsModel {
 		$environment = $container->get( 'settings.environment' );
 		assert( $environment instanceof Environment );
 
@@ -126,7 +126,7 @@ $services = array(
 			$environment->is_sandbox() ? $container->get( 'wcgateway.settings.invoice-prefix-random' ) : $container->get( 'wcgateway.settings.invoice-prefix' )
 		);
 	},
-	'settings.data.paylater-messaging'                    => static function ( ContainerInterface $container ) : array {
+	'settings.data.paylater-messaging'                    => static function ( ContainerInterface $container ): array {
 		// TODO: Create an AbstractDataModel wrapper for this configuration!
 
 		$config_factors = $container->get( 'paylater-configurator.factory.config' );
@@ -150,7 +150,7 @@ $services = array(
 	 *
 	 * @deprecated Directly use 'settings.connection-state' instead of this.
 	 */
-	'settings.environment'                                => static function ( ContainerInterface $container ) : Environment {
+	'settings.environment'                                => static function ( ContainerInterface $container ): Environment {
 		$state = $container->get( 'settings.connection-state' );
 		assert( $state instanceof ConnectionState );
 
@@ -162,7 +162,7 @@ $services = array(
 	 *
 	 * @deprecated Use 'settings.connection-state' instead.
 	 */
-	'settings.flag.is-connected'                          => static function ( ContainerInterface $container ) : bool {
+	'settings.flag.is-connected'                          => static function ( ContainerInterface $container ): bool {
 		$state = $container->get( 'settings.connection-state' );
 		assert( $state instanceof ConnectionState );
 
@@ -174,71 +174,71 @@ $services = array(
 	 *
 	 * @deprecated Use 'settings.connection-state' instead.
 	 */
-	'settings.flag.is-sandbox'                            => static function ( ContainerInterface $container ) : bool {
+	'settings.flag.is-sandbox'                            => static function ( ContainerInterface $container ): bool {
 		$state = $container->get( 'settings.connection-state' );
 		assert( $state instanceof ConnectionState );
 
 		return $state->is_sandbox();
 	},
-	'settings.rest.onboarding'                            => static function ( ContainerInterface $container ) : OnboardingRestEndpoint {
+	'settings.rest.onboarding'                            => static function ( ContainerInterface $container ): OnboardingRestEndpoint {
 		return new OnboardingRestEndpoint( $container->get( 'settings.data.onboarding' ) );
 	},
-	'settings.rest.common'                                => static function ( ContainerInterface $container ) : CommonRestEndpoint {
+	'settings.rest.common'                                => static function ( ContainerInterface $container ): CommonRestEndpoint {
 		return new CommonRestEndpoint(
 			$container->get( 'settings.data.general' ),
 			$container->get( 'api.endpoint.partners' )
 		);
 	},
-	'settings.rest.payment'                               => static function ( ContainerInterface $container ) : PaymentRestEndpoint {
+	'settings.rest.payment'                               => static function ( ContainerInterface $container ): PaymentRestEndpoint {
 		return new PaymentRestEndpoint(
 			$container->get( 'settings.data.payment' ),
 			$container->get( 'settings.data.definition.methods' ),
 			$container->get( 'settings.data.definition.method_dependencies' )
 		);
 	},
-	'settings.rest.styling'                               => static function ( ContainerInterface $container ) : StylingRestEndpoint {
+	'settings.rest.styling'                               => static function ( ContainerInterface $container ): StylingRestEndpoint {
 		return new StylingRestEndpoint(
 			$container->get( 'settings.data.styling' ),
 			$container->get( 'settings.service.sanitizer' )
 		);
 	},
-	'settings.rest.refresh_feature_status'                => static function ( ContainerInterface $container ) : RefreshFeatureStatusEndpoint {
+	'settings.rest.refresh_feature_status'                => static function ( ContainerInterface $container ): RefreshFeatureStatusEndpoint {
 		return new RefreshFeatureStatusEndpoint(
 			$container->get( 'wcgateway.settings' ),
 			new Cache( 'ppcp-timeout' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'settings.rest.authentication'                        => static function ( ContainerInterface $container ) : AuthenticationRestEndpoint {
+	'settings.rest.authentication'                        => static function ( ContainerInterface $container ): AuthenticationRestEndpoint {
 		return new AuthenticationRestEndpoint(
 			$container->get( 'settings.service.authentication_manager' ),
 			$container->get( 'settings.service.data-manager' )
 		);
 	},
-	'settings.rest.login_link'                            => static function ( ContainerInterface $container ) : LoginLinkRestEndpoint {
+	'settings.rest.login_link'                            => static function ( ContainerInterface $container ): LoginLinkRestEndpoint {
 		return new LoginLinkRestEndpoint(
 			$container->get( 'settings.service.connection-url-generator' ),
 		);
 	},
-	'settings.rest.webhooks'                              => static function ( ContainerInterface $container ) : WebhookSettingsEndpoint {
+	'settings.rest.webhooks'                              => static function ( ContainerInterface $container ): WebhookSettingsEndpoint {
 		return new WebhookSettingsEndpoint(
 			$container->get( 'api.endpoint.webhook' ),
 			$container->get( 'webhook.registrar' ),
 			$container->get( 'webhook.status.simulation' )
 		);
 	},
-	'settings.rest.pay_later_messaging'                   => static function ( ContainerInterface $container ) : PayLaterMessagingEndpoint {
+	'settings.rest.pay_later_messaging'                   => static function ( ContainerInterface $container ): PayLaterMessagingEndpoint {
 		return new PayLaterMessagingEndpoint(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'paylater-configurator.endpoint.save-config' )
 		);
 	},
-	'settings.rest.settings'                              => static function ( ContainerInterface $container ) : SettingsRestEndpoint {
+	'settings.rest.settings'                              => static function ( ContainerInterface $container ): SettingsRestEndpoint {
 		return new SettingsRestEndpoint(
 			$container->get( 'settings.data.settings' )
 		);
 	},
-	'settings.casual-selling.supported-countries'         => static function ( ContainerInterface $container ) : array {
+	'settings.casual-selling.supported-countries'         => static function ( ContainerInterface $container ): array {
 		return array(
 			'AR',
 			'AU',
@@ -288,13 +288,13 @@ $services = array(
 			'VN',
 		);
 	},
-	'settings.casual-selling.eligible'                    => static function ( ContainerInterface $container ) : bool {
+	'settings.casual-selling.eligible'                    => static function ( ContainerInterface $container ): bool {
 		$country            = $container->get( 'api.shop.country' );
 		$eligible_countries = $container->get( 'settings.casual-selling.supported-countries' );
 
 		return in_array( $country, $eligible_countries, true );
 	},
-	'settings.handler.connection-listener'                => static function ( ContainerInterface $container ) : ConnectionListener {
+	'settings.handler.connection-listener'                => static function ( ContainerInterface $container ): ConnectionListener {
 		$page_id = $container->has( 'wcgateway.current-ppcp-settings-page-id' ) ? $container->get( 'wcgateway.current-ppcp-settings-page-id' ) : '';
 
 		return new ConnectionListener(
@@ -305,16 +305,16 @@ $services = array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'settings.service.signup-link-cache'                  => static function ( ContainerInterface $container ) : Cache {
+	'settings.service.signup-link-cache'                  => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-signup-link' );
 	},
-	'settings.service.onboarding-url-manager'             => static function ( ContainerInterface $container ) : OnboardingUrlManager {
+	'settings.service.onboarding-url-manager'             => static function ( ContainerInterface $container ): OnboardingUrlManager {
 		return new OnboardingUrlManager(
 			$container->get( 'settings.service.signup-link-cache' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'settings.service.connection-url-generator'           => static function ( ContainerInterface $container ) : ConnectionUrlGenerator {
+	'settings.service.connection-url-generator'           => static function ( ContainerInterface $container ): ConnectionUrlGenerator {
 		return new ConnectionUrlGenerator(
 			$container->get( 'api.env.endpoint.partner-referrals' ),
 			$container->get( 'api.repository.partner-referrals-data' ),
@@ -322,7 +322,7 @@ $services = array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'settings.service.authentication_manager'             => static function ( ContainerInterface $container ) : AuthenticationManager {
+	'settings.service.authentication_manager'             => static function ( ContainerInterface $container ): AuthenticationManager {
 		return new AuthenticationManager(
 			$container->get( 'settings.data.general' ),
 			$container->get( 'api.env.paypal-host' ),
@@ -333,15 +333,15 @@ $services = array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'settings.service.rest-service'                       => static function ( ContainerInterface $container ) : InternalRestService {
+	'settings.service.rest-service'                       => static function ( ContainerInterface $container ): InternalRestService {
 		return new InternalRestService(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'settings.service.sanitizer'                          => static function ( ContainerInterface $container ) : DataSanitizer {
+	'settings.service.sanitizer'                          => static function ( ContainerInterface $container ): DataSanitizer {
 		return new DataSanitizer();
 	},
-	'settings.service.data-manager'                       => static function ( ContainerInterface $container ) : SettingsDataManager {
+	'settings.service.data-manager'                       => static function ( ContainerInterface $container ): SettingsDataManager {
 		return new SettingsDataManager(
 			$container->get( 'settings.data.definition.methods' ),
 			$container->get( 'settings.data.onboarding' ),
@@ -353,7 +353,7 @@ $services = array(
 			$container->get( 'settings.data.todos' ),
 		);
 	},
-	'settings.service.script-data-handler'                => static function ( ContainerInterface $container ) : ScriptDataHandler {
+	'settings.service.script-data-handler'                => static function ( ContainerInterface $container ): ScriptDataHandler {
 		$settings = $container->get( 'wcgateway.settings' );
 		$settings_url = $container->get( 'settings.url' );
 		$paylater_is_available = $container->get( 'paylater-configurator.is-available' );
@@ -396,7 +396,7 @@ $services = array(
 		$c->get( 'settings.service.data-migration' ),
 		$c->get( 'api.merchant_id' ) !== ''
 	),
-	'settings.rest.todos'                                 => static function ( ContainerInterface $container ) : TodosRestEndpoint {
+	'settings.rest.todos'                                 => static function ( ContainerInterface $container ): TodosRestEndpoint {
 		return new TodosRestEndpoint(
 			$container->get( 'settings.data.todos' ),
 			$container->get( 'settings.data.definition.todos' ),
@@ -404,17 +404,17 @@ $services = array(
 			$container->get( 'settings.service.todos_sorting' )
 		);
 	},
-	'settings.data.todos'                                 => static function ( ContainerInterface $container ) : TodosModel {
+	'settings.data.todos'                                 => static function ( ContainerInterface $container ): TodosModel {
 		return new TodosModel();
 	},
-	'settings.data.definition.todos'                      => static function ( ContainerInterface $container ) : TodosDefinition {
+	'settings.data.definition.todos'                      => static function ( ContainerInterface $container ): TodosDefinition {
 		return new TodosDefinition(
 			$container->get( 'settings.service.todos_eligibilities' ),
 			$container->get( 'settings.data.general' ),
 			$container->get( 'settings.data.todos' )
 		);
 	},
-	'settings.data.definition.methods'                    => static function ( ContainerInterface $container ) : PaymentMethodsDefinition {
+	'settings.data.definition.methods'                    => static function ( ContainerInterface $container ): PaymentMethodsDefinition {
 		$axo_checkout_config_notice = $container->get( 'axo.checkout-config-notice.raw' );
 		$axo_incompatible_plugins_notice = $container->get( 'axo.incompatible-plugins-notice.raw' );
 
@@ -432,10 +432,10 @@ $services = array(
 			$axo_notices
 		);
 	},
-	'settings.data.definition.method_dependencies'        => static function ( ContainerInterface $container ) : PaymentMethodsDependenciesDefinition {
+	'settings.data.definition.method_dependencies'        => static function ( ContainerInterface $container ): PaymentMethodsDependenciesDefinition {
 		return new PaymentMethodsDependenciesDefinition( $container->get( 'wcgateway.settings' ) );
 	},
-	'settings.service.pay_later_status'                   => static function ( ContainerInterface $container ) : array {
+	'settings.service.pay_later_status'                   => static function ( ContainerInterface $container ): array {
 		$pay_later_endpoint = $container->get( 'settings.rest.pay_later_messaging' );
 		$pay_later_settings = $pay_later_endpoint->get_details()->get_data();
 
@@ -456,7 +456,7 @@ $services = array(
 			'is_enabled_for_any_location' => $is_pay_later_messaging_enabled_for_any_location,
 		);
 	},
-	'settings.service.button_locations'                   => static function ( ContainerInterface $container ) : array {
+	'settings.service.button_locations'                   => static function ( ContainerInterface $container ): array {
 		$styling_endpoint = $container->get( 'settings.rest.styling' );
 		$styling_data = $styling_endpoint->get_details()->get_data()['data'];
 
@@ -466,7 +466,7 @@ $services = array(
 			'product_enabled'        => $styling_data['product']->enabled ?? false,
 		);
 	},
-	'settings.service.gateways_status'                    => static function ( ContainerInterface $container ) : array {
+	'settings.service.gateways_status'                    => static function ( ContainerInterface $container ): array {
 		$payment_endpoint = $container->get( 'settings.rest.payment' );
 		$settings = $payment_endpoint->get_details()->get_data();
 
@@ -477,7 +477,7 @@ $services = array(
 			'card-button' => $settings['data']['ppcp-card-button-gateway']['enabled'] ?? false,
 		);
 	},
-	'settings.service.merchant_capabilities'              => static function ( ContainerInterface $container ) : array {
+	'settings.service.merchant_capabilities'              => static function ( ContainerInterface $container ): array {
 		/**
 		 * Use the REST API filter to collect eligibility flags.
 		 *
@@ -505,7 +505,7 @@ $services = array(
 		);
 	},
 
-	'settings.service.todos_eligibilities'                => static function ( ContainerInterface $container ) : TodosEligibilityService {
+	'settings.service.todos_eligibilities'                => static function ( ContainerInterface $container ): TodosEligibilityService {
 		$pay_later_service = $container->get( 'settings.service.pay_later_status' );
 		$pay_later_statuses = $pay_later_service['statuses'];
 		$is_pay_later_messaging_enabled_for_any_location = $pay_later_service['is_enabled_for_any_location'];
@@ -575,13 +575,13 @@ $services = array(
 			$is_working_capital_feature_flag_enabled && $is_working_capital_eligible // Enable Working Capital.
 		);
 	},
-	'settings.rest.features'                              => static function ( ContainerInterface $container ) : FeaturesRestEndpoint {
+	'settings.rest.features'                              => static function ( ContainerInterface $container ): FeaturesRestEndpoint {
 		return new FeaturesRestEndpoint(
 			$container->get( 'settings.data.definition.features' ),
 			$container->get( 'settings.rest.settings' )
 		);
 	},
-	'settings.data.definition.features'                   => static function ( ContainerInterface $container ) : FeaturesDefinition {
+	'settings.data.definition.features'                   => static function ( ContainerInterface $container ): FeaturesDefinition {
 		$features = apply_filters(
 			'woocommerce_paypal_payments_rest_common_merchant_features',
 			array()
@@ -620,7 +620,7 @@ $services = array(
 			$container->get( 'settings.data.settings' )
 		);
 	},
-	'settings.service.features_eligibilities'             => static function( ContainerInterface $container ): FeaturesEligibilityService {
+	'settings.service.features_eligibilities'             => static function ( ContainerInterface $container ): FeaturesEligibilityService {
 
 		$messages_apply = $container->get( 'button.helper.messages-apply' );
 		assert( $messages_apply instanceof MessagesApply );
@@ -641,7 +641,7 @@ $services = array(
 			'MX' === $container->get( 'settings.data.general' )->get_merchant_country(), // Installments eligibility.
 		);
 	},
-	'settings.service.todos_sorting'                      => static function ( ContainerInterface $container ) : TodosSortingAndFilteringService {
+	'settings.service.todos_sorting'                      => static function ( ContainerInterface $container ): TodosSortingAndFilteringService {
 		return new TodosSortingAndFilteringService(
 			$container->get( 'settings.data.todos' )
 		);
@@ -649,7 +649,7 @@ $services = array(
 	'settings.service.gateway-redirect'                   => static function (): GatewayRedirectService {
 		return new GatewayRedirectService();
 	},
-	'settings.services.loading-screen-service'            => static function ( ContainerInterface $container ) : LoadingScreenService {
+	'settings.services.loading-screen-service'            => static function ( ContainerInterface $container ): LoadingScreenService {
 		return new LoadingScreenService();
 	},
 	/**
@@ -686,7 +686,7 @@ $services = array(
 			$container->get( 'settings.data.general' )
 		);
 	},
-	'settings.merchant-details'                           => static function ( ContainerInterface $container ) : MerchantDetails {
+	'settings.merchant-details'                           => static function ( ContainerInterface $container ): MerchantDetails {
 		$data = $container->get( 'settings.data.general' );
 		assert( $data instanceof GeneralSettings );
 
@@ -705,7 +705,7 @@ if ( ! SettingsModule::should_use_the_old_ui() ) {
 	 * (onboarding/connected) and connection-aware environment checks.
 	 * This is the preferred solution to check environment and connection state.
 	 */
-	$services['settings.connection-state'] = static function ( ContainerInterface $container ) : ConnectionState {
+	$services['settings.connection-state'] = static function ( ContainerInterface $container ): ConnectionState {
 		$data = $container->get( 'settings.data.general' );
 		assert( $data instanceof GeneralSettings );
 

--- a/modules/ppcp-settings/src/Data/AbstractDataModel.php
+++ b/modules/ppcp-settings/src/Data/AbstractDataModel.php
@@ -37,7 +37,7 @@ abstract class AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	abstract protected function get_defaults() : array;
+	abstract protected function get_defaults(): array;
 
 	/**
 	 * Constructor.
@@ -56,7 +56,7 @@ abstract class AbstractDataModel {
 	/**
 	 * Loads the model data from WordPress options.
 	 */
-	public function load() : void {
+	public function load(): void {
 		$saved_data    = get_option( static::OPTION_KEY, array() );
 		$filtered_data = array_intersect_key( (array) $saved_data, $this->data );
 		$this->data    = array_merge( $this->data, $filtered_data );
@@ -65,14 +65,14 @@ abstract class AbstractDataModel {
 	/**
 	 * Saves the model data to WordPress options.
 	 */
-	public function save() : void {
+	public function save(): void {
 		update_option( static::OPTION_KEY, $this->data );
 	}
 
 	/**
 	 * Deletes the settings entry from the WordPress database.
 	 */
-	public function purge() : void {
+	public function purge(): void {
 		delete_option( static::OPTION_KEY );
 	}
 
@@ -81,7 +81,7 @@ abstract class AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	public function to_array() : array {
+	public function to_array(): array {
 		return array_merge( array(), $this->data );
 	}
 
@@ -90,7 +90,7 @@ abstract class AbstractDataModel {
 	 *
 	 * @param array $data The model data.
 	 */
-	public function from_array( array $data ) : void {
+	public function from_array( array $data ): void {
 		foreach ( $data as $key => $value ) {
 			if ( ! array_key_exists( $key, $this->data ) ) {
 				continue;
@@ -112,7 +112,7 @@ abstract class AbstractDataModel {
 	 *
 	 * @return string The generated setter method name.
 	 */
-	private function get_setter_name( $field_key ) : string {
+	private function get_setter_name( $field_key ): string {
 		if ( ! is_string( $field_key ) ) {
 			return '';
 		}

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -85,7 +85,7 @@ class PaymentMethodsDefinition {
 	 *
 	 * @return array
 	 */
-	public function get_definitions() : array {
+	public function get_definitions(): array {
 		// Refresh the WooCommerce gateway details before we build the definitions.
 		$this->wc_gateways = WC()->payment_gateways()->payment_gateways();
 		$all_methods       = array_merge(
@@ -132,7 +132,7 @@ class PaymentMethodsDefinition {
 		string $icon,
 		$fields = array(),
 		array $warning_messages = array()
-	) : array {
+	): array {
 		$gateway = $this->wc_gateways[ $gateway_id ] ?? null;
 
 		$gateway_title       = $gateway ? $gateway->get_title() : $title;
@@ -177,7 +177,7 @@ class PaymentMethodsDefinition {
 	 *
 	 * @return array
 	 */
-	public function group_paypal_methods() : array {
+	public function group_paypal_methods(): array {
 		$group = array(
 			array(
 				'id'          => PayPalGateway::ID,
@@ -231,7 +231,7 @@ class PaymentMethodsDefinition {
 	 *
 	 * @return array
 	 */
-	public function group_card_methods() : array {
+	public function group_card_methods(): array {
 		$group = array();
 
 		if ( ! $this->general_settings->own_brand_only() ) {
@@ -290,7 +290,7 @@ class PaymentMethodsDefinition {
 	 *
 	 * @return array List of payment method definitions.
 	 */
-	public function group_apms() : array {
+	public function group_apms(): array {
 		$group = array(
 			array(
 				'id'          => BancontactGateway::ID,

--- a/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
@@ -303,5 +303,4 @@ class TodosDefinition {
 
 		return true;
 	}
-
 }

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -72,7 +72,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	protected function get_defaults() : array {
+	protected function get_defaults(): array {
 		return array(
 			'use_sandbox'           => false, // UI state, not a connection detail.
 			'use_manual_connection' => false, // UI state, not a connection detail.
@@ -100,7 +100,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_sandbox() : bool {
+	public function get_sandbox(): bool {
 		return (bool) $this->data['use_sandbox'];
 	}
 
@@ -109,7 +109,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @param bool $use_sandbox Whether to use sandbox mode.
 	 */
-	public function set_sandbox( bool $use_sandbox ) : void {
+	public function set_sandbox( bool $use_sandbox ): void {
 		$this->data['use_sandbox'] = $use_sandbox;
 	}
 
@@ -118,7 +118,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_manual_connection() : bool {
+	public function get_manual_connection(): bool {
 		return (bool) $this->data['use_manual_connection'];
 	}
 
@@ -127,7 +127,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @param bool $use_manual_connection Whether to use manual connection.
 	 */
-	public function set_manual_connection( bool $use_manual_connection ) : void {
+	public function set_manual_connection( bool $use_manual_connection ): void {
 		$this->data['use_manual_connection'] = $use_manual_connection;
 	}
 
@@ -136,7 +136,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	public function get_woo_settings() : array {
+	public function get_woo_settings(): array {
 		$settings = $this->woo_settings;
 
 		$settings['own_brand_only'] = $this->own_brand_only();
@@ -151,7 +151,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return void
 	 */
-	public function set_merchant_data( MerchantConnectionDTO $connection ) : void {
+	public function set_merchant_data( MerchantConnectionDTO $connection ): void {
 		$this->data['sandbox_merchant']   = $connection->is_sandbox;
 		$this->data['merchant_id']        = sanitize_text_field( $connection->merchant_id );
 		$this->data['merchant_email']     = sanitize_email( $connection->merchant_email );
@@ -167,7 +167,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return MerchantConnectionDTO All connection details.
 	 */
-	public function get_merchant_data() : MerchantConnectionDTO {
+	public function get_merchant_data(): MerchantConnectionDTO {
 		return new MerchantConnectionDTO(
 			$this->is_sandbox_merchant(),
 			$this->data['client_id'],
@@ -184,7 +184,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return void
 	 */
-	public function reset_merchant_data() : void {
+	public function reset_merchant_data(): void {
 		$defaults = $this->get_defaults();
 
 		$this->data['sandbox_merchant']   = $defaults['sandbox_merchant'];
@@ -202,7 +202,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function is_sandbox_merchant() : bool {
+	public function is_sandbox_merchant(): bool {
 		return $this->data['sandbox_merchant'];
 	}
 
@@ -211,7 +211,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function is_merchant_connected() : bool {
+	public function is_merchant_connected(): bool {
 		return $this->data['merchant_email']
 			&& $this->data['merchant_id']
 			&& $this->data['client_id']
@@ -226,7 +226,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function is_business_seller() : bool {
+	public function is_business_seller(): bool {
 		return SellerTypeEnum::BUSINESS === $this->data['seller_type'];
 	}
 
@@ -238,7 +238,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function is_casual_seller() : bool {
+	public function is_casual_seller(): bool {
 		return SellerTypeEnum::PERSONAL === $this->data['seller_type'];
 	}
 
@@ -247,7 +247,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return string
 	 */
-	public function get_merchant_id() : string {
+	public function get_merchant_id(): string {
 		return $this->data['merchant_id'];
 	}
 
@@ -256,7 +256,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return string
 	 */
-	public function get_merchant_email() : string {
+	public function get_merchant_email(): string {
 		return $this->data['merchant_email'];
 	}
 
@@ -265,7 +265,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return string
 	 */
-	public function get_merchant_country() : string {
+	public function get_merchant_country(): string {
 		// When we don't know the merchant's real country, we assume it's the Woo store-country.
 		if ( empty( $this->data['merchant_country'] ) ) {
 			return $this->woo_settings['country'];
@@ -284,7 +284,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return void
 	 */
-	public function set_installation_path( string $installation_path ) : void {
+	public function set_installation_path( string $installation_path ): void {
 		// The installation path can be set only once.
 		if ( InstallationPathEnum::is_valid( $this->data['wc_installation_path'] ?? '' ) ) {
 			return;
@@ -303,7 +303,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return string
 	 */
-	public function get_installation_path() : string {
+	public function get_installation_path(): string {
 		return $this->data['wc_installation_path'] ?? InstallationPathEnum::DIRECT;
 	}
 
@@ -314,7 +314,7 @@ class GeneralSettings extends AbstractDataModel {
 	 * @param string $reason The reason for resetting the path, must be an allowed value.
 	 * @return bool Whether the reset was successful.
 	 */
-	public function reset_installation_path( string $reason ) : bool {
+	public function reset_installation_path( string $reason ): bool {
 		if ( ! in_array( $reason, self::ALLOWED_RESET_REASONS, true ) ) {
 			return false;
 		}
@@ -329,7 +329,7 @@ class GeneralSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function own_brand_only() : bool {
+	public function own_brand_only(): bool {
 		/**
 		 * If the current store is not eligible for WooPayments, we have to also show the other payment methods.
 		 */

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -94,7 +94,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_completed() : bool {
+	public function get_completed(): bool {
 		return (bool) $this->data['completed'];
 	}
 
@@ -103,7 +103,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @param bool $state Whether the onboarding process has been completed.
 	 */
-	public function set_completed( bool $state ) : void {
+	public function set_completed( bool $state ): void {
 		$this->data['completed'] = $state;
 	}
 
@@ -112,7 +112,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @return int
 	 */
-	public function get_step() : int {
+	public function get_step(): int {
 		return (int) $this->data['step'];
 	}
 
@@ -121,7 +121,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @param int $step The current onboarding step.
 	 */
-	public function set_step( int $step ) : void {
+	public function set_step( int $step ): void {
 		$this->data['step'] = $step;
 	}
 
@@ -130,7 +130,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @return bool|null
 	 */
-	public function get_casual_seller() : ?bool {
+	public function get_casual_seller(): ?bool {
 		return $this->data['is_casual_seller'];
 	}
 
@@ -139,7 +139,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @param bool|null $casual_seller Whether the merchant uses a personal account for selling.
 	 */
-	public function set_casual_seller( ?bool $casual_seller ) : void {
+	public function set_casual_seller( ?bool $casual_seller ): void {
 		$this->data['is_casual_seller'] = $casual_seller;
 	}
 
@@ -148,7 +148,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_accept_card_payments() : bool {
+	public function get_accept_card_payments(): bool {
 		return (bool) $this->data['accept_card_payments'];
 	}
 
@@ -157,7 +157,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @param bool|null $accept_cards Whether to accept card payments via the PayPal plugin.
 	 */
-	public function set_accept_card_payments( ?bool $accept_cards ) : void {
+	public function set_accept_card_payments( ?bool $accept_cards ): void {
 		$this->data['accept_card_payments'] = $accept_cards;
 	}
 
@@ -166,7 +166,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @return string[]
 	 */
-	public function get_products() : array {
+	public function get_products(): array {
 		return $this->data['products'];
 	}
 
@@ -175,7 +175,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @param string[] $products Any of ['virtual'|'physical'|'subscriptions'].
 	 */
-	public function set_products( array $products ) : void {
+	public function set_products( array $products ): void {
 		$this->data['products'] = $products;
 	}
 
@@ -184,7 +184,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	public function get_flags() : array {
+	public function get_flags(): array {
 		return $this->flags;
 	}
 
@@ -193,7 +193,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function is_setup_done() : bool {
+	public function is_setup_done(): bool {
 		return (bool) $this->data['setup_done'];
 	}
 
@@ -202,7 +202,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 *
 	 * @param bool $done Whether the onboarding process has been setup_done.
 	 */
-	public function set_setup_done( bool $done ) : void {
+	public function set_setup_done( bool $done ): void {
 		$this->data['setup_done'] = $done;
 	}
 

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -35,7 +35,7 @@ class PaymentSettings extends AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	protected function get_defaults() : array {
+	protected function get_defaults(): array {
 		return array(
 			'paypal_show_logo'           => false,
 			'fastlane_cardholder_name'   => false,
@@ -48,7 +48,7 @@ class PaymentSettings extends AbstractDataModel {
 	/**
 	 * Saves the model data to WordPress options.
 	 */
-	public function save() : void {
+	public function save(): void {
 		parent::save();
 
 		foreach ( $this->unsaved_gateways as $gateway ) {
@@ -68,7 +68,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param string $method_id  ID of the payment method.
 	 * @param bool   $is_enabled Whether to enable the method.
 	 */
-	public function toggle_method_state( string $method_id, bool $is_enabled ) : void {
+	public function toggle_method_state( string $method_id, bool $is_enabled ): void {
 		switch ( $method_id ) {
 			case 'venmo':
 				$this->set_venmo_enabled( $is_enabled );
@@ -95,7 +95,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param string $method_id ID of the payment method.
 	 * @return bool True, if the method is enabled. False if it's disabled or not existing.
 	 */
-	public function is_method_enabled( string $method_id ) : bool {
+	public function is_method_enabled( string $method_id ): bool {
 		switch ( $method_id ) {
 			case 'venmo':
 				return $this->get_venmo_enabled();
@@ -121,7 +121,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param string $title     The new title.
 	 * @return void
 	 */
-	public function set_method_title( string $method_id, string $title ) : void {
+	public function set_method_title( string $method_id, string $title ): void {
 		$gateway = $this->get_gateway( $method_id );
 
 		if ( $gateway ) {
@@ -138,7 +138,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param string $description The new description.
 	 * @return void
 	 */
-	public function set_method_description( string $method_id, string $description ) : void {
+	public function set_method_description( string $method_id, string $description ): void {
 		$gateway = $this->get_gateway( $method_id );
 
 		if ( $gateway ) {
@@ -153,7 +153,7 @@ class PaymentSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_paypal_show_logo() : bool {
+	public function get_paypal_show_logo(): bool {
 		return (bool) $this->data['paypal_show_logo'];
 	}
 
@@ -162,7 +162,7 @@ class PaymentSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_fastlane_cardholder_name() : bool {
+	public function get_fastlane_cardholder_name(): bool {
 		return (bool) $this->data['fastlane_cardholder_name'];
 	}
 
@@ -171,7 +171,7 @@ class PaymentSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_fastlane_display_watermark() : bool {
+	public function get_fastlane_display_watermark(): bool {
 		return (bool) $this->data['fastlane_display_watermark'];
 	}
 
@@ -180,7 +180,7 @@ class PaymentSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_venmo_enabled() : bool {
+	public function get_venmo_enabled(): bool {
 		return (bool) $this->data['venmo_enabled'];
 	}
 
@@ -189,7 +189,7 @@ class PaymentSettings extends AbstractDataModel {
 	 *
 	 * @return bool
 	 */
-	public function get_paylater_enabled() : bool {
+	public function get_paylater_enabled(): bool {
 		return (bool) $this->data['paylater_enabled'];
 	}
 
@@ -199,7 +199,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param bool $value The value.
 	 * @return void
 	 */
-	public function set_paypal_show_logo( bool $value ) : void {
+	public function set_paypal_show_logo( bool $value ): void {
 		$this->data['paypal_show_logo'] = $value;
 	}
 
@@ -209,7 +209,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param bool $value The value.
 	 * @return void
 	 */
-	public function set_fastlane_cardholder_name( bool $value ) : void {
+	public function set_fastlane_cardholder_name( bool $value ): void {
 		$this->data['fastlane_cardholder_name'] = $value;
 	}
 
@@ -219,7 +219,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param bool $value The value.
 	 * @return void
 	 */
-	public function set_fastlane_display_watermark( bool $value ) : void {
+	public function set_fastlane_display_watermark( bool $value ): void {
 		$this->data['fastlane_display_watermark'] = $value;
 	}
 
@@ -229,7 +229,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param bool $value The value.
 	 * @return void
 	 */
-	public function set_venmo_enabled( bool $value ) : void {
+	public function set_venmo_enabled( bool $value ): void {
 		$this->data['venmo_enabled'] = $value;
 	}
 
@@ -239,7 +239,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param bool $value The value.
 	 * @return void
 	 */
-	public function set_paylater_enabled( bool $value ) : void {
+	public function set_paylater_enabled( bool $value ): void {
 		$this->data['paylater_enabled'] = $value;
 	}
 
@@ -249,7 +249,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param string $method_id ID of the payment method.
 	 * @return WC_Payment_Gateway|null
 	 */
-	private function get_gateway( string $method_id ) : ?WC_Payment_Gateway {
+	private function get_gateway( string $method_id ): ?WC_Payment_Gateway {
 		if ( isset( $this->unsaved_gateways[ $method_id ] ) ) {
 			return $this->unsaved_gateways[ $method_id ];
 		}
@@ -272,7 +272,7 @@ class PaymentSettings extends AbstractDataModel {
 	 * @param WC_Payment_Gateway $gateway The gateway object.
 	 * @return void
 	 */
-	private function modified_gateway( WC_Payment_Gateway $gateway ) : void {
+	private function modified_gateway( WC_Payment_Gateway $gateway ): void {
 		$this->unsaved_gateways[ $gateway->id ] = $gateway;
 	}
 }

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -82,7 +82,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	protected function get_defaults() : array {
+	protected function get_defaults(): array {
 		return array(
 			// Free-form string values.
 			'invoice_prefix'         => $this->invoice_prefix,
@@ -115,7 +115,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return string The invoice prefix.
 	 */
-	public function get_invoice_prefix() : string {
+	public function get_invoice_prefix(): string {
 		return $this->data['invoice_prefix'];
 	}
 
@@ -124,7 +124,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param string $prefix The invoice prefix to set.
 	 */
-	public function set_invoice_prefix( string $prefix ) : void {
+	public function set_invoice_prefix( string $prefix ): void {
 		$this->data['invoice_prefix'] = $this->sanitizer->sanitize_text( $prefix );
 	}
 
@@ -142,7 +142,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param string $name The brand name to set.
 	 */
-	public function set_brand_name( string $name ) : void {
+	public function set_brand_name( string $name ): void {
 		$this->data['brand_name'] = $this->sanitizer->sanitize_text( $name );
 	}
 
@@ -151,7 +151,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return string The soft descriptor.
 	 */
-	public function get_soft_descriptor() : string {
+	public function get_soft_descriptor(): string {
 		return $this->data['soft_descriptor'];
 	}
 
@@ -160,7 +160,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param string $descriptor The soft descriptor to set.
 	 */
-	public function set_soft_descriptor( string $descriptor ) : void {
+	public function set_soft_descriptor( string $descriptor ): void {
 		$descriptor = $this->sanitizer->sanitize_text( $descriptor );
 		$descriptor = preg_replace( '/[^a-zA-Z0-9\-*. ]/', '', $descriptor ) ?? '';
 
@@ -172,7 +172,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return string The subtotal adjustment setting.
 	 */
-	public function get_subtotal_adjustment() : string {
+	public function get_subtotal_adjustment(): string {
 		return $this->data['subtotal_adjustment'];
 	}
 
@@ -181,7 +181,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param string $adjustment The subtotal adjustment to set.
 	 */
-	public function set_subtotal_adjustment( string $adjustment ) : void {
+	public function set_subtotal_adjustment( string $adjustment ): void {
 		$this->data['subtotal_adjustment'] = $this->sanitizer->sanitize_enum( $adjustment, self::SUBTOTAL_ADJUSTMENT_OPTIONS );
 	}
 
@@ -190,7 +190,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return string The landing page setting.
 	 */
-	public function get_landing_page() : string {
+	public function get_landing_page(): string {
 		return $this->data['landing_page'];
 	}
 
@@ -199,7 +199,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param string $page The landing page to set.
 	 */
-	public function set_landing_page( string $page ) : void {
+	public function set_landing_page( string $page ): void {
 		$this->data['landing_page'] = $this->sanitizer->sanitize_enum( $page, self::LANDING_PAGE_OPTIONS );
 	}
 
@@ -208,7 +208,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return string The button language.
 	 */
-	public function get_button_language() : string {
+	public function get_button_language(): string {
 		return $this->data['button_language'];
 	}
 
@@ -217,7 +217,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param string $language The button language to set.
 	 */
-	public function set_button_language( string $language ) : void {
+	public function set_button_language( string $language ): void {
 		$this->data['button_language'] = $this->sanitizer->sanitize_text( $language );
 	}
 
@@ -226,7 +226,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return string The 3D Secure setting.
 	 */
-	public function get_three_d_secure() : string {
+	public function get_three_d_secure(): string {
 		return $this->data['three_d_secure'];
 	}
 
@@ -256,7 +256,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param string $setting The 3D Secure setting to set.
 	 */
-	public function set_three_d_secure( string $setting ) : void {
+	public function set_three_d_secure( string $setting ): void {
 		$this->data['three_d_secure'] = $this->sanitizer->sanitize_enum( $setting, self::THREE_D_SECURE_OPTIONS );
 	}
 
@@ -265,7 +265,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return bool True if authorize only is enabled, false otherwise.
 	 */
-	public function get_authorize_only() : bool {
+	public function get_authorize_only(): bool {
 		return $this->data['authorize_only'];
 	}
 
@@ -274,7 +274,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param bool $authorize Whether to enable authorize only.
 	 */
-	public function set_authorize_only( bool $authorize ) : void {
+	public function set_authorize_only( bool $authorize ): void {
 		$this->data['authorize_only'] = $this->sanitizer->sanitize_bool( $authorize );
 	}
 
@@ -283,7 +283,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return bool True if capturing virtual orders is enabled, false otherwise.
 	 */
-	public function get_capture_virtual_orders() : bool {
+	public function get_capture_virtual_orders(): bool {
 		return $this->data['capture_virtual_orders'];
 	}
 
@@ -292,7 +292,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param bool $capture Whether to capture virtual orders.
 	 */
-	public function set_capture_virtual_orders( bool $capture ) : void {
+	public function set_capture_virtual_orders( bool $capture ): void {
 		$this->data['capture_virtual_orders'] = $this->sanitizer->sanitize_bool( $capture );
 	}
 
@@ -301,7 +301,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return bool True if saving PayPal and Venmo is enabled, false otherwise.
 	 */
-	public function get_save_paypal_and_venmo() : bool {
+	public function get_save_paypal_and_venmo(): bool {
 		return $this->data['save_paypal_and_venmo'];
 	}
 
@@ -310,7 +310,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param bool $save Whether to save PayPal and Venmo.
 	 */
-	public function set_save_paypal_and_venmo( bool $save ) : void {
+	public function set_save_paypal_and_venmo( bool $save ): void {
 		$this->data['save_paypal_and_venmo'] = $this->sanitizer->sanitize_bool( $save );
 	}
 
@@ -319,7 +319,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return bool True if the contact module feature is enabled, false otherwise.
 	 */
-	public function get_enable_contact_module() : bool {
+	public function get_enable_contact_module(): bool {
 		return $this->data['enable_contact_module'];
 	}
 
@@ -328,7 +328,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param bool $save Whether to use the contact module feature.
 	 */
-	public function set_enable_contact_module( bool $save ) : void {
+	public function set_enable_contact_module( bool $save ): void {
 		$this->data['enable_contact_module'] = $this->sanitizer->sanitize_bool( $save );
 	}
 
@@ -337,7 +337,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return bool True if saving card details is enabled, false otherwise.
 	 */
-	public function get_save_card_details() : bool {
+	public function get_save_card_details(): bool {
 		return $this->data['save_card_details'];
 	}
 
@@ -346,7 +346,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param bool $save Whether to save card details.
 	 */
-	public function set_save_card_details( bool $save ) : void {
+	public function set_save_card_details( bool $save ): void {
 		$this->data['save_card_details'] = $this->sanitizer->sanitize_bool( $save );
 	}
 
@@ -355,7 +355,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return bool True if Pay Now is enabled, false otherwise.
 	 */
-	public function get_enable_pay_now() : bool {
+	public function get_enable_pay_now(): bool {
 		return $this->data['enable_pay_now'];
 	}
 
@@ -364,7 +364,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param bool $enable Whether to enable Pay Now.
 	 */
-	public function set_enable_pay_now( bool $enable ) : void {
+	public function set_enable_pay_now( bool $enable ): void {
 		$this->data['enable_pay_now'] = $this->sanitizer->sanitize_bool( $enable );
 	}
 
@@ -373,7 +373,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return bool True if logging is enabled, false otherwise.
 	 */
-	public function get_enable_logging() : bool {
+	public function get_enable_logging(): bool {
 		return $this->data['enable_logging'];
 	}
 
@@ -382,7 +382,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param bool $enable Whether to enable logging.
 	 */
-	public function set_enable_logging( bool $enable ) : void {
+	public function set_enable_logging( bool $enable ): void {
 		$this->data['enable_logging'] = $this->sanitizer->sanitize_bool( $enable );
 	}
 
@@ -391,7 +391,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return array The array of disabled cards.
 	 */
-	public function get_disabled_cards() : array {
+	public function get_disabled_cards(): array {
 		return $this->data['disabled_cards'];
 	}
 
@@ -400,7 +400,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param array $cards The array of cards to disable.
 	 */
-	public function set_disabled_cards( array $cards ) : void {
+	public function set_disabled_cards( array $cards ): void {
 		$this->data['disabled_cards'] = array_map(
 			array( $this->sanitizer, 'sanitize_text' ),
 			$cards
@@ -412,7 +412,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @return bool True if Stay Updated is enabled, false otherwise.
 	 */
-	public function get_stay_updated() : bool {
+	public function get_stay_updated(): bool {
 		return $this->data['stay_updated'];
 	}
 
@@ -421,7 +421,7 @@ class SettingsModel extends AbstractDataModel {
 	 *
 	 * @param bool $save Whether to save the Stay Updated.
 	 */
-	public function set_stay_updated( bool $save ) : void {
+	public function set_stay_updated( bool $save ): void {
 		$this->data['stay_updated'] = $this->sanitizer->sanitize_bool( $save );
 	}
 }

--- a/modules/ppcp-settings/src/Data/StylingSettings.php
+++ b/modules/ppcp-settings/src/Data/StylingSettings.php
@@ -51,7 +51,7 @@ class StylingSettings extends AbstractDataModel {
 	 *
 	 * @return array
 	 */
-	protected function get_defaults() : array {
+	protected function get_defaults(): array {
 		return array(
 			'cart'             => new LocationStylingDTO( 'cart' ),
 			'classic_checkout' => new LocationStylingDTO( 'classic_checkout' ),
@@ -66,7 +66,7 @@ class StylingSettings extends AbstractDataModel {
 	 *
 	 * @return LocationStylingDTO
 	 */
-	public function get_cart() : LocationStylingDTO {
+	public function get_cart(): LocationStylingDTO {
 		return $this->data['cart'];
 	}
 
@@ -76,7 +76,7 @@ class StylingSettings extends AbstractDataModel {
 	 * @param mixed $styles The new styling details.
 	 * @return void
 	 */
-	public function set_cart( $styles ) : void {
+	public function set_cart( $styles ): void {
 		$this->data['cart'] = $this->sanitizer->sanitize_location_style( $styles );
 	}
 
@@ -85,7 +85,7 @@ class StylingSettings extends AbstractDataModel {
 	 *
 	 * @return LocationStylingDTO
 	 */
-	public function get_classic_checkout() : LocationStylingDTO {
+	public function get_classic_checkout(): LocationStylingDTO {
 		return $this->data['classic_checkout'];
 	}
 
@@ -95,7 +95,7 @@ class StylingSettings extends AbstractDataModel {
 	 * @param mixed $styles The new styling details.
 	 * @return void
 	 */
-	public function set_classic_checkout( $styles ) : void {
+	public function set_classic_checkout( $styles ): void {
 		$this->data['classic_checkout'] = $this->sanitizer->sanitize_location_style( $styles );
 	}
 
@@ -104,7 +104,7 @@ class StylingSettings extends AbstractDataModel {
 	 *
 	 * @return LocationStylingDTO
 	 */
-	public function get_express_checkout() : LocationStylingDTO {
+	public function get_express_checkout(): LocationStylingDTO {
 		return $this->data['express_checkout'];
 	}
 
@@ -114,7 +114,7 @@ class StylingSettings extends AbstractDataModel {
 	 * @param mixed $styles The new styling details.
 	 * @return void
 	 */
-	public function set_express_checkout( $styles ) : void {
+	public function set_express_checkout( $styles ): void {
 		$this->data['express_checkout'] = $this->sanitizer->sanitize_location_style( $styles );
 	}
 
@@ -123,7 +123,7 @@ class StylingSettings extends AbstractDataModel {
 	 *
 	 * @return LocationStylingDTO
 	 */
-	public function get_mini_cart() : LocationStylingDTO {
+	public function get_mini_cart(): LocationStylingDTO {
 		return $this->data['mini_cart'];
 	}
 
@@ -133,7 +133,7 @@ class StylingSettings extends AbstractDataModel {
 	 * @param mixed $styles The new styling details.
 	 * @return void
 	 */
-	public function set_mini_cart( $styles ) : void {
+	public function set_mini_cart( $styles ): void {
 		$this->data['mini_cart'] = $this->sanitizer->sanitize_location_style( $styles );
 	}
 
@@ -142,7 +142,7 @@ class StylingSettings extends AbstractDataModel {
 	 *
 	 * @return LocationStylingDTO
 	 */
-	public function get_product() : LocationStylingDTO {
+	public function get_product(): LocationStylingDTO {
 		return $this->data['product'];
 	}
 
@@ -152,7 +152,7 @@ class StylingSettings extends AbstractDataModel {
 	 * @param mixed $styles The new styling details.
 	 * @return void
 	 */
-	public function set_product( $styles ) : void {
+	public function set_product( $styles ): void {
 		$this->data['product'] = $this->sanitizer->sanitize_location_style( $styles );
 	}
 }

--- a/modules/ppcp-settings/src/Endpoint/AuthenticationRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/AuthenticationRestEndpoint.php
@@ -77,7 +77,7 @@ class AuthenticationRestEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * POST /wp-json/wc/v3/wc_paypal/authenticate/direct
 		 * {
@@ -173,7 +173,7 @@ class AuthenticationRestEndpoint extends RestEndpoint {
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
-	public function connect_direct( WP_REST_Request $request ) : WP_REST_Response {
+	public function connect_direct( WP_REST_Request $request ): WP_REST_Response {
 		$client_id     = $request->get_param( 'clientId' );
 		$client_secret = $request->get_param( 'clientSecret' );
 		$use_sandbox   = $request->get_param( 'useSandbox' );
@@ -199,7 +199,7 @@ class AuthenticationRestEndpoint extends RestEndpoint {
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
-	public function connect_oauth( WP_REST_Request $request ) : WP_REST_Response {
+	public function connect_oauth( WP_REST_Request $request ): WP_REST_Response {
 		$shared_id   = $request->get_param( 'sharedId' );
 		$auth_code   = $request->get_param( 'authCode' );
 		$use_sandbox = $request->get_param( 'useSandbox' );
@@ -216,7 +216,7 @@ class AuthenticationRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function disconnect( WP_REST_Request $request ) : WP_REST_Response {
+	public function disconnect( WP_REST_Request $request ): WP_REST_Response {
 		$reset_settings = $request->get_param( 'reset' );
 
 		$this->authentication_manager->disconnect();

--- a/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/CommonRestEndpoint.php
@@ -137,7 +137,7 @@ class CommonRestEndpoint extends RestEndpoint {
 	 * @param bool $full_route Whether to return the full endpoint path or just the route name.
 	 * @return string The full path to the REST endpoint.
 	 */
-	public static function seller_account_route( bool $full_route = false ) : string {
+	public static function seller_account_route( bool $full_route = false ): string {
 		if ( $full_route ) {
 			return '/' . static::NAMESPACE . '/' . self::SELLER_ACCOUNT_PATH;
 		}
@@ -148,7 +148,7 @@ class CommonRestEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * GET /wp-json/wc/v3/wc_paypal/common
 		 */
@@ -210,7 +210,7 @@ class CommonRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The common settings.
 	 */
-	public function get_details() : WP_REST_Response {
+	public function get_details(): WP_REST_Response {
 		$js_data = $this->sanitize_for_javascript(
 			$this->settings->to_array(),
 			$this->field_map
@@ -229,7 +229,7 @@ class CommonRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The new common settings.
 	 */
-	public function update_details( WP_REST_Request $request ) : WP_REST_Response {
+	public function update_details( WP_REST_Request $request ): WP_REST_Response {
 		$wp_data = $this->sanitize_for_wordpress(
 			$request->get_params(),
 			$this->field_map
@@ -246,7 +246,7 @@ class CommonRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response Merchant details.
 	 */
-	public function get_merchant_details() : WP_REST_Response {
+	public function get_merchant_details(): WP_REST_Response {
 		$js_data    = array(); // No persistent data.
 		$extra_data = $this->add_merchant_info( array() );
 
@@ -260,7 +260,7 @@ class CommonRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response Seller details, provided by PayPal's API.
 	 */
-	public function get_seller_account_info() : WP_REST_Response {
+	public function get_seller_account_info(): WP_REST_Response {
 		try {
 			$seller_status = $this->partners_endpoint->seller_status();
 
@@ -282,7 +282,7 @@ class CommonRestEndpoint extends RestEndpoint {
 	 *
 	 * @return array Updated extra_data collection.
 	 */
-	protected function add_merchant_info( array $extra_data ) : array {
+	protected function add_merchant_info( array $extra_data ): array {
 		$extra_data['merchant'] = $this->sanitize_for_javascript(
 			$this->settings->to_array(),
 			$this->merchant_info_map
@@ -306,7 +306,7 @@ class CommonRestEndpoint extends RestEndpoint {
 	 *
 	 * @return array Updated extra_data collection.
 	 */
-	protected function add_woo_settings( array $extra_data ) : array {
+	protected function add_woo_settings( array $extra_data ): array {
 		$extra_data['wooSettings'] = $this->sanitize_for_javascript(
 			$this->settings->get_woo_settings(),
 			$this->woo_settings_map

--- a/modules/ppcp-settings/src/Endpoint/LoginLinkRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/LoginLinkRestEndpoint.php
@@ -51,7 +51,7 @@ class LoginLinkRestEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * POST /wp-json/wc/v3/wc_paypal/login_link
 		 * {
@@ -104,7 +104,7 @@ class LoginLinkRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The login URL or an error response.
 	 */
-	public function get_login_url( WP_REST_Request $request ) : WP_REST_Response {
+	public function get_login_url( WP_REST_Request $request ): WP_REST_Response {
 		$use_sandbox = $request->get_param( 'useSandbox' );
 		$products    = $request->get_param( 'products' );
 		$flags       = (array) $request->get_param( 'options' );

--- a/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/OnboardingRestEndpoint.php
@@ -113,7 +113,7 @@ class OnboardingRestEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * GET /wp-json/wc/v3/wc_paypal/onboarding
 		 */
@@ -149,7 +149,7 @@ class OnboardingRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The current state of the onboarding wizard.
 	 */
-	public function get_details() : WP_REST_Response {
+	public function get_details(): WP_REST_Response {
 		$js_data = $this->sanitize_for_javascript(
 			$this->profile->to_array(),
 			$this->field_map
@@ -175,7 +175,7 @@ class OnboardingRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The updated state of the onboarding wizard.
 	 */
-	public function update_details( WP_REST_Request $request ) : WP_REST_Response {
+	public function update_details( WP_REST_Request $request ): WP_REST_Response {
 		$wp_data = $this->sanitize_for_wordpress(
 			$request->get_params(),
 			$this->field_map

--- a/modules/ppcp-settings/src/Endpoint/PayLaterMessagingEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/PayLaterMessagingEndpoint.php
@@ -58,7 +58,7 @@ class PayLaterMessagingEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * GET wc/v3/wc_paypal/pay_later_messaging
 		 */
@@ -91,7 +91,7 @@ class PayLaterMessagingEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The current payment methods details.
 	 */
-	public function get_details() : WP_REST_Response {
+	public function get_details(): WP_REST_Response {
 		return $this->return_success( ( new ConfigFactory() )->from_settings( $this->settings ) );
 	}
 
@@ -102,7 +102,7 @@ class PayLaterMessagingEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The updated Pay Later Messaging configuration details.
 	 */
-	public function update_details( WP_REST_Request $request ) : WP_REST_Response {
+	public function update_details( WP_REST_Request $request ): WP_REST_Response {
 		$this->save_config->save_config( $request->get_json_params() );
 
 		return $this->get_details();

--- a/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
@@ -109,7 +109,7 @@ class PaymentRestEndpoint extends RestEndpoint {
 	 *
 	 * @return array[]
 	 */
-	protected function gateways() : array {
+	protected function gateways(): array {
 		$methods = $this->payment_methods_definition->get_definitions();
 
 		// Add dependency information to the methods.
@@ -119,7 +119,7 @@ class PaymentRestEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * GET wc/v3/wc_paypal/payment
 		 */
@@ -159,7 +159,7 @@ class PaymentRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The current payment methods details.
 	 */
-	public function get_details() : WP_REST_Response {
+	public function get_details(): WP_REST_Response {
 		$gateway_settings    = array();
 		$all_payment_methods = $this->gateways();
 
@@ -216,7 +216,7 @@ class PaymentRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The updated payment methods details.
 	 */
-	public function update_details( WP_REST_Request $request ) : WP_REST_Response {
+	public function update_details( WP_REST_Request $request ): WP_REST_Response {
 		$request_data = $request->get_params();
 		$all_methods  = $this->gateways();
 

--- a/modules/ppcp-settings/src/Endpoint/RefreshFeatureStatusEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/RefreshFeatureStatusEndpoint.php
@@ -82,7 +82,7 @@ class RefreshFeatureStatusEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * POST /wp-json/wc/v3/wc_paypal/refresh-features
 		 */
@@ -103,7 +103,7 @@ class RefreshFeatureStatusEndpoint extends RestEndpoint {
 	 * @param WP_REST_Request $request Full data about the request.
 	 * @return WP_REST_Response
 	 */
-	public function refresh_status( WP_REST_Request $request ) : WP_REST_Response {
+	public function refresh_status( WP_REST_Request $request ): WP_REST_Response {
 		$now               = time();
 		$last_request_time = $this->cache->get( self::CACHE_KEY ) ?: 0;
 		$seconds_missing   = $last_request_time + self::TIMEOUT - $now;

--- a/modules/ppcp-settings/src/Endpoint/RestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/RestEndpoint.php
@@ -26,7 +26,7 @@ abstract class RestEndpoint extends WC_REST_Controller {
 	 *
 	 * Override this method if custom permissions required.
 	 */
-	public function check_permission() : bool {
+	public function check_permission(): bool {
 		return current_user_can( 'manage_woocommerce' );
 	}
 
@@ -38,7 +38,7 @@ abstract class RestEndpoint extends WC_REST_Controller {
 	 *
 	 * @return WP_REST_Response The successful response.
 	 */
-	protected function return_success( $data, array $extra = array() ) : WP_REST_Response {
+	protected function return_success( $data, array $extra = array() ): WP_REST_Response {
 		$response = array(
 			'success' => true,
 			'data'    => $data,
@@ -65,7 +65,7 @@ abstract class RestEndpoint extends WC_REST_Controller {
 	 *
 	 * @return WP_REST_Response The error response.
 	 */
-	protected function return_error( string $reason, $details = null ) : WP_REST_Response {
+	protected function return_error( string $reason, $details = null ): WP_REST_Response {
 		$response = array(
 			'success' => false,
 			'message' => $reason,
@@ -90,7 +90,7 @@ abstract class RestEndpoint extends WC_REST_Controller {
 	 *
 	 * @return array An array of sanitized parameters.
 	 */
-	protected function sanitize_for_wordpress( array $params, array $field_map ) : array {
+	protected function sanitize_for_wordpress( array $params, array $field_map ): array {
 		$sanitized = array();
 
 		foreach ( $field_map as $key => $details ) {
@@ -136,7 +136,7 @@ abstract class RestEndpoint extends WC_REST_Controller {
 	 *
 	 * @return array An array of sanitized data with keys renamed for JavaScript use.
 	 */
-	protected function sanitize_for_javascript( array $data, array $field_map ) : array {
+	protected function sanitize_for_javascript( array $data, array $field_map ): array {
 		$sanitized = array();
 
 		foreach ( $field_map as $key => $details ) {
@@ -160,7 +160,7 @@ abstract class RestEndpoint extends WC_REST_Controller {
 	 * @return bool The boolean value.
 	 * @todo Switch to the DataSanitizer class.
 	 */
-	public function to_boolean( $value ) : bool {
+	public function to_boolean( $value ): bool {
 		return (bool) $value;
 	}
 
@@ -172,7 +172,7 @@ abstract class RestEndpoint extends WC_REST_Controller {
 	 * @return int The numeric value.
 	 * @todo Switch to the DataSanitizer class.
 	 */
-	public function to_number( $value ) : int {
+	public function to_number( $value ): int {
 		return (int) $value;
 	}
 }

--- a/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
@@ -115,7 +115,7 @@ class SettingsRestEndpoint extends RestEndpoint {
 	/**
 	 * Registers the REST API routes for settings management.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * GET wc/v3/wc_paypal/settings
 		 * POST wc/v3/wc_paypal/settings
@@ -143,7 +143,7 @@ class SettingsRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The response containing settings data or error details.
 	 */
-	public function get_details() : WP_REST_Response {
+	public function get_details(): WP_REST_Response {
 		$js_data = $this->sanitize_for_javascript(
 			$this->settings->to_array(),
 			$this->field_map
@@ -158,7 +158,7 @@ class SettingsRestEndpoint extends RestEndpoint {
 	 * @param WP_REST_Request $request The request instance containing new settings.
 	 * @return WP_REST_Response The response containing updated settings or error details.
 	 */
-	public function update_details( WP_REST_Request $request ) : WP_REST_Response {
+	public function update_details( WP_REST_Request $request ): WP_REST_Response {
 		$wp_data = $this->sanitize_for_wordpress(
 			$request->get_params(),
 			$this->field_map

--- a/modules/ppcp-settings/src/Endpoint/StylingRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/StylingRestEndpoint.php
@@ -102,7 +102,7 @@ class StylingRestEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * GET wc/v3/wc_paypal/styling
 		 */
@@ -138,7 +138,7 @@ class StylingRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The current styling details.
 	 */
-	public function get_details() : WP_REST_Response {
+	public function get_details(): WP_REST_Response {
 		$js_data = $this->sanitize_for_javascript(
 			$this->settings->to_array(),
 			$this->field_map
@@ -156,7 +156,7 @@ class StylingRestEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response The updated styling details.
 	 */
-	public function update_details( WP_REST_Request $request ) : WP_REST_Response {
+	public function update_details( WP_REST_Request $request ): WP_REST_Response {
 		$wp_data = $this->sanitize_for_wordpress(
 			$request->get_params(),
 			$this->field_map

--- a/modules/ppcp-settings/src/Endpoint/WebhookSettingsEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/WebhookSettingsEndpoint.php
@@ -73,7 +73,7 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 	/**
 	 * Configure REST API routes.
 	 */
-	public function register_routes() : void {
+	public function register_routes(): void {
 		/**
 		 * GET /wp-json/wc/v3/wc_paypal/webhooks
 		 * POST /wp-json/wc/v3/wc_paypal/webhooks
@@ -122,7 +122,7 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function get_webhooks() : WP_REST_Response {
+	public function get_webhooks(): WP_REST_Response {
 		$webhooks = $this->get_webhook_data();
 		if ( ! $webhooks ) {
 			return $this->return_error( 'No webhooks found.' );
@@ -151,7 +151,7 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function resubscribe_webhooks() : WP_REST_Response {
+	public function resubscribe_webhooks(): WP_REST_Response {
 		if ( ! $this->webhook_registrar->register() ) {
 			return $this->return_error( 'Webhook subscription failed.' );
 		}
@@ -164,7 +164,7 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function simulate_webhooks_start() : WP_REST_Response {
+	public function simulate_webhooks_start(): WP_REST_Response {
 		try {
 			$this->webhook_simulation->start();
 
@@ -179,7 +179,7 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function check_simulated_webhook_state() : WP_REST_Response {
+	public function check_simulated_webhook_state(): WP_REST_Response {
 		try {
 			$state = $this->webhook_simulation->get_state();
 
@@ -198,7 +198,7 @@ class WebhookSettingsEndpoint extends RestEndpoint {
 	 *
 	 * @return Webhook|null The webhook data instance, or null.
 	 */
-	private function get_webhook_data() : ?Webhook {
+	private function get_webhook_data(): ?Webhook {
 		try {
 			$api_response = $this->webhook_endpoint->list();
 

--- a/modules/ppcp-settings/src/Enum/InstallationPathEnum.php
+++ b/modules/ppcp-settings/src/Enum/InstallationPathEnum.php
@@ -41,7 +41,7 @@ class InstallationPathEnum {
 	 *
 	 * @return array List of all valid options.
 	 */
-	public static function get_valid_values() : array {
+	public static function get_valid_values(): array {
 		return array(
 			self::CORE_PROFILER,
 			self::PAYMENT_SETTINGS,
@@ -55,7 +55,7 @@ class InstallationPathEnum {
 	 * @param string $type The value to validate.
 	 * @return bool True, if the value is a valid installation path.
 	 */
-	public static function is_valid( string $type ) : bool {
+	public static function is_valid( string $type ): bool {
 		return in_array( $type, self::get_valid_values(), true );
 	}
 }

--- a/modules/ppcp-settings/src/Enum/ProductChoicesEnum.php
+++ b/modules/ppcp-settings/src/Enum/ProductChoicesEnum.php
@@ -36,7 +36,7 @@ class ProductChoicesEnum {
 	 *
 	 * @return array List of all valid products.
 	 */
-	public static function get_valid_values() : array {
+	public static function get_valid_values(): array {
 		return array(
 			self::VIRTUAL,
 			self::PHYSICAL,
@@ -50,7 +50,7 @@ class ProductChoicesEnum {
 	 * @param string $type The value to validate.
 	 * @return bool True, if the value is a valid product.
 	 */
-	public static function is_valid( string $type ) : bool {
+	public static function is_valid( string $type ): bool {
 		return in_array( $type, self::get_valid_values(), true );
 	}
 }

--- a/modules/ppcp-settings/src/Enum/SellerTypeEnum.php
+++ b/modules/ppcp-settings/src/Enum/SellerTypeEnum.php
@@ -33,7 +33,7 @@ class SellerTypeEnum {
 	 *
 	 * @return array List of all valid seller_types.
 	 */
-	public static function get_valid_values() : array {
+	public static function get_valid_values(): array {
 		return array(
 			self::BUSINESS,
 			self::PERSONAL,
@@ -47,7 +47,7 @@ class SellerTypeEnum {
 	 * @param string $type The value to validate.
 	 * @return bool True, if the value is a valid seller_type.
 	 */
-	public static function is_valid( string $type ) : bool {
+	public static function is_valid( string $type ): bool {
 		return in_array( $type, self::get_valid_values(), true );
 	}
 }

--- a/modules/ppcp-settings/src/Handler/ConnectionListener.php
+++ b/modules/ppcp-settings/src/Handler/ConnectionListener.php
@@ -122,7 +122,7 @@ class ConnectionListener {
 	 *
 	 * @throws RuntimeException If the merchant ID does not match the ID previously set via OAuth.
 	 */
-	public function process( int $user_id, array $request ) : void {
+	public function process( int $user_id, array $request ): void {
 		$this->user_id      = $user_id;
 		$this->request_data = $request;
 
@@ -143,7 +143,7 @@ class ConnectionListener {
 	 * @param string $token The OAuth token extracted from the request.
 	 * @return void
 	 */
-	private function process_oauth_token( string $token ) : void {
+	private function process_oauth_token( string $token ): void {
 		if ( ! $token ) {
 			return;
 		}
@@ -211,7 +211,7 @@ class ConnectionListener {
 	 *
 	 * @return bool True, if the request contains valid connection details.
 	 */
-	private function is_valid_request() : bool {
+	private function is_valid_request(): bool {
 		if ( $this->user_id < 1 || ! $this->settings_page_id ) {
 			return false;
 		}
@@ -242,7 +242,7 @@ class ConnectionListener {
 	 * @param string $state The state to set.
 	 * @return void
 	 */
-	private function set_token_state( string $token, string $state ) : void {
+	private function set_token_state( string $token, string $state ): void {
 		$data = array(
 			'token' => $token,
 			'state' => $state,
@@ -258,7 +258,7 @@ class ConnectionListener {
 	 * @param string $token The token to check.
 	 * @return string The current state of the token, or empty string if the token doesn't match.
 	 */
-	private function get_token_state( string $token ) : string {
+	private function get_token_state( string $token ): string {
 		$data = get_transient( self::TOKEN_STATE_TRANSIENT );
 
 		if ( empty( $data ) || ! is_array( $data ) || empty( $data['token'] ) || empty( $data['state'] ) ) {
@@ -275,7 +275,7 @@ class ConnectionListener {
 	 * @param string $token The token to check.
 	 * @return bool True if the token is currently being processed, false otherwise.
 	 */
-	private function is_token_processing( string $token ) : bool {
+	private function is_token_processing( string $token ): bool {
 		return $this->get_token_state( $token ) === self::TOKEN_STATE_PROCESSING;
 	}
 
@@ -285,7 +285,7 @@ class ConnectionListener {
 	 * @param string $token The token to check.
 	 * @return bool True if the token has been processed, false otherwise.
 	 */
-	private function was_token_processed( string $token ) : bool {
+	private function was_token_processed( string $token ): bool {
 		return $this->get_token_state( $token ) === self::TOKEN_STATE_PROCESSED;
 	}
 
@@ -295,7 +295,7 @@ class ConnectionListener {
 	 * @return array Structured array with 'is_sandbox', 'merchant_id', and 'merchant_email' keys,
 	 *               or an empty array on failure.
 	 */
-	private function extract_data() : array {
+	private function extract_data(): array {
 		$this->logger->info( 'Extracting connection data from request...' );
 
 		$merchant_id    = $this->get_merchant_id_from_request( $this->request_data );
@@ -318,7 +318,7 @@ class ConnectionListener {
 	 *
 	 * @return void
 	 */
-	private function redirect_after_authentication() : void {
+	private function redirect_after_authentication(): void {
 		$redirect_url = $this->get_onboarding_redirect_url();
 
 		$this->redirector->redirect( $redirect_url );
@@ -330,7 +330,7 @@ class ConnectionListener {
 	 *
 	 * @return string The sanitized token, or an empty string.
 	 */
-	private function get_token_from_request() : string {
+	private function get_token_from_request(): string {
 		return $this->sanitize_string( $this->request_data['ppcpToken'] ?? '' );
 	}
 
@@ -341,7 +341,7 @@ class ConnectionListener {
 	 *
 	 * @return string The sanitized merchant ID, or an empty string.
 	 */
-	private function get_merchant_id_from_request( array $request ) : string {
+	private function get_merchant_id_from_request( array $request ): string {
 		return $this->sanitize_string( $request['merchantIdInPayPal'] ?? '' );
 	}
 
@@ -356,7 +356,7 @@ class ConnectionListener {
 	 *
 	 * @return string The sanitized merchant email, or an empty string.
 	 */
-	private function get_merchant_email_from_request( array $request ) : string {
+	private function get_merchant_email_from_request( array $request ): string {
 		return $this->sanitize_merchant_email( $request['merchantId'] ?? '' );
 	}
 
@@ -371,7 +371,7 @@ class ConnectionListener {
 	 *
 	 * @return string A valid SellerTypeEnum value.
 	 */
-	private function get_seller_type_from_request( array $request ) : string {
+	private function get_seller_type_from_request( array $request ): string {
 		$account_status = $request['accountStatus'] ?? '';
 
 		if ( 'BUSINESS_ACCOUNT' === $account_status ) {
@@ -401,7 +401,7 @@ class ConnectionListener {
 	 *
 	 * @return string Sanitized value.
 	 */
-	private function sanitize_string( string $value ) : string {
+	private function sanitize_string( string $value ): string {
 		return trim( sanitize_text_field( wp_unslash( $value ) ) );
 	}
 
@@ -412,7 +412,7 @@ class ConnectionListener {
 	 *
 	 * @return string Sanitized email address.
 	 */
-	private function sanitize_merchant_email( string $email ) : string {
+	private function sanitize_merchant_email( string $email ): string {
 		return sanitize_text_field( str_replace( ' ', '+', $email ) );
 	}
 
@@ -421,7 +421,7 @@ class ConnectionListener {
 	 *
 	 * @return string
 	 */
-	private function get_onboarding_redirect_url() : string {
+	private function get_onboarding_redirect_url(): string {
 		/**
 		 * The URL opened at the end of onboarding after saving the merchant ID/email.
 		 */

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -121,7 +121,7 @@ class AuthenticationManager {
 	 *
 	 * @return array
 	 */
-	public function get_account_details() : array {
+	public function get_account_details(): array {
 		return array(
 			'is_sandbox'     => $this->common_settings->is_sandbox_merchant(),
 			'is_connected'   => $this->common_settings->is_merchant_connected(),
@@ -135,7 +135,7 @@ class AuthenticationManager {
 	 *
 	 * @return void
 	 */
-	public function disconnect() : void {
+	public function disconnect(): void {
 		$this->logger->info( 'Disconnecting merchant from PayPal...' );
 
 		$this->common_settings->reset_merchant_data();
@@ -175,7 +175,7 @@ class AuthenticationManager {
 	 * @return void
 	 * @throws RuntimeException When invalid client ID or secret provided.
 	 */
-	public function validate_id_and_secret( string $client_id, string $client_secret ) : void {
+	public function validate_id_and_secret( string $client_id, string $client_secret ): void {
 		if ( empty( $client_id ) ) {
 			throw new RuntimeException( 'No client ID provided.' );
 		}
@@ -202,7 +202,7 @@ class AuthenticationManager {
 	 * @return void
 	 * @throws RuntimeException When failed to retrieve payee.
 	 */
-	public function authenticate_via_direct_api( bool $use_sandbox, string $client_id, string $client_secret ) : void {
+	public function authenticate_via_direct_api( bool $use_sandbox, string $client_id, string $client_secret ): void {
 		$this->logger->info(
 			'Attempting manual connection to PayPal...',
 			array(
@@ -236,7 +236,7 @@ class AuthenticationManager {
 	 * @param bool   $use_sandbox Whether it's a sandbox or production account.
 	 * @return void
 	 */
-	public function remember_oauth_connection_details( string $shared_id, string $auth_code, bool $use_sandbox ) : void {
+	public function remember_oauth_connection_details( string $shared_id, string $auth_code, bool $use_sandbox ): void {
 		$this->logger->info(
 			'Storing one-time OAuth credentials...',
 			array(
@@ -260,7 +260,7 @@ class AuthenticationManager {
 	 *
 	 * @return void
 	 */
-	private function remove_oauth_connection_details() : void {
+	private function remove_oauth_connection_details(): void {
 		delete_option( self::OAUTH_OPTION_NAME );
 	}
 
@@ -270,7 +270,7 @@ class AuthenticationManager {
 	 * @return OAuthConnectionDTO The stored oauth credentials.
 	 * @throws RuntimeException When no stored credentials are found, or they have expired.
 	 */
-	private function retrieve_oauth_connection_details() : OAuthConnectionDTO {
+	private function retrieve_oauth_connection_details(): OAuthConnectionDTO {
 		$oauth_data = get_option( self::OAUTH_OPTION_NAME );
 
 		if ( ! $oauth_data instanceof OAuthConnectionDTO ) {
@@ -300,7 +300,7 @@ class AuthenticationManager {
 	 * @return void
 	 * @throws RuntimeException When invalid shared ID or auth provided.
 	 */
-	private function validate_id_and_auth_code( string $shared_id, string $auth_code ) : void {
+	private function validate_id_and_auth_code( string $shared_id, string $auth_code ): void {
 		if ( empty( $shared_id ) ) {
 			throw new RuntimeException( 'No onboarding ID provided.' );
 		}
@@ -322,7 +322,7 @@ class AuthenticationManager {
 	 * @return MerchantConnectionDTO A DTO containing the connection details.
 	 * @throws RuntimeException When failed to retrieve payee.
 	 */
-	private function authenticate_via_oauth( bool $use_sandbox, string $shared_id, string $auth_code ) : MerchantConnectionDTO {
+	private function authenticate_via_oauth( bool $use_sandbox, string $shared_id, string $auth_code ): MerchantConnectionDTO {
 		$this->logger->info(
 			'Attempting OAuth login to PayPal...',
 			array(
@@ -363,7 +363,7 @@ class AuthenticationManager {
 	 *
 	 * @throws RuntimeException Missing or invalid credentials.
 	 */
-	public function handle_oauth_authentication( array $request_data ) : void {
+	public function handle_oauth_authentication( array $request_data ): void {
 		$merchant_id    = $request_data['merchant_id'] ?? '';
 		$merchant_email = $request_data['merchant_email'] ?? '';
 		$seller_type    = $request_data['seller_type'] ?? '';
@@ -422,7 +422,7 @@ class AuthenticationManager {
 		string $client_id,
 		string $client_secret,
 		bool $use_sandbox
-	) : array {
+	): array {
 		$host = $this->connection_host->get_value( $use_sandbox );
 
 		$bearer = new PayPalBearer(
@@ -495,7 +495,7 @@ class AuthenticationManager {
 	 * @return array
 	 * @throws RuntimeException When failed to fetch credentials.
 	 */
-	private function get_credentials( string $shared_id, string $auth_code, bool $use_sandbox ) : array {
+	private function get_credentials( string $shared_id, string $auth_code, bool $use_sandbox ): array {
 		$login_handler = $this->login_endpoint->get_value( $use_sandbox );
 		$nonce         = $this->referrals_data->nonce();
 
@@ -516,7 +516,7 @@ class AuthenticationManager {
 	 *
 	 * @return void
 	 */
-	private function enrich_merchant_details() : void {
+	private function enrich_merchant_details(): void {
 		if ( ! $this->common_settings->is_merchant_connected() ) {
 			return;
 		}
@@ -563,7 +563,7 @@ class AuthenticationManager {
 	 * @param mixed  $details Optional. Additional details to log.
 	 * @return void
 	 */
-	private function enrichment_failed( string $reason, $details = null ) : void {
+	private function enrichment_failed( string $reason, $details = null ): void {
 		$this->logger->warning(
 			'Failed to enrich merchant details: ' . $reason,
 			array(
@@ -581,7 +581,7 @@ class AuthenticationManager {
 	 * @param MerchantConnectionDTO $connection Connection details to persist.
 	 * @return void
 	 */
-	private function update_connection_details( MerchantConnectionDTO $connection ) : void {
+	private function update_connection_details( MerchantConnectionDTO $connection ): void {
 		$this->logger->info(
 			'Updating connection details',
 			(array) $connection

--- a/modules/ppcp-settings/src/Service/BrandedExperience/ActivationDetector.php
+++ b/modules/ppcp-settings/src/Service/BrandedExperience/ActivationDetector.php
@@ -25,7 +25,7 @@ class ActivationDetector {
 	 *
 	 * @return string The installation path.
 	 */
-	public function detect_activation_path() : string {
+	public function detect_activation_path(): string {
 		/**
 		 * Get the custom attachment detail which was added by WooCommerce
 		 *

--- a/modules/ppcp-settings/src/Service/ConnectionUrlGenerator.php
+++ b/modules/ppcp-settings/src/Service/ConnectionUrlGenerator.php
@@ -87,7 +87,7 @@ class ConnectionUrlGenerator {
 	 *
 	 * @return string The generated PayPal onboarding URL.
 	 */
-	public function generate( array $products = array(), array $flags = array(), bool $use_sandbox = false ) : string {
+	public function generate( array $products = array(), array $flags = array(), bool $use_sandbox = false ): string {
 		$cache_key      = $this->cache_key( $products, $flags, $use_sandbox );
 		$user_id        = get_current_user_id();
 		$onboarding_url = $this->url_manager->get( $cache_key, $user_id );
@@ -123,7 +123,7 @@ class ConnectionUrlGenerator {
 	 *
 	 * @return string The cache key, defining the product list and environment.
 	 */
-	protected function cache_key( array $products, array $flags, bool $for_sandbox ) : string {
+	protected function cache_key( array $products, array $flags, bool $for_sandbox ): string {
 		$environment = $for_sandbox ? 'sandbox' : 'production';
 
 		// Sort products alphabetically, to improve cache implementation.
@@ -145,7 +145,7 @@ class ConnectionUrlGenerator {
 	 *
 	 * @return string The cached URL, or an empty string if no URL is found.
 	 */
-	protected function try_get_from_cache( OnboardingUrl $onboarding_url, string $cache_key ) : string {
+	protected function try_get_from_cache( OnboardingUrl $onboarding_url, string $cache_key ): string {
 		try {
 			if ( $onboarding_url->load() ) {
 				$this->logger->debug( 'Loaded onboarding URL from cache: ' . $cache_key );
@@ -179,7 +179,7 @@ class ConnectionUrlGenerator {
 	 *
 	 * @return string The generated URL or an empty string on failure.
 	 */
-	protected function generate_new_url( bool $for_sandbox, array $products, array $flags, OnboardingUrl $onboarding_url, string $cache_key ) : string {
+	protected function generate_new_url( bool $for_sandbox, array $products, array $flags, OnboardingUrl $onboarding_url, string $cache_key ): string {
 		$query_args = array( 'displayMode' => 'minibrowser' );
 		$onboarding_url->init();
 
@@ -214,7 +214,7 @@ class ConnectionUrlGenerator {
 	 *
 	 * @return array The prepared referral data.
 	 */
-	protected function prepare_referral_data( array $products, array $flags, string $onboarding_token ) : array {
+	protected function prepare_referral_data( array $products, array $flags, string $onboarding_token ): array {
 		return $this->referrals_data->data(
 			$products,
 			$onboarding_token,
@@ -229,7 +229,7 @@ class ConnectionUrlGenerator {
 	 * @param OnboardingUrl $onboarding_url The OnboardingUrl object.
 	 * @param string        $url            The URL to persist.
 	 */
-	protected function persist_url( OnboardingUrl $onboarding_url, string $url ) : void {
+	protected function persist_url( OnboardingUrl $onboarding_url, string $url ): void {
 		$onboarding_url->set( $url );
 		$onboarding_url->persist();
 	}

--- a/modules/ppcp-settings/src/Service/DataSanitizer.php
+++ b/modules/ppcp-settings/src/Service/DataSanitizer.php
@@ -23,7 +23,7 @@ class DataSanitizer {
 	 * @param ?string $location Name of the location.
 	 * @return LocationStylingDTO Styling data.
 	 */
-	public function sanitize_location_style( $data, ?string $location = null ) : LocationStylingDTO {
+	public function sanitize_location_style( $data, ?string $location = null ): LocationStylingDTO {
 		if ( $data instanceof LocationStylingDTO ) {
 			if ( $location ) {
 				$data->location = $location;
@@ -74,7 +74,7 @@ class DataSanitizer {
 	 * @param string $default Default value.
 	 * @return string Sanitized string.
 	 */
-	public function sanitize_text( $value, string $default = '' ) : string {
+	public function sanitize_text( $value, string $default = '' ): string {
 		return sanitize_text_field( $value ?? $default );
 	}
 
@@ -89,7 +89,7 @@ class DataSanitizer {
 	 * @param string   $default      Default value.
 	 * @return string Sanitized string.
 	 */
-	public function sanitize_enum( $value, array $valid_values, string $default = '' ) : string {
+	public function sanitize_enum( $value, array $valid_values, string $default = '' ): string {
 		if ( empty( $valid_values ) ) {
 			return $default;
 		}
@@ -114,7 +114,7 @@ class DataSanitizer {
 	 * @param mixed $value Value to sanitize.
 	 * @return bool Sanitized boolean.
 	 */
-	public function sanitize_bool( $value ) : bool {
+	public function sanitize_bool( $value ): bool {
 		return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 	}
 
@@ -127,7 +127,7 @@ class DataSanitizer {
 	 * @param mixed $value Value to sanitize.
 	 * @return int Sanitized integer.
 	 */
-	public function sanitize_int( $value ) : int {
+	public function sanitize_int( $value ): int {
 		return (int) filter_var( $value, FILTER_VALIDATE_INT );
 	}
 
@@ -138,7 +138,7 @@ class DataSanitizer {
 	 * @param callable   $sanitize_callback Callback to sanitize each item in the array.
 	 * @return array Array with sanitized items.
 	 */
-	public function sanitize_array( ?array $array, callable $sanitize_callback ) : array {
+	public function sanitize_array( ?array $array, callable $sanitize_callback ): array {
 		if ( ! is_array( $array ) ) {
 			return array();
 		}
@@ -153,7 +153,7 @@ class DataSanitizer {
 	 * @param string[] $valid_values List of allowed values.
 	 * @return string|null Matching value if found, null otherwise.
 	 */
-	private function find_enum_value( string $value, array $valid_values ) : ?string {
+	private function find_enum_value( string $value, array $valid_values ): ?string {
 		foreach ( $valid_values as $valid_value ) {
 			// Compare both strings case-insensitive and binary safe.
 			// Note: This function is safe for ASCII but can fail for unicode-characters.

--- a/modules/ppcp-settings/src/Service/FeaturesEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/FeaturesEligibilityService.php
@@ -100,7 +100,7 @@ class FeaturesEligibilityService {
 	 *
 	 * @return array<string, callable>
 	 */
-	public function get_eligibility_checks() : array {
+	public function get_eligibility_checks(): array {
 		return array(
 			'save_paypal_and_venmo'           => fn() => $this->is_save_paypal_eligible,
 			'advanced_credit_and_debit_cards' => $this->check_acdc_eligible,

--- a/modules/ppcp-settings/src/Service/InternalRestService.php
+++ b/modules/ppcp-settings/src/Service/InternalRestService.php
@@ -109,7 +109,7 @@ class InternalRestService {
 	 *
 	 * @return array A list of cookies that are required to authenticate the user.
 	 */
-	private function build_authentication_cookie() : array {
+	private function build_authentication_cookie(): array {
 		$cookies = array();
 
 		// Cookie names are defined in constants and can be changed by site owners.

--- a/modules/ppcp-settings/src/Service/OnboardingUrlManager.php
+++ b/modules/ppcp-settings/src/Service/OnboardingUrlManager.php
@@ -60,7 +60,7 @@ class OnboardingUrlManager {
 	 *
 	 * @return OnboardingUrl
 	 */
-	public function get( string $cache_key_prefix, int $user_id ) : OnboardingUrl {
+	public function get( string $cache_key_prefix, int $user_id ): OnboardingUrl {
 		return new OnboardingUrl( $this->cache, $cache_key_prefix, $user_id );
 	}
 
@@ -73,7 +73,7 @@ class OnboardingUrlManager {
 	 *
 	 * @return bool True, if the token is valid. False otherwise.
 	 */
-	public function validate_token_and_delete( string $token, int $user_id ) : bool {
+	public function validate_token_and_delete( string $token, int $user_id ): bool {
 		if ( $user_id < 1 || strlen( $token ) < 10 ) {
 			return false;
 		}

--- a/modules/ppcp-settings/src/Service/ScriptDataHandler.php
+++ b/modules/ppcp-settings/src/Service/ScriptDataHandler.php
@@ -206,7 +206,7 @@ class ScriptDataHandler {
 		);
 
 		$transformed_button_choices = array_map(
-			function( $key, $value ) {
+			function ( $key, $value ) {
 				return array(
 					'value' => $key,
 					'label' => $value,

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -138,7 +138,7 @@ class SettingsDataManager {
 	 *
 	 * @return void
 	 */
-	public function reset_all_settings() : void {
+	public function reset_all_settings(): void {
 		/**
 		 * Broadcast the settings-reset event to allow other modules to perform
 		 * cleanup tasks, if needed.
@@ -163,7 +163,7 @@ class SettingsDataManager {
 	 * @param ConfigurationFlagsDTO $flags The configuration flags.
 	 * @return void
 	 */
-	public function set_defaults_for_new_merchant( ConfigurationFlagsDTO $flags ) : void {
+	public function set_defaults_for_new_merchant( ConfigurationFlagsDTO $flags ): void {
 		if ( $this->onboarding_profile->is_setup_done() ) {
 			return;
 		}
@@ -193,7 +193,7 @@ class SettingsDataManager {
 	 * @param ConfigurationFlagsDTO $flags The configuration flags.
 	 * @return void
 	 */
-	protected function apply_configuration( ConfigurationFlagsDTO $flags ) : void {
+	protected function apply_configuration( ConfigurationFlagsDTO $flags ): void {
 		// Apply defaults for the "Settings" tab.
 		$this->apply_payment_settings( $flags );
 
@@ -209,7 +209,7 @@ class SettingsDataManager {
 	 *
 	 * @return void
 	 */
-	public function sync_gateway_settings() : void {
+	public function sync_gateway_settings(): void {
 		$flags = new ConfigurationFlagsDTO();
 
 		$profile_data = $this->onboarding_profile->to_array();
@@ -228,7 +228,7 @@ class SettingsDataManager {
 	 * @param ConfigurationFlagsDTO $flags Shop configuration flags.
 	 * @return void
 	 */
-	protected function toggle_payment_gateways( ConfigurationFlagsDTO $flags ) : void {
+	protected function toggle_payment_gateways( ConfigurationFlagsDTO $flags ): void {
 		// First, disable all payment methods.
 		$methods_paypal = $this->methods_definition->group_paypal_methods();
 		$methods_cards  = $this->methods_definition->group_card_methods();
@@ -297,7 +297,7 @@ class SettingsDataManager {
 	 * @param ConfigurationFlagsDTO $flags Shop configuration flags.
 	 * @return void
 	 */
-	protected function apply_payment_settings( ConfigurationFlagsDTO $flags ) : void {
+	protected function apply_payment_settings( ConfigurationFlagsDTO $flags ): void {
 		// Enable Pay-Now experience for all merchants.
 		$this->payment_settings->set_enable_pay_now( true );
 
@@ -315,7 +315,7 @@ class SettingsDataManager {
 	 * @param ConfigurationFlagsDTO $flags Shop configuration flags.
 	 * @return void
 	 */
-	protected function apply_location_styles( ConfigurationFlagsDTO $flags ) : void {
+	protected function apply_location_styles( ConfigurationFlagsDTO $flags ): void {
 		$methods_full = array(
 			PayPalGateway::ID,
 			'venmo',
@@ -358,7 +358,7 @@ class SettingsDataManager {
 	 * @param ConfigurationFlagsDTO $flags Shop configuration flags.
 	 * @return void
 	 */
-	protected function apply_pay_later_messaging( ConfigurationFlagsDTO $flags ) : void {
+	protected function apply_pay_later_messaging( ConfigurationFlagsDTO $flags ): void {
 		$config = $this->paylater_messaging['read'];
 
 		$config['cart']['status']     = 'enabled';

--- a/modules/ppcp-settings/src/Service/TodosSortingAndFilteringService.php
+++ b/modules/ppcp-settings/src/Service/TodosSortingAndFilteringService.php
@@ -81,7 +81,7 @@ class TodosSortingAndFilteringService {
 	public function sort_todos_by_priority( array $todos ): array {
 		usort(
 			$todos,
-			function( $a, $b ) {
+			function ( $a, $b ) {
 				$priority_a = $a['priority'] ?? 999;
 				$priority_b = $b['priority'] ?? 999;
 				return $priority_a <=> $priority_b;
@@ -104,14 +104,14 @@ class TodosSortingAndFilteringService {
 
 		$group_todos = array_filter(
 			$todos,
-			function( $todo ) use ( $group_ids ) {
+			function ( $todo ) use ( $group_ids ) {
 				return in_array( $todo['id'], $group_ids, true );
 			}
 		);
 
 		$other_todos = array_filter(
 			$todos,
-			function( $todo ) use ( $group_ids ) {
+			function ( $todo ) use ( $group_ids ) {
 				return ! in_array( $todo['id'], $group_ids, true );
 			}
 		);
@@ -127,7 +127,7 @@ class TodosSortingAndFilteringService {
 			$matching_todo = current(
 				array_filter(
 					$group_todos,
-					function( $todo ) use ( $todo_id ) {
+					function ( $todo ) use ( $todo_id ) {
 						return $todo['id'] === $todo_id;
 					}
 				)

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -65,7 +65,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	/**
 	 * Returns whether the old settings UI should be loaded.
 	 */
-	public static function should_use_the_old_ui() : bool {
+	public static function should_use_the_old_ui(): bool {
 		/**
 		 * Determine if the new Settings UI is disabled via feature flag.
 		 *
@@ -94,18 +94,18 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function services() : array {
+	public function services(): array {
 		return require __DIR__ . '/../services.php';
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function run( ContainerInterface $container ) : bool {
+	public function run( ContainerInterface $container ): bool {
 		if ( self::should_use_the_old_ui() ) {
 			add_filter(
 				'woocommerce_paypal_payments_inside_settings_page_header',
-				static fn() : string => sprintf(
+				static fn(): string => sprintf(
 					'<button type="button" class="button button-settings-switch-ui" aria-describedby="switch-ui-desc">%s</button><span id="switch-ui-desc" class="screen-reader-text">%s</span>',
 					esc_html__( 'Switch to New Settings', 'woocommerce-paypal-payments' ),
 					esc_html__( 'This action will permanently switch to the new settings interface and cannot be undone', 'woocommerce-paypal-payments' )
@@ -228,7 +228,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'admin_enqueue_scripts',
-			function ( string $hook_suffix ) use ( $container ) : void {
+			function ( string $hook_suffix ) use ( $container ): void {
 				$script_data_handler = $container->get( 'settings.service.script-data-handler' );
 				$script_data_handler->localize_scripts( $hook_suffix );
 			}
@@ -236,7 +236,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_admin_options_wrapper',
-			function () use ( $container ) : void {
+			function () use ( $container ): void {
 				global $hide_save_button;
 				$hide_save_button = true;
 
@@ -249,7 +249,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'rest_api_init',
-			static function () use ( $container ) : void {
+			static function () use ( $container ): void {
 				$endpoints = array(
 					'onboarding'             => $container->get( 'settings.rest.onboarding' ),
 					'common'                 => $container->get( 'settings.rest.common' ),
@@ -274,7 +274,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'admin_init',
-			static function () use ( $container ) : void {
+			static function () use ( $container ): void {
 				$connection_handler = $container->get( 'settings.handler.connection-listener' );
 				assert( $connection_handler instanceof ConnectionListener );
 
@@ -285,7 +285,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'woocommerce_paypal_payments_merchant_disconnected',
-			static function () use ( $container ) : void {
+			static function () use ( $container ): void {
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );
 				assert( $logger instanceof LoggerInterface );
 				$logger->info( 'Merchant disconnected, reset onboarding' );
@@ -310,7 +310,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'woocommerce_paypal_payments_authenticated_merchant',
-			static function () use ( $container ) : void {
+			static function () use ( $container ): void {
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );
 				assert( $logger instanceof LoggerInterface );
 				$logger->info( 'Merchant connected, complete onboarding and set defaults.' );
@@ -341,7 +341,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_filter(
 			'woocommerce_paypal_payments_payment_methods',
-			function ( array $payment_methods ) use ( $container ) : array {
+			function ( array $payment_methods ) use ( $container ): array {
 				$all_payment_methods = $payment_methods;
 
 				$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
@@ -426,7 +426,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function ( $methods ) use ( $container ) : array {
+			function ( $methods ) use ( $container ): array {
 				$is_onboarded = $container->get( 'api.merchant_id' ) !== '';
 				if ( ! is_array( $methods ) || ! $is_onboarded ) {
 					return $methods;
@@ -464,7 +464,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		 */
 		add_action(
 			'woocommerce_admin_field_payment_gateways',
-			function () use ( $container ) : void {
+			function () use ( $container ): void {
 				$all_gateway_ids  = $container->get( 'settings.config.all-gateway-ids' );
 				$payment_gateways = WC()->payment_gateways->payment_gateways;
 
@@ -493,7 +493,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			static function ( $methods ) use ( $container ) : array {
+			static function ( $methods ) use ( $container ): array {
 				if ( ! is_array( $methods ) ) {
 					return $methods;
 				}
@@ -684,7 +684,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		// Do not render Pay Later messaging if the "Save PayPal and Venmo" setting is enabled.
 		add_filter(
 			'woocommerce_paypal_payments_should_render_pay_later_messaging',
-			static function() use ( $container ): bool {
+			static function () use ( $container ): bool {
 				$settings_model = $container->get( 'settings.data.settings' );
 				assert( $settings_model instanceof SettingsModel );
 
@@ -695,7 +695,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		// Migration code to update BN code of merchants that are on whitelabel mode (own_brand_only false) to use the whitelabel BN code (direct).
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
-			static function() use ( $container ) {
+			static function () use ( $container ) {
 				$general_settings = $container->get( 'settings.data.general' );
 				assert( $general_settings instanceof GeneralSettings );
 
@@ -720,7 +720,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * @param ContainerInterface $container The DI container provider.
 	 * @return void
 	 */
-	protected function apply_branded_only_limitations( ContainerInterface $container ) : void {
+	protected function apply_branded_only_limitations( ContainerInterface $container ): void {
 		$settings = $container->get( 'settings.data.general' );
 		assert( $settings instanceof GeneralSettings );
 
@@ -753,7 +753,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * @param ContainerInterface $container The DI container provider.
 	 * @return void
 	 */
-	protected function initialize_branded_only( ContainerInterface $container ) : void {
+	protected function initialize_branded_only( ContainerInterface $container ): void {
 		$path_repository = $container->get( 'settings.service.branded-experience.path-repository' );
 		assert( $path_repository instanceof PathRepository );
 
@@ -773,7 +773,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 *
 	 * @return void
 	 */
-	protected function render_header() : void {
+	protected function render_header(): void {
 		echo '<h2>' . esc_html__( 'PayPal', 'woocommerce-paypal-payments' );
 		wc_back_link( __( 'Return to payments', 'woocommerce-paypal-payments' ), admin_url( 'admin.php?page=wc-settings&tab=checkout' ) );
 		echo '</h2>';
@@ -784,7 +784,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 *
 	 * @return void
 	 */
-	protected function render_content() : void {
+	protected function render_content(): void {
 		echo '<div id="ppcp-settings-container"></div>';
 	}
 
@@ -794,7 +794,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * @param string $gateway_name The gateway name.
 	 * @return bool True if the payment gateway with the given name is enabled, otherwise false.
 	 */
-	protected function is_gateway_enabled( string $gateway_name ) : bool {
+	protected function is_gateway_enabled( string $gateway_name ): bool {
 		$gateway_settings = get_option( "woocommerce_{$gateway_name}_settings", array() );
 		$gateway_enabled  = $gateway_settings['enabled'] ?? false;
 

--- a/modules/ppcp-uninstall/services.php
+++ b/modules/ppcp-uninstall/services.php
@@ -22,7 +22,7 @@ use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
 
 return array(
-	'uninstall.ppcp-all-option-names'           => function( ContainerInterface $container ) : array {
+	'uninstall.ppcp-all-option-names'           => function ( ContainerInterface $container ): array {
 		return array(
 			$container->get( 'webhook.last-webhook-storage.key' ),
 			'woocommerce_ppcp-is_pay_later_settings_migrated',
@@ -40,7 +40,7 @@ return array(
 		);
 	},
 
-	'uninstall.ppcp-all-scheduled-action-names' => function( ContainerInterface $container ) : array {
+	'uninstall.ppcp-all-scheduled-action-names' => function ( ContainerInterface $container ): array {
 		return array(
 			'woocommerce_paypal_payments_check_pui_payment_captured',
 			'woocommerce_paypal_payments_check_saved_payment',
@@ -48,17 +48,17 @@ return array(
 		);
 	},
 
-	'uninstall.ppcp-all-action-names'           => function( ContainerInterface $container ) : array {
+	'uninstall.ppcp-all-action-names'           => function ( ContainerInterface $container ): array {
 		return array(
 			'woocommerce_paypal_payments_uninstall',
 		);
 	},
 
-	'uninstall.clear-db-endpoint'               => function( ContainerInterface $container ) : string {
+	'uninstall.clear-db-endpoint'               => function ( ContainerInterface $container ): string {
 		return 'ppcp-clear-db';
 	},
 
-	'uninstall.clear-database-script-data'      => function( ContainerInterface $container ) : array {
+	'uninstall.clear-database-script-data'      => function ( ContainerInterface $container ): array {
 		return array(
 			'clearDb' => array(
 				'endpoint'            => \WC_AJAX::get_endpoint( $container->get( 'uninstall.clear-db-endpoint' ) ),
@@ -83,7 +83,7 @@ return array(
 		return plugins_url( '/modules/ppcp-uninstall/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
 
-	'uninstall.clear-db-assets'                 => function( ContainerInterface $container ) : ClearDatabaseAssets {
+	'uninstall.clear-db-assets'                 => function ( ContainerInterface $container ): ClearDatabaseAssets {
 		return new ClearDatabaseAssets(
 			$container->get( 'uninstall.module-url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -92,7 +92,7 @@ return array(
 		);
 	},
 
-	'uninstall.clear-db'                        => function( ContainerInterface $container ) : ClearDatabaseInterface {
+	'uninstall.clear-db'                        => function ( ContainerInterface $container ): ClearDatabaseInterface {
 		return new ClearDatabase();
 	},
 );

--- a/modules/ppcp-uninstall/src/ClearDatabase.php
+++ b/modules/ppcp-uninstall/src/ClearDatabase.php
@@ -17,7 +17,7 @@ class ClearDatabase implements ClearDatabaseInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function delete_options( array $option_names ):void {
+	public function delete_options( array $option_names ): void {
 		foreach ( $option_names as $option_name ) {
 			delete_option( $option_name );
 		}
@@ -26,7 +26,7 @@ class ClearDatabase implements ClearDatabaseInterface {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function clear_scheduled_actions( array $action_names ):void {
+	public function clear_scheduled_actions( array $action_names ): void {
 		foreach ( $action_names as $action_name ) {
 			as_unschedule_action( $action_name );
 		}

--- a/modules/ppcp-uninstall/src/ClearDatabaseInterface.php
+++ b/modules/ppcp-uninstall/src/ClearDatabaseInterface.php
@@ -36,5 +36,4 @@ interface ClearDatabaseInterface {
 	 * @throws RuntimeException If problem clearing.
 	 */
 	public function clear_actions( array $action_names ): void;
-
 }

--- a/modules/ppcp-vaulting/services.php
+++ b/modules/ppcp-vaulting/services.php
@@ -20,13 +20,13 @@ return array(
 		$endpoint = $container->get( 'api.endpoint.payment-token' );
 		return new PaymentTokenRepository( $factory, $endpoint );
 	},
-	'vaulting.customer-approval-listener' => function( ContainerInterface $container ) : CustomerApprovalListener {
+	'vaulting.customer-approval-listener' => function ( ContainerInterface $container ): CustomerApprovalListener {
 		return new CustomerApprovalListener(
 			$container->get( 'api.endpoint.payment-token' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'vaulting.credit-card-handler'        => function( ContainerInterface $container ): VaultedCreditCardHandler {
+	'vaulting.credit-card-handler'        => function ( ContainerInterface $container ): VaultedCreditCardHandler {
 		return new VaultedCreditCardHandler(
 			$container->get( 'wc-subscriptions.helper' ),
 			$container->get( 'vaulting.repository.payment-token' ),
@@ -39,13 +39,13 @@ return array(
 			$container->get( 'wcgateway.settings' )
 		);
 	},
-	'vaulting.payment-token-factory'      => function( ContainerInterface $container ): PaymentTokenFactory {
+	'vaulting.payment-token-factory'      => function ( ContainerInterface $container ): PaymentTokenFactory {
 		return new PaymentTokenFactory();
 	},
-	'vaulting.payment-token-helper'       => function( ContainerInterface $container ): PaymentTokenHelper {
+	'vaulting.payment-token-helper'       => function ( ContainerInterface $container ): PaymentTokenHelper {
 		return new PaymentTokenHelper();
 	},
-	'vaulting.payment-tokens-migration'   => function( ContainerInterface $container ): PaymentTokensMigration {
+	'vaulting.payment-tokens-migration'   => function ( ContainerInterface $container ): PaymentTokensMigration {
 		return new PaymentTokensMigration(
 			$container->get( 'vaulting.payment-token-factory' ),
 			$container->get( 'vaulting.repository.payment-token' ),
@@ -53,7 +53,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'vaulting.wc-payment-tokens'          => static function( ContainerInterface $container ): WooCommercePaymentTokens {
+	'vaulting.wc-payment-tokens'          => static function ( ContainerInterface $container ): WooCommercePaymentTokens {
 		return new WooCommercePaymentTokens(
 			$container->get( 'vaulting.payment-token-helper' ),
 			$container->get( 'vaulting.payment-token-factory' ),
@@ -61,7 +61,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'vaulting.vault-v3-enabled'           => static function( ContainerInterface $container ): bool {
+	'vaulting.vault-v3-enabled'           => static function ( ContainerInterface $container ): bool {
 		return $container->has( 'save-payment-methods.eligible' ) && $container->get( 'save-payment-methods.eligible' );
 	},
 );

--- a/modules/ppcp-vaulting/src/PaymentTokenRepository.php
+++ b/modules/ppcp-vaulting/src/PaymentTokenRepository.php
@@ -105,7 +105,7 @@ class PaymentTokenRepository {
 	 */
 	private function token_contains_source( array $tokens, string $source_type ): bool {
 		foreach ( $tokens as $token ) {
-			if ( isset( $token->source()->card ) && 'card' === $source_type || isset( $token->source()->paypal ) && 'paypal' === $source_type ) {
+			if ( ( isset( $token->source()->card ) && 'card' === $source_type ) || ( isset( $token->source()->paypal ) && 'paypal' === $source_type ) ) {
 				return true;
 			}
 		}

--- a/modules/ppcp-vaulting/src/PaymentTokensMigration.php
+++ b/modules/ppcp-vaulting/src/PaymentTokensMigration.php
@@ -74,7 +74,7 @@ class PaymentTokensMigration {
 	 *
 	 * @param int $id WooCommerce customer id.
 	 */
-	public function migrate_payment_tokens_for_user( int $id ):void {
+	public function migrate_payment_tokens_for_user( int $id ): void {
 		$tokens       = $this->payment_token_repository->all_for_user_id( $id );
 		$total_tokens = count( $tokens );
 		$this->logger->info( 'Migrating ' . (string) $total_tokens . ' tokens for user ' . (string) $id );

--- a/modules/ppcp-vaulting/src/VaultedCreditCardHandler.php
+++ b/modules/ppcp-vaulting/src/VaultedCreditCardHandler.php
@@ -31,7 +31,10 @@ use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
  */
 class VaultedCreditCardHandler {
 
-	use OrderMetaTrait, TransactionIdHandlingTrait, PaymentsStatusHandlingTrait, FreeTrialHandlerTrait;
+	use OrderMetaTrait;
+	use TransactionIdHandlingTrait;
+	use PaymentsStatusHandlingTrait;
+	use FreeTrialHandlerTrait;
 
 	/**
 	 * The subscription helper.

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -32,7 +32,8 @@ use WP_User_Query;
  * @psalm-suppress MissingConstructor
  */
 class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule {
-	use ModuleClassNameIdTrait, ContextTrait;
+	use ModuleClassNameIdTrait;
+	use ContextTrait;
 
 	/**
 	 * Session Handler
@@ -65,7 +66,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_action(
 			'woocommerce_init',
-			function() use ( $container ) {
+			function () use ( $container ) {
 				$listener = $container->get( 'vaulting.customer-approval-listener' );
 				assert( $listener instanceof CustomerApprovalListener );
 
@@ -76,7 +77,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 		add_action(
 			'woocommerce_created_customer',
-			function( int $customer_id ) use ( $subscription_helper, $container ) {
+			function ( int $customer_id ) use ( $subscription_helper, $container ) {
 				if ( $container->has( 'save-payment-methods.eligible' ) && $container->get( 'save-payment-methods.eligible' ) ) {
 					return;
 				}
@@ -123,7 +124,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 			 * @psalm-suppress MissingClosureParamType
 			 * @psalm-suppress MissingClosureReturnType
 			 */
-			function( $tokens, $customer_id, $gateway_id ) {
+			function ( $tokens, $customer_id, $gateway_id ) {
 				if ( ! is_array( $tokens ) ) {
 					return $tokens;
 				}
@@ -161,7 +162,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $item, $payment_token ) {
+			function ( $item, $payment_token ) {
 				if ( ! is_array( $item ) || ! is_a( $payment_token, WC_Payment_Token::class ) ) {
 					return $item;
 				}
@@ -189,7 +190,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_action(
 			'wp',
-			function() use ( $container ) {
+			function () use ( $container ) {
 				if ( $container->get( 'vaulting.vault-v3-enabled' ) ) {
 					return;
 				}
@@ -256,7 +257,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 		 */
 		add_action(
 			'pcp_migrate_payment_tokens',
-			function() use ( $container ) {
+			function () use ( $container ) {
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );
 				assert( $logger instanceof LoggerInterface );
 
@@ -266,7 +267,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 		add_action(
 			'woocommerce_paypal_payments_payment_tokens_migration',
-			function( int $customer_id ) use ( $container ) {
+			function ( int $customer_id ) use ( $container ) {
 				$migration = $container->get( 'vaulting.payment-tokens-migration' );
 				assert( $migration instanceof PaymentTokensMigration );
 
@@ -281,7 +282,7 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $methods ) {
+			function ( $methods ) {
 				global $wp;
 
 				if ( ! is_array( $methods ) ) {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -152,7 +152,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'wcgateway.credit-card-labels'                         => static function ( ContainerInterface $container ) : array {
+	'wcgateway.credit-card-labels'                         => static function ( ContainerInterface $container ): array {
 		return array(
 			'visa'       => _x(
 				'Visa',
@@ -191,7 +191,7 @@ return array(
 			),
 		);
 	},
-	'wcgateway.credit-card-icons'                          => static function ( ContainerInterface $container ) : array {
+	'wcgateway.credit-card-icons'                          => static function ( ContainerInterface $container ): array {
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
@@ -278,7 +278,7 @@ return array(
 	},
 
 	// Checks, if the current admin page contains settings for this plugin's payment methods.
-	'wcgateway.is-ppcp-settings-payment-methods-page'      => static function ( ContainerInterface $container ) : bool {
+	'wcgateway.is-ppcp-settings-payment-methods-page'      => static function ( ContainerInterface $container ): bool {
 		if ( ! $container->get( 'wcgateway.is-ppcp-settings-page' ) ) {
 			return false;
 		}
@@ -365,14 +365,14 @@ return array(
 			$container->get( 'wcgateway.settings.status' )
 		);
 	},
-	'wcgateway.store-country'                              => static function(): string {
+	'wcgateway.store-country'                              => static function (): string {
 		$location = wc_get_base_location();
 		return $location['country'];
 	},
-	'wcgateway.send-only-message'                          => static function() {
+	'wcgateway.send-only-message'                          => static function () {
 		return __( "<strong>Important</strong>: Your current WooCommerce store location is in a \"send-only\" country, according to PayPal's policies. Sellers in these countries are unable to receive payments via PayPal. Since receiving payments is essential for using the PayPal Payments extension, you will not be able to connect your PayPal account while operating from a \"send-only\" country. To activate PayPal, please update your WooCommerce store location to a supported region and connect a PayPal account eligible for receiving payments.", 'woocommerce-paypal-payments' );
 	},
-	'wcgateway.send-only-countries'                        => static function() {
+	'wcgateway.send-only-countries'                        => static function () {
 		return array(
 			'AO',
 			'AI',
@@ -454,7 +454,7 @@ return array(
 			'ZW',
 		);
 	},
-	'wcgateway.is-send-only-country'                       => static function( ContainerInterface $container ) {
+	'wcgateway.is-send-only-country'                       => static function ( ContainerInterface $container ) {
 		$store_country = $container->get( 'wcgateway.store-country' );
 		$send_only_countries = $container->get( 'wcgateway.send-only-countries' );
 		return in_array( $store_country, $send_only_countries, true );
@@ -1311,7 +1311,7 @@ return array(
 		return $fields;
 	},
 
-	'wcgateway.all-funding-sources'                        => static function( ContainerInterface $container ): array {
+	'wcgateway.all-funding-sources'                        => static function ( ContainerInterface $container ): array {
 		return array(
 			'card'       => _x( 'Credit or debit cards', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'sepa'       => _x( 'SEPA-Lastschrift', 'Name of payment method', 'woocommerce-paypal-payments' ),
@@ -1328,7 +1328,7 @@ return array(
 		);
 	},
 
-	'wcgateway.extra-funding-sources'                      => static function( ContainerInterface $container ): array {
+	'wcgateway.extra-funding-sources'                      => static function ( ContainerInterface $container ): array {
 		return array(
 			'googlepay' => _x( 'Google Pay', 'Name of payment method', 'woocommerce-paypal-payments' ),
 			'applepay'  => _x( 'Apple Pay', 'Name of payment method', 'woocommerce-paypal-payments' ),
@@ -1338,10 +1338,10 @@ return array(
 	/**
 	 * The sources that do not cause issues about redirecting (on mobile, ...) and sometimes not returning back.
 	 */
-	'wcgateway.funding-sources-without-redirect'           => static function( ContainerInterface $container ): array {
+	'wcgateway.funding-sources-without-redirect'           => static function ( ContainerInterface $container ): array {
 		return array( 'paypal', 'paylater', 'venmo', 'card' );
 	},
-	'wcgateway.settings.funding-sources'                   => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.funding-sources'                   => static function ( ContainerInterface $container ): array {
 		return array_diff_key(
 			$container->get( 'wcgateway.all-funding-sources' ),
 			array_flip(
@@ -1353,7 +1353,7 @@ return array(
 		);
 	},
 
-	'wcgateway.checkout.address-preset'                    => static function( ContainerInterface $container ): CheckoutPayPalAddressPreset {
+	'wcgateway.checkout.address-preset'                    => static function ( ContainerInterface $container ): CheckoutPayPalAddressPreset {
 
 		return new CheckoutPayPalAddressPreset(
 			$container->get( 'session.handler' )
@@ -1362,13 +1362,13 @@ return array(
 	'wcgateway.url'                                        => static function ( ContainerInterface $container ): string {
 		return plugins_url( $container->get( 'wcgateway.relative-path' ), $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
-	'wcgateway.relative-path'                              => static function( ContainerInterface $container ): string {
+	'wcgateway.relative-path'                              => static function ( ContainerInterface $container ): string {
 		return 'modules/ppcp-wc-gateway/';
 	},
-	'wcgateway.absolute-path'                              => static function( ContainerInterface $container ): string {
+	'wcgateway.absolute-path'                              => static function ( ContainerInterface $container ): string {
 		return plugin_dir_path( $container->get( 'ppcp.path-to-plugin-main-file' ) ) . $container->get( 'wcgateway.relative-path' );
 	},
-	'wcgateway.endpoint.return-url'                        => static function ( ContainerInterface $container ) : ReturnUrlEndpoint {
+	'wcgateway.endpoint.return-url'                        => static function ( ContainerInterface $container ): ReturnUrlEndpoint {
 		$gateway  = $container->get( 'wcgateway.paypal-gateway' );
 		$endpoint = $container->get( 'api.endpoint.order' );
 		return new ReturnUrlEndpoint(
@@ -1378,7 +1378,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'wcgateway.endpoint.refresh-feature-status'            => static function ( ContainerInterface $container ) : RefreshFeatureStatusEndpoint {
+	'wcgateway.endpoint.refresh-feature-status'            => static function ( ContainerInterface $container ): RefreshFeatureStatusEndpoint {
 		return new RefreshFeatureStatusEndpoint(
 			$container->get( 'wcgateway.settings' ),
 			new Cache( 'ppcp-timeout' ),
@@ -1410,7 +1410,7 @@ return array(
 		return new TransactionUrlProvider( $sandbox_url_base, $live_url_base );
 	},
 
-	'wcgateway.configuration.card-configuration'           => static function ( ContainerInterface $container ) : CardPaymentsConfiguration {
+	'wcgateway.configuration.card-configuration'           => static function ( ContainerInterface $container ): CardPaymentsConfiguration {
 		return new CardPaymentsConfiguration(
 			$container->get( 'settings.connection-state' ),
 			$container->get( 'wcgateway.settings' ),
@@ -1420,7 +1420,7 @@ return array(
 		);
 	},
 
-	'wcgateway.helper.dcc-product-status'                  => static function ( ContainerInterface $container ) : DCCProductStatus {
+	'wcgateway.helper.dcc-product-status'                  => static function ( ContainerInterface $container ): DCCProductStatus {
 
 		$settings         = $container->get( 'wcgateway.settings' );
 		$partner_endpoint = $container->get( 'api.endpoint.partners' );
@@ -1453,7 +1453,7 @@ return array(
 		);
 	},
 
-	'wcgateway.funding-source.renderer'                    => function ( ContainerInterface $container ) : FundingSourceRenderer {
+	'wcgateway.funding-source.renderer'                    => function ( ContainerInterface $container ): FundingSourceRenderer {
 		return new FundingSourceRenderer(
 			$container->get( 'wcgateway.settings' ),
 			array_merge(
@@ -1502,13 +1502,13 @@ return array(
 			(string) $source_website_id()
 		);
 	},
-	'wcgateway.pay-upon-invoice-helper'                    => static function( ContainerInterface $container ): PayUponInvoiceHelper {
+	'wcgateway.pay-upon-invoice-helper'                    => static function ( ContainerInterface $container ): PayUponInvoiceHelper {
 		return new PayUponInvoiceHelper(
 			$container->get( 'wcgateway.checkout-helper' ),
 			$container->get( 'api.shop.country' )
 		);
 	},
-	'wcgateway.pay-upon-invoice-product-status'            => static function( ContainerInterface $container ): PayUponInvoiceProductStatus {
+	'wcgateway.pay-upon-invoice-product-status'            => static function ( ContainerInterface $container ): PayUponInvoiceProductStatus {
 		return new PayUponInvoiceProductStatus(
 			$container->get( 'wcgateway.settings' ),
 			$container->get( 'api.endpoint.partners' ),
@@ -1539,7 +1539,7 @@ return array(
 			$container->get( 'api.factory.capture' )
 		);
 	},
-	'wcgateway.oxxo'                                       => static function( ContainerInterface $container ): OXXO {
+	'wcgateway.oxxo'                                       => static function ( ContainerInterface $container ): OXXO {
 		return new OXXO(
 			$container->get( 'wcgateway.checkout-helper' ),
 			$container->get( 'wcgateway.url' ),
@@ -1549,7 +1549,7 @@ return array(
 			$container->get( 'api.factory.capture' )
 		);
 	},
-	'wcgateway.oxxo-gateway'                               => static function( ContainerInterface $container ): OXXOGateway {
+	'wcgateway.oxxo-gateway'                               => static function ( ContainerInterface $container ): OXXOGateway {
 		return new OXXOGateway(
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'api.factory.purchase-unit' ),
@@ -1561,7 +1561,7 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'wcgateway.logging.is-enabled'                         => static function ( ContainerInterface $container ) : bool {
+	'wcgateway.logging.is-enabled'                         => static function ( ContainerInterface $container ): bool {
 		$settings = $container->get( 'wcgateway.settings' );
 
 		// Check if logging was enabled in plugin settings.
@@ -1583,7 +1583,7 @@ return array(
 		return apply_filters( 'woocommerce_paypal_payments_is_logging_enabled', $is_enabled );
 	},
 
-	'wcgateway.use-place-order-button'                     => function ( ContainerInterface $container ) : bool {
+	'wcgateway.use-place-order-button'                     => function ( ContainerInterface $container ): bool {
 		/**
 		 * Whether to use the standard "Place order" button with redirect to PayPal instead of the PayPal smart buttons.
 		 */
@@ -1592,7 +1592,7 @@ return array(
 			false
 		);
 	},
-	'wcgateway.place-order-button-text'                    => function ( ContainerInterface $container ) : string {
+	'wcgateway.place-order-button-text'                    => function ( ContainerInterface $container ): string {
 		/**
 		 * The text for the standard "Place order" button, when the "Place order" button mode is enabled.
 		 */
@@ -1601,7 +1601,7 @@ return array(
 			__( 'Proceed to PayPal', 'woocommerce-paypal-payments' )
 		);
 	},
-	'wcgateway.place-order-button-description'             => function ( ContainerInterface $container ) : string {
+	'wcgateway.place-order-button-description'             => function ( ContainerInterface $container ): string {
 		/**
 		 * The text for additional description, when the "Place order" button mode is enabled.
 		 */
@@ -1687,7 +1687,7 @@ return array(
 	'wcgateway.settings.has_enabled_separate_button_gateways' => static function ( ContainerInterface $container ): bool {
 		return (bool) $container->get( 'wcgateway.settings.allow_card_button_gateway' );
 	},
-	'wcgateway.settings.should-disable-fraudnet-checkbox'  => static function( ContainerInterface $container ): bool {
+	'wcgateway.settings.should-disable-fraudnet-checkbox'  => static function ( ContainerInterface $container ): bool {
 		$pui_helper = $container->get( 'wcgateway.pay-upon-invoice-helper' );
 		assert( $pui_helper instanceof PayUponInvoiceHelper );
 
@@ -1843,16 +1843,16 @@ return array(
 			esc_html( $pui_button_text )
 		);
 	},
-	'pui.status-cache'                                     => static function( ContainerInterface $container ): Cache {
+	'pui.status-cache'                                     => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-pui-status-cache' );
 	},
-	'installments.status-cache'                            => static function( ContainerInterface $container ): Cache {
+	'installments.status-cache'                            => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-installments-status-cache' );
 	},
-	'dcc.status-cache'                                     => static function( ContainerInterface $container ): Cache {
+	'dcc.status-cache'                                     => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-dcc-status-cache' );
 	},
-	'wcgateway.button.locations'                           => static function( ContainerInterface $container ): array {
+	'wcgateway.button.locations'                           => static function ( ContainerInterface $container ): array {
 		return array(
 			'product'   => 'Single Product',
 			'cart'      => 'Classic Cart',
@@ -1860,12 +1860,12 @@ return array(
 			'mini-cart' => 'Mini Cart',
 		);
 	},
-	'wcgateway.button.default-locations'                   => static function( ContainerInterface $container ): array {
+	'wcgateway.button.default-locations'                   => static function ( ContainerInterface $container ): array {
 		$button_locations = $container->get( 'wcgateway.button.locations' );
 		unset( $button_locations['mini-cart'] );
 		return array_keys( $button_locations );
 	},
-	'wcgateway.button.recommended-styling-notice'          => static function ( ContainerInterface $container ) : string {
+	'wcgateway.button.recommended-styling-notice'          => static function ( ContainerInterface $container ): string {
 		if ( CartCheckoutDetector::has_block_checkout() ) {
 			$block_checkout_page_string_html = '<a href="' . esc_url( wc_get_page_permalink( 'checkout' ) ) . '">' . __( 'Checkout block', 'woocommerce-paypal-payments' ) . '</a>';
 		} else {
@@ -1883,7 +1883,7 @@ return array(
 
 		return '<div class="ppcp-notice ppcp-notice-warning"><p>' . $notice_content . '</p></div>';
 	},
-	'wcgateway.settings.pay-later.messaging-locations'     => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.pay-later.messaging-locations'     => static function ( ContainerInterface $container ): array {
 		$button_locations = $container->get( 'wcgateway.button.locations' );
 		unset( $button_locations['mini-cart'] );
 		return array_merge(
@@ -1894,12 +1894,12 @@ return array(
 			)
 		);
 	},
-	'wcgateway.settings.pay-later.default-messaging-locations' => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.pay-later.default-messaging-locations' => static function ( ContainerInterface $container ): array {
 		$locations = $container->get( 'wcgateway.settings.pay-later.messaging-locations' );
 		unset( $locations['home'] );
 		return array_keys( $locations );
 	},
-	'wcgateway.settings.pay-later.button-locations'        => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.pay-later.button-locations'        => static function ( ContainerInterface $container ): array {
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
@@ -1909,7 +1909,7 @@ return array(
 
 		return array_intersect_key( $button_locations, array_flip( $smart_button_selected_locations ) );
 	},
-	'wcgateway.settings.pay-later.default-button-locations' => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.pay-later.default-button-locations' => static function ( ContainerInterface $container ): array {
 		return $container->get( 'wcgateway.button.default-locations' );
 	},
 	'wcgateway.ppcp-gateways'                              => static function ( ContainerInterface $container ): array {
@@ -1941,7 +1941,7 @@ return array(
 
 		return $settings->has( 'fraudnet_enabled' ) && $settings->get( 'fraudnet_enabled' );
 	},
-	'wcgateway.fraudnet-assets'                            => function( ContainerInterface $container ) : FraudNetAssets {
+	'wcgateway.fraudnet-assets'                            => function ( ContainerInterface $container ): FraudNetAssets {
 		return new FraudNetAssets(
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -1953,18 +1953,18 @@ return array(
 			$container->get( 'wcgateway.is-fraudnet-enabled' )
 		);
 	},
-	'wcgateway.cli.settings.command'                       => function( ContainerInterface $container ) : SettingsCommand {
+	'wcgateway.cli.settings.command'                       => function ( ContainerInterface $container ): SettingsCommand {
 		return new SettingsCommand(
 			$container->get( 'wcgateway.settings' )
 		);
 	},
 	'wcgateway.display-manager'                            => SingletonDecorator::make(
-		static function( ContainerInterface $container ): DisplayManager {
+		static function ( ContainerInterface $container ): DisplayManager {
 			$settings = $container->get( 'wcgateway.settings' );
 			return new DisplayManager( $settings );
 		}
 	),
-	'wcgateway.wp-paypal-locales-map'                      => static function( ContainerInterface $container ): array {
+	'wcgateway.wp-paypal-locales-map'                      => static function ( ContainerInterface $container ): array {
 		return apply_filters(
 			'woocommerce_paypal_payments_button_locales',
 			array(
@@ -2012,7 +2012,7 @@ return array(
 			)
 		);
 	},
-	'wcgateway.endpoint.capture-card-payment'              => static function( ContainerInterface $container ): CaptureCardPayment {
+	'wcgateway.endpoint.capture-card-payment'              => static function ( ContainerInterface $container ): CaptureCardPayment {
 		return new CaptureCardPayment(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
@@ -2026,14 +2026,14 @@ return array(
 		);
 	},
 
-	'wcgateway.settings.wc-tasks.simple-redirect-task-factory' => static function(): SimpleRedirectTaskFactoryInterface {
+	'wcgateway.settings.wc-tasks.simple-redirect-task-factory' => static function (): SimpleRedirectTaskFactoryInterface {
 		return new SimpleRedirectTaskFactory();
 	},
-	'wcgateway.settings.wc-tasks.task-registrar'           => static function(): TaskRegistrarInterface {
+	'wcgateway.settings.wc-tasks.task-registrar'           => static function (): TaskRegistrarInterface {
 		return new TaskRegistrar();
 	},
 
-	'wcgateway.settings.wc-tasks.pay-later-task-config'    => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.wc-tasks.pay-later-task-config'    => static function ( ContainerInterface $container ): array {
 		$section_id = PayPalGateway::ID;
 		$pay_later_tab_id = Settings::PAY_LATER_TAB_ID;
 
@@ -2051,7 +2051,7 @@ return array(
 		return array();
 	},
 
-	'wcgateway.settings.wc-tasks.connect-task-config'      => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.wc-tasks.connect-task-config'      => static function ( ContainerInterface $container ): array {
 		$is_connected = $container->get( 'settings.flag.is-connected' );
 		$is_current_country_send_only = $container->get( 'wcgateway.is-send-only-country' );
 
@@ -2069,7 +2069,7 @@ return array(
 		return array();
 	},
 
-	'wcgateway.settings.wc-tasks.working-capital-config'   => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.wc-tasks.working-capital-config'   => static function ( ContainerInterface $container ): array {
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
@@ -2095,7 +2095,7 @@ return array(
 		);
 	},
 
-	'wcgateway.settings.wc-tasks.task-config-services'     => static function(): array {
+	'wcgateway.settings.wc-tasks.task-config-services'     => static function (): array {
 		return array(
 			'wcgateway.settings.wc-tasks.pay-later-task-config',
 			'wcgateway.settings.wc-tasks.connect-task-config',
@@ -2113,7 +2113,7 @@ return array(
 	 *     redirect_url: string
 	 * }>
 	 */
-	'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' => static function ( ContainerInterface $container ): array {
 		$list_of_config = array();
 		$task_config_services = $container->get( 'wcgateway.settings.wc-tasks.task-config-services' );
 
@@ -2132,7 +2132,7 @@ return array(
 	 *
 	 * @returns SimpleRedirectTask[]
 	 */
-	'wcgateway.settings.wc-tasks.simple-redirect-tasks'    => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.wc-tasks.simple-redirect-tasks'    => static function ( ContainerInterface $container ): array {
 		$simple_redirect_tasks_config = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-tasks-config' );
 		$simple_redirect_task_factory = $container->get( 'wcgateway.settings.wc-tasks.simple-redirect-task-factory' );
 		assert( $simple_redirect_task_factory instanceof SimpleRedirectTaskFactoryInterface );
@@ -2150,11 +2150,11 @@ return array(
 		return $simple_redirect_tasks;
 	},
 
-	'wcgateway.settings.inbox-note-factory'                => static function(): InboxNoteFactory {
+	'wcgateway.settings.inbox-note-factory'                => static function (): InboxNoteFactory {
 		return new InboxNoteFactory();
 	},
 
-	'wcgateway.settings.inbox-note-registrar'              => static function( ContainerInterface $container ): InboxNoteRegistrar {
+	'wcgateway.settings.inbox-note-registrar'              => static function ( ContainerInterface $container ): InboxNoteRegistrar {
 		return new InboxNoteRegistrar( $container->get( 'wcgateway.settings.inbox-notes' ), $container->get( 'ppcp.plugin' ) );
 	},
 
@@ -2163,7 +2163,7 @@ return array(
 	 *
 	 * @returns InboxNoteInterface[]
 	 */
-	'wcgateway.settings.inbox-notes'                       => static function( ContainerInterface $container ): array {
+	'wcgateway.settings.inbox-notes'                       => static function ( ContainerInterface $container ): array {
 		$inbox_note_factory = $container->get( 'wcgateway.settings.inbox-note-factory' );
 		assert( $inbox_note_factory instanceof InboxNoteFactory );
 
@@ -2265,7 +2265,7 @@ return array(
 		);
 	},
 
-	'wcgateway.void-button.assets'                         => function( ContainerInterface $container ) : VoidButtonAssets {
+	'wcgateway.void-button.assets'                         => function ( ContainerInterface $container ): VoidButtonAssets {
 		return new VoidButtonAssets(
 			$container->get( 'wcgateway.url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -2273,7 +2273,7 @@ return array(
 			$container->get( 'wcgateway.processor.refunds' )
 		);
 	},
-	'wcgateway.void-button.endpoint'                       => function( ContainerInterface $container ) : VoidOrderEndpoint {
+	'wcgateway.void-button.endpoint'                       => function ( ContainerInterface $container ): VoidOrderEndpoint {
 		return new VoidOrderEndpoint(
 			$container->get( 'button.request-data' ),
 			$container->get( 'api.endpoint.order' ),
@@ -2282,7 +2282,7 @@ return array(
 		);
 	},
 
-	'wcgateway.settings.admin-settings-enabled'            => static function( ContainerInterface $container ): bool {
+	'wcgateway.settings.admin-settings-enabled'            => static function ( ContainerInterface $container ): bool {
 		return $container->has( 'settings.url' ) && ! SettingsModule::should_use_the_old_ui();
 	},
 
@@ -2324,7 +2324,7 @@ return array(
 	 * This is a helper service which is used by the `MerchantDetails` class and
 	 * should not be directly accessed.
 	 */
-	'wcgateway.feature-eligibility.list'                   => static function( ContainerInterface $container ): array {
+	'wcgateway.feature-eligibility.list'                   => static function ( ContainerInterface $container ): array {
 		return array(
 			MerchantDetails::FEATURE_SAVE_PAYPAL_VENMO => $container->get( 'save-payment-methods.eligibility.check' ),
 			MerchantDetails::FEATURE_ADVANCED_CARD_PROCESSING => $container->get( 'card-fields.eligibility.check' ),
@@ -2337,7 +2337,7 @@ return array(
 	/**
 	 * Returns a prefix for the site, ensuring the same site always gets the same prefix (unless the URL changes).
 	 */
-	'wcgateway.settings.invoice-prefix'                    => static function( ContainerInterface $container ): string {
+	'wcgateway.settings.invoice-prefix'                    => static function ( ContainerInterface $container ): string {
 		$site_url = get_site_url( get_current_blog_id() );
 		$hash     = md5( $site_url );
 		$letters  = preg_replace( '~\d~', '', $hash ) ?? '';
@@ -2349,7 +2349,7 @@ return array(
 	/**
 	 * Returns random 6 characters length alphabetic prefix, followed by a hyphen.
 	 */
-	'wcgateway.settings.invoice-prefix-random'             => static function( ContainerInterface $container ): string {
+	'wcgateway.settings.invoice-prefix-random'             => static function ( ContainerInterface $container ): string {
 		$characters = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 		$prefix = '';
 		for ( $i = 0; $i < 6; $i++ ) {
@@ -2359,34 +2359,34 @@ return array(
 		return $prefix . '-';
 	},
 
-	'wcgateway.store-api.endpoint.cart'                    => static function( ContainerInterface $container ) : CartEndpoint {
+	'wcgateway.store-api.endpoint.cart'                    => static function ( ContainerInterface $container ): CartEndpoint {
 		return new CartEndpoint(
 			$container->get( 'wcgateway.store-api.factory.cart' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 
-	'wcgateway.store-api.factory.cart'                     => static function( ContainerInterface $container ) : CartFactory {
+	'wcgateway.store-api.factory.cart'                     => static function ( ContainerInterface $container ): CartFactory {
 		return new CartFactory(
 			$container->get( 'wcgateway.store-api.factory.cart-totals' ),
 			$container->get( 'wcgateway.store-api.factory.shipping-rates' )
 		);
 	},
-	'wcgateway.store-api.factory.cart-totals'              => static function( ContainerInterface $container ) : CartTotalsFactory {
+	'wcgateway.store-api.factory.cart-totals'              => static function ( ContainerInterface $container ): CartTotalsFactory {
 		return new CartTotalsFactory(
 			$container->get( 'wcgateway.store-api.factory.money' )
 		);
 	},
-	'wcgateway.store-api.factory.shipping-rates'           => static function( ContainerInterface $container ) : ShippingRatesFactory {
+	'wcgateway.store-api.factory.shipping-rates'           => static function ( ContainerInterface $container ): ShippingRatesFactory {
 		return new ShippingRatesFactory(
 			$container->get( 'wcgateway.store-api.factory.money' )
 		);
 	},
-	'wcgateway.store-api.factory.money'                    => static function( ContainerInterface $container ) : MoneyFactory {
+	'wcgateway.store-api.factory.money'                    => static function ( ContainerInterface $container ): MoneyFactory {
 		return new MoneyFactory();
 	},
 
-	'wcgateway.shipping.callback.endpoint'                 => static function( ContainerInterface $container ) : ShippingCallbackEndpoint {
+	'wcgateway.shipping.callback.endpoint'                 => static function ( ContainerInterface $container ): ShippingCallbackEndpoint {
 		return new ShippingCallbackEndpoint(
 			$container->get( 'wcgateway.store-api.endpoint.cart' ),
 			$container->get( 'api.factory.amount' ),
@@ -2394,14 +2394,14 @@ return array(
 		);
 	},
 
-	'wcgateway.shipping.callback.factory.url'              => static function( ContainerInterface $container ) : ShippingCallbackUrlFactory {
+	'wcgateway.shipping.callback.factory.url'              => static function ( ContainerInterface $container ): ShippingCallbackUrlFactory {
 		return new ShippingCallbackUrlFactory(
 			$container->get( 'wcgateway.store-api.endpoint.cart' ),
 			$container->get( 'wcgateway.shipping.callback.endpoint' )
 		);
 	},
 
-	'wcgateway.server-side-shipping-callback-enabled'      => static function( ContainerInterface $container ) : bool {
+	'wcgateway.server-side-shipping-callback-enabled'      => static function ( ContainerInterface $container ): bool {
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.server_side_shipping_callback_enabled',
@@ -2409,7 +2409,7 @@ return array(
 		);
 	},
 
-	'wcgateway.appswitch-enabled'                          => static function( ContainerInterface $container ) : bool {
+	'wcgateway.appswitch-enabled'                          => static function ( ContainerInterface $container ): bool {
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.appswitch_enabled',

--- a/modules/ppcp-wc-gateway/src/Admin/FeesRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Admin/FeesRenderer.php
@@ -23,7 +23,7 @@ class FeesRenderer {
 	 *
 	 * @return string
 	 */
-	public function render( WC_Order $wc_order ) : string {
+	public function render( WC_Order $wc_order ): string {
 		$breakdown        = $wc_order->get_meta( PayPalGateway::FEES_META_KEY );
 		$refund_breakdown = $wc_order->get_meta( PayPalGateway::REFUND_FEES_META_KEY ) ?: array();
 

--- a/modules/ppcp-wc-gateway/src/Admin/RenderAuthorizeAction.php
+++ b/modules/ppcp-wc-gateway/src/Admin/RenderAuthorizeAction.php
@@ -37,7 +37,7 @@ class RenderAuthorizeAction {
 	 *
 	 * @return array
 	 */
-	public function render( array $order_actions, \WC_Order $wc_order ) : array {
+	public function render( array $order_actions, \WC_Order $wc_order ): array {
 
 		if ( ! $this->should_render_for_order( $wc_order ) ) {
 			return $order_actions;
@@ -57,7 +57,7 @@ class RenderAuthorizeAction {
 	 *
 	 * @return bool
 	 */
-	private function should_render_for_order( \WC_Order $order ) : bool {
+	private function should_render_for_order( \WC_Order $order ): bool {
 		$status               = $order->get_status();
 		$not_allowed_statuses = array( 'refunded', 'cancelled', 'failed' );
 		return $this->column->should_render_for_order( $order ) &&

--- a/modules/ppcp-wc-gateway/src/Admin/RenderReauthorizeAction.php
+++ b/modules/ppcp-wc-gateway/src/Admin/RenderReauthorizeAction.php
@@ -37,7 +37,7 @@ class RenderReauthorizeAction {
 	 *
 	 * @return array
 	 */
-	public function render( array $order_actions, \WC_Order $wc_order ) : array {
+	public function render( array $order_actions, \WC_Order $wc_order ): array {
 
 		if ( ! $this->should_render_for_order( $wc_order ) ) {
 			return $order_actions;
@@ -57,7 +57,7 @@ class RenderReauthorizeAction {
 	 *
 	 * @return bool
 	 */
-	private function should_render_for_order( \WC_Order $order ) : bool {
+	private function should_render_for_order( \WC_Order $order ): bool {
 		$status               = $order->get_status();
 		$not_allowed_statuses = array( 'refunded', 'cancelled', 'failed' );
 		return $this->column->should_render_for_order( $order ) &&

--- a/modules/ppcp-wc-gateway/src/Assets/FraudNetAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/FraudNetAssets.php
@@ -127,7 +127,7 @@ class FraudNetAssets {
 	public function register_assets(): void {
 		add_action(
 			'wp_enqueue_scripts',
-			function() {
+			function () {
 				if ( $this->should_load_fraudnet_script() ) {
 					wp_enqueue_script(
 						'ppcp-fraudnet',
@@ -176,7 +176,7 @@ class FraudNetAssets {
 	 *
 	 * @return bool true if enabled, otherwise false.
 	 */
-	protected function are_buttons_enabled_for_context() : bool {
+	protected function are_buttons_enabled_for_context(): bool {
 		if ( ! in_array( PayPalGateway::ID, $this->enabled_ppcp_gateways(), true ) ) {
 			return false;
 		}

--- a/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/SettingsPageAssets.php
@@ -265,5 +265,4 @@ class SettingsPageAssets {
 			true
 		);
 	}
-
 }

--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -120,7 +120,7 @@ class DisableGateways {
 	 *
 	 * @return bool
 	 */
-	private function disable_all_gateways() : bool {
+	private function disable_all_gateways(): bool {
 		if ( is_null( WC()->payment_gateways ) ) {
 			return false;
 		}

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -198,4 +198,3 @@ class CaptureCardPayment {
 		return $decoded_response;
 	}
 }
-

--- a/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
@@ -159,7 +159,7 @@ class ReturnUrlEndpoint {
 		if ( isset( $success['result'] ) && 'success' === $success['result'] ) {
 			add_filter(
 				'allowed_redirect_hosts',
-				function( $allowed_hosts ) : array {
+				function ( $allowed_hosts ): array {
 					$allowed_hosts[] = 'www.paypal.com';
 					$allowed_hosts[] = 'www.sandbox.paypal.com';
 					return (array) $allowed_hosts;

--- a/modules/ppcp-wc-gateway/src/Endpoint/VoidOrderEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/VoidOrderEndpoint.php
@@ -195,4 +195,3 @@ class VoidOrderEndpoint {
 		$wc_order->set_status( 'refunded' );
 	}
 }
-

--- a/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CardButtonGateway.php
@@ -30,7 +30,9 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\SettingsRenderer;
  */
 class CardButtonGateway extends \WC_Payment_Gateway {
 
-	use ProcessPaymentTrait, FreeTrialHandlerTrait, GatewaySettingsRendererTrait;
+	use ProcessPaymentTrait;
+	use FreeTrialHandlerTrait;
+	use GatewaySettingsRendererTrait;
 
 	const ID = 'ppcp-card-button-gateway';
 

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -42,7 +42,11 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
  */
 class CreditCardGateway extends \WC_Payment_Gateway_CC {
 
-	use ProcessPaymentTrait, GatewaySettingsRendererTrait, TransactionIdHandlingTrait, PaymentsStatusHandlingTrait, FreeTrialHandlerTrait;
+	use ProcessPaymentTrait;
+	use GatewaySettingsRendererTrait;
+	use TransactionIdHandlingTrait;
+	use PaymentsStatusHandlingTrait;
+	use FreeTrialHandlerTrait;
 
 	const ID = 'ppcp-credit-card-gateway';
 
@@ -375,7 +379,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 *
 	 * @return bool
 	 */
-	public function is_available() : bool {
+	public function is_available(): bool {
 		return $this->is_enabled();
 	}
 

--- a/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/OXXO/OXXO.php
@@ -130,7 +130,7 @@ class OXXO {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $message, $order ) {
+			function ( $message, $order ) {
 				if ( ! is_string( $message ) || ! $order instanceof WC_Order ) {
 					return $message;
 				}
@@ -177,7 +177,7 @@ class OXXO {
 
 		add_filter(
 			'ppcp_payment_capture_reversed_webhook_update_status_note',
-			function( string $note, WC_Order $wc_order, string $event_type ): string {
+			function ( string $note, WC_Order $wc_order, string $event_type ): string {
 				if ( $wc_order->get_payment_method() === OXXOGateway::ID && $event_type === 'PAYMENT.CAPTURE.DENIED' ) {
 					$note = __( 'OXXO voucher has expired or the buyer didn\'t complete the payment successfully.', 'woocommerce-paypal-payments' );
 				}
@@ -190,7 +190,7 @@ class OXXO {
 
 		add_action(
 			'add_meta_boxes',
-			function( string $post_type ) {
+			function ( string $post_type ) {
 				/**
 				 * Class and function exist in WooCommerce.
 				 *
@@ -211,7 +211,7 @@ class OXXO {
 							add_meta_box(
 								'ppcp_oxxo_payer_action',
 								__( 'OXXO Voucher/Ticket', 'woocommerce-paypal-payments' ),
-								function() use ( $payer_action ) {
+								function () use ( $payer_action ) {
 									echo '<p><a class="button" href="' . esc_url( $payer_action ) . '" target="_blank">' . esc_html__( 'See OXXO voucher', 'woocommerce-paypal-payments' ) . '</a></p>';
 								},
 								$screen,
@@ -226,7 +226,7 @@ class OXXO {
 
 		add_action(
 			'woocommerce_order_details_before_order_table_items',
-			function( WC_Order $order ) {
+			function ( WC_Order $order ) {
 				if ( $order->get_payment_method() === OXXOGateway::ID ) {
 					$payer_action = $order->get_meta( 'ppcp_oxxo_payer_action' );
 					if ( $payer_action ) {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -42,7 +42,12 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
  */
 class PayPalGateway extends \WC_Payment_Gateway {
 
-	use ProcessPaymentTrait, FreeTrialHandlerTrait, GatewaySettingsRendererTrait, OrderMetaTrait, TransactionIdHandlingTrait, PaymentsStatusHandlingTrait;
+	use ProcessPaymentTrait;
+	use FreeTrialHandlerTrait;
+	use GatewaySettingsRendererTrait;
+	use OrderMetaTrait;
+	use TransactionIdHandlingTrait;
+	use PaymentsStatusHandlingTrait;
 
 	public const ID                            = 'ppcp-gateway';
 	public const INTENT_META_KEY               = '_ppcp_paypal_intent';
@@ -465,10 +470,9 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 *
 	 * @return bool
 	 */
-	private function is_credit_card_tab() : bool {
+	private function is_credit_card_tab(): bool {
 		return is_admin()
 			&& CreditCardGateway::ID === $this->page_id;
-
 	}
 
 	/**
@@ -476,7 +480,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 *
 	 * @return bool
 	 */
-	private function is_pui_tab():bool {
+	private function is_pui_tab(): bool {
 		if ( 'DE' !== $this->api_shop_country ) {
 			return false;
 		}
@@ -489,7 +493,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 *
 	 * @return bool true if is connection tab, otherwise false
 	 */
-	protected function is_connection_tab() : bool {
+	protected function is_connection_tab(): bool {
 		return is_admin()
 			&& Settings::CONNECTION_TAB_ID === $this->page_id;
 	}
@@ -499,7 +503,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 *
 	 * @return bool true if is pay-later tab, otherwise false
 	 */
-	protected function is_pay_later_tab() : bool {
+	protected function is_pay_later_tab(): bool {
 		return is_admin()
 			&& Settings::PAY_LATER_TAB_ID === $this->page_id;
 	}
@@ -509,7 +513,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 *
 	 * @return bool
 	 */
-	private function is_paypal_tab() : bool {
+	private function is_paypal_tab(): bool {
 		return ! $this->is_credit_card_tab()
 			&& is_admin()
 			&& self::ID === $this->page_id;

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -438,7 +438,7 @@ class PayUponInvoice {
 					! is_array( $methods )
 					|| ! $this->is_connected
 					// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					|| ! ( is_checkout() || isset( $_GET['pay_for_order'] ) && $_GET['pay_for_order'] === 'true' )
+					|| ! ( is_checkout() || ( isset( $_GET['pay_for_order'] ) && $_GET['pay_for_order'] === 'true' ) )
 				) {
 					return $methods;
 				}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -248,7 +248,7 @@ class PayUponInvoice {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( WC_Order $order, bool $sent_to_admin, bool $plain_text, $email ) {
+			function ( WC_Order $order, bool $sent_to_admin, bool $plain_text, $email ) {
 				if (
 					! $sent_to_admin
 					&& PayUponInvoiceGateway::ID === $order->get_payment_method()
@@ -317,7 +317,7 @@ class PayUponInvoice {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $description, $id ): string {
+			function ( $description, $id ): string {
 				if ( ! is_string( $description ) || ! is_string( $id ) ) {
 					return $description;
 				}
@@ -389,7 +389,7 @@ class PayUponInvoice {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $fields, WP_Error $errors ) {
+			function ( $fields, WP_Error $errors ) {
 				if ( ! is_array( $fields ) ) {
 					return;
 				}
@@ -474,7 +474,7 @@ class PayUponInvoice {
 
 		add_action(
 			'woocommerce_settings_checkout',
-			function() {
+			function () {
 				if (
 				PayUponInvoiceGateway::ID === $this->current_ppcp_settings_page_id
 				&& $this->pui_product_status->is_active()
@@ -496,7 +496,7 @@ class PayUponInvoice {
 						<div class="notice notice-error">
 							<?php
 							array_map(
-								static function( $message ) {
+								static function ( $message ) {
 									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 									echo '<p>' . $message . '</p>';
 								},
@@ -525,7 +525,7 @@ class PayUponInvoice {
 
 		add_action(
 			'add_meta_boxes',
-			function( string $post_type ) {
+			function ( string $post_type ) {
 				/**
 				 * Class and function exist in WooCommerce.
 				 *
@@ -546,7 +546,7 @@ class PayUponInvoice {
 							add_meta_box(
 								'ppcp_pui_ratepay_payment_instructions',
 								__( 'RatePay payment instructions', 'woocommerce-paypal-payments' ),
-								function() use ( $instructions ) {
+								function () use ( $instructions ) {
 									$payment_reference   = $instructions[0] ?? '';
 									$bic                 = $instructions[1]->bic ?? '';
 									$bank_name           = $instructions[1]->bank_name ?? '';

--- a/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/ProcessPaymentTrait.php
@@ -80,7 +80,7 @@ trait ProcessPaymentTrait {
 	 * @param Throwable $exception The exception to format.
 	 * @return string
 	 */
-	protected function format_exception( Throwable $exception ) : string {
+	protected function format_exception( Throwable $exception ): string {
 		$message = $exception->getMessage();
 		if ( is_a( $exception, PayPalApiException::class ) ) {
 			$message = $exception->get_details( $message );

--- a/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
@@ -166,7 +166,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return void
 	 */
-	public function refresh() : void {
+	public function refresh(): void {
 		$this->is_resolved = false;
 	}
 
@@ -175,7 +175,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return void
 	 */
-	private function ensure_resolved_values() : void {
+	private function ensure_resolved_values(): void {
 		if ( $this->is_resolved ) {
 			return;
 		}
@@ -188,7 +188,7 @@ class CardPaymentsConfiguration {
 	/**
 	 * Refreshes the internal gateway configuration based on the current settings.
 	 */
-	private function resolve() : void {
+	private function resolve(): void {
 		$show_on_card_options = array_keys( PropertiesDictionary::cardholder_name_options() );
 		$show_on_card_value   = null;
 
@@ -285,7 +285,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return bool
 	 */
-	public function use_acdc() : bool {
+	public function use_acdc(): bool {
 		$this->ensure_resolved_values();
 
 		return $this->use_acdc;
@@ -299,7 +299,7 @@ class CardPaymentsConfiguration {
 	 * @internal Use "is_acdc_enabled()" or "is_bcdc_enabled()" instead.
 	 * @return bool
 	 */
-	public function is_enabled() : bool {
+	public function is_enabled(): bool {
 		$this->ensure_resolved_values();
 
 		return $this->is_enabled;
@@ -317,7 +317,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return bool
 	 */
-	public function is_acdc_enabled() : bool {
+	public function is_acdc_enabled(): bool {
 		return $this->is_enabled() && $this->use_acdc();
 	}
 
@@ -329,7 +329,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return bool
 	 */
-	public function is_bcdc_enabled() : bool {
+	public function is_bcdc_enabled(): bool {
 		if ( 'MX' === $this->store_country || ! $this->use_acdc() ) {
 			$bcdc_setting = get_option( 'woocommerce_ppcp-card-button-gateway_settings' );
 			$enabled      = $bcdc_setting['enabled'] ?? '';
@@ -348,7 +348,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return bool
 	 */
-	public function use_fastlane() : bool {
+	public function use_fastlane(): bool {
 		return $this->is_acdc_enabled() && $this->use_fastlane;
 	}
 
@@ -359,7 +359,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return string Display title of the gateway.
 	 */
-	public function gateway_title( string $fallback = '' ) : string {
+	public function gateway_title( string $fallback = '' ): string {
 		$this->ensure_resolved_values();
 		if ( $this->gateway_title ) {
 			return $this->gateway_title;
@@ -375,7 +375,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return string Display description of the gateway.
 	 */
-	public function gateway_description( string $fallback = '' ) : string {
+	public function gateway_description( string $fallback = '' ): string {
 		$this->ensure_resolved_values();
 		if ( $this->gateway_description ) {
 			return $this->gateway_description;
@@ -395,7 +395,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return string ['yes'|'no']
 	 */
-	public function show_name_on_card() : string {
+	public function show_name_on_card(): string {
 		$this->ensure_resolved_values();
 
 		return $this->show_name_on_card;
@@ -409,7 +409,7 @@ class CardPaymentsConfiguration {
 	 *
 	 * @return bool True means, the default watermark is displayed to customers.
 	 */
-	public function show_fastlane_watermark() : bool {
+	public function show_fastlane_watermark(): bool {
 		$this->ensure_resolved_values();
 
 		return ! $this->hide_fastlane_watermark;

--- a/modules/ppcp-wc-gateway/src/Helper/ConnectionState.php
+++ b/modules/ppcp-wc-gateway/src/Helper/ConnectionState.php
@@ -53,7 +53,7 @@ class ConnectionState {
 	 *
 	 * @param bool $is_sandbox Whether to connect to a sandbox environment.
 	 */
-	public function connect( bool $is_sandbox = false ) : void {
+	public function connect( bool $is_sandbox = false ): void {
 		if ( ! $this->is_connected ) {
 			/**
 			 * Action that fires before the connection status changes from
@@ -69,7 +69,7 @@ class ConnectionState {
 	/**
 	 * Set connection status to "not connected to PayPal" (start onboarding).
 	 */
-	public function disconnect() : void {
+	public function disconnect(): void {
 		if ( $this->is_connected ) {
 			/**
 			 * Action that fires before the connection status changes from
@@ -86,7 +86,7 @@ class ConnectionState {
 	 *
 	 * @return Environment The environment instance.
 	 */
-	public function get_environment() : Environment {
+	public function get_environment(): Environment {
 		return $this->environment;
 	}
 
@@ -95,7 +95,7 @@ class ConnectionState {
 	 *
 	 * @return bool True, if onboarding was completed and connection details are present.
 	 */
-	public function is_connected() : bool {
+	public function is_connected(): bool {
 		return $this->is_connected;
 	}
 
@@ -104,7 +104,7 @@ class ConnectionState {
 	 *
 	 * @return bool True, if we don't know merchant connection details.
 	 */
-	public function is_onboarding() : bool {
+	public function is_onboarding(): bool {
 		return ! $this->is_connected;
 	}
 
@@ -113,7 +113,7 @@ class ConnectionState {
 	 *
 	 * @return bool True, if connected to a sandbox environment.
 	 */
-	public function is_sandbox() : bool {
+	public function is_sandbox(): bool {
 		return $this->is_connected && $this->environment->is_sandbox();
 	}
 
@@ -122,7 +122,7 @@ class ConnectionState {
 	 *
 	 * @return bool True, if connected to a production environment.
 	 */
-	public function is_production() : bool {
+	public function is_production(): bool {
 		return $this->is_connected && $this->environment->is_production();
 	}
 
@@ -131,7 +131,7 @@ class ConnectionState {
 	 *
 	 * @return string Name of the currently connected environment; empty string if not connected.
 	 */
-	public function current_environment() : string {
+	public function current_environment(): string {
 		return $this->is_connected ? $this->environment->current_environment() : '';
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -76,7 +76,7 @@ class DCCProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_local_state() : ?bool {
+	protected function check_local_state(): ?bool {
 		if ( $this->cache->has( self::DCC_STATUS_CACHE_KEY ) ) {
 			return wc_string_to_bool( $this->cache->get( self::DCC_STATUS_CACHE_KEY ) );
 		}
@@ -89,7 +89,7 @@ class DCCProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ) : bool {
+	protected function check_active_state( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->products() as $product ) {
 			if ( ! in_array(
 				$product->vetting_status(),

--- a/modules/ppcp-wc-gateway/src/Helper/DisplayManager.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DisplayManager.php
@@ -56,5 +56,4 @@ class DisplayManager {
 		$this->rules[ $key ] = $rule;
 		return $rule;
 	}
-
 }

--- a/modules/ppcp-wc-gateway/src/Helper/DisplayRule.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DisplayRule.php
@@ -297,5 +297,4 @@ class DisplayRule {
 	public function json(): string {
 		return wp_json_encode( $this->to_array() ) ?: '';
 	}
-
 }

--- a/modules/ppcp-wc-gateway/src/Helper/Environment.php
+++ b/modules/ppcp-wc-gateway/src/Helper/Environment.php
@@ -46,7 +46,7 @@ class Environment {
 	 * @param bool $is_sandbox Whether this instance represents a sandbox environment.
 	 * @return string The environment name.
 	 */
-	private function prepare_environment_name( bool $is_sandbox ) : string {
+	private function prepare_environment_name( bool $is_sandbox ): string {
 		if ( $is_sandbox ) {
 			return self::SANDBOX;
 		}
@@ -59,7 +59,7 @@ class Environment {
 	 *
 	 * @param bool $is_sandbox Whether this instance represents a sandbox environment.
 	 */
-	public function set_environment( bool $is_sandbox ) : void {
+	public function set_environment( bool $is_sandbox ): void {
 		$new_environment = $this->prepare_environment_name( $is_sandbox );
 
 		if ( $new_environment !== $this->environment_name ) {
@@ -84,7 +84,7 @@ class Environment {
 	 *
 	 * @return string
 	 */
-	public function current_environment() : string {
+	public function current_environment(): string {
 		return $this->environment_name;
 	}
 
@@ -98,7 +98,7 @@ class Environment {
 	 *
 	 * @return bool
 	 */
-	public function current_environment_is( string $environment ) : bool {
+	public function current_environment_is( string $environment ): bool {
 		return $this->current_environment() === $environment;
 	}
 
@@ -107,7 +107,7 @@ class Environment {
 	 *
 	 * @return bool
 	 */
-	public function is_sandbox() : bool {
+	public function is_sandbox(): bool {
 		return $this->current_environment() === self::SANDBOX;
 	}
 
@@ -116,7 +116,7 @@ class Environment {
 	 *
 	 * @return bool
 	 */
-	public function is_production() : bool {
+	public function is_production(): bool {
 		return $this->current_environment() === self::PRODUCTION;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/EnvironmentConfig.php
+++ b/modules/ppcp-wc-gateway/src/Helper/EnvironmentConfig.php
@@ -54,7 +54,7 @@ class EnvironmentConfig {
 	 * @param U      $sandbox_value    Value for the sandbox environment.
 	 * @return self<U>
 	 */
-	public static function create( string $data_type, $production_value, $sandbox_value ) : self {
+	public static function create( string $data_type, $production_value, $sandbox_value ): self {
 		assert(
 			gettype( $production_value ) === $data_type || $production_value instanceof $data_type,
 			"Production value must be of type '$data_type'"

--- a/modules/ppcp-wc-gateway/src/Helper/InstallmentsProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/InstallmentsProductStatus.php
@@ -65,7 +65,7 @@ class InstallmentsProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_local_state() : ?bool {
+	protected function check_local_state(): ?bool {
 		if ( $this->cache->has( self::INSTALLMENTS_STATUS_CACHE_KEY ) ) {
 			return wc_string_to_bool( $this->cache->get( self::INSTALLMENTS_STATUS_CACHE_KEY ) );
 		}
@@ -78,7 +78,7 @@ class InstallmentsProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ) : bool {
+	protected function check_active_state( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->capabilities() as $capability ) {
 			if ( $capability->name() !== 'INSTALLMENTS' ) {
 				continue;
@@ -98,7 +98,7 @@ class InstallmentsProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ): void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/MerchantDetails.php
+++ b/modules/ppcp-wc-gateway/src/Helper/MerchantDetails.php
@@ -90,7 +90,7 @@ class MerchantDetails {
 	 *
 	 * @return string
 	 */
-	public function get_merchant_country() : string {
+	public function get_merchant_country(): string {
 		return $this->merchant_country;
 	}
 
@@ -100,7 +100,7 @@ class MerchantDetails {
 	 *
 	 * @return string
 	 */
-	public function get_shop_country() : string {
+	public function get_shop_country(): string {
 		return $this->store_country;
 	}
 
@@ -117,7 +117,7 @@ class MerchantDetails {
 	 * @param string $feature One of the public self::FEATURE_* values.
 	 * @return bool Whether the merchant can use the relevant feature.
 	 */
-	public function is_eligible_for( string $feature ) : bool {
+	public function is_eligible_for( string $feature ): bool {
 		if ( ! array_key_exists( $feature, $this->eligibility_checks ) ) {
 			return false;
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -65,7 +65,7 @@ class PayUponInvoiceProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_local_state() : ?bool {
+	protected function check_local_state(): ?bool {
 		if ( $this->cache->has( self::PUI_STATUS_CACHE_KEY ) ) {
 			return wc_string_to_bool( $this->cache->get( self::PUI_STATUS_CACHE_KEY ) );
 		}
@@ -78,7 +78,7 @@ class PayUponInvoiceProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ) : bool {
+	protected function check_active_state( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->products() as $product ) {
 			if ( $product->name() !== 'PAYMENT_METHODS' ) {
 				continue;
@@ -111,7 +111,7 @@ class PayUponInvoiceProductStatus extends ProductStatus {
 	}
 
 	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ) : void {
+	protected function clear_state( ?Settings $settings = null ): void {
 		if ( null === $settings ) {
 			$settings = $this->settings;
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/RefundFeesUpdater.php
+++ b/modules/ppcp-wc-gateway/src/Helper/RefundFeesUpdater.php
@@ -191,5 +191,4 @@ class RefundFeesUpdater {
 
 		return $notes;
 	}
-
 }

--- a/modules/ppcp-wc-gateway/src/Notice/SendOnlyCountryNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/SendOnlyCountryNotice.php
@@ -99,7 +99,7 @@ class SendOnlyCountryNotice {
 	 *
 	 * @return bool
 	 */
-	protected function is_ppcp_page():bool {
+	protected function is_ppcp_page(): bool {
 		return $this->is_ppcp_settings_page || $this->is_wc_gateways_list_page;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
+++ b/modules/ppcp-wc-gateway/src/Notice/UnsupportedCurrencyAdminNotice.php
@@ -73,7 +73,6 @@ class UnsupportedCurrencyAdminNotice {
 		$this->supported_currencies     = $supported_currencies;
 		$this->is_wc_gateways_list_page = $is_wc_gateways_list_page;
 		$this->is_ppcp_settings_page    = $is_ppcp_settings_page;
-
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/AuthorizedPaymentsProcessor.php
@@ -33,7 +33,8 @@ use WooCommerce\PayPalCommerce\WcGateway\Notice\AuthorizeOrderActionNotice;
  */
 class AuthorizedPaymentsProcessor {
 
-	use PaymentsStatusHandlingTrait, TransactionIdHandlingTrait;
+	use PaymentsStatusHandlingTrait;
+	use TransactionIdHandlingTrait;
 
 	const SUCCESSFUL        = 'SUCCESSFUL';
 	const ALREADY_CAPTURED  = 'ALREADY_CAPTURED';
@@ -474,5 +475,4 @@ class AuthorizedPaymentsProcessor {
 			}
 		);
 	}
-
 }

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -77,7 +77,7 @@ trait OrderMetaTrait {
 	 * @param Order    $order    The PayPal order which provides the details.
 	 * @return void
 	 */
-	private function add_contact_details_to_wc_order( WC_Order $wc_order, Order $order ) : void {
+	private function add_contact_details_to_wc_order( WC_Order $wc_order, Order $order ): void {
 		$shipping_details = $this->get_shipping_details( $order );
 
 		if ( ! $shipping_details ) {
@@ -115,7 +115,7 @@ trait OrderMetaTrait {
 	 * @param Order $order The PayPal order that contains potential shipping information.
 	 * @return ?Shipping The shipping details, or null if none present.
 	 */
-	private function get_shipping_details( Order $order ) : ?Shipping {
+	private function get_shipping_details( Order $order ): ?Shipping {
 		foreach ( $order->purchase_units() as $unit ) {
 			$shipping = $unit->shipping();
 			if ( $shipping ) {

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -38,7 +38,9 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  */
 class OrderProcessor {
 
-	use OrderMetaTrait, PaymentsStatusHandlingTrait, TransactionIdHandlingTrait;
+	use OrderMetaTrait;
+	use PaymentsStatusHandlingTrait;
+	use TransactionIdHandlingTrait;
 
 	/**
 	 * The environment.

--- a/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/RefundProcessor.php
@@ -107,7 +107,7 @@ class RefundProcessor {
 	 *
 	 * @phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag.Missing
 	 */
-	public function process( WC_Order $wc_order, ?float $amount = null, string $reason = '' ) : bool {
+	public function process( WC_Order $wc_order, ?float $amount = null, string $reason = '' ): bool {
 		try {
 			$payment_gateways = WC()->payment_gateways()->payment_gateways();
 			if ( ! isset( $payment_gateways[ $wc_order->get_payment_method() ] ) || ! $payment_gateways[ $wc_order->get_payment_method() ]->supports( 'refunds' ) ) {

--- a/modules/ppcp-wc-gateway/src/Processor/TransactionIdHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/TransactionIdHandlingTrait.php
@@ -90,5 +90,4 @@ trait TransactionIdHandlingTrait {
 
 		return null;
 	}
-
 }

--- a/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/HeaderRenderer.php
@@ -46,7 +46,7 @@ class HeaderRenderer {
 	 *
 	 * @return bool
 	 */
-	public function should_render() : bool {
+	public function should_render(): bool {
 		return ! empty( $this->page_id );
 	}
 

--- a/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SectionsRenderer.php
@@ -99,7 +99,7 @@ class SectionsRenderer {
 	 *
 	 * @return bool
 	 */
-	public function should_render() : bool {
+	public function should_render(): bool {
 		return $this->page_id && $this->is_connected;
 	}
 

--- a/modules/ppcp-wc-gateway/src/Settings/Settings.php
+++ b/modules/ppcp-wc-gateway/src/Settings/Settings.php
@@ -155,7 +155,7 @@ class Settings implements ContainerInterface {
 	 *
 	 * @return bool
 	 */
-	private function load() : bool {
+	private function load(): bool {
 		if ( $this->settings ) {
 			return false;
 		}

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -277,7 +277,7 @@ class SettingsListener {
 					sleep( $this->onboarding_retry_delay );
 				}
 
-				$retry_count++;
+				++$retry_count;
 				$this->logger->info( 'Retrying onboarding return URL, retry nr: ' . ( (string) $retry_count ) );
 				$redirect_url = add_query_arg( 'ppcpRetry', $retry_count );
 				$this->redirector->redirect( $redirect_url );
@@ -569,7 +569,7 @@ class SettingsListener {
 	 *
 	 * @return array
 	 */
-	private function read_active_credentials_from_settings( array $settings ) : array {
+	private function read_active_credentials_from_settings( array $settings ): array {
 		if ( ! isset( $settings['client_id_sandbox'] ) && ! isset( $settings['client_id_production'] ) ) {
 			return $settings;
 		}
@@ -713,7 +713,7 @@ class SettingsListener {
 	 *
 	 * @return bool
 	 */
-	private function is_valid_site_request() : bool {
+	private function is_valid_site_request(): bool {
 
 		if ( empty( $this->page_id ) ) {
 			return false;

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsRenderer.php
@@ -132,7 +132,7 @@ class SettingsRenderer {
 	 *
 	 * @return array
 	 */
-	public function messages() : array {
+	public function messages(): array {
 
 		$messages = array();
 
@@ -507,7 +507,7 @@ $data_rows_html
 	 *
 	 * @param array $config The configuration array.
 	 */
-	private function render_preview_block( array $config ) : void {
+	private function render_preview_block( array $config ): void {
 		$id      = $config['preview']['id'] ?? '';
 		$type    = $config['preview']['type'] ?? 'button';
 		$message = $config['preview']['message'] ?? __( 'Button Styling Preview', 'woocommerce-paypal-payments' );

--- a/modules/ppcp-wc-gateway/src/Shipping/ShippingCallbackUrlFactory.php
+++ b/modules/ppcp-wc-gateway/src/Shipping/ShippingCallbackUrlFactory.php
@@ -23,7 +23,7 @@ class ShippingCallbackUrlFactory {
 	/**
 	 * Creates the callback URL.
 	 */
-	public function create() : string {
+	public function create(): string {
 		$cart_response = $this->cart_endpoint->get_cart();
 
 		$url = $this->shipping_callback_endpoint->url();

--- a/modules/ppcp-wc-gateway/src/StoreApi/Entity/CartTotals.php
+++ b/modules/ppcp-wc-gateway/src/StoreApi/Entity/CartTotals.php
@@ -91,6 +91,4 @@ class CartTotals {
 	public function total_tax(): Money {
 		return $this->total_tax;
 	}
-
-
 }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -325,7 +325,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
-			static function() use ( $c ) {
+			static function () use ( $c ) {
 				$dcc_status_cache = $c->get( 'dcc.status-cache' );
 				assert( $dcc_status_cache instanceof Cache );
 				$pui_status_cache = $c->get( 'pui.status-cache' );
@@ -465,7 +465,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			add_action(
 				'init',
-				function() use ( $c ) {
+				function () use ( $c ) {
 					\WP_CLI::add_command(
 						'pcp settings',
 						$c->get( 'wcgateway.cli.settings.command' )
@@ -477,7 +477,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function( ?Settings $settings = null ) use ( $c ): void {
+			function ( ?Settings $settings = null ) use ( $c ): void {
 
 				// Clear DCC Product status.
 				$dcc_product_status = $c->get( 'wcgateway.helper.dcc-product-status' );
@@ -522,7 +522,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
-			function( string $installed_plugin_version ) use ( $c ) {
+			function ( string $installed_plugin_version ) use ( $c ) {
 				$settings = $c->get( 'wcgateway.settings' );
 				assert( $settings instanceof Settings );
 
@@ -535,7 +535,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		add_filter(
 			'woocommerce_paypal_payments_rest_common_merchant_features',
-			static function ( array $features ) use ( $c ) : array {
+			static function ( array $features ) use ( $c ): array {
 				$is_connected = $c->get( 'settings.flag.is-connected' );
 
 				if ( ! $is_connected ) {
@@ -597,7 +597,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Add processing instruction request data for OXXO payment.
 		add_filter(
 			'ppcp_create_order_request_body_data',
-			static function ( array $data, string $payment_method, array $request ) use ( $c ) : array {
+			static function ( array $data, string $payment_method, array $request ) use ( $c ): array {
 				if ( $payment_method !== OXXOGateway::ID ) {
 					return $data;
 				}
@@ -1019,7 +1019,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	 * @param WC_Order|mixed $order The order to verify.
 	 * @return bool True, if it's a valid order that was paid via PayPal.
 	 */
-	private function is_order_paid_by_paypal( $order ) : bool {
+	private function is_order_paid_by_paypal( $order ): bool {
 		if ( ! $order instanceof WC_Order ) {
 			return false;
 		}
@@ -1083,7 +1083,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	 * @param WC_Order|mixed $order The order which is rendered.
 	 * @return void
 	 */
-	private function display_original_contact_in_order_details( $order ) : void {
+	private function display_original_contact_in_order_details( $order ): void {
 		if ( ! $this->is_order_paid_by_paypal( $order ) ) {
 			return;
 		}

--- a/modules/ppcp-wc-subscriptions/services.php
+++ b/modules/ppcp-wc-subscriptions/services.php
@@ -19,7 +19,7 @@ return array(
 	'wc-subscriptions.helper'                            => static function ( ContainerInterface $container ): SubscriptionHelper {
 		return new SubscriptionHelper();
 	},
-	'wc-subscriptions.helpers.real-time-account-updater' => static function ( ContainerInterface $container ) : RealTimeAccountUpdaterHelper {
+	'wc-subscriptions.helpers.real-time-account-updater' => static function ( ContainerInterface $container ): RealTimeAccountUpdaterHelper {
 		return new RealTimeAccountUpdaterHelper();
 	},
 	'wc-subscriptions.renewal-handler'                   => static function ( ContainerInterface $container ): RenewalHandler {
@@ -55,7 +55,7 @@ return array(
 		$endpoint = $container->get( 'api.endpoint.payment-token' );
 		return new PaymentTokenRepository( $factory, $endpoint );
 	},
-	'wc-subscriptions.endpoint.subscription-change-payment-method' => static function( ContainerInterface $container ): SubscriptionChangePaymentMethod {
+	'wc-subscriptions.endpoint.subscription-change-payment-method' => static function ( ContainerInterface $container ): SubscriptionChangePaymentMethod {
 		return new SubscriptionChangePaymentMethod(
 			$container->get( 'button.request-data' )
 		);

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -187,7 +187,7 @@ class WcSubscriptionsModule implements ServiceModule, ExtendingModule, Executabl
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $methods ) use ( $c ) {
+			function ( $methods ) use ( $c ) {
 				if ( ! is_array( $methods ) ) {
 					return $methods;
 				}

--- a/modules/ppcp-webhooks/extensions.php
+++ b/modules/ppcp-webhooks/extensions.php
@@ -40,7 +40,7 @@ return array(
 				'requirements' => array(),
 				'gateway'      => Settings::CONNECTION_TAB_ID,
 				'classes'      => array( 'ppcp-webhooks-table' ),
-				'value'        => function () use ( $container ) : array {
+				'value'        => function () use ( $container ): array {
 					return $container->get( 'webhook.status.registered-webhooks-data' );
 				},
 			),

--- a/modules/ppcp-webhooks/factories.php
+++ b/modules/ppcp-webhooks/factories.php
@@ -13,7 +13,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
-	'webhook.status.registered-webhooks' => function( ContainerInterface $container ) : array {
+	'webhook.status.registered-webhooks' => function ( ContainerInterface $container ): array {
 		$endpoint = $container->get( 'api.endpoint.webhook' );
 		assert( $endpoint instanceof WebhookEndpoint );
 

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -37,7 +37,7 @@ use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 
 return array(
 
-	'webhook.registrar'                       => function( ContainerInterface $container ) : WebhookRegistrar {
+	'webhook.registrar'                       => function ( ContainerInterface $container ): WebhookRegistrar {
 		$factory      = $container->get( 'api.factory.webhook' );
 		$endpoint     = $container->get( 'api.endpoint.webhook' );
 		$rest_endpoint = $container->get( 'webhook.endpoint.controller' );
@@ -51,7 +51,7 @@ return array(
 			$logger
 		);
 	},
-	'webhook.endpoint.controller'             => function( ContainerInterface $container ) : IncomingWebhookEndpoint {
+	'webhook.endpoint.controller'             => function ( ContainerInterface $container ): IncomingWebhookEndpoint {
 		$webhook_endpoint = $container->get( 'api.endpoint.webhook' );
 		$webhook  = $container->get( 'webhook.current' );
 		$handler          = $container->get( 'webhook.endpoint.handler' );
@@ -69,10 +69,10 @@ return array(
 			$webhook_event_factory,
 			$simulation,
 			$last_webhook_storage,
-			... $handler
+			...$handler
 		);
 	},
-	'webhook.endpoint.handler'                => function( ContainerInterface $container ) : array {
+	'webhook.endpoint.handler'                => function ( ContainerInterface $container ): array {
 		$logger         = $container->get( 'woocommerce.logger.woocommerce' );
 		$prefix         = $container->get( 'api.prefix' );
 		$order_endpoint = $container->get( 'api.endpoint.order' );
@@ -106,7 +106,7 @@ return array(
 		);
 	},
 
-	'webhook.current'                         => function( ContainerInterface $container ) : ?Webhook {
+	'webhook.current'                         => function ( ContainerInterface $container ): ?Webhook {
 		$data = (array) get_option( WebhookRegistrar::KEY, array() );
 		if ( empty( $data ) ) {
 			return null;
@@ -125,11 +125,11 @@ return array(
 		}
 	},
 
-	'webhook.is-registered'                   => function( ContainerInterface $container ) : bool {
+	'webhook.is-registered'                   => function ( ContainerInterface $container ): bool {
 		return $container->get( 'webhook.current' ) !== null;
 	},
 
-	'webhook.status.registered-webhooks-data' => function( ContainerInterface $container ) : array {
+	'webhook.status.registered-webhooks-data' => function ( ContainerInterface $container ): array {
 		$empty_placeholder = __( 'No webhooks found.', 'woocommerce-paypal-payments' );
 
 		$webhooks = array();
@@ -166,7 +166,7 @@ return array(
 		);
 	},
 
-	'webhook.status.simulation'               => function( ContainerInterface $container ) : WebhookSimulation {
+	'webhook.status.simulation'               => function ( ContainerInterface $container ): WebhookSimulation {
 		$webhook_endpoint = $container->get( 'api.endpoint.webhook' );
 		$webhook  = $container->get( 'webhook.current' );
 		return new WebhookSimulation(
@@ -177,7 +177,7 @@ return array(
 		);
 	},
 
-	'webhook.status.assets'                   => function( ContainerInterface $container ) : WebhooksStatusPageAssets {
+	'webhook.status.assets'                   => function ( ContainerInterface $container ): WebhooksStatusPageAssets {
 		return new WebhooksStatusPageAssets(
 			$container->get( 'webhook.module-url' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -185,7 +185,7 @@ return array(
 		);
 	},
 
-	'webhook.endpoint.resubscribe'            => static function ( ContainerInterface $container ) : ResubscribeEndpoint {
+	'webhook.endpoint.resubscribe'            => static function ( ContainerInterface $container ): ResubscribeEndpoint {
 		$registrar = $container->get( 'webhook.registrar' );
 		$request_data            = $container->get( 'button.request-data' );
 
@@ -195,7 +195,7 @@ return array(
 		);
 	},
 
-	'webhook.endpoint.simulate'               => static function ( ContainerInterface $container ) : SimulateEndpoint {
+	'webhook.endpoint.simulate'               => static function ( ContainerInterface $container ): SimulateEndpoint {
 		$simulation = $container->get( 'webhook.status.simulation' );
 		$request_data = $container->get( 'button.request-data' );
 
@@ -204,7 +204,7 @@ return array(
 			$request_data
 		);
 	},
-	'webhook.endpoint.simulation-state'       => static function ( ContainerInterface $container ) : SimulationStateEndpoint {
+	'webhook.endpoint.simulation-state'       => static function ( ContainerInterface $container ): SimulationStateEndpoint {
 		$simulation = $container->get( 'webhook.status.simulation' );
 
 		return new SimulationStateEndpoint(

--- a/modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php
@@ -22,7 +22,8 @@ use WP_REST_Response;
  */
 class PaymentCaptureCompleted implements RequestHandler {
 
-	use TransactionIdHandlingTrait, RequestHandlerTrait;
+	use TransactionIdHandlingTrait;
+	use RequestHandlerTrait;
 
 	/**
 	 * The logger.

--- a/modules/ppcp-webhooks/src/Handler/PaymentCaptureRefunded.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentCaptureRefunded.php
@@ -23,7 +23,9 @@ use WP_REST_Response;
  */
 class PaymentCaptureRefunded implements RequestHandler {
 
-	use TransactionIdHandlingTrait, RefundMetaTrait, RequestHandlerTrait;
+	use TransactionIdHandlingTrait;
+	use RefundMetaTrait;
+	use RequestHandlerTrait;
 
 	/**
 	 * The logger.

--- a/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentSaleCompleted.php
@@ -65,7 +65,6 @@ class PaymentSaleCompleted implements RequestHandler {
 	 */
 	public function responsible_for_request( WP_REST_Request $request ): bool {
 		return in_array( $request['event_type'], $this->event_types(), true );
-
 	}
 
 	/**

--- a/modules/ppcp-webhooks/src/Handler/PaymentSaleRefunded.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentSaleRefunded.php
@@ -22,7 +22,9 @@ use WP_REST_Response;
  */
 class PaymentSaleRefunded implements RequestHandler {
 
-	use TransactionIdHandlingTrait, RefundMetaTrait, RequestHandlerTrait;
+	use TransactionIdHandlingTrait;
+	use RefundMetaTrait;
+	use RequestHandlerTrait;
 
 	/**
 	 * The logger.
@@ -67,7 +69,6 @@ class PaymentSaleRefunded implements RequestHandler {
 	 */
 	public function responsible_for_request( WP_REST_Request $request ): bool {
 		return in_array( $request['event_type'], $this->event_types(), true );
-
 	}
 
 	/**

--- a/modules/ppcp-webhooks/src/Handler/RequestHandler.php
+++ b/modules/ppcp-webhooks/src/Handler/RequestHandler.php
@@ -31,7 +31,7 @@ interface RequestHandler {
 	 *
 	 * @return bool
 	 */
-	public function responsible_for_request( WP_REST_Request $request): bool;
+	public function responsible_for_request( WP_REST_Request $request ): bool;
 
 	/**
 	 * Responsible for handling the request.
@@ -40,5 +40,5 @@ interface RequestHandler {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function handle_request( WP_REST_Request $request): WP_REST_Response;
+	public function handle_request( WP_REST_Request $request ): WP_REST_Response;
 }

--- a/modules/woocommerce-logging/services.php
+++ b/modules/woocommerce-logging/services.php
@@ -15,7 +15,7 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
 return array(
-	'woocommerce.logger.source'      => function(): string {
+	'woocommerce.logger.source'      => function (): string {
 		return 'woocommerce-paypal-payments';
 	},
 	'woocommerce.logger.woocommerce' => function ( ContainerInterface $container ): LoggerInterface {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,13 +7,31 @@
 	<config name="testVersion" value="7.4-" />
 
 	<!-- Rules -->
-	<rule ref="WooCommerce-Core" />
+	<rule ref="WooCommerce-Core">
+		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped" />
+		<exclude name="WordPress.WP.GetMetaSingle.Missing" />
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.Found" />
+		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed" />
+		<exclude name="Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence.MissingParentheses" />
+		<exclude name="Universal.Operators.DisallowShortTernary.Found" />
+		<exclude name="Universal.CodeAnalysis.NoEchoSprintf.Found" />
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.arrayFound" />
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.newFound" />
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.listFound" />
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.resourceFound" />
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound" />
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.classFound" />
+		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.stringFound" />
+	</rule>
 
 	<rule ref="WordPress.WP.I18n">
-		<properties>
-			<property name="text_domain" type="array" value="woocommerce-paypal-payments" />
-		</properties>
-	</rule>
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="woocommerce-paypal-payments" />
+            </property>
+        </properties>
+    </rule>
+
 
 	<rule ref="PHPCompatibility">
 		<exclude-pattern>tests/</exclude-pattern>
@@ -22,7 +40,6 @@
 	<rule ref="WordPress">
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
-		<exclude name="WordPress.PHP.DisallowShortTernary" />
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
 	</rule>
 
@@ -57,6 +74,15 @@
 	<rule ref="Generic.Commenting.DocComment">
 		<exclude name="Generic.Commenting.DocComment.MissingShort" />
 	</rule>
+
+	<rule ref="WordPress.WP.Capabilities">
+    	<properties>
+    		<property name="custom_capabilities" type="array">
+    				<element value="manage_woocommerce"/>
+    		</property>
+    	</properties>
+    </rule>
+
 
 	<arg name="extensions" value="php"/>
 	<file>api</file>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,6 @@
 		<exclude name="WordPress.WP.GetMetaSingle.Missing" />
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.Found" />
 		<exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed" />
-		<exclude name="Generic.CodeAnalysis.RequireExplicitBooleanOperatorPrecedence.MissingParentheses" />
 		<exclude name="Universal.Operators.DisallowShortTernary.Found" />
 		<exclude name="Universal.CodeAnalysis.NoEchoSprintf.Found" />
 		<exclude name="Universal.NamingConventions.NoReservedKeywordParameterNames.arrayFound" />

--- a/src/Http/RedirectorInterface.php
+++ b/src/Http/RedirectorInterface.php
@@ -18,5 +18,5 @@ interface RedirectorInterface {
 	 *
 	 * @param string $location The URL to redirect to.
 	 */
-	public function redirect( string $location): void;
+	public function redirect( string $location ): void;
 }

--- a/src/services.php
+++ b/src/services.php
@@ -18,27 +18,27 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WpOop\WordPress\Plugin\PluginInterface;
 
 return array(
-	'ppcp.plugin'                   => function( ContainerInterface $container ) : PluginInterface {
+	'ppcp.plugin'                   => function ( ContainerInterface $container ): PluginInterface {
 		$factory = new FilePathPluginFactory( new StringVersionFactory() );
 		return $factory->createPluginFromFilePath( dirname( realpath( __FILE__ ), 2 ) . '/woocommerce-paypal-payments.php' );
 	},
-	'ppcp.asset-version'            => function( ContainerInterface $container ) : string {
+	'ppcp.asset-version'            => function ( ContainerInterface $container ): string {
 		$plugin = $container->get( 'ppcp.plugin' );
 		assert( $plugin instanceof PluginInterface );
 
 		return (string) $plugin->getVersion();
 	},
 
-	'http.redirector'               => function( ContainerInterface $container ) : RedirectorInterface {
+	'http.redirector'               => function ( ContainerInterface $container ): RedirectorInterface {
 		return new WpRedirector();
 	},
-	'ppcp.path-to-plugin-folder'    => function( ContainerInterface $container ) : string {
+	'ppcp.path-to-plugin-folder'    => function ( ContainerInterface $container ): string {
 		/** @var Properties $properties */
 		$properties = $container->get( Package::PROPERTIES );
 
 		return $properties->basePath();
 	},
-	'ppcp.path-to-plugin-main-file' => function( ContainerInterface $container ) : string {
+	'ppcp.path-to-plugin-main-file' => function ( ContainerInterface $container ): string {
 		/** @var Properties $properties */
 		$properties = $container->get( Package::PROPERTIES );
 

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -208,7 +208,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 		 * @param array $links
 		 * @return array
 		 */
-		function( $links ) {
+		function ( $links ) {
 			if ( ! is_woocommerce_activated() ) {
 				return $links;
 			}
@@ -235,7 +235,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 		 * @param string $file
 		 * @return array
 		 */
-		function( $links, $file ) {
+		function ( $links, $file ) {
 			if ( plugin_basename( __FILE__ ) !== $file ) {
 				return $links;
 			}
@@ -272,7 +272,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 	add_action(
 		'before_woocommerce_init',
-		function() {
+		function () {
 			if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 				/**
 				 * Skip WC class check.


### PR DESCRIPTION
### Description

Upgrade WC sniffs to a PHP8 compatible version and update the format of multiple codebase files. 

- [Bump woocommerce-sniffs to v1.0.1](https://github.com/woocommerce/woocommerce-paypal-payments/commit/2ab3b5ef54a2fda871b3e586c0e4ea1c4c840518)
- [Fix parenthesis PHPCS error](https://github.com/woocommerce/woocommerce-paypal-payments/commit/fef445c928f7983b0f0610c2f90754fdeba0d11b) and [Fixing PHPCS parenthesis issue](https://github.com/woocommerce/woocommerce-paypal-payments/pull/3607/commits/6856448c63d111f390185ca0f5c034ef82084cdd)
- [Auto-Fix PHPCS spacing issues](https://github.com/woocommerce/woocommerce-paypal-payments/commit/060a86f5c9693872328e4fbb9f58718e8456d091) 
- [Auto-Fix grouped "use" statement issues.](https://github.com/woocommerce/woocommerce-paypal-payments/commit/e2fb54c7a9b4ae9e6ab16a0ece955af22df22f01)
- [Auto-Fix standalone increment issues](https://github.com/woocommerce/woocommerce-paypal-payments/commit/4c9ca19ec813e681a7417c429f75659fd65791ae)
- [Auto-Fix not necessary colon](https://github.com/woocommerce/woocommerce-paypal-payments/commit/ddb0ae3b11e23e7408ba572f48deefccbf14b3b8)
- [Fix loose equality ignore comment](https://github.com/woocommerce/woocommerce-paypal-payments/commit/720acca8a5a337ed5f2d6e2b0540066f20cf1189)
- [Fix else with simple inner ifs](https://github.com/woocommerce/woocommerce-paypal-payments/commit/224900c6a4c0b28fce71442015f451489cb07d96)
- [Fix empty catch clause](https://github.com/woocommerce/woocommerce-paypal-payments/commit/2925b73430ca9fe9c6d7ae9fb4f8056942acb43d)
- [Fix psalm false positive](https://github.com/woocommerce/woocommerce-paypal-payments/pull/3607/commits/11ef14b13ce0714e4aac1c9c08c88cf48f051328)

### Steps to Test

ℹ️  Note: Most of the changes are simple space reformatting applied with phpcbf. So, optionally, setting Hide whitespace in the review settings can simplify and reduce the number of files and changes to review.

<img width="340" height="268" alt="Screenshot 2025-08-22 at 17 28 07" src="https://github.com/user-attachments/assets/2cc80d90-7104-42de-a0c2-bc53397c316e" />

ℹ️  Also, checking commit by commit is a better strategy as all the related changes are grouped by commit.

1. Checkout this PR.
2. Run phpcs ( or ddev:lint ) using PHP 7.4. No errors are shown
3. Run phpcs ( or ddev:lint ) using PHP 8. No errors are shown
4. Go to Files changed or inspect the changes files by each commit
5. Pay special attention to this change  [Fix parenthesis PHPCS error](https://github.com/woocommerce/woocommerce-paypal-payments/commit/fef445c928f7983b0f0610c2f90754fdeba0d11b) and [Fixing PHPCS parenthesis issue](https://github.com/woocommerce/woocommerce-paypal-payments/pull/3607/commits/6856448c63d111f390185ca0f5c034ef82084cdd)
6.  Pay special attention to this change [Fix loose equality ignore comment](https://github.com/woocommerce/woocommerce-paypal-payments/commit/720acca8a5a337ed5f2d6e2b0540066f20cf1189)
7. Pay special attention to this change [Fix else with simple inner ifs](https://github.com/woocommerce/woocommerce-paypal-payments/commit/224900c6a4c0b28fce71442015f451489cb07d96)
8. Pay special attention to this change [Fix empty catch clause](https://github.com/woocommerce/woocommerce-paypal-payments/commit/2925b73430ca9fe9c6d7ae9fb4f8056942acb43d)
9. Final rules in phcs.dist.xml makes sense

### Screenshots


https://github.com/user-attachments/assets/6d04d3f7-3fce-43d1-84d7-5a7d51e0f540


### Rule exclusions

ℹ️  I decided to exclude some rules that we didn't have before this change. So we can keep the code changes to a minimum. Please let me know if you think some of them should be not excluded.

- WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Has been excluded because [this reason)](https://github.com/WordPress/WordPress-Coding-Standards/issues/2374)
- WordPress.WP.GetMetaSingle.Missing -- Controversial. It's the default param and it's inside an array_filter
- Generic.CodeAnalysis.UnusedFunctionParameter.Found and Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Controversial +  $container is a standard $param in all our services and modules, so, I decided towards exclude this rule
-  Universal.Operators.DisallowShortTernary.Found -- Was here previously, but rule name has been updated.
-  Universal.CodeAnalysis.NoEchoSprintf.Found -- Controversial + some legacy code there using echo sprintf. I lean towards rule exclusion 
- Universal.NamingConventions.NoReservedKeywordParameterNames -- Controversial + I decided towards exclusion of the rule instead of touching too much code. 
	
		