### PR TITLE
Fix E_DEPRECATED warning for implicit nullable parameter in PHP 8.4

### DIFF
--- a/modules/ppcp-googlepay/src/Assets/Button.php
+++ b/modules/ppcp-googlepay/src/Assets/Button.php
@@ -119,7 +119,7 @@ class Button implements ButtonInterface {
 		SettingsStatus $settings_status,
 		LoggerInterface $logger,
 		Context $context,
-		SettingsModel $new_settings = null
+		?SettingsModel $new_settings = null
 	) {
 
 		$this->module_url          = $module_url;


### PR DESCRIPTION
Change `SettingsModel $new_settings = null` to `?SettingsModel $new_settings = null` in GooglePay Button constructor to use explicit nullable type syntax.