### PR TITLE
Do not use SSSC when Pay Now Experience is disabled

### DIFF
--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -523,7 +523,8 @@ class CreateOrderEndpoint implements EndpointInterface {
 			->with_custom_return_url( $return_url )
 			->with_custom_cancel_url( $return_url );
 
-		if ( $this->server_side_shipping_callback_enabled
+		if ( $this->should_handle_shipping_in_paypal( $funding_source )
+			&& $this->server_side_shipping_callback_enabled
 			&& $shipping_preference === ExperienceContext::SHIPPING_PREFERENCE_GET_FROM_FILE ) {
 			$experience_context = $experience_context->with_shipping_callback();
 		}

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/Troubleshooting.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/Troubleshooting.js
@@ -24,9 +24,12 @@ const Troubleshooting = () => {
 			<SettingsBlock>
 				<ControlToggleButton
 					label={ __( 'Logging', 'woocommerce-paypal-payments' ) }
-					description={ __(
-						'Log additional debugging information in the WooCommerce logs that can assist technical staff to determine issues.',
-						'woocommerce-paypal-payments'
+					description={ sprintf(
+						__(
+							'Log additional debugging information in the WooCommerce logs that can assist technical staff to determine issues. <a href="%s" target="_blank" rel="noopener noreferrer">View logs</a>.',
+							'woocommerce-paypal-payments'
+						),
+						'admin.php?page=wc-status&tab=logs'
 					) }
 					value={ logging }
 					onChange={ setLogging }

--- a/tests/qa-legacy-ui/.eslintignore
+++ b/tests/qa-legacy-ui/.eslintignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-utils/
+playwright-report/
+storage-states/
+test-results/

--- a/tests/qa-legacy-ui/.gitignore
+++ b/tests/qa-legacy-ui/.gitignore
@@ -2,7 +2,7 @@
 .vscode
 node_modules
 playwright-utils
-playwright-report
+playwright-report*
 playwright/.cache
 storage-states
 test-results

--- a/tests/qa-legacy-ui/resources/pcp-config.ts
+++ b/tests/qa-legacy-ui/resources/pcp-config.ts
@@ -16,7 +16,7 @@ const standardPaymentsDefault: PcpSettings.StandardPayments = {
 };
 
 export const pcpConfigDefault: PcpConfig = {
-	clearPCPDB: false, // clear PCP DB
+	clearPCPDB: true, // clear PCP DB
 	merchant: merchants[ country ],
 	standardPayments: standardPaymentsDefault,
 };

--- a/tests/qa-legacy-ui/tests/03-plugin-settings/connection.spec.ts
+++ b/tests/qa-legacy-ui/tests/03-plugin-settings/connection.spec.ts
@@ -14,8 +14,10 @@ test.describe( 'Сonnection', () => {
 		connection,
 	} ) => {
 		await connection.visit();
-		await connection.disconnectMerchant();
-
+		const disconnectButton = connection.disconnectAccountButton();
+		await expect( disconnectButton ).toBeVisible();
+		await disconnectButton.click();
+		await expect ( connection.page ).toHaveURL( connection.url );
 		await expect(
 			connection.toggleToManualCredentialInputButton()
 		).toBeVisible();

--- a/tests/qa-legacy-ui/utils/admin/connection.ts
+++ b/tests/qa-legacy-ui/utils/admin/connection.ts
@@ -8,6 +8,7 @@ import urls from '../urls';
  */
 import { PcpMerchant } from '../../resources';
 import { generateRandomString } from '../helpers';
+import { expect } from 'playwright/test';
 
 export class Connection extends PcpSettingsPage {
 	url = urls.pcp.connection;
@@ -36,13 +37,11 @@ export class Connection extends PcpSettingsPage {
 			name: 'Test payments with PayPal sandbox',
 		} );
 	toggleToManualCredentialInputButton = () =>
-		this.page.getByRole( 'button', {
-			name: 'Toggle to manual credential input',
-		} );
+		this.page.locator( 'button[id="ppcp[toggle_manual_input]"]' );
 	documentationLink = () =>
 		this.page.getByRole( 'link', { name: 'documentation', exact: true } );
 
-	sandboxCheckbox = () => this.page.getByLabel( 'Sandbox', { exact: true } );
+	sandboxCheckbox = () => this.page.locator( '#ppcp-sandbox_on' );
 
 	liveEmailAddressInput = () => this.page.getByLabel( 'Live Email address' );
 	liveMerchantIdInput = () => this.page.getByLabel( 'Live Merchant Id' );
@@ -51,12 +50,13 @@ export class Connection extends PcpSettingsPage {
 		this.page.locator( 'input[name="ppcp\\[client_secret_production\\]"]' );
 
 	sandboxEmailAddressInput = () =>
-		this.page.getByLabel( 'Sandbox Email address' );
+		this.page.locator( '#ppcp-merchant_email_sandbox' );
 	sandboxMerchantIdInput = () =>
-		this.page.getByLabel( 'Sandbox Merchant Id' );
-	sandboxClientIdInput = () => this.page.getByLabel( 'Sandbox Client Id' );
+		this.page.locator( '#ppcp-merchant_id_sandbox' );
+	sandboxClientIdInput = () =>
+		this.page.locator( '#ppcp-client_id_sandbox' );
 	sandboxSecretKeyInput = () =>
-		this.page.locator( 'input[name="ppcp\\[client_secret_sandbox\\]"]' );
+		this.page.locator( 'input[name="ppcp[client_secret_sandbox]"]' );
 
 	statusConnected = () => this.page.getByText( 'Status: Connected' );
 	disconnectAccountButton = () =>
@@ -102,43 +102,6 @@ export class Connection extends PcpSettingsPage {
 	};
 
 	/**
-	 * Checks if merchant is connected
-	 *
-	 * @param data
-	 */
-	isMerchantConnected = async ( data? ) => {
-		if ( ! ( await this.disconnectAccountButton().isVisible() ) ) {
-			return false;
-		}
-
-		const emailInput = this.sandboxEmailAddressInput();
-		const merchantIdInput = this.sandboxMerchantIdInput();
-		const clientIdInput = this.sandboxClientIdInput();
-		const secretKeyInput = this.sandboxSecretKeyInput();
-
-		const emailInputValue = ( await emailInput.inputValue() ).trim();
-		const merchantIdValue = ( await merchantIdInput.inputValue() ).trim();
-		const clientIdValue = ( await clientIdInput.inputValue() ).trim();
-		const secretKeyValue = ( await secretKeyInput.inputValue() ).trim();
-
-		if ( ! data ) {
-			return (
-				emailInputValue !== '' &&
-				merchantIdValue !== '' &&
-				clientIdValue !== '' &&
-				secretKeyValue !== ''
-			);
-		}
-
-		return (
-			emailInputValue === data.email &&
-			merchantIdValue === data.account_id &&
-			clientIdValue === data.client_id &&
-			secretKeyValue === data.client_secret
-		);
-	};
-
-	/**
 	 * Connects PayPal merchant with options
 	 *
 	 * @param merchant
@@ -150,23 +113,46 @@ export class Connection extends PcpSettingsPage {
 			enablePayUponInvoice: false,
 		}
 	) => {
+		await this.page.waitForLoadState();
 		if ( options.enablePayUponInvoice ) {
 			await this.onboardPayUponInvoiceCheckbox().check();
 		} else if ( await this.onboardPayUponInvoiceCheckbox().isVisible() ) {
 			await this.onboardPayUponInvoiceCheckbox().uncheck();
 		}
 
-		await this.toggleToManualCredentialInputButton().click();
-		await this.page.waitForTimeout( 500 );
-		await this.sandboxCheckbox().check();
-		await this.sandboxEmailAddressInput().fill( merchant.email );
-		await this.sandboxMerchantIdInput().fill( merchant.account_id );
-		await this.sandboxClientIdInput().fill( merchant.client_id );
-		await this.sandboxSecretKeyInput().fill( merchant.client_secret );
-		await this.saveChangesButton().click();
+		const toggleToManualCredentialInputButton =
+			this.toggleToManualCredentialInputButton();
+		await expect( toggleToManualCredentialInputButton ).toBeVisible();
+		await toggleToManualCredentialInputButton.click( { force: true } );
+		
+		const sandboxCheckbox = this.sandboxCheckbox();
+		await expect( sandboxCheckbox ).toBeVisible();
+		await sandboxCheckbox.check({ force: true });
+		await expect( this.sandboxCheckbox() ).toBeChecked();
+		
+		const sandboxEmailAddressInput = this.sandboxEmailAddressInput();
+		await expect( sandboxEmailAddressInput ).toBeVisible();
+		await sandboxEmailAddressInput.fill( merchant.email );
+		
+		const sandboxMerchantIdInput = this.sandboxMerchantIdInput();
+		await expect( sandboxMerchantIdInput ).toBeVisible();
+		await sandboxMerchantIdInput.fill( merchant.account_id );
+		
+		const sandboxClientIdInput = this.sandboxClientIdInput();
+		await expect( sandboxClientIdInput ).toBeVisible();
+		await sandboxClientIdInput.fill( merchant.client_id );
+		
+		const sandboxSecretKeyInput = this.sandboxSecretKeyInput();
+		await expect( sandboxSecretKeyInput ).toBeVisible();
+		await sandboxSecretKeyInput.fill( merchant.client_secret );
+		
+		const saveChangesButton = this.saveChangesButton();
+		await expect( saveChangesButton ).toBeVisible();
+		await saveChangesButton.click();
 		await this.page.waitForLoadState();
 		// make sure Connection page has been loaded:
-		await this.disconnectAccountButton().waitFor( { state: 'visible' } );
+		
+		await expect( this.disconnectAccountButton() ).toBeVisible();
 		await this.updateInvoicePrefix();
 	};
 
@@ -175,32 +161,6 @@ export class Connection extends PcpSettingsPage {
 	) => {
 		await this.invoicePrefixInput().fill( `${ prefix }-` );
 		await this.saveChanges();
-	};
-
-	/**
-	 * Disconnects PayPal merchant
-	 */
-	disconnectMerchant = async () => {
-		const disconnectButton = this.disconnectAccountButton();
-
-		if ( await disconnectButton.isVisible() ) {
-			await disconnectButton.click();
-		}
-		await this.page.waitForLoadState();
-		// make sure Account Setup page has been loaded:
-		await this.toggleToManualCredentialInputButton().waitFor( {
-			state: 'visible',
-		} );
-	};
-
-	clearDB = async () => {
-		this.page.on( 'dialog', ( dialog ) => dialog.accept() );
-		await this.clearNowButton().click();
-		await this.page.waitForLoadState();
-		// make sure Account Setup page has been loaded:
-		await this.toggleToManualCredentialInputButton().waitFor( {
-			state: 'visible',
-		} );
 	};
 
 	// Assertions

--- a/tests/qa-legacy-ui/utils/frontend/paypal-ui.ts
+++ b/tests/qa-legacy-ui/utils/frontend/paypal-ui.ts
@@ -719,46 +719,47 @@ export class PayPalUI {
 		await this.debitOrCreditCardPayNowButton().click();
 		await this.page.waitForTimeout( 2500 );
 
-		const firstName = this.debitOrCreditCardFirstNameInput();
-		if ( await firstName.isVisible() ) {
-			await firstName.fill( customer.first_name );
-		}
-		const lastName = this.debitOrCreditCardLastNameInput();
-		if ( await lastName.isVisible() ) {
-			await lastName.fill( customer.last_name );
-		}
-		const street = this.debitOrCreditCardStreetInput();
-		if ( await street.isVisible() ) {
-			await street.fill( customer.billing.address_1 );
-		}
-		const apartment = this.debitOrCreditCardApartmentInput();
-		if ( await apartment.isVisible() ) {
-			await apartment.fill( customer.billing.address_2 );
-		}
-		const city = this.debitOrCreditCardCityInput();
-		if ( await city.isVisible() ) {
-			await city.fill( customer.billing.city );
-		}
-		const state = this.debitOrCreditCardStateInput();
-		if ( await state.isVisible() ) {
-			await state.fill( customer.billing.state );
-		}
-		const postcode = this.debitOrCreditCardZipCodeInput();
-		if ( await postcode.isVisible() ) {
-			await postcode.fill( customer.billing.postcode );
-		}
-		const phone = this.debitOrCreditCardPhoneInput();
-		if ( await phone.isVisible() ) {
-			await phone.fill( customer.billing.phone );
-		}
-		const email = this.debitOrCreditCardEmailInput();
-		if ( await email.isVisible() ) {
-			await email.fill( customer.billing.email );
-		}
-		const payNow = this.debitOrCreditCardPayNowButton();
-		if ( await payNow.isVisible() ) {
-			await payNow.click();
-		}
+		// Commented by MUtkin on 30-09-2025 due to changed UI behavior by PayPal
+		// const firstName = this.debitOrCreditCardFirstNameInput();
+		// if ( await firstName.isVisible() ) {
+		// 	await firstName.fill( customer.first_name );
+		// }
+		// const lastName = this.debitOrCreditCardLastNameInput();
+		// if ( await lastName.isVisible() ) {
+		// 	await lastName.fill( customer.last_name );
+		// }
+		// const street = this.debitOrCreditCardStreetInput();
+		// if ( await street.isVisible() ) {
+		// 	await street.fill( customer.billing.address_1 );
+		// }
+		// const apartment = this.debitOrCreditCardApartmentInput();
+		// if ( await apartment.isVisible() ) {
+		// 	await apartment.fill( customer.billing.address_2 );
+		// }
+		// const city = this.debitOrCreditCardCityInput();
+		// if ( await city.isVisible() ) {
+		// 	await city.fill( customer.billing.city );
+		// }
+		// const state = this.debitOrCreditCardStateInput();
+		// if ( await state.isVisible() ) {
+		// 	await state.fill( customer.billing.state );
+		// }
+		// const postcode = this.debitOrCreditCardZipCodeInput();
+		// if ( await postcode.isVisible() ) {
+		// 	await postcode.fill( customer.billing.postcode );
+		// }
+		// const phone = this.debitOrCreditCardPhoneInput();
+		// if ( await phone.isVisible() ) {
+		// 	await phone.fill( customer.billing.phone );
+		// }
+		// const email = this.debitOrCreditCardEmailInput();
+		// if ( await email.isVisible() ) {
+		// 	await email.fill( customer.billing.email );
+		// }
+		// const payNow = this.debitOrCreditCardPayNowButton();
+		// if ( await payNow.isVisible() ) {
+		// 	await payNow.click();
+		// }
 	};
 
 	/**

--- a/tests/qa-legacy-ui/utils/utils.ts
+++ b/tests/qa-legacy-ui/utils/utils.ts
@@ -6,8 +6,8 @@ import {
 	RequestUtils,
 	Plugins,
 	WooCommerceUtils,
-	Login,
 	restLogin,
+	expect,
 } from '@inpsyde/playwright-utils/build';
 /**
  * Internal dependencies
@@ -31,13 +31,13 @@ import {
 } from './frontend';
 import {
 	subscriptionsPlugin,
-	disableNoncePlugin,
 	wpDebuggingPlugin,
 	pcpPlugin,
 	PcpMerchant,
 	PcpConfig,
 } from '../resources';
-import { getCustomerStorageStateName } from './helpers';
+import { generateRandomString, getCustomerStorageStateName } from './helpers';
+import urls from './urls';
 
 export class Utils {
 	plugins: Plugins;
@@ -193,34 +193,131 @@ export class Utils {
 		);
 	};
 
+
+	/**
+	 * Onboard with Pay Upon Invoice (PUI)
+	 * Only for German merchant
+	 *
+	 */
+	onboardWithPui = async () => {
+		const nonce = await this.requestUtils.getRegexMatchValueOnPage(
+			urls.pcp.connection,
+			/"update_signup_links_nonce":"([^"]+)"/
+		);
+
+		const response = await this.requestUtils.request.post(
+			'/?wc-ajax=ppc-update-signup-links', {
+				data: {
+					nonce,
+					settings: { 'ppcp-onboarding-pui': true },
+				}
+			},
+		);
+		const result = response.ok();
+		await expect( result ).toBeTruthy();
+		return result;
+	}
+
+	/**
+	 * Connects merchant via form post request
+	 *
+	 */
 	connectMerchant = async (
 		merchant: PcpMerchant,
 		options = {
 			enablePayUponInvoice: false,
 		}
-	) => {
-		await this.connection.visit();
-		// check if merchant with expected email is not connected
-		const isExpectedMerchantConnected =
-			await this.connection.isMerchantConnected( merchant );
-		if ( ! isExpectedMerchantConnected ) {
-			await this.connection.disconnectMerchant();
-			await this.connection.connectMerchant( merchant, options );
-		}
-	};
+	 ) => {
+		const ppcpNonce = await this.requestUtils.getRegexMatchValueOnPage(
+			urls.pcp.connection,
+			/<input type="hidden" name="ppcp-nonce" value="([^"]+)">/
+		);
+		
+		const wpnonce = await this.requestUtils.getPageNonce( urls.pcp.connection );
+		
+		const formData = {
+			'_wpnonce': wpnonce,
+			'ppcp-nonce': ppcpNonce,
+			'ppcp[sandbox_on]': '1',
+			'ppcp[merchant_email_production]': '',
+			'ppcp[merchant_id_production]': '',
+			'ppcp[client_id_production]': '',
+			'ppcp[client_secret_production]': '',
+			'ppcp[merchant_email_sandbox]': merchant.email,
+			'ppcp[merchant_id_sandbox]': merchant.account_id,
+			'ppcp[client_id_sandbox]': merchant.client_id,
+			'ppcp[client_secret_sandbox]': merchant.client_secret,
+			'ppcp[soft_descriptor]': '',
+			'ppcp[prefix]': `${ generateRandomString( 10 ) }-`,
+			'ppcp[stay_updated]': '1',
+			'ppcp[subtotal_mismatch_behavior]': 'extra_line',
+			'ppcp[subtotal_mismatch_line_name]': '',
+			'save': 'Save changes',
+		};
 
+		if( options.enablePayUponInvoice === true ) {
+			formData[ 'ppcp_onboarding_dcc' ] = 'basic';
+			await this.onboardWithPui();
+		}
+		
+		const response = await this.requestUtils.submitPageForm( urls.pcp.connection, formData );
+		const result = response.ok();
+		await expect( result ).toBeTruthy();
+		return result;
+	}
+
+	/**
+	 * Disconnects merchant via form post request
+	 *
+	 */
 	disconnectMerchant = async () => {
-		await this.connection.visit();
-		await this.connection.disconnectMerchant();
-	};
+		const ppcpNonce = await this.requestUtils.getRegexMatchValueOnPage(
+			urls.pcp.connection,
+			/<input type="hidden" name="ppcp-nonce" value="([^"]+)">/
+		);
+		const wpnonce = await this.requestUtils.getPageNonce( urls.pcp.connection );
+		const formData = {
+			'_wpnonce': wpnonce,
+			'ppcp-nonce': ppcpNonce,
+			'ppcp[merchant_email_production]': '',
+			'ppcp[merchant_id_production]': '',
+			'ppcp[client_id_production]': '',
+			'ppcp[client_secret_production]': '',
+			'ppcp[merchant_email_sandbox]': '',
+			'ppcp[merchant_id_sandbox]': '',
+			'ppcp[client_id_sandbox]': '',
+			'ppcp[client_secret_sandbox]': '',
+			'ppcp[soft_descriptor]': '',
+			'ppcp[prefix]': '',
+			'ppcp[stay_updated]': '1',
+			'ppcp[subtotal_mismatch_behavior]': 'extra_line',
+			'ppcp[subtotal_mismatch_line_name]': '',
+			'save': 'Save changes',
+		};
+		const response = await this.requestUtils.submitPageForm( urls.pcp.connection, formData );
+		const result = response.ok();
+		await expect( result ).toBeTruthy();
+		return result;
+	}
 
