### PR TITLE
Verify JWT claims (5486)

### DIFF
--- a/modules/ppcp-agentic-commerce/docs/authentication-via-jwt.md
+++ b/modules/ppcp-agentic-commerce/docs/authentication-via-jwt.md
@@ -128,3 +128,53 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 | `merchant_mismatch`       | 403         | Token not valid for this merchant          |
 | `merchant_not_configured` | 500         | Merchant ID not configured on store        |
 | `key_unavailable`         | 503         | Could not retrieve PayPal public keys      |
+
+## Local Development
+
+The relaxed authentication service `SandboxAuthService` is a drop-in replacement to unlock REST
+endpoints on a local or dev environment without providing a cryptographically valid JWT token.
+
+This drop-in is automatically enabled when connected using a PayPal sandbox merchant.
+
+To simulate real production authentication as a sandbox merchant, the following flag can be used in
+`wp-config.php`:
+
+```php
+define( 'PPCP_AGENTIC_FULL_AUTH', true );
+```
+
+### Relaxed Rules
+
+The sandbox authentication mainly checks if the Authorization header and the JWT payload have a
+valid structure, and uses the expected issuer string.
+
+| Feature                     | SandboxAuthService         | JwtAuthService                        |
+|-----------------------------|----------------------------|---------------------------------------|
+| **Header format**           | ✅ Required (Bearer prefix) | ✅ Required (Bearer prefix)            |
+| **JWT structure**           | ✅ Must have 3 parts        | ✅ Must have 3 parts                   |
+| **Valid JSON in payload**   | ✅ Must be parseable        | ✅ Must be parseable                   |
+| **Cryptographic signature** | ❌ Not verified             | ✅ Verified against PayPal public keys |
+| **Token expiration (exp)**  | ❌ Not checked              | ✅ Must not be expired                 |
+| **Issues-at time (iat)**    | ❌ Not checked              | ✅ Must be past not-before time        |
+| **Issuer claim (iss)**      | ✅ Must be `paypal.com`     | ✅ Must be `paypal.com`                |
+| **Required scopes**         | ❌ Not checked              | ✅ Must include endpoint scopes        |
+| **Merchant ID match**       | ❌ Not checked              | ✅ Must match configured merchant      |
+
+**Token acceptance scenarios:**
+
+| Token Type           | SandboxAuthService | JwtAuthService                  |
+|----------------------|--------------------|---------------------------------|
+| Valid PayPal token   | ✅ Accepted         | ✅ Accepted                      |
+| Expired PayPal token | ✅ Accepted         | ❌ Rejected (expired)            |
+| Wrong merchant ID    | ✅ Accepted         | ❌ Rejected (merchant mismatch)  |
+| Invalid signature    | ✅ Accepted         | ❌ Rejected (invalid signature)  |
+| Missing scopes       | ✅ Accepted         | ❌ Rejected (insufficient scope) |
+| Wrong issuer         | ❌ Rejected         | ❌ Rejected                      |
+| Malformed JSON       | ❌ Rejected         | ❌ Rejected                      |
+| Missing "Bearer"     | ❌ Rejected         | ❌ Rejected                      |
+
+### Security Notes
+
+- Production environments **always** use full authentication
+- Sandbox mode cannot process real payments
+- Relaxed auth only affects development workflows

