### PR TITLE
Add Canada to Pay Later country list (5477)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -837,7 +837,7 @@ return array(
 				'AU',
 				'IT',
 				'ES',
-				'CA'
+				'CA',
 			)
 		);
 	},

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -837,6 +837,7 @@ return array(
 				'AU',
 				'IT',
 				'ES',
+				'CA'
 			)
 		);
 	},

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -101,7 +101,7 @@ class FeaturesDefinition {
 			'US',
 			'DE',
 			'AU',
-			'CA'
+			'CA',
 		);
 		$store_country         = $this->settings->get_woo_settings()['country'];
 		$country_location      = in_array( $store_country, $paylater_countries, true ) ? strtolower( $store_country ) : 'us';

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -101,6 +101,7 @@ class FeaturesDefinition {
 			'US',
 			'DE',
 			'AU',
+			'CA'
 		);
 		$store_country         = $this->settings->get_woo_settings()['country'];
 		$country_location      = in_array( $store_country, $paylater_countries, true ) ? strtolower( $store_country ) : 'us';


### PR DESCRIPTION
### Description

Add Canada to Pay Later country list 

Notice that until 12th, the Feature won't work on the PayPal side. This feature only covers enabling the feature for Canada.

### Steps to Test

1. Set your store to Canada
2. See Pay Later Feature
3. Enable Pay Later 
4. See the tab  Pay Later Messaging

