### PR TITLE
Disable ACDC methods during BCDC migration for legacy UI merchants (5399)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -385,6 +385,7 @@ $services = array(
 		$c->get( 'api.helpers.dccapplies' ),
 		$c->get( 'wcgateway.helper.dcc-product-status' ),
 		$c->get( 'wcgateway.configuration.card-configuration' ),
+		$c->get( 'settings.data.definition.methods' ),
 		$c->get( 'ppcp-local-apms.payment-methods' ),
 	),
 	'settings.service.data-migration.general-settings'    => static fn( ContainerInterface $c ): SettingsMigration => new SettingsMigration(

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -13,6 +13,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDefinition;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
@@ -33,6 +34,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	protected DccApplies $dcc_applies;
 	protected DCCProductStatus $dcc_status;
 	protected CardPaymentsConfiguration $dcc_configuration;
+	protected PaymentMethodsDefinition $methods_definition;
 
 	/**
 	 * The list of local apm methods.
@@ -47,14 +49,16 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		DccApplies $dcc_applies,
 		DCCProductStatus $dcc_status,
 		CardPaymentsConfiguration $dcc_configuration,
+		PaymentMethodsDefinition $methods_definition,
 		array $local_apms
 	) {
-		$this->settings          = $settings;
-		$this->payment_settings  = $payment_settings;
-		$this->dcc_applies       = $dcc_applies;
-		$this->dcc_status        = $dcc_status;
-		$this->local_apms        = $local_apms;
-		$this->dcc_configuration = $dcc_configuration;
+		$this->settings           = $settings;
+		$this->payment_settings   = $payment_settings;
+		$this->dcc_applies        = $dcc_applies;
+		$this->dcc_status         = $dcc_status;
+		$this->local_apms         = $local_apms;
+		$this->dcc_configuration  = $dcc_configuration;
+		$this->methods_definition = $methods_definition;
 	}
 
 	public function migrate(): void {
@@ -75,32 +79,18 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			}
 		}
 
-		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {
-			update_option( self::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
-		}
-
 		foreach ( $this->map() as $old_key => $method_name ) {
 			if ( $this->settings->has( $old_key ) && $this->settings->get( $old_key ) ) {
 				$this->payment_settings->toggle_method_state( $method_name, true );
 			}
 		}
 
-		$this->payment_settings->save();
-	}
+		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {
+			$this->disable_acdc_methods();
+			update_option( self::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
+		}
 
-	/**
-	 * Maps old setting keys to new payment method names.
-	 *
-	 * @return array<string, string>
-	 */
-	protected function map(): array {
-		return array(
-			'dcc_enabled'              => CreditCardGateway::ID,
-			'axo_enabled'              => AxoGateway::ID,
-			'applepay_button_enabled'  => ApplePayGateway::ID,
-			'googlepay_button_enabled' => GooglePayGateway::ID,
-			'pay_later_button_enabled' => 'pay-later',
-		);
+		$this->payment_settings->save();
 	}
 
 	/**
@@ -125,5 +115,41 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 
 		$disabled_funding = $this->settings->has( 'disable_funding' ) ? $this->settings->get( 'disable_funding' ) : array();
 		return ! in_array( 'card', $disabled_funding, true );
+	}
+
+
+	/**
+	 * Maps old setting keys to new payment method names.
+	 *
+	 * @return array<string, string>
+	 */
+	protected function map(): array {
+		return array(
+			'dcc_enabled'              => CreditCardGateway::ID,
+			'axo_enabled'              => AxoGateway::ID,
+			'applepay_button_enabled'  => ApplePayGateway::ID,
+			'googlepay_button_enabled' => GooglePayGateway::ID,
+			'pay_later_button_enabled' => 'pay-later',
+		);
+	}
+
+	/**
+	 * Disables all ACDC card payment methods.
+	 *
+	 * Iterates through all card payment methods defined in the methods definition
+	 * and disables each one by toggling its state to false. This is used during
+	 * migration when a merchant is switching from ACDC to BCDC classification.
+	 *
+	 * In the legacy UI, merchants could have certain methods (like Google Pay)
+	 * enabled together with BCDC. During migration, we need to disable all ACDC
+	 * card methods to ensure proper BCDC-only state in the new UI.
+	 *
+	 * @return void
+	 */
+	protected  function disable_acdc_methods(): void {
+		foreach ( $this->methods_definition->group_card_methods() as $method ) {
+			$this->payment_settings->toggle_method_state( $method['id'], false );
+			$this->payment_settings->save();
+		}
 	}
 }

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -146,7 +146,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	 *
 	 * @return void
 	 */
-	protected  function disable_acdc_methods(): void {
+	protected function disable_acdc_methods(): void {
 		foreach ( $this->methods_definition->group_card_methods() as $method ) {
 			$this->payment_settings->toggle_method_state( $method['id'], false );
 			$this->payment_settings->save();


### PR DESCRIPTION
## Issue Description
During migration from legacy to new UI, ACDC-eligible merchants who were using BCDC need to have all ACDC card payment methods disabled to maintain proper BCDC-only state. Currently, when these merchants migrate, the BCDC override flag is set correctly but ACDC card methods may remain enabled, creating potential conflicts.

## PR Description
Adds logic to explicitly disable all ACDC card payment methods during migration when ACDC-eligible merchants were using BCDC in the legacy UI, ensuring clean BCDC-only state in the new UI.

**Changes:**
- Implemented `disable_acdc_methods()` method in `PaymentSettingsMigration` class
- Method iterates through all card payment methods from `PaymentMethodsDefinition`
- Disables each ACDC card method via `toggle_method_state(false)`
- Called during migration when `is_bcdc_enabled_for_acdc_merchant()` returns true

**Problem Addressed:**
In the legacy UI, ACDC-eligible merchants could use BCDC (Standard Card buttons) while having other card-related methods (like Google Pay) enabled simultaneously. Without explicit cleanup during migration, these ACDC methods could remain active in the new UI, causing:
- Payment method conflicts
- Inconsistent payment processing behavior
- Confusion about which card processing method is active

<table>
<tr>
<td width="50%">

**Before Migration**

</td>
<td width="50%">

**After**

</td>
</tr>

<tr>
<td width="50%">

<img width="920" height="845" alt="Screenshot 2025-10-01 at 20 53 58" src="https://github.com/user-attachments/assets/5deb8ac5-b237-4799-9683-2685cae4772f" />

</td>
<td width="50%">

<img width="1528" height="766" alt="Screenshot 2025-09-29 at 15 46 42" src="https://github.com/user-attachments/assets/8744d0a7-e68d-4102-8fc2-a36a38c40b48" />

</td>
</tr>

<tr>
<td width="50%">

<img width="993" height="804" alt="Screenshot 2025-10-01 at 20 54 24" src="https://github.com/user-attachments/assets/8621f017-dc78-4f68-b3f0-2eb7dd7dd608" />

</td>
<td width="50%">

<img width="888" height="744" alt="Screenshot 2025-10-01 at 20 55 51" src="https://github.com/user-attachments/assets/75d98347-32e4-48dd-b913-0040b219dd6b" />

</td>
</tr>
</table>

