### PR TITLE
Fix ACDC payment method disappears after plugin update (5693)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -350,7 +350,8 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$pui_status = $c->get( 'wcgateway.pay-upon-invoice-product-status' );
 				assert( $pui_status instanceof PayUponInvoiceProductStatus );
 				$pui_status->is_active();
-			}
+			},
+			20
 		);
 
 		add_action(


### PR DESCRIPTION
### Description

After updating the plugin, some users experience the ACDC payment method and settings tab disappearing. This primarily impacts legacy UI users and those who migrated from legacy UI to new UI.

The issue most likely stems from a race condition between migration hooks that run at the same priority during plugin updates.

Running the cache and failure registry cleanup at priority 20 ensures it executes after `SavePaymentMethodsModule` (priority 10) potentially registers an API failure, so the failure registry stays cleared for subsequent page loads.