### PR TITLE
Add fallback for getting subscription order address in classic contexts (5215)

### DIFF
--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -412,7 +412,8 @@ return array(
 			$container->get( 'wcgateway.funding-source.renderer' ),
 			$container->get( 'session.handler' ),
 			$container->get( 'wc-subscriptions.helper' ),
-			$container->get( 'button.session.factory.card-data' )
+			$container->get( 'button.session.factory.card-data' ),
+			$container->get( 'api.factory.shipping' )
 		);
 	},
 

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -24,6 +24,7 @@ use WC_Tax;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingFactory;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataFactory;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -60,16 +61,20 @@ class WooCommerceOrderCreator {
 
 	protected CartDataFactory $cart_data_factory;
 
+	protected $shipping_factory;
+
 	public function __construct(
 		FundingSourceRenderer $funding_source_renderer,
 		SessionHandler $session_handler,
 		SubscriptionHelper $subscription_helper,
-		CartDataFactory $cart_data_factory
+		CartDataFactory $cart_data_factory,
+		ShippingFactory $shipping_factory
 	) {
 		$this->funding_source_renderer = $funding_source_renderer;
 		$this->session_handler         = $session_handler;
 		$this->subscription_helper     = $subscription_helper;
 		$this->cart_data_factory       = $cart_data_factory;
+		$this->shipping_factory        = $shipping_factory;
 	}
 
 	/**
@@ -198,6 +203,13 @@ class WooCommerceOrderCreator {
 		$shipping_address = null;
 		$billing_address  = null;
 		$shipping_options = null;
+		$wc_customer = WC()->customer;
+
+		if ( ! $shipping && $needs_shipping ) {
+			if ( $wc_customer instanceof WC_Customer ) {
+				$shipping = $this->shipping_factory->from_wc_customer( $wc_customer, true );
+			}
+		}
 
 		if ( $payer ) {
 			$address     = $payer->address();
@@ -205,7 +217,6 @@ class WooCommerceOrderCreator {
 			$payer_phone = $payer->phone();
 
 			$wc_email    = null;
-			$wc_customer = WC()->customer;
 			if ( $wc_customer instanceof WC_Customer ) {
 				$wc_email = $wc_customer->get_email();
 			}


### PR DESCRIPTION
The `WooCommerceOrderCreator` class relied on the PayPal order object having the `purchase_units` property to obtain the shipping address. For subscriptions, `purchase_units` is not set in the PayPal order, so subscription order creation was failing in classic non-checkout contexts because the address was missing.

This PR solves that by adding a fallback to build the `Shipping` object from the current `WC_Customer` object through the `ShippingFactory` when the address is missing.