### PR TITLE
Fix PayPalCartResponse issues (5634)

### DIFF
--- a/modules/ppcp-agentic-commerce/src/Endpoint/CheckoutEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/CheckoutEndpoint.php
@@ -122,7 +122,7 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 		if ( $cart->issues() ) {
 			$cart_response = $this->response_factory->from_cart( $cart );
 
-			return $this->cart_details( $cart_response );
+			return $this->cart_details( $cart_response, 200 );
 		}
 
 		// It's time to create the WooCommerce order.
@@ -136,7 +136,7 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 
 		$response = $this->response_factory->from_order( $order, $cart );
 
-		return $this->cart_details( $response );
+		return $this->cart_details( $response, 200 );
 	}
 
 	/**

--- a/modules/ppcp-agentic-commerce/src/Endpoint/CheckoutEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/CheckoutEndpoint.php
@@ -120,7 +120,7 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 
 		// If the cart has _any_ validation issue, stop here.
 		if ( $cart->issues() ) {
-			$cart_response = $this->response_factory->from_cart( $cart );
+			$cart_response = $this->response_factory->from_cart( $cart, $cart_id );
 
 			return $this->cart_details( $cart_response, 200 );
 		}
@@ -134,7 +134,7 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 
 		$this->flush_local_cart( $cart_id );
 
-		$response = $this->response_factory->from_order( $order, $cart );
+		$response = $this->response_factory->from_order( $order, $cart, $cart_id );
 
 		return $this->cart_details( $response, 200 );
 	}

--- a/modules/ppcp-agentic-commerce/src/Endpoint/GetCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/GetCartEndpoint.php
@@ -65,7 +65,7 @@ class GetCartEndpoint extends AgenticRestEndpoint {
 			return $this->error( $session );
 		}
 
-		$response = $this->response_factory->from_cart( $session['cart'] );
+		$response = $this->response_factory->from_cart( $session['cart'], $cart_id );
 
 		return $this->cart_details( $response, 200 );
 	}

--- a/modules/ppcp-agentic-commerce/src/Endpoint/GetCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/GetCartEndpoint.php
@@ -65,11 +65,7 @@ class GetCartEndpoint extends AgenticRestEndpoint {
 			return $this->error( $session );
 		}
 
-		$response = $this->response_factory->active_cart(
-			$session['cart'],
-			$cart_id,
-			$session['ec_token']
-		);
+		$response = $this->response_factory->from_cart( $session['cart'] );
 
 		return $this->cart_details( $response, 200 );
 	}

--- a/modules/ppcp-agentic-commerce/src/Endpoint/ReplaceCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/ReplaceCartEndpoint.php
@@ -105,7 +105,7 @@ class ReplaceCartEndpoint extends AgenticRestEndpoint {
 			);
 		}
 
-		$response = $this->response_factory->from_cart( $new_cart );
+		$response = $this->response_factory->from_cart( $new_cart, $cart_id );
 
 		return $this->cart_details( $response, 200 );
 	}

--- a/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
@@ -31,24 +31,18 @@ class CartResponse {
 
 	/**
 	 * The cart ID used by the API to reference to an existing cart.
-	 *
-	 * @var string The cart ID is usually part of the REST endpoint path.
 	 */
 	private string $cart_id;
 
 	/**
 	 * Used to track cart lifecycle.
 	 * Possible values: CREATED, INCOMPLETE, READY, COMPLETED
-	 *
-	 * @var string Business workflow state.
 	 */
 	protected string $status = 'INCOMPLETE';
 
 	/**
 	 * Used to determine the next step.
 	 * Possible values: VALID, INVALID, REQUIRES_ADDITIONAL_INFORMATION
-	 *
-	 * @var string Data validation state.
 	 */
 	protected string $validation_status = 'INVALID';
 