-	clearPcpDb = async ( data: PcpMerchant ) => {
-		await this.connection.visit();
-		if ( ! ( await this.connection.isMerchantConnected() ) ) {
-			await this.connection.connectMerchant( data );
-		}
-		await this.connection.clearDB();
-	};
+	/**
+	 * Clear PCP DB via request
+	 *
+	 */
+	clearPcpDb = async () => {
+		const nonce = await this.requestUtils.getRegexMatchValueOnPage(
+			urls.pcp.connection,
+			/"clearDb":\{[^}]*"nonce":"([^"]+)"/
+		);
+
+		const response = await this.requestUtils.request.post(
+			'/?wc-ajax=ppcp-clear-db',
+			{ data: { nonce } },
+		);
+		const result = response.ok();
+		await expect( result ).toBeTruthy();
+		return result;
+	}
 
 	/**
 	 * Enable PayPal funding source
@@ -353,7 +450,13 @@ export class Utils {
 
 		if ( data.merchant ) {
 			if ( data.clearPCPDB ) {
-				await this.clearPcpDb( data.merchant );
+				// Make sure merchant is connected to clear PCP DB
+				await this.disconnectMerchant();
+				await this.connectMerchant(
+					data.merchant,
+					{ enablePayUponInvoice: !!data.enablePayUponInvoice },
+				);
+				await this.clearPcpDb();
 			}
 
 			if ( data.merchantIsDisconnected ) {
@@ -361,9 +464,11 @@ export class Utils {
 				return;
 			}
 
-			await this.connectMerchant( data.merchant, {
-				enablePayUponInvoice: data.enablePayUponInvoice || false,
-			} );
+			await this.disconnectMerchant();
+			await this.connectMerchant(
+				data.merchant,
+				{ enablePayUponInvoice: !!data.enablePayUponInvoice },
+			);
 		}
 
 		if ( data.standardPayments ) {

--- a/tests/qa-legacy-ui/utils/utils.ts
+++ b/tests/qa-legacy-ui/utils/utils.ts
@@ -117,6 +117,14 @@ export class Utils {
 
 	restoreCustomer = async ( customer: WooCommerce.CreateCustomer ) => {
 		await this.wooCommerceUtils.deleteCustomer( customer );
+		if ( customer.username ) {
+			const user = await this.requestUtils.getUserByName(
+				customer.username
+			);
+			if ( user.length ) {
+				await this.requestUtils.deleteUser( user[ 0 ].id );
+			}
+		}
 		await this.wooCommerceUtils.createCustomer( customer );
 		const storageStateName = getCustomerStorageStateName( customer );
 		const storageStatePath = `${ process.env.STORAGE_STATE_PATH }/${ storageStateName }.json`;

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-checkout.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-checkout.data.ts
@@ -8,8 +8,8 @@ const customer = customers.usa;
 const savePaymentMethodData: ShopOrder[] = [
 	{
 		// FAIL: vaulted PayPal button is not displayed, "Saved token for ppcp-gateway" is displayed.
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Checkout - PayPal - Save payment method',
+		// https://inpsyde.atlassian.net/browse/PCP-5382
+		title: 'PCP-5382 | Vaulting - Transaction - Checkout - PayPal - Save payment method',
 		...orders.default,
 		payment: {
 			...payments.payPal,
@@ -29,7 +29,7 @@ const savePaymentMethodData: ShopOrder[] = [
 	},
 	{
 		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Checkout - ACDC - Do not save payment method',
+		title: 'PCP-5383 | Vaulting - Transaction - Checkout - ACDC - Do not save payment method',
 		...orders.default,
 		payment: {
 			...payments.acdc,
@@ -41,8 +41,8 @@ const savePaymentMethodData: ShopOrder[] = [
 
 const acdcAdditionalCardData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Checkout - ACDC - Pay with card other then saved and do not save it',
+		// https://inpsyde.atlassian.net/browse/PCP-5384
+		title: 'PCP-5384 | Vaulting - Transaction - Checkout - ACDC - Pay with card other then saved and do not save it',
 		...orders.default,
 		payment: {
 			...payments.acdc,
@@ -51,8 +51,8 @@ const acdcAdditionalCardData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Checkout - ACDC - Pay with card other then saved and save it',
+		// https://inpsyde.atlassian.net/browse/PCP-5385
+		title: 'PCP-5385 | Vaulting - Transaction - Checkout - ACDC - Pay with card other then saved and save it',
 		...orders.default,
 		payment: {
 			...payments.acdc,

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-cart.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-cart.data.ts
@@ -8,8 +8,8 @@ const customer = customers.usa;
 const savePaymentMethodData: ShopOrder[] = [
 	{
 		// FAIL: vaulted PayPal button is not displayed.
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Classic cart - PayPal - Save payment method',
+		// https://inpsyde.atlassian.net/browse/PCP-5397
+		title: 'PCP-5397 | Vaulting - Transaction - Classic cart - PayPal - Save payment method',
 		...orders.default,
 		payment: {
 			...payments.payPal,
@@ -22,8 +22,8 @@ const savePaymentMethodData: ShopOrder[] = [
 const vaultedPaymentMethodData: ShopOrder[] = [
 	{
 		// FAIL: vaulted PayPal button is not displayed.
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Classic cart - PayPal - Pay with vaulted account',
+		// https://inpsyde.atlassian.net/browse/PCP-5398
+		title: 'PCP-5398 | Vaulting - Transaction - Classic cart - PayPal - Pay with vaulted account',
 		...orders.default,
 		payment: {
 			...payments.payPal,

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-checkout.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-checkout.data.ts
@@ -7,8 +7,8 @@ const customer = customers.usa;
 
 const savePaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - PayPal - Save payment method',
+		// https://inpsyde.atlassian.net/browse/PCP-5389
+		title: 'PCP-5389 | Vaulting - Transaction - Classic checkout - PayPal - Save payment method',
 		...orders.default,
 		payment: {
 			...payments.payPal,
@@ -27,8 +27,8 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Do not save payment method',
+		// https://inpsyde.atlassian.net/browse/PCP-5388
+		title: 'PCP-5388 | Vaulting - Transaction - Classic checkout - ACDC - Do not save payment method',
 		...orders.default,
 		payment: {
 			...payments.acdc,
@@ -40,8 +40,8 @@ const savePaymentMethodData: ShopOrder[] = [
 
 const acdcAdditionalCardData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved and do not save it',
+		// https://inpsyde.atlassian.net/browse/PCP-5387
+		title: 'PCP-5387 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved and do not save it',
 		...orders.default,
 		payment: {
 			...payments.acdc,
@@ -50,8 +50,8 @@ const acdcAdditionalCardData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved and save it',
+		// https://inpsyde.atlassian.net/browse/PCP-5386
+		title: 'PCP-5386 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved and save it',
 		...orders.default,
 		payment: {
 			...payments.acdc,

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-pay-by-link.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-pay-by-link.data.ts
@@ -7,8 +7,8 @@ const customer = customers.usa;
 
 const savePaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - PayPal - Save payment method',
+		// https://inpsyde.atlassian.net/browse/PCP-5390
+		title: 'PCP-5390 | Vaulting - Transaction - Pay by link - PayPal - Save payment method',
 		...orders.default,
 		payment: {
 			...payments.payPal,
@@ -17,8 +17,8 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Save payment method',
+		// https://inpsyde.atlassian.net/browse/PCP-5391
+		title: 'PCP-5391 | Vaulting - Transaction - Pay by link - ACDC - Save payment method',
 		...orders.default,
 		payment: {
 			...payments.acdc,
@@ -27,8 +27,8 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Do not save payment method',
+		// https://inpsyde.atlassian.net/browse/PCP-5392
+		title: 'PCP-5392 | Vaulting - Transaction - Pay by link - ACDC - Do not save payment method',
 		...orders.default,
 		payment: {
 			...payments.acdc,
@@ -40,8 +40,8 @@ const savePaymentMethodData: ShopOrder[] = [
 
 const acdcAdditionalCardData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Pay with card other then saved and do not save it',
+		// https://inpsyde.atlassian.net/browse/PCP-5393
+		title: 'PCP-5393 | Vaulting - Transaction - Pay by link - ACDC - Pay with card other then saved and do not save it',
 		...orders.default,
 		payment: {
 			...payments.acdc,
@@ -50,8 +50,8 @@ const acdcAdditionalCardData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Pay with card other then saved and save it',
+		// https://inpsyde.atlassian.net/browse/PCP-5394
+		title: 'PCP-5394 | Vaulting - Transaction - Pay by link - ACDC - Pay with card other then saved and save it',
 		...orders.default,
 		payment: {
 			...payments.acdc,
@@ -63,8 +63,8 @@ const acdcAdditionalCardData: ShopOrder[] = [
 
 const vaultedPaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - PayPal - Pay with vaulted account',
+		// https://inpsyde.atlassian.net/browse/PCP-5395
+		title: 'PCP-5395 | Vaulting - Transaction - Pay by link - PayPal - Pay with vaulted account',
 		...orders.default,
 		payment: {
 			...payments.payPal,
@@ -74,8 +74,8 @@ const vaultedPaymentMethodData: ShopOrder[] = [
 	},
 	{
 		// Fails due to: https://inpsyde.atlassian.net/browse/PCP-4788
-		// https://inpsyde.atlassian.net/browse/PCP-
-		title: 'PCP-0000 | Vaulting - Transaction - Pay by link - ACDC - Pay with saved card',
+		// https://inpsyde.atlassian.net/browse/PCP-5396
+		title: 'PCP-5396 | Vaulting - Transaction - Pay by link - ACDC - Pay with saved card',
 		...orders.default,
 		payment: {
 			...payments.acdc,

--- a/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
@@ -161,7 +161,7 @@ test.describe( () => {
 	} );
 
 	test(
-		'PCP-0000 | Vaulting - My Account - Payment Methods - PayPal - Unable to save additional account',
+		'PCP-5380 | Vaulting - My Account - Payment Methods - PayPal - Unable to save additional account',
 		annotateVisitor( customer ),
 		async ( { customerPaymentMethods } ) => {
 			// Preconditions
@@ -190,7 +190,7 @@ test.describe( () => {
 	} );
 
 	test(
-		'PCP-0000 | Vaulting - My Account - Payment Methods - ACDC - Save additional card',
+		'PCP-5381 | Vaulting - My Account - Payment Methods - ACDC - Save additional card',
 		annotateVisitor( customer ),
 		async ( { utils, customerPaymentMethods, classicCheckout } ) => {
 			// Preconditions

--- a/tests/qa/tests/08-subscription/_test-data/subscription-renewal.data.ts
+++ b/tests/qa/tests/08-subscription/_test-data/subscription-renewal.data.ts
@@ -75,8 +75,9 @@ const payPalRenewal: ShopOrder[] = [
 
 const payPalFreeTrialRenewal: ShopOrder[] = [
 	{
+		// Fail: https://inpsyde.atlassian.net/browse/PCP-4980
 		// https://inpsyde.atlassian.net/browse/PCP-4915
-		title: 'PCP-4915 | PayPal subscription - Free trial order renewal', //bug: https://inpsyde.atlassian.net/browse/PCP-4980
+		title: 'PCP-4915 | PayPal subscription - Free trial order renewal',
 		...orders.default,
 		payment: payments.payPal,
 		merchant,

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -110,7 +110,7 @@ export class PayPalUi {
 		this.page.frameLocator( '#braintree-hosted-field-cvv' ).locator( '#cvv' );
 	fastlaneCardHolderInput = () =>
 		this.page
-			.frameLocator( '#cardholder-name iframe' )
+			.frameLocator( '#braintree-hosted-field-cardholderName' )
 			.locator( '#cardholder-name' );
 	fastlaneOtpWindow = () =>
 		this.page.getByTestId( 'modal-sheet-inner-sheet' );

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -235,16 +235,16 @@ export class PayPalUi {
 		// Map to the tested method
 		switch ( shortcut ) {
 			case 'paypal':
-				// pay with vaulted account
+				await this.payPalGateway().click();
+				popup = await this.openPayPalPupup();
+
 				if ( payment.isVaulted ) {
-					// await this.assertVaultedPaymentMethodIsDisplayed( payment );
-					popup = await this.openPayPalPupup();
+					// pay with vaulted account
 					await expect( popup.submitPaymentButton() ).toBeVisible();
 					await popup.completePayment();
 					break;
 				}
-				// open expected PayPal popup
-				popup = await this.openPayPalPupup();
+
 				// pay with given PayPal account
 				await popup.completePayPalPayment( payPalAccount );
 				break;


### PR DESCRIPTION
SSSC should not be used when Pay Now Experience is disabled. Added the missing check for the order creation parameters.

Not sure if these flags are a bit confusing and should be refactored, but currently the idea is that "Pay Now Experience" (`'button.handle-shipping-in-paypal'` service) enables the shipping callbacks. And then if `'wcgateway.server-side-shipping-callback-enabled'` is enabled (default now) the SSSC is used, otherwise the old JS callback.