### PR TITLE
[Unit Tests] Add missing Stubs for running UNIt tests with coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "test:unit-js": "wp-scripts test-unit-js --config ./tests/js/jest.config.json",
     "ddev:composer-update": "ddev composer update && ddev composer update --lock",
     "ddev:unit-tests": "ddev exec phpunit",
+    "ddev:unit-tests:coverage": "ddev exec XDEBUG_MODE=coverage phpunit --coverage-html coverage/",
     "ddev:e2e-tests": "(cp -n .env.e2e.example .env.e2e || true) && ddev php tests/e2e/PHPUnit/setup.php && ddev exec phpunit -c tests/e2e/phpunit.xml.dist",
     "ddev:pw-install": "ddev yarn playwright install --with-deps",
     "ddev:pw-tests": "ddev yarn playwright test",

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -10,7 +10,11 @@ require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway_CC.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Ajax.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Checkout.php';
+require_once TESTS_ROOT_DIR . '/stubs/WC_Session_Handler.php';
+require_once TESTS_ROOT_DIR . '/stubs/WC_REST_Controller.php';
 require_once TESTS_ROOT_DIR . '/stubs/Task.php';
 require_once TESTS_ROOT_DIR . '/stubs/DefaultPaymentGateways.php';
+require_once TESTS_ROOT_DIR . '/stubs/NoteTraits.php';
+require_once TESTS_ROOT_DIR . '/stubs/AbstractPaymentMethodType.php';
 
 Hamcrest\Util::registerGlobalFunctions();

--- a/tests/stubs/AbstractPaymentMethodType.php
+++ b/tests/stubs/AbstractPaymentMethodType.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\Payments\Integrations;
+
+if (!class_exists('AbstractPaymentMethodType')) {
+	/**
+	 * Stub for WooCommerce Blocks AbstractPaymentMethodType
+	 */
+	abstract class AbstractPaymentMethodType {
+		/**
+		 * Payment method name/id/slug.
+		 *
+		 * @var string
+		 */
+		protected $name = '';
+
+		/**
+		 * Get payment method name.
+		 *
+		 * @return string
+		 */
+		public function get_name() {
+			return $this->name;
+		}
+
+		/**
+		 * Returns an array of scripts/handles to be registered for this payment method.
+		 *
+		 * @return array
+		 */
+		abstract public function get_payment_method_script_handles();
+
+		/**
+		 * Returns an array of key=>value pairs of data made available to the payment methods script.
+		 *
+		 * @return array
+		 */
+		public function get_payment_method_data() {
+			return [];
+		}
+
+		/**
+		 * An array of supported features for this payment method.
+		 *
+		 * @return string[]
+		 */
+		public function get_supported_features() {
+			return [];
+		}
+
+		/**
+		 * Initialize the payment method.
+		 */
+		public function initialize() {
+			// Stub method
+		}
+
+		/**
+		 * Returns true if the payment method is active.
+		 *
+		 * @return boolean
+		 */
+		public function is_active() {
+			return true;
+		}
+	}
+}

--- a/tests/stubs/NoteTraits.php
+++ b/tests/stubs/NoteTraits.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Automattic\WooCommerce\Admin\Notes;
+
+if (!trait_exists('NoteTraits')) {
+	/**
+	 * Stub for WooCommerce Admin NoteTraits
+	 */
+	trait NoteTraits {
+		/**
+		 * Get the note.
+		 */
+		public static function get_note() {
+			return null;
+		}
+
+		/**
+		 * Possibly add the note.
+		 */
+		public static function possibly_add_note() {
+			// Stub method
+		}
+
+		/**
+		 * Can the note be added?
+		 */
+		public static function can_be_added() {
+			return false;
+		}
+	}
+}

