### PR TITLE
Create 'Things to do next' item for global Pay Later messaging enablement (5188)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -519,13 +519,25 @@ $services = array(
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
+		$settings_model = $container->get( 'settings.data.settings' );
+		assert( $settings_model instanceof SettingsModel );
+
+		$messages_apply = $container->get( 'button.helper.messages-apply' );
+		assert( $messages_apply instanceof MessagesApply );
+
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
 			getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
 		);
 
-		$is_working_capital_eligible = $container->get( 'settings.data.general' )->get_merchant_country() === 'US' && $container->get( 'settings.data.settings' )->get_stay_updated();
+		$is_working_capital_eligible = $container->get( 'settings.data.general' )->get_merchant_country() === 'US' && $settings_model->get_stay_updated();
+
+		$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
+		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
+			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
+			true
+		);
 
 		/**
 		 * Initializes TodosEligibilityService with eligibility conditions for various PayPal features.
@@ -551,6 +563,9 @@ $services = array(
 		 * @param bool $is_google_pay_eligible              - Show if merchant is eligible (ACDC) but doesn't have Google Pay on PayPal.
 		 * @param bool $is_enable_apple_pay_eligible        - Show if merchant has Apple Pay capability but hasn't enabled the gateway.
 		 * @param bool $is_enable_google_pay_eligible       - Show if merchant has Google Pay capability but hasn't enabled the gateway.
+		 * @param bool $is_enable_installments_eligible     - Show if merchant has installments capability and merchant country is MX.
+		 * @param bool $is_working_capital_eligible         - Show if feature flag is enabled, merchant country is US and "Stay Updated" is turned On.
+		 * @param bool $is_pay_later_messaging_auto_enabled - Show if feature flag is enabled, Pay later messaging is enabled for the merchant country and "Stay Updated" is turned On.
 		 */
 		return new TodosEligibilityService(
 			$container->get( 'axo.eligible' ) && $capabilities['acdc'] && ! $gateways['axo'],                  // Enable Fastlane.
@@ -572,7 +587,8 @@ $services = array(
 			$container->get( 'applepay.eligible' ) && $capabilities['apple_pay'] && ! $gateways['apple_pay'],                                       // Enable Apple Pay.
 			$container->get( 'googlepay.eligible' ) && $capabilities['google_pay'] && ! $gateways['google_pay'],
 			! $capabilities['installments'] && 'MX' === $container->get( 'settings.data.general' )->get_merchant_country(), // Enable Installments for Mexico.
-			$is_working_capital_feature_flag_enabled && $is_working_capital_eligible // Enable Working Capital.
+			$is_working_capital_feature_flag_enabled && $is_working_capital_eligible, // Enable Working Capital.
+			$is_paylater_messaging_force_enabled_feature_flag_enabled && $messages_apply->for_country() && $settings_model->get_stay_updated() // Pay later messaging auto enabled.
 		);
 	},
 	'settings.rest.features'                              => static function ( ContainerInterface $container ): FeaturesRestEndpoint {

--- a/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
@@ -244,6 +244,16 @@ class TodosDefinition {
 				),
 				'priority'    => 14,
 			),
+			'pay_later_messaging_is_auto_enabled'            => array(
+				'title'       => __( 'PayPal Pay Later messaging successfully enabled', 'woocommerce-paypal-payments' ),
+				'description' => __( 'PayPal is now displaying this flexible payment option earlier in the shopping experience. This update was made based on your “Stay Updated” preference and the messaging can be customized or disabled through the Pay Later settings.', 'woocommerce-paypal-payments' ),
+				'isEligible'  => $eligibility_checks['pay_later_messaging_is_auto_enabled'],
+				'action'      => array(
+					'type'      => 'tab',
+					'tab'       => 'pay_later_messaging',
+				),
+				'priority'    => 15,
+			),
 		);
 
 		$todo_items['check_settings_after_migration'] = array(

--- a/modules/ppcp-settings/src/Service/TodosEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/TodosEligibilityService.php
@@ -131,6 +131,8 @@ class TodosEligibilityService {
 
 	private bool $is_working_capital_eligible;
 
+	private bool $is_pay_later_messaging_auto_enabled;
+
 	/**
 	 * Constructor.
 	 *
@@ -151,6 +153,7 @@ class TodosEligibilityService {
 	 * @param bool $is_enable_google_pay_eligible       Whether enabling Google Pay is eligible.
 	 * @param bool $is_enable_installments_eligible     Whether enabling Installments is eligible.
 	 * @param bool $is_working_capital_eligible         Whether applying for Working Capital is eligible.
+	 * @param bool $is_pay_later_messaging_auto_enabled Whether the Pay later messaging is force enabled.
 	 */
 	public function __construct(
 		bool $is_fastlane_eligible,
@@ -169,7 +172,8 @@ class TodosEligibilityService {
 		bool $is_enable_apple_pay_eligible,
 		bool $is_enable_google_pay_eligible,
 		bool $is_enable_installments_eligible,
-		bool $is_working_capital_eligible
+		bool $is_working_capital_eligible,
+		bool $is_pay_later_messaging_auto_enabled
 	) {
 		$this->is_fastlane_eligible                      = $is_fastlane_eligible;
 		$this->is_pay_later_messaging_eligible           = $is_pay_later_messaging_eligible;
@@ -188,6 +192,7 @@ class TodosEligibilityService {
 		$this->is_enable_google_pay_eligible             = $is_enable_google_pay_eligible;
 		$this->is_enable_installments_eligible           = $is_enable_installments_eligible;
 		$this->is_working_capital_eligible               = $is_working_capital_eligible;
+		$this->is_pay_later_messaging_auto_enabled       = $is_pay_later_messaging_auto_enabled;
 	}
 
 	/**
@@ -214,6 +219,7 @@ class TodosEligibilityService {
 			'enable_google_pay'                    => fn() => $this->is_enable_google_pay_eligible,
 			'enable_installments'                  => fn() => $this->is_enable_installments_eligible,
 			'apply_for_working_capital'            => fn() => $this->is_working_capital_eligible,
+			'pay_later_messaging_is_auto_enabled'  => fn() => $this->is_pay_later_messaging_auto_enabled,
 		);
 	}
 }


### PR DESCRIPTION
## Issue Description

After updating to version 3.1.0, users with "Stay Updated" enabled will have Pay Later messaging automatically activated. This PR adds a ‘Things to do next’ item to inform users about this change when they visit the new UI of the plugin

## PR Description

- Only displays on new settings pages
- Shows when Pay Later messaging was automatically enabled due to 3.1.0 update
- Triggered by the same conditions as the automatic enablement:
  - Feature flag enabled
  - Pay Later messaging available for store's country
  - "Stay Updated" preference is enabled

<img width="996" height="408" alt="Screenshot 2025-08-25 at 15 31 46" src="https://github.com/user-attachments/assets/ab608b6c-a4e2-476a-b42d-88936437b756" />