--- a/modules/ppcp-agentic-commerce/docs/authentication-via-jwt.md
+++ b/modules/ppcp-agentic-commerce/docs/authentication-via-jwt.md
@@ -1,0 +1,130 @@
+# JWT Authentication Flow
+
+## Overview
+
+The Agentic Commerce API uses JWT (JSON Web Tokens) for authenticating requests from PayPal's
+Commerce Platform. This document explains how JWT authentication works in our implementation.
+
+## What is a JWT?
+
+A JWT is a compact, URL-safe token consisting of three Base64-encoded parts separated by dots (`.`):
+
+```
+<header>.<payload>.<signature>
+```
+
+- **Header** - Token metadata (algorithm, type)
+- **Payload** - Claims/data (base64-decodable)
+- **Signature** - Cryptographic signature verifying token authenticity
+
+## Authentication Flow
+
+```
+1. Request arrives via the HTTP `Authorization` header
+   ↓
+2. AgenticRestEndpoint.check_permission() extracts token
+   ↓
+3. JwtAuthService.get_token() parses and validates token
+   - Extracts JWT from "Bearer {token}" format
+   - Decodes using PayPal's public keys (via PayPalJwkProvider)
+   - Verifies signature, expiration, and validity
+   ↓
+4. JwtAuthService.verify_claims() validates business rules
+   - Verifies issuer is "paypal.com"
+   - Checks required scopes are present
+   - Verifies merchant ID matches configured merchant
+   ↓
+5. Request proceeds if authentication successful
+```
+
+## Token Payload Structure
+
+PayPal tokens contain these standard JWT claims:
+
+```json
+{
+  "iss": "paypal.com",              // Issuer (verified by verify_claims)
+  "sub": "woo_syde_merchant_id",    // Subject (ignored)
+  "aud": "woocommerce.com",         // Audience (ignored)
+  "scope": ["cart","checkout"],     // Permission scopes (verified by verify_claims)
+  "external_id": ["PayPal:ABC123"], // PayPal merchant ID (verified by verify_claims)
+  "iat": 1761153926,                // Issued at (verified by JWT::decode)
+  "exp": 1763745926                 // Expires at (verified by JWT::decode)
+}
+```
+
+## Verification Steps
+
+### Automatic Verification (JWT::decode)
+
+These are handled automatically by the Firebase JWT library:
+
+- **Signature** - Cryptographically verified using PayPal's public keys
+- **Expiration (`exp`)** - Token must not be expired
+- **Not Before (`iat`)** - Token must be valid at current time
+
+### Business Rule Verification (verify_claims)
+
+Additional checks performed by our code:
+
+- **Issuer (`iss`)** - Must be exactly "paypal.com"
+- **Scopes (`scope`)** - Must contain all required permissions for the endpoint
+- **Merchant ID (`external_id`)** - Must match the PayPal merchant ID configured on this WooCommerce store
+
+## Implementation Classes
+
+### JwtAuthService
+
+Handles token parsing and validation:
+
+```php
+// Parse and decode token
+$token = $auth_service->get_token( $bearer_token );
+
+// Verify claims
+$result = $auth_service->verify_claims( $token, ['cart'] );
+```
+
+### AgenticRestEndpoint
+
+Base class for all agentic endpoints. Orchestrates authentication in `check_permission()`:
+
+```php
+public function check_permission( WP_REST_Request $request ) {
+    $token = $request->get_header( 'Authorization' );
+    $context = $this->auth_service->get_token( $token );
+    
+    if ( is_wp_error( $context ) ) {
+        return $context; // 401/503 error
+    }
+    
+    return $this->auth_service->verify_claims( $context, static::REQUIRED_SCOPES );
+}
+```
+
+### Endpoint Scope Requirements
+
+Each endpoint can specify required scopes via a constant - the default scope is `array( 'cart' )`:
+
+```php
+class CreateCartEndpoint extends AgenticRestEndpoint {
+    protected const REQUIRED_SCOPES = array( 'cart' );
+}
+
+class CheckoutEndpoint extends AgenticRestEndpoint {
+    protected const REQUIRED_SCOPES = array( 'cart', 'checkout' );
+}
+```
+
+## Error Responses
+
+| Error Code                | HTTP Status | Description                                |
+|---------------------------|-------------|--------------------------------------------|
+| `missing_token`           | 401         | Authorization header missing or empty      |
+| `invalid_jwt`             | 401         | Token format invalid or signature mismatch |
+| `invalid_issuer`          | 401         | Token not issued by PayPal                 |
+| `invalid_token`           | 401         | Token claims malformed                     |
+| `insufficient_scope`      | 403         | Token lacks required permissions           |
+| `merchant_mismatch`       | 403         | Token not valid for this merchant          |
+| `merchant_not_configured` | 500         | Merchant ID not configured on store        |
+| `key_unavailable`         | 503         | Could not retrieve PayPal public keys      |

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -16,8 +16,8 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\CreateCartEndpoint;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\GetCartEndpoint;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\UpdateCartEndpoint;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\ReplaceCartEndpoint;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\PayPalJwkProvider;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Setting\AgenticSettingsEndpoint;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Setting\AgenticSettingsDataModel;
@@ -51,8 +51,8 @@ return array(
 	'agentic.auth.key_provider'                => static function (): PayPalJwkProvider {
 		return new PayPalJwkProvider();
 	},
-	'agentic.auth.service'                     => static function ( ContainerInterface $c ): JwtAuthService {
-		return new JwtAuthService(
+	'agentic.auth.provider'                    => static function ( ContainerInterface $c ): AuthServiceProvider {
+		return new AuthServiceProvider(
 			$c->get( 'agentic.auth.key_provider' ),
 			$c->get( 'agentic.merchant.provider' )
 		);
@@ -66,28 +66,28 @@ return array(
 	// REST endpoints.
 	'agentic.rest.create_cart'                 => static function ( ContainerInterface $c ): CreateCartEndpoint {
 		return new CreateCartEndpoint(
-			$c->get( 'agentic.auth.service' ),
+			$c->get( 'agentic.auth.provider' ),
 			$c->get( 'agentic.session.handler' ),
 			$c->get( 'agentic.response.factory' )
 		);
 	},
 	'agentic.rest.get_cart'                    => static function ( ContainerInterface $container ): GetCartEndpoint {
 		return new GetCartEndpoint(
-			$container->get( 'agentic.auth.service' ),
+			$container->get( 'agentic.auth.provider' ),
 			$container->get( 'agentic.session.handler' ),
 			$container->get( 'agentic.response.factory' )
 		);
 	},
 	'agentic.rest.update_cart'                 => static function ( ContainerInterface $container ): UpdateCartEndpoint {
 		return new UpdateCartEndpoint(
-			$container->get( 'agentic.auth.service' ),
+			$container->get( 'agentic.auth.provider' ),
 			$container->get( 'agentic.session.handler' ),
 			$container->get( 'agentic.response.factory' )
 		);
 	},
 	'agentic.rest.replace_cart'                => static function ( ContainerInterface $container ): ReplaceCartEndpoint {
 		return new ReplaceCartEndpoint(
-			$container->get( 'agentic.auth.service' ),
+			$container->get( 'agentic.auth.provider' ),
 			$container->get( 'agentic.session.handler' ),
 			$container->get( 'agentic.response.factory' )
 		);
@@ -133,17 +133,17 @@ return array(
 	'agentic.settings.model'                   => static function (): AgenticSettingsDataModel {
 		return new AgenticSettingsDataModel();
 	},
-	'agentic.settings.endpoint'                => static function ( ContainerInterface $container ): AgenticSettingsEndpoint {
+	'agentic.settings.endpoint'                => static function ( ContainerInterface $c ): AgenticSettingsEndpoint {
 		return new AgenticSettingsEndpoint(
-			$container->get( 'agentic.settings.model' )
+			$c->get( 'agentic.settings.model' )
 		);
 	},
-	'agentic.settings.module'                  => static function ( ContainerInterface $container ): AgenticSettingsModule {
+	'agentic.settings.module'                  => static function ( ContainerInterface $c ): AgenticSettingsModule {
 		return new AgenticSettingsModule(
-			$container->get( 'ppcp.path-to-plugin-folder' ),
-			$container->get( 'ppcp.path-to-plugin-main-file' ),
-			$container->get( 'agentic.settings.endpoint' ),
-			$container->get( 'agentic.registration.eligibility' )
+			$c->get( 'ppcp.path-to-plugin-folder' ),
+			$c->get( 'ppcp.path-to-plugin-main-file' ),
+			$c->get( 'agentic.settings.endpoint' ),
+			$c->get( 'agentic.registration.eligibility' )
 		);
 	},
 );

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -53,6 +53,7 @@ return array(
 	},
 	'agentic.auth.provider'                    => static function ( ContainerInterface $c ): AuthServiceProvider {
 		return new AuthServiceProvider(
+			$c->get( 'settings.connection-state' ),
 			$c->get( 'agentic.auth.key_provider' ),
 			$c->get( 'agentic.merchant.provider' )
 		);

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -53,7 +53,8 @@ return array(
 	},
 	'agentic.auth.service'                     => static function ( ContainerInterface $c ): JwtAuthService {
 		return new JwtAuthService(
-			$c->get( 'agentic.auth.key_provider' )
+			$c->get( 'agentic.auth.key_provider' ),
+			$c->get( 'agentic.merchant.provider' )
 		);
 	},
 

--- a/modules/ppcp-agentic-commerce/src/Auth/AuthServiceProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/AuthServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
+
+use WooCommerce\PayPalCommerce\AgenticCommerce\Merchant\MerchantMetadataProvider;
+
+class AuthServiceProvider {
+
+	private ?JwtAuthService $instance = null;
+
+	protected PayPalJwkProvider $jwk_provider;
+
+	protected MerchantMetadataProvider $metadata_provider;
+
+	public function __construct( PayPalJwkProvider $jwk_provider, MerchantMetadataProvider $metadata_provider ) {
+		$this->jwk_provider      = $jwk_provider;
+		$this->metadata_provider = $metadata_provider;
+	}
+
+	public function auth_service(): JwtAuthService {
+		if ( ! $this->instance ) {
+			$this->instance = $this->choose_auth_service();
+		}
+
+		return $this->instance;
+	}
+
+	private function choose_auth_service(): JwtAuthService {
+		return new JwtAuthService( $this->jwk_provider, $this->metadata_provider );
+	}
+}

--- a/modules/ppcp-agentic-commerce/src/Auth/AuthServiceProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/AuthServiceProvider.php
@@ -32,6 +32,13 @@ class AuthServiceProvider {
 	}
 
 	private function choose_auth_service(): JwtAuthService {
+		$is_sandbox    = $this->connection_state->is_sandbox();
+		$use_full_auth = defined( 'PPCP_AGENTIC_FULL_AUTH' ) && PPCP_AGENTIC_FULL_AUTH;
+
+		if ( $is_sandbox && ! $use_full_auth ) {
+			return new SandboxAuthService( $this->jwk_provider, $this->metadata_provider );
+		}
+
 		return new JwtAuthService( $this->jwk_provider, $this->metadata_provider );
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/AuthServiceProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/AuthServiceProvider.php
@@ -5,16 +5,20 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Merchant\MerchantMetadataProvider;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 
 class AuthServiceProvider {
 
 	private ?JwtAuthService $instance = null;
 
-	protected PayPalJwkProvider $jwk_provider;
+	private ConnectionState $connection_state;
 
-	protected MerchantMetadataProvider $metadata_provider;
+	private PayPalJwkProvider $jwk_provider;
 
-	public function __construct( PayPalJwkProvider $jwk_provider, MerchantMetadataProvider $metadata_provider ) {
+	private MerchantMetadataProvider $metadata_provider;
+
+	public function __construct( ConnectionState $connection_state, PayPalJwkProvider $jwk_provider, MerchantMetadataProvider $metadata_provider ) {
+		$this->connection_state  = $connection_state;
 		$this->jwk_provider      = $jwk_provider;
 		$this->metadata_provider = $metadata_provider;
 	}

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -8,6 +8,7 @@ use Exception;
 use stdClass;
 use WP_Error;
 use Firebase\JWT\JWT;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Merchant\MerchantMetadataProvider;
 
 class JwtAuthService {
 
@@ -18,8 +19,11 @@ class JwtAuthService {
 
 	private PayPalJwkProvider $jwk_provider;
 
-	public function __construct( PayPalJwkProvider $jwk_provider ) {
-		$this->jwk_provider = $jwk_provider;
+	private MerchantMetadataProvider $metadata_provider;
+
+	public function __construct( PayPalJwkProvider $jwk_provider, MerchantMetadataProvider $metadata_provider ) {
+		$this->jwk_provider      = $jwk_provider;
+		$this->metadata_provider = $metadata_provider;
 	}
 
 	/**
@@ -59,7 +63,7 @@ class JwtAuthService {
 	/**
 	 * Verifies token claims against business requirements.
 	 *
-	 * @param object $context Decoded JWT payload.
+	 * @param object $context         Decoded JWT payload.
 	 * @param array  $required_scopes Required permission scopes.
 	 * @return true|WP_Error
 	 */
@@ -88,6 +92,36 @@ class JwtAuthService {
 			return new WP_Error(
 				'insufficient_scope',
 				'Token does not have required permissions',
+				array( 'status' => 403 )
+			);
+		}
+
+		// Verify merchant ID matches.
+		$metadata = $this->metadata_provider->get_metadata();
+		if ( ! $metadata->paypal_merchant_id ) {
+			return new WP_Error(
+				'merchant_not_configured',
+				'Merchant ID is not configured',
+				array( 'status' => 500 )
+			);
+		}
+
+		$external_ids = $context->external_id ?? array();
+		if ( ! is_array( $external_ids ) ) {
+			return new WP_Error(
+				'invalid_token',
+				'Token merchant identifiers are malformed',
+				array( 'status' => 401 )
+			);
+		}
+
+		$expected_id     = 'PayPal:' . $metadata->paypal_merchant_id;
+		$has_merchant_id = in_array( $expected_id, $external_ids, true );
+
+		if ( ! $has_merchant_id ) {
+			return new WP_Error(
+				'merchant_mismatch',
+				'Token is not valid for this merchant',
 				array( 'status' => 403 )
 			);
 		}

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -15,11 +15,11 @@ class JwtAuthService {
 	/**
 	 * The exact issuer string that we expect to see in the JWT payload.
 	 */
-	private const EXPECTED_ISSUER = 'paypal.com';
+	protected const EXPECTED_ISSUER = 'paypal.com';
 
-	private PayPalJwkProvider $jwk_provider;
+	protected PayPalJwkProvider $jwk_provider;
 
-	private MerchantMetadataProvider $metadata_provider;
+	protected MerchantMetadataProvider $metadata_provider;
 
 	public function __construct( PayPalJwkProvider $jwk_provider, MerchantMetadataProvider $metadata_provider ) {
 		$this->jwk_provider      = $jwk_provider;
@@ -29,23 +29,14 @@ class JwtAuthService {
 	/**
 	 * Parses and validates JWT token.
 	 *
-	 * @param string|null $token Bearer token from Authorization header.
+	 * @param string|null $auth_header Bearer token from Authorization header.
 	 * @return stdClass|WP_Error Decoded token or validation error.
 	 */
-	public function get_token( ?string $token ) {
-		$string_token = trim( $token ?? '' );
+	public function get_token( ?string $auth_header ) {
+		$jwt = $this->extract_jwt_from_header( $auth_header );
 
-		if ( $string_token === '' ) {
-			return new WP_Error( 'missing_token', 'Please provide a valid token', array( 'status' => 401 ) );
-		}
-
-		if ( 0 !== stripos( $string_token, 'Bearer' ) ) {
-			return new WP_Error( 'invalid_jwt', 'Please provide a valid token', array( 'status' => 401 ) );
-		}
-
-		$jwt = trim( (string) substr( $string_token, 6 ) );
-		if ( empty( $jwt ) ) {
-			return new WP_Error( 'missing_token', 'Bearer prefix without token found', array( 'status' => 401 ) );
+		if ( is_wp_error( $jwt ) ) {
+			return $jwt;
 		}
 
 		$keys = $this->jwk_provider->keys();
@@ -127,5 +118,32 @@ class JwtAuthService {
 		}
 
 		return true;
+	}
+
+	/**
+	 * @param string|null $auth_header Bearer token from Authorization header.
+	 * @return string|WP_Error The encoded JWT string, or WP_Error on failure.
+	 */
+	protected function extract_jwt_from_header( ?string $auth_header ) {
+		$string_token = trim( $auth_header ?? '' );
+
+		if ( $string_token === '' ) {
+			return new WP_Error( 'missing_token', 'Please provide a valid token', array( 'status' => 401 ) );
+		}
+
+		if ( 0 !== stripos( $string_token, 'Bearer' ) ) {
+			return new WP_Error( 'invalid_jwt', 'Please provide a valid token', array( 'status' => 401 ) );
+		}
+
+		$jwt = trim( (string) substr( $string_token, 6 ) );
+		if ( empty( $jwt ) ) {
+			return new WP_Error( 'missing_token', 'Bearer prefix without token found', array( 'status' => 401 ) );
+		}
+
+		if ( 2 !== substr_count( $jwt, '.' ) ) {
+			return new WP_Error( 'invalid_jwt', 'Wrong number of segments in the token', array( 'status' => 401 ) );
+		}
+
+		return $jwt;
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -30,7 +30,7 @@ class JwtAuthService {
 	 * Parses and validates JWT token.
 	 *
 	 * @param string|null $auth_header Bearer token from Authorization header.
-	 * @return stdClass|WP_Error Decoded token or validation error.
+	 * @return object|WP_Error Decoded token or validation error.
 	 */
 	public function get_token( ?string $auth_header ) {
 		$jwt = $this->extract_jwt_from_header( $auth_header );

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -11,6 +11,11 @@ use Firebase\JWT\JWT;
 
 class JwtAuthService {
 
+	/**
+	 * The exact issuer string that we expect to see in the JWT payload.
+	 */
+	private const EXPECTED_ISSUER = 'paypal.com';
+
 	private PayPalJwkProvider $jwk_provider;
 
 	public function __construct( PayPalJwkProvider $jwk_provider ) {
@@ -49,5 +54,44 @@ class JwtAuthService {
 		} catch ( Exception $exception ) {
 			return new WP_Error( 'invalid_jwt', $exception->getMessage(), array( 'status' => 401 ) );
 		}
+	}
+
+	/**
+	 * Verifies token claims against business requirements.
+	 *
+	 * @param object $context Decoded JWT payload.
+	 * @param array  $required_scopes Required permission scopes.
+	 * @return true|WP_Error
+	 */
+	public function verify_claims( object $context, array $required_scopes ) {
+		// Verify issuer.
+		if ( ! isset( $context->iss ) || $context->iss !== self::EXPECTED_ISSUER ) {
+			return new WP_Error(
+				'invalid_issuer',
+				'Token issuer is not recognized',
+				array( 'status' => 401 )
+			);
+		}
+
+		// Verify required scopes are present.
+		$token_scopes = $context->scope ?? array();
+		if ( ! is_array( $token_scopes ) ) {
+			return new WP_Error(
+				'invalid_token',
+				'Token scopes are malformed',
+				array( 'status' => 401 )
+			);
+		}
+
+		$missing_scopes = array_diff( $required_scopes, $token_scopes );
+		if ( ! empty( $missing_scopes ) ) {
+			return new WP_Error(
+				'insufficient_scope',
+				'Token does not have required permissions',
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/JwtAuthService.php
@@ -18,10 +18,12 @@ class JwtAuthService {
 	}
 
 	/**
-	 * @param string|null $token
-	 * @return stdClass|WP_Error
+	 * Parses and validates JWT token.
+	 *
+	 * @param string|null $token Bearer token from Authorization header.
+	 * @return stdClass|WP_Error Decoded token or validation error.
 	 */
-	public function validate_request( ?string $token ) {
+	public function get_token( ?string $token ) {
 		$string_token = trim( $token ?? '' );
 
 		if ( $string_token === '' ) {

--- a/modules/ppcp-agentic-commerce/src/Auth/SandboxAuthService.php
+++ b/modules/ppcp-agentic-commerce/src/Auth/SandboxAuthService.php
@@ -1,0 +1,70 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Auth;
+
+use Exception;
+use stdClass;
+use WP_Error;
+use Firebase\JWT\JWT;
+
+/**
+ * JWT Authentication layer for local testing and development.
+ *
+ * The decision to use this service is made in `AuthServiceProvider`
+ *
+ * This service is automatically used when the site connects to a
+ * sandbox merchant account (cannot process real payments).
+ *
+ * To simulate full production authentication for a sandbox merchant,
+ * add this flag to wp-config:
+ *   define( 'PPCP_AGENTIC_FULL_AUTH', true )
+ */
+class SandboxAuthService extends JwtAuthService {
+
+	/**
+	 * Parses and validates JWT token.
+	 *
+	 * @param string|null $auth_header Bearer token from Authorization header.
+	 * @return object|WP_Error Decoded token or validation error.
+	 */
+	public function get_token( ?string $auth_header ) {
+		$jwt = $this->extract_jwt_from_header( $auth_header );
+
+		if ( is_wp_error( $jwt ) ) {
+			return $jwt;
+		}
+
+		$encoded_parts = explode( '.', $jwt );
+
+		try {
+			$payload_json = JWT::urlsafeB64Decode( $encoded_parts[1] );
+			$payload      = (object) JWT::jsonDecode( $payload_json );
+		} catch ( Exception $exception ) {
+			return new WP_Error( 'invalid_jwt', $exception->getMessage(), array( 'status' => 401 ) );
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Verifies token claims against business requirements.
+	 *
+	 * @param object $context         Decoded JWT payload.
+	 * @param array  $required_scopes Required permission scopes.
+	 * @return true|WP_Error
+	 */
+	public function verify_claims( object $context, array $required_scopes ) {
+		// Verify issuer.
+		if ( ! isset( $context->iss ) || $context->iss !== self::EXPECTED_ISSUER ) {
+			return new WP_Error(
+				'invalid_issuer',
+				'Token issuer is not recognized',
+				array( 'status' => 401 )
+			);
+		}
+
+		return true;
+	}
+}

--- a/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
@@ -50,7 +50,7 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 	 */
 	public function check_permission( WP_REST_Request $request ) {
 		$token   = $request->get_header( 'Authorization' );
-		$context = $this->auth_service->validate_request( $token );
+		$context = $this->auth_service->get_token( $token );
 
 		if ( is_wp_error( $context ) ) {
 			assert( $context instanceof WP_Error );

--- a/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
@@ -17,7 +17,7 @@ use WP_Error;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\AgenticError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\InvalidRequestError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\CartResponse;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
 
@@ -35,14 +35,14 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 	 */
 	protected const REQUIRED_SCOPES = array( 'cart' );
 
-	private JwtAuthService $auth_service;
+	private AuthServiceProvider $auth_provider;
 
 	protected AgenticSessionHandler $session_handler;
 
 	protected ResponseFactory $response_factory;
 
-	public function __construct( JwtAuthService $auth_service, AgenticSessionHandler $session_handler, ResponseFactory $response_factory ) {
-		$this->auth_service     = $auth_service;
+	public function __construct( AuthServiceProvider $auth_provider, AgenticSessionHandler $session_handler, ResponseFactory $response_factory ) {
+		$this->auth_provider    = $auth_provider;
 		$this->session_handler  = $session_handler;
 		$this->response_factory = $response_factory;
 	}
@@ -54,8 +54,9 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 	 * @return bool|WP_Error True if access is granted, otherwise a WP_Error object.
 	 */
 	public function check_permission( WP_REST_Request $request ) {
-		$token   = $request->get_header( 'Authorization' );
-		$context = $this->auth_service->get_token( $token );
+		$token        = $request->get_header( 'Authorization' );
+		$auth_service = $this->auth_provider->auth_service();
+		$context      = $auth_service->get_token( $token );
 
 		if ( is_wp_error( $context ) ) {
 			assert( $context instanceof WP_Error );
@@ -63,7 +64,7 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 			return $context;
 		}
 
-		return $this->auth_service->verify_claims( $context, static::REQUIRED_SCOPES );
+		return $auth_service->verify_claims( $context, static::REQUIRED_SCOPES );
 	}
 
 	/**

--- a/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
@@ -30,6 +30,11 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 	 */
 	protected const NAMESPACE = 'wc/v3/agentic';
 
+	/**
+	 * JWT scope(s) required for the endpoint.
+	 */
+	protected const REQUIRED_SCOPES = array( 'cart' );
+
 	private JwtAuthService $auth_service;
 
 	protected AgenticSessionHandler $session_handler;
@@ -58,9 +63,7 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 			return $context;
 		}
 
-		// TODO: verify the merchant details in $context.
-
-		return true;
+		return $this->auth_service->verify_claims( $context, static::REQUIRED_SCOPES );
 	}
 
 	/**

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -31,17 +31,10 @@ class JwtAuthServiceTest extends TestCase {
 		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
 		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
 
-		if ( $jwk_key !== null ) {
-			$jwk_provider->shouldReceive( 'keys' )
-				->once()
-				->andReturn( $jwk_key );
-		}
-
-		if ( $metadata !== null ) {
-			$metadata_provider->shouldReceive( 'get_metadata' )
-				->once()
-				->andReturn( $metadata );
-		}
+		$jwk_provider->allows( 'keys' )
+			->andReturn( $jwk_key );
+		$metadata_provider->allows( 'get_metadata' )
+			->andReturn( $metadata );
 
 		return new JwtAuthService( $jwk_provider, $metadata_provider );
 	}
@@ -160,8 +153,7 @@ class JwtAuthServiceTest extends TestCase {
 		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
 		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
 
-		$jwk_provider->shouldReceive( 'keys' )
-			->once()
+		$jwk_provider->allows( 'keys' )
 			->andReturn( null );
 
 		$service = new JwtAuthService( $jwk_provider, $metadata_provider );

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -12,6 +12,8 @@ use WP_Error;
 use Mockery;
 use Firebase\JWT\Key;
 use Firebase\JWT\JWT;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Merchant\MerchantMetadata;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Merchant\MerchantMetadataProvider;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService
@@ -30,18 +32,19 @@ class JwtAuthServiceTest extends TestCase {
 		string $expected_error_code,
 		bool $needs_key
 	): void {
-		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
 
 		if ( $needs_key ) {
 			$key = new Key( 'test-secret-key', 'HS256' );
-			$provider->shouldReceive( 'keys' )
+			$jwk_provider->shouldReceive( 'keys' )
 				->once()
 				->andReturn( $key );
 		} else {
-			$provider->shouldReceive( 'keys' )->never();
+			$jwk_provider->shouldReceive( 'keys' )->never();
 		}
 
-		$service = new JwtAuthService( $provider );
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
 		$result  = $service->get_token( $token );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
@@ -69,62 +72,62 @@ class JwtAuthServiceTest extends TestCase {
 		);
 
 		return array(
-			'null token'           => array(
+			'null token'             => array(
 				'token'      => null,
 				'error_code' => 'missing_token',
 				'needs_key'  => false,
 			),
-			'empty string'         => array(
+			'empty string'           => array(
 				'token'      => '',
 				'error_code' => 'missing_token',
 				'needs_key'  => false,
 			),
-			'only whitespace'      => array(
+			'only whitespace'        => array(
 				'token'      => '   ',
 				'error_code' => 'missing_token',
 				'needs_key'  => false,
 			),
-			'bearer with no token' => array(
+			'bearer with no token'   => array(
 				'token'      => 'Bearer ',
 				'error_code' => 'missing_token',
 				'needs_key'  => false,
 			),
-			'bearer whitespace'    => array(
+			'bearer whitespace'      => array(
 				'token'      => 'Bearer   ',
 				'error_code' => 'missing_token',
 				'needs_key'  => false,
 			),
-			'not bearer format'    => array(
+			'not bearer format'      => array(
 				'token'      => 'NotBearerFormat',
 				'error_code' => 'invalid_jwt',
 				'needs_key'  => false,
 			),
-			'invalid signature'    => array(
+			'invalid signature'      => array(
 				'token'      => 'Bearer ' . $invalid_jwt,
 				'error_code' => 'invalid_jwt',
 				'needs_key'  => true,
 			),
-			'malformed (1 segment)' => array(
-				'token'        => 'Bearer randomgarbage',
-				'error_code'   => 'invalid_jwt',
-				'needs_key'    => true,
+			'malformed (1 segment)'  => array(
+				'token'      => 'Bearer randomgarbage',
+				'error_code' => 'invalid_jwt',
+				'needs_key'  => true,
 			),
 			'malformed (2 segments)' => array(
-				'token'        => 'Bearer invalid.token',
-				'error_code'   => 'invalid_jwt',
-				'needs_key'    => true,
+				'token'      => 'Bearer invalid.token',
+				'error_code' => 'invalid_jwt',
+				'needs_key'  => true,
 			),
 			'malformed (4 segments)' => array(
-				'token'        => 'Bearer a.b.c.d',
-				'error_code'   => 'invalid_jwt',
-				'needs_key'    => true,
+				'token'      => 'Bearer a.b.c.d',
+				'error_code' => 'invalid_jwt',
+				'needs_key'  => true,
 			),
-			'expired token'        => array(
+			'expired token'          => array(
 				'token'      => 'Bearer ' . $expired_jwt,
 				'error_code' => 'invalid_jwt',
 				'needs_key'  => true,
 			),
-			'not yet valid token'  => array(
+			'not yet valid token'    => array(
 				'token'      => 'Bearer ' . $future_jwt,
 				'error_code' => 'invalid_jwt',
 				'needs_key'  => true,
@@ -138,12 +141,14 @@ class JwtAuthServiceTest extends TestCase {
 	 * THEN should return WP_Error with 'key_unavailable' code and 503 status
 	 */
 	public function test_validate_request_handles_unavailable_key(): void {
-		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$provider          = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+
 		$provider->shouldReceive( 'keys' )
 			->once()
 			->andReturn( null );
 
-		$service = new JwtAuthService( $provider );
+		$service = new JwtAuthService( $provider, $metadata_provider );
 		$result  = $service->get_token( 'Bearer some.valid.token' );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
@@ -167,12 +172,14 @@ class JwtAuthServiceTest extends TestCase {
 
 		$key = new Key( 'test-secret-key', 'HS256' );
 
-		$provider = Mockery::mock( PayPalJwkProvider::class );
+		$provider          = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+
 		$provider->shouldReceive( 'keys' )
 			->once()
 			->andReturn( $key );
 
-		$service = new JwtAuthService( $provider );
+		$service = new JwtAuthService( $provider, $metadata_provider );
 
 		$valid_jwt = JWT::encode( (array) $expected_payload, 'test-secret-key', 'HS256' );
 		$token     = $prefix . ' ' . $valid_jwt;
@@ -190,5 +197,322 @@ class JwtAuthServiceTest extends TestCase {
 			'mixedcase' => array( 'BeArEr' ),
 			'standard'  => array( 'Bearer' ),
 		);
+	}
+
+	/**
+	 * GIVEN valid token with correct issuer, scopes, and merchant ID
+	 * WHEN verify_claims is called
+	 * THEN should return true
+	 */
+	public function test_verify_claims_accepts_valid_token(): void {
+		$token = (object) array(
+			'iss'         => 'paypal.com',
+			'scope'       => array( 'cart', 'checkout' ),
+			'external_id' => array( 'PayPal:MERCHANT123' ),
+		);
+
+		$metadata = new MerchantMetadata(
+			'Test Store',
+			'https://example.com',
+			'US',
+			'USD',
+			'MERCHANT123',
+			'https://example.com'
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+		$metadata_provider->shouldReceive( 'get_metadata' )
+			->once()
+			->andReturn( $metadata );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * GIVEN token with invalid issuer
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'invalid_issuer' code and 401 status
+	 *
+	 * @dataProvider invalidIssuerProvider
+	 */
+	public function test_verify_claims_rejects_invalid_issuer( $issuer ): void {
+		$token = (object) array(
+			'iss'         => $issuer,
+			'scope'       => array( 'cart' ),
+			'external_id' => array( 'PayPal:MERCHANT123' ),
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_issuer', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	public function invalidIssuerProvider(): array {
+		return array(
+			'wrong issuer'  => array( 'evil.com' ),
+			'empty string'  => array( '' ),
+			'null'          => array( null ),
+			'almost right'  => array( 'paypal.com.evil.com' ),
+			'subdomain'     => array( 'sub.paypal.com' ),
+		);
+	}
+
+	/**
+	 * GIVEN token missing issuer field
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'invalid_issuer' code and 401 status
+	 */
+	public function test_verify_claims_rejects_missing_issuer(): void {
+		$token = (object) array(
+			'scope'       => array( 'cart' ),
+			'external_id' => array( 'PayPal:MERCHANT123' ),
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_issuer', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * GIVEN token with insufficient scopes
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'insufficient_scope' code and 403 status
+	 */
+	public function test_verify_claims_rejects_insufficient_scopes(): void {
+		$token = (object) array(
+			'iss'         => 'paypal.com',
+			'scope'       => array( 'cart' ),
+			'external_id' => array( 'PayPal:MERCHANT123' ),
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart', 'checkout' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'insufficient_scope', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * GIVEN token with malformed scopes
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'invalid_token' code and 401 status
+	 *
+	 * @dataProvider malformedScopesProvider
+	 */
+	public function test_verify_claims_rejects_malformed_scopes( $scopes ): void {
+		$token = (object) array(
+			'iss'         => 'paypal.com',
+			'scope'       => $scopes,
+			'external_id' => array( 'PayPal:MERCHANT123' ),
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_token', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	public function malformedScopesProvider(): array {
+		return array(
+			'string instead of array' => array( 'cart' ),
+			'object instead of array' => array( (object) array( 'cart' ) ),
+			'integer'                 => array( 123 ),
+		);
+	}
+
+	/**
+	 * GIVEN token missing scope field
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'insufficient_scope' code and 403 status
+	 */
+	public function test_verify_claims_treats_missing_scope_as_no_scopes(): void {
+		$token = (object) array(
+			'iss'         => 'paypal.com',
+			'external_id' => array( 'PayPal:MERCHANT123' ),
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'insufficient_scope', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * GIVEN token with merchant ID mismatch
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'merchant_mismatch' code and 403 status
+	 */
+	public function test_verify_claims_rejects_merchant_mismatch(): void {
+		$token = (object) array(
+			'iss'         => 'paypal.com',
+			'scope'       => array( 'cart' ),
+			'external_id' => array( 'PayPal:WRONG_MERCHANT' ),
+		);
+
+		$metadata = new MerchantMetadata(
+			'Test Store',
+			'https://example.com',
+			'US',
+			'USD',
+			'MERCHANT123',
+			'https://example.com'
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+		$metadata_provider->shouldReceive( 'get_metadata' )
+			->once()
+			->andReturn( $metadata );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'merchant_mismatch', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * GIVEN token with malformed external_id
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'invalid_token' code and 401 status
+	 *
+	 * @dataProvider malformedExternalIdProvider
+	 */
+	public function test_verify_claims_rejects_malformed_external_id( $external_id ): void {
+		$token = (object) array(
+			'iss'         => 'paypal.com',
+			'scope'       => array( 'cart' ),
+			'external_id' => $external_id,
+		);
+
+		$metadata = new MerchantMetadata(
+			'Test Store',
+			'https://example.com',
+			'US',
+			'USD',
+			'MERCHANT123',
+			'https://example.com'
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+		$metadata_provider->shouldReceive( 'get_metadata' )
+			->once()
+			->andReturn( $metadata );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_token', $result->get_error_code() );
+		$this->assertSame( 401, $result->get_error_data()['status'] );
+	}
+
+	public function malformedExternalIdProvider(): array {
+		return array(
+			'string instead of array' => array( 'PayPal:MERCHANT123' ),
+			'object instead of array' => array( (object) array( 'PayPal:MERCHANT123' ) ),
+			'integer'                 => array( 123 ),
+		);
+	}
+
+	/**
+	 * GIVEN token missing external_id field
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'merchant_mismatch' code and 403 status
+	 */
+	public function test_verify_claims_treats_missing_external_id_as_no_merchant(): void {
+		$token = (object) array(
+			'iss'   => 'paypal.com',
+			'scope' => array( 'cart' ),
+		);
+
+		$metadata = new MerchantMetadata(
+			'Test Store',
+			'https://example.com',
+			'US',
+			'USD',
+			'MERCHANT123',
+			'https://example.com'
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+		$metadata_provider->shouldReceive( 'get_metadata' )
+			->once()
+			->andReturn( $metadata );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'merchant_mismatch', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * GIVEN merchant ID is not configured
+	 * WHEN verify_claims is called
+	 * THEN should return WP_Error with 'merchant_not_configured' code and 500 status
+	 */
+	public function test_verify_claims_rejects_missing_merchant_config(): void {
+		$token = (object) array(
+			'iss'         => 'paypal.com',
+			'scope'       => array( 'cart' ),
+			'external_id' => array( 'PayPal:MERCHANT123' ),
+		);
+
+		$metadata = new MerchantMetadata(
+			'Test Store',
+			'https://example.com',
+			'US',
+			'USD',
+			'', // Empty merchant ID
+			'https://example.com'
+		);
+
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
+		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+		$metadata_provider->shouldReceive( 'get_metadata' )
+			->once()
+			->andReturn( $metadata );
+
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		$result  = $service->verify_claims( $token, array( 'cart' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'merchant_not_configured', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -42,7 +42,7 @@ class JwtAuthServiceTest extends TestCase {
 		}
 
 		$service = new JwtAuthService( $provider );
-		$result  = $service->validate_request( $token );
+		$result  = $service->get_token( $token );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( $expected_error_code, $result->get_error_code() );
@@ -144,7 +144,7 @@ class JwtAuthServiceTest extends TestCase {
 			->andReturn( null );
 
 		$service = new JwtAuthService( $provider );
-		$result  = $service->validate_request( 'Bearer some.valid.token' );
+		$result  = $service->get_token( 'Bearer some.valid.token' );
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'key_unavailable', $result->get_error_code() );
@@ -177,7 +177,7 @@ class JwtAuthServiceTest extends TestCase {
 		$valid_jwt = JWT::encode( (array) $expected_payload, 'test-secret-key', 'HS256' );
 		$token     = $prefix . ' ' . $valid_jwt;
 
-		$result = $service->validate_request( $token );
+		$result = $service->get_token( $token );
 
 		$this->assertInstanceOf( \stdClass::class, $result );
 		$this->assertEquals( $expected_payload, $result );

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -21,35 +21,96 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Merchant\MerchantMetadataProvider
 class JwtAuthServiceTest extends TestCase {
 
 	/**
-	 * GIVEN invalid or missing tokens
-	 * WHEN validate_request is called
-	 * THEN should return WP_Error with appropriate code and 401 status
+	 * Creates a JwtAuthService with mocked dependencies.
 	 *
-	 * @dataProvider invalidTokenProvider
+	 * @param MerchantMetadata|null $metadata Optional metadata to return.
+	 * @param Key|null              $jwk_key  Optional JWK key to return.
+	 * @return JwtAuthService
 	 */
-	public function test_validate_request_rejects_invalid_tokens(
-		?string $token,
-		string $expected_error_code,
-		bool $needs_key
-	): void {
+	private function create_service( ?MerchantMetadata $metadata = null, ?Key $jwk_key = null ): JwtAuthService {
 		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
 		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
 
-		if ( $needs_key ) {
-			$key = new Key( 'test-secret-key', 'HS256' );
+		if ( $jwk_key !== null ) {
 			$jwk_provider->shouldReceive( 'keys' )
 				->once()
-				->andReturn( $key );
-		} else {
-			$jwk_provider->shouldReceive( 'keys' )->never();
+				->andReturn( $jwk_key );
 		}
 
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
+		if ( $metadata !== null ) {
+			$metadata_provider->shouldReceive( 'get_metadata' )
+				->once()
+				->andReturn( $metadata );
+		}
+
+		return new JwtAuthService( $jwk_provider, $metadata_provider );
+	}
+
+	/**
+	 * Creates a default test merchant metadata.
+	 *
+	 * @param string $merchant_id Merchant ID to use.
+	 * @return MerchantMetadata
+	 */
+	private function create_metadata( string $merchant_id = 'MERCHANT123' ): MerchantMetadata {
+		return new MerchantMetadata(
+			'Test Store',
+			'https://example.com',
+			'US',
+			'USD',
+			$merchant_id,
+			'https://example.com'
+		);
+	}
+
+	/**
+	 * Creates a token object with specified claims.
+	 *
+	 * @param array $claims Token claims.
+	 * @return object
+	 */
+	private function create_token( array $claims ): object {
+		return (object) array_merge(
+			array(
+				'iss'         => 'paypal.com',
+				'scope'       => array( 'cart' ),
+				'external_id' => array( 'PayPal:MERCHANT123' ),
+			),
+			$claims
+		);
+	}
+
+	/**
+	 * Asserts that result is a WP_Error with expected code and HTTP status.
+	 *
+	 * @param mixed  $result      Result to check.
+	 * @param string $error_code  Expected error code.
+	 * @param int    $http_status Expected HTTP status.
+	 */
+	private function assert_error_response( $result, string $error_code, int $http_status ): void {
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( $error_code, $result->get_error_code() );
+		$this->assertSame( $http_status, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * GIVEN invalid or missing tokens
+	 * WHEN get_token is called
+	 * THEN should return WP_Error with appropriate code and HTTP status
+	 *
+	 * @dataProvider invalidTokenProvider
+	 */
+	public function test_get_token_rejects_invalid_tokens(
+		?string $token,
+		string $expected_error_code,
+		int $expected_status,
+		bool $needs_key
+	): void {
+		$key     = $needs_key ? new Key( 'test-secret-key', 'HS256' ) : null;
+		$service = $this->create_service( null, $key );
 		$result  = $service->get_token( $token );
 
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( $expected_error_code, $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
+		$this->assert_error_response( $result, $expected_error_code, $expected_status );
 	}
 
 	public function invalidTokenProvider(): array {
@@ -72,114 +133,59 @@ class JwtAuthServiceTest extends TestCase {
 		);
 
 		return array(
-			'null token'             => array(
-				'token'      => null,
-				'error_code' => 'missing_token',
-				'needs_key'  => false,
-			),
-			'empty string'           => array(
-				'token'      => '',
-				'error_code' => 'missing_token',
-				'needs_key'  => false,
-			),
-			'only whitespace'        => array(
-				'token'      => '   ',
-				'error_code' => 'missing_token',
-				'needs_key'  => false,
-			),
-			'bearer with no token'   => array(
-				'token'      => 'Bearer ',
-				'error_code' => 'missing_token',
-				'needs_key'  => false,
-			),
-			'bearer whitespace'      => array(
-				'token'      => 'Bearer   ',
-				'error_code' => 'missing_token',
-				'needs_key'  => false,
-			),
-			'not bearer format'      => array(
-				'token'      => 'NotBearerFormat',
-				'error_code' => 'invalid_jwt',
-				'needs_key'  => false,
-			),
-			'invalid signature'      => array(
-				'token'      => 'Bearer ' . $invalid_jwt,
-				'error_code' => 'invalid_jwt',
-				'needs_key'  => true,
-			),
-			'malformed (1 segment)'  => array(
-				'token'      => 'Bearer randomgarbage',
-				'error_code' => 'invalid_jwt',
-				'needs_key'  => true,
-			),
-			'malformed (2 segments)' => array(
-				'token'      => 'Bearer invalid.token',
-				'error_code' => 'invalid_jwt',
-				'needs_key'  => true,
-			),
-			'malformed (4 segments)' => array(
-				'token'      => 'Bearer a.b.c.d',
-				'error_code' => 'invalid_jwt',
-				'needs_key'  => true,
-			),
-			'expired token'          => array(
-				'token'      => 'Bearer ' . $expired_jwt,
-				'error_code' => 'invalid_jwt',
-				'needs_key'  => true,
-			),
-			'not yet valid token'    => array(
-				'token'      => 'Bearer ' . $future_jwt,
-				'error_code' => 'invalid_jwt',
-				'needs_key'  => true,
-			),
+			// Missing token scenarios (401).
+			'null token'             => array( null, 'missing_token', 401, false ),
+			'empty string'           => array( '', 'missing_token', 401, false ),
+			'only whitespace'        => array( '   ', 'missing_token', 401, false ),
+			'bearer with no token'   => array( 'Bearer ', 'missing_token', 401, false ),
+			'bearer whitespace'      => array( 'Bearer   ', 'missing_token', 401, false ),
+
+			// Format and validation errors (401).
+			'not bearer format'      => array( 'NotBearerFormat', 'invalid_jwt', 401, false ),
+			'invalid signature'      => array( 'Bearer ' . $invalid_jwt, 'invalid_jwt', 401, true ),
+			'malformed (1 segment)'  => array( 'Bearer randomgarbage', 'invalid_jwt', 401, true ),
+			'malformed (2 segments)' => array( 'Bearer invalid.token', 'invalid_jwt', 401, true ),
+			'malformed (4 segments)' => array( 'Bearer a.b.c.d', 'invalid_jwt', 401, true ),
+			'expired token'          => array( 'Bearer ' . $expired_jwt, 'invalid_jwt', 401, true ),
+			'not yet valid token'    => array( 'Bearer ' . $future_jwt, 'invalid_jwt', 401, true ),
 		);
 	}
 
 	/**
 	 * GIVEN provider returns null (key unavailable)
-	 * WHEN validate_request is called with valid Bearer token
+	 * WHEN get_token is called with valid Bearer token
 	 * THEN should return WP_Error with 'key_unavailable' code and 503 status
 	 */
-	public function test_validate_request_handles_unavailable_key(): void {
-		$provider          = Mockery::mock( PayPalJwkProvider::class );
+	public function test_get_token_handles_unavailable_key(): void {
+		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
 		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
 
-		$provider->shouldReceive( 'keys' )
+		$jwk_provider->shouldReceive( 'keys' )
 			->once()
 			->andReturn( null );
 
-		$service = new JwtAuthService( $provider, $metadata_provider );
+		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
 		$result  = $service->get_token( 'Bearer some.valid.token' );
 
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'key_unavailable', $result->get_error_code() );
-		$this->assertSame( 503, $result->get_error_data()['status'] );
+		$this->assert_error_response( $result, 'key_unavailable', 503 );
 	}
 
 	/**
 	 * GIVEN valid Bearer token with correct signature
-	 * WHEN validate_request is called
+	 * WHEN get_token is called
 	 * THEN should return decoded stdClass payload
 	 *
 	 * @dataProvider bearerCaseProvider
 	 */
-	public function test_validate_request_returns_decoded_payload_for_valid_jwt( string $prefix ): void {
+	public function test_get_token_returns_decoded_payload_for_valid_jwt( string $prefix ): void {
 		$expected_payload = (object) array(
 			'sub'  => '1234567890',
 			'name' => 'John Doe',
 			'iat'  => 1516239022,
 		);
 
-		$key = new Key( 'test-secret-key', 'HS256' );
-
-		$provider          = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-
-		$provider->shouldReceive( 'keys' )
-			->once()
-			->andReturn( $key );
-
-		$service = new JwtAuthService( $provider, $metadata_provider );
+		$key     = new Key( 'test-secret-key', 'HS256' );
+		$service = $this->create_service( null, $key );
 
 		$valid_jwt = JWT::encode( (array) $expected_payload, 'test-secret-key', 'HS256' );
 		$token     = $prefix . ' ' . $valid_jwt;
@@ -205,314 +211,99 @@ class JwtAuthServiceTest extends TestCase {
 	 * THEN should return true
 	 */
 	public function test_verify_claims_accepts_valid_token(): void {
-		$token = (object) array(
-			'iss'         => 'paypal.com',
-			'scope'       => array( 'cart', 'checkout' ),
-			'external_id' => array( 'PayPal:MERCHANT123' ),
-		);
+		$token    = $this->create_token( array( 'scope' => array( 'cart', 'checkout' ) ) );
+		$metadata = $this->create_metadata();
+		$service  = $this->create_service( $metadata );
 
-		$metadata = new MerchantMetadata(
-			'Test Store',
-			'https://example.com',
-			'US',
-			'USD',
-			'MERCHANT123',
-			'https://example.com'
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-		$metadata_provider->shouldReceive( 'get_metadata' )
-			->once()
-			->andReturn( $metadata );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
+		$result = $service->verify_claims( $token, array( 'cart' ) );
 
 		$this->assertTrue( $result );
 	}
 
 	/**
-	 * GIVEN token with invalid issuer
+	 * GIVEN token with validation errors
 	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'invalid_issuer' code and 401 status
+	 * THEN should return WP_Error with appropriate code and status
 	 *
-	 * @dataProvider invalidIssuerProvider
+	 * @dataProvider claimValidationErrorProvider
 	 */
-	public function test_verify_claims_rejects_invalid_issuer( $issuer ): void {
-		$token = (object) array(
-			'iss'         => $issuer,
-			'scope'       => array( 'cart' ),
-			'external_id' => array( 'PayPal:MERCHANT123' ),
-		);
+	public function test_verify_claims_rejects_invalid_claims(
+		array $token_data,
+		?string $merchant_id,
+		string $error_code,
+		int $http_status
+	): void {
+		$token   = $this->create_token( $token_data );
+		$service = $this->create_service( $merchant_id !== null ? $this->create_metadata( $merchant_id ) : null );
 
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+		$result = $service->verify_claims( $token, array( 'cart' ) );
 
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_issuer', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
+		$this->assert_error_response( $result, $error_code, $http_status );
 	}
 
-	public function invalidIssuerProvider(): array {
+	public function claimValidationErrorProvider(): array {
 		return array(
-			'wrong issuer'  => array( 'evil.com' ),
-			'empty string'  => array( '' ),
-			'null'          => array( null ),
-			'almost right'  => array( 'paypal.com.evil.com' ),
-			'subdomain'     => array( 'sub.paypal.com' ),
+			// Issuer validation (401) - Must be exactly "paypal.com".
+			'wrong issuer'            => array(
+				'token_data'  => array( 'iss' => 'evil.com' ),
+				'merchant_id' => null,
+				'error_code'  => 'invalid_issuer',
+				'http_status' => 401,
+			),
+			'empty issuer'            => array(
+				'token_data'  => array( 'iss' => '' ),
+				'merchant_id' => null,
+				'error_code'  => 'invalid_issuer',
+				'http_status' => 401,
+			),
+			'issuer subdomain'        => array(
+				'token_data'  => array( 'iss' => 'sub.paypal.com' ),
+				'merchant_id' => null,
+				'error_code'  => 'invalid_issuer',
+				'http_status' => 401,
+			),
+
+			// Scope validation (401/403).
+			'insufficient scopes'     => array(
+				'token_data'  => array( 'scope' => array() ),
+				'merchant_id' => null,
+				'error_code'  => 'insufficient_scope',
+				'http_status' => 403,
+			),
+
+			// Type validation (401) - scope and external_id must be arrays.
+			'scope not array'         => array(
+				'token_data'  => array( 'scope' => 'cart' ),
+				'merchant_id' => null,
+				'error_code'  => 'invalid_token',
+				'http_status' => 401,
+			),
+			'external_id not array'   => array(
+				'token_data'  => array( 'external_id' => 'PayPal:MERCHANT123' ),
+				'merchant_id' => 'MERCHANT123',
+				'error_code'  => 'invalid_token',
+				'http_status' => 401,
+			),
+
+			// Merchant validation (403/500).
+			'merchant mismatch'       => array(
+				'token_data'  => array( 'external_id' => array( 'PayPal:WRONG_MERCHANT' ) ),
+				'merchant_id' => 'MERCHANT123',
+				'error_code'  => 'merchant_mismatch',
+				'http_status' => 403,
+			),
+			'missing external_id'     => array(
+				'token_data'  => array( 'external_id' => null ),
+				'merchant_id' => 'MERCHANT123',
+				'error_code'  => 'merchant_mismatch',
+				'http_status' => 403,
+			),
+			'merchant not configured' => array(
+				'token_data'  => array(),
+				'merchant_id' => '',
+				'error_code'  => 'merchant_not_configured',
+				'http_status' => 500,
+			),
 		);
-	}
-
-	/**
-	 * GIVEN token missing issuer field
-	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'invalid_issuer' code and 401 status
-	 */
-	public function test_verify_claims_rejects_missing_issuer(): void {
-		$token = (object) array(
-			'scope'       => array( 'cart' ),
-			'external_id' => array( 'PayPal:MERCHANT123' ),
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_issuer', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN token with insufficient scopes
-	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'insufficient_scope' code and 403 status
-	 */
-	public function test_verify_claims_rejects_insufficient_scopes(): void {
-		$token = (object) array(
-			'iss'         => 'paypal.com',
-			'scope'       => array( 'cart' ),
-			'external_id' => array( 'PayPal:MERCHANT123' ),
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart', 'checkout' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'insufficient_scope', $result->get_error_code() );
-		$this->assertSame( 403, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN token with malformed scopes
-	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'invalid_token' code and 401 status
-	 *
-	 * @dataProvider malformedScopesProvider
-	 */
-	public function test_verify_claims_rejects_malformed_scopes( $scopes ): void {
-		$token = (object) array(
-			'iss'         => 'paypal.com',
-			'scope'       => $scopes,
-			'external_id' => array( 'PayPal:MERCHANT123' ),
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_token', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
-	}
-
-	public function malformedScopesProvider(): array {
-		return array(
-			'string instead of array' => array( 'cart' ),
-			'object instead of array' => array( (object) array( 'cart' ) ),
-			'integer'                 => array( 123 ),
-		);
-	}
-
-	/**
-	 * GIVEN token missing scope field
-	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'insufficient_scope' code and 403 status
-	 */
-	public function test_verify_claims_treats_missing_scope_as_no_scopes(): void {
-		$token = (object) array(
-			'iss'         => 'paypal.com',
-			'external_id' => array( 'PayPal:MERCHANT123' ),
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'insufficient_scope', $result->get_error_code() );
-		$this->assertSame( 403, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN token with merchant ID mismatch
-	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'merchant_mismatch' code and 403 status
-	 */
-	public function test_verify_claims_rejects_merchant_mismatch(): void {
-		$token = (object) array(
-			'iss'         => 'paypal.com',
-			'scope'       => array( 'cart' ),
-			'external_id' => array( 'PayPal:WRONG_MERCHANT' ),
-		);
-
-		$metadata = new MerchantMetadata(
-			'Test Store',
-			'https://example.com',
-			'US',
-			'USD',
-			'MERCHANT123',
-			'https://example.com'
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-		$metadata_provider->shouldReceive( 'get_metadata' )
-			->once()
-			->andReturn( $metadata );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'merchant_mismatch', $result->get_error_code() );
-		$this->assertSame( 403, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN token with malformed external_id
-	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'invalid_token' code and 401 status
-	 *
-	 * @dataProvider malformedExternalIdProvider
-	 */
-	public function test_verify_claims_rejects_malformed_external_id( $external_id ): void {
-		$token = (object) array(
-			'iss'         => 'paypal.com',
-			'scope'       => array( 'cart' ),
-			'external_id' => $external_id,
-		);
-
-		$metadata = new MerchantMetadata(
-			'Test Store',
-			'https://example.com',
-			'US',
-			'USD',
-			'MERCHANT123',
-			'https://example.com'
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-		$metadata_provider->shouldReceive( 'get_metadata' )
-			->once()
-			->andReturn( $metadata );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_token', $result->get_error_code() );
-		$this->assertSame( 401, $result->get_error_data()['status'] );
-	}
-
-	public function malformedExternalIdProvider(): array {
-		return array(
-			'string instead of array' => array( 'PayPal:MERCHANT123' ),
-			'object instead of array' => array( (object) array( 'PayPal:MERCHANT123' ) ),
-			'integer'                 => array( 123 ),
-		);
-	}
-
-	/**
-	 * GIVEN token missing external_id field
-	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'merchant_mismatch' code and 403 status
-	 */
-	public function test_verify_claims_treats_missing_external_id_as_no_merchant(): void {
-		$token = (object) array(
-			'iss'   => 'paypal.com',
-			'scope' => array( 'cart' ),
-		);
-
-		$metadata = new MerchantMetadata(
-			'Test Store',
-			'https://example.com',
-			'US',
-			'USD',
-			'MERCHANT123',
-			'https://example.com'
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-		$metadata_provider->shouldReceive( 'get_metadata' )
-			->once()
-			->andReturn( $metadata );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'merchant_mismatch', $result->get_error_code() );
-		$this->assertSame( 403, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * GIVEN merchant ID is not configured
-	 * WHEN verify_claims is called
-	 * THEN should return WP_Error with 'merchant_not_configured' code and 500 status
-	 */
-	public function test_verify_claims_rejects_missing_merchant_config(): void {
-		$token = (object) array(
-			'iss'         => 'paypal.com',
-			'scope'       => array( 'cart' ),
-			'external_id' => array( 'PayPal:MERCHANT123' ),
-		);
-
-		$metadata = new MerchantMetadata(
-			'Test Store',
-			'https://example.com',
-			'US',
-			'USD',
-			'', // Empty merchant ID
-			'https://example.com'
-		);
-
-		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
-		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
-		$metadata_provider->shouldReceive( 'get_metadata' )
-			->once()
-			->andReturn( $metadata );
-
-		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
-		$result  = $service->verify_claims( $token, array( 'cart' ) );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'merchant_not_configured', $result->get_error_code() );
-		$this->assertSame( 500, $result->get_error_data()['status'] );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/CartPayloadBuilder.php
+++ b/tests/PHPUnit/AgenticCommerce/CartPayloadBuilder.php
@@ -1,0 +1,181 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce;
+
+/**
+ * Fluent builder for cart payloads.
+ */
+class CartPayloadBuilder {
+	/**
+	 * Cart items.
+	 *
+	 * @var array
+	 */
+	private array $items = array();
+
+	/**
+	 * Shipping information.
+	 *
+	 * @var array|null
+	 */
+	private ?array $shipping = null;
+
+	/**
+	 * Payment method type.
+	 *
+	 * @var string
+	 */
+	private string $payment_type = 'paypal';
+
+	/**
+	 * Add a cart item.
+	 *
+	 * @param string $item_id  Item ID.
+	 * @param int    $quantity Quantity.
+	 * @param string $value    Price value.
+	 * @param string $currency Currency code.
+	 * @return self
+	 */
+	public function with_item(
+		string $item_id = 'TEST-001',
+		int $quantity = 1,
+		string $value = '25.00',
+		string $currency = 'USD'
+	): self {
+		$this->items[] = array(
+			'item_id'  => $item_id,
+			'quantity' => $quantity,
+			'price'    => array(
+				'currency_code' => $currency,
+				'value'         => $value,
+			),
+		);
+		return $this;
+	}
+
+	/**
+	 * Add a cart item using a named fixture.
+	 *
+	 * @param string $fixture_name Fixture name.
+	 * @return self
+	 */
+	public function with_item_fixture( string $fixture_name ): self {
+		$fixtures = array(
+			'default'     => array( 'TEST-001', 1, '25.00', 'USD' ),
+			'expensive'   => array( 'TEST-002', 1, '99.99', 'USD' ),
+			'multi'       => array( 'TEST-003', 5, '10.00', 'USD' ),
+			'old_item'    => array( 'OLD-ITEM-001', 1, '25.00', 'USD' ),
+			'new_item_2'  => array( 'NEW-ITEM-002', 3, '50.00', 'USD' ),
+			'new_item_3'  => array( 'NEW-ITEM-003', 1, '30.00', 'USD' ),
+			'eur_item'    => array( 'NEW-ITEM-002', 5, '99.99', 'EUR' ),
+		);
+
+		if ( ! isset( $fixtures[ $fixture_name ] ) ) {
+			throw new \InvalidArgumentException( "Unknown item fixture: {$fixture_name}" );
+		}
+
+		return $this->with_item( ...$fixtures[ $fixture_name ] );
+	}
+
+	/**
+	 * Add US shipping address.
+	 *
+	 * @param string $full_name Full name.
+	 * @param string $address   Street address.
+	 * @param string $city      City.
+	 * @param string $state     State code.
+	 * @param string $zip       ZIP code.
+	 * @return self
+	 */
+	public function with_us_shipping(
+		string $full_name = 'John Doe',
+		string $address = '123 Main St',
+		string $city = 'San Jose',
+		string $state = 'CA',
+		string $zip = '95131'
+	): self {
+		$this->shipping = array(
+			'name'    => array( 'full_name' => $full_name ),
+			'address' => array(
+				'address_line_1' => $address,
+				'admin_area_2'   => $city,
+				'admin_area_1'   => $state,
+				'postal_code'    => $zip,
+				'country_code'   => 'US',
+			),
+		);
+		return $this;
+	}
+
+	/**
+	 * Add German shipping address.
+	 *
+	 * @param string $full_name Full name.
+	 * @param string $address   Street address.
+	 * @param string $city      City.
+	 * @param string $state     State code.
+	 * @param string $zip       ZIP code.
+	 * @return self
+	 */
+	public function with_de_shipping(
+		string $full_name = 'New Name',
+		string $address = '456 New Ave',
+		string $city = 'Berlin',
+		string $state = 'BE',
+		string $zip = '10115'
+	): self {
+		$this->shipping = array(
+			'name'    => array( 'full_name' => $full_name ),
+			'address' => array(
+				'address_line_1' => $address,
+				'admin_area_2'   => $city,
+				'admin_area_1'   => $state,
+				'postal_code'    => $zip,
+				'country_code'   => 'DE',
+			),
+		);
+		return $this;
+	}
+
+	/**
+	 * Add shipping using a named fixture.
+	 *
+	 * @param string $fixture_name Fixture name.
+	 * @return self
+	 */
+	public function with_shipping_fixture( string $fixture_name ): self {
+		$fixtures = array(
+			'us_default' => array( 'with_us_shipping', array() ),
+			'us_john'    => array( 'with_us_shipping', array( 'John Doe', '123 Main St' ) ),
+			'us_old'     => array( 'with_us_shipping', array( 'Old Name', '123 Old St' ) ),
+			'de_default' => array( 'with_de_shipping', array() ),
+			'de_new'     => array( 'with_de_shipping', array( 'New Name', '456 New Ave' ) ),
+		);
+
+		if ( ! isset( $fixtures[ $fixture_name ] ) ) {
+			throw new \InvalidArgumentException( "Unknown shipping fixture: {$fixture_name}" );
+		}
+
+		list( $method, $args ) = $fixtures[ $fixture_name ];
+		return $this->$method( ...$args );
+	}
+
+	/**
+	 * Build and return the cart payload as an array.
+	 *
+	 * @return array
+	 */
+	public function to_array(): array {
+		$cart = array(
+			'items'          => $this->items,
+			'payment_method' => array( 'type' => $this->payment_type ),
+		);
+
+		if ( $this->shipping ) {
+			$cart['shipping'] = $this->shipping;
+		}
+
+		return $cart;
+	}
+}

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/AgenticEndpointTestCase.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/AgenticEndpointTestCase.php
@@ -1,0 +1,61 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
+use WooCommerce\PayPalCommerce\AgenticCommerce\CartPayloadBuilder;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
+use Mockery;
+
+/**
+ * Base test case for Agentic Commerce endpoint tests.
+ */
+abstract class AgenticEndpointTestCase extends TestCase {
+
+	/**
+	 * Create standard mocks for endpoint tests.
+	 *
+	 * @return array{auth_provider: AuthServiceProvider&\Mockery\MockInterface, session_handler: AgenticSessionHandler&\Mockery\MockInterface, response_factory: ResponseFactory&\Mockery\MockInterface}
+	 */
+	protected function create_mocks(): array {
+		$auth_service  = Mockery::mock( JwtAuthService::class );
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
+
+		return array(
+			'auth_provider'    => $auth_provider,
+			'session_handler'  => Mockery::mock( AgenticSessionHandler::class ),
+			'response_factory' => Mockery::mock( ResponseFactory::class ),
+		);
+	}
+
+	/**
+	 * Start building a cart payload.
+	 *
+	 * @return CartPayloadBuilder
+	 */
+	protected function cart(): CartPayloadBuilder {
+		return new CartPayloadBuilder();
+	}
+
+	/**
+	 * Assert that response contains error information.
+	 *
+	 * @param array $data Response data.
+	 */
+	protected function assert_error_response( array $data ): void {
+		$has_error_info = isset( $data['validation_issues'] )
+			|| isset( $data['error'] )
+			|| isset( $data['message'] )
+			|| isset( $data['issues'] );
+
+		$this->assertTrue(
+			$has_error_info,
+			'Response should contain error information. Got: ' . json_encode( $data )
+		);
+	}
+}

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\NewCartResponse;
@@ -39,9 +40,17 @@ class CreateCartEndpointTest extends TestCase {
 
 		when( 'wp_generate_password' )->justReturn( $sample_token );
 
-		$auth             = Mockery::mock( JwtAuthService::class );
-		$session_handler  = Mockery::mock( AgenticSessionHandler::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
+		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
+		$session_handler = Mockery::mock( AgenticSessionHandler::class );
+		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		// Mock session handler - it should create a cart session and return the cart ID.
 		$session_handler->shouldReceive( 'create_cart_session' )
@@ -65,8 +74,8 @@ class CreateCartEndpointTest extends TestCase {
 				$ec_token
 			) );
 
-		// Pass session_handler as 2nd argument
-		$endpoint = new CreateCartEndpoint( $auth, $session_handler, $response_factory );
+		// Pass auth_provider as 1st argument.
+		$endpoint = new CreateCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'POST', '/wp-json/paypal/v1/merchant-cart' );
 		$request->set_body( json_encode( $cart_data ) );

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/CreateCartEndpointTest.php
@@ -3,56 +3,28 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
-use WooCommerce\PayPalCommerce\TestCase;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\NewCartResponse;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
 use WP_REST_Request;
-use Mockery;
 use function Brain\Monkey\Functions\when;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\CreateCartEndpoint
  */
-class CreateCartEndpointTest extends TestCase {
+class CreateCartEndpointTest extends AgenticEndpointTestCase {
 
 	public function test_create_cart_returns_201_created(): void {
 		$sample_token = 'random-string';
 		$cart_id      = 't_mock_cart_id_12345';
-		$cart_data    = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'TEST-001',
-					'quantity' => 1,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '25.00',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-		);
+		$cart_data    = $this->cart()->with_item()->to_array();
 
 		when( 'wp_generate_password' )->justReturn( $sample_token );
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
-		$auth_service = Mockery::mock( JwtAuthService::class );
-		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
-		$auth_provider = Mockery::mock( AuthServiceProvider::class );
-		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
-		$session_handler = Mockery::mock( AgenticSessionHandler::class );
-		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
-		$response_factory = Mockery::mock( ResponseFactory::class );
+		$mocks            = $this->create_mocks();
+		$session_handler  = $mocks['session_handler'];
+		$response_factory = $mocks['response_factory'];
 
-		// Mock auth provider to return auth service.
-		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
-
-		// Mock session handler - it should create a cart session and return the cart ID.
+		// Verify cart session is created with correct token.
 		$session_handler->shouldReceive( 'create_cart_session' )
 			->once()
 			->withArgs( function( $cart, $ec_token ) use ( $sample_token ) {
@@ -60,22 +32,15 @@ class CreateCartEndpointTest extends TestCase {
 			} )
 			->andReturn( $cart_id );
 
-		// Mock response factory - now expects 3 arguments: cart, cart_id, ec_token.
-		$response_factory->shouldReceive( 'new_cart' )
-			->once()
-			->withArgs( function( $cart, $received_cart_id, $ec_token ) use ( $cart_id, $sample_token ) {
-				return $cart instanceof PayPalCart
-					&& $received_cart_id === $cart_id
-					&& $ec_token === $sample_token;
-			} )
+		// Mock response factory.
+		$response_factory->allows( 'new_cart' )
 			->andReturnUsing( fn( $cart, $cart_id, $ec_token ) => new NewCartResponse(
 				$cart,
 				$cart_id,
 				$ec_token
 			) );
 
-		// Pass auth_provider as 1st argument.
-		$endpoint = new CreateCartEndpoint( $auth_provider, $session_handler, $response_factory );
+		$endpoint = new CreateCartEndpoint( $mocks['auth_provider'], $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'POST', '/wp-json/paypal/v1/merchant-cart' );
 		$request->set_body( json_encode( $cart_data ) );

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/GetCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/GetCartEndpointTest.php
@@ -3,61 +3,30 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
-use WooCommerce\PayPalCommerce\TestCase;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\NewCartResponse;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
 use WP_REST_Request;
-use Mockery;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\GetCartEndpoint
  */
-class GetCartEndpointTest extends TestCase {
+class GetCartEndpointTest extends AgenticEndpointTestCase {
 
 	public function test_get_cart_returns_200_ok_when_cart_exists(): void {
 		$cart_id      = 't_mock_cart_id_12345';
 		$ec_token     = 'EC-12345TOKEN';
 		$created_time = time();
 
-		$mock_cart_data = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'TEST-001',
-					'quantity' => 2,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '50.00',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-		);
+		$mock_cart_data = $this->cart()->with_item( 'TEST-001', 2, '50.00' )->to_array();
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
-		$auth_service = Mockery::mock( JwtAuthService::class );
-		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
-		$auth_provider = Mockery::mock( AuthServiceProvider::class );
-		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
-		$session_handler = Mockery::mock( AgenticSessionHandler::class );
-		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
-		$response_factory = Mockery::mock( ResponseFactory::class );
+		$mocks            = $this->create_mocks();
+		$session_handler  = $mocks['session_handler'];
+		$response_factory = $mocks['response_factory'];
 
-		// Mock auth provider to return auth service.
-		$auth_provider->allows( 'auth_service' )
-			->andReturn( $auth_service );
-
-		// Mock cart object
 		$mock_cart = PayPalCart::from_array( $mock_cart_data );
 
-		// Mock session handler - it should load the cart session
-		$session_handler->shouldReceive( 'load_cart_session' )
-			->once()
+		// Mock session handler.
+		$session_handler->allows( 'load_cart_session' )
 			->with( $cart_id )
 			->andReturn(
 				array(
@@ -67,14 +36,8 @@ class GetCartEndpointTest extends TestCase {
 				)
 			);
 
-		// Mock response factory
-		$response_factory->shouldReceive( 'active_cart' )
-			->once()
-			->withArgs( function( $cart, $received_cart_id, $received_ec_token ) use ( $cart_id, $ec_token ) {
-				return $cart instanceof PayPalCart
-					&& $received_cart_id === $cart_id
-					&& $received_ec_token === $ec_token;
-			} )
+		// Mock response factory.
+		$response_factory->allows( 'active_cart' )
 			->andReturnUsing( fn( $cart, $cart_id, $ec_token ) => new NewCartResponse(
 				$cart,
 				$cart_id,
@@ -82,7 +45,7 @@ class GetCartEndpointTest extends TestCase {
 				'ACTIVE'
 			) );
 
-		$endpoint = new GetCartEndpoint( $auth_provider, $session_handler, $response_factory );
+		$endpoint = new GetCartEndpoint( $mocks['auth_provider'], $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'GET', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -95,29 +58,18 @@ class GetCartEndpointTest extends TestCase {
 		$this->assertSame( 200, $response->get_status() );
 	}
 
-	public function test_get_cart_returns_error_when_cart_not_found(): void {
-		$cart_id = 't_nonexistent_cart_id';
+	public function test_get_cart_returns_error_when_cart_unavailable(): void {
+		$cart_id = 't_unavailable_cart_id';
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
-		$auth_service = Mockery::mock( JwtAuthService::class );
-		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
-		$auth_provider = Mockery::mock( AuthServiceProvider::class );
-		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
-		$session_handler = Mockery::mock( AgenticSessionHandler::class );
-		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
-		$response_factory = Mockery::mock( ResponseFactory::class );
+		$mocks           = $this->create_mocks();
+		$session_handler = $mocks['session_handler'];
 
-		// Mock auth provider to return auth service.
-		$auth_provider->allows( 'auth_service' )
-			->andReturn( $auth_service );
-
-		// Mock session handler - return null for non-existent cart
-		$session_handler->shouldReceive( 'load_cart_session' )
-			->once()
+		// Mock session handler - return null for unavailable cart (not found or expired).
+		$session_handler->allows( 'load_cart_session' )
 			->with( $cart_id )
 			->andReturn( null );
 
-		$endpoint = new GetCartEndpoint( $auth_provider, $session_handler, $response_factory );
+		$endpoint = new GetCartEndpoint( $mocks['auth_provider'], $session_handler, $mocks['response_factory'] );
 
 		$request = new WP_REST_Request( 'GET', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -126,60 +78,7 @@ class GetCartEndpointTest extends TestCase {
 		$data     = $response->get_data();
 
 		$this->assertIsArray( $data );
-
-		// Error responses should not have 200 status
 		$this->assertNotSame( 200, $response->get_status() );
-
-		// The response should have error information - check for any of these keys
-		$has_error_info = isset( $data['validation_issues'] )
-			|| isset( $data['error'] )
-			|| isset( $data['message'] )
-			|| isset( $data['issues'] );
-
-		$this->assertTrue( $has_error_info, 'Response should contain error information. Got: ' . json_encode( $data ) );
-	}
-
-	public function test_get_cart_returns_error_when_cart_expired(): void {
-		$cart_id = 't_expired_cart_id';
-
-		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
-		$auth_service = Mockery::mock( JwtAuthService::class );
-		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
-		$auth_provider = Mockery::mock( AuthServiceProvider::class );
-		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
-		$session_handler = Mockery::mock( AgenticSessionHandler::class );
-		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
-		$response_factory = Mockery::mock( ResponseFactory::class );
-
-		// Mock auth provider to return auth service.
-		$auth_provider->allows( 'auth_service' )
-			->andReturn( $auth_service );
-
-		// Mock session handler - return null for expired cart
-		$session_handler->shouldReceive( 'load_cart_session' )
-			->once()
-			->with( $cart_id )
-			->andReturn( null );
-
-		$endpoint = new GetCartEndpoint( $auth_provider, $session_handler, $response_factory );
-
-		$request = new WP_REST_Request( 'GET', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
-		$request->set_param( 'cart_id', $cart_id );
-
-		$response = $endpoint->get_cart( $request );
-		$data     = $response->get_data();
-
-		$this->assertIsArray( $data );
-
-		// Error responses should not have 200 status
-		$this->assertNotSame( 200, $response->get_status() );
-
-		// The response should have error information
-		$has_error_info = isset( $data['validation_issues'] )
-			|| isset( $data['error'] )
-			|| isset( $data['message'] )
-			|| isset( $data['issues'] );
-
-		$this->assertTrue( $has_error_info, 'Response should contain error information. Got: ' . json_encode( $data ) );
+		$this->assert_error_response( $data );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/GetCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/GetCartEndpointTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\NewCartResponse;
@@ -38,12 +39,18 @@ class GetCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )
+			->andReturn( $auth_service );
 
 		// Mock cart object
 		$mock_cart = PayPalCart::from_array( $mock_cart_data );
@@ -75,7 +82,7 @@ class GetCartEndpointTest extends TestCase {
 				'ACTIVE'
 			) );
 
-		$endpoint = new GetCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new GetCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'GET', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -91,12 +98,18 @@ class GetCartEndpointTest extends TestCase {
 	public function test_get_cart_returns_error_when_cart_not_found(): void {
 		$cart_id = 't_nonexistent_cart_id';
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )
+			->andReturn( $auth_service );
 
 		// Mock session handler - return null for non-existent cart
 		$session_handler->shouldReceive( 'load_cart_session' )
@@ -104,7 +117,7 @@ class GetCartEndpointTest extends TestCase {
 			->with( $cart_id )
 			->andReturn( null );
 
-		$endpoint = new GetCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new GetCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'GET', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -129,12 +142,18 @@ class GetCartEndpointTest extends TestCase {
 	public function test_get_cart_returns_error_when_cart_expired(): void {
 		$cart_id = 't_expired_cart_id';
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )
+			->andReturn( $auth_service );
 
 		// Mock session handler - return null for expired cart
 		$session_handler->shouldReceive( 'load_cart_session' )
@@ -142,7 +161,7 @@ class GetCartEndpointTest extends TestCase {
 			->with( $cart_id )
 			->andReturn( null );
 
-		$endpoint = new GetCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new GetCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'GET', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/ReplaceCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/ReplaceCartEndpointTest.php
@@ -3,83 +3,37 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
-use WooCommerce\PayPalCommerce\TestCase;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\CartResponse;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
 use WP_REST_Request;
-use Mockery;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\ReplaceCartEndpoint
  */
-class ReplaceCartEndpointTest extends TestCase {
+class ReplaceCartEndpointTest extends AgenticEndpointTestCase {
 
 	public function test_replace_cart_returns_200_ok_on_successful_replacement(): void {
 		$cart_id      = 't_mock_cart_id_12345';
 		$ec_token     = 'EC-12345TOKEN';
 		$created_time = time();
 
-		$existing_cart_data = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'OLD-ITEM-001',
-					'quantity' => 1,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '25.00',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-		);
+		$existing_cart_data = $this->cart()
+			->with_item_fixture( 'old_item' )
+			->to_array();
 
-		$replacement_cart_data = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'NEW-ITEM-002',
-					'quantity' => 3,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '50.00',
-					),
-				),
-				array(
-					'item_id'  => 'NEW-ITEM-003',
-					'quantity' => 1,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '30.00',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-		);
+		$replacement_cart_data = $this->cart()
+			->with_item_fixture( 'new_item_2' )
+			->with_item_fixture( 'new_item_3' )
+			->to_array();
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
-		$auth_service = Mockery::mock( JwtAuthService::class );
-		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
-		$auth_provider = Mockery::mock( AuthServiceProvider::class );
-		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
-		$session_handler = Mockery::mock( AgenticSessionHandler::class );
-		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
-		$response_factory = Mockery::mock( ResponseFactory::class );
-
-		// Mock auth provider to return auth service.
-		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
+		$mocks            = $this->create_mocks();
+		$session_handler  = $mocks['session_handler'];
+		$response_factory = $mocks['response_factory'];
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
-		// First call - verify cart exists
-		$session_handler->shouldReceive( 'load_cart_session' )
-			->once()
+		// Mock session handler.
+		$session_handler->allows( 'load_cart_session' )
 			->with( $cart_id )
 			->andReturn(
 				array(
@@ -89,24 +43,14 @@ class ReplaceCartEndpointTest extends TestCase {
 				)
 			);
 
-		// Mock replacement operation
-		$session_handler->shouldReceive( 'update_cart_session' )
-			->once()
-			->withArgs( function ( $received_cart_id, $new_cart ) use ( $cart_id ) {
-				return $received_cart_id === $cart_id && $new_cart instanceof PayPalCart;
-			} )
+		$session_handler->allows( 'update_cart_session' )
 			->andReturn( true );
 
-		// Mock response factory - uses from_cart (not active_cart or new_cart)
-		$replacement_cart = PayPalCart::from_array( $replacement_cart_data );
-		$response_factory->shouldReceive( 'from_cart' )
-			->once()
-			->withArgs( function ( $cart ) {
-				return $cart instanceof PayPalCart;
-			} )
+		// Mock response factory.
+		$response_factory->allows( 'from_cart' )
 			->andReturnUsing( fn( $cart ) => new CartResponse( $cart ) );
 
-		$endpoint = new ReplaceCartEndpoint( $auth_provider, $session_handler, $response_factory );
+		$endpoint = new ReplaceCartEndpoint( $mocks['auth_provider'], $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -123,41 +67,19 @@ class ReplaceCartEndpointTest extends TestCase {
 	public function test_replace_cart_returns_error_when_cart_not_found(): void {
 		$cart_id = 't_nonexistent_cart_id';
 
-		$replacement_data = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'TEST-001',
-					'quantity' => 2,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '25.00',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-		);
+		$replacement_data = $this->cart()
+			->with_item( 'TEST-001', 2 )
+			->to_array();
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
-		$auth_service = Mockery::mock( JwtAuthService::class );
-		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
-		$auth_provider = Mockery::mock( AuthServiceProvider::class );
-		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
-		$session_handler = Mockery::mock( AgenticSessionHandler::class );
-		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
-		$response_factory = Mockery::mock( ResponseFactory::class );
+		$mocks           = $this->create_mocks();
+		$session_handler = $mocks['session_handler'];
 
-		// Mock auth provider to return auth service.
-		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
-
-		// Mock session handler - return null for non-existent cart
-		$session_handler->shouldReceive( 'load_cart_session' )
-			->once()
+		// Mock session handler - return null for non-existent cart.
+		$session_handler->allows( 'load_cart_session' )
 			->with( $cart_id )
 			->andReturn( null );
 
-		$endpoint = new ReplaceCartEndpoint( $auth_provider, $session_handler, $response_factory );
+		$endpoint = new ReplaceCartEndpoint( $mocks['auth_provider'], $session_handler, $mocks['response_factory'] );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -167,17 +89,8 @@ class ReplaceCartEndpointTest extends TestCase {
 		$data     = $response->get_data();
 
 		$this->assertIsArray( $data );
-
-		// Error responses should not have 200 status
 		$this->assertNotSame( 200, $response->get_status() );
-
-		// The response should have error information
-		$has_error_info = isset( $data['validation_issues'] )
-			|| isset( $data['error'] )
-			|| isset( $data['message'] )
-			|| isset( $data['issues'] );
-
-		$this->assertTrue( $has_error_info, 'Response should contain error information. Got: ' . json_encode( $data ) );
+		$this->assert_error_response( $data );
 	}
 
 	public function test_replace_cart_completely_replaces_items(): void {
@@ -185,81 +98,24 @@ class ReplaceCartEndpointTest extends TestCase {
 		$ec_token     = 'EC-12345TOKEN';
 		$created_time = time();
 
-		// Original cart has 1 item
-		$existing_cart_data = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'OLD-ITEM-001',
-					'quantity' => 1,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '25.00',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-			'shipping'       => array(
-				'name'    => array(
-					'full_name' => 'Old Name',
-				),
-				'address' => array(
-					'address_line_1' => '123 Old St',
-					'admin_area_2'   => 'San Jose',
-					'admin_area_1'   => 'CA',
-					'postal_code'    => '95131',
-					'country_code'   => 'US',
-				),
-			),
-		);
+		$existing_cart_data = $this->cart()
+			->with_item_fixture( 'old_item' )
+			->with_shipping_fixture( 'us_old' )
+			->to_array();
 
-		// Replacement cart has completely different items and shipping
-		$replacement_cart_data = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'NEW-ITEM-002',
-					'quantity' => 5,
-					'price'    => array(
-						'currency_code' => 'EUR',
-						'value'         => '99.99',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-			'shipping'       => array(
-				'name'    => array(
-					'full_name' => 'New Name',
-				),
-				'address' => array(
-					'address_line_1' => '456 New Ave',
-					'admin_area_2'   => 'Berlin',
-					'admin_area_1'   => 'BE',
-					'postal_code'    => '10115',
-					'country_code'   => 'DE',
-				),
-			),
-		);
+		$replacement_cart_data = $this->cart()
+			->with_item_fixture( 'eur_item' )
+			->with_shipping_fixture( 'de_new' )
+			->to_array();
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
-		$auth_service = Mockery::mock( JwtAuthService::class );
-		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
-		$auth_provider = Mockery::mock( AuthServiceProvider::class );
-		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
-		$session_handler = Mockery::mock( AgenticSessionHandler::class );
-		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
-		$response_factory = Mockery::mock( ResponseFactory::class );
-
-		// Mock auth provider to return auth service.
-		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
+		$mocks            = $this->create_mocks();
+		$session_handler  = $mocks['session_handler'];
+		$response_factory = $mocks['response_factory'];
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
-		// Mock load existing cart
-		$session_handler->shouldReceive( 'load_cart_session' )
-			->once()
+		// Mock load existing cart.
+		$session_handler->allows( 'load_cart_session' )
 			->with( $cart_id )
 			->andReturn(
 				array(
@@ -269,7 +125,7 @@ class ReplaceCartEndpointTest extends TestCase {
 				)
 			);
 
-		// Verify that update receives completely new data (full replacement)
+		// Verify that update receives completely new data (full replacement).
 		$session_handler->shouldReceive( 'update_cart_session' )
 			->once()
 			->withArgs( function ( $received_cart_id, $new_cart ) use ( $cart_id ) {
@@ -279,7 +135,7 @@ class ReplaceCartEndpointTest extends TestCase {
 
 				$cart_array = $new_cart->to_array();
 
-				// Should have NEW item only (not old)
+				// Should have NEW item only (not old).
 				if ( count( $cart_array['items'] ) !== 1 ) {
 					return false;
 				}
@@ -288,7 +144,7 @@ class ReplaceCartEndpointTest extends TestCase {
 					return false;
 				}
 
-				// Should have NEW shipping info
+				// Should have NEW shipping info.
 				if ( $cart_array['shipping']['name']['full_name'] !== 'New Name' ) {
 					return false;
 				}
@@ -301,13 +157,11 @@ class ReplaceCartEndpointTest extends TestCase {
 			} )
 			->andReturn( true );
 
-		// Mock response factory
-		$replacement_cart = PayPalCart::from_array( $replacement_cart_data );
-		$response_factory->shouldReceive( 'from_cart' )
-			->once()
+		// Mock response factory.
+		$response_factory->allows( 'from_cart' )
 			->andReturnUsing( fn( $cart ) => new CartResponse( $cart ) );
 
-		$endpoint = new ReplaceCartEndpoint( $auth_provider, $session_handler, $response_factory );
+		$endpoint = new ReplaceCartEndpoint( $mocks['auth_provider'], $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -323,55 +177,21 @@ class ReplaceCartEndpointTest extends TestCase {
 		$ec_token     = 'EC-12345TOKEN';
 		$created_time = time();
 
-		$existing_cart_data = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'OLD-ITEM-001',
-					'quantity' => 1,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '25.00',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-		);
+		$existing_cart_data = $this->cart()
+			->with_item_fixture( 'old_item' )
+			->to_array();
 
-		$replacement_data = array(
-			'items'          => array(
-				array(
-					'item_id'  => 'NEW-ITEM-002',
-					'quantity' => 3,
-					'price'    => array(
-						'currency_code' => 'USD',
-						'value'         => '50.00',
-					),
-				),
-			),
-			'payment_method' => array(
-				'type' => 'paypal',
-			),
-		);
+		$replacement_data = $this->cart()
+			->with_item_fixture( 'new_item_2' )
+			->to_array();
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
-		$auth_service = Mockery::mock( JwtAuthService::class );
-		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
-		$auth_provider = Mockery::mock( AuthServiceProvider::class );
-		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
-		$session_handler = Mockery::mock( AgenticSessionHandler::class );
-		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
-		$response_factory = Mockery::mock( ResponseFactory::class );
-
-		// Mock auth provider to return auth service.
-		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
+		$mocks           = $this->create_mocks();
+		$session_handler = $mocks['session_handler'];
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
-		// Mock load existing cart
-		$session_handler->shouldReceive( 'load_cart_session' )
-			->once()
+		// Mock load existing cart.
+		$session_handler->allows( 'load_cart_session' )
 			->with( $cart_id )
 			->andReturn(
 				array(
@@ -381,12 +201,11 @@ class ReplaceCartEndpointTest extends TestCase {
 				)
 			);
 
-		// Mock replacement operation fails
-		$session_handler->shouldReceive( 'update_cart_session' )
-			->once()
+		// Mock replacement operation fails.
+		$session_handler->allows( 'update_cart_session' )
 			->andReturn( false );
 
-		$endpoint = new ReplaceCartEndpoint( $auth_provider, $session_handler, $response_factory );
+		$endpoint = new ReplaceCartEndpoint( $mocks['auth_provider'], $session_handler, $mocks['response_factory'] );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -396,16 +215,7 @@ class ReplaceCartEndpointTest extends TestCase {
 		$data     = $response->get_data();
 
 		$this->assertIsArray( $data );
-
-		// Error responses should not have 200 status
 		$this->assertNotSame( 200, $response->get_status() );
-
-		// The response should have error information
-		$has_error_info = isset( $data['validation_issues'] )
-			|| isset( $data['error'] )
-			|| isset( $data['message'] )
-			|| isset( $data['issues'] );
-
-		$this->assertTrue( $has_error_info, 'Response should contain error information. Got: ' . json_encode( $data ) );
+		$this->assert_error_response( $data );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/ReplaceCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/ReplaceCartEndpointTest.php
@@ -11,6 +11,7 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
 use WP_REST_Request;
 use Mockery;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint\ReplaceCartEndpoint
@@ -62,12 +63,17 @@ class ReplaceCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
@@ -86,7 +92,7 @@ class ReplaceCartEndpointTest extends TestCase {
 		// Mock replacement operation
 		$session_handler->shouldReceive( 'update_cart_session' )
 			->once()
-			->withArgs( function( $received_cart_id, $new_cart ) use ( $cart_id ) {
+			->withArgs( function ( $received_cart_id, $new_cart ) use ( $cart_id ) {
 				return $received_cart_id === $cart_id && $new_cart instanceof PayPalCart;
 			} )
 			->andReturn( true );
@@ -95,12 +101,12 @@ class ReplaceCartEndpointTest extends TestCase {
 		$replacement_cart = PayPalCart::from_array( $replacement_cart_data );
 		$response_factory->shouldReceive( 'from_cart' )
 			->once()
-			->withArgs( function( $cart ) {
+			->withArgs( function ( $cart ) {
 				return $cart instanceof PayPalCart;
 			} )
 			->andReturnUsing( fn( $cart ) => new CartResponse( $cart ) );
 
-		$endpoint = new ReplaceCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new ReplaceCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -133,12 +139,17 @@ class ReplaceCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		// Mock session handler - return null for non-existent cart
 		$session_handler->shouldReceive( 'load_cart_session' )
@@ -146,7 +157,7 @@ class ReplaceCartEndpointTest extends TestCase {
 			->with( $cart_id )
 			->andReturn( null );
 
-		$endpoint = new ReplaceCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new ReplaceCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -232,12 +243,17 @@ class ReplaceCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
@@ -256,7 +272,7 @@ class ReplaceCartEndpointTest extends TestCase {
 		// Verify that update receives completely new data (full replacement)
 		$session_handler->shouldReceive( 'update_cart_session' )
 			->once()
-			->withArgs( function( $received_cart_id, $new_cart ) use ( $cart_id ) {
+			->withArgs( function ( $received_cart_id, $new_cart ) use ( $cart_id ) {
 				if ( $received_cart_id !== $cart_id || ! ( $new_cart instanceof PayPalCart ) ) {
 					return false;
 				}
@@ -291,7 +307,7 @@ class ReplaceCartEndpointTest extends TestCase {
 			->once()
 			->andReturnUsing( fn( $cart ) => new CartResponse( $cart ) );
 
-		$endpoint = new ReplaceCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new ReplaceCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -339,12 +355,17 @@ class ReplaceCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
@@ -365,7 +386,7 @@ class ReplaceCartEndpointTest extends TestCase {
 			->once()
 			->andReturn( false );
 
-		$endpoint = new ReplaceCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new ReplaceCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/UpdateCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/UpdateCartEndpointTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\JwtAuthService;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Response\NewCartResponse;
@@ -51,12 +52,17 @@ class UpdateCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
@@ -109,7 +115,7 @@ class UpdateCartEndpointTest extends TestCase {
 				'ACTIVE'
 			) );
 
-		$endpoint = new UpdateCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new UpdateCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -139,12 +145,17 @@ class UpdateCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		// Mock session handler - return null for non-existent cart
 		$session_handler->shouldReceive( 'load_cart_session' )
@@ -152,7 +163,7 @@ class UpdateCartEndpointTest extends TestCase {
 			->with( $cart_id )
 			->andReturn( null );
 
-		$endpoint = new UpdateCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new UpdateCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -209,12 +220,17 @@ class UpdateCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
@@ -238,7 +254,7 @@ class UpdateCartEndpointTest extends TestCase {
 			} )
 			->andReturn( false );
 
-		$endpoint = new UpdateCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new UpdateCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -295,12 +311,17 @@ class UpdateCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
@@ -330,7 +351,7 @@ class UpdateCartEndpointTest extends TestCase {
 			->with( $cart_id )
 			->andReturn( null );
 
-		$endpoint = new UpdateCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new UpdateCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );
@@ -401,12 +422,17 @@ class UpdateCartEndpointTest extends TestCase {
 			),
 		);
 
-		/** @var JwtAuthService&\Mockery\MockInterface $auth */
-		$auth = Mockery::mock( JwtAuthService::class );
+		/** @var JwtAuthService&\Mockery\MockInterface $auth_service */
+		$auth_service = Mockery::mock( JwtAuthService::class );
+		/** @var AuthServiceProvider&\Mockery\MockInterface $auth_provider */
+		$auth_provider = Mockery::mock( AuthServiceProvider::class );
 		/** @var AgenticSessionHandler&\Mockery\MockInterface $session_handler */
 		$session_handler = Mockery::mock( AgenticSessionHandler::class );
 		/** @var ResponseFactory&\Mockery\MockInterface $response_factory */
 		$response_factory = Mockery::mock( ResponseFactory::class );
+
+		// Mock auth provider to return auth service.
+		$auth_provider->allows( 'auth_service' )->andReturn( $auth_service );
 
 		$existing_cart = PayPalCart::from_array( $existing_cart_data );
 
@@ -471,7 +497,7 @@ class UpdateCartEndpointTest extends TestCase {
 				'ACTIVE'
 			) );
 
-		$endpoint = new UpdateCartEndpoint( $auth, $session_handler, $response_factory );
+		$endpoint = new UpdateCartEndpoint( $auth_provider, $session_handler, $response_factory );
 
 		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
 		$request->set_param( 'cart_id', $cart_id );


### PR DESCRIPTION
### Description

Completes JWT authentication layer for Agentic Commerce endpoints with business rule validation and sandbox development support.

**Authentication Flow:**
- `verify_claims()` validates issuer (`paypal.com`), required scopes, and merchant ID matching
- `AuthServiceProvider` dynamically selects authentication service based on environment
- `SandboxAuthService` enables local development with expired/shared test tokens

**Sandbox Mode:**
Automatically bypasses signature verification, expiration checks, and merchant ID validation when connected to PayPal sandbox. Re-enable full authentication with `define('PPCP_AGENTIC_FULL_AUTH', true)`.

**Documentation:**
Added [comprehensive JWT authentication guide](https://github.com/woocommerce/woocommerce-paypal-payments/blob/43f188c17ff8b04110cb5d9f014c6eeeb754ae96/modules/ppcp-agentic-commerce/docs/authentication-via-jwt.md) with comparison tables showing validation differences between production and sandbox modes:
