### PR TITLE
Enable wp debugging in ddev config (5626)

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -28,6 +28,9 @@ web_environment:
   - ADMIN_PASS=admin
   - ADMIN_EMAIL=admin@example.com
   - WC_VERSION=10.1.2
+  - WP_DEBUG=true
+  - WP_DEBUG_DISPLAY=true
+  - WP_DEBUG_LOG=true
 
 # Key features of ddev's config.yaml:
 


### PR DESCRIPTION
### Description

Enable wp debugging in ddev config

### Steps to Test

1. Create a fresh ddev env using this branch
2. Check that WP_DEBUG is set true bu default
