### PR TITLE
Restore PayPal as chosen gateway after App Switch resume (5233)

### DIFF
--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -315,6 +315,46 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		);
 
 		/**
+		 * Restore PayPal as the chosen payment method when returning from an App Switch flow.
+		 *
+		 * Context:
+		 * --------
+		 * When Fastlane (AXO) is active, AxoModule forces the chosen payment method to
+		 * AxoGateway on every checkout page load. This causes a problem when the customer
+		 * initiated checkout with PayPal and was redirected to the PayPal app
+		 * (App Switch): after resuming, the checkout would incorrectly show AxoGateway,
+		 * leading to validation errors and failed payments.
+		 *
+		 * Solution:
+		 * ---------
+		 * This handler runs after the AxoModule one (priority 20). It checks for the
+		 * PayPal return URL query arguments that indicate an App Switch resume, and if
+		 * present, forces the chosen method back to PayPalGateway. This ensures the
+		 * resumed PayPal flow continues as expected.
+		 */
+		add_action(
+			'template_redirect',
+			function () use ( $container ) {
+				// phpcs:ignore WordPress.Security.NonceVerification
+				if ( ! isset( $_GET[ ReturnUrlFactory::PCP_QUERY_ARG ] ) ) {
+					return;
+				}
+
+				if ( is_checkout_pay_page() ) {
+					return;
+				}
+
+				// phpcs:ignore WordPress.Security.NonceVerification
+				if ( ! isset( $_GET[ CreateOrderEndpoint::RETURN_URL_CART_QUERY_ARG ] ) ) {
+					return;
+				}
+
+				WC()->session->set( 'chosen_payment_method', PayPalGateway::ID );
+			},
+			20
+		);
+
+		/**
 		 * By default, WC asks to log in when opening a non-guest Pay for order page as a guest,
 		 * so we disable this for cross-browser AppSwitch.
 		 *


### PR DESCRIPTION
## Issue Description
When Fastlane (AXO) is enabled, the `AxoModule` forces the checkout session's `chosen_payment_method` to `AxoGateway` on every `template_redirect`. This breaks the PayPal App Switch flow:
* Customer starts checkout with PayPal.
* Redirects to PayPal app (App Switch).
* On return, checkout page reloads with `chosen_payment_method` set to `AxoGateway` instead of `PayPalGateway`.
* This leads to validation errors (e.g. empty email) and prevents completing the payment.

**Steps to reproduce:**
1. Enable Fastlane and App Switch flags.
2. Enable Pay Now experience.
3. Go to classic checkout, select PayPal, and trigger App Switch.
4. Return from PayPal app.
5. Observe checkout has switched to ACDC (Axo) instead of PayPal.

## PR Description
This PR ensures PayPal remains the active gateway when resuming from an App Switch flow.
* Added a new `template_redirect` handler (priority 20) to run after the Axo handler.
* Detects App Switch return requests via `ReturnUrlFactory::PCP_QUERY_ARG` and `CreateOrderEndpoint::RETURN_URL_CART_QUERY_ARG`.
* Forces `WC()->session->set( 'chosen_payment_method', PayPalGateway::ID )`.
* Prevents AXO from overriding PayPal during App Switch resume, fixing validation errors.

**Result:**
* Fastlane still defaults to `AxoGateway` when applicable.
* On App Switch resume, checkout correctly restores PayPal as the chosen method.