### PR TITLE
Update Fastlane card placeholder design (5050)

### DIFF
--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -49,49 +49,51 @@ $fast-transition-duration: 0.5s;
 	&__content {
 		position: relative;
 		box-sizing: border-box;
-		aspect-ratio: 1.586;
 		margin: 1em 0;
 		border-radius: 10px;
 		width: 100%;
-		box-shadow: 0 3px 10px -3px rgba(0, 0, 0, .2666666667);
-		background-image: linear-gradient(60deg, rgba(0, 0, 0, 0.0666666667), rgba(204, 204, 204, 0.0666666667) 65%, rgba(255, 255, 255, 0.4) 68%, rgba(255, 255, 255, 0));
-		border: 2px solid #ccc;
-		background-color: #f6f6f6;
+		background-color: #F8F9FA;
+		border: 2px solid #ECEEF2;
 	}
 
 	&__meta {
 		width: 100%;
 		text-align: left;
+		padding: 10px 15px;
+		display: flex;
+		gap: 15px;
 
 		&-digits {
-			margin-top: 76px;
-			font-size: 24px;
-			text-shadow: 0 -1px 1px #fff, 0 1px 1px rgba(0, 0, 0, .2666666667);
+			font-size: 1.1em;
+			width: 100%;
 			color: #666;
-			text-align: center;
 			font-family: monospace;
+			font-weight: bold;
 		}
 
 		&-logo {
-			position: absolute;
-			right: 32px;
-			top: 32px;
-			height: 40px;
-		}
-
-		&-expiry {
-			text-align: right;
-			font-size: 14px;
-			padding-right: 32px;
+			align-self: center;
+			width: 60px;
+			flex-grow: 1;
+			flex-shrink: 0;
 		}
 
 		&-name {
-			text-transform: uppercase;
-			position: absolute;
-			left: 24px;
-			bottom: 20px;
-			line-height: 1em;
+			padding-right: 20px;
+			position: relative;
+			&::after {
+				content: "•";
+				position: absolute;
+				right: 10px;
+				transform: translateX(50%);
+				color: #ECEEF2;
+			}
 		}
+	}
+
+	&__meta-container {
+		display: flex;
+		flex-wrap: wrap;
 	}
 
 	&__edit {
@@ -110,10 +112,6 @@ $fast-transition-duration: 0.5s;
 			text-decoration: underline;
 		}
 	}
-}
-
-.wc-block-axo-block-card__meta-icon {
-	max-height: 25px;
 }
 
 // 3. Express Payment Block

