### PR TITLE
Add missing offboarding scenarios (5549)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -10,6 +10,7 @@ namespace WooCommerce\PayPalCommerce;
 use WooCommerce\PayPalCommerce\PayLaterBlock\PayLaterBlockModule;
 use WooCommerce\PayPalCommerce\PayLaterWCBlocks\PayLaterWCBlocksModule;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\PayLaterConfiguratorModule;
+use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 
 return static function ( string $root_dir ): iterable {
 	$modules_dir = "$root_dir/modules";
@@ -86,10 +87,12 @@ return static function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-axo-block/module.php" )();
 	}
 
-	if ( apply_filters(
-		'woocommerce.feature-flags.woocommerce_paypal_payments.agentic_commerce_enabled',
-		getenv( 'PCP_AGENTIC_COMMERCE_ENABLED' ) === '1'
-	) ) {
+	if ( ! SettingsModule::should_use_the_old_ui()
+		&& apply_filters(
+			'woocommerce.feature-flags.woocommerce_paypal_payments.agentic_commerce_enabled',
+			getenv( 'PCP_AGENTIC_COMMERCE_ENABLED' ) === '1'
+		)
+	) {
 		$modules[] = ( require "$modules_dir/ppcp-agentic-commerce/module.php" )();
 	}
 

--- a/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
+++ b/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
@@ -65,8 +65,8 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 		assert( $settings_module instanceof AgenticSettingsModule );
 		$settings_module->init();
 
-		// Uninstall logic always registered.
-		$this->add_uninstall_action( $registration_handler );
+		// Always register cleanup logic.
+		$this->add_cleanup_actions( $registration_handler );
 
 		// Sync eligibility cache on init (when WC is available).
 		$this->sync_eligibility_cache( $agentic_settings, $eligibility_check );
@@ -110,9 +110,22 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 	}
 
 	/**
-	 * Intentionally a separate method to make uninstall logic stand out.
+	 * Intentionally a separate method to make global cleanup logic stand out.
 	 */
