### PR TITLE
Pay by link with PayPal error on front end when no shipping address (5167)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -353,6 +353,7 @@ class PurchaseUnitFactory {
 		return ! $this->shipping_needed( ...array_values( $items ) ) ||
 				! $shipping_address ||
 				empty( $shipping_address->country_code() ) ||
+				empty( $shipping_address->address_line_1() ) ||
 				( ! $shipping_address->postal_code() && ! $this->country_without_postal_code( $shipping_address->country_code() ) );
 	}
 }

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -56,6 +56,7 @@ class PurchaseUnitFactoryTest extends TestCase
         $address
             ->shouldReceive('postal_code')
             ->andReturn('12345');
+		$address->shouldReceive('address_line_1')->andReturn('Berlin Street');
         $shipping = Mockery::mock(Shipping::class);
         $shipping
             ->shouldReceive('address')
@@ -114,7 +115,9 @@ class PurchaseUnitFactoryTest extends TestCase
         $address = Mockery::mock(Address::class);
         $address->shouldReceive('country_code')->andReturn('DE');
         $address->shouldReceive('postal_code')->andReturn('12345');
-        $shipping = Mockery::mock(Shipping::class);
+	    $address->shouldReceive('address_line_1')->andReturn('Berlin Street');
+
+	    $shipping = Mockery::mock(Shipping::class);
         $shipping->shouldReceive('address')->andReturn($address);
         $shippingFactory = Mockery::mock(ShippingFactory::class);
         $shippingFactory
@@ -159,7 +162,9 @@ class PurchaseUnitFactoryTest extends TestCase
         $address
             ->expects('postal_code')
             ->andReturn('');
-        $shipping = Mockery::mock(Shipping::class);
+	    $address->shouldReceive('address_line_1')->andReturn('Berlin Street');
+
+	    $shipping = Mockery::mock(Shipping::class);
         $shipping
             ->expects('address')
             ->andReturn($address);
@@ -221,6 +226,51 @@ class PurchaseUnitFactoryTest extends TestCase
         $unit = $testee->from_wc_order($wcOrder);
         $this->assertEquals(null, $unit->shipping());
     }
+
+	public function testWcOrderShippingGetsDroppedWhenNoAddressLine1()
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
+		$wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+		$amount = Mockery::mock(Amount::class);
+		$amountFactory = Mockery::mock(AmountFactory::class);
+		$amountFactory
+			->expects('from_wc_order')
+			->with($wcOrder)
+			->andReturn($amount);
+		$itemFactory = Mockery::mock(ItemFactory::class);
+		$itemFactory
+			->expects('from_wc_order')
+			->with($wcOrder)
+			->andReturn([$this->item]);
+
+		$address = Mockery::mock(Address::class);
+		$address
+			->expects('country_code')
+			->andReturn('DE');
+		$address->shouldReceive('postal_code')->andReturn('12345');
+		$address->shouldReceive('address_line_1')->andReturn('');
+
+		$shipping = Mockery::mock(Shipping::class);
+		$shipping
+			->expects('address')
+			->andReturn($address);
+		$shippingFactory = Mockery::mock(ShippingFactory::class);
+		$shippingFactory
+			->expects('from_wc_order')
+			->with($wcOrder)
+			->andReturn($shipping);
+		$paymentsFacory = Mockery::mock(PaymentsFactory::class);
+		$testee = new PurchaseUnitFactory(
+			$amountFactory,
+			$itemFactory,
+			$shippingFactory,
+			$paymentsFacory
+		);
+
+		$unit = $testee->from_wc_order($wcOrder);
+		$this->assertEquals(null, $unit->shipping());
+	}
 
     public function testWcCartDefault()
     {


### PR DESCRIPTION
### Description

When creating an order from WordPress Admin without filling in the Address field, the Order Page has no validator, and the PayPal payment fails.

This PR tweaks `PurchaseUnitFactory::should_disable_shipping` method to also check for Address lines besides ZIP code and Country Code.

### Steps to Test

1. Navigate to WooCommerce->Orders->Add new order
2. Enter a customer, for instance, admin, add the billing info
3. Enter shipping i,nfo but do not populate shipping address (any of the lines)
4. Add a physical product, click on recalculate totals and create the order
5. Click on the Customer payment link to see the order
6. Click to pay with PayPal
7. Order can be completed


### Demo


https://github.com/user-attachments/assets/4385baed-98cd-40fb-9201-3b5fb8a96390