--- a/modules/ppcp-axo-block/resources/css/gateway.scss
+++ b/modules/ppcp-axo-block/resources/css/gateway.scss
@@ -59,23 +59,30 @@ $fast-transition-duration: 0.5s;
 	&__meta {
 		width: 100%;
 		text-align: left;
-		padding: 10px 15px;
+		padding: 15px;
 		display: flex;
 		gap: 15px;
 
 		&-digits {
-			font-size: 1.1em;
-			width: 100%;
+			font-size: 18px;
+			line-height: 1em;
 			color: #666;
 			font-family: monospace;
 			font-weight: bold;
+			width: 100%;
 		}
 
 		&-logo {
-			align-self: center;
 			width: 60px;
+			align-self: center;
 			flex-grow: 1;
 			flex-shrink: 0;
+
+			img {
+				max-width: 100%;
+				display: block;
+				margin: 0;
+			}
 		}
 
 		&-name {
@@ -86,14 +93,22 @@ $fast-transition-duration: 0.5s;
 				position: absolute;
 				right: 10px;
 				transform: translateX(50%);
-				color: #ECEEF2;
+				color: #6d6d6d;
 			}
+		}
+
+		&-name,
+		&-expiry {
+			font-size: 16px;
+			line-height: 1em;
+			color: #6d6d6d;
 		}
 	}
 
 	&__meta-container {
 		display: flex;
 		flex-wrap: wrap;
+		row-gap: .5em;
 	}
 
 	&__edit {

--- a/modules/ppcp-axo-block/resources/js/components/Card/Card.js
+++ b/modules/ppcp-axo-block/resources/js/components/Card/Card.js
@@ -48,14 +48,16 @@ const Card = ( { fastlaneSdk, showWatermark = true } ) => {
 						<div className="wc-block-checkout-axo-block-card__meta-logo">
 							{ cardLogo }
 						</div>
-						<div className="wc-block-checkout-axo-block-card__meta-digits">
-							{ `**** **** **** ${ lastDigits }` }
-						</div>
-						<div className="wc-block-checkout-axo-block-card__meta-expiry">
-							{ formattedExpiry }
-						</div>
-						<div className="wc-block-checkout-axo-block-card__meta-name">
-							{ name }
+						<div className="wc-block-checkout-axo-block-card__meta-container">
+							<div className="wc-block-checkout-axo-block-card__meta-digits">
+								{ `•••• ${ lastDigits }` }
+							</div>
+							<div className="wc-block-checkout-axo-block-card__meta-name">
+								{ name }
+							</div>
+							<div className="wc-block-checkout-axo-block-card__meta-expiry">
+								{ formattedExpiry }
+							</div>
 						</div>
 					</div>
 				</div>

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -101,6 +101,7 @@
 
 .axo-checkout-wrapper {
 	margin-bottom: 20px;
+	padding: 0 10px;
 
 	.axo-checkout-header-section {
 		display: flex;
@@ -109,81 +110,49 @@
 		margin-bottom: 1em;
 	}
 
-	.axo-checkout-card-preview {
-		border: 2px solid #cccccc;
-		border-radius: 10px;
-		padding: 16px 20px;
-		background-color: #f6f6f6;
-	}
-
-	.ppcp-card-icon-wrapper {
-		float: right;
-	}
-
-	.ppcp-card-icon {
-		width: auto;
-		height: 25px;
-	}
-
-	.axo-card-number {
-		font-family: monospace;
-		font-size: 1rem;
-		margin-top: 10px;
-	}
-
-	.axo-card-owner {
-		text-transform: uppercase;
-	}
 
 	.styled-card {
 		position: relative;
-		width: 100%;
-		max-width: 340px;
-		height: 210px;
-		margin: 0 auto;
-		box-shadow: 0 3px 10px -3px #0004;
-		background-image: linear-gradient(60deg, #0001, #ccc1 65%, #fff6 68%, #fff0);
 		box-sizing: border-box;
-		padding: 0;
+		margin: 1em 0;
+		border-radius: 10px;
+		width: 100%;
+		max-width: 350px;
+		background-color: #F8F9FA;
+		border: 2px solid #ECEEFE;
+		text-align: left;
+		padding: 10px 15px;
+		display: flex;
+		gap: 15px;
 
 		.ppcp-card-icon-wrapper {
-			position: absolute;
-			right: 32px;
-			top: 32px;
-			height: 40px;
+			align-self: center;
+			width: 60px;
+			flex-shrink: 0;
+		}
+
+		.axo-card-meta-wrapper {
+			display: flex;
+			flex-wrap: wrap;
 		}
 
 		.axo-card-number {
-			margin-top: 76px;
-			font-size: 24px;
-			text-shadow: 0 -1px 1px #fff, 0 1px 1px #0004;
+			font-size: 1.1em;
+			width: 100%;
 			color: #666;
-			text-align: center;
-		}
-
-		.axo-card-expiry {
-			font-size: 14px;
-			padding-right: 32px;
-			text-align: right;
+			font-family: monospace;
+			font-weight: bold;
 		}
 
 		.axo-card-owner {
-			position: absolute;
-			left: 24px;
-			bottom: 20px;
-			line-height: 1em;
-		}
-
-		@media (max-width: 480px) {
-			.axo-card-number {
-				font-size: 20px;
-				text-align: left;
-				padding-left: 20px;
-			}
-		}
-		@media (max-width: 360px) {
-			.axo-card-number {
-				font-size: 16px;
+			padding-right: 20px;
+			position: relative;
+			&::after {
+				content: "•";
+				position: absolute;
+				right: 10px;
+				transform: translateX(50%);
+				color: #ECEEF2;
 			}
 		}
 	}
@@ -227,10 +196,11 @@
 		float: none;
 		vertical-align: middle;
 	}
+}
 
-	.ppcp-card-icon {
-		max-height: 25px;
-	}
+#payment .payment_methods li.payment_method_ppcp-axo-gateway .ppcp-card-icon {
+	float: none;
+	max-height: initial
 }
 
 @media screen and (max-width: 719px) {

--- a/modules/ppcp-axo/resources/css/styles.scss
+++ b/modules/ppcp-axo/resources/css/styles.scss
@@ -121,27 +121,36 @@
 		background-color: #F8F9FA;
 		border: 2px solid #ECEEFE;
 		text-align: left;
-		padding: 10px 15px;
+		padding: 15px;
 		display: flex;
 		gap: 15px;
 
 		.ppcp-card-icon-wrapper {
-			align-self: center;
 			width: 60px;
+			align-self: center;
+			flex-grow: 1;
 			flex-shrink: 0;
+
+			img {
+				max-width: 100%;
+				display: block;
+				margin: 0!important;
+			}
 		}
 
 		.axo-card-meta-wrapper {
 			display: flex;
 			flex-wrap: wrap;
+			row-gap: .5em;
 		}
 
 		.axo-card-number {
-			font-size: 1.1em;
-			width: 100%;
+			font-size: 18px;
+			line-height: 1em;
 			color: #666;
 			font-family: monospace;
 			font-weight: bold;
+			width: 100%;
 		}
 
 		.axo-card-owner {
@@ -152,8 +161,15 @@
 				position: absolute;
 				right: 10px;
 				transform: translateX(50%);
-				color: #ECEEF2;
+				color: #6d6d6d;
 			}
+		}
+
+		.axo-card-owner,
+		.axo-card-expiry{
+			font-size: 16px;
+			color: #6d6d6d;
+			line-height: 1em;
 		}
 	}
 }