--- a/tests/stubs/WC_REST_Controller.php
+++ b/tests/stubs/WC_REST_Controller.php
@@ -1,0 +1,277 @@
+<?php
+if (!class_exists('WP_Error')) {
+	/**
+	 * Stub for WordPress Error
+	 */
+	class WP_Error {
+		protected $errors = array();
+		protected $error_data = array();
+
+		public function __construct($code = '', $message = '', $data = '') {
+			if (!empty($code)) {
+				$this->errors[$code][] = $message;
+			}
+			if (!empty($data)) {
+				$this->error_data[$code] = $data;
+			}
+		}
+
+		public function get_error_code() {
+			$codes = $this->get_error_codes();
+			return empty($codes) ? '' : $codes[0];
+		}
+
+		public function get_error_codes() {
+			return array_keys($this->errors);
+		}
+
+		public function get_error_message($code = '') {
+			if (empty($code)) {
+				$code = $this->get_error_code();
+			}
+			$messages = $this->get_error_messages($code);
+			return empty($messages) ? '' : $messages[0];
+		}
+
+		public function get_error_messages($code = '') {
+			if (empty($code)) {
+				return array_reduce($this->errors, 'array_merge', array());
+			}
+			return isset($this->errors[$code]) ? $this->errors[$code] : array();
+		}
+	}
+}
+
+if (!class_exists('WP_REST_Request')) {
+	/**
+	 * Stub for WordPress REST Request
+	 */
+	class WP_REST_Request {
+		protected $params = array();
+
+		public function get_param($key) {
+			return isset($this->params[$key]) ? $this->params[$key] : null;
+		}
+
+		public function get_params() {
+			return $this->params;
+		}
+
+		public function set_param($key, $value) {
+			$this->params[$key] = $value;
+		}
+	}
+}
+
+if (!class_exists('WP_REST_Response')) {
+	/**
+	 * Stub for WordPress REST Response
+	 */
+	class WP_REST_Response {
+		protected $data;
+		protected $status;
+
+		public function __construct($data = null, $status = 200) {
+			$this->data = $data;
+			$this->status = $status;
+		}
+
+		public function get_data() {
+			return $this->data;
+		}
+
+		public function get_status() {
+			return $this->status;
+		}
+	}
+}
+
+if (!class_exists('WP_REST_Controller')) {
+	/**
+	 * Stub for WordPress REST Controller
+	 */
+	abstract class WP_REST_Controller {
+		/**
+		 * The namespace of this controller's route.
+		 *
+		 * @var string
+		 */
+		protected $namespace;
+
+		/**
+		 * The base of this controller's route.
+		 *
+		 * @var string
+		 */
+		protected $rest_base;
+
+		/**
+		 * Registers the routes for the objects of the controller.
+		 */
+		public function register_routes() {}
+
+		/**
+		 * Checks if a given request has access to get items.
+		 *
+		 * @param WP_REST_Request $request Full data about the request.
+		 * @return WP_Error|bool
+		 */
+		public function get_items_permissions_check($request) {
+			return true;
+		}
+
+		/**
+		 * Retrieves a collection of items.
+		 *
+		 * @param WP_REST_Request $request Full data about the request.
+		 * @return WP_REST_Response|WP_Error
+		 */
+		public function get_items($request) {
+			return new WP_REST_Response(array(), 200);
+		}
+
+		/**
+		 * Checks if a given request has access to get a specific item.
+		 *
+		 * @param WP_REST_Request $request Full data about the request.
+		 * @return WP_Error|bool
+		 */
+		public function get_item_permissions_check($request) {
+			return true;
+		}
+
+		/**
+		 * Retrieves one item from the collection.
+		 *
+		 * @param WP_REST_Request $request Full data about the request.
+		 * @return WP_REST_Response|WP_Error
+		 */
+		public function get_item($request) {
+			return new WP_REST_Response(array(), 200);
+		}
+
+		/**
+		 * Retrieves the item's schema.
+		 *
+		 * @return array
+		 */
+		public function get_item_schema() {
+			return array();
+		}
+	}
+}
+
+if (!class_exists('WC_REST_Controller')) {
+	/**
+	 * Stub for WooCommerce REST Controller
+	 */
+	abstract class WC_REST_Controller extends WP_REST_Controller {
+		/**
+		 * Endpoint namespace.
+		 *
+		 * @var string
+		 */
+		protected $namespace = 'wc/v3';
+
+		/**
+		 * Route base.
+		 *
+		 * @var string
+		 */
+		protected $rest_base = '';
+
+		/**
+		 * Get normalized rest base.
+		 *
+		 * @return string
+		 */
+		protected function get_normalized_rest_base() {
+			return preg_replace('/\(.*\)\//i', '', $this->rest_base);
+		}
+
+		/**
+		 * Check batch limit.
+		 *
+		 * @param array $items Request items.
+		 * @return bool|WP_Error
+		 */
+		protected function check_batch_limit($items) {
+			$limit = apply_filters('woocommerce_rest_batch_items_limit', 100, $this->get_normalized_rest_base());
+			$total = 0;
+
+			if (!empty($items['create'])) {
+				$total += count($items['create']);
+			}
+			if (!empty($items['update'])) {
+				$total += count($items['update']);
+			}
+			if (!empty($items['delete'])) {
+				$total += count($items['delete']);
+			}
+
+			if ($total > $limit) {
+				return new WP_Error(
+					'woocommerce_rest_request_entity_too_large',
+					sprintf(__('Unable to accept more than %s items for this request.', 'woocommerce'), $limit),
+					array('status' => 413)
+				);
+			}
+
+			return true;
+		}
+
+		/**
+		 * Add meta query.
+		 *
+		 * @param array $args       Query args.
+		 * @param array $meta_query Meta query.
+		 * @return array
+		 */
+		protected function add_meta_query($args, $meta_query) {
+			if (empty($args['meta_query'])) {
+				$args['meta_query'] = array();
+			}
+
+			$args['meta_query'][] = $meta_query;
+
+			return $args;
+		}
+
+		/**
+		 * Get the batch schema.
+		 *
+		 * @return array
+		 */
+		public function get_public_batch_schema() {
+			return array(
+				'$schema'    => 'http://json-schema.org/draft-04/schema#',
+				'title'      => 'batch',
+				'type'       => 'object',
+				'properties' => array(
+					'create' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type' => 'object',
+						),
+					),
+					'update' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type' => 'object',
+						),
+					),
+					'delete' => array(
+						'type'  => 'array',
+						'items' => array(
+							'type' => 'integer',
+						),
+					),
+				),
+			);
+		}
+	}
+}
+
+
+
+

