### PR TITLE
Consolidate merchant details before and after onboarding (5311)

### DIFF
--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -42,7 +42,7 @@ return array(
 			$container->get( 'applepay.supported-countries' ),
 			$container->get( 'applepay.supported-currencies' ),
 			$container->get( 'api.shop.currency.getter' ),
-			$container->get( 'api.shop.country' )
+			$container->get( 'api.merchant.country' )
 		);
 	},
 	'applepay.status-cache'                    => static function ( ContainerInterface $container ): Cache {

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -344,7 +344,7 @@ return array(
 	'button.helper.messages-apply'                => static function ( ContainerInterface $container ): MessagesApply {
 		return new MessagesApply(
 			$container->get( 'api.paylater-countries' ),
-			$container->get( 'api.shop.country' )
+			$container->get( 'api.merchant.country' )
 		);
 	},
 	'button.helper.disabled-funding-sources'      => static function ( ContainerInterface $container ): DisabledFundingSources {

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -42,7 +42,7 @@ return array(
 			$container->get( 'googlepay.supported-countries' ),
 			$container->get( 'googlepay.supported-currencies' ),
 			$container->get( 'api.shop.currency.getter' ),
-			$container->get( 'api.shop.country' )
+			$container->get( 'api.merchant.country' )
 		);
 	},
 

--- a/modules/ppcp-save-payment-methods/services.php
+++ b/modules/ppcp-save-payment-methods/services.php
@@ -34,7 +34,7 @@ return array(
 	'save-payment-methods.helpers.save-payment-methods-applies' => static function ( ContainerInterface $container ): SavePaymentMethodsApplies {
 		return new SavePaymentMethodsApplies(
 			$container->get( 'save-payment-methods.supported-countries' ),
-			$container->get( 'api.shop.country' )
+			$container->get( 'api.merchant.country' )
 		);
 	},
 	'save-payment-methods.supported-countries'           => static function ( ContainerInterface $container ): array {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -665,7 +665,7 @@ $services = array(
 			$container->get( 'googlepay.eligibility.check' ), // Google Pay eligibility.
 			$container->get( 'applepay.eligibility.check' ), // Apple Pay eligibility.
 			$pay_later_eligible, // Pay Later eligibility.
-			'MX' === $container->get( 'settings.data.general' )->get_merchant_country(), // Installments eligibility.
+			'MX' === $container->get( 'api.merchant.country' ), // Installments eligibility.
 			$apm_eligible  // Pay with Crypto eligibility.
 		);
 	},

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
@@ -420,8 +421,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		add_filter(
 			'woocommerce_paypal_payments_payment_methods',
 			function ( array $payment_methods ) use ( $container ): array {
-				$all_payment_methods = $payment_methods;
-
 				$merchant_capabilities = $container->get( 'settings.service.merchant_capabilities' );
 
 				$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
@@ -439,12 +438,15 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$general_settings = $container->get( 'settings.data.general' );
 				assert( $general_settings instanceof GeneralSettings );
 
-				$merchant_data    = $general_settings->get_merchant_data();
-				$merchant_country = $merchant_data->merchant_country;
+				$messages_apply = $container->get( 'button.helper.messages-apply' );
+				assert( $messages_apply instanceof MessagesApply );
+				$pay_later_eligible = $messages_apply->for_country();
+
+				$merchant_country = $container->get( 'api.merchant.country' );
 
 				// Unset BCDC if merchant is eligible for ACDC and country is eligible for card fields.
 				$card_fields_eligible = $container->get( 'card-fields.eligible' );
-				if ( 'MX' !== $container->get( 'api.shop.country' ) ) {
+				if ( 'MX' !== $merchant_country ) {
 					if ( $dcc_product_status->is_active() && $card_fields_eligible ) {
 						unset( $payment_methods[ CardButtonGateway::ID ] );
 					} else {
@@ -454,7 +456,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				}
 
 				// Unset Venmo when store location is not United States.
-				if ( $container->get( 'api.shop.country' ) !== 'US' ) {
+				if ( $merchant_country !== 'US' ) {
 					unset( $payment_methods['venmo'] );
 				}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -432,15 +432,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$applepay_product_status = $container->get( 'applepay.apple-product-status' );
 				assert( $applepay_product_status instanceof AppleProductStatus );
 
-				$dcc_applies = $container->get( 'api.helpers.dccapplies' );
-				assert( $dcc_applies instanceof DCCApplies );
-
 				$general_settings = $container->get( 'settings.data.general' );
 				assert( $general_settings instanceof GeneralSettings );
-
-				$messages_apply = $container->get( 'button.helper.messages-apply' );
-				assert( $messages_apply instanceof MessagesApply );
-				$pay_later_eligible = $messages_apply->for_country();
 
 				$merchant_country = $container->get( 'api.merchant.country' );
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1320,7 +1320,7 @@ return array(
 		$fields['disable_cards']['options'] = $card_options;
 		$fields['card_icons']['options']    = array_merge( $dark_versions, $card_options );
 
-		if ( $container->get( 'api.shop.country' ) !== 'MX' ) {
+		if ( $container->get( 'api.merchant.country' ) !== 'MX' ) {
 			unset( $fields['mexico_installments'] );
 			unset( $fields['mexico_installments_action_link'] );
 		}


### PR DESCRIPTION
### Description

Use `api.merchant.country` instead of `api.shop.country` when applicable to select PayPal country when merchant is onboarded or shop country otherwise.

