### PR TITLE
Refactor Canada pay later auto enable logic (5478)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -828,7 +828,7 @@ return array(
 	'api.paylater.is-canada-released'                => static function ( ContainerInterface $container ): bool {
 		// Check if current date is after November 12th, 2025 (Expected PayPal release date).
 		// @todo Remove this logic after the next release
-		$release_date = '2025-10-12';
+		$release_date = '2025-11-12';
 		$current_date = current_time( 'Y-m-d' );
 
 		return $current_date >= $release_date;

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -825,20 +825,34 @@ return array(
 			'SE',
 		);
 	},
+	'api.paylater.is-canada-released'                => static function ( ContainerInterface $container ): bool {
+		// Check if current date is after November 12th, 2025 (Expected PayPal release date).
+		// @todo Remove this logic after the next release
+		$release_date = '2025-10-12';
+		$current_date = current_time( 'Y-m-d' );
 
+		return $current_date >= $release_date;
+	},
 	'api.paylater-countries'                         => static function ( ContainerInterface $container ): array {
+		$default_countries = array(
+			'US',
+			'DE',
+			'GB',
+			'FR',
+			'AU',
+			'IT',
+			'ES',
+		);
+
+		// @todo Remove this logic after the next release.
+		// Instead add CA as a default country directly.
+		if ( $container->get( 'api.paylater.is-canada-released' ) ) {
+			$default_countries[] = 'CA';
+		}
+
 		return apply_filters(
 			'woocommerce_paypal_payments_supported_paylater_countries',
-			array(
-				'US',
-				'DE',
-				'GB',
-				'FR',
-				'AU',
-				'IT',
-				'ES',
-				'CA',
-			)
+			$default_countries
 		);
 	},
 	'api.order-helper'                               => static function ( ContainerInterface $container ): OrderHelper {

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -827,9 +827,9 @@ return array(
 	},
 	'api.paylater.is-canada-released'                => static function ( ContainerInterface $container ): bool {
 		// Check if current date is after November 12th, 2025 (Expected PayPal release date).
-		// @todo Remove this logic after the next release
+		// @todo Remove this logic after the next release.
 		$release_date = '2025-11-12';
-		$current_date = current_time( 'Y-m-d' );
+		$current_date = gmdate( 'Y-m-d' );
 
 		return $current_date >= $release_date;
 	},

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -98,7 +98,6 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		 *
 		 * This action runs during plugin updates to automatically enable Pay Later messaging for stores
 		 * that meet the following criteria:
-		 * - Date is after 12th November 2025 (PayPal release time)
 		 * - Store Country is set as Canada
 		 * - The "Stay updated" checkbox is enabled (checked in either old or new UI)
 		 *
@@ -108,6 +107,7 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		 *
 		 * When all conditions are met, this will:
 		 * - Enable Pay Later messaging
+		 * - Enable Pay Later Payment Method
 		 * - Add default messaging locations (product, cart, checkout) to existing selections
 		 *
 		 * @todo Remove this auto-enablement logic after the next release
@@ -117,15 +117,6 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
 			static function () use ( $c ) {
-
-				// Check if current date is after November 12th, 2025 (Expected PayPal release date).
-				$release_date = '2025-11-12';
-				$current_date = current_time( 'Y-m-d' );
-
-				if ( $current_date < $release_date ) {
-					return;
-				}
-
 				// Check if the "Stay updated" checkbox is enabled (checked in either old or new UI).
 				$settings_model = $c->get( 'settings.data.settings' );
 				assert( $settings_model instanceof SettingsModel );

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -62,8 +62,7 @@ class FeaturesDefinition {
 		FeaturesEligibilityService $eligibilities,
 		GeneralSettings $settings,
 		array $merchant_capabilities,
-		SettingsModel $plugin_settings,
-		array $paylater_countries = array()
+		SettingsModel $plugin_settings
 	) {
 		$this->eligibilities         = $eligibilities;
 		$this->settings              = $settings;
@@ -94,7 +93,7 @@ class FeaturesDefinition {
 	 * @return array[] The array of all available features.
 	 */
 	public function all_available_features(): array {
-		$paylater_documentation_countries = array(
+		$paylater_documentation_supported_countries = array(
 			'UK',
 			'ES',
 			'IT',
@@ -104,9 +103,9 @@ class FeaturesDefinition {
 			'AU',
 		);
 
-		$store_country         = $this->settings->get_woo_settings()['country'];
-		$country_location      = in_array( $store_country, $paylater_documentation_countries, true ) ? strtolower( $store_country ) : 'us';
-		$save_paypal_and_venmo = $this->plugin_settings->get_save_paypal_and_venmo();
+		$store_country                  = $this->settings->get_woo_settings()['country'];
+		$paylater_docs_country_location = in_array( $store_country, $paylater_documentation_supported_countries, true ) ? strtolower( $store_country ) : 'us';
+		$save_paypal_and_venmo          = $this->plugin_settings->get_save_paypal_and_venmo();
 
 		$feature_items = array(
 			'save_paypal_and_venmo'           => array(
@@ -314,7 +313,7 @@ class FeaturesDefinition {
 					array(
 						'type'  => 'tertiary',
 						'text'  => __( 'Learn more', 'woocommerce-paypal-payments' ),
-						'url'   => "https://www.paypal.com/$country_location/business/accept-payments/checkout/installments",
+						'url'   => "https://www.paypal.com/$paylater_docs_country_location/business/accept-payments/checkout/installments",
 						'class' => 'small-button',
 					),
 				),
@@ -368,8 +367,7 @@ class FeaturesDefinition {
 						'text'     => __( 'Sign up', 'woocommerce-paypal-payments' ),
 						'urls'     => array(
 							'sandbox' => 'https://www.sandbox.paypal.com/bizsignup/add-product?product=CRYPTO_PYMTS',
-							'live'    => 'https://www.paypal.com/bizsignup/add-product?product=CRYPTO_PYMTS
-',
+							'live'    => 'https://www.paypal.com/bizsignup/add-product?product=CRYPTO_PYMTS',
 						),
 						'showWhen' => 'disabled',
 						'class'    => 'small-button',

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -62,7 +62,8 @@ class FeaturesDefinition {
 		FeaturesEligibilityService $eligibilities,
 		GeneralSettings $settings,
 		array $merchant_capabilities,
-		SettingsModel $plugin_settings
+		SettingsModel $plugin_settings,
+		array $paylater_countries = array()
 	) {
 		$this->eligibilities         = $eligibilities;
 		$this->settings              = $settings;
@@ -93,7 +94,7 @@ class FeaturesDefinition {
 	 * @return array[] The array of all available features.
 	 */
 	public function all_available_features(): array {
-		$paylater_countries    = array(
+		$paylater_documentation_countries = array(
 			'UK',
 			'ES',
 			'IT',
@@ -101,10 +102,10 @@ class FeaturesDefinition {
 			'US',
 			'DE',
 			'AU',
-			'CA',
 		);
+
 		$store_country         = $this->settings->get_woo_settings()['country'];
-		$country_location      = in_array( $store_country, $paylater_countries, true ) ? strtolower( $store_country ) : 'us';
+		$country_location      = in_array( $store_country, $paylater_documentation_countries, true ) ? strtolower( $store_country ) : 'us';
 		$save_paypal_and_venmo = $this->plugin_settings->get_save_paypal_and_venmo();
 
 		$feature_items = array(

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -455,6 +455,11 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					unset( $payment_methods['venmo'] );
 				}
 
+				// @todo Remove this logic after the next release. Unset PayPal Pay Later if shop is Canadian and Canadian Pay Later is not released.
+				if ( $container->get( 'api.shop.country' ) === 'CA' && ! $container->get( 'api.paylater.is-canada-released' ) ) {
+					unset( $payment_methods['pay-later'] );
+				}
+
 				// Unset if country/currency is not supported or merchant not eligible for Google Pay.
 				if ( ! $container->get( 'googlepay.eligible' ) || ! $googlepay_product_status->is_active() ) {
 					unset( $payment_methods['ppcp-googlepay'] );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -455,11 +455,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					unset( $payment_methods['venmo'] );
 				}
 
-				// @todo Remove this logic after the next release. Unset PayPal Pay Later if shop is Canadian and Canadian Pay Later is not released.
-				if ( $container->get( 'api.shop.country' ) === 'CA' && ! $container->get( 'api.paylater.is-canada-released' ) ) {
-					unset( $payment_methods['pay-later'] );
-				}
-
 				// Unset if country/currency is not supported or merchant not eligible for Google Pay.
 				if ( ! $container->get( 'googlepay.eligible' ) || ! $googlepay_product_status->is_active() ) {
 					unset( $payment_methods['ppcp-googlepay'] );

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -583,7 +583,11 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				);
 
 				// When local APMs are available, then PayLater messaging is also available.
-				$features['pay_later_messaging'] = $features['alternative_payment_methods'];
+				// @todo Remove this logic after the next release. If Store is Canada and PayLater for Canada is not released, then PayLater messaging is not available.
+				$is_paylater_canada_released     = $c->get( 'api.paylater.is-canada-released' );
+				$features['pay_later_messaging'] = array(
+					'enabled' => $features['alternative_payment_methods']['enabled'] && ( $c->get( 'api.shop.country' ) !== 'CA' || $is_paylater_canada_released ),
+				);
 
 				$features['installments'] = array(
 					'enabled' => $installments_product_status->is_active(),


### PR DESCRIPTION
### Description

This PR makes some tweaks on https://github.com/woocommerce/woocommerce-paypal-payments/pull/3819 and https://github.com/woocommerce/woocommerce-paypal-payments/pull/3813

- Always enable PayLater Method and Messages after update if the store is Canadian. (Doesn't matter the date)
- Block the PayLater Messaging tab  til 12th November if the store is Canadian

### Steps to Test

https://github.com/user-attachments/assets/386e3f3c-3499-4a08-bcff-20bbb0e158d5


