### PR TITLE
ppcp-session SettingsProvider migration (5613)

### DIFF
--- a/modules/ppcp-session/services.php
+++ b/modules/ppcp-session/services.php
@@ -19,7 +19,7 @@ return array(
 	},
 	'session.cancellation.view'       => function ( ContainerInterface $container ): CancelView {
 		return new CancelView(
-			$container->get( 'wcgateway.settings' ),
+			$container->get( 'settings.settings-provider' ),
 			$container->get( 'wcgateway.funding-source.renderer' )
 		);
 	},

--- a/modules/ppcp-session/src/Cancellation/CancelView.php
+++ b/modules/ppcp-session/src/Cancellation/CancelView.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Session\Cancellation;
 
-use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
 
 /**
@@ -17,11 +17,11 @@ use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
  */
 class CancelView {
 	/**
-	 * The settings.
+	 * The settings provider.
 	 *
-	 * @var ContainerInterface
+	 * @var SettingsProvider
 	 */
-	protected $settings;
+	protected $settings_provider;
 
 	/**
 	 * The funding source renderer.
@@ -33,14 +33,14 @@ class CancelView {
 	/**
 	 * CancelView constructor.
 	 *
-	 * @param ContainerInterface    $settings The settings.
+	 * @param SettingsProvider      $settings_provider The settings provider.
 	 * @param FundingSourceRenderer $funding_source_renderer The funding source renderer.
 	 */
 	public function __construct(
-		ContainerInterface $settings,
+		SettingsProvider $settings_provider,
 		FundingSourceRenderer $funding_source_renderer
 	) {
-		$this->settings                = $settings;
+		$this->settings_provider       = $settings_provider;
 		$this->funding_source_renderer = $funding_source_renderer;
 	}
 
@@ -59,7 +59,7 @@ class CancelView {
 			<?php
 			$name = $funding_source ?
 				$this->funding_source_renderer->render_name( $funding_source )
-				: ( $this->settings->has( 'title' ) ? $this->settings->get( 'title' ) : __( 'PayPal', 'woocommerce-paypal-payments' ) );
+				: $this->settings_provider->paypal_gateway_title();
 			printf(
 					// translators: %3$ is funding source like "PayPal" or "Venmo", other placeholders are html tags for a link.
 				esc_html__(

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -152,16 +152,17 @@ class PaymentSettings extends AbstractDataModel {
 	 * Gets the payment method title.
 	 *
 	 * @param string $method_id ID of the payment method.
+	 * @param string $default_title Default title to return if method not found.
 	 * @return string The method title, or an empty string if not found.
 	 */
-	public function get_method_title( string $method_id ): string {
+	public function get_method_title( string $method_id, string $default_title = '' ): string {
 		$gateway = $this->get_gateway( $method_id );
 
 		if ( $gateway ) {
 			return $gateway->title;
 		}
 
-		return '';
+		return $default_title;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -149,6 +149,22 @@ class PaymentSettings extends AbstractDataModel {
 	}
 
 	/**
+	 * Gets the payment method title.
+	 *
+	 * @param string $method_id ID of the payment method.
+	 * @return string The method title, or an empty string if not found.
+	 */
+	public function get_method_title( string $method_id ): string {
+		$gateway = $this->get_gateway( $method_id );
+
+		if ( $gateway ) {
+			return $gateway->title;
+		}
+
+		return '';
+	}
+
+	/**
 	 * Get PayPal show logo.
 	 *
 	 * @return bool

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -14,6 +14,7 @@ namespace WooCommerce\PayPalCommerce\Settings\Data;
 
 use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 class SettingsProvider {
 	private GeneralSettings $general_settings;
@@ -265,6 +266,21 @@ class SettingsProvider {
 	 */
 	public function paylater_enabled(): bool {
 		return $this->payment_settings->get_paylater_enabled();
+	}
+
+	/**
+	 * Gets the PayPal gateway title as configured in WooCommerce settings.
+	 *
+	 * @return string The gateway title, defaults to 'PayPal' if not set.
+	 */
+	public function paypal_gateway_title(): string {
+		$title = $this->payment_settings->get_method_title( PayPalGateway::ID );
+
+		if ( empty( $title ) ) {
+			return __( 'PayPal', 'woocommerce-paypal-payments' );
+		}
+
+		return $title;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -274,13 +274,7 @@ class SettingsProvider {
 	 * @return string The gateway title, defaults to 'PayPal' if not set.
 	 */
 	public function paypal_gateway_title(): string {
-		$title = $this->payment_settings->get_method_title( PayPalGateway::ID );
-
-		if ( empty( $title ) ) {
-			return __( 'PayPal', 'woocommerce-paypal-payments' );
-		}
-
-		return $title;
+		return $this->payment_settings->get_method_title( PayPalGateway::ID, 'PayPal' );
 	}
 
 	/**


### PR DESCRIPTION
This PR replaces `wcgateway.settings` service with the new `SettingsProvider` in `ppcp-session` module.

### PR Changes
- New method `PaymentSettings::get_method_title()` to retrieve the title of a WooCommerce payment gateway
- New method `SettingsProvider::paypal_gateway_title()` to return the PayPal gateway title
- Updates service from `wcgateway.settings` to use new `settings.settings-provider` in `CancelView.php`
