### PR TITLE
Hide "Disable Specific Credit Cards" for BCDC countries (4490)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/OtherSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/OtherSettings.js
@@ -6,10 +6,12 @@ import {
 	ControlRadioGroup,
 } from '../../../../../ReusableComponents/Controls';
 import { SettingsHooks } from '../../../../../../data';
+import { useMerchantInfo } from '../../../../../../data/common/hooks';
 
 const OtherSettings = () => {
 	const { disabledCards, setDisabledCards, threeDSecure, setThreeDSecure } =
 		SettingsHooks.useSettings();
+	const { features } = useMerchantInfo();
 
 	const disabledCardChoices = window.ppcpSettings.disabledCardsChoices;
 	const threeDSecureOptions = window.ppcpSettings.threeDSecureOptions;
@@ -25,27 +27,30 @@ const OtherSettings = () => {
 				'woocommerce-paypal-payments'
 			) }
 		>
-			<SettingsBlock
-				title={ __(
-					'Disable specific credit cards',
-					'woocommerce-paypal-payments'
-				) }
-				description={ __(
-					'By default, all possible credit cards will be accepted. Card types added here will be rejected at checkout.',
-					'woocommerce-paypal-payments'
-				) }
-			>
-				<ControlSelect
-					options={ disabledCardChoices }
-					value={ disabledCards }
-					onChange={ setDisabledCards }
-					isMulti={ true }
-					placeholder={ __(
-						'Show all cards',
+			{ features.advanced_credit_and_debit_cards.enabled && (
+				<SettingsBlock
+					title={ __(
+						'Disable specific credit cards',
 						'woocommerce-paypal-payments'
 					) }
-				/>
-			</SettingsBlock>
+					description={ __(
+						'By default, all possible credit cards will be accepted. Card types added here will be rejected at checkout.',
+						'woocommerce-paypal-payments'
+					) }
+				>
+					<ControlSelect
+						options={ disabledCardChoices }
+						value={ disabledCards }
+						onChange={ setDisabledCards }
+						isMulti={ true }
+						placeholder={ __(
+							'Show all cards',
+							'woocommerce-paypal-payments'
+						) }
+					/>
+				</SettingsBlock>
+			) }
+
 			<SettingsBlock
 				title={ __( '3D Secure', 'woocommerce-paypal-payments' ) }
 				description={ __(

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -549,6 +549,8 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$dcc_product_status = $c->get( 'wcgateway.helper.dcc-product-status' );
 				assert( $dcc_product_status instanceof DCCProductStatus );
 
+				$dcc_applies = $c->get( 'api.helpers.dccapplies' );
+
 				$apms_product_status = $c->get( 'ppcp-local-apms.product-status' );
 				assert( $apms_product_status instanceof LocalApmProductStatus );
 
@@ -563,7 +565,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				);
 
 				$features['advanced_credit_and_debit_cards'] = array(
-					'enabled' => $dcc_product_status->is_active(),
+					'enabled' => $dcc_product_status->is_active() && $dcc_applies->for_country_currency(),
 				);
 
 				$features['alternative_payment_methods'] = array(


### PR DESCRIPTION
### Description

This PR:

- Tweaks `advanced_credit_and_debit_cards` to check if merchant country supports ACDC
- Hide "Disable Specific Credit Cards" option if does not support ACDC

### Steps to Test

1. Go to WC settings and set a Country supporting ACDC (like USA)
2. Go to PayPal settings / Expert Settings / Other payment method settings 
3. You can see "Disable Specific Credit Cards"
4. Go to WC settings and set a Country **not** supporting ACDC (like Vietnam)
5. Go to PayPal settings / Expert Settings / Other payment method settings 
6. You CANNOT see "Disable Specific Credit Cards"

### Demo


https://github.com/user-attachments/assets/11eb9305-c950-4cce-b57e-32b83c1d52ef


