### PR TITLE
Fix wrong gateway selected during AppSwitch payment processing (5458)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/paypal.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal.js
@@ -158,6 +158,16 @@ export const PayPalComponent = ( {
 		onClick();
 	};
 
+	const handleCancel = () => {
+		// Don't call onClose if AppSwitch is enabled - PayPal SDK fires onCancel
+		// when switching to the app, but the user hasn't actually canceled
+		if ( shouldEnableAppSwitch() ) {
+			return;
+		}
+
+		onClose();
+	};
+
 	const handleButtonInit = () => {
 		if ( fundingSource === 'paypal' ) {
 			const buttonInstance = paypalButtonRef.current?.state?.parent;
@@ -452,7 +462,7 @@ export const PayPalComponent = ( {
 			<PayPalButton
 				style={ style }
 				onClick={ handleClick }
-				onCancel={ onClose }
+				onCancel={ handleCancel }
 				onError={ onClose }
 				createVaultSetupToken={ () => createVaultSetupToken( config ) }
 				onApprove={ ( { vaultSetupToken } ) =>
@@ -468,7 +478,7 @@ export const PayPalComponent = ( {
 				fundingSource={ fundingSource }
 				style={ style }
 				onClick={ handleClick }
-				onCancel={ onClose }
+				onCancel={ handleCancel }
 				onError={ onClose }
 				createSubscription={ ( data, actions ) =>
 					createSubscription( data, actions, config )
@@ -507,7 +517,7 @@ export const PayPalComponent = ( {
 			style={ style }
 			onInit={ handleButtonInit }
 			onClick={ handleClick }
-			onCancel={ onClose }
+			onCancel={ handleCancel }
 			onError={ onClose }
 			createOrder={ ( data ) =>
 				createOrder( data, config, onError, onClose )


### PR DESCRIPTION
During the AppSwitch flow, when returning from the PayPal app, the `onCancel` callback is triggered.

The previous approach was forwarding PayPal's `onCancel` callback to Woo's express button `onClose` callback. The problem with this approach is that Woo switches to the previously selected payment method whenever the `onClose` callback is triggered. 

This caused the selected payment gateway to become `ppcp-credit-card-gateway` at the time of payment processing, which was first on the list of registered payment methods and used as the default gateway.

As a workaround, this PR solves that by adding a new dedicated handler for `onCancel`, and returning early if it is detected that AppSwitch is enabled.

Additionally, this will be reported to the PayPal JS SDK team, because calling `onCancel` when returning from AppSwitch should not be the intended behavior.