### PR TITLE
Fix 3.2.0 release issues (5408)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PaymentTokenEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentTokenEndpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The payment token endpoint.
+ * Payment tokens for vault version 2 endpoint.
  *
  * @package WooCommerce\PayPalCommerce\ApiClient\Endpoint
  */

--- a/modules/ppcp-api-client/src/Endpoint/PaymentTokensEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PaymentTokensEndpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Payment tokens version 3 endpoint.
+ * Payment tokens for vault version 3 endpoint.
  *
  * @package WooCommerce\PayPalCommerce\ApiClient\Endpoint
  */

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MessagesBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MessagesBootstrap.js
@@ -105,7 +105,7 @@ class MessagesBootstrap {
 					setVisible( renderer.config.wrapper, shouldShow );
 					renderer.renderWithAmount( this.lastAmount );
 				} )
-				.catch( ( err ) => console.error( err ) );
+				.catch( () => {} ); // Element not found, this is expected for certain contexts.
 		} );
 	}
 }

--- a/modules/ppcp-save-payment-methods/resources/js/add-payment-method.js
+++ b/modules/ppcp-save-payment-methods/resources/js/add-payment-method.js
@@ -3,7 +3,7 @@ import {
 	ORDER_BUTTON_SELECTOR,
 	PaymentMethods,
 } from '../../../ppcp-button/resources/js/modules/Helper/CheckoutMethodState';
-import { loadScript } from '@paypal/paypal-js';
+import { loadPayPalScript } from '../../../ppcp-button/resources/js/modules/Helper/PayPalScriptLoading';
 import ErrorHandler from '../../../ppcp-button/resources/js/modules/ErrorHandler';
 import { buttonConfiguration, cardFieldsConfiguration } from './Configuration';
 import { renderFields } from '../../../ppcp-card-fields/resources/js/Render';
