### PR TITLE
Add landing page enum

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ExperienceContextBuilder.php
+++ b/modules/ppcp-api-client/src/Factory/ExperienceContextBuilder.php
@@ -163,7 +163,7 @@ class ExperienceContextBuilder {
 	public function with_current_landing_page(): ExperienceContextBuilder {
 		$builder = clone $this;
 
-		$landing_page = $this->settings->landing_page();
+		$landing_page = $this->settings->landing_page_enum();
 		if ( empty( $landing_page ) ) {
 			$landing_page = ExperienceContext::LANDING_PAGE_NO_PREFERENCE;
 		}

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -206,6 +206,23 @@ class SettingsModel extends AbstractDataModel {
 	}
 
 	/**
+	 * Converts the landing page setting value to the corresponding API enum string.
+	 *
+	 * @return string The corresponding API enum string ('NO_PREFERENCE', 'LOGIN', 'GUEST_CHECKOUT').
+	 */
+	public function get_landing_page_enum(): string {
+		$landing_page = $this->get_landing_page();
+
+		$map = array(
+			'any'            => 'NO_PREFERENCE',
+			'login'          => 'LOGIN',
+			'guest_checkout' => 'GUEST_CHECKOUT',
+		);
+
+		return $map[ $landing_page ] ?? 'NO_PREFERENCE';
+	}
+
+	/**
 	 * Gets the button language setting.
 	 *
 	 * @return string The button language.

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -313,6 +313,15 @@ class SettingsProvider {
 	}
 
 	/**
+	 * Gets the landing page setting as API enum value.
+	 *
+	 * @return string The landing page API enum ('NO_PREFERENCE', 'LOGIN', 'GUEST_CHECKOUT').
+	 */
+	public function landing_page_enum(): string {
+		return $this->settings_model->get_landing_page_enum();
+	}
+
+	/**
 	 * Gets the button language setting.
 	 *
 	 * @return string The button language.

--- a/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ExperienceContextBuilderTest.php
@@ -105,7 +105,7 @@ class ExperienceContextBuilderTest extends TestCase
 	public function testCurrentLandingPage($value, $expected)
 	{
 		$this->settings
-			->expects('landing_page')
+			->expects('landing_page_enum')
 			->andReturn($value);
 
 		$result = $this->sut


### PR DESCRIPTION
This PR fixes an issue with landing page setting value mapping, it adds a new enum method to get the correct values.