### PR TITLE
Disable simulate-event endpoint for webhook verification (5621)

### DIFF
--- a/modules/ppcp-webhooks/src/Status/WebhookSimulation.php
+++ b/modules/ppcp-webhooks/src/Status/WebhookSimulation.php
@@ -79,6 +79,9 @@ class WebhookSimulation {
 	 * @throws Exception If failed to start simulation.
 	 */
 	public function start( ?Webhook $webhook = null ): void {
+		// Disabled for 3.3.1 release.
+		return;
+
 		if ( ! $webhook ) {
 			$webhook = $this->webhook;
 		}

--- a/modules/ppcp-webhooks/src/WebhookModule.php
+++ b/modules/ppcp-webhooks/src/WebhookModule.php
@@ -155,7 +155,12 @@ class WebhookModule implements ServiceModule, FactoryModule, ExtendingModule, Ex
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
-			static function ( $installed_plugin_version ) use ( $container ) {
+			static function ( string $installed_plugin_version ) use ( $container ) {
+				// Skip on fresh installation.
+				if ( empty( $installed_plugin_version ) ) {
+					return;
+				}
+
 				// Disabled when upgrading from 3.3.0.
 				if ( version_compare( $installed_plugin_version, '3.3.0', '=' ) ) {
 					return;

--- a/modules/ppcp-webhooks/src/WebhookModule.php
+++ b/modules/ppcp-webhooks/src/WebhookModule.php
@@ -156,6 +156,9 @@ class WebhookModule implements ServiceModule, FactoryModule, ExtendingModule, Ex
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
 			static function () use ( $container ) {
+				// Disabled for 3.3.1 release.
+				return;
+
 				$registrar = $container->get( 'webhook.registrar' );
 				assert( $registrar instanceof WebhookRegistrar );
 				add_action(

--- a/modules/ppcp-webhooks/src/WebhookModule.php
+++ b/modules/ppcp-webhooks/src/WebhookModule.php
@@ -155,9 +155,11 @@ class WebhookModule implements ServiceModule, FactoryModule, ExtendingModule, Ex
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
-			static function () use ( $container ) {
-				// Disabled for 3.3.1 release.
-				return;
+			static function ( $installed_plugin_version ) use ( $container ) {
+				// Disabled when upgrading from 3.3.0.
+				if ( version_compare( $installed_plugin_version, '3.3.0', '=' ) ) {
+					return;
+				}
 
 				$registrar = $container->get( 'webhook.registrar' );
 				assert( $registrar instanceof WebhookRegistrar );

--- a/tests/PHPUnit/Webhooks/Status/WebhookSimulationTest.php
+++ b/tests/PHPUnit/Webhooks/Status/WebhookSimulationTest.php
@@ -48,6 +48,8 @@ class WebhookSimulationTest extends TestCase
 
     public function testSimulation()
     {
+	    $this->markTestSkipped('Disabled for 3.3.1 release.');
+
 		$this->webhook_endpoint
 			->expects('simulate')
 			->with($this->webhook, $this->event_type, $this->event_version)
@@ -73,6 +75,8 @@ class WebhookSimulationTest extends TestCase
 
     public function testSimulationWhenNoWebhook()
     {
+	    $this->markTestSkipped('Disabled for 3.3.1 release.');
+
 		$this->sut = new WebhookSimulation($this->webhook_endpoint, null, $this->event_type, $this->event_version);
 
 		self::assertFalse($this->sut->is_simulation_event($this->createEvent($this->event_id)));


### PR DESCRIPTION
This PR disables calling simulate webhook and resubscribe webhooks on plugin upgrade.