### PR TITLE
Use correct instantPaymentsOnly setting in PayPal Settings

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/PaypalSettings.js
@@ -19,6 +19,8 @@ const PaypalSettings = ( { hasContactModule } ) => {
 		setContactModule,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
+		instantPaymentsOnly,
+		setInstantPaymentsOnly,
 		brandName,
 		setBrandName,
 		softDescriptor,
@@ -68,8 +70,8 @@ const PaypalSettings = ( { hasContactModule } ) => {
 						'If enabled, PayPal will not allow buyers to use funding sources that take additional time to complete, such as eChecks.',
 						'woocommerce-paypal-payments'
 					) }
-					value={ savePaypalAndVenmo }
-					onChange={ setSavePaypalAndVenmo }
+					value={ instantPaymentsOnly }
+					onChange={ setInstantPaymentsOnly }
 				/>
 			</SettingsBlock>
 

--- a/modules/ppcp-settings/resources/js/data/settings/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/settings/hooks.js
@@ -61,6 +61,9 @@ export const useSettings = () => {
 
 	const [ subtotalAdjustment, setSubtotalAdjustment ] =
 		usePersistent( 'subtotalAdjustment' );
+	const [ instantPaymentsOnly, setInstantPaymentsOnly ] = usePersistent(
+		'instantPaymentsOnly'
+	);
 	const [ landingPage, setLandingPage ] = usePersistent( 'landingPage' );
 	const [ buttonLanguage, setButtonLanguage ] =
 		usePersistent( 'buttonLanguage' );
@@ -86,7 +89,6 @@ export const useSettings = () => {
 
 	const [ threeDSecure, setThreeDSecure ] = usePersistent( 'threeDSecure' );
 
-
 	return {
 		invoicePrefix,
 		setInvoicePrefix,
@@ -108,6 +110,8 @@ export const useSettings = () => {
 		setStayUpdated,
 		subtotalAdjustment,
 		setSubtotalAdjustment,
+		instantPaymentsOnly,
+		setInstantPaymentsOnly,
 		brandName,
 		setBrandName,
 		softDescriptor,

--- a/modules/ppcp-settings/resources/js/data/settings/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/settings/reducer.js
@@ -40,6 +40,7 @@ const defaultPersistent = Object.freeze( {
 	authorizeOnly: false, // Whether to only authorize payments initially
 	captureVirtualOrders: false, // Auto-capture virtual-only orders
 	savePaypalAndVenmo: false, // Enable PayPal & Venmo vaulting
+	instantPaymentsOnly: false, // Enable the instant payments only
 	enableContactModule: false, // Enable the "Custom Shipping Contact" feature
 	saveCardDetails: false, // Enable card vaulting
 	enablePayNow: false, // Enable Pay Now experience

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -99,6 +99,7 @@ class SettingsModel extends AbstractDataModel {
 			'authorize_only'         => false,
 			'capture_virtual_orders' => false,
 			'save_paypal_and_venmo'  => false,
+			'instant_payments_only'  => false,
 			'enable_contact_module'  => true,
 			'save_card_details'      => false,
 			'enable_pay_now'         => false,
@@ -312,6 +313,24 @@ class SettingsModel extends AbstractDataModel {
 	 */
 	public function set_save_paypal_and_venmo( bool $save ): void {
 		$this->data['save_paypal_and_venmo'] = $this->sanitizer->sanitize_bool( $save );
+	}
+
+	/**
+	 * Gets the instant payments only setting.
+	 *
+	 * @return bool True if instant payments only setting is enabled, false otherwise.
+	 */
+	public function get_instant_payments_only(): bool {
+		return $this->data['instant_payments_only'];
+	}
+
+	/**
+	 * Sets the instant payments only setting.
+	 *
+	 * @param bool $save Whether to use instant payments only.
+	 */
+	public function set_instant_payments_only( bool $save ): void {
+		$this->data['instant_payments_only'] = $this->sanitizer->sanitize_bool( $save );
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
@@ -56,6 +56,10 @@ class SettingsRestEndpoint extends RestEndpoint {
 		'subtotal_adjustment'    => array(
 			'js_name' => 'subtotalAdjustment',
 		),
+		'instant_payments_only'  => array(
+			'js_name'  => 'instantPaymentsOnly',
+			'sanitize' => 'to_boolean',
+		),
 		'landing_page'           => array(
 			'js_name' => 'landingPage',
 		),


### PR DESCRIPTION
## Issue Description
The "Instant payments only" toggle is incorrectly using `savePaypalAndVenmo` state instead of its own dedicated state variable. This causes the toggle to modify the wrong setting, creating unexpected behavior where toggling "Instant payments only" also affects the "Save PayPal and Venmo" setting.

**Steps to Reproduce:**
1. Go to the Settings tab
2. Toggle "Instant Payments Only"
3. Notice that it also enables "Save PayPal and Venmo" option

**Expected Behavior:**
Toggling "Instant Payments Only" should save independently without affecting the "Save PayPal and Venmo" setting.

## PR Description
Fixes incorrect state binding for the "Instant payments only" toggle by implementing proper state management across the entire stack.

**Changes:**

**Frontend (React):**
- Updated `PaypalSettings.js` to use `instantPaymentsOnly` and `setInstantPaymentsOnly` instead of `savePaypalAndVenmo`
- Added `instantPaymentsOnly` persistent state accessor to `useSettings` hook
- Added `instantPaymentsOnly` property to Redux store reducer with default value of `false`

**Backend (PHP):**
- Added `instant_payments_only` to `SettingsModel` defaults
- Implemented `get_instant_payments_only()` and `set_instant_payments_only()` methods
- Added proper sanitization for the new setting

**Impact:**
- ✅ **Bug fixed**: "Instant payments only" toggle now works independently
- ✅ **No interference**: Toggle no longer affects "Save PayPal and Venmo" setting
- ✅ **Proper state management**: Complete implementation from UI to database
- ✅ **Data integrity**: Setting properly persisted and retrieved from database

