### PR TITLE
feat: Implement Level 2 card processing support (5686)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -69,6 +69,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderHelper;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderTransient;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelEligibility;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelHelper;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PurchaseUnitSanitizer;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\CustomerRepository;
@@ -389,6 +391,8 @@ return array(
 			$item_factory,
 			$shipping_factory,
 			$payments_factory,
+			$container->get( 'api.helpers.paymentLevelHelper' ),
+			$container->get( 'api.helpers.paymentLevelEligibility' ),
 			$prefix,
 			$soft_descriptor,
 			$sanitizer
@@ -1000,5 +1004,12 @@ return array(
 		return $container->get( 'settings.flag.is-connected' )
 			? $container->get( 'settings.data.general' )->get_merchant_country()
 			: $container->get( 'api.shop.country' );
+	},
+	'api.helpers.paymentLevelHelper'                 => static fn(): PaymentLevelHelper => new PaymentLevelHelper(),
+	'api.helpers.paymentLevelEligibility'            => static function ( ContainerInterface $container ): PaymentLevelEligibility {
+		return new PaymentLevelEligibility(
+			$container->get( 'settings.settings-provider' ),
+			$container->get( 'api.merchant.country' )
+		);
 	},
 );

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -1009,7 +1009,8 @@ return array(
 	'api.helpers.paymentLevelEligibility'            => static function ( ContainerInterface $container ): PaymentLevelEligibility {
 		return new PaymentLevelEligibility(
 			$container->get( 'settings.settings-provider' ),
-			$container->get( 'api.merchant.country' )
+			$container->get( 'api.merchant.country' ),
+			$container->get( 'api.shop.currency.getter' )
 		);
 	},
 );

