### PR TITLE
Agentic: Add Price Validation (5630)

### DIFF
--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -38,6 +38,7 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\AgenticCheckoutProcessor;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\PayPalOrderManager;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\ProductValidator;
+use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\PriceValidator;
 use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\InventoryValidator;
 use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\ShippingValidator;
 use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\CartValidationProcessor;
@@ -160,6 +161,11 @@ return array(
 	},
 	'agentic.validator.product'           => static function ( ContainerInterface $c ): ProductValidator {
 		return new ProductValidator(
+			$c->get( 'agentic.helper.product-manager' )
+		);
+	},
+	'agentic.validator.price'             => static function ( ContainerInterface $c ): PriceValidator {
+		return new PriceValidator(
 			$c->get( 'agentic.helper.product-manager' )
 		);
 	},

--- a/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
+++ b/modules/ppcp-agentic-commerce/src/AgenticCommerceModule.php
@@ -49,6 +49,7 @@ class AgenticCommerceModule implements ServiceModule, ExecutableModule {
 	 */
 	private const CART_VALIDATION_SERVICES = array(
 		'agentic.validator.product',
+		'agentic.validator.price',
 		'agentic.validator.inventory',
 		'agentic.validator.shipping',
 		'agentic.validator.currency',

--- a/modules/ppcp-agentic-commerce/src/CartValidation/PriceValidator.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/PriceValidator.php
@@ -82,9 +82,11 @@ class PriceValidator implements ValidatorInterface {
 				$store_price
 			),
 			sprintf(
-				'The price of %s has changed %s %s %s.',
+				'The price of %s has %s from %s %s to %s %s.',
 				$product->get_name(),
-				$is_increase ? 'from' : 'to',
+				$is_increase ? 'increased' : 'decreased',
+				$cart_price->currency_code(),
+				CartHelper::format_price( $cart_price->value() ),
 				$cart_price->currency_code(),
 				CartHelper::format_price( $store_price )
 			),

--- a/modules/ppcp-agentic-commerce/src/CartValidation/PriceValidator.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/PriceValidator.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Price Validator for Agentic Commerce.
+ *
+ * @package WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation;
+
+use WooCommerce\PayPalCommerce\AgenticCommerce\Enums\ErrorCode;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\CartHelper;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\ProductManager;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\CartItem;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\PriceMismatch;
+use WooCommerce\PayPalCommerce\AgenticCommerce\Validation\ValidationIssue;
+
+class PriceValidator implements ValidatorInterface {
+	private ProductManager $product_manager;
+
+	public function __construct( ProductManager $product_manager ) {
+		$this->product_manager = $product_manager;
+	}
+
+	public function validate( PayPalCart $cart ) {
+		// Skip validation if the cart contains an inventory issue.
+		if ( $cart->has_validation_issue( ErrorCode::INVENTORY_ISSUE ) ) {
+			return null;
+		}
+
+		$issues = array();
+
+		foreach ( $cart->items() as $key => $item ) {
+			$issue = $this->validate_price_matches_store( $key, $item );
+
+			if ( $issue ) {
+				$issues[] = $issue;
+			}
+		}
+
+		return $issues;
+	}
+
+	private function validate_price_matches_store( int $key, CartItem $item ): ?ValidationIssue {
+		$field = "items[{$key}]";
+
+		$product = $this->product_manager->find_product( $item );
+
+		if ( ! $product ) {
+			return null;
+		}
+
+		$cart_price = $item->price();
+
+		if ( ! $cart_price ) {
+			return null;
+		}
+
+		$store_price = (float) $product->get_price();
+
+		if ( abs( $cart_price->value() - $store_price ) > 0.01 ) {
+			return $this->create_price_mismatch_issue( $product, $cart_price, $store_price, $field );
+		}
+
+		return null;
+	}
+
+	private function create_price_mismatch_issue( $product, $cart_price, float $store_price, string $field ): PriceMismatch {
+		$price_difference = $store_price - $cart_price->value();
+		$is_increase      = $price_difference > 0;
+
+		$context            = $this->build_mismatch_context( $cart_price, $store_price, $price_difference, $is_increase );
+		$resolution_options = $this->build_resolution_options( $cart_price, $store_price, $price_difference, $is_increase );
+
+		return new PriceMismatch(
+			sprintf(
+				"Price mismatch for '%s': cart price is %s but store price is %s",
+				$product->get_name(),
+				$cart_price->value(),
+				$store_price
+			),
+			sprintf(
+				'The price of %s has changed %s %s %s.',
+				$product->get_name(),
+				$is_increase ? 'from' : 'to',
+				$cart_price->currency_code(),
+				CartHelper::format_price( $store_price )
+			),
+			$field,
+			$context,
+			$resolution_options
+		);
+	}
+
+	private function build_mismatch_context( $cart_price, float $store_price, float $price_difference, bool $is_increase ): array {
+		$context = array(
+			'specific_issue' => 'PRICE_MISMATCH',
+			'original_price' => CartHelper::format_price( $cart_price->value() ),
+			'current_price'  => CartHelper::format_price( $store_price ),
+			'currency_code'  => $cart_price->currency_code(),
+		);
+
+		if ( $is_increase ) {
+			$context['price_increase'] = CartHelper::format_price( $price_difference );
+		} else {
+			$context['price_decrease'] = CartHelper::format_price( abs( $price_difference ) );
+		}
+
+		return $context;
+	}
+
+	private function build_resolution_options( $cart_price, float $store_price, float $price_difference, bool $is_increase ): array {
+		return array(
+			array(
+				'action'   => 'ACCEPT_NEW_PRICE',
+				'label'    => sprintf( 'Continue with %s %s', $cart_price->currency_code(), CartHelper::format_price( $store_price ) ),
+				'metadata' => array(
+					'cost_impact' => sprintf( '%s%s', $is_increase ? '+' : '-', CartHelper::format_price( abs( $price_difference ) ) ),
+					'priority'    => 'high',
+				),
+			),
+			array(
+				'action'   => 'REMOVE_ITEM',
+				'label'    => 'Remove from cart',
+				'metadata' => array(
+					'cost_impact' => sprintf( '-%s', CartHelper::format_price( $cart_price->value() ) ),
+					'priority'    => 'medium',
+				),
+			),
+		);
+	}
+}

--- a/modules/ppcp-agentic-commerce/src/CartValidation/PriceValidator.php
+++ b/modules/ppcp-agentic-commerce/src/CartValidation/PriceValidator.php
@@ -91,6 +91,7 @@ class PriceValidator implements ValidatorInterface {
 				CartHelper::format_price( $store_price )
 			),
 			$field,
+			'',
 			$context,
 			$resolution_options
 		);

--- a/modules/ppcp-agentic-commerce/src/Helper/CartHelper.php
+++ b/modules/ppcp-agentic-commerce/src/Helper/CartHelper.php
@@ -55,6 +55,16 @@ class CartHelper {
 		);
 	}
 
+	/**
+	 * Formats a price value to two decimal places.
+	 *
+	 * @param float $value The price value to format.
+	 * @return string The formatted price (e.g., "123.45").
+	 */
+	public static function format_price( float $value ): string {
+		return number_format( $value, 2, '.', '' );
+	}
+
 	public static function full_customer_name( PayPalCart $cart, string $default = '' ): string {
 		$full_name = '';
 		$customer  = $cart->customer();


### PR DESCRIPTION
### Description

Validates that PayPal cart item prices match current WooCommerce store prices.

**Example**
PayPal cart has item at `$29.99`, WooCommerce store price is `$39.99` → returns validation error with resolution options (`ACCEPT_NEW_PRICE`, `REMOVE_ITEM`)

### Changes
  - Add `PriceValidator` returning `PRICING_ERROR` with `PRICE_MISMATCH`
  - Add `CartHelper::format_price()` for consistent formatting
  - Skip validation when `INVENTORY_ISSUE` present

