### PR TITLE
Fix/improve BCDC migration logic for ACDC merchants

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -382,6 +382,8 @@ $services = array(
 	'settings.service.data-migration.payment-settings'    => static fn( ContainerInterface $c ): PaymentSettingsMigration => new PaymentSettingsMigration(
 		$c->get( 'wcgateway.settings' ),
 		$c->get( 'settings.data.payment' ),
+		$c->get( 'api.helpers.dccapplies' ),
+		$c->get( 'wcgateway.helper.dcc-product-status' ),
 		$c->get( 'ppcp-local-apms.payment-methods' ),
 	),
 	'settings.service.data-migration.general-settings'    => static fn( ContainerInterface $c ): SettingsMigration => new SettingsMigration(

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -384,6 +384,7 @@ $services = array(
 		$c->get( 'settings.data.payment' ),
 		$c->get( 'api.helpers.dccapplies' ),
 		$c->get( 'wcgateway.helper.dcc-product-status' ),
+		$c->get( 'wcgateway.configuration.card-configuration' ),
 		$c->get( 'ppcp-local-apms.payment-methods' ),
 	),
 	'settings.service.data-migration.general-settings'    => static fn( ContainerInterface $c ): SettingsMigration => new SettingsMigration(

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -173,7 +173,7 @@ class PaymentMethodsDefinition {
 	// Payment method groups.
 
 	/**
-	 * Define PayPal related payment methods.
+	 * Defines PayPal's branded payment methods; not affected by the "own_brand_only" setting.
 	 *
 	 * @return array
 	 */
@@ -214,20 +214,19 @@ class PaymentMethodsDefinition {
 			),
 		);
 
-		if ( ! $this->general_settings->own_brand_only() ) {
-			$group[] = array(
-				'id'          => CardButtonGateway::ID,
-				'title'       => __( 'Credit and debit card payments', 'woocommerce-paypal-payments' ),
-				'description' => __( "Accept all major credit and debit cards - even if your customer doesn't have a PayPal account . ", 'woocommerce-paypal-payments' ),
-				'icon'        => 'payment-method-cards',
-			);
-		}
+		// This CardButtonGateway is a branded gateway!
+		$group[] = array(
+			'id'          => CardButtonGateway::ID,
+			'title'       => __( 'Credit and debit card payments', 'woocommerce-paypal-payments' ),
+			'description' => __( "Accept all major credit and debit cards - even if your customer doesn't have a PayPal account . ", 'woocommerce-paypal-payments' ),
+			'icon'        => 'payment-method-cards',
+		);
 
 		return apply_filters( 'woocommerce_paypal_payments_gateway_group_paypal', $group );
 	}
 
 	/**
-	 * Define card related payment methods.
+	 * Define embedded payment methods, which are only available in whitelabel mode.
 	 *
 	 * @return array
 	 */

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -108,7 +108,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	 *
 	 * @return bool True if BCDC is enabled for ACDC merchant, false otherwise.
 	 */
-	protected function is_bcdc_enabled_for_acdc_merchant(): bool {
+	public function is_bcdc_enabled_for_acdc_merchant(): bool {
 		$is_acdc_merchant = $this->dcc_applies->for_country_currency() && $this->dcc_status->is_active();
 		if ( ! $is_acdc_merchant ) {
 			return false;

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -9,11 +9,14 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
 
+use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
@@ -25,6 +28,8 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 
 	protected Settings $settings;
 	protected PaymentSettings $payment_settings;
+	protected DccApplies $dcc_applies;
+	protected DCCProductStatus $dcc_status;
 
 	/**
 	 * The list of local apm methods.
@@ -36,10 +41,14 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	public function __construct(
 		Settings $settings,
 		PaymentSettings $payment_settings,
+		DccApplies $dcc_applies,
+		DCCProductStatus $dcc_status,
 		array $local_apms
 	) {
 		$this->settings         = $settings;
 		$this->payment_settings = $payment_settings;
+		$this->dcc_applies      = $dcc_applies;
+		$this->dcc_status       = $dcc_status;
 		$this->local_apms       = $local_apms;
 	}
 
@@ -59,6 +68,10 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 					}
 				}
 			}
+		}
+
+		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {
+			$this->payment_settings->toggle_method_state( CreditCardGateway::ID, true );
 		}
 
 		foreach ( $this->map() as $old_key => $method_name ) {
@@ -83,5 +96,28 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			'googlepay_button_enabled' => GooglePayGateway::ID,
 			'pay_later_button_enabled' => 'pay-later',
 		);
+	}
+
+	/**
+	 * Checks if BCDC is enabled for ACDC merchant.
+	 *
+	 * This method verifies two conditions:
+	 * 1. The merchant is an ACDC merchant - determined by
+	 *    checking if DCC applies for the current country/currency and DCC status is active
+	 * 2. The Card Button Gateway is enabled in WooCommerce settings
+	 *
+	 * @return bool True if BCDC is enabled for ACDC merchant, false otherwise.
+	 */
+	protected function is_bcdc_enabled_for_acdc_merchant(): bool {
+		$is_acdc_merchant = $this->dcc_applies->for_country_currency() && $this->dcc_status->is_active();
+		if ( ! $is_acdc_merchant ) {
+			return false;
+		}
+
+		$card_button_gateway_id = CardButtonGateway::ID;
+		$card_button_gateway_settings = get_option( "woocommerce_{$card_button_gateway_id}_settings", array() );
+		$card_button_gateway_enabled  = $card_button_gateway_settings['enabled'] ?? false;
+
+		return $card_button_gateway_enabled === 'yes';
 	}
 }

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
@@ -30,6 +31,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	protected PaymentSettings $payment_settings;
 	protected DccApplies $dcc_applies;
 	protected DCCProductStatus $dcc_status;
+	protected CardPaymentsConfiguration $dcc_configuration;
 
 	/**
 	 * The list of local apm methods.
@@ -43,13 +45,15 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		PaymentSettings $payment_settings,
 		DccApplies $dcc_applies,
 		DCCProductStatus $dcc_status,
+		CardPaymentsConfiguration $dcc_configuration,
 		array $local_apms
 	) {
-		$this->settings         = $settings;
-		$this->payment_settings = $payment_settings;
-		$this->dcc_applies      = $dcc_applies;
-		$this->dcc_status       = $dcc_status;
-		$this->local_apms       = $local_apms;
+		$this->settings          = $settings;
+		$this->payment_settings  = $payment_settings;
+		$this->dcc_applies       = $dcc_applies;
+		$this->dcc_status        = $dcc_status;
+		$this->local_apms        = $local_apms;
+		$this->dcc_configuration = $dcc_configuration;
 	}
 
 	public function migrate(): void {
@@ -104,7 +108,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	 * This method verifies two conditions:
 	 * 1. The merchant is an ACDC merchant - determined by
 	 *    checking if DCC applies for the current country/currency and DCC status is active
-	 * 2. The Card Button Gateway is enabled in WooCommerce settings
+	 * 2. The BCDC is enabled
 	 *
 	 * @return bool True if BCDC is enabled for ACDC merchant, false otherwise.
 	 */
@@ -114,10 +118,11 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			return false;
 		}
 
-		$card_button_gateway_id = CardButtonGateway::ID;
-		$card_button_gateway_settings = get_option( "woocommerce_{$card_button_gateway_id}_settings", array() );
-		$card_button_gateway_enabled  = $card_button_gateway_settings['enabled'] ?? false;
+		if ( $this->dcc_configuration->is_acdc_enabled() ) {
+			return false;
+		}
 
-		return $card_button_gateway_enabled === 'yes';
+		$disabled_funding = $this->settings->has( 'disable_funding' ) ? $this->settings->get( 'disable_funding' ) : array();
+		return ! in_array( 'card', $disabled_funding, true );
 	}
 }

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -743,7 +743,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		 */
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
-			static function (string $installed_plugin_version) use ( $container ) {
+			static function ( string $installed_plugin_version ) use ( $container ) {
 				if ( '3.1.0' !== $installed_plugin_version ) {
 					return;
 				}
@@ -761,8 +761,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$payment_settings->toggle_method_state( CreditCardGateway::ID, true );
 			}
 		);
-
-
 
 		return true;
 	}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -759,6 +759,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				assert( $payment_settings instanceof PaymentSettings );
 
 				$payment_settings->toggle_method_state( CreditCardGateway::ID, true );
