### PR TITLE
[Refactor] Create a settings provider facade class (5597)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -30,6 +30,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\TodosDefinition;
@@ -83,6 +84,15 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
 $services = array(
 	'settings.url'                                        => static function ( ContainerInterface $container ): string {
 		return plugins_url( '/modules/ppcp-settings/', $container->get( 'ppcp.path-to-plugin-main-file' ) );
+	},
+	'settings.settings-provider'                          => static function ( ContainerInterface $container ): SettingsProvider {
+		return new SettingsProvider(
+			$container->get( 'settings.data.general' ),
+			$container->get( 'settings.data.onboarding' ),
+			$container->get( 'settings.data.payment' ),
+			$container->get( 'settings.data.settings' ),
+			$container->get( 'settings.data.styling' ),
+		);
 	},
 	'settings.data.onboarding'                            => static function ( ContainerInterface $container ): OnboardingProfile {
 		$can_use_casual_selling      = $container->get( 'settings.casual-selling.eligible' );

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -75,7 +75,7 @@ class SettingsProvider {
 	 * @return bool
 	 */
 	public function casual_seller(): bool {
-		return (bool) $this->general_settings->is_casual_seller();
+		return $this->general_settings->is_casual_seller();
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -12,18 +12,28 @@ declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Data;
 
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 
 class SettingsProvider {
 	private GeneralSettings $general_settings;
 	private OnboardingProfile $onboarding_profile;
+	private PaymentSettings $payment_settings;
+	private SettingsModel $settings_model;
+	private StylingSettings $styling_settings;
 
 	public function __construct(
 		GeneralSettings $general_settings,
-		OnboardingProfile $onboarding_profile
+		OnboardingProfile $onboarding_profile,
+		PaymentSettings $payment_settings,
+		SettingsModel $settings_model,
+		StylingSettings $styling_settings
 	) {
 		$this->general_settings   = $general_settings;
 		$this->onboarding_profile = $onboarding_profile;
+		$this->payment_settings   = $payment_settings;
+		$this->settings_model     = $settings_model;
+		$this->styling_settings   = $styling_settings;
 	}
 
 	/**
@@ -36,39 +46,12 @@ class SettingsProvider {
 	}
 
 	/**
-	 * Returns the list of read-only customization flags.
-	 *
-	 * @return array
-	 */
-	public function woo_settings(): array {
-		return $this->general_settings->get_woo_settings();
-	}
-
-	/**
-	 * Returns the full merchant connection DTO for the current connection.
-	 *
-	 * @return MerchantConnectionDTO All connection details.
-	 */
-	public function merchant_data(): MerchantConnectionDTO {
-		return $this->general_settings->get_merchant_data();
-	}
-
-	/**
 	 * Whether the currently connected merchant is a sandbox account.
 	 *
 	 * @return bool
 	 */
 	public function sandbox_merchant(): bool {
 		return $this->general_settings->is_sandbox_merchant();
-	}
-
-	/**
-	 * Whether the merchant successfully logged into their PayPal account.
-	 *
-	 * @return bool
-	 */
-	public function merchant_connected(): bool {
-		return $this->general_settings->is_merchant_connected();
 	}
 
 	/**
@@ -93,6 +76,33 @@ class SettingsProvider {
 	 */
 	public function casual_seller(): bool {
 		return (bool) $this->general_settings->is_casual_seller();
+	}
+
+	/**
+	 * Returns the list of read-only customization flags.
+	 *
+	 * @return array
+	 */
+	public function woo_settings(): array {
+		return $this->general_settings->get_woo_settings();
+	}
+
+	/**
+	 * Returns the full merchant connection DTO for the current connection.
+	 *
+	 * @return MerchantConnectionDTO All connection details.
+	 */
+	public function merchant_data(): MerchantConnectionDTO {
+		return $this->general_settings->get_merchant_data();
+	}
+
+	/**
+	 * Whether the merchant successfully logged into their PayPal account.
+	 *
+	 * @return bool
+	 */
+	public function merchant_connected(): bool {
+		return $this->general_settings->is_merchant_connected();
 	}
 
 	/**
@@ -122,6 +132,24 @@ class SettingsProvider {
 		return $this->general_settings->get_merchant_country();
 	}
 
+	/**
+	 * Whether the plugin is in the branded-experience mode and shows/enables only
+	 * payment methods that are PayPal's own brand.
+	 *
+	 * @return bool
+	 */
+	public function own_brand_only(): bool {
+		return $this->general_settings->own_brand_only();
+	}
+
+	/**
+	 * Retrieves the installation path. Used for the branded experience.
+	 *
+	 * @return string
+	 */
+	public function installation_path(): string {
+		return $this->general_settings->get_installation_path();
+	}
 	/**
 	 * Gets the Onboarding 'completed' flag.
 	 *
@@ -192,5 +220,249 @@ class SettingsProvider {
 	 */
 	public function gateways_refreshed(): bool {
 		return $this->onboarding_profile->is_gateways_refreshed();
+	}
+
+	/**
+	 * If it should show the PayPal logo.
+	 *
+	 * @return bool
+	 */
+	public function show_paypal_logo(): bool {
+		return $this->payment_settings->get_paypal_show_logo();
+	}
+
+	/**
+	 * If it should show CardHolder name.
+	 *
+	 * @return bool
+	 */
+	public function show_cardholder_name(): bool {
+		return $this->payment_settings->get_cardholder_name();
+	}
+
+	/**
+	 * Get if Fastlane should display watermark.
+	 *
+	 * @return bool
+	 */
+	public function show_fastlane_watermark(): bool {
+		return $this->payment_settings->get_fastlane_display_watermark();
+	}
+
+	/**
+	 * Get if Venmo is enabled.
+	 *
+	 * @return bool
+	 */
+	public function venmo_enabled(): bool {
+		return $this->payment_settings->get_venmo_enabled();
+	}
+
+	/**
+	 * Get if Pay Later is enabled.
+	 *
+	 * @return bool
+	 */
+	public function paylater_enabled(): bool {
+		return $this->payment_settings->get_paylater_enabled();
+	}
+
+	/**
+	 * Gets the invoice prefix.
+	 *
+	 * @return string The invoice prefix.
+	 */
+	public function invoice_prefix(): string {
+		return $this->settings_model->get_invoice_prefix();
+	}
+
+	/**
+	 * Gets the brand name.
+	 *
+	 * @return string The brand name.
+	 */
+	public function brand_name(): string {
+		return $this->settings_model->get_brand_name();
+	}
+
+	/**
+	 * Gets the soft descriptor.
+	 *
+	 * @return string The soft descriptor.
+	 */
+	public function soft_descriptor(): string {
+		return $this->settings_model->get_soft_descriptor();
+	}
+
+	/**
+	 * Gets the subtotal adjustment setting.
+	 *
+	 * @return string The subtotal adjustment setting.
+	 */
+	public function subtotal_adjustment(): string {
+		return $this->settings_model->get_subtotal_adjustment();
+	}
+
+	/**
+	 * Gets the landing page setting.
+	 *
+	 * @return string The landing page setting.
+	 */
+	public function landing_page(): string {
+		return $this->settings_model->get_landing_page();
+	}
+
+	/**
+	 * Gets the button language setting.
+	 *
+	 * @return string The button language.
+	 */
+	public function button_language(): string {
+		return $this->settings_model->get_button_language();
+	}
+
+	/**
+	 * Gets the 3D Secure setting.
+	 *
+	 * @return string The 3D Secure setting.
+	 */
+	public function three_d_secure(): string {
+		return $this->settings_model->get_three_d_secure();
+	}
+
+	/**
+	 * Gets the authorize only setting.
+	 *
+	 * @return bool True if authorize only is enabled, false otherwise.
+	 */
+	public function authorize_only(): bool {
+		return $this->settings_model->get_authorize_only();
+	}
+
+	/**
+	 * Gets the capture virtual orders setting.
+	 *
+	 * @return bool True if capturing virtual orders is enabled, false otherwise.
+	 */
+	public function capture_virtual_orders(): bool {
+		return $this->settings_model->get_capture_virtual_orders();
+	}
+
+	/**
+	 * Gets the save PayPal and Venmo setting.
+	 *
+	 * @return bool True if saving PayPal and Venmo is enabled, false otherwise.
+	 */
+	public function save_paypal_and_venmo(): bool {
+		return $this->settings_model->get_save_paypal_and_venmo();
+	}
+
+	/**
+	 * Gets the instant payments only setting.
+	 *
+	 * @return bool True if instant payments only setting is enabled, false otherwise.
+	 */
+	public function instant_payments_only(): bool {
+		return $this->settings_model->get_instant_payments_only();
+	}
+
+	/**
+	 * Gets the custom-shipping-contact flag ("Contact Module").
+	 *
+	 * @return bool True if the contact module feature is enabled, false otherwise.
+	 */
+	public function enable_contact_module(): bool {
+		return $this->settings_model->get_enable_contact_module();
+	}
+
+	/**
+	 * Gets the save card details setting.
+	 *
+	 * @return bool True if saving card details is enabled, false otherwise.
+	 */
+	public function save_card_details(): bool {
+		return $this->settings_model->get_save_card_details();
+	}
+
+	/**
+	 * Gets the enable Pay Now setting.
+	 *
+	 * @return bool True if Pay Now is enabled, false otherwise.
+	 */
+	public function enable_pay_now(): bool {
+		return $this->settings_model->get_enable_pay_now();
+	}
+
+	/**
+	 * Gets the enable logging setting.
+	 *
+	 * @return bool True if logging is enabled, false otherwise.
+	 */
+	public function enable_logging(): bool {
+		return $this->settings_model->get_enable_logging();
+	}
+
+	/**
+	 * Gets the disabled cards.
+	 *
+	 * @return array The array of disabled cards.
+	 */
+	public function disabled_cards(): array {
+		return $this->settings_model->get_disabled_cards();
+	}
+
+
+	/**
+	 * Gets the Stay Updated setting.
+	 *
+	 * @return bool True if Stay Updated is enabled, false otherwise.
+	 */
+	public function stay_updated(): bool {
+		return $this->settings_model->get_stay_updated();
+	}
+
+	/**
+	 * Get styling details for Cart and Block Cart.
+	 *
+	 * @return LocationStylingDTO
+	 */
+	public function styling_cart(): LocationStylingDTO {
+		return $this->styling_settings->get_cart();
+	}
+
+	/**
+	 * Get styling details for Classic Checkout.
+	 *
+	 * @return LocationStylingDTO
+	 */
+	public function styling_classic_checkout(): LocationStylingDTO {
+		return $this->styling_settings->get_classic_checkout();
+	}
+
+	/**
+	 * Get styling details for Express Checkout.
+	 *
+	 * @return LocationStylingDTO
+	 */
+	public function styling_express_checkout(): LocationStylingDTO {
+		return $this->styling_settings->get_express_checkout();
+	}
+
+	/**
+	 * Get styling details for Mini Cart
+	 *
+	 * @return LocationStylingDTO
+	 */
+	public function styling_mini_cart(): LocationStylingDTO {
+		return $this->styling_settings->get_mini_cart();
+	}
+
+	/**
+	 * Get styling details for Product Page.
+	 *
+	 * @return LocationStylingDTO
+	 */
+	public function styling_product(): LocationStylingDTO {
+		return $this->styling_settings->get_product();
 	}
 }

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * PayPal Commerce Provider Class
+ *
+ * The goal of the class is to have all new settings UI classes injected and serve as settings provider from one single place.
+ * Modules would use this SettingsProvider class to update the code from using the legacy Settings class to use the new settings.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Data
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Data;
+
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
+
+class SettingsProvider {
+	private GeneralSettings $general_settings;
+	private OnboardingProfile $onboarding_profile;
+
+	public function __construct(
+		GeneralSettings $general_settings,
+		OnboardingProfile $onboarding_profile
+	) {
+		$this->general_settings   = $general_settings;
+		$this->onboarding_profile = $onboarding_profile;
+	}
+
+	/**
+	 * Gets the 'use sandbox' setting.
+	 *
+	 * @return bool
+	 */
+	public function use_sandbox(): bool {
+		return $this->general_settings->get_sandbox();
+	}
+
+	/**
+	 * Returns the list of read-only customization flags.
+	 *
+	 * @return array
+	 */
+	public function woo_settings(): array {
+		return $this->general_settings->get_woo_settings();
+	}
+
+	/**
+	 * Returns the full merchant connection DTO for the current connection.
+	 *
+	 * @return MerchantConnectionDTO All connection details.
+	 */
+	public function merchant_data(): MerchantConnectionDTO {
+		return $this->general_settings->get_merchant_data();
+	}
+
+	/**
+	 * Whether the currently connected merchant is a sandbox account.
+	 *
+	 * @return bool
+	 */
+	public function sandbox_merchant(): bool {
+		return $this->general_settings->is_sandbox_merchant();
+	}
+
+	/**
+	 * Whether the merchant successfully logged into their PayPal account.
+	 *
+	 * @return bool
+	 */
+	public function merchant_connected(): bool {
+		return $this->general_settings->is_merchant_connected();
+	}
+
+	/**
+	 * Whether the merchant uses a business account.
+	 *
+	 * Note: It's possible that the seller type is unknown, and both methods,
+	 * `is_casual_seller()` and `is_business_seller()` return false.
+	 *
+	 * @return bool
+	 */
+	public function business_seller(): bool {
+		return $this->general_settings->is_business_seller();
+	}
+
+	/**
+	 * Whether the merchant is a casual seller using a personal account.
+	 *
+	 * Note: It's possible that the seller type is unknown, and both methods,
+	 * `is_casual_seller()` and `is_business_seller()` return false.
+	 *
+	 * @return bool
+	 */
+	public function casual_seller(): bool {
+		return (bool) $this->general_settings->is_casual_seller();
+	}
+
+	/**
+	 * Gets the currently connected merchant ID.
+	 *
+	 * @return string
+	 */
+	public function merchant_id(): string {
+		return $this->general_settings->get_merchant_id();
+	}
+
+	/**
+	 * Gets the currently connected merchant's email.
+	 *
+	 * @return string
+	 */
+	public function merchant_email(): string {
+		return $this->general_settings->get_merchant_email();
+	}
+
+	/**
+	 * Gets the currently connected merchant's country.
+	 *
+	 * @return string
+	 */
+	public function merchant_country(): string {
+		return $this->general_settings->get_merchant_country();
+	}
+
+	/**
+	 * Gets the Onboarding 'completed' flag.
+	 *
+	 * @return bool
+	 */
+	public function onboarding_completed(): bool {
+		return $this->onboarding_profile->get_completed();
+	}
+
+	/**
+	 * Gets the Onboarding 'step' setting.
+	 *
+	 * @return int
+	 */
+	public function onboarding_step(): int {
+		return $this->onboarding_profile->get_step();
+	}
+
+	/**
+	 * Whether the merchant wants to accept card payments via the PayPal plugin.
+	 *
+	 * @return bool
+	 */
+	public function accept_card_payments(): bool {
+		return $this->onboarding_profile->get_accept_card_payments();
+	}
+
+	/**
+	 * Gets the active product types for this store.
+	 *
+	 * @return string[] Any of ['virtual'|'physical'|'subscriptions'].
+	 */
+	public function products(): array {
+		return $this->onboarding_profile->get_products();
+	}
+
+	/**
+	 * Returns the list of read-only customization flags
+	 *
+	 * @return array
+	 */
+	public function flags(): array {
+		return $this->onboarding_profile->get_flags();
+	}
+
+	/**
+	 * Gets the 'setup_done' flag.
+	 *
+	 * @return bool
+	 */
+	public function setup_done(): bool {
+		return $this->onboarding_profile->is_setup_done();
+	}
+
+	/**
+	 * Get whether gateways have been synced.
+	 *
+	 * @return bool
+	 */
+	public function gateways_synced(): bool {
+		return $this->onboarding_profile->is_gateways_synced();
+	}
+
+	/**
+	 * Get whether gateways have been refreshed.
+	 *
+	 * @return bool
+	 */
+	public function gateways_refreshed(): bool {
+		return $this->onboarding_profile->is_gateways_refreshed();
+	}
+}

--- a/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
+++ b/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
@@ -7,7 +7,11 @@ namespace PHPUnit\Settings\Data;
 use Mockery;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\TestCase;
 
@@ -18,14 +22,26 @@ class SettingsProviderTest extends TestCase {
 	private const EXPECTED_VALUE_ARRAY = array();
 	private const EXPECTED_VALUE_INT = 2;
 
+	private GeneralSettings $general_settings;
+	private OnboardingProfile $onboarding_profile;
+	private PaymentSettings $payment_settings;
+	private SettingsModel $settings_model;
+	private StylingSettings $styling_settings;
+
 	public function setUp(): void {
 		// Mock Models
-		$this->general_settings = Mockery::mock( GeneralSettings::class );
+		$this->general_settings   = Mockery::mock( GeneralSettings::class );
 		$this->onboarding_profile = Mockery::mock( OnboardingProfile::class );
+		$this->payment_settings   = Mockery::mock( PaymentSettings::class );
+		$this->settings_model     = Mockery::mock( SettingsModel::class );
+		$this->styling_settings   = Mockery::mock( StylingSettings::class );
 
 		$this->provider = new SettingsProvider(
 			$this->general_settings,
-			$this->onboarding_profile
+			$this->onboarding_profile,
+			$this->payment_settings,
+			$this->settings_model,
+			$this->styling_settings
 		);
 	}
 
@@ -64,13 +80,16 @@ class SettingsProviderTest extends TestCase {
 		return array_merge(
 			$this->get_model_data( $this->get_general_settings_data(), 'general_settings' ),
 			$this->get_model_data( $this->get_onboarding_profile_data(), 'onboarding_profile' ),
+			$this->get_model_data( $this->get_payment_settings_data(), 'payment_settings' ),
+			$this->get_model_data( $this->get_settings_model_data(), 'settings_model' ),
+			$this->get_model_data( $this->get_styling_settings_data(), 'styling_settings' ),
 		);
 	}
 
 	/**
 	 * Attach a model into the test data.
 	 *
-	 * @param array $data
+	 * @param array  $data
 	 * @param string $model
 	 *
 	 * @return array
@@ -79,6 +98,7 @@ class SettingsProviderTest extends TestCase {
 		return array_map(
 			function ( array $method_data ) use ( $model ) {
 				$method_data['model'] = $model;
+
 				return $method_data;
 			},
 			$data
@@ -87,8 +107,8 @@ class SettingsProviderTest extends TestCase {
 
 	/**
 	 * Test data for the GeneralSettings model.
-	 * @see GeneralSettings
 	 * @return array
+	 * @see GeneralSettings
 	 */
 	private function get_general_settings_data(): array {
 		return array(
@@ -105,7 +125,7 @@ class SettingsProviderTest extends TestCase {
 			array(
 				'provider_method' => 'merchant_data',
 				'model_method'    => 'get_merchant_data',
-				'expected_value'  => new MerchantConnectionDTO(true, '','',''),
+				'expected_value'  => new MerchantConnectionDTO( true, '', '', '' ),
 			),
 			array(
 				'provider_method' => 'sandbox_merchant',
@@ -142,13 +162,23 @@ class SettingsProviderTest extends TestCase {
 				'model_method'    => 'get_merchant_country',
 				'expected_value'  => self::EXPECTED_VALUE_STRING
 			),
+			array(
+				'provider_method' => 'own_brand_only',
+				'model_method'    => 'own_brand_only',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'installation_path',
+				'model_method'    => 'get_installation_path',
+				'expected_value'  => self::EXPECTED_VALUE_STRING
+			),
 		);
 	}
 
 	/**
 	 * Test data for the OnboardingProfile model.
-	 * @see OnboardingProfile
 	 * @return array
+	 * @see OnboardingProfile
 	 */
 	private function get_onboarding_profile_data(): array {
 		return array(
@@ -191,6 +221,173 @@ class SettingsProviderTest extends TestCase {
 				'provider_method' => 'gateways_refreshed',
 				'model_method'    => 'is_gateways_refreshed',
 				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+		);
+	}
+
+	/**
+	 * Test data for the PaymentSettings model.
+	 * @return array
+	 * @see PaymentSettings
+	 */
+	private function get_payment_settings_data(): array {
+		return array(
+			array(
+				'provider_method' => 'show_paypal_logo',
+				'model_method'    => 'get_paypal_show_logo',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'show_cardholder_name',
+				'model_method'    => 'get_cardholder_name',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'show_fastlane_watermark',
+				'model_method'    => 'get_fastlane_display_watermark',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'venmo_enabled',
+				'model_method'    => 'get_venmo_enabled',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'paylater_enabled',
+				'model_method'    => 'get_paylater_enabled',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+		);
+	}
+
+	/**
+	 * Test data for the SettingsModel model.
+	 * @return array
+	 * @see SettingsModel
+	 */
+	private function get_settings_model_data(): array {
+		return array(
+			array(
+				'provider_method' => 'invoice_prefix',
+				'model_method'    => 'get_invoice_prefix',
+				'expected_value'  => self::EXPECTED_VALUE_STRING
+			),
+			array(
+				'provider_method' => 'brand_name',
+				'model_method'    => 'get_brand_name',
+				'expected_value'  => self::EXPECTED_VALUE_STRING
+			),
+			array(
+				'provider_method' => 'soft_descriptor',
+				'model_method'    => 'get_soft_descriptor',
+				'expected_value'  => self::EXPECTED_VALUE_STRING,
+			),
+			array(
+				'provider_method' => 'subtotal_adjustment',
+				'model_method'    => 'get_subtotal_adjustment',
+				'expected_value'  => self::EXPECTED_VALUE_STRING,
+			),
+			array(
+				'provider_method' => 'landing_page',
+				'model_method'    => 'get_landing_page',
+				'expected_value'  => self::EXPECTED_VALUE_STRING,
+			),
+			array(
+				'provider_method' => 'button_language',
+				'model_method'    => 'get_button_language',
+				'expected_value'  => self::EXPECTED_VALUE_STRING,
+			),
+			array(
+				'provider_method' => 'three_d_secure',
+				'model_method'    => 'get_three_d_secure',
+				'expected_value'  => self::EXPECTED_VALUE_STRING,
+			),
+			array(
+				'provider_method' => 'authorize_only',
+				'model_method'    => 'get_authorize_only',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'capture_virtual_orders',
+				'model_method'    => 'get_capture_virtual_orders',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'save_paypal_and_venmo',
+				'model_method'    => 'get_save_paypal_and_venmo',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'instant_payments_only',
+				'model_method'    => 'get_instant_payments_only',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'enable_contact_module',
+				'model_method'    => 'get_enable_contact_module',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'save_card_details',
+				'model_method'    => 'get_save_card_details',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'enable_pay_now',
+				'model_method'    => 'get_enable_pay_now',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'enable_logging',
+				'model_method'    => 'get_enable_logging',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'disabled_cards',
+				'model_method'    => 'get_disabled_cards',
+				'expected_value'  => self::EXPECTED_VALUE_ARRAY,
+			),
+			array(
+				'provider_method' => 'stay_updated',
+				'model_method'    => 'get_stay_updated',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+		);
+	}
+
+	/**
+	 * Test data for the StylingSettings model.
+	 * @return array
+	 * @see StylingSettings
+	 */
+	private function get_styling_settings_data(): array {
+		$styling_dto = new LocationStylingDTO();
+
+		return array(
+			array(
+				'provider_method' => 'styling_cart',
+				'model_method'    => 'get_cart',
+				'expected_value'  => $styling_dto
+			),
+			array(
+				'provider_method' => 'styling_classic_checkout',
+				'model_method'    => 'get_classic_checkout',
+				'expected_value'  => $styling_dto
+			),
+			array(
+				'provider_method' => 'styling_express_checkout',
+				'model_method'    => 'get_express_checkout',
+				'expected_value'  => $styling_dto,
+			),
+			array(
+				'provider_method' => 'styling_mini_cart',
+				'model_method'    => 'get_mini_cart',
+				'expected_value'  => $styling_dto,
+			),
+			array(
+				'provider_method' => 'styling_product',
+				'model_method'    => 'get_product',
+				'expected_value'  => $styling_dto,
 			),
 		);
 	}

--- a/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
+++ b/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace PHPUnit\Settings\Data;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
+use WooCommerce\PayPalCommerce\TestCase;
+
+class SettingsProviderTest extends TestCase {
+
+	private const EXPECTED_VALUE_STRING = 'EXPECTED_VALUE';
+	private const EXPECTED_VALUE_BOOL = true;
+	private const EXPECTED_VALUE_ARRAY = array();
+	private const EXPECTED_VALUE_INT = 2;
+
+	public function setUp(): void {
+		// Mock Models
+		$this->general_settings = Mockery::mock( GeneralSettings::class );
+		$this->onboarding_profile = Mockery::mock( OnboardingProfile::class );
+
+		$this->provider = new SettingsProvider(
+			$this->general_settings,
+			$this->onboarding_profile
+		);
+	}
+
+	/**
+	 * Test SettingsProvider delegates the calls to the model.
+	 *
+	 * @dataProvider settings_method_provider
+	 *
+	 * @param string $provider_method The method name in the SettingsProvider class.
+	 * @param string $model The model mapped in the provider.
+	 * @param string $model_method The method name of the mocked model.
+	 * @param mixed  $expected_value The expected return value of the mocked model method.
+	 */
+	public function test_settings_method_delegation(
+		string $provider_method,
+		string $model_method,
+		$expected_value,
+		string $model
+	): void {
+		// Access the mocked model (i.e $this->general_settings)
+		$target_mock = $this->$model;
+
+		//The model should receive the model method call and return the expected value.
+		$target_mock->shouldReceive( $model_method )->andReturn( $expected_value );
+
+		// Call the method in the provider class.
+		$result = $this->provider->$provider_method();
+
+		$this->assertSame( $expected_value, $result );
+	}
+
+	/**
+	 * Data provider for SettingsProvider class.
+	 */
+	public function settings_method_provider(): array {
+		return array_merge(
+			$this->get_model_data( $this->get_general_settings_data(), 'general_settings' ),
+			$this->get_model_data( $this->get_onboarding_profile_data(), 'onboarding_profile' ),
+		);
+	}
+
+	/**
+	 * Attach a model into the test data.
+	 *
+	 * @param array $data
+	 * @param string $model
+	 *
+	 * @return array
+	 */
+	private function get_model_data( array $data, string $model ): array {
+		return array_map(
+			function ( array $method_data ) use ( $model ) {
+				$method_data['model'] = $model;
+				return $method_data;
+			},
+			$data
+		);
+	}
+
+	/**
+	 * Test data for the GeneralSettings model.
+	 * @see GeneralSettings
+	 * @return array
+	 */
+	private function get_general_settings_data(): array {
+		return array(
+			array(
+				'provider_method' => 'use_sandbox',
+				'model_method'    => 'get_sandbox',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'woo_settings',
+				'model_method'    => 'get_woo_settings',
+				'expected_value'  => self::EXPECTED_VALUE_ARRAY
+			),
+			array(
+				'provider_method' => 'merchant_data',
+				'model_method'    => 'get_merchant_data',
+				'expected_value'  => new MerchantConnectionDTO(true, '','',''),
+			),
+			array(
+				'provider_method' => 'sandbox_merchant',
+				'model_method'    => 'is_sandbox_merchant',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'merchant_connected',
+				'model_method'    => 'is_merchant_connected',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'business_seller',
+				'model_method'    => 'is_business_seller',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'casual_seller',
+				'model_method'    => 'is_casual_seller',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'merchant_id',
+				'model_method'    => 'get_merchant_id',
+				'expected_value'  => self::EXPECTED_VALUE_STRING
+			),
+			array(
+				'provider_method' => 'merchant_email',
+				'model_method'    => 'get_merchant_email',
+				'expected_value'  => self::EXPECTED_VALUE_STRING
+			),
+			array(
+				'provider_method' => 'merchant_country',
+				'model_method'    => 'get_merchant_country',
+				'expected_value'  => self::EXPECTED_VALUE_STRING
+			),
+		);
+	}
+
+	/**
+	 * Test data for the OnboardingProfile model.
+	 * @see OnboardingProfile
+	 * @return array
+	 */
+	private function get_onboarding_profile_data(): array {
+		return array(
+			array(
+				'provider_method' => 'onboarding_completed',
+				'model_method'    => 'get_completed',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL
+			),
+			array(
+				'provider_method' => 'onboarding_step',
+				'model_method'    => 'get_step',
+				'expected_value'  => self::EXPECTED_VALUE_INT
+			),
+			array(
+				'provider_method' => 'accept_card_payments',
+				'model_method'    => 'get_accept_card_payments',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'products',
+				'model_method'    => 'get_products',
+				'expected_value'  => self::EXPECTED_VALUE_ARRAY,
+			),
+			array(
+				'provider_method' => 'flags',
+				'model_method'    => 'get_flags',
+				'expected_value'  => self::EXPECTED_VALUE_ARRAY,
+			),
+			array(
+				'provider_method' => 'setup_done',
+				'model_method'    => 'is_setup_done',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'gateways_synced',
+				'model_method'    => 'is_gateways_synced',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+			array(
+				'provider_method' => 'gateways_refreshed',
+				'model_method'    => 'is_gateways_refreshed',
+				'expected_value'  => self::EXPECTED_VALUE_BOOL,
+			),
+		);
+	}
+}


### PR DESCRIPTION
### Description

- Create a class `SettingsProvider` to have all new settings UI classes (GeneralSettings.php, OnboardingProfile.php, PaymentSettings.php, SettingsModel.php and StylingSettings.php) injected and serve as a settings provider from one single place.
- Add the service for instantiating the class and injecting the Models
- Tests

### Steps to Test

-  Examine `SettingsProviderTest` data methods
-  Observe the mapped methods make sense in their respective models
