### PR TITLE
 Add debug mode for JS SDK (PCP-5260)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1469,6 +1469,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'vault'            => ( $this->can_save_vault_token() || $this->subscription_helper->need_subscription_intent( $subscription_mode ) ) ? 'true' : 'false',
 			'commit'           => in_array( $current_context, $this->pay_now_contexts, true ) ? 'true' : 'false',
 			'intent'           => $intent,
+			'debug'            => defined( 'WP_DEBUG' ) && WP_DEBUG,
 		);
 
 		if (

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1469,8 +1469,11 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'vault'            => ( $this->can_save_vault_token() || $this->subscription_helper->need_subscription_intent( $subscription_mode ) ) ? 'true' : 'false',
 			'commit'           => in_array( $current_context, $this->pay_now_contexts, true ) ? 'true' : 'false',
 			'intent'           => $intent,
-			'debug'            => defined( 'WP_DEBUG' ) && WP_DEBUG,
 		);
+
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$params['debug'] = true;
+		}
 
 		if (
 			$this->settings->has( 'subscriptions_mode' )


### PR DESCRIPTION
## The problem
There is no way to enable [debug mode](https://developer.paypal.com/sdk/js/configuration/#debug) in PayPal JS SDK without editing the plugin code.

## The solution
This PR adds `debug=true` to the SDK script parameters when `WP_DEBUG` constant is set to true in WP config. This way of triggering debug mode was chosen for consistency with the rest of the plugin, enabling debugging features in the same way.

## Video with WP_DEBUG on and off

https://github.com/user-attachments/assets/2b072f9d-8bbf-498e-8239-ce981c5bac59

