### PR TITLE
Check for messages visibility setting before rendering (5317)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MessagesBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MessagesBootstrap.js
@@ -94,18 +94,15 @@ class MessagesBootstrap {
 
 	render() {
 		this.renderers.forEach( ( renderer ) => {
+			const shouldShow = this.shouldShow( renderer );
+
+			if ( ! shouldShow ) {
+				return;
+			}
+
 			waitForElement( renderer.config.wrapper )
 				.then( () => {
-					const shouldShow = this.shouldShow( renderer );
 					setVisible( renderer.config.wrapper, shouldShow );
-					if ( ! shouldShow ) {
-						return;
-					}
-
-					if ( ! renderer.shouldRender() ) {
-						return;
-					}
-
 					renderer.renderWithAmount( this.lastAmount );
 				} )
 				.catch( ( err ) => console.error( err ) );


### PR DESCRIPTION
The `waitForElement` utility returns a promise that can be rejected with an error whenever the passed element does not exist.

This PR moves the `shouldShow` condition outside the `waitForElement` callback to reduce the number of console errors whenever the messages wrapper does not exist.