### PR TITLE
Update LoginLinkRestEndpoint.php

### DIFF
--- a/modules/ppcp-settings/src/Endpoint/LoginLinkRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/LoginLinkRestEndpoint.php
@@ -89,6 +89,9 @@ class LoginLinkRestEndpoint extends RestEndpoint {
 							'type' => 'bool',
 						),
 						'sanitize_callback' => function ( $flags ) {
+							if ( is_object( $flags ) ) {
+   								$flags = json_decode( json_encode( $flags ), true );
+							}
 							return array_map( array( $this, 'to_boolean' ), $flags );
 						},
 					),


### PR DESCRIPTION


**Issue**: #3731

### Description

Add optional type conversion, to fix the fatal PHP error with PHP 8.3 in case a object is passed by WordPress to the sanitize_callback function in LoginLinkRestEndpoint.php of an array.

Fixes #3731

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->


1. Setup and install WordPress in a PHP 8.3.25 environment.
2. Install WooCommerce version 10.2.2.
3. Activate the PayPal payment plugin (v3.1.2).
4. Open the plugin settings.

**Without bugfix**: endlessly loading spinner
**With bugfix**: working buttons, PayPal connection could be established

For images see the related issue, please.

### Environment

- WordPress Version: 6.8.3
- WooCommerce Version: 10.2.2
- Plugin Version: 3.1.2
- PHP Version: 8.3.25
- Browser [e.g. Chrome, Safari] and Version: Chrome, x64, Version 139.0.7258.139
- No other browser plugin enabled


### Documentation

No documentation required, as it solves a PHP fatal error in the Rest API backend.

### Changelog Entry

> Bugfix: Add optional type conversion, to fix the fatal PHP error with PHP 8.3 in case a object is passed by WordPress to the sanitize_callback function in LoginLinkRestEndpoint.php instead of an array.

Closes #3731 .
