### PR TITLE
Remove migration banner/buttons [5357]

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,8 @@
 
 = 3.1.1 - 2025-09-26 =
 * Fix - Fix BCDC in branded-only mode #3699
-* Fix - Fix BCDC migration logic for ACDC merchants #3702
 * Fix - Restore BCDC button for ACDC merchants in legacy UI #3703
+* Fix - Temporarily pause new UI upgrades while improving migration experience #3705
 
 = 3.1.0 - 2025-09-02 =
 * Enhancement - Fastlane now available for British & Australian merchants #3589

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -129,6 +129,9 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 						return $notices;
 					}
 
+					// phpcs:ignore -- yes, this code is intentionally and temporarily commented out.
+					/*
+					# PCP-5357 - This notification is temporarily disabled
 					$message = sprintf(
 					// translators: %1$s is the URL for the startup guide.
 						__(
@@ -139,6 +142,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					);
 
 					$notices[] = new Message( $message, 'info', false, 'ppcp-notice-wrapper' );
+					*/
 
 					$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
 					// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -107,6 +107,9 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 */
 	public function run( ContainerInterface $container ): bool {
 		if ( self::should_use_the_old_ui() ) {
+			// phpcs:ignore -- yes, this code is intentionally and temporarily commented out.
+			/*
+			# PCP-5357 - This button is temporarily disabled
 			add_filter(
 				'woocommerce_paypal_payments_inside_settings_page_header',
 				static fn(): string => sprintf(
@@ -115,6 +118,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					esc_html__( 'This action will permanently switch to the new settings interface and cannot be undone', 'woocommerce-paypal-payments' )
 				)
 			);
+			*/
 
 			/**
 			 * Adds notes to old UI settings screens.

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2232,7 +2232,7 @@ return array(
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-settings-migration-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
-				SettingsModule::should_use_the_old_ui(),
+				false, // # PCP-5357 temporarily disabled - SettingsModule::should_use_the_old_ui(),
 				new InboxNoteAction(
 					'switch_to_new_settings',
 					__( 'Switch to New Settings', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
### Description

Removes all migration paths that allowed merchants to upgrade from the legacy UI to the new settings UI.

This is a temporary change while prepare/fix some BCDC related upgrade issues for legacy merchants.

Removed upgrade options:
- The "Switch to New Settings" button in the settings page header
- The migration announcement/banner on the settings page
- The Inbox item on the WooCommerce → Home page

### Screenshots of removed items

<img width="944" height="260" alt="CleanShot 2025-09-26 at 21 24 33@2x" src="https://github.com/user-attachments/assets/3d846ef5-dfab-4240-ab62-5521ebe597fd" />
<img width="2184" height="398" alt="CleanShot 2025-09-26 at 21 25 40@2x" src="https://github.com/user-attachments/assets/5979ac6d-468e-48d7-a7fd-0f99707d1330" />
<img width="1564" height="815" alt="CleanShot 2025-09-26 at 21 26 22@2x" src="https://github.com/user-attachments/assets/d293e3ed-2ecc-45f2-b9b8-dd67bcbf6edb" />
