### PR TITLE
Agentic: Add full cart replacement endpoint (5269)

### DIFF
--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\CreateCartEndpoint;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\GetCartEndpoint;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\UpdateCartEndpoint;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\ReplaceCartEndpoint;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\PayPalJwkProvider;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
@@ -59,6 +60,14 @@ return array(
 
 	'agentic.rest.update_cart'                 => static function ( ContainerInterface $container ): UpdateCartEndpoint {
 		return new UpdateCartEndpoint(
+			$container->get( 'agentic.auth.service' ),
+			$container->get( 'agentic.session.handler' ),
+			$container->get( 'agentic.response.factory' )
+		);
+	},
+
+	'agentic.rest.replace_cart'                => static function ( ContainerInterface $container ): ReplaceCartEndpoint {
+		return new ReplaceCartEndpoint(
 			$container->get( 'agentic.auth.service' ),
 			$container->get( 'agentic.session.handler' ),
 			$container->get( 'agentic.response.factory' )

--- a/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
+++ b/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
@@ -33,6 +33,7 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 		'agentic.rest.create_cart',
 		'agentic.rest.get_cart',
 		'agentic.rest.update_cart',
+		'agentic.rest.replace_cart',
 	);
 
 	public function services(): array {

--- a/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\InvalidRequestError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\CartResponse;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
 
 /**
  * Base class for REST controllers in the agentic commerce module.
@@ -31,10 +32,13 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 
 	private JwtAuthService $auth_service;
 
+	protected AgenticSessionHandler $session_handler;
+
 	protected ResponseFactory $response_factory;
 
-	public function __construct( JwtAuthService $auth_service, ResponseFactory $response_factory ) {
+	public function __construct( JwtAuthService $auth_service, AgenticSessionHandler $session_handler, ResponseFactory $response_factory ) {
 		$this->auth_service     = $auth_service;
+		$this->session_handler  = $session_handler;
 		$this->response_factory = $response_factory;
 	}
 

--- a/modules/ppcp-agentic-commerce/src/Endpoint/CreateCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/CreateCartEndpoint.php
@@ -34,29 +34,6 @@ class CreateCartEndpoint extends AgenticRestEndpoint {
 	protected const METHOD = 'POST';
 
 	/**
-	 * The agentic session handler.
-	 *
-	 * @var AgenticSessionHandler
-	 */
-	private AgenticSessionHandler $session_handler;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param JwtAuthService        $auth_service The JWT auth service.
-	 * @param AgenticSessionHandler $session_handler The session handler.
-	 * @param ResponseFactory       $response_factory The response factory.
-	 */
-	public function __construct(
-		JwtAuthService $auth_service,
-		AgenticSessionHandler $session_handler,
-		ResponseFactory $response_factory
-	) {
-		parent::__construct( $auth_service, $response_factory );
-		$this->session_handler = $session_handler;
-	}
-
-	/**
 	 * Register REST API routes.
 	 *
 	 * @return void

--- a/modules/ppcp-agentic-commerce/src/Endpoint/GetCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/GetCartEndpoint.php
@@ -33,29 +33,6 @@ class GetCartEndpoint extends AgenticRestEndpoint {
 	protected const METHOD = 'GET';
 
 	/**
-	 * The agentic session handler.
-	 *
-	 * @var AgenticSessionHandler
-	 */
-	private AgenticSessionHandler $session_handler;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param JwtAuthService        $auth_service The JWT auth service.
-	 * @param AgenticSessionHandler $session_handler The session handler.
-	 * @param ResponseFactory       $response_factory The response factory.
-	 */
-	public function __construct(
-		JwtAuthService $auth_service,
-		AgenticSessionHandler $session_handler,
-		ResponseFactory $response_factory
-	) {
-		parent::__construct( $auth_service, $response_factory );
-		$this->session_handler = $session_handler;
-	}
-
-	/**
 	 * Register REST API routes.
 	 *
 	 * @return void

--- a/modules/ppcp-agentic-commerce/src/Endpoint/ReplaceCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/ReplaceCartEndpoint.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Replace Cart Endpoint for Agentic Commerce.
+ *
+ * PUT /api/paypal/v1/merchant-cart/{cart_id}
+ *
+ * @package WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\AgenticError;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\CartNotFoundError;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
+
+/**
+ * Replace Cart REST endpoint.
+ *
+ * Fully replaces an existing cart while preserving the payment token.
+ */
+class ReplaceCartEndpoint extends AgenticRestEndpoint {
+	/**
+	 * The endpoint path following PayPal specs.
+	 */
+	protected const PATH = 'merchant-cart/(?P<cart_id>[a-zA-Z0-9_-]+)';
+
+	/**
+	 * The expected HTTP method.
+	 */
+	protected const METHOD = 'PUT';
+
+	/**
+	 * The agentic session handler.
+	 *
+	 * @var AgenticSessionHandler
+	 */
+	private AgenticSessionHandler $session_handler;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param JwtAuthService        $auth_service The JWT auth service.
+	 * @param AgenticSessionHandler $session_handler The session handler.
+	 * @param ResponseFactory       $response_factory The response factory.
+	 */
+	public function __construct(
+		JwtAuthService $auth_service,
+		AgenticSessionHandler $session_handler,
+		ResponseFactory $response_factory
+	) {
+		parent::__construct( $auth_service, $response_factory );
+		$this->session_handler = $session_handler;
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			self::NAMESPACE,
+			self::PATH,
+			array(
+				'methods'             => self::METHOD,
+				'callback'            => array( $this, 'replace_cart' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => array(
+					'cart_id' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'validate_callback' => function ( $param ) {
+							return is_string( $param ) && strlen( $param ) >= 10;
+						},
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Replace an existing cart with new data.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response The REST response.
+	 */
+	public function replace_cart( WP_REST_Request $request ): WP_REST_Response {
+		$cart_id = $request->get_param( 'cart_id' );
+
+		// Verify cart exists.
+		$session = $this->session_handler->load_cart_session( $cart_id );
+
+		if ( ! $session ) {
+			return $this->error(
+				new CartNotFoundError(
+					"Cart with ID '{$cart_id}' does not exist or has expired",
+					array(
+						array(
+							'field'       => 'cartId',
+							'issue'       => 'NOT_FOUND',
+							'description' => "Cart with ID '{$cart_id}' does not exist. Verify cart ID or create a new cart.",
+						),
+					)
+				)
+			);
+		}
+
+		$data = $this->parse_json_body( $request );
+
+		if ( $data instanceof AgenticError ) {
+			return $this->error( $data );
+		}
+
+		$new_cart = PayPalCart::from_array( $data );
+
+		// Replace the cart session (preserving ec_token).
+		$update_result = $this->session_handler->update_cart_session( $cart_id, $new_cart );
+
+		if ( ! $update_result ) {
+			return $this->error(
+				new CartNotFoundError(
+					'Failed to replace cart',
+					array(
+						array(
+							'issue'       => 'CART_REPLACE_FAILED',
+							'description' => 'Cart replacement operation failed.',
+						),
+					)
+				)
+			);
+		}
+
+		$response = $this->response_factory->from_cart( $new_cart );
+
+		// Return 200 OK (not 201 Created).
+		return $this->cart_details( $response, 200 );
+	}
+}

--- a/modules/ppcp-agentic-commerce/src/Endpoint/ReplaceCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/ReplaceCartEndpoint.php
@@ -37,29 +37,6 @@ class ReplaceCartEndpoint extends AgenticRestEndpoint {
 	protected const METHOD = 'PUT';
 
 	/**
-	 * The agentic session handler.
-	 *
-	 * @var AgenticSessionHandler
-	 */
-	private AgenticSessionHandler $session_handler;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param JwtAuthService        $auth_service The JWT auth service.
-	 * @param AgenticSessionHandler $session_handler The session handler.
-	 * @param ResponseFactory       $response_factory The response factory.
-	 */
-	public function __construct(
-		JwtAuthService $auth_service,
-		AgenticSessionHandler $session_handler,
-		ResponseFactory $response_factory
-	) {
-		parent::__construct( $auth_service, $response_factory );
-		$this->session_handler = $session_handler;
-	}
-
-	/**
 	 * Register REST API routes.
 	 *
 	 * @return void

--- a/modules/ppcp-agentic-commerce/src/Endpoint/UpdateCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/UpdateCartEndpoint.php
@@ -36,29 +36,6 @@ class UpdateCartEndpoint extends AgenticRestEndpoint {
 	protected const METHOD = 'PUT';
 
 	/**
-	 * The agentic session handler.
-	 *
-	 * @var AgenticSessionHandler
-	 */
-	private AgenticSessionHandler $session_handler;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param JwtAuthService        $auth_service The JWT auth service.
-	 * @param AgenticSessionHandler $session_handler The session handler.
-	 * @param ResponseFactory       $response_factory The response factory.
-	 */
-	public function __construct(
-		JwtAuthService $auth_service,
-		AgenticSessionHandler $session_handler,
-		ResponseFactory $response_factory
-	) {
-		parent::__construct( $auth_service, $response_factory );
-		$this->session_handler = $session_handler;
-	}
-
-	/**
 	 * Register REST API routes.
 	 *
 	 * @return void

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/ReplaceCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/ReplaceCartEndpointTest.php
@@ -1,0 +1,390 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Response\CartResponse;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
+use WP_REST_Request;
+use Mockery;
+
+/**
+ * @covers ReplaceCartEndpoint
+ */
+class ReplaceCartEndpointTest extends TestCase {
+
+	public function test_replace_cart_returns_200_ok_on_successful_replacement(): void {
+		$cart_id      = 't_mock_cart_id_12345';
+		$ec_token     = 'EC-12345TOKEN';
+		$created_time = time();
+
+		$existing_cart_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => 'OLD-ITEM-001',
+					'quantity' => 1,
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => '25.00',
+					),
+				),
+			),
+			'payment_method' => array(
+				'type' => 'paypal',
+			),
+		);
+
+		$replacement_cart_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => 'NEW-ITEM-002',
+					'quantity' => 3,
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => '50.00',
+					),
+				),
+				array(
+					'item_id'  => 'NEW-ITEM-003',
+					'quantity' => 1,
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => '30.00',
+					),
+				),
+			),
+			'payment_method' => array(
+				'type' => 'paypal',
+			),
+		);
+
+		/** @var JwtAuthService&\Mockery\MockInterface $auth */
+		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
+		$session_handler = Mockery::mock( AgenticSessionHandler::class );
+		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
+		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		$existing_cart = PayPalCart::from_array( $existing_cart_data );
+
+		// First call - verify cart exists
+		$session_handler->shouldReceive( 'load_cart_session' )
+			->once()
+			->with( $cart_id )
+			->andReturn(
+				array(
+					'cart'     => $existing_cart,
+					'ec_token' => $ec_token,
+					'created'  => $created_time,
+				)
+			);
+
+		// Mock replacement operation
+		$session_handler->shouldReceive( 'update_cart_session' )
+			->once()
+			->withArgs( function( $received_cart_id, $new_cart ) use ( $cart_id ) {
+				return $received_cart_id === $cart_id && $new_cart instanceof PayPalCart;
+			} )
+			->andReturn( true );
+
+		// Mock response factory - uses from_cart (not active_cart or new_cart)
+		$replacement_cart = PayPalCart::from_array( $replacement_cart_data );
+		$response_factory->shouldReceive( 'from_cart' )
+			->once()
+			->withArgs( function( $cart ) {
+				return $cart instanceof PayPalCart;
+			} )
+			->andReturnUsing( fn( $cart ) => new CartResponse( $cart ) );
+
+		$endpoint = new ReplaceCartEndpoint( $auth, $session_handler, $response_factory );
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $replacement_cart_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'status', $data );
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_replace_cart_returns_error_when_cart_not_found(): void {
+		$cart_id = 't_nonexistent_cart_id';
+
+		$replacement_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => 'TEST-001',
+					'quantity' => 2,
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => '25.00',
+					),
+				),
+			),
+			'payment_method' => array(
+				'type' => 'paypal',
+			),
+		);
+
+		/** @var JwtAuthService&\Mockery\MockInterface $auth */
+		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
+		$session_handler = Mockery::mock( AgenticSessionHandler::class );
+		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
+		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock session handler - return null for non-existent cart
+		$session_handler->shouldReceive( 'load_cart_session' )
+			->once()
+			->with( $cart_id )
+			->andReturn( null );
+
+		$endpoint = new ReplaceCartEndpoint( $auth, $session_handler, $response_factory );
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $replacement_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data );
+
+		// Error responses should not have 200 status
+		$this->assertNotSame( 200, $response->get_status() );
+
+		// The response should have error information
+		$has_error_info = isset( $data['validation_issues'] )
+			|| isset( $data['error'] )
+			|| isset( $data['message'] )
+			|| isset( $data['issues'] );
+
+		$this->assertTrue( $has_error_info, 'Response should contain error information. Got: ' . json_encode( $data ) );
+	}
+
+	public function test_replace_cart_completely_replaces_items(): void {
+		$cart_id      = 't_mock_cart_id_12345';
+		$ec_token     = 'EC-12345TOKEN';
+		$created_time = time();
+
+		// Original cart has 1 item
+		$existing_cart_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => 'OLD-ITEM-001',
+					'quantity' => 1,
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => '25.00',
+					),
+				),
+			),
+			'payment_method' => array(
+				'type' => 'paypal',
+			),
+			'shipping'       => array(
+				'name'    => array(
+					'full_name' => 'Old Name',
+				),
+				'address' => array(
+					'address_line_1' => '123 Old St',
+					'admin_area_2'   => 'San Jose',
+					'admin_area_1'   => 'CA',
+					'postal_code'    => '95131',
+					'country_code'   => 'US',
+				),
+			),
+		);
+
+		// Replacement cart has completely different items and shipping
+		$replacement_cart_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => 'NEW-ITEM-002',
+					'quantity' => 5,
+					'price'    => array(
+						'currency_code' => 'EUR',
+						'value'         => '99.99',
+					),
+				),
+			),
+			'payment_method' => array(
+				'type' => 'paypal',
+			),
+			'shipping'       => array(
+				'name'    => array(
+					'full_name' => 'New Name',
+				),
+				'address' => array(
+					'address_line_1' => '456 New Ave',
+					'admin_area_2'   => 'Berlin',
+					'admin_area_1'   => 'BE',
+					'postal_code'    => '10115',
+					'country_code'   => 'DE',
+				),
+			),
+		);
+
+		/** @var JwtAuthService&\Mockery\MockInterface $auth */
+		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
+		$session_handler = Mockery::mock( AgenticSessionHandler::class );
+		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
+		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		$existing_cart = PayPalCart::from_array( $existing_cart_data );
+
+		// Mock load existing cart
+		$session_handler->shouldReceive( 'load_cart_session' )
+			->once()
+			->with( $cart_id )
+			->andReturn(
+				array(
+					'cart'     => $existing_cart,
+					'ec_token' => $ec_token,
+					'created'  => $created_time,
+				)
+			);
+
+		// Verify that update receives completely new data (full replacement)
+		$session_handler->shouldReceive( 'update_cart_session' )
+			->once()
+			->withArgs( function( $received_cart_id, $new_cart ) use ( $cart_id ) {
+				if ( $received_cart_id !== $cart_id || ! ( $new_cart instanceof PayPalCart ) ) {
+					return false;
+				}
+
+				$cart_array = $new_cart->to_array();
+
+				// Should have NEW item only (not old)
+				if ( count( $cart_array['items'] ) !== 1 ) {
+					return false;
+				}
+
+				if ( $cart_array['items'][0]['item_id'] !== 'NEW-ITEM-002' ) {
+					return false;
+				}
+
+				// Should have NEW shipping info
+				if ( $cart_array['shipping']['name']['full_name'] !== 'New Name' ) {
+					return false;
+				}
+
+				if ( $cart_array['shipping']['address']['address_line_1'] !== '456 New Ave' ) {
+					return false;
+				}
+
+				return true;
+			} )
+			->andReturn( true );
+
+		// Mock response factory
+		$replacement_cart = PayPalCart::from_array( $replacement_cart_data );
+		$response_factory->shouldReceive( 'from_cart' )
+			->once()
+			->andReturnUsing( fn( $cart ) => new CartResponse( $cart ) );
+
+		$endpoint = new ReplaceCartEndpoint( $auth, $session_handler, $response_factory );
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $replacement_cart_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function test_replace_cart_returns_error_when_replacement_fails(): void {
+		$cart_id      = 't_mock_cart_id_12345';
+		$ec_token     = 'EC-12345TOKEN';
+		$created_time = time();
+
+		$existing_cart_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => 'OLD-ITEM-001',
+					'quantity' => 1,
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => '25.00',
+					),
+				),
+			),
+			'payment_method' => array(
+				'type' => 'paypal',
+			),
+		);
+
+		$replacement_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => 'NEW-ITEM-002',
+					'quantity' => 3,
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => '50.00',
+					),
+				),
+			),
+			'payment_method' => array(
+				'type' => 'paypal',
+			),
+		);
+
+		/** @var JwtAuthService&\Mockery\MockInterface $auth */
+		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
+		$session_handler = Mockery::mock( AgenticSessionHandler::class );
+		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
+		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		$existing_cart = PayPalCart::from_array( $existing_cart_data );
+
+		// Mock load existing cart
+		$session_handler->shouldReceive( 'load_cart_session' )
+			->once()
+			->with( $cart_id )
+			->andReturn(
+				array(
+					'cart'     => $existing_cart,
+					'ec_token' => $ec_token,
+					'created'  => $created_time,
+				)
+			);
+
+		// Mock replacement operation fails
+		$session_handler->shouldReceive( 'update_cart_session' )
+			->once()
+			->andReturn( false );
+
+		$endpoint = new ReplaceCartEndpoint( $auth, $session_handler, $response_factory );
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $replacement_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+		$data     = $response->get_data();
+
+		$this->assertIsArray( $data );
+
+		// Error responses should not have 200 status
+		$this->assertNotSame( 200, $response->get_status() );
+
+		// The response should have error information
+		$has_error_info = isset( $data['validation_issues'] )
+			|| isset( $data['error'] )
+			|| isset( $data['message'] )
+			|| isset( $data['issues'] );
+
+		$this->assertTrue( $has_error_info, 'Response should contain error information. Got: ' . json_encode( $data ) );
+	}
+}


### PR DESCRIPTION
### Description
This PR implements the **full cart replacement** functionality. It introduces a new REST endpoint that allows complete replacement of an existing cart's contents while preserving the payment token.

This change enables replacing an entire cart in a single operation, which is more efficient than partial updates when the cart contents need to be completely changed.

### Key changes include:
- Add the **PUT /merchant-cart/{cart_id}** endpoint (`ReplaceCartEndpoint`) to allow full replacement of an existing cart session.
- Verify cart existence before performing replacement operation.
- Preserve the `ec_token` (payment token) during cart replacement to maintain payment context.
- Return **200 OK** status (not 201 Created) to indicate successful replacement of existing resource.
- Add test coverage for successful replacement, cart not found scenarios, complete data replacement validation, and failure handling.