### PR TITLE
Remove temporary Pay Later messaging auto-enablement logic (5310)

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -14,9 +14,6 @@ use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Product;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;
-use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
-use WooCommerce\PayPalCommerce\Settings\SettingsModule;
-use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -24,7 +21,6 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\CartCheckoutDetector;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
@@ -93,67 +89,6 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		add_action( 'woocommerce_paypal_payments_gateway_migrate', static fn() => delete_transient( 'ppcp_has_ppec_subscriptions' ) );
 
 		$this->legacy_ui_card_payment_mapping( $c );
-
-		/**
-		 * Automatically enable Pay Later messaging for eligible stores during plugin update.
-		 *
-		 * This action runs during plugin updates to automatically enable Pay Later messaging for stores
-		 * that meet the following criteria:
-		 * - Feature flag 'paylater_messaging_force_enabled' is enabled (default: true, can be disabled via filter)
-		 * - Pay Later messaging is available for the store's country
-		 * - The "Stay updated" checkbox is enabled (checked in either old or new UI)
-		 *
-		 * The "Stay updated" setting is retrieved differently based on the UI version:
-		 * - Legacy UI: Retrieved from wcgateway.settings
-		 * - New UI: Retrieved from settings.data.settings model
-		 *
-		 * When all conditions are met, this will:
-		 * - Enable Pay Later messaging
-		 * - Add default messaging locations (product, cart, checkout) to existing selections
-		 *
-		 * @todo Remove this auto-enablement logic after the next release
-		 *
-		 * @hook woocommerce_paypal_payments_gateway_migrate_on_update
-		 */
-		add_action(
-			'woocommerce_paypal_payments_gateway_migrate_on_update',
-			static function () use ( $c ) {
-				if ( ! apply_filters(
-				// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
-					'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
-					true
-				) ) {
-					return;
-				}
-
-				$messages_apply = $c->get( 'button.helper.messages-apply' );
-				assert( $messages_apply instanceof MessagesApply );
-
-				$settings_model = $c->get( 'settings.data.settings' );
-				assert( $settings_model instanceof SettingsModel );
-
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
-
-				$stay_updated = SettingsModule::should_use_the_old_ui()
-					? $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' )
-					: $settings_model->get_stay_updated();
-
-				if ( ! $messages_apply->for_country() || ! $stay_updated ) {
-					return;
-				}
-
-				$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
-
-				$settings->set( 'pay_later_messaging_enabled', true );
-				$settings->set(
-					'pay_later_messaging_locations',
-					array_unique( array_merge( $selected_locations, array( 'product', 'cart', 'checkout' ) ) )
-				);
-
-				$settings->persist();
-			}
-		);
 
 		return true;
 	}

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Compat;
 
 use Exception;
-use WC_Cart;
 use WC_Order;
 use WC_Order_Item_Product;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -533,12 +533,6 @@ $services = array(
 
 		$is_working_capital_eligible = $container->get( 'settings.data.general' )->get_merchant_country() === 'US' && $settings_model->get_stay_updated();
 
-		$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
-		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
-			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
-			true
-		);
-
 		/**
 		 * Initializes TodosEligibilityService with eligibility conditions for various PayPal features.
 		 * Each parameter determines whether a specific feature should be shown in the Things To Do list.
@@ -565,7 +559,6 @@ $services = array(
 		 * @param bool $is_enable_google_pay_eligible       - Show if merchant has Google Pay capability but hasn't enabled the gateway.
 		 * @param bool $is_enable_installments_eligible     - Show if merchant has installments capability and merchant country is MX.
 		 * @param bool $is_working_capital_eligible         - Show if feature flag is enabled, merchant country is US and "Stay Updated" is turned On.
-		 * @param bool $is_pay_later_messaging_auto_enabled - Show if feature flag is enabled, Pay later messaging is enabled for the merchant country and "Stay Updated" is turned On.
 		 */
 		return new TodosEligibilityService(
 			$container->get( 'axo.eligible' ) && $capabilities['acdc'] && ! $gateways['axo'],                  // Enable Fastlane.
@@ -587,8 +580,7 @@ $services = array(
 			$container->get( 'applepay.eligible' ) && $capabilities['apple_pay'] && ! $gateways['apple_pay'],                                       // Enable Apple Pay.
 			$container->get( 'googlepay.eligible' ) && $capabilities['google_pay'] && ! $gateways['google_pay'],
 			! $capabilities['installments'] && 'MX' === $container->get( 'settings.data.general' )->get_merchant_country(), // Enable Installments for Mexico.
-			$is_working_capital_feature_flag_enabled && $is_working_capital_eligible, // Enable Working Capital.
-			$is_paylater_messaging_force_enabled_feature_flag_enabled && $messages_apply->for_country() && $settings_model->get_stay_updated() // Pay later messaging auto enabled.
+			$is_working_capital_feature_flag_enabled && $is_working_capital_eligible // Enable Working Capital.
 		);
 	},
 	'settings.rest.features'                              => static function ( ContainerInterface $container ): FeaturesRestEndpoint {

--- a/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
@@ -244,16 +244,6 @@ class TodosDefinition {
 				),
 				'priority'    => 14,
 			),
