### PR TITLE
Override flag to keep BCDC for ACDC merchants during migration (5362)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -385,6 +385,7 @@ $services = array(
 		$c->get( 'api.helpers.dccapplies' ),
 		$c->get( 'wcgateway.helper.dcc-product-status' ),
 		$c->get( 'wcgateway.configuration.card-configuration' ),
+		$c->get( 'dcc.status-cache' ),
 		$c->get( 'ppcp-local-apms.payment-methods' ),
 	),
 	'settings.service.data-migration.general-settings'    => static fn( ContainerInterface $c ): SettingsMigration => new SettingsMigration(

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
 
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
@@ -33,6 +34,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	protected DccApplies $dcc_applies;
 	protected DCCProductStatus $dcc_status;
 	protected CardPaymentsConfiguration $dcc_configuration;
+	protected Cache $dcc_status_cache;
 
 	/**
 	 * The list of local apm methods.
@@ -47,6 +49,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		DccApplies $dcc_applies,
 		DCCProductStatus $dcc_status,
 		CardPaymentsConfiguration $dcc_configuration,
+		Cache $dcc_status_cache,
 		array $local_apms
 	) {
 		$this->settings          = $settings;
@@ -54,6 +57,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		$this->dcc_applies       = $dcc_applies;
 		$this->dcc_status        = $dcc_status;
 		$this->local_apms        = $local_apms;
+		$this->dcc_status_cache = $dcc_status_cache;
 		$this->dcc_configuration = $dcc_configuration;
 	}
 
@@ -77,6 +81,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 
 		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {
 			update_option( self::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
+			$this->handle_bcdc_migration_override();
 		}
 
 		foreach ( $this->map() as $old_key => $method_name ) {
@@ -125,5 +130,24 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 
 		$disabled_funding = $this->settings->has( 'disable_funding' ) ? $this->settings->get( 'disable_funding' ) : array();
 		return ! in_array( 'card', $disabled_funding, true );
+	}
+
+	/**
+	 * Handles BCDC migration override processing for merchants migrated from legacy UI.
+	 *
+	 * This method runs during settings migration to ensure proper BCDC eligibility
+	 * for ACDC-eligible merchants who were using Standard Card buttons (BCDC) in the
+	 * legacy UI. It forces BCDC classification by manipulating ACDC cache and settings
+	 * regardless of country or ACDC eligibility responses.
+	 *
+	 * Clears existing ACDC status cache, disables ACDC, and rebuilds cache to ensure
+	 * migrated merchants maintain their Standard Card button functionality in the new UI.
+	 */
+	protected function handle_bcdc_migration_override(): void {
+		$this->dcc_status_cache->delete( DCCProductStatus::DCC_STATUS_CACHE_KEY );
+		$this->settings->set( DCCProductStatus::SETTINGS_KEY, DCCProductStatus::SETTINGS_VALUE_DISABLED );
+		$this->settings->persist();
+
+		$this->dcc_status_cache->set( DCCProductStatus::DCC_STATUS_CACHE_KEY, DCCProductStatus::SETTINGS_VALUE_DISABLED, MONTH_IN_SECONDS );
 	}
 }

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -14,7 +14,6 @@ use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
-use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
@@ -26,6 +25,8 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  * Handles migration of payment settings.
  */
 class PaymentSettingsMigration implements SettingsMigrationInterface {
+
+	public const OPTION_NAME_BCDC_MIGRATION_OVERRIDE = 'woocommerce_paypal_payments_bcdc_migration_override';
 
 	protected Settings $settings;
 	protected PaymentSettings $payment_settings;
@@ -75,7 +76,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		}
 
 		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {
-			$this->payment_settings->toggle_method_state( CreditCardGateway::ID, true );
+			update_option( self::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
 		}
 
 		foreach ( $this->map() as $old_key => $method_name ) {

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -248,40 +248,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		$this->apply_branded_only_limitations( $container );
 
-		/**
-		 * Handle BCDC migration override flag for merchants migrated from legacy UI.
-		 *
-		 * This action runs once on init when the BCDC migration override flag is set,
-		 * indicating that a ACDC eligible merchant was using Standard Card buttons (BCDC) in the
-		 * legacy UI and has migrated to the new UI. It ensures proper BCDC eligibility
-		 * by manipulating ACDC cache and settings to force BCDC classification.
-		 *
-		 * The override flag is created during UI migration when we
-		 * detect evidence of BCDC usage in legacy settings, allowing merchants to
-		 * maintain their Standard Card button functionality in the new UI regardless
-		 * of country or ACDC eligibility responses.
-		 */
-		add_action(
-			'init',
-			static function () use ( $container ): void {
-				if ( ! get_option( PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE ) ) {
-					return;
-				}
-
-				$settings = $container->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
-
-				$dcc_status_cache = $container->get( 'dcc.status-cache' );
-				assert( $dcc_status_cache instanceof Cache );
-
-				$dcc_status_cache->delete( DCCProductStatus::DCC_STATUS_CACHE_KEY );
-				$settings->set( DCCProductStatus::SETTINGS_KEY, DCCProductStatus::SETTINGS_VALUE_DISABLED );
-				$settings->persist();
-
-				$dcc_status_cache->set( DCCProductStatus::DCC_STATUS_CACHE_KEY, DCCProductStatus::SETTINGS_VALUE_DISABLED, MONTH_IN_SECONDS );
-			}
-		);
-
 		add_action(
 			'admin_enqueue_scripts',
 			function ( string $hook_suffix ) use ( $container ): void {

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -278,7 +278,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$settings->set( DCCProductStatus::SETTINGS_KEY, DCCProductStatus::SETTINGS_VALUE_DISABLED );
 				$settings->persist();
 
-				$dcc_status_cache->set( DCCProductStatus::DCC_STATUS_CACHE_KEY, DCCProductStatus::SETTINGS_VALUE_ENABLED, MONTH_IN_SECONDS );
+				$dcc_status_cache->set( DCCProductStatus::DCC_STATUS_CACHE_KEY, DCCProductStatus::SETTINGS_VALUE_DISABLED, MONTH_IN_SECONDS );
 			}
 		);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -13,7 +13,6 @@ use WC_Payment_Gateway;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -13,6 +13,7 @@ use WC_Payment_Gateway;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
@@ -246,6 +247,40 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$loading_screen_service->register();
 
 		$this->apply_branded_only_limitations( $container );
+
+		/**
+		 * Handle BCDC migration override flag for merchants migrated from legacy UI.
+		 *
+		 * This action runs once on init when the BCDC migration override flag is set,
+		 * indicating that a ACDC eligible merchant was using Standard Card buttons (BCDC) in the
+		 * legacy UI and has migrated to the new UI. It ensures proper BCDC eligibility
+		 * by manipulating ACDC cache and settings to force BCDC classification.
+		 *
+		 * The override flag is created during UI migration when we
+		 * detect evidence of BCDC usage in legacy settings, allowing merchants to
+		 * maintain their Standard Card button functionality in the new UI regardless
+		 * of country or ACDC eligibility responses.
+		 */
+		add_action(
+			'init',
+			static function () use ( $container ): void {
+				if ( ! get_option( PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE ) ) {
+					return;
+				}
+
+				$settings = $container->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				$dcc_status_cache = $container->get( 'dcc.status-cache' );
+				assert( $dcc_status_cache instanceof Cache );
+
+				$dcc_status_cache->delete( DCCProductStatus::DCC_STATUS_CACHE_KEY );
+				$settings->set( DCCProductStatus::SETTINGS_KEY, DCCProductStatus::SETTINGS_VALUE_DISABLED );
+				$settings->persist();
+
+				$dcc_status_cache->set( DCCProductStatus::DCC_STATUS_CACHE_KEY, DCCProductStatus::SETTINGS_VALUE_ENABLED, MONTH_IN_SECONDS );
+			}
+		);
 
 		add_action(
 			'admin_enqueue_scripts',


### PR DESCRIPTION
## Issue Description
This change affects ACDC merchants on the legacy UI that migrate to the new UI. We need to ensure merchants who were using Standard Card buttons (BCDC) in the legacy UI can maintain that functionality after migrating, regardless of country or API eligibility responses.

## PR Description
Implements BCDC migration override functionality to preserve Standard Card button access for eligible merchants during UI migration.

**Changes:**
- Added BCDC migration override flag detection and setting during UI migration
- Implemented init action handler to process override flag and force BCDC eligibility
- Added logic to manipulate ACDC cache and settings when override flag is present

**Technical Implementation:**
- **During Migration:** Detects ACDC merchants using Standard Card buttons via `is_bcdc_enabled_for_acdc_merchant()` and sets `OPTION_NAME_BCDC_MIGRATION_OVERRIDE` flag
- **On Init:** Processes override flag to delete ACDC cache, disable ACDC
- **Result:** Forces BCDC eligibility regardless of API responses when flag is present

**Acceptance Criteria:**
- ✅ **Case 1:** US merchants with Standard Card buttons maintain black card button visibility after migration
- ✅ **Case 2:** US merchants with Advanced Card processing continue with embedded fields (no override flag set)  
- ✅ **Case 3:** US merchants with disabled cards get ACDC features available but disabled (no override flag set)

**Impact:**
- Preserves existing BCDC functionality for migrated merchants
- Prevents loss of Standard Card button payment options
- Maintains backward compatibility during UI transition
- Creates "read-only" flag as specified (switching to ACDC is separate issue scope)

<table>
<tr>
<td width="50%">

**Before Migration**

</td>
<td width="50%">

**After Migration**

</td>
</tr>

<tr>
<td width="50%">

<img width="1348" height="476" alt="Screenshot 2025-09-29 at 15 36 28" src="https://github.com/user-attachments/assets/1c555ac0-38eb-451c-8f79-c54c57914af6" />

</td>
<td width="50%">

<img width="1528" height="766" alt="Screenshot 2025-09-29 at 15 46 42" src="https://github.com/user-attachments/assets/8744d0a7-e68d-4102-8fc2-a36a38c40b48" />

</td>
</tr>
</table>