### PR TITLE
Add ddev command to reset wp install

### DIFF
--- a/.ddev/commands/web/wp-cleanup
+++ b/.ddev/commands/web/wp-cleanup
@@ -1,16 +1,8 @@
 #!/bin/bash
 
 show-help() {
-	echo -e "\nDelete all posts -p [post type]"
-	echo -e "\tExample: ddev wp-cleanup -p shop_order,product"
 	echo -e "\nDelete all logs -l [wp-content path]"
 	echo -e "\tExample: ddev wp-cleanup -l uploads/wc-logs\n"
-}
-
-delete-posts() {
-	for post in $(wp post list --post_type=$1 --format=ids --path=.ddev/wordpress); do
-		wp post delete $post --force --path=.ddev/wordpress
-	done
 }
 
 delete-logs() {
@@ -19,12 +11,8 @@ delete-logs() {
 
 declare -i param_counter=0
 
-while getopts "p:l:h" arg; do
+while getopts "l:h" arg; do
 	case $arg in
-	p)
-		delete-posts $OPTARG
-		param_counter+=1
-		;;
 	l)
 		delete-logs $OPTARG
 		param_counter+=1

--- a/.ddev/commands/web/wp-reset
+++ b/.ddev/commands/web/wp-reset
@@ -25,7 +25,7 @@ reset-database() {
 
 	echo "Installing WordPress..."
 	wp core install \
-		--url=wp-test-site.ddev.site \
+		--url="${DDEV_PRIMARY_URL}" \
 		--title="${WP_TITLE}" \
 		--admin_user="${ADMIN_USER}" \
 		--admin_password="${ADMIN_PASS}" \

--- a/.ddev/commands/web/wp-reset
+++ b/.ddev/commands/web/wp-reset
@@ -10,7 +10,7 @@ show-help() {
 remove-plugins() {
 	echo "Deactivating all plugins..."
 	wp plugin deactivate --all --path=.ddev/wordpress
-	
+
 	echo "Deleting all plugins..."
 	wp plugin delete --all --path=.ddev/wordpress
 }
@@ -26,10 +26,10 @@ reset-database() {
 	echo "Installing WordPress..."
 	wp core install \
 		--url=wp-test-site.ddev.site \
-		--title="WooCommerce PayPal Payments" \
-		--admin_user=admin \
-		--admin_password=password \
-		--admin_email=test@ddev.site \
+		--title="${WP_TITLE}" \
+		--admin_user="${ADMIN_USER}" \
+		--admin_password="${ADMIN_PASS}" \
+		--admin_email="${ADMIN_EMAIL}" \
 		--path=.ddev/wordpress
 
 	echo "Database reset and WordPress installation completed!"

--- a/.ddev/commands/web/wp-reset
+++ b/.ddev/commands/web/wp-reset
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+show-help() {
+	echo -e "\nReset the WordPress database and reinstall WordPress"
+	echo -e "\tExample: ddev wp-reset"
+	echo -e "\nRemove all plugins --clean-plugins"
+	echo -e "\tExample: ddev wp-reset --clean-plugins\n"
+}
+
+remove-plugins() {
+	echo "Deactivating all plugins..."
+	wp plugin deactivate --all --path=.ddev/wordpress
+	
+	echo "Deleting all plugins..."
+	wp plugin delete --all --path=.ddev/wordpress
+}
+
+reset-database() {
+	echo "Resetting database..."
+	wp db reset --yes --path=.ddev/wordpress
+
+	if [ "$1" = "clean-plugins" ]; then
+		remove-plugins
+	fi
+
+	echo "Installing WordPress..."
+	wp core install \
+		--url=wp-test-site.ddev.site \
+		--title="WooCommerce PayPal Payments" \
+		--admin_user=admin \
+		--admin_password=password \
+		--admin_email=test@ddev.site \
+		--path=.ddev/wordpress
+
+	echo "Database reset and WordPress installation completed!"
+}
+
+clean_plugins=false
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+	--clean-plugins)
+		clean_plugins=true
+		shift
+		;;
+	-h|--help)
+		show-help
+		exit 0
+		;;
+	*)
+		echo "Unknown option: $1"
+		show-help
+		exit 1
+		;;
+	esac
+done
+
+if [ "$clean_plugins" = true ]; then
+	reset-database "clean-plugins"
+else
+	reset-database
+fi


### PR DESCRIPTION
This PR adds `ddev wp-reset` command to reset the WordPress installation, by default it does not delete all plugins but can do so by passing `--clean-plugins` argument to the command. 