### PR TITLE
Fix context method visibility

### DIFF
--- a/modules/ppcp-button/src/Helper/Context.php
+++ b/modules/ppcp-button/src/Helper/Context.php
@@ -299,7 +299,7 @@ class Context {
 	 *
 	 * @return bool
 	 */
-	private function is_add_payment_method_page(): bool {
+	public function is_add_payment_method_page(): bool {
 		/**
 		 * Needed for WordPress `query_vars`.
 		 *

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -251,7 +251,7 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 					'wp_enqueue_scripts',
 					function () use ( $c ) {
 						$context = $c->get( 'button.helper.context' );
-						assert($context instanceof Context);
+						assert( $context instanceof Context );
 						if ( ! is_user_logged_in() || ! ( $context->is_add_payment_method_page() || $context->is_subscription_change_payment_method_page() ) ) {
 							return;
 						}

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentTokenForGuest;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
@@ -250,6 +251,7 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 					'wp_enqueue_scripts',
 					function () use ( $c ) {
 						$context = $c->get( 'button.helper.context' );
+						assert($context instanceof Context);
 						if ( ! is_user_logged_in() || ! ( $context->is_add_payment_method_page() || $context->is_subscription_change_payment_method_page() ) ) {
 							return;
 						}


### PR DESCRIPTION
This PR makes `Context::is_add_payment_method_page` method public to avoid fatal error when used by consumers.