### PR TITLE
Enable extension of the agentic validation (5271)

### DIFF
--- a/modules/ppcp-agentic-commerce/docs/cart-validation.md
+++ b/modules/ppcp-agentic-commerce/docs/cart-validation.md
@@ -1,0 +1,230 @@
+# Cart Validation
+
+Cart validators verify business rules before cart operations complete. Each validator checks one specific aspect (inventory, pricing, shipping, etc.) and reports issues found.
+
+## Quick Reference
+
+**For experienced developers:**
+
+1. Implement `ValidatorInterface` with a `validate()` method
+2. Return `null` (valid) or `ValidationIssue` / `ValidationIssue[]` (problems found)
+3. Register via `woocommerce_paypal_payments_agentic_commerce_validators` hook
+
+## How Validation Works
+
+**When validators run:**
+- `POST /merchant-cart` - Cart creation
+- `PUT /merchant-cart/{id}` - Cart updates
+- `POST /merchant-cart/{id}/checkout` - Checkout attempts
+
+**What happens with issues:**
+1. AI agent receives all issues and attempts resolution with buyer
+2. Checkout is blocked until all issues are resolved
+
+**Execution order:** Validators run in registration order.
+
+## Writing a Validator
+
+### Interface Location
+
+```
+modules/ppcp-agentic-commerce/src/CartValidation/ValidatorInterface.php
+```
+
+### Return Values
+
+Return one of:
+- `null` or `array()` - No issues found
+- `ValidationIssue` - Single issue
+- `ValidationIssue[]` - Multiple issues
+
+```php
+// Valid cart.
+return null;
+return array();
+
+// Single problem.
+return new MissingField( 'shipping_address is required' );
+
+// Multiple problems.
+return array( $issue1, $issue2 );
+```
+
+### Simple Example
+
+Minimum order validator with no dependencies:
+
+```php
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation;
+
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\CartHelper;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\BusinessRuleViolation;
+
+class MinimumOrderValidator implements ValidatorInterface {
+    private const MIN_ORDER_AMOUNT = 15.00;
+
+    public function validate( PayPalCart $cart ) {
+        $total = CartHelper::cart_item_total( $cart );
+
+        if ( $total < self::MIN_ORDER_AMOUNT ) {
+            return new BusinessRuleViolation(
+                sprintf( 'Order minimum is $%.2f', self::MIN_ORDER_AMOUNT )
+            );
+        }
+
+        return null;
+    }
+}
+```
+
+### Example with Dependencies
+
+Product availability validator using `ProductManager`:
+
+```php
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation;
+
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\ProductManager;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\InvalidData;
+
+class ProductAvailabilityValidator implements ValidatorInterface {
+
+    private ProductManager $product_manager;
+
+    public function __construct( ProductManager $product_manager ) {
+        $this->product_manager = $product_manager;
+    }
+
+    public function validate( PayPalCart $cart ) {
+        $issues = array();
+
+        foreach ( $cart->items() as $key => $item ) {
+            $product = $this->product_manager->find_product( $item );
+
+            if ( ! $product || $product->get_status() !== 'publish' ) {
+                $issues[] = new InvalidData(
+                    'Product is no longer available',
+                    sprintf( 'Product "%s" cannot be purchased at the moment', $item->name() ),                    
+                    "items[{$key}]"
+                );
+            }
+        }
+
+        return $issues ?: null;
+    }
+}
+```
+
+## Registration
+
+### Internal Development (DI Container)
+
+**Step 1:** Add validator to `modules/ppcp-agentic-commerce/services.php`:
+
+```php
+'agentic.validator.minimum-order' => static function ( ContainerInterface $c ): MinimumOrderValidator {
+    return new MinimumOrderValidator();
+},
+
+'agentic.validator.product-availability' => static function ( ContainerInterface $c ): ProductAvailabilityValidator {
+    return new ProductAvailabilityValidator(
+        $c->get( 'agentic.helper.product-manager' )
+    );
+},
+```
+
+**Step 2:** Add service ID to `CART_VALIDATION_SERVICES` in `AgenticCommerceModule.php`:
+
+```php
+private const CART_VALIDATION_SERVICES = array(
+    'agentic.validator.product',
+    'agentic.validator.inventory',
+    'agentic.validator.minimum-order',        // ← Your validator
+    'agentic.validator.product-availability', // ← Your validator
+);
+```
+
+**Important:** Array order determines execution order.
+This array is then processed by the `woocommerce_paypal_payments_agentic_commerce_validators` action to register the validators.
+
+### Third-Party Plugins (Hook-Based)
+
+Third-party plugins cannot access the DI container. Use the WordPress action hook instead:
+
+```php
+add_action(
+    'woocommerce_paypal_payments_agentic_commerce_validators',
+    function( $processor ) {
+        // Instantiate directly (check constructor for required dependencies)
+        $validator = new MinimumOrderValidator();
+        $processor->register_validator( $validator );
+    }
+);
+```
+
+**Complete plugin example:**
+
+```php
+<?php
+/**
+ * Plugin Name: Custom Cart Validation
+ */
+ 
+use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\ValidatorInterface;
+use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\CartValidationProcessor;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\BusinessRuleViolation;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+
+class My_Custom_Validator implements ValidatorInterface {
+    
+    public function validate( PayPalCart $cart ) {
+        if ( count( $cart->items() ) > 50 ) {
+            return new BusinessRuleViolation( 'Maximum 50 items per cart' );
+        }
+        
+        return null;
+    }
+}
+
+add_action(
+    'woocommerce_paypal_payments_agentic_commerce_validators',
+    function( CartValidationProcessor $processor ) {
+        $processor->register_validator( new My_Custom_Validator() );
+    }
+);
+```
+
+## Best Practices
+
+**Single Responsibility**
+
+Each validator checks one business rule. Don't combine inventory + pricing in one validator.
+
+**Clear Messages**
+
+Error messages are shown to buyers via AI agent. Be specific and actionable:
+
+```php
+// ✗ Bad - generic issue and vague message.
+return new BusinessRuleViolation( 'Invalid order' );
+
+// ✓ Good - specific issue, clear message.
+return new ShippingUnavailable( 'This product ships to US addresses only' );
+```
+
+**Performance Matters**
+
+- Leverage helper class caching where available
+- Consider checking `$cart->has_validation_issue()` to skip redundant checks
+
+**Validation Issue Types**
+
+Locate the most suitable issue class in `modules/ppcp-agentic-commerce/src/Validation`. Consider adding a new one if needed.

