### PR TITLE
[QA] Test keys added for some vaulting tests

### DIFF
--- a/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
@@ -161,7 +161,7 @@ test.describe( () => {
 	} );
 
 	test(
-		'PCP-0000 | Vaulting - My Account - Payment Methods - PayPal - Unable to save additional account',
+		'PCP-5380 | Vaulting - My Account - Payment Methods - PayPal - Unable to save additional account',
 		annotateVisitor( customer ),
 		async ( { customerPaymentMethods } ) => {
 			// Preconditions
@@ -190,7 +190,7 @@ test.describe( () => {
 	} );
 
 	test(
-		'PCP-0000 | Vaulting - My Account - Payment Methods - ACDC - Save additional card',
+		'PCP-5381 | Vaulting - My Account - Payment Methods - ACDC - Save additional card',
 		annotateVisitor( customer ),
 		async ( { utils, customerPaymentMethods, classicCheckout } ) => {
 			// Preconditions


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

### Description

Test cases have been created on Xray and test keys have been added to the related tests in automation suite.

* PCP-5380 | Vaulting - My Account - Payment Methods - PayPal - Unable to save additional account
* PCP-5381 | Vaulting - My Account - Payment Methods - ACDC - Save additional card
