### PR TITLE
Log reCaptcha rejections

### DIFF
--- a/modules/ppcp-fraud-protection/services.php
+++ b/modules/ppcp-fraud-protection/services.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\FraudProtection;
 
+use WooCommerce\PayPalCommerce\FraudProtection\PersistentCounter;
 use WooCommerce\PayPalCommerce\FraudProtection\Recaptcha\Recaptcha;
 use WooCommerce\PayPalCommerce\FraudProtection\Recaptcha\RecaptchaIntegration;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -12,23 +13,25 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 return array(
-	'fraud-protection.url'                       => static function ( ContainerInterface $container ): string {
+	'fraud-protection.url'                               => static function ( ContainerInterface $container ): string {
 		return plugins_url( '/modules/ppcp-fraud-protection/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
 
-	'fraud-protection.recaptcha'                 => static function ( ContainerInterface $container ): Recaptcha {
+	'fraud-protection.recaptcha'                         => static function ( ContainerInterface $container ): Recaptcha {
 		return new Recaptcha(
 			$container->get( 'fraud-protection.recaptcha.integration' ),
 			$container->get( 'fraud-protection.recaptcha.payment-methods' ),
 			$container->get( 'fraud-protection.url' ),
 			$container->get( 'ppcp.asset-version' ),
-			$container->get( 'woocommerce.logger.woocommerce' )
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'fraud-protection.recaptcha.rejection-counter' ),
+			$container->get( 'fraud-protection.recaptcha.rejection-logger.source' )
 		);
 	},
-	'fraud-protection.recaptcha.integration'     => static function (): RecaptchaIntegration {
+	'fraud-protection.recaptcha.integration'             => static function (): RecaptchaIntegration {
 		return new RecaptchaIntegration();
 	},
-	'fraud-protection.recaptcha.payment-methods' => static function (): array {
+	'fraud-protection.recaptcha.payment-methods'         => static function (): array {
 		return apply_filters(
 			'woocommerce_paypal_payments_recaptcha_payment_methods',
 			array(
@@ -37,5 +40,16 @@ return array(
 				CardButtonGateway::ID,
 			)
 		);
+	},
+	'fraud-protection.recaptcha.rejection-counter'       => static function ( ContainerInterface $container ): PersistentCounter {
+		return new PersistentCounter(
+			$container->get( 'fraud-protection.recaptcha.rejection-counter.option-id' )
+		);
+	},
+	'fraud-protection.recaptcha.rejection-counter.option-id' => static function (): string {
+		return 'ppcp_recaptcha_rejection_counter';
+	},
+	'fraud-protection.recaptcha.rejection-logger.source' => static function (): string {
+		return 'woocommerce-paypal-payments-recaptcha';
 	},
 );

--- a/modules/ppcp-fraud-protection/services.php
+++ b/modules/ppcp-fraud-protection/services.php
@@ -4,7 +4,6 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\FraudProtection;
 
-use WooCommerce\PayPalCommerce\FraudProtection\PersistentCounter;
 use WooCommerce\PayPalCommerce\FraudProtection\Recaptcha\Recaptcha;
 use WooCommerce\PayPalCommerce\FraudProtection\Recaptcha\RecaptchaIntegration;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -13,25 +12,24 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 return array(
-	'fraud-protection.url'                               => static function ( ContainerInterface $container ): string {
+	'fraud-protection.url'                         => static function ( ContainerInterface $container ): string {
 		return plugins_url( '/modules/ppcp-fraud-protection/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
 	},
 
-	'fraud-protection.recaptcha'                         => static function ( ContainerInterface $container ): Recaptcha {
+	'fraud-protection.recaptcha'                   => static function ( ContainerInterface $container ): Recaptcha {
 		return new Recaptcha(
 			$container->get( 'fraud-protection.recaptcha.integration' ),
 			$container->get( 'fraud-protection.recaptcha.payment-methods' ),
 			$container->get( 'fraud-protection.url' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'fraud-protection.recaptcha.rejection-counter' ),
-			$container->get( 'fraud-protection.recaptcha.rejection-logger.source' )
+			$container->get( 'fraud-protection.recaptcha.rejection-counter' )
 		);
 	},
-	'fraud-protection.recaptcha.integration'             => static function (): RecaptchaIntegration {
+	'fraud-protection.recaptcha.integration'       => static function (): RecaptchaIntegration {
 		return new RecaptchaIntegration();
 	},
-	'fraud-protection.recaptcha.payment-methods'         => static function (): array {
+	'fraud-protection.recaptcha.payment-methods'   => static function (): array {
 		return apply_filters(
 			'woocommerce_paypal_payments_recaptcha_payment_methods',
 			array(
@@ -41,15 +39,9 @@ return array(
 			)
 		);
 	},
-	'fraud-protection.recaptcha.rejection-counter'       => static function ( ContainerInterface $container ): PersistentCounter {
+	'fraud-protection.recaptcha.rejection-counter' => static function ( ContainerInterface $container ): PersistentCounter {
 		return new PersistentCounter(
-			$container->get( 'fraud-protection.recaptcha.rejection-counter.option-id' )
+			Recaptcha::REJECTION_COUNTER_OPTION
 		);
-	},
-	'fraud-protection.recaptcha.rejection-counter.option-id' => static function (): string {
-		return 'ppcp_recaptcha_rejection_counter';
-	},
-	'fraud-protection.recaptcha.rejection-logger.source' => static function (): string {
-		return 'woocommerce-paypal-payments-recaptcha';
 	},
 );

--- a/modules/ppcp-fraud-protection/src/FraudProtectionModule.php
+++ b/modules/ppcp-fraud-protection/src/FraudProtectionModule.php
@@ -42,6 +42,16 @@ class FraudProtectionModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		add_filter(
+			'woocommerce_generate_ppcp_recaptcha_log_html',
+			function () use ( $container ): string {
+				$recaptcha = $container->get( 'fraud-protection.recaptcha' );
+				assert( $recaptcha instanceof Recaptcha );
+
+				return $recaptcha->render_settings_page_log();
+			}
+		);
+
 		add_action(
 			'wp_enqueue_scripts',
 			static function () use ( $container ): void {

--- a/modules/ppcp-fraud-protection/src/PersistentCounter.php
+++ b/modules/ppcp-fraud-protection/src/PersistentCounter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\FraudProtection;
+
+/**
+ * A counter saving the current state into WP option.
+ */
+class PersistentCounter {
+	protected string $option_id;
+
+	public function __construct( string $option_id ) {
+		$this->option_id = $option_id;
+	}
+
+	public function increment(): void {
+		update_option( $this->option_id, $this->current() + 1 );
+	}
+
+	public function current(): int {
+		return (int) get_option( $this->option_id, 0 );
+	}
+}

--- a/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
+++ b/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
@@ -7,6 +7,8 @@ namespace WooCommerce\PayPalCommerce\FraudProtection\Recaptcha;
 use Automattic\WooCommerce\Utilities\OrderUtil;
 use Psr\Log\LoggerInterface;
 use WC_Order;
+use WC_Product;
+use WooCommerce\PayPalCommerce\FraudProtection\PersistentCounter;
 use WP_Error;
 
 class Recaptcha {
@@ -32,26 +34,38 @@ class Recaptcha {
 
 	private LoggerInterface $logger;
 
+	private PersistentCounter $rejection_counter;
+
+	private string $rejection_logger_source;
+
+	private float $last_v3_score = 0;
+
 	/**
 	 * @param RecaptchaIntegration $integration
 	 * @param string[]             $payment_methods The methods that require captcha.
 	 * @param string               $module_url
 	 * @param string               $asset_version
 	 * @param LoggerInterface      $logger
+	 * @param PersistentCounter    $rejection_counter
+	 * @param string               $rejection_logger_source
 	 */
 	public function __construct(
 		RecaptchaIntegration $integration,
 		array $payment_methods,
 		string $module_url,
 		string $asset_version,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		PersistentCounter $rejection_counter,
+		string $rejection_logger_source
 	) {
 
-		$this->integration     = $integration;
-		$this->payment_methods = $payment_methods;
-		$this->module_url      = $module_url;
-		$this->asset_version   = $asset_version;
-		$this->logger          = $logger;
+		$this->integration             = $integration;
+		$this->payment_methods         = $payment_methods;
+		$this->module_url              = $module_url;
+		$this->asset_version           = $asset_version;
+		$this->logger                  = $logger;
+		$this->rejection_counter       = $rejection_counter;
+		$this->rejection_logger_source = $rejection_logger_source;
 	}
 
 	protected function should_use_recaptcha(): bool {
@@ -71,6 +85,20 @@ class Recaptcha {
 		}
 
 		return true;
+	}
+
+	public function render_settings_page_log(): string {
+		$count = esc_attr( (string) $this->rejection_counter->current() );
+		$url   = esc_url( admin_url( 'admin.php?page=wc-status&tab=logs&source=' . $this->rejection_logger_source ) );
+		return "
+		<tr valign='top'>
+			<td colspan='2' style='padding: 0;'>
+				<h4>Requests rejected by reCAPTCHA v3:
+					$count
+					<a href='$url'>view logs</a>
+				</h4>
+			</td>
+		</tr>";
 	}
 
 	public function enqueue_scripts(): void {
@@ -165,6 +193,15 @@ class Recaptcha {
 			: $this->verify_v2( $token, $this->integration->get_option( 'secret_key_v2' ) );
 
 		if ( ! $success ) {
+			if ( $version === 'v3' ) {
+				$content = $request_data;
+				// Sending only form to reduce the amount of data.
+				if ( isset( $request_data['form'] ) ) {
+					$content = $request_data['form'];
+				}
+				$this->log_rejection( 'Create Order AJAX', $content );
+			}
+
 			wp_send_json_error(
 				array(
 					'message' => __(
@@ -204,7 +241,6 @@ class Recaptcha {
 				(string) ( $_POST['ppcp_recaptcha_version'] ?? '' )
 			)
 		);
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		if ( ! in_array( $payment_method, $this->payment_methods, true ) ) {
 			return;
@@ -231,6 +267,11 @@ class Recaptcha {
 			: $this->verify_v2( $token, $this->integration->get_option( 'secret_key_v2' ) );
 
 		if ( ! $success ) {
+			if ( $version === 'v3' ) {
+				$content = $_POST;
+				$this->log_rejection( 'Classic Checkout Submission', $content );
+			}
+
 			wc_add_notice(
 				__(
 					'CAPTCHA verification failed. Please try again.',
@@ -239,6 +280,7 @@ class Recaptcha {
 				'error'
 			);
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 
 	/**
@@ -302,6 +344,12 @@ class Recaptcha {
 				: $this->verify_v2( $token, $this->integration->get_option( 'secret_key_v2' ) );
 
 			if ( ! $success ) {
+				if ( $version === 'v3' ) {
+					$content = $data;
+					unset( $content['extensions'] );
+					$this->log_rejection( 'Block Checkout Submission', $content );
+				}
+
 				return new WP_Error(
 					self::ERROR_CODE_VERIFICATION_FAILED,
 					__(
@@ -430,6 +478,8 @@ class Recaptcha {
 			$threshold,
 			$result
 		);
+
+		$this->last_v3_score = $score;
 
 		if ( $is_valid ) {
 			$customer_id = $this->customer_identifier();
@@ -564,7 +614,73 @@ class Recaptcha {
 		) ?: '';
 	}
 
+	private function customer_user_agent(): string {
+		return sanitize_text_field(
+			(string) ( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ?? '' ) )
+		);
+	}
+
 	private function score_threshold(): float {
 		return floatval( $this->integration->get_option( 'score_threshold', 0.5 ) );
+	}
+
+	private function cart_contents(): array {
+		$cart = WC()->cart;
+		if ( ! isset( $cart ) || $cart->is_empty() ) {
+			return array();
+		}
+		$cart_data = array(
+			'items'  => array(),
+			'totals' => array(
+				'subtotal' => $cart->subtotal,
+				'tax'      => $cart->get_total_tax(),
+				'shipping' => $cart->get_shipping_total(),
+				'total'    => $cart->total,
+			),
+		);
+
+		foreach ( $cart->get_cart() as $cart_item ) {
+			$product = $cart_item['data'];
+			if ( ! $product instanceof WC_Product ) {
+				continue;
+			}
+
+			$cart_data['items'][] = array(
+				'product_id' => $cart_item['product_id'],
+				'name'       => $product->get_name(),
+				'quantity'   => $cart_item['quantity'],
+				'price'      => $product->get_price(),
+				'line_total' => $cart_item['line_total'],
+				'variation'  => $cart_item['variation'] ?? array(),
+			);
+		}
+
+		return $cart_data;
+	}
+
+
+	private function log_rejection( string $endpoint_name, array $request_data ): void {
+		$this->rejection_counter->increment();
+
+		if ( ! wc_string_to_bool( $this->integration->get_option( 'log_rejections' ) ) ) {
+			return;
+		}
+
+		$ip         = $this->customer_ip();
+		$user_agent = $this->customer_user_agent();
+
+		unset( $request_data['ppcp_recaptcha_token'] );
+		unset( $request_data['ppcp_recaptcha_version'] );
+		unset( $request_data['g-recaptcha-response'] );
+		$request_data_str = wp_json_encode( $request_data );
+
+		$cart = wp_json_encode( $this->cart_contents() );
+
+		$this->logger->debug(
+			"Rejected by v3 reCAPTCHA at {$endpoint_name} with score {$this->last_v3_score}, IP: {$ip}, User Agent: {$user_agent}, request content: {$request_data_str}, cart: {$cart}",
+			array(
+				'source' => $this->rejection_logger_source,
+			)
+		);
 	}
 }

--- a/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
+++ b/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
@@ -672,14 +672,15 @@ class Recaptcha {
 		unset( $request_data['ppcp_recaptcha_token'] );
 		unset( $request_data['ppcp_recaptcha_version'] );
 		unset( $request_data['g-recaptcha-response'] );
-		$request_data_str = wp_json_encode( $request_data );
 
-		$cart = wp_json_encode( $this->cart_contents() );
+		$cart = $this->cart_contents();
 
 		$this->logger->debug(
-			"Rejected by v3 reCAPTCHA at {$endpoint_name} with score {$this->last_v3_score}, IP: {$ip}, User Agent: {$user_agent}, request content: {$request_data_str}, cart: {$cart}",
+			"Rejected by v3 reCAPTCHA at {$endpoint_name} with score {$this->last_v3_score}, IP: {$ip}, User Agent: {$user_agent}.",
 			array(
 				'source' => $this->rejection_logger_source,
+				'request' => $request_data,
+				'cart'    => $cart,
 			)
 		);
 	}

--- a/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
+++ b/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
@@ -18,6 +18,8 @@ class Recaptcha {
 	private const CAPTCHA_USAGE_LIMIT            = 5;
 	private const CAPTCHA_RESULT_TRANSIENT_KEY   = 'ppcp_recaptcha_result_';
 	private const CAPTCHA_RESULT_META_KEY        = 'ppcp_recaptcha_captcha_result';
+	public const REJECTION_LOGGER_SOURCE         = 'woocommerce-paypal-payments-recaptcha';
+	public const REJECTION_COUNTER_OPTION        = 'ppcp_recaptcha_rejection_counter';
 
 	private RecaptchaIntegration $integration;
 
@@ -36,8 +38,6 @@ class Recaptcha {
 
 	private PersistentCounter $rejection_counter;
 
-	private string $rejection_logger_source;
-
 	private float $last_v3_score = 0;
 
 	/**
@@ -47,7 +47,6 @@ class Recaptcha {
 	 * @param string               $asset_version
 	 * @param LoggerInterface      $logger
 	 * @param PersistentCounter    $rejection_counter
-	 * @param string               $rejection_logger_source
 	 */
 	public function __construct(
 		RecaptchaIntegration $integration,
@@ -55,17 +54,15 @@ class Recaptcha {
 		string $module_url,
 		string $asset_version,
 		LoggerInterface $logger,
-		PersistentCounter $rejection_counter,
-		string $rejection_logger_source
+		PersistentCounter $rejection_counter
 	) {
 
-		$this->integration             = $integration;
-		$this->payment_methods         = $payment_methods;
-		$this->module_url              = $module_url;
-		$this->asset_version           = $asset_version;
-		$this->logger                  = $logger;
-		$this->rejection_counter       = $rejection_counter;
-		$this->rejection_logger_source = $rejection_logger_source;
+		$this->integration       = $integration;
+		$this->payment_methods   = $payment_methods;
+		$this->module_url        = $module_url;
+		$this->asset_version     = $asset_version;
+		$this->logger            = $logger;
+		$this->rejection_counter = $rejection_counter;
 	}
 
 	protected function should_use_recaptcha(): bool {
@@ -89,7 +86,7 @@ class Recaptcha {
 
 	public function render_settings_page_log(): string {
 		$count = esc_attr( (string) $this->rejection_counter->current() );
-		$url   = esc_url( admin_url( 'admin.php?page=wc-status&tab=logs&source=' . $this->rejection_logger_source ) );
+		$url   = esc_url( admin_url( 'admin.php?page=wc-status&tab=logs&source=' . self::REJECTION_LOGGER_SOURCE ) );
 		return "
 		<tr valign='top'>
 			<td colspan='2' style='padding: 0;'>
@@ -678,7 +675,7 @@ class Recaptcha {
 		$this->logger->debug(
 			"Rejected by v3 reCAPTCHA at {$endpoint_name} with score {$this->last_v3_score}, IP: {$ip}, User Agent: {$user_agent}.",
 			array(
-				'source' => $this->rejection_logger_source,
+				'source'  => self::REJECTION_LOGGER_SOURCE,
 				'request' => $request_data,
 				'cart'    => $cart,
 			)

--- a/modules/ppcp-fraud-protection/src/Recaptcha/RecaptchaIntegration.php
+++ b/modules/ppcp-fraud-protection/src/Recaptcha/RecaptchaIntegration.php
@@ -34,6 +34,10 @@ class RecaptchaIntegration extends WC_Integration {
 				'default' => 'no',
 			),
 
+			'log'             => array(
+				'type' => 'ppcp_recaptcha_log',
+			),
+
 			'v3_title'        => array(
 				'title'       => 'reCAPTCHA v3 Settings',
 				'type'        => 'title',
@@ -126,6 +130,14 @@ class RecaptchaIntegration extends WC_Integration {
 				'default'     => 'no',
 				'description' =>
 					'Display reCAPTCHA verification details in a metabox on order edit pages',
+			),
+			'log_rejections'  => array(
+				'title'       => 'Log',
+				'type'        => 'checkbox',
+				'label'       => 'Log rejected attempts',
+				'default'     => 'no',
+				'description' =>
+					'Log information about the checkout attempts rejected by v3 reCAPTCHA',
 			),
 		);
 	}

--- a/modules/ppcp-uninstall/services.php
+++ b/modules/ppcp-uninstall/services.php
@@ -39,6 +39,7 @@ return array(
 			SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI,
 			SwitchSettingsUiEndpoint::OPTION_NAME_MIGRATION_IS_DONE,
 			PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE,
+			$container->get( 'fraud-protection.recaptcha.rejection-counter.option-id' ),
 		);
 	},
 

--- a/modules/ppcp-uninstall/services.php
+++ b/modules/ppcp-uninstall/services.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Uninstall;
 
 use WooCommerce\PayPalCommerce\ApiClient\Repository\PayPalRequestIdRepository;
+use WooCommerce\PayPalCommerce\FraudProtection\Recaptcha\Recaptcha;
 use WooCommerce\PayPalCommerce\Settings\Ajax\SwitchSettingsUiEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
 use WooCommerce\PayPalCommerce\Uninstall\Assets\ClearDatabaseAssets;
@@ -39,7 +40,7 @@ return array(
 			SwitchSettingsUiEndpoint::OPTION_NAME_SHOULD_USE_OLD_UI,
 			SwitchSettingsUiEndpoint::OPTION_NAME_MIGRATION_IS_DONE,
 			PaymentSettingsMigration::OPTION_NAME_BCDC_MIGRATION_OVERRIDE,
-			$container->get( 'fraud-protection.recaptcha.rejection-counter.option-id' ),
+			Recaptcha::REJECTION_COUNTER_OPTION,
 		);
 	},
 


### PR DESCRIPTION
Added an option for enabling logging of requests rejected by reCaptcha v3, and also a counter.

The logs are saved to the WC logs using `woocommerce-paypal-payments-recaptcha` source, the "view logs" link opens the WC logs page filtered by this source.
The log entry includes the endpoint name, reCaptcha score, IP, user-agent, request body (omitting some data like reCaptcha keys to keep it more readable) and the current cart if available.

The rendering of the counter and the link was supposed to be inside the `RecaptchaIntegration` class but we cannot add any constructor parameters here because WC needs to create a class instance, so moved into `Recaptcha`.

<img width="795" height="290" alt="image" src="https://github.com/user-attachments/assets/e7b48070-42d9-46b2-9d99-c03adf0773a6" />

<img width="857" height="381" alt="image" src="https://github.com/user-attachments/assets/70c90e7f-2dad-4001-94a9-d7412b323e81" />

<img width="707" height="315" alt="image" src="https://github.com/user-attachments/assets/f410f430-1acf-4b06-bbe4-3edf4d9c4b36" />
