### PR TITLE
Fix 'Proceed to PayPal' button label not reverted on block checkout when totals are 0 (2903)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -103,8 +103,9 @@ if ( blockEnabled ) {
 			edit: descriptionElement,
 			placeOrderButtonLabel: config.placeOrderButtonText,
 			ariaLabel: config.title,
-			canMakePayment: () => {
-				return true;
+			canMakePayment: ( cartData ) => {
+				const totals = cartData?.cartTotals?.total_price;
+				return parseInt( totals ) > 0;
 			},
 			supports: {
 				features,

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -104,8 +104,8 @@ if ( blockEnabled ) {
 			placeOrderButtonLabel: config.placeOrderButtonText,
 			ariaLabel: config.title,
 			canMakePayment: ( cartData ) => {
-				const totals = cartData?.cartTotals?.total_price;
-				return parseInt( totals ) > 0;
+				const total = cartData?.cartTotals?.total_price;
+				return parseInt( total ) > 0;
 			},
 			supports: {
 				features,


### PR DESCRIPTION
### Description

Tweaks the code to only enable ppcp-gateway when totals are more than 0€

### Steps to Test

1. Create percentage coupon with amount 100% (or fixed amount that covers full checkout amount)
2. Navigate to shop
3. Add product to cart
4. Navigate to block checkout page
5. Select PayPal as paypement method
6. Total is more than 0
7.  It shows "Proceed to PayPal" button as expected
8. Apply the 100% coupon
9. Now total should be 0
10. It shows "Place Order" button
11. Click on it
12. Order is confirmed

Observe that before this PR, the PayPal gateway was hidden but the Place order’ button label was still called ‘Proceed to PayPal’

### Demo


https://github.com/user-attachments/assets/ebe756fc-71ef-4052-91d7-ee9ffa99c9c1


