### PR TITLE
Enable BCDC for already migrated ACDC merchants (5373)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -262,19 +262,19 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
-		/**
-		 * Set the BCDC override flag during plugin update, if the merchant has enabled BCDC
-		 * in the legacy settings.
-		 *
-		 * Corrects the BCDC flag for already-migrated merchants, as the previous migration logic
-		 * did not create this flag.  This ensures merchants who migrated before the override flag
-		 * implementation don't lose their Standard Card button functionality.
-		 *
-		 * @param false|string $previous_version The previously installed plugin version,
-		 *                                       or false on first installation.
-		 */
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
+			/**
+			 * Set the BCDC override flag during plugin update, if the merchant has enabled BCDC
+			 * in the legacy settings.
+			 *
+			 * Corrects the BCDC flag for already-migrated merchants, as the previous migration logic
+			 * did not create this flag.  This ensures merchants who migrated before the override flag
+			 * implementation don't lose their Standard Card button functionality.
+			 *
+			 * @param false|string $previous_version The previously installed plugin version,
+			 *                                       or false on first installation.
+			 */
 			static function ( $previous_version ) use ( $container ): void {
 				// Only run this migration logic when updating from version 3.1.1 or older.
 				if ( $previous_version && version_compare( $previous_version, '3.1.1', 'gt' ) ) {

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -239,17 +239,17 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		$this->apply_branded_only_limitations( $container );
 
+		/**
+		 * Override ACDC status with BCDC for eligible merchants.
+		 *
+		 * This filter determines whether to force BCDC (Standard Card buttons) classification
+		 * for merchants instead of ACDC (Advanced Card processing). It handles two scenarios:
+		 *
+		 * @param bool|null $use_bcdc Whether to use BCDC instead of ACDC.
+		 * @return bool|null True to force BCDC classification, false/null otherwise.
+		 */
 		add_filter(
 			'woocommerce_paypal_payments_override_acdc_status_with_bcdc',
-			/**
-			 * Override ACDC status with BCDC for eligible merchants.
-			 *
-			 * This filter determines whether to force BCDC (Standard Card buttons) classification
-			 * for merchants instead of ACDC (Advanced Card processing). It handles two scenarios:
-			 *
-			 * @param bool|null $use_bcdc Whether to use BCDC instead of ACDC.
-			 * @return bool|null True to force BCDC classification, false/null otherwise.
-			 */
 			static function ( ?bool $use_bcdc ) use ( $container ) {
 				$check_override = $container->get( 'settings.migration.bcdc-override-check' );
 				assert( is_callable( $check_override ) );
@@ -262,19 +262,19 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		/**
+		 * Set the BCDC override flag during plugin update, if the merchant has enabled BCDC
+		 * in the legacy settings.
+		 *
+		 * Corrects the BCDC flag for already-migrated merchants, as the previous migration logic
+		 * did not create this flag.  This ensures merchants who migrated before the override flag
+		 * implementation don't lose their Standard Card button functionality.
+		 *
+		 * @param false|string $previous_version The previously installed plugin version,
+		 *                                       or false on first installation.
+		 */
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
-			/**
-			 * Set the BCDC override flag during plugin update, if the merchant has enabled BCDC
-			 * in the legacy settings.
-			 *
-			 * Corrects the BCDC flag for already-migrated merchants, as the previous migration logic
-			 * did not create this flag.  This ensures merchants who migrated before the override flag
-			 * implementation don't lose their Standard Card button functionality.
-			 *
-			 * @param false|string $previous_version The previously installed plugin version,
-			 *                                       or false on first installation.
-			 */
 			static function ( $previous_version ) use ( $container ): void {
 				// Only run this migration logic when updating from version 3.1.1 or older.
 				if ( $previous_version && version_compare( $previous_version, '3.1.1', 'gt' ) ) {

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -39,7 +39,6 @@ use WooCommerce\PayPalCommerce\Settings\Handler\ConnectionListener;
 use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\PathRepository;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
-use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -59,6 +58,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Axo\Helper\CompatibilityChecker;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
+use Throwable;
 
 /**
  * Class SettingsModule
@@ -239,31 +239,17 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		$this->apply_branded_only_limitations( $container );
 
-		/**
-		 * Override ACDC status with BCDC for eligible merchants.
-		 *
-		 * This filter determines whether to force BCDC (Standard Card buttons) classification
-		 * for merchants instead of ACDC (Advanced Card processing). It handles two scenarios:
-		 *
-		 * 1. Merchants with existing BCDC override flag set during migration
-		 * 2. Already-migrated merchants who have BCDC evidence but missing override flag
-		 *
-		 * For scenario 2, this acts as a one-time fix mechanism that:
-		 * - Checks if merchant has BCDC enabled in legacy settings
-		 * - Verifies override flag is not already set (to avoid duplicate processing)
-		 * - Sets the override flag in database
-		 * - Forces BCDC classification
-		 *
-		 * This ensures merchants who migrated before the override flag implementation
-		 * don't lose their Standard Card button functionality.
-		 *
-		 * @param bool|null $use_bcdc Whether to use BCDC instead of ACDC.
-		 * @return bool True to force BCDC classification, false/null otherwise.
-		 *
-		 * @hook woocommerce_paypal_payments_override_acdc_status_with_bcdc
-		 */
 		add_filter(
 			'woocommerce_paypal_payments_override_acdc_status_with_bcdc',
+			/**
+			 * Override ACDC status with BCDC for eligible merchants.
+			 *
+			 * This filter determines whether to force BCDC (Standard Card buttons) classification
+			 * for merchants instead of ACDC (Advanced Card processing). It handles two scenarios:
+			 *
+			 * @param bool|null $use_bcdc Whether to use BCDC instead of ACDC.
+			 * @return bool|null True to force BCDC classification, false/null otherwise.
+			 */
 			static function ( ?bool $use_bcdc ) use ( $container ) {
 				$check_override = $container->get( 'settings.migration.bcdc-override-check' );
 				assert( is_callable( $check_override ) );
@@ -272,20 +258,47 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					$use_bcdc = true;
 				}
 
-				$payment_settings_migration = $container->get( 'settings.service.data-migration.payment-settings' );
-				assert( $payment_settings_migration instanceof PaymentSettingsMigration );
+				return $use_bcdc;
+			}
+		);
 
-				$payment_settings = $container->get( 'settings.data.payment' );
-				assert( $payment_settings instanceof PaymentSettings );
-
-				// One-time fix: Set override flag for already-migrated merchants with BCDC evidence.
-				if ( $payment_settings_migration->is_bcdc_enabled_for_acdc_merchant() && ! $check_override() ) {
-					update_option( PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
-					$payment_settings->toggle_method_state( CardButtonGateway::ID, true );
-					$use_bcdc = true;
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			/**
+			 * Set the BCDC override flag during plugin update, if the merchant has enabled BCDC
+			 * in the legacy settings.
+			 *
+			 * Corrects the BCDC flag for already-migrated merchants, as the previous migration logic
+			 * did not create this flag.  This ensures merchants who migrated before the override flag
+			 * implementation don't lose their Standard Card button functionality.
+			 *
+			 * @param false|string $previous_version The previously installed plugin version,
+			 *                                       or false on first installation.
+			 */
+			static function ( $previous_version ) use ( $container ): void {
+				// Only run this migration logic when updating from version 3.1.1 or older.
+				if ( $previous_version && version_compare( $previous_version, '3.1.1', 'gt' ) ) {
+					return;
 				}
 
-				return $use_bcdc;
+				try {
+					$payment_settings_migration = $container->get( 'settings.service.data-migration.payment-settings' );
+					assert( $payment_settings_migration instanceof PaymentSettingsMigration );
+
+					if ( ! $payment_settings_migration->is_bcdc_enabled_for_acdc_merchant() ) {
+						return;
+					}
+
+					$payment_settings = $container->get( 'settings.data.payment' );
+					assert( $payment_settings instanceof PaymentSettings );
+
+					// One-time fix: Set override flag for already-migrated merchants with BCDC evidence.
+					update_option( PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
+					$payment_settings->toggle_method_state( CardButtonGateway::ID, true );
+				} catch ( Throwable $error ) {
+					// Something failed - ignore the error and assume there is no migration data.
+					return;
+				}
 			}
 		);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -239,6 +239,29 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		$this->apply_branded_only_limitations( $container );
 
+		/**
+		 * Override ACDC status with BCDC for eligible merchants.
+		 *
+		 * This filter determines whether to force BCDC (Standard Card buttons) classification
+		 * for merchants instead of ACDC (Advanced Card processing). It handles two scenarios:
+		 *
+		 * 1. Merchants with existing BCDC override flag set during migration
+		 * 2. Already-migrated merchants who have BCDC evidence but missing override flag
+		 *
+		 * For scenario 2, this acts as a one-time fix mechanism that:
+		 * - Checks if merchant has BCDC enabled in legacy settings
+		 * - Verifies override flag is not already set (to avoid duplicate processing)
+		 * - Sets the override flag in database
+		 * - Forces BCDC classification
+		 *
+		 * This ensures merchants who migrated before the override flag implementation
+		 * don't lose their Standard Card button functionality.
+		 *
+		 * @param bool|null $use_bcdc Whether to use BCDC instead of ACDC.
+		 * @return bool True to force BCDC classification, false/null otherwise.
+		 *
+		 * @hook woocommerce_paypal_payments_override_acdc_status_with_bcdc
+		 */
 		add_filter(
 			'woocommerce_paypal_payments_override_acdc_status_with_bcdc',
 			static function ( ?bool $use_bcdc ) use ( $container ) {
@@ -246,6 +269,15 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				assert( is_callable( $check_override ) );
 
 				if ( $check_override() ) {
+					$use_bcdc = true;
+				}
+
+				$payment_settings_migration = $container->get( 'settings.service.data-migration.payment-settings' );
+				assert( $payment_settings_migration instanceof PaymentSettingsMigration );
+
+				// One-time fix: Set override flag for already-migrated merchants with BCDC evidence.
+				if ( $payment_settings_migration->is_bcdc_enabled_for_acdc_merchant() && ! $check_override() ) {
+					update_option( PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
 					$use_bcdc = true;
 				}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -275,9 +275,13 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$payment_settings_migration = $container->get( 'settings.service.data-migration.payment-settings' );
 				assert( $payment_settings_migration instanceof PaymentSettingsMigration );
 
+				$payment_settings = $container->get( 'settings.data.payment' );
+				assert( $payment_settings instanceof PaymentSettings );
+
 				// One-time fix: Set override flag for already-migrated merchants with BCDC evidence.
 				if ( $payment_settings_migration->is_bcdc_enabled_for_acdc_merchant() && ! $check_override() ) {
 					update_option( PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
+					$payment_settings->toggle_method_state( CardButtonGateway::ID, true );
 					$use_bcdc = true;
 				}
 


### PR DESCRIPTION
## Issue Description
Provide a mechanism to enable BCDC (Standard Card buttons) for ACDC merchants who already migrated to the new UI but were using BCDC in the legacy UI before migration. This addresses merchants who migrated before the BCDC override flag implementation and are currently stuck without ACDC or BCDC.

## PR Description
Implements a one-time fix mechanism to restore BCDC functionality for ACDC merchants who migrated to the new UI before the BCDC override flag feature was implemented.

**Changes:**
- Enhanced `woocommerce_paypal_payments_override_acdc_status_with_bcdc` filter to detect already-migrated merchants
- Added automatic BCDC override flag setting for eligible merchants missing the flag
- Integrated toggle to enable CardButtonGateway for affected merchants
- Added comprehensive PHPDoc documentation explaining both migration scenarios

**How It Works:**

The filter now handles two scenarios:

1. **Merchants with existing override flag** (from original implementation)
   - Checks for `OPTION_NAME_BCDC_MIGRATION_OVERRIDE` flag
   - Forces BCDC classification when flag is present

2. **Already-migrated merchants without flag** (one-time fix)
   - Detects BCDC evidence in legacy settings via `is_bcdc_enabled_for_acdc_merchant()`
   - Verifies override flag is not already set (idempotent operation)
   - Sets the override flag in database
   - Enables CardButtonGateway payment method
   - Forces BCDC classification

**Impact:**
- ✅ **Already-migrated merchants**: Automatically restored to BCDC with Standard Card buttons
- ✅ **Newly-migrating merchants**: Continue to work with existing override flag mechanism
- ✅ **Correctly-configured merchants**: No changes (idempotent, safe to run multiple times)
- ✅ **User experience**: Merchants regain Standard Card button functionality without manual intervention

**Acceptance Criteria Coverage:**
- ✅ **Case 1**: Already-migrated ACDC merchants with BCDC evidence get flag set and Standard Card buttons restored
- ✅ **Case 2**: Already-migrated ACDC merchants without BCDC evidence remain unchanged
- ✅ **Case 3**: Merchants with existing override flag are unaffected (idempotent)

<table>
<tr>
<td width="50%">

**Before**

</td>
<td width="50%">

**After**

</td>
</tr>

<tr>
<td width="50%">

<img width="1019" height="659" alt="Screenshot 2025-09-30 at 13 42 05" src="https://github.com/user-attachments/assets/e20c6437-cabb-43ad-b5a0-134c67f897ba" />

</td>
<td width="50%">

<img width="1528" height="766" alt="Screenshot 2025-09-29 at 15 46 42" src="https://github.com/user-attachments/assets/8744d0a7-e68d-4102-8fc2-a36a38c40b48" />

</td>
</tr>
</table>