### PR TITLE
JWT Authentication [5266]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "wikimedia/composer-merge-plugin": "^2.0",
         "wp-oop/wordpress-interface": "^0.1.0-alpha1",
         "dhii/versions": "^0.1.0-alpha1",
-        "symfony/polyfill-php80": "^1.19"
+        "symfony/polyfill-php80": "^1.19",
+        "firebase/php-jwt": "^6.0"
     },
     "require-dev": {
         "inpsyde/composer-assets-compiler": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1ad62ff0a56f3dbf9600eef6de90a8a",
+    "content-hash": "32456c5109a3cc7f38c238776f0a1d21",
     "packages": [
         {
             "name": "container-interop/service-provider",
@@ -293,6 +293,69 @@
                 "source": "https://github.com/Dhii/versions/tree/v0.1.0-alpha3"
             },
             "time": "2021-12-08T16:54:50+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/a49db6f0a5033aef5143295342f1c95521b075ff",
+                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4||^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^6.5||^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^1.0||^2.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.10.0"
+            },
+            "time": "2023-12-01T16:26:39+00:00"
         },
         {
             "name": "psr/container",

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -21,5 +21,7 @@ return array(
 	JwtAuthService::class     => static fn( ContainerInterface $c ): JwtAuthService => new JwtAuthService(
 		$c->get( PayPalJwkProvider::class )
 	),
-	CreateCartEndpoint::class => static fn(): CreateCartEndpoint => new CreateCartEndpoint(),
+	CreateCartEndpoint::class => static fn( ContainerInterface $c ): CreateCartEndpoint => new CreateCartEndpoint(
+		$c->get( JwtAuthService::class )
+	),
 );

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -23,6 +23,7 @@ return array(
 	),
 
 	'agentic.rest.create_cart'  => static fn( ContainerInterface $c ): CreateCartEndpoint => new CreateCartEndpoint(
-		$c->get( 'agentic.auth.service' )
+		$c->get( 'agentic.auth.service' ),
+		$c->get( 'agentic.response.factory' ),
 	),
 );

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -16,12 +16,13 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\PayPalJwkProvider;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 
 return array(
-	ResponseFactory::class    => static fn(): ResponseFactory => new ResponseFactory(),
-	PayPalJwkProvider::class  => static fn(): PayPalJwkProvider => new PayPalJwkProvider(),
-	JwtAuthService::class     => static fn( ContainerInterface $c ): JwtAuthService => new JwtAuthService(
-		$c->get( PayPalJwkProvider::class )
+	'agentic.response.factory'  => static fn(): ResponseFactory => new ResponseFactory(),
+	'agentic.auth.key_provider' => static fn(): PayPalJwkProvider => new PayPalJwkProvider(),
+	'agentic.auth.service'      => static fn( ContainerInterface $c ): JwtAuthService => new JwtAuthService(
+		$c->get( 'agentic.auth.key_provider' )
 	),
-	CreateCartEndpoint::class => static fn( ContainerInterface $c ): CreateCartEndpoint => new CreateCartEndpoint(
-		$c->get( JwtAuthService::class )
+
+	'agentic.rest.create_cart'  => static fn( ContainerInterface $c ): CreateCartEndpoint => new CreateCartEndpoint(
+		$c->get( 'agentic.auth.service' )
 	),
 );

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -14,13 +14,6 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\CreateCartEndpoint;
 
 return array(
-	'agentic.response.factory' => static function ( ContainerInterface $container ): ResponseFactory {
-		return new ResponseFactory();
-	},
-
-	// REST endpoints.
-
-	'agentic.rest.create_cart' => static function ( ContainerInterface $container ): CreateCartEndpoint {
-		return new CreateCartEndpoint();
-	},
+	ResponseFactory::class    => static fn(): ResponseFactory => new ResponseFactory(),
+	CreateCartEndpoint::class => static fn(): CreateCartEndpoint => new CreateCartEndpoint(),
 );

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -16,14 +16,24 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\PayPalJwkProvider;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 
 return array(
-	'agentic.response.factory'  => static fn(): ResponseFactory => new ResponseFactory(),
-	'agentic.auth.key_provider' => static fn(): PayPalJwkProvider => new PayPalJwkProvider(),
-	'agentic.auth.service'      => static fn( ContainerInterface $c ): JwtAuthService => new JwtAuthService(
-		$c->get( 'agentic.auth.key_provider' )
-	),
+	'agentic.response.factory'  => static function (): ResponseFactory {
+		return new ResponseFactory();
+	},
+	'agentic.auth.key_provider' => static function (): PayPalJwkProvider {
+		return new PayPalJwkProvider();
+	},
+	'agentic.auth.service'      => static function ( ContainerInterface $c ): JwtAuthService {
+		return new JwtAuthService(
+			$c->get( 'agentic.auth.key_provider' )
+		);
+	},
 
-	'agentic.rest.create_cart'  => static fn( ContainerInterface $c ): CreateCartEndpoint => new CreateCartEndpoint(
-		$c->get( 'agentic.auth.service' ),
-		$c->get( 'agentic.response.factory' ),
-	),
+	// REST endpoints.
+
+	'agentic.rest.create_cart'  => static function ( ContainerInterface $c ): CreateCartEndpoint {
+		return new CreateCartEndpoint(
+			$c->get( 'agentic.auth.service' ),
+			$c->get( 'agentic.response.factory' ),
+		);
+	},
 );

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -12,8 +12,14 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\CreateCartEndpoint;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\PayPalJwkProvider;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 
 return array(
 	ResponseFactory::class    => static fn(): ResponseFactory => new ResponseFactory(),
+	PayPalJwkProvider::class  => static fn(): PayPalJwkProvider => new PayPalJwkProvider(),
+	JwtAuthService::class     => static fn( ContainerInterface $c ): JwtAuthService => new JwtAuthService(
+		$c->get( PayPalJwkProvider::class )
+	),
 	CreateCartEndpoint::class => static fn(): CreateCartEndpoint => new CreateCartEndpoint(),
 );

--- a/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
+++ b/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
@@ -14,7 +14,6 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\AgenticRestEndpoint;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\CreateCartEndpoint;
 
 /**
  * Entry point that integrates agentic commerce logic with the plugin's DI system.
@@ -26,7 +25,7 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 	 * A list of all REST services that this module needs to register on init.
 	 */
 	private const REST_ENDPOINT_SERVICES = array(
-		CreateCartEndpoint::class,
+		'agentic.rest.create_cart',
 	);
 
 	public function services(): array {

--- a/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
+++ b/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\AgenticRestEndpoint;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\CreateCartEndpoint;
 
 /**
  * Entry point that integrates agentic commerce logic with the plugin's DI system.
@@ -25,7 +26,7 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 	 * A list of all REST services that this module needs to register on init.
 	 */
 	private const REST_ENDPOINT_SERVICES = array(
-		'agentic.rest.create_cart',
+		CreateCartEndpoint::class,
 	);
 
 	public function services(): array {

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -1,0 +1,14 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
+
+use WP_Error;
+
+class JwtAuthService {
+
+	public function validate_request() {
+		return new WP_Error( 'missing_token', '', array('status' => 401 ) );
+	}
+}

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -5,11 +5,15 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
 use WP_Error;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Firebase\JWT\SignatureInvalidException;
 
 class JwtAuthService {
 
 	public function validate_request( ?string $token ): WP_Error {
 		$string_token = trim( $token ?? '' );
+
 		if ( $string_token === '' ) {
 			return new WP_Error( 'missing_token', '', array( 'status' => 401 ) );
 		}
@@ -23,7 +27,25 @@ class JwtAuthService {
 			return new WP_Error( 'missing_token', '', array( 'status' => 401 ) );
 		}
 
+		try {
+			$decoded = JWT::decode( $jwt, new Key( $this->public_key_string(), 'HS256' ) );
+		} catch ( SignatureInvalidException $exception ) {
+			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
+		}
+
 		// temp response.
 		return new WP_Error( 'valid_jwt', '', array( 'status' => 200 ) );
+	}
+
+	private function public_key_string(): string {
+		return <<<'EOF'
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvv7Pi1nWWrJj4n5+6gX9
+B7BQpctaPEg9VdVK1kzc9xBNwZobeWEgEmiUGtkrn8S5R6Q4NmB4hnb8F5jeCX5O
+kyA49mgzw4wNXUPGTGMY5Eoxt9zu1Heaivkljh4+wN6d01oIFkHT6E7VjEJOG2RA
+49t7fgQ1phJIUK39B0RAXIG2pYicbujeiiJ12iQipMjY/TVD0KZgUc2Vj2apk7Dv
+1YBqFG+HlSG5hWu880IzGQE9Pds5qekIawJJyed08otq29hDHlFd28B0fFhdzcu8
+cN83NxddXBlh77b8+a7gaWC5/Iw45THRpIsiG41uX0r0INEDcnR3qCUkz6m9LOVW
+kQIDAQAB
+EOF;
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -25,27 +25,27 @@ class JwtAuthService {
 		$string_token = trim( $token ?? '' );
 
 		if ( $string_token === '' ) {
-			return new WP_Error( 'missing_token', '', array( 'status' => 401 ) );
+			return new WP_Error( 'missing_token', 'Please provide a valid token', array( 'status' => 401 ) );
 		}
 
 		if ( 0 !== stripos( $string_token, 'Bearer' ) ) {
-			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
+			return new WP_Error( 'invalid_jwt', 'Please provide a valid token', array( 'status' => 401 ) );
 		}
 
 		$jwt = trim( (string) substr( $string_token, 6 ) );
 		if ( empty( $jwt ) ) {
-			return new WP_Error( 'missing_token', '', array( 'status' => 401 ) );
+			return new WP_Error( 'missing_token', 'Bearer prefix without token found', array( 'status' => 401 ) );
 		}
 
 		$keys = $this->jwk_provider->keys();
 		if ( ! $keys ) {
-			return new WP_Error( 'key_unavailable', '', array( 'status' => 503 ) );
+			return new WP_Error( 'key_unavailable', 'Could not retrieve public JWT key', array( 'status' => 503 ) );
 		}
 
 		try {
 			return JWT::decode( $jwt, $keys );
 		} catch ( Exception $exception ) {
-			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
+			return new WP_Error( 'invalid_jwt', $exception->getMessage(), array( 'status' => 401 ) );
 		}
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -6,12 +6,21 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
 use WP_Error;
 use Firebase\JWT\JWT;
-use Firebase\JWT\Key;
 use Firebase\JWT\SignatureInvalidException;
 
 class JwtAuthService {
 
-	public function validate_request( ?string $token ): WP_Error {
+	private PayPalJwkProvider $jwk_provider;
+
+	public function __construct( PayPalJwkProvider $jwk_provider ) {
+		$this->jwk_provider = $jwk_provider;
+	}
+
+	/**
+	 * @param string|null $token
+	 * @return \stdClass|WP_Error
+	 */
+	public function validate_request( ?string $token ) {
 		$string_token = trim( $token ?? '' );
 
 		if ( $string_token === '' ) {
@@ -27,25 +36,15 @@ class JwtAuthService {
 			return new WP_Error( 'missing_token', '', array( 'status' => 401 ) );
 		}
 
+		$keys = $this->jwk_provider->keys();
+		if ( ! $keys ) {
+			return new WP_Error( 'key_unavailable', '', array( 'status' => 503 ) );
+		}
+
 		try {
-			$decoded = JWT::decode( $jwt, new Key( $this->public_key_string(), 'HS256' ) );
+			return JWT::decode( $jwt, $keys );
 		} catch ( SignatureInvalidException $exception ) {
 			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
 		}
-
-		// temp response.
-		return new WP_Error( 'valid_jwt', '', array( 'status' => 200 ) );
-	}
-
-	private function public_key_string(): string {
-		return <<<'EOF'
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvv7Pi1nWWrJj4n5+6gX9
-B7BQpctaPEg9VdVK1kzc9xBNwZobeWEgEmiUGtkrn8S5R6Q4NmB4hnb8F5jeCX5O
-kyA49mgzw4wNXUPGTGMY5Eoxt9zu1Heaivkljh4+wN6d01oIFkHT6E7VjEJOG2RA
-49t7fgQ1phJIUK39B0RAXIG2pYicbujeiiJ12iQipMjY/TVD0KZgUc2Vj2apk7Dv
-1YBqFG+HlSG5hWu880IzGQE9Pds5qekIawJJyed08otq29hDHlFd28B0fFhdzcu8
-cN83NxddXBlh77b8+a7gaWC5/Iw45THRpIsiG41uX0r0INEDcnR3qCUkz6m9LOVW
-kQIDAQAB
-EOF;
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -7,6 +7,8 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 use WP_Error;
 use Firebase\JWT\JWT;
 use Firebase\JWT\SignatureInvalidException;
+use Firebase\JWT\ExpiredException;
+use Firebase\JWT\BeforeValidException;
 
 class JwtAuthService {
 
@@ -44,6 +46,10 @@ class JwtAuthService {
 		try {
 			return JWT::decode( $jwt, $keys );
 		} catch ( SignatureInvalidException $exception ) {
+			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
+		} catch ( ExpiredException $exception ) {
+			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
+		} catch ( BeforeValidException $exception ) {
 			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
 		}
 	}

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -8,7 +8,22 @@ use WP_Error;
 
 class JwtAuthService {
 
-	public function validate_request() {
-		return new WP_Error( 'missing_token', '', array('status' => 401 ) );
+	public function validate_request( ?string $token ): WP_Error {
+		$string_token = trim( $token ?? '' );
+		if ( $string_token === '' ) {
+			return new WP_Error( 'missing_token', '', array( 'status' => 401 ) );
+		}
+
+		if ( 0 !== stripos( $string_token, 'Bearer' ) ) {
+			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
+		}
+
+		$jwt = trim( (string) substr( $string_token, 6 ) );
+		if ( empty( $jwt ) ) {
+			return new WP_Error( 'missing_token', '', array( 'status' => 401 ) );
+		}
+
+		// temp response.
+		return new WP_Error( 'valid_jwt', '', array( 'status' => 200 ) );
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -4,9 +4,10 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
+use Exception;
+use stdClass;
 use WP_Error;
 use Firebase\JWT\JWT;
-use Exception;
 
 class JwtAuthService {
 
@@ -18,7 +19,7 @@ class JwtAuthService {
 
 	/**
 	 * @param string|null $token
-	 * @return \stdClass|WP_Error
+	 * @return stdClass|WP_Error
 	 */
 	public function validate_request( ?string $token ) {
 		$string_token = trim( $token ?? '' );

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -6,9 +6,7 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
 use WP_Error;
 use Firebase\JWT\JWT;
-use Firebase\JWT\SignatureInvalidException;
-use Firebase\JWT\ExpiredException;
-use Firebase\JWT\BeforeValidException;
+use Exception;
 
 class JwtAuthService {
 
@@ -45,11 +43,7 @@ class JwtAuthService {
 
 		try {
 			return JWT::decode( $jwt, $keys );
-		} catch ( SignatureInvalidException $exception ) {
-			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
-		} catch ( ExpiredException $exception ) {
-			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
-		} catch ( BeforeValidException $exception ) {
+		} catch ( Exception $exception ) {
 			return new WP_Error( 'invalid_jwt', '', array( 'status' => 401 ) );
 		}
 	}

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -7,6 +7,17 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 class PayPalJwkProvider {
 
 	public function keys(): array {
+		return $this->get_cached() ?? $this->fetch_keys();
+	}
+
+	protected function get_cached(): ?array {
+		return array(
+			'key1' => 'value1',
+			'key2' => 'value2',
+		);
+	}
+
+	protected function fetch_keys(): array {
 		return array();
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -5,19 +5,30 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
 class PayPalJwkProvider {
+	private ?array $cache = null;
 
 	public function keys(): array {
-		return $this->get_cached() ?? $this->fetch_keys();
+		$cached = $this->cache_get();
+
+		if ( null !== $cached ) {
+			return $cached;
+		}
+
+		$keys = $this->fetch();
+		$this->cache_set( $keys );
+
+		return $keys;
 	}
 
-	protected function get_cached(): ?array {
-		return array(
-			'key1' => 'value1',
-			'key2' => 'value2',
-		);
+	protected function cache_get(): ?array {
+		return $this->cache;
 	}
 
-	protected function fetch_keys(): array {
+	protected function cache_set( array $value ): void {
+		$this->cache = $value;
+	}
+
+	protected function fetch(): array {
 		return array();
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -4,31 +4,36 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
+use Firebase\JWT\Key;
+
 class PayPalJwkProvider {
-	private ?array $cache = null;
+	private ?Key $cache = null;
 
-	public function keys(): array {
-		$cached = $this->cache_get();
+	public function keys(): ?Key {
+		$keys = $this->cache_get();
 
-		if ( null !== $cached ) {
-			return $cached;
+		if ( null !== $keys ) {
+			return $keys;
 		}
 
-		$keys = $this->fetch();
-		$this->cache_set( $keys );
+		$key_string = $this->fetch_key_material();
+		if ( $key_string ) {
+			$keys = new Key( $key_string, 'HS256' );
+			$this->cache_set( $keys );
+		}
 
 		return $keys;
 	}
 
-	protected function cache_get(): ?array {
+	protected function cache_get(): ?Key {
 		return $this->cache;
 	}
 
-	protected function cache_set( array $value ): void {
+	protected function cache_set( Key $value ): void {
 		$this->cache = $value;
 	}
 
-	protected function fetch(): array {
-		return array();
+	protected function fetch_key_material(): string {
+		return 'test';
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -7,7 +7,7 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 use Firebase\JWT\Key;
 
 class PayPalJwkProvider {
-	private const ALGORITHM = 'HS256';
+	private const ALGORITHM = 'RS256';
 
 	private ?Key $cache = null;
 
@@ -40,6 +40,7 @@ class PayPalJwkProvider {
 	protected function fetch_key_material(): string {
 		// todo - the string should be fetched from a .well-known URL.
 		return <<<'EOF'
+-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvv7Pi1nWWrJj4n5+6gX9
 B7BQpctaPEg9VdVK1kzc9xBNwZobeWEgEmiUGtkrn8S5R6Q4NmB4hnb8F5jeCX5O
 kyA49mgzw4wNXUPGTGMY5Eoxt9zu1Heaivkljh4+wN6d01oIFkHT6E7VjEJOG2RA
@@ -47,6 +48,7 @@ kyA49mgzw4wNXUPGTGMY5Eoxt9zu1Heaivkljh4+wN6d01oIFkHT6E7VjEJOG2RA
 1YBqFG+HlSG5hWu880IzGQE9Pds5qekIawJJyed08otq29hDHlFd28B0fFhdzcu8
 cN83NxddXBlh77b8+a7gaWC5/Iw45THRpIsiG41uX0r0INEDcnR3qCUkz6m9LOVW
 kQIDAQAB
+-----END PUBLIC KEY-----
 EOF;
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -39,13 +39,19 @@ class PayPalJwkProvider {
 	}
 
 	protected function fetch_key_material(): ?Key {
-		$remove_user_agent = static function ( $args, $url ): array {
-			if ( $url === self::JWKS_URL ) {
-				$args['user-agent'] = '';
-			}
+		$remove_user_agent =
+			/**
+			 * @param mixed|array  $args
+			 * @param mixed|string $url
+			 * @return mixed|array
+			 */
+			static function ( $args, $url ) {
+				if ( is_array( $args ) && $url === self::JWKS_URL ) {
+					$args['user-agent'] = '';
+				}
 
-			return $args;
-		};
+				return $args;
+			};
 
 		add_filter( 'http_request_args', $remove_user_agent, 10, 2 );
 		$response = wp_remote_get( self::JWKS_URL );
@@ -59,7 +65,7 @@ class PayPalJwkProvider {
 			$body = wp_remote_retrieve_body( $response );
 			$data = json_decode( $body, true, 512, JSON_THROW_ON_ERROR );
 
-			if ( ! $data || empty( $data['keys'] ) ) {
+			if ( ! is_array( $data ) || empty( $data['keys'] ) ) {
 				return null;
 			}
 

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
+
+class PayPalJwkProvider {
+
+	public function keys(): array {
+		return array();
+	}
+}

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -20,7 +20,7 @@ class PayPalJwkProvider {
 			return $keys;
 		}
 
-		$keys = $this->fetch_key_material();
+		$keys = $this->fetch_key();
 		if ( ! $keys ) {
 			return null;
 		}
@@ -38,7 +38,7 @@ class PayPalJwkProvider {
 		$this->cache = $value;
 	}
 
-	protected function fetch_key_material(): ?Key {
+	protected function fetch_key(): ?Key {
 		$remove_user_agent =
 			/**
 			 * @param mixed|array  $args

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -7,6 +7,8 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 use Firebase\JWT\Key;
 
 class PayPalJwkProvider {
+	private const ALGORITHM = 'HS256';
+
 	private ?Key $cache = null;
 
 	public function keys(): ?Key {
@@ -17,10 +19,12 @@ class PayPalJwkProvider {
 		}
 
 		$key_string = $this->fetch_key_material();
-		if ( $key_string ) {
-			$keys = new Key( $key_string, 'HS256' );
-			$this->cache_set( $keys );
+		if ( ! $key_string ) {
+			return null;
 		}
+
+		$keys = new Key( $key_string, self::ALGORITHM );
+		$this->cache_set( $keys );
 
 		return $keys;
 	}
@@ -34,6 +38,15 @@ class PayPalJwkProvider {
 	}
 
 	protected function fetch_key_material(): string {
-		return 'test';
+		// todo - the string should be fetched from a .well-known URL.
+		return <<<'EOF'
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvv7Pi1nWWrJj4n5+6gX9
+B7BQpctaPEg9VdVK1kzc9xBNwZobeWEgEmiUGtkrn8S5R6Q4NmB4hnb8F5jeCX5O
+kyA49mgzw4wNXUPGTGMY5Eoxt9zu1Heaivkljh4+wN6d01oIFkHT6E7VjEJOG2RA
+49t7fgQ1phJIUK39B0RAXIG2pYicbujeiiJ12iQipMjY/TVD0KZgUc2Vj2apk7Dv
+1YBqFG+HlSG5hWu880IzGQE9Pds5qekIawJJyed08otq29hDHlFd28B0fFhdzcu8
+cN83NxddXBlh77b8+a7gaWC5/Iw45THRpIsiG41uX0r0INEDcnR3qCUkz6m9LOVW
+kQIDAQAB
+EOF;
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/PayPalJwkProvider.php
@@ -4,10 +4,12 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
+use Firebase\JWT\JWK;
 use Firebase\JWT\Key;
+use Exception;
 
 class PayPalJwkProvider {
-	private const ALGORITHM = 'RS256';
+	private const JWKS_URL = 'https://www.paypal.ai/.well-known/jwks.json';
 
 	private ?Key $cache = null;
 
@@ -18,12 +20,11 @@ class PayPalJwkProvider {
 			return $keys;
 		}
 
-		$key_string = $this->fetch_key_material();
-		if ( ! $key_string ) {
+		$keys = $this->fetch_key_material();
+		if ( ! $keys ) {
 			return null;
 		}
 
-		$keys = new Key( $key_string, self::ALGORITHM );
 		$this->cache_set( $keys );
 
 		return $keys;
@@ -37,18 +38,37 @@ class PayPalJwkProvider {
 		$this->cache = $value;
 	}
 
-	protected function fetch_key_material(): string {
-		// todo - the string should be fetched from a .well-known URL.
-		return <<<'EOF'
------BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvv7Pi1nWWrJj4n5+6gX9
-B7BQpctaPEg9VdVK1kzc9xBNwZobeWEgEmiUGtkrn8S5R6Q4NmB4hnb8F5jeCX5O
-kyA49mgzw4wNXUPGTGMY5Eoxt9zu1Heaivkljh4+wN6d01oIFkHT6E7VjEJOG2RA
-49t7fgQ1phJIUK39B0RAXIG2pYicbujeiiJ12iQipMjY/TVD0KZgUc2Vj2apk7Dv
-1YBqFG+HlSG5hWu880IzGQE9Pds5qekIawJJyed08otq29hDHlFd28B0fFhdzcu8
-cN83NxddXBlh77b8+a7gaWC5/Iw45THRpIsiG41uX0r0INEDcnR3qCUkz6m9LOVW
-kQIDAQAB
------END PUBLIC KEY-----
-EOF;
+	protected function fetch_key_material(): ?Key {
+		$remove_user_agent = static function ( $args, $url ): array {
+			if ( $url === self::JWKS_URL ) {
+				$args['user-agent'] = '';
+			}
+
+			return $args;
+		};
+
+		add_filter( 'http_request_args', $remove_user_agent, 10, 2 );
+		$response = wp_remote_get( self::JWKS_URL );
+		remove_filter( 'http_request_args', $remove_user_agent, 10 );
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		try {
+			$body = wp_remote_retrieve_body( $response );
+			$data = json_decode( $body, true, 512, JSON_THROW_ON_ERROR );
+
+			if ( ! $data || empty( $data['keys'] ) ) {
+				return null;
+			}
+
+			$keys = JWK::parseKeySet( $data );
+
+			// Return the first (and only) key from the keyset.
+			return reset( $keys ) ?: null;
+		} catch ( Exception $exception ) {
+			return null;
+		}
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
@@ -13,9 +13,11 @@ use JsonException;
 use WC_REST_Controller;
 use WP_REST_Request;
 use WP_REST_Response;
+use WP_Error;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\AgenticError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\InvalidRequestError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\CartResponse;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 
 /**
  * Base class for REST controllers in the agentic commerce module.
@@ -26,15 +28,30 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 	 */
 	protected const NAMESPACE = 'wc/v3/agentic';
 
+	private JwtAuthService $auth_service;
+
+	public function __construct( JwtAuthService $auth_service ) {
+		$this->auth_service = $auth_service;
+	}
+
 	/**
 	 * Verify JWT access.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return bool True if access is granted.
+	 * @return bool|WP_Error True if access is granted, otherwise a WP_Error object.
 	 */
-	public function check_permission( WP_REST_Request $request ): bool {
-		// TODO: Implement JWT validation
-		// Extract and validate PayPal JWT token from Authorization header.
+	public function check_permission( WP_REST_Request $request ) {
+		$token   = $request->get_header( 'Authorization' );
+		$context = $this->auth_service->validate_request( $token );
+
+		if ( is_wp_error( $context ) ) {
+			assert( $context instanceof WP_Error );
+
+			return $context;
+		}
+
+		// TODO: verify the merchant details in $context.
+
 		return true;
 	}
 

--- a/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\AgenticError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\InvalidRequestError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\CartResponse;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 
 /**
  * Base class for REST controllers in the agentic commerce module.
@@ -30,8 +31,11 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 
 	private JwtAuthService $auth_service;
 
-	public function __construct( JwtAuthService $auth_service ) {
-		$this->auth_service = $auth_service;
+	protected ResponseFactory $response_factory;
+
+	public function __construct( JwtAuthService $auth_service, ResponseFactory $response_factory ) {
+		$this->auth_service     = $auth_service;
+		$this->response_factory = $response_factory;
 	}
 
 	/**

--- a/modules/ppcp-agentic-commerce/src/Endpoint/CreateCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/CreateCartEndpoint.php
@@ -48,13 +48,9 @@ class CreateCartEndpoint extends AgenticRestEndpoint {
 			return $this->error( $data );
 		}
 
-		$cart = PayPalCart::from_array( $data );
+		$cart     = PayPalCart::from_array( $data );
+		$response = $this->response_factory->new_cart( $cart );
 
-		// todo - the token represents a checkout-session, linked to the cart; via #5272-persist-cart.
-		$token = wp_generate_password( 12, false );
-
-		$new_cart = new NewCartResponse( $cart, $token );
-
-		return $this->cart_details( $new_cart, 201 );
+		return $this->cart_details( $response, 201 );
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
+++ b/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
@@ -14,7 +14,10 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
 
 class ResponseFactory {
 	public function new_cart( PayPalCart $cart ): NewCartResponse {
-		return new NewCartResponse( $cart, 'not-implemented' );
+		// todo - the token represents a checkout-session, linked to the cart; via #5272-persist-cart.
+		$token = wp_generate_password( 12, false );
+
+		return new NewCartResponse( $cart, $token );
 	}
 
 	public function from_order( WC_Order $order, PayPalCart $cart ): PaidCartResponse {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "ddev:pw-install": "ddev yarn playwright install --with-deps",
     "ddev:pw-tests": "ddev yarn playwright test",
     "ddev:test": "yarn run ddev:unit-tests && yarn run ddev:e2e-tests && yarn run ddev:pw-tests",
+    "ddev:tdd": "sh -c 'ddev exec phpunit --stop-on-failure -v ${1:+--filter $1}' --",
     "ddev:lint": "yarn ddev:phpcs && yarn ddev:psalm",
     "ddev:phpcs": "ddev exec phpcs --parallel=8 -s --runtime-set ignore_warnings_on_exit 1",
     "ddev:psalm": "ddev exec psalm --show-info=false --threads=8 --diff",

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -13,90 +13,123 @@ use Mockery;
 use Firebase\JWT\Key;
 use Firebase\JWT\JWT;
 
+/**
+ * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService
+ */
 class JwtAuthServiceTest extends TestCase {
 
 	/**
-	 * GIVEN no Authorization header exists
+	 * GIVEN invalid or missing tokens
 	 * WHEN validate_request is called
-	 * THEN should return WP_Error with 'missing_token' code and 401 status
-	 */
-	public function test_validate_request_returns_error_when_no_authorization_header(): void {
-		$provider = Mockery::mock( PayPalJwkProvider::class );
-		$service  = new JwtAuthService( $provider );
-
-		$result = $service->validate_request( null );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'missing_token', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN empty or whitespace-only authorization header
-	 * WHEN validate_request is called
-	 * THEN should return WP_Error with 'missing_token' code and 401 status
+	 * THEN should return WP_Error with appropriate code and 401 status
 	 *
-	 * @dataProvider emptyTokenProvider
+	 * @dataProvider invalidTokenProvider
 	 */
-	public function test_validate_request_handles_empty_tokens( string $token ): void {
+	public function test_validate_request_rejects_invalid_tokens(
+		?string $token,
+		string $expected_error_code,
+		bool $needs_key
+	): void {
 		$provider = Mockery::mock( PayPalJwkProvider::class );
-		$service  = new JwtAuthService( $provider );
 
-		$result = $service->validate_request( $token );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'missing_token', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
-	}
-
-	public function emptyTokenProvider(): array {
-		return [
-			'empty string'         => [ '' ],
-			'only whitespace'      => [ '   ' ],
-			'bearer with no token' => [ 'Bearer ' ],
-			'bearer whitespace'    => [ 'Bearer   ' ],
-		];
-	}
-
-	/**
-	 * GIVEN malformed authorization header (not Bearer format)
-	 * WHEN validate_request is called
-	 * THEN should return WP_Error with 'invalid_jwt' code and 401 status
-	 */
-	public function test_validate_request_rejects_malformed_format(): void {
-		$provider = Mockery::mock( PayPalJwkProvider::class );
-		$service  = new JwtAuthService( $provider );
-
-		$result = $service->validate_request( 'NotBearerFormat' );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN valid Bearer format but invalid JWT token
-	 * WHEN validate_request is called
-	 * THEN should return WP_Error with 'invalid_jwt' code and 401 status
-	 */
-	public function test_validate_request_rejects_invalid_jwt(): void {
-		$key = new Key( 'test-key-material', 'HS256' );
-
-		$provider = Mockery::mock( PayPalJwkProvider::class );
-		$provider->shouldReceive( 'keys' )
-			->once()
-			->andReturn( $key );
+		if ( $needs_key ) {
+			$key = new Key( 'test-secret-key', 'HS256' );
+			$provider->shouldReceive( 'keys' )
+				->once()
+				->andReturn( $key );
+		} else {
+			$provider->shouldReceive( 'keys' )->never();
+		}
 
 		$service = new JwtAuthService( $provider );
-
-		// Invalid JWT: malformed, wrong signature, or can't be decoded
-		$invalid_jwt = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.invalid_signature';
-
-		$result = $service->validate_request( $invalid_jwt );
+		$result  = $service->validate_request( $token );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
+		$this->assertSame( $expected_error_code, $result->get_error_code() );
 		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	public function invalidTokenProvider(): array {
+		$invalid_jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.invalid_signature';
+		$expired_jwt = JWT::encode(
+			array(
+				'sub' => '1234567890',
+				'exp' => time() - 3600,
+			),
+			'test-secret-key',
+			'HS256'
+		);
+		$future_jwt  = JWT::encode(
+			array(
+				'sub' => '1234567890',
+				'nbf' => time() + 3600,
+			),
+			'test-secret-key',
+			'HS256'
+		);
+
+		return array(
+			'null token'           => array(
+				'token'      => null,
+				'error_code' => 'missing_token',
+				'needs_key'  => false,
+			),
+			'empty string'         => array(
+				'token'      => '',
+				'error_code' => 'missing_token',
+				'needs_key'  => false,
+			),
+			'only whitespace'      => array(
+				'token'      => '   ',
+				'error_code' => 'missing_token',
+				'needs_key'  => false,
+			),
+			'bearer with no token' => array(
+				'token'      => 'Bearer ',
+				'error_code' => 'missing_token',
+				'needs_key'  => false,
+			),
+			'bearer whitespace'    => array(
+				'token'      => 'Bearer   ',
+				'error_code' => 'missing_token',
+				'needs_key'  => false,
+			),
+			'not bearer format'    => array(
+				'token'      => 'NotBearerFormat',
+				'error_code' => 'invalid_jwt',
+				'needs_key'  => false,
+			),
+			'invalid signature'    => array(
+				'token'      => 'Bearer ' . $invalid_jwt,
+				'error_code' => 'invalid_jwt',
+				'needs_key'  => true,
+			),
+			'malformed (1 segment)' => array(
+				'token'        => 'Bearer randomgarbage',
+				'error_code'   => 'invalid_jwt',
+				'needs_key'    => true,
+			),
+			'malformed (2 segments)' => array(
+				'token'        => 'Bearer invalid.token',
+				'error_code'   => 'invalid_jwt',
+				'needs_key'    => true,
+			),
+			'malformed (4 segments)' => array(
+				'token'        => 'Bearer a.b.c.d',
+				'error_code'   => 'invalid_jwt',
+				'needs_key'    => true,
+			),
+			'expired token'        => array(
+				'token'      => 'Bearer ' . $expired_jwt,
+				'error_code' => 'invalid_jwt',
+				'needs_key'  => true,
+			),
+			'not yet valid token'  => array(
+				'token'      => 'Bearer ' . $future_jwt,
+				'error_code' => 'invalid_jwt',
+				'needs_key'  => true,
+			),
+		);
 	}
 
 	/**
@@ -111,8 +144,7 @@ class JwtAuthServiceTest extends TestCase {
 			->andReturn( null );
 
 		$service = new JwtAuthService( $provider );
-
-		$result = $service->validate_request( 'Bearer some.valid.token' );
+		$result  = $service->validate_request( 'Bearer some.valid.token' );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'key_unavailable', $result->get_error_code() );
@@ -123,8 +155,10 @@ class JwtAuthServiceTest extends TestCase {
 	 * GIVEN valid Bearer token with correct signature
 	 * WHEN validate_request is called
 	 * THEN should return decoded stdClass payload
+	 *
+	 * @dataProvider bearerCaseProvider
 	 */
-	public function test_validate_request_returns_decoded_payload_for_valid_jwt(): void {
+	public function test_validate_request_returns_decoded_payload_for_valid_jwt( string $prefix ): void {
 		$expected_payload = (object) array(
 			'sub'  => '1234567890',
 			'name' => 'John Doe',
@@ -140,100 +174,13 @@ class JwtAuthServiceTest extends TestCase {
 
 		$service = new JwtAuthService( $provider );
 
-		// Generate a real valid JWT using the same secret
 		$valid_jwt = JWT::encode( (array) $expected_payload, 'test-secret-key', 'HS256' );
-		$token     = 'Bearer ' . $valid_jwt;
-
-		$result = $service->validate_request( $token );
-
-		$this->assertInstanceOf( \stdClass::class, $result );
-		$this->assertEquals( $expected_payload, $result );
-	}
-
-	/**
-	 * GIVEN expired JWT token
-	 * WHEN validate_request is called
-	 * THEN should return WP_Error with 'invalid_jwt' code
-	 */
-	public function test_validate_request_rejects_expired_jwt(): void {
-		$expired_payload = array(
-			'sub' => '1234567890',
-			'exp' => time() - 3600, // Expired 1 hour ago
-		);
-
-		$key = new Key( 'test-secret-key', 'HS256' );
-
-		$provider = Mockery::mock( PayPalJwkProvider::class );
-		$provider->shouldReceive( 'keys' )
-			->once()
-			->andReturn( $key );
-
-		$service = new JwtAuthService( $provider );
-
-		$expired_jwt = JWT::encode( $expired_payload, 'test-secret-key', 'HS256' );
-		$token       = 'Bearer ' . $expired_jwt;
-
-		$result = $service->validate_request( $token );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN the JWT token is not valid yet
-	 * WHEN validate_request is called
-	 * THEN should return WP_Error with 'invalid_jwt' code
-	 */
-	public function test_validate_request_rejects_not_yet_valid_jwt(): void {
-		$expired_payload = array(
-			'sub' => '1234567890',
-			'nbf' => time() + 3600, // Valid in hour, but not right now
-		);
-
-		$key = new Key( 'test-secret-key', 'HS256' );
-
-		$provider = Mockery::mock( PayPalJwkProvider::class );
-		$provider->shouldReceive( 'keys' )
-			->once()
-			->andReturn( $key );
-
-		$service = new JwtAuthService( $provider );
-
-		$expired_jwt = JWT::encode( $expired_payload, 'test-secret-key', 'HS256' );
-		$token       = 'Bearer ' . $expired_jwt;
-
-		$result = $service->validate_request( $token );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN Bearer prefix in different cases
-	 * WHEN validate_request is called
-	 * THEN should handle all case variations
-	 *
-	 * @dataProvider bearerCaseProvider
-	 */
-	public function test_validate_request_handles_case_insensitive_bearer( string $prefix ): void {
-		$payload = array( 'sub' => 'test' );
-		$key     = new Key( 'test-secret-key', 'HS256' );
-
-		$provider = Mockery::mock( PayPalJwkProvider::class );
-		$provider->shouldReceive( 'keys' )
-			->once()
-			->andReturn( $key );
-
-		$service = new JwtAuthService( $provider );
-
-		$valid_jwt = JWT::encode( $payload, 'test-secret-key', 'HS256' );
 		$token     = $prefix . ' ' . $valid_jwt;
 
 		$result = $service->validate_request( $token );
 
 		$this->assertInstanceOf( \stdClass::class, $result );
+		$this->assertEquals( $expected_payload, $result );
 	}
 
 	public function bearerCaseProvider(): array {

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -97,4 +97,24 @@ class JwtAuthServiceTest extends TestCase {
 		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
 		$this->assertSame( 401, $result->get_error_data()['status'] );
 	}
+
+	/**
+	 * GIVEN provider returns null (key unavailable)
+	 * WHEN validate_request is called with valid Bearer token
+	 * THEN should return WP_Error with 'key_unavailable' code and 503 status
+	 */
+	public function test_validate_request_handles_unavailable_key(): void {
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$provider->shouldReceive( 'keys' )
+			->once()
+			->andReturn( null );
+
+		$service = new JwtAuthService( $provider );
+
+		$result = $service->validate_request( 'Bearer some.valid.token' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'key_unavailable', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -209,4 +209,39 @@ class JwtAuthServiceTest extends TestCase {
 		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
 		$this->assertSame( 401, $result->get_error_data()['status'] );
 	}
+
+	/**
+	 * GIVEN Bearer prefix in different cases
+	 * WHEN validate_request is called
+	 * THEN should handle all case variations
+	 *
+	 * @dataProvider bearerCaseProvider
+	 */
+	public function test_validate_request_handles_case_insensitive_bearer( string $prefix ): void {
+		$payload = array( 'sub' => 'test' );
+		$key     = new Key( 'test-secret-key', 'HS256' );
+
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$provider->shouldReceive( 'keys' )
+			->once()
+			->andReturn( $key );
+
+		$service = new JwtAuthService( $provider );
+
+		$valid_jwt = JWT::encode( $payload, 'test-secret-key', 'HS256' );
+		$token     = $prefix . ' ' . $valid_jwt;
+
+		$result = $service->validate_request( $token );
+
+		$this->assertInstanceOf( \stdClass::class, $result );
+	}
+
+	public function bearerCaseProvider(): array {
+		return array(
+			'lowercase' => array( 'bearer' ),
+			'uppercase' => array( 'BEARER' ),
+			'mixedcase' => array( 'BeArEr' ),
+			'standard'  => array( 'Bearer' ),
+		);
+	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -11,6 +11,7 @@ use WooCommerce\PayPalCommerce\TestCase;
 use WP_Error;
 use Mockery;
 use Firebase\JWT\Key;
+use Firebase\JWT\JWT;
 
 class JwtAuthServiceTest extends TestCase {
 
@@ -116,5 +117,36 @@ class JwtAuthServiceTest extends TestCase {
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'key_unavailable', $result->get_error_code() );
 		$this->assertSame( 503, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * GIVEN valid Bearer token with correct signature
+	 * WHEN validate_request is called
+	 * THEN should return decoded stdClass payload
+	 */
+	public function test_validate_request_returns_decoded_payload_for_valid_jwt(): void {
+		$expected_payload = (object) array(
+			'sub'  => '1234567890',
+			'name' => 'John Doe',
+			'iat'  => 1516239022,
+		);
+
+		$key = new Key( 'test-secret-key', 'HS256' );
+
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$provider->shouldReceive( 'keys' )
+			->once()
+			->andReturn( $key );
+
+		$service = new JwtAuthService( $provider );
+
+		// Generate a real valid JWT using the same secret
+		$valid_jwt = JWT::encode( (array) $expected_payload, 'test-secret-key', 'HS256' );
+		$token     = 'Bearer ' . $valid_jwt;
+
+		$result = $service->validate_request( $token );
+
+		$this->assertInstanceOf( \stdClass::class, $result );
+		$this->assertEquals( $expected_payload, $result );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -149,4 +149,64 @@ class JwtAuthServiceTest extends TestCase {
 		$this->assertInstanceOf( \stdClass::class, $result );
 		$this->assertEquals( $expected_payload, $result );
 	}
+
+	/**
+	 * GIVEN expired JWT token
+	 * WHEN validate_request is called
+	 * THEN should return WP_Error with 'invalid_jwt' code
+	 */
+	public function test_validate_request_rejects_expired_jwt(): void {
+		$expired_payload = array(
+			'sub' => '1234567890',
+			'exp' => time() - 3600, // Expired 1 hour ago
+		);
+
+		$key = new Key( 'test-secret-key', 'HS256' );
+
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$provider->shouldReceive( 'keys' )
+			->once()
+			->andReturn( $key );
+
+		$service = new JwtAuthService( $provider );
+
+		$expired_jwt = JWT::encode( $expired_payload, 'test-secret-key', 'HS256' );
+		$token       = 'Bearer ' . $expired_jwt;
+
+		$result = $service->validate_request( $token );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * GIVEN the JWT token is not valid yet
+	 * WHEN validate_request is called
+	 * THEN should return WP_Error with 'invalid_jwt' code
+	 */
+	public function test_validate_request_rejects_not_yet_valid_jwt(): void {
+		$expired_payload = array(
+			'sub' => '1234567890',
+			'nbf' => time() + 3600, // Valid in hour, but not right now
+		);
+
+		$key = new Key( 'test-secret-key', 'HS256' );
+
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$provider->shouldReceive( 'keys' )
+			->once()
+			->andReturn( $key );
+
+		$service = new JwtAuthService( $provider );
+
+		$expired_jwt = JWT::encode( $expired_payload, 'test-secret-key', 'HS256' );
+		$token       = 'Bearer ' . $expired_jwt;
+
+		$result = $service->validate_request( $token );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -9,6 +9,8 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
 use WooCommerce\PayPalCommerce\TestCase;
 use WP_Error;
+use Mockery;
+use Firebase\JWT\Key;
 
 class JwtAuthServiceTest extends TestCase {
 
@@ -18,7 +20,8 @@ class JwtAuthServiceTest extends TestCase {
 	 * THEN should return WP_Error with 'missing_token' code and 401 status
 	 */
 	public function test_validate_request_returns_error_when_no_authorization_header(): void {
-		$service = new JwtAuthService();
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$service  = new JwtAuthService( $provider );
 
 		$result = $service->validate_request( null );
 
@@ -35,7 +38,8 @@ class JwtAuthServiceTest extends TestCase {
 	 * @dataProvider emptyTokenProvider
 	 */
 	public function test_validate_request_handles_empty_tokens( string $token ): void {
-		$service = new JwtAuthService();
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$service  = new JwtAuthService( $provider );
 
 		$result = $service->validate_request( $token );
 
@@ -59,7 +63,8 @@ class JwtAuthServiceTest extends TestCase {
 	 * THEN should return WP_Error with 'invalid_jwt' code and 401 status
 	 */
 	public function test_validate_request_rejects_malformed_format(): void {
-		$service = new JwtAuthService();
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$service  = new JwtAuthService( $provider );
 
 		$result = $service->validate_request( 'NotBearerFormat' );
 
@@ -74,7 +79,14 @@ class JwtAuthServiceTest extends TestCase {
 	 * THEN should return WP_Error with 'invalid_jwt' code and 401 status
 	 */
 	public function test_validate_request_rejects_invalid_jwt(): void {
-		$service = new JwtAuthService();
+		$key = new Key( 'test-key-material', 'HS256' );
+
+		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$provider->shouldReceive( 'keys' )
+			->once()
+			->andReturn( $key );
+
+		$service = new JwtAuthService( $provider );
 
 		// Invalid JWT: malformed, wrong signature, or can't be decoded
 		$invalid_jwt = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.invalid_signature';

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -67,4 +67,22 @@ class JwtAuthServiceTest extends TestCase {
 		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
 		$this->assertSame( 401, $result->get_error_data()['status'] );
 	}
+
+	/**
+	 * GIVEN valid Bearer format but invalid JWT token
+	 * WHEN validate_request is called
+	 * THEN should return WP_Error with 'invalid_jwt' code and 401 status
+	 */
+	public function test_validate_request_rejects_invalid_jwt(): void {
+		$service = new JwtAuthService();
+
+		// Invalid JWT: malformed, wrong signature, or can't be decoded
+		$invalid_jwt = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.invalid_signature';
+
+		$result = $service->validate_request( $invalid_jwt );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Tests for JWT authentication service.
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use WP_Error;
+
+class JwtAuthServiceTest extends TestCase {
+
+	/**
+	 * GIVEN no Authorization header exists
+	 * WHEN validate_request is called
+	 * THEN should return WP_Error with 'missing_token' code and 401 status
+	 */
+	public function test_validate_request_returns_error_when_no_authorization_header(): void {
+		$service = new JwtAuthService();
+
+		$result = $service->validate_request( null );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_token', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+}

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -26,4 +26,45 @@ class JwtAuthServiceTest extends TestCase {
 		$this->assertSame( 'missing_token', $result->get_error_code() );
 		$this->assertSame( 401, $result->get_error_data()['status'] );
 	}
+
+	/**
+	 * GIVEN empty or whitespace-only authorization header
+	 * WHEN validate_request is called
+	 * THEN should return WP_Error with 'missing_token' code and 401 status
+	 *
+	 * @dataProvider emptyTokenProvider
+	 */
+	public function test_validate_request_handles_empty_tokens( string $token ): void {
+		$service = new JwtAuthService();
+
+		$result = $service->validate_request( $token );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_token', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	public function emptyTokenProvider(): array {
+		return [
+			'empty string'         => [ '' ],
+			'only whitespace'      => [ '   ' ],
+			'bearer with no token' => [ 'Bearer ' ],
+			'bearer whitespace'    => [ 'Bearer   ' ],
+		];
+	}
+
+	/**
+	 * GIVEN malformed authorization header (not Bearer format)
+	 * WHEN validate_request is called
+	 * THEN should return WP_Error with 'invalid_jwt' code and 401 status
+	 */
+	public function test_validate_request_rejects_malformed_format(): void {
+		$service = new JwtAuthService();
+
+		$result = $service->validate_request( 'NotBearerFormat' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_jwt', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -130,4 +130,31 @@ class PayPalJwkProviderTest extends TestCase {
 
 		$this->assertNull( $result );
 	}
+
+	/**
+	 * GIVEN no cached key exists
+	 * AND fetch returns an empty string
+	 * WHEN keys() is called
+	 * THEN should return null without caching
+	 */
+	public function test_returns_null_when_fetch_returns_nothing(): void {
+		$provider = Mockery::mock( PayPalJwkProvider::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$provider->shouldReceive( 'cache_get' )
+			->once()
+			->andReturn( null );
+
+		$provider->shouldReceive( 'fetch_key_material' )
+			->once()
+			->andReturn( '' );
+
+		$provider->shouldReceive( 'cache_set' )
+			->never();
+
+		$result = $provider->keys();
+
+		$this->assertNull( $result );
+	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -22,7 +22,7 @@ class PayPalJwkProviderTest extends TestCase {
 	 * THEN should return the cached key without fetching
 	 */
 	public function test_returns_cached_key_when_available(): void {
-		$cached_key = new Key( 'cached-key-string', 'HS256' );
+		$cached_key = new Key( 'cached-key-string', 'RS256' );
 
 		$provider = Mockery::mock( PayPalJwkProvider::class )
 			->makePartial()
@@ -32,11 +32,9 @@ class PayPalJwkProviderTest extends TestCase {
 			->once()
 			->andReturn( $cached_key );
 
-		$provider->shouldReceive( 'fetch_key_material' )
-			->never();
+		$provider->shouldReceive( 'fetch_key_material' )->never();
 
-		$provider->shouldReceive( 'cache_set' )
-			->never();
+		$provider->shouldReceive( 'cache_set' )->never();
 
 		$result = $provider->keys();
 
@@ -47,11 +45,15 @@ class PayPalJwkProviderTest extends TestCase {
 	/**
 	 * GIVEN no cached key exists
 	 * WHEN keys() is called
-	 * THEN should fetch key string, create Key instance, cache it, and return it
+	 * THEN should fetch key material and handle result appropriately
+	 *
+	 * @dataProvider fetchScenarioProvider
 	 */
-	public function test_fetches_and_caches_key_when_cache_empty(): void {
-		$key_string = 'fresh-key-string';
-
+	public function test_handles_fetch_scenarios(
+		string $key_material,
+		bool $should_cache,
+		?string $expected_algorithm
+	): void {
 		$provider = Mockery::mock( PayPalJwkProvider::class )
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
@@ -62,21 +64,44 @@ class PayPalJwkProviderTest extends TestCase {
 
 		$provider->shouldReceive( 'fetch_key_material' )
 			->once()
-			->andReturn( $key_string );
+			->andReturn( $key_material );
 
-		$provider->shouldReceive( 'cache_set' )
-			->once()
-			->withArgs(
-				fn( $key ) => $key instanceof Key
-					&& $key->getKeyMaterial() === $key_string
-					&& $key->getAlgorithm() === 'RS256'
-			);
+		if ( $should_cache ) {
+			$provider->shouldReceive( 'cache_set' )
+				->once()
+				->withArgs(
+					fn( $key ) => $key instanceof Key
+						&& $key->getKeyMaterial() === $key_material
+						&& $key->getAlgorithm() === $expected_algorithm
+				);
+		} else {
+			$provider->shouldReceive( 'cache_set' )->never();
+		}
 
 		$result = $provider->keys();
 
-		$this->assertInstanceOf( Key::class, $result );
-		$this->assertSame( $key_string, $result->getKeyMaterial() );
-		$this->assertSame( 'RS256', $result->getAlgorithm() );
+		if ( $should_cache ) {
+			$this->assertInstanceOf( Key::class, $result );
+			$this->assertSame( $key_material, $result->getKeyMaterial() );
+			$this->assertSame( $expected_algorithm, $result->getAlgorithm() );
+		} else {
+			$this->assertNull( $result );
+		}
+	}
+
+	public function fetchScenarioProvider(): array {
+		return array(
+			'successful fetch'   => array(
+				'key_material'       => 'fresh-key-string',
+				'should_cache'       => true,
+				'expected_algorithm' => 'RS256',
+			),
+			'empty string fetch' => array(
+				'key_material'       => '',
+				'should_cache'       => false,
+				'expected_algorithm' => null,
+			),
+		);
 	}
 
 	/**
@@ -95,66 +120,12 @@ class PayPalJwkProviderTest extends TestCase {
 			->once()
 			->andReturn( $key_string );
 
-		$result1 = $provider->keys(); // Fresh fetch.
+		$result1 = $provider->keys();
 		$this->assertInstanceOf( Key::class, $result1 );
 		$this->assertSame( $key_string, $result1->getKeyMaterial() );
 
-		$result2 = $provider->keys(); // Cache hit, no second fetch.
+		$result2 = $provider->keys();
 		$this->assertInstanceOf( Key::class, $result2 );
 		$this->assertSame( $result1, $result2 );
-	}
-
-	/**
-	 * GIVEN no cached key exists
-	 * AND fetch returns empty string
-	 * WHEN keys() is called
-	 * THEN should return null without caching
-	 */
-	public function test_returns_null_when_fetch_returns_empty_string(): void {
-		$provider = Mockery::mock( PayPalJwkProvider::class )
-			->makePartial()
-			->shouldAllowMockingProtectedMethods();
-
-		$provider->shouldReceive( 'cache_get' )
-			->once()
-			->andReturn( null );
-
-		$provider->shouldReceive( 'fetch_key_material' )
-			->once()
-			->andReturn( '' );
-
-		$provider->shouldReceive( 'cache_set' )
-			->never();
-
-		$result = $provider->keys();
-
-		$this->assertNull( $result );
-	}
-
-	/**
-	 * GIVEN no cached key exists
-	 * AND fetch returns an empty string
-	 * WHEN keys() is called
-	 * THEN should return null without caching
-	 */
-	public function test_returns_null_when_fetch_returns_nothing(): void {
-		$provider = Mockery::mock( PayPalJwkProvider::class )
-			->makePartial()
-			->shouldAllowMockingProtectedMethods();
-
-		$provider->shouldReceive( 'cache_get' )
-			->once()
-			->andReturn( null );
-
-		$provider->shouldReceive( 'fetch_key_material' )
-			->once()
-			->andReturn( '' );
-
-		$provider->shouldReceive( 'cache_set' )
-			->never();
-
-		$result = $provider->keys();
-
-		$this->assertNull( $result );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -32,7 +32,7 @@ class PayPalJwkProviderTest extends TestCase {
 			->once()
 			->andReturn( $cached_key );
 
-		$provider->shouldReceive( 'fetch_key_material' )->never();
+		$provider->shouldReceive( 'fetch_key' )->never();
 
 		$provider->shouldReceive( 'cache_set' )->never();
 
@@ -61,7 +61,7 @@ class PayPalJwkProviderTest extends TestCase {
 			->once()
 			->andReturn( null );
 
-		$provider->shouldReceive( 'fetch_key_material' )
+		$provider->shouldReceive( 'fetch_key' )
 			->once()
 			->andReturn( $key_material );
 
@@ -108,7 +108,7 @@ class PayPalJwkProviderTest extends TestCase {
 			->makePartial()
 			->shouldAllowMockingProtectedMethods();
 
-		$provider->shouldReceive( 'fetch_key_material' )
+		$provider->shouldReceive( 'fetch_key' )
 			->once()
 			->andReturn( $fetched_key );
 

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -9,18 +9,38 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
 use WooCommerce\PayPalCommerce\TestCase;
 
+/**
+ * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Auth\PayPalJwkProvider
+ */
 class PayPalJwkProviderTest extends TestCase {
 
 	/**
-	 * GIVEN PayPalJwkProvider instance
+	 * GIVEN cached keys are available
 	 * WHEN keys() is called
-	 * THEN should return an array
+	 * THEN should return the cached keys without fetching
 	 */
-	public function test_keys_returns_array(): void {
-		$provider = new PayPalJwkProvider();
+	public function test_returns_cached_keys_when_available(): void {
+		$cached_keys = array(
+			'key1' => 'value1',
+			'key2' => 'value2',
+		);
+
+		$provider = $this->getMockBuilder( PayPalJwkProvider::class )
+			->onlyMethods( array( 'get_cached', 'fetch_keys' ) )
+			->getMock();
+
+		$provider->method( 'get_cached' )
+			->willReturn( $cached_keys );
+
+		$provider->expects( $this->never() )
+			->method( 'fetch_keys' );
 
 		$result = $provider->keys();
 
-		$this->assertIsArray( $result );
+		$this->assertSame( $cached_keys, $result );
+
+		$result = $provider->keys();
+
+		$this->assertSame( $fresh_keys, $result );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -50,9 +50,8 @@ class PayPalJwkProviderTest extends TestCase {
 	 * @dataProvider fetchScenarioProvider
 	 */
 	public function test_handles_fetch_scenarios(
-		string $key_material,
-		bool $should_cache,
-		?string $expected_algorithm
+		?Key $key_material,
+		bool $should_cache
 	): void {
 		$provider = Mockery::mock( PayPalJwkProvider::class )
 			->makePartial()
@@ -69,11 +68,7 @@ class PayPalJwkProviderTest extends TestCase {
 		if ( $should_cache ) {
 			$provider->shouldReceive( 'cache_set' )
 				->once()
-				->withArgs(
-					fn( $key ) => $key instanceof Key
-						&& $key->getKeyMaterial() === $key_material
-						&& $key->getAlgorithm() === $expected_algorithm
-				);
+				->with( $key_material );
 		} else {
 			$provider->shouldReceive( 'cache_set' )->never();
 		}
@@ -82,8 +77,7 @@ class PayPalJwkProviderTest extends TestCase {
 
 		if ( $should_cache ) {
 			$this->assertInstanceOf( Key::class, $result );
-			$this->assertSame( $key_material, $result->getKeyMaterial() );
-			$this->assertSame( $expected_algorithm, $result->getAlgorithm() );
+			$this->assertSame( $key_material, $result );
 		} else {
 			$this->assertNull( $result );
 		}
@@ -91,15 +85,13 @@ class PayPalJwkProviderTest extends TestCase {
 
 	public function fetchScenarioProvider(): array {
 		return array(
-			'successful fetch'   => array(
-				'key_material'       => 'fresh-key-string',
-				'should_cache'       => true,
-				'expected_algorithm' => 'RS256',
+			'successful fetch' => array(
+				'key_material' => new Key( 'fresh-key-string', 'RS256' ),
+				'should_cache' => true,
 			),
-			'empty string fetch' => array(
-				'key_material'       => '',
-				'should_cache'       => false,
-				'expected_algorithm' => null,
+			'null fetch'       => array(
+				'key_material' => null,
+				'should_cache' => false,
 			),
 		);
 	}
@@ -110,7 +102,7 @@ class PayPalJwkProviderTest extends TestCase {
 	 * THEN should fetch once and return cached key on subsequent calls
 	 */
 	public function test_caches_key_after_first_fetch(): void {
-		$key_string = 'fresh-key-string';
+		$fetched_key = new Key( 'fresh-key-string', 'RS256' );
 
 		$provider = Mockery::mock( PayPalJwkProvider::class )
 			->makePartial()
@@ -118,11 +110,11 @@ class PayPalJwkProviderTest extends TestCase {
 
 		$provider->shouldReceive( 'fetch_key_material' )
 			->once()
-			->andReturn( $key_string );
+			->andReturn( $fetched_key );
 
 		$result1 = $provider->keys();
 		$this->assertInstanceOf( Key::class, $result1 );
-		$this->assertSame( $key_string, $result1->getKeyMaterial() );
+		$this->assertSame( $fetched_key, $result1 );
 
 		$result2 = $provider->keys();
 		$this->assertInstanceOf( Key::class, $result2 );

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -26,14 +26,17 @@ class PayPalJwkProviderTest extends TestCase {
 		);
 
 		$provider = $this->getMockBuilder( PayPalJwkProvider::class )
-			->onlyMethods( array( 'get_cached', 'fetch_keys' ) )
+			->onlyMethods( array( 'cache_get', 'cache_set', 'fetch' ) )
 			->getMock();
 
-		$provider->method( 'get_cached' )
+		$provider->method( 'cache_get' )
 			->willReturn( $cached_keys );
 
 		$provider->expects( $this->never() )
-			->method( 'fetch_keys' );
+			->method( 'fetch' );
+
+		$provider->expects( $this->never() )
+			->method( 'cache_set' );
 
 		$result = $provider->keys();
 
@@ -45,7 +48,7 @@ class PayPalJwkProviderTest extends TestCase {
 	 * WHEN keys() is called
 	 * THEN should fetch and return fresh keys
 	 */
-	public function test_fetches_keys_when_cache_empty(): void {
+	public function test_fetches_and_caches_keys_when_cache_empty(): void {
 		$fresh_keys = array(
 			'kty' => 'RSA',
 			'kid' => 'test-key-id',
@@ -54,11 +57,11 @@ class PayPalJwkProviderTest extends TestCase {
 		);
 
 		$provider = $this->getMockBuilder( PayPalJwkProvider::class )
-			->onlyMethods( array( 'fetch_keys' ) )
+			->onlyMethods( array( 'fetch' ) )
 			->getMock();
 
 		$provider->expects( $this->once() )
-			->method( 'fetch_keys' )
+			->method( 'fetch' )
 			->willReturn( $fresh_keys );
 
 		$result = $provider->keys();

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Tests for PayPal JWK (JSON Web Key) provider.
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
+
+use WooCommerce\PayPalCommerce\TestCase;
+
+class PayPalJwkProviderTest extends TestCase {
+
+	/**
+	 * GIVEN PayPalJwkProvider instance
+	 * WHEN keys() is called
+	 * THEN should return an array
+	 */
+	public function test_keys_returns_array(): void {
+		$provider = new PayPalJwkProvider();
+
+		$result = $provider->keys();
+
+		$this->assertIsArray( $result );
+	}
+}

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -38,6 +38,28 @@ class PayPalJwkProviderTest extends TestCase {
 		$result = $provider->keys();
 
 		$this->assertSame( $cached_keys, $result );
+	}
+
+	/**
+	 * GIVEN no cached keys exist
+	 * WHEN keys() is called
+	 * THEN should fetch and return fresh keys
+	 */
+	public function test_fetches_keys_when_cache_empty(): void {
+		$fresh_keys = array(
+			'kty' => 'RSA',
+			'kid' => 'test-key-id',
+			'n'   => 'test-modulus',
+			'e'   => 'AQAB',
+		);
+
+		$provider = $this->getMockBuilder( PayPalJwkProvider::class )
+			->onlyMethods( array( 'fetch_keys' ) )
+			->getMock();
+
+		$provider->expects( $this->once() )
+			->method( 'fetch_keys' )
+			->willReturn( $fresh_keys );
 
 		$result = $provider->keys();
 

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -8,6 +8,8 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use Firebase\JWT\Key;
+use Mockery;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Auth\PayPalJwkProvider
@@ -15,57 +17,117 @@ use WooCommerce\PayPalCommerce\TestCase;
 class PayPalJwkProviderTest extends TestCase {
 
 	/**
-	 * GIVEN cached keys are available
+	 * GIVEN cached key is available
 	 * WHEN keys() is called
-	 * THEN should return the cached keys without fetching
+	 * THEN should return the cached key without fetching
 	 */
-	public function test_returns_cached_keys_when_available(): void {
-		$cached_keys = array(
-			'key1' => 'value1',
-			'key2' => 'value2',
-		);
+	public function test_returns_cached_key_when_available(): void {
+		$cached_key = new Key( 'cached-key-string', 'HS256' );
 
-		$provider = $this->getMockBuilder( PayPalJwkProvider::class )
-			->onlyMethods( array( 'cache_get', 'cache_set', 'fetch' ) )
-			->getMock();
+		$provider = Mockery::mock( PayPalJwkProvider::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		$provider->method( 'cache_get' )
-			->willReturn( $cached_keys );
+		$provider->shouldReceive( 'cache_get' )
+			->once()
+			->andReturn( $cached_key );
 
-		$provider->expects( $this->never() )
-			->method( 'fetch' );
+		$provider->shouldReceive( 'fetch_key_material' )
+			->never();
 
-		$provider->expects( $this->never() )
-			->method( 'cache_set' );
+		$provider->shouldReceive( 'cache_set' )
+			->never();
 
 		$result = $provider->keys();
 
-		$this->assertSame( $cached_keys, $result );
+		$this->assertInstanceOf( Key::class, $result );
+		$this->assertSame( $cached_key, $result );
 	}
 
 	/**
-	 * GIVEN no cached keys exist
+	 * GIVEN no cached key exists
 	 * WHEN keys() is called
-	 * THEN should fetch and return fresh keys
+	 * THEN should fetch key string, create Key instance, cache it, and return it
 	 */
-	public function test_fetches_and_caches_keys_when_cache_empty(): void {
-		$fresh_keys = array(
-			'kty' => 'RSA',
-			'kid' => 'test-key-id',
-			'n'   => 'test-modulus',
-			'e'   => 'AQAB',
-		);
+	public function test_fetches_and_caches_key_when_cache_empty(): void {
+		$key_string = 'fresh-key-string';
 
-		$provider = $this->getMockBuilder( PayPalJwkProvider::class )
-			->onlyMethods( array( 'fetch' ) )
-			->getMock();
+		$provider = Mockery::mock( PayPalJwkProvider::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
 
-		$provider->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( $fresh_keys );
+		$provider->shouldReceive( 'cache_get' )
+			->once()
+			->andReturn( null );
+
+		$provider->shouldReceive( 'fetch_key_material' )
+			->once()
+			->andReturn( $key_string );
+
+		$provider->shouldReceive( 'cache_set' )
+			->once()
+			->withArgs(
+				fn( $key ) => $key instanceof Key
+					&& $key->getKeyMaterial() === $key_string
+					&& $key->getAlgorithm() === 'HS256'
+			);
 
 		$result = $provider->keys();
 
-		$this->assertSame( $fresh_keys, $result );
+		$this->assertInstanceOf( Key::class, $result );
+		$this->assertSame( $key_string, $result->getKeyMaterial() );
+		$this->assertSame( 'HS256', $result->getAlgorithm() );
+	}
+
+	/**
+	 * GIVEN no cached key exists initially
+	 * WHEN keys() is called multiple times
+	 * THEN should fetch once and return cached key on subsequent calls
+	 */
+	public function test_caches_key_after_first_fetch(): void {
+		$key_string = 'fresh-key-string';
+
+		$provider = Mockery::mock( PayPalJwkProvider::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$provider->shouldReceive( 'fetch_key_material' )
+			->once()
+			->andReturn( $key_string );
+
+		$result1 = $provider->keys(); // Fresh fetch.
+		$this->assertInstanceOf( Key::class, $result1 );
+		$this->assertSame( $key_string, $result1->getKeyMaterial() );
+
+		$result2 = $provider->keys(); // Cache hit, no second fetch.
+		$this->assertInstanceOf( Key::class, $result2 );
+		$this->assertSame( $result1, $result2 );
+	}
+
+	/**
+	 * GIVEN no cached key exists
+	 * AND fetch returns empty string
+	 * WHEN keys() is called
+	 * THEN should return null without caching
+	 */
+	public function test_returns_null_when_fetch_returns_empty_string(): void {
+		$provider = Mockery::mock( PayPalJwkProvider::class )
+			->makePartial()
+			->shouldAllowMockingProtectedMethods();
+
+		$provider->shouldReceive( 'cache_get' )
+			->once()
+			->andReturn( null );
+
+		$provider->shouldReceive( 'fetch_key_material' )
+			->once()
+			->andReturn( '' );
+
+		$provider->shouldReceive( 'cache_set' )
+			->never();
+
+		$result = $provider->keys();
+
+		$this->assertNull( $result );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/PayPalJwkProviderTest.php
@@ -69,14 +69,14 @@ class PayPalJwkProviderTest extends TestCase {
 			->withArgs(
 				fn( $key ) => $key instanceof Key
 					&& $key->getKeyMaterial() === $key_string
-					&& $key->getAlgorithm() === 'HS256'
+					&& $key->getAlgorithm() === 'RS256'
 			);
 
 		$result = $provider->keys();
 
 		$this->assertInstanceOf( Key::class, $result );
 		$this->assertSame( $key_string, $result->getKeyMaterial() );
-		$this->assertSame( 'HS256', $result->getAlgorithm() );
+		$this->assertSame( 'RS256', $result->getAlgorithm() );
 	}
 
 	/**

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
@@ -4,7 +4,9 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 use WP_REST_Request;
+use Mockery;
 use function Brain\Monkey\Functions\when;
 
 /**
@@ -13,7 +15,9 @@ use function Brain\Monkey\Functions\when;
 class CreateCartEndpointTest extends TestCase {
 
 	public function test_create_cart_returns_201_created(): void {
-		$endpoint = new CreateCartEndpoint();
+		$auth = Mockery::mock( JwtAuthService::class );
+
+		$endpoint = new CreateCartEndpoint( $auth );
 
 		when( 'wp_generate_password' )->justReturn( 'random-string' );
 

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
@@ -12,10 +12,11 @@ use function Brain\Monkey\Functions\when;
  */
 class CreateCartEndpointTest extends TestCase {
 
-	public function test_create_cart_returns_valid_response(): void {
+	public function test_create_cart_returns_201_created(): void {
 		$endpoint = new CreateCartEndpoint();
 
 		when( 'wp_generate_password' )->justReturn( 'random-string' );
+
 		$request = new WP_REST_Request( 'POST', '/wp-json/paypal/v1/merchant-cart' );
 		$request->set_body( json_encode( array(
 			'items'          => array(
@@ -40,5 +41,7 @@ class CreateCartEndpointTest extends TestCase {
 		$this->assertEmpty( $data['validation_issues'] );
 		$this->assertSame( 'CREATED', $data['status'] );
 		$this->assertSame( 'VALID', $data['validation_status'] );
+
+		$this->assertSame( 201, $response->get_status() );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
@@ -5,6 +5,9 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Response\NewCartResponse;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
 use WP_REST_Request;
 use Mockery;
 use function Brain\Monkey\Functions\when;
@@ -15,14 +18,8 @@ use function Brain\Monkey\Functions\when;
 class CreateCartEndpointTest extends TestCase {
 
 	public function test_create_cart_returns_201_created(): void {
-		$auth = Mockery::mock( JwtAuthService::class );
-
-		$endpoint = new CreateCartEndpoint( $auth );
-
-		when( 'wp_generate_password' )->justReturn( 'random-string' );
-
-		$request = new WP_REST_Request( 'POST', '/wp-json/paypal/v1/merchant-cart' );
-		$request->set_body( json_encode( array(
+		$sample_token = 'random-string';
+		$cart_data    = array(
 			'items'          => array(
 				array(
 					'item_id'  => 'TEST-001',
@@ -36,7 +33,25 @@ class CreateCartEndpointTest extends TestCase {
 			'payment_method' => array(
 				'type' => 'paypal',
 			),
-		) ) );
+		);
+
+		when( 'wp_generate_password' )->justReturn( $sample_token );
+
+		$auth             = Mockery::mock( JwtAuthService::class );
+		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		$response_factory->shouldReceive( 'new_cart' )
+			->once()
+			->withArgs( fn( $cart ) => $cart instanceof PayPalCart )
+			->andReturnUsing( fn( $cart ) => new NewCartResponse(
+				$cart,
+				$sample_token
+			) );
+
+		$endpoint = new CreateCartEndpoint( $auth, $response_factory );
+
+		$request = new WP_REST_Request( 'POST', '/wp-json/paypal/v1/merchant-cart' );
+		$request->set_body( json_encode( $cart_data ) );
 
 		$response = $endpoint->create_cart( $request );
 		$data     = $response->get_data();

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -12,14 +12,13 @@ require_once TESTS_ROOT_DIR . '/stubs/WC_Ajax.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Checkout.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Session.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Session_Handler.php';
-require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Controller.php';
-require_once TESTS_ROOT_DIR . '/stubs/WC_REST_Controller.php';
 require_once TESTS_ROOT_DIR . '/stubs/Task.php';
 require_once TESTS_ROOT_DIR . '/stubs/DefaultPaymentGateways.php';
 require_once TESTS_ROOT_DIR . '/stubs/NoteTraits.php';
 require_once TESTS_ROOT_DIR . '/stubs/AbstractPaymentMethodType.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Request.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Response.php';
+require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Controller.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_REST_Controller.php';
 
 Hamcrest\Util::registerGlobalFunctions();

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -16,6 +16,7 @@ require_once TESTS_ROOT_DIR . '/stubs/Task.php';
 require_once TESTS_ROOT_DIR . '/stubs/DefaultPaymentGateways.php';
 require_once TESTS_ROOT_DIR . '/stubs/NoteTraits.php';
 require_once TESTS_ROOT_DIR . '/stubs/AbstractPaymentMethodType.php';
+require_once TESTS_ROOT_DIR . '/stubs/WP_Error.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Request.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Response.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Controller.php';

--- a/tests/stubs/WP_Error.php
+++ b/tests/stubs/WP_Error.php
@@ -1,0 +1,25 @@
+<?php
+
+class WP_Error {
+	private $code;
+	private $message;
+	private $data;
+
+	public function __construct( $code = '', $message = '', $data = '' ) {
+		$this->code    = $code;
+		$this->message = $message;
+		$this->data    = $data;
+	}
+
+	public function get_error_code() {
+		return $this->code;
+	}
+
+	public function get_error_message( $code = '' ) {
+		return $this->message;
+	}
+
+	public function get_error_data( $code = '' ) {
+		return $this->data;
+	}
+}


### PR DESCRIPTION
### Description

Implements JWT authentication for the Agentic Commerce REST API endpoints. 

It introduces two core components:
1. `PayPalJwkProvider` for managing PayPal's public keys with in-memory caching
2. `JwtAuthService` for validating Bearer tokens from Authorization headers

The authentication layer is integrated into the `AgenticRestEndpoint` base class (via the `check_permission` method), ensuring all agentic endpoints are protected.

Note: This PR adds the library `firebase/php-jwt` via composer to the plugin

