### PR TITLE
Add Pay Later messaging enablement banner for legacy UI (5189)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
@@ -55,6 +56,7 @@ use WooCommerce\PayPalCommerce\Settings\Enum\ProductChoicesEnum;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Axo\Helper\CompatibilityChecker;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class SettingsModule
@@ -113,7 +115,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			);
 
 			/**
-			 * Adds new settings discovery notice.
+			 * Adds notes to old UI settings screens.
 			 *
 			 * @param Message[] $notices
 			 * @return Message[]
@@ -135,6 +137,35 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					);
 
 					$notices[] = new Message( $message, 'info', false, 'ppcp-notice-wrapper' );
+
+					$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
+					// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
+						'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
+						true
+					);
+
+					$messages_apply = $container->get( 'button.helper.messages-apply' );
+					assert( $messages_apply instanceof MessagesApply );
+
+					$settings = $container->get( 'wcgateway.settings' );
+					assert( $settings instanceof Settings );
+
+					$stay_updated = $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
+
+					if ( $is_paylater_messaging_force_enabled_feature_flag_enabled && $messages_apply->for_country() && $stay_updated ) {
+						$paylater_enablement_message = sprintf(
+						// translators: %1$s is the URL for Stay Updated setting, %2$s is the URL for Pay Later settings.
+							__(
+								'<strong>PayPal Pay Later messaging successfully enabled</strong>, now displaying this flexible payment option earlier in the shopping experience. This update was made based on your <a href="%1$s">Stay Updated</a> preference and can be customized or disabled through the <a href="%2$s">Pay Later settings</a>.',
+								'woocommerce-paypal-payments'
+							),
+							admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#ppcp-stay_updated_field' ),
+							admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' )
+						);
+
+						$notices[] = new Message( $paylater_enablement_message, 'info', false, 'ppcp-notice-wrapper' );
+					}
+
 					return $notices;
 				}
 			);


### PR DESCRIPTION
## Issue Description

After updating to version 3.1.0, users with "Stay Updated" enabled will have Pay Later messaging automatically activated. This PR adds a notification banner to inform users about this change when they visit the legacy PayPal Payments settings pages.

## PR Description

- Only displays on legacy PayPal Payments settings pages
- Shows when Pay Later messaging was automatically enabled due to 3.1.0 update
- Triggered by the same conditions as the automatic enablement:
  - Feature flag enabled
  - Pay Later messaging available for store's country  
  - "Stay Updated" preference is enabled

<img width="1548" height="144" alt="Screenshot 2025-08-25 at 14 25 56" src="https://github.com/user-attachments/assets/d4ab62db-b99d-4cca-9eac-652062379964" />
