### PR TITLE
Add weekly build GH Workflow (5303)

### DIFF
--- a/.github/workflows/weekly-builds.yml
+++ b/.github/workflows/weekly-builds.yml
@@ -74,3 +74,29 @@ jobs:
           asset_name: woocommerce-paypal-payments-weekly.zip
           asset_content_type: application/zip
           max_releases: 1
+
+  notify-slack:
+    if: always() && github.repository_owner == 'woocommerce'
+    name: Send Slack notification
+    runs-on: ubuntu-latest
+    needs: [ update-tag, build, deploy ]
+    steps:
+      - name: Send success message to Slack
+        if: needs.deploy.result == 'success'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.WEEKLY_RELEASE_SLACK_HOOK }}
+          webhook-type: webhook-trigger
+          payload: |
+              "status": "🎉 A new Weekly Pre Release has been uploaded",
+              "workflow": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Send failure message to Slack
+        if: needs.deploy.result == 'failure' || needs.build.result == 'failure' || needs.update-tag.result == 'failure'
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.WEEKLY_RELEASE_SLACK_HOOK }}
+          webhook-type: webhook-trigger
+          payload: |
+              "status": "😰 Ups! It was an error uploading the Weekly Pre Release",
+              "workflow": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/weekly-builds.yml
+++ b/.github/workflows/weekly-builds.yml
@@ -1,0 +1,76 @@
+name: 'Weekly builds'
+on:
+  schedule:
+    - cron:  '0 11 * * 2' # Run every Tuesday at 11 AM UTC (12pm CET)
+  workflow_dispatch:
+
+env:
+  SOURCE_REF: develop
+  TARGET_REF: weekly
+  RELEASE_ID: 248387138 # https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/weekly
+
+jobs:
+  update-tag:
+    if: github.repository_owner == 'woocommerce'
+    name: Update weekly tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Update weekly tag commit ref
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const sourceRef = process.env.SOURCE_REF;
+            const targetRef = process.env.TARGET_REF;
+            const branchData = await github.rest.repos.getBranch({
+              ...context.repo,
+              branch: sourceRef,
+            });
+            await github.rest.git.updateRef({
+              ...context.repo,
+              ref: `tags/${ targetRef }`,
+              sha: branchData.data.commit.sha,
+            });
+
+  build:
+    if: github.repository_owner == 'woocommerce'
+    name: Build package
+    needs: update-tag
+    uses: inpsyde/reusable-workflows/.github/workflows/build-plugin-archive.yml@a9af34f34e95cbe18703198c7e972e97ebcd7473
+    with:
+      PHP_VERSION: 7.4
+      NODE_VERSION: 22
+      PLUGIN_MAIN_FILE: ./woocommerce-paypal-payments.php
+      PLUGIN_VERSION: weekly
+      PLUGIN_FOLDER_NAME: woocommerce-paypal-payments
+      ARCHIVE_NAME: woocommerce-paypal-payments-weekly.zip
+      COMPILE_ASSETS_ARGS: '-vv --env=root'
+
+  deploy:
+    if: github.repository_owner == 'woocommerce'
+    name: Upload weekly build
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: woocommerce-paypal-payments-weekly.zip
+          path: ./artifacts
+
+      - name: Create and upload zip file
+        run: |
+          zip -r ./artifacts/woocommerce-paypal-payments-weekly.zip ./artifacts/woocommerce-paypal-payments
+
+      - name: Update weekly release
+        uses: WebFreak001/deploy-nightly@v3.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/${{ env.RELEASE_ID }}/assets{?name,label}
+          release_id: ${{ env.RELEASE_ID }}
+          asset_path: ./artifacts/woocommerce-paypal-payments-weekly.zip
+          asset_name: woocommerce-paypal-payments-weekly.zip
+          asset_content_type: application/zip
+          max_releases: 1


### PR DESCRIPTION
### Description

- Creates a GitHub Actions workflow triggered every Tuesday 12pm CET or when manually dispatched in the Actions tab
- The worklow compiles the plugin using develop branch and uploads the zip file into [weekly pre-release ](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/weekly)
- The workflow notifies in #c-paypal-payments-int when suceeed or failure


<img width="1587" height="756" alt="Screenshot 2025-09-18 at 22 25 19" src="https://github.com/user-attachments/assets/4ee8023b-f3e6-40dd-970d-9c2b693110aa" />

<img width="565" height="186" alt="Screenshot 2025-09-18 at 23 43 16" src="https://github.com/user-attachments/assets/958187ec-080e-4d56-a2a0-8b35899fdc7e" />


### Steps to Test

1. See the actions successfully taken[ in a fork of this repo ](https://github.com/puntope/woocommerce-paypal-payments/actions/workflows/weekly-builds.yml)
2. Check how the zip was added in [weekly pre-release ](https://github.com/puntope/woocommerce-paypal-payments/releases/tag/weekly) in the forked repo
3. Verify if that ZIP works by installing it in a WordPress site
4. Check the newly created [weekly pre-release in this repo ](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/weekly)
5. Merge and dispatch the action to verify it updates the zip in [this repo weekly pre-release](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/weekly) and notifies in slack
6. Wait til next Tuesday, 12UTC (11AM CET) to see if the action generates the zip correctly

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [x] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->