### PR TITLE
Prevent potential warning when simulating cart for variations (5537)

### DIFF
--- a/modules/ppcp-button/src/Helper/CartProductsHelper.php
+++ b/modules/ppcp-button/src/Helper/CartProductsHelper.php
@@ -202,6 +202,9 @@ class CartProductsHelper {
 
 		$variations = array();
 		foreach ( $post_variations as $key => $value ) {
+			if ( ! isset( $value['name'], $value['value'] ) ) {
+				continue;
+			}
 			$variations[ $value['name'] ] = $value['value'];
 		}
 


### PR DESCRIPTION
### Description

Based on the Support thread, I wonder if the reason is that after those delays, the selector form is reset after adding it to the cart, and the `element.value` gets undefined when accessing the DOM, Since it's undefined, the key is not computed in the backend, producing the warning.

In this PR -- We are just defensive checking if the value and name are there before continuing to avoid warnings. 

### Steps to Test

1. Malform value for variations by Harcoding -- `unset $value['value']` in  `modules/ppcp-button/src/Helper/CartProductsHelper.php:205` or set `value` as undefined in `modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js:226`

2. Go to product variation. 
3. Add a product. No warnings
4. Click on PayPal button. No warnings (even tho it will fail)
5. Restore the malformation of value.
6. Add product and PayPal button works

