### PR TITLE
Automatically enables Pay Later on 12th November for Canadian stores (5478)

### DIFF
--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -203,7 +203,7 @@ class WooCommerceOrderCreator {
 		$shipping_address = null;
 		$billing_address  = null;
 		$shipping_options = null;
-		$wc_customer = WC()->customer;
+		$wc_customer      = WC()->customer;
 
 		if ( ! $shipping && $needs_shipping ) {
 			if ( $wc_customer instanceof WC_Customer ) {
@@ -216,7 +216,7 @@ class WooCommerceOrderCreator {
 			$payer_name  = $payer->name();
 			$payer_phone = $payer->phone();
 
-			$wc_email    = null;
+			$wc_email = null;
 			if ( $wc_customer instanceof WC_Customer ) {
 				$wc_email = $wc_customer->get_email();
 			}

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -12,7 +12,11 @@ namespace WooCommerce\PayPalCommerce\Compat;
 use Exception;
 use WC_Order;
 use WC_Order_Item_Product;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -88,6 +92,67 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		add_action( 'woocommerce_paypal_payments_gateway_migrate', static fn() => delete_transient( 'ppcp_has_ppec_subscriptions' ) );
 
 		$this->legacy_ui_card_payment_mapping( $c );
+
+		/**
+		 * Automatically enable Pay Later messaging for Canadian stores during plugin update.
+		 *
+		 * This action runs during plugin updates to automatically enable Pay Later messaging for stores
+		 * that meet the following criteria:
+		 * - Date is after 12th November 2025 (PayPal release time)
+		 * - Store Country is set as Canada
+		 * - The "Stay updated" checkbox is enabled (checked in either old or new UI)
+		 *
+		 * The "Stay updated" setting is retrieved differently based on the UI version:
+		 * - Legacy UI: Retrieved from wcgateway.settings
+		 * - New UI: Retrieved from settings.data.settings model
+		 *
+		 * When all conditions are met, this will:
+		 * - Enable Pay Later messaging
+		 * - Add default messaging locations (product, cart, checkout) to existing selections
+		 *
+		 * @todo Remove this auto-enablement logic after the next release
+		 *
+		 * @hook woocommerce_paypal_payments_gateway_migrate
+		 */
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			static function () use ( $c ) {
+
+				// Check if current date is after November 12th, 2025 (Expected PayPal release date).
+				$paypal_expected_release_date = strtotime( '2025-10-12 00:00:00' );
+				if ( current_time( 'timestamp' ) < $paypal_expected_release_date ) {
+					return;
+				}
+
+				// Check if the "Stay updated" checkbox is enabled (checked in either old or new UI)
+				$settings_model = $c->get( 'settings.data.settings' );
+				assert( $settings_model instanceof SettingsModel );
+
+				$settings = $c->get( 'wcgateway.settings' );
+				assert( $settings instanceof Settings );
+
+				$stay_updated = SettingsModule::should_use_the_old_ui()
+					? $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' )
+					: $settings_model->get_stay_updated();
+
+				// Store Country is set as Canada.
+				if ( $c->get( 'api.shop.country' ) !== 'CA' || ! $stay_updated ) {
+					return;
+				}
+
+				// Enable Pay Later messaging.
+				$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
+				$settings->set( 'pay_later_messaging_enabled', true );
+				$settings->set( 'pay_later_messaging_locations', array_unique( array_merge( $selected_locations, array( 'product', 'cart', 'checkout' ) ) ) );
+				$settings->persist();
+
+				// Enable Pay Later Payment Method.
+				$payment_settings = $c->get( 'settings.data.payment' );
+				assert( $payment_settings instanceof PaymentSettings );
+				$payment_settings->set_paylater_enabled( true );
+				$payment_settings->save();
+			}
+		);
 
 		return true;
 	}

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -119,12 +119,14 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			static function () use ( $c ) {
 
 				// Check if current date is after November 12th, 2025 (Expected PayPal release date).
-				$paypal_expected_release_date = strtotime( '2025-11-12 00:00:00' );
-				if ( current_time( 'timestamp' ) < $paypal_expected_release_date ) {
+				$release_date = '2025-11-12';
+				$current_date = current_time( 'Y-m-d' );
+
+				if ( $current_date < $release_date ) {
 					return;
 				}
 
-				// Check if the "Stay updated" checkbox is enabled (checked in either old or new UI)
+				// Check if the "Stay updated" checkbox is enabled (checked in either old or new UI).
 				$settings_model = $c->get( 'settings.data.settings' );
 				assert( $settings_model instanceof SettingsModel );
 

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -119,7 +119,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			static function () use ( $c ) {
 
 				// Check if current date is after November 12th, 2025 (Expected PayPal release date).
-				$paypal_expected_release_date = strtotime( '2025-10-12 00:00:00' );
+				$paypal_expected_release_date = strtotime( '2025-11-12 00:00:00' );
 				if ( current_time( 'timestamp' ) < $paypal_expected_release_date ) {
 					return;
 				}

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -613,6 +613,7 @@ $services = array(
 			'save_paypal'                 => $features['save_paypal_and_venmo']['enabled'] ?? false,
 			'alternative_payment_methods' => $features['alternative_payment_methods']['enabled'] ?? false,
 			'installments'                => $features['installments']['enabled'] ?? false,
+			'pay_later_messaging'         => $features['pay_later_messaging']['enabled'] ?? false,
 		);
 
 		$merchant_capabilities = array(
@@ -621,7 +622,7 @@ $services = array(
 			'apm'          => $capabilities['alternative_payment_methods'], // Alternative payment methods eligibility.
 			'google_pay'   => $capabilities['acdc'] && $capabilities['google_pay'], // Google Pay eligibility.
 			'apple_pay'    => $capabilities['acdc'] && $capabilities['apple_pay'], // Apple Pay eligibility.
-			'pay_later'    => $capabilities['acdc'] && ! $gateways['card-button'], // Pay Later eligibility.
+			'pay_later'    => $capabilities['pay_later_messaging'] && $capabilities['acdc'] && ! $gateways['card-button'], // Pay Later eligibility.
 			'installments' => $capabilities['installments'], // Installments eligibility.
 		);
 		return new FeaturesDefinition(


### PR DESCRIPTION
### Description

- This PR implements automatic enablement of Pay Later messaging and Pay Later Method for Canadian stores that have opted into automatic feature updates. This only happens if the date is after 12th November (Time of the PayPal release)

- This PR also fixes a bug in Pay Later capabilities. That was only checking for ACDC but not Pay Later Feature
- This PR also reformats some PHPCS errors in WooCommerceOrderCreator


- Before Nov 12: $current_date < $release_date = true → returns early (dont enable PayLater)
- On Nov 12: $current_date < $release_date = false → continues execution (enable PayLater)
- After Nov 12: $current_date < $release_date = false → continues execution (enable PayLater) 

### Steps to Test

Case: Before Release date

1. You have the Stay updated option checked 
2. Connect to a PayPal account with DCC available.
3. Go to PayPal -> Payment Methods and deactivate Pay Later if it was present and activated
4. Set Woo Store to Canada in Settings
5. Increase the plugin version (or reduce the one in `woocommerce-ppcp-version` option) to trigger the updated
6. Do a request (like refreshing page)
7. Go to PayPal -> Payment Methods and see Pay Later NOT activated


Case: After Release date

1. Tweak the [modules/ppcp-compat/src/CompatModule.php  line 122](https://github.com/woocommerce/woocommerce-paypal-payments/compare/release/3.3.0...PCP-5478-stay-updated-automatically-enable-pay-later-messaging-for-existing-ca-merchant-setups-when-updating-the-plugin?expand=1#diff-8454313b74246e67dac24662dbae270135107d575711f11040ab5695341a98d1R122) and set the date at some point before yesterday. 
2. Repeat steps 1-6 of the previous case
3.  Go to PayPal -> Payment Methods and see Pay Later activated

Case: Non-Canadian stores

1.  Repeat steps 1-6 of the previous case (Case: After Release date)
2.  Go to PayPal -> Payment Methods and see Pay Later NOT activated


Case: Stay Update not checked

1. Skip step 1 of previous cases
2. Repeat steps 2-6 of the first case  (Case: After Release date)
3. Go to PayPal -> Payment Methods and see Pay Later NOT activated


### Demo


https://github.com/user-attachments/assets/0cc7e502-7c84-4538-8da9-4e6740b017cc


