### PR TITLE
ppcp-blocks SettingsProvider migration (5602)

### DIFF
--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -74,7 +74,7 @@ return array(
 	'applepay.has_validated'                   => static function ( ContainerInterface $container ): bool {
 		$cache = $container->get( 'applepay.status-cache' );
 		assert( $cache instanceof Cache );
-		return $cache->has( AppleProductStatus::SETTINGS_KEY );
+		return $cache->has( AppleProductStatus::KEY );
 	},
 
 	'applepay.is_validated'                    => static function ( ContainerInterface $container ): bool {

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -58,10 +58,10 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function ( ?Settings $settings = null ) use ( $c ): void {
+			function () use ( $c ): void {
 				$apm_status = $c->get( 'applepay.apple-product-status' );
 				assert( $apm_status instanceof AppleProductStatus );
-				$apm_status->clear( $settings );
+				$apm_status->clear();
 			}
 		);
 

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -38,7 +38,9 @@ class ApplePayButton implements ButtonInterface {
 	protected OrderProcessor $order_processor;
 	protected bool $reload_cart = false;
 	private string $version;
+	/** @psalm-suppress PropertyNotSetInConstructor */
 	private string $module_url;
+	private AssetGetter $asset_getter;
 	private DataToAppleButtonScripts $script_data;
 	private SettingsStatus $settings_status;
 	protected CartProductsHelper $cart_products;

--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Blocks;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
 use WooCommerce\PayPalCommerce\Blocks\Endpoint\UpdateShippingEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 
@@ -29,7 +30,7 @@ return array(
 			function () use ( $container ): SmartButtonInterface {
 				return $container->get( 'button.smart-button' );
 			},
-			$container->get( 'wcgateway.settings' ),
+			$container->get( 'settings.settings-provider' ),
 			$container->get( 'wcgateway.settings.status' ),
 			$container->get( 'wcgateway.paypal-gateway' ),
 			$container->get( 'blocks.settings.final_review_enabled' ),
@@ -51,17 +52,21 @@ return array(
 			function () use ( $container ): SmartButtonInterface {
 				return $container->get( 'button.smart-button' );
 			},
-			$container->get( 'wcgateway.settings' ),
-			$container->get( 'wcgateway.configuration.card-configuration' )
+			$container->get( 'settings.settings-provider' ),
+			$container->get( 'wcgateway.configuration.card-configuration' ),
+			$container->get( 'blocks.card-icons' )
 		);
 	},
 	'blocks.settings.final_review_enabled' => static function ( ContainerInterface $container ): bool {
-		$settings = $container->get( 'wcgateway.settings' );
-		assert( $settings instanceof ContainerInterface );
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
 
-		return $settings->has( 'blocks_final_review_enabled' ) ?
-			(bool) $settings->get( 'blocks_final_review_enabled' ) :
-			true;
+		return ! $settings_provider->enable_pay_now();
+	},
+
+	'blocks.card-icons'                    => static function (): array {
+		$settings = get_option( 'woocommerce-ppcp-settings', array() );
+		return isset( $settings['card_icons'] ) ? (array) $settings['card_icons'] : array();
 	},
 
 	'blocks.endpoint.update-shipping'      => static function ( ContainerInterface $container ): UpdateShippingEndpoint {

--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -64,9 +64,11 @@ return array(
 		return ! $settings_provider->enable_pay_now();
 	},
 
-	'blocks.card-icons'                    => static function (): array {
-		$settings = get_option( 'woocommerce-ppcp-settings', array() );
-		return isset( $settings['card_icons'] ) ? (array) $settings['card_icons'] : array();
+	'blocks.card-icons'                    => static function ( ContainerInterface $container ): array {
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
+
+		return $settings_provider->card_icons();
 	},
 
 	'blocks.endpoint.update-shipping'      => static function ( ContainerInterface $container ): UpdateShippingEndpoint {

--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -53,8 +53,7 @@ return array(
 				return $container->get( 'button.smart-button' );
 			},
 			$container->get( 'settings.settings-provider' ),
-			$container->get( 'wcgateway.configuration.card-configuration' ),
-			$container->get( 'blocks.card-icons' )
+			$container->get( 'wcgateway.configuration.card-configuration' )
 		);
 	},
 	'blocks.settings.final_review_enabled' => static function ( ContainerInterface $container ): bool {
@@ -62,13 +61,6 @@ return array(
 		assert( $settings_provider instanceof SettingsProvider );
 
 		return ! $settings_provider->enable_pay_now();
-	},
-
-	'blocks.card-icons'                    => static function ( ContainerInterface $container ): array {
-		$settings_provider = $container->get( 'settings.settings-provider' );
-		assert( $settings_provider instanceof SettingsProvider );
-
-		return $settings_provider->card_icons();
 	},
 
 	'blocks.endpoint.update-shipping'      => static function ( ContainerInterface $container ): UpdateShippingEndpoint {

--- a/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
+++ b/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
@@ -53,18 +53,12 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 	protected CardPaymentsConfiguration $card_payments_configuration;
 
 	/**
-	 * @var array
-	 */
-	protected array $card_icons;
-
-	/**
 	 * @param AssetGetter                   $asset_getter
 	 * @param string                        $version The assets version.
 	 * @param CreditCardGateway             $gateway
 	 * @param SmartButtonInterface|callable $smart_button The smart button script loading handler.
 	 * @param SettingsProvider              $settings_provider The settings provider.
 	 * @param CardPaymentsConfiguration     $card_payments_configuration
-	 * @param array                         $card_icons The card icons.
 	 */
 	public function __construct(
 		AssetGetter $asset_getter,
@@ -72,8 +66,7 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 		CreditCardGateway $gateway,
 		$smart_button,
 		SettingsProvider $settings_provider,
-		CardPaymentsConfiguration $card_payments_configuration,
-		array $card_icons
+		CardPaymentsConfiguration $card_payments_configuration
 	) {
 		$this->name                        = CreditCardGateway::ID;
 		$this->asset_getter                = $asset_getter;
@@ -82,7 +75,6 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 		$this->smart_button                = $smart_button;
 		$this->plugin_settings             = $settings_provider;
 		$this->card_payments_configuration = $card_payments_configuration;
-		$this->card_icons                  = $card_icons;
 	}
 
 	/**
@@ -132,7 +124,7 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 			'supports'            => $this->gateway->supports,
 			'save_card_text'      => esc_html__( 'Save your card', 'woocommerce-paypal-payments' ),
 			'is_vaulting_enabled' => $this->plugin_settings->save_card_details(),
-			'card_icons'          => $this->card_icons,
+			'card_icons'          => $this->plugin_settings->card_icons(),
 			'name_on_card'        => $this->card_payments_configuration->show_name_on_card(),
 		);
 	}

--- a/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
+++ b/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
@@ -12,9 +12,9 @@ namespace WooCommerce\PayPalCommerce\Blocks;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class AdvancedCardPaymentMethod
@@ -44,37 +44,45 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 	private $smart_button;
 
 	/**
-	 * The settings.
+	 * The settings provider.
 	 *
-	 * @var Settings
+	 * @var SettingsProvider
 	 */
-	protected $plugin_settings;
+	protected SettingsProvider $plugin_settings;
 
 	protected CardPaymentsConfiguration $card_payments_configuration;
+
+	/**
+	 * @var array
+	 */
+	protected array $card_icons;
 
 	/**
 	 * @param AssetGetter                   $asset_getter
 	 * @param string                        $version The assets version.
 	 * @param CreditCardGateway             $gateway
 	 * @param SmartButtonInterface|callable $smart_button The smart button script loading handler.
-	 * @param Settings                      $settings
+	 * @param SettingsProvider              $settings_provider The settings provider.
 	 * @param CardPaymentsConfiguration     $card_payments_configuration
+	 * @param array                         $card_icons The card icons.
 	 */
 	public function __construct(
 		AssetGetter $asset_getter,
 		string $version,
 		CreditCardGateway $gateway,
 		$smart_button,
-		Settings $settings,
-		CardPaymentsConfiguration $card_payments_configuration
+		SettingsProvider $settings_provider,
+		CardPaymentsConfiguration $card_payments_configuration,
+		array $card_icons
 	) {
 		$this->name                        = CreditCardGateway::ID;
 		$this->asset_getter                = $asset_getter;
 		$this->version                     = $version;
 		$this->gateway                     = $gateway;
 		$this->smart_button                = $smart_button;
-		$this->plugin_settings             = $settings;
+		$this->plugin_settings             = $settings_provider;
 		$this->card_payments_configuration = $card_payments_configuration;
+		$this->card_icons                  = $card_icons;
 	}
 
 	/**
@@ -123,8 +131,8 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 			'scriptData'          => $script_data,
 			'supports'            => $this->gateway->supports,
 			'save_card_text'      => esc_html__( 'Save your card', 'woocommerce-paypal-payments' ),
-			'is_vaulting_enabled' => $this->plugin_settings->has( 'vault_enabled_dcc' ) && $this->plugin_settings->get( 'vault_enabled_dcc' ),
-			'card_icons'          => $this->plugin_settings->has( 'card_icons' ) ? (array) $this->plugin_settings->get( 'card_icons' ) : array(),
+			'is_vaulting_enabled' => $this->plugin_settings->save_card_details(),
+			'card_icons'          => $this->card_icons,
 			'name_on_card'        => $this->card_payments_configuration->show_name_on_card(),
 		);
 	}

--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -18,8 +18,6 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
-use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
  * Class BlocksModule
@@ -71,10 +69,6 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 			'woocommerce_blocks_payment_method_type_registration',
 			function ( PaymentMethodRegistry $payment_method_registry ) use ( $c ): void {
 				$payment_method_registry->register( $c->get( 'blocks.method' ) );
-
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
-
 				$payment_method_registry->register( $c->get( 'blocks.advanced-card-method' ) );
 			}
 		);

--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -17,9 +17,9 @@ use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
@@ -43,11 +43,11 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	private $smart_button;
 
 	/**
-	 * The settings.
+	 * The settings provider.
 	 *
-	 * @var Settings
+	 * @var SettingsProvider
 	 */
-	private $plugin_settings;
+	private SettingsProvider $plugin_settings;
 
 	/**
 	 * The Settings status helper.
@@ -130,7 +130,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	 * @param AssetGetter                   $asset_getter
 	 * @param string                        $version    The assets version.
 	 * @param SmartButtonInterface|callable $smart_button The smart button script loading handler.
-	 * @param Settings                      $plugin_settings The settings.
+	 * @param SettingsProvider              $plugin_settings The settings provider.
 	 * @param SettingsStatus                $settings_status The Settings status helper.
 	 * @param PayPalGateway                 $gateway The WC gateway.
 	 * @param bool                          $final_review_enabled Whether the final review is enabled.
@@ -147,7 +147,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		AssetGetter $asset_getter,
 		string $version,
 		$smart_button,
-		Settings $plugin_settings,
+		SettingsProvider $plugin_settings,
 		SettingsStatus $settings_status,
 		PayPalGateway $gateway,
 		bool $final_review_enabled,
@@ -187,10 +187,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 	 * {@inheritDoc}
 	 */
 	public function is_active() {
-		// Do not load when definitely not needed,
-		// but we still need to check the locations later and handle in JS
-		// because has_block cannot be called here (too early).
-		return $this->plugin_settings->has( 'enabled' ) && $this->plugin_settings->get( 'enabled' );
+		return $this->plugin_settings->is_method_enabled( PayPalGateway::ID );
 	}
 
 	/**

--- a/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
+++ b/modules/ppcp-compat/src/Settings/SettingsTabMapHelper.php
@@ -54,6 +54,7 @@ class SettingsTabMapHelper {
 			'vault_enabled'               => FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO,
 			'3d_secure_contingency'       => 'three_d_secure',
 			'stay_updated'                => 'stay_updated',
+			'card_icons'                  => 'card_icons',
 		);
 	}
 

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -24,8 +24,8 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class GooglepayModule
@@ -55,10 +55,10 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function ( ?Settings $settings = null ) use ( $c ): void {
+			function () use ( $c ): void {
 				$apm_status = $c->get( 'googlepay.helpers.apm-product-status' );
 				assert( $apm_status instanceof ApmProductStatus );
-				$apm_status->clear( $settings );
+				$apm_status->clear();
 			}
 		);
 

--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -109,6 +109,7 @@ class SettingsModel extends AbstractDataModel {
 
 			// Array of string values.
 			'disabled_cards'         => array(),
+			'card_icons'             => array(),
 		);
 	}
 
@@ -441,6 +442,27 @@ class SettingsModel extends AbstractDataModel {
 		$this->data['disabled_cards'] = array_map(
 			array( $this->sanitizer, 'sanitize_text' ),
 			$cards
+		);
+	}
+
+	/**
+	 * Gets the card icons.
+	 *
+	 * @return array The array of card icons.
+	 */
+	public function get_card_icons(): array {
+		return $this->data['card_icons'];
+	}
+
+	/**
+	 * Sets the card icons.
+	 *
+	 * @param array $icons The array of card icons.
+	 */
+	public function set_card_icons( array $icons ): void {
+		$this->data['card_icons'] = array_map(
+			array( $this->sanitizer, 'sanitize_text' ),
+			$icons
 		);
 	}
 

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -493,4 +493,14 @@ class SettingsProvider {
 	public function styling_product(): LocationStylingDTO {
 		return $this->styling_settings->get_product();
 	}
+
+	/**
+	 * Checks if the provided payment method is enabled.
+	 *
+	 * @param string $method_id ID of the payment method.
+	 * @return bool True if the method is enabled, false otherwise.
+	 */
+	public function is_method_enabled( string $method_id ): bool {
+		return $this->payment_settings->is_method_enabled( $method_id );
+	}
 }

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -439,6 +439,14 @@ class SettingsProvider {
 		return $this->settings_model->get_disabled_cards();
 	}
 
+	/**
+	 * Gets the card icons.
+	 *
+	 * @return array The array of card icons.
+	 */
+	public function card_icons(): array {
+		return $this->settings_model->get_card_icons();
+	}
 
 	/**
 	 * Gets the Stay Updated setting.

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -515,12 +515,12 @@ class SettingsListener {
 			$this->client_credentials_cache->delete( SdkClientToken::CACHE_KEY );
 		}
 
-		if ( $this->pui_status_cache->has( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY ) ) {
-			$this->pui_status_cache->delete( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY );
+		if ( $this->pui_status_cache->has( PayUponInvoiceProductStatus::KEY ) ) {
+			$this->pui_status_cache->delete( PayUponInvoiceProductStatus::KEY );
 		}
 
-		if ( $this->dcc_status_cache->has( DCCProductStatus::DCC_STATUS_CACHE_KEY ) ) {
-			$this->dcc_status_cache->delete( DCCProductStatus::DCC_STATUS_CACHE_KEY );
+		if ( $this->dcc_status_cache->has( DCCProductStatus::KEY ) ) {
+			$this->dcc_status_cache->delete( DCCProductStatus::KEY );
 		}
 
 		/**

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -335,8 +335,8 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$pui_status_cache = $c->get( 'pui.status-cache' );
 				assert( $pui_status_cache instanceof Cache );
 
-				$dcc_status_cache->delete( DCCProductStatus::DCC_STATUS_CACHE_KEY );
-				$pui_status_cache->delete( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY );
+				$dcc_status_cache->delete( DCCProductStatus::KEY );
+				$pui_status_cache->delete( PayUponInvoiceProductStatus::KEY );
 
 				$settings = $c->get( 'wcgateway.settings' );
 				$settings->set( 'products_dcc_enabled', false );
@@ -481,24 +481,24 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function ( ?Settings $settings = null ) use ( $c ): void {
+			function () use ( $c ): void {
 
 				// Clear DCC Product status.
 				$dcc_product_status = $c->get( 'wcgateway.helper.dcc-product-status' );
 				if ( $dcc_product_status instanceof DCCProductStatus ) {
-					$dcc_product_status->clear( $settings );
+					$dcc_product_status->clear();
 				}
 
 				// Clear Pay Upon Invoice status.
 				$pui_product_status = $c->get( 'wcgateway.pay-upon-invoice-product-status' );
 				if ( $pui_product_status instanceof PayUponInvoiceProductStatus ) {
-					$pui_product_status->clear( $settings );
+					$pui_product_status->clear();
 				}
 
 				// Clear PWC status.
 				$pwc_product_status = $c->get( 'wcgateway.pwc-product-status' );
 				if ( $pwc_product_status instanceof PWCProductStatus ) {
-					$pwc_product_status->clear( $settings );
+					$pwc_product_status->clear();
 				}
 
 				$reference_transaction_status_cache = $c->get( 'api.reference-transaction-status-cache' );


### PR DESCRIPTION
This PR replaces `wcgateway.settings` service with the new `SettingsProvider` in `ppcp-blocks` module.

### PR Changes
- ppcp-settings module:
   - Added `is_method_enabled()` method to `SettingsProvider` to check if a payment gateway is enabled
- ppcp-blocks module:
   - Replaced all `wcgateway.settings` references with `settings.settings-provider`
   - Add `card_icons` to `SettingsModel` and `SettingsProvider`
   - Removed unused `Settings` import and assertion from `BlocksModule.php`