### PR TITLE
Fix get status null given error

### DIFF
--- a/modules/ppcp-button/src/Helper/Context.php
+++ b/modules/ppcp-button/src/Helper/Context.php
@@ -270,10 +270,13 @@ class Context {
 			return false;
 		}
 
-		try {
-			$subscription_status = $this->subscription_status->get_status( $subscription_id );
-		} catch ( RuntimeException | PayPalApiException $exception ) {
-			$subscription_status = '';
+		$subscription_status = '';
+		if ( $subscription_id ) {
+			try {
+				$subscription_status = $this->subscription_status->get_status( $subscription_id );
+			} catch ( RuntimeException | PayPalApiException $exception ) {
+				return false;
+			}
 		}
 
 		if ( $subscription_id &&


### PR DESCRIPTION
This PR fixes the following when subscription id is null:
```
Fatal error: Uncaught TypeError: Argument 1 passed to WooCommerce\PayPalCommerce\PayPalSubscriptions\SubscriptionStatus::get_status() must be of the type string, null given
```