### PR TITLE
Bugfixes after ProductStatus migration (5703)

### DIFF
--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -104,7 +104,7 @@ class ApiModule implements ServiceModule, FactoryModule, ExtendingModule, Execut
 		);
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function () use ( $c ) {
+			static function () use ( $c ) {
 				$failure_registry = $c->has( 'api.helper.failure-registry' ) ? $c->get( 'api.helper.failure-registry' ) : null;
 
 				if ( $failure_registry instanceof FailureRegistry ) {

--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -57,12 +57,16 @@ return array(
 		 *  - Removed validation-text logic without replacement
 		 *
 		 *  This file is not migrated and will be dropped soon.
-		 *//*
+		 */
+
+		/*
+		 * phpcs:disable Squiz.Commenting.BlockComment.NoCapital
 		if ( ! $container->get( 'applepay.has_validated' ) ) {
 			$domain_validation_text = __( 'The domain has not yet been validated. Use the Apple Pay button to validate the domain ❌', 'woocommerce-paypal-payments' );
 		} elseif ( $container->get( 'applepay.is_validated' ) ) {
 			$domain_validation_text = __( 'Status: Domain successfully validated ✔️', 'woocommerce-paypal-payments' );
 		}
+		phpcs:enable Squiz.Commenting.BlockComment.NoCapital
 		*/
 
 		// Device eligibility.

--- a/modules/ppcp-applepay/extensions.php
+++ b/modules/ppcp-applepay/extensions.php
@@ -52,11 +52,18 @@ return array(
 
 		// Domain validation.
 		$domain_validation_text = __( 'Status: Domain validation failed ❌', 'woocommerce-paypal-payments' );
+		/**
+		 *  TODO: #legacy-ui code cleanup:
+		 *  - Removed validation-text logic without replacement
+		 *
+		 *  This file is not migrated and will be dropped soon.
+		 *//*
 		if ( ! $container->get( 'applepay.has_validated' ) ) {
 			$domain_validation_text = __( 'The domain has not yet been validated. Use the Apple Pay button to validate the domain ❌', 'woocommerce-paypal-payments' );
 		} elseif ( $container->get( 'applepay.is_validated' ) ) {
 			$domain_validation_text = __( 'Status: Domain successfully validated ✔️', 'woocommerce-paypal-payments' );
 		}
+		*/
 
 		// Device eligibility.
 		$device_eligibility_text = __( 'Status: Your current browser/device does not seem to support Apple Pay ❌', 'woocommerce-paypal-payments' );

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
 use WooCommerce\PayPalCommerce\Common\Pattern\SingletonDecorator;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 return array(
 	// @deprecated - use `applepay.eligibility.check` instead.
@@ -71,14 +72,9 @@ return array(
 		);
 	},
 
-	'applepay.has_validated'                   => static function ( ContainerInterface $container ): bool {
-		$cache = $container->get( 'applepay.status-cache' );
-		assert( $cache instanceof Cache );
-		return $cache->has( AppleProductStatus::SETTINGS_KEY );
-	},
-
 	'applepay.is_validated'                    => static function ( ContainerInterface $container ): bool {
 		$settings = $container->get( 'settings.settings-provider' );
+		assert( $settings instanceof  SettingsProvider );
 		return $settings->applepay_validated();
 	},
 

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -67,15 +67,9 @@ return array(
 			$container->get( 'wcgateway.is-ppcp-settings-page' ),
 			$container->get( 'applepay.available' ) || ( ! $container->get( 'applepay.is_referral' ) ),
 			$container->get( 'applepay.server_supported' ),
-			$container->get( 'applepay.is_validated' ),
+			$container->get( 'settings.settings-provider' ),
 			$container->get( 'applepay.button' )
 		);
-	},
-
-	'applepay.is_validated'                    => static function ( ContainerInterface $container ): bool {
-		$settings = $container->get( 'settings.settings-provider' );
-		assert( $settings instanceof  SettingsProvider );
-		return $settings->applepay_validated();
 	},
 
 	'applepay.apple-product-status'            => SingletonDecorator::make(

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -57,10 +57,10 @@ class ApplepayModule implements ServiceModule, ExtendingModule, ExecutableModule
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function ( ?Settings $settings = null ) use ( $c ): void {
+			static function () use ( $c ): void {
 				$apm_status = $c->get( 'applepay.apple-product-status' );
 				assert( $apm_status instanceof AppleProductStatus );
-				$apm_status->clear( $settings );
+				$apm_status->clear();
 			}
 		);
 

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -178,20 +178,22 @@ class ApplePayButton implements ButtonInterface {
 	}
 
 	/**
-	 * Method to validate the merchant in the db flag
-	 * On fail triggers and option that shows an admin notice showing the error
-	 * On success removes such flag
+	 * Handles a validation notice from the front-end, which indicates that Apple Pay was
+	 * loaded. This notification verifies, that the domain verification was successful and
+	 * Apple Pay can be fully used.
 	 */
 	public function validate(): void {
 		$applepay_request_data_object = $this->applepay_data_object_http();
 		if ( ! $this->is_nonce_valid() ) {
 			return;
 		}
+
 		$applepay_request_data_object->validation_data();
 		$this->payment_settings->set_applepay_validated( $applepay_request_data_object->validated_flag() );
 		$this->payment_settings->save();
 		wp_send_json_success();
 	}
+
 	/**
 	 * Method to validate and update the shipping contact of the user
 	 * It updates the amount paying information if needed

--- a/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
+++ b/modules/ppcp-applepay/src/Helper/AvailabilityNotice.php
@@ -9,10 +9,11 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Applepay\Helper;
 
-use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
-use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton;
 use WooCommerce\PayPalCommerce\Applepay\Assets\AppleProductStatus;
+use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
+use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 /**
  * Class AvailabilityNotice
@@ -21,52 +22,38 @@ class AvailabilityNotice {
 
 	/**
 	 * The product status handler.
-	 *
-	 * @var AppleProductStatus
 	 */
-	private $product_status;
+	private AppleProductStatus $product_status;
 
 	/**
 	 * Indicates if we're on the WooCommerce gateways list page.
-	 *
-	 * @var bool
 	 */
-	private $is_wc_gateways_list_page;
+	private bool $is_wc_gateways_list_page;
 
 	/**
 	 * Indicates if we're on a PPCP Settings page.
-	 *
-	 * @var bool
 	 */
-	private $is_ppcp_settings_page;
+	private bool $is_ppcp_settings_page;
 
 	/**
 	 * Indicates if ApplePay is available to be enabled.
-	 *
-	 * @var bool
 	 */
-	private $is_available;
+	private bool $is_available;
 
 	/**
 	 * Indicates if this server is supported for ApplePay.
-	 *
-	 * @var bool
 	 */
-	private $is_server_supported;
+	private bool $is_server_supported;
 
 	/**
-	 * Indicates if the merchant is validated for ApplePay.
-	 *
-	 * @var bool
+	 * Used to verify if the merchant-validation (domain registration) was successful
 	 */
-	private $is_merchant_validated;
+	private SettingsProvider $settings;
 
 	/**
 	 * The button.
-	 *
-	 * @var ApplePayButton
 	 */
-	private $button;
+	private ApplePayButton $button;
 
 	/**
 	 * Class ApmProductStatus constructor.
@@ -76,7 +63,7 @@ class AvailabilityNotice {
 	 * @param bool               $is_ppcp_settings_page Indicates if we're on a PPCP Settings page.
 	 * @param bool               $is_available Indicates if ApplePay is available to be enabled.
 	 * @param bool               $is_server_supported Indicates if this server is supported for ApplePay.
-	 * @param bool               $is_merchant_validated Indicates if the merchant is validated for ApplePay.
+	 * @param SettingsProvider   $settings Used to inspect the domain verification status.
 	 * @param ApplePayButton     $button The button.
 	 */
 	public function __construct(
@@ -85,7 +72,7 @@ class AvailabilityNotice {
 		bool $is_ppcp_settings_page,
 		bool $is_available,
 		bool $is_server_supported,
-		bool $is_merchant_validated,
+		SettingsProvider $settings,
 		ApplePayButton $button
 	) {
 		$this->product_status           = $product_status;
@@ -93,7 +80,7 @@ class AvailabilityNotice {
 		$this->is_ppcp_settings_page    = $is_ppcp_settings_page;
 		$this->is_available             = $is_available;
 		$this->is_server_supported      = $is_server_supported;
-		$this->is_merchant_validated    = $is_merchant_validated;
+		$this->settings                 = $settings;
 		$this->button                   = $button;
 	}
 
@@ -138,7 +125,7 @@ class AvailabilityNotice {
 			return;
 		}
 
-		if ( ! $this->is_merchant_validated ) {
+		if ( ! $this->settings->applepay_validated() ) {
 			$this->add_merchant_not_validated_notice();
 		}
 	}

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -55,10 +55,10 @@ class GooglepayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function ( ?Settings $settings = null ) use ( $c ): void {
+			static function () use ( $c ): void {
 				$apm_status = $c->get( 'googlepay.helpers.apm-product-status' );
 				assert( $apm_status instanceof ApmProductStatus );
-				$apm_status->clear( $settings );
+				$apm_status->clear();
 			}
 		);
 

--- a/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
@@ -146,7 +146,7 @@ class LoginSellerEndpoint implements EndpointInterface {
 			$this->settings->persist();
 
 			/**
-			 * TODO: Legacy code cleanup:
+			 * TODO: #legacy-ui code cleanup:
 			 * - Removed PayUponInvoiceProductStatus::clear() logic without replacement
 			 * - Removed DCCProductStatus::clear() logic without replacement
 			 *

--- a/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
+++ b/modules/ppcp-onboarding/src/Endpoint/LoginSellerEndpoint.php
@@ -143,10 +143,17 @@ class LoginSellerEndpoint implements EndpointInterface {
 			$data       = $this->request_data->read_request( $this->nonce() );
 			$is_sandbox = isset( $data['env'] ) && 'sandbox' === $data['env'];
 			$this->settings->set( 'sandbox_on', $is_sandbox );
-			$this->settings->set( 'products_dcc_enabled', null );
-			$this->settings->set( 'products_pui_enabled', null );
 			$this->settings->persist();
-			do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $this->settings );
+
+			/**
+			 * TODO: Legacy code cleanup:
+			 * - Removed PayUponInvoiceProductStatus::clear() logic without replacement
+			 * - Removed DCCProductStatus::clear() logic without replacement
+			 *
+			 * This class is not migrated and will be dropped soon.
+			 */
+
+			do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 
 			$endpoint    = $is_sandbox ? $this->login_seller_sandbox : $this->login_seller_production;
 			$credentials = $endpoint->credentials_for(

--- a/modules/ppcp-onboarding/src/OnboardingRESTController.php
+++ b/modules/ppcp-onboarding/src/OnboardingRESTController.php
@@ -242,9 +242,15 @@ class OnboardingRESTController {
 			return array();
 		}
 
-		$settings->set( 'products_dcc_enabled', null );
-		$settings->set( 'products_pui_enabled', null );
-		do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $settings );
+		/**
+		 * TODO: Legacy code cleanup:
+		 * - Removed PayUponInvoiceProductStatus::clear() logic without replacement
+		 * - Removed DCCProductStatus::clear() logic without replacement
+		 *
+		 * This class is not migrated and will be dropped soon.
+		 */
+
+		do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 
 		if ( ! $settings->persist() ) {
 			return new \WP_Error(

--- a/modules/ppcp-onboarding/src/OnboardingRESTController.php
+++ b/modules/ppcp-onboarding/src/OnboardingRESTController.php
@@ -243,7 +243,7 @@ class OnboardingRESTController {
 		}
 
 		/**
-		 * TODO: Legacy code cleanup:
+		 * TODO: #legacy-ui code cleanup:
 		 * - Removed PayUponInvoiceProductStatus::clear() logic without replacement
 		 * - Removed DCCProductStatus::clear() logic without replacement
 		 *

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -320,19 +320,14 @@ class PaymentSettings extends AbstractDataModel {
 	}
 
 	/**
-	 * Get Apple Pay validated.
-	 *
-	 * @return bool
+	 * Whether the domain verification for ApplePay completed successfully.
 	 */
 	public function get_applepay_validated(): bool {
 		return (bool) $this->data['applepay_validated'];
 	}
 
 	/**
-	 * Set Apple Pay validated.
-	 *
-	 * @param bool $value The value.
-	 * @return void
+	 * Whether the domain verification for ApplePay completed successfully.
 	 */
 	public function set_applepay_validated( bool $value ): void {
 		$this->data['applepay_validated'] = $value;

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -504,9 +504,7 @@ class SettingsProvider {
 	}
 
 	/**
-	 * Get if Apple Pay is validated.
-	 *
-	 * @return bool
+	 * Whether the domain verification for ApplePay completed successfully.
 	 */
 	public function applepay_validated(): bool {
 		return $this->payment_settings->get_applepay_validated();

--- a/modules/ppcp-settings/src/Endpoint/RefreshFeatureStatusEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/RefreshFeatureStatusEndpoint.php
@@ -120,7 +120,7 @@ class RefreshFeatureStatusEndpoint extends RestEndpoint {
 
 		$this->cache->set( self::CACHE_KEY, $now, self::TIMEOUT );
 
-		do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $this->settings );
+		do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 
 		$this->logger->info( 'Feature status refreshed successfully' );
 

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -159,7 +159,7 @@ class AuthenticationManager {
 		/**
 		 * Clear the APM eligibility flags from the default settings object.
 		 */
-		do_action( 'woocommerce_paypal_payments_clear_apm_product_status', null );
+		do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 	}
 
 	/**
@@ -616,7 +616,7 @@ class AuthenticationManager {
 			/**
 			 * Clear the APM eligibility flags from the default settings object.
 			 */
-			do_action( 'woocommerce_paypal_payments_clear_apm_product_status', null );
+			do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 
 			/**
 			 * Subscribe the new merchant to relevant PayPal webhooks.

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1868,9 +1868,6 @@ return array(
 	'installments.status-cache'                            => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-installments-status-cache' );
 	},
-	'pwc.status-cache'                                     => static function ( ContainerInterface $container ): Cache {
-		return new Cache( 'ppcp-paypal-pwc-status-cache' );
-	},
 	'wcgateway.button.locations'                           => static function ( ContainerInterface $container ): array {
 		return array(
 			'product'   => 'Single Product',

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -563,7 +563,6 @@ return array(
 			$container->get( 'wcgateway.current-ppcp-settings-page-id' ),
 			$container->get( 'onboarding.signup-link-cache' ),
 			$container->get( 'onboarding.signup-link-ids' ),
-			$container->get( 'pui.status-cache' ),
 			$container->get( 'http.redirector' ),
 			$container->get( 'api.partner_merchant_id-production' ),
 			$container->get( 'api.partner_merchant_id-sandbox' ),
@@ -1865,9 +1864,6 @@ return array(
 			esc_url( $pui_button_url ),
 			esc_html( $pui_button_text )
 		);
-	},
-	'pui.status-cache'                                     => static function ( ContainerInterface $container ): Cache {
-		return new Cache( 'ppcp-paypal-pui-status-cache' );
 	},
 	'installments.status-cache'                            => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-installments-status-cache' );

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -564,7 +564,6 @@ return array(
 			$container->get( 'onboarding.signup-link-cache' ),
 			$container->get( 'onboarding.signup-link-ids' ),
 			$container->get( 'pui.status-cache' ),
-			$container->get( 'dcc.status-cache' ),
 			$container->get( 'http.redirector' ),
 			$container->get( 'api.partner_merchant_id-production' ),
 			$container->get( 'api.partner_merchant_id-sandbox' ),
@@ -1875,9 +1874,6 @@ return array(
 	},
 	'pwc.status-cache'                                     => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-paypal-pwc-status-cache' );
-	},
-	'dcc.status-cache'                                     => static function ( ContainerInterface $container ): Cache {
-		return new Cache( 'ppcp-paypal-dcc-status-cache' );
 	},
 	'wcgateway.button.locations'                           => static function ( ContainerInterface $container ): array {
 		return array(

--- a/modules/ppcp-wc-gateway/src/Endpoint/RefreshFeatureStatusEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/RefreshFeatureStatusEndpoint.php
@@ -99,7 +99,7 @@ class RefreshFeatureStatusEndpoint {
 		}
 
 		$this->cache->set( self::CACHE_KEY, $now, self::TIMEOUT );
-		do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $this->settings );
+		do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 		wp_send_json_success();
 	}
 

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -103,13 +103,6 @@ class SettingsListener {
 	protected $signup_link_ids;
 
 	/**
-	 * The PUI status cache.
-	 *
-	 * @var Cache
-	 */
-	protected $pui_status_cache;
-
-	/**
 	 * The HTTP redirector.
 	 *
 	 * @var RedirectorInterface
@@ -174,7 +167,6 @@ class SettingsListener {
 	 * @param string                     $page_id ID of the current PPCP gateway settings page, or empty if it is not such page.
 	 * @param Cache                      $signup_link_cache The signup link cache.
 	 * @param array                      $signup_link_ids Signup link ids.
-	 * @param Cache                      $pui_status_cache The PUI status cache.
 	 * @param RedirectorInterface        $redirector The HTTP redirector.
 	 * @param string                     $partner_merchant_id_production Partner merchant ID production.
 	 * @param string                     $partner_merchant_id_sandbox Partner merchant ID sandbox.
@@ -193,7 +185,6 @@ class SettingsListener {
 		string $page_id,
 		Cache $signup_link_cache,
 		array $signup_link_ids,
-		Cache $pui_status_cache,
 		RedirectorInterface $redirector,
 		string $partner_merchant_id_production,
 		string $partner_merchant_id_sandbox,
@@ -214,7 +205,6 @@ class SettingsListener {
 		$this->page_id                            = $page_id;
 		$this->signup_link_cache                  = $signup_link_cache;
 		$this->signup_link_ids                    = $signup_link_ids;
-		$this->pui_status_cache                   = $pui_status_cache;
 		$this->redirector                         = $redirector;
 		$this->partner_merchant_id_production     = $partner_merchant_id_production;
 		$this->partner_merchant_id_sandbox        = $partner_merchant_id_sandbox;

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -465,9 +465,15 @@ class SettingsListener {
 		// phpcs:enable phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( $credentials_change_status ) {
 			if ( self::CREDENTIALS_UNCHANGED !== $credentials_change_status ) {
-				$this->settings->set( 'products_dcc_enabled', null );
-				$this->settings->set( 'products_pui_enabled', null );
-				do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $this->settings );
+				/**
+				 * TODO: Legacy code cleanup:
+				 * - Removed PayUponInvoiceProductStatus::clear() logic without replacement
+				 * - Removed DCCProductStatus::clear() logic without replacement
+				 *
+				 * This class is not migrated and will be dropped soon.
+				 */
+
+				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 			}
 
 			if ( in_array(

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -466,7 +466,7 @@ class SettingsListener {
 		if ( $credentials_change_status ) {
 			if ( self::CREDENTIALS_UNCHANGED !== $credentials_change_status ) {
 				/**
-				 * TODO: Legacy code cleanup:
+				 * TODO: #legacy-ui code cleanup:
 				 * - Removed PayUponInvoiceProductStatus::clear() logic without replacement
 				 * - Removed DCCProductStatus::clear() logic without replacement
 				 *
@@ -502,7 +502,7 @@ class SettingsListener {
 		}
 
 		/**
-		 * TODO: Legacy code cleanup:
+		 * TODO: #legacy-ui code cleanup:
 		 * - Removed PayUponInvoiceProductStatus::clear() logic without replacement
 		 * - Removed DCCProductStatus::clear() logic without replacement
 		 *

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -515,13 +515,13 @@ class SettingsListener {
 			$this->client_credentials_cache->delete( SdkClientToken::CACHE_KEY );
 		}
 
-		if ( $this->pui_status_cache->has( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY ) ) {
-			$this->pui_status_cache->delete( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY );
-		}
-
-		if ( $this->dcc_status_cache->has( DCCProductStatus::DCC_STATUS_CACHE_KEY ) ) {
-			$this->dcc_status_cache->delete( DCCProductStatus::DCC_STATUS_CACHE_KEY );
-		}
+		/**
+		 * TODO: Legacy code cleanup:
+		 * - Removed PayUponInvoiceProductStatus::clear() logic without replacement
+		 * - Removed DCCProductStatus::clear() logic without replacement
+		 *
+		 * This class is not migrated and will be dropped soon.
+		 */
 
 		/**
 		 * The hook fired during listening the request so a module can remove also the cache or other logic.

--- a/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
+++ b/modules/ppcp-wc-gateway/src/Settings/SettingsListener.php
@@ -110,13 +110,6 @@ class SettingsListener {
 	protected $pui_status_cache;
 
 	/**
-	 * The DCC status cache.
-	 *
-	 * @var Cache
-	 */
-	protected $dcc_status_cache;
-
-	/**
 	 * The HTTP redirector.
 	 *
 	 * @var RedirectorInterface
@@ -182,7 +175,6 @@ class SettingsListener {
 	 * @param Cache                      $signup_link_cache The signup link cache.
 	 * @param array                      $signup_link_ids Signup link ids.
 	 * @param Cache                      $pui_status_cache The PUI status cache.
-	 * @param Cache                      $dcc_status_cache The DCC status cache.
 	 * @param RedirectorInterface        $redirector The HTTP redirector.
 	 * @param string                     $partner_merchant_id_production Partner merchant ID production.
 	 * @param string                     $partner_merchant_id_sandbox Partner merchant ID sandbox.
@@ -202,7 +194,6 @@ class SettingsListener {
 		Cache $signup_link_cache,
 		array $signup_link_ids,
 		Cache $pui_status_cache,
-		Cache $dcc_status_cache,
 		RedirectorInterface $redirector,
 		string $partner_merchant_id_production,
 		string $partner_merchant_id_sandbox,
@@ -224,7 +215,6 @@ class SettingsListener {
 		$this->signup_link_cache                  = $signup_link_cache;
 		$this->signup_link_ids                    = $signup_link_ids;
 		$this->pui_status_cache                   = $pui_status_cache;
-		$this->dcc_status_cache                   = $dcc_status_cache;
 		$this->redirector                         = $redirector;
 		$this->partner_merchant_id_production     = $partner_merchant_id_production;
 		$this->partner_merchant_id_sandbox        = $partner_merchant_id_sandbox;

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -330,14 +330,6 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
 			static function () use ( $c ) {
-				$pui_status_cache = $c->get( 'pui.status-cache' );
-				assert( $pui_status_cache instanceof Cache );
-
-				$pui_status_cache->delete( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY );
-
-				$settings = $c->get( 'wcgateway.settings' );
-				$settings->set( 'products_pui_enabled', false );
-				$settings->persist();
 				do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $settings );
 
 				$dcc_status = $c->get( 'wcgateway.helper.dcc-product-status' );
@@ -347,6 +339,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 				$pui_status = $c->get( 'wcgateway.pay-upon-invoice-product-status' );
 				assert( $pui_status instanceof PayUponInvoiceProductStatus );
+				$pui_status->clear();
 				$pui_status->is_active();
 			}
 		);

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -327,11 +327,17 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 			}
 		);
 
+		// Clear the cached ProductStatus information on plugin update.
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
-			static function () use ( $c ) {
-				do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $settings );
+			static function () {
+				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
+			}
+		);
 
+		add_action(
+			'woocommerce_paypal_payments_clear_apm_product_status',
+			static function () use ( $c ) {
 				$dcc_status = $c->get( 'wcgateway.helper.dcc-product-status' );
 				assert( $dcc_status instanceof DCCProductStatus );
 				$dcc_status->clear();
@@ -470,24 +476,23 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		// Clears product status when appropriate.
 		add_action(
 			'woocommerce_paypal_payments_clear_apm_product_status',
-			function ( ?Settings $settings = null ) use ( $c ): void {
-
+			static function () use ( $c ): void {
 				// Clear DCC Product status.
 				$dcc_product_status = $c->get( 'wcgateway.helper.dcc-product-status' );
 				if ( $dcc_product_status instanceof DCCProductStatus ) {
-					$dcc_product_status->clear( $settings );
+					$dcc_product_status->clear();
 				}
 
 				// Clear Pay Upon Invoice status.
 				$pui_product_status = $c->get( 'wcgateway.pay-upon-invoice-product-status' );
 				if ( $pui_product_status instanceof PayUponInvoiceProductStatus ) {
-					$pui_product_status->clear( $settings );
+					$pui_product_status->clear();
 				}
 
 				// Clear PWC status.
 				$pwc_product_status = $c->get( 'wcgateway.pwc-product-status' );
 				if ( $pwc_product_status instanceof PWCProductStatus ) {
-					$pwc_product_status->clear( $settings );
+					$pwc_product_status->clear();
 				}
 
 				$reference_transaction_status_cache = $c->get( 'api.reference-transaction-status-cache' );

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -330,23 +330,19 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate_on_update',
 			static function () use ( $c ) {
-				$dcc_status_cache = $c->get( 'dcc.status-cache' );
-				assert( $dcc_status_cache instanceof Cache );
 				$pui_status_cache = $c->get( 'pui.status-cache' );
 				assert( $pui_status_cache instanceof Cache );
 
-				$dcc_status_cache->delete( DCCProductStatus::DCC_STATUS_CACHE_KEY );
 				$pui_status_cache->delete( PayUponInvoiceProductStatus::PUI_STATUS_CACHE_KEY );
 
 				$settings = $c->get( 'wcgateway.settings' );
-				$settings->set( 'products_dcc_enabled', false );
 				$settings->set( 'products_pui_enabled', false );
 				$settings->persist();
 				do_action( 'woocommerce_paypal_payments_clear_apm_product_status', $settings );
 
-				// Update caches.
 				$dcc_status = $c->get( 'wcgateway.helper.dcc-product-status' );
 				assert( $dcc_status instanceof DCCProductStatus );
+				$dcc_status->clear();
 				$dcc_status->is_active();
 
 				$pui_status = $c->get( 'wcgateway.pay-upon-invoice-product-status' );

--- a/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
+++ b/tests/PHPUnit/WcGateway/Settings/SettingsListenerTest.php
@@ -15,6 +15,10 @@ use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
 use function Brain\Monkey\Functions\when;
 
+/**
+ * TODO: #legacy-ui code cleanup
+ * This test can be dropped as the covered class will be deleted
+ */
 class SettingsListenerTest extends ModularTestCase
 {
 	public function setUp(): void
@@ -41,8 +45,6 @@ class SettingsListenerTest extends ModularTestCase
 		$bearer = Mockery::mock(Bearer::class);
 		$signup_link_cache = Mockery::mock(Cache::class);
 		$signup_link_ids = array();
-        $pui_status_cache = Mockery::mock(Cache::class);
-        $dcc_status_cache = Mockery::mock(Cache::class);
 		$reference_transaction_status = Mockery::mock(ReferenceTransactionStatus::class);
 		$subscription_helper = Mockery::mock(SubscriptionHelper::class);
 		$logger = Mockery::mock(LoggerInterface::class);
@@ -59,8 +61,6 @@ class SettingsListenerTest extends ModularTestCase
 			PayPalGateway::ID,
 			$signup_link_cache,
 			$signup_link_ids,
-            $pui_status_cache,
-            $dcc_status_cache,
 			new RedirectorStub(),
 			'',
 			'',
@@ -97,10 +97,6 @@ class SettingsListenerTest extends ModularTestCase
 			->andReturn(false);
 		$signup_link_cache->shouldReceive('has')
 			->andReturn(false);
-        $pui_status_cache->shouldReceive('has')
-            ->andReturn(false);
-        $dcc_status_cache->shouldReceive('has')
-            ->andReturn(false);
 		$reference_transaction_status_cache->shouldReceive('has')
 			->andReturn(false);
 		$client_credentials_cache->shouldReceive('has')->andReturn(true);


### PR DESCRIPTION
### Description

After decoupling the `ProductStatus` class from the legacy `Settings` service, some modules were still using legacy syntax:

- Passing `$settings` to the `clear()` method
- Referencing cache items that are not used anymore
- An action to clear caches did pass the `Settings` instance unnecessarily

This PR cleans up these remaining issues to make the plugin usable