### PR TITLE
Fix PayPal button is missing from product page for PayPal subscription (5175)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.js
@@ -264,12 +264,15 @@ class SingleProductBootstrap {
 			if ( this.subscriptionButtonsLoaded ) {
 				return;
 			}
+
 			loadPaypalJsScript(
 				{
 					clientId: PayPalCommerceGateway.client_id,
 					currency: PayPalCommerceGateway.currency,
 					intent: 'subscription',
 					vault: true,
+					disable_funding:
+						this.gateway.url_params[ 'disable-funding' ],
 				},
 				actionHandler.subscriptionsConfiguration( subscription_plan ),
 				this.gateway.button.wrapper

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.js
@@ -243,15 +243,6 @@ class SingleProductBootstrap {
 			this.form(),
 			this.errorHandler
 		);
-		if (
-			! this.gateway.vaultingEnabled &&
-			[ 'subscription', 'variable-subscription' ].includes(
-				this.gateway.productType
-			) &&
-			this.gateway.manualRenewalEnabled !== '1'
-		) {
-			return;
-		}
 
 		if (
 			PayPalCommerceGateway.data_client_id.has_subscriptions &&
@@ -285,6 +276,16 @@ class SingleProductBootstrap {
 			);
 
 			this.subscriptionButtonsLoaded = true;
+			return;
+		}
+
+		if (
+			! this.gateway.vaultingEnabled &&
+			[ 'subscription', 'variable-subscription' ].includes(
+				this.gateway.productType
+			) &&
+			this.gateway.manualRenewalEnabled !== '1'
+		) {
 			return;
 		}
 


### PR DESCRIPTION
## Issue Description

PayPal subscription products are missing the PayPal payment button on the product page.

**Steps to reproduce:**

- Create PayPal subscription product
- Navigate to shop and click on PayPal subscription product
- Observe PayPal button is missing

## PR Description

This PR fixes the missing PayPal button issue for subscription products by adding a check to detect PayPal subscriptions before checking the vaulting