### PR TITLE
Disable reCAPTCHA validation in pay for order page (5521)

### DIFF
--- a/modules/ppcp-fraud-protection/src/FraudProtectionModule.php
+++ b/modules/ppcp-fraud-protection/src/FraudProtectionModule.php
@@ -101,17 +101,15 @@ class FraudProtectionModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
-		foreach ( array( 'woocommerce_checkout_process', 'woocommerce_before_pay_action' ) as $hook ) {
-			add_action(
-				$hook,
-				static function () use ( $container ): void {
-					$recaptcha = $container->get( 'fraud-protection.recaptcha' );
-					assert( $recaptcha instanceof Recaptcha );
+		add_action(
+			'woocommerce_checkout_process',
+			static function () use ( $container ): void {
+				$recaptcha = $container->get( 'fraud-protection.recaptcha' );
+				assert( $recaptcha instanceof Recaptcha );
 
-					$recaptcha->validate_classic_checkout();
-				}
-			);
-		}
+				$recaptcha->validate_classic_checkout();
+			}
+		);
 
 		add_action(
 			'woocommerce_blocks_loaded',


### PR DESCRIPTION
The `woocommerce_before_pay_action` runs only on the pay for order page, and requires an already existing order, making reCAPTCHA validation at this point unnecessary.

This PR removes this hook from the validation logic to solve fatal errors triggered by failed reCAPTCHA validation on the pay for order page.