### PR TITLE
Agentic: Add currency validation for cart items (5632)

### DIFF
--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -41,6 +41,7 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\CartTransformer;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\ProductValidator;
 use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\InventoryValidator;
+use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\CurrencyValidator;
 use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\CartValidationProcessor;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Inspector\InspectionSessionData;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Inspector\Page\RegistrationStatusSection;
@@ -159,6 +160,9 @@ return array(
 		return new InventoryValidator(
 			$c->get( 'agentic.helper.product-manager' )
 		);
+	},
+	'agentic.validator.currency'          => static function (): CurrencyValidator {
+		return new CurrencyValidator();
 	},
 
 	// REST endpoints.

--- a/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
+++ b/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
@@ -50,6 +50,7 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 	private const CART_VALIDATION_SERVICES = array(
 		'agentic.validator.product',
 		'agentic.validator.inventory',
+		'agentic.validator.currency',
 	);
 
 	public function services(): array {

--- a/modules/ppcp-agentic-commerce/src/CartValidation/CurrencyValidator.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/CurrencyValidator.php
@@ -59,13 +59,17 @@ class CurrencyValidator implements ValidatorInterface {
 	 * @return array|null Currency data or null if no currency.
 	 */
 	private function extract_currency_at_index( PayPalCart $cart, int $index ): ?array {
-		$item     = $cart->items()[ $index ];
-		$currency = $item->price()?->currency_code();
+		$item  = $cart->items()[ $index ];
+		$price = $item->price();
 
-		return $currency ? array(
+		if ( ! $price || ! $price->currency_code() ) {
+			return null;
+		}
+
+		return array(
 			'index'    => $index,
-			'currency' => $currency,
-		) : null;
+			'currency' => $price->currency_code(),
+		);
 	}
 
 	/**

--- a/modules/ppcp-agentic-commerce/src/CartValidation/CurrencyValidator.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/CurrencyValidator.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Currency Validator for Agentic Commerce.
+ *
+ * @package WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation;
+
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\CurrencyMismatch;
+
+class CurrencyValidator implements ValidatorInterface {
+
+	public function validate( PayPalCart $cart ) {
+		$issues = array();
+
+		// Extract all currencies from cart items.
+		$cart_currencies = $this->extract_cart_currencies( $cart );
+
+		// If no currencies found, nothing to validate.
+		if ( empty( $cart_currencies ) ) {
+			return $issues;
+		}
+
+		// Validate all items have the same currency.
+		$currency_issue = $this->validate_consistent_currency( $cart_currencies );
+		if ( $currency_issue ) {
+			$issues[] = $currency_issue;
+			// Don't check store currency if items have mixed currencies.
+			return $issues;
+		}
+
+		// At this point, all currencies are the same - check against store.
+		$cart_currency        = $cart_currencies[0]['currency'];
+		$first_currency_index = $cart_currencies[0]['index'];
+		$store_currency_issue = $this->validate_store_currency( $cart_currency, $first_currency_index );
+		if ( $store_currency_issue ) {
+			$issues[] = $store_currency_issue;
+		}
+
+		return $issues;
+	}
+
+	/**
+	 * Extracts all currencies with their item indices from the cart.
+	 *
+	 * @param PayPalCart $cart The cart to extract currencies from.
+	 * @return array Array of ['index' => int, 'currency' => string].
+	 */
+	private function extract_cart_currencies( PayPalCart $cart ): array {
+		$currencies = array();
+		foreach ( $cart->items() as $key => $item ) {
+			$price = $item->price();
+			if ( $price && $price->currency_code() ) {
+				$currencies[] = array(
+					'index'    => $key,
+					'currency' => $price->currency_code(),
+				);
+			}
+		}
+		return $currencies;
+	}
+
+	/**
+	 * Validates that all currencies are the same.
+	 *
+	 * @param array $currencies Array of ['index' => int, 'currency' => string].
+	 * @return CurrencyMismatch|null Validation issue if currencies are inconsistent.
+	 */
+	private function validate_consistent_currency( array $currencies ): ?CurrencyMismatch {
+		$unique_currencies = array_unique(
+			array_column( $currencies, 'currency' )
+		);
+
+		// If all items have the same currency, validation passes.
+		if ( count( $unique_currencies ) === 1 ) {
+			return null;
+		}
+
+		// Find the first mismatch.
+		$reference_currency = $currencies[0]['currency'];
+		$mismatch           = current(
+			array_filter(
+				$currencies,
+				fn( $item ) => $item['currency'] !== $reference_currency
+			)
+		);
+
+		return new CurrencyMismatch(
+			sprintf(
+				'Mixed currencies detected: item %d has currency %s, expected %s',
+				$mismatch['index'],
+				$mismatch['currency'],
+				$reference_currency
+			),
+			'All items in the cart must use the same currency.',
+			"items[{$mismatch['index']}].price.currency_code"
+		);
+	}
+
+	/**
+	 * Validates that the cart currency matches the WooCommerce store currency.
+	 *
+	 * @param string $cart_currency The cart's currency code.
+	 * @param int    $item_index    The index of the first item with this currency.
+	 * @return CurrencyMismatch|null Validation issue if currency doesn't match store settings.
+	 */
+	private function validate_store_currency( string $cart_currency, int $item_index ): ?CurrencyMismatch {
+		$store_currency = get_woocommerce_currency();
+
+		if ( $cart_currency !== $store_currency ) {
+			return new CurrencyMismatch(
+				sprintf(
+					'Cart currency %s does not match store currency %s',
+					$cart_currency,
+					$store_currency
+				),
+				sprintf(
+					'This store only accepts payments in %s.',
+					$store_currency
+				),
+				"items[{$item_index}].price.currency_code"
+			);
+		}
+
+		return null;
+	}
+}

--- a/modules/ppcp-agentic-commerce/src/CartValidation/CurrencyValidator.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/CurrencyValidator.php
@@ -15,33 +15,23 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\CurrencyMismatch;
 class CurrencyValidator implements ValidatorInterface {
 
 	public function validate( PayPalCart $cart ) {
-		$issues = array();
-
-		// Extract all currencies from cart items.
 		$cart_currencies = $this->extract_cart_currencies( $cart );
 
-		// If no currencies found, nothing to validate.
 		if ( empty( $cart_currencies ) ) {
-			return $issues;
+			return array();
 		}
 
-		// Validate all items have the same currency.
-		$currency_issue = $this->validate_consistent_currency( $cart_currencies );
-		if ( $currency_issue ) {
-			$issues[] = $currency_issue;
-			// Don't check store currency if items have mixed currencies.
-			return $issues;
+		$consistency_issue = $this->validate_consistent_currency( $cart_currencies );
+		if ( $consistency_issue ) {
+			return array( $consistency_issue );
 		}
 
-		// At this point, all currencies are the same - check against store.
-		$cart_currency        = $cart_currencies[0]['currency'];
-		$first_currency_index = $cart_currencies[0]['index'];
-		$store_currency_issue = $this->validate_store_currency( $cart_currency, $first_currency_index );
-		if ( $store_currency_issue ) {
-			$issues[] = $store_currency_issue;
-		}
+		$store_issue = $this->validate_store_currency(
+			$cart_currencies[0]['currency'],
+			$cart_currencies[0]['index']
+		);
 
-		return $issues;
+		return array_filter( array( $store_issue ) );
 	}
 
 	/**
@@ -51,17 +41,31 @@ class CurrencyValidator implements ValidatorInterface {
 	 * @return array Array of ['index' => int, 'currency' => string].
 	 */
 	private function extract_cart_currencies( PayPalCart $cart ): array {
-		$currencies = array();
-		foreach ( $cart->items() as $key => $item ) {
-			$price = $item->price();
-			if ( $price && $price->currency_code() ) {
-				$currencies[] = array(
-					'index'    => $key,
-					'currency' => $price->currency_code(),
-				);
-			}
-		}
-		return $currencies;
+		return array_values(
+			array_filter(
+				array_map(
+					fn( $index ) => $this->extract_currency_at_index( $cart, $index ),
+					array_keys( $cart->items() )
+				)
+			)
+		);
+	}
+
+	/**
+	 * Extracts currency from a specific cart item index.
+	 *
+	 * @param PayPalCart $cart  The cart.
+	 * @param int        $index The item index.
+	 * @return array|null Currency data or null if no currency.
+	 */
+	private function extract_currency_at_index( PayPalCart $cart, int $index ): ?array {
+		$item     = $cart->items()[ $index ];
+		$currency = $item->price()?->currency_code();
+
+		return $currency ? array(
+			'index'    => $index,
+			'currency' => $currency,
+		) : null;
 	}
 
 	/**
@@ -71,21 +75,17 @@ class CurrencyValidator implements ValidatorInterface {
 	 * @return CurrencyMismatch|null Validation issue if currencies are inconsistent.
 	 */
 	private function validate_consistent_currency( array $currencies ): ?CurrencyMismatch {
-		$unique_currencies = array_unique(
-			array_column( $currencies, 'currency' )
-		);
+		$unique_currencies = array_unique( array_column( $currencies, 'currency' ) );
 
-		// If all items have the same currency, validation passes.
 		if ( count( $unique_currencies ) === 1 ) {
 			return null;
 		}
 
-		// Find the first mismatch.
-		$reference_currency = $currencies[0]['currency'];
-		$mismatch           = current(
+		$reference = $currencies[0];
+		$mismatch  = current(
 			array_filter(
 				$currencies,
-				fn( $item ) => $item['currency'] !== $reference_currency
+				fn( $item ) => $item['currency'] !== $reference['currency']
 			)
 		);
 
@@ -94,7 +94,7 @@ class CurrencyValidator implements ValidatorInterface {
 				'Mixed currencies detected: item %d has currency %s, expected %s',
 				$mismatch['index'],
 				$mismatch['currency'],
-				$reference_currency
+				$reference['currency']
 			),
 			'All items in the cart must use the same currency.',
 			"items[{$mismatch['index']}].price.currency_code"

--- a/modules/ppcp-agentic-commerce/src/Validation/CurrencyMismatch.php
+++ b/modules/ppcp-agentic-commerce/src/Validation/CurrencyMismatch.php
@@ -1,0 +1,16 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\Validation;
+
+use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
+
+/**
+ * When to use:
+ * - Cart items have different currencies (mixed currency not supported).
+ * - Cart currency does not match WooCommerce store currency.
+ */
+class CurrencyMismatch extends BusinessRuleViolation {
+	protected const ISSUE_CODE = ErrorCode::PRICING_ERROR;
+}

--- a/tests/PHPUnit/AgenticCommerce/CartValidation/CurrencyValidatorTest.php
+++ b/tests/PHPUnit/AgenticCommerce/CartValidation/CurrencyValidatorTest.php
@@ -1,0 +1,261 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation;
+
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\CurrencyMismatch;
+use WooCommerce\PayPalCommerce\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\CurrencyValidator
+ */
+class CurrencyValidatorTest extends TestCase {
+
+	private CurrencyValidator $validator;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->validator = new CurrencyValidator();
+	}
+
+	public function test_validate_returns_null_for_valid_cart(): void {
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$cart = $this->create_cart_with_items(
+			array(
+				array( 'currency' => 'USD', 'value' => 10.0 ),
+				array( 'currency' => 'USD', 'value' => 20.0 ),
+			)
+		);
+
+		$result = $this->validator->validate( $cart );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	public function test_validate_detects_mixed_currencies(): void {
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$cart = $this->create_cart_with_items(
+			array(
+				array( 'currency' => 'USD', 'value' => 10.0 ),
+				array( 'currency' => 'EUR', 'value' => 20.0 ),
+			)
+		);
+
+		$result = $this->validator->validate( $cart );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertInstanceOf( CurrencyMismatch::class, $result[0] );
+
+		$issue_data = $result[0]->to_array();
+		$this->assertStringContainsString( 'Mixed currencies detected', $issue_data['message'] );
+		$this->assertSame( 'items[1].price.currency_code', $issue_data['field'] );
+	}
+
+	public function test_validate_detects_store_currency_mismatch(): void {
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$cart = $this->create_cart_with_items(
+			array(
+				array( 'currency' => 'EUR', 'value' => 10.0 ),
+				array( 'currency' => 'EUR', 'value' => 20.0 ),
+			)
+		);
+
+		$result = $this->validator->validate( $cart );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertInstanceOf( CurrencyMismatch::class, $result[0] );
+
+		$issue_data = $result[0]->to_array();
+		$this->assertStringContainsString( 'Cart currency EUR does not match store currency USD', $issue_data['message'] );
+		$this->assertStringContainsString( 'This store only accepts payments in USD', $issue_data['user_message'] );
+		$this->assertSame( 'items[0].price.currency_code', $issue_data['field'] );
+	}
+
+	public function test_validate_returns_null_for_empty_cart(): void {
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$cart = PayPalCart::from_array(
+			array(
+				'items'          => array(),
+				'payment_method' => 'paypal',
+			)
+		);
+
+		$result = $this->validator->validate( $cart );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	public function test_validates_with_some_items_without_prices(): void {
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$cart_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => '1',
+					'quantity' => 1,
+					'name'     => 'Item with price',
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => 10.0,
+					),
+				),
+				array(
+					'item_id'  => '2',
+					'quantity' => 1,
+					'name'     => 'Item without price',
+					// No price field
+				),
+			),
+			'payment_method' => 'paypal',
+		);
+
+		$cart   = PayPalCart::from_array( $cart_data );
+		$result = $this->validator->validate( $cart );
+
+		$this->assertIsArray( $result );
+		$this->assertEmpty( $result );
+	}
+
+	public function test_detects_mismatch_skipping_empty_items(): void {
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$cart_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => '1',
+					'quantity' => 1,
+					'name'     => 'Item without price',
+					// No price field
+				),
+				array(
+					'item_id'  => '2',
+					'quantity' => 1,
+					'name'     => 'Item with USD',
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => 10.0,
+					),
+				),
+				array(
+					'item_id'  => '3',
+					'quantity' => 1,
+					'name'     => 'Item with EUR',
+					'price'    => array(
+						'currency_code' => 'EUR',
+						'value'         => 20.0,
+					),
+				),
+			),
+			'payment_method' => 'paypal',
+		);
+
+		$cart   = PayPalCart::from_array( $cart_data );
+		$result = $this->validator->validate( $cart );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertInstanceOf( CurrencyMismatch::class, $result[0] );
+
+		$issue_data = $result[0]->to_array();
+		$this->assertStringContainsString( 'Mixed currencies detected', $issue_data['message'] );
+		$this->assertStringContainsString( 'EUR', $issue_data['message'] );
+		$this->assertStringContainsString( 'USD', $issue_data['message'] );
+		$this->assertSame( 'items[2].price.currency_code', $issue_data['field'] );
+	}
+
+	public function test_store_mismatch_points_to_correct_index(): void {
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$cart_data = array(
+			'items'          => array(
+				array(
+					'item_id'  => '1',
+					'quantity' => 1,
+					'name'     => 'Item without price',
+					// No price field
+				),
+				array(
+					'item_id'  => '2',
+					'quantity' => 1,
+					'name'     => 'Item with EUR',
+					'price'    => array(
+						'currency_code' => 'EUR',
+						'value'         => 10.0,
+					),
+				),
+			),
+			'payment_method' => 'paypal',
+		);
+
+		$cart   = PayPalCart::from_array( $cart_data );
+		$result = $this->validator->validate( $cart );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertInstanceOf( CurrencyMismatch::class, $result[0] );
+
+		$issue_data = $result[0]->to_array();
+		$this->assertStringContainsString( 'Cart currency EUR does not match store currency USD', $issue_data['message'] );
+		$this->assertSame( 'items[1].price.currency_code', $issue_data['field'] );
+	}
+
+	public function test_mixed_currency_prevents_store_check(): void {
+		when( 'get_woocommerce_currency' )->justReturn( 'GBP' );
+
+		$cart = $this->create_cart_with_items(
+			array(
+				array( 'currency' => 'USD', 'value' => 10.0 ),
+				array( 'currency' => 'EUR', 'value' => 20.0 ),
+			)
+		);
+
+		$result = $this->validator->validate( $cart );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertInstanceOf( CurrencyMismatch::class, $result[0] );
+
+		$issue = $result[0]->to_array();
+		$this->assertStringContainsString( 'Mixed currencies detected', $issue['message'] );
+	}
+
+	/**
+	 * Helper method to create a cart with items.
+	 *
+	 * @param array $items Array of items with currency and value.
+	 * @return PayPalCart
+	 */
+	private function create_cart_with_items( array $items ): PayPalCart {
+		$cart_items = array();
+
+		foreach ( $items as $index => $item_data ) {
+			$cart_items[] = array(
+				'item_id'  => (string) ( $index + 1 ),
+				'quantity' => 1,
+				'name'     => "Item $index",
+				'price'    => array(
+					'currency_code' => $item_data['currency'],
+					'value'         => $item_data['value'],
+				),
+			);
+		}
+
+		return PayPalCart::from_array(
+			array(
+				'items'          => $cart_items,
+				'payment_method' => 'paypal',
+			)
+		);
+	}
+}

