### PR TITLE
Align Fastlane currency support with ACDC matrix (5298)

### DIFF
--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -157,7 +157,7 @@ return array(
 	'axo.supported-country-currency-matrix'  => static function ( ContainerInterface $container ): array {
 		$dcc_allowed_country_currency_matrix = $container->get( 'api.dcc-supported-country-currency-matrix' );
 		$matrix = array(
-			'US' => $dcc_allowed_country_currency_matrix['US']
+			'US' => $dcc_allowed_country_currency_matrix['US'],
 		);
 
 		if ( $container->get( 'axo.uk.enabled' ) ) {

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -155,23 +155,17 @@ return array(
 	 * The matrix which countries and currency combinations can be used for AXO.
 	 */
 	'axo.supported-country-currency-matrix'  => static function ( ContainerInterface $container ): array {
+		$dcc_allowed_country_currency_matrix = $container->get( 'api.dcc-supported-country-currency-matrix' );
 		$matrix = array(
-			'US' => array(
-				'AUD',
-				'CAD',
-				'EUR',
-				'GBP',
-				'JPY',
-				'USD',
-			),
+			'US' => $dcc_allowed_country_currency_matrix['US']
 		);
 
 		if ( $container->get( 'axo.uk.enabled' ) ) {
-			$matrix['GB'] = array( 'GBP' );
+			$matrix['GB'] = $dcc_allowed_country_currency_matrix['GB'];
 		}
 
 		if ( $container->get( 'axo.au.enabled' ) ) {
-			$matrix['AU'] = array( 'AUD' );
+			$matrix['AU'] = $dcc_allowed_country_currency_matrix['AU'];
 		}
 
 		/**


### PR DESCRIPTION
## Issue Description
Currently Fastlane has its own restricted currency matrix that limits availability compared to ACDC. Since Fastlane is built on top of ACDC infrastructure, it should support the same currencies as ACDC rather than having separate limitations.

## PR Description
This PR removes Fastlane's hardcoded currency restrictions and aligns it with ACDC's currency support matrix.

**Changes:**
- Updated `axo.supported-country-currency-matrix` service to reference `api.dcc-supported-country-currency-matrix`
- Removed hardcoded currency arrays for US, GB, and AU markets
- Fastlane now inherits the same currency eligibility as ACDC for each supported country