### PR TITLE
[Fix] Google Pay does not update the WC address correctly (PCP-5247)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
+++ b/modules/ppcp-button/resources/js/modules/OnApproveHandler/onApproveForContinue.js
@@ -35,6 +35,10 @@ const onApprove = ( context, errorHandler ) => {
 			payload.payer = data.payer;
 		}
 
+		if ( canCreateOrder && data.shippingAddress ) {
+			payload.shipping_address = data.shippingAddress;
+		}
+
 		return fetch( context.config.ajax.approve_order.endpoint, {
 			method: 'POST',
 			headers: {

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -399,7 +399,8 @@ return array(
 			$container->get( 'session.handler' ),
 			$container->get( 'wc-subscriptions.helper' ),
 			$container->get( 'button.session.factory.card-data' ),
-			$container->get( 'api.factory.shipping' )
+			$container->get( 'api.factory.shipping' ),
+			$container->get( 'api.factory.payer' )
 		);
 	},
 

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -245,7 +245,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 
 			$should_create_wc_order = $data['should_create_wc_order'] ?? false;
 			if ( ! $this->final_review_enabled && ! $this->context->is_checkout() && $should_create_wc_order ) {
-				$wc_order = $this->wc_order_creator->create_from_paypal_order( $order, WC()->cart );
+				$wc_order = $this->wc_order_creator->create_from_paypal_order( $order, WC()->cart, $data );
 				$this->gateway->process_payment( $wc_order->get_id() );
 				$order_received_url = $wc_order->get_checkout_order_received_url();
 

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce\Button\Helper
  */
 
-declare(strict_types=1);
+declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\Button\Helper;
 
@@ -24,6 +24,7 @@ use WC_Tax;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingFactory;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataFactory;
@@ -62,19 +63,22 @@ class WooCommerceOrderCreator {
 	protected CartDataFactory $cart_data_factory;
 
 	protected $shipping_factory;
+	protected PayerFactory $payer_factory;
 
 	public function __construct(
 		FundingSourceRenderer $funding_source_renderer,
 		SessionHandler $session_handler,
 		SubscriptionHelper $subscription_helper,
 		CartDataFactory $cart_data_factory,
-		ShippingFactory $shipping_factory
+		ShippingFactory $shipping_factory,
+		PayerFactory $payer_factory
 	) {
 		$this->funding_source_renderer = $funding_source_renderer;
 		$this->session_handler         = $session_handler;
 		$this->subscription_helper     = $subscription_helper;
 		$this->cart_data_factory       = $cart_data_factory;
 		$this->shipping_factory        = $shipping_factory;
+		$this->payer_factory           = $payer_factory;
 	}
 
 	/**
@@ -82,9 +86,11 @@ class WooCommerceOrderCreator {
 	 *
 	 * @param Order            $order The PayPal order.
 	 * @param WC_Cart|CartData $cart The WC cart (converted into CartData).
+	 * @param array|null       $paypal_data The PayPal Response Data.
+	 *
 	 * @throws RuntimeException If problem creating.
 	 */
-	public function create_from_paypal_order( Order $order, $cart ): WC_Order {
+	public function create_from_paypal_order( Order $order, $cart, ?array $paypal_data = null ): WC_Order {
 		$cart_data = $cart;
 		if ( $cart_data instanceof WC_Cart ) {
 			$cart_data = $this->cart_data_factory->from_current_cart( $cart_data );
@@ -97,9 +103,8 @@ class WooCommerceOrderCreator {
 		}
 
 		try {
-			$payer          = $order->payer();
-			$purchase_units = $order->purchase_units();
-			$shipping       = ! empty( $purchase_units ) ? $purchase_units[0]->shipping() : null;
+			$payer    = $this->get_payer( $order, $paypal_data );
+			$shipping = $this->get_shipping( $order, $paypal_data );
 
 			$this->configure_payment_source( $wc_order );
 			$this->configure_customer( $wc_order, $cart_data );
@@ -203,7 +208,7 @@ class WooCommerceOrderCreator {
 		$shipping_address = null;
 		$billing_address  = null;
 		$shipping_options = null;
-		$wc_customer = WC()->customer;
+		$wc_customer      = WC()->customer;
 
 		if ( ! $shipping && $needs_shipping ) {
 			if ( $wc_customer instanceof WC_Customer ) {
@@ -216,7 +221,7 @@ class WooCommerceOrderCreator {
 			$payer_name  = $payer->name();
 			$payer_phone = $payer->phone();
 
-			$wc_email    = null;
+			$wc_email = null;
 			if ( $wc_customer instanceof WC_Customer ) {
 				$wc_email = $wc_customer->get_email();
 			}
@@ -291,6 +296,7 @@ class WooCommerceOrderCreator {
 	 * Configures the payment source.
 	 *
 	 * @param WC_Order $wc_order The WC order.
+	 *
 	 * @return void
 	 */
 	protected function configure_payment_source( WC_Order $wc_order ): void {
@@ -310,6 +316,7 @@ class WooCommerceOrderCreator {
 
 		if ( $current_user->ID !== 0 ) {
 			$wc_order->set_customer_id( $current_user->ID );
+
 			return;
 		}
 
@@ -324,6 +331,7 @@ class WooCommerceOrderCreator {
 	 *
 	 * @param WC_Order $wc_order The WC order.
 	 * @param string[] $coupons The list of applied coupons.
+	 *
 	 * @return void
 	 */
 	protected function configure_coupons( WC_Order $wc_order, array $coupons ): void {
@@ -338,6 +346,7 @@ class WooCommerceOrderCreator {
 	 * @param WC_Product            $product The Product.
 	 * @param WC_Order_Item_Product $item The line item.
 	 * @param float|string          $subtotal The subtotal.
+	 *
 	 * @return void
 	 * @psalm-suppress InvalidScalarArgument
 	 */
@@ -353,6 +362,7 @@ class WooCommerceOrderCreator {
 	 * Checks if the product with given ID is WC subscription.
 	 *
 	 * @param int $product_id The product ID.
+	 *
 	 * @return bool true if the product is subscription, otherwise false.
 	 */
 	protected function is_subscription( int $product_id ): bool {
@@ -368,6 +378,7 @@ class WooCommerceOrderCreator {
 	 *
 	 * @param WC_Order $wc_order The WC order.
 	 * @param int      $product_id The product ID.
+	 *
 	 * @return WC_Subscription The subscription order
 	 * @throws RuntimeException If problem creating.
 	 */
@@ -387,5 +398,49 @@ class WooCommerceOrderCreator {
 		}
 
 		return $subscription;
+	}
+
+
+	/**
+	 * Get the Payer from the PayPal order with fallback to the PayPal response data.
+	 *
+	 * @param Order      $order The PayPal Order.
+	 * @param array|null $paypal_data The PayPal Response data.
+	 *
+	 * @return Payer|null The Payer object or null if no payer information is available.
+	 */
+	private function get_payer( Order $order, ?array $paypal_data = null ): ?Payer {
+		$payer = $order->payer();
+		if ( is_null( $payer ) && isset( $paypal_data['payer'] ) ) {
+			$payer = $this->payer_factory->from_paypal_response( json_decode( wp_json_encode( $paypal_data['payer'] ) ) );
+		}
+
+		return $payer;
+	}
+
+	/**
+	 * Get the Shipping information from the PayPal order with fallback to the PayPal response data.
+	 *
+	 * @param Order      $order The PayPal Order.
+	 * @param array|null $paypal_data The PayPal Response data.
+	 *
+	 * @return Shipping|null The shipping object or null if no shipping information is available.
+	 */
+	private function get_shipping( Order $order, ?array $paypal_data = null ): ?Shipping {
+		$purchase_units = $order->purchase_units();
+		$shipping       = ! empty( $purchase_units ) ? $purchase_units[0]->shipping() : null;
+
+		if ( $shipping && is_null( $shipping->address() ) && isset( $paypal_data['shipping_address'] ) ) {
+			$paypal_data['shipping_address']['options'] = array_map(
+				function ( $option ) {
+					return $option->to_array();
+				},
+				$shipping->options()
+			);
+			$shipping_address_data                      = json_decode( wp_json_encode( $paypal_data['shipping_address'] ) );
+			$shipping                                   = $this->shipping_factory->from_paypal_response( $shipping_address_data );
+		}
+
+		return $shipping;
 	}
 }

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -412,7 +412,8 @@ class WooCommerceOrderCreator {
 	private function get_payer( Order $order, ?array $paypal_data = null ): ?Payer {
 		$payer = $order->payer();
 		if ( is_null( $payer ) && isset( $paypal_data['payer'] ) ) {
-			$payer = $this->payer_factory->from_paypal_response( json_decode( wp_json_encode( $paypal_data['payer'] ) ) );
+			$payer_data = json_decode( wp_json_encode( $paypal_data['payer'] ) ?: '' );
+			$payer      = $this->payer_factory->from_paypal_response( $payer_data );
 		}
 
 		return $payer;
@@ -437,7 +438,7 @@ class WooCommerceOrderCreator {
 				},
 				$shipping->options()
 			);
-			$shipping_address_data                      = json_decode( wp_json_encode( $paypal_data['shipping_address'] ) );
+			$shipping_address_data                      = json_decode( wp_json_encode( $paypal_data['shipping_address'] ) ?: '' );
 			$shipping                                   = $this->shipping_factory->from_paypal_response( $shipping_address_data );
 		}
 

--- a/modules/ppcp-googlepay/resources/js/Context/CartBlockHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/CartBlockHandler.js
@@ -1,13 +1,5 @@
 import BaseHandler from './BaseHandler';
 
-class CartBlockHandler extends BaseHandler {
-	createOrder() {
-		return this.externalHandler.createOrder();
-	}
-
-	approveOrder( data, actions ) {
-		return this.externalHandler.onApprove( data, actions );
-	}
-}
+class CartBlockHandler extends BaseHandler {}
 
 export default CartBlockHandler;

--- a/modules/ppcp-googlepay/resources/js/Context/CheckoutBlockHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/CheckoutBlockHandler.js
@@ -1,13 +1,5 @@
 import BaseHandler from './BaseHandler';
 
-class CheckoutBlockHandler extends BaseHandler {
-	createOrder() {
-		return this.externalHandler.createOrder();
-	}
-
-	approveOrder( data, actions ) {
-		return this.externalHandler.onApprove( data, actions );
-	}
-}
+class CheckoutBlockHandler extends BaseHandler {}
 
 export default CheckoutBlockHandler;

--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -77,6 +77,17 @@ const ORDER_FAILED = 'failed';
  */
 const ORDER_INCOMPLETE = 'payerAction';
 
+function getAddressFromData( data ) {
+	return {
+		country_code: data.countryCode,
+		address_line_1: data.address1,
+		address_line_2: data.address2,
+		admin_area_1: data.administrativeArea,
+		admin_area_2: data.locality,
+		postal_code: data.postalCode,
+	};
+}
+
 function payerDataFromPaymentResponse( response ) {
 	const raw = response?.paymentMethodData?.info?.billingAddress;
 
@@ -86,14 +97,17 @@ function payerDataFromPaymentResponse( response ) {
 			given_name: raw.name.split( ' ' )[ 0 ], // Assuming first name is the first part
 			surname: raw.name.split( ' ' ).slice( 1 ).join( ' ' ), // Assuming last name is the rest
 		},
-		address: {
-			country_code: raw.countryCode,
-			address_line_1: raw.address1,
-			address_line_2: raw.address2,
-			admin_area_1: raw.administrativeArea,
-			admin_area_2: raw.locality,
-			postal_code: raw.postalCode,
+		address: getAddressFromData( raw ),
+	};
+}
+
+function shippingAddressDataFromPaymentResponse( response ) {
+	const shippingAddress = response?.shippingAddress;
+	return {
+		name: {
+			full_name: shippingAddress.name,
 		},
+		address: getAddressFromData( shippingAddress ),
 	};
 }
 
@@ -829,10 +843,13 @@ class GooglepayButton extends PaymentButton {
 
 	async processPayment( paymentData ) {
 		this.logGroup( 'processPayment' );
-
 		let result;
 
+		this.log( 'processPayment paymentData', paymentData );
+
 		const payer = payerDataFromPaymentResponse( paymentData );
+		const shippingAddress =
+			shippingAddressDataFromPaymentResponse( paymentData );
 
 		const paymentResponse = ( state, intent = null, message = null ) => {
 			const response = {
@@ -909,7 +926,7 @@ class GooglepayButton extends PaymentButton {
 			this.log( 'approveOrder', orderID );
 
 			await this.contextHandler.approveOrder(
-				{ orderID, payer },
+				{ orderID, payer, shippingAddress },
 				{
 					restart: () =>
 						new Promise( ( resolve ) => {

--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -845,8 +845,6 @@ class GooglepayButton extends PaymentButton {
 		this.logGroup( 'processPayment' );
 		let result;
 
-		this.log( 'processPayment paymentData', paymentData );
-
 		const payer = payerDataFromPaymentResponse( paymentData );
 		const shippingAddress =
 			shippingAddressDataFromPaymentResponse( paymentData );


### PR DESCRIPTION
### Description

Fix bug in Google Pay for  Cart and Checkout Blocks when no address is set in the store

[The Update Data from PayPal ](https://developers.google.com/pay/api/web/reference/client#onPaymentDataChanged) only gets intermediate shipping data; it's better to handle the shipping data when payment is processed and load it inside the WC Order in the backend. The removed Handler expected some shipping in the order data that will never be available, making the order to fail. 

### Steps to Test

1. As a guest with a clean browser session, add a physical product to the cart.
2. Go to the block cart.
3. Pay via Google Pay.
4. Order can be completed and fills the address correctly

1. As a guest with a clean browser session, add a physical product to the cart.
2. Go to the block checkout.
3. Pay via Google Pay.
4. Order can be completed and fills the address correctly

### Demo

https://github.com/user-attachments/assets/ae057809-eb70-4c2b-8eb2-8f3227534401





