### PR TITLE
Disable SSSC when site is using plain permalinks (5440)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2368,10 +2368,15 @@ return array(
 	},
 
 	'wcgateway.server-side-shipping-callback-enabled'      => static function ( ContainerInterface $container ): bool {
+		// SSSC depends on Woo's Store API, which doesn't work with plain permalinks.
+		$has_plain_permalinks = empty( get_option( 'permalink_structure' ) );
+
+		$enabled = getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) !== '0' && ! $has_plain_permalinks;
+
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.server_side_shipping_callback_enabled',
-			getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) !== '0'
+			$enabled
 		);
 	},
 


### PR DESCRIPTION
SSSC depends on Woo's Store API update customer endpoint, which currently does not work on sites with plain permalinks due to the bug described in [this thread](https://inpsyde.slack.com/archives/C01DZR401NG/p1759880563876229). 

As a workaround, this PR disables SSSC when the site is using plain permalinks.