--- a/modules/ppcp-axo/resources/js/Views/CardView.js
+++ b/modules/ppcp-axo/resources/js/Views/CardView.js
@@ -55,18 +55,21 @@ class CardView {
                                     alt="${ data.value( 'brand' ) }"
                                 >
                             </div>
-                            <div class="axo-card-number">${
-								data.value( 'lastDigits' )
-									? '**** **** **** ' +
-									  data.value( 'lastDigits' )
-									: ''
-							}</div>
-                            <div class="axo-card-expiry">${ expiry[ 1 ] }/${
-								expiry[ 0 ]
-							}</div>
-                            <div class="axo-card-owner">${ data.value(
-								'name'
-							) }</div>
+                            <div class="axo-card-meta-wrapper">
+                             <div class="axo-card-number">${
+									data.value( 'lastDigits' )
+										? '•••• ' + data.value( 'lastDigits' )
+										: ''
+								}</div>
+                             <div class="axo-card-owner">${ data.value(
+									'name'
+								) }</div>
+                             <div class="axo-card-expiry">${ expiry[ 1 ] }/${
+									expiry[ 0 ]
+								}</div>
+
+                    </div>
+
                         </div>
                         ${ selectOtherPaymentMethod() }
                     </div>


### PR DESCRIPTION
This PR updates the design of the Fastlane card placeholder in both classic and block checkout according to the provided designs.

Classic checkout:

<img width="754" height="674" alt="Classic-Checkout-–-Test-08-28-2025_04_01_PM" src="https://github.com/user-attachments/assets/fb78ae27-37dd-4ee4-b393-2a851c551c93" />

Block checkout:

<img width="1050" height="724" alt="Checkout-–-Test-08-28-2025_03_29_PM" src="https://github.com/user-attachments/assets/48181606-0433-4d61-8bcb-4b805a74f5f0" />
