### PR TITLE
[Fix] Can not pay with Google Pay when Pay Now is disabled (5542)

### DIFF
--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -79,12 +79,12 @@ const ORDER_INCOMPLETE = 'payerAction';
 
 function getAddressFromData( data ) {
 	return {
-		country_code: data.countryCode,
-		address_line_1: data.address1,
-		address_line_2: data.address2,
-		admin_area_1: data.administrativeArea,
-		admin_area_2: data.locality,
-		postal_code: data.postalCode,
+		country_code: data?.countryCode,
+		address_line_1: data?.address1,
+		address_line_2: data?.address2,
+		admin_area_1: data?.administrativeArea,
+		admin_area_2: data?.locality,
+		postal_code: data?.postalCode,
 	};
 }
 
@@ -102,10 +102,13 @@ function payerDataFromPaymentResponse( response ) {
 }
 
 function shippingAddressDataFromPaymentResponse( response ) {
-	const shippingAddress = response?.shippingAddress;
+	const shippingAddress =
+		response?.shippingAddress ??
+		response?.paymentMethodData?.info?.billingAddress;
+
 	return {
 		name: {
-			full_name: shippingAddress.name,
+			full_name: shippingAddress?.name,
 		},
 		address: getAddressFromData( shippingAddress ),
 	};


### PR DESCRIPTION
### Description

This PR addresses an edge case when trying to pay with Google Pay without a Shipping Address.

- Use Billing Address as fallback
- Prevent runtime exceptions in objects by prefixing them with `?` Optional Chaining Operator

### Steps to Test

1. Enable shipping if not enabled and create at least two sipping methods (free and flat rate)
2. Navigate to Payment method tab and enable Google Pay if not enabled and save settings
3. Navigate to Setting tab and disable Pay Now and save settings
4. Navigate to Styling tab and enable Google Pay on Product page and save settings
5. Navigate to shop add product to cart and navigate to classic cart 
6. Click on Google Pay button
7. Payment succeeded
8. Enable Pay Now again
9. Go to a product and click on Google Pay
10. Payment succeeded
