### PR TITLE
fix: defer currency check to prevent early translation loading (5709)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -198,7 +198,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		assert( $loading_screen_service instanceof LoadingScreenService );
 		$loading_screen_service->register();
 
-		$this->apply_branded_only_limitations( $container );
+		add_action( 'init', fn() => $this->apply_branded_only_limitations( $container ), 1 );
 
 		/**
 		 * Override ACDC status with BCDC for eligible merchants.


### PR DESCRIPTION
WooCommerce PayPal Payments was calling get_woocommerce_currency() during plugins_loaded hook, which triggered Aelia Currency Switcher's filter before WordPress translations were ready. This caused PHP notices upon every page load:

  "Translation loading for the wc-aelia-foundation-classes domain was
   triggered too early"

Root cause: SettingsModule::run() called apply_branded_only_limitations() directly, which fetches GeneralSettings requiring the current currency. When Aelia hooks into woocommerce_currency filter, it calls __() for translations before the init action has fired.

Fix: Defer apply_branded_only_limitations() to the init action (priority 1) so currency detection happens after translations are available.