### PR TITLE
ppcp-api-client SettingsProvider migration (5598) 

### DIFF
--- a/modules/ppcp-api-client/factories.php
+++ b/modules/ppcp-api-client/factories.php
@@ -16,7 +16,7 @@ return array(
 
 	'wcgateway.builder.experience-context' => static function ( ContainerInterface $container ): ExperienceContextBuilder {
 		return new ExperienceContextBuilder(
-			$container->get( 'wcgateway.settings' ),
+			$container->get( 'settings.settings-provider' ),
 			$container->get( 'wcgateway.shipping.callback.factory.url' )
 		);
 	},

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -84,6 +84,7 @@ use WooCommerce\PayPalCommerce\Settings\Enum\InstallationPathEnum;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\EnvironmentConfig;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 return array(
 	'api.host'                                       => static function ( ContainerInterface $container ): string {
@@ -217,7 +218,7 @@ return array(
 			$logger,
 			$settings,
 			$customer_repository,
-			$container->get( 'wc-subscriptions.subscription_mode' )
+			$container->get( 'api.subscription_mode' )
 		);
 	},
 	'api.endpoint.payments'                          => static function ( ContainerInterface $container ): PaymentsEndpoint {
@@ -999,5 +1000,27 @@ return array(
 		return $container->get( 'settings.flag.is-connected' )
 			? $container->get( 'settings.data.general' )->get_merchant_country()
 			: $container->get( 'api.shop.country' );
+	},
+	'api.subscription_mode'                          => static function ( ContainerInterface $container ): string {
+		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
+		assert( $subscription_helper instanceof SubscriptionHelper );
+
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
+
+		if ( ! $subscription_helper->plugin_is_active() ) {
+			return SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_DISABLED;
+		}
+
+		$vaulting                = $settings_provider->save_paypal_and_venmo();
+		$subscription_mode_value = $vaulting ? SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING : SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS;
+
+		/**
+		 * Allows disabling the subscription mode when using the new settings UI.
+		 *
+		 * @returns bool true if the subscription mode should be disabled, false otherwise (default is false).
+		 */
+		$subscription_mode_disabled = (bool) apply_filters( 'woocommerce_paypal_payments_subscription_mode_disabled', false );
+		return $subscription_mode_disabled ? SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_DISABLED : $subscription_mode_value;
 	},
 );

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -84,7 +84,6 @@ use WooCommerce\PayPalCommerce\Settings\Enum\InstallationPathEnum;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\EnvironmentConfig;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 return array(
 	'api.host'                                       => static function ( ContainerInterface $container ): string {

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -252,13 +252,16 @@ return array(
 		assert( $session_handler instanceof SessionHandler );
 		$bn_code         = $session_handler->bn_code();
 
+		$settings = $container->get( 'settings.settings-provider' );
+		assert( $settings instanceof SettingsProvider );
+
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 		return new OrderEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$order_factory,
 			$patch_collection_factory,
-			'CAPTURE',
+			$settings->authorize_only() ? 'AUTHORIZE' : 'CAPTURE',
 			$logger,
 			$subscription_helper,
 			$container->get( 'wcgateway.is-fraudnet-enabled' ),

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -79,6 +79,7 @@ use WooCommerce\PayPalCommerce\ApiClient\VaultV2\PaymentTokenEndpoint;
 use WooCommerce\PayPalCommerce\Common\Pattern\SingletonDecorator;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\Enum\InstallationPathEnum;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
@@ -139,7 +140,7 @@ return array(
 			$container->get( 'api.key' ),
 			$container->get( 'api.secret' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'wcgateway.settings' )
+			$container->get( 'settings.settings-provider' )
 		);
 	},
 	'api.endpoint.partners'                          => static function ( ContainerInterface $container ): PartnersEndpoint {
@@ -209,14 +210,15 @@ return array(
 	},
 	'api.endpoint.identity-token'                    => static function ( ContainerInterface $container ): IdentityToken {
 		$logger = $container->get( 'woocommerce.logger.woocommerce' );
-		$settings = $container->get( 'wcgateway.settings' );
+		$settings = $container->get( 'settings.settings-provider' );
 		$customer_repository = $container->get( 'api.repository.customer' );
 		return new IdentityToken(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$logger,
 			$settings,
-			$customer_repository
+			$customer_repository,
+			$container->get( 'wc-subscriptions.subscription_mode' )
 		);
 	},
 	'api.endpoint.payments'                          => static function ( ContainerInterface $container ): PaymentsEndpoint {
@@ -250,17 +252,13 @@ return array(
 		assert( $session_handler instanceof SessionHandler );
 		$bn_code         = $session_handler->bn_code();
 
-		$settings = $container->get( 'wcgateway.settings' );
-		assert( $settings instanceof Settings );
-
-		$intent                         = $settings->has( 'intent' ) && strtoupper( (string) $settings->get( 'intent' ) ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 		return new OrderEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
 			$order_factory,
 			$patch_collection_factory,
-			$intent,
+			'CAPTURE',
 			$logger,
 			$subscription_helper,
 			$container->get( 'wcgateway.is-fraudnet-enabled' ),
@@ -855,17 +853,16 @@ return array(
 	},
 	'api.helper.purchase-unit-sanitizer'             => SingletonDecorator::make(
 		static function ( ContainerInterface $container ): PurchaseUnitSanitizer {
-			$settings  = $container->get( 'wcgateway.settings' );
-			assert( $settings instanceof Settings );
+			$settings  = $container->get( 'settings.settings-provider' );
+			assert( $settings instanceof SettingsProvider );
 
-			$behavior  = $settings->has( 'subtotal_mismatch_behavior' ) ? $settings->get( 'subtotal_mismatch_behavior' ) : null;
-			$line_name = $settings->has( 'subtotal_mismatch_line_name' ) ? $settings->get( 'subtotal_mismatch_line_name' ) : null;
-			return new PurchaseUnitSanitizer( $behavior, $line_name );
+			$subtotal_adjustment  = $settings->subtotal_adjustment();
+			return new PurchaseUnitSanitizer( $subtotal_adjustment );
 		}
 	),
 	'api.client-credentials'                         => static function ( ContainerInterface $container ): ClientCredentials {
 		return new ClientCredentials(
-			$container->get( 'wcgateway.settings' )
+			$container->get( 'settings.settings-provider' )
 		);
 	},
 	'api.paypal-bearer-cache'                        => static function ( ContainerInterface $container ): Cache {

--- a/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
+++ b/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
 
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 
@@ -20,16 +21,16 @@ class ClientCredentials {
 	/**
 	 * The settings.
 	 *
-	 * @var Settings
+	 * @var SettingsProvider
 	 */
 	protected $settings;
 
 	/**
 	 * ClientCredentials constructor.
 	 *
-	 * @param Settings $settings The settings.
+	 * @param SettingsProvider $settings The settings.
 	 */
-	public function __construct( Settings $settings ) {
+	public function __construct( SettingsProvider $settings ) {
 		$this->settings = $settings;
 	}
 
@@ -40,8 +41,9 @@ class ClientCredentials {
 	 * @throws NotFoundException If setting does not found.
 	 */
 	public function credentials(): string {
-		$client_id     = $this->settings->has( 'client_id' ) ? $this->settings->get( 'client_id' ) : '';
-		$client_secret = $this->settings->has( 'client_secret' ) ? $this->settings->get( 'client_secret' ) : '';
+		$merchant_data = $this->settings->merchant_data();
+		$client_id     = $merchant_data->client_id;
+		$client_secret = $merchant_data->client_secret;
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		return 'Basic ' . base64_encode( $client_id . ':' . $client_secret );

--- a/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
+++ b/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
 
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 
 /**

--- a/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
+++ b/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
@@ -37,7 +37,6 @@ class ClientCredentials {
 	 * Returns encoded client credentials.
 	 *
 	 * @return string
-	 * @throws NotFoundException If setting does not found.
 	 */
 	public function credentials(): string {
 		$merchant_data = $this->settings->merchant_data();

--- a/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce\ApiClient\Authentication
  */
 
-declare( strict_types = 1 );
+declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
 
@@ -14,7 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use Psr\Log\LoggerInterface;
-use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 /**
  * Class PayPalBearer
@@ -28,7 +28,7 @@ class PayPalBearer implements Bearer {
 	/**
 	 * The settings.
 	 *
-	 * @var ?ContainerInterface
+	 * @var ?SettingsProvider
 	 */
 	protected $settings;
 
@@ -70,12 +70,12 @@ class PayPalBearer implements Bearer {
 	/**
 	 * PayPalBearer constructor.
 	 *
-	 * @param Cache               $cache    The cache.
-	 * @param string              $host     The host.
-	 * @param string              $key      The key.
-	 * @param string              $secret   The secret.
-	 * @param LoggerInterface     $logger   The logger.
-	 * @param ?ContainerInterface $settings The settings.
+	 * @param Cache             $cache The cache.
+	 * @param string            $host The host.
+	 * @param string            $key The key.
+	 * @param string            $secret The secret.
+	 * @param LoggerInterface   $logger The logger.
+	 * @param ?SettingsProvider $settings The settings.
 	 */
 	public function __construct(
 		Cache $cache,
@@ -83,7 +83,7 @@ class PayPalBearer implements Bearer {
 		string $key,
 		string $secret,
 		LoggerInterface $logger,
-		?ContainerInterface $settings
+		?SettingsProvider $settings
 	) {
 
 		$this->cache    = $cache;
@@ -97,8 +97,8 @@ class PayPalBearer implements Bearer {
 	/**
 	 * Returns a bearer token.
 	 *
-	 * @throws RuntimeException When request fails.
 	 * @return Token
+	 * @throws RuntimeException When request fails.
 	 */
 	public function bearer(): Token {
 		try {
@@ -116,15 +116,12 @@ class PayPalBearer implements Bearer {
 	 * @return string The client ID from settings, or the key defined via constructor.
 	 */
 	private function get_key(): string {
-		if (
-			$this->settings
-			&& $this->settings->has( 'client_id' )
-			&& $this->settings->get( 'client_id' )
-		) {
-			return $this->settings->get( 'client_id' );
+		if ( is_null( $this->settings ) ) {
+			return $this->key;
 		}
 
-		return $this->key;
+		$merchant_data = $this->settings->merchant_data();
+		return $merchant_data->client_id;
 	}
 
 	/**
@@ -133,22 +130,19 @@ class PayPalBearer implements Bearer {
 	 * @return string The client secret from settings, or the value defined via constructor.
 	 */
 	private function get_secret(): string {
-		if (
-			$this->settings
-			&& $this->settings->has( 'client_secret' )
-			&& $this->settings->get( 'client_secret' )
-		) {
-			return $this->settings->get( 'client_secret' );
+		if ( is_null( $this->settings ) ) {
+			return $this->secret;
 		}
 
-		return $this->secret;
+		$merchant_data = $this->settings->merchant_data();
+		return $merchant_data->client_secret;
 	}
 
 	/**
 	 * Creates a new bearer token.
 	 *
-	 * @throws RuntimeException When request fails.
 	 * @return Token
+	 * @throws RuntimeException When request fails.
 	 */
 	private function newBearer(): Token {
 		$key    = $this->get_key();

--- a/modules/ppcp-api-client/src/Endpoint/IdentityToken.php
+++ b/modules/ppcp-api-client/src/Endpoint/IdentityToken.php
@@ -15,7 +15,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\CustomerRepository;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
  * Class IdentityToken
@@ -48,7 +49,7 @@ class IdentityToken {
 	/**
 	 * The settings
 	 *
-	 * @var Settings
+	 * @var SettingsProvider
 	 */
 	private $settings;
 
@@ -60,26 +61,36 @@ class IdentityToken {
 	protected $customer_repository;
 
 	/**
+	 * WooCommerce subscriptions mode.
+	 *
+	 * @var string
+	 */
+	private string $subscription_mode;
+
+	/**
 	 * IdentityToken constructor.
 	 *
 	 * @param string             $host The host.
 	 * @param Bearer             $bearer The bearer.
 	 * @param LoggerInterface    $logger The logger.
-	 * @param Settings           $settings The settings.
+	 * @param SettingsProvider   $settings The settings.
 	 * @param CustomerRepository $customer_repository The customer repository.
+	 * @param string             $subscription_mode WooCommerce subscriptions mode.
 	 */
 	public function __construct(
 		string $host,
 		Bearer $bearer,
 		LoggerInterface $logger,
-		Settings $settings,
-		CustomerRepository $customer_repository
+		SettingsProvider $settings,
+		CustomerRepository $customer_repository,
+		string $subscription_mode
 	) {
 		$this->host                = $host;
 		$this->bearer              = $bearer;
 		$this->logger              = $logger;
 		$this->settings            = $settings;
 		$this->customer_repository = $customer_repository;
+		$this->subscription_mode   = $subscription_mode;
 	}
 
 	/**
@@ -101,11 +112,12 @@ class IdentityToken {
 				'Content-Type'  => 'application/json',
 			),
 		);
-		if (
-			( $this->settings->has( 'vault_enabled' ) && $this->settings->get( 'vault_enabled' ) )
-			|| ( $this->settings->has( 'vault_enabled_dcc' ) && $this->settings->get( 'vault_enabled_dcc' ) )
-			|| ( $this->settings->has( 'subscriptions_mode' ) && $this->settings->get( 'subscriptions_mode' ) === 'vaulting_api' )
-		) {
+
+		$vault_enabled               = $this->settings->save_paypal_and_venmo();
+		$vault_enabled_dcc           = $this->settings->save_card_details();
+		$subscriptions_mode_vaulting = $this->subscription_mode === SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING;
+
+		if ( $vault_enabled || $vault_enabled_dcc || $subscriptions_mode_vaulting ) {
 			$customer_id = $this->customer_repository->customer_id_for_user( ( $user_id ) );
 			update_user_meta( $user_id, 'ppcp_customer_id', $customer_id );
 			$args['body'] = wp_json_encode(

--- a/modules/ppcp-api-client/src/Factory/ExperienceContextBuilder.php
+++ b/modules/ppcp-api-client/src/Factory/ExperienceContextBuilder.php
@@ -13,7 +13,7 @@ use WC_AJAX;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\CallbackConfig;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
-use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Shipping\ShippingCallbackUrlFactory;
 
@@ -28,14 +28,14 @@ class ExperienceContextBuilder {
 	private ExperienceContext $experience_context;
 
 	/**
-	 * The Settings.
+	 * The Settings Provider class.
 	 */
-	private ContainerInterface $settings;
+	private SettingsProvider $settings;
 
 	private ShippingCallbackUrlFactory $shipping_callback_url_factory;
 
 	public function __construct(
-		ContainerInterface $settings,
+		SettingsProvider $settings,
 		ShippingCallbackUrlFactory $shipping_callback_url_factory
 	) {
 		$this->experience_context = new ExperienceContext();
@@ -134,7 +134,7 @@ class ExperienceContextBuilder {
 	public function with_current_brand_name(): ExperienceContextBuilder {
 		$builder = clone $this;
 
-		$brand_name = $this->settings->has( 'brand_name' ) ? (string) $this->settings->get( 'brand_name' ) : '';
+		$brand_name = $this->settings->brand_name();
 		if ( empty( $brand_name ) ) {
 			$brand_name = null;
 		}
@@ -163,9 +163,7 @@ class ExperienceContextBuilder {
 	public function with_current_landing_page(): ExperienceContextBuilder {
 		$builder = clone $this;
 
-		$landing_page = $this->settings->has( 'landing_page' ) ?
-			(string) $this->settings->get( 'landing_page' )
-			: ExperienceContext::LANDING_PAGE_NO_PREFERENCE;
+		$landing_page = $this->settings->landing_page();
 		if ( empty( $landing_page ) ) {
 			$landing_page = ExperienceContext::LANDING_PAGE_NO_PREFERENCE;
 		}
@@ -184,7 +182,7 @@ class ExperienceContextBuilder {
 
 		$builder->experience_context = $builder->experience_context
 			->with_payment_method_preference(
-				$this->settings->has( 'payee_preferred' ) && $this->settings->get( 'payee_preferred' ) ?
+				$this->settings->instant_payments_only() ?
 					ExperienceContext::PAYMENT_METHOD_IMMEDIATE_PAYMENT_REQUIRED
 					: ExperienceContext::PAYMENT_METHOD_UNRESTRICTED
 			);

--- a/modules/ppcp-api-client/src/Helper/PurchaseUnitSanitizer.php
+++ b/modules/ppcp-api-client/src/Helper/PurchaseUnitSanitizer.php
@@ -79,20 +79,15 @@ class PurchaseUnitSanitizer {
 	 * PurchaseUnitSanitizer constructor.
 	 *
 	 * @param string|null $mode The mismatch handling mode, ditch or extra_line.
-	 * @param string|null $extra_line_name The name of the extra line.
 	 */
-	public function __construct( ?string $mode = null, ?string $extra_line_name = null ) {
+	public function __construct( ?string $mode = null ) {
 
 		if ( ! in_array( $mode, self::VALID_MODES, true ) ) {
 			$mode = self::MODE_DITCH;
 		}
 
-		if ( ! $extra_line_name ) {
-			$extra_line_name = self::EXTRA_LINE_NAME;
-		}
-
 		$this->mode            = $mode;
-		$this->extra_line_name = $extra_line_name;
+		$this->extra_line_name = self::EXTRA_LINE_NAME;
 	}
 
 	/**

--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -31,10 +31,9 @@ return array(
 		return $eligibility_check();
 	},
 	'axo.eligibility.check'                  => static function ( ContainerInterface $container ): callable {
-		$axo_applies = $container->get( 'axo.service.axo-applies' );
-		assert( $axo_applies instanceof AxoApplies );
-
-		return static function () use ( $axo_applies ): bool {
+		return static function () use ( $container ): bool {
+			$axo_applies = $container->get( 'axo.service.axo-applies' );
+			assert( $axo_applies instanceof AxoApplies );
 			return $axo_applies->for_country_currency() && $axo_applies->for_merchant();
 		};
 	},

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -82,6 +82,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 use WooCommerce\PayPalCommerce\Settings\Service\InternalRestService;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 $services = array(
 	'settings.url'                                        => static function ( ContainerInterface $container ): string {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -82,7 +82,6 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
 use WooCommerce\PayPalCommerce\Settings\Service\InternalRestService;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
-use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 $services = array(
 	'settings.url'                                        => static function ( ContainerInterface $container ): string {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -104,7 +104,7 @@ $services = array(
 		$can_use_subscriptions       = $container->has( 'wc-subscriptions.helper' ) && $container->get( 'wc-subscriptions.helper' )
 																								->plugin_is_active();
 		$should_skip_payment_methods = class_exists( '\WC_Payments' );
-		$can_use_fastlane            = $container->get( 'axo.eligible' );
+		$can_use_fastlane            = $container->get( 'axo.eligibility.check' );
 		$can_use_pay_later           = $container->get( 'button.helper.messages-apply' );
 
 		return new OnboardingProfile(

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -39,13 +39,13 @@ class OnboardingProfile extends AbstractDataModel {
 	/**
 	 * Constructor.
 	 *
-	 * @param bool $can_use_casual_selling Whether casual selling is enabled in the store's country.
-	 * @param bool $can_use_vaulting       Whether vaulting is enabled in the store's country.
-	 * @param bool $can_use_card_payments  Whether credit card payments are possible.
-	 * @param bool $can_use_subscriptions  Whether WC Subscriptions plugin is active.
-	 * @param bool $should_skip_payment_methods  Whether it should skip payment methods screen.
-	 * @param bool $can_use_fastlane  Whether it can use Fastlane or not.
-	 * @param bool $can_use_pay_later  Whether it can use Pay Later or not.
+	 * @param bool     $can_use_casual_selling Whether casual selling is enabled in the store's country.
+	 * @param bool     $can_use_vaulting       Whether vaulting is enabled in the store's country.
+	 * @param bool     $can_use_card_payments  Whether credit card payments are possible.
+	 * @param bool     $can_use_subscriptions  Whether WC Subscriptions plugin is active.
+	 * @param bool     $should_skip_payment_methods  Whether it should skip payment methods screen.
+	 * @param callable $can_use_fastlane  Callable to check whether it can use Fastlane or not.
+	 * @param bool     $can_use_pay_later  Whether it can use Pay Later or not.
 	 *
 	 * @throws RuntimeException If the OPTION_KEY is not defined in the child class.
 	 */
@@ -55,7 +55,7 @@ class OnboardingProfile extends AbstractDataModel {
 		bool $can_use_card_payments = false,
 		bool $can_use_subscriptions = false,
 		bool $should_skip_payment_methods = false,
-		bool $can_use_fastlane = false,
+		callable $can_use_fastlane,
 		bool $can_use_pay_later = false
 	) {
 		parent::__construct();
@@ -65,7 +65,7 @@ class OnboardingProfile extends AbstractDataModel {
 		$this->flags['can_use_card_payments']       = $can_use_card_payments;
 		$this->flags['can_use_subscriptions']       = $can_use_subscriptions;
 		$this->flags['should_skip_payment_methods'] = $should_skip_payment_methods;
-		$this->flags['can_use_fastlane']            = $can_use_fastlane;
+		$this->flags['can_use_fastlane']            = fn() => $can_use_fastlane();
 		$this->flags['can_use_pay_later']           = $can_use_pay_later;
 	}
 

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -65,7 +65,7 @@ class OnboardingProfile extends AbstractDataModel {
 		$this->flags['can_use_card_payments']       = $can_use_card_payments;
 		$this->flags['can_use_subscriptions']       = $can_use_subscriptions;
 		$this->flags['should_skip_payment_methods'] = $should_skip_payment_methods;
-		$this->flags['can_use_fastlane']            = fn() => $can_use_fastlane();
+		$this->flags['can_use_fastlane']            = fn(): bool => $can_use_fastlane();
 		$this->flags['can_use_pay_later']           = $can_use_pay_later;
 	}
 

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -185,7 +185,16 @@ class OnboardingProfile extends AbstractDataModel {
 	 * @return array
 	 */
 	public function get_flags(): array {
-		return $this->flags;
+		return array_map(
+			function ( $flag ) {
+				if ( is_callable( $flag ) ) {
+					return $flag();
+				} else {
+					return $flag;
+				}
+			}, 
+			$this->flags
+		);
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -192,7 +192,7 @@ class OnboardingProfile extends AbstractDataModel {
 				} else {
 					return $flag;
 				}
-			}, 
+			},
 			$this->flags
 		);
 	}

--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -65,7 +65,7 @@ class OnboardingProfile extends AbstractDataModel {
 		$this->flags['can_use_card_payments']       = $can_use_card_payments;
 		$this->flags['can_use_subscriptions']       = $can_use_subscriptions;
 		$this->flags['should_skip_payment_methods'] = $should_skip_payment_methods;
-		$this->flags['can_use_fastlane']            = fn(): bool => $can_use_fastlane();
+		$this->flags['can_use_fastlane']            = $can_use_fastlane;
 		$this->flags['can_use_pay_later']           = $can_use_pay_later;
 	}
 
@@ -186,7 +186,7 @@ class OnboardingProfile extends AbstractDataModel {
 	 */
 	public function get_flags(): array {
 		return array_map(
-			function ( $flag ) {
+			function ( $flag ): bool {
 				if ( is_callable( $flag ) ) {
 					return $flag();
 				} else {

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -322,7 +322,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if instant payments only setting is enabled, false otherwise.
 	 */
 	public function get_instant_payments_only(): bool {
-		return $this->data['instant_payments_only'];
+		return $this->data['instant_payments_only'] ?? false;
 	}
 
 	/**

--- a/modules/ppcp-wc-subscriptions/services.php
+++ b/modules/ppcp-wc-subscriptions/services.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcSubscriptions;
 
-use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Endpoint\SubscriptionChangePaymentMethod;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;

--- a/modules/ppcp-wc-subscriptions/services.php
+++ b/modules/ppcp-wc-subscriptions/services.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcSubscriptions;
 
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Endpoint\SubscriptionChangePaymentMethod;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
@@ -84,5 +85,27 @@ return array(
 			$container->get( 'vaulting.repository.payment-token' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
+	},
+	'wc-subscriptions.subscription_mode'                 => static function ( ContainerInterface $container ) {
+		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
+		assert( $subscription_helper instanceof SubscriptionHelper );
+
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
+
+		if ( ! $subscription_helper->plugin_is_active() ) {
+			return null;
+		}
+
+		$vaulting                = $settings_provider->save_paypal_and_venmo();
+		$subscription_mode_value = $vaulting ? SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING : SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS;
+
+		/**
+		 * Allows disabling the subscription mode when using the new settings UI.
+		 *
+		 * @returns bool true if the subscription mode should be disabled, false otherwise (default is false).
+		 */
+		$subscription_mode_disabled = (bool) apply_filters( 'woocommerce_paypal_payments_subscription_mode_disabled', false );
+		return $subscription_mode_disabled ? SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_DISABLED : $subscription_mode_value;
 	},
 );

--- a/modules/ppcp-wc-subscriptions/services.php
+++ b/modules/ppcp-wc-subscriptions/services.php
@@ -86,26 +86,4 @@ return array(
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
-	'wc-subscriptions.subscription_mode'                 => static function ( ContainerInterface $container ) {
-		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
-		assert( $subscription_helper instanceof SubscriptionHelper );
-
-		$settings_provider = $container->get( 'settings.settings-provider' );
-		assert( $settings_provider instanceof SettingsProvider );
-
-		if ( ! $subscription_helper->plugin_is_active() ) {
-			return null;
-		}
-
-		$vaulting                = $settings_provider->save_paypal_and_venmo();
-		$subscription_mode_value = $vaulting ? SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING : SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS;
-
-		/**
-		 * Allows disabling the subscription mode when using the new settings UI.
-		 *
-		 * @returns bool true if the subscription mode should be disabled, false otherwise (default is false).
-		 */
-		$subscription_mode_disabled = (bool) apply_filters( 'woocommerce_paypal_payments_subscription_mode_disabled', false );
-		return $subscription_mode_disabled ? SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_DISABLED : $subscription_mode_value;
-	},
 );

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -26,6 +26,10 @@ use WP_Query;
  */
 class SubscriptionHelper {
 
+	public const SUBSCRIPTION_MODE_VALUE_VAULTING      = 'vaulting_api';
+	public const SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS = 'subscriptions_api';
+	public const SUBSCRIPTION_MODE_VALUE_DISABLED      = 'disable_paypal_subscriptions';
+
 	/**
 	 * Whether the current product is a subscription.
 	 *

--- a/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
@@ -8,6 +8,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use Psr\Log\LoggerInterface;
 use Mockery;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use function Brain\Monkey\Functions\expect;
@@ -30,9 +32,13 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('debug');
-        $settings = Mockery::mock(Settings::class);
-        $settings->shouldReceive('has')->andReturn(true);
-        $settings->shouldReceive('get')->andReturn('');
+        $settings = Mockery::mock(SettingsProvider::class);
+        $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
+			true,
+	        'key',
+	        'secret',
+	        '123'
+        ));
         $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
         $headers->shouldReceive('getAll');
 
@@ -85,9 +91,13 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('debug');
-        $settings = Mockery::mock(Settings::class);
-        $settings->shouldReceive('has')->andReturn(true);
-        $settings->shouldReceive('get')->andReturn('');
+	    $settings = Mockery::mock(SettingsProvider::class);
+	    $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
+		    true,
+		    'key',
+		    'secret',
+		    '123'
+	    ));
 		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
 		$headers->shouldReceive('getAll');
 
@@ -137,9 +147,13 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('warning');
-        $settings = Mockery::mock(Settings::class);
-        $settings->shouldReceive('has')->andReturn(true);
-        $settings->shouldReceive('get')->andReturn('');
+	    $settings = Mockery::mock(SettingsProvider::class);
+	    $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
+		    true,
+		    'key',
+		    'secret',
+		    '123'
+	    ));
 
         $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
 
@@ -161,9 +175,13 @@ class PayPalBearerTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('warning');
         $logger->shouldReceive('debug');
-        $settings = Mockery::mock(Settings::class);
-        $settings->shouldReceive('has')->andReturn(true);
-        $settings->shouldReceive('get')->andReturn('');
+	    $settings = Mockery::mock(SettingsProvider::class);
+	    $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
+		    true,
+		    'key',
+		    'secret',
+		    '123'
+	    ));
 		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
 		$headers->shouldReceive('getAll');
 
@@ -211,9 +229,13 @@ class PayPalBearerTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('warning');
         $logger->shouldReceive('debug');
-        $settings = Mockery::mock(Settings::class);
-        $settings->shouldReceive('has')->andReturn(true);
-        $settings->shouldReceive('get')->andReturn('');
+	    $settings = Mockery::mock(SettingsProvider::class);
+	    $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
+		    true,
+		    'key',
+		    'secret',
+		    '123'
+	    ));
 		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
 		$headers->shouldReceive('getAll');
 

--- a/tests/PHPUnit/ApiClient/Endpoint/IdentityTokenTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/IdentityTokenTest.php
@@ -11,8 +11,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\CustomerRepository;
 use Mockery;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
@@ -24,6 +24,7 @@ class IdentityTokenTest extends TestCase
     private $settings;
     private $customer_repository;
     private $sut;
+    private string $subscription_mode;
 
     public function setUp(): void
     {
@@ -32,15 +33,17 @@ class IdentityTokenTest extends TestCase
         $this->host = 'https://example.com/';
         $this->bearer = Mockery::mock(Bearer::class);
         $this->logger = Mockery::mock(LoggerInterface::class);
-        $this->settings = Mockery::mock(Settings::class);
+        $this->settings = Mockery::mock(SettingsProvider::class);
         $this->customer_repository = Mockery::mock(CustomerRepository::class);
+        $this->subscription_mode = 'vaulting_api';
 
         $this->sut = new IdentityToken(
         	$this->host,
 			$this->bearer,
 			$this->logger,
 			$this->settings,
-			$this->customer_repository
+			$this->customer_repository,
+			$this->subscription_mode
 		);
     }
 
@@ -58,8 +61,8 @@ class IdentityTokenTest extends TestCase
 		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
 		$headers->shouldReceive('getAll');
 		$this->logger->shouldReceive('debug');
-		$this->settings->shouldReceive('has')->andReturn(true);
-		$this->settings->shouldReceive('get')->andReturn(true);
+		$this->settings->shouldReceive('save_paypal_and_venmo')->andReturn(true);
+		$this->settings->shouldReceive('save_card_details')->andReturn(true);
 		$this->customer_repository->shouldReceive('customer_id_for_user')->andReturn('prefix1');
         expect('update_user_meta')->with($id, 'ppcp_customer_id', 'prefix1');
 
@@ -112,8 +115,8 @@ class IdentityTokenTest extends TestCase
         expect('is_wp_error')->andReturn(true);
         $this->logger->shouldReceive('log');
         $this->logger->shouldReceive('debug');
-		$this->settings->shouldReceive('has')->andReturn(true);
-		$this->settings->shouldReceive('get')->andReturn(true);
+		$this->settings->shouldReceive('save_card_details')->andReturn(true);
+		$this->settings->shouldReceive('save_paypal_and_venmo')->andReturn(true);
         $this->customer_repository->shouldReceive('customer_id_for_user')->andReturn('prefix1');
         expect('update_user_meta')->with($id, 'ppcp_customer_id', 'prefix1');
 
@@ -140,8 +143,8 @@ class IdentityTokenTest extends TestCase
         expect('wp_remote_retrieve_response_code')->andReturn(500);
         $this->logger->shouldReceive('log');
         $this->logger->shouldReceive('debug');
-		$this->settings->shouldReceive('has')->andReturn(true);
-		$this->settings->shouldReceive('get')->andReturn(true);
+		$this->settings->shouldReceive('save_paypal_and_venmo')->andReturn(true);
+		$this->settings->shouldReceive('save_card_details')->andReturn(true);
         $this->customer_repository->shouldReceive('customer_id_for_user')->andReturn('prefix1');
         expect('update_user_meta')->with($id, 'ppcp_customer_id', 'prefix1');
 

--- a/tests/PHPUnit/ApiClient/Entity/PurchaseUnitTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/PurchaseUnitTest.php
@@ -565,7 +565,7 @@ class PurchaseUnitTest extends TestCase
 			$items
 		);
 
-		$testee->set_sanitizer(new PurchaseUnitSanitizer(PurchaseUnitSanitizer::MODE_EXTRA_LINE, $expected['extra_line_name'] ?? null));
+		$testee->set_sanitizer(new PurchaseUnitSanitizer(PurchaseUnitSanitizer::MODE_EXTRA_LINE ));
 
 		$countItemsBefore = count($items);
 		$array = $testee->to_array();
@@ -574,7 +574,7 @@ class PurchaseUnitTest extends TestCase
 
 		$this->assertEquals($countItemsBefore + 1, $countItemsAfter, $message);
 		$this->assertEquals($expected['extra_line_value'], $extraItem['unit_amount']['value'], $message);
-		$this->assertEquals($expected['extra_line_name'] ?? PurchaseUnitSanitizer::EXTRA_LINE_NAME, $extraItem['name'], $message);
+		$this->assertEquals(PurchaseUnitSanitizer::EXTRA_LINE_NAME, $extraItem['name'], $message);
 
 		foreach ($array['items'] as $i => $item) {
 			$this->assertEquals($expected['item_value'][$i], $item['unit_amount']['value'], $message);

--- a/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
@@ -5,9 +5,8 @@ namespace PHPUnit\ApiClient\Factory;
 
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
-use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Shipping\ShippingCallbackUrlFactory;
 use function Brain\Monkey\Functions\expect;
 use Mockery;
@@ -24,7 +23,7 @@ class ExperienceContextBuilderTest extends TestCase
 	{
 		parent::setUp();
 
-		$this->settings = Mockery::mock(Settings::class);
+		$this->settings = Mockery::mock(SettingsProvider::class);
 		$this->shipping_callback_url_factory = Mockery::mock(ShippingCallbackUrlFactory::class);
 
 		$this->sut = new ExperienceContextBuilder($this->settings, $this->shipping_callback_url_factory);
@@ -67,18 +66,12 @@ class ExperienceContextBuilderTest extends TestCase
 	/**
 	 * @dataProvider brandNameDataProvider
 	 */
-	public function testCurrentBrandName($has, $value, $expected)
+	public function testCurrentBrandName($value, $expected)
 	{
+
 		$this->settings
-			->expects('has')
-			->with('brand_name')
-			->andReturn($has);
-		if ($has) {
-			$this->settings
-				->expects('get')
-				->with('brand_name')
-				->andReturn($value);
-		}
+			->expects('brand_name')
+			->andReturn($value);
 
 		$result = $this->sut
 			->with_current_brand_name()
@@ -97,17 +90,10 @@ class ExperienceContextBuilderTest extends TestCase
 	public function brandNameDataProvider()
 	{
 		yield [
-			false,
 			'',
 			null,
 		];
 		yield [
-			true,
-			'',
-			null,
-		];
-		yield [
-			true,
 			'company',
 			'company',
 		];
@@ -116,18 +102,11 @@ class ExperienceContextBuilderTest extends TestCase
 	/**
 	 * @dataProvider landingPageDataProvider
 	 */
-	public function testCurrentLandingPage($has, $value, $expected)
+	public function testCurrentLandingPage($value, $expected)
 	{
 		$this->settings
-			->expects('has')
-			->with('landing_page')
-			->andReturn($has);
-		if ($has) {
-			$this->settings
-				->expects('get')
-				->with('landing_page')
-				->andReturn($value);
-		}
+			->expects('landing_page')
+			->andReturn($value);
 
 		$result = $this->sut
 			->with_current_landing_page()
@@ -141,17 +120,10 @@ class ExperienceContextBuilderTest extends TestCase
 	public function landingPageDataProvider()
 	{
 		yield [
-			false,
 			'',
 			ExperienceContext::LANDING_PAGE_NO_PREFERENCE,
 		];
 		yield [
-			true,
-			'',
-			ExperienceContext::LANDING_PAGE_NO_PREFERENCE,
-		];
-		yield [
-			true,
 			ExperienceContext::LANDING_PAGE_LOGIN,
 			ExperienceContext::LANDING_PAGE_LOGIN,
 		];
@@ -160,18 +132,11 @@ class ExperienceContextBuilderTest extends TestCase
 	/**
 	 * @dataProvider paymentMethodPreferenceDataProvider
 	 */
-	public function testCurrentPaymentMethodPreference($has, $value, $expected)
+	public function testCurrentPaymentMethodPreference( $value, $expected)
 	{
 		$this->settings
-			->expects('has')
-			->with('payee_preferred')
-			->andReturn($has);
-		if ($has) {
-			$this->settings
-				->expects('get')
-				->with('payee_preferred')
-				->andReturn($value);
-		}
+			->expects('instant_payments_only')
+			->andReturn($value);
 
 		$result = $this->sut
 			->with_current_payment_method_preference()
@@ -185,17 +150,10 @@ class ExperienceContextBuilderTest extends TestCase
 	public function paymentMethodPreferenceDataProvider()
 	{
 		yield [
-			false,
 			'',
 			ExperienceContext::PAYMENT_METHOD_UNRESTRICTED,
 		];
 		yield [
-			true,
-			'',
-			ExperienceContext::PAYMENT_METHOD_UNRESTRICTED,
-		];
-		yield [
-			true,
 			'yes',
 			ExperienceContext::PAYMENT_METHOD_IMMEDIATE_PAYMENT_REQUIRED,
 		];


### PR DESCRIPTION
This PR replaces `wcgateway.settings` service with the new `SettingsProvider` in `ppcp-api-client` module.

### PR Changes

**Tweak OnboardingProfile**

In order to avoid a loop when using api.bearer. `can_use_fastlane` has been refactored to a callback using `axo.eligibility.check `

**Tweak ExperienceContextBuilder for using SettingsProvider**

- get( 'brand_name')  → SettingsProvider::brand_name 
- get( 'landing_page')  → SettingsProvider::landing_page 
- get( 'payee_preferred')  → SettingsProvider::instant_payments_only 
- Tweak tests  

**Tweak IdentityToken for using SettingsProvider**

- get( 'vault_enabled')  → SettingsProvider::save_paypal_and_venmo 
- get( 'vault_enabled_dcc')  → SettingsProvider::save_card_details 
- get( 'subscriptions_mode')  → Copy `SubscriptionSettingsMapHelper::mapped_value` logic into $container->get( 'wc-subscriptions.subscription_mode' ) as this setting doesn't exist in the new settings. Then remove the Mapper when the refctor is completed ⚠️ 
- Tweak tests


**Tweak OrderEndpoint removing `wcgateway.settings` usages**

-  get( 'intent' ) →  SettingsProvider::authorize_only ( true 'AUTHORIZE'  false: 'CAPTURE' )  ⚠️ 


**Tweak PurchaseUnitSanitizer for using SettingsProvider**

- get('subtotal_mismatch_behavior') → SettingsProvider::subtotal_adjustment
- get('subtotal_mismatch_line_name') -> removed. Using the default, as I didn't find the setting for this ⚠️ 
- Tweak tests

**Tweak ClientCredentials for using SettingsProvider**

- get( 'client_id' ) → SettingsProvider::merchant_data->client_id
- get( 'client_secret' ) → SettingsProvider::merchant_data->client_secret
- Tweak tests

**Tweak PayPalBearer for using SettingsProvider**

- get( 'client_id' ) → SettingsProvider::merchant_data->client_id
- get( 'client_secret' ) → SettingsProvider::merchant_data->client_secret
- Tweak tests

