### PR TITLE
Replace title on step 4 onboarding in ACDC region (4466)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepPaymentMethods.js
@@ -79,7 +79,10 @@ const PaymentStepTitle = ( ownBrandOnly ) => {
 			'woocommerce-paypal-payments'
 		);
 	}
-	return __( 'Add Credit and Debit Cards', 'woocommerce-paypal-payments' );
+	return __(
+		'Add Expanded Checkout for more ways to pay',
+		'woocommerce-paypal-payments'
+	);
 };
 
 const OptionalMethodDescription = () => {


### PR DESCRIPTION
### Description

This PR replaces title on step 4 onboarding in ACDC region “Add Credit and Debit Cards" with “Add Expanded Checkout for more ways to pay”

### Steps to Test

1. Onboard in ACDC region
2. Go to step 4
3. See that the title is "Add Expanded Checkout for more ways to pay"

### Documentation

No

### Changelog Entry

> Title on step 4 onboarding in ACDC region replaced

Closes # .
