### PR TITLE
Add eslint mapping for resolving custom aliases (5337)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,18 @@
 	},
 	"rules": {
 		"no-console": ["error", { "allow": ["warn", "error"] }]
+	},
+	"import/resolver": {
+		"alias": {
+			"map": [
+				// Special case for ppcp-button. Everything is under modules
+				["@ppcp-button", "./ppcp-button/resources/js/modules"],
+				// Dynamic pattern for other modules
+				["/^@(ppcp-\w+)$/", ",./$1/resources/js"]
+			],
+			"extensions": [".js", ".jsx", ".ts", ".tsx"]
+		}
 	}
+
+
 }


### PR DESCRIPTION
### Description

Prevents` import/no-unresolved` warnings in the IDE for the custom aliases.

### Steps to Test

1. Run `npm run build:modules` 
2. Everything compiles fine
3. Go to your PHP Storm IDE
4. See that @ppcp-button imports are not showing a warning anymore
5. See that @ppcp-blocks imports are not showing a warning anymore

