### PR TITLE
Improve Data Sanitization in Fastlane Checkout Forms (5533)

### DIFF
--- a/modules/ppcp-axo/package.json
+++ b/modules/ppcp-axo/package.json
@@ -11,7 +11,8 @@
     ],
     "dependencies": {
         "@paypal/paypal-js": "^6.0.0",
-        "core-js": "^3.39"
+        "core-js": "^3.39",
+        "escape-html": "^1.0.3"
     },
     "devDependencies": {
         "@babel/core": "^7.26",

--- a/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
+++ b/modules/ppcp-axo/resources/js/Components/FormFieldGroup.js
@@ -1,3 +1,5 @@
+import escapeHtml from 'escape-html';
+
 class FormFieldGroup {
 	#stored;
 	#data = {};
@@ -30,7 +32,8 @@ class FormFieldGroup {
 		}
 
 		if ( typeof this.#fields[ fieldKey ].valueCallback === 'function' ) {
-			return this.#fields[ fieldKey ].valueCallback( this.#data );
+			const value = this.#fields[ fieldKey ].valueCallback( this.#data );
+			return this.#escapeValue( value );
 		}
 
 		const path = this.#fields[ fieldKey ].valuePath;
@@ -46,7 +49,23 @@ class FormFieldGroup {
 					acc && acc[ key ] !== undefined ? acc[ key ] : undefined,
 				this.#data
 			);
-		return value ? value : '';
+		return this.#escapeValue( value );
+	}
+
+	/**
+	 * Escapes a value for HTML output.
+	 *
+	 * @param {*} value - The value to escape
+	 * @return {string} - The escaped string safe for HTML output
+	 */
+	#escapeValue( value ) {
+		if ( value === null || value === undefined ) {
+			return '';
+		}
+
+		const stringValue = String( value );
+
+		return escapeHtml( stringValue );
 	}
 
 	/**

--- a/modules/ppcp-axo/yarn.lock
+++ b/modules/ppcp-axo/yarn.lock
@@ -1415,6 +1415,11 @@ escalade@^3.2.0:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
+escape-html@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
+  integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
+
 eslint-scope@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
In the ppcp-axo module, data from multiple sources (PayPal API responses, WooCommerce checkout form inputs) was being rendered directly into HTML templates via string interpolation without sanitization.

This PR fixes it by adding HTML escaping using the `escape-html` library in the `FormFieldGroup.dataValue()` method, which now acts as a single sanitization point for all template data.