### PR TITLE
Check that cart is initialized before trying to access it (5692)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -202,6 +202,10 @@ class PayPalSubscriptionsModule implements ServiceModule, ExtendingModule, Execu
 			 * @psalm-suppress MissingClosureParamType
 			 */
 			static function ( $passed_validation, $product_id ) use ( $c ) {
+				if ( ! WC()->cart ) {
+					return $passed_validation;
+				}
+
 				if ( WC()->cart->is_empty() || wcs_is_manual_renewal_enabled() ) {
 					return $passed_validation;
 				}


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
Adds check that the cart exists before trying to access it on `woocommerce_add_to_cart_validation` hook.

We noticed the error on WooCommerce.com when passing the `add-to-cart` query string directly to a REST endpoint, most likely by a bot or AI agent

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

1. Don't check out this branch yet.
2. Install and activate WooCommerce Subscriptions
3. Ensure you have at least one published product. Note the product id
4. Make the following request using a valid product id: `curl -i 'https://woocommerce-paypal-payments.ddev.site/wp-json/?add-to-cart=<product_id>'`
5. You should see the following fatal error:
`Uncaught Error: Call to a member function is_empty() on null in /var/www/html/.ddev/wordpress/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php:205`
6. Check out this branch and make the request from step 4 again.
7. Instead of the error in `PayPalSubscriptionsModule.php`, you should now see a fatal caused by `class-wc-form-handler.php` in WooCommerce itself (fix pending in https://github.com/woocommerce/woocommerce/pull/62644)
`Uncaught Error: Call to a member function add_to_cart() on null in /var/www/html/.ddev/wordpress/wp-content/plugins/woocommerce/includes/class-wc-form-handler.php:872`

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.


