### PR TITLE
Migrate AppSwitch cross-browser handling logic to frontend (5428)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ReturnUrlFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ReturnUrlFactory.php
@@ -25,13 +25,14 @@ class ReturnUrlFactory {
 		array $request_data = array(),
 		array $custom_query_args = array()
 	): string {
-		return add_query_arg(
-			array_merge(
-				array( self::PCP_QUERY_ARG => 'button' ),
-				$custom_query_args
-			),
-			$this->wc_url_from_context( $context, $request_data )
+		$base_url = $this->wc_url_from_context( $context, $request_data );
+
+		$hash_params = array_merge(
+			array( self::PCP_QUERY_ARG => 'button' ),
+			$custom_query_args
 		);
+
+		return $base_url . '#' . http_build_query( $hash_params );
 	}
 
 	protected function wc_url_from_context( string $context, array $request_data = array() ): string {

--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -25,6 +25,7 @@ import { loadPaypalScript } from './modules/Helper/ScriptLoading';
 import buttonModuleWatcher from './modules/ButtonModuleWatcher';
 import MessagesBootstrap from './modules/ContextBootstrap/MessagesBootstrap';
 import { apmButtonsInit } from './modules/Helper/ApmButtons';
+import CrossBrowserCartRestorer from './modules/Helper/CrossBrowserCartRestorer';
 
 // TODO: could be a good idea to have a separate spinner for each gateway,
 // but I think we care mainly about the script loading, so one spinner should be enough.
@@ -44,6 +45,16 @@ const bootstrap = () => {
 			document.querySelector( '.woocommerce-notices-wrapper' )
 	);
 	const spinner = new Spinner();
+
+	// Check if we need to handle cross-browser AppSwitch
+	const crossBrowserCartRestorer = new CrossBrowserCartRestorer(
+		PayPalCommerceGateway
+	);
+
+	if ( crossBrowserCartRestorer.shouldRestore() ) {
+		crossBrowserCartRestorer.restore();
+		return; // Stop bootstrap - we're handling cross-browser order creation
+	}
 
 	const formSaver = new FormSaver(
 		PayPalCommerceGateway.ajax.save_checkout_form.endpoint,
@@ -90,7 +101,10 @@ const bootstrap = () => {
 	};
 
 	const doBasicCheckoutValidation = () => {
-		if ( PayPalCommerceGateway.basic_checkout_validation_enabled || PayPalCommerceGateway.is_free_trial_cart ) {
+		if (
+			PayPalCommerceGateway.basic_checkout_validation_enabled ||
+			PayPalCommerceGateway.is_free_trial_cart
+		) {
 			// A quick fix to get the errors about empty form fields before attempting PayPal order,
 			// it should solve #513 for most of the users, but it is not a proper solution.
 			// Currently it is disabled by default because a better solution is now implemented

--- a/modules/ppcp-button/resources/js/modules/Helper/CrossBrowserCartRestorer.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/CrossBrowserCartRestorer.js
@@ -1,0 +1,147 @@
+import ResumeFlowHelper from './ResumeFlowHelper';
+import Spinner from './Spinner';
+
+/**
+ * Handles cross-browser cart restoration for AppSwitch flows
+ */
+class CrossBrowserCartRestorer {
+	constructor( config ) {
+		this.config = config;
+	}
+
+	/**
+	 * Check if we should restore (create cross-browser order)
+	 *
+	 * @return {boolean} True if this is a cross-browser AppSwitch return
+	 */
+	shouldRestore() {
+		if ( ! this.isAppSwitchReturn() ) {
+			return false;
+		}
+
+		const cartKey = this.getCartKeyFromHash();
+		const savedCartHash = this.getSavedCartHashFromHash();
+
+		if ( ! cartKey || ! savedCartHash ) {
+			return false;
+		}
+
+		const currentCartHash = this.config.cart_hash;
+
+		// If cart hashes match, no need for cross-browser handling.
+		return currentCartHash !== savedCartHash;
+	}
+
+	restore() {
+		const cartKey = this.getCartKeyFromHash();
+		this.createCrossBrowserOrder( cartKey );
+	}
+
+	createCrossBrowserOrder( cartKey ) {
+		const endpointConfig = this.config.ajax?.create_cross_browser_order;
+
+		if ( ! endpointConfig || ! endpointConfig.endpoint ) {
+			console.error(
+				'Create cross-browser order endpoint not configured'
+			);
+			return;
+		}
+
+		const spinner = Spinner.fullPage();
+		spinner.block();
+
+		fetch( endpointConfig.endpoint, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			credentials: 'same-origin',
+			body: JSON.stringify( {
+				nonce: endpointConfig.nonce,
+				cart_key: cartKey,
+			} ),
+		} )
+			.then( ( response ) => response.json() )
+			.then( ( response ) => {
+				const { success, data } = response;
+
+				if ( ! success ) {
+					console.error(
+						'Cross-browser order creation failed:',
+						data?.message
+					);
+					return;
+				}
+
+				if ( ! data.redirect ) {
+					console.error(
+						'Missing redirect URL in cross-browser order creation response'
+					);
+					return;
+				}
+
+				this.cleanCrossBrowserAppSwitchParams();
+				window.location.href = data.redirect + window.location.hash;
+			} )
+			.catch( ( error ) => {
+				console.error( 'Error creating cross-browser order:', error );
+			} )
+			.finally( () => spinner.unblock() );
+	}
+
+	/**
+	 * Clean cross-browser AppSwitch params from hash while preserving PayPal's params
+	 */
+	cleanCrossBrowserAppSwitchParams() {
+		if ( ! window.location.hash ) {
+			return;
+		}
+
+		const CROSS_BROWSER_APPSWITCH_PARAMS = [
+			'pcp-return',
+			'pcp-cart',
+			'pcp-cart-hash',
+		];
+
+		const hashString = window.location.hash.substring( 1 );
+		const params = hashString.split( '&' );
+
+		const cleanedParams = params.filter( ( param ) => {
+			const paramName = param.split( '=' )[ 0 ];
+			return ! CROSS_BROWSER_APPSWITCH_PARAMS.includes( paramName );
+		} );
+
+		const baseUrl = window.location.pathname + window.location.search;
+
+		const newHash = '#' + cleanedParams.join( '&' );
+		window.history.replaceState( null, '', baseUrl + newHash );
+	}
+
+	isAppSwitchReturn() {
+		const params = this.getHashParams();
+		return params[ 'pcp-return' ] === 'button';
+	}
+
+	getCartKeyFromHash() {
+		const params = this.getHashParams();
+		return params[ 'pcp-cart' ] || null;
+	}
+
+	getSavedCartHashFromHash() {
+		const params = this.getHashParams();
+		return params[ 'pcp-cart-hash' ] || null;
+	}
+
+	getHashParams() {
+		if ( ! window.location.hash ) {
+			return {};
+		}
+
+		const hashString = window.location.hash.substring( 1 );
+		const params = new URLSearchParams( hashString );
+
+		return Object.fromEntries( params );
+	}
+}
+
+export default CrossBrowserCartRestorer;

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -28,6 +28,7 @@ use WooCommerce\PayPalCommerce\Button\Assets\SmartButton;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ChangeCartEndpoint;
+use WooCommerce\PayPalCommerce\Button\Endpoint\CreateCrossBrowserOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\CreateOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\DataClientIdEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\GetOrderEndpoint;
@@ -260,6 +261,19 @@ return array(
 			$wc_order_creator,
 			$logger,
 			$context
+		);
+	},
+	'button.endpoint.create-cross-browser-order'  => static function ( ContainerInterface $container ): CreateCrossBrowserOrderEndpoint {
+		$request_data      = $container->get( 'button.request-data' );
+		$cart_data_storage = $container->get( 'button.session.storage.card-data.transient' );
+		$order_endpoint    = $container->get( 'api.endpoint.order' );
+		$wc_order_creator  = $container->get( 'button.helper.wc-order-creator' );
+
+		return new CreateCrossBrowserOrderEndpoint(
+			$request_data,
+			$cart_data_storage,
+			$order_endpoint,
+			$wc_order_creator
 		);
 	},
 	'button.endpoint.approve-subscription'        => static function ( ContainerInterface $container ): ApproveSubscriptionEndpoint {

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -27,6 +27,7 @@ use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveSubscriptionEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\CartScriptParamsEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ChangeCartEndpoint;
+use WooCommerce\PayPalCommerce\Button\Endpoint\CreateCrossBrowserOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\CreateOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\DataClientIdEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\GetOrderEndpoint;
@@ -1247,6 +1248,10 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 					'wp_rest_nonce'          => wp_create_nonce( 'wc_store_api' ),
 					'update_shipping_method' => \WC_AJAX::get_endpoint( 'update_shipping_method' ),
 				),
+				'create_cross_browser_order'     => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreateCrossBrowserOrderEndpoint::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreateCrossBrowserOrderEndpoint::nonce() ),
+				),
 			),
 			'cart_contains_subscription'              => $this->subscription_helper->cart_contains_subscription(),
 			'subscription_plan_id'                    => $this->subscription_helper->paypal_subscription_id(),
@@ -1380,6 +1385,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'productType'                             => null,
 			'manualRenewalEnabled'                    => $this->subscription_helper->accept_manual_renewals(),
 			'final_review_enabled'                    => $this->final_review_enabled,
+			'cart_hash'                               => WC()->cart ? WC()->cart->get_cart_hash() : '',
 		);
 
 		if ( is_product() ) {

--- a/modules/ppcp-button/src/ButtonModule.php
+++ b/modules/ppcp-button/src/ButtonModule.php
@@ -20,6 +20,7 @@ use WooCommerce\PayPalCommerce\Button\Endpoint\ValidateCheckoutEndpoint;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ApproveOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\ChangeCartEndpoint;
+use WooCommerce\PayPalCommerce\Button\Endpoint\CreateCrossBrowserOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\CreateOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\DataClientIdEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\GetOrderEndpoint;
@@ -104,7 +105,7 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 
 		$this->register_ajax_endpoints( $c );
 
-		$this->register_appswitch_crossbrowser_handler( $c );
+		$this->register_crossbrowser_order_filters( $c );
 
 		return true;
 	}
