### PR TITLE
Fix BCDC availability for branded-only sites [5344]

### DIFF
--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -173,7 +173,7 @@ class PaymentMethodsDefinition {
 	// Payment method groups.
 
 	/**
-	 * Define PayPal related payment methods.
+	 * Defines PayPal's branded payment methods; not affected by the "own_brand_only" setting.
 	 *
 	 * @return array
 	 */
@@ -214,20 +214,19 @@ class PaymentMethodsDefinition {
 			),
 		);
 
-		if ( ! $this->general_settings->own_brand_only() ) {
-			$group[] = array(
-				'id'          => CardButtonGateway::ID,
-				'title'       => __( 'Credit and debit card payments', 'woocommerce-paypal-payments' ),
-				'description' => __( "Accept all major credit and debit cards - even if your customer doesn't have a PayPal account . ", 'woocommerce-paypal-payments' ),
-				'icon'        => 'payment-method-cards',
-			);
-		}
+		// This CardButtonGateway is a branded gateway!
+		$group[] = array(
+			'id'          => CardButtonGateway::ID,
+			'title'       => __( 'Credit and debit card payments', 'woocommerce-paypal-payments' ),
+			'description' => __( "Accept all major credit and debit cards - even if your customer doesn't have a PayPal account . ", 'woocommerce-paypal-payments' ),
+			'icon'        => 'payment-method-cards',
+		);
 
 		return apply_filters( 'woocommerce_paypal_payments_gateway_group_paypal', $group );
 	}
 
 	/**
-	 * Define card related payment methods.
+	 * Define embedded payment methods, which are only available in whitelabel mode.
 	 *
 	 * @return array
 	 */

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -747,6 +747,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		add_filter( 'woocommerce_paypal_payments_is_eligible_for_axo', '__return_false' );
 		add_filter( 'woocommerce_paypal_payments_is_eligible_for_save_payment_methods', '__return_false' );
 		add_filter( 'woocommerce_paypal_payments_is_eligible_for_card_fields', '__return_false' );
+		add_filter( 'woocommerce_paypal_payments_is_acdc_active', '__return_false' );
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
@@ -24,8 +24,9 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
  * configuration.
  *
  * Terminology:
- * - DCC or ACDC refers to the new "Advanced Card Processing" integration.
- * - BCDC is the older "Credit and Debit Cards" integration.
+ * - DCC or ACDC are synonymous referring to the "expanded integration"
+ *       The credit card form is embedded inline on the checkout page.
+ * - BCDC is the "Branded" card payment integration (branded button that opens a modal)
  * - AXO is Fastlane, which is an improved UI for ACDC.
  *
  * Technical implementation via the JS SDK:
@@ -141,8 +142,8 @@ class CardPaymentsConfiguration {
 	 * @param ConnectionState  $connection_state Connection state instance.
 	 * @param Settings         $settings         Plugin settings instance.
 	 * @param DccApplies       $dcc_applies      DCC eligibility helper.
-	 * @param DCCProductStatus $dcc_status        Manages the Seller status.
-	 * @param string           $store_country The shop's country code.
+	 * @param DCCProductStatus $dcc_status       Manages the Seller status.
+	 * @param string           $store_country    The shop's country code.
 	 */
 	public function __construct(
 		ConnectionState $connection_state,


### PR DESCRIPTION
### Description

Makes the branded payment method "_Credit and debit card payments_" available for merchants that onboarded in branded-only mode. I.e. the "black button"

### Steps to Test

1. Set the WooCommerce shop country to Japan
    - Japan allows BCDC & branded-only
3. Install the plugin in branded-only mode, complete onboarding
4. Verify the PayPal settings → Payment Methods display the "Credit and debit card payments"; enable it
5. Visit the classic checkout and verify the 

### Screenshots and Details

<details>
<summary><strong>Details: Onboard in branded-only mode</strong></summary>

- Delete the WP option entry `woocommerce_payments_nox_profile`
  - `ddev wp option delete woocommerce_payments_nox_profile`
- Deactivate and uninstall the PayPal payments plugin
- Navigate to the WooCommerce → Payment settings
- Install the PayPal payments plugin from this page

https://github.com/user-attachments/assets/cdc515eb-a549-48c5-a34f-7e80dc9ad530

</details>

_Note: Screenshots are wrong - they should say "Japan" not "Brazil"_
<img width="1238" height="940" alt="CleanShot 2025-09-25 at 21 29 03" src="https://github.com/user-attachments/assets/4525c95f-8cca-4e6f-a75c-d754cc2a9eef" />

<img width="1238" height="940" alt="CleanShot 2025-09-25 at 21 34 53" src="https://github.com/user-attachments/assets/db04f9d8-adec-4e62-b156-495c09ef6031" />
