### PR TITLE
Replace undefined `should_render_fastlane()` method call in AxoModule (5438)

### DIFF
--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -354,7 +354,7 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $args ) use ( $c ): array {
+			function ( $args ) use ( $c ): array {
 				$axo_applies = $c->get( 'axo.service.axo-applies' );
 				assert( $axo_applies instanceof AxoApplies );
 

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -354,14 +354,15 @@ class AxoModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function( $args, $endpoint ) use ( $c ): array {
-				if ( $this->should_render_fastlane( $c ) ) {
+			function( $args ) use ( $c ): array {
+				$axo_applies = $c->get( 'axo.service.axo-applies' );
+				assert( $axo_applies instanceof AxoApplies );
+
+				if ( $axo_applies->should_render_fastlane() ) {
 					$args['ppcp_fastlane_error'] = '1';
 				}
 				return $args;
 			},
-			10,
-			2
 		);
 
 		// Remove Fastlane on the Pay for Order page.


### PR DESCRIPTION
## Issue Description
The `AxoModule` class was calling an undefined method `$this->should_render_fastlane()` in the `ppcp_return_url_error_args` filter callback

## PR Description
This PR fixes the undefined method error in `AxoModule` by properly using the `AxoApplies` service from the dependency container.

### Changes
- Replaced `$this->should_render_fastlane()` call with proper service injection in AxoModule
- Added `$axo_applies` service retrieval from container with type assertion
- Called `$axo_applies->should_render_fastlane()` instead of the non-existent method
- Removed unused `$endpoint` parameter from filter callback signature
- Simplified filter hook parameters (removed explicit priority)