### PR TITLE
Pay with Crypto: Fix order-received page showing minimal content (5560)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -198,6 +198,8 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 
 		add_action( 'woocommerce_before_thankyou', array( $this, 'handle_cancelled_local_apm' ) );
 
+		add_action( 'woocommerce_before_thankyou', array( $this, 'handle_pwc_order_received_redirect' ) );
+
 		add_action(
 			'woocommerce_paypal_payments_payment_capture_completed_webhook_handler',
 			function ( WC_Order $wc_order, string $order_id ) use ( $c ) {
@@ -453,6 +455,46 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 			},
 			11
 		);
+	}
+
+	/**
+	 * Handle PWC order received page redirect to strip token parameter.
+	 *
+	 * PayPal automatically appends a 'token' parameter to return URLs after crypto payments.
+	 * When the 'token' parameter is present on the order-received page, WooCommerce displays
+	 * a minimal page instead of the full order details.
+	 *
+	 * This intercepts PWC orders on 'woocommerce_before_thankyou' and redirects to a clean
+	 * URL without the token, allowing WooCommerce to display the full order-received page.
+	 *
+	 * Note: PWC uses ORDER_COMPLETE_ON_PAYMENT_APPROVAL, so the token serves no purpose
+	 * but we can't prevent PayPal from appending it.
+	 *
+	 * @param int $order_id The order ID.
+	 * @return void
+	 */
+	public function handle_pwc_order_received_redirect( $order_id ): void {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// Only intercept if 'token' parameter is present.
+		if ( ! isset( $_GET['token'] ) ) {
+			return;
+		}
+		// phpcs:enable
+
+		$order = wc_get_order( $order_id );
+		if ( ! $order instanceof WC_Order ) {
+			return;
+		}
+
+		// Only handle PWC - other payment methods may use 'token' legitimately (e.g., 3DS).
+		if ( $order->get_payment_method() !== PWCGateway::ID ) {
+			return;
+		}
+
+		// Redirect to clean URL, allowing WooCommerce to display the full order-received page.
+		$clean_url = remove_query_arg( 'token', $order->get_checkout_order_received_url() );
+		wp_safe_redirect( $clean_url );
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
### Description

PayPal automatically appends a `?token=` parameter to the return URL after crypto payments, which causes WooCommerce to display a minimal page instead of the full order details.

This PR intercepts PWC orders on the `woocommerce_before_thankyou` hook and redirects to a clean URL without the token parameter, allowing WooCommerce to display the full order-received page normally.

### Screenshots

|Before|After|
|-|-|
|<img width="826" height="626" alt="pwc_before" src="https://github.com/user-attachments/assets/eef79190-2320-44a2-8ab4-f302ad29e5be" />|<img width="830" height="710" alt="after_pwc" src="https://github.com/user-attachments/assets/fcd73939-5dc6-4c3f-a15f-6833c3756797" />|

### Testing
1. Enable Pay with Crypto
2. Complete a crypto payment as a logged-in user
3. Verify the order-received page shows full order details (not minimal view)
