### PR TITLE
Pay Later Messaging Settings tab broken/missing (5409)

### DIFF
--- a/modules/ppcp-paylater-configurator/services.php
+++ b/modules/ppcp-paylater-configurator/services.php
@@ -48,12 +48,10 @@ return array(
 		$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
 		assert( $dcc_product_status instanceof DCCProductStatus );
 
-		$card_fields_eligible = $container->get( 'card-fields.eligible' );
-
 		$vault_enabled = $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' );
 
 		// Pay Later Messaging is available if vaulting is not enabled, the shop country is supported, and is eligible for ACDC.
-		return ! $vault_enabled && $messages_apply->for_country() && $dcc_product_status->is_active() && $card_fields_eligible;
+		return ! $vault_enabled && $messages_apply->for_country() && $dcc_product_status->is_active();
 	},
 	'paylater-configurator.messaging-locations'  => static function ( ContainerInterface $container ): array {
 		// Get an array of locations that display the Pay-Later message.


### PR DESCRIPTION
Pay Later Messaging tab is missing if you upgrade from 3.1.0 to 3.1.1 to 3.1.2. If you upgrade from 3.1.0 to 3.1.2, the Pay Later Messaging tab will still show.

### Possible Cause
It could be related to store being in "branded-only" mode, in [release 3.1.1](https://github.com/woocommerce/woocommerce-paypal-payments/releases/tag/3.1.1)  both PRs ([#3699](https://github.com/woocommerce/woocommerce-paypal-payments/pull/3699) and [#3703](https://github.com/woocommerce/woocommerce-paypal-payments/pull/3703)) introduced or modify the `apply_branded_only_limitations()` method in `SettingsModule.php:794-811` which adds these filters when in "branded-only" mode:
```
woocommerce_paypal_payments_is_eligible_for_card_fields → __return_false
woocommerce_paypal_payments_is_acdc_active → __return_false
```
The tab checks [the following](https://github.com/woocommerce/woocommerce-paypal-payments/blob/develop/modules/ppcp-paylater-configurator/services.php#L56) for visibility, which in branded mode returns false for card field eligible:
```
  return ! $vault_enabled
      && $messages_apply->for_country()
      && $dcc_product_status->is_active()
      && $card_fields_eligible;  // ← THIS BECOMES FALSE
```

This PR removes `$card_fields_eligible` check and relies only on  $dcc_product_status active for checking ACDC eligibility.