### PR TITLE
ACDC payment method disappears from Checkout after updating the plugin (5693)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -22,6 +22,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\LocalApmProductStatus;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
@@ -328,6 +329,13 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
 			static function () use ( $c ) {
+				$timeout_cache = new Cache( 'ppcp-timeout' );
+				$timeout_cache->delete( 'refresh_feature_status_timeout' );
+
+				$failure_registry = $c->get( 'api.helper.failure-registry' );
+				assert( $failure_registry instanceof FailureRegistry );
+				$failure_registry->clear_failures( FailureRegistry::SELLER_STATUS_KEY );
+
 				$dcc_status_cache = $c->get( 'dcc.status-cache' );
 				assert( $dcc_status_cache instanceof Cache );
 				$pui_status_cache = $c->get( 'pui.status-cache' );
@@ -337,12 +345,11 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$pui_status_cache->delete( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY );
 
 				$settings = $c->get( 'wcgateway.settings' );
-				$settings->set( 'products_dcc_enabled', false );
-				$settings->set( 'products_pui_enabled', false );
+				$settings->set( 'products_dcc_enabled', '' );
+				$settings->set( 'products_pui_enabled', '' );
 				$settings->persist();
 				do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $settings );
 
-				// Update caches.
 				$dcc_status = $c->get( 'wcgateway.helper.dcc-product-status' );
 				assert( $dcc_status instanceof DCCProductStatus );
 				$dcc_status->is_active();

--- a/tests/integration/PHPUnit/WcGateway/PluginUpdateMigrationTest.php
+++ b/tests/integration/PHPUnit/WcGateway/PluginUpdateMigrationTest.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Tests\Integration;
+
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\Tests\Integration\TestCase;
+
+class PluginUpdateMigrationTest extends TestCase {
+	private $original_version;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->original_version = get_option( 'woocommerce-ppcp-version' );
+
+		$timeout_cache = new Cache( 'ppcp-timeout' );
+		$timeout_cache->delete( 'refresh_feature_status_timeout' );
+
+		$failure_registry_cache = new Cache( 'ppcp-paypal-api-status-cache' );
+		$failure_registry_cache->delete( 'failure_registry_seller_status' );
+
+		$dcc_cache = new Cache( 'ppcp-paypal-dcc-status-cache' );
+		$dcc_cache->delete( 'dcc_status_cache' );
+
+		$pui_cache = new Cache( 'ppcp-paypal-pui-status-cache' );
+		$pui_cache->delete( 'pui_status_cache' );
+	}
+
+	public function tearDown(): void {
+		if ( $this->original_version ) {
+			update_option( 'woocommerce-ppcp-version', $this->original_version );
+		}
+
+		parent::tearDown();
+	}
+
+	public function test_migration_on_update_clears_caches_and_resets_settings(): void {
+		update_option( 'woocommerce-ppcp-version', '2.9.6' );
+
+		// Simulates stale caches that would persist across plugin updates which could potentially
+		// block fresh capability checks.
+		$timeout_cache = new Cache( 'ppcp-timeout' );
+		$timeout_cache->set( 'refresh_feature_status_timeout', time(), 60 );
+
+		$failure_registry_cache = new Cache( 'ppcp-paypal-api-status-cache' );
+		$failure_registry_cache->set( 'failure_registry_seller_status', time(), DAY_IN_SECONDS );
+
+		$dcc_cache = new Cache( 'ppcp-paypal-dcc-status-cache' );
+		$dcc_cache->set( 'dcc_status_cache', 'yes', MONTH_IN_SECONDS );
+
+		$container       = $this->getContainer();
+		$settings        = $container->get( 'wcgateway.settings' );
+		$current_version = (string) $container->get( 'ppcp.plugin' )->getVersion();
+
+		// Setting to false would create a "disabled" state could prevent triggering fresh API check,
+		// the migration should reset these to empty string.
+		$settings->set( 'products_dcc_enabled', false );
+		$settings->set( 'products_pui_enabled', false );
+		$settings->persist();
+
+		update_option( 'woocommerce-ppcp-version', $current_version );
+		do_action( 'woocommerce_paypal_payments_gateway_migrate', '2.9.6' );
+		do_action( 'woocommerce_paypal_payments_gateway_migrate_on_update' );
+
+		// Verify capability caches are cleared.
+		$this->assertFalse( $timeout_cache->has( 'refresh_feature_status_timeout' ) );
+		$this->assertFalse( $failure_registry_cache->has( 'failure_registry_seller_status' ) );
+
+		// Verify settings reset to empty string (unknown state).
+		$this->assertSame( '', $settings->get( 'products_dcc_enabled' ) );
+		$this->assertSame( '', $settings->get( 'products_pui_enabled' ) );
+	}
+}

--- a/tests/integration/PHPUnit/WcGateway/PluginUpdateMigrationTest.php
+++ b/tests/integration/PHPUnit/WcGateway/PluginUpdateMigrationTest.php
@@ -7,12 +7,8 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\Tests\Integration\TestCase;
 
 class PluginUpdateMigrationTest extends TestCase {
-	private $original_version;
-
 	public function setUp(): void {
 		parent::setUp();
-
-		$this->original_version = get_option( 'woocommerce-ppcp-version' );
 
 		$timeout_cache = new Cache( 'ppcp-timeout' );
 		$timeout_cache->delete( 'refresh_feature_status_timeout' );
@@ -25,14 +21,6 @@ class PluginUpdateMigrationTest extends TestCase {
 
 		$pui_cache = new Cache( 'ppcp-paypal-pui-status-cache' );
 		$pui_cache->delete( 'pui_status_cache' );
-	}
-
-	public function tearDown(): void {
-		if ( $this->original_version ) {
-			update_option( 'woocommerce-ppcp-version', $this->original_version );
-		}
-
-		parent::tearDown();
 	}
 
 	public function test_migration_on_update_clears_caches_and_resets_settings(): void {


### PR DESCRIPTION
After updating the plugin, some users experience ACDC payment method and settings tab disappearing. This may impact legacy UI and users who migrated from legacy UI to new UI. Fresh setups on new UI appear unaffected.

### Possible Cause
Incomplete cache invalidation during plugin updates.

### PR Changes
This PR ensures more capability-related caches are properly invalidated during updates, including:
- Clear `RefreshFeatureStatusEndpoint` throttle cache to allow immediate feature refresh
- Clear `FailureRegistry` to reset API failure tracking
- Set `products_dcc_enabled` and `products_pui_enabled` to empty string ('') instead of false to force fresh capability checks from PayPal API