@@ -13,7 +13,7 @@ import {
 } from '../../../ppcp-button/resources/js/modules/Helper/Hiding';
 
 ( function ( { ppcp_add_payment_method, jQuery } ) {
-	document.addEventListener( 'DOMContentLoaded', () => {
+	document.addEventListener( 'DOMContentLoaded', async () => {
 		jQuery( document.body ).on(
 			'click init_add_payment_method',
 			'.payment_methods input.input-radio',
@@ -41,69 +41,88 @@ import {
 			}
 		}
 
-		setTimeout( () => {
-			loadScript( {
-				clientId: ppcp_add_payment_method.client_id,
-				merchantId: ppcp_add_payment_method.merchant_id,
-				dataUserIdToken: ppcp_add_payment_method.id_token,
-				components: 'buttons,card-fields',
-			} ).then( ( paypal ) => {
-				const errorHandler = new ErrorHandler(
-					ppcp_add_payment_method.labels.error.generic,
-					document.querySelector( '.woocommerce-notices-wrapper' )
-				);
-				errorHandler.clear();
+		const errorHandler = new ErrorHandler(
+			ppcp_add_payment_method.labels.error.generic,
+			document.querySelector( '.woocommerce-notices-wrapper' )
+		);
+		errorHandler.clear();
 
-				const paypalButtonContainer = document.querySelector(
-					`#ppc-button-${ PaymentMethods.PAYPAL }-save-payment-method`
-				);
+		try {
+			const config = {
+				url_params: {
+					'client-id': ppcp_add_payment_method.client_id,
+					'merchant-id': ppcp_add_payment_method.merchant_id,
+					components: 'buttons,card-fields',
+				},
+				save_payment_methods: {
+					id_token: ppcp_add_payment_method.id_token,
+				},
+				user: {
+					is_logged: true,
+				},
+			};
 
-				if ( paypalButtonContainer ) {
-					paypal
-						.Buttons(
-							buttonConfiguration(
-								ppcp_add_payment_method,
-								errorHandler
-							)
+			const paypal = await loadPayPalScript(
+				'ppcp-add-payment-method',
+				config
+			);
+
+			const paypalButtonContainer = document.querySelector(
+				`#ppc-button-${ PaymentMethods.PAYPAL }-save-payment-method`
+			);
+
+			if ( paypalButtonContainer ) {
+				paypal
+					.Buttons(
+						buttonConfiguration(
+							ppcp_add_payment_method,
+							errorHandler
 						)
-						.render(
-							`#ppc-button-${ PaymentMethods.PAYPAL }-save-payment-method`
-						);
-				}
-
-				const cardFields = paypal.CardFields(
-					cardFieldsConfiguration(
-						ppcp_add_payment_method,
-						errorHandler
 					)
-				);
+					.render(
+						`#ppc-button-${ PaymentMethods.PAYPAL }-save-payment-method`
+					);
+			}
 
-				if ( cardFields.isEligible() ) {
-					renderFields( cardFields );
+			const cardFields = paypal.CardFields(
+				cardFieldsConfiguration(
+					ppcp_add_payment_method,
+					errorHandler
+				)
+			);
+
+			if ( cardFields.isEligible() ) {
+				renderFields( cardFields );
+			}
+
+			const placeOrderButton =
+				document.querySelector( '#place_order' );
+			placeOrderButton?.addEventListener( 'click', ( event ) => {
+				const cardPaymentToken = document.querySelector(
+					'input[name="wc-ppcp-credit-card-gateway-payment-token"]:checked'
+				)?.value;
+				if (
+					getCurrentPaymentMethod() !==
+						'ppcp-credit-card-gateway' ||
+					( cardPaymentToken && cardPaymentToken !== 'new' )
+				) {
+					return;
 				}
-
-				const placeOrderButton =
-					document.querySelector( '#place_order' );
-				placeOrderButton?.addEventListener( 'click', ( event ) => {
-					const cardPaymentToken = document.querySelector(
-						'input[name="wc-ppcp-credit-card-gateway-payment-token"]:checked'
-					)?.value;
-					if (
-						getCurrentPaymentMethod() !==
-							'ppcp-credit-card-gateway' ||
-						( cardPaymentToken && cardPaymentToken !== 'new' )
-					) {
-						return;
-					}
-					placeOrderButton.disabled = true;
-					event.preventDefault();
-					cardFields.submit().catch( ( error ) => {
-						console.error( error );
-						placeOrderButton.disabled = false;
-					} );
+				placeOrderButton.disabled = true;
+				event.preventDefault();
+				cardFields.submit().catch( ( error ) => {
+					console.error( error );
+					errorHandler.message( ppcp_add_payment_method.error_message );
+					placeOrderButton.disabled = false;
 				} );
 			} );
-		}, 1000 );
+		} catch ( error ) {
+			console.error( 'Failed to load PayPal script:', error );
+			errorHandler.message(
+				ppcp_add_payment_method.labels.error.generic ||
+				'Failed to load PayPal. Please refresh the page.'
+			);
+		}
 	} );
 } )( {
 	ppcp_add_payment_method: window.ppcp_add_payment_method,

--- a/modules/ppcp-save-payment-methods/resources/js/add-payment-method.js
+++ b/modules/ppcp-save-payment-methods/resources/js/add-payment-method.js
@@ -58,7 +58,7 @@ import {
 					id_token: ppcp_add_payment_method.id_token,
 				},
 				user: {
-					is_logged: true,
+					is_logged: ppcp_add_payment_method.user?.is_logged ?? false,
 				},
 			};
 

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -304,6 +304,9 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 									'subscription_id_to_change_payment' => $is_subscription_change_payment_method_page ? (int) $change_payment_method : 0,
 									'error_message'        => __( 'Could not save payment method.', 'woocommerce-paypal-payments' ),
 									'verification_method'  => $verification_method,
+									'user'                 => array(
+										'is_logged' => is_user_logged_in(),
+									),
 									'ajax'                 => array(
 										'create_setup_token'   => array(
 											'endpoint' => \WC_AJAX::get_endpoint( CreateSetupToken::ENDPOINT ),

--- a/modules/ppcp-save-payment-methods/src/Service/PaymentMethodTokensChecker.php
+++ b/modules/ppcp-save-payment-methods/src/Service/PaymentMethodTokensChecker.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\SavePaymentMethods\Service;
 
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
 class PaymentMethodTokensChecker {
 
@@ -35,12 +36,16 @@ class PaymentMethodTokensChecker {
 			return false;
 		}
 
-		$tokens = $this->payment_method_tokens_endpoint->payment_tokens_for_customer( $customer_id );
-		foreach ( $tokens as $token ) {
-			$payment_source = $token['payment_source']->name() ?? '';
-			if ( $payment_source === 'paypal' ) {
-				return true;
+		try {
+			$tokens = $this->payment_method_tokens_endpoint->payment_tokens_for_customer( $customer_id );
+			foreach ( $tokens as $token ) {
+				$payment_source = $token['payment_source']->name() ?? '';
+				if ( $payment_source === 'paypal' ) {
+					return true;
+				}
 			}
+		} catch ( RuntimeException $e ) {
+			return false;
 		}
 
 		return false;

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -192,46 +192,44 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 		add_action(
 			'wp',
 			function () use ( $container ) {
-				if ( $container->get( 'vaulting.vault-v3-enabled' ) ) {
+				global $wp;
+				if ( ! isset( $wp->query_vars['delete-payment-method'] ) ) {
 					return;
 				}
 
-				global $wp;
+				$token_id = absint( $wp->query_vars['delete-payment-method'] );
+				$token    = WC_Payment_Tokens::get( $token_id );
 
-				if ( isset( $wp->query_vars['delete-payment-method'] ) ) {
-					$token_id = absint( $wp->query_vars['delete-payment-method'] );
-					$token    = WC_Payment_Tokens::get( $token_id );
+				if (
+					is_null( $token )
+					|| ( $token->get_gateway_id() !== PayPalGateway::ID && $token->get_gateway_id() !== CreditCardGateway::ID )
+				) {
+					return;
+				}
 
-					if (
-						is_null( $token )
-						|| ( $token->get_gateway_id() !== PayPalGateway::ID && $token->get_gateway_id() !== CreditCardGateway::ID )
-					) {
-						return;
-					}
+				// phpcs:ignore WordPress.Security.NonceVerification
+				$wpnonce         = wc_clean( wp_unslash( $_REQUEST['_wpnonce'] ?? '' ) );
+				$token_id_string = (string) $token_id;
+				$action          = 'delete-payment-method-' . $token_id_string;
+				if (
+					$token->get_user_id() !== get_current_user_id()
+					|| ! isset( $wpnonce ) || ! is_string( $wpnonce )
+					|| wp_verify_nonce( $wpnonce, $action ) === false
+				) {
+					wc_add_notice( __( 'Invalid payment method.', 'woocommerce-paypal-payments' ), 'error' );
+					wp_safe_redirect( wc_get_account_endpoint_url( 'payment-methods' ) );
+					exit();
+				}
 
-					// phpcs:ignore WordPress.Security.NonceVerification
-					$wpnonce         = wc_clean( wp_unslash( $_REQUEST['_wpnonce'] ?? '' ) );
-					$token_id_string = (string) $token_id;
-					$action          = 'delete-payment-method-' . $token_id_string;
-					if (
-						$token->get_user_id() !== get_current_user_id()
-						|| ! isset( $wpnonce ) || ! is_string( $wpnonce )
-						|| wp_verify_nonce( $wpnonce, $action ) === false
-					) {
-						wc_add_notice( __( 'Invalid payment method.', 'woocommerce-paypal-payments' ), 'error' );
-						wp_safe_redirect( wc_get_account_endpoint_url( 'payment-methods' ) );
-						exit();
-					}
+				try {
+					do_action( 'woocommerce_paypal_payments_before_delete_payment_token', $token->get_token() );
 
-					try {
-						do_action( 'woocommerce_paypal_payments_before_delete_payment_token', $token->get_token() );
+					$payment_token_endpoint = $container->get( 'api.endpoint.payment-token' );
+					$payment_token_endpoint->delete_token_by_id( $token->get_token() );
+				} catch ( RuntimeException $exception ) {
+					wc_add_notice( __( 'Could not delete payment token. ', 'woocommerce-paypal-payments' ) . $exception->getMessage(), 'error' );
 
-						$payment_token_endpoint = $container->get( 'api.endpoint.payment-token' );
-						$payment_token_endpoint->delete_token_by_id( $token->get_token() );
-					} catch ( RuntimeException $exception ) {
-						wc_add_notice( __( 'Could not delete payment token. ', 'woocommerce-paypal-payments' ) . $exception->getMessage(), 'error' );
-						return;
-					}
+					return;
 				}
 			}
 		);

--- a/tests/PHPUnit/SavePaymentMethods/Service/PaymentMethodTokensCheckerTest.php
+++ b/tests/PHPUnit/SavePaymentMethods/Service/PaymentMethodTokensCheckerTest.php
@@ -1,0 +1,35 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\SavePaymentMethods\Service;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\TestCase;
+
+class PaymentMethodTokensCheckerTest extends TestCase {
+
+	public function test_handle_exception_when_resource_not_found() {
+		$endpoint = mockery::mock( PaymentTokensEndpoint::class );
+		$endpoint
+			->expects( 'payment_tokens_for_customer' )
+			->andThrow( new PayPalApiException() );
+
+		$checker = new PaymentMethodTokensChecker( $endpoint );
+
+		$this->assertFalse( $checker->has_paypal_payment_token( 'abc123' ) );
+	}
+
+	public function test_handle_runtime_exception_when_network_error() {
+		$endpoint = mockery::mock( PaymentTokensEndpoint::class );
+		$endpoint
+			->expects( 'payment_tokens_for_customer' )
+			->andThrow( new RuntimeException() );
+
+		$checker = new PaymentMethodTokensChecker( $endpoint );
+
+		$this->assertFalse( $checker->has_paypal_payment_token( 'abc123' ) );
+	}
+}


### PR DESCRIPTION
This PR fixes issues found in 3.2.0-rc1 release package including:
- PCP-5381 | Vaulting - My Account - Payment Methods - ACDC - Save additional card
- PCP-1732 | Vaulting - My Account - Payment Methods - PayPal - Delete saved payment method
- PCP-2048 | PayPal subscription - Order renewal - PCP-4915 | PayPal subscription - Free trial order renewal
- PCP-4500 | Vaulting - My Account - Payment Methods - ACDC - Save payment method

It also includes a refactor to rely on async/await instead of setTimeout for loading PayPal script in save payments screen.