### PR TITLE
Prevent redirect on checkout failure for trial vaulting subscriptions (5055)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/paypal.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal.js
@@ -322,6 +322,15 @@ export const PayPalComponent = ( {
 			if ( config.scriptData.continuation ) {
 				return true;
 			}
+
+			// Don't redirect for trial vaulting subscriptions
+			if (
+				cartHasSubscriptionProducts( config.scriptData ) &&
+				config.scriptData.is_free_trial_cart
+			) {
+				return true;
+			}
+
 			if ( shouldskipFinalConfirmation() ) {
 				location.href = getCheckoutRedirectUrl();
 			}


### PR DESCRIPTION
## Issue Description

Trial vaulting subscriptions on block checkout were experiencing unwanted redirects when checkout processing failed. After a payment failure, users were automatically redirected to a continuation page instead of remaining on the checkout to see error messages or retry the payment. This prevented users from completing their subscription purchase.

**Steps to reproduce:**
- Create trial vaulting subscription product
- Navigate to block checkout as guest
- Attempt PayPal payment that results in checkout failure
- Observe automatic redirect instead of error handling

## PR Description
This PR fixes the unwanted redirect behavior for trial vaulting subscriptions by adding a condition to the onCheckoutFail handler. When checkout fails for trial vaulting subscriptions, the system now skips the continuation redirect logic and allows the user to remain on the block checkout page.