### PR TITLE
Fix APM icon size in Classic Checkout (5555)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/resources/css/gateway.scss
+++ b/modules/ppcp-local-alternative-payment-methods/resources/css/gateway.scss
@@ -1,0 +1,3 @@
+.payment_methods li[class*="payment_method_ppcp-"] label img {
+	max-height: 24px;
+}

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -74,6 +74,21 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 
 		$this->register_pwc_feature_flag_filters();
 
+		add_action(
+			'wp_enqueue_scripts',
+			function () use ( $c ) {
+				$module_url    = $c->get( 'ppcp-local-apms.url' );
+				$asset_version = $c->get( 'ppcp.asset-version' );
+
+				wp_enqueue_style(
+					'ppcp-local-apms-gateway',
+					untrailingslashit( $module_url ) . '/assets/css/gateway.css',
+					array(),
+					$asset_version
+				);
+			}
+		);
+
 		/**
 		 * The "woocommerce_payment_gateways" filter is responsible for ADDING
 		 * custom payment gateways to WooCommerce. Here, we add all the local

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -77,6 +77,10 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 		add_action(
 			'wp_enqueue_scripts',
 			function () use ( $c ) {
+				if ( ! is_checkout() && ! is_cart() && ! is_wc_endpoint_url( 'order-pay' ) ) {
+					return;
+				}
+
 				$module_url    = $c->get( 'ppcp-local-apms.url' );
 				$asset_version = $c->get( 'ppcp.asset-version' );
 

--- a/modules/ppcp-local-alternative-payment-methods/webpack.config.js
+++ b/modules/ppcp-local-alternative-payment-methods/webpack.config.js
@@ -36,6 +36,7 @@ module.exports = {
 		'pwc-payment-method': path.resolve(
 			'./resources/js/pwc-payment-method.js'
 		),
+		gateway: path.resolve( './resources/css/gateway.scss' ),
 	},
 	output: {
 		path: path.resolve( __dirname, 'assets/' ),


### PR DESCRIPTION
### Description

Limit APM icon height to 24px in the classic checkout.

### Note

The original issue is reproducible when Credit Card processing is not present in the checkout.

### Screenshot

|Before|After|
|-|-|
|<img width="555" height="832" alt="before_pwc" src="https://github.com/user-attachments/assets/6f7eabcf-3185-4d3d-bd31-347b14e3cb48" />|<img width="1033" height="746" alt="after_pwc" src="https://github.com/user-attachments/assets/8d021277-5705-4037-8aaa-376e1f1ca687" />|