### PR TITLE
Add CODEOWNERS file for automatic PR review assignments (5321)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS file for PayPal Payments Plugin
+# This file defines code owners who will automatically be requested for review
+# when a pull request touches files matching the specified patterns.
+
+# Global owners - will be requested for review on all changes
+# @Dinamiko is listed first as dev lead, followed by team members in alphabetical order
+* @Dinamiko @AlexP11223 @danieldudzic @hmouhtar @Narek13 @puntope @stracker-phil
+
+# You can also add specific patterns for different parts of the codebase:
+# Examples (uncomment and modify as needed):
+# /src/                    @Dinamiko @stracker-phil
+# /tests/                  @AlexP11223 @hmouhtar
+# /assets/                 @danieldudzic @puntope
+# /.github/workflows/      @Narek13
+# /docs/                   @Dinamiko


### PR DESCRIPTION
## Issue Description
Create a CODEOWNERS file to automatically assign PR code reviews to team members, streamlining the review process and ensuring consistent code oversight across the repository.

## PR Description
This PR adds a `.github/CODEOWNERS` file that automatically requests reviews from all team members when pull requests are opened.

### Changes
- Added `.github/CODEOWNERS` file with all team members as global code owners
- @Dinamiko is listed first as dev lead, followed by team members in alphabetical order (@AlexP11223, @danieldudzic, @hmouhtar, @Narek13, @puntope, @stracker-phil)
- Includes commented examples for future customization of specific directory ownership

### Benefits
- Automatic review assignments on all PRs
- Reduces manual work of assigning reviewers
- All team members notified when PRs are opened

### Testing
- CODEOWNERS file syntax validated by GitHub ✓
- File placed in `.github/` directory following GitHub best practices
