### PR TITLE
Migrate ProductStatus result caching (5703)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -71,6 +71,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderTransient;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PurchaseUnitSanitizer;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatusResultCache;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\CustomerRepository;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\OrderRepository;
 use WooCommerce\PayPalCommerce\ApiClient\Repository\PartnerReferralsData;
@@ -863,6 +864,9 @@ return array(
 			return new PurchaseUnitSanitizer( $behavior, $line_name );
 		}
 	),
+	'api.helper.product-status-result-cache'         => static function (): ProductStatusResultCache {
+		return new ProductStatusResultCache();
+	},
 	'api.client-credentials'                         => static function ( ContainerInterface $container ): ClientCredentials {
 		return new ClientCredentials(
 			$container->get( 'wcgateway.settings' )

--- a/modules/ppcp-api-client/src/Helper/ProductStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatus.php
@@ -86,14 +86,14 @@ abstract class ProductStatus {
 			return $this->is_eligible;
 		}
 
+		$local_state = $this->check_local_state();
+		if ( is_bool( $local_state ) ) {
+			$this->is_eligible = $local_state;
+
+			return $this->is_eligible;
+		}
+
 		try {
-			$local_state = $this->check_local_state();
-			if ( is_bool( $local_state ) ) {
-				$this->is_eligible = $local_state;
-
-				return $this->is_eligible;
-			}
-
 			// Check using the merchant-API.
 			$seller_status     = $this->get_seller_status_object();
 			$this->is_eligible = $this->check_active_state( $seller_status );

--- a/modules/ppcp-api-client/src/Helper/ProductStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatus.php
@@ -149,12 +149,20 @@ abstract class ProductStatus {
 
 	protected function mark_as_enabled(): void {
 		$this->is_eligible = true;
-		$this->result_cache->set( static::KEY, self::STATE_IS_ENABLED );
+		$this->result_cache->set( static::KEY, self::STATE_IS_ENABLED, $this->get_cache_lifespan( true ) );
 	}
 
 	protected function mark_as_disabled(): void {
 		$this->is_eligible = false;
-		$this->result_cache->set( static::KEY, self::STATE_IS_DISABLED );
+		$this->result_cache->set( static::KEY, self::STATE_IS_DISABLED, $this->get_cache_lifespan( false ) );
+	}
+
+	/**
+	 * Defines the result-cache lifespan, in seconds. By default, the result does not expire,
+	 * but child classes can override this to define custom TTLs.
+	 */
+	protected function get_cache_lifespan( bool $is_eligible ): int {
+		return 0;
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Helper/ProductStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatus.php
@@ -83,25 +83,30 @@ abstract class ProductStatus {
 		$this->has_request_failure = false;
 
 		if ( ! $this->is_onboarded() ) {
-			return $this->is_eligible;
+			return false;
 		}
 
 		$local_state = $this->check_local_state();
 		if ( is_bool( $local_state ) ) {
 			$this->is_eligible = $local_state;
 
-			return $this->is_eligible;
+			return $local_state;
 		}
 
+		// Check using the merchant-API.
 		try {
-			// Check using the merchant-API.
-			$seller_status     = $this->get_seller_status_object();
-			$this->is_eligible = $this->check_active_state( $seller_status );
+			$seller_status = $this->get_seller_status_object();
+
+			if ( $this->check_api_response( $seller_status ) ) {
+				$this->mark_as_enabled();
+			} else {
+				$this->mark_as_disabled();
+			}
 		} catch ( Exception $exception ) {
 			$this->has_request_failure = true;
 		}
 
-		return $this->is_eligible;
+		return (bool) $this->is_eligible;
 	}
 
 	/**
@@ -125,7 +130,7 @@ abstract class ProductStatus {
 	 * @return bool
 	 * @throws RuntimeException When the check failed.
 	 */
-	abstract protected function check_active_state( SellerStatus $seller_status ): bool;
+	abstract protected function check_api_response( SellerStatus $seller_status ): bool;
 
 	/**
 	 * Can be overwritten by child classes to filter the local state.
@@ -143,10 +148,12 @@ abstract class ProductStatus {
 	}
 
 	protected function mark_as_enabled(): void {
+		$this->is_eligible = true;
 		$this->result_cache->set( static::KEY, self::STATE_IS_ENABLED );
 	}
 
 	protected function mark_as_disabled(): void {
+		$this->is_eligible = false;
 		$this->result_cache->set( static::KEY, self::STATE_IS_DISABLED );
 	}
 

--- a/modules/ppcp-api-client/src/Helper/ProductStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatus.php
@@ -11,10 +11,8 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 
 use RuntimeException;
 use Exception;
-use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class ProductStatus
@@ -23,77 +21,99 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
  */
 abstract class ProductStatus {
 	/**
+	 * The product key, must be declared by the implementing class.
+	 */
+	public const KEY = '';
+
+	public const STATE_IS_ENABLED  = 'yes';
+	public const STATE_IS_DISABLED = 'no';
+
+	/**
 	 * Caches the SellerStatus API response to avoid duplicate API calls
 	 * during the same request.
-	 *
-	 * @var ?SellerStatus
 	 */
 	private static ?SellerStatus $seller_status = null;
 
-	/**
-	 * The current status stored in memory.
-	 *
-	 * @var bool|null
-	 */
 	private ?bool $is_eligible = null;
 
-	/**
-	 * If there was a request failure.
-	 *
-	 * @var bool
-	 */
 	private bool $has_request_failure = false;
 
 	/**
 	 * Whether the merchant onboarding process was completed and the
 	 * merchant API is available.
-	 *
-	 * @var bool
 	 */
 	private bool $is_connected;
 
-	/**
-	 * The partners endpoint.
-	 *
-	 * @var PartnersEndpoint
-	 */
 	private PartnersEndpoint $partners_endpoint;
 
-	/**
-	 * The API failure registry
-	 *
-	 * @var FailureRegistry
-	 */
 	private FailureRegistry $api_failure_registry;
 
-	/**
-	 * AppleProductStatus constructor.
-	 *
-	 * @param bool             $is_connected         Whether the merchant is connected.
-	 * @param PartnersEndpoint $partners_endpoint    The Partner Endpoint.
-	 * @param FailureRegistry  $api_failure_registry The API failure registry.
-	 */
+	protected ProductStatusResultCache $result_cache;
+
 	public function __construct(
 		bool $is_connected,
 		PartnersEndpoint $partners_endpoint,
-		FailureRegistry $api_failure_registry
+		FailureRegistry $api_failure_registry,
+		ProductStatusResultCache $result_cache
 	) {
+
 		$this->is_connected         = $is_connected;
 		$this->partners_endpoint    = $partners_endpoint;
 		$this->api_failure_registry = $api_failure_registry;
+		$this->result_cache         = $result_cache;
 	}
 
 	/**
-	 * Uses local data (DB values, hooks) to determine if the feature is eligible.
+	 * Decides, if the specific product (feature) is available for the authenticated
+	 * merchant.
 	 *
-	 * Returns true when the feature is available, and false if ineligible.
-	 * On failure, an RuntimeException is thrown.
+	 * The availability is determined by inspecting the SellerStatus response
+	 * returned by the API. On first check, the result is cached to avoid calling the
+	 * API again on subsequent checks.
 	 *
-	 * @return null|bool Boolean to indicate the status; null if the status not locally defined.
-	 * @throws RuntimeException When the check failed.
-	 * @throws NotFoundException When a relevant service or setting was not found.
+	 * In case the onboarding is not completed, the feature is marked as not-available
+	 * without caching it, to fetch a fresh value directly after login.
 	 */
-	abstract protected function check_local_state(): ?bool;
+	public function is_active(): bool {
+		if ( is_bool( $this->is_eligible ) ) {
+			return $this->is_eligible;
+		}
+
+		$this->is_eligible         = false;
+		$this->has_request_failure = false;
+
+		if ( ! $this->is_onboarded() ) {
+			return $this->is_eligible;
+		}
+
+		try {
+			$local_state = $this->check_local_state();
+			if ( is_bool( $local_state ) ) {
+				$this->is_eligible = $local_state;
+
+				return $this->is_eligible;
+			}
+
+			// Check using the merchant-API.
+			$seller_status     = $this->get_seller_status_object();
+			$this->is_eligible = $this->check_active_state( $seller_status );
+		} catch ( Exception $exception ) {
+			$this->has_request_failure = true;
+		}
+
+		return $this->is_eligible;
+	}
+
+	/**
+	 * Instantly resets the local cache, so that the next call to `is_active()` triggers
+	 * a new API request to determine the feature availability.
+	 */
+	public function clear(): void {
+		$this->is_eligible         = null;
+		$this->has_request_failure = false;
+
+		$this->result_cache->clear( static::KEY );
+	}
 
 	/**
 	 * Inspects the API response of the SellerStatus to determine feature eligibility.
@@ -108,48 +128,26 @@ abstract class ProductStatus {
 	abstract protected function check_active_state( SellerStatus $seller_status ): bool;
 
 	/**
-	 * Clears the eligibility status from the local cache/DB to enforce a new
-	 * API call on the next eligibility check.
+	 * Can be overwritten by child classes to filter the local state.
 	 *
-	 * @param Settings|null $settings See description in {@see self::clear()}.
-	 * @return void
+	 * This check is used to determine the `is_active()` state of the product.
 	 */
-	abstract protected function clear_state( ?Settings $settings = null ): void;
+	public function check_local_state( bool $skip_filters = false ): ?bool {
+		$local_state = $this->result_cache->get( static::KEY );
 
-	/**
-	 * Whether the merchant has access to the feature.
-	 *
-	 * @return bool
-	 */
-	public function is_active(): bool {
-		if ( null !== $this->is_eligible ) {
-			return $this->is_eligible;
+		if ( $local_state ) {
+			return wc_string_to_bool( $local_state );
 		}
 
-		$this->is_eligible         = false;
-		$this->has_request_failure = false;
+		return null;
+	}
 
-		if ( ! $this->is_onboarded() ) {
-			return $this->is_eligible;
-		}
+	protected function mark_as_enabled(): void {
+		$this->result_cache->set( static::KEY, self::STATE_IS_ENABLED );
+	}
 
-		try {
-			// Try to use filters and DB values to determine the state.
-			$local_state = $this->check_local_state();
-			if ( null !== $local_state ) {
-				$this->is_eligible = $local_state;
-
-				return $this->is_eligible;
-			}
-
-			// Check using the merchant-API.
-			$seller_status     = $this->get_seller_status_object();
-			$this->is_eligible = $this->check_active_state( $seller_status );
-		} catch ( Exception $exception ) {
-			$this->has_request_failure = true;
-		}
-
-		return $this->is_eligible;
+	protected function mark_as_disabled(): void {
+		$this->result_cache->set( static::KEY, self::STATE_IS_DISABLED );
 	}
 
 	/**
@@ -188,21 +186,5 @@ abstract class ProductStatus {
 	 */
 	public function has_request_failure(): bool {
 		return $this->has_request_failure;
-	}
-
-	/**
-	 * Clears the persisted result to force a recheck.
-	 *
-	 * Accepts a Settings object to don't override other sequential settings that are being updated
-	 * elsewhere.
-	 *
-	 * @param Settings|null $settings The settings object.
-	 * @return void
-	 */
-	public function clear( ?Settings $settings = null ): void {
-		$this->is_eligible         = null;
-		$this->has_request_failure = false;
-
-		$this->clear_state( $settings );
 	}
 }

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -15,4 +15,8 @@ class ProductStatusResultCache {
 	public function get( string $key ): string {
 		return $this->cache[ $key ] ?? '';
 	}
+
+	public function set( string $key, string $value ): void {
+		$this->cache[ $key ] = $value;
+	}
 }

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -10,9 +10,14 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 
 class ProductStatusResultCache {
+	private const CACHE_KEY = 'woocommerce-ppcp-cache-product-status';
+
+	private bool $loaded = false;
 	private array $cache = array();
 
 	public function get( string $key ): string {
+		$this->load();
+
 		return $this->cache[ $key ] ?? '';
 	}
 
@@ -22,5 +27,21 @@ class ProductStatusResultCache {
 
 	public function clear( string $key ): void {
 		unset( $this->cache[ $key ] );
+	}
+
+	private function load(): void {
+		if ( $this->loaded ) {
+			return;
+		}
+		$this->loaded = true;
+
+		$data = get_transient( self::CACHE_KEY );
+
+		if ( is_array( $data ) ) {
+			$this->cache = array_map(
+				static fn( $value ) => (string) $value,
+				$data
+			);
+		}
 	}
 }

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -66,4 +66,11 @@ class ProductStatusResultCache {
 	protected function save_to_storage( array $data ): void {
 		set_transient( self::CACHE_KEY, $data );
 	}
+
+	/**
+	 * Low-level time access for expiration control; can be overridden for testing.
+	 */
+	protected function get_time(): int {
+		return time();
+	}
 }

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Caches the API results for the ProductStatus class.
+ *
+ * @package WooCommerce\PayPalCommerce\ApiClient\Helper
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+class ProductStatusResultCache {
+}

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -18,13 +18,23 @@ class ProductStatusResultCache {
 	public function get( string $key ): string {
 		$this->load();
 
-		return $this->cache[ $key ] ?? '';
+		if ( ! isset( $this->cache[ $key ] ) ) {
+			return '';
+		}
+
+		$entry = $this->cache[ $key ];
+
+		return $entry['value'] ?? '';
 	}
 
-	public function set( string $key, string $value ): void {
+	public function set( string $key, string $value, int $expiration = 0 ): void {
 		$this->load();
 
-		$this->cache[ $key ] = $value;
+		$this->cache[ $key ] = array(
+			'value'      => $value,
+			'expires_at' => $expiration > 0 ? $this->get_time() + $expiration : 0,
+		);
+
 		$this->save();
 	}
 
@@ -41,7 +51,7 @@ class ProductStatusResultCache {
 		}
 
 		$this->cache  = array_map(
-			static fn( $value ) => (string) $value,
+			static fn( $value ) => (array) $value,
 			$this->load_from_storage()
 		);
 		$this->loaded = true;

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -19,4 +19,8 @@ class ProductStatusResultCache {
 	public function set( string $key, string $value ): void {
 		$this->cache[ $key ] = $value;
 	}
+
+	public function clear( string $key ): void {
+		unset( $this->cache[ $key ] );
+	}
 }

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -22,26 +22,48 @@ class ProductStatusResultCache {
 	}
 
 	public function set( string $key, string $value ): void {
+		$this->load();
+
 		$this->cache[ $key ] = $value;
+		$this->save();
 	}
 
 	public function clear( string $key ): void {
+		$this->load();
+
 		unset( $this->cache[ $key ] );
+		$this->save();
 	}
 
 	private function load(): void {
 		if ( $this->loaded ) {
 			return;
 		}
-		$this->loaded = true;
 
+		$this->cache  = array_map(
+			static fn( $value ) => (string) $value,
+			$this->load_from_storage()
+		);
+		$this->loaded = true;
+	}
+
+	private function save(): void {
+		$this->save_to_storage( $this->cache );
+	}
+
+	/**
+	 * Low-level data retrieval; can be overridden for testing.
+	 */
+	protected function load_from_storage(): array {
 		$data = get_transient( self::CACHE_KEY );
 
-		if ( is_array( $data ) ) {
-			$this->cache = array_map(
-				static fn( $value ) => (string) $value,
-				$data
-			);
-		}
+		return is_array( $data ) ? $data : array();
+	}
+
+	/**
+	 * Low-level data storage; can be overridden for testing.
+	 */
+	protected function save_to_storage( array $data ): void {
+		set_transient( self::CACHE_KEY, $data );
 	}
 }

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -10,4 +10,9 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 
 class ProductStatusResultCache {
+	private array $cache = array();
+
+	public function get( string $key ): string {
+		return $this->cache[ $key ] ?? '';
+	}
 }

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -24,7 +24,10 @@ class ProductStatusResultCache {
 
 		$entry = $this->cache[ $key ];
 		$now   = $this->get_time();
+
 		if ( ! empty( $entry['expires_at'] ) && $entry['expires_at'] < $now ) {
+			$this->clear( $key );
+
 			return '';
 		}
 

--- a/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatusResultCache.php
@@ -23,6 +23,10 @@ class ProductStatusResultCache {
 		}
 
 		$entry = $this->cache[ $key ];
+		$now   = $this->get_time();
+		if ( ! empty( $entry['expires_at'] ) && $entry['expires_at'] < $now ) {
+			return '';
+		}
 
 		return $entry['value'] ?? '';
 	}

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -84,10 +84,10 @@ return array(
 	'applepay.apple-product-status'            => SingletonDecorator::make(
 		static function ( ContainerInterface $container ): AppleProductStatus {
 			return new AppleProductStatus(
-				$container->get( 'wcgateway.settings' ),
-				$container->get( 'api.endpoint.partners' ),
 				$container->get( 'settings.flag.is-connected' ),
-				$container->get( 'api.helper.failure-registry' )
+				$container->get( 'api.endpoint.partners' ),
+				$container->get( 'api.helper.failure-registry' ),
+				$container->get( 'api.helper.product-status-result-cache' )
 			);
 		}
 	),

--- a/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
+++ b/modules/ppcp-applepay/src/Assets/AppleProductStatus.php
@@ -9,106 +9,41 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Applepay\Assets;
 
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusCapability;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 
-/**
- * Class AppleProductStatus
- */
 class AppleProductStatus extends ProductStatus {
+	public const KEY             = 'products_apple_enabled';
 	public const CAPABILITY_NAME = 'APPLE_PAY';
-	public const SETTINGS_KEY    = 'products_apple_enabled';
 
-	public const SETTINGS_VALUE_ENABLED   = 'yes';
-	public const SETTINGS_VALUE_DISABLED  = 'no';
-	public const SETTINGS_VALUE_UNDEFINED = '';
+	public function check_local_state( bool $skip_filters = false ): ?bool {
+		$state = null;
 
-	/**
-	 * The settings.
-	 *
-	 * @var Settings
-	 */
-	private Settings $settings;
-
-	/**
-	 * AppleProductStatus constructor.
-	 *
-	 * @param Settings         $settings             The Settings.
-	 * @param PartnersEndpoint $partners_endpoint    The Partner Endpoint.
-	 * @param bool             $is_connected         The onboarding state.
-	 * @param FailureRegistry  $api_failure_registry The API failure registry.
-	 */
-	public function __construct(
-		Settings $settings,
-		PartnersEndpoint $partners_endpoint,
-		bool $is_connected,
-		FailureRegistry $api_failure_registry
-	) {
-		parent::__construct( $is_connected, $partners_endpoint, $api_failure_registry );
-
-		$this->settings = $settings;
-	}
-
-	/** {@inheritDoc} */
-	protected function check_local_state(): ?bool {
-		$status_override = apply_filters( 'woocommerce_paypal_payments_apple_pay_product_status', null );
-		if ( null !== $status_override ) {
-			return $status_override;
+		if ( ! $skip_filters ) {
+			$state = apply_filters( 'woocommerce_paypal_payments_apple_pay_product_status', null );
 		}
 
-		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
-			return wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
-		}
-
-		return null;
+		return is_bool( $state ) ? $state : parent::check_local_state();
 	}
 
-	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ): bool {
-		// Check the seller status for the intended capability.
-		$has_capability = false;
+	protected function check_api_response( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->products() as $product ) {
 			if ( $product->name() !== 'PAYMENT_METHODS' ) {
 				continue;
 			}
 
 			if ( in_array( self::CAPABILITY_NAME, $product->capabilities(), true ) ) {
-				$has_capability = true;
+				return true;
 			}
 		}
 
-		if ( ! $has_capability ) {
-			foreach ( $seller_status->capabilities() as $capability ) {
-				if ( $capability->name() === self::CAPABILITY_NAME && $capability->status() === SellerStatusCapability::STATUS_ACTIVE ) {
-					$has_capability = true;
-				}
+		foreach ( $seller_status->capabilities() as $capability ) {
+			if ( $capability->name() === self::CAPABILITY_NAME && $capability->status() === SellerStatusCapability::STATUS_ACTIVE ) {
+				return true;
 			}
 		}
 
-		// Settings used as a cache; `settings->set` is compatible with new UI.
-		if ( $has_capability ) {
-			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-		} else {
-			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_DISABLED );
-		}
-		$this->settings->persist();
-
-		return $has_capability;
-	}
-
-	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ): void {
-		if ( null === $settings ) {
-			$settings = $this->settings;
-		}
-
-		if ( $settings->has( self::SETTINGS_KEY ) ) {
-			$settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_UNDEFINED );
-			$settings->persist();
-		}
+		return false;
 	}
 }

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -78,10 +78,10 @@ return array(
 	'googlepay.helpers.apm-product-status'      => SingletonDecorator::make(
 		static function ( ContainerInterface $container ): ApmProductStatus {
 			return new ApmProductStatus(
-				$container->get( 'wcgateway.settings' ),
-				$container->get( 'api.endpoint.partners' ),
 				$container->get( 'settings.flag.is-connected' ),
-				$container->get( 'api.helper.failure-registry' )
+				$container->get( 'api.endpoint.partners' ),
+				$container->get( 'api.helper.failure-registry' ),
+				$container->get( 'api.helper.product-status-result-cache' )
 			);
 		}
 	),

--- a/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
+++ b/modules/ppcp-googlepay/src/Helper/ApmProductStatus.php
@@ -5,110 +5,45 @@
  * @package WooCommerce\PayPalCommerce\Googlepay\Helper
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Googlepay\Helper;
 
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusCapability;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 
-/**
- * Class ApmProductStatus
- */
 class ApmProductStatus extends ProductStatus {
+	public const KEY             = 'products_googlepay_enabled';
 	public const CAPABILITY_NAME = 'GOOGLE_PAY';
-	public const SETTINGS_KEY    = 'products_googlepay_enabled';
 
-	public const SETTINGS_VALUE_ENABLED   = 'yes';
-	public const SETTINGS_VALUE_DISABLED  = 'no';
-	public const SETTINGS_VALUE_UNDEFINED = '';
+	public function check_local_state( bool $skip_filters = false ): ?bool {
+		$state = null;
 
-	/**
-	 * The settings.
-	 *
-	 * @var Settings
-	 */
-	private Settings $settings;
-
-	/**
-	 * ApmProductStatus constructor.
-	 *
-	 * @param Settings         $settings             The Settings.
-	 * @param PartnersEndpoint $partners_endpoint    The Partner Endpoint.
-	 * @param bool             $is_connected         The onboarding state.
-	 * @param FailureRegistry  $api_failure_registry The API failure registry.
-	 */
-	public function __construct(
-		Settings $settings,
-		PartnersEndpoint $partners_endpoint,
-		bool $is_connected,
-		FailureRegistry $api_failure_registry
-	) {
-		parent::__construct( $is_connected, $partners_endpoint, $api_failure_registry );
-
-		$this->settings = $settings;
-	}
-
-	/** {@inheritDoc} */
-	protected function check_local_state(): ?bool {
-		$status_override = apply_filters( 'woocommerce_paypal_payments_google_pay_product_status', null );
-		if ( null !== $status_override ) {
-			return $status_override;
+		if ( ! $skip_filters ) {
+			$state = apply_filters( 'woocommerce_paypal_payments_google_pay_product_status', null );
 		}
 
-		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
-			return wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
-		}
-
-		return null;
+		return is_bool( $state ) ? $state : parent::check_local_state();
 	}
 
-	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ): bool {
-		// Check the seller status for the intended capability.
-		$has_capability = false;
+	protected function check_api_response( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->products() as $product ) {
 			if ( $product->name() !== 'PAYMENT_METHODS' ) {
 				continue;
 			}
 
 			if ( in_array( self::CAPABILITY_NAME, $product->capabilities(), true ) ) {
-				$has_capability = true;
+				return true;
 			}
 		}
 
-		if ( ! $has_capability ) {
-			foreach ( $seller_status->capabilities() as $capability ) {
-				if ( $capability->name() === self::CAPABILITY_NAME && $capability->status() === SellerStatusCapability::STATUS_ACTIVE ) {
-					$has_capability = true;
-				}
+		foreach ( $seller_status->capabilities() as $capability ) {
+			if ( $capability->name() === self::CAPABILITY_NAME && $capability->status() === SellerStatusCapability::STATUS_ACTIVE ) {
+				return true;
 			}
 		}
 
-		// Settings used as a cache; `settings->set` is compatible with new UI.
-		if ( $has_capability ) {
-			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-		} else {
-			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_DISABLED );
-		}
-		$this->settings->persist();
-
-		return $has_capability;
-	}
-
-	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ): void {
-		if ( null === $settings ) {
-			$settings = $this->settings;
-		}
-
-		if ( $settings->has( self::SETTINGS_KEY ) ) {
-			$settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_UNDEFINED );
-			$settings->persist();
-		}
+		return false;
 	}
 }

--- a/modules/ppcp-local-alternative-payment-methods/services.php
+++ b/modules/ppcp-local-alternative-payment-methods/services.php
@@ -67,10 +67,10 @@ return array(
 	},
 	'ppcp-local-apms.product-status'            => static function ( ContainerInterface $container ): LocalApmProductStatus {
 		return new LocalApmProductStatus(
-			$container->get( 'wcgateway.settings' ),
-			$container->get( 'api.endpoint.partners' ),
 			$container->get( 'settings.flag.is-connected' ),
-			$container->get( 'api.helper.failure-registry' )
+			$container->get( 'api.endpoint.partners' ),
+			$container->get( 'api.helper.failure-registry' ),
+			$container->get( 'api.helper.product-status-result-cache' )
 		);
 	},
 	'ppcp-local-apms.pwc.wc-gateway'            => static function ( ContainerInterface $container ): PWCGateway {

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalApmProductStatus.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalApmProductStatus.php
@@ -9,91 +9,22 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods;
 
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 
-/**
- * Class LocalApmProductStatus
- */
 class LocalApmProductStatus extends ProductStatus {
-	public const SETTINGS_KEY = 'products_local_apms_enabled';
+	public const KEY = 'products_local_apms_enabled';
 
-	public const SETTINGS_VALUE_ENABLED   = 'yes';
-	public const SETTINGS_VALUE_DISABLED  = 'no';
-	public const SETTINGS_VALUE_UNDEFINED = '';
-
-	/**
-	 * The settings.
-	 *
-	 * @var Settings
-	 */
-	private Settings $settings;
-
-	/**
-	 * ApmProductStatus constructor.
-	 *
-	 * @param Settings         $settings             The Settings.
-	 * @param PartnersEndpoint $partners_endpoint    The Partner Endpoint.
-	 * @param bool             $is_connected         The onboarding state.
-	 * @param FailureRegistry  $api_failure_registry The API failure registry.
-	 */
-	public function __construct(
-		Settings $settings,
-		PartnersEndpoint $partners_endpoint,
-		bool $is_connected,
-		FailureRegistry $api_failure_registry
-	) {
-		parent::__construct( $is_connected, $partners_endpoint, $api_failure_registry );
-
-		$this->settings = $settings;
-	}
-
-	/** {@inheritDoc} */
-	protected function check_local_state(): ?bool {
-		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
-			return wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
-		}
-
-		return null;
-	}
-
-	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ): bool {
-		$has_capability = false;
-
+	protected function check_api_response( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->capabilities() as $capability ) {
 			if ( 'ACTIVE' !== $capability->status() ) {
 				continue;
 			}
 			if ( 'PAYPAL_CHECKOUT_ALTERNATIVE_PAYMENT_METHODS' === $capability->name() ) {
-				$has_capability = true;
-				break;
+				return true;
 			}
 		}
 
-		// Settings used as a cache; `settings->set` is compatible with new UI.
-		if ( $has_capability ) {
-			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-		} else {
-			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_DISABLED );
-		}
-		$this->settings->persist();
-
-		return $has_capability;
-	}
-
-	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ): void {
-		if ( null === $settings ) {
-			$settings = $this->settings;
-		}
-
-		if ( $settings->has( self::SETTINGS_KEY ) ) {
-			$settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_UNDEFINED );
-			$settings->persist();
-		}
+		return false;
 	}
 }

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1540,11 +1540,10 @@ return array(
 	},
 	'wcgateway.installments-product-status'                => static function ( ContainerInterface $container ): InstallmentsProductStatus {
 		return new InstallmentsProductStatus(
-			$container->get( 'wcgateway.settings' ),
-			$container->get( 'api.endpoint.partners' ),
-			$container->get( 'installments.status-cache' ),
 			$container->get( 'settings.flag.is-connected' ),
-			$container->get( 'api.helper.failure-registry' )
+			$container->get( 'api.endpoint.partners' ),
+			$container->get( 'api.helper.failure-registry' ),
+			$container->get( 'api.helper.product-status-result-cache' )
 		);
 	},
 	'wcgateway.pwc-product-status'                         => static function ( ContainerInterface $container ): PWCProductStatus {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1549,11 +1549,10 @@ return array(
 	},
 	'wcgateway.pwc-product-status'                         => static function ( ContainerInterface $container ): PWCProductStatus {
 		return new PWCProductStatus(
-			$container->get( 'wcgateway.settings' ),
-			$container->get( 'api.endpoint.partners' ),
-			$container->get( 'pwc.status-cache' ),
 			$container->get( 'settings.flag.is-connected' ),
-			$container->get( 'api.helper.failure-registry' )
+			$container->get( 'api.endpoint.partners' ),
+			$container->get( 'api.helper.failure-registry' ),
+			$container->get( 'api.helper.product-status-result-cache' )
 		);
 	},
 	'wcgateway.pay-upon-invoice'                           => static function ( ContainerInterface $container ): PayUponInvoice {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1532,11 +1532,10 @@ return array(
 	},
 	'wcgateway.pay-upon-invoice-product-status'            => static function ( ContainerInterface $container ): PayUponInvoiceProductStatus {
 		return new PayUponInvoiceProductStatus(
-			$container->get( 'wcgateway.settings' ),
-			$container->get( 'api.endpoint.partners' ),
-			$container->get( 'pui.status-cache' ),
 			$container->get( 'settings.flag.is-connected' ),
-			$container->get( 'api.helper.failure-registry' )
+			$container->get( 'api.endpoint.partners' ),
+			$container->get( 'api.helper.failure-registry' ),
+			$container->get( 'api.helper.product-status-result-cache' )
 		);
 	},
 	'wcgateway.installments-product-status'                => static function ( ContainerInterface $container ): InstallmentsProductStatus {

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1440,17 +1440,12 @@ return array(
 	},
 
 	'wcgateway.helper.dcc-product-status'                  => static function ( ContainerInterface $container ): DCCProductStatus {
-
-		$settings         = $container->get( 'wcgateway.settings' );
-		$partner_endpoint = $container->get( 'api.endpoint.partners' );
-
 		return new DCCProductStatus(
-			$settings,
-			$partner_endpoint,
-			$container->get( 'dcc.status-cache' ),
-			$container->get( 'api.helpers.dccapplies' ),
 			$container->get( 'settings.flag.is-connected' ),
-			$container->get( 'api.helper.failure-registry' )
+			$container->get( 'api.endpoint.partners' ),
+			$container->get( 'api.helper.failure-registry' ),
+			$container->get( 'api.helper.product-status-result-cache' ),
+			$container->get( 'api.helpers.dccapplies' )
 		);
 	},
 

--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -5,104 +5,53 @@
  * @package WooCommerce\PayPalCommerce\WcGateway\Helper
  */
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusProduct;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatusResultCache;
 
-/**
- * Class DccProductStatus
- */
 class DCCProductStatus extends ProductStatus {
-	public const SETTINGS_KEY         = 'products_dcc_enabled';
-	public const DCC_STATUS_CACHE_KEY = 'dcc_status_cache';
+	public const KEY = 'products_dcc_enabled';
 
-	public const SETTINGS_VALUE_ENABLED   = 'yes';
-	public const SETTINGS_VALUE_DISABLED  = 'no';
-	public const SETTINGS_VALUE_UNDEFINED = '';
-
-	/**
-	 * The Cache.
-	 *
-	 * @var Cache
-	 */
-	protected Cache $cache;
-
-	/**
-	 * The settings.
-	 *
-	 * @var Settings
-	 */
-	private Settings $settings;
-
-	/**
-	 * The dcc applies helper.
-	 *
-	 * @var DccApplies
-	 */
 	protected DccApplies $dcc_applies;
 
-	/**
-	 * DccProductStatus constructor.
-	 *
-	 * @param Settings         $settings             The Settings.
-	 * @param PartnersEndpoint $partners_endpoint    The Partner Endpoint.
-	 * @param Cache            $cache                The cache.
-	 * @param DccApplies       $dcc_applies          The dcc applies helper.
-	 * @param bool             $is_connected         The onboarding state.
-	 * @param FailureRegistry  $api_failure_registry The API failure registry.
-	 */
 	public function __construct(
-		Settings $settings,
-		PartnersEndpoint $partners_endpoint,
-		Cache $cache,
-		DccApplies $dcc_applies,
 		bool $is_connected,
-		FailureRegistry $api_failure_registry
+		PartnersEndpoint $partners_endpoint,
+		FailureRegistry $api_failure_registry,
+		ProductStatusResultCache $result_cache,
+		DccApplies $dcc_applies
 	) {
-		parent::__construct( $is_connected, $partners_endpoint, $api_failure_registry );
+		parent::__construct( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
 
-		$this->settings    = $settings;
-		$this->cache       = $cache;
 		$this->dcc_applies = $dcc_applies;
 	}
 
-	/** {@inheritDoc} */
-	protected function check_local_state(): ?bool {
-		/**
-		 * Force BCDC (Standard Cards) for merchants migrated from legacy UI.
-		 *
-		 * This filter allows migrated merchants that used Standard Card buttons
-		 * in the legacy UI to maintain BCDC functionality in the new UI, regardless
-		 * of ACDC eligibility API responses.
-		 */
-		$bcdc_override = apply_filters( 'woocommerce_paypal_payments_override_acdc_status_with_bcdc', null );
-		if ( true === $bcdc_override ) {
-			// When overriding, short-circuit and mark ACDC as not available.
-			return false;
+	public function check_local_state( bool $skip_filters = false ): ?bool {
+		$state = null;
+
+		if ( ! $skip_filters ) {
+			/**
+			 * Force BCDC (Standard Cards) for merchants migrated from legacy UI.
+			 *
+			 * This filter allows migrated merchants that used Standard Card buttons
+			 * in the legacy UI to maintain BCDC functionality in the new UI, regardless
+			 * of ACDC eligibility API responses.
+			 */
+			$state = apply_filters( 'woocommerce_paypal_payments_override_acdc_status_with_bcdc', null );
 		}
 
-		if ( $this->cache->has( self::DCC_STATUS_CACHE_KEY ) ) {
-			return wc_string_to_bool( $this->cache->get( self::DCC_STATUS_CACHE_KEY ) );
-		}
-
-		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
-			return wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
-		}
-
-		return null;
+		return is_bool( $state ) ? $state : parent::check_local_state();
 	}
 
-	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ): bool {
+	protected function check_api_response( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->products() as $product ) {
 			if ( ! in_array(
 				$product->vetting_status(),
@@ -116,39 +65,19 @@ class DCCProductStatus extends ProductStatus {
 				continue;
 			}
 
-			// Settings used as a cache; `settings->set` is compatible with new UI.
 			if ( in_array( 'CUSTOM_CARD_PROCESSING', $product->capabilities(), true ) ) {
-				$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-				$this->settings->persist();
-
-				$this->cache->set( self::DCC_STATUS_CACHE_KEY, self::SETTINGS_VALUE_ENABLED, MONTH_IN_SECONDS );
-
 				return true;
 			}
 		}
 
-		if ( $this->dcc_applies->for_country_currency() ) {
-			$expiration = 3 * HOUR_IN_SECONDS;
-		} else {
-			$expiration = MONTH_IN_SECONDS;
-		}
-
-		$this->cache->set( self::DCC_STATUS_CACHE_KEY, self::SETTINGS_VALUE_DISABLED, $expiration );
-
 		return false;
 	}
 
-	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ): void {
-		if ( null === $settings ) {
-			$settings = $this->settings;
+	protected function get_cache_lifespan( bool $is_eligible ): int {
+		if ( ! $is_eligible && $this->dcc_applies->for_country_currency() ) {
+			return 3 * HOUR_IN_SECONDS;
 		}
 
-		if ( $settings->has( self::SETTINGS_KEY ) ) {
-			$settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_UNDEFINED );
-			$settings->persist();
-		}
-
-		$this->cache->delete( self::DCC_STATUS_CACHE_KEY );
+		return MONTH_IN_SECONDS;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/InstallmentsProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/InstallmentsProductStatus.php
@@ -5,109 +5,31 @@
  * @package WooCommerce\PayPalCommerce\WcGateway\Helper
  */
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusProduct;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 
-/**
- * Class InstallmentsProductStatus
- */
 class InstallmentsProductStatus extends ProductStatus {
-	public const SETTINGS_KEY                  = 'products_installments_enabled';
-	public const INSTALLMENTS_STATUS_CACHE_KEY = 'installments_status_cache';
+	public const KEY = 'products_installments_enabled';
 
-	public const SETTINGS_VALUE_ENABLED   = 'yes';
-	public const SETTINGS_VALUE_DISABLED  = 'no';
-	public const SETTINGS_VALUE_UNDEFINED = '';
-
-	/**
-	 * The Cache.
-	 *
-	 * @var Cache
-	 */
-	protected Cache $cache;
-
-	/**
-	 * The settings.
-	 *
-	 * @var Settings
-	 */
-	private Settings $settings;
-
-	/**
-	 * InstallmentsProductStatus constructor.
-	 *
-	 * @param Settings         $settings             The Settings.
-	 * @param PartnersEndpoint $partners_endpoint    The Partner Endpoint.
-	 * @param Cache            $cache                The cache.
-	 * @param bool             $is_connected         The onboarding state.
-	 * @param FailureRegistry  $api_failure_registry The API failure registry.
-	 */
-	public function __construct(
-		Settings $settings,
-		PartnersEndpoint $partners_endpoint,
-		Cache $cache,
-		bool $is_connected,
-		FailureRegistry $api_failure_registry
-	) {
-		parent::__construct( $is_connected, $partners_endpoint, $api_failure_registry );
-
-		$this->settings = $settings;
-		$this->cache    = $cache;
-	}
-
-	/** {@inheritDoc} */
-	protected function check_local_state(): ?bool {
-		if ( $this->cache->has( self::INSTALLMENTS_STATUS_CACHE_KEY ) ) {
-			return wc_string_to_bool( $this->cache->get( self::INSTALLMENTS_STATUS_CACHE_KEY ) );
-		}
-
-		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
-			return wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
-		}
-
-		return null;
-	}
-
-	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ): bool {
+	protected function check_api_response( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->capabilities() as $capability ) {
 			if ( $capability->name() !== 'INSTALLMENTS' ) {
 				continue;
 			}
 
 			if ( $capability->status() === 'ACTIVE' ) {
-				$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-				$this->settings->persist();
-				$this->cache->set( self::INSTALLMENTS_STATUS_CACHE_KEY, self::SETTINGS_VALUE_ENABLED, MONTH_IN_SECONDS );
 				return true;
 			}
 		}
 
-		$this->cache->set( self::INSTALLMENTS_STATUS_CACHE_KEY, self::SETTINGS_VALUE_DISABLED, MONTH_IN_SECONDS );
-
 		return false;
 	}
 
-	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ): void {
-		if ( null === $settings ) {
-			$settings = $this->settings;
-		}
-
-		if ( $settings->has( self::SETTINGS_KEY ) ) {
-			$settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_UNDEFINED );
-			$settings->persist();
-		}
-
-		$this->cache->delete( self::INSTALLMENTS_STATUS_CACHE_KEY );
+	protected function get_cache_lifespan(): int {
+		return MONTH_IN_SECONDS;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/InstallmentsProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/InstallmentsProductStatus.php
@@ -29,7 +29,7 @@ class InstallmentsProductStatus extends ProductStatus {
 		return false;
 	}
 
-	protected function get_cache_lifespan(): int {
+	protected function get_cache_lifespan( bool $is_eligible ): int {
 		return MONTH_IN_SECONDS;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/PWCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PWCProductStatus.php
@@ -5,98 +5,25 @@
  * @package WooCommerce\PayPalCommerce\WcGateway\Helper
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusCapability;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 
 class PWCProductStatus extends ProductStatus {
-	public const CAPABILITY_NAME      = 'CRYPTO_PYMTS';
-	public const SETTINGS_KEY         = 'products_pwc_enabled';
-	public const PWC_STATUS_CACHE_KEY = 'pwc_status_cache';
+	public const KEY             = 'products_pwc_enabled';
+	public const CAPABILITY_NAME = 'CRYPTO_PYMTS';
 
-	public const SETTINGS_VALUE_ENABLED   = 'yes';
-	public const SETTINGS_VALUE_DISABLED  = 'no';
-	public const SETTINGS_VALUE_UNDEFINED = '';
-
-	protected Cache $cache;
-
-	private Settings $settings;
-
-	/**
-	 * PWCProductStatus constructor.
-	 *
-	 * @param Settings         $settings             The Settings.
-	 * @param PartnersEndpoint $partners_endpoint    The Partner Endpoint.
-	 * @param Cache            $cache                The cache.
-	 * @param bool             $is_connected         The onboarding state.
-	 * @param FailureRegistry  $api_failure_registry The API failure registry.
-	 */
-	public function __construct(
-		Settings $settings,
-		PartnersEndpoint $partners_endpoint,
-		Cache $cache,
-		bool $is_connected,
-		FailureRegistry $api_failure_registry
-	) {
-		parent::__construct( $is_connected, $partners_endpoint, $api_failure_registry );
-
-		$this->settings = $settings;
-		$this->cache    = $cache;
-	}
-
-	protected function check_local_state(): ?bool {
-		if ( $this->cache->has( self::PWC_STATUS_CACHE_KEY ) ) {
-			return wc_string_to_bool( $this->cache->get( self::PWC_STATUS_CACHE_KEY ) );
-		}
-
-		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
-			return wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
-		}
-
-		return null;
-	}
-
-	protected function check_active_state( SellerStatus $seller_status ): bool {
-		// Check the seller status for the intended capability.
-		$has_capability = false;
-
+	protected function check_api_response( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->capabilities() as $capability ) {
 			if ( $capability->name() === self::CAPABILITY_NAME && $capability->status() === SellerStatusCapability::STATUS_ACTIVE ) {
-				$has_capability = true;
-				break;
+				return true;
 			}
 		}
 
-		// Settings used as a cache; `settings->set` is compatible with new UI.
-		if ( $has_capability ) {
-			$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-			$this->settings->persist();
-			$this->cache->set( self::PWC_STATUS_CACHE_KEY, self::SETTINGS_VALUE_ENABLED, MONTH_IN_SECONDS );
-			return true;
-		}
-
-		$this->cache->set( self::PWC_STATUS_CACHE_KEY, self::SETTINGS_VALUE_DISABLED, MONTH_IN_SECONDS );
 		return false;
-	}
-
-	protected function clear_state( ?Settings $settings = null ): void {
-		if ( null === $settings ) {
-			$settings = $this->settings;
-		}
-
-		if ( $settings->has( self::SETTINGS_KEY ) ) {
-			$settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_UNDEFINED );
-			$settings->persist();
-		}
-
-		$this->cache->delete( self::PWC_STATUS_CACHE_KEY );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -5,80 +5,18 @@
  * @package WooCommerce\PayPalCommerce\WcGateway\Helper
  */
 
-declare( strict_types=1 );
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatusProduct;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 
-/**
- * Class PayUponInvoiceProductStatus
- */
 class PayUponInvoiceProductStatus extends ProductStatus {
-	public const SETTINGS_KEY         = 'products_pui_enabled';
-	public const PUI_STATUS_CACHE_KEY = 'pui_status_cache';
+	public const KEY = 'products_pui_enabled';
 
-	public const SETTINGS_VALUE_ENABLED   = 'yes';
-	public const SETTINGS_VALUE_DISABLED  = 'no';
-	public const SETTINGS_VALUE_UNDEFINED = '';
-
-	/**
-	 * The Cache.
-	 *
-	 * @var Cache
-	 */
-	protected Cache $cache;
-
-	/**
-	 * The settings.
-	 *
-	 * @var Settings
-	 */
-	private Settings $settings;
-
-	/**
-	 * PayUponInvoiceProductStatus constructor.
-	 *
-	 * @param Settings         $settings             The Settings.
-	 * @param PartnersEndpoint $partners_endpoint    The Partner Endpoint.
-	 * @param Cache            $cache                The cache.
-	 * @param bool             $is_connected         The onboarding state.
-	 * @param FailureRegistry  $api_failure_registry The API failure registry.
-	 */
-	public function __construct(
-		Settings $settings,
-		PartnersEndpoint $partners_endpoint,
-		Cache $cache,
-		bool $is_connected,
-		FailureRegistry $api_failure_registry
-	) {
-		parent::__construct( $is_connected, $partners_endpoint, $api_failure_registry );
-
-		$this->settings = $settings;
-		$this->cache    = $cache;
-	}
-
-	/** {@inheritDoc} */
-	protected function check_local_state(): ?bool {
-		if ( $this->cache->has( self::PUI_STATUS_CACHE_KEY ) ) {
-			return wc_string_to_bool( $this->cache->get( self::PUI_STATUS_CACHE_KEY ) );
-		}
-
-		if ( $this->settings->has( self::SETTINGS_KEY ) && ( $this->settings->get( self::SETTINGS_KEY ) ) ) {
-			return wc_string_to_bool( $this->settings->get( self::SETTINGS_KEY ) );
-		}
-
-		return null;
-	}
-
-	/** {@inheritDoc} */
-	protected function check_active_state( SellerStatus $seller_status ): bool {
+	protected function check_api_response( SellerStatus $seller_status ): bool {
 		foreach ( $seller_status->products() as $product ) {
 			if ( $product->name() !== 'PAYMENT_METHODS' ) {
 				continue;
@@ -96,31 +34,15 @@ class PayUponInvoiceProductStatus extends ProductStatus {
 				continue;
 			}
 
-			// Settings used as a cache; `settings->set` is compatible with new UI.
 			if ( in_array( 'PAY_UPON_INVOICE', $product->capabilities(), true ) ) {
-				$this->settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_ENABLED );
-				$this->settings->persist();
-				$this->cache->set( self::PUI_STATUS_CACHE_KEY, self::SETTINGS_VALUE_ENABLED, MONTH_IN_SECONDS );
 				return true;
 			}
 		}
 
-		$this->cache->set( self::PUI_STATUS_CACHE_KEY, self::SETTINGS_VALUE_DISABLED, MONTH_IN_SECONDS );
-
 		return false;
 	}
 
-	/** {@inheritDoc} */
-	protected function clear_state( ?Settings $settings = null ): void {
-		if ( null === $settings ) {
-			$settings = $this->settings;
-		}
-
-		if ( $settings->has( self::SETTINGS_KEY ) ) {
-			$settings->set( self::SETTINGS_KEY, self::SETTINGS_VALUE_UNDEFINED );
-			$settings->persist();
-		}
-
-		$this->cache->delete( self::PUI_STATUS_CACHE_KEY );
+	protected function get_cache_lifespan(): int {
+		return MONTH_IN_SECONDS;
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceProductStatus.php
@@ -42,7 +42,7 @@ class PayUponInvoiceProductStatus extends ProductStatus {
 		return false;
 	}
 
-	protected function get_cache_lifespan(): int {
+	protected function get_cache_lifespan( bool $is_eligible ): int {
 		return MONTH_IN_SECONDS;
 	}
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -72,16 +72,74 @@ class ProductStatusResultCacheTest extends TestCase {
 		$this->assertSame( 'value3', $testee->get( 'key3' ) );
 	}
 
-	public function test_value_accessible_before_expiration(): void {
+	public function test_multiple_keys_with_different_expirations(): void {
 		TestProductStatusResultCache::set_time( 1000 );
 		$testee = new TestProductStatusResultCache();
 
-		$testee->set( 'test_key', 'test_value', 100 );
+		$testee->set( 'short_ttl', 'value1', 30 );
+		$testee->set( 'long_ttl', 'value2', 120 );
 
 		TestProductStatusResultCache::set_time( 1050 );
+
+		$this->assertSame( '', $testee->get( 'short_ttl' ) );
+		$this->assertSame( 'value2', $testee->get( 'long_ttl' ) );
+	}
+
+	/**
+	 * @dataProvider expiration_data_provider
+	 */
+	public function test_value_expiration_behavior( int $expiration, int $test_delay, string $value, string $expected_value ): void {
+		$start_time = 1000;
+		TestProductStatusResultCache::set_time( $start_time );
+		$testee = new TestProductStatusResultCache();
+
+		$testee->set( 'test_key', $value, $expiration );
+
+		TestProductStatusResultCache::set_time( $start_time + $test_delay );
 		$result = $testee->get( 'test_key' );
 
-		$this->assertSame( 'test_value', $result );
+		$this->assertSame( $expected_value, $result );
+	}
+
+	public function expiration_data_provider(): array {
+		return [
+			'no delay'       => [
+				'expiration'     => 100,
+				'test_delay'     => 0,
+				'value'          => 'yes',
+				'expected_value' => 'yes',
+			],
+			'short delay'    => [
+				'expiration'     => 100,
+				'test_delay'     => 1,
+				'value'          => 'yes',
+				'expected_value' => 'yes',
+			],
+			'long delay'     => [
+				'expiration'     => 100,
+				'test_delay'     => 99,
+				'value'          => 'yes',
+				'expected_value' => 'yes',
+			],
+			'full delay'     => [
+				'expiration'     => 100,
+				'test_delay'     => 100,
+				'value'          => 'yes',
+				'expected_value' => 'yes',
+			],
+			'after delay'    => [
+				'expiration'     => 100,
+				'test_delay'     => 101,
+				'value'          => 'yes',
+				'expected_value' => '',
+			],
+			'no expiration'  => [
+				'expiration'     => 0,
+				'test_delay'     => 999999,
+				'value'          => 'permanent',
+				'expected_value' => 'permanent',
+			],
+		];
 	}
 
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -72,28 +72,35 @@ class ProductStatusResultCacheTest extends TestCase {
 		$this->assertSame( 'value3', $testee->get( 'key3' ) );
 	}
 
-	public function test_value_expiration_logic(): void {
-		when( 'time' )->justReturn( 1000 );
+	public function test_value_accessible_before_expiration(): void {
+		TestProductStatusResultCache::set_time( 1000 );
 		$testee = new TestProductStatusResultCache();
 
 		$testee->set( 'test_key', 'test_value', 100 );
 
-		when( 'time' )->justReturn( 1050 );
-		$result1 = $testee->get( 'test_key' );
-		when( 'time' )->justReturn( 1150 );
-		$result2 = $testee->get( 'test_key' );
+		TestProductStatusResultCache::set_time( 1050 );
+		$result = $testee->get( 'test_key' );
 
-		$this->assertSame( 'test_value', $result1 );
-		$this->assertSame( '', $result2 );
+		$this->assertSame( 'test_value', $result );
 	}
 
 }
 
 class TestProductStatusResultCache extends ProductStatusResultCache {
 	private static array $storage = array();
+	private static int $current_time = 0;
 
 	public static function reset_storage(): void {
-		self::$storage = array();
+		self::$storage      = array();
+		self::$current_time = 0;
+	}
+
+	public static function set_time( int $time ): void {
+		self::$current_time = $time;
+	}
+
+	protected function get_time(): int {
+		return self::$current_time > 0 ? self::$current_time : parent::get_time();
 	}
 
 	protected function load_from_storage(): array {

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -9,17 +9,18 @@ use function Brain\Monkey\Functions\when;
 class ProductStatusResultCacheTest extends TestCase {
 
 	public function setUp(): void {
+		parent::setUp();
 		when( 'get_transient' )->justReturn( array() );
 		when( 'set_transient' )->justReturn( true );
 	}
 
-	public function test_if_class_exists(): void {
-		$testee = new ProductStatusResultCache();
-		$this->assertInstanceOf( ProductStatusResultCache::class, $testee );
+	public function tearDown(): void {
+		TestProductStatusResultCache::reset_storage();
+		parent::tearDown();
 	}
 
 	public function test_get_returns_empty_string_for_non_existent_key(): void {
-		$testee = new ProductStatusResultCache();
+		$testee = new TestProductStatusResultCache();
 
 		$result = $testee->get( 'non_existent_key' );
 
@@ -27,7 +28,7 @@ class ProductStatusResultCacheTest extends TestCase {
 	}
 
 	public function test_set_stores_value_and_get_retrieves_it(): void {
-		$testee = new ProductStatusResultCache();
+		$testee = new TestProductStatusResultCache();
 
 		$testee->set( 'test_key', 'test_value' );
 		$result = $testee->get( 'test_key' );
@@ -36,7 +37,7 @@ class ProductStatusResultCacheTest extends TestCase {
 	}
 
 	public function test_clear_removes_value(): void {
-		$testee = new ProductStatusResultCache();
+		$testee = new TestProductStatusResultCache();
 
 		$testee->set( 'test_key', 'test_value' );
 		$testee->clear( 'test_key' );
@@ -59,6 +60,10 @@ class ProductStatusResultCacheTest extends TestCase {
 
 class TestProductStatusResultCache extends ProductStatusResultCache {
 	private static array $storage = array();
+
+	public static function reset_storage(): void {
+		self::$storage = array();
+	}
 
 	protected function load_from_storage(): array {
 		return self::$storage;

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -72,6 +72,21 @@ class ProductStatusResultCacheTest extends TestCase {
 		$this->assertSame( 'value3', $testee->get( 'key3' ) );
 	}
 
+	public function test_value_expiration_logic(): void {
+		when( 'time' )->justReturn( 1000 );
+		$testee = new TestProductStatusResultCache();
+
+		$testee->set( 'test_key', 'test_value', 100 );
+
+		when( 'time' )->justReturn( 1050 );
+		$result1 = $testee->get( 'test_key' );
+		when( 'time' )->justReturn( 1150 );
+		$result2 = $testee->get( 'test_key' );
+
+		$this->assertSame( 'test_value', $result1 );
+		$this->assertSame( '', $result2 );
+	}
+
 }
 
 class TestProductStatusResultCache extends ProductStatusResultCache {

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
 
 class ProductStatusResultCacheTest extends TestCase {
 
@@ -37,6 +38,19 @@ class ProductStatusResultCacheTest extends TestCase {
 		$result = $testee->get( 'test_key' );
 
 		$this->assertSame( '', $result );
+	}
+
+	public function test_data_persists_across_instances(): void {
+		when( 'get_transient' )
+			->justReturn( array( 'test_key' => 'test_value' ) );
+
+		$cache1 = new ProductStatusResultCache();
+		$cache1->set( 'test_key', 'test_value' );
+
+		$cache2 = new ProductStatusResultCache();
+		$result = $cache2->get( 'test_key' );
+
+		$this->assertSame( 'test_value', $result );
 	}
 
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -1,0 +1,14 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+use WooCommerce\PayPalCommerce\TestCase;
+
+class ProductStatusResultCacheTest extends TestCase {
+
+	public function test_if_class_exists(): void {
+		$testee = new ProductStatusResultCache();
+		$this->assertInstanceOf( ProductStatusResultCache::class, $testee );
+	}
+}

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -11,4 +11,13 @@ class ProductStatusResultCacheTest extends TestCase {
 		$testee = new ProductStatusResultCache();
 		$this->assertInstanceOf( ProductStatusResultCache::class, $testee );
 	}
+
+	public function test_get_returns_empty_string_for_non_existent_key(): void {
+		$testee = new ProductStatusResultCache();
+
+		$result = $testee->get( 'non_existent_key' );
+
+		$this->assertSame( '', $result );
+	}
+
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -56,6 +56,19 @@ class ProductStatusResultCacheTest extends TestCase {
 		$this->assertSame( 'test_value', $result );
 	}
 
+	public function test_handles_multiple_keys_independently(): void {
+		$testee = new TestProductStatusResultCache();
+
+		$testee->set( 'key1', 'dummy' );
+		$testee->set( 'key1', 'value1' );
+		$testee->set( 'key2', 'value2' );
+		$testee->set( 'key3', 'value3' );
+
+		$this->assertSame( 'value1', $testee->get( 'key1' ) );
+		$this->assertSame( 'value2', $testee->get( 'key2' ) );
+		$this->assertSame( 'value3', $testee->get( 'key3' ) );
+	}
+
 }
 
 class TestProductStatusResultCache extends ProductStatusResultCache {

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -6,6 +6,9 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 use WooCommerce\PayPalCommerce\TestCase;
 use function Brain\Monkey\Functions\when;
 
+/**
+ * @covers \WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatusResultCache
+ */
 class ProductStatusResultCacheTest extends TestCase {
 
 	public function setUp(): void {

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -29,4 +29,14 @@ class ProductStatusResultCacheTest extends TestCase {
 		$this->assertSame( 'test_value', $result );
 	}
 
+	public function test_clear_removes_value(): void {
+		$testee = new ProductStatusResultCache();
+
+		$testee->set( 'test_key', 'test_value' );
+		$testee->clear( 'test_key' );
+		$result = $testee->get( 'test_key' );
+
+		$this->assertSame( '', $result );
+	}
+
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -8,6 +8,11 @@ use function Brain\Monkey\Functions\when;
 
 class ProductStatusResultCacheTest extends TestCase {
 
+	public function setUp(): void {
+		when( 'get_transient' )->justReturn( array() );
+		when( 'set_transient' )->justReturn( true );
+	}
+
 	public function test_if_class_exists(): void {
 		$testee = new ProductStatusResultCache();
 		$this->assertInstanceOf( ProductStatusResultCache::class, $testee );
@@ -41,16 +46,25 @@ class ProductStatusResultCacheTest extends TestCase {
 	}
 
 	public function test_data_persists_across_instances(): void {
-		when( 'get_transient' )
-			->justReturn( array( 'test_key' => 'test_value' ) );
-
-		$cache1 = new ProductStatusResultCache();
+		$cache1 = new TestProductStatusResultCache();
 		$cache1->set( 'test_key', 'test_value' );
 
-		$cache2 = new ProductStatusResultCache();
+		$cache2 = new TestProductStatusResultCache();
 		$result = $cache2->get( 'test_key' );
 
 		$this->assertSame( 'test_value', $result );
 	}
 
+}
+
+class TestProductStatusResultCache extends ProductStatusResultCache {
+	private static array $storage = array();
+
+	protected function load_from_storage(): array {
+		return self::$storage;
+	}
+
+	protected function save_to_storage( array $data ): void {
+		self::$storage = $data;
+	}
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusResultCacheTest.php
@@ -20,4 +20,13 @@ class ProductStatusResultCacheTest extends TestCase {
 		$this->assertSame( '', $result );
 	}
 
+	public function test_set_stores_value_and_get_retrieves_it(): void {
+		$testee = new ProductStatusResultCache();
+
+		$testee->set( 'test_key', 'test_value' );
+		$result = $testee->get( 'test_key' );
+
+		$this->assertSame( 'test_value', $result );
+	}
+
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -7,6 +7,7 @@ use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 use Mockery;
+use function Brain\Monkey\Functions\when;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus
@@ -53,9 +54,29 @@ class ProductStatusTest extends TestCase {
 		$this->assertTrue( $result );
 	}
 
+	public function test_check_local_state_returns_true_when_cache_has_yes(): void {
+		$is_connected         = true;
+		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
+
+		$result_cache->shouldReceive( 'get' )
+			->with( TestProductStatus::KEY )
+			->andReturn( 'yes' );
+
+		when( 'wc_string_to_bool' )->justReturn( true );
+
+		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+
+		$result = $testee->check_local_state();
+
+		$this->assertTrue( $result );
+	}
 }
 
 class TestProductStatus extends ProductStatus {
+
+	public const KEY = 'test_product';
 
 	protected function check_active_state( SellerStatus $seller_status ): bool {
 		return true;

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -26,21 +26,15 @@ class ProductStatusTest extends TestCase {
 
 		when( 'wc_string_to_bool' )->alias( static fn( $value ) => 'yes' === strtolower( $value ) );
 
-		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
-			define( 'MINUTE_IN_SECONDS', 60 );
-		}
+		defined( 'MINUTE_IN_SECONDS' ) || define( 'MINUTE_IN_SECONDS', 60 );
 	}
 
-	private function create_test_product_status( bool $is_connected, $result_cache = null ): TestProductStatus {
-		if ( null === $result_cache ) {
-			$result_cache = $this->result_cache;
-		}
-
+	private function create_test_product_status( bool $is_connected = true ): TestProductStatus {
 		return new TestProductStatus(
 			$is_connected,
 			$this->partners_endpoint,
 			$this->api_failure_registry,
-			$result_cache
+			$this->result_cache
 		);
 	}
 
@@ -48,14 +42,14 @@ class ProductStatusTest extends TestCase {
 		$testee = $this->create_test_product_status( false );
 
 		// Mock that every cache::get() returns true. Should never be called.
-		$this->result_cache->allows( 'get' )->andReturn( true );
+		$this->result_cache->allows( 'get' )->andReturn( 'yes' );
 
 		$result = $testee->is_active();
 
 		$this->assertFalse( $result );
 	}
 
-	public function test_is_active_uses_local_state_when_available(): void {
+	public function test_local_state_skips_api_check(): void {
 		// Mock cache returning "yes" so check_local_state() returns true
 		$this->result_cache->shouldReceive( 'get' )
 			->with( TestProductStatus::KEY )
@@ -64,7 +58,7 @@ class ProductStatusTest extends TestCase {
 		// PartnersEndpoint should never be called when local state is available
 		$this->partners_endpoint->shouldNotReceive( 'seller_status' );
 
-		$testee = $this->create_test_product_status( true );
+		$testee = $this->create_test_product_status();
 
 		$result = $testee->is_active();
 
@@ -78,12 +72,10 @@ class ProductStatusTest extends TestCase {
 		string $cache_value,
 		?bool $expected_result
 	): void {
-		$result_cache = Mockery::mock( ProductStatusResultCache::class );
-		$result_cache->shouldReceive( 'get' )
-			->with( TestProductStatus::KEY )
-			->andReturn( $cache_value );
+		$this->result_cache = Mockery::mock( ProductStatusResultCache::class );
+		$this->result_cache->allows( 'get' )->andReturn( $cache_value );
 
-		$testee = $this->create_test_product_status( true, $result_cache );
+		$testee = $this->create_test_product_status();
 
 		$result = $testee->check_local_state();
 
@@ -93,96 +85,48 @@ class ProductStatusTest extends TestCase {
 	public function check_local_state_provider(): array {
 		return array(
 			'cache_has_yes'  => array(
-				'cache_value'    => 'yes',
+				'cache_value'     => 'yes',
 				'expected_result' => true,
 			),
 			'cache_has_no'   => array(
-				'cache_value'    => 'no',
+				'cache_value'     => 'no',
 				'expected_result' => false,
 			),
 			'cache_is_empty' => array(
-				'cache_value'    => '',
+				'cache_value'     => '',
 				'expected_result' => null,
 			),
 		);
 	}
 
 	/**
-	 * @dataProvider api_result_provider
+	 * @dataProvider verify_api_result_cache_provider
 	 */
-	public function test_is_active_calls_api_once_and_caches_in_memory(
-		bool $api_result
-	): void {
-		// Reset static seller_status cache between dataProvider iterations
-		TestProductStatus::reset_seller_status();
+	public function test_is_active_calls_api_once_then_caches_in_memory( bool $api_response ): void {
+		$this->result_cache->allows( 'get' )->andReturn( '' );
 
-		// Mock cache as empty so API will be called
-		$this->result_cache->shouldReceive( 'get' )
-			->with( TestProductStatus::KEY )
-			->andReturn( '' );
-
-		// Mock failure registry to allow API call
-		$this->api_failure_registry->shouldReceive( 'has_failure_in_timeframe' )
-			->andReturn( false );
-
-		// Mock API response - should be called ONCE
-		$seller_status = Mockery::mock( SellerStatus::class );
-		$this->partners_endpoint->shouldReceive( 'seller_status' )
-			->once()
-			->andReturn( $seller_status );
-
-		$testee = $this->create_test_product_status( true );
-		$testee->set_active_state_result( $api_result );
+		$testee = $this->create_test_product_status();
+		$testee->mock_api_response_state( $api_response );
 
 		// First call: triggers API and caches result in memory
 		$result = $testee->is_active();
-		$this->assertSame( $api_result, $result );
+		$this->assertEquals( $api_response, $result, 'The API result was not used' );
+
+		// Test: Change API response; should not impact next assertion, which comes from cache.
+		$testee->mock_api_response_state( ! $api_response );
 
 		// Second call: served from memory cache, API not called again
 		$result = $testee->is_active();
-		$this->assertSame( $api_result, $result );
+		$this->assertEquals( $api_response, $result, 'The cached result should be returned, but the API was queried again' );
 	}
 
-	public function api_result_provider(): array {
+	public function verify_api_result_cache_provider(): array {
 		return array(
-			'api_returns_true'  => array( 'api_result' => true ),
-			'api_returns_false' => array( 'api_result' => false ),
-		);
-	}
-
-	/**
-	 * @dataProvider state_change_provider
-	 */
-	public function test_state_change_methods_update_cache(
-		string $method_name,
-		?bool $expected_state
-	): void {
-		TestProductStatusResultCache::reset_storage();
-
-		$result_cache = new TestProductStatusResultCache();
-		$testee       = $this->create_test_product_status( true, $result_cache );
-
-		// Before: cache is empty, check_local_state returns null
-		$this->assertNull( $testee->check_local_state() );
-
-		$testee->$method_name();
-
-		$this->assertSame( $expected_state, $testee->check_local_state() );
-	}
-
-	public function state_change_provider(): array {
-		return array(
-			'mark_as_enabled'  => array(
-				'method_name'    => 'test_mark_as_enabled',
-				'expected_state' => true,
+			'api_returns_true'  => array(
+				'api_response' => true,
 			),
-			'mark_as_disabled' => array(
-				'method_name'    => 'test_mark_as_disabled',
-				'expected_state' => false,
-			),
-			'clear'            => array(
-				'method_name'    => 'clear',
-				'expected_state' => null,
+			'api_returns_false' => array(
+				'api_response' => false,
 			),
 		);
 	}
@@ -192,27 +136,20 @@ class TestProductStatus extends ProductStatus {
 
 	public const KEY = 'test_product';
 
-	private bool $active_state_result = true;
+	private bool $dummy_api_result = false;
 
+	// Sample "API check."
 	protected function check_active_state( SellerStatus $seller_status ): bool {
-		return $this->active_state_result;
+		return $this->dummy_api_result;
 	}
 
-	public function set_active_state_result( bool $result ): void {
-		$this->active_state_result = $result;
+	// Dummy override without logic.
+	protected function get_seller_status_object(): SellerStatus {
+		return Mockery::mock( SellerStatus::class );
 	}
 
-	public static function reset_seller_status(): void {
-		$reflection = new \ReflectionClass( ProductStatus::class );
-		$property   = $reflection->getProperty( 'seller_status' );
-		$property->setValue( null, null );
-	}
-
-	public function test_mark_as_enabled(): void {
-		$this->mark_as_enabled();
-	}
-
-	public function test_mark_as_disabled(): void {
-		$this->mark_as_disabled();
+	// Not an API, just used for testing.
+	public function mock_api_response_state( bool $result ): void {
+		$this->dummy_api_result = $result;
 	}
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -1,0 +1,41 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
+use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use Mockery;
+
+/**
+ * @covers ProductStatus
+ */
+class ProductStatusTest extends TestCase {
+
+	public function test_can_instantiate_concrete_implementation(): void {
+		$is_connected         = true;
+		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+
+		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry );
+
+		$this->assertInstanceOf( ProductStatus::class, $testee );
+	}
+
+}
+
+class TestProductStatus extends ProductStatus {
+
+	protected function check_local_state(): ?bool {
+		return null;
+	}
+
+	protected function check_active_state( SellerStatus $seller_status ): bool {
+		return true;
+	}
+
+	protected function clear_state( ?Settings $settings = null ): void {
+	}
+}

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -36,12 +36,41 @@ class ProductStatusTest extends TestCase {
 		$this->assertFalse( $result );
 	}
 
+	public function test_is_active_uses_local_state_when_available(): void {
+		$is_connected         = true;
+		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+
+		// PartnersEndpoint should never be called when local state is available
+		$partners_endpoint->shouldNotReceive( 'seller_status' );
+
+		$testee = new TestProductStatusWithLocalState( $is_connected, $partners_endpoint, $api_failure_registry );
+
+		$result = $testee->is_active();
+
+		$this->assertTrue( $result );
+	}
+
 }
 
 class TestProductStatus extends ProductStatus {
 
 	protected function check_local_state(): ?bool {
 		return null;
+	}
+
+	protected function check_active_state( SellerStatus $seller_status ): bool {
+		return true;
+	}
+
+	protected function clear_state( ?Settings $settings = null ): void {
+	}
+}
+
+class TestProductStatusWithLocalState extends ProductStatus {
+
+	protected function check_local_state(): ?bool {
+		return true;
 	}
 
 	protected function check_active_state( SellerStatus $seller_status ): bool {

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -91,6 +91,23 @@ class ProductStatusTest extends TestCase {
 
 		$this->assertFalse( $result );
 	}
+
+	public function test_check_local_state_returns_null_when_cache_is_empty(): void {
+		$is_connected         = true;
+		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
+
+		$result_cache->shouldReceive( 'get' )
+			->with( TestProductStatus::KEY )
+			->andReturn( '' );
+
+		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+
+		$result = $testee->check_local_state();
+
+		$this->assertNull( $result );
+	}
 }
 
 class TestProductStatus extends ProductStatus {

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -23,6 +23,12 @@ class ProductStatusTest extends TestCase {
 		$this->partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
 		$this->api_failure_registry = Mockery::mock( FailureRegistry::class );
 		$this->result_cache         = Mockery::mock( ProductStatusResultCache::class );
+
+		when( 'wc_string_to_bool' )->alias( static fn( $value ) => 'yes' === strtolower( $value ) );
+
+		if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+			define( 'MINUTE_IN_SECONDS', 60 );
+		}
 	}
 
 	private function create_test_product_status( bool $is_connected, $result_cache = null ): TestProductStatus {
@@ -55,8 +61,6 @@ class ProductStatusTest extends TestCase {
 			->with( TestProductStatus::KEY )
 			->andReturn( 'yes' );
 
-		when( 'wc_string_to_bool' )->justReturn( true );
-
 		// PartnersEndpoint should never be called when local state is available
 		$this->partners_endpoint->shouldNotReceive( 'seller_status' );
 
@@ -72,17 +76,12 @@ class ProductStatusTest extends TestCase {
 	 */
 	public function test_check_local_state_returns_expected_value(
 		string $cache_value,
-		?bool $wc_string_result,
 		?bool $expected_result
 	): void {
 		$result_cache = Mockery::mock( ProductStatusResultCache::class );
 		$result_cache->shouldReceive( 'get' )
 			->with( TestProductStatus::KEY )
 			->andReturn( $cache_value );
-
-		if ( null !== $wc_string_result ) {
-			when( 'wc_string_to_bool' )->justReturn( $wc_string_result );
-		}
 
 		$testee = $this->create_test_product_status( true, $result_cache );
 
@@ -94,35 +93,98 @@ class ProductStatusTest extends TestCase {
 	public function check_local_state_provider(): array {
 		return array(
 			'cache_has_yes'  => array(
-				'cache_value'      => 'yes',
-				'wc_string_result' => true,
-				'expected_result'  => true,
+				'cache_value'    => 'yes',
+				'expected_result' => true,
 			),
 			'cache_has_no'   => array(
-				'cache_value'      => 'no',
-				'wc_string_result' => false,
-				'expected_result'  => false,
+				'cache_value'    => 'no',
+				'expected_result' => false,
 			),
 			'cache_is_empty' => array(
-				'cache_value'      => '',
-				'wc_string_result' => null,
-				'expected_result'  => null,
+				'cache_value'    => '',
+				'expected_result' => null,
 			),
 		);
 	}
 
-	public function test_mark_as_enabled_stores_yes_in_cache(): void {
+	/**
+	 * @dataProvider api_result_provider
+	 */
+	public function test_is_active_calls_api_once_and_caches_in_memory(
+		bool $api_result
+	): void {
+		// Reset static seller_status cache between dataProvider iterations
+		TestProductStatus::reset_seller_status();
+
+		// Mock cache as empty so API will be called
+		$this->result_cache->shouldReceive( 'get' )
+			->with( TestProductStatus::KEY )
+			->andReturn( '' );
+
+		// Mock failure registry to allow API call
+		$this->api_failure_registry->shouldReceive( 'has_failure_in_timeframe' )
+			->andReturn( false );
+
+		// Mock API response - should be called ONCE
+		$seller_status = Mockery::mock( SellerStatus::class );
+		$this->partners_endpoint->shouldReceive( 'seller_status' )
+			->once()
+			->andReturn( $seller_status );
+
+		$testee = $this->create_test_product_status( true );
+		$testee->set_active_state_result( $api_result );
+
+		// First call: triggers API and caches result in memory
+		$result = $testee->is_active();
+		$this->assertSame( $api_result, $result );
+
+		// Second call: served from memory cache, API not called again
+		$result = $testee->is_active();
+		$this->assertSame( $api_result, $result );
+	}
+
+	public function api_result_provider(): array {
+		return array(
+			'api_returns_true'  => array( 'api_result' => true ),
+			'api_returns_false' => array( 'api_result' => false ),
+		);
+	}
+
+	/**
+	 * @dataProvider state_change_provider
+	 */
+	public function test_state_change_methods_update_cache(
+		string $method_name,
+		?bool $expected_state
+	): void {
+		TestProductStatusResultCache::reset_storage();
+
 		$result_cache = new TestProductStatusResultCache();
 		$testee       = $this->create_test_product_status( true, $result_cache );
 
 		// Before: cache is empty, check_local_state returns null
 		$this->assertNull( $testee->check_local_state() );
 
-		$testee->public_mark_as_enabled();
+		$testee->$method_name();
 
-		// After: check_local_state returns true
-		when( 'wc_string_to_bool' )->justReturn( true );
-		$this->assertTrue( $testee->check_local_state() );
+		$this->assertSame( $expected_state, $testee->check_local_state() );
+	}
+
+	public function state_change_provider(): array {
+		return array(
+			'mark_as_enabled'  => array(
+				'method_name'    => 'test_mark_as_enabled',
+				'expected_state' => true,
+			),
+			'mark_as_disabled' => array(
+				'method_name'    => 'test_mark_as_disabled',
+				'expected_state' => false,
+			),
+			'clear'            => array(
+				'method_name'    => 'clear',
+				'expected_state' => null,
+			),
+		);
 	}
 }
 
@@ -130,11 +192,27 @@ class TestProductStatus extends ProductStatus {
 
 	public const KEY = 'test_product';
 
+	private bool $active_state_result = true;
+
 	protected function check_active_state( SellerStatus $seller_status ): bool {
-		return true;
+		return $this->active_state_result;
 	}
 
-	public function public_mark_as_enabled(): void {
+	public function set_active_state_result( bool $result ): void {
+		$this->active_state_result = $result;
+	}
+
+	public static function reset_seller_status(): void {
+		$reflection = new \ReflectionClass( ProductStatus::class );
+		$property   = $reflection->getProperty( 'seller_status' );
+		$property->setValue( null, null );
+	}
+
+	public function test_mark_as_enabled(): void {
 		$this->mark_as_enabled();
+	}
+
+	public function test_mark_as_disabled(): void {
+		$this->mark_as_disabled();
 	}
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -6,7 +6,6 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use Mockery;
 
 /**
@@ -18,8 +17,9 @@ class ProductStatusTest extends TestCase {
 		$is_connected         = true;
 		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
 		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
 
-		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry );
+		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
 
 		$this->assertInstanceOf( ProductStatus::class, $testee );
 	}
@@ -28,8 +28,9 @@ class ProductStatusTest extends TestCase {
 		$is_connected         = false;
 		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
 		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
 
-		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry );
+		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
 
 		$result = $testee->is_active();
 
@@ -40,11 +41,12 @@ class ProductStatusTest extends TestCase {
 		$is_connected         = true;
 		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
 		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
 
 		// PartnersEndpoint should never be called when local state is available
 		$partners_endpoint->shouldNotReceive( 'seller_status' );
 
-		$testee = new TestProductStatusWithLocalState( $is_connected, $partners_endpoint, $api_failure_registry );
+		$testee = new TestProductStatusWithLocalState( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
 
 		$result = $testee->is_active();
 
@@ -55,28 +57,18 @@ class ProductStatusTest extends TestCase {
 
 class TestProductStatus extends ProductStatus {
 
-	protected function check_local_state(): ?bool {
-		return null;
-	}
-
 	protected function check_active_state( SellerStatus $seller_status ): bool {
 		return true;
-	}
-
-	protected function clear_state( ?Settings $settings = null ): void {
 	}
 }
 
 class TestProductStatusWithLocalState extends ProductStatus {
 
-	protected function check_local_state(): ?bool {
+	public function check_local_state( bool $skip_filters = false ): ?bool {
 		return true;
 	}
 
 	protected function check_active_state( SellerStatus $seller_status ): bool {
 		return true;
-	}
-
-	protected function clear_state( ?Settings $settings = null ): void {
 	}
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -14,24 +14,36 @@ use function Brain\Monkey\Functions\when;
  */
 class ProductStatusTest extends TestCase {
 
-	public function test_can_instantiate_concrete_implementation(): void {
-		$is_connected         = true;
-		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
-		$api_failure_registry = Mockery::mock( FailureRegistry::class );
-		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
+	private $partners_endpoint;
+	private $api_failure_registry;
 
-		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+	public function setUp(): void {
+		parent::setUp();
+		$this->partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$this->api_failure_registry = Mockery::mock( FailureRegistry::class );
+	}
+
+	private function create_test_product_status( bool $is_connected, $result_cache = null ): TestProductStatus {
+		if ( null === $result_cache ) {
+			$result_cache = Mockery::mock( ProductStatusResultCache::class );
+		}
+
+		return new TestProductStatus(
+			$is_connected,
+			$this->partners_endpoint,
+			$this->api_failure_registry,
+			$result_cache
+		);
+	}
+
+	public function test_can_instantiate_concrete_implementation(): void {
+		$testee = $this->create_test_product_status( true );
 
 		$this->assertInstanceOf( ProductStatus::class, $testee );
 	}
 
 	public function test_is_active_returns_false_when_not_onboarded(): void {
-		$is_connected         = false;
-		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
-		$api_failure_registry = Mockery::mock( FailureRegistry::class );
-		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
-
-		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+		$testee = $this->create_test_product_status( false );
 
 		$result = $testee->is_active();
 
@@ -39,83 +51,68 @@ class ProductStatusTest extends TestCase {
 	}
 
 	public function test_is_active_uses_local_state_when_available(): void {
-		$is_connected         = true;
-		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
-		$api_failure_registry = Mockery::mock( FailureRegistry::class );
-		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
-
 		// PartnersEndpoint should never be called when local state is available
-		$partners_endpoint->shouldNotReceive( 'seller_status' );
+		$this->partners_endpoint->shouldNotReceive( 'seller_status' );
 
-		$testee = new TestProductStatusWithLocalState( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+		$testee = new TestProductStatusWithLocalState(
+			true,
+			$this->partners_endpoint,
+			$this->api_failure_registry,
+			Mockery::mock( ProductStatusResultCache::class )
+		);
 
 		$result = $testee->is_active();
 
 		$this->assertTrue( $result );
 	}
 
-	public function test_check_local_state_returns_true_when_cache_has_yes(): void {
-		$is_connected         = true;
-		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
-		$api_failure_registry = Mockery::mock( FailureRegistry::class );
-		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
-
+	/**
+	 * @dataProvider check_local_state_provider
+	 */
+	public function test_check_local_state_returns_expected_value(
+		string $cache_value,
+		?bool $wc_string_result,
+		?bool $expected_result
+	): void {
+		$result_cache = Mockery::mock( ProductStatusResultCache::class );
 		$result_cache->shouldReceive( 'get' )
 			->with( TestProductStatus::KEY )
-			->andReturn( 'yes' );
+			->andReturn( $cache_value );
 
-		when( 'wc_string_to_bool' )->justReturn( true );
+		if ( null !== $wc_string_result ) {
+			when( 'wc_string_to_bool' )->justReturn( $wc_string_result );
+		}
 
-		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+		$testee = $this->create_test_product_status( true, $result_cache );
 
 		$result = $testee->check_local_state();
 
-		$this->assertTrue( $result );
+		$this->assertSame( $expected_result, $result );
 	}
 
-	public function test_check_local_state_returns_false_when_cache_has_no(): void {
-		$is_connected         = true;
-		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
-		$api_failure_registry = Mockery::mock( FailureRegistry::class );
-		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
-
-		$result_cache->shouldReceive( 'get' )
-			->with( TestProductStatus::KEY )
-			->andReturn( 'no' );
-
-		when( 'wc_string_to_bool' )->justReturn( false );
-
-		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
-
-		$result = $testee->check_local_state();
-
-		$this->assertFalse( $result );
-	}
-
-	public function test_check_local_state_returns_null_when_cache_is_empty(): void {
-		$is_connected         = true;
-		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
-		$api_failure_registry = Mockery::mock( FailureRegistry::class );
-		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
-
-		$result_cache->shouldReceive( 'get' )
-			->with( TestProductStatus::KEY )
-			->andReturn( '' );
-
-		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
-
-		$result = $testee->check_local_state();
-
-		$this->assertNull( $result );
+	public function check_local_state_provider(): array {
+		return array(
+			'cache_has_yes'  => array(
+				'cache_value'      => 'yes',
+				'wc_string_result' => true,
+				'expected_result'  => true,
+			),
+			'cache_has_no'   => array(
+				'cache_value'      => 'no',
+				'wc_string_result' => false,
+				'expected_result'  => false,
+			),
+			'cache_is_empty' => array(
+				'cache_value'      => '',
+				'wc_string_result' => null,
+				'expected_result'  => null,
+			),
+		);
 	}
 
 	public function test_mark_as_enabled_stores_yes_in_cache(): void {
-		$is_connected         = true;
-		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
-		$api_failure_registry = Mockery::mock( FailureRegistry::class );
-		$result_cache         = new TestProductStatusResultCache();
-
-		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+		$result_cache = new TestProductStatusResultCache();
+		$testee       = $this->create_test_product_status( true, $result_cache );
 
 		// Before: cache is empty, check_local_state returns null
 		$this->assertNull( $testee->check_local_state() );

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -139,7 +139,7 @@ class TestProductStatus extends ProductStatus {
 	private bool $dummy_api_result = false;
 
 	// Sample "API check."
-	protected function check_active_state( SellerStatus $seller_status ): bool {
+	protected function check_api_response( SellerStatus $seller_status ): bool {
 		return $this->dummy_api_result;
 	}
 

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -16,16 +16,18 @@ class ProductStatusTest extends TestCase {
 
 	private $partners_endpoint;
 	private $api_failure_registry;
+	private $result_cache;
 
 	public function setUp(): void {
 		parent::setUp();
 		$this->partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
 		$this->api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$this->result_cache         = Mockery::mock( ProductStatusResultCache::class );
 	}
 
 	private function create_test_product_status( bool $is_connected, $result_cache = null ): TestProductStatus {
 		if ( null === $result_cache ) {
-			$result_cache = Mockery::mock( ProductStatusResultCache::class );
+			$result_cache = $this->result_cache;
 		}
 
 		return new TestProductStatus(
@@ -36,14 +38,11 @@ class ProductStatusTest extends TestCase {
 		);
 	}
 
-	public function test_can_instantiate_concrete_implementation(): void {
-		$testee = $this->create_test_product_status( true );
-
-		$this->assertInstanceOf( ProductStatus::class, $testee );
-	}
-
 	public function test_is_active_returns_false_when_not_onboarded(): void {
 		$testee = $this->create_test_product_status( false );
+
+		// Mock that every cache::get() returns true. Should never be called.
+		$this->result_cache->allows( 'get' )->andReturn( true );
 
 		$result = $testee->is_active();
 
@@ -51,15 +50,17 @@ class ProductStatusTest extends TestCase {
 	}
 
 	public function test_is_active_uses_local_state_when_available(): void {
+		// Mock cache returning "yes" so check_local_state() returns true
+		$this->result_cache->shouldReceive( 'get' )
+			->with( TestProductStatus::KEY )
+			->andReturn( 'yes' );
+
+		when( 'wc_string_to_bool' )->justReturn( true );
+
 		// PartnersEndpoint should never be called when local state is available
 		$this->partners_endpoint->shouldNotReceive( 'seller_status' );
 
-		$testee = new TestProductStatusWithLocalState(
-			true,
-			$this->partners_endpoint,
-			$this->api_failure_registry,
-			Mockery::mock( ProductStatusResultCache::class )
-		);
+		$testee = $this->create_test_product_status( true );
 
 		$result = $testee->is_active();
 
@@ -135,16 +136,5 @@ class TestProductStatus extends ProductStatus {
 
 	public function public_mark_as_enabled(): void {
 		$this->mark_as_enabled();
-	}
-}
-
-class TestProductStatusWithLocalState extends ProductStatus {
-
-	public function check_local_state( bool $skip_filters = false ): ?bool {
-		return true;
-	}
-
-	protected function check_active_state( SellerStatus $seller_status ): bool {
-		return true;
 	}
 }

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -10,7 +10,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use Mockery;
 
 /**
- * @covers ProductStatus
+ * @covers \WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatus
  */
 class ProductStatusTest extends TestCase {
 

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -24,6 +24,18 @@ class ProductStatusTest extends TestCase {
 		$this->assertInstanceOf( ProductStatus::class, $testee );
 	}
 
+	public function test_is_active_returns_false_when_not_onboarded(): void {
+		$is_connected         = false;
+		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+
+		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry );
+
+		$result = $testee->is_active();
+
+		$this->assertFalse( $result );
+	}
+
 }
 
 class TestProductStatus extends ProductStatus {

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -72,6 +72,25 @@ class ProductStatusTest extends TestCase {
 
 		$this->assertTrue( $result );
 	}
+
+	public function test_check_local_state_returns_false_when_cache_has_no(): void {
+		$is_connected         = true;
+		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
+
+		$result_cache->shouldReceive( 'get' )
+			->with( TestProductStatus::KEY )
+			->andReturn( 'no' );
+
+		when( 'wc_string_to_bool' )->justReturn( false );
+
+		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+
+		$result = $testee->check_local_state();
+
+		$this->assertFalse( $result );
+	}
 }
 
 class TestProductStatus extends ProductStatus {

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -108,6 +108,21 @@ class ProductStatusTest extends TestCase {
 
 		$this->assertNull( $result );
 	}
+
+	public function test_mark_as_enabled_stores_yes_in_cache(): void {
+		$is_connected         = true;
+		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
+
+		$result_cache->shouldReceive( 'set' )
+			->with( TestProductStatus::KEY, 'yes' )
+			->once();
+
+		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
+
+		$testee->public_mark_as_enabled();
+	}
 }
 
 class TestProductStatus extends ProductStatus {
@@ -116,6 +131,10 @@ class TestProductStatus extends ProductStatus {
 
 	protected function check_active_state( SellerStatus $seller_status ): bool {
 		return true;
+	}
+
+	public function public_mark_as_enabled(): void {
+		$this->mark_as_enabled();
 	}
 }
 

--- a/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ProductStatusTest.php
@@ -113,15 +113,18 @@ class ProductStatusTest extends TestCase {
 		$is_connected         = true;
 		$partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
 		$api_failure_registry = Mockery::mock( FailureRegistry::class );
-		$result_cache         = Mockery::mock( ProductStatusResultCache::class );
-
-		$result_cache->shouldReceive( 'set' )
-			->with( TestProductStatus::KEY, 'yes' )
-			->once();
+		$result_cache         = new TestProductStatusResultCache();
 
 		$testee = new TestProductStatus( $is_connected, $partners_endpoint, $api_failure_registry, $result_cache );
 
+		// Before: cache is empty, check_local_state returns null
+		$this->assertNull( $testee->check_local_state() );
+
 		$testee->public_mark_as_enabled();
+
+		// After: check_local_state returns true
+		when( 'wc_string_to_bool' )->justReturn( true );
+		$this->assertTrue( $testee->check_local_state() );
 	}
 }
 


### PR DESCRIPTION
### Description

The `ProductStatus` implementations are used to determine specific merchant eligibilities based on the `SellerStatus` API response.

As this is an expensive check, the result is cached in the local DB - until now, we used the (legacy) `Settings` class to store the decision. This was pure convenience, and is now resolved by implementing a proper `ProductStatusResultCache` class, which is specialized to store the product eligibility result.

Additionally, this PR consolidates most of the business logic in the abstract base class, instead of repeating code in child classes - such as `clear_state()` method, or redefining identical values such as ´SETTINGS_VALUE_ENABLED` in every class.

### Result

Reduced the base class to a single abstract method, which parses the `SellerStatus` to decide the eligibility.

The remaining logic is handled by the base class, including cache management. Reduces the child class code by roughly 60% in most cases, making them easier to maintain.

The two classes `ProductStatus` and `ProductStatusResultCache` are now fully covered with unit tests to ensure the infrastructure is stable across future changes.