-			'pay_later_messaging_is_auto_enabled'  => array(
-				'title'       => __( 'PayPal Pay Later messaging successfully enabled', 'woocommerce-paypal-payments' ),
-				'description' => __( 'PayPal is now displaying this flexible payment option earlier in the shopping experience. This update was made based on your “Stay Updated” preference and the messaging can be customized or disabled through the Pay Later settings.', 'woocommerce-paypal-payments' ),
-				'isEligible'  => $eligibility_checks['pay_later_messaging_is_auto_enabled'],
-				'action'      => array(
-					'type' => 'tab',
-					'tab'  => 'pay_later_messaging',
-				),
-				'priority'    => 15,
-			),
 		);
 
 		$todo_items['check_settings_after_migration'] = array(

--- a/modules/ppcp-settings/src/Service/TodosEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/TodosEligibilityService.php
@@ -131,8 +131,6 @@ class TodosEligibilityService {
 
 	private bool $is_working_capital_eligible;
 
-	private bool $is_pay_later_messaging_auto_enabled;
-
 	/**
 	 * Constructor.
 	 *
@@ -153,7 +151,6 @@ class TodosEligibilityService {
 	 * @param bool $is_enable_google_pay_eligible       Whether enabling Google Pay is eligible.
 	 * @param bool $is_enable_installments_eligible     Whether enabling Installments is eligible.
 	 * @param bool $is_working_capital_eligible         Whether applying for Working Capital is eligible.
-	 * @param bool $is_pay_later_messaging_auto_enabled Whether the Pay later messaging is force enabled.
 	 */
 	public function __construct(
 		bool $is_fastlane_eligible,
@@ -172,8 +169,7 @@ class TodosEligibilityService {
 		bool $is_enable_apple_pay_eligible,
 		bool $is_enable_google_pay_eligible,
 		bool $is_enable_installments_eligible,
-		bool $is_working_capital_eligible,
-		bool $is_pay_later_messaging_auto_enabled
+		bool $is_working_capital_eligible
 	) {
 		$this->is_fastlane_eligible                      = $is_fastlane_eligible;
 		$this->is_pay_later_messaging_eligible           = $is_pay_later_messaging_eligible;
@@ -192,7 +188,6 @@ class TodosEligibilityService {
 		$this->is_enable_google_pay_eligible             = $is_enable_google_pay_eligible;
 		$this->is_enable_installments_eligible           = $is_enable_installments_eligible;
 		$this->is_working_capital_eligible               = $is_working_capital_eligible;
-		$this->is_pay_later_messaging_auto_enabled       = $is_pay_later_messaging_auto_enabled;
 	}
 
 	/**
@@ -219,7 +214,6 @@ class TodosEligibilityService {
 			'enable_google_pay'                    => fn() => $this->is_enable_google_pay_eligible,
 			'enable_installments'                  => fn() => $this->is_enable_installments_eligible,
 			'apply_for_working_capital'            => fn() => $this->is_working_capital_eligible,
-			'pay_later_messaging_is_auto_enabled'  => fn() => $this->is_pay_later_messaging_auto_enabled,
 		);
 	}
 }

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -18,7 +18,6 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
-use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
@@ -39,7 +38,6 @@ use WooCommerce\PayPalCommerce\Settings\Handler\ConnectionListener;
 use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\PathRepository;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
-use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
@@ -56,7 +54,6 @@ use WooCommerce\PayPalCommerce\Settings\Enum\ProductChoicesEnum;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Axo\Helper\CompatibilityChecker;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class SettingsModule
@@ -137,34 +134,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					);
 
 					$notices[] = new Message( $message, 'info', false, 'ppcp-notice-wrapper' );
-
-					$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
-					// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
-						'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
-						true
-					);
-
-					$messages_apply = $container->get( 'button.helper.messages-apply' );
-					assert( $messages_apply instanceof MessagesApply );
-
-					$settings = $container->get( 'wcgateway.settings' );
-					assert( $settings instanceof Settings );
-
-					$stay_updated = $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
-
-					if ( $is_paylater_messaging_force_enabled_feature_flag_enabled && $messages_apply->for_country() && $stay_updated ) {
-						$paylater_enablement_message = sprintf(
-						// translators: %1$s is the URL for Stay Updated setting, %2$s is the URL for Pay Later settings.
-							__(
-								'<strong>PayPal Pay Later messaging successfully enabled</strong>, now displaying this flexible payment option earlier in the shopping experience. This update was made based on your <a href="%1$s">Stay Updated</a> preference and can be customized or disabled through the <a href="%2$s">Pay Later settings</a>.',
-								'woocommerce-paypal-payments'
-							),
-							admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#ppcp-stay_updated_field' ),
-							admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' )
-						);
-
-						$notices[] = new Message( $paylater_enablement_message, 'info', false, 'ppcp-notice-wrapper' );
-					}
 
 					return $notices;
 				}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2184,23 +2184,9 @@ return array(
 			getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
 		);
 
-		$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
-		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
-			'woocommerce.feature-flags.woocommerce_paypal_payments.paylater_messaging_force_enabled',
-			true
-		);
-
 		$stay_updated = SettingsModule::should_use_the_old_ui()
 			? $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' )
 			: $settings_model->get_stay_updated();
-
-		$stay_updated_field_link = SettingsModule::should_use_the_old_ui()
-			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-connection#ppcp-stay_updated_field' )
-			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&panel=settings#ppcp-stay-updated' );
-
-		$paylater_messaging_tab_link = SettingsModule::should_use_the_old_ui()
-			? admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' )
-			: admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&panel=pay-later-messaging' );
 
 		$message = sprintf(
 		// translators: %1$s is the URL for the startup guide.
@@ -2238,28 +2224,6 @@ return array(
 					'switch_to_new_settings',
 					__( 'Switch to New Settings', 'woocommerce-paypal-payments' ),
 					admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-					Note::E_WC_ADMIN_NOTE_UNACTIONED,
-					true
-				)
-			),
-			$inbox_note_factory->create_note(
-				__( 'PayPal Pay Later Messaging now enabled', 'woocommerce-paypal-payments' ),
-				sprintf(
-				// translators: %1$s is the URL for Pay Later messaging documentation.
-					__(
-						'PayPal Pay Later messaging was included in the 3.1 version release and has now been enabled on your store based on your <a href="%1$s">STAY UPDATED</a> preference.<br>This feature displays the payment option earlier in the shopping experience to drive customer engagement and can be fully customized or disabled through the PayPal admin panel.',
-						'woocommerce-paypal-payments'
-					),
-					$stay_updated_field_link
-				),
-				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
-				'ppcp-settings-paylater-messaging-force-enabled-inbox-note',
-				Note::E_WC_ADMIN_NOTE_UNACTIONED,
-				$is_paylater_messaging_force_enabled_feature_flag_enabled && $messages_apply->for_country() && $stay_updated,
-				new InboxNoteAction(
-					'review_pay_later_settings',
-					__( 'Review Pay Later settings', 'woocommerce-paypal-payments' ),
-					$paylater_messaging_tab_link,
 					Note::E_WC_ADMIN_NOTE_UNACTIONED,
 					true
 				)


### PR DESCRIPTION
## Issue Description
The 3.1.0 update automatically enabled Pay Later messaging for all eligible merchants. This logic needs to be removed again.

## PR Description
Removes the temporary Pay Later messaging auto-enablement logic that was introduced in the 3.1.0 update. This functionality automatically enabled Pay Later messaging during plugin updates for eligible stores, but was always intended to be temporary cleanup after the initial rollout.

**Changes:**
- Removed the info notice
- Removed the Inbox note
- Removed feature flag `paylater_messaging_force_enabled` usage
- Deleted associated TODO item from overview tab