### PR TITLE
Restore gateway description filter hook in PayPalGateway (5306)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -432,12 +432,16 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 */
 	public function get_description() {
 		$gateway_settings = get_option( $this->get_option_key(), array() );
+		$description      = array_key_exists( 'description', $gateway_settings ) ? $gateway_settings['description'] : $this->description;
 
-		if ( array_key_exists( 'description', $gateway_settings ) ) {
-			return $gateway_settings['description'];
-		}
-
-		return $this->description;
+		/**
+		 * Filters the gateway description.
+		 *
+		 * @param string $description Gateway description (already sanitized with wp_kses_post).
+		 * @param PayPalGateway $gateway Gateway instance.
+		 * @return string Filtered gateway description.
+		 */
+		return apply_filters( 'woocommerce_paypal_payments_gateway_description', wp_kses_post( $description ), $this );
 	}
 
 	/**


### PR DESCRIPTION
## Issue Description
In version 3.0.9, the `PayPalGateway` class inherited `get_description()` from `WC_Payment_Gateway`, which fired the `woocommerce_gateway_description` filter hook. In version 3.1.0, this method was overridden without including the filter, breaking backward compatibility for users who rely on this hook to modify gateway descriptions.

## PR Description
Restores the gateway description filter hook that was inadvertently removed in version 3.1.0, allowing third-party code to modify PayPal gateway descriptions.

**Changes:**
- Added `apply_filters()` call to `get_description()` method in `PayPalGateway` class
- Filter name: `woocommerce_paypal_payments_gateway_description` (plugin-specific)
- Applies `wp_kses_post()` sanitization before filtering for security
- Passes full gateway instance as second parameter for maximum flexibility

**User Report:**
User reported that custom code using gateway description filters stopped working after updating from 3.0.9 to 3.1.0. The filter was previously available through the parent `WC_Payment_Gateway` class but was lost when we overrode `get_description()`.

**Implementation:**
```php
/**
 * Filters the gateway description.
 *
 * @param string        $description Gateway description (already sanitized with wp_kses_post).
 * @param PayPalGateway $gateway     Gateway instance.
 * @return string Filtered gateway description.
 */
return apply_filters( 
    'woocommerce_paypal_payments_gateway_description', 
    wp_kses_post( $description ), 
    $this 
);