### PR TITLE
Improve test coverage report (5449)

### DIFF
--- a/.ddev/docker-compose.phpunit.yaml
+++ b/.ddev/docker-compose.phpunit.yaml
@@ -1,0 +1,4 @@
+services:
+    web:
+        volumes:
+            - ../coverage-report:/var/www/html/.ddev/wordpress/coverage:ro

--- a/.ddev/docker-compose.phpunit.yaml
+++ b/.ddev/docker-compose.phpunit.yaml
@@ -1,4 +1,4 @@
 services:
     web:
         volumes:
-            - ../coverage-report:/var/www/html/.ddev/wordpress/coverage:ro
+            - ../coverage:/var/www/html/.ddev/wordpress/coverage:ro

--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ Optionally, change the `PAYPAL_INTEGRATION_DATE` constant to `gmdate( 'Y-m-d' )`
 
 Run `yarn ddev:unit-tests:coverage` 
 
-This command will generate a `coverage` folder in the project root. Open this in your browser to inspect the Unit Test coverage.
+This command generates a full test coverage report, available at the URL https://woocommerce-paypal-payments.ddev.site/coverage
+
+Note: The code coverage report requires XDebug to be enabled. Run `ddev xdebug on` if no report is generated.
 
 ### Building a release package
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,6 @@ Run `yarn ddev:unit-tests:coverage`
 
 This command generates a full test coverage report, available at the URL https://woocommerce-paypal-payments.ddev.site/coverage
 
-Note: The code coverage report requires XDebug to be enabled. Run `ddev xdebug on` if no report is generated.
-
 ### Building a release package
 
 If you want to build a release package

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "ci": [
             "vendor/bin/phpcs"
         ],
-        "unit": "./vendor/bin/phpunit --coverage-html build/coverage-report"
+        "unit": "vendor/bin/phpunit"
     },
     "extra": {
         "installer-types": [

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "test:unit-js": "wp-scripts test-unit-js --config ./tests/js/jest.config.json",
     "ddev:composer-update": "ddev composer update && ddev composer update --lock",
     "ddev:unit-tests": "ddev exec phpunit",
-    "ddev:unit-tests:coverage": "ddev exec XDEBUG_MODE=coverage phpunit --coverage-html coverage/",
+    "ddev:unit-tests:coverage": "ddev xdebug on && ddev exec XDEBUG_MODE=coverage phpunit --coverage-html coverage/",
     "ddev:e2e-tests": "(cp -n .env.e2e.example .env.e2e || true) && ddev php tests/e2e/PHPUnit/setup.php && ddev exec phpunit -c tests/e2e/phpunit.xml.dist",
     "ddev:pw-install": "ddev yarn playwright install --with-deps",
     "ddev:pw-tests": "ddev yarn playwright test",


### PR DESCRIPTION
### Description

Addresses minor convenience issues with the PHPUnit test coverage report:

1. A new volume mounts the coverage report in the `/coverage` folder at the root of the dev domain
2. The `yarn ddev:unit-tests:coverage` command auto-enabled XDebug (required for the coverage report)
3. Minor update to the README.md file to document the changes
4. Removed confusing script details from `composer.json` as we don't use them and they did not work