--- a/tests/PHPUnit/AgenticCommerce/Validation/ValidationIssueTest.php
+++ b/tests/PHPUnit/AgenticCommerce/Validation/ValidationIssueTest.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\TestCase;
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Validation\InvalidAddress
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Validation\InsufficientQuantity
  * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Validation\CouponInvalid
+ * @covers \WooCommerce\PayPalCommerce\AgenticCommerce\Validation\CurrencyMismatch
  */
 class ValidationIssueTest extends TestCase {
 
@@ -73,6 +74,7 @@ class ValidationIssueTest extends TestCase {
 			'InvalidAddress'       => array( InvalidAddress::class ),
 			'InsufficientQuantity' => array( InsufficientQuantity::class ),
 			'CouponInvalid'        => array( CouponInvalid::class ),
+			'CurrencyMismatch'     => array( CurrencyMismatch::class ),
 		);
 	}
 }


### PR DESCRIPTION
### Description

Implements currency validation for cart items to ensure all items use the same currency and match the WooCommerce store currency.

### Validation Rules
  1. **Mixed currency check**: All cart items must use the same currency (WooCommerce doesn't support mixed currencies)
  2. **Store currency check**: Cart currency must match WooCommerce store settings
  3. **Skip logic**: Store validation only runs if currencies are consistent
