### PR TITLE
Fix the top bar underline offset in the Settings UI (5203)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_navigation.scss
@@ -7,7 +7,7 @@ $margin_bottom: 48px;
 	--color-disabled: #CCC;
 	--navbar-height: 40px;
 	--navbar-vertical-padding: 10px;
-	--subnavigation-height: 40px;
+	--subnavigation-height: 38px;
 
 	// Styling.
 	position: sticky;
@@ -93,7 +93,6 @@ $margin_bottom: 48px;
 	}
 
 	.ppcp--top-sub-navigation {
-		height: var(--subnavigation-height);
 		margin: 0;
 		padding: 0;
 
@@ -108,6 +107,12 @@ $margin_bottom: 48px;
 			&[data-focus-visible="true"]:focus:not(:disabled) {
 				outline: none;
 			}
+		}
+	}
+
+	@media screen and (max-width: 782px) {
+		.ppcp--top-sub-navigation {
+			height: var(--subnavigation-height);
 		}
 	}
 


### PR DESCRIPTION
### Description

This PR will fix the top bar underline offset in the Settings UI, both in desktop and mobile.

### Screenshots

|Before|After|
|-|-|
|<img width="1072" height="545" alt="old_ui_offset" src="https://github.com/user-attachments/assets/f9e7f99b-6317-4d3c-8cc4-a37c5b87cdc3" />|<img width="1052" height="553" alt="new_ui_offset" src="https://github.com/user-attachments/assets/7e5f7b8d-9baa-4b0b-8278-44f9b17d8394" />|
