### PR TITLE
Replace placeholder text with PayPal-approved verbiage (5097)

### DIFF
--- a/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/TodosDefinition.php
@@ -235,8 +235,8 @@ class TodosDefinition {
 				'priority'    => 13,
 			),
 			'apply_for_working_capital'            => array(
-				'title'       => __( 'Start your PayPal Working Capital application', 'woocommerce-paypal-payments' ),
-				'description' => __( 'Hey, you are eligible for credit. Click here to learn more and sign up', 'woocommerce-paypal-payments' ),
+				'title'       => __( 'Discover how PayPal Working Capital can fuel your business growth', 'woocommerce-paypal-payments' ),
+				'description' => __( 'Approved loans are quickly deposited, so you can put them to work right away. Check eligibility.', 'woocommerce-paypal-payments' ),
 				'isEligible'  => $eligibility_checks['apply_for_working_capital'],
 				'action'      => array(
 					'type' => 'external',

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2214,14 +2214,14 @@ return array(
 		return array(
 			$inbox_note_factory->create_note(
 				__( 'PayPal Working Capital', 'woocommerce-paypal-payments' ),
-				__( 'Fast funds with payments that flex with your PayPal sales The PayPal Working Capital business loan is primarily based on your PayPal account history. Apply for $1,000-$200,000 (and up to $300,000 for repeat borrowers) with no credit check.† If approved, loans are funded in minutes.', 'woocommerce-paypal-payments' ),
+				__( 'Business loans from $1k to $230k for first-time borrowers. Looking to fuel your business growth? With a PayPal Working Capital loan, approved loans are funded in minutes and repaid as a share of your sales. Minimum payment required every 90 days. The lender for PayPal Working Capital is WebBank.', 'woocommerce-paypal-payments' ),
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-working-capital-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
 				$is_working_capital_feature_flag_enabled && $container->get( 'api.shop.country' ) === 'US' && $stay_updated,
 				new InboxNoteAction(
-					'apply_now',
-					__( 'Apply now', 'woocommerce-paypal-payments' ),
+					'learn_more',
+					__( 'Learn More', 'woocommerce-paypal-payments' ),
 					'http://example.com/',
 					Note::E_WC_ADMIN_NOTE_UNACTIONED,
 					true

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2105,7 +2105,7 @@ return array(
 			array(
 				'id'           => 'ppcp-working-capital-task',
 				'title'        => __( 'Fuel your business growth with a PayPal Working Capital loan. Check eligibility', 'woocommerce-paypal-payments' ),
-				'description'  => __( '', 'woocommerce-paypal-payments' ),
+				'description'  => '',
 				'redirect_url' => 'http://example.com/',
 			),
 		);

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2104,8 +2104,7 @@ return array(
 		return array(
 			array(
 				'id'           => 'ppcp-working-capital-task',
-				'title'        => __( 'Start your PayPal Working Capital application', 'woocommerce-paypal-payments' ),
-				'description'  => __( 'Hey, you are eligible for credit. Click here to learn more and sign up', 'woocommerce-paypal-payments' ),
+				'title'        => __( 'Fuel your business growth with a PayPal Working Capital loan. Check eligibility', 'woocommerce-paypal-payments' ),
 				'redirect_url' => 'http://example.com/',
 			),
 		);

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2105,6 +2105,7 @@ return array(
 			array(
 				'id'           => 'ppcp-working-capital-task',
 				'title'        => __( 'Fuel your business growth with a PayPal Working Capital loan. Check eligibility', 'woocommerce-paypal-payments' ),
+				'description'  => __( '', 'woocommerce-paypal-payments' ),
 				'redirect_url' => 'http://example.com/',
 			),
 		);


### PR DESCRIPTION
### Description

This PR:

- Replaces the text for Working Capital Inbox Notification
- Replaces the text for Working Capital WooCommerce Things to do next
- Replaces the text for Working Capital PayPal Things to do next

⚠️  Learn more and links are not yet updated (still pointing to example.com)
⚠️  Banner under WooCommerce Overview is not covered in this PR

### Steps to Test

See screenshots and Jira tasks for a  better understanding

1. Force enabling working capital feature, check Stay updated box and and set a US WooCommerce store
2. Go to Inbox notifications and see the new Inbox matching the new copy 
3. Go to WooCommerce Things to do next and see the new content matching the new copy 
4. PayPal Things to do next ans see the new content matching the new copy 

<img width="747" height="649" alt="Screenshot 2025-10-28 at 18 56 26" src="https://github.com/user-attachments/assets/068b0eee-8f00-4b9a-8463-7b1ee4a8d853" />
<img width="958" height="596" alt="Screenshot 2025-10-28 at 18 55 20" src="https://github.com/user-attachments/assets/c8722078-93d0-43eb-a01f-32fe16671d04" />
<img width="1016" height="498" alt="Screenshot 2025-10-28 at 18 52 21" src="https://github.com/user-attachments/assets/c329de93-7cc4-47b6-b8c1-940c848fa8a2" />


