### PR TITLE
Keep order customer association after cross-browser AppSwitch for logged in users

### DIFF
--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -375,7 +375,7 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		 */
 		add_filter(
 			'woocommerce_order_received_verify_known_shoppers',
-			static function( $result ) {
+			static function ( $result ) {
 				if ( ! is_order_received_page() ) {
 					return $result;
 				}
@@ -417,8 +417,8 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		add_filter(
 			'woocommerce_order_email_verification_required',
 			static function (
-			$email_verification_required,
-			$order
+				$email_verification_required,
+				$order
 			) {
 				if ( ! $order instanceof WC_Order ) {
 					return $email_verification_required;

--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -237,6 +237,10 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		);
 	}
 
+	private static function is_cross_browser_order( WC_Order $wc_order ): bool {
+		return wc_string_to_bool( $wc_order->get_meta( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY ) );
+	}
+
 	private function register_appswitch_crossbrowser_handler( ContainerInterface $container ): void {
 		if ( ! $container->get( 'wcgateway.appswitch-enabled' ) ) {
 			return;
@@ -346,7 +350,7 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 					return $allcaps;
 				}
 
-				if ( ! wc_string_to_bool( $wc_order->get_meta( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY ) ) ) {
+				if ( ! self::is_cross_browser_order( $wc_order ) ) {
 					return $allcaps;
 				}
 
@@ -391,7 +395,7 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 					return $result;
 				}
 
-				if ( ! wc_string_to_bool( $wc_order->get_meta( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY ) ) ) {
+				if ( ! self::is_cross_browser_order( $wc_order ) ) {
 					return $result;
 				}
 
@@ -420,7 +424,7 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 					return $email_verification_required;
 				}
 
-				if ( ! wc_string_to_bool( $order->get_meta( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY ) ) ) {
+				if ( ! self::is_cross_browser_order( $order ) ) {
 					return $email_verification_required;
 				}
 

--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button;
 
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ReturnUrlFactory;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveSubscriptionEndpoint;
@@ -31,6 +32,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 /**
  * Class ButtonModule
@@ -299,10 +301,64 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 				$wc_order = $wc_order_creator->create_from_paypal_order( $paypal_order, $cart_data );
 
+				$wc_order->update_meta_data( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY, wc_bool_to_string( true ) );
+				$wc_order->save();
+
 				// Redirect via JS because we need to keep the # parameters which are not accessible on the server side.
 				// phpcs:ignore WordPress.Security.EscapeOutput
 				echo "<script>location.href = '" . $wc_order->get_checkout_payment_url() . "' + location.hash;</script>";
 			}
+		);
+
+		/**
+		 * By default, WC asks to log in when opening a non-guest Pay for order page as a guest,
+		 * so we disable this for cross-browser AppSwitch.
+		 *
+		 * @param array<string, bool> $allcaps Array of key/value pairs where keys represent a capability name
+		 *                           and boolean values represent whether the user has that capability.
+		 * @param string[] $caps Required primitive capabilities for the requested capability.
+		 * @param array $args {
+		 *      Arguments that accompany the requested capability check.
+		 *
+		 * @type string    $0 Requested capability.
+		 * @type int       $1 Concerned user ID.
+		 * @type mixed  ...$2 Optional second and further parameters, typically object ID.
+		 *  }
+		 *
+		 * @returns array<string, bool>
+		 *
+		 * @psalm-suppress MissingClosureParamType
+		 */
+		add_filter(
+			'user_has_cap',
+			static function ( $allcaps, $cap, $args ) {
+				if ( ! in_array( 'pay_for_order', $cap, true ) ) {
+					return $allcaps;
+				}
+
+				$wc_order_id = $args[2] ?? null;
+				if ( ! is_int( $wc_order_id ) ) {
+					return $allcaps;
+				}
+
+				$wc_order = wc_get_order( $wc_order_id );
+				if ( ! $wc_order instanceof WC_Order ) {
+					return $allcaps;
+				}
+
+				if ( ! wc_string_to_bool( $wc_order->get_meta( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY ) ) ) {
+					return $allcaps;
+				}
+
+				return array_merge(
+					$allcaps,
+					array(
+						'pay_for_order' => true,
+					)
+				);
+			},
+			10,
+			3
 		);
 	}
 }

--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -362,6 +362,44 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		);
 
 		/**
+		 * By default, WC asks to log in when opening a non-guest order received page as a guest,
+		 * so we disable this for cross-browser AppSwitch.
+		 *
+		 * @param bool $result
+		 *
+		 * @psalm-suppress MissingClosureParamType
+		 */
+		add_filter(
+			'woocommerce_order_received_verify_known_shoppers',
+			static function( $result ) {
+				if ( ! is_order_received_page() ) {
+					return $result;
+				}
+
+				$wc_order = null;
+			    // phpcs:disable WordPress.Security.NonceVerification
+				if ( isset( $_GET['key'] ) && is_string( $_GET['key'] ) ) {
+					$wc_order_key = sanitize_text_field( wp_unslash( $_GET['key'] ) );
+					// phpcs:enable WordPress.Security.NonceVerification
+
+					$wc_order_id = wc_get_order_id_by_order_key( $wc_order_key );
+
+					$wc_order = wc_get_order( $wc_order_id );
+				}
+
+				if ( ! $wc_order instanceof WC_Order ) {
+					return $result;
+				}
+
+				if ( ! wc_string_to_bool( $wc_order->get_meta( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY ) ) ) {
+					return $result;
+				}
+
+				return false;
+			}
+		);
+
+		/**
 		 * Disabling the email prompt on Pay for order page for guests.
 		 * Should not affect anything in most cases because it is skipped for just created orders (< 10 min).
 		 *

--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -360,5 +360,36 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			10,
 			3
 		);
+
+		/**
+		 * Disabling the email prompt on Pay for order page for guests.
+		 * Should not affect anything in most cases because it is skipped for just created orders (< 10 min).
+		 *
+		 * @param bool $email_verification_required
+		 * @param WC_Order $order
+		 *
+		 * @returns bool
+		 *
+		 * @psalm-suppress MissingClosureParamType
+		 */
+		add_filter(
+			'woocommerce_order_email_verification_required',
+			static function (
+			$email_verification_required,
+			$order
+			) {
+				if ( ! $order instanceof WC_Order ) {
+					return $email_verification_required;
+				}
+
+				if ( ! wc_string_to_bool( $order->get_meta( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY ) ) ) {
+					return $email_verification_required;
+				}
+
+				return false;
+			},
+			10,
+			2
+		);
 	}
 }

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -97,7 +97,7 @@ class WooCommerceOrderCreator {
 			$shipping       = ! empty( $purchase_units ) ? $purchase_units[0]->shipping() : null;
 
 			$this->configure_payment_source( $wc_order );
-			$this->configure_customer( $wc_order );
+			$this->configure_customer( $wc_order, $cart_data );
 			$this->configure_line_items( $wc_order, $cart_data, $payer, $shipping );
 			$this->configure_addresses( $wc_order, $payer, $shipping, $cart_data->needs_shipping() );
 			$this->configure_coupons( $wc_order, $cart_data->coupons() );
@@ -293,15 +293,18 @@ class WooCommerceOrderCreator {
 
 	/**
 	 * Configures the customer ID.
-	 *
-	 * @param WC_Order $wc_order The WC order.
-	 * @return void
 	 */
-	protected function configure_customer( WC_Order $wc_order ): void {
+	protected function configure_customer( WC_Order $wc_order, CartData $cart_data ): void {
 		$current_user = wp_get_current_user();
 
 		if ( $current_user->ID !== 0 ) {
 			$wc_order->set_customer_id( $current_user->ID );
+			return;
+		}
+
+		$saved_user_id = $cart_data->user_id();
+		if ( $saved_user_id !== 0 ) {
+			$wc_order->set_customer_id( $saved_user_id );
 		}
 	}
 

--- a/modules/ppcp-button/src/Session/CartData.php
+++ b/modules/ppcp-button/src/Session/CartData.php
@@ -22,6 +22,8 @@ class CartData {
 
 	protected bool $needs_shipping;
 
+	protected int $user_id;
+
 	protected string $cart_hash;
 
 	protected ?string $paypal_order_id = null;
@@ -30,17 +32,20 @@ class CartData {
 	 * @param array<string, array<string, mixed>> $items The cart items like in $cart->get_cart_for_session() or $cart->get_cart().
 	 * @param string[]                            $coupons
 	 * @param bool                                $needs_shipping
+	 * @param int                                 $user_id
 	 * @param string                              $cart_hash
 	 */
 	public function __construct(
 		array $items,
 		array $coupons,
 		bool $needs_shipping,
+		int $user_id,
 		string $cart_hash
 	) {
 		$this->items          = $items;
 		$this->coupons        = $coupons;
 		$this->needs_shipping = $needs_shipping;
+		$this->user_id        = $user_id;
 		$this->cart_hash      = $cart_hash;
 	}
 
@@ -78,6 +83,10 @@ class CartData {
 		return $this->needs_shipping;
 	}
 
+	public function user_id(): int {
+		return $this->user_id;
+	}
+
 	public function cart_hash(): string {
 		return $this->cart_hash;
 	}
@@ -95,6 +104,7 @@ class CartData {
 			'items'           => $this->items,
 			'coupons'         => $this->coupons,
 			'needs_shipping'  => $this->needs_shipping,
+			'user_id'         => $this->user_id,
 			'cart_hash'       => $this->cart_hash,
 			'paypal_order_id' => $this->paypal_order_id,
 		);
@@ -105,6 +115,7 @@ class CartData {
 			$data['items'] ?? array(),
 			$data['coupons'] ?? array(),
 			(bool) ( $data['needs_shipping'] ?? false ),
+			(int) ( $data['user_id'] ?? 0 ),
 			$data['cart_hash'] ?? ''
 		);
 		$cart_data->paypal_order_id = $data['paypal_order_id'] ?? null;

--- a/modules/ppcp-button/src/Session/CartDataFactory.php
+++ b/modules/ppcp-button/src/Session/CartDataFactory.php
@@ -28,6 +28,7 @@ class CartDataFactory {
 			$cart->get_cart_for_session(),
 			$cart->get_applied_coupons(),
 			$cart->needs_shipping(),
+			get_current_user_id(),
 			$cart->get_cart_hash()
 		);
 	}

--- a/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
@@ -244,13 +244,13 @@ class TodosDefinition {
 				),
 				'priority'    => 14,
 			),
-			'pay_later_messaging_is_auto_enabled'            => array(
+			'pay_later_messaging_is_auto_enabled'  => array(
 				'title'       => __( 'PayPal Pay Later messaging successfully enabled', 'woocommerce-paypal-payments' ),
 				'description' => __( 'PayPal is now displaying this flexible payment option earlier in the shopping experience. This update was made based on your “Stay Updated” preference and the messaging can be customized or disabled through the Pay Later settings.', 'woocommerce-paypal-payments' ),
 				'isEligible'  => $eligibility_checks['pay_later_messaging_is_auto_enabled'],
 				'action'      => array(
-					'type'      => 'tab',
-					'tab'       => 'pay_later_messaging',
+					'type' => 'tab',
+					'tab'  => 'pay_later_messaging',
 				),
 				'priority'    => 15,
 			),

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -60,6 +60,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	public const ORIGINAL_EMAIL_META_KEY = '_ppcp_paypal_billing_email';
 	public const ORIGINAL_PHONE_META_KEY = '_ppcp_paypal_billing_phone';
 
+	public const CROSS_BROWSER_APPSWITCH_META_KEY = '_ppcp_cross_browser_appswitch';
+
 	/**
 	 * List of payment sources for which we are expected to store the payer email in the WC Order metadata.
 	 */


### PR DESCRIPTION
Now preserving the customer id in the order if the user was logged in when starting the checkout. That is we started checkout in a non-default browser logged in as `user1`, and finished in the default browser as a guest, the order will belong to `user1`. 

The log-in prompt after the redirect to the default browser as a guest is disabled.

There is one a bit weird edge, when logged in as different users in both browsers. For now just using the user from the default browser to avoid confusion like going to My Account after the payment and not seeing the order. Maybe a better approach could be to force logout in the default browser. Anyway, hopefully this happens very rarely.

Also I added the `woocommerce_order_email_verification_required` filter handler to skip email prompt for such orders. It should not be needed in most cases because it is already skipped if the order was created less than 10 minutes ago, but probably a good idea to add that, e.g. if AppSwitch failed and finishing a bit later via another method.