### PR TITLE
Classic checkout - Guest user - Trial vaulting subscription validation does not work (5056)

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -90,7 +90,7 @@ const bootstrap = () => {
 	};
 
 	const doBasicCheckoutValidation = () => {
-		if ( PayPalCommerceGateway.basic_checkout_validation_enabled ) {
+		if ( PayPalCommerceGateway.basic_checkout_validation_enabled || PayPalCommerceGateway.is_free_trial_cart ) {
 			// A quick fix to get the errors about empty form fields before attempting PayPal order,
 			// it should solve #513 for most of the users, but it is not a proper solution.
 			// Currently it is disabled by default because a better solution is now implemented

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -8,6 +8,7 @@ import {
 	handleShippingAddressChange,
 } from '../Helper/ShippingHandler.js';
 import { PaymentContext } from '../Helper/CheckoutMethodState';
+import {reusableBlock} from "@wordpress/icons";
 
 class Renderer {
 	constructor(
@@ -129,11 +130,13 @@ class Renderer {
 				style,
 				...contextConfig,
 				onClick: ( data, actions ) => {
+                    let result;
 					if ( this.onSmartButtonClick ) {
-						this.onSmartButtonClick( data, actions );
+						result = this.onSmartButtonClick( data, actions );
 					}
 
 					venmoButtonClicked = data.fundingSource === 'venmo';
+                    return result;
 				},
 				onInit: ( data, actions ) => {
 					if ( this.onSmartButtonsInit ) {

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -8,7 +8,6 @@ import {
 	handleShippingAddressChange,
 } from '../Helper/ShippingHandler.js';
 import { PaymentContext } from '../Helper/CheckoutMethodState';
-import {reusableBlock} from "@wordpress/icons";
 
 class Renderer {
 	constructor(


### PR DESCRIPTION
Validation on classic checkout page triggered after finishing steps on PayPal popup.

If guest user does not populate mandatory billing info filed and click on PayPal button, validation should be triggered at this moment. But now it is showing after finishing process on PayPal popup.

### Steps To Reproduce
- Navigate to shop as guest
- Add trial vaulting subscription to cart
- Navigate to classic checkout 
- Do not populate mandatory billing info fields
- Click on PayPal button
   - Observe validation is not triggered at this point
- Finish steps on PayPal popup
   - Observe validation is triggered now

### Changes in this PR
Free trial subscription for guest user has a different flow (creates setup token) than the regular subscriptions flow which validates checkout on server side. In this case we have to validate on client side before server side is reached.

It adds the free trial context to `doBasicCheckoutValidation` conditional to force checkout validation. 
I noticed that `actions.reject()` was not working when executed inside `onSmartButtonClick`, the reason was that the return value from `onSmartButtonClick` was not being handled in `Renderer.js` onClick. The PR modifies the `onClick` handler in `Renderer.js` to return the result from `onSmartButtonClick`.