### PR TITLE
Fix duplicate captures and double stock reductions (5461)

### DIFF
--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -203,7 +203,7 @@ class WooCommerceOrderCreator {
 		$shipping_address = null;
 		$billing_address  = null;
 		$shipping_options = null;
-		$wc_customer = WC()->customer;
+		$wc_customer      = WC()->customer;
 
 		if ( ! $shipping && $needs_shipping ) {
 			if ( $wc_customer instanceof WC_Customer ) {
@@ -216,7 +216,7 @@ class WooCommerceOrderCreator {
 			$payer_name  = $payer->name();
 			$payer_phone = $payer->phone();
 
-			$wc_email    = null;
+			$wc_email = null;
 			if ( $wc_customer instanceof WC_Customer ) {
 				$wc_email = $wc_customer->get_email();
 			}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -68,6 +68,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\FeesUpdater;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\InstallmentsProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\OrderLockHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\RefundFeesUpdater;
@@ -587,7 +588,8 @@ return array(
 			$container->get( 'api.factory.purchase-unit' ),
 			$container->get( 'api.factory.payer' ),
 			$container->get( 'api.factory.shipping-preference' ),
-			$container->get( 'wcgateway.builder.experience-context' )
+			$container->get( 'wcgateway.builder.experience-context' ),
+			$container->get( 'wcgateway.helper.order-lock' )
 		);
 	},
 	'wcgateway.processor.refunds'                          => static function ( ContainerInterface $container ): RefundProcessor {
@@ -2380,6 +2382,12 @@ return array(
 			// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.appswitch_enabled',
 			getenv( 'PCP_APPSWITCH_ENABLED' ) !== '0'
+		);
+	},
+
+	'wcgateway.helper.order-lock'                          => static function ( ContainerInterface $container ): OrderLockHelper {
+		return new OrderLockHelper(
+			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 );

--- a/modules/ppcp-wc-gateway/src/Helper/OrderLockHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/OrderLockHelper.php
@@ -42,7 +42,7 @@ class OrderLockHelper {
 		);
 
 		$current_time = time();
-		$lock_value   = $current_time . ':' . $request_id;
+		$lock_value   = (string) $current_time . ':' . $request_id;
 
 		// Get any existing lock.
 		$existing_lock = $wc_order->get_meta( self::LOCK_META_KEY );
@@ -220,9 +220,9 @@ class OrderLockHelper {
 
 		if ( $request_id === null ) {
 			// Use a combination of time and random for uniqueness.
-			$request_id = substr( md5( microtime( true ) . wp_rand() ), 0, 8 );
+			$request_id = substr( md5( (string) microtime( true ) . (string) wp_rand() ), 0, 8 );
 		}
 
-		return $request_id;
+		return (string) $request_id;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/OrderLockHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/OrderLockHelper.php
@@ -1,0 +1,228 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+use Psr\Log\LoggerInterface;
+use WC_Order;
+
+/**
+ * Helper class for managing order processing locks to prevent race conditions.
+ */
+class OrderLockHelper {
+	const LOCK_META_KEY = '_ppcp_processing_lock';
+	const LOCK_TIMEOUT  = 15;
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private $logger;
+
+	/**
+	 * OrderLockHelper constructor.
+	 *
+	 * @param LoggerInterface $logger The logger.
+	 */
+	public function __construct( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	public function acquire_lock( WC_Order $wc_order ): bool {
+		$order_id   = $wc_order->get_id();
+		$request_id = $this->get_request_id();
+
+		$this->logger->info(
+			sprintf(
+				'Attempting to acquire lock for order #%d (request: %s)',
+				$order_id,
+				$request_id
+			)
+		);
+
+		$current_time = time();
+		$lock_value   = $current_time . ':' . $request_id;
+
+		// Get any existing lock.
+		$existing_lock = $wc_order->get_meta( self::LOCK_META_KEY );
+
+		if ( $existing_lock ) {
+			$lock_time   = 0;
+			$lock_holder = 'unknown';
+
+			// Parse existing lock - expects 'timestamp:request_id' format.
+			if ( strpos( $existing_lock, ':' ) !== false ) {
+				list( $time_part, $holder_part ) = explode( ':', $existing_lock, 2 );
+
+				// Only update time if it's numeric.
+				if ( is_numeric( $time_part ) ) {
+					$lock_time = (int) $time_part;
+				}
+				$lock_holder = $holder_part;
+			} else {
+				// Corrupted or malformed lock value - log and treat as very old (time 0).
+				$this->logger->warning(
+					sprintf(
+						'⚠️ Found malformed lock value for order #%d: "%s" - treating as expired.',
+						$order_id,
+						$existing_lock
+					)
+				);
+			}
+
+			$age = $current_time - $lock_time;
+
+			// If the lock is not expired, deny access.
+			if ( $age < self::LOCK_TIMEOUT ) {
+				$this->logger->info(
+					sprintf(
+						'✗ Lock already held for order #%d by request %s (age: %ds, current: %s)',
+						$order_id,
+						$lock_holder,
+						$age,
+						$request_id
+					)
+				);
+				return false;
+			}
+
+			// Lock is expired, we can take it.
+			$this->logger->info(
+				sprintf(
+					'⚠️ Found expired lock for order #%d (holder: %s, age: %ds) - taking over',
+					$order_id,
+					$lock_holder,
+					$age
+				)
+			);
+		}
+
+		// Set our lock (this will overwrite any expired or malformed lock).
+		$wc_order->update_meta_data( self::LOCK_META_KEY, $lock_value );
+		$wc_order->save_meta_data();
+
+		// Verify we actually have the lock.
+		$stored_lock = $wc_order->get_meta( self::LOCK_META_KEY, true );
+
+		if ( $stored_lock === $lock_value ) {
+			$this->logger->info(
+				sprintf(
+					'✓ Lock acquired for order #%d by request %s',
+					$order_id,
+					$request_id
+				)
+			);
+			return true;
+		} else {
+			$this->logger->error(
+				sprintf(
+					'✗ CRITICAL: Failed to verify lock for order #%d - expected: %s, got: %s',
+					$order_id,
+					$lock_value,
+					$stored_lock
+				)
+			);
+			return false;
+		}
+	}
+
+	/**
+	 * Releases the processing lock for the given order.
+	 *
+	 * @param WC_Order $wc_order The WooCommerce order.
+	 * @return void
+	 */
+	public function release_lock( WC_Order $wc_order ): void {
+		$order_id   = $wc_order->get_id();
+		$request_id = $this->get_request_id();
+
+		// Get the current lock value for debugging.
+		$current_lock = $wc_order->get_meta( self::LOCK_META_KEY, true );
+
+		if ( ! $current_lock ) {
+			$this->logger->warning(
+				sprintf(
+					'⚠️ Attempted to release lock for order #%d but no lock exists (request: %s)',
+					$order_id,
+					$request_id
+				)
+			);
+			return;
+		}
+
+		$lock_parts   = explode( ':', $current_lock );
+		$lock_request = $lock_parts[1] ?? 'unknown';
+
+		$wc_order->delete_meta_data( self::LOCK_META_KEY );
+		$wc_order->save_meta_data();
+
+		$this->logger->info(
+			sprintf(
+				'✓ Lock released for order #%d (was held by: %s, released by: %s)',
+				$order_id,
+				$lock_request,
+				$request_id
+			)
+		);
+	}
+
+	/**
+	 * Checks if the given order has an active processing lock.
+	 *
+	 * @param WC_Order $wc_order The WooCommerce order.
+	 * @return bool True if order is locked, false otherwise.
+	 */
+	public function is_locked( WC_Order $wc_order ): bool {
+		$lock_value = $wc_order->get_meta( self::LOCK_META_KEY, true );
+
+		if ( ! $lock_value ) {
+			return false;
+		}
+
+		$lock_parts   = explode( ':', $lock_value );
+		$lock_time    = (int) $lock_parts[0];
+		$lock_request = $lock_parts[1] ?? 'unknown';
+
+		$age       = time() - $lock_time;
+		$is_locked = $age < self::LOCK_TIMEOUT;
+
+		if ( $is_locked ) {
+			$this->logger->debug(
+				sprintf(
+					'Order #%d is locked by request %s (age: %ds)',
+					$wc_order->get_id(),
+					$lock_request,
+					$age
+				)
+			);
+		} else {
+			$this->logger->debug(
+				sprintf(
+					'Order #%d has expired lock from request %s (age: %ds)',
+					$wc_order->get_id(),
+					$lock_request,
+					$age
+				)
+			);
+		}
+
+		return $is_locked;
+	}
+
+	/**
+	 * Get a unique request identifier.
+	 *
+	 * @return string
+	 */
+	private function get_request_id(): string {
+		static $request_id = null;
+
+		if ( $request_id === null ) {
+			// Use a combination of time and random for uniqueness.
+			$request_id = substr( md5( microtime( true ) . wp_rand() ), 0, 8 );
+		}
+
+		return $request_id;
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -219,8 +219,7 @@ class OrderProcessor {
 	 * @param WC_Order $wc_order The WooCommerce order.
 	 *
 	 * @throws PayPalOrderMissingException If no PayPal order.
-	 * @throws RuntimeException If order retrieval fails.
-	 * @throws Exception If processing fails (General exception).
+	 * @throws \Exception If processing fails (General exception).
 	 */
 	public function process( WC_Order $wc_order ): void {
 		$order_id = $wc_order->get_id();
@@ -257,7 +256,7 @@ class OrderProcessor {
 						$this->logger->info( sprintf( 'Retrieved PayPal order %s from API', $order_id_meta ) );
 					} catch ( RuntimeException $exception ) {
 						$this->logger->error( sprintf( 'Failed to retrieve PayPal order: %s', $exception->getMessage() ) );
-						throw new Exception( __( 'Could not retrieve PayPal order.', 'woocommerce-paypal-payments' ) );
+						throw new \Exception( __( 'Could not retrieve PayPal order.', 'woocommerce-paypal-payments' ) );
 					}
 				} else {
 					$is_paypal_return = isset( $_GET['wc-ajax'] ) && wc_clean( wp_unslash( $_GET['wc-ajax'] ) ) === 'ppc-return-url'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -294,7 +293,7 @@ class OrderProcessor {
 
 			if ( $this->order_helper->contains_physical_goods( $order ) && ! $this->order_is_ready_for_process( $order ) ) {
 				$this->logger->error( sprintf( 'Order #%d not ready for processing (physical goods check)', $order_id ) );
-				throw new Exception(
+				throw new \Exception(
 					__(
 						'The payment is not ready for processing yet.',
 						'woocommerce-paypal-payments'

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -27,6 +27,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderHelper;
 use WooCommerce\PayPalCommerce\Button\Helper\ThreeDSecure;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\OrderLockHelper;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vaulting\PaymentTokenRepository;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\PayPalOrderMissingException;
@@ -153,6 +154,13 @@ class OrderProcessor {
 	private ExperienceContextBuilder $experience_context_builder;
 
 	/**
+	 * The order lock helper.
+	 *
+	 * @var OrderLockHelper
+	 */
+	private $order_lock_helper;
+
+	/**
 	 * OrderProcessor constructor.
 	 *
 	 * @param SessionHandler              $session_handler The Session Handler.
@@ -184,7 +192,8 @@ class OrderProcessor {
 		PurchaseUnitFactory $purchase_unit_factory,
 		PayerFactory $payer_factory,
 		ShippingPreferenceFactory $shipping_preference_factory,
-		ExperienceContextBuilder $experience_context_builder
+		ExperienceContextBuilder $experience_context_builder,
+		OrderLockHelper $order_lock_helper
 	) {
 
 		$this->session_handler               = $session_handler;
@@ -201,6 +210,7 @@ class OrderProcessor {
 		$this->payer_factory                 = $payer_factory;
 		$this->shipping_preference_factory   = $shipping_preference_factory;
 		$this->experience_context_builder    = $experience_context_builder;
+		$this->order_lock_helper             = $order_lock_helper;
 	}
 
 	/**
@@ -209,87 +219,136 @@ class OrderProcessor {
 	 * @param WC_Order $wc_order The WooCommerce order.
 	 *
 	 * @throws PayPalOrderMissingException If no PayPal order.
-	 * @throws Exception If processing fails.
+	 * @throws Exception If processing fails (General exception).
+	 * @throws Exception If order locking fails or the order is not ready for processing.
 	 */
 	public function process( WC_Order $wc_order ): void {
-		$order = $this->session_handler->order();
-		if ( ! $order ) {
-			// phpcs:ignore WordPress.Security.NonceVerification
-			$order_id = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) ?: wc_clean( wp_unslash( $_POST['paypal_order_id'] ?? '' ) );
-			if ( is_string( $order_id ) && $order_id ) {
-				try {
-					$order = $this->order_endpoint->order( $order_id );
-				} catch ( RuntimeException $exception ) {
-					throw new Exception( __( 'Could not retrieve PayPal order.', 'woocommerce-paypal-payments' ) );
-				}
-			} else {
-				$is_paypal_return = isset( $_GET['wc-ajax'] ) && wc_clean( wp_unslash( $_GET['wc-ajax'] ) ) === 'ppc-return-url'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$order_id = $wc_order->get_id();
 
-				if ( $is_paypal_return ) {
-					$this->logger->warning(
-						sprintf(
-							'No PayPal order ID found for WooCommerce order #%d.',
-							$wc_order->get_id()
+		// Try to acquire lock to prevent race conditions.
+		if ( ! $this->order_lock_helper->acquire_lock( $wc_order ) ) {
+			$this->logger->info(
+				sprintf(
+					'Order #%d is already being processed, skipping.',
+					$order_id
+				)
+			);
+			return;
+		}
+
+		$this->logger->info( sprintf( 'Lock acquired for order #%d', $order_id ) );
+
+		try {
+			$this->logger->info( sprintf( 'Beginning PayPal order retrieval for order #%d', $order_id ) );
+
+			$order = $this->session_handler->order();
+			if ( ! $order ) {
+				// phpcs:ignore WordPress.Security.NonceVerification
+				$order_id_meta = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) ?: wc_clean( wp_unslash( $_POST['paypal_order_id'] ?? '' ) );
+
+				$this->logger->info( sprintf( 'No session order found, checking meta/POST for PayPal order ID: %s', $order_id_meta ?: 'none' ) );
+
+				if ( is_string( $order_id_meta ) && $order_id_meta ) {
+					try {
+						$order = $this->order_endpoint->order( $order_id_meta );
+						$this->logger->info( sprintf( 'Retrieved PayPal order %s from API', $order_id_meta ) );
+					} catch ( RuntimeException $exception ) {
+						$this->logger->error( sprintf( 'Failed to retrieve PayPal order: %s', $exception->getMessage() ) );
+						throw new Exception( __( 'Could not retrieve PayPal order.', 'woocommerce-paypal-payments' ) );
+					}
+				} else {
+					$is_paypal_return = isset( $_GET['wc-ajax'] ) && wc_clean( wp_unslash( $_GET['wc-ajax'] ) ) === 'ppc-return-url'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+					if ( $is_paypal_return ) {
+						$this->logger->warning(
+							sprintf(
+								'No PayPal order ID found for WooCommerce order #%d.',
+								$order_id
+							)
+						);
+					}
+
+					throw new PayPalOrderMissingException(
+						esc_attr__(
+							'There was an error processing your order. Please check for any charges in your payment method and review your order history before placing the order again.',
+							'woocommerce-paypal-payments'
 						)
 					);
 				}
+			}
 
-				throw new PayPalOrderMissingException(
-					esc_attr__(
-						'There was an error processing your order. Please check for any charges in your payment method and review your order history before placing the order again.',
+			// Do not continue if PayPal order status is completed.
+			$this->logger->info( sprintf( 'Checking PayPal order status for order #%d', $order_id ) );
+			$order = $this->order_endpoint->order( $order->id() );
+
+			if ( $order->status()->is( OrderStatus::COMPLETED ) ) {
+				$this->logger->warning( 'Could not process PayPal completed order #' . $order->id() . ', Status: ' . $order->status()->name() );
+				return;
+			}
+
+			$this->logger->info( sprintf( 'Adding PayPal meta for order #%d', $order_id ) );
+			$this->add_paypal_meta( $wc_order, $order, $this->environment );
+
+			if ( $this->order_helper->contains_physical_goods( $order ) && ! $this->order_is_ready_for_process( $order ) ) {
+				$this->logger->error( sprintf( 'Order #%d not ready for processing (physical goods check)', $order_id ) );
+				throw new Exception(
+					__(
+						'The payment is not ready for processing yet.',
 						'woocommerce-paypal-payments'
 					)
 				);
 			}
-		}
 
-		// Do not continue if PayPal order status is completed.
-		$order = $this->order_endpoint->order( $order->id() );
-		if ( $order->status()->is( OrderStatus::COMPLETED ) ) {
-			$this->logger->warning( 'Could not process PayPal completed order #' . $order->id() . ', Status: ' . $order->status()->name() );
-			return;
-		}
-
-		$this->add_paypal_meta( $wc_order, $order, $this->environment );
-
-		if ( $this->order_helper->contains_physical_goods( $order ) && ! $this->order_is_ready_for_process( $order ) ) {
-			throw new Exception(
-				__(
-					'The payment is not ready for processing yet.',
-					'woocommerce-paypal-payments'
-				)
-			);
-		}
-
-		$order = $this->patch_order( $wc_order, $order );
-
-		if ( $order->intent() === 'CAPTURE' ) {
-			$order = $this->order_endpoint->capture( $order );
-		}
-
-		if ( $order->intent() === 'AUTHORIZE' ) {
-			$order = $this->order_endpoint->authorize( $order );
-
-			$wc_order->update_meta_data( AuthorizedPaymentsProcessor::CAPTURED_META_KEY, 'false' );
-
-			if ( $this->subscription_helper->has_subscription( $wc_order->get_id() ) ) {
-				$wc_order->update_meta_data( '_ppcp_captured_vault_webhook', 'false' );
+			$this->logger->info( sprintf( 'Patching order #%d', $order_id ) );
+			if ( ! $order->status()->is( OrderStatus::APPROVED ) ) {
+				$order = $this->patch_order( $wc_order, $order );
 			}
+
+			if ( $order->intent() === 'CAPTURE' ) {
+				$this->logger->info( sprintf( 'Capturing payment for order #%d', $order_id ) );
+				$order = $this->order_endpoint->capture( $order );
+				$this->logger->info( sprintf( 'Payment captured successfully for order #%d', $order_id ) );
+			}
+
+			if ( $order->intent() === 'AUTHORIZE' ) {
+				$this->logger->info( sprintf( 'Authorizing payment for order #%d', $order_id ) );
+				$order = $this->order_endpoint->authorize( $order );
+				$this->logger->info( sprintf( 'Payment authorized successfully for order #%d', $order_id ) );
+
+				$wc_order->update_meta_data( AuthorizedPaymentsProcessor::CAPTURED_META_KEY, 'false' );
+
+				if ( $this->subscription_helper->has_subscription( $wc_order->get_id() ) ) {
+					$wc_order->update_meta_data( '_ppcp_captured_vault_webhook', 'false' );
+				}
+			}
+
+			$transaction_id = $this->get_paypal_order_transaction_id( $order );
+
+			if ( $transaction_id ) {
+				$this->logger->info( sprintf( 'Updating transaction ID %s for order #%d', $transaction_id, $order_id ) );
+				$this->update_transaction_id( $transaction_id, $wc_order );
+			}
+
+			$this->logger->info( sprintf( 'Handling order status update for order #%d', $order_id ) );
+			$this->handle_new_order_status( $order, $wc_order );
+
+			if ( $this->capture_authorized_downloads( $order ) ) {
+				$this->logger->info( sprintf( 'Capturing authorized downloads for order #%d', $order_id ) );
+				$this->authorized_payments_processor->capture_authorized_payment( $wc_order );
+			}
+
+			$this->logger->info( sprintf( 'Firing after_order_processor action for order #%d', $order_id ) );
+			do_action( 'woocommerce_paypal_payments_after_order_processor', $wc_order, $order );
+
+			$this->logger->info( sprintf( 'Successfully completed processing for order #%d', $order_id ) );
+
+		} catch ( \Exception $e ) {
+			$this->logger->error( sprintf( 'Exception in OrderProcessor for order #%d: %s', $order_id, $e->getMessage() ) );
+			throw $e;
+		} finally {
+			$this->order_lock_helper->release_lock( $wc_order );
+			$this->logger->info( sprintf( 'Lock released for order #%d', $order_id ) );
 		}
-
-		$transaction_id = $this->get_paypal_order_transaction_id( $order );
-
-		if ( $transaction_id ) {
-			$this->update_transaction_id( $transaction_id, $wc_order );
-		}
-
-		$this->handle_new_order_status( $order, $wc_order );
-
-		if ( $this->capture_authorized_downloads( $order ) ) {
-			$this->authorized_payments_processor->capture_authorized_payment( $wc_order );
-		}
-
-		do_action( 'woocommerce_paypal_payments_after_order_processor', $wc_order, $order );
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -244,9 +244,10 @@ class OrderProcessor {
 			$order = $this->session_handler->order();
 			if ( ! $order ) {
 				// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				$post_order_id = $_POST['paypal_order_id'] ?? '';
-				$post_order_id = is_string( $post_order_id ) ? wc_clean( wp_unslash( $post_order_id ) ) : '';
-				$order_id_meta = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) ?: $post_order_id;
+				$post_order_id     = $_POST['paypal_order_id'] ?? '';
+				$post_order_id     = is_string( $post_order_id ) ? wc_clean( wp_unslash( $post_order_id ) ) : '';
+				$order_id_meta_raw = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
+				$order_id_meta     = ( is_string( $order_id_meta_raw ) && $order_id_meta_raw ) ? $order_id_meta_raw : $post_order_id;
 
 				$this->logger->info( sprintf( 'No session order found, checking meta/POST for PayPal order ID: %s', $order_id_meta ?: 'none' ) );
 

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -249,7 +249,7 @@ class OrderProcessor {
 				$order_id_meta_raw = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
 				$order_id_meta     = ( is_string( $order_id_meta_raw ) && $order_id_meta_raw ) ? $order_id_meta_raw : $post_order_id;
 
-				$this->logger->info( sprintf( 'No session order found, checking meta/POST for PayPal order ID: %s', $order_id_meta ?: 'none' ) );
+				$this->logger->info( sprintf( 'No session order found, checking meta/POST for PayPal order ID: %s', is_string( $order_id_meta ) ? $order_id_meta : 'none' ) );
 
 				if ( is_string( $order_id_meta ) && $order_id_meta ) {
 					try {

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -243,8 +243,10 @@ class OrderProcessor {
 
 			$order = $this->session_handler->order();
 			if ( ! $order ) {
-				// phpcs:ignore WordPress.Security.NonceVerification
-				$order_id_meta = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) ?: wc_clean( wp_unslash( $_POST['paypal_order_id'] ?? '' ) );
+				// phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				$post_order_id = $_POST['paypal_order_id'] ?? '';
+				$post_order_id = is_string( $post_order_id ) ? wc_clean( wp_unslash( $post_order_id ) ) : '';
+				$order_id_meta = $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) ?: $post_order_id;
 
 				$this->logger->info( sprintf( 'No session order found, checking meta/POST for PayPal order ID: %s', $order_id_meta ?: 'none' ) );
 

--- a/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderProcessor.php
@@ -219,8 +219,8 @@ class OrderProcessor {
 	 * @param WC_Order $wc_order The WooCommerce order.
 	 *
 	 * @throws PayPalOrderMissingException If no PayPal order.
+	 * @throws RuntimeException If order retrieval fails.
 	 * @throws Exception If processing fails (General exception).
-	 * @throws Exception If order locking fails or the order is not ready for processing.
 	 */
 	public function process( WC_Order $wc_order ): void {
 		$order_id = $wc_order->get_id();

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -80,6 +80,7 @@ return array(
 		$payment_token_factory = $container->get( 'vaulting.payment-token-factory' );
 		$payment_token_helper = $container->get( 'vaulting.payment-token-helper' );
 		$refund_fees_updater = $container->get( 'wcgateway.helper.refund-fees-updater' );
+		$order_lock = $container->get( 'wcgateway.helper.order-lock' );
 
 		return array(
 			new CheckoutOrderApproved(
@@ -93,7 +94,7 @@ return array(
 			new CheckoutPaymentApprovalReversed( $logger ),
 			new PaymentCaptureRefunded( $logger, $refund_fees_updater ),
 			new PaymentCaptureReversed( $logger ),
-			new PaymentCaptureCompleted( $logger, $order_endpoint ),
+			new PaymentCaptureCompleted( $logger, $order_endpoint, $order_lock ),
 			new VaultPaymentTokenCreated( $logger, $prefix, $authorized_payments_processor, $payment_token_factory, $payment_token_helper ),
 			new VaultPaymentTokenDeleted( $logger ),
 			new PaymentCapturePending( $logger ),

--- a/modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\OrderLockHelper;
 use WP_REST_Response;
 
 /**
@@ -40,17 +41,27 @@ class PaymentCaptureCompleted implements RequestHandler {
 	private $order_endpoint;
 
 	/**
+	 * The order lock helper.
+	 *
+	 * @var OrderLockHelper
+	 */
+	private $order_lock_helper;
+
+	/**
 	 * PaymentCaptureCompleted constructor.
 	 *
 	 * @param LoggerInterface $logger The logger.
 	 * @param OrderEndpoint   $order_endpoint The order endpoint.
+	 * @param OrderLockHelper $order_lock_helper The order lock helper.
 	 */
 	public function __construct(
 		LoggerInterface $logger,
-		OrderEndpoint $order_endpoint
+		OrderEndpoint $order_endpoint,
+		OrderLockHelper $order_lock_helper
 	) {
-		$this->logger         = $logger;
-		$this->order_endpoint = $order_endpoint;
+		$this->logger            = $logger;
+		$this->order_endpoint    = $order_endpoint;
+		$this->order_lock_helper = $order_lock_helper;
 	}
 
 	/**
@@ -111,6 +122,18 @@ class PaymentCaptureCompleted implements RequestHandler {
 		if ( $wc_order->get_status() !== 'on-hold' ) {
 			return $this->success_response();
 		}
+
+		// Check if order is being processed elsewhere.
+		if ( $this->order_lock_helper->is_locked( $wc_order ) ) {
+			$this->logger->info(
+				sprintf(
+					'Order #%d is being processed elsewhere, webhook will skip.',
+					$wc_order->get_id()
+				)
+			);
+			return $this->success_response();
+		}
+
 		$wc_order->add_order_note(
 			__( 'Payment successfully captured.', 'woocommerce-paypal-payments' )
 		);

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -63,7 +63,7 @@ class OrderProcessorTest extends TestCase
 
         $wcOrder = Mockery::mock(\WC_Order::class);
 		$wcOrder->shouldReceive('get_id')->andReturn(1);
-		$wcOrder->expects('get_items')->andReturn([]);
+		$wcOrder->shouldReceive('get_items')->andReturn([]);
         $wcOrder->shouldReceive('get_id')->andReturn(1);
 
         $orderStatus = Mockery::mock(OrderStatus::class);
@@ -287,8 +287,8 @@ class OrderProcessorTest extends TestCase
             ->with($currentOrder)
             ->andReturn($currentOrder);
         $orderFactory = Mockery::mock(OrderFactory::class);
-        $orderFactory
-            ->expects('from_wc_order')
+		$orderFactory
+			->shouldReceive('from_wc_order')
             ->with($wcOrder, $currentOrder)
             ->andReturn($currentOrder);
         $threeDSecure = Mockery::mock(ThreeDSecure::class);

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -143,6 +143,7 @@ class OrderProcessorTest extends TestCase
 
         $logger = Mockery::mock(LoggerInterface::class);
 		$logger->shouldReceive('info')->byDefault();
+		$logger->shouldReceive('error')->byDefault();
 
         $subscription_helper = Mockery::mock(SubscriptionHelper::class);
         $subscription_helper->shouldReceive('has_subscription');
@@ -223,7 +224,7 @@ class OrderProcessorTest extends TestCase
 
         $wcOrder = Mockery::mock(\WC_Order::class);
 		$wcOrder->shouldReceive('get_id')->andReturn(1);
-		$wcOrder->expects('get_items')->andReturn([]);
+		$wcOrder->shouldReceive('get_items')->andReturn([]);
 		$orderStatus = Mockery::mock(OrderStatus::class);
         $orderStatus
             ->shouldReceive('is')
@@ -296,6 +297,7 @@ class OrderProcessorTest extends TestCase
 
 		$logger = Mockery::mock(LoggerInterface::class);
 		$logger->shouldReceive('info')->byDefault();
+		$logger->shouldReceive('error')->byDefault();
 		$subscription_helper = Mockery::mock(SubscriptionHelper::class);
 
 		$order_helper = Mockery::mock(OrderHelper::class);
@@ -366,6 +368,8 @@ class OrderProcessorTest extends TestCase
 		    ->andReturn(null);
 
         $wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn(1);
+		$wcOrder->shouldReceive('get_items')->andReturn([]);
 
         $wcOrder->shouldReceive('set_transaction_id')
             ->with($transactionId);
@@ -426,6 +430,7 @@ class OrderProcessorTest extends TestCase
 
 		$logger = Mockery::mock(LoggerInterface::class);
 		$logger->shouldReceive('info')->byDefault();
+		$logger->shouldReceive('error')->byDefault();
 		$subscription_helper = Mockery::mock(SubscriptionHelper::class);
 
 		$order_helper = Mockery::mock(OrderHelper::class);
@@ -451,18 +456,18 @@ class OrderProcessorTest extends TestCase
 			$order_lock_helper
         );
 
-        $wcOrder
-            ->expects('update_meta_data')
-            ->with(
-                PayPalGateway::ORDER_ID_META_KEY,
-                $orderId
-            );
-        $wcOrder
-            ->expects('update_meta_data')
-            ->with(
-                PayPalGateway::INTENT_META_KEY,
-                $orderIntent
-            );
+		$wcOrder
+			->shouldReceive('update_meta_data')
+			->with(
+				PayPalGateway::ORDER_ID_META_KEY,
+				$orderId
+			);
+		$wcOrder
+			->shouldReceive('update_meta_data')
+			->with(
+				PayPalGateway::INTENT_META_KEY,
+				$orderIntent
+			);
 		$wcOrder->shouldReceive('save');
 
 		$order_helper->shouldReceive('contains_physical_goods')->andReturn(true);

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -118,7 +118,7 @@ class OrderProcessorTest extends TestCase
 	    $orderEndpoint->shouldReceive('order')->andReturn($currentOrder);
 
         $orderEndpoint
-            ->expects('patch_order_with')
+            ->shouldReceive('patch_order_with')
             ->with($currentOrder, $currentOrder)
             ->andReturn($currentOrder);
         $orderEndpoint

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -128,7 +128,7 @@ class OrderProcessorTest extends TestCase
 
         $orderFactory = Mockery::mock(OrderFactory::class);
         $orderFactory
-            ->expects('from_wc_order')
+            ->shouldReceive('from_wc_order')
             ->with($wcOrder, $currentOrder)
             ->andReturn($currentOrder);
 

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -189,6 +189,9 @@ class OrderProcessorTest extends TestCase
                 PayPalGateway::INTENT_META_KEY,
                 $orderIntent
             );
+		$wcOrder
+			->expects('update_meta_data')
+			->with(PayPalGateway::ORDER_PAYMENT_MODE_META_KEY, 'live');
         $wcOrder
             ->expects('update_status')
             ->with('on-hold', 'Awaiting payment.');
@@ -275,8 +278,8 @@ class OrderProcessorTest extends TestCase
 
 	    $orderEndpoint->shouldReceive('order')->andReturn($currentOrder);
 
-        $orderEndpoint
-            ->expects('patch_order_with')
+		$orderEndpoint
+			->shouldReceive('patch_order_with')
             ->with($currentOrder, $currentOrder)
             ->andReturn($currentOrder);
         $orderEndpoint
@@ -379,12 +382,12 @@ class OrderProcessorTest extends TestCase
 		    ->shouldReceive('is')
 		    ->with(OrderStatus::COMPLETED)
 		    ->andReturn(false);
-        $orderStatus
-            ->expects('is')
+		$orderStatus
+			->shouldReceive('is')
             ->with(OrderStatus::APPROVED)
             ->andReturn(false);
 		$orderStatus
-			->expects('is')
+			->shouldReceive('is')
 			->with(OrderStatus::CREATED)
 			->andReturn(false);
         $orderId = 'abc';

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -149,6 +149,8 @@ class OrderProcessorTest extends TestCase
 
         $order_helper = Mockery::mock(OrderHelper::class);
 		$order_lock_helper = Mockery::mock(OrderLockHelper::class);
+		$order_lock_helper->shouldReceive('acquire_lock')->once()->andReturn(true);
+		$order_lock_helper->shouldReceive('release_lock')->once();
 
         $testee = new OrderProcessor(
             $sessionHandler,
@@ -220,6 +222,7 @@ class OrderProcessorTest extends TestCase
 	        ->andReturn(null);
 
         $wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn(1);
 		$wcOrder->expects('get_items')->andReturn([]);
 		$orderStatus = Mockery::mock(OrderStatus::class);
         $orderStatus
@@ -296,6 +299,8 @@ class OrderProcessorTest extends TestCase
 
 		$order_helper = Mockery::mock(OrderHelper::class);
 		$order_lock_helper = Mockery::mock(OrderLockHelper::class);
+		$order_lock_helper->shouldReceive('acquire_lock')->once()->andReturn(true);
+		$order_lock_helper->shouldReceive('release_lock')->once();
 
 		$testee = new OrderProcessor(
             $sessionHandler,
@@ -426,6 +431,8 @@ class OrderProcessorTest extends TestCase
 
 		$order_helper = Mockery::mock(OrderHelper::class);
 		$order_lock_helper = Mockery::mock(OrderLockHelper::class);
+		$order_lock_helper->shouldReceive('acquire_lock')->once()->andReturn(true);
+		$order_lock_helper->shouldReceive('release_lock')->once();
 
 		$testee = new OrderProcessor(
             $sessionHandler,

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderHelper;
 use WooCommerce\PayPalCommerce\Button\Helper\ThreeDSecure;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\OrderLockHelper;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -147,6 +148,7 @@ class OrderProcessorTest extends TestCase
         $subscription_helper->shouldReceive('has_subscription');
 
         $order_helper = Mockery::mock(OrderHelper::class);
+		$order_lock_helper = Mockery::mock(OrderLockHelper::class);
 
         $testee = new OrderProcessor(
             $sessionHandler,
@@ -162,7 +164,8 @@ class OrderProcessorTest extends TestCase
 			Mockery::mock(PurchaseUnitFactory::class),
 			Mockery::mock(PayerFactory::class),
 			Mockery::mock(ShippingPreferenceFactory::class),
-			Mockery::mock(ExperienceContextBuilder::class)
+			Mockery::mock(ExperienceContextBuilder::class),
+			$order_lock_helper
         );
 
         $wcOrder
@@ -292,6 +295,7 @@ class OrderProcessorTest extends TestCase
 		$subscription_helper = Mockery::mock(SubscriptionHelper::class);
 
 		$order_helper = Mockery::mock(OrderHelper::class);
+		$order_lock_helper = Mockery::mock(OrderLockHelper::class);
 
 		$testee = new OrderProcessor(
             $sessionHandler,
@@ -307,7 +311,8 @@ class OrderProcessorTest extends TestCase
 			Mockery::mock(PurchaseUnitFactory::class),
 			Mockery::mock(PayerFactory::class),
 			Mockery::mock(ShippingPreferenceFactory::class),
-			Mockery::mock(ExperienceContextBuilder::class)
+			Mockery::mock(ExperienceContextBuilder::class),
+			$order_lock_helper
         );
 
         $wcOrder
@@ -420,6 +425,7 @@ class OrderProcessorTest extends TestCase
 		$subscription_helper = Mockery::mock(SubscriptionHelper::class);
 
 		$order_helper = Mockery::mock(OrderHelper::class);
+		$order_lock_helper = Mockery::mock(OrderLockHelper::class);
 
 		$testee = new OrderProcessor(
             $sessionHandler,
@@ -435,7 +441,8 @@ class OrderProcessorTest extends TestCase
 			Mockery::mock(PurchaseUnitFactory::class),
 			Mockery::mock(PayerFactory::class),
 			Mockery::mock(ShippingPreferenceFactory::class),
-			Mockery::mock(ExperienceContextBuilder::class)
+			Mockery::mock(ExperienceContextBuilder::class),
+			$order_lock_helper
         );
 
         $wcOrder

--- a/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderProcessorTest.php
@@ -62,9 +62,8 @@ class OrderProcessorTest extends TestCase
 		    ->andReturn(null);
 
         $wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn(1);
 		$wcOrder->expects('get_items')->andReturn([]);
-        $wcOrder->expects('update_meta_data')
-            ->with(PayPalGateway::ORDER_PAYMENT_MODE_META_KEY, 'live');
         $wcOrder->shouldReceive('get_id')->andReturn(1);
 
         $orderStatus = Mockery::mock(OrderStatus::class);
@@ -143,6 +142,7 @@ class OrderProcessorTest extends TestCase
             ->andReturnFalse();
 
         $logger = Mockery::mock(LoggerInterface::class);
+		$logger->shouldReceive('info')->byDefault();
 
         $subscription_helper = Mockery::mock(SubscriptionHelper::class);
         $subscription_helper->shouldReceive('has_subscription');
@@ -295,6 +295,7 @@ class OrderProcessorTest extends TestCase
             ->andReturnFalse();
 
 		$logger = Mockery::mock(LoggerInterface::class);
+		$logger->shouldReceive('info')->byDefault();
 		$subscription_helper = Mockery::mock(SubscriptionHelper::class);
 
 		$order_helper = Mockery::mock(OrderHelper::class);
@@ -366,9 +367,6 @@ class OrderProcessorTest extends TestCase
 
         $wcOrder = Mockery::mock(\WC_Order::class);
 
-        $wcOrder->expects('update_meta_data')
-            ->with(PayPalGateway::ORDER_PAYMENT_MODE_META_KEY, 'live');
-
         $wcOrder->shouldReceive('set_transaction_id')
             ->with($transactionId);
 
@@ -427,6 +425,7 @@ class OrderProcessorTest extends TestCase
         $settings = Mockery::mock(Settings::class);
 
 		$logger = Mockery::mock(LoggerInterface::class);
+		$logger->shouldReceive('info')->byDefault();
 		$subscription_helper = Mockery::mock(SubscriptionHelper::class);
 
 		$order_helper = Mockery::mock(OrderHelper::class);


### PR DESCRIPTION
### Description

This PR will introduce an **order locking mechanism** to prevent race conditions that can occur when multiple processes (like the customer's browser returning from checkout and an incoming PayPal webhook) try to finalize the same order simultaneously. This addresses issues that lead to multiple payment captures and order status discrepancies.

### Steps to test

1.  **Baseline Test:** Place an order using both **Classic** and **Block** checkouts to confirm successful and failed payment scenarios still function correctly.
2.  **Race Condition Test:** Simulate a race condition between the customer's browser returning from checkout and an incoming PayPal webhook for a single order. Verify that the lock mechanism prevents the order from being processed twice (e.g., prevents double stock reduction).