### PR TITLE
Prevent APM Methods to show in the UI when not eligible (5466)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/services.php
+++ b/modules/ppcp-local-alternative-payment-methods/services.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
 
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\LocalApmProductStatus;
 
 return array(
 	'ppcp-local-apms.url'                       => static function ( ContainerInterface $container ): string {
@@ -218,5 +218,14 @@ return array(
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'ppcp-local-apms.multibanco.wc-gateway' )
 		);
+	},
+	'ppcp-local-apms.eligibility.check'         => static function ( ContainerInterface $container ): bool {
+		$general_settings = $container->get( 'settings.data.general' );
+		assert( $general_settings instanceof GeneralSettings );
+
+		$merchant_data    = $general_settings->get_merchant_data();
+		$merchant_country = $merchant_data->merchant_country;
+		$ineligible_countries = array( 'RU', 'BR', 'JP' );
+		return ! in_array( $merchant_country, $ineligible_countries, true );
 	},
 );

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -656,10 +656,7 @@ $services = array(
 		assert( $messages_apply instanceof MessagesApply );
 		$pay_later_eligible = $messages_apply->for_country();
 
-		// TODO: Variable "merchant_country" contains "shop-country". Which is correct?
-		$merchant_country     = $container->get( 'api.shop.country' );
-		$ineligible_countries = array( 'RU', 'BR', 'JP' );
-		$apm_eligible         = ! in_array( $merchant_country, $ineligible_countries, true );
+		$apm_eligible = $container->get( 'ppcp-local-apms.eligibility.check' );
 
 		return new FeaturesEligibilityService(
 			$container->get( 'save-payment-methods.eligible' ), // Save PayPal and Venmo eligibility.
@@ -672,6 +669,7 @@ $services = array(
 			$apm_eligible  // Pay with Crypto eligibility.
 		);
 	},
+
 	'settings.service.todos_sorting'                      => static function ( ContainerInterface $container ): TodosSortingAndFilteringService {
 		return new TodosSortingAndFilteringService(
 			$container->get( 'settings.data.todos' )

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -500,6 +500,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					unset( $payment_methods[ PWCGateway::ID ] );
 				}
 
+				$this->unset_apm_payment_methods_when_not_eligible( $container, $payment_methods );
+
 				return $payment_methods;
 			}
 		);
@@ -913,5 +915,22 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$gateway_enabled  = $gateway_settings['enabled'] ?? false;
 
 		return $gateway_enabled === 'yes';
+	}
+
+	protected function unset_apm_payment_methods_when_not_eligible( ContainerInterface $container, array &$payment_methods ): void {
+		$apm_eligible = $container->get( 'ppcp-local-apms.eligibility.check' );
+
+		if ( $apm_eligible ) {
+			return;
+		}
+
+		$apm_payment_methods     = $container->get( 'ppcp-local-apms.payment-methods' );
+		$apm_payment_methods_ids = array_column( $apm_payment_methods, 'id' );
+
+		foreach ( $payment_methods as $id => $payment_method ) {
+			if ( in_array( $id, $apm_payment_methods_ids, true ) ) {
+				unset( $payment_methods[ $id ] );
+			}
+		}
 	}
 }

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -500,7 +500,11 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					unset( $payment_methods[ PWCGateway::ID ] );
 				}
 
-				$this->unset_apm_payment_methods_when_not_eligible( $container, $payment_methods );
+				$apm_eligible = $container->get( 'ppcp-local-apms.eligibility.check' );
+				if ( ! $apm_eligible ) {
+					$apm_payment_methods_ids = array_column( $container->get( 'ppcp-local-apms.payment-methods' ), 'id' );
+					$payment_methods         = array_diff_key( $payment_methods, array_flip( $apm_payment_methods_ids ) );
+				}
 
 				return $payment_methods;
 			}
@@ -915,22 +919,5 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$gateway_enabled  = $gateway_settings['enabled'] ?? false;
 
 		return $gateway_enabled === 'yes';
-	}
-
-	protected function unset_apm_payment_methods_when_not_eligible( ContainerInterface $container, array &$payment_methods ): void {
-		$apm_eligible = $container->get( 'ppcp-local-apms.eligibility.check' );
-
-		if ( $apm_eligible ) {
-			return;
-		}
-
-		$apm_payment_methods     = $container->get( 'ppcp-local-apms.payment-methods' );
-		$apm_payment_methods_ids = array_column( $apm_payment_methods, 'id' );
-
-		foreach ( $payment_methods as $id => $payment_method ) {
-			if ( in_array( $id, $apm_payment_methods_ids, true ) ) {
-				unset( $payment_methods[ $id ] );
-			}
-		}
 	}
 }

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -500,10 +500,13 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					unset( $payment_methods[ PWCGateway::ID ] );
 				}
 
+				// Unset all AMP methods when the merchant is not eligible.
 				$apm_eligible = $container->get( 'ppcp-local-apms.eligibility.check' );
 				if ( ! $apm_eligible ) {
-					$apm_payment_methods_ids = array_column( $container->get( 'ppcp-local-apms.payment-methods' ), 'id' );
-					$payment_methods         = array_diff_key( $payment_methods, array_flip( $apm_payment_methods_ids ) );
+					$payment_methods = array_diff_key(
+						$payment_methods,
+						array_column( $container->get( 'ppcp-local-apms.payment-methods' ), 'id', 'id' )
+					);
 				}
 
 				return $payment_methods;


### PR DESCRIPTION
### Description

- Add a new static function in service.php to check eligibility for APM based on Merchant country
- Use that check to hide or show APM Gateway methods

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Set USA merchant in PayPal 
2. Feature APM is available
3. APM Methods are available and visible in UI
4.  Set Brazil, Rusia or Japan merchant in PayPal 
5. Feature APM is NOT available
6. APM Methods are not available nor visible in UI

