### PR TITLE
Allow Fastlane based on PayPal merchant country when available (5532)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -508,7 +508,7 @@ return array(
 			$container->get( 'api.dcc-supported-country-currency-matrix' ),
 			$container->get( 'api.dcc-supported-country-card-matrix' ),
 			$container->get( 'api.shop.currency.getter' ),
-			$container->get( 'api.shop.country' )
+			$container->get( 'api.merchant.country' )
 		);
 	},
 
@@ -1005,5 +1005,14 @@ return array(
 			),
 			PPCP_PAYPAL_BN_CODE
 		);
+	},
+	/**
+	 * If connected, return the PayPal Onboarded merchant country.
+	 * Fallback to WooCommerce Store Country otherwise.
+	 */
+	'api.merchant.country'                           => static function ( ContainerInterface $container ): string {
+		return $container->get( 'settings.flag.is-connected' )
+			? $container->get( 'settings.data.general' )->get_merchant_country()
+			: $container->get( 'api.shop.country' );
 	},
 );

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -42,7 +42,7 @@ return array(
 		return new AxoApplies(
 			$container->get( 'axo.supported-country-currency-matrix' ),
 			$container->get( 'api.shop.currency.getter' ),
-			$container->get( 'api.shop.country' ),
+			$container->get( 'api.merchant.country' ),
 			$container->get( 'wcgateway.configuration.card-configuration' ),
 			$container->get( 'wc-subscriptions.helper' )
 		);

--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -31,7 +31,7 @@ return array(
 	'card-fields.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ): CardFieldsApplies {
 		return new CardFieldsApplies(
 			$container->get( 'card-fields.supported-country-matrix' ),
-			$container->get( 'api.shop.country' )
+			$container->get( 'api.merchant.country' )
 		);
 	},
 	'card-fields.supported-country-matrix'             => static function ( ContainerInterface $container ): array {


### PR DESCRIPTION
### Description

- Shows FastLane Alternative PaymentMethod if when Merchant is Onboarded in an eligible country 

### Steps to Test

1. Reset Onboarding
2. Currency --  USD
3. WooCommerce Store -- Brazil (or a country not fastlane eligible)
4. Fastlane is logo is not showing 
5. Set WooCommerce Store -- USA
6. Fastlane is logo is showing 
7. Complete onboarding - Select Biz account and Card payments
8. Connect to a Sandbox account in USA (As is a country Fastlane eligible)
9. See Fastlane method in payment methods
10. Disable it, save
11. Go to Overview and refresh - See Fastlane in TODOs
12. Set WooCommerce Store -- Brazil (or a country not fastlane eligible)
13. See Fastlane method in payment methods still (as the onboarding is in USA)
14. Reset Onboarding
15. Complete onboarding - Select Biz account and Card payments
16. Connect to Sandbox Brazil (or a country not fastlane eligible)
17. Fastlane method is not there
18. Change Woo store -- USA
19. Fastlane method is not there
