### PR TITLE
Enable AppSwitch and SSSC  feature flags by default (5363)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2371,7 +2371,7 @@ return array(
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.server_side_shipping_callback_enabled',
-			getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) === '1'
+			getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) !== '0'
 		);
 	},
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2379,7 +2379,7 @@ return array(
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.appswitch_enabled',
-			getenv( 'PCP_APPSWITCH_ENABLED' ) === '1'
+			getenv( 'PCP_APPSWITCH_ENABLED' ) !== '0'
 		);
 	},
 );


### PR DESCRIPTION
## Issue Description
Enable App Switch and Server Side Shipping Callback features by default for broader merchant adoption and testing.

## PR Description
Changes feature flag logic from opt-in to opt-out behavior for App Switch and Server Side Shipping Callback features, enabling them by default.

**Changes:**

**App Switch Feature Flag:**
- Changed from `getenv( 'PCP_APPSWITCH_ENABLED' ) === '1'` (opt-in)
- To `getenv( 'PCP_APPSWITCH_ENABLED' ) !== '0'` (opt-out)
- Feature now enabled by default unless explicitly disabled

**Server Side Shipping Callback Feature Flag:**
- Changed from `getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) === '1'` (opt-in)
- To `getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) !== '0'` (opt-out)
- Feature now enabled by default unless explicitly disabled

**Impact:**
- Both features are now active by default for all merchants
- Features can still be disabled by setting environment variables to `0`:
  - `PCP_APPSWITCH_ENABLED=0`
  - `PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED=0`