--- a/tests/stubs/WC_Session_Handler.php
+++ b/tests/stubs/WC_Session_Handler.php
@@ -1,0 +1,116 @@
+<?php
+
+if (!class_exists('WC_Session')) {
+	/**
+	 * Stub for WooCommerce Session base class
+	 */
+	abstract class WC_Session {
+		/**
+		 * Session data.
+		 *
+		 * @var array
+		 */
+		protected $_data = [];
+
+		/**
+		 * Dirty when the session needs saving.
+		 *
+		 * @var bool
+		 */
+		protected $_dirty = false;
+
+		/**
+		 * Get a session variable.
+		 *
+		 * @param string $key Key.
+		 * @param mixed  $default Default value.
+		 * @return mixed
+		 */
+		public function get($key, $default = null) {
+			return isset($this->_data[$key]) ? $this->_data[$key] : $default;
+		}
+
+		/**
+		 * Set a session variable.
+		 *
+		 * @param string $key Key.
+		 * @param mixed  $value Value.
+		 */
+		public function set($key, $value) {
+			if ($value !== $this->get($key)) {
+				$this->_data[$key] = $value;
+				$this->_dirty = true;
+			}
+		}
+
+		/**
+		 * Get customer ID.
+		 *
+		 * @return int
+		 */
+		public function get_customer_id() {
+			return 0;
+		}
+	}
+}
+
+if (!class_exists('WC_Session_Handler')) {
+	/**
+	 * Stub for WooCommerce Session Handler
+	 */
+	class WC_Session_Handler extends WC_Session {
+		/**
+		 * Constructor
+		 */
+		public function __construct() {
+			$this->_data = [];
+		}
+
+		/**
+		 * Init hooks and session data.
+		 */
+		public function init() {}
+
+		/**
+		 * Get session cookie.
+		 *
+		 * @return bool|array
+		 */
+		public function get_session_cookie() {
+			return false;
+		}
+
+		/**
+		 * Get session data.
+		 *
+		 * @return array
+		 */
+		public function get_session_data() {
+			return $this->_data;
+		}
+
+		/**
+		 * Save data.
+		 */
+		public function save_data() {}
+
+		/**
+		 * Destroy all session data.
+		 */
+		public function destroy_session() {
+			$this->_data = [];
+		}
+
+		/**
+		 * Forget session.
+		 */
+		public function forget_session() {
+			$this->destroy_session();
+		}
+
+		/**
+		 * Cleanup sessions.
+		 */
+		public function cleanup_sessions() {}
+	}
+}


### PR DESCRIPTION
### Description

Adds missing stubs, allowing PHPUnit tests to run with coverage

### Steps to Test

1.Checkout PR
2. Run `npm run ddev:xdebug-on`
3. Run `npm run ddev:unit-tests:coverage` 
4. See coverage folder created  



https://github.com/user-attachments/assets/77c39b9b-0902-4502-ba19-3f54c77ed07e

 
<img width="1723" height="941" alt="Screenshot 2025-10-16 at 15 56 11" src="https://github.com/user-attachments/assets/26f027b0-b654-4c8e-981a-caaee8614fe8" />




### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Closes # .
