### PR TITLE
Fatal error in Visual Composer front-end editor due to strict $hook_suffix type in SettingsModule.php (5469)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -295,7 +295,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function ( string $hook_suffix ) use ( $container ): void {
+			function ( $hook_suffix ) use ( $container ): void {
 				if ( ! is_string( $hook_suffix ) ) {
 					return;
 				}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -290,8 +290,19 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'admin_enqueue_scripts',
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
 			function ( string $hook_suffix ) use ( $container ): void {
+				if ( ! is_string( $hook_suffix ) ) {
+					return;
+				}
+
 				$script_data_handler = $container->get( 'settings.service.script-data-handler' );
+				assert( $script_data_handler instanceof ScriptDataHandler );
+
 				$script_data_handler->localize_scripts( $hook_suffix );
 			}
 		);

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -39,6 +39,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\PathRepository
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
+use WooCommerce\PayPalCommerce\Settings\Service\ScriptDataHandler;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;


### PR DESCRIPTION
This PR fixes type error `Argument #1 ($hook_suffix) must be of type string, null given` by removing param type and return early if it's not a string.