+				$payment_settings->save();
 			}
 		);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -40,6 +40,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\PathRepository
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
@@ -721,6 +722,47 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				}
 			}
 		);
+
+		/**
+		 * Migrates BCDC settings for existing ACDC merchants upgrading from version 3.1.0.
+		 *
+		 * This migration hook ensures that existing merchants who upgrade from version 3.1.0
+		 * have their ACDC payment method automatically enabled
+		 *
+		 * The migration specifically targets merchants who:
+		 * - Are upgrading from exactly version 3.1.0
+		 * - Are ACDC-eligible
+		 * - Have the BCDC enabled in their WooCommerce settings
+		 *
+		 * This ensures continuity of payment functionality for affected users during
+		 * the upgrade process without requiring manual configuration.
+		 *
+		 * @param string $installed_plugin_version The previous version being upgraded from.
+		 *
+		 * @since 3.1.1
+		 */
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			static function (string $installed_plugin_version) use ( $container ) {
+				if ( '3.1.0' !== $installed_plugin_version ) {
+					return;
+				}
+
+				$payment_settings_migration = $container->get( 'settings.service.data-migration.payment-settings' );
+				assert( $payment_settings_migration instanceof PaymentSettingsMigration );
+
+				if ( ! $payment_settings_migration->is_bcdc_enabled_for_acdc_merchant() ) {
+					return;
+				}
+
+				$payment_settings = $container->get( 'settings.data.payment' );
+				assert( $payment_settings instanceof PaymentSettings );
+
+				$payment_settings->toggle_method_state( CreditCardGateway::ID, true );
+			}
+		);
+
+
 
 		return true;
 	}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -747,6 +747,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		add_filter( 'woocommerce_paypal_payments_is_eligible_for_axo', '__return_false' );
 		add_filter( 'woocommerce_paypal_payments_is_eligible_for_save_payment_methods', '__return_false' );
 		add_filter( 'woocommerce_paypal_payments_is_eligible_for_card_fields', '__return_false' );
