### PR TITLE
Disable SSSC if no webhooks

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2368,7 +2368,7 @@ return array(
 	},
 
 	'wcgateway.server-side-shipping-callback-enabled'      => static function ( ContainerInterface $container ): bool {
-		// SSSC depends on Woo's Store API, which doesn't work with plain permalinks.
+		// SSSC depends on Woo's Store API, which currently doesn't work with plain permalinks because of the rest_get_url_prefix bug.
 		$has_plain_permalinks = empty( get_option( 'permalink_structure' ) );
 
 		$enabled = getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) !== '0' && ! $has_plain_permalinks;

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -101,6 +101,7 @@ use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Factory\CartTotalsFactory;
 use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Factory\MoneyFactory;
 use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Factory\ShippingRatesFactory;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use WooCommerce\PayPalCommerce\Webhooks\WebhookEventStorage;
 
 return array(
 	'wcgateway.paypal-gateway'                             => static function ( ContainerInterface $container ): PayPalGateway {
@@ -2371,7 +2372,15 @@ return array(
 		// SSSC depends on Woo's Store API, which currently doesn't work with plain permalinks because of the rest_get_url_prefix bug.
 		$has_plain_permalinks = empty( get_option( 'permalink_structure' ) );
 
-		$enabled = getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) !== '0' && ! $has_plain_permalinks;
+		$last_webhook_storage = $container->get( 'webhook.last-webhook-storage' );
+		assert( $last_webhook_storage instanceof WebhookEventStorage );
+
+		// Not directly related, but if webhooks are not arriving then SSSC probably is not accessible too.
+		$webhooks_working = ! $last_webhook_storage->is_empty();
+
+		$enabled = getenv( 'PCP_SERVER_SIDE_SHIPPING_CALLBACK_ENABLED' ) !== '0'
+			&& ! $has_plain_permalinks
+			&& $webhooks_working;
 
 		return apply_filters(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -48,6 +48,7 @@ return array(
 			$endpoint,
 			$rest_endpoint,
 			$last_webhook_storage,
+			$container->get( 'webhook.status.simulation' ),
 			$logger
 		);
 	},

--- a/modules/ppcp-webhooks/src/Status/WebhookSimulation.php
+++ b/modules/ppcp-webhooks/src/Status/WebhookSimulation.php
@@ -78,12 +78,16 @@ class WebhookSimulation {
 	 *
 	 * @throws Exception If failed to start simulation.
 	 */
-	public function start(): void {
-		if ( ! $this->webhook ) {
+	public function start( ?Webhook $webhook = null ): void {
+		if ( ! $webhook ) {
+			$webhook = $this->webhook;
+		}
+
+		if ( ! $webhook ) {
 			throw new Exception( 'Webhooks not registered' );
 		}
 
-		$event = $this->webhook_endpoint->simulate( $this->webhook, $this->event_type, $this->resource_version );
+		$event = $this->webhook_endpoint->simulate( $webhook, $this->event_type, $this->resource_version );
 
 		$this->save(
 			array(

--- a/modules/ppcp-webhooks/src/WebhookRegistrar.php
+++ b/modules/ppcp-webhooks/src/WebhookRegistrar.php
@@ -8,6 +8,7 @@ use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookFactory;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 
 /**
  * The WebhookRegistrar registers and unregisters webhooks with PayPal.
@@ -24,6 +25,8 @@ class WebhookRegistrar {
 
 	private WebhookEventStorage $last_webhook_event_storage;
 
+	private WebhookSimulation $webhook_simulation;
+
 	private LoggerInterface $logger;
 
 	public function __construct(
@@ -31,6 +34,7 @@ class WebhookRegistrar {
 		WebhookEndpoint $endpoint,
 		IncomingWebhookEndpoint $incoming_webhook_endpoint,
 		WebhookEventStorage $last_webhook_event_storage,
+		WebhookSimulation $webhook_simulation,
 		LoggerInterface $logger
 	) {
 
@@ -38,6 +42,7 @@ class WebhookRegistrar {
 		$this->endpoint                   = $endpoint;
 		$this->incoming_webhook_endpoint  = $incoming_webhook_endpoint;
 		$this->last_webhook_event_storage = $last_webhook_event_storage;
+		$this->webhook_simulation         = $webhook_simulation;
 		$this->logger                     = $logger;
 	}
 
@@ -59,11 +64,17 @@ class WebhookRegistrar {
 			if ( empty( $created->id() ) ) {
 				return false;
 			}
+
 			update_option(
 				self::KEY,
 				$created->to_array()
 			);
+
 			$this->last_webhook_event_storage->clear();
+
+			// Check whether webhooks are arriving (e.g. for the Status page).
+			$this->webhook_simulation->start( $created );
+
 			$this->logger->info( 'Webhooks subscribed.' );
 			return true;
 		} catch ( RuntimeException $error ) {

--- a/modules/ppcp-webhooks/src/WebhookRegistrar.php
+++ b/modules/ppcp-webhooks/src/WebhookRegistrar.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * The WebhookRegistrar registers and unregisters webhooks with PayPal.
- *
- * @package WooCommerce\PayPalCommerce\Webhooks
- */
 
 declare(strict_types=1);
 
@@ -15,69 +10,33 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookFactory;
 
 /**
- * Class WebhookRegistrar
+ * The WebhookRegistrar registers and unregisters webhooks with PayPal.
  */
 class WebhookRegistrar {
-
-
 	const EVENT_HOOK = 'ppcp-register-event';
 	const KEY        = 'ppcp-webhook';
 
-	/**
-	 * The Webhook factory.
-	 *
-	 * @var WebhookFactory
-	 */
-	private $webhook_factory;
+	private WebhookFactory $webhook_factory;
 
-	/**
-	 * The Webhook endpoint.
-	 *
-	 * @var WebhookEndpoint
-	 */
-	private $endpoint;
+	private WebhookEndpoint $endpoint;
 
-	/**
-	 * The WordPress Rest API endpoint.
-	 *
-	 * @var IncomingWebhookEndpoint
-	 */
-	private $rest_endpoint;
+	private IncomingWebhookEndpoint $incoming_webhook_endpoint;
 
-	/**
-	 * The last webhook event storage.
-	 *
-	 * @var WebhookEventStorage
-	 */
-	private $last_webhook_event_storage;
+	private WebhookEventStorage $last_webhook_event_storage;
 
-	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
-	private $logger;
+	private LoggerInterface $logger;
 
-	/**
-	 * WebhookRegistrar constructor.
-	 *
-	 * @param WebhookFactory          $webhook_factory The Webhook factory.
-	 * @param WebhookEndpoint         $endpoint The Webhook endpoint.
-	 * @param IncomingWebhookEndpoint $rest_endpoint The WordPress Rest API endpoint.
-	 * @param WebhookEventStorage     $last_webhook_event_storage The last webhook event storage.
-	 * @param LoggerInterface         $logger The logger.
-	 */
 	public function __construct(
 		WebhookFactory $webhook_factory,
 		WebhookEndpoint $endpoint,
-		IncomingWebhookEndpoint $rest_endpoint,
+		IncomingWebhookEndpoint $incoming_webhook_endpoint,
 		WebhookEventStorage $last_webhook_event_storage,
 		LoggerInterface $logger
 	) {
 
 		$this->webhook_factory            = $webhook_factory;
 		$this->endpoint                   = $endpoint;
-		$this->rest_endpoint              = $rest_endpoint;
+		$this->incoming_webhook_endpoint  = $incoming_webhook_endpoint;
 		$this->last_webhook_event_storage = $last_webhook_event_storage;
 		$this->logger                     = $logger;
 	}
@@ -91,8 +50,8 @@ class WebhookRegistrar {
 		$this->unregister();
 
 		$webhook = $this->webhook_factory->for_url_and_events(
-			$this->rest_endpoint->url(),
-			$this->rest_endpoint->handled_event_types()
+			$this->incoming_webhook_endpoint->url(),
+			$this->incoming_webhook_endpoint->handled_event_types()
 		);
 
 		try {


### PR DESCRIPTION
Currently there is a confusing generic error in PayPal when the server-side callback is not working/not accessible. So we should  only use SSSC after checking basic prerequisites such as that webhooks are working (not directly related, but if webhooks are not arriving then SSSC probably is not accessible too), unless enforced with a filter.

Added a check for webhooks via the last webhook storage, e.g. like on the Status page. And now automatically requesting a test webhook after (re-)registering webhooks, otherwise the status would update only after performing the payment or pressing the Simulate button.