### PR TITLE
Webhook transient lock

### DIFF
--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -43,12 +43,14 @@ return array(
 		$rest_endpoint = $container->get( 'webhook.endpoint.controller' );
 		$last_webhook_storage = $container->get( 'webhook.last-webhook-storage' );
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
+
 		return new WebhookRegistrar(
 			$factory,
 			$endpoint,
 			$rest_endpoint,
 			$last_webhook_storage,
 			$container->get( 'webhook.status.simulation' ),
+			$container->get( 'webhook.orchestration' ),
 			$logger
 		);
 	},

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -52,6 +52,11 @@ return array(
 			$logger
 		);
 	},
+	'webhook.orchestration'                   => static function ( ContainerInterface $container ): WebhookOrchestrator {
+		return new WebhookOrchestrator(
+			$container->get( 'woocommerce.logger.woocommerce' )
+		);
+	},
 	'webhook.endpoint.controller'             => function ( ContainerInterface $container ): IncomingWebhookEndpoint {
 		$webhook_endpoint = $container->get( 'api.endpoint.webhook' );
 		$webhook  = $container->get( 'webhook.current' );

--- a/modules/ppcp-webhooks/src/WebhookOrchestrator.php
+++ b/modules/ppcp-webhooks/src/WebhookOrchestrator.php
@@ -1,0 +1,60 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Webhooks;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Orchestrates webhook operations with lock protection to prevent race conditions.
+ */
+class WebhookOrchestrator {
+
+	private const LOCK_KEY      = 'ppcp_webhook_operation_lock';
+	private const LOCK_DURATION = 60;
+
+	private LoggerInterface $logger;
+
+	public function __construct( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Execute a webhook operation with lock protection.
+	 *
+	 * @param string   $action    Which operation is started (for logging).
+	 * @param callable $operation The operation to execute.
+	 * @return mixed The result of the operation, or null if locked.
+	 */
+	public function with_lock( string $action, callable $operation ) {
+		if ( $this->is_locked() ) {
+			$this->logger->info( "Webhook operation '$action' skipped - lock held by another process." );
+
+			return null;
+		}
+
+		$this->acquire_lock( $action );
+
+		try {
+			$this->logger->debug( "Webhook operation '$action' started." );
+
+			return $operation();
+		} finally {
+			$this->release_lock( $action );
+		}
+	}
+
+	private function is_locked(): bool {
+		return false !== get_transient( self::LOCK_KEY );
+	}
+
+	private function acquire_lock( string $action ): void {
+		set_transient( self::LOCK_KEY, true, self::LOCK_DURATION );
+		$this->logger->debug( "Webhook lock acquired for '$action'." );
+	}
+
+	private function release_lock( string $action ): void {
+		delete_transient( self::LOCK_KEY );
+		$this->logger->debug( "Webhook lock released for '$action'." );
+	}
+}

--- a/modules/ppcp-webhooks/src/WebhookRegistrar.php
+++ b/modules/ppcp-webhooks/src/WebhookRegistrar.php
@@ -27,6 +27,8 @@ class WebhookRegistrar {
 
 	private WebhookSimulation $webhook_simulation;
 
+	private WebhookOrchestrator $webhook_orchestrator;
+
 	private LoggerInterface $logger;
 
 	public function __construct(
@@ -35,6 +37,7 @@ class WebhookRegistrar {
 		IncomingWebhookEndpoint $incoming_webhook_endpoint,
 		WebhookEventStorage $last_webhook_event_storage,
 		WebhookSimulation $webhook_simulation,
+		WebhookOrchestrator $webhook_orchestrator,
 		LoggerInterface $logger
 	) {
 
@@ -43,6 +46,7 @@ class WebhookRegistrar {
 		$this->incoming_webhook_endpoint  = $incoming_webhook_endpoint;
 		$this->last_webhook_event_storage = $last_webhook_event_storage;
 		$this->webhook_simulation         = $webhook_simulation;
+		$this->webhook_orchestrator       = $webhook_orchestrator;
 		$this->logger                     = $logger;
 	}
 
@@ -52,7 +56,32 @@ class WebhookRegistrar {
 	 * @return bool
 	 */
 	public function register(): bool {
-		$this->unregister();
+		$result = $this->webhook_orchestrator->with_lock(
+			'register',
+			fn() => $this->do_register()
+		);
+
+		// If locked (null), treat as failure.
+		return $result ?? false;
+	}
+
+	/**
+	 * Unregister webhooks with PayPal.
+	 */
+	public function unregister(): void {
+		$this->webhook_orchestrator->with_lock(
+			'unregister',
+			fn() => $this->do_unregister()
+		);
+	}
+
+	/**
+	 * Internal registration logic.
+	 *
+	 * @return bool
+	 */
+	private function do_register(): bool {
+		$this->do_unregister();
 
 		$webhook = $this->webhook_factory->for_url_and_events(
 			$this->incoming_webhook_endpoint->url(),
@@ -84,9 +113,9 @@ class WebhookRegistrar {
 	}
 
 	/**
-	 * Unregister webhooks with PayPal.
+	 * Internal unregister logic.
 	 */
-	public function unregister(): void {
+	private function do_unregister(): void {
 		try {
 			$webhooks = $this->endpoint->list();
 			foreach ( $webhooks as $webhook ) {


### PR DESCRIPTION
### Description

Implements a 60-second lock using a transient for the webhook "register" and "unregister" operations. The goal is to prevent race conditions

Full sequence of the new webhook registration process:
```log
1.  Debug - #8479 - [New Request] POST /wp-json/wc/v3/wc_paypal/webhooks
2.  Debug - #8479 - Webhook lock acquired for 'register'. ← NEW LOCK
3.  Debug - #8479 - Webhook operation 'register' started.
4.  Debug - #8479 - GET https://api-m.sandbox.paypal.com/v1/notifications/webhooks
5.  Debug - #8479 - DELETE https://api-m.sandbox.paypal.com/v1/notifications/webhooks/...
6.  Info  - #8479 - Webhooks deleted.
7.  Debug - #8479 - POST https://api-m.sandbox.paypal.com/v1/notifications/webhooks
8.  Debug - #8479 - POST https://api-m.sandbox.paypal.com/v1/notifications/simulate-event
9.  Info  - #8479 - Webhooks subscribed.
10. Debug - #8479 - Webhook lock released for 'register'. ← NEW UNLOCK
11. Debug - #8479 - GET https://api-m.sandbox.paypal.com/v1/notifications/webhooks
```