### PR TITLE
Override flag to keep BCDC for ACDC merchants during migration [5362]

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -716,6 +716,9 @@ $services = array(
 
 		return new MerchantDetails( $merchant_country, $woo_data['country'], $eligibility_checks );
 	},
+	'settings.migration.bcdc-override-check'              => static function (): callable {
+		return static fn(): bool => (bool) get_option( PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE );
+	},
 );
 
 if ( ! SettingsModule::should_use_the_old_ui() ) {

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -14,7 +14,6 @@ use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
-use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
@@ -26,6 +25,8 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  * Handles migration of payment settings.
  */
 class PaymentSettingsMigration implements SettingsMigrationInterface {
+
+	public const OPTION_NAME_BCDC_MIGRATION_OVERRIDE = 'woocommerce_paypal_payments_bcdc_migration_override';
 
 	protected Settings $settings;
 	protected PaymentSettings $payment_settings;
@@ -75,7 +76,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		}
 
 		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {
-			$this->payment_settings->toggle_method_state( CreditCardGateway::ID, true );
+			update_option( self::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
 		}
 
 		foreach ( $this->map() as $old_key => $method_name ) {

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -240,7 +240,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$this->apply_branded_only_limitations( $container );
 
 		add_filter(
-			'woocommerce_ppcp_override_acdc_status_with_bcdc',
+			'woocommerce_paypal_payments_override_acdc_status_with_bcdc',
 			static function ( ?bool $use_bcdc ) use ( $container ) {
 				$check_override = $container->get( 'settings.migration.bcdc-override-check' );
 				assert( is_callable( $check_override ) );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -239,6 +239,20 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		$this->apply_branded_only_limitations( $container );
 
+		add_filter(
+			'woocommerce_ppcp_override_acdc_status_with_bcdc',
+			static function ( ?bool $use_bcdc ) use ( $container ) {
+				$check_override = $container->get( 'settings.migration.bcdc-override-check' );
+				assert( is_callable( $check_override ) );
+
+				if ( $check_override() ) {
+					$use_bcdc = true;
+				}
+
+				return $use_bcdc;
+			}
+		);
+
 		add_action(
 			'admin_enqueue_scripts',
 			function ( string $hook_suffix ) use ( $container ): void {

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -77,6 +77,15 @@ class DCCProductStatus extends ProductStatus {
 
 	/** {@inheritDoc} */
 	protected function check_local_state(): ?bool {
+		/**
+		 * Allows other modules to disable the ACDC eligibility of this merchant by returning false.
+		 */
+		$bcdc_override = apply_filters( 'woocommerce_ppcp_override_acdc_status_with_bcdc', null );
+		if ( true === $bcdc_override ) {
+			// When overriding, short-circuit and mark ACDC as not available.
+			return false;
+		}
+
 		if ( $this->cache->has( self::DCC_STATUS_CACHE_KEY ) ) {
 			return wc_string_to_bool( $this->cache->get( self::DCC_STATUS_CACHE_KEY ) );
 		}

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -84,7 +84,7 @@ class DCCProductStatus extends ProductStatus {
 		 * in the legacy UI to maintain BCDC functionality in the new UI, regardless
 		 * of ACDC eligibility API responses.
 		 */
-		$bcdc_override = apply_filters( 'woocommerce_ppcp_override_acdc_status_with_bcdc', null );
+		$bcdc_override = apply_filters( 'woocommerce_paypal_payments_override_acdc_status_with_bcdc', null );
 		if ( true === $bcdc_override ) {
 			// When overriding, short-circuit and mark ACDC as not available.
 			return false;

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -78,7 +78,11 @@ class DCCProductStatus extends ProductStatus {
 	/** {@inheritDoc} */
 	protected function check_local_state(): ?bool {
 		/**
-		 * Allows other modules to disable the ACDC eligibility of this merchant by returning false.
+		 * Force BCDC (Standard Cards) for merchants migrated from legacy UI.
+		 *
+		 * This filter allows migrated merchants that used Standard Card buttons
+		 * in the legacy UI to maintain BCDC functionality in the new UI, regardless
+		 * of ACDC eligibility API responses.
 		 */
 		$bcdc_override = apply_filters( 'woocommerce_ppcp_override_acdc_status_with_bcdc', null );
 		if ( true === $bcdc_override ) {


### PR DESCRIPTION
## Issue Description
This change affects ACDC merchants on the legacy UI that migrate to the new UI. We need to ensure merchants who were using Standard Card buttons (BCDC) in the legacy UI can maintain that functionality after migrating, regardless of country or API eligibility responses.

## PR Description
Implements BCDC migration override functionality to preserve Standard Card button access for eligible merchants during UI migration.

**Changes:**
- Added BCDC migration override flag detection and setting during UI migration
- Implemented action handler to process override flag and force BCDC eligibility
- Added `woocommerce_paypal_payments_override_acdc_status_with_bcdc` filter to Force BCDC (Standard Cards) for merchants migrated from legacy UI.

**Technical Implementation:**
- **During Migration:** Detects ACDC merchants using Standard Card buttons via `is_bcdc_enabled_for_acdc_merchant()` and sets `OPTION_NAME_BCDC_MIGRATION_OVERRIDE` flag
- **Uses  `woocommerce_paypal_payments_override_acdc_status_with_bcdc`:** Filter to Force BCDC (Standard Cards) for merchants migrated from legacy UI.
- **Result:** Forces BCDC eligibility regardless of API responses when flag is present

**Acceptance Criteria:**
- ✅ **Case 1:** US merchants with Standard Card buttons maintain black card button visibility after migration
- ✅ **Case 2:** US merchants with Advanced Card processing continue with embedded fields (no override flag set)  
- ✅ **Case 3:** US merchants with disabled cards get ACDC features available but disabled (no override flag set)

**Impact:**
- Preserves existing BCDC functionality for migrated merchants
- Prevents loss of Standard Card button payment options
- Maintains backward compatibility during UI transition
- Creates "read-only" flag as specified (switching to ACDC is separate issue scope)

<table>
<tr>
<td width="50%">

**Before Migration**

</td>
<td width="50%">

**After Migration**

</td>
</tr>

<tr>
<td width="50%">

<img width="1348" height="476" alt="Screenshot 2025-09-29 at 15 36 28" src="https://github.com/user-attachments/assets/1c555ac0-38eb-451c-8f79-c54c57914af6" />

</td>
<td width="50%">

<img width="1528" height="766" alt="Screenshot 2025-09-29 at 15 46 42" src="https://github.com/user-attachments/assets/8744d0a7-e68d-4102-8fc2-a36a38c40b48" />

</td>
</tr>
</table>