@@ -235,124 +236,30 @@ class ButtonModule implements ServiceModule, ExtendingModule, ExecutableModule {
 				$endpoint->handle_request();
 			}
 		);
+
+		add_action(
+			'wc_ajax_' . CreateCrossBrowserOrderEndpoint::ENDPOINT,
+			static function () use ( $container ) {
+				$endpoint = $container->get( 'button.endpoint.create-cross-browser-order' );
+				assert( $endpoint instanceof CreateCrossBrowserOrderEndpoint );
+				$endpoint->handle_request();
+			}
+		);
 	}
 
 	private static function is_cross_browser_order( WC_Order $wc_order ): bool {
 		return wc_string_to_bool( $wc_order->get_meta( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY ) );
 	}
 
-	private function register_appswitch_crossbrowser_handler( ContainerInterface $container ): void {
+	/**
+	 * Register filters that handle cross-browser AppSwitch orders.
+	 * These filters allow guests to access pay-for-order and order-received pages
+	 * for orders created via cross-browser AppSwitch flows.
+	 */
+	private function register_crossbrowser_order_filters( ContainerInterface $container ): void {
 		if ( ! $container->get( 'wcgateway.appswitch-enabled' ) ) {
 			return;
 		}
-
-		// After returning from cross-browser AppSwitch (started in non-default browser, then redirected to the default one)
-		// we need to retrieve the saved cart and PayPal order, create a WC order and redirect to Pay for order.
-		add_action(
-			'wp',
-			static function () use ( $container ) {
-				// phpcs:ignore WordPress.Security.NonceVerification
-				if ( ! isset( $_GET[ ReturnUrlFactory::PCP_QUERY_ARG ] ) ) {
-					return;
-				}
-
-				if ( is_checkout_pay_page() ) {
-					return;
-				}
-
-				// phpcs:ignore WordPress.Security.NonceVerification
-				if ( ! isset( $_GET[ CreateOrderEndpoint::RETURN_URL_CART_QUERY_ARG ] ) ) {
-					return;
-				}
-
-				// phpcs:ignore WordPress.Security.NonceVerification
-				$cart_key = wc_clean( wp_unslash( $_GET[ CreateOrderEndpoint::RETURN_URL_CART_QUERY_ARG ] ) );
-				if ( ! is_string( $cart_key ) ) {
-					return;
-				}
-
-				$card_data_storage = $container->get( 'button.session.storage.card-data.transient' );
-				assert( $card_data_storage instanceof CartDataTransientStorage );
-
-				$cart_data = $card_data_storage->get( $cart_key );
-				if ( ! $cart_data ) {
-					return;
-				}
-
-				// Delete the data to avoid accidentally triggering it again, duplicating orders etc.
-				$card_data_storage->remove( $cart_data );
-
-				if ( ! WC()->cart ) {
-					return;
-				}
-				// The current cart is the same, so we don't need to do anything (probably not cross-browser).
-				if ( WC()->cart->get_cart_hash() === $cart_data->cart_hash() ) {
-					return;
-				}
-
-				$paypal_order_id = $cart_data->paypal_order_id();
-				if ( empty( $paypal_order_id ) ) {
-					return;
-				}
-
-				$order_endpoint = $container->get( 'api.endpoint.order' );
-				assert( $order_endpoint instanceof OrderEndpoint );
-
-				$paypal_order = $order_endpoint->order( $paypal_order_id );
-
-				$wc_order_creator = $container->get( 'button.helper.wc-order-creator' );
-				assert( $wc_order_creator instanceof WooCommerceOrderCreator );
-
-				$wc_order = $wc_order_creator->create_from_paypal_order( $paypal_order, $cart_data );
-
-				$wc_order->update_meta_data( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY, wc_bool_to_string( true ) );
-				$wc_order->save();
-
-				// Redirect via JS because we need to keep the # parameters which are not accessible on the server side.
-				// phpcs:ignore WordPress.Security.EscapeOutput
-				echo "<script>location.href = '" . $wc_order->get_checkout_payment_url() . "' + location.hash;</script>";
-			}
-		);
-
-		/**
-		 * Restore PayPal as the chosen payment method when returning from an App Switch flow.
-		 *
-		 * Context:
-		 * --------
-		 * When Fastlane (AXO) is active, AxoModule forces the chosen payment method to
-		 * AxoGateway on every checkout page load. This causes a problem when the customer
-		 * initiated checkout with PayPal and was redirected to the PayPal app
-		 * (App Switch): after resuming, the checkout would incorrectly show AxoGateway,
-		 * leading to validation errors and failed payments.
-		 *
-		 * Solution:
-		 * ---------
-		 * This handler runs after the AxoModule one (priority 20). It checks for the
-		 * PayPal return URL query arguments that indicate an App Switch resume, and if
-		 * present, forces the chosen method back to PayPalGateway. This ensures the
-		 * resumed PayPal flow continues as expected.
-		 */
-		add_action(
-			'template_redirect',
-			function () use ( $container ) {
-				// phpcs:ignore WordPress.Security.NonceVerification
-				if ( ! isset( $_GET[ ReturnUrlFactory::PCP_QUERY_ARG ] ) ) {
-					return;
-				}
-
-				if ( is_checkout_pay_page() ) {
-					return;
-				}
-
-				// phpcs:ignore WordPress.Security.NonceVerification
-				if ( ! isset( $_GET[ CreateOrderEndpoint::RETURN_URL_CART_QUERY_ARG ] ) ) {
-					return;
-				}
-
-				WC()->session->set( 'chosen_payment_method', PayPalGateway::ID );
-			},
-			20
-		);
 
 		/**
 		 * By default, WC asks to log in when opening a non-guest Pay for order page as a guest,

--- a/modules/ppcp-button/src/Endpoint/CreateCrossBrowserOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateCrossBrowserOrderEndpoint.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * The endpoint to create WooCommerce order for cross-browser AppSwitch flows.
+ *
+ * @package WooCommerce\PayPalCommerce\Button\Endpoint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Endpoint;
+
+use Exception;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\Button\Helper\WooCommerceOrderCreator;
+use WooCommerce\PayPalCommerce\Button\Session\CartDataTransientStorage;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+class CreateCrossBrowserOrderEndpoint implements EndpointInterface {
+
+	const ENDPOINT = 'ppc-create-cross-browser-order';
+
+	private RequestData $request_data;
+
+	private CartDataTransientStorage $cart_data_storage;
+
+	private OrderEndpoint $order_endpoint;
+
+	private WooCommerceOrderCreator $wc_order_creator;
+
+	public function __construct(
+		RequestData $request_data,
+		CartDataTransientStorage $cart_data_storage,
+		OrderEndpoint $order_endpoint,
+		WooCommerceOrderCreator $wc_order_creator
+	) {
+		$this->request_data      = $request_data;
+		$this->cart_data_storage = $cart_data_storage;
+		$this->order_endpoint    = $order_endpoint;
+		$this->wc_order_creator  = $wc_order_creator;
+	}
+
+	public static function nonce(): string {
+		return self::ENDPOINT;
+	}
+
+	public function handle_request(): bool {
+		try {
+			$data = $this->request_data->read_request( self::nonce() );
+
+			if ( ! isset( $data['cart_key'] ) ) {
+				wp_send_json_error( array( 'message' => 'Cart key missing' ) );
+				return false;
+			}
+
+			$cart_key  = $data['cart_key'];
+			$cart_data = $this->cart_data_storage->get( $cart_key );
+
+			if ( ! $cart_data ) {
+				wp_send_json_error( array( 'message' => 'Cart data not found' ) );
+				return false;
+			}
+
+			$this->cart_data_storage->remove( $cart_data );
+
+			if ( WC()->cart && WC()->cart->get_cart_hash() === $cart_data->cart_hash() ) {
+				wp_send_json_success( array( 'message' => 'Cart already current' ) );
+				return true;
+			}
+
+			$paypal_order_id = $cart_data->paypal_order_id();
+			if ( empty( $paypal_order_id ) ) {
+				wp_send_json_error( array( 'message' => 'PayPal order ID missing' ) );
+				return false;
+			}
+
+			$paypal_order = $this->order_endpoint->order( $paypal_order_id );
+			$wc_order     = $this->wc_order_creator->create_from_paypal_order( $paypal_order, $cart_data );
+
+			$wc_order->update_meta_data( PayPalGateway::CROSS_BROWSER_APPSWITCH_META_KEY, wc_bool_to_string( true ) );
+			$wc_order->save();
+
+			wp_send_json_success(
+				array(
+					'redirect' => $wc_order->get_checkout_payment_url(),
+				)
+			);
+			return true;
+
+		} catch ( Exception $exception ) {
+			wp_send_json_error( array( 'message' => $exception->getMessage() ) );
+			return false;
+		}
+	}
+}

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -506,6 +506,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 				assert( ! empty( $key ) );
 
 				$custom_args[ self::RETURN_URL_CART_QUERY_ARG ] = $key;
+				$custom_args['pcp-cart-hash']                    = $cart_data->cart_hash();
 			} catch ( Throwable $exception ) {
 				$this->logger->error( 'Failed to serialize cart: ' . $exception->getMessage() );
 			}


### PR DESCRIPTION
The previous approach for handling cross-browser AppSwitch flows relied on adding query parameters to the return URL. This approach broke the same-tab AppSwitch flow because with the addition of the query parameters, the browser detected the return URL as a different URL and opened a new tab, causing all orders to go through the resume flow.

To solve this, this PR migrates the cross-browser detection and handling logic to the frontend.