### PR TITLE
[Refactor] Use PaymentMethodsEligibilityService for filtering Payment Methods in Settings (5561)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -11,9 +11,11 @@ namespace WooCommerce\PayPalCommerce\Settings;
 
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BlikGateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\EPSGateway;
@@ -59,6 +61,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigrati
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\SettingsTabMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\StylingSettingsMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\OnboardingUrlManager;
+use WooCommerce\PayPalCommerce\Settings\Service\PaymentMethodsEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\ScriptDataHandler;
 use WooCommerce\PayPalCommerce\Settings\Service\TodosEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\TodosSortingAndFilteringService;
@@ -72,7 +75,6 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\PWCProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\Endpoint\SaveConfig;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
@@ -669,7 +671,24 @@ $services = array(
 			$apm_eligible  // Pay with Crypto eligibility.
 		);
 	},
+	'settings.service.payment_methods_eligibilities'      => static function ( ContainerInterface $container ): PaymentMethodsEligibilityService {
+		$applepay_product_status = $container->get( 'applepay.apple-product-status' );
+		assert( $applepay_product_status instanceof AppleProductStatus );
 
+		$googlepay_product_status = $container->get( 'googlepay.helpers.apm-product-status' );
+		assert( $googlepay_product_status instanceof ApmProductStatus );
+
+		return new PaymentMethodsEligibilityService(
+			$container->get( 'api.shop.country' ),
+			$container->get( 'ppcp-local-apms.eligibility.check' ),
+			$container->get( 'settings.service.merchant_capabilities' ),
+			$container->get( 'wcgateway.helper.dcc-product-status' ),
+			$container->get( 'axo.eligibility.check' ),
+			$container->get( 'card-fields.eligibility.check' ),
+			$applepay_product_status->is_active() && $container->get( 'applepay.eligible' ),
+			$applepay_product_status->is_active() && $container->get( 'googlepay.eligible' ),
+		);
+	},
 	'settings.service.todos_sorting'                      => static function ( ContainerInterface $container ): TodosSortingAndFilteringService {
 		return new TodosSortingAndFilteringService(
 			$container->get( 'settings.data.todos' )

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -679,14 +679,14 @@ $services = array(
 		assert( $googlepay_product_status instanceof ApmProductStatus );
 
 		return new PaymentMethodsEligibilityService(
-			$container->get( 'api.shop.country' ),
+			$container->get( 'api.merchant.country' ),
 			$container->get( 'ppcp-local-apms.eligibility.check' ),
 			$container->get( 'settings.service.merchant_capabilities' ),
 			$container->get( 'wcgateway.helper.dcc-product-status' ),
 			$container->get( 'axo.eligibility.check' ),
 			$container->get( 'card-fields.eligibility.check' ),
 			$applepay_product_status->is_active() && $container->get( 'applepay.eligible' ),
-			$applepay_product_status->is_active() && $container->get( 'googlepay.eligible' ),
+			$googlepay_product_status->is_active() && $container->get( 'googlepay.eligible' ),
 		);
 	},
 	'settings.service.todos_sorting'                      => static function ( ContainerInterface $container ): TodosSortingAndFilteringService {

--- a/modules/ppcp-settings/src/Service/PaymentMethodsEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/PaymentMethodsEligibilityService.php
@@ -148,7 +148,7 @@ class PaymentMethodsEligibilityService {
 	}
 
 	/**
-	 * Whether Card Fields is supported. It requires aso ACDC to be supported.
+	 * Whether Card Fields is supported. It requires also ACDC to be supported.
 	 *
 	 * @return bool
 	 */

--- a/modules/ppcp-settings/src/Service/PaymentMethodsEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/PaymentMethodsEligibilityService.php
@@ -48,7 +48,6 @@ class PaymentMethodsEligibilityService {
 	 */
 	private array $merchant_capabilities;
 
-
 	/**
 	 * ACDC Seller status.
 	 */
@@ -78,19 +77,6 @@ class PaymentMethodsEligibilityService {
 	 */
 	private bool $google_pay_available;
 
-
-	/**
-	 * Constructor.
-	 *
-	 * @param string           $merchant_country PayPal Country (or Woo Country if not onboarded).
-	 * @param bool             $is_apm_eligible If alternative payment methods are eligible.
-	 * @param array            $merchant_capabilities Array of Merchant capabilities (true: enabled / false: disabled).
-	 * @param DCCProductStatus $dcc_product_status ACDC Seller status.
-	 * @param callable         $axo_eligible Whether Axo is eligible.
-	 * @param callable         $card_fields_eligible Whether Card Fields is eligible.
-	 * @param bool             $apple_pay_available Whether Apple Pay is available.
-	 * @param bool             $google_pay_available Whether Google Pay is available.
-	 */
 	public function __construct(
 		string $merchant_country,
 		bool $is_apm_eligible,

--- a/modules/ppcp-settings/src/Service/PaymentMethodsEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/PaymentMethodsEligibilityService.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Payment Methods eligibility service.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service;
+
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BlikGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\EPSGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\IDealGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MultibancoGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MyBankGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PWCGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
+
+/**
+ * Manages eligibility checks for various PayPal Commerce features.
+ */
+class PaymentMethodsEligibilityService {
+
+	/**
+	 * PayPal Country (or Woo Country if not onboarded)
+	 */
+	private string $merchant_country;
+
+	/**
+	 * If alternative payment methods are eligible.
+	 */
+	private bool $is_apm_eligible;
+
+	/**
+	 * Array of Merchant capabilities (true: enabled / false: disabled)
+	 */
+	private array $merchant_capabilities;
+
+
+	/**
+	 * ACDC Seller status.
+	 */
+	private DCCProductStatus $dcc_product_status;
+
+	/**
+	 * Whether Axo is eligible.
+	 *
+	 * @var callable
+	 */
+	private $axo_eligible;
+
+	/**
+	 * Whether Card Fields is eligible.
+	 *
+	 * @var callable
+	 */
+	private $card_fields_eligible;
+
+	/**
+	 * Whether Apple Pay is available
+	 */
+	private bool $apple_pay_available;
+
+	/**
+	 * Whether Google Pay is available
+	 */
+	private bool $google_pay_available;
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string           $merchant_country PayPal Country (or Woo Country if not onboarded).
+	 * @param bool             $is_apm_eligible If alternative payment methods are eligible.
+	 * @param array            $merchant_capabilities Array of Merchant capabilities (true: enabled / false: disabled).
+	 * @param DCCProductStatus $dcc_product_status ACDC Seller status.
+	 * @param callable         $axo_eligible Whether Axo is eligible.
+	 * @param callable         $card_fields_eligible Whether Card Fields is eligible.
+	 * @param bool             $apple_pay_available Whether Apple Pay is available.
+	 * @param bool             $google_pay_available Whether Google Pay is available.
+	 */
+	public function __construct(
+		string $merchant_country,
+		bool $is_apm_eligible,
+		array $merchant_capabilities,
+		DCCProductStatus $dcc_product_status,
+		callable $axo_eligible,
+		callable $card_fields_eligible,
+		bool $apple_pay_available,
+		bool $google_pay_available
+	) {
+		$this->merchant_country      = $merchant_country;
+		$this->is_apm_eligible       = $is_apm_eligible;
+		$this->merchant_capabilities = $merchant_capabilities;
+		$this->dcc_product_status    = $dcc_product_status;
+		$this->axo_eligible          = $axo_eligible;
+		$this->card_fields_eligible  = $card_fields_eligible;
+		$this->apple_pay_available   = $apple_pay_available;
+		$this->google_pay_available  = $google_pay_available;
+	}
+
+	/**
+	 * Returns all eligibility checks as callables.
+	 *
+	 * @return array<string, callable>
+	 */
+	public function get_eligibility_checks(): array {
+		return array(
+			BancontactGateway::ID     => fn() => ! $this->is_mexico_merchant() && $this->is_apm_eligible,
+			BlikGateway::ID           => fn() => ! $this->is_mexico_merchant() && $this->is_apm_eligible,
+			EPSGateway::ID            => fn() => ! $this->is_mexico_merchant() && $this->is_apm_eligible,
+			IDealGateway::ID          => fn() => ! $this->is_mexico_merchant() && $this->is_apm_eligible,
+			MyBankGateway::ID         => fn() => ! $this->is_mexico_merchant() && $this->is_apm_eligible,
+			P24Gateway::ID            => fn() => ! $this->is_mexico_merchant() && $this->is_apm_eligible,
+			TrustlyGateway::ID        => fn() => ! $this->is_mexico_merchant() && $this->is_apm_eligible,
+			MultibancoGateway::ID     => fn() => ! $this->is_mexico_merchant() && $this->is_apm_eligible,
+			OXXO::ID                  => fn() => $this->is_mexico_merchant() && $this->is_apm_eligible,
+			PWCGateway::ID            => fn() => $this->has_pwc_capability() && $this->is_apm_eligible,
+			PayUponInvoiceGateway::ID => fn() => $this->merchant_country === 'DE',
+			CreditCardGateway::ID     => fn() => $this->is_mexico_merchant() || $this->is_card_fields_supported(),
+			CardButtonGateway::ID     => fn() => $this->is_mexico_merchant() || ! $this->is_card_fields_supported(),
+			GooglePayGateway::ID      => fn() => $this->google_pay_available,
+			ApplePayGateway::ID       => fn() => $this->apple_pay_available,
+			AxoGateway::ID            => fn() => $this->dcc_product_status->is_active() && call_user_func( $this->axo_eligible ),
+			'venmo'                   => fn() => $this->merchant_country === 'US',
+		);
+	}
+
+	/**
+	 * Whether merchant country is mexico.
+	 *
+	 * @return bool
+	 */
+	private function is_mexico_merchant(): bool {
+		return $this->merchant_country === 'MX';
+	}
+
+	/**
+	 * Whether Card Fields is supported. It requires aso ACDC to be supported.
+	 *
+	 * @return bool
+	 */
+	private function is_card_fields_supported(): bool {
+		return $this->dcc_product_status->is_active() && call_user_func( $this->card_fields_eligible );
+	}
+
+	/**
+	 * Whether Pay With Crypto capability is enabled.
+	 *
+	 * @return bool
+	 */
+	private function has_pwc_capability(): bool {
+		return $this->merchant_capabilities[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ] ?? false;
+	}
+}

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -13,25 +13,11 @@ use WC_Payment_Gateway;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
-use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
-use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
-use WooCommerce\PayPalCommerce\Googlepay\Helper\ApmProductStatus;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BlikGateway;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\EPSGateway;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\IDealGateway;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MultibancoGateway;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MyBankGateway;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PWCGateway;
-use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
 use WooCommerce\PayPalCommerce\Settings\Ajax\SwitchSettingsUiEndpoint;
-use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
@@ -42,6 +28,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\PathRepository
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
+use WooCommerce\PayPalCommerce\Settings\Service\PaymentMethodsEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\ScriptDataHandler;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -52,7 +39,6 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 use WooCommerce\PayPalCommerce\Settings\Service\SettingsDataManager;
 use WooCommerce\PayPalCommerce\Settings\DTO\ConfigurationFlagsDTO;
 use WooCommerce\PayPalCommerce\Settings\Enum\ProductChoicesEnum;
@@ -421,87 +407,13 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		add_filter(
 			'woocommerce_paypal_payments_payment_methods',
 			function ( array $payment_methods ) use ( $container ): array {
-				$merchant_capabilities = $container->get( 'settings.service.merchant_capabilities' );
+				$payment_methods_eligibility_service = $container->get( 'settings.service.payment_methods_eligibilities' );
+				assert( $payment_methods_eligibility_service instanceof PaymentMethodsEligibilityService );
 
-				$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
-				assert( $dcc_product_status instanceof DCCProductStatus );
-
-				$googlepay_product_status = $container->get( 'googlepay.helpers.apm-product-status' );
-				assert( $googlepay_product_status instanceof ApmProductStatus );
-
-				$applepay_product_status = $container->get( 'applepay.apple-product-status' );
-				assert( $applepay_product_status instanceof AppleProductStatus );
-
-				$general_settings = $container->get( 'settings.data.general' );
-				assert( $general_settings instanceof GeneralSettings );
-
-				$merchant_country = $container->get( 'api.merchant.country' );
-
-				// Unset BCDC if merchant is eligible for ACDC and country is eligible for card fields.
-				$card_fields_eligible = $container->get( 'card-fields.eligible' );
-				if ( 'MX' !== $merchant_country ) {
-					if ( $dcc_product_status->is_active() && $card_fields_eligible ) {
-						unset( $payment_methods[ CardButtonGateway::ID ] );
-					} else {
-						// For non-ACDC regions unset ACDC.
-						unset( $payment_methods[ CreditCardGateway::ID ] );
+				foreach ( $payment_methods_eligibility_service->get_eligibility_checks() as $payment_method_id => $payment_method_check ) {
+					if ( isset( $payment_methods[ $payment_method_id ] ) && call_user_func( $payment_method_check ) === false ) {
+						unset( $payment_methods[ $payment_method_id ] );
 					}
-				}
-
-				// Unset Venmo when store location is not United States.
-				if ( $merchant_country !== 'US' ) {
-					unset( $payment_methods['venmo'] );
-				}
-
-				// Unset if country/currency is not supported or merchant not eligible for Google Pay.
-				if ( ! $container->get( 'googlepay.eligible' ) || ! $googlepay_product_status->is_active() ) {
-					unset( $payment_methods['ppcp-googlepay'] );
-				}
-
-				// Unset if country/currency is not supported or merchant not eligible for Apple Pay.
-				if ( ! $container->get( 'applepay.eligible' ) || ! $applepay_product_status->is_active() ) {
-					unset( $payment_methods['ppcp-applepay'] );
-				}
-
-				// Unset Fastlane if country/currency is not supported or merchant is not eligible for BCDC.
-				if ( ! $container->get( 'axo.eligible' ) || ! $dcc_product_status->is_active() ) {
-					unset( $payment_methods['ppcp-axo-gateway'] );
-				}
-
-				// Unset OXXO if merchant country is not Mexico.
-				if ( 'MX' !== $merchant_country ) {
-					unset( $payment_methods[ OXXO::ID ] );
-				}
-
-				// Unset Pay Upon Invoice if merchant country is not Germany.
-				if ( 'DE' !== $merchant_country ) {
-					unset( $payment_methods[ PayUponInvoiceGateway::ID ] );
-				}
-
-				// Unset all APMs other than OXXO for Mexico.
-				if ( 'MX' === $merchant_country ) {
-					unset( $payment_methods[ BancontactGateway::ID ] );
-					unset( $payment_methods[ BlikGateway::ID ] );
-					unset( $payment_methods[ EPSGateway::ID ] );
-					unset( $payment_methods[ IDealGateway::ID ] );
-					unset( $payment_methods[ MyBankGateway::ID ] );
-					unset( $payment_methods[ P24Gateway::ID ] );
-					unset( $payment_methods[ TrustlyGateway::ID ] );
-					unset( $payment_methods[ MultibancoGateway::ID ] );
-				}
-
-				// Unset PWC if the merchant does not have capability.
-				if ( ! $merchant_capabilities[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ] ) {
-					unset( $payment_methods[ PWCGateway::ID ] );
-				}
-
-				// Unset all AMP methods when the merchant is not eligible.
-				$apm_eligible = $container->get( 'ppcp-local-apms.eligibility.check' );
-				if ( ! $apm_eligible ) {
-					$payment_methods = array_diff_key(
-						$payment_methods,
-						array_column( $container->get( 'ppcp-local-apms.payment-methods' ), 'id', 'id' )
-					);
 				}
 
 				return $payment_methods;

--- a/tests/PHPUnit/Settings/Service/PaymentMethodsEligibilityServiceTest.php
+++ b/tests/PHPUnit/Settings/Service/PaymentMethodsEligibilityServiceTest.php
@@ -1,0 +1,223 @@
+<?php
+declare( strict_types=1 );
+
+namespace PHPUnit\Settings\Service;
+
+
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BancontactGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\BlikGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\EPSGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\IDealGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MultibancoGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\MyBankGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PWCGateway;
+use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
+use WooCommerce\PayPalCommerce\Settings\Service\PaymentMethodsEligibilityService;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
+use Mockery;
+
+class PaymentMethodsEligibilityServiceTest extends TestCase {
+
+	public function test_apm_mexico(): void {
+		$service = $this->get_service( 'MX' );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks[ OXXO::ID ]() );
+		$this->assertFalse( $eligibility_checks[ PWCGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ BancontactGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ BlikGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ EPSGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ IDealGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ MyBankGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ P24Gateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ TrustlyGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ MultibancoGateway::ID ]() );
+	}
+
+	public function test_apm_no_mexico(): void {
+		$service = $this->get_service( 'US' );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks[ OXXO::ID ]() );
+		$this->assertFalse( $eligibility_checks[ PWCGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ BancontactGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ BlikGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ EPSGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ IDealGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ MyBankGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ P24Gateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ TrustlyGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ MultibancoGateway::ID ]() );
+	}
+
+	public function test_apm_not_eligible(): void {
+		$service = $this->get_service( 'US', false );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks[ OXXO::ID ]() );
+		$this->assertFalse( $eligibility_checks[ PWCGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ BancontactGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ BlikGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ EPSGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ IDealGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ MyBankGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ P24Gateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ TrustlyGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ MultibancoGateway::ID ]() );
+	}
+
+	public function test_pwc_disabled(): void {
+		$service = $this->get_service();
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks[ PWCGateway::ID ]() );
+	}
+
+	public function test_pwc_enabled(): void {
+		$service = $this->get_service('US', true, true, true, true, true, true, [ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => true ]  );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks[ PWCGateway::ID ]() );
+	}
+
+	public function test_pay_upon_invoice_germany(): void {
+		$service = $this->get_service( 'DE' );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks[ PayUponInvoiceGateway::ID ]() );
+	}
+
+	public function test_pay_upon_invoice_not_germany(): void {
+		$service = $this->get_service( 'US' );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks[ PayUponInvoiceGateway::ID ]() );
+	}
+
+	public function test_is_card_fields_supported_mexico(): void {
+		$service = $this->get_service( 'MX' );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks[ CreditCardGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ CardButtonGateway::ID ]() );
+	}
+
+	public function test_is_card_fields_not_supported_mexico(): void {
+		$service = $this->get_service( 'MX', true, true, true, false );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks[ CreditCardGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ CardButtonGateway::ID ]() );
+	}
+
+	public function test_is_card_fields_supported(): void {
+		$service = $this->get_service();
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks[ CreditCardGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ CardButtonGateway::ID ]() );
+	}
+
+	public function test_is_card_fields_not_supported(): void {
+		$service = $this->get_service( 'US', true, true, true, false );;
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks[ CreditCardGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ CardButtonGateway::ID ]() );
+	}
+
+	public function test_dcc_status_inactive(): void {
+		$service = $this->get_service( 'US', true, false );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks[ CreditCardGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ AxoGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ CardButtonGateway::ID ]() );
+	}
+
+	public function test_axo_active(): void {
+		$service = $this->get_service();
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks[ AxoGateway::ID ]() );
+	}
+
+	public function test_axo_inactive(): void {
+		$service = $this->get_service( 'US', true, true, false );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks[ AxoGateway::ID ]() );
+	}
+
+	public function test_apple_and_google_active(): void {
+		$service = $this->get_service( 'US' );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks[ ApplePayGateway::ID ]() );
+		$this->assertTrue( $eligibility_checks[ GooglePayGateway::ID ]() );
+	}
+
+	public function test_apple_and_google_inactive(): void {
+		$service = $this->get_service( 'US', true, true, true, true, false, false );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks[ ApplePayGateway::ID ]() );
+		$this->assertFalse( $eligibility_checks[ GooglePayGateway::ID ]() );
+	}
+
+	public function test_venmo_us(): void {
+		$service = $this->get_service( 'US' );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertTrue( $eligibility_checks['venmo']() );
+	}
+
+	public function test_venmo_not_us(): void {
+		$service = $this->get_service( 'CA' );
+		$eligibility_checks = $service->get_eligibility_checks();
+
+		$this->assertFalse( $eligibility_checks['venmo']() );
+	}
+
+
+	private function expect_dcc_product_status( bool $status ): DCCProductStatus {
+		$dcc_product_status = Mockery::mock( DCCProductStatus::class );
+		$dcc_product_status->shouldReceive( 'is_active' )->andReturn( $status );
+
+		return $dcc_product_status;
+	}
+
+	private function get_service(
+		string $country_code = 'US',
+		bool $apm_enabled = true,
+		bool $dcc_product_status_enabled = true,
+		bool $axo_enabled = true,
+		bool $card_fields_enabled = true,
+		bool $apple_pay_enabled = true,
+		bool $google_pay_enabled = true,
+		array $merchant_capabilities = array()
+	): PaymentMethodsEligibilityService {
+		$dcc_product_status = $this->expect_dcc_product_status( $dcc_product_status_enabled );
+
+		return new PaymentMethodsEligibilityService(
+			$country_code,
+			$apm_enabled,
+			$merchant_capabilities,
+			$dcc_product_status,
+			fn() => $axo_enabled,
+			fn() => $card_fields_enabled,
+			$apple_pay_enabled,
+			$google_pay_enabled
+		);
+	}
+}


### PR DESCRIPTION
### Description

- Create `PaymentMethodsEligibilityService` in order to check the eligibilities for the PaymentMethods
- Refactor the SettingsModule to use this class for filtering out deactivated Payment Methods
- Tests

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Test with Mexico (see that Oxo is the only APM).  
2. Test with US -- Verify that Venmo, Apple Pay and Google Pay appears
3. Test with DE -- Verify Pay Upon Invoice appears
4. Test PWC method
5. Test Fastlane (aka AXO) appears when ADCD is enabled and is AXO eligible.
