### PR TITLE
Add try/catch for token validation exception (5668)

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -199,45 +199,60 @@ class SavePaymentMethodsModule implements ServiceModule, ExtendingModule, Execut
 							$wc_payment_tokens = $c->get( 'vaulting.wc-payment-tokens' );
 							assert( $wc_payment_tokens instanceof WooCommercePaymentTokens );
 
-							if ( $wc_order->get_payment_method() === CreditCardGateway::ID ) {
-								$token = new \WC_Payment_Token_CC();
-								$token->set_token( $token_id );
-								$token->set_user_id( $wc_order->get_customer_id() );
-								$token->set_gateway_id( CreditCardGateway::ID );
+							try {
+								if ( $wc_order->get_payment_method() === CreditCardGateway::ID ) {
+									$token = new \WC_Payment_Token_CC();
+									$token->set_token( $token_id );
+									$token->set_user_id( $wc_order->get_customer_id() );
+									$token->set_gateway_id( CreditCardGateway::ID );
 
-								$token->set_last4( $payment_source->properties()->last_digits ?? '' );
-								$expiry = explode( '-', $payment_source->properties()->expiry ?? '' );
-								$token->set_expiry_year( $expiry[0] ?? '' );
-								$token->set_expiry_month( $expiry[1] ?? '' );
-								$token->set_card_type( $payment_source->properties()->brand ?? '' );
+									$token->set_last4( $payment_source->properties()->last_digits ?? '' );
+									$expiry = explode( '-', $payment_source->properties()->expiry ?? '' );
+									$token->set_expiry_year( $expiry[0] ?? '' );
+									$token->set_expiry_month( $expiry[1] ?? '' );
+									$token->set_card_type( $payment_source->properties()->brand ?? '' );
 
-								$token->save();
-							}
-
-							if ( $wc_order->get_payment_method() === PayPalGateway::ID ) {
-								switch ( $payment_source->name() ) {
-									case 'venmo':
-										$wc_payment_tokens->create_payment_token_venmo(
-											$wc_order->get_customer_id(),
-											$token_id,
-											$payment_source->properties()->email_address ?? ''
-										);
-										break;
-									case 'apple_pay':
-										$wc_payment_tokens->create_payment_token_applepay(
-											$wc_order->get_customer_id(),
-											$token_id
-										);
-										break;
-									case 'paypal':
-									default:
-										$wc_payment_tokens->create_payment_token_paypal(
-											$wc_order->get_customer_id(),
-											$token_id,
-											$payment_source->properties()->email_address ?? ''
-										);
-										break;
+									$token->save();
 								}
+
+								if ( $wc_order->get_payment_method() === PayPalGateway::ID ) {
+									switch ( $payment_source->name() ) {
+										case 'venmo':
+											$wc_payment_tokens->create_payment_token_venmo(
+												$wc_order->get_customer_id(),
+												$token_id,
+												$payment_source->properties()->email_address ?? ''
+											);
+											break;
+										case 'apple_pay':
+											$wc_payment_tokens->create_payment_token_applepay(
+												$wc_order->get_customer_id(),
+												$token_id
+											);
+											break;
+										case 'paypal':
+										default:
+											$wc_payment_tokens->create_payment_token_paypal(
+												$wc_order->get_customer_id(),
+												$token_id,
+												$payment_source->properties()->email_address ?? ''
+											);
+											break;
+									}
+								}
+							} catch ( \Exception $exception ) {
+								$logger = $c->get( 'woocommerce.logger.woocommerce' );
+								assert( $logger instanceof LoggerInterface );
+
+								$logger->warning(
+									'Failed to save payment token for order: ' . $exception->getMessage(),
+									array(
+										'order_id'    => $wc_order->get_id(),
+										'customer_id' => $customer_id,
+										'token_id'    => $token_id,
+										'exception'   => $exception,
+									)
+								);
 							}
 						}
 					},


### PR DESCRIPTION

### Description

This PR allows that any token validation error will keep track in the logs without hampering the order itself

### Steps to Test

It's an intermittent issue on the affected site, whereby repro is hard, but we know the exact flow as shared by Syde and described in the WooCommerce issue:

The PayPal Payments plugin attempts to save a payment token after the successful capture.

WooCommerce core then validates the token fields in class-wc-payment-token-data-store.php:44.

If WooCommerce detects missing or invalid fields, it throws the “Invalid or missing payment token fields” exception.

The PayPal Payments plugin catches that exception and triggers handle_payment_failure().

The order status is then switched to failed even though the payment was captured

### Documentation

No

### Changelog Entry

> Handle token validation failure

Closes #3940
