### PR TITLE
Exclude node_modules in scoper

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -23,6 +23,7 @@ $finders = array(
 				'.idea',
 				'.psalm',
 				'tests',
+				'node_modules',
 			)
 		)
 		->in( '.' ),


### PR DESCRIPTION
Looks like Scoper was wasting lots of time going through every file in `node_modules`.

Now it's excluded and the packages should be created much faster.

I diffed the old and the new package, the only difference was in some auto-generated Composer files, so it should be ok.

<img width="758" height="212" alt="image" src="https://github.com/user-attachments/assets/e314af70-ffd2-4f45-894c-b85237310168" />
