### PR TITLE
[Fix] Google Pay shows address and shipping method selection for virtual products (PCP-5248) 

### DIFF
--- a/modules/ppcp-googlepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/BaseHandler.js
@@ -18,7 +18,10 @@ class BaseHandler {
 
 	shippingAllowed() {
 		// Status of the shipping settings in WooCommerce.
-		return this.buttonConfig.shipping.configured;
+		return (
+			this.buttonConfig.shipping.enabled &&
+			this.buttonConfig.shipping.configured
+		);
 	}
 
 	transactionInfo() {

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -465,7 +465,7 @@ class Button implements ButtonInterface {
 			}
 		}
 
-		if ( ! WC()->cart->needs_shipping() ) {
+		if ( WC()->cart && ! WC()->cart->needs_shipping() ) {
 			$use_shipping_form = false;
 		}
 

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -465,7 +465,7 @@ class Button implements ButtonInterface {
 			}
 		}
 
-		if ( WC()->cart && ! WC()->cart->needs_shipping() ) {
+		if ( ! is_null( WC()->cart ) && ! WC()->cart->needs_shipping() ) {
 			$use_shipping_form = false;
 		}
 

--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -465,6 +465,10 @@ class Button implements ButtonInterface {
 			}
 		}
 
+		if ( ! WC()->cart->needs_shipping() ) {
+			$use_shipping_form = false;
+		}
+
 		$shipping = array(
 			'enabled'    => $use_shipping_form,
 			'configured' => wc_shipping_enabled() && wc_get_shipping_method_count( false, true ) > 0,


### PR DESCRIPTION
### Description

Removes the need for shipping for virtual and downloadable products in Google Pay

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Enable Pay Now
2. Enable a Shipping method (i.e Free Shipping)
3. Enable Google Pay
4. Add only a Virtual or downloadable product
5. Go to Cart (Blocks)  
6. Pay with Google Pay
7. Shipping is not shown in the iframe
8. Order can be completed
10. Add a physical product 
11. Go to Cart (Blocks)  
6. Pay with Google Pay
7. Shipping is shown in the iframe
8. Order can be completed
