### PR TITLE
Reload buttons on AppSwitch cancel callback (5237)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CartActionHandler.js
@@ -89,15 +89,17 @@ class CartActionHandler {
 		return {
 			createOrder,
 			onApprove: onApprove( this, this.errorHandler ),
+			onCancel: () => {
+				ResumeFlowHelper.reloadButtonsIfRequired(
+					this.config.button.wrapper
+				);
+			},
 			onError: () => {
 				this.errorHandler.genericError();
 
-				if ( ResumeFlowHelper.isResumeFlow() ) {
-					ResumeFlowHelper.cleanHashParams();
-					jQuery( this.config.button.wrapper ).trigger(
-						'ppcp-reload-buttons'
-					);
-				}
+				ResumeFlowHelper.reloadButtonsIfRequired(
+					this.config.button.wrapper
+				);
 			},
 		};
 	}

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/CheckoutActionHandler.js
@@ -161,6 +161,10 @@ class CheckoutActionHandler {
 			onApprove: onApprove( this, this.errorHandler ),
 			onCancel: () => {
 				spinner.unblock();
+
+				ResumeFlowHelper.reloadButtonsIfRequired(
+					this.config.button.wrapper
+				);
 			},
 			onError: ( err ) => {
 				console.error( err );
@@ -172,12 +176,9 @@ class CheckoutActionHandler {
 
 				this.errorHandler.genericError();
 
-				if ( ResumeFlowHelper.isResumeFlow() ) {
-					ResumeFlowHelper.cleanHashParams();
-					jQuery( this.config.button.wrapper ).trigger(
-						'ppcp-reload-buttons'
-					);
-				}
+				ResumeFlowHelper.reloadButtonsIfRequired(
+					this.config.button.wrapper
+				);
 			},
 		};
 	}

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
@@ -66,12 +66,9 @@ class SingleProductActionHandler {
 			onError: ( err ) => {
 				console.error( err );
 
-				if ( ResumeFlowHelper.isResumeFlow() ) {
-					ResumeFlowHelper.cleanHashParams();
-					jQuery( this.config.button.wrapper ).trigger(
-						'ppcp-reload-buttons'
-					);
-				}
+				ResumeFlowHelper.reloadButtonsIfRequired(
+					this.config.button.wrapper
+				);
 			},
 		};
 	}
@@ -95,12 +92,9 @@ class SingleProductActionHandler {
 					this.errorHandler.genericError();
 				}
 
-				if ( ResumeFlowHelper.isResumeFlow() ) {
-					ResumeFlowHelper.cleanHashParams();
-					jQuery( this.config.button.wrapper ).trigger(
-						'ppcp-reload-buttons'
-					);
-				}
+				ResumeFlowHelper.reloadButtonsIfRequired(
+					this.config.button.wrapper
+				);
 			},
 			onCancel: () => {
 				// Could be used for every product type,
@@ -110,6 +104,10 @@ class SingleProductActionHandler {
 				} else {
 					this.refreshMiniCart();
 				}
+
+				ResumeFlowHelper.reloadButtonsIfRequired(
+					this.config.button.wrapper
+				);
 			},
 		};
 	}

--- a/modules/ppcp-button/resources/js/modules/Helper/ResumeFlowHelper.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/ResumeFlowHelper.js
@@ -54,6 +54,13 @@ class ResumeFlowHelper {
 			return paramName === 'switch_initiated_time';
 		} );
 	}
+
+	static reloadButtonsIfRequired( buttonWrapper ) {
+		if ( this.isResumeFlow() ) {
+			this.cleanHashParams();
+			jQuery( buttonWrapper ).trigger( 'ppcp-reload-buttons' );
+		}
+	}
 }
 
 export default ResumeFlowHelper;


### PR DESCRIPTION
When the AppSwitch resume flow is detected, the buttons are not rendered, which is the intended behaviour. However, when the user manually cancels the payment in the PayPal modal, the page gets stuck in a loop where the buttons are never rendered because the `onCancel` callback hash param in the URL keeps triggering the resume flow, even upon reloading the page.

To fix this, this PR reuses the same logic that is applied in the `onError` callback: removing the AppSwitch hash params from the URL and triggering the button reload event.