--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -145,8 +145,10 @@ return array(
 	},
 
 	// Validation services.
-	'agentic.validation.processor'        => static function (): CartValidationProcessor {
-		return new CartValidationProcessor();
+	'agentic.validation.processor'        => static function ( ContainerInterface $c ): CartValidationProcessor {
+		return new CartValidationProcessor(
+			$c->get( 'agentic.logger' )
+		);
 	},
 	'agentic.validator.product'           => static function ( ContainerInterface $c ): ProductValidator {
 		return new ProductValidator(

--- a/modules/ppcp-agentic-commerce/src/CartValidation/CartValidationProcessor.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/CartValidationProcessor.php
@@ -30,7 +30,17 @@ class CartValidationProcessor {
 		foreach ( $validators as $validator ) {
 			$issues = $validator->validate( $current_cart );
 
-			if ( ! empty( $issues ) ) {
+			if ( empty( $issues ) ) {
+				continue;
+			}
+
+			if ( ! is_array( $issues ) ) {
+				$issues = array( $issues );
+			}
+
+			$issues = array_filter( $issues, static fn( $issue ) => $issue instanceof ValidationIssue );
+
+			if ( $issues ) {
 				$current_cart = $current_cart->with_validation_issues( ...$issues );
 			}
 		}

--- a/modules/ppcp-agentic-commerce/src/CartValidation/CartValidationProcessor.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/CartValidationProcessor.php
@@ -9,9 +9,15 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation;
 
+use Throwable;
+use Psr\Log\LoggerInterface;
+
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\ValidationIssue;
 
 class CartValidationProcessor {
+
+	private LoggerInterface $logger;
 
 	/**
 	 * @var ValidatorInterface[]
@@ -19,6 +25,10 @@ class CartValidationProcessor {
 	private array $validators = array();
 
 	private bool $did_register_validators = false;
+
+	public function __construct( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
 
 	/**
 	 * @return PayPalCart Cart with accumulated validation issues.
@@ -28,7 +38,25 @@ class CartValidationProcessor {
 		$current_cart = $cart;
 
 		foreach ( $validators as $validator ) {
-			$issues = $validator->validate( $current_cart );
+			try {
+				$issues = $validator->validate( $current_cart );
+			} catch ( Throwable $error ) {
+				/*
+				 * Internal validators do not throw anything.
+				 * This protects us against third party validators blocking the REST endpoint by
+				 * throwing an unexpected exception.
+				 */
+
+				$this->logger->error(
+					sprintf(
+						'[VALIDATE] Unexpected cart validation error by "%s": %s',
+						get_class( $validator ),
+						$error->getMessage()
+					)
+				);
+
+				continue;
+			}
 
 			if ( empty( $issues ) ) {
 				continue;

--- a/modules/ppcp-agentic-commerce/src/CartValidation/InventoryValidator.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/InventoryValidator.php
@@ -24,7 +24,7 @@ class InventoryValidator implements ValidatorInterface {
 		$this->product_manager = $product_manager;
 	}
 
-	public function validate( PayPalCart $cart ): ?array {
+	public function validate( PayPalCart $cart ) {
 		// Skip validation if the cart already annotates an inventory issue.
 		if ( $cart->has_validation_issue( ErrorCode::INVENTORY_ISSUE ) ) {
 			return null;

--- a/modules/ppcp-agentic-commerce/src/CartValidation/ProductValidator.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/ProductValidator.php
@@ -23,7 +23,7 @@ class ProductValidator implements ValidatorInterface {
 		$this->product_manager = $product_manager;
 	}
 
-	public function validate( PayPalCart $cart ): ?array {
+	public function validate( PayPalCart $cart ) {
 		// Skip validation if the cart already annotates an inventory issue.
 		if ( $cart->has_validation_issue( ErrorCode::INVENTORY_ISSUE ) ) {
 			return null;

--- a/modules/ppcp-agentic-commerce/src/CartValidation/ValidatorInterface.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/ValidatorInterface.php
@@ -9,8 +9,13 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\ValidationIssue;
 interface ValidatorInterface {
 
 	/**
+	 * Validates cart against business rules.
+	 *
 	 * @param PayPalCart $cart The cart to validate.
-	 * @return ValidationIssue[]|null List of detected validation issues or null if no issues found.
+	 *
+	 * @return ValidationIssue|ValidationIssue[]|null An empty array or null if valid.
+	 *                                                Otherwise, a list of all validation issues
+	 *                                                that were detected.
 	 */
-	public function validate( PayPalCart $cart ): ?array;
+	public function validate( PayPalCart $cart );
 }

--- a/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/AgenticRestEndpoint.php
@@ -16,7 +16,6 @@ use JsonException;
 use WC_REST_Controller;
 use Psr\Log\LoggerInterface;
 
-use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\Http\BadRequestError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\Http\InternalServerError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\Http\NotFoundError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\AgenticError;

--- a/modules/ppcp-agentic-commerce/src/Helper/CartHelper.php
+++ b/modules/ppcp-agentic-commerce/src/Helper/CartHelper.php
@@ -38,7 +38,7 @@ class CartHelper {
 	}
 
 	/**
-	 * Sums (price * quantity) for each item. Items without price are treated as 0.0.
+	 * Sums (price * quantity) for each item. Items without a price are treated as 0.0.
 	 */
 	public static function cart_item_total( PayPalCart $cart ): float {
 		return array_reduce(

--- a/modules/ppcp-agentic-commerce/src/Schema/AgenticSchema.php
+++ b/modules/ppcp-agentic-commerce/src/Schema/AgenticSchema.php
@@ -108,7 +108,8 @@ abstract class AgenticSchema {
 	 * @return static New instance with the additional validation issue.
 	 */
 	final public function with_validation_issues( ValidationIssue ...$issues ): self {
-		$new_instance                    = clone $this;
+		$new_instance = clone $this;
+
 		$new_instance->validation_issues = array_merge( $new_instance->validation_issues, $issues );
 
 		return $new_instance;

--- a/modules/ppcp-agentic-commerce/src/Validation/BusinessRuleViolation.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/BusinessRuleViolation.php
@@ -1,0 +1,17 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
+
+use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
+
+/**
+ * A generic business rule issue, intended as a base class for
+ * more specific issues or third party code.
+ */
+class BusinessRuleViolation extends ValidationIssue {
+	protected const ISSUE_TYPE = ErrorType::BUSINESS_RULE;
+	protected const ISSUE_CODE = ErrorCode::BUSINESS_RULE_ERROR;
+}

--- a/modules/ppcp-agentic-commerce/src/Validation/CouponInvalid.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/CouponInvalid.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
 
 /**
  * When to use:
@@ -13,7 +12,6 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
  * - Coupon not applicable to cart items.
  * - Coupon usage limit reached.
  */
-class CouponInvalid extends ValidationIssue {
+class CouponInvalid extends BusinessRuleViolation {
 	protected const ISSUE_CODE = ErrorCode::PRICING_ERROR;
-	protected const ISSUE_TYPE = ErrorType::BUSINESS_RULE;
 }

--- a/modules/ppcp-agentic-commerce/src/Validation/InsufficientQuantity.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/InsufficientQuantity.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
 
 /**
  * When to use:
@@ -13,7 +12,6 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
  * - Stock reduced between cart creation and checkout.
  * - High-demand item with limited availability.
  */
-class InsufficientQuantity extends ValidationIssue {
+class InsufficientQuantity extends BusinessRuleViolation {
 	protected const ISSUE_CODE = ErrorCode::INVENTORY_ISSUE;
-	protected const ISSUE_TYPE = ErrorType::BUSINESS_RULE;
 }

--- a/modules/ppcp-agentic-commerce/src/Validation/InvalidAddress.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/InvalidAddress.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
 
 /**
  * When to use:
@@ -13,7 +12,6 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
  * - Address is incomplete or malformed.
  * - Postal code format is invalid.
  */
-class InvalidAddress extends ValidationIssue {
+class InvalidAddress extends InvalidData {
 	protected const ISSUE_CODE = ErrorCode::SHIPPING_ERROR;
-	protected const ISSUE_TYPE = ErrorType::INVALID_DATA;
 }

--- a/modules/ppcp-agentic-commerce/src/Validation/InvalidData.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/InvalidData.php
@@ -9,44 +9,14 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
 
 /**
+ * A generic invalid-data-issue, intended as a base class for
+ * more specific issues or third party code.
+ *
  * When to use:
  * - Provided data is incorrect, e.g., malformed email.
  * - Unexpected data format, e.g., non-numeric price.
  */
 class InvalidData extends ValidationIssue {
-	protected const ISSUE_CODE = ErrorCode::DATA_ERROR;
 	protected const ISSUE_TYPE = ErrorType::INVALID_DATA;
+	protected const ISSUE_CODE = ErrorCode::DATA_ERROR;
 }
-
-/*
-Sample:
-{
-	"code": "DATA_ERROR",
-	"type": "INVALID_DATA",
-	"message": "Shipping address could not be validated",
-	"user_message": "We couldn't verify this shipping address. Please check and correct any errors.",
-	"field": "shipping_address",
-	"context": {
-		"specific_issue": "INVALID_SHIPPING_ADDRESS",
-		"suggested_address": {
-			"address_line_1": "123 Main St",
-			"admin_area_2": "San Jose",
-			"admin_area_1": "CA",
-			"postal_code": "95131-1234",
-			"country_code": "US"
-		}
-	},
-	"resolution_options": [
-		{
-			"action": "UPDATE_ADDRESS",
-			"label": "Use suggested address",
-			"metadata": {"priority": "high", "auto_applicable": true}
-		},
-		{
-			"action": "UPDATE_ADDRESS",
-			"label": "Edit address manually",
-			"metadata": {"priority": "medium"}
-		}
-	]
-}
-*/

--- a/modules/ppcp-agentic-commerce/src/Validation/InvalidProduct.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/InvalidProduct.php
@@ -5,14 +5,12 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
 
 /**
  * When to use:
  * - Product ID doesn't exist in WooCommerce.
  * - Invalid or malformed item_id.
  */
-class InvalidProduct extends ValidationIssue {
+class InvalidProduct extends InvalidData {
 	protected const ISSUE_CODE = ErrorCode::INVENTORY_ISSUE;
-	protected const ISSUE_TYPE = ErrorType::INVALID_DATA;
 }

--- a/modules/ppcp-agentic-commerce/src/Validation/ItemOutOfStock.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/ItemOutOfStock.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
 
 /**
  * When to use:
@@ -13,7 +12,6 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
  * - No stock remaining.
  * - Item temporarily out of inventory.
  */
-class ItemOutOfStock extends ValidationIssue {
+class ItemOutOfStock extends BusinessRuleViolation {
 	protected const ISSUE_CODE = ErrorCode::INVENTORY_ISSUE;
-	protected const ISSUE_TYPE = ErrorType::BUSINESS_RULE;
 }

--- a/modules/ppcp-agentic-commerce/src/Validation/MissingField.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/MissingField.php
@@ -16,31 +16,3 @@ class MissingField extends ValidationIssue {
 	protected const ISSUE_CODE = ErrorCode::DATA_ERROR;
 	protected const ISSUE_TYPE = ErrorType::MISSING_FIELD;
 }
-
-/*
-Sample:
-{
-	"code": "DATA_ERROR",
-	"type": "MISSING_FIELD",
-	"message": "Required field missing",
-	"user_message": "Please provide a shipping address to calculate delivery options.",
-	"field": "shipping_address",
-	"context": {
-		"specific_issue": "MISSING_REQUIRED_FIELD",
-		"missing_fields": ["shipping_address.postal_code"],
-		"field_requirements": {
-			"postal_code": {
-				"format": "^[0-9]{5}(-[0-9]{4})?$",
-				"example": "95131"
-			}
-		}
-	},
-	"resolution_options": [
-		{
-			"action": "PROVIDE_MISSING_FIELD",
-			"label": "Add shipping address",
-			"metadata": {"priority": "HIGH"}
-		}
-	]
-}
-*/

--- a/modules/ppcp-agentic-commerce/src/Validation/PriceMismatch.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/PriceMismatch.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
 
 /**
  * When to use:
@@ -13,7 +12,6 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
  * - Promotional pricing ended.
  * - Dynamic pricing adjustments occurred.
  */
-class PriceMismatch extends ValidationIssue {
+class PriceMismatch extends BusinessRuleViolation {
 	protected const ISSUE_CODE = ErrorCode::PRICING_ERROR;
-	protected const ISSUE_TYPE = ErrorType::BUSINESS_RULE;
 }

--- a/modules/ppcp-agentic-commerce/src/Validation/ShippingUnavailable.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/ShippingUnavailable.php
@@ -5,7 +5,6 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
 
 /**
  * When to use:
@@ -13,7 +12,6 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorType;
  * - Regional restrictions apply.
  * - No shipping methods available for this address.
  */
-class ShippingUnavailable extends ValidationIssue {
+class ShippingUnavailable extends BusinessRuleViolation {
 	protected const ISSUE_CODE = ErrorCode::SHIPPING_ERROR;
-	protected const ISSUE_TYPE = ErrorType::BUSINESS_RULE;
 }

--- a/modules/ppcp-agentic-commerce/src/Validation/ValidationIssue.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/ValidationIssue.php
@@ -49,6 +49,7 @@ abstract class ValidationIssue {
 	 *
 	 * @param string $message      Technical error description.
 	 * @param string $user_message Optional. Customer friendly error message.
+	 * @param string $field        Optional. Identifies the field that triggered the issue.
 	 */
 	public function __construct( string $message, string $user_message = '', string $field = '' ) {
 		$this->message      = $message ?: 'Validation error occurred';
@@ -56,14 +57,26 @@ abstract class ValidationIssue {
 		$this->field        = $field;
 	}
 
+	/**
+	 * Returns the error code, which is a high-level description of the problem.
+	 * Possible values are defined in the `Enums/ErrorCode` class.
+	 */
 	public function code(): string {
 		return static::ISSUE_CODE;
 	}
 
+	/**
+	 * Returns the error type, which classifies the issue.
+	 * Possible values are defined in the `Enums/ErrorType` class.
+	 */
+	public function type(): string {
+		return static::ISSUE_TYPE;
+	}
+
 	public function to_array(): array {
 		$data = array(
-			'code'    => static::ISSUE_CODE,
-			'type'    => static::ISSUE_TYPE,
+			'code'    => $this->code(),
+			'type'    => $this->type(),
 			'message' => (string) substr( $this->message, 0, 255 ),
 		);
 


### PR DESCRIPTION
### Description

Prepares the agentic `CartValidationProcessor` for extension by new internal or third-party rules:

- Providing generic `ValidationIssue` classes
- More relaxed return value handling of `validate()` method
- Documentation for internal and third-party devs