-	private function add_uninstall_action( RegistrationService $registration_service ): void {
+	private function add_cleanup_actions( RegistrationService $registration_service ): void {
+		// Disconnect merchant via settings UI (change merchant ID).
+		add_action(
+			'woocommerce_paypal_payments_merchant_disconnected',
+			static fn() => $registration_service->deregister()
+		);
+
+		// Plugin is deactivated.
+		add_action(
+			'woocommerce_paypal_payments_gateway_deactivate',
+			static fn() => $registration_service->deregister()
+		);
+
+		// Plugin is uninstalled.
 		add_action(
 			'woocommerce_paypal_payments_uninstall',
 			static fn() => $registration_service->deregister()

--- a/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
+++ b/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
@@ -60,13 +60,16 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 		$eligibility_check = $container->get( 'agentic.registration.eligibility' );
 		assert( $eligibility_check instanceof RegistrationEligibility );
 
+		$ingestion_manager = $container->get( 'agentic.ingestion-manager' );
+		assert( $ingestion_manager instanceof IngestionManager );
+
 		// Settings extension always available (merchants need to see the toggle).
 		$settings_module = $container->get( 'agentic.settings.module' );
 		assert( $settings_module instanceof AgenticSettingsModule );
 		$settings_module->init();
 
 		// Always register cleanup logic.
-		$this->add_cleanup_actions( $registration_handler );
+		$this->add_cleanup_actions( $registration_handler, $ingestion_manager );
 
 		// Sync eligibility cache on init (when WC is available).
 		$this->sync_eligibility_cache( $agentic_settings, $eligibility_check );
@@ -97,14 +100,7 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 		);
 
 		// Product ingestion.
-		add_action(
-			'init',
-			static function () use ( $container ) {
-				$ingestion_manager = $container->get( 'agentic.ingestion-manager' );
-				assert( $ingestion_manager instanceof IngestionManager );
-				$ingestion_manager->init();
-			}
-		);
+		add_action( 'init', static fn() => $ingestion_manager->init() );
 
 		return true;
 	}
@@ -112,7 +108,13 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 	/**
 	 * Intentionally a separate method to make global cleanup logic stand out.
 	 */
-	private function add_cleanup_actions( RegistrationService $registration_service ): void {
+	private function add_cleanup_actions( RegistrationService $registration_service, IngestionManager $ingestion_manager ): void {
+		// Handle plugin cleanup and remove scheduled task.
+		add_action(
+			'woocommerce_paypal_payments_agentic_commerce_deregistered',
+			static fn() => $ingestion_manager->clear_recurring_schedule()
+		);
+
 		// Disconnect merchant via settings UI (change merchant ID).
 		add_action(
 			'woocommerce_paypal_payments_merchant_disconnected',

--- a/modules/ppcp-agentic-commerce/src/Ingestion/IngestionManager.php
+++ b/modules/ppcp-agentic-commerce/src/Ingestion/IngestionManager.php
@@ -75,6 +75,19 @@ class IngestionManager {
 	}
 
 	/**
+	 * Unschedules the recurring action when the store is unregistered.
+	 *
+	 * @return void
+	 */
+	public function clear_recurring_schedule(): void {
+		if ( ! as_next_scheduled_action( 'ppcp_agentic_sync_batch' ) ) {
+			return;
+		}
+
+		as_unschedule_action( 'ppcp_agentic_sync_batch', array(), 'ppcp_agentic_sync' );
+	}
+
+	/**
 	 * Process the next batch of products for sync.
 	 *
 	 * @throws \Exception When an error occurs during sync.

--- a/modules/ppcp-agentic-commerce/src/Merchant/MerchantMetadata.php
+++ b/modules/ppcp-agentic-commerce/src/Merchant/MerchantMetadata.php
@@ -16,7 +16,7 @@ class MerchantMetadata {
 	public string $store_name;
 
 	/**
-	 * Store URL (canonical, without trailing slash).
+	 * Store URL (canonical, without a trailing slash).
 	 *
 	 * CRITICAL: This serves as the stable identifier for this merchant.
 	 *
@@ -29,7 +29,14 @@ class MerchantMetadata {
 	 *
 	 * @var string
 	 */
-	public string $country;
+	public string $store_country;
+
+	/**
+	 * Country of the PayPal merchant (ISO 3166-1 alpha-2).
+	 *
+	 * @var string
+	 */
+	public string $merchant_country;
 
 	/**
 	 * Base currency code (ISO 4217).
@@ -57,24 +64,27 @@ class MerchantMetadata {
 	 *
 	 * @param string $store_name         Store name.
 	 * @param string $store_url          Store URL (canonical identifier).
-	 * @param string $country            Base country code.
+	 * @param string $store_country      Base country code.
 	 * @param string $currency           Base currency code.
 	 * @param string $paypal_merchant_id PayPal merchant ID.
 	 * @param string $catalog_url        Catalog URL.
+	 * @param string $merchant_country   Merchant country code.
 	 */
 	public function __construct(
 		string $store_name,
 		string $store_url,
-		string $country,
+		string $store_country,
 		string $currency,
 		string $paypal_merchant_id,
-		string $catalog_url
+		string $catalog_url,
+		string $merchant_country
 	) {
 		$this->store_name         = $store_name;
 		$this->store_url          = $store_url;
-		$this->country            = $country;
+		$this->store_country      = $store_country;
 		$this->currency           = $currency;
 		$this->paypal_merchant_id = $paypal_merchant_id;
 		$this->catalog_url        = $catalog_url;
+		$this->merchant_country   = $merchant_country;
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Merchant/MerchantMetadataProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Merchant/MerchantMetadataProvider.php
@@ -24,14 +24,19 @@ class MerchantMetadataProvider {
 	 * Get current merchant metadata.
 	 */
 	public function get_metadata(): MerchantMetadata {
-		$merchant = $this->get_merchant_connection();
+		$merchant    = $this->get_merchant_connection();
+		$merchant_id = '';
+
+		if ( $this->general_settings->is_merchant_connected() ) {
+			$merchant_id = $merchant->merchant_id;
+		}
 
 		return new MerchantMetadata(
 			get_bloginfo( 'name' ),
 			$this->get_canonical_store_url(),
 			WC()->countries->get_base_country(),
 			get_woocommerce_currency(),
-			$merchant->merchant_id,
+			$merchant_id,
 			$this->get_canonical_store_url()
 		);
 	}

--- a/modules/ppcp-agentic-commerce/src/Merchant/MerchantMetadataProvider.php
+++ b/modules/ppcp-agentic-commerce/src/Merchant/MerchantMetadataProvider.php
@@ -37,7 +37,8 @@ class MerchantMetadataProvider {
 			WC()->countries->get_base_country(),
 			get_woocommerce_currency(),
 			$merchant_id,
-			$this->get_canonical_store_url()
+			$this->get_canonical_store_url(),
+			$merchant->merchant_country
 		);
 	}
 

--- a/modules/ppcp-agentic-commerce/src/Registration/RegistrationEligibility.php
+++ b/modules/ppcp-agentic-commerce/src/Registration/RegistrationEligibility.php
@@ -20,8 +20,9 @@ class RegistrationEligibility {
 			return false;
 		}
 
-		$country = strtoupper( trim( $merchant->country ) );
+		$store_country    = strtoupper( trim( $merchant->store_country ) );
+		$merchant_country = strtoupper( trim( $merchant->merchant_country ) );
 
-		return 'US' === $country;
+		return 'US' === $store_country && 'US' === $merchant_country;
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Registration/RegistrationEligibility.php
+++ b/modules/ppcp-agentic-commerce/src/Registration/RegistrationEligibility.php
@@ -15,7 +15,12 @@ class RegistrationEligibility {
 
 	public function is_eligible(): bool {
 		$merchant = $this->metadata_provider->get_metadata();
-		$country  = strtoupper( trim( $merchant->country ) );
+
+		if ( ! $merchant->paypal_merchant_id ) {
+			return false;
+		}
+
+		$country = strtoupper( trim( $merchant->country ) );
 
 		return 'US' === $country;
 	}

--- a/modules/ppcp-agentic-commerce/src/Registration/RegistrationService.php
+++ b/modules/ppcp-agentic-commerce/src/Registration/RegistrationService.php
@@ -55,6 +55,8 @@ class RegistrationService {
 
 		if ( $result->success ) {
 			$this->save_registration_token( $token );
+
+			do_action( 'woocommerce_paypal_payments_agentic_commerce_registered' );
 		} else {
 			$this->delete_registration_token();
 
@@ -91,6 +93,8 @@ class RegistrationService {
 				$result->error ?? 'Deregistration failed'
 			);
 		}
+
+		do_action( 'woocommerce_paypal_payments_agentic_commerce_deregistered' );
 
 		return $result;
 	}

--- a/modules/ppcp-agentic-commerce/src/Registration/RegistrationService.php
+++ b/modules/ppcp-agentic-commerce/src/Registration/RegistrationService.php
@@ -120,7 +120,7 @@ class RegistrationService {
 		$payload = array(
 			'storeName'          => $metadata->store_name,
 			'storeUrl'           => $metadata->store_url,
-			'country'            => $metadata->country,
+			'country'            => $metadata->store_country,
 			'currency'           => $metadata->currency,
 			'paypalMerchantId'   => $metadata->paypal_merchant_id,
 			'wooMerchantId'      => $metadata->store_url,

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1593,10 +1593,26 @@ return array(
 		);
 	},
 	'wcgateway.logging.is-enabled'                         => static function ( ContainerInterface $container ): bool {
-		$settings = $container->get( 'wcgateway.settings' );
-
-		// Check if logging was enabled in plugin settings.
-		$is_enabled = $settings->has( 'logging_enabled' ) && $settings->get( 'logging_enabled' );
+		/**
+		 * Check if logging was enabled in plugin settings.
+		 *
+		 * We have different logic for the legacy/new UI, as the legacy Settings instance uses
+		 * translation functions too early, and cause a _load_textdomain_just_in_time warning.
+		 * This prevents us from creating a logger instance before the 'init' hook.
+		 *
+		 * The SettingsModel (new UI) does not depend on translations, and allows accessing the
+		 * 'woocommerce.logger.woocommerce' service already during module `::run()` methods.
+		 */
+		if ( SettingsModule::should_use_the_old_ui() ) {
+			// Note: Legacy UI, works after 'init' hook.
+			$settings   = $container->get( 'wcgateway.settings' );
+			$is_enabled = $settings->has( 'logging_enabled' ) && $settings->get( 'logging_enabled' );
+		} else {
+			// Note: New UI, works instantly.
+			$settings = $container->get( 'settings.data.settings' );
+			assert( $settings instanceof SettingsModel );
+			$is_enabled = $settings->get_enable_logging();
+		}
 
 		// If not enabled, check if plugin is in onboarding mode.
 		if ( ! $is_enabled ) {

--- a/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Auth/JwtAuthServiceTest.php
@@ -52,7 +52,8 @@ class JwtAuthServiceTest extends TestCase {
 			'US',
 			'USD',
 			$merchant_id,
-			'https://example.com'
+			'https://example.com',
+			'CA'
 		);
 	}
 

--- a/tests/PHPUnit/AgenticCommerce/Merchant/MerchantMetadataProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Merchant/MerchantMetadataProviderTest.php
@@ -20,41 +20,18 @@ class MerchantMetadataProviderTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->general_settings = Mockery::mock( GeneralSettings::class );
+		$this->general_settings = $this->createStub( GeneralSettings::class );
 		$this->testee           = new MerchantMetadataProvider( $this->general_settings );
 	}
 
-	public function test_get_metadata_returns_complete_merchant_metadata(): void {
-		$merchant_connection = new MerchantConnectionDTO(
-			true,
-			'API_USER123',
-			'API_KEY123',
-			'MERCHANT123',
-			'test@example.com',
-			'CA'
-		);
-
-		$this->general_settings->allows( 'get_merchant_data' )
-			->andReturn( $merchant_connection );
-		$this->general_settings->allows( 'is_merchant_connected' )
-			->andReturn( true );
-
-		when( 'get_bloginfo' )->justReturn( 'Test Store' );
-		when( 'get_site_url' )->justReturn( 'https://example.com' );
-		when( 'untrailingslashit' )->returnArg();
-		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
-
-		$wc_countries = Mockery::mock( 'overload:WC_Countries' );
-		$wc_countries->allows( 'get_base_country' )->andReturn( 'US' );
-
-		when( 'WC' )->alias(
-			function () use ( $wc_countries ) {
-				$wc            = new \stdClass();
-				$wc->countries = $wc_countries;
-
-				return $wc;
-			}
-		);
+	/**
+	 * GIVEN a connected merchant with complete store information
+	 * WHEN metadata is requested
+	 * THEN all merchant and store metadata is populated correctly
+	 */
+	public function test_get_metadata_returns_complete_merchant_metadata_when_merchant_connected(): void {
+		$this->setup_connected_merchant( 'CA' );
+		$this->setup_store_metadata( 'Test Store', 'https://example.com', 'USD', 'US' );
 
 		$metadata = $this->testee->get_metadata();
 
@@ -68,32 +45,169 @@ class MerchantMetadataProviderTest extends TestCase {
 		$this->assertSame( 'CA', $metadata->merchant_country );
 	}
 
-	public function test_canonical_url_removes_trailing_slash(): void {
+	/**
+	 * GIVEN a merchant that is not connected to PayPal
+	 * WHEN metadata is requested
+	 * THEN store metadata is populated, but PayPal merchant ID is empty
+	 */
+	public function test_get_metadata_returns_empty_merchant_id_when_merchant_not_connected(): void {
+		$this->setup_disconnected_merchant( 'US' );
+		$this->setup_store_metadata( 'Disconnected Store', 'https://disconnected.com', 'EUR', 'DE' );
+
+		$metadata = $this->testee->get_metadata();
+
+		$this->assertSame( 'Disconnected Store', $metadata->store_name );
+		$this->assertSame( '', $metadata->paypal_merchant_id );
+		$this->assertSame( 'DE', $metadata->store_country );
+		$this->assertSame( 'EUR', $metadata->currency );
+		$this->assertSame( 'US', $metadata->merchant_country );
+	}
+
+	/**
+	 * GIVEN a site URL with a trailing slash
+	 * WHEN metadata is requested
+	 * THEN the trailing slash is removed from store_url and catalog_url to create canonical URLs
+	 * AND both URLs are identical
+	 *
+	 * @dataProvider trailing_slash_provider
+	 */
+	public function test_get_metadata_normalizes_urls_by_removing_trailing_slash(
+		string $site_url,
+		string $expected_url
+	): void {
+		$this->setup_connected_merchant( 'US' );
+		$this->setup_store_metadata( 'Store', $site_url, 'USD', 'US' );
+
+		$metadata = $this->testee->get_metadata();
+
+		$this->assertSame( $expected_url, $metadata->store_url );
+		$this->assertSame( $expected_url, $metadata->catalog_url );
+		$this->assertSame( $metadata->store_url, $metadata->catalog_url, 'store_url and catalog_url must be identical' );
+	}
+
+	public function trailing_slash_provider(): array {
+		return [
+			'url with trailing slash' => [
+				'site_url'     => 'https://example.com/',
+				'expected_url' => 'https://example.com',
+			],
+			'url without trailing slash' => [
+				'site_url'     => 'https://example.com',
+				'expected_url' => 'https://example.com',
+			],
+			'url with multiple trailing slashes' => [
+				'site_url'     => 'https://example.com///',
+				'expected_url' => 'https://example.com',
+			],
+		];
+	}
+
+	/**
+	 * GIVEN merchants from different countries with different store configurations
+	 * WHEN metadata is requested
+	 * THEN the correct country codes and currencies are populated
+	 * AND merchant_country differs from store_country when PayPal account is in a different country
+	 *
+	 * @dataProvider merchant_configuration_provider
+	 */
+	public function test_get_metadata_handles_different_merchant_and_store_countries(
+		string $merchant_country,
+		string $store_country,
+		string $currency
+	): void {
+		$this->setup_connected_merchant( $merchant_country );
+		$this->setup_store_metadata( 'Global Store', 'https://store.example', $currency, $store_country );
+
+		$metadata = $this->testee->get_metadata();
+
+		$this->assertSame( $merchant_country, $metadata->merchant_country );
+		$this->assertSame( $store_country, $metadata->store_country );
+		$this->assertSame( $currency, $metadata->currency );
+	}
+
+	public function merchant_configuration_provider(): array {
+		return [
+			'US merchant with Canadian store' => [
+				'merchant_country' => 'US',
+				'store_country'    => 'CA',
+				'currency'         => 'CAD',
+			],
+			'Canadian merchant with US store' => [
+				'merchant_country' => 'CA',
+				'store_country'    => 'US',
+				'currency'         => 'USD',
+			],
+			'UK merchant with UK store' => [
+				'merchant_country' => 'GB',
+				'store_country'    => 'GB',
+				'currency'         => 'GBP',
+			],
+			'German merchant with EU store' => [
+				'merchant_country' => 'DE',
+				'store_country'    => 'DE',
+				'currency'         => 'EUR',
+			],
+		];
+	}
+
+	/**
+	 * Sets up a connected merchant with the given country.
+	 */
+	private function setup_connected_merchant( string $merchant_country ): void {
 		$merchant_connection = new MerchantConnectionDTO(
 			true,
 			'API_USER123',
 			'API_KEY123',
 			'MERCHANT123',
 			'test@example.com',
-			'US'
+			$merchant_country
 		);
 
-		$this->general_settings->allows( 'get_merchant_data' )
-			->andReturn( $merchant_connection );
-		$this->general_settings->allows( 'is_merchant_connected' )
-			->andReturn( true );
+		$this->general_settings->method( 'get_merchant_data' )
+			->willReturn( $merchant_connection );
+		$this->general_settings->method( 'is_merchant_connected' )
+			->willReturn( true );
+	}
 
-		when( 'get_bloginfo' )->justReturn( 'Store' );
-		when( 'get_site_url' )->justReturn( 'https://example.com/' );
+	/**
+	 * Sets up a disconnected merchant with the given country.
+	 */
+	private function setup_disconnected_merchant( string $merchant_country ): void {
+		$merchant_connection = new MerchantConnectionDTO(
+			false,
+			'',
+			'',
+			'',
+			'',
+			$merchant_country
+		);
+
+		$this->general_settings->method( 'get_merchant_data' )
+			->willReturn( $merchant_connection );
+		$this->general_settings->method( 'is_merchant_connected' )
+			->willReturn( false );
+	}
+
+	/**
+	 * Sets up WordPress and WooCommerce store metadata.
+	 */
+	private function setup_store_metadata(
+		string $store_name,
+		string $site_url,
+		string $currency,
+		string $store_country
+	): void {
+		when( 'get_bloginfo' )->justReturn( $store_name );
+		when( 'get_site_url' )->justReturn( $site_url );
+		when( 'get_woocommerce_currency' )->justReturn( $currency );
 		when( 'untrailingslashit' )->alias(
 			function ( $url ) {
 				return rtrim( $url, '/' );
 			}
 		);
-		when( 'get_woocommerce_currency' )->justReturn( 'EUR' );
 
 		$wc_countries = Mockery::mock( 'overload:WC_Countries' );
-		$wc_countries->allows( 'get_base_country' )->andReturn( 'DE' );
+		$wc_countries->allows( 'get_base_country' )->andReturn( $store_country );
 
 		when( 'WC' )->alias(
 			function () use ( $wc_countries ) {
@@ -103,87 +217,5 @@ class MerchantMetadataProviderTest extends TestCase {
 				return $wc;
 			}
 		);
-
-		$metadata = $this->testee->get_metadata();
-
-		$this->assertSame( 'https://example.com', $metadata->store_url );
-		$this->assertSame( 'https://example.com', $metadata->catalog_url );
-	}
-
-	public function test_store_url_and_catalog_url_are_identical(): void {
-		$merchant_connection = new MerchantConnectionDTO(
-			true,
-			'API_USER123',
-			'API_KEY123',
-			'MERCHANT123',
-			'test@example.com',
-			'US'
-		);
-
-		$this->general_settings->allows( 'get_merchant_data' )
-			->andReturn( $merchant_connection );
-		$this->general_settings->allows( 'is_merchant_connected' )
-			->andReturn( true );
-
-		when( 'get_bloginfo' )->justReturn( 'My Store' );
-		when( 'get_site_url' )->justReturn( 'https://mystore.com' );
-		when( 'untrailingslashit' )->returnArg();
-		when( 'get_woocommerce_currency' )->justReturn( 'GBP' );
-
-		$wc_countries = Mockery::mock( 'overload:WC_Countries' );
-		$wc_countries->allows( 'get_base_country' )->andReturn( 'GB' );
-
-		when( 'WC' )->alias(
-			function () use ( $wc_countries ) {
-				$wc            = new \stdClass();
-				$wc->countries = $wc_countries;
-
-				return $wc;
-			}
-		);
-
-		$metadata = $this->testee->get_metadata();
-
-		$this->assertSame( $metadata->store_url, $metadata->catalog_url );
-	}
-
-	public function test_uses_wordpress_and_woocommerce_functions(): void {
-		$merchant_connection = new MerchantConnectionDTO(
-			true,
-			'API_USER123',
-			'API_KEY123',
-			'MERCHANT123',
-			'test@example.com',
-			'US'
-		);
-
-		$this->general_settings->allows( 'get_merchant_data' )
-			->andReturn( $merchant_connection );
-		$this->general_settings->allows( 'is_merchant_connected' )
-			->andReturn( true );
-
-		when( 'get_bloginfo' )->justReturn( 'WP Store' );
-		when( 'get_site_url' )->justReturn( 'https://wpstore.test' );
-		when( 'untrailingslashit' )->returnArg();
-		when( 'get_woocommerce_currency' )->justReturn( 'CAD' );
-
-		$wc_countries = Mockery::mock( 'overload:WC_Countries' );
-		$wc_countries->allows( 'get_base_country' )->andReturn( 'CA' );
-
-		when( 'WC' )->alias(
-			function () use ( $wc_countries ) {
-				$wc            = new \stdClass();
-				$wc->countries = $wc_countries;
-
-				return $wc;
-			}
-		);
-
-		$metadata = $this->testee->get_metadata();
-
-		$this->assertSame( 'WP Store', $metadata->store_name );
-		$this->assertSame( 'CAD', $metadata->currency );
-		$this->assertSame( 'CA', $metadata->store_country );
-		$this->assertSame( 'US', $metadata->merchant_country );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Merchant/MerchantMetadataProviderTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Merchant/MerchantMetadataProviderTest.php
@@ -30,11 +30,14 @@ class MerchantMetadataProviderTest extends TestCase {
 			'API_USER123',
 			'API_KEY123',
 			'MERCHANT123',
-			'test@example.com'
+			'test@example.com',
+			'CA'
 		);
 
 		$this->general_settings->allows( 'get_merchant_data' )
 			->andReturn( $merchant_connection );
+		$this->general_settings->allows( 'is_merchant_connected' )
+			->andReturn( true );
 
 		when( 'get_bloginfo' )->justReturn( 'Test Store' );
 		when( 'get_site_url' )->justReturn( 'https://example.com' );
@@ -58,10 +61,11 @@ class MerchantMetadataProviderTest extends TestCase {
 		$this->assertInstanceOf( MerchantMetadata::class, $metadata );
 		$this->assertSame( 'Test Store', $metadata->store_name );
 		$this->assertSame( 'https://example.com', $metadata->store_url );
-		$this->assertSame( 'US', $metadata->country );
+		$this->assertSame( 'US', $metadata->store_country );
 		$this->assertSame( 'USD', $metadata->currency );
 		$this->assertSame( 'MERCHANT123', $metadata->paypal_merchant_id );
 		$this->assertSame( 'https://example.com', $metadata->catalog_url );
+		$this->assertSame( 'CA', $metadata->merchant_country );
 	}
 
 	public function test_canonical_url_removes_trailing_slash(): void {
@@ -70,11 +74,14 @@ class MerchantMetadataProviderTest extends TestCase {
 			'API_USER123',
 			'API_KEY123',
 			'MERCHANT123',
-			'test@example.com'
+			'test@example.com',
+			'US'
 		);
 
 		$this->general_settings->allows( 'get_merchant_data' )
 			->andReturn( $merchant_connection );
+		$this->general_settings->allows( 'is_merchant_connected' )
+			->andReturn( true );
 
 		when( 'get_bloginfo' )->justReturn( 'Store' );
 		when( 'get_site_url' )->justReturn( 'https://example.com/' );
@@ -109,11 +116,14 @@ class MerchantMetadataProviderTest extends TestCase {
 			'API_USER123',
 			'API_KEY123',
 			'MERCHANT123',
-			'test@example.com'
+			'test@example.com',
+			'US'
 		);
 
 		$this->general_settings->allows( 'get_merchant_data' )
 			->andReturn( $merchant_connection );
+		$this->general_settings->allows( 'is_merchant_connected' )
+			->andReturn( true );
 
 		when( 'get_bloginfo' )->justReturn( 'My Store' );
 		when( 'get_site_url' )->justReturn( 'https://mystore.com' );
@@ -143,11 +153,14 @@ class MerchantMetadataProviderTest extends TestCase {
 			'API_USER123',
 			'API_KEY123',
 			'MERCHANT123',
-			'test@example.com'
+			'test@example.com',
+			'US'
 		);
 
 		$this->general_settings->allows( 'get_merchant_data' )
 			->andReturn( $merchant_connection );
+		$this->general_settings->allows( 'is_merchant_connected' )
+			->andReturn( true );
 
 		when( 'get_bloginfo' )->justReturn( 'WP Store' );
 		when( 'get_site_url' )->justReturn( 'https://wpstore.test' );
@@ -170,6 +183,7 @@ class MerchantMetadataProviderTest extends TestCase {
 
 		$this->assertSame( 'WP Store', $metadata->store_name );
 		$this->assertSame( 'CAD', $metadata->currency );
-		$this->assertSame( 'CA', $metadata->country );
+		$this->assertSame( 'CA', $metadata->store_country );
+		$this->assertSame( 'US', $metadata->merchant_country );
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Merchant/MerchantMetadataTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Merchant/MerchantMetadataTest.php
@@ -16,26 +16,29 @@ class MerchantMetadataTest extends TestCase {
 	public function test_constructor_sets_all_properties(
 		string $store_name,
 		string $store_url,
-		string $country,
+		string $store_country,
 		string $currency,
 		string $paypal_merchant_id,
-		string $catalog_url
+		string $catalog_url,
+		string $merchant_country
 	): void {
 		$metadata = new MerchantMetadata(
 			$store_name,
 			$store_url,
-			$country,
+			$store_country,
 			$currency,
 			$paypal_merchant_id,
-			$catalog_url
+			$catalog_url,
+			$merchant_country
 		);
 
 		$this->assertSame( $store_name, $metadata->store_name );
 		$this->assertSame( $store_url, $metadata->store_url );
-		$this->assertSame( $country, $metadata->country );
+		$this->assertSame( $store_country, $metadata->store_country );
 		$this->assertSame( $currency, $metadata->currency );
 		$this->assertSame( $paypal_merchant_id, $metadata->paypal_merchant_id );
 		$this->assertSame( $catalog_url, $metadata->catalog_url );
+		$this->assertSame( $merchant_country, $metadata->merchant_country );
 	}
 
 	public function metadata_scenarios_provider(): array {
@@ -47,6 +50,7 @@ class MerchantMetadataTest extends TestCase {
 				'USD',
 				'MERCHANT123',
 				'https://example.com/catalog.json',
+				'US',
 			),
 			'uk_store'           => array(
 				'UK Shop',
@@ -55,8 +59,10 @@ class MerchantMetadataTest extends TestCase {
 				'GBP',
 				'MERCHANT456',
 				'https://shop.example.co.uk/feed',
+				'GB',
 			),
 			'minimal_data'       => array(
+				'',
 				'',
 				'',
 				'',
@@ -71,6 +77,7 @@ class MerchantMetadataTest extends TestCase {
 				'D',
 				'M',
 				'C',
+				'M',
 			),
 		);
 	}

--- a/tests/PHPUnit/AgenticCommerce/Registration/RegistrationEligibilityTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Registration/RegistrationEligibilityTest.php
@@ -26,6 +26,7 @@ class RegistrationEligibilityTest extends TestCase {
 				'',
 				'MERCHANT123',
 				'https://example.com',
+				$store_country
 			) );
 
 		$result = new RegistrationEligibility( $data_provider );

--- a/tests/PHPUnit/AgenticCommerce/Registration/RegistrationServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Registration/RegistrationServiceTest.php
@@ -23,8 +23,8 @@ class RegistrationServiceTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->connection_state  = Mockery::mock( ConnectionState::class );
-		$this->metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
+		$this->connection_state  = $this->createStub( ConnectionState::class );
+		$this->metadata_provider = $this->createStub( MerchantMetadataProvider::class );
 	}
 
 	private function create_testable_service( bool $has_token = false ): TestableRegistrationService {
@@ -35,7 +35,7 @@ class RegistrationServiceTest extends TestCase {
 		);
 	}
 
-	private function stub_metadata(): MerchantMetadata {
+	private function stub_merchant_metadata(): MerchantMetadata {
 		$metadata = new MerchantMetadata(
 			'Test Store',
 			'https://example.com',
@@ -46,13 +46,44 @@ class RegistrationServiceTest extends TestCase {
 			'US'
 		);
 
-		$this->metadata_provider->allows( 'get_metadata' )
-			->andReturn( $metadata );
+		$this->metadata_provider->method( 'get_metadata' )->willReturn( $metadata );
 
 		return $metadata;
 	}
 
-	public function test_is_registered_returns_false_without_token(): void {
+	private function stub_successful_webhook_response(): void {
+		when( 'wp_remote_post' )->returnArg();
+		when( 'is_wp_error' )->justReturn( false );
+		when( 'wp_remote_retrieve_body' )->justReturn(
+			json_encode(
+				array(
+					'success' => true,
+					'message' => 'Operation successful',
+				)
+			)
+		);
+	}
+
+	private function stub_failed_webhook_response( string $error_message ): void {
+		when( 'wp_remote_post' )->returnArg();
+		when( 'is_wp_error' )->justReturn( false );
+		when( 'wp_remote_retrieve_body' )->justReturn(
+			json_encode(
+				array(
+					'success' => false,
+					'message' => 'Operation failed',
+					'error'   => $error_message,
+				)
+			)
+		);
+	}
+
+	/**
+	 * GIVEN a store without a registration token
+	 * WHEN checking registration status
+	 * THEN the store should not be considered registered
+	 */
+	public function test_store_is_not_registered_without_token(): void {
 		$testee = $this->create_testable_service( false );
 
 		$result = $testee->is_registered();
@@ -60,7 +91,12 @@ class RegistrationServiceTest extends TestCase {
 		$this->assertFalse( $result );
 	}
 
-	public function test_is_registered_returns_true_with_token(): void {
+	/**
+	 * GIVEN a store with a valid registration token
+	 * WHEN checking registration status
+	 * THEN the store should be considered registered
+	 */
+	public function test_store_is_registered_with_token(): void {
 		$testee = $this->create_testable_service( true );
 
 		$result = $testee->is_registered();
@@ -68,104 +104,76 @@ class RegistrationServiceTest extends TestCase {
 		$this->assertTrue( $result );
 	}
 
-	public function test_is_registered_returns_true_after_successful_registration(): void {
-		$this->stub_metadata();
-		$this->connection_state->allows( 'is_production' )->andReturn( false );
-
-		when( 'wp_remote_post' )->returnArg();
-		when( 'is_wp_error' )->justReturn( false );
-		when( 'wp_remote_retrieve_body' )->justReturn(
-			json_encode(
-				array(
-					'success' => true,
-					'message' => 'Registration successful',
-				)
-			)
-		);
+	/**
+	 * GIVEN an unregistered store with valid merchant metadata
+	 * WHEN registering with PayPal Agentic Commerce
+	 * AND the webhook returns success
+	 * THEN registration should succeed with valid result
+	 * AND the registration token should be persisted
+	 * AND the store should be marked as registered
+	 */
+	public function test_registration_succeeds_with_valid_merchant_data(): void {
+		$this->stub_merchant_metadata();
+		$this->connection_state->method( 'is_production' )->willReturn( false );
+		$this->stub_successful_webhook_response();
 
 		$testee = $this->create_testable_service( false );
 
 		$this->assertFalse( $testee->is_registered() );
 
-		$testee->register();
+		$result = $testee->register();
 
+		$this->assertInstanceOf( RegistrationResult::class, $result );
+		$this->assertTrue( $result->success );
+		$this->assertTrue( $testee->was_token_saved );
 		$this->assertTrue( $testee->is_registered() );
-	}
-
-	public function test_is_registered_returns_false_after_deregistration(): void {
-		$this->connection_state->allows( 'is_production' )->andReturn( false );
-
-		when( 'wp_remote_post' )->returnArg();
-		when( 'is_wp_error' )->justReturn( false );
-		when( 'wp_remote_retrieve_body' )->justReturn(
-			json_encode(
-				array(
-					'success' => true,
-					'message' => 'Deregistration successful',
-				)
-			)
-		);
-
-		$testee = $this->create_testable_service( true );
-
-		$this->assertTrue( $testee->is_registered() );
-
-		$testee->deregister();
-
-		$this->assertFalse( $testee->is_registered() );
-	}
-
-	public function test_deregister_returns_null_when_not_registered(): void {
-		$testee = $this->create_testable_service( false );
-
-		$result = $testee->deregister();
-
-		$this->assertNull( $result );
 	}
 
 	/**
-	 * @dataProvider registration_outcomes_provider
+	 * GIVEN an unregistered store
+	 * WHEN registering with PayPal Agentic Commerce
+	 * AND the webhook returns a failure response
+	 * THEN registration should fail with error
+	 * AND the registration token should not be saved
 	 */
-	public function test_register_outcomes( bool $success, string $error_code = null ): void {
-		$this->stub_metadata();
-		$this->connection_state->allows( 'is_production' )->andReturn( false );
-
-		when( 'wp_remote_post' )->returnArg();
-		when( 'is_wp_error' )->justReturn( false );
-		when( 'wp_remote_retrieve_body' )->justReturn(
-			json_encode(
-				array(
-					'success' => $success,
-					'message' => $success ? 'Registration successful' : 'Registration failed',
-					'error'   => $success ? null : 'Error details',
-				)
-			)
-		);
+	public function test_registration_fails_when_webhook_returns_error(): void {
+		$this->stub_merchant_metadata();
+		$this->connection_state->method( 'is_production' )->willReturn( false );
+		$this->stub_failed_webhook_response( 'Invalid merchant data' );
 
 		$testee = $this->create_testable_service( false );
 		$result = $testee->register();
 
-		if ( $success ) {
-			$this->assertInstanceOf( RegistrationResult::class, $result );
-			$this->assertTrue( $result->success );
-			$this->assertTrue( $testee->was_token_saved );
-		} else {
-			$this->assertInstanceOf( WP_Error::class, $result );
-			$this->assertSame( $error_code, $result->get_error_code() );
-			$this->assertFalse( $testee->was_token_saved );
-		}
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'registration_failed', $result->get_error_code() );
+		$this->assertSame( 'Invalid merchant data', $result->get_error_message() );
+		$this->assertFalse( $testee->was_token_saved );
 	}
 
-	public function registration_outcomes_provider(): array {
-		return array(
-			'success' => array( true ),
-			'failure' => array( false, 'registration_failed' ),
-		);
+	/**
+	 * GIVEN an already registered store
+	 * WHEN attempting to register again
+	 * THEN registration should fail with appropriate error
+	 */
+	public function test_registration_fails_when_already_registered(): void {
+		$testee = $this->create_testable_service( true );
+
+		$result = $testee->register();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'registration_failed', $result->get_error_code() );
+		$this->assertSame( 'Already registered', $result->get_error_message() );
 	}
 
-	public function test_register_webhook_network_error(): void {
-		$this->stub_metadata();
-		$this->connection_state->allows( 'is_production' )->andReturn( false );
+	/**
+	 * GIVEN an unregistered store
+	 * WHEN registering with PayPal Agentic Commerce
+	 * AND the webhook request encounters a network error
+	 * THEN registration should fail with network error details
+	 */
+	public function test_registration_fails_on_webhook_network_error(): void {
+		$this->stub_merchant_metadata();
+		$this->connection_state->method( 'is_production' )->willReturn( false );
 
 		$wp_error = new WP_Error( 'http_request_failed', 'Connection timeout' );
 
@@ -184,9 +192,15 @@ class RegistrationServiceTest extends TestCase {
 		$this->assertSame( 'Connection timeout', $result->get_error_message() );
 	}
 
-	public function test_register_json_parsing_error(): void {
-		$this->stub_metadata();
-		$this->connection_state->allows( 'is_production' )->andReturn( false );
+	/**
+	 * GIVEN an unregistered store
+	 * WHEN registering with PayPal Agentic Commerce
+	 * AND the webhook returns invalid JSON response
+	 * THEN registration should fail with JSON parsing error
+	 */
+	public function test_registration_fails_on_invalid_json_response(): void {
+		$this->stub_merchant_metadata();
+		$this->connection_state->method( 'is_production' )->willReturn( false );
 
 		when( 'wp_remote_post' )->returnArg();
 		when( 'is_wp_error' )->alias(
@@ -204,49 +218,71 @@ class RegistrationServiceTest extends TestCase {
 	}
 
 	/**
-	 * @dataProvider deregistration_outcomes_provider
+	 * GIVEN a registered store
+	 * WHEN deregistering from PayPal Agentic Commerce
+	 * AND the webhook returns success
+	 * THEN deregistration should succeed with valid result
+	 * AND the registration token should be deleted
+	 * AND the store should no longer be registered
 	 */
-	public function test_deregister_outcomes( bool $success, string $error_code = null ): void {
-		$this->connection_state->allows( 'is_production' )->andReturn( false );
+	public function test_deregistration_succeeds_for_registered_store(): void {
+		$this->connection_state->method( 'is_production' )->willReturn( false );
+		$this->stub_successful_webhook_response();
 
-		when( 'wp_remote_post' )->returnArg();
-		when( 'is_wp_error' )->justReturn( false );
-		when( 'wp_remote_retrieve_body' )->justReturn(
-			json_encode(
-				array(
-					'success' => $success,
-					'message' => $success ? 'Deregistration successful' : 'Deregistration failed',
-					'error'   => $success ? null : 'Token not found',
-				)
-			)
-		);
+		$testee = $this->create_testable_service( true );
+
+		$this->assertTrue( $testee->is_registered() );
+
+		$result = $testee->deregister();
+
+		$this->assertInstanceOf( RegistrationResult::class, $result );
+		$this->assertTrue( $result->success );
+		$this->assertTrue( $testee->was_token_deleted );
+		$this->assertFalse( $testee->is_registered() );
+	}
+
+	/**
+	 * GIVEN a registered store
+	 * WHEN deregistering from PayPal Agentic Commerce
+	 * AND the webhook returns a failure response
+	 * THEN deregistration should fail with error
+	 * AND the registration token should still be deleted locally
+	 */
+	public function test_deregistration_fails_when_webhook_returns_error(): void {
+		$this->connection_state->method( 'is_production' )->willReturn( false );
+		$this->stub_failed_webhook_response( 'Token not found' );
 
 		$testee = $this->create_testable_service( true );
 		$result = $testee->deregister();
 
-		if ( $success ) {
-			$this->assertInstanceOf( RegistrationResult::class, $result );
-			$this->assertTrue( $result->success );
-		} else {
-			$this->assertInstanceOf( WP_Error::class, $result );
-			$this->assertSame( $error_code, $result->get_error_code() );
-		}
-
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'deregistration_failed', $result->get_error_code() );
+		$this->assertSame( 'Token not found', $result->get_error_message() );
 		$this->assertTrue( $testee->was_token_deleted );
 	}
 
-	public function deregistration_outcomes_provider(): array {
-		return array(
-			'success' => array( true ),
-			'failure' => array( false, 'deregistration_failed' ),
-		);
+	/**
+	 * GIVEN an unregistered store
+	 * WHEN attempting to deregister
+	 * THEN deregistration should return null without making API calls
+	 */
+	public function test_deregistration_returns_null_when_not_registered(): void {
+		$testee = $this->create_testable_service( false );
+
+		$result = $testee->deregister();
+
+		$this->assertNull( $result );
 	}
 
 	/**
-	 * @dataProvider environment_urls_provider
+	 * GIVEN a registered store in production mode
+	 * WHEN deregistering from PayPal Agentic Commerce
+	 * THEN the production webhook URL should be called
+	 *
+	 * @dataProvider environment_webhook_urls_provider
 	 */
-	public function test_uses_correct_environment_url( bool $is_production, string $expected_url ): void {
-		$this->connection_state->allows( 'is_production' )->andReturn( $is_production );
+	public function test_uses_correct_webhook_url_for_environment( bool $is_production, string $expected_url ): void {
+		$this->connection_state->method( 'is_production' )->willReturn( $is_production );
 
 		when( 'is_wp_error' )->justReturn( false );
 		when( 'wp_remote_retrieve_body' )->justReturn(
@@ -269,10 +305,16 @@ class RegistrationServiceTest extends TestCase {
 		$this->assertTrue( $result->success );
 	}
 
-	public function environment_urls_provider(): array {
+	public function environment_webhook_urls_provider(): array {
 		return array(
-			'production' => array( true, 'https://d.joinhoney.com/webhooks/ws/uninstall' ),
-			'sandbox'    => array( false, 'https://d-sandbox.joinhoney.com/webhooks/ws/uninstall' ),
+			'production environment uses live webhook URL' => array(
+				true,
+				'https://d.joinhoney.com/webhooks/ws/uninstall',
+			),
+			'sandbox environment uses sandbox webhook URL' => array(
+				false,
+				'https://d-sandbox.joinhoney.com/webhooks/ws/uninstall',
+			),
 		);
 	}
 }

--- a/tests/PHPUnit/AgenticCommerce/Registration/RegistrationServiceTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Registration/RegistrationServiceTest.php
@@ -42,7 +42,8 @@ class RegistrationServiceTest extends TestCase {
 			'US',
 			'USD',
 			'MERCHANT123',
-			'https://example.com/catalog.json'
+			'https://example.com/catalog.json',
+			'US'
 		);
 
 		$this->metadata_provider->allows( 'get_metadata' )


### PR DESCRIPTION
### Description

Support new offboarding scenarios that clean up the agentic-commerce integration

**Clean up steps**

✅ Before: Call the joinhoney "uninstall" webhook
✨ New: Clear the scheduled ingestion event

**Cleanup scenarios**

✅ Before: Plugin uninstallation
✨ New: Plugin deactivation
✨ New: Merchant disconnect via Settings

**Restrictions**

✅ Before: Shop country must be `US`
✨ New: Merchant country must be `US`
✨ New: Agentic is only available with new Settings UI
✨ New: Merchant must have completed onboarding (→ we need a merchant_id)

### Technical change

The decision on whether to enable logging relies on a value in the Setting class. The (legacy) Settings class has a dependency on translations, making it available only on/after the `init` hook fired; since we want to use logging in agentic even before the init hook fired, this PR also includes a small refactoring of the **`wcgateway.logging.is-enabled `** service, to make it available instantly when using the new UI

Commit: https://github.com/woocommerce/woocommerce-paypal-payments/pull/3868/commits/358b3b3eec94b156cf4f1aec6ada1a3038fdf8ed