### PR TITLE
ppcp-paypal-subscriptions SettingsProvider migration (5611)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\PayPalSubscriptions;
 
-use ActionScheduler_Store;
 use WC_Order;
 use WC_Product;
 use WC_Product_Subscription_Variation;
@@ -24,9 +23,8 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WP_Post;
 
@@ -163,12 +161,8 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			function ( $product_id ) use ( $c ) {
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
-
-				try {
-					$subscriptions_mode = $settings->get( 'subscriptions_mode' );
-				} catch ( NotFoundException $exception ) {
+				$subscriptions_mode = $this->get_subscriptions_mode( $c );
+				if ( empty( $subscriptions_mode ) ) {
 					return;
 				}
 
@@ -201,7 +195,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			static function ( $passed_validation, $product_id ) use ( $c ) {
+			function ( $passed_validation, $product_id ) use ( $c ) {
 				if ( WC()->cart->is_empty() || wcs_is_manual_renewal_enabled() ) {
 					return $passed_validation;
 				}
@@ -213,10 +207,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 					return false;
 				}
 
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
-
-				$subscriptions_mode     = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
+				$subscriptions_mode     = $this->get_subscriptions_mode( $c );
 				$is_paypal_subscription = static function ( $product ) use ( $subscriptions_mode ): bool {
 					return $product &&
 						in_array( $product->get_type(), array( 'subscription', 'variable-subscription' ), true ) &&
@@ -434,31 +425,24 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 				if ( wcs_is_manual_renewal_enabled() ) {
 					return;
 				}
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
 
-				try {
-					$subscriptions_mode = $settings->get( 'subscriptions_mode' );
-					if ( $subscriptions_mode === 'subscriptions_api' ) {
-						/**
-						 * Needed for getting global post object.
-						 *
-						 * @psalm-suppress InvalidGlobal
-						 */
-						global $post;
-						$product = wc_get_product( $post->ID );
-						if ( ! is_a( $product, WC_Product::class ) ) {
-							return;
-						}
-
-						$environment = $c->get( 'settings.environment' );
-						echo '<div class="options_group subscription_pricing show_if_subscription hidden">';
-						$this->render_paypal_subscription_fields( $product, $environment );
-						echo '</div>';
-
+				$subscriptions_mode = $this->get_subscriptions_mode( $c );
+				if ( $subscriptions_mode === 'subscriptions_api' ) {
+					/**
+					 * Needed for getting global post object.
+					 *
+					 * @psalm-suppress InvalidGlobal
+					 */
+					global $post;
+					$product = wc_get_product( $post->ID );
+					if ( ! is_a( $product, WC_Product::class ) ) {
+						return;
 					}
-				} catch ( NotFoundException $exception ) {
-					return;
+
+					$environment = $c->get( 'settings.environment' );
+					echo '<div class="options_group subscription_pricing show_if_subscription hidden">';
+					$this->render_paypal_subscription_fields( $product, $environment );
+					echo '</div>';
 				}
 			}
 		);
@@ -474,23 +458,16 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 				if ( wcs_is_manual_renewal_enabled() ) {
 					return;
 				}
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
 
-				try {
-					$subscriptions_mode = $settings->get( 'subscriptions_mode' );
-					if ( $subscriptions_mode === 'subscriptions_api' ) {
-						$product = wc_get_product( $variation->ID );
-						if ( ! is_a( $product, WC_Product_Subscription_Variation::class ) ) {
-							return;
-						}
-
-						$environment = $c->get( 'settings.environment' );
-						$this->render_paypal_subscription_fields( $product, $environment );
-
+				$subscriptions_mode = $this->get_subscriptions_mode( $c );
+				if ( $subscriptions_mode === 'subscriptions_api' ) {
+					$product = wc_get_product( $variation->ID );
+					if ( ! is_a( $product, WC_Product_Subscription_Variation::class ) ) {
+						return;
 					}
-				} catch ( NotFoundException $exception ) {
-					return;
+
+					$environment = $c->get( 'settings.environment' );
+					$this->render_paypal_subscription_fields( $product, $environment );
 				}
 			},
 			10,
@@ -509,8 +486,7 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 					return;
 				}
 
-				$settings          = $c->get( 'wcgateway.settings' );
-				$subscription_mode = $settings->has( 'subscriptions_mode' ) ? $settings->get( 'subscriptions_mode' ) : '';
+				$subscription_mode = $this->get_subscriptions_mode( $c );
 				if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) || $subscription_mode !== 'subscriptions_api' ) {
 					return;
 				}
@@ -747,5 +723,30 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 				'</label><input type="text" class="short ppcp_subscription_plan_name" id="ppcp_subscription_plan_name-' . esc_attr( (string) $product->get_id() ) . '" name="_ppcp_subscription_plan_name" value="' . esc_attr( $subscription_plan_name ) . '"></p>'
 			);
 		}
+	}
+
+	/**
+	 * Gets the PayPal Subscriptions mode.
+	 *
+	 * @param ContainerInterface $container The service container.
+	 * @return string The subscriptions mode: 'vaulting_api', 'subscriptions_api', 'disable_paypal_subscriptions', or empty string if WC Subscriptions is not active.
+	 */
+	private function get_subscriptions_mode( ContainerInterface $container ): string {
+		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
+		assert( $subscription_helper instanceof SubscriptionHelper );
+
+		if ( ! $subscription_helper->plugin_is_active() ) {
+			return '';
+		}
+
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
+
+		$vaulting                = $settings_provider->save_paypal_and_venmo();
+		$subscription_mode_value = $vaulting ? 'vaulting_api' : 'subscriptions_api';
+
+		$subscription_mode_disabled = (bool) apply_filters( 'woocommerce_paypal_payments_subscription_mode_disabled', false );
+
+		return $subscription_mode_disabled ? 'disable_paypal_subscriptions' : $subscription_mode_value;
 	}
 }


### PR DESCRIPTION
This PR replaces `wcgateway.settings` service with the new `SettingsProvider` in `ppcp-paypal-subscriptions` module.

### PR Changes
- Adds `get_subscriptions_mode()` to `PayPalSubscriptionsModule`, this method is the same as [the one](https://github.com/woocommerce/woocommerce-paypal-payments/pull/3944/files#diff-c978e44135b8e9eca7a3a0d3b432c720633f764bb7e98b80043db439ca1db074R558-R578) created in `ppcp-wc-subscriptions module`, we'll reuse it from there once merged and delete it from here. The reason to not add it to `SettingsProvider` is because we'll need to inject new services and we do not want to do that in `SettingsProvider`.
- Replaces get subscriptions mode in all locations where `Settings` is used