### PR TITLE
Remove use of PayPal JS SDK actions with AppSwitch (5502)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/paypal.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal.js
@@ -29,6 +29,15 @@ const namespace = 'ppcpBlocksPaypalExpressButtons';
 let registeredContext = false;
 let paypalScriptPromise = null;
 
+export const shouldEnableAppSwitch = ( config ) => {
+	// AppSwitch should only be enabled in Pay Now flows with server side shipping callback.
+	return (
+		config.scriptData.appswitch.enabled &&
+		! config.scriptData.final_review_enabled &&
+		config.scriptData.server_side_shipping_callback.enabled
+	);
+};
+
 export const PayPalComponent = ( {
 	config,
 	onClick,
@@ -161,7 +170,7 @@ export const PayPalComponent = ( {
 	const handleCancel = () => {
 		// Don't call onClose if AppSwitch is enabled - PayPal SDK fires onCancel
 		// when switching to the app, but the user hasn't actually canceled
-		if ( shouldEnableAppSwitch() ) {
+		if ( shouldEnableAppSwitch( config ) ) {
 			return;
 		}
 
@@ -445,15 +454,6 @@ export const PayPalComponent = ( {
 		};
 	};
 
-	const shouldEnableAppSwitch = () => {
-		// AppSwitch should only be enabled in Pay Now flows with server side shipping callback.
-		return (
-			config.scriptData.appswitch.enabled &&
-			! config.scriptData.final_review_enabled &&
-			config.scriptData.server_side_shipping_callback.enabled
-		);
-	};
-
 	if (
 		cartHasSubscriptionProducts( config.scriptData ) &&
 		config.scriptData.is_free_trial_cart
@@ -512,7 +512,7 @@ export const PayPalComponent = ( {
 	return (
 		<PayPalButton
 			ref={ paypalButtonRef }
-			appSwitchWhenAvailable={ shouldEnableAppSwitch() }
+			appSwitchWhenAvailable={ shouldEnableAppSwitch( config ) }
 			fundingSource={ fundingSource }
 			style={ style }
 			onInit={ handleButtonInit }

--- a/modules/ppcp-blocks/resources/js/paypal-config.js
+++ b/modules/ppcp-blocks/resources/js/paypal-config.js
@@ -2,7 +2,7 @@ import {
 	paypalOrderToWcAddresses,
 	paypalSubscriptionToWcAddresses,
 } from './Helper/Address';
-import ResumeFlowHelper from '../../../ppcp-button/resources/js/modules/Helper/ResumeFlowHelper';
+import { shouldEnableAppSwitch } from './Components/paypal';
 
 export const createOrder = async ( data, config, onError, onClose ) => {
 	try {
@@ -73,7 +73,7 @@ export const handleApprove = async (
 		let order;
 
 		// actions.order.get is not available on the AppSwitch flow.
-		if ( ! ResumeFlowHelper.isResumeFlow() ) {
+		if ( ! shouldEnableAppSwitch( config ) ) {
 			order = await actions.order.get();
 		} else {
 			const res = await fetch(


### PR DESCRIPTION
Usage of PayPal JS SDK actions has stopped being supported when AppSwitch is enabled, causing errors during the onApprove callback. 

This PR fixes it by switching the order retrieval to a server-side endpoint rather than SDK actions whenever AppSwitch is enabled.