### PR TITLE
Fix sync checkout fields and headers in Fastlane flow

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -470,15 +470,11 @@ class AxoManager {
 			'.woocommerce-billing-fields .form-row:visible'
 		);
 		const $billingHeaders = this.$( '.woocommerce-billing-fields h3' );
-		if ( this.billingView.isActive() ) {
-			if ( $billingFields.length ) {
-				$billingHeaders.show();
-			} else {
-				$billingHeaders.hide();
-			}
-		} else {
-			$billingHeaders.show();
-		}
+            if ( $billingFields.length ) {
+                $billingHeaders.show();
+            } else {
+                $billingHeaders.hide();
+            }
 	}
 
 	ensureShippingFieldsConsistency() {
@@ -486,15 +482,11 @@ class AxoManager {
 			'.woocommerce-shipping-fields .form-row:visible'
 		);
 		const $shippingHeaders = this.$( '.woocommerce-shipping-fields h3' );
-		if ( this.shippingView.isActive() ) {
-			if ( $shippingFields.length ) {
-				$shippingHeaders.show();
-			} else {
-				$shippingHeaders.hide();
-			}
-		} else {
-			$shippingHeaders.show();
-		}
+            if ( $shippingFields.length ) {
+                $shippingHeaders.show();
+            } else {
+                $shippingHeaders.hide();
+            }
 	}
 
 	showAxoEmailField() {


### PR DESCRIPTION
In the Fastlane flow, we had shipping and billing headers displayed while shipping and billing checkout fields were hidden.
It happened because before showing or hiding headers we checked not just whether fields are displayed, but also whether they are active. But whether they are active or not is unrelated; we only care about fields' visibility when hiding/showing headers.

Before:

https://github.com/user-attachments/assets/6503c3ea-caba-47d0-be11-1c5a417c267e

After:

https://github.com/user-attachments/assets/eff471f6-88b2-4c7f-8618-d363282d8337