+		add_filter( 'woocommerce_paypal_payments_is_acdc_active', '__return_false' );
 	}
 
 	/**

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -732,7 +732,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		 * The migration specifically targets merchants who:
 		 * - Are upgrading from exactly version 3.1.0
 		 * - Are ACDC-eligible
-		 * - Have the BCDC enabled in their WooCommerce settings
+		 * - Have the BCDC enabled
 		 *
 		 * This ensures continuity of payment functionality for affected users during
 		 * the upgrade process without requiring manual configuration.

--- a/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
@@ -24,8 +24,9 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
  * configuration.
  *
  * Terminology:
- * - DCC or ACDC refers to the new "Advanced Card Processing" integration.
- * - BCDC is the older "Credit and Debit Cards" integration.
+ * - DCC or ACDC are synonymous referring to the "expanded integration"
+ *       The credit card form is embedded inline on the checkout page.
+ * - BCDC is the "Branded" card payment integration (branded button that opens a modal)
  * - AXO is Fastlane, which is an improved UI for ACDC.
  *
  * Technical implementation via the JS SDK:
@@ -141,8 +142,8 @@ class CardPaymentsConfiguration {
 	 * @param ConnectionState  $connection_state Connection state instance.
 	 * @param Settings         $settings         Plugin settings instance.
 	 * @param DccApplies       $dcc_applies      DCC eligibility helper.
-	 * @param DCCProductStatus $dcc_status        Manages the Seller status.
-	 * @param string           $store_country The shop's country code.
+	 * @param DCCProductStatus $dcc_status       Manages the Seller status.
+	 * @param string           $store_country    The shop's country code.
 	 */
 	public function __construct(
 		ConnectionState $connection_state,


### PR DESCRIPTION
## Issue Description
Currently, BCDC-eligible ACDC merchants lose their payment method functionality when migrating to new settings UI, requiring manual reconfiguration.

## PR Description
This PR adds migration support to automatically enable the ACDC payment method for eligible merchants during plugin upgrades, ensuring seamless payment functionality continuity.

### Changes Made

#### 1. Enhanced PaymentSettingsMigration Class
- **Added `is_bcdc_enabled_for_acdc_merchant()` method** to check BCDC enablement for ACDC merchants
- **Updated `migrate()` method** to automatically enable `CreditCardGateway` when BCDC is ON for ACDC merchants
- Method verifies two key conditions:
  - Merchant is ACDC-eligible (country/currency support + active DCC status)
  - BCDC is enabled

#### 2. Version-Specific Migration Hook
- **Added migration action hook** for merchants upgrading from version 3.1.0
- **Automatically enables ACDC payment method** for existing merchants who had BCDC enabled
- Targets specific upgrade path: `3.1.0` → `3.1.1`