@@ -57,11 +51,6 @@ class CartResponse {
 	 */
 	protected string $token = '';
 
-	/**
-	 * Constructor.
-	 *
-	 * @param PayPalCart $cart The PayPal cart.
-	 */
 	public function __construct( PayPalCart $cart, string $cart_id = '' ) {
 		$this->cart    = $cart;
 		$this->cart_id = $cart_id;

--- a/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
@@ -14,6 +14,19 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\ValidationIssue;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\CartHelper;
 
 class CartResponse {
+	private const ALLOWED_STATUS = array(
+		'CREATED',
+		'INCOMPLETE',
+		'READY',
+		'COMPLETED',
+	);
+
+	private const ALLOWED_VALIDATION_STATUS = array(
+		'VALID',
+		'INVALID',
+		'REQUIRES_ADDITIONAL_INFORMATION',
+	);
+
 	protected PayPalCart $cart;
 
 	/**
@@ -94,8 +107,8 @@ class CartResponse {
 	public function to_array(): array {
 		$data = array(
 			'id'                => $this->cart_id,
-			'status'            => $this->status,
-			'validation_status' => $this->validation_status,
+			'status'            => $this->status(),
+			'validation_status' => $this->validation_status(),
 			'validation_issues' => array_map(
 				static fn( ValidationIssue $issue ) => $issue->to_array(),
 				$this->cart->issues()
@@ -104,5 +117,21 @@ class CartResponse {
 		);
 
 		return array_merge( $data, $this->cart->to_array() );
+	}
+
+	public function status(): string {
+		if ( in_array( $this->status, self::ALLOWED_STATUS, true ) ) {
+			return $this->status;
+		}
+
+		return 'INCOMPLETE';
+	}
+
+	public function validation_status(): string {
+		if ( in_array( $this->validation_status, self::ALLOWED_VALIDATION_STATUS, true ) ) {
+			return $this->validation_status;
+		}
+
+		return 'INVALID';
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
@@ -109,7 +109,7 @@ class CartResponse {
 		return array_merge( $data, $this->cart->to_array() );
 	}
 
-	public function status(): string {
+	private function status(): string {
 		if ( in_array( $this->status, self::ALLOWED_STATUS, true ) ) {
 			return $this->status;
 		}
@@ -117,7 +117,7 @@ class CartResponse {
 		return 'INCOMPLETE';
 	}
 
-	public function validation_status(): string {
+	private function validation_status(): string {
 		if ( in_array( $this->validation_status, self::ALLOWED_VALIDATION_STATUS, true ) ) {
 			return $this->validation_status;
 		}

--- a/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
@@ -34,7 +34,7 @@ class CartResponse {
 	 *
 	 * @var string The cart ID is usually part of the REST endpoint path.
 	 */
-	protected string $cart_id = '';
+	private string $cart_id;
 
 	/**
 	 * Used to track cart lifecycle.
@@ -62,8 +62,9 @@ class CartResponse {
 	 *
 	 * @param PayPalCart $cart The PayPal cart.
 	 */
-	public function __construct( PayPalCart $cart ) {
-		$this->cart = $cart;
+	public function __construct( PayPalCart $cart, string $cart_id = '' ) {
+		$this->cart    = $cart;
+		$this->cart_id = $cart_id;
 
 		if ( ! $this->cart->issues() ) {
 			$this->validation_status = 'VALID';

--- a/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
@@ -2,7 +2,7 @@
 /**
  * PayPal Cart Response (new cart created).
  *
- * @package WooCommerce\PayPalCommerce\AgenticCommerce\Response\
+ * @package WooCommerce\PayPalCommerce\AgenticCommerce\Response
  */
 
 declare( strict_types = 1 );
@@ -14,14 +14,6 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PaymentMethod;
 
 class NewCartResponse extends CartResponse {
 
-	/**
-	 * Constructor.
-	 *
-	 * @param PayPalCart $cart The PayPal cart.
-	 * @param string     $cart_id The cart ID.
-	 * @param string     $token The EC token.
-	 * @param string     $status The cart status (CREATED or ACTIVE).
-	 */
 	public function __construct(
 		PayPalCart $cart,
 		string $cart_id,

--- a/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
@@ -14,12 +14,9 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PaymentMethod;
 
 class NewCartResponse extends CartResponse {
 
-	public function __construct(
-		PayPalCart $cart,
-		string $cart_id,
-		string $token,
-		string $status = 'CREATED'
-	) {
+	protected string $status = 'CREATED';
+
+	public function __construct( PayPalCart $cart, string $cart_id, string $token ) {
 		parent::__construct( $cart, $cart_id );
 		$this->token = $token;
 	}

--- a/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
@@ -20,10 +20,8 @@ class NewCartResponse extends CartResponse {
 		string $token,
 		string $status = 'CREATED'
 	) {
-		parent::__construct( $cart );
-		$this->cart_id = $cart_id;
-		$this->token   = $token;
-		$this->status  = $status;
+		parent::__construct( $cart, $cart_id );
+		$this->token = $token;
 	}
 
 	/**

--- a/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
@@ -20,11 +20,6 @@ class NewCartResponse extends CartResponse {
 		$this->token = $token;
 	}
 
-	/**
-	 * Convert to array for API response.
-	 *
-	 * @return array The response array.
-	 */
 	public function to_array(): array {
 		$data = parent::to_array();
 

--- a/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/NewCartResponse.php
@@ -10,7 +10,6 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Response;
 
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PaymentMethod;
 
 class NewCartResponse extends CartResponse {
 
@@ -29,14 +28,11 @@ class NewCartResponse extends CartResponse {
 	public function to_array(): array {
 		$data = parent::to_array();
 
-		$method = PaymentMethod::from_array(
-			array(
-				'type'  => 'paypal', // hard-coded.
-				'token' => $this->token,
-			)
+		// For security reasons, the token is only included in the "New Cart" response.
+		$data['payment_method'] = array(
+			'type'  => 'paypal', // hard-coded.
+			'token' => $this->token,
 		);
-
-		$data['payment_method'] = $method->to_array();
 
 		// Add sandbox approval URL for testing.
 		// In production, PayPal Commerce Platform handles approval automatically.

--- a/modules/ppcp-agentic-commerce/src/Response/PaidCartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/PaidCartResponse.php
@@ -19,8 +19,8 @@ class PaidCartResponse extends CartResponse {
 	 */
 	protected ?WC_Order $wc_order = null;
 
-	public function __construct( PayPalCart $cart, WC_Order $wc_order ) {
-		parent::__construct( $cart );
+	public function __construct( PayPalCart $cart, string $cart_id, WC_Order $wc_order ) {
+		parent::__construct( $cart, $cart_id );
 		$this->wc_order = $wc_order;
 		$this->status   = 'COMPLETED';
 	}

--- a/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
+++ b/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
@@ -20,10 +20,10 @@ class ResponseFactory {
 	}
 
 	public function from_order( WC_Order $order, PayPalCart $cart, string $cart_id ): PaidCartResponse {
-		return new PaidCartResponse( $cart, $order );
+		return new PaidCartResponse( $cart, $cart_id, $order );
 	}
 
 	public function from_cart( PayPalCart $cart, string $cart_id ): CartResponse {
-		return new CartResponse( $cart );
+		return new CartResponse( $cart, $cart_id );
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
+++ b/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
@@ -19,11 +19,11 @@ class ResponseFactory {
 		return new NewCartResponse( $cart, $cart_id, $token );
 	}
 
-	public function from_order( WC_Order $order, PayPalCart $cart ): PaidCartResponse {
+	public function from_order( WC_Order $order, PayPalCart $cart, string $cart_id ): PaidCartResponse {
 		return new PaidCartResponse( $cart, $order );
 	}
 
-	public function from_cart( PayPalCart $cart ): CartResponse {
+	public function from_cart( PayPalCart $cart, string $cart_id ): CartResponse {
 		return new CartResponse( $cart );
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
+++ b/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
@@ -15,11 +15,8 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
 
 class ResponseFactory {
 	public function new_cart( PayPalCart $cart, string $cart_id, string $token ): NewCartResponse {
-		return new NewCartResponse( $cart, $cart_id, $token, 'CREATED' );
-	}
-
-	public function active_cart( PayPalCart $cart, string $cart_id, string $token ): NewCartResponse {
-		return new NewCartResponse( $cart, $cart_id, $token, 'ACTIVE' );
+		// The only response that includes the token!
+		return new NewCartResponse( $cart, $cart_id, $token );
 	}
 
 	public function from_order( WC_Order $order, PayPalCart $cart ): PaidCartResponse {

--- a/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
+++ b/modules/ppcp-agentic-commerce/src/Response/ResponseFactory.php
@@ -14,47 +14,18 @@ use WC_Order;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
 
 class ResponseFactory {
-	/**
-	 * Create a new cart response (status: CREATED).
-	 *
-	 * @param PayPalCart $cart The cart object.
-	 * @param string     $cart_id The cart ID.
-	 * @param string     $token The payment token.
-	 * @return NewCartResponse The response object.
-	 */
 	public function new_cart( PayPalCart $cart, string $cart_id, string $token ): NewCartResponse {
 		return new NewCartResponse( $cart, $cart_id, $token, 'CREATED' );
 	}
 
-	/**
-	 * Create an active cart response (status: ACTIVE).
-	 *
-	 * @param PayPalCart $cart The cart object.
-	 * @param string     $cart_id The cart ID.
-	 * @param string     $token The payment token.
-	 * @return NewCartResponse The response object.
-	 */
 	public function active_cart( PayPalCart $cart, string $cart_id, string $token ): NewCartResponse {
 		return new NewCartResponse( $cart, $cart_id, $token, 'ACTIVE' );
 	}
 
-	/**
-	 * Create a paid cart response.
-	 *
-	 * @param WC_Order   $order The WooCommerce order.
-	 * @param PayPalCart $cart The cart object.
-	 * @return PaidCartResponse The response object.
-	 */
 	public function from_order( WC_Order $order, PayPalCart $cart ): PaidCartResponse {
 		return new PaidCartResponse( $cart, $order );
 	}
 
-	/**
-	 * Create a basic cart response.
-	 *
-	 * @param PayPalCart $cart The cart object.
-	 * @return CartResponse The response object.
-	 */
 	public function from_cart( PayPalCart $cart ): CartResponse {
 		return new CartResponse( $cart );
 	}

--- a/tests/PHPUnit/AgenticCommerce/Endpoint/GetCartEndpointTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Endpoint/GetCartEndpointTest.php
@@ -5,7 +5,7 @@ namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
 use WP_REST_Request;
 
-use WooCommerce\PayPalCommerce\AgenticCommerce\Response\NewCartResponse;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Response\CartResponse;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
 
 /**
@@ -38,12 +38,10 @@ class GetCartEndpointTest extends AgenticEndpointTestCase {
 			);
 
 		// Mock response factory.
-		$response_factory->allows( 'active_cart' )
-			->andReturnUsing( fn( $cart, $cart_id, $ec_token ) => new NewCartResponse(
+		$response_factory->allows( 'from_cart' )
+			->andReturnUsing( fn( $cart, $cart_id ) => new CartResponse(
 				$cart,
-				$cart_id,
-				$ec_token,
-				'ACTIVE'
+				$cart_id
 			) );
 
 		$endpoint = new GetCartEndpoint(
@@ -63,6 +61,8 @@ class GetCartEndpointTest extends AgenticEndpointTestCase {
 
 		$this->assertIsArray( $data );
 		$this->assertArrayHasKey( 'status', $data );
+		$this->assertArrayHasKey( 'payment_method', $data );
+		$this->assertArrayNotHasKey( 'token', $data['payment_method'], 'Token is only expected when creating a new cart.' );
 		$this->assertSame( 200, $response->get_status() );
 	}
 


### PR DESCRIPTION
### Description

This PR addresses some problems with invalid details returned by the REST endpoints.

**Critical problems:**
- The status `ACTIVE` does not exist and should not be returned
- The payment token is only expected when creating a new cart, not on get cart or replace cart
- The required cart ID was not present in all responses

Plus, some method did miss the mandatory status code `200`