### PR TITLE
Add "View logs" link to logging settings description (5297)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/Troubleshooting.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/Troubleshooting.js
@@ -24,9 +24,12 @@ const Troubleshooting = () => {
 			<SettingsBlock>
 				<ControlToggleButton
 					label={ __( 'Logging', 'woocommerce-paypal-payments' ) }
-					description={ __(
-						'Log additional debugging information in the WooCommerce logs that can assist technical staff to determine issues.',
-						'woocommerce-paypal-payments'
+					description={ sprintf(
+						__(
+							'Log additional debugging information in the WooCommerce logs that can assist technical staff to determine issues. <a href="%s" target="_blank" rel="noopener noreferrer">View logs</a>.',
+							'woocommerce-paypal-payments'
+						),
+						'admin.php?page=wc-status&tab=logs'
 					) }
 					value={ logging }
 					onChange={ setLogging }


### PR DESCRIPTION
## Issue Description
The legacy settings UI includes a direct link to view plugin logs in the logging configuration section. The new React-based settings UI should include the same functionality to maintain feature parity and provide easy access to troubleshooting logs.

## PR Description
Adds "View logs" link to the logging settings description in the new React-based settings UI, matching the functionality available in the legacy UI.

**Changes:**
- Added "View logs" link in logging toggle description using `sprintf` pattern
- Link points to `admin.php?page=wc-status&tab=logs` (WooCommerce logs page)
- Opens in new tab with `target="_blank"` and security attributes
- Maintains translatable string format for internationalization

<table>
<tr>
<td width="50%">

**Before**

</td>
<td width="50%">

**After**

</td>
</tr>

<tr>
<td width="50%">

<img width="997" height="223" alt="Screenshot 2025-10-06 at 16 46 09" src="https://github.com/user-attachments/assets/2c18ae84-2222-455d-8948-714565f2fb89" />

</td>
<td width="50%">

<img width="970" height="220" alt="Screenshot 2025-10-06 at 16 46 46" src="https://github.com/user-attachments/assets/f02e1d21-e779-4bbe-8d36-6483f3f52255" />

</td>
</tr>
</table>
