### PR TITLE
Make migration available again (5361)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -107,9 +107,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 */
 	public function run( ContainerInterface $container ): bool {
 		if ( self::should_use_the_old_ui() ) {
-			// phpcs:ignore -- yes, this code is intentionally and temporarily commented out.
-			/*
-			# PCP-5357 - This button is temporarily disabled
 			add_filter(
 				'woocommerce_paypal_payments_inside_settings_page_header',
 				static fn(): string => sprintf(
@@ -118,7 +115,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					esc_html__( 'This action will permanently switch to the new settings interface and cannot be undone', 'woocommerce-paypal-payments' )
 				)
 			);
-			*/
 
 			/**
 			 * Adds notes to old UI settings screens.

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -129,9 +129,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 						return $notices;
 					}
 
-					// phpcs:ignore -- yes, this code is intentionally and temporarily commented out.
-					/*
-					# PCP-5357 - This notification is temporarily disabled
 					$message = sprintf(
 					// translators: %1$s is the URL for the startup guide.
 						__(
@@ -142,7 +139,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					);
 
 					$notices[] = new Message( $message, 'info', false, 'ppcp-notice-wrapper' );
-					*/
 
 					$is_paylater_messaging_force_enabled_feature_flag_enabled = apply_filters(
 					// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2232,7 +2232,7 @@ return array(
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-settings-migration-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
-				false, // # PCP-5357 temporarily disabled - SettingsModule::should_use_the_old_ui(),
+				SettingsModule::should_use_the_old_ui(),
 				new InboxNoteAction(
 					'switch_to_new_settings',
 					__( 'Switch to New Settings', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
## Issue Description
Restore all migration UX/notifications.
- "Switch to new Settings" button in settings page header
- The migration announcement/banner on the settings page  
- The inbox notification on Woo's "Home" tab

## PR Description
This PR restores migration UX/notifications by uncommenting previously disabled code, reversing the removal of migration interface elements.

**Changes:**
- Uncommented `woocommerce_paypal_payments_inside_settings_page_header` filter to restore "Switch to New Settings" button
- Re-enabled the migration announcement/banner on the settings page  
- Restored inbox notification on Woo's "Home" tab

<table>
<tr>
<td width="50%">

**Before**

</td>
<td width="50%">

**After**

</td>
</tr>

<tr>
<td width="50%">

<img width="1567" height="485" alt="Screenshot 2025-09-29 at 16 12 04" src="https://github.com/user-attachments/assets/26f3e787-d511-4483-9400-d001e4924d6d" />

</td>
<td width="50%">

<img width="1538" height="577" alt="Screenshot 2025-09-29 at 16 11 43" src="https://github.com/user-attachments/assets/692b7b79-3c33-41f3-8bdd-247c45ab872a" />

</td>
</tr>

<tr>
<td width="50%">

<img width="1728" height="479" alt="Screenshot 2025-09-29 at 16 12 41" src="https://github.com/user-attachments/assets/ef35507f-4d34-44ee-961f-e21907a35af6" />

</td>
<td width="50%">

<img width="1728" height="714" alt="Screenshot 2025-09-29 at 16 13 01" src="https://github.com/user-attachments/assets/b588d67e-cde6-4ca6-926c-4bb356c8320f" />

</td>
</tr>
</table>