### PR TITLE
Don't filter tokens on changing payment method of a subscription (5333)

### DIFF
--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -128,6 +128,10 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 					return $tokens;
 				}
 
+				if ( isset( $_GET['change_payment_method'] ) && is_wc_endpoint_url( 'order-pay' ) ) {
+					return $tokens;
+				}
+
 				$is_post = isset( $_SERVER['REQUEST_METHOD'] ) && $_SERVER['REQUEST_METHOD'] === 'POST';
 
 				// Exclude ApplePay tokens from payment pages.


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
When changing payment method of a subscription, don't filter the token.

### Steps to Test

1. Ensure WooCommerce Subscription is installed
2. Create a simple subscription product and make a purchase of the product using PayPal
3. Once completed, change the payment method via edit-order screen

    <kbd><img width="288" height="87" alt="image" src="https://github.com/user-attachments/assets/ebd8736f-b2e4-456d-8e0f-8c80ed61ca1f" /></kbd>

4. PayPal should be shown in the list and selected

    <kbd><img width="436" height="174" alt="image" src="https://github.com/user-attachments/assets/5bcfd1d4-d712-4415-ae07-5e9fed39fdbd" /></kbd>

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

