### PR TITLE
Remove delayed self-enabling feature for Pay Later Messaging Canada

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -825,14 +825,6 @@ return array(
 			'SE',
 		);
 	},
-	'api.paylater.is-canada-released'                => static function ( ContainerInterface $container ): bool {
-		// Check if current date is after November 12th, 2025 (Expected PayPal release date).
-		// @todo Remove this logic after the next release.
-		$release_date = '2025-11-12';
-		$current_date = gmdate( 'Y-m-d' );
-
-		return $current_date >= $release_date;
-	},
 	'api.paylater-countries'                         => static function ( ContainerInterface $container ): array {
 		$default_countries = array(
 			'US',
@@ -842,14 +834,8 @@ return array(
 			'AU',
 			'IT',
 			'ES',
+			'CA',
 		);
-
-		// @todo Remove this logic after the next release.
-		// Instead add CA as a default country directly.
-		if ( $container->get( 'api.paylater.is-canada-released' ) ) {
-			$default_countries[] = 'CA';
-		}
-
 		return apply_filters(
 			'woocommerce_paypal_payments_supported_paylater_countries',
 			$default_countries

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -110,8 +110,6 @@ class CompatModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		 * - Enable Pay Later Payment Method
 		 * - Add default messaging locations (product, cart, checkout) to existing selections
 		 *
-		 * @todo Remove this auto-enablement logic after the next release
-		 *
 		 * @hook woocommerce_paypal_payments_gateway_migrate
 		 */
 		add_action(

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -585,10 +585,8 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				);
 
 				// When local APMs are available, then PayLater messaging is also available.
-				// @todo Remove this logic after the next release. If Store is Canada and PayLater for Canada is not released, then PayLater messaging is not available.
-				$is_paylater_canada_released                                 = $c->get( 'api.paylater.is-canada-released' );
 				$features[ FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING ] = array(
-					'enabled' => $features[ FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS ]['enabled'] && ( $c->get( 'api.shop.country' ) !== 'CA' || $is_paylater_canada_released ),
+					'enabled' => $features[ FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS ]['enabled'],
 				);
 
 				$features[ FeaturesDefinition::FEATURE_INSTALLMENTS ] = array(


### PR DESCRIPTION
### Description

Removes the scripts created in https://github.com/woocommerce/woocommerce-paypal-payments/pull/3822  for autoloading Pay Later Messaging in Canada right after 12 November.

