### PR TITLE
Clear BCDC Migration Override Flag on "Start Over" and Plugin Uninstall (5462)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -272,6 +272,22 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		/**
+		 * Clean up migration-related options on settings reset.
+		 *
+		 * Removes migration state flags when merchant disconnects via "Start Over"
+		 * to ensure a clean state for subsequent merchant connections.
+		 *
+		 * Removed options:
+		 * - BCDC migration override flag (OPTION_NAME_BCDC_MIGRATION_OVERRIDE)
+		 */
+		add_action(
+			'woocommerce_paypal_payments_reset_settings',
+			static function (): void {
+				delete_option( PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE );
+			}
+		);
+
 		add_action(
 			'admin_enqueue_scripts',
 			function ( string $hook_suffix ) use ( $container ): void {

--- a/modules/ppcp-uninstall/services.php
+++ b/modules/ppcp-uninstall/services.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Uninstall;
 
 use WooCommerce\PayPalCommerce\ApiClient\Repository\PayPalRequestIdRepository;
 use WooCommerce\PayPalCommerce\Settings\Ajax\SwitchSettingsUiEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
 use WooCommerce\PayPalCommerce\Uninstall\Assets\ClearDatabaseAssets;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
@@ -37,6 +38,7 @@ return array(
 			'ppcp_payment_tokens_migration_initialized',
 			SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI,
 			SwitchSettingsUiEndpoint::OPTION_NAME_MIGRATION_IS_DONE,
+			PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE,
 		);
 	},
 


### PR DESCRIPTION
## Issue Description
The `OPTION_NAME_BCDC_MIGRATION_OVERRIDE` flag persists in the database after using "Start Over" or uninstalling the plugin, potentially causing merchants to lose access to Fastlane/ACDC payment methods when reconnecting with different merchant accounts.

The BCDC migration override flag is set for ACDC-eligible merchants who were using Standard Card buttons (BCDC) in legacy UI. However, this flag was not cleared when merchants disconnect via "Start Over" or when the plugin is uninstalled, causing the flag to incorrectly affect payment method availability for new merchant connections.

## PR Description
Implements proper cleanup of BCDC migration override flag during "Start Over" and plugin uninstall to prevent the flag from persisting across different merchant connections.

**Changes:**

**Plugin Uninstall Cleanup:**
- Added `PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE` to uninstall cleanup list
- Flag is now removed when plugin is uninstalled
- Ensures clean state on plugin reinstall

**"Start Over" Cleanup:**
- Added action hook handler for `woocommerce_paypal_payments_reset_settings`
- Deletes BCDC override flag when merchant disconnects via "Start Over"
- Prevents flag from affecting subsequent merchant connections

**Acceptance Criteria:**
- [x] BCDC override flag cleared when "Start Over" is triggered
- [x] BCDC override flag removed during plugin uninstall
- [x] Merchants can access Fastlane/ACDC after reconnecting with eligible accounts
- [x] No regression in existing BCDC migration functionality