### PR TITLE
Update ddev default config (5244)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -19,15 +19,15 @@ hooks:
   pre-start:
     - exec-host: "mkdir -p .ddev/wordpress/wp-content/plugins/${DDEV_PROJECT}"
 web_environment:
-  - WP_VERSION=6.7.1
+  - WP_VERSION=6.8.2
   - WP_LOCALE=en_US
   - WP_TITLE=WooCommerce PayPal Payments
-  - WP_MULTISITE=true
+  - WP_MULTISITE=false
   - WP_MULTISITE_SLUGS=de,es
   - ADMIN_USER=admin
   - ADMIN_PASS=admin
   - ADMIN_EMAIL=admin@example.com
-  - WC_VERSION=9.5.1
+  - WC_VERSION=10.1.2
 
 # Key features of ddev's config.yaml:
 

--- a/.ddev/docker-compose.wp-plugin.yaml
+++ b/.ddev/docker-compose.wp-plugin.yaml
@@ -1,4 +1,3 @@
-version: '3.6'
 services:
     web:
         volumes:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ You can install WooCommerce PayPal Payments locally using the dev environment of
 To set up the DDEV environment, follow these steps:
 
 0. Install Docker and [DDEV](https://ddev.readthedocs.io/en/stable/).
-1. Edit the [configuration](https://docs.ddev.com/en/stable/users/configuration/config/#managing-configuration) in the [`.ddev/config.yml`](.ddev/config.yaml) file if needed.
-2. `$ ddev setup` to setup and orchestrate the plugin, WooCommerce and WordPress
+1. Edit the [configuration](https://docs.ddev.com/en/stable/users/configuration/config/#managing-configuration) in the `.ddev/config.local.yml` file if needed. 
+2. Run `$ ddev start && ddev orchestrate` to setup and orchestrate the plugin, WooCommerce and WordPress (you can also use `$ yarn ddev:setup`)
 3. Open https://woocommerce-paypal-payments.ddev.site 
 
 Use `$ ddev reset` for reinstallation (will destroy all site data).


### PR DESCRIPTION
### Description

Update ddev.config with:

- New version of WooCommerce
- New version of WordPress
- Disable Multisite by default

Additionally this PR

- Fixes a warning regarding version prop in a yml file in ddev
- Tweaks the readme 

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Clone this PR in a fresh folder
2. Optionally copy .ddev/config.yml in .ddev/config.local.yml  and change name of the project
3. Run `ddev start && ddev orchestrate`
4. Site is created with no warnings, with no multisite, WordPress 6.8.2 and WooCommerce 10.1.2
