### PR TITLE
[QA] Fix E2E Tests for PayPal Transactions in Classic Checkout

### DIFF
--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -235,16 +235,16 @@ export class PayPalUi {
 		// Map to the tested method
 		switch ( shortcut ) {
 			case 'paypal':
-				// pay with vaulted account
+				await this.payPalGateway().click();
+				popup = await this.openPayPalPupup();
+
 				if ( payment.isVaulted ) {
-					// await this.assertVaultedPaymentMethodIsDisplayed( payment );
-					popup = await this.openPayPalPupup();
+					// pay with vaulted account
 					await expect( popup.submitPaymentButton() ).toBeVisible();
 					await popup.completePayment();
 					break;
 				}
-				// open expected PayPal popup
-				popup = await this.openPayPalPupup();
+
 				// pay with given PayPal account
 				await popup.completePayPalPayment( payPalAccount );
 				break;


### PR DESCRIPTION

### Description

Fixes an issue the in flow for  E2E tests PayPal Transactions using Classic Checkout where clicking on PayPal Gatweway was missing.

### Steps to Test

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Closes # .
