### PR TITLE
Fix incorrect context when using mini-cart in product pages (5308)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstrap.js
@@ -10,8 +10,17 @@ class MiniCartBootstrap {
 	}
 
 	init() {
+		/*
+		The context coming from the server can be inaccurate because the product
+		context takes precedence over the mini-cart context, so we hardcode it.
+		 */
+		const miniCartConfig = {
+			...PayPalCommerceGateway,
+			context: 'mini-cart',
+		};
+
 		this.actionHandler = new CartActionHandler(
-			PayPalCommerceGateway,
+			miniCartConfig,
 			this.errorHandler
 		);
 		this.render();


### PR DESCRIPTION
For express button requests, the context is first determined server-side using the [Context](https://github.com/woocommerce/woocommerce-paypal-payments/blob/develop/modules/ppcp-button/src/Helper/Context.php#L169) helper and then localized as a value which is then sent in the AJAX requests.

There is no way to determine server-side if the current context is for the mini-cart. The current approach uses mini-cart as the default context if no other context matches the current request. 

The problem with this approach is that when using the mini-cart express buttons on a single product page, the `product` context takes precedence over the default `mini-cart` context, causing the reported issue.

To fix this, the mini-cart context has been hardcoded in the AJAX request that is sent from the miniCart actionHandler.