--- a/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
+++ b/modules/ppcp-api-client/src/Entity/PurchaseUnit.php
@@ -80,6 +80,13 @@ class PurchaseUnit {
 	private $payments;
 
 	/**
+	 * The supplementary data (Level 2/3 card processing).
+	 *
+	 * @var array|null
+	 */
+	private $supplementary_data;
+
+	/**
 	 * Whether the unit contains physical goods.
 	 *
 	 * @var bool
@@ -115,7 +122,8 @@ class PurchaseUnit {
 		string $custom_id = '',
 		string $invoice_id = '',
 		string $soft_descriptor = '',
-		?Payments $payments = null
+		?Payments $payments = null,
+		?array $supplementary_data = null
 	) {
 
 		$this->amount       = $amount;
@@ -141,10 +149,11 @@ class PurchaseUnit {
 				}
 			)
 		);
-		$this->custom_id       = $custom_id;
-		$this->invoice_id      = $invoice_id;
-		$this->soft_descriptor = $soft_descriptor;
-		$this->payments        = $payments;
+		$this->custom_id          = $custom_id;
+		$this->invoice_id         = $invoice_id;
+		$this->soft_descriptor    = $soft_descriptor;
+		$this->payments           = $payments;
+		$this->supplementary_data = $supplementary_data;
 	}
 
 	/**
@@ -257,6 +266,15 @@ class PurchaseUnit {
 	}
 
 	/**
+	 * Returns the supplementary data.
+	 *
+	 * @return array|null
+	 */
+	public function supplementary_data(): ?array {
+		return $this->supplementary_data;
+	}
+
+	/**
 	 * Returns the Items.
 	 *
 	 * @return Item[]
@@ -310,6 +328,10 @@ class PurchaseUnit {
 		}
 		if ( $this->soft_descriptor() ) {
 			$purchase_unit['soft_descriptor'] = $this->soft_descriptor();
+		}
+
+		if ( $this->supplementary_data() ) {
+			$purchase_unit['supplementary_data'] = $this->supplementary_data();
 		}
 
 		$has_ditched_items_breakdown = false;

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -127,10 +127,10 @@ class PurchaseUnitFactory {
 		$custom_id       = (string) $order->get_id();
 		$invoice_id      = $this->prefix . $order->get_order_number();
 		$soft_descriptor = $this->sanitize_soft_descriptor( $this->soft_descriptor );
+		$payment_level   = null;
 
-		$payment_level = null;
-		if ( $this->payment_level_eligibility->is_eligible( $order ) ) {
-			$payment_level = $this->payment_level_helper->build( $order, 'level_2' );
+		if ( $this->payment_level_eligibility->is_eligible( $order->get_payment_method() ) ) {
+			$payment_level = $this->payment_level_helper->build( $amount, 'level_2' );
 		}
 
 		$purchase_unit = new PurchaseUnit(
@@ -166,7 +166,7 @@ class PurchaseUnitFactory {
 	 *
 	 * @return PurchaseUnit
 	 */
-	public function from_wc_cart( ?\WC_Cart $cart = null, bool $with_shipping_options = false ): PurchaseUnit {
+	public function from_wc_cart( ?\WC_Cart $cart = null, bool $with_shipping_options = false, string $payment_method = '' ): PurchaseUnit {
 		if ( ! $cart ) {
 			$cart = WC()->cart ?? new \WC_Cart();
 		}
@@ -207,7 +207,13 @@ class PurchaseUnitFactory {
 		}
 		$invoice_id      = '';
 		$soft_descriptor = $this->sanitize_soft_descriptor( $this->soft_descriptor );
-		$purchase_unit   = new PurchaseUnit(
+		$payment_level   = null;
+
+		if ( $this->payment_level_eligibility->is_eligible( $payment_method ) ) {
+			$payment_level = $this->payment_level_helper->build( $amount, 'level_2' );
+		}
+
+		$purchase_unit = new PurchaseUnit(
 			$amount,
 			$items,
 			$shipping,
@@ -215,7 +221,9 @@ class PurchaseUnitFactory {
 			$description,
 			$custom_id,
 			$invoice_id,
-			$soft_descriptor
+			$soft_descriptor,
+			null,
+			$payment_level['supplementary_data'] ?? null
 		);
 
 		$this->init_purchase_unit( $purchase_unit );

--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -13,6 +13,8 @@ use WC_Session_Handler;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Item;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelEligibility;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelHelper;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PurchaseUnitSanitizer;
 use WooCommerce\PayPalCommerce\Webhooks\CustomIds;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Address;
@@ -50,6 +52,10 @@ class PurchaseUnitFactory {
 	 */
 	private $payments_factory;
 
+	private PaymentLevelHelper $payment_level_helper;
+
+	private PaymentLevelEligibility $payment_level_eligibility;
+
 	/**
 	 * The Prefix.
 	 *
@@ -71,34 +77,27 @@ class PurchaseUnitFactory {
 	 */
 	private $sanitizer;
 
-	/**
-	 * PurchaseUnitFactory constructor.
-	 *
-	 * @param AmountFactory          $amount_factory The amount factory.
-	 * @param ItemFactory            $item_factory The item factory.
-	 * @param ShippingFactory        $shipping_factory The shipping factory.
-	 * @param PaymentsFactory        $payments_factory The payments factory.
-	 * @param string                 $prefix The prefix.
-	 * @param string                 $soft_descriptor The soft descriptor.
-	 * @param ?PurchaseUnitSanitizer $sanitizer The purchase unit to_array sanitizer.
-	 */
 	public function __construct(
 		AmountFactory $amount_factory,
 		ItemFactory $item_factory,
 		ShippingFactory $shipping_factory,
 		PaymentsFactory $payments_factory,
+		PaymentLevelHelper $payment_level_helper,
+		PaymentLevelEligibility $payment_level_eligibility,
 		string $prefix = 'WC-',
 		string $soft_descriptor = '',
 		?PurchaseUnitSanitizer $sanitizer = null
 	) {
 
-		$this->amount_factory   = $amount_factory;
-		$this->item_factory     = $item_factory;
-		$this->shipping_factory = $shipping_factory;
-		$this->payments_factory = $payments_factory;
-		$this->prefix           = $prefix;
-		$this->soft_descriptor  = $soft_descriptor;
-		$this->sanitizer        = $sanitizer;
+		$this->amount_factory            = $amount_factory;
+		$this->item_factory              = $item_factory;
+		$this->shipping_factory          = $shipping_factory;
+		$this->payments_factory          = $payments_factory;
+		$this->payment_level_helper      = $payment_level_helper;
+		$this->payment_level_eligibility = $payment_level_eligibility;
+		$this->prefix                    = $prefix;
+		$this->soft_descriptor           = $soft_descriptor;
+		$this->sanitizer                 = $sanitizer;
 	}
 
 	/**
@@ -129,6 +128,11 @@ class PurchaseUnitFactory {
 		$invoice_id      = $this->prefix . $order->get_order_number();
 		$soft_descriptor = $this->sanitize_soft_descriptor( $this->soft_descriptor );
 
+		$payment_level = null;
+		if ( $this->payment_level_eligibility->is_eligible( $order ) ) {
+			$payment_level = $this->payment_level_helper->build( $order, 'level_2' );
+		}
+
 		$purchase_unit = new PurchaseUnit(
 			$amount,
 			$items,
@@ -137,7 +141,9 @@ class PurchaseUnitFactory {
 			$description,
 			$custom_id,
 			$invoice_id,
-			$soft_descriptor
+			$soft_descriptor,
+			null,
+			$payment_level['supplementary_data'] ?? null
 		);
 
 		$this->init_purchase_unit( $purchase_unit );

--- a/modules/ppcp-api-client/src/Helper/PaymentLevelEligibility.php
+++ b/modules/ppcp-api-client/src/Helper/PaymentLevelEligibility.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Checks eligibility for Level 2/3 card processing.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+
+class PaymentLevelEligibility {
+
+	protected SettingsProvider $settings;
+	protected string $country;
+
+	public function __construct( SettingsProvider $settings, string $country ) {
+		$this->settings = $settings;
+		$this->country  = $country;
+	}
+
+	/**
+	 * Checks if order is eligible for Level 2/3 processing.
+	 *
+	 * @param WC_Order $order The WooCommerce order.
+	 * @return bool True if eligible.
+	 */
+	public function is_eligible( WC_Order $order ): bool {
+		if ( ! $this->settings->payment_level_processing() ) {
+			return false;
+		}
+
+		if ( ! $this->is_valid_country() ) {
+			return false;
+		}
+
+		if ( ! $this->is_valid_currency( $order ) ) {
+			return false;
+		}
+
+		if ( ! $this->is_valid_payment_method( $order ) ) {
+			return false;
+		}
+
+		/**
+		 * Filters whether an order is eligible for Level 2/3 processing.
+		 *
+		 * @param bool     $is_eligible Whether the order is eligible.
+		 * @param WC_Order $order       The WooCommerce order.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_level_processing_eligible',
+			true,
+			$order
+		);
+	}
+
+	private function is_valid_country(): bool {
+		/**
+		 * Filters the allowed countries for Level 2/3 processing.
+		 *
+		 * @param array $countries Array of allowed country codes.
+		 */
+		$allowed_countries = apply_filters(
+			'woocommerce_paypal_payments_level_processing_countries',
+			array( 'US' )
+		);
+
+		return in_array( $this->country, $allowed_countries, true );
+	}
+
+	private function is_valid_currency( WC_Order $order ): bool {
+		/**
+		 * Filters the allowed currencies for Level 2/3 processing.
+		 *
+		 * @param array $currencies Array of allowed currency codes.
+		 */
+		$allowed_currencies = apply_filters(
+			'woocommerce_paypal_payments_level_processing_currencies',
+			array( 'USD' )
+		);
+
+		return in_array( $order->get_currency(), $allowed_currencies, true );
+	}
+
+	private function is_valid_payment_method( WC_Order $order ): bool {
+		/**
+		 * Filters the allowed payment methods for Level 2/3 processing.
+		 *
+		 * @param array $methods Array of allowed payment method IDs.
+		 */
+		$allowed_methods = apply_filters(
+			'woocommerce_paypal_payments_level_processing_payment_methods',
+			array( 'ppcp-credit-card-gateway' )
+		);
+
+		return in_array( $order->get_payment_method(), $allowed_methods, true );
+	}
+}

--- a/modules/ppcp-api-client/src/Helper/PaymentLevelEligibility.php
+++ b/modules/ppcp-api-client/src/Helper/PaymentLevelEligibility.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 
-use WC_Order;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 class PaymentLevelEligibility {

--- a/modules/ppcp-api-client/src/Helper/PaymentLevelEligibility.php
+++ b/modules/ppcp-api-client/src/Helper/PaymentLevelEligibility.php
@@ -16,19 +16,21 @@ class PaymentLevelEligibility {
 
 	protected SettingsProvider $settings;
 	protected string $country;
+	protected CurrencyGetter $shop_currency;
 
-	public function __construct( SettingsProvider $settings, string $country ) {
-		$this->settings = $settings;
-		$this->country  = $country;
+	public function __construct( SettingsProvider $settings, string $country, CurrencyGetter $shop_currency ) {
+		$this->settings      = $settings;
+		$this->country       = $country;
+		$this->shop_currency = $shop_currency;
 	}
 
 	/**
-	 * Checks if order is eligible for Level 2/3 processing.
+	 * Checks if payment is eligible for Level 2/3 processing.
 	 *
-	 * @param WC_Order $order The WooCommerce order.
+	 * @param string $payment_method
 	 * @return bool True if eligible.
 	 */
-	public function is_eligible( WC_Order $order ): bool {
+	public function is_eligible( string $payment_method ): bool {
 		if ( ! $this->settings->payment_level_processing() ) {
 			return false;
 		}
@@ -37,24 +39,22 @@ class PaymentLevelEligibility {
 			return false;
 		}
 
-		if ( ! $this->is_valid_currency( $order ) ) {
+		if ( ! $this->is_valid_currency() ) {
 			return false;
 		}
 
-		if ( ! $this->is_valid_payment_method( $order ) ) {
+		if ( ! $this->is_valid_payment_method( $payment_method ) ) {
 			return false;
 		}
 
 		/**
-		 * Filters whether an order is eligible for Level 2/3 processing.
+		 * Filters whether the payment is eligible for Level 2/3 processing.
 		 *
-		 * @param bool     $is_eligible Whether the order is eligible.
-		 * @param WC_Order $order       The WooCommerce order.
+		 * @param bool $is_eligible Whether the payment is eligible.
 		 */
 		return apply_filters(
 			'woocommerce_paypal_payments_level_processing_eligible',
 			true,
-			$order
 		);
 	}
 
@@ -72,7 +72,7 @@ class PaymentLevelEligibility {
 		return in_array( $this->country, $allowed_countries, true );
 	}
 
-	private function is_valid_currency( WC_Order $order ): bool {
+	private function is_valid_currency(): bool {
 		/**
 		 * Filters the allowed currencies for Level 2/3 processing.
 		 *
@@ -83,10 +83,10 @@ class PaymentLevelEligibility {
 			array( 'USD' )
 		);
 
-		return in_array( $order->get_currency(), $allowed_currencies, true );
+		return in_array( $this->shop_currency->get(), $allowed_currencies, true );
 	}
 
-	private function is_valid_payment_method( WC_Order $order ): bool {
+	private function is_valid_payment_method( string $payment_method ): bool {
 		/**
 		 * Filters the allowed payment methods for Level 2/3 processing.
 		 *
@@ -97,6 +97,6 @@ class PaymentLevelEligibility {
 			array( 'ppcp-credit-card-gateway' )
 		);
 
-		return in_array( $order->get_payment_method(), $allowed_methods, true );
+		return in_array( $payment_method, $allowed_methods, true );
 	}
 }

--- a/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
+++ b/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Helper for building Level 2/3 card processing data from WooCommerce orders.
+ * Helper for building Level 2/3 card processing data.
  *
  * @package WooCommerce\PayPalCommerce\ApiClient\Helper
  */
@@ -10,20 +10,22 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 
 use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 
 class PaymentLevelHelper {
 
 	/**
-	 * Builds supplementary card data from WooCommerce order.
+	 * Builds supplementary card data.
 	 *
-	 * @param WC_Order $order The WooCommerce order.
-	 * @param string   $level The processing level ('level_2' or 'level_3').
+	 * @param Amount $amount The Amount object based off a WooCommerce cart.
+	 * @param string $level The processing level ('level_2' or 'level_3').
 	 * @return array{
 	 *     supplementary_data: array{
 	 *         card: array{
 	 *             level_2?: array{
 	 *                 customer_reference: string,
-	 *                 tax_total: array{
+	 *                 tax_total?: array{
 	 *                     currency_code: string,
 	 *                     value: string
 	 *                 }
@@ -32,7 +34,7 @@ class PaymentLevelHelper {
 	 *     }
 	 * }|null Supplementary data array ready for PurchaseUnit, or null if no data could be built.
 	 */
-	public function build( WC_Order $order, string $level ): ?array {
+	public function build( Amount $amount, string $level ): ?array {
 		$data = array(
 			'supplementary_data' => array(
 				'card' => array(),
@@ -40,7 +42,10 @@ class PaymentLevelHelper {
 		);
 
 		if ( 'level_2' === $level ) {
-			$data['supplementary_data']['card']['level_2'] = $this->build_level_2( $order );
+			$breakdown = $amount->breakdown();
+			$tax_total = $breakdown ? $breakdown->tax_total() : null;
+
+			$data['supplementary_data']['card']['level_2'] = $this->build_level_2( $tax_total );
 		}
 
 		/* phpcs:disable Squiz.PHP.CommentedOutCode.Found
@@ -59,34 +64,37 @@ class PaymentLevelHelper {
 	/**
 	 * Builds Level 2 card data.
 	 *
-	 * @param WC_Order $order The WooCommerce order.
+	 * @param Money|null $tax_total The tax total amount.
 	 * @return array{
-	 *     customer_reference: string,
-	 *     tax_total: array{
+	 *     invoice_id: string,
+	 *     tax_total?: array{
 	 *         currency_code: string,
 	 *         value: string
 	 *     }
 	 * } Level 2 data array.
 	 */
-	private function build_level_2( WC_Order $order ): array {
+	private function build_level_2( ?Money $tax_total ): array {
 		/**
-		 * Filters the Level 2 customer reference/PO number.
+		 * Filters the Level 2 invoice ID.
 		 *
-		 * @param string   $customer_reference The customer reference (default: order ID).
-		 * @param WC_Order $order              The WooCommerce order.
+		 * @param string $invoice_id The invoice ID (default: unique cart identifier).
 		 */
-		$customer_reference = apply_filters(
-			'woocommerce_paypal_payments_level2_customer_reference',
-			(string) $order->get_id(),
-			$order
+		$invoice_id = apply_filters(
+			'woocommerce_paypal_payments_level2_invoice_id',
+			'INV_' . strtoupper( uniqid() )
 		);
 
-		return array(
-			'customer_reference' => (string) substr( $customer_reference, 0, 17 ),
-			'tax_total'          => array(
-				'currency_code' => $order->get_currency(),
-				'value'         => number_format( (float) $order->get_total_tax(), 2, '.', '' ),
-			),
+		$level_2 = array(
+			'invoice_id' => (string) substr( $invoice_id, 0, 127 ),
 		);
+
+		if ( $tax_total ) {
+			$level_2['tax_total'] = array(
+				'currency_code' => $tax_total->currency_code(),
+				'value'         => $tax_total->value_str(),
+			);
+		}
+
+		return $level_2;
 	}
 }

--- a/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
+++ b/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
@@ -40,10 +40,7 @@ class PaymentLevelHelper {
 		);
 
 		if ( 'level_2' === $level ) {
-			$level_2_data = $this->build_level_2( $order );
-			if ( $level_2_data ) {
-				$data['supplementary_data']['card']['level_2'] = $level_2_data;
-			}
+			$data['supplementary_data']['card']['level_2'] = $this->build_level_2( $order );
 		}
 
 		/* phpcs:disable Squiz.PHP.CommentedOutCode.Found
@@ -85,7 +82,7 @@ class PaymentLevelHelper {
 		);
 
 		return array(
-			'customer_reference' => substr( $customer_reference, 0, 17 ),
+			'customer_reference' => (string) substr( $customer_reference, 0, 17 ),
 			'tax_total'          => array(
 				'currency_code' => $order->get_currency(),
 				'value'         => number_format( (float) $order->get_total_tax(), 2, '.', '' ),

--- a/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
+++ b/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
@@ -24,7 +24,7 @@ class PaymentLevelHelper {
 	 *     supplementary_data: array{
 	 *         card: array{
 	 *             level_2?: array{
-	 *                 customer_reference: string,
+	 *                 invoice_id: string,
 	 *                 tax_total?: array{
 	 *                     currency_code: string,
 	 *                     value: string

--- a/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
+++ b/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Helper for building Level 2/3 card processing data from WooCommerce orders.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+use WC_Order;
+
+class PaymentLevelHelper {
+
+	/**
+	 * Builds supplementary card data from WooCommerce order.
+	 *
+	 * @param WC_Order $order The WooCommerce order.
+	 * @param string   $level The processing level ('level_2' or 'level_3').
+	 * @return array{
+	 *     supplementary_data: array{
+	 *         card: array{
+	 *             level_2?: array{
+	 *                 customer_reference: string,
+	 *                 tax_total: array{
+	 *                     currency_code: string,
+	 *                     value: string
+	 *                 }
+	 *             }
+	 *         }
+	 *     }
+	 * }|null Supplementary data array ready for PurchaseUnit, or null if no data could be built.
+	 */
+	public function build( WC_Order $order, string $level ): ?array {
+		$data = array(
+			'supplementary_data' => array(
+				'card' => array(),
+			),
+		);
+
+		if ( 'level_2' === $level ) {
+			$level_2_data = $this->build_level_2( $order );
+			if ( $level_2_data ) {
+				$data['supplementary_data']['card']['level_2'] = $level_2_data;
+			}
+		}
+
+		/* phpcs:disable Squiz.PHP.CommentedOutCode.Found
+			Future: level_3 support
+			if ( 'level_3' === $level ) {
+				$level_3_data = $this->build_level_3( $order );
+				if ( $level_3_data ) {
+					$data['supplementary_data']['card']['level_3'] = $level_3_data;
+				}
+			}
+		*/
+
+		return ! empty( $data['supplementary_data']['card'] ) ? $data : null;
+	}
+
+	/**
+	 * Builds Level 2 card data.
+	 *
+	 * @param WC_Order $order The WooCommerce order.
+	 * @return array{
+	 *     customer_reference: string,
+	 *     tax_total: array{
+	 *         currency_code: string,
+	 *         value: string
+	 *     }
+	 * } Level 2 data array.
+	 */
+	private function build_level_2( WC_Order $order ): array {
+		/**
+		 * Filters the Level 2 customer reference/PO number.
+		 *
+		 * @param string   $customer_reference The customer reference (default: order ID).
+		 * @param WC_Order $order              The WooCommerce order.
+		 */
+		$customer_reference = apply_filters(
+			'woocommerce_paypal_payments_level2_customer_reference',
+			(string) $order->get_id(),
+			$order
+		);
+
+		return array(
+			'customer_reference' => substr( $customer_reference, 0, 17 ),
+			'tax_total'          => array(
+				'currency_code' => $order->get_currency(),
+				'value'         => number_format( (float) $order->get_total_tax(), 2, '.', '' ),
+			),
+		);
+	}
+}

--- a/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
+++ b/modules/ppcp-api-client/src/Helper/PaymentLevelHelper.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 
-use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -312,7 +312,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 				}
 				$this->purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 			} else {
-				$this->purchase_unit = $this->purchase_unit_factory->from_wc_cart( null, $this->should_handle_shipping_in_paypal( $funding_source ) );
+				$this->purchase_unit = $this->purchase_unit_factory->from_wc_cart( null, $this->should_handle_shipping_in_paypal( $funding_source ), $payment_method );
 
 				// Do not allow completion by webhooks when started via non-checkout buttons,
 				// it is needed only for some APMs in checkout.

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/Modal.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/Modal.js
@@ -12,7 +12,7 @@ import { PaymentHooks } from '@ppcp-settings/data';
 
 const Modal = ( { method, setModalIsVisible, onSave } ) => {
 	const { all: paymentMethods } = PaymentHooks.usePaymentMethods();
-	const { paypalShowLogo, cardholderName, fastlaneDisplayWatermark } =
+	const { paypalShowLogo, cardholderName, paymentLevelProcessing, fastlaneDisplayWatermark } =
 		PaymentHooks.usePaymentMethodsModal();
 
 	const [ settings, setSettings ] = useState( () => {
@@ -41,6 +41,7 @@ const Modal = ( { method, setModalIsVisible, onSave } ) => {
 
 		initialSettings.paypalShowLogo = paypalShowLogo;
 		initialSettings.cardholderName = cardholderName;
+		initialSettings.paymentLevelProcessing = paymentLevelProcessing;
 		initialSettings.fastlaneDisplayWatermark = fastlaneDisplayWatermark;
 
 		return initialSettings;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -38,6 +38,7 @@ const TabPaymentMethods = () => {
 				'paypalShowLogo',
 				'threeDSecure',
 				'cardholderName',
+				'paymentLevelProcessing',
 				'fastlaneDisplayWatermark',
 			];
 

--- a/modules/ppcp-settings/resources/js/data/payment/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/payment/hooks.js
@@ -132,6 +132,7 @@ export const usePaymentMethodsModal = () => {
 
 	const [ paypalShowLogo ] = usePersistent( 'paypalShowLogo' );
 	const [ cardholderName ] = usePersistent( 'cardholderName' );
+	const [ paymentLevelProcessing ] = usePersistent( 'paymentLevelProcessing' );
 	const [ fastlaneDisplayWatermark ] = usePersistent(
 		'fastlaneDisplayWatermark'
 	);
@@ -139,6 +140,7 @@ export const usePaymentMethodsModal = () => {
 	return {
 		paypalShowLogo,
 		cardholderName,
+        paymentLevelProcessing,
 		fastlaneDisplayWatermark,
 	};
 };

--- a/modules/ppcp-settings/resources/js/data/payment/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/payment/reducer.js
@@ -44,6 +44,7 @@ const defaultPersistent = Object.freeze( {
 	paypalShowLogo: false,
 	threeDSecure: 'no-3d-secure',
 	cardholderName: false,
+    paymentLevelProcessing: false,
 	fastlaneDisplayWatermark: false,
 	__meta: false,
 } );

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -243,11 +243,19 @@ class PaymentMethodsDefinition {
 				'description' => __( "Present custom credit and debit card fields to your payers so they can pay with credit and debit cards using your site's branding.", 'woocommerce-paypal-payments' ),
 				'icon'        => 'payment-method-advanced-cards',
 				'fields'      => array(
-					'cardholderName' => array(
+					'cardholderName'         => array(
 						'type'    => 'toggle',
 						'default' => $this->settings->get_cardholder_name(),
 						'label'   => __(
 							'Display cardholder name',
+							'woocommerce-paypal-payments'
+						),
+					),
+					'paymentLevelProcessing' => array(
+						'type'    => 'toggle',
+						'default' => $this->settings->get_payment_level_processing(),
+						'label'   => __(
+							'Enable Level 2/Level 3 data processing for eligible transactions',
 							'woocommerce-paypal-payments'
 						),
 					),

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -39,6 +39,7 @@ class PaymentSettings extends AbstractDataModel {
 		return array(
 			'paypal_show_logo'           => false,
 			'cardholder_name'            => false,
+			'payment_level_processing'   => false,
 			'fastlane_display_watermark' => false,
 			'venmo_enabled'              => false,
 			'paylater_enabled'           => false,
@@ -167,6 +168,15 @@ class PaymentSettings extends AbstractDataModel {
 	}
 
 	/**
+	 * Get payment level processing.
+	 *
+	 * @return bool
+	 */
+	public function get_payment_level_processing(): bool {
+		return (bool) $this->data['payment_level_processing'];
+	}
+
+	/**
 	 * Get Fastlane display watermark.
 	 *
 	 * @return bool
@@ -211,6 +221,16 @@ class PaymentSettings extends AbstractDataModel {
 	 */
 	public function set_cardholder_name( bool $value ): void {
 		$this->data['cardholder_name'] = $value;
+	}
+
+	/**
+	 * Set payment level processing.
+	 *
+	 * @param bool $value The value.
+	 * @return void
+	 */
+	public function set_payment_level_processing( bool $value ): void {
+		$this->data['payment_level_processing'] = $value;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -241,6 +241,15 @@ class SettingsProvider {
 	}
 
 	/**
+	 * If payment level processing is enabled.
+	 *
+	 * @return bool
+	 */
+	public function payment_level_processing(): bool {
+		return $this->payment_settings->get_payment_level_processing();
+	}
+
+	/**
 	 * Get if Fastlane should display watermark.
 	 *
 	 * @return bool

--- a/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
@@ -81,6 +81,10 @@ class PaymentRestEndpoint extends RestEndpoint {
 			'js_name'  => 'cardholderName',
 			'sanitize' => 'to_boolean',
 		),
+		'payment_level_processing'   => array(
+			'js_name'  => 'paymentLevelProcessing',
+			'sanitize' => 'to_boolean',
+		),
 		'fastlane_display_watermark' => array(
 			'js_name'  => 'fastlaneDisplayWatermark',
 			'sanitize' => 'to_boolean',
@@ -204,6 +208,7 @@ class PaymentRestEndpoint extends RestEndpoint {
 
 		$gateway_settings['paypalShowLogo']           = $this->payment_settings->get_paypal_show_logo();
 		$gateway_settings['cardholderName']           = $this->payment_settings->get_cardholder_name();
+		$gateway_settings['paymentLevelProcessing']   = $this->payment_settings->get_payment_level_processing();
 		$gateway_settings['fastlaneDisplayWatermark'] = $this->payment_settings->get_fastlane_display_watermark();
 
 		return $this->return_success( apply_filters( 'woocommerce_paypal_payments_payment_methods', $gateway_settings ) );

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -15,6 +15,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelHelper;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
 
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use function Brain\Monkey\Functions\expect;
 
 class PurchaseUnitFactoryTest extends TestCase
@@ -39,6 +41,7 @@ class PurchaseUnitFactoryTest extends TestCase
         $wcOrder = Mockery::mock(\WC_Order::class);
         $wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
         $wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+	    $wcOrder->shouldReceive('get_payment_method')->andReturn(PayPalGateway::ID);
         $amount = Mockery::mock(Amount::class);
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amountFactory
@@ -73,7 +76,7 @@ class PurchaseUnitFactoryTest extends TestCase
 	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
 	    $paymentLevelEligibility
 		    ->shouldReceive('is_eligible')
-		    ->with($wcOrder)
+		    ->with(PayPalGateway::ID)
 		    ->andReturn(false);
 
         $testee = new PurchaseUnitFactory(
@@ -98,16 +101,18 @@ class PurchaseUnitFactoryTest extends TestCase
     }
 
 	public function testWcOrderWithNegativeFees()
-    {
-        $wcOrder = Mockery::mock(\WC_Order::class);
-        $wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
-        $wcOrder->expects('get_id')->andReturn($this->wcOrderId);
-        $amount = Mockery::mock(Amount::class);
-        $amountFactory = Mockery::mock(AmountFactory::class);
-        $amountFactory
-            ->shouldReceive('from_wc_order')
-            ->with($wcOrder)
-            ->andReturn($amount);
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
+		$wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+		$wcOrder->shouldReceive('get_payment_method')->andReturn(PayPalGateway::ID);
+
+		$amount = Mockery::mock(Amount::class);
+		$amountFactory = Mockery::mock(AmountFactory::class);
+		$amountFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn($amount);
 
 		$fee = Mockery::mock(Item::class, [
 			'category' => Item::DIGITAL_GOODS,
@@ -117,51 +122,52 @@ class PurchaseUnitFactoryTest extends TestCase
 			'unit_amount' => new Money(-5, 'USD'),
 		]);
 
-        $itemFactory = Mockery::mock(ItemFactory::class);
-        $itemFactory
-            ->shouldReceive('from_wc_order')
-            ->with($wcOrder)
-            ->andReturn([$this->item, $fee, $discount]);
+		$itemFactory = Mockery::mock(ItemFactory::class);
+		$itemFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn([$this->item, $fee, $discount]);
 
-        $address = Mockery::mock(Address::class);
-        $address->shouldReceive('country_code')->andReturn('DE');
-        $address->shouldReceive('postal_code')->andReturn('12345');
-	    $address->shouldReceive('address_line_1')->andReturn('Berlin Street');
+		$address = Mockery::mock(Address::class);
+		$address->shouldReceive('country_code')->andReturn('DE');
+		$address->shouldReceive('postal_code')->andReturn('12345');
+		$address->shouldReceive('address_line_1')->andReturn('Berlin Street');
 
-	    $shipping = Mockery::mock(Shipping::class);
-        $shipping->shouldReceive('address')->andReturn($address);
-        $shippingFactory = Mockery::mock(ShippingFactory::class);
-        $shippingFactory
-            ->shouldReceive('from_wc_order')
-            ->with($wcOrder)
-            ->andReturn($shipping);
-        $paymentsFacory = Mockery::mock(PaymentsFactory::class);
+		$shipping = Mockery::mock(Shipping::class);
+		$shipping->shouldReceive('address')->andReturn($address);
+		$shippingFactory = Mockery::mock(ShippingFactory::class);
+		$shippingFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn($shipping);
+		$paymentsFacory = Mockery::mock(PaymentsFactory::class);
 
-	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
-	    $paymentLevelEligibility
-		    ->shouldReceive('is_eligible')
-		    ->with($wcOrder)
-		    ->andReturn(false);
+		$paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+		$paymentLevelEligibility
+			->shouldReceive('is_eligible')
+			->with(PayPalGateway::ID)
+			->andReturn(false);
 
-        $testee = new PurchaseUnitFactory(
-            $amountFactory,
-            $itemFactory,
-            $shippingFactory,
-            $paymentsFacory,
-	        Mockery::mock(PaymentLevelHelper::class),
-	        $paymentLevelEligibility
-        );
+		$testee = new PurchaseUnitFactory(
+			$amountFactory,
+			$itemFactory,
+			$shippingFactory,
+			$paymentsFacory,
+			Mockery::mock(PaymentLevelHelper::class),
+			$paymentLevelEligibility
+		);
 
-        $unit = $testee->from_wc_order($wcOrder);
-        $this->assertTrue(is_a($unit, PurchaseUnit::class));
-        $this->assertEquals([$this->item, $fee], $unit->items());
-    }
+		$unit = $testee->from_wc_order($wcOrder);
+		$this->assertTrue(is_a($unit, PurchaseUnit::class));
+		$this->assertEquals([$this->item, $fee], $unit->items());
+	}
 
     public function testWcOrderShippingGetsDroppedWhenNoPostalCode()
     {
         $wcOrder = Mockery::mock(\WC_Order::class);
         $wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
         $wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+	    $wcOrder->shouldReceive('get_payment_method')->andReturn(PayPalGateway::ID);
         $amount = Mockery::mock(Amount::class);
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amountFactory
@@ -198,7 +204,7 @@ class PurchaseUnitFactoryTest extends TestCase
 	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
 	    $paymentLevelEligibility
 		    ->shouldReceive('is_eligible')
-		    ->with($wcOrder)
+		    ->with(PayPalGateway::ID)
 		    ->andReturn(false);
 
         $testee = new PurchaseUnitFactory(
@@ -219,6 +225,7 @@ class PurchaseUnitFactoryTest extends TestCase
         $wcOrder = Mockery::mock(\WC_Order::class);
         $wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
         $wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+	    $wcOrder->shouldReceive('get_payment_method')->andReturn(PayPalGateway::ID);
         $amount = Mockery::mock(Amount::class);
         $amountFactory = Mockery::mock(AmountFactory::class);
         $amountFactory
@@ -249,7 +256,7 @@ class PurchaseUnitFactoryTest extends TestCase
 	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
 	    $paymentLevelEligibility
 		    ->shouldReceive('is_eligible')
-		    ->with($wcOrder)
+		    ->with(PayPalGateway::ID)
 		    ->andReturn(false);
 
         $testee = new PurchaseUnitFactory(
@@ -270,6 +277,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$wcOrder = Mockery::mock(\WC_Order::class);
 		$wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
 		$wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+		$wcOrder->shouldReceive('get_payment_method')->andReturn(PayPalGateway::ID);
 		$amount = Mockery::mock(Amount::class);
 		$amountFactory = Mockery::mock(AmountFactory::class);
 		$amountFactory
@@ -303,7 +311,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
 		$paymentLevelEligibility
 			->shouldReceive('is_eligible')
-			->with($wcOrder)
+			->with(PayPalGateway::ID)
 			->andReturn(false);
 
 		$testee = new PurchaseUnitFactory(
@@ -358,13 +366,19 @@ class PurchaseUnitFactoryTest extends TestCase
             ->andReturn($shipping);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
 
+	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+	    $paymentLevelEligibility
+		    ->shouldReceive('is_eligible')
+		    ->with('')
+		    ->andReturn(false);
+
         $testee = new PurchaseUnitFactory(
             $amountFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory,
 	        Mockery::mock(PaymentLevelHelper::class),
-	        Mockery::mock(PaymentLevelEligibility::class)
+	        $paymentLevelEligibility
         );
 
         $unit = $testee->from_wc_cart($wcCart);
@@ -399,13 +413,20 @@ class PurchaseUnitFactoryTest extends TestCase
             ->andReturn([$this->item]);
         $shippingFactory = Mockery::mock(ShippingFactory::class);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
+
+	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+	    $paymentLevelEligibility
+		    ->shouldReceive('is_eligible')
+		    ->with('')
+		    ->andReturn(false);
+
         $testee = new PurchaseUnitFactory(
             $amountFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory,
 	        Mockery::mock(PaymentLevelHelper::class),
-	        Mockery::mock(PaymentLevelEligibility::class)
+	        $paymentLevelEligibility
         );
 
         $unit = $testee->from_wc_cart($wcCart);
@@ -443,13 +464,20 @@ class PurchaseUnitFactoryTest extends TestCase
             ->expects('from_wc_customer')
             ->andReturn($shipping);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
+
+	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+	    $paymentLevelEligibility
+		    ->shouldReceive('is_eligible')
+		    ->with('')
+		    ->andReturn(false);
+
         $testee = new PurchaseUnitFactory(
             $amountFactory,
             $itemFactory,
             $shippingFactory,
             $paymentsFacory,
 	        Mockery::mock(PaymentLevelHelper::class),
-	        Mockery::mock(PaymentLevelEligibility::class)
+	        $paymentLevelEligibility
         );
 
         $unit = $testee->from_wc_cart($wcCart);
@@ -659,6 +687,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$wcOrder = Mockery::mock(\WC_Order::class);
 		$wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
 		$wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+		$wcOrder->shouldReceive('get_payment_method')->andReturn(CreditCardGateway::ID);
 
 		// Mock Amount with to_array() expectation
 		$amount = Mockery::mock(Amount::class);
@@ -721,7 +750,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
 		$paymentLevelEligibility
 			->shouldReceive('is_eligible')
-			->with($wcOrder)
+			->with(CreditCardGateway::ID)
 			->andReturn(true);
 
 		// Mock Level 2 data structure
@@ -729,7 +758,7 @@ class PurchaseUnitFactoryTest extends TestCase
 			'supplementary_data' => [
 				'card' => [
 					'level_2' => [
-						'customer_reference' => '12345',
+						'invoice_id' => 'INV_12345',
 						'tax_total' => [
 							'currency_code' => 'USD',
 							'value' => '8.50'
@@ -742,7 +771,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$paymentLevelHelper = Mockery::mock(PaymentLevelHelper::class);
 		$paymentLevelHelper
 			->shouldReceive('build')
-			->with($wcOrder, 'level_2')
+			->with($amount, 'level_2')
 			->andReturn($level2Data);
 
 		$testee = new PurchaseUnitFactory(
@@ -764,7 +793,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$this->assertArrayHasKey('supplementary_data', $unitArray);
 		$this->assertArrayHasKey('card', $unitArray['supplementary_data']);
 		$this->assertArrayHasKey('level_2', $unitArray['supplementary_data']['card']);
-		$this->assertEquals('12345', $unitArray['supplementary_data']['card']['level_2']['customer_reference']);
+		$this->assertEquals('INV_12345', $unitArray['supplementary_data']['card']['level_2']['invoice_id']);  // Changed field name
 		$this->assertEquals('USD', $unitArray['supplementary_data']['card']['level_2']['tax_total']['currency_code']);
 		$this->assertEquals('8.50', $unitArray['supplementary_data']['card']['level_2']['tax_total']['value']);
 	}
@@ -774,6 +803,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$wcOrder = Mockery::mock(\WC_Order::class);
 		$wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
 		$wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+		$wcOrder->shouldReceive('get_payment_method')->andReturn(PayPalGateway::ID);
 
 		// Mock Amount with to_array() expectation
 		$amount = Mockery::mock(Amount::class);
@@ -836,7 +866,7 @@ class PurchaseUnitFactoryTest extends TestCase
 		$paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
 		$paymentLevelEligibility
 			->shouldReceive('is_eligible')
-			->with($wcOrder)
+			->with(PayPalGateway::ID)
 			->andReturn(false);
 
 		$paymentLevelHelper = Mockery::mock(PaymentLevelHelper::class);

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -10,6 +10,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelEligibility;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelHelper;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
 
@@ -67,11 +69,20 @@ class PurchaseUnitFactoryTest extends TestCase
             ->with($wcOrder)
             ->andReturn($shipping);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
+
+	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+	    $paymentLevelEligibility
+		    ->shouldReceive('is_eligible')
+		    ->with($wcOrder)
+		    ->andReturn(false);
+
         $testee = new PurchaseUnitFactory(
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        $paymentLevelEligibility
         );
 
         $unit = $testee->from_wc_order($wcOrder);
@@ -125,11 +136,20 @@ class PurchaseUnitFactoryTest extends TestCase
             ->with($wcOrder)
             ->andReturn($shipping);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
+
+	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+	    $paymentLevelEligibility
+		    ->shouldReceive('is_eligible')
+		    ->with($wcOrder)
+		    ->andReturn(false);
+
         $testee = new PurchaseUnitFactory(
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        $paymentLevelEligibility
         );
 
         $unit = $testee->from_wc_order($wcOrder);
@@ -174,11 +194,20 @@ class PurchaseUnitFactoryTest extends TestCase
             ->with($wcOrder)
             ->andReturn($shipping);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
+
+	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+	    $paymentLevelEligibility
+		    ->shouldReceive('is_eligible')
+		    ->with($wcOrder)
+		    ->andReturn(false);
+
         $testee = new PurchaseUnitFactory(
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        $paymentLevelEligibility
         );
 
         $unit = $testee->from_wc_order($wcOrder);
@@ -216,11 +245,20 @@ class PurchaseUnitFactoryTest extends TestCase
             ->with($wcOrder)
             ->andReturn($shipping);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
+
+	    $paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+	    $paymentLevelEligibility
+		    ->shouldReceive('is_eligible')
+		    ->with($wcOrder)
+		    ->andReturn(false);
+
         $testee = new PurchaseUnitFactory(
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        $paymentLevelEligibility
         );
 
         $unit = $testee->from_wc_order($wcOrder);
@@ -261,11 +299,20 @@ class PurchaseUnitFactoryTest extends TestCase
 			->with($wcOrder)
 			->andReturn($shipping);
 		$paymentsFacory = Mockery::mock(PaymentsFactory::class);
+
+		$paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+		$paymentLevelEligibility
+			->shouldReceive('is_eligible')
+			->with($wcOrder)
+			->andReturn(false);
+
 		$testee = new PurchaseUnitFactory(
 			$amountFactory,
 			$itemFactory,
 			$shippingFactory,
-			$paymentsFacory
+			$paymentsFacory,
+			Mockery::mock(PaymentLevelHelper::class),
+			$paymentLevelEligibility
 		);
 
 		$unit = $testee->from_wc_order($wcOrder);
@@ -310,11 +357,14 @@ class PurchaseUnitFactoryTest extends TestCase
             ->with($wcCustomer, false)
             ->andReturn($shipping);
         $paymentsFacory = Mockery::mock(PaymentsFactory::class);
+
         $testee = new PurchaseUnitFactory(
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        Mockery::mock(PaymentLevelEligibility::class)
         );
 
         $unit = $testee->from_wc_cart($wcCart);
@@ -353,7 +403,9 @@ class PurchaseUnitFactoryTest extends TestCase
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        Mockery::mock(PaymentLevelEligibility::class)
         );
 
         $unit = $testee->from_wc_cart($wcCart);
@@ -395,7 +447,9 @@ class PurchaseUnitFactoryTest extends TestCase
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        Mockery::mock(PaymentLevelEligibility::class)
         );
 
         $unit = $testee->from_wc_cart($wcCart);
@@ -420,7 +474,9 @@ class PurchaseUnitFactoryTest extends TestCase
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        Mockery::mock(PaymentLevelEligibility::class)
         );
 
         $response = (object) [
@@ -461,7 +517,9 @@ class PurchaseUnitFactoryTest extends TestCase
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        Mockery::mock(PaymentLevelEligibility::class)
         );
 
         $response = (object) [
@@ -488,7 +546,9 @@ class PurchaseUnitFactoryTest extends TestCase
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFacory
+            $paymentsFacory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        Mockery::mock(PaymentLevelEligibility::class)
         );
 
         $response = (object) [
@@ -530,7 +590,9 @@ class PurchaseUnitFactoryTest extends TestCase
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFactory
+            $paymentsFactory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        Mockery::mock(PaymentLevelEligibility::class)
         );
 
         $response = (object)[
@@ -572,7 +634,9 @@ class PurchaseUnitFactoryTest extends TestCase
             $amountFactory,
             $itemFactory,
             $shippingFactory,
-            $paymentsFactory
+            $paymentsFactory,
+	        Mockery::mock(PaymentLevelHelper::class),
+	        Mockery::mock(PaymentLevelEligibility::class)
         );
 
         $response = (object)[
@@ -589,4 +653,212 @@ class PurchaseUnitFactoryTest extends TestCase
         $unit = $testee->from_paypal_response($response);
         $this->assertNull($unit->payments());
     }
+
+	public function testWcOrderWithLevel2Processing()
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
+		$wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+
+		// Mock Amount with to_array() expectation
+		$amount = Mockery::mock(Amount::class);
+		$amount->shouldReceive('to_array')->andReturn([
+			'currency_code' => 'USD',
+			'value' => '100.00'
+		]);
+
+		$amountFactory = Mockery::mock(AmountFactory::class);
+		$amountFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn($amount);
+
+		// Mock Item with to_array() expectation
+		$item = Mockery::mock(Item::class);
+		$item->shouldReceive('to_array')->andReturn([
+			'name' => 'Test Item',
+			'unit_amount' => ['currency_code' => 'USD', 'value' => '100.00'],
+			'quantity' => '1'
+		]);
+		$item->shouldReceive('unit_amount')->andReturn(new Money(100.0, 'USD'));
+		$item->shouldReceive('category')->andReturn(Item::PHYSICAL_GOODS);
+
+		$itemFactory = Mockery::mock(ItemFactory::class);
+		$itemFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn([$item]);
+
+		$address = Mockery::mock(Address::class);
+		$address->shouldReceive('country_code')->andReturn('US');
+		$address->shouldReceive('postal_code')->andReturn('12345');
+		$address->shouldReceive('address_line_1')->andReturn('123 Main St');
+		$address->shouldReceive('to_array')->andReturn([
+			'country_code' => 'US',
+			'postal_code' => '12345',
+			'address_line_1' => '123 Main St'
+		]);
+
+		$shipping = Mockery::mock(Shipping::class);
+		$shipping->shouldReceive('address')->andReturn($address);
+		$shipping->shouldReceive('to_array')->andReturn([
+			'address' => [
+				'country_code' => 'US',
+				'postal_code' => '12345',
+				'address_line_1' => '123 Main St'
+			]
+		]);
+
+		$shippingFactory = Mockery::mock(ShippingFactory::class);
+		$shippingFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn($shipping);
+
+		$paymentsFactory = Mockery::mock(PaymentsFactory::class);
+
+		// Mock Level 2 processing to return true
+		$paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+		$paymentLevelEligibility
+			->shouldReceive('is_eligible')
+			->with($wcOrder)
+			->andReturn(true);
+
+		// Mock Level 2 data structure
+		$level2Data = [
+			'supplementary_data' => [
+				'card' => [
+					'level_2' => [
+						'customer_reference' => '12345',
+						'tax_total' => [
+							'currency_code' => 'USD',
+							'value' => '8.50'
+						]
+					]
+				]
+			]
+		];
+
+		$paymentLevelHelper = Mockery::mock(PaymentLevelHelper::class);
+		$paymentLevelHelper
+			->shouldReceive('build')
+			->with($wcOrder, 'level_2')
+			->andReturn($level2Data);
+
+		$testee = new PurchaseUnitFactory(
+			$amountFactory,
+			$itemFactory,
+			$shippingFactory,
+			$paymentsFactory,
+			$paymentLevelHelper,
+			$paymentLevelEligibility
+		);
+
+		$unit = $testee->from_wc_order($wcOrder);
+
+		// Assert that the purchase unit was created
+		$this->assertTrue(is_a($unit, PurchaseUnit::class));
+
+		// Assert that supplementary_data is present in the array output
+		$unitArray = $unit->to_array();
+		$this->assertArrayHasKey('supplementary_data', $unitArray);
+		$this->assertArrayHasKey('card', $unitArray['supplementary_data']);
+		$this->assertArrayHasKey('level_2', $unitArray['supplementary_data']['card']);
+		$this->assertEquals('12345', $unitArray['supplementary_data']['card']['level_2']['customer_reference']);
+		$this->assertEquals('USD', $unitArray['supplementary_data']['card']['level_2']['tax_total']['currency_code']);
+		$this->assertEquals('8.50', $unitArray['supplementary_data']['card']['level_2']['tax_total']['value']);
+	}
+
+	public function testWcOrderWithoutLevel2ProcessingWhenNotEligible()
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->expects('get_order_number')->andReturn($this->wcOrderNumber);
+		$wcOrder->expects('get_id')->andReturn($this->wcOrderId);
+
+		// Mock Amount with to_array() expectation
+		$amount = Mockery::mock(Amount::class);
+		$amount->shouldReceive('to_array')->andReturn([
+			'currency_code' => 'EUR',
+			'value' => '100.00'
+		]);
+
+		$amountFactory = Mockery::mock(AmountFactory::class);
+		$amountFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn($amount);
+
+		// Mock Item with to_array() expectation
+		$item = Mockery::mock(Item::class);
+		$item->shouldReceive('to_array')->andReturn([
+			'name' => 'Test Item',
+			'unit_amount' => ['currency_code' => 'EUR', 'value' => '100.00'],
+			'quantity' => '1'
+		]);
+		$item->shouldReceive('unit_amount')->andReturn(new Money(100.0, 'EUR'));
+		$item->shouldReceive('category')->andReturn(Item::PHYSICAL_GOODS);
+
+		$itemFactory = Mockery::mock(ItemFactory::class);
+		$itemFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn([$item]);
+
+		$address = Mockery::mock(Address::class);
+		$address->shouldReceive('country_code')->andReturn('DE');
+		$address->shouldReceive('postal_code')->andReturn('12345');
+		$address->shouldReceive('address_line_1')->andReturn('Berlin Street');
+		$address->shouldReceive('to_array')->andReturn([
+			'country_code' => 'DE',
+			'postal_code' => '12345',
+			'address_line_1' => 'Berlin Street'
+		]);
+
+		$shipping = Mockery::mock(Shipping::class);
+		$shipping->shouldReceive('address')->andReturn($address);
+		$shipping->shouldReceive('to_array')->andReturn([
+			'address' => [
+				'country_code' => 'DE',
+				'postal_code' => '12345',
+				'address_line_1' => 'Berlin Street'
+			]
+		]);
+
+		$shippingFactory = Mockery::mock(ShippingFactory::class);
+		$shippingFactory
+			->shouldReceive('from_wc_order')
+			->with($wcOrder)
+			->andReturn($shipping);
+
+		$paymentsFactory = Mockery::mock(PaymentsFactory::class);
+
+		// Mock Level 2 processing to return false (not eligible)
+		$paymentLevelEligibility = Mockery::mock(PaymentLevelEligibility::class);
+		$paymentLevelEligibility
+			->shouldReceive('is_eligible')
+			->with($wcOrder)
+			->andReturn(false);
+
+		$paymentLevelHelper = Mockery::mock(PaymentLevelHelper::class);
+		// build() should NOT be called when not eligible
+		$paymentLevelHelper->shouldNotReceive('build');
+
+		$testee = new PurchaseUnitFactory(
+			$amountFactory,
+			$itemFactory,
+			$shippingFactory,
+			$paymentsFactory,
+			$paymentLevelHelper,
+			$paymentLevelEligibility
+		);
+
+		$unit = $testee->from_wc_order($wcOrder);
+
+		// Assert that the purchase unit was created
+		$this->assertTrue(is_a($unit, PurchaseUnit::class));
+
+		// Assert that supplementary_data is NOT present
+		$unitArray = $unit->to_array();
+		$this->assertArrayNotHasKey('supplementary_data', $unitArray);
+	}
 }

--- a/tests/PHPUnit/ApiClient/Helper/PaymentLevelEligibilityTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/PaymentLevelEligibilityTest.php
@@ -1,0 +1,161 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+use Brain\Monkey\Functions;
+
+class PaymentLevelEligibilityTest extends TestCase {
+
+	private $settings;
+	private $currency_getter;
+	private PaymentLevelEligibility $testee;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->settings = Mockery::mock( SettingsProvider::class );
+		$this->currency_getter = Mockery::mock( CurrencyGetter::class );
+	}
+
+	/**
+	 * Test eligibility when all conditions are met.
+	 */
+	public function test_is_eligible_when_all_conditions_met(): void {
+		$this->settings->expects('payment_level_processing')->once()->andReturn(true);
+		$this->currency_getter->expects('get')->once()->andReturn('USD');
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_countries', ['US'])
+			->andReturn(['US']);
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_currencies', ['USD'])
+			->andReturn(['USD']);
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_payment_methods', ['ppcp-credit-card-gateway'])
+			->andReturn(['ppcp-credit-card-gateway']);
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_eligible', true)
+			->andReturn(true);
+
+		$this->testee = new PaymentLevelEligibility(
+			$this->settings,
+			'US',
+			$this->currency_getter
+		);
+
+		$result = $this->testee->is_eligible('ppcp-credit-card-gateway');
+
+		$this->assertTrue($result);
+	}
+
+	/**
+	 * Test eligibility fails when feature setting is disabled.
+	 */
+	public function test_is_not_eligible_when_feature_disabled(): void {
+		$this->settings->expects('payment_level_processing')->once()->andReturn(false);
+
+		$this->testee = new PaymentLevelEligibility(
+			$this->settings,
+			'US',
+			$this->currency_getter
+		);
+
+		$result = $this->testee->is_eligible('ppcp-credit-card-gateway');
+
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Test eligibility fails with invalid country.
+	 */
+	public function test_is_not_eligible_with_invalid_country(): void {
+		$this->settings->expects('payment_level_processing')->once()->andReturn(true);
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_countries', ['US'])
+			->andReturn(['US']);
+
+		$this->testee = new PaymentLevelEligibility(
+			$this->settings,
+			'GB', // UK not allowed
+			$this->currency_getter
+		);
+
+		$result = $this->testee->is_eligible('ppcp-credit-card-gateway');
+
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Test eligibility fails with invalid currency.
+	 */
+	public function test_is_not_eligible_with_invalid_currency(): void {
+		$this->settings->expects('payment_level_processing')->once()->andReturn(true);
+		$this->currency_getter->expects('get')->once()->andReturn('EUR');
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_countries', ['US'])
+			->andReturn(['US']);
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_currencies', ['USD'])
+			->andReturn(['USD']);
+
+		$this->testee = new PaymentLevelEligibility(
+			$this->settings,
+			'US',
+			$this->currency_getter
+		);
+
+		$result = $this->testee->is_eligible('ppcp-credit-card-gateway');
+
+		$this->assertFalse($result);
+	}
+
+	/**
+	 * Test eligibility fails with invalid payment method.
+	 */
+	public function test_is_not_eligible_with_invalid_payment_method(): void {
+		$this->settings->expects('payment_level_processing')->once()->andReturn(true);
+		$this->currency_getter->expects('get')->once()->andReturn('USD');
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_countries', ['US'])
+			->andReturn(['US']);
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_currencies', ['USD'])
+			->andReturn(['USD']);
+
+		Functions\expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_level_processing_payment_methods', ['ppcp-credit-card-gateway'])
+			->andReturn(['ppcp-credit-card-gateway']);
+
+		$this->testee = new PaymentLevelEligibility(
+			$this->settings,
+			'US',
+			$this->currency_getter
+		);
+
+		$result = $this->testee->is_eligible('paypal'); // PayPal wallet not allowed
+
+		$this->assertFalse($result);
+	}
+}

--- a/tests/PHPUnit/ApiClient/Helper/PaymentLevelHelperTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/PaymentLevelHelperTest.php
@@ -1,0 +1,132 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use Mockery;
+use function Brain\Monkey\Functions\expect;
+
+class PaymentLevelHelperTest extends TestCase
+{
+	public function testBuildLevel2WithDefaultCustomerReference()
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn(12345);
+		$wcOrder->shouldReceive('get_currency')->andReturn('USD');
+		$wcOrder->shouldReceive('get_total_tax')->andReturn(8.5);
+
+		expect('apply_filters')
+			->with(
+				'woocommerce_paypal_payments_level2_customer_reference',
+				'12345',
+				$wcOrder
+			)
+			->andReturn('12345');
+
+		$helper = new PaymentLevelHelper();
+		$result = $helper->build($wcOrder, 'level_2');
+
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('supplementary_data', $result);
+		$this->assertArrayHasKey('card', $result['supplementary_data']);
+		$this->assertArrayHasKey('level_2', $result['supplementary_data']['card']);
+
+		$level2 = $result['supplementary_data']['card']['level_2'];
+		$this->assertEquals('12345', $level2['customer_reference']);
+		$this->assertEquals('USD', $level2['tax_total']['currency_code']);
+		$this->assertEquals('8.50', $level2['tax_total']['value']);
+	}
+
+	public function testBuildLevel2FormatsDecimalTaxCorrectly()
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn(12345);
+		$wcOrder->shouldReceive('get_currency')->andReturn('USD');
+		$wcOrder->shouldReceive('get_total_tax')->andReturn(12.456);
+
+		expect('apply_filters')
+			->with(
+				'woocommerce_paypal_payments_level2_customer_reference',
+				'12345',
+				$wcOrder
+			)
+			->andReturn('12345');
+
+		$helper = new PaymentLevelHelper();
+		$result = $helper->build($wcOrder, 'level_2');
+
+		$level2 = $result['supplementary_data']['card']['level_2'];
+		$this->assertEquals('12.46', $level2['tax_total']['value']);
+	}
+
+	public function testBuildLevel2WithDifferentCurrencies()
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn(12345);
+		$wcOrder->shouldReceive('get_currency')->andReturn('EUR');
+		$wcOrder->shouldReceive('get_total_tax')->andReturn(15.0);
+
+		expect('apply_filters')
+			->with(
+				'woocommerce_paypal_payments_level2_customer_reference',
+				'12345',
+				$wcOrder
+			)
+			->andReturn('12345');
+
+		$helper = new PaymentLevelHelper();
+		$result = $helper->build($wcOrder, 'level_2');
+
+		$level2 = $result['supplementary_data']['card']['level_2'];
+		$this->assertEquals('EUR', $level2['tax_total']['currency_code']);
+	}
+
+	public function testBuildReturnsNullForInvalidLevel()
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+
+		$helper = new PaymentLevelHelper();
+		$result = $helper->build($wcOrder, 'invalid_level');
+
+		$this->assertNull($result);
+	}
+
+	public function testBuildLevel2ReturnsCorrectStructure()
+	{
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn(99999);
+		$wcOrder->shouldReceive('get_currency')->andReturn('USD');
+		$wcOrder->shouldReceive('get_total_tax')->andReturn(25.75);
+
+		expect('apply_filters')
+			->with(
+				'woocommerce_paypal_payments_level2_customer_reference',
+				'99999',
+				$wcOrder
+			)
+			->andReturn('99999');
+
+		$helper = new PaymentLevelHelper();
+		$result = $helper->build($wcOrder, 'level_2');
+
+		// Verify exact structure matches the array shape docblock
+		$this->assertIsArray($result);
+		$this->assertArrayHasKey('supplementary_data', $result);
+		$this->assertIsArray($result['supplementary_data']);
+		$this->assertArrayHasKey('card', $result['supplementary_data']);
+		$this->assertIsArray($result['supplementary_data']['card']);
+		$this->assertArrayHasKey('level_2', $result['supplementary_data']['card']);
+
+		$level2 = $result['supplementary_data']['card']['level_2'];
+		$this->assertIsArray($level2);
+		$this->assertArrayHasKey('customer_reference', $level2);
+		$this->assertArrayHasKey('tax_total', $level2);
+		$this->assertIsString($level2['customer_reference']);
+		$this->assertIsArray($level2['tax_total']);
+		$this->assertArrayHasKey('currency_code', $level2['tax_total']);
+		$this->assertArrayHasKey('value', $level2['tax_total']);
+		$this->assertIsString($level2['tax_total']['currency_code']);
+		$this->assertIsString($level2['tax_total']['value']);
+	}
+}

--- a/tests/PHPUnit/ApiClient/Helper/PaymentLevelHelperTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/PaymentLevelHelperTest.php
@@ -3,29 +3,38 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\AmountBreakdown;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
 use function Brain\Monkey\Functions\expect;
 
 class PaymentLevelHelperTest extends TestCase
 {
-	public function testBuildLevel2WithDefaultCustomerReference()
+	public function testBuildLevel2WithDefaultInvoiceId()
 	{
-		$wcOrder = Mockery::mock(\WC_Order::class);
-		$wcOrder->shouldReceive('get_id')->andReturn(12345);
-		$wcOrder->shouldReceive('get_currency')->andReturn('USD');
-		$wcOrder->shouldReceive('get_total_tax')->andReturn(8.5);
+		$taxTotal = Mockery::mock(Money::class);
+		$taxTotal->shouldReceive('currency_code')->andReturn('USD');
+		$taxTotal->shouldReceive('value_str')->andReturn('8.50');
+
+		$breakdown = Mockery::mock(AmountBreakdown::class);
+		$breakdown->shouldReceive('tax_total')->andReturn($taxTotal);
+
+		$amount = Mockery::mock(Amount::class);
+		$amount->shouldReceive('breakdown')->andReturn($breakdown);
 
 		expect('apply_filters')
 			->with(
-				'woocommerce_paypal_payments_level2_customer_reference',
-				'12345',
-				$wcOrder
+				'woocommerce_paypal_payments_level2_invoice_id',
+				Mockery::pattern('/^INV_[A-Z0-9]+$/')
 			)
-			->andReturn('12345');
+			->andReturnUsing(function($hook, $value) {
+				return $value; // Return the generated invoice ID
+			});
 
 		$helper = new PaymentLevelHelper();
-		$result = $helper->build($wcOrder, 'level_2');
+		$result = $helper->build($amount, 'level_2');
 
 		$this->assertIsArray($result);
 		$this->assertArrayHasKey('supplementary_data', $result);
@@ -33,82 +42,147 @@ class PaymentLevelHelperTest extends TestCase
 		$this->assertArrayHasKey('level_2', $result['supplementary_data']['card']);
 
 		$level2 = $result['supplementary_data']['card']['level_2'];
-		$this->assertEquals('12345', $level2['customer_reference']);
+		$this->assertArrayHasKey('invoice_id', $level2);
+		$this->assertStringStartsWith('INV_', $level2['invoice_id']);
 		$this->assertEquals('USD', $level2['tax_total']['currency_code']);
 		$this->assertEquals('8.50', $level2['tax_total']['value']);
 	}
 
-	public function testBuildLevel2FormatsDecimalTaxCorrectly()
+	public function testBuildLevel2WithCustomInvoiceId()
 	{
-		$wcOrder = Mockery::mock(\WC_Order::class);
-		$wcOrder->shouldReceive('get_id')->andReturn(12345);
-		$wcOrder->shouldReceive('get_currency')->andReturn('USD');
-		$wcOrder->shouldReceive('get_total_tax')->andReturn(12.456);
+		$taxTotal = Mockery::mock(Money::class);
+		$taxTotal->shouldReceive('currency_code')->andReturn('USD');
+		$taxTotal->shouldReceive('value_str')->andReturn('10.00');
+
+		$breakdown = Mockery::mock(AmountBreakdown::class);
+		$breakdown->shouldReceive('tax_total')->andReturn($taxTotal);
+
+		$amount = Mockery::mock(Amount::class);
+		$amount->shouldReceive('breakdown')->andReturn($breakdown);
 
 		expect('apply_filters')
 			->with(
-				'woocommerce_paypal_payments_level2_customer_reference',
-				'12345',
-				$wcOrder
+				'woocommerce_paypal_payments_level2_invoice_id',
+				Mockery::pattern('/^INV_[A-Z0-9]+$/')
 			)
-			->andReturn('12345');
+			->andReturn('CUSTOM-INV-12345');
 
 		$helper = new PaymentLevelHelper();
-		$result = $helper->build($wcOrder, 'level_2');
+		$result = $helper->build($amount, 'level_2');
 
 		$level2 = $result['supplementary_data']['card']['level_2'];
-		$this->assertEquals('12.46', $level2['tax_total']['value']);
+		$this->assertEquals('CUSTOM-INV-12345', $level2['invoice_id']);
 	}
 
-	public function testBuildLevel2WithDifferentCurrencies()
+	public function testBuildLevel2TruncatesInvoiceIdTo127Characters()
 	{
-		$wcOrder = Mockery::mock(\WC_Order::class);
-		$wcOrder->shouldReceive('get_id')->andReturn(12345);
-		$wcOrder->shouldReceive('get_currency')->andReturn('EUR');
-		$wcOrder->shouldReceive('get_total_tax')->andReturn(15.0);
+		$taxTotal = Mockery::mock(Money::class);
+		$taxTotal->shouldReceive('currency_code')->andReturn('USD');
+		$taxTotal->shouldReceive('value_str')->andReturn('5.00');
+
+		$breakdown = Mockery::mock(AmountBreakdown::class);
+		$breakdown->shouldReceive('tax_total')->andReturn($taxTotal);
+
+		$amount = Mockery::mock(Amount::class);
+		$amount->shouldReceive('breakdown')->andReturn($breakdown);
+
+		$longInvoiceId = str_repeat('A', 150); // 150 characters
 
 		expect('apply_filters')
 			->with(
-				'woocommerce_paypal_payments_level2_customer_reference',
-				'12345',
-				$wcOrder
+				'woocommerce_paypal_payments_level2_invoice_id',
+				Mockery::pattern('/^INV_[A-Z0-9]+$/')
 			)
-			->andReturn('12345');
+			->andReturn($longInvoiceId);
 
 		$helper = new PaymentLevelHelper();
-		$result = $helper->build($wcOrder, 'level_2');
+		$result = $helper->build($amount, 'level_2');
 
 		$level2 = $result['supplementary_data']['card']['level_2'];
-		$this->assertEquals('EUR', $level2['tax_total']['currency_code']);
+		$this->assertEquals(127, strlen($level2['invoice_id']));
+		$this->assertEquals(substr($longInvoiceId, 0, 127), $level2['invoice_id']);
+	}
+
+	public function testBuildLevel2WithNullTaxTotal()
+	{
+		$breakdown = Mockery::mock(AmountBreakdown::class);
+		$breakdown->shouldReceive('tax_total')->andReturn(null);
+
+		$amount = Mockery::mock(Amount::class);
+		$amount->shouldReceive('breakdown')->andReturn($breakdown);
+
+		expect('apply_filters')
+			->with(
+				'woocommerce_paypal_payments_level2_invoice_id',
+				Mockery::pattern('/^INV_[A-Z0-9]+$/')
+			)
+			->andReturnUsing(function($hook, $value) {
+				return $value;
+			});
+
+		$helper = new PaymentLevelHelper();
+		$result = $helper->build($amount, 'level_2');
+
+		$level2 = $result['supplementary_data']['card']['level_2'];
+		$this->assertArrayHasKey('invoice_id', $level2);
+		$this->assertArrayNotHasKey('tax_total', $level2);
+	}
+
+	public function testBuildLevel2WithNullBreakdown()
+	{
+		$amount = Mockery::mock(Amount::class);
+		$amount->shouldReceive('breakdown')->andReturn(null);
+
+		expect('apply_filters')
+			->with(
+				'woocommerce_paypal_payments_level2_invoice_id',
+				Mockery::pattern('/^INV_[A-Z0-9]+$/')
+			)
+			->andReturnUsing(function($hook, $value) {
+				return $value;
+			});
+
+		$helper = new PaymentLevelHelper();
+		$result = $helper->build($amount, 'level_2');
+
+		$level2 = $result['supplementary_data']['card']['level_2'];
+		$this->assertArrayHasKey('invoice_id', $level2);
+		$this->assertArrayNotHasKey('tax_total', $level2);
 	}
 
 	public function testBuildReturnsNullForInvalidLevel()
 	{
-		$wcOrder = Mockery::mock(\WC_Order::class);
+		$amount = Mockery::mock(Amount::class);
 
 		$helper = new PaymentLevelHelper();
-		$result = $helper->build($wcOrder, 'invalid_level');
+		$result = $helper->build($amount, 'invalid_level');
 
 		$this->assertNull($result);
 	}
 
 	public function testBuildLevel2ReturnsCorrectStructure()
 	{
-		$wcOrder = Mockery::mock(\WC_Order::class);
-		$wcOrder->shouldReceive('get_id')->andReturn(99999);
-		$wcOrder->shouldReceive('get_currency')->andReturn('USD');
-		$wcOrder->shouldReceive('get_total_tax')->andReturn(25.75);
+		$taxTotal = Mockery::mock(Money::class);
+		$taxTotal->shouldReceive('currency_code')->andReturn('USD');
+		$taxTotal->shouldReceive('value_str')->andReturn('25.75');
+
+		$breakdown = Mockery::mock(AmountBreakdown::class);
+		$breakdown->shouldReceive('tax_total')->andReturn($taxTotal);
+
+		$amount = Mockery::mock(Amount::class);
+		$amount->shouldReceive('breakdown')->andReturn($breakdown);
 
 		expect('apply_filters')
 			->with(
-				'woocommerce_paypal_payments_level2_customer_reference',
-				'99999',
-				$wcOrder
+				'woocommerce_paypal_payments_level2_invoice_id',
+				Mockery::pattern('/^INV_[A-Z0-9]+$/')
 			)
-			->andReturn('99999');
+			->andReturnUsing(function($hook, $value) {
+				return $value;
+			});
 
 		$helper = new PaymentLevelHelper();
-		$result = $helper->build($wcOrder, 'level_2');
+		$result = $helper->build($amount, 'level_2');
 
 		// Verify exact structure matches the array shape docblock
 		$this->assertIsArray($result);
@@ -120,9 +194,9 @@ class PaymentLevelHelperTest extends TestCase
 
 		$level2 = $result['supplementary_data']['card']['level_2'];
 		$this->assertIsArray($level2);
-		$this->assertArrayHasKey('customer_reference', $level2);
+		$this->assertArrayHasKey('invoice_id', $level2);
 		$this->assertArrayHasKey('tax_total', $level2);
-		$this->assertIsString($level2['customer_reference']);
+		$this->assertIsString($level2['invoice_id']);
 		$this->assertIsArray($level2['tax_total']);
 		$this->assertArrayHasKey('currency_code', $level2['tax_total']);
 		$this->assertArrayHasKey('value', $level2['tax_total']);


### PR DESCRIPTION
## Level 2 Card Processing Implementation

Implements Level 2 card processing for PayPal ACDC (Advanced Credit and Debit Card) payments, enabling lower interchange rates for eligible B2B transactions on Visa and Mastercard.

### Changes

**New Classes:**
- `PaymentLevelEligibility` - Validates payment eligibility for Level 2/3 processing based on merchant country, shop currency, payment method, and feature setting
- `PaymentLevelHelper` - Builds Level 2 supplementary card data structure from Amount entities

**Modified Classes:**
- `PurchaseUnit` - Added `supplementary_data` constructor parameter and array output support
- `PurchaseUnitFactory` - Integrated Level 2 data building in both `from_wc_cart()` (checkout) and `from_wc_order()` (pay-now)

**Settings:**
- Added `payment_level_processing` feature setting to enable/disable Level 2/3 processing

<img width="1048" height="469" alt="Screenshot 2025-12-26 at 17 37 03" src="https://github.com/user-attachments/assets/46f38863-e099-4696-8b8b-e37ab2cfbc13" />

### How It Works

Level 2 data is automatically included for eligible transactions when:
1. Feature setting `payment_level_processing` is enabled
2. Merchant country is US
3. Shop currency is USD
4. Payment method is ACDC (credit card gateway)

**Supports both contexts:**
- **Checkout flow** - Level 2 data built from cart Amount before WC order exists
- **Pay-now flow** - Level 2 data built from existing WC order Amount

**Level 2 Data Structure:**
```json
{
  "supplementary_data": {
    "card": {
      "level_2": {
        "invoice_id": "INV_6789ABCD",
        "tax_total": {
          "currency_code": "USD",
          "value": "8.50"
        }
      }
    }
  }
}
```

### Card Network Validation

Card network validation (Visa/Mastercard only) is **not** implemented at order creation time because the card brand is not available until after the customer enters card details in PayPal's hosted fields. PayPal automatically filters Level 2 data for non-Visa/Mastercard transactions. See [PCP-5686 comment](https://inpsyde.atlassian.net/browse/PCP-5686?focusedCommentId=365263) for detailed analysis and implementation options.

### Filters

**`woocommerce_paypal_payments_level2_invoice_id`**
- Customize the Level 2 invoice ID (default: generated unique ID with `INV_` prefix, max 127 chars)

**`woocommerce_paypal_payments_level_processing_eligible`**
- Override eligibility determination for specific payments

**`woocommerce_paypal_payments_level_processing_countries`**
- Modify allowed merchant countries (default: `['US']`)

**`woocommerce_paypal_payments_level_processing_currencies`**
- Modify allowed currencies (default: `['USD']`)

**`woocommerce_paypal_payments_level_processing_payment_methods`**
- Modify allowed payment methods (default: `['ppcp-credit-card-gateway']`)

### Testing Notes

- [ ] Enable `payment_level_processing` feature flag
- [ ] Test with US merchant, USD currency, ACDC payment in **checkout**
- [ ] Test with existing order in **pay-now** context
- [ ] Verify Level 2 data in PayPal Orders API request payload
- [ ] Test with ineligible conditions (non-US, non-USD, non-ACDC)
- [ ] Verify no Level 2 data sent when feature flag is disabled
- [ ] Test invoice_id filter customization

### Future Work

- Level 3 implementation with line-item details (separate ticket)
