### PR TITLE
Disable cross-browser AppSwitch query parameters (5441)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ReturnUrlFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ReturnUrlFactory.php
@@ -25,15 +25,6 @@ class ReturnUrlFactory {
 		array $request_data = array(),
 		array $custom_query_args = array()
 	): string {
-		// TODO: Temporarily disabled cross-browser appswitch query params.
-		// This logic will be migrated to the frontend using hash params instead of query params
-		// return add_query_arg(
-		// array_merge(
-		// array( self::PCP_QUERY_ARG => 'button' ),
-		// $custom_query_args
-		// ),
-		// $this->wc_url_from_context( $context, $request_data )
-		// );
 		return $this->wc_url_from_context( $context, $request_data );
 	}
 

--- a/modules/ppcp-api-client/src/Factory/ReturnUrlFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ReturnUrlFactory.php
@@ -25,13 +25,16 @@ class ReturnUrlFactory {
 		array $request_data = array(),
 		array $custom_query_args = array()
 	): string {
-		return add_query_arg(
-			array_merge(
-				array( self::PCP_QUERY_ARG => 'button' ),
-				$custom_query_args
-			),
-			$this->wc_url_from_context( $context, $request_data )
-		);
+		// TODO: Temporarily disabled cross-browser appswitch query params.
+		// This logic will be migrated to the frontend using hash params instead of query params
+		// return add_query_arg(
+		// array_merge(
+		// array( self::PCP_QUERY_ARG => 'button' ),
+		// $custom_query_args
+		// ),
+		// $this->wc_url_from_context( $context, $request_data )
+		// );
+		return $this->wc_url_from_context( $context, $request_data );
 	}
 
 	protected function wc_url_from_context( string $context, array $request_data = array() ): string {

--- a/tests/PHPUnit/ApiClient/Factory/ReturnUrlFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ReturnUrlFactoryTest.php
@@ -37,7 +37,7 @@ class ReturnUrlFactoryTest extends TestCase
 
 		$result = $this->testee->from_context($context);
 
-		$this->assertEquals('https://example.com/cart?pcp-return=button', $result);
+		$this->assertEquals('https://example.com/cart', $result);
 	}
 
     public function testFromContextProductReturnsProductUrl()
@@ -56,7 +56,7 @@ class ReturnUrlFactoryTest extends TestCase
 
         $result = $this->testee->from_context('product', $request_data);
 
-        $this->assertEquals('https://example.com/product/123?pcp-return=button', $result);
+        $this->assertEquals('https://example.com/product/123', $result);
     }
 
     public function testFromContextProductThrowsExceptionWhenNoUrl()
@@ -90,7 +90,7 @@ class ReturnUrlFactoryTest extends TestCase
 
         $result = $this->testee->from_context('pay-now', $request_data);
 
-        $this->assertEquals('https://example.com/checkout/pay/123?key=abc&pcp-return=button', $result);
+        $this->assertEquals('https://example.com/checkout/pay/123?key=abc', $result);
     }
 
     public function testFromContextPayNowThrowsExceptionWhenOrderNotFound()
@@ -110,7 +110,7 @@ class ReturnUrlFactoryTest extends TestCase
 
         $result = $this->testee->from_context('checkout');
 
-        $this->assertEquals('https://example.com/checkout?pcp-return=button', $result);
+        $this->assertEquals('https://example.com/checkout', $result);
     }
 
     public function testFromContextDefaultReturnsCheckoutUrl()
@@ -119,17 +119,8 @@ class ReturnUrlFactoryTest extends TestCase
 
         $result = $this->testee->from_context('unknown-context');
 
-        $this->assertEquals('https://example.com/checkout?pcp-return=button', $result);
+        $this->assertEquals('https://example.com/checkout', $result);
     }
-
-	public function testFromContextReturnsCartUrlWithCustomArgs()
-	{
-		when('wc_get_cart_url')->justReturn('https://example.com/cart');
-
-		$result = $this->testee->from_context('cart', [], ['session' => '123']);
-
-		$this->assertEquals('https://example.com/cart?pcp-return=button&session=123', $result);
-	}
 
 	public function cartContextProvider(): array
 	{


### PR DESCRIPTION
The current approach for handling cross-browser AppSwitch flows relies on adding query parameters to the return URL. This approach broke the same-tab AppSwitch flow because with the addition of the query parameters, the browser detects the return URL as a different URL and opens a new tab, causing all orders to go through the resume flow.

This will be solved on a later release by https://github.com/woocommerce/woocommerce-paypal-payments/pull/3755, in the meantime, PayPal has requested to disable support for cross-browser AppSwitch, which is done in this PR.