### PR TITLE
ppcp-wc-subscriptions SettingsProvider migration (5618)

### DIFF
--- a/modules/ppcp-wc-subscriptions/services.php
+++ b/modules/ppcp-wc-subscriptions/services.php
@@ -33,7 +33,7 @@ return array(
 		$purchase_unit_factory = $container->get( 'api.factory.purchase-unit' );
 		$payer_factory         = $container->get( 'api.factory.payer' );
 		$environment           = $container->get( 'settings.environment' );
-		$settings                      = $container->get( 'wcgateway.settings' );
+		$settings_provider             = $container->get( 'settings.settings-provider' );
 		$authorized_payments_processor = $container->get( 'wcgateway.processor.authorized-payments' );
 		$funding_source_renderer       = $container->get( 'wcgateway.funding-source.renderer' );
 		return new RenewalHandler(
@@ -44,7 +44,7 @@ return array(
 			$container->get( 'api.factory.shipping-preference' ),
 			$payer_factory,
 			$environment,
-			$settings,
+			$settings_provider,
 			$authorized_payments_processor,
 			$funding_source_renderer,
 			$container->get( 'wc-subscriptions.helpers.real-time-account-updater' ),
@@ -69,7 +69,7 @@ return array(
 	},
 	'wc-subscriptions.vault-v2.display-saved-payment-tokens' => static function ( ContainerInterface $container ): DisplaySavedPaymentTokens {
 		return new DisplaySavedPaymentTokens(
-			$container->get( 'wcgateway.settings' ),
+			$container->get( 'settings.settings-provider' ),
 			$container->get( 'wc-subscriptions.helper' )
 		);
 	},

--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -37,7 +37,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderMetaTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\PaymentsStatusHandlingTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\RealTimeAccountUpdaterHelper;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
@@ -100,11 +100,11 @@ class RenewalHandler {
 	protected $environment;
 
 	/**
-	 * The settings
+	 * The settings provider
 	 *
-	 * @var Settings
+	 * @var SettingsProvider
 	 */
-	protected $settings;
+	protected $settings_provider;
 
 	/**
 	 * The processor for authorized payments.
@@ -163,7 +163,7 @@ class RenewalHandler {
 	 * @param ShippingPreferenceFactory    $shipping_preference_factory The shipping_preference factory.
 	 * @param PayerFactory                 $payer_factory The payer factory.
 	 * @param Environment                  $environment The environment.
-	 * @param Settings                     $settings The Settings.
+	 * @param SettingsProvider             $settings_provider The Settings Provider.
 	 * @param AuthorizedPaymentsProcessor  $authorized_payments_processor The Authorized Payments Processor.
 	 * @param FundingSourceRenderer        $funding_source_renderer The funding source renderer.
 	 * @param RealTimeAccountUpdaterHelper $real_time_account_updater_helper Real Time Account Updater helper.
@@ -180,7 +180,7 @@ class RenewalHandler {
 		ShippingPreferenceFactory $shipping_preference_factory,
 		PayerFactory $payer_factory,
 		Environment $environment,
-		Settings $settings,
+		SettingsProvider $settings_provider,
 		AuthorizedPaymentsProcessor $authorized_payments_processor,
 		FundingSourceRenderer $funding_source_renderer,
 		RealTimeAccountUpdaterHelper $real_time_account_updater_helper,
@@ -197,7 +197,7 @@ class RenewalHandler {
 		$this->shipping_preference_factory      = $shipping_preference_factory;
 		$this->payer_factory                    = $payer_factory;
 		$this->environment                      = $environment;
-		$this->settings                         = $settings;
+		$this->settings_provider                = $settings_provider;
 		$this->authorized_payments_processor    = $authorized_payments_processor;
 		$this->funding_source_renderer          = $funding_source_renderer;
 		$this->real_time_account_updater_helper = $real_time_account_updater_helper;
@@ -475,13 +475,9 @@ class RenewalHandler {
 	 * @param Order $order The PayPal order.
 	 *
 	 * @return bool
-	 * @throws NotFoundException When a setting was not found.
 	 */
 	protected function capture_authorized_downloads( Order $order ): bool {
-		if (
-			! $this->settings->has( 'capture_for_virtual_only' )
-			|| ! $this->settings->get( 'capture_for_virtual_only' )
-		) {
+		if ( ! $this->settings_provider->capture_virtual_orders() ) {
 			return false;
 		}
 

--- a/modules/ppcp-wc-subscriptions/src/VaultV2/DisplaySavedPaymentTokens.php
+++ b/modules/ppcp-wc-subscriptions/src/VaultV2/DisplaySavedPaymentTokens.php
@@ -5,22 +5,21 @@ namespace WooCommerce\PayPalCommerce\WcSubscriptions\VaultV2;
 
 use WC_Payment_Token_CC;
 use WC_Payment_Tokens;
-use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 class DisplaySavedPaymentTokens {
 
-	private Settings $settings;
+	private SettingsProvider $settings_provider;
 	private SubscriptionHelper $subscription_helper;
 
 	public function __construct(
-		Settings $settings,
+		SettingsProvider $settings_provider,
 		SubscriptionHelper $subscription_helper
 	) {
-		$this->settings            = $settings;
+		$this->settings_provider   = $settings_provider;
 		$this->subscription_helper = $subscription_helper;
 	}
 
@@ -35,8 +34,7 @@ class DisplaySavedPaymentTokens {
 		string $id,
 		string $description
 	): string {
-		if ( $this->settings->has( 'vault_enabled' )
-			&& $this->settings->get( 'vault_enabled' )
+		if ( $this->settings_provider->save_paypal_and_venmo()
 			&& PayPalGateway::ID === $id
 			&& $this->subscription_helper->is_subscription_change_payment()
 		) {
@@ -63,14 +61,12 @@ class DisplaySavedPaymentTokens {
 	 * @param string $id The payment gateway Id.
 	 * @param array  $default_fields Default payment gateway fields.
 	 * @return array|mixed|string
-	 * @throws NotFoundException When setting was not found.
 	 */
 	public function display_saved_credit_cards(
 		string $id,
 		array $default_fields
 	) {
-		if ( $this->settings->has( 'vault_enabled_dcc' )
-			&& $this->settings->get( 'vault_enabled_dcc' )
+		if ( $this->settings_provider->save_card_details()
 			&& $this->subscription_helper->is_subscription_change_payment()
 			&& CreditCardGateway::ID === $id
 		) {

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -26,7 +26,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Endpoint\SubscriptionChangePaymentMethod;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
@@ -487,10 +487,13 @@ class WcSubscriptionsModule implements ServiceModule, ExtendingModule, Executabl
 		add_filter(
 			'woocommerce_paypal_payments_paypal_gateway_supports',
 			function ( array $supports ) use ( $c ): array {
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
+				$settings_provider = $c->get( 'settings.settings-provider' );
+				assert( $settings_provider instanceof SettingsProvider );
 
-				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
+				$subscription_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscription_helper instanceof SubscriptionHelper );
+
+				$subscriptions_mode = $this->get_subscriptions_mode( $settings_provider, $subscription_helper );
 				if ( 'disable_paypal_subscriptions' === $subscriptions_mode ) {
 					return $supports;
 				}
@@ -504,15 +507,17 @@ class WcSubscriptionsModule implements ServiceModule, ExtendingModule, Executabl
 		add_filter(
 			'woocommerce_paypal_payments_credit_card_gateway_supports',
 			function ( array $supports ) use ( $c ): array {
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
+				$settings_provider = $c->get( 'settings.settings-provider' );
+				assert( $settings_provider instanceof SettingsProvider );
 
-				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
+				$subscription_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscription_helper instanceof SubscriptionHelper );
+
+				$subscriptions_mode = $this->get_subscriptions_mode( $settings_provider, $subscription_helper );
 				if ( 'disable_paypal_subscriptions' === $subscriptions_mode ) {
 					return $supports;
 				}
-				$vaulting_enabled = $settings->has( 'vault_enabled_dcc' ) && $settings->get( 'vault_enabled_dcc' );
-				if ( ! $vaulting_enabled ) {
+				if ( ! $settings_provider->save_card_details() ) {
 					return $supports;
 				}
 				return array_merge(
@@ -525,10 +530,13 @@ class WcSubscriptionsModule implements ServiceModule, ExtendingModule, Executabl
 		add_filter(
 			'woocommerce_paypal_payments_card_button_gateway_supports',
 			function ( array $supports ) use ( $c ): array {
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
+				$settings_provider = $c->get( 'settings.settings-provider' );
+				assert( $settings_provider instanceof SettingsProvider );
 
-				$subscriptions_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
+				$subscription_helper = $c->get( 'wc-subscriptions.helper' );
+				assert( $subscription_helper instanceof SubscriptionHelper );
+
+				$subscriptions_mode = $this->get_subscriptions_mode( $settings_provider, $subscription_helper );
 				if ( 'disable_paypal_subscriptions' === $subscriptions_mode ) {
 					return $supports;
 				}
@@ -538,5 +546,34 @@ class WcSubscriptionsModule implements ServiceModule, ExtendingModule, Executabl
 				);
 			}
 		);
+	}
+
+	/**
+	 * Gets the subscriptions mode based on settings.
+	 *
+	 * @param SettingsProvider   $settings_provider The settings provider.
+	 * @param SubscriptionHelper $subscription_helper The subscription helper.
+	 * @return string The subscriptions mode ('vaulting_api', 'subscriptions_api', or 'disable_paypal_subscriptions').
+	 */
+	private function get_subscriptions_mode(
+		SettingsProvider $settings_provider,
+		SubscriptionHelper $subscription_helper
+	): string {
+		if ( ! $subscription_helper->plugin_is_active() ) {
+			return '';
+		}
+
+		$subscription_mode_disabled = (bool) apply_filters(
+			'woocommerce_paypal_payments_subscription_mode_disabled',
+			false
+		);
+
+		if ( $subscription_mode_disabled ) {
+			return 'disable_paypal_subscriptions';
+		}
+
+		return $settings_provider->save_paypal_and_venmo()
+			? 'vaulting_api'
+			: 'subscriptions_api';
 	}
 }


### PR DESCRIPTION
This PR replaces `wcgateway.settings` service with the new `SettingsProvider` in `ppcp-wc-subscriptions` module.

### PR Changes
- Replaces old settings methods with new provider methods:
  - `vault_enabled` → `save_paypal_and_venmo()`
  - `vault_enabled_dcc` → `save_card_details()`
  - `capture_for_virtual_only` → `capture_virtual_orders()`
- Implements new method `get_subscriptions_mode()` to centralize subscription mode determination logic based on `SettingsProvider` and subscription helper
- Removes unnecessary `NotFoundException` exception handling as the new provider doesn't throw these exceptions

