### PR TITLE
ppcp-vaulting SettingsProvider migration (5616)

### DIFF
--- a/modules/ppcp-vaulting/services.php
+++ b/modules/ppcp-vaulting/services.php
@@ -36,7 +36,7 @@ return array(
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'settings.environment' ),
 			$container->get( 'wcgateway.processor.authorized-payments' ),
-			$container->get( 'wcgateway.settings' )
+			$container->get( 'settings.settings-provider' )
 		);
 	},
 	'vaulting.payment-token-factory'      => function ( ContainerInterface $container ): PaymentTokenFactory {

--- a/modules/ppcp-vaulting/src/VaultedCreditCardHandler.php
+++ b/modules/ppcp-vaulting/src/VaultedCreditCardHandler.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Vaulting;
 
-use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
-use WC_Customer;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
@@ -18,6 +16,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingPreferenceFactory;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
@@ -93,11 +92,11 @@ class VaultedCreditCardHandler {
 	protected $authorized_payments_processor;
 
 	/**
-	 * The settings.
+	 * The settings provider.
 	 *
-	 * @var ContainerInterface
+	 * @var SettingsProvider
 	 */
-	protected $config;
+	private SettingsProvider $settings_provider;
 
 	/**
 	 * VaultedCreditCardHandler constructor
@@ -110,7 +109,7 @@ class VaultedCreditCardHandler {
 	 * @param OrderEndpoint               $order_endpoint The order endpoint.
 	 * @param Environment                 $environment The environment.
 	 * @param AuthorizedPaymentsProcessor $authorized_payments_processor The processor for authorized payments.
-	 * @param ContainerInterface          $config The settings.
+	 * @param SettingsProvider            $settings_provider The settings provider.
 	 */
 	public function __construct(
 		SubscriptionHelper $subscription_helper,
@@ -121,7 +120,7 @@ class VaultedCreditCardHandler {
 		OrderEndpoint $order_endpoint,
 		Environment $environment,
 		AuthorizedPaymentsProcessor $authorized_payments_processor,
-		ContainerInterface $config
+		SettingsProvider $settings_provider
 	) {
 		$this->subscription_helper           = $subscription_helper;
 		$this->payment_token_repository      = $payment_token_repository;
@@ -131,7 +130,7 @@ class VaultedCreditCardHandler {
 		$this->order_endpoint                = $order_endpoint;
 		$this->environment                   = $environment;
 		$this->authorized_payments_processor = $authorized_payments_processor;
-		$this->config                        = $config;
+		$this->settings_provider             = $settings_provider;
 	}
 
 	/**
@@ -204,7 +203,7 @@ class VaultedCreditCardHandler {
 			if ( $this->is_free_trial_order( $wc_order ) ) {
 				$this->authorized_payments_processor->void_authorizations( $order );
 				$wc_order->payment_complete();
-			} elseif ( $this->config->has( 'intent' ) && strtoupper( (string) $this->config->get( 'intent' ) ) === 'CAPTURE' ) {
+			} elseif ( ! $this->settings_provider->authorize_only() ) {
 				$this->authorized_payments_processor->capture_authorized_payment( $wc_order );
 			}
 

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -22,7 +22,6 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WP_User_Query;
 
 /**
@@ -231,24 +230,6 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 
 					return;
 				}
-			}
-		);
-
-		add_action(
-			'woocommerce_paypal_payments_gateway_migrate_on_update',
-			function () use ( $container ) {
-				$settings_model = $container->get( 'settings.data.settings' );
-				assert( $settings_model instanceof SettingsModel );
-
-				if ( $settings_model->get_save_paypal_and_venmo() ) {
-					$settings_model->set_save_card_details( true );
-					$settings_model->save();
-				}
-
-				$logger = $container->get( 'woocommerce.logger.woocommerce' );
-				assert( $logger instanceof LoggerInterface );
-
-				$this->migrate_payment_tokens( $logger );
 			}
 		);
 

--- a/modules/ppcp-vaulting/src/VaultingModule.php
+++ b/modules/ppcp-vaulting/src/VaultingModule.php
@@ -22,7 +22,7 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WP_User_Query;
 
 /**
@@ -237,11 +237,12 @@ class VaultingModule implements ServiceModule, ExtendingModule, ExecutableModule
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
 			function () use ( $container ) {
-				$settings = $container->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
-				if ( $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' ) && $settings->has( 'vault_enabled_dcc' ) ) {
-					$settings->set( 'vault_enabled_dcc', true );
-					$settings->persist();
+				$settings_model = $container->get( 'settings.data.settings' );
+				assert( $settings_model instanceof SettingsModel );
+
+				if ( $settings_model->get_save_paypal_and_venmo() ) {
+					$settings_model->set_save_card_details( true );
+					$settings_model->save();
 				}
 
 				$logger = $container->get( 'woocommerce.logger.woocommerce' );

--- a/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
+++ b/tests/PHPUnit/Vaulting/VaultedCreditCardHandlerTest.php
@@ -3,8 +3,7 @@
 namespace PHPUnit\Vaulting;
 
 use Mockery;
-use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
-use WC_Customer;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
@@ -35,7 +34,7 @@ class VaultedCreditCardHandlerTest extends TestCase
 	private $orderEndpoint;
 	private $environment;
 	private $authorizedPaymentProcessor;
-	private $config;
+	private $settingsProvider;
 	private $testee;
 
 	public function setUp(): void
@@ -50,7 +49,7 @@ class VaultedCreditCardHandlerTest extends TestCase
 		$this->orderEndpoint = Mockery::mock(OrderEndpoint::class);
 		$this->environment = Mockery::mock(Environment::class);
 		$this->authorizedPaymentProcessor = Mockery::mock(AuthorizedPaymentsProcessor::class);
-		$this->config = Mockery::mock(ContainerInterface::class);
+		$this->settingsProvider = Mockery::mock(SettingsProvider::class);
 
 		$this->testee = new VaultedCreditCardHandler(
 			$this->subscriptionHelper,
@@ -61,7 +60,7 @@ class VaultedCreditCardHandlerTest extends TestCase
 			$this->orderEndpoint,
 			$this->environment,
 			$this->authorizedPaymentProcessor,
-			$this->config
+			$this->settingsProvider
 		);
 	}
 
@@ -87,8 +86,6 @@ class VaultedCreditCardHandlerTest extends TestCase
 		$purchaseUnit = Mockery::mock(PurchaseUnit::class);
 		$this->purchaseUnitFactory->shouldReceive('from_wc_order')
 			->andReturn($purchaseUnit);
-
-		$customer = Mockery::mock(WC_Customer::class);
 
 		$payer = Mockery::mock(Payer::class);
 		$payer->shouldReceive('email_address');
@@ -129,9 +126,11 @@ class VaultedCreditCardHandlerTest extends TestCase
 
 		$this->environment->shouldReceive('current_environment_is')->andReturn(true);
 
-		$this->config->shouldReceive('has')->andReturn(false);
+		$this->settingsProvider->shouldReceive('authorize_only')->andReturn(false);
+		$this->authorizedPaymentProcessor->shouldReceive('capture_authorized_payment')
+			->with($wcOrder);
 
-		$result = $this->testee->handle_payment($tokenId, $wcOrder, $customer);
+		$result = $this->testee->handle_payment($tokenId, $wcOrder);
 		$this->assertInstanceOf(\WC_Order::class, $result);
 	}
 }


### PR DESCRIPTION
This PR replaces `wcgateway.settings` service with the new `SettingsProvider` in `ppcp-vaulting` module.

### PR Changes
- Removes `woocommerce_paypal_payments_gateway_migrate_on_update` hook because it triggers vault v2 payment tokens migration on each plugin upgrade, this migration was needed before vault v3 was implemented. Migration logic is still there and can be run via: `do_action('pcp_migrate_payment_tokens')`.
  - Note: the callback also updates `vault_enabled_dcc`, this was also needed before vault v3 but it's not needed anymore, that logic should belong to the new settings UI module.
- Replaces legacy `intent` setting with the new `authorize_only` from SettingsProvider.