### PR TITLE
ppcp-paylater-block, ppcp-paylater-configurator and ppcp-paylater-wc-blocks SettingsProvider migration (5610)

### DIFF
--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -18,7 +18,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameI
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 /**
  * Class PayLaterBlockModule
@@ -75,8 +75,8 @@ class PayLaterBlockModule implements ServiceModule, ExtendingModule, ExecutableM
 		add_action(
 			'init',
 			function () use ( $c ): void {
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
+				$settings_provider = $c->get( 'settings.settings-provider' );
+				assert( $settings_provider instanceof SettingsProvider );
 
 				$asset_getter = $c->get( 'paylater-block.asset_getter' );
 				assert( $asset_getter instanceof AssetGetter );
@@ -99,7 +99,7 @@ class PayLaterBlockModule implements ServiceModule, ExtendingModule, ExecutableM
 							),
 						),
 						'settingsUrl'         => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'vaultingEnabled'     => $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' ),
+						'vaultingEnabled'     => $settings_provider->save_paypal_and_venmo(),
 						'placementEnabled'    => self::is_block_enabled( $c->get( 'wcgateway.settings.status' ) ),
 						'payLaterSettingsUrl' => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' ),
 					)

--- a/modules/ppcp-paylater-configurator/extensions.php
+++ b/modules/ppcp-paylater-configurator/extensions.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\PayLaterConfigurator;
 
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 return array(
 	'wcgateway.settings.fields' => function ( array $fields, ContainerInterface $container ): array {
@@ -66,9 +66,9 @@ return array(
 			'pay_later_home_message_preview',
 		);
 
-		$settings = $container->get( 'wcgateway.settings' );
-		assert( $settings instanceof Settings );
-		$vault_enabled = $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' );
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
+		$vault_enabled = $settings_provider->save_paypal_and_venmo();
 
 		if ( ! $vault_enabled ) {
 			$old_fields[] = 'pay_later_messaging_enabled';

--- a/modules/ppcp-paylater-configurator/services.php
+++ b/modules/ppcp-paylater-configurator/services.php
@@ -17,7 +17,8 @@ use WooCommerce\PayPalCommerce\PayLaterConfigurator\Factory\ConfigFactory;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 
 return array(
 	'paylater-configurator.asset_getter'         => static function ( ContainerInterface $container ): AssetGetter {
@@ -31,49 +32,39 @@ return array(
 	},
 	'paylater-configurator.endpoint.save-config' => static function ( ContainerInterface $container ): SaveConfig {
 		return new SaveConfig(
-			$container->get( 'wcgateway.settings' ),
+			$container->get( 'settings.data.paylater-messaging-settings' ),
 			$container->get( 'button.request-data' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 	'paylater-configurator.endpoint.get-config'  => static function ( ContainerInterface $container ): GetConfig {
 		return new GetConfig(
-			$container->get( 'wcgateway.settings' ),
+			$container->get( 'settings.data.paylater-messaging-settings' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 	'paylater-configurator.is-available'         => static function ( ContainerInterface $container ): bool {
-		// Test, if Pay-Later is available; depends on the shop country and Vaulting status.
 		$messages_apply = $container->get( 'button.helper.messages-apply' );
 		assert( $messages_apply instanceof MessagesApply );
 
-		$settings = $container->get( 'wcgateway.settings' );
-		assert( $settings instanceof Settings );
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
 
 		$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
 		assert( $dcc_product_status instanceof DCCProductStatus );
 
-		$vault_enabled = $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' );
+		$vault_enabled = $settings_provider->save_paypal_and_venmo();
 
-		// Pay Later Messaging is available if vaulting is not enabled, the shop country is supported, and is eligible for ACDC.
 		return ! $vault_enabled && $messages_apply->for_country() && $dcc_product_status->is_active();
 	},
 	'paylater-configurator.messaging-locations'  => static function ( ContainerInterface $container ): array {
-		// Get an array of locations that display the Pay-Later message.
-		$settings = $container->get( 'wcgateway.settings' );
-		assert( $settings instanceof Settings );
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
 
-		$is_enabled = $settings->has( 'pay_later_messaging_enabled' ) && $settings->get( 'pay_later_messaging_enabled' );
-
-		if ( ! $is_enabled ) {
+		if ( ! $settings_provider->paylater_enabled() ) {
 			return array();
 		}
 
-		$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
-		if ( is_array( $selected_locations ) ) {
-			return $selected_locations;
-		}
-
-		return array();
+		return $settings_provider->pay_later_messaging_locations();
 	},
 );

--- a/modules/ppcp-paylater-configurator/src/Endpoint/GetConfig.php
+++ b/modules/ppcp-paylater-configurator/src/Endpoint/GetConfig.php
@@ -12,7 +12,7 @@ namespace WooCommerce\PayPalCommerce\PayLaterConfigurator\Endpoint;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\Factory\ConfigFactory;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 
 /**
  * Class GetConfig.
@@ -20,41 +20,18 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 class GetConfig {
 	const ENDPOINT = 'ppc-get-message-config';
 
-	/**
-	 * The settings.
-	 *
-	 * @var Settings
-	 */
-	protected $settings;
+	protected PayLaterMessagingSettings $settings;
+	private LoggerInterface $logger;
 
-	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
-	 * GetConfig constructor.
-	 *
-	 * @param Settings        $settings The settings.
-	 * @param LoggerInterface $logger The logger.
-	 */
-	public function __construct( Settings $settings, LoggerInterface $logger ) {
+	public function __construct( PayLaterMessagingSettings $settings, LoggerInterface $logger ) {
 		$this->settings = $settings;
 		$this->logger   = $logger;
 	}
 
-	/**
-	 * Returns the nonce.
-	 */
 	public static function nonce(): string {
 		return self::ENDPOINT;
 	}
 
-	/**
-	 * Handles the request.
-	 */
 	public function handle_request(): bool {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			$this->logger->error( 'User does not have permission: manage_woocommerce' );

--- a/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
+++ b/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
@@ -12,7 +12,7 @@ namespace WooCommerce\PayPalCommerce\PayLaterConfigurator\Endpoint;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 
 /**
  * Class SaveConfig.
@@ -20,36 +20,12 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 class SaveConfig {
 	const ENDPOINT = 'ppc-save-message-config';
 
-	/**
-	 * The settings.
-	 *
-	 * @var Settings
-	 */
-	protected $settings;
+	protected PayLaterMessagingSettings $settings;
+	protected RequestData $request_data;
+	private LoggerInterface $logger;
 
-	/**
-	 * The request data.
-	 *
-	 * @var RequestData
-	 */
-	protected $request_data;
-
-	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
-	 * SaveConfig constructor.
-	 *
-	 * @param Settings        $settings The settings.
-	 * @param RequestData     $request_data The request data.
-	 * @param LoggerInterface $logger The logger.
-	 */
 	public function __construct(
-		Settings $settings,
+		PayLaterMessagingSettings $settings,
 		RequestData $request_data,
 		LoggerInterface $logger
 	) {
@@ -58,16 +34,10 @@ class SaveConfig {
 		$this->logger       = $logger;
 	}
 
-	/**
-	 * Returns the nonce.
-	 */
 	public static function nonce(): string {
 		return self::ENDPOINT;
 	}
 
-	/**
-	 * Handles the request.
-	 */
 	public function handle_request(): bool {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			wp_send_json_error( 'Not admin.', 403 );
@@ -89,63 +59,24 @@ class SaveConfig {
 		}
 	}
 
-	/**
-	 * Saves the config into the old settings.
-	 *
-	 * @param array $config The configurator config.
-	 */
 	public function save_config( array $config ): void {
-		// TODO new-ux: We should convert this to a new AbstractDataModel class in the settings folder!
-		$this->settings->set( 'pay_later_enable_styling_per_messaging_location', true );
-		$this->settings->set( 'pay_later_messaging_enabled', true );
+		$this->settings->set_styling_per_location( true );
+		$this->settings->set_messaging_enabled( true );
 
 		$enabled_locations = array();
 		foreach ( $config as $placement => $data ) {
-			$this->save_config_for_location( $data, $placement );
-
 			if ( $placement === 'custom_placement' ) {
 				$data = $data[0] ?? array();
 			}
 
-			if ( $data['status'] === 'enabled' ) {
+			$this->settings->set_location_from_config( $placement, $data );
+
+			if ( ( $data['status'] ?? '' ) === 'enabled' ) {
 				$enabled_locations[] = $placement;
 			}
 		}
 
-		$this->settings->set( 'pay_later_messaging_locations', $enabled_locations );
-
-		$this->settings->persist();
-	}
-
-	/**
-	 * Saves the config for a location into the old settings.
-	 *
-	 * @param array  $config The configurator config for a location.
-	 * @param string $location The location name in the old settings.
-	 */
-	private function save_config_for_location( array $config, string $location ): void {
-		$this->set_value_if_present( $config, 'layout', "pay_later_{$location}_message_layout" );
-
-		$this->set_value_if_present( $config, 'color', "pay_later_{$location}_message_flex_color" );
-		$this->set_value_if_present( $config, 'ratio', "pay_later_{$location}_message_flex_ratio" );
-
-		$this->set_value_if_present( $config, 'logo-position', "pay_later_{$location}_message_position" );
-		$this->set_value_if_present( $config, 'logo-type', "pay_later_{$location}_message_logo" );
-		$this->set_value_if_present( $config, 'logo-color', "pay_later_{$location}_message_color" );
-		$this->set_value_if_present( $config, 'text-size', "pay_later_{$location}_message_text_size" );
-		$this->set_value_if_present( $config, 'text-color', "pay_later_{$location}_message_color" );
-	}
-
-	/**
-	 * Sets the value in the settings if it is available in the config.
-	 *
-	 * @param array  $config The configurator config.
-	 * @param string $key The key in the config.
-	 * @param string $settings_key The key in the settings.
-	 */
-	private function set_value_if_present( array $config, string $key, string $settings_key ): void {
-		if ( isset( $config[ $key ] ) ) {
-			$this->settings->set( $settings_key, $config[ $key ] );
-		}
+		$this->settings->set_messaging_locations( $enabled_locations );
+		$this->settings->save();
 	}
 }

--- a/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
+++ b/modules/ppcp-paylater-configurator/src/Factory/ConfigFactory.php
@@ -9,137 +9,25 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\PayLaterConfigurator\Factory;
 
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 
 /**
  * Class ConfigFactory.
  */
 class ConfigFactory {
 	/**
-	 * Returns the configurator config for the given old settings.
+	 * Returns the configurator config from the PayLaterMessagingSettings.
 	 *
-	 * @param Settings $settings The settings.
+	 * @param PayLaterMessagingSettings $settings The pay later messaging settings.
 	 */
-	public function from_settings( Settings $settings ): array {
+	public function from_settings( PayLaterMessagingSettings $settings ): array {
 		return array(
-			'cart'             => $this->for_location( $settings, 'cart' ),
-			'checkout'         => $this->for_location( $settings, 'checkout' ),
-			'product'          => $this->for_location( $settings, 'product' ),
-			'shop'             => $this->for_location( $settings, 'shop' ),
-			'home'             => $this->for_location( $settings, 'home' ),
-			'custom_placement' => array( $this->for_location( $settings, 'woocommerceBlock' ) ),
+			'cart'             => $settings->get_location_config( 'cart' ),
+			'checkout'         => $settings->get_location_config( 'checkout' ),
+			'product'          => $settings->get_location_config( 'product' ),
+			'shop'             => $settings->get_location_config( 'shop' ),
+			'home'             => $settings->get_location_config( 'home' ),
+			'custom_placement' => array( $settings->get_location_config( 'custom_placement' ) ),
 		);
-	}
-
-	/**
-	 * Returns the configurator config for a location.
-	 *
-	 * @param Settings $settings The settings.
-	 * @param string   $location The location name in the old settings.
-	 */
-	private function for_location( Settings $settings, string $location ): array {
-		$selected_locations = $settings->has( 'pay_later_messaging_locations' ) ? $settings->get( 'pay_later_messaging_locations' ) : array();
-
-		switch ( $location ) {
-			case 'shop':
-			case 'home':
-				$config = $this->for_shop_or_home( $settings, $location, $selected_locations );
-				break;
-			case 'woocommerceBlock':
-				$config = $this->for_woocommerce_block( $selected_locations );
-				break;
-			default:
-				$config = $this->for_default_location( $settings, $location, $selected_locations );
-				break;
-		}
-
-		return $config;
-	}
-
-	/**
-	 * Returns the configurator config for shop, home locations.
-	 *
-	 * @param Settings $settings The settings.
-	 * @param string   $location The location.
-	 * @param string[] $selected_locations The list of selected locations.
-	 * @return array{
-	 *     layout: string,
-	 *     color: string,
-	 *     ratio: string,
-	 *     status: "disabled"|"enabled",
-	 *     placement: string
-	 * } The configurator config map.
-	 */
-	private function for_shop_or_home( Settings $settings, string $location, array $selected_locations ): array {
-		return array(
-			'layout'    => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'flex' ),
-			'color'     => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_color", 'black' ),
-			'ratio'     => $this->get_or_default( $settings, "pay_later_{$location}_message_flex_ratio", '8x1' ),
-			'status'    => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
-			'placement' => $location,
-		);
-	}
-
-	/**
-	 * Returns the configurator config for woocommerceBlock location.
-	 *
-	 * @param array $selected_locations The list of selected locations.
-	 * @return array{
-	 *     status: "disabled"|"enabled",
-	 *     message_reference: string
-	 * } The configurator config map.
-	 */
-	private function for_woocommerce_block( array $selected_locations ): array {
-		return array(
-			'status'            => in_array( 'custom_placement', $selected_locations, true ) ? 'enabled' : 'disabled',
-			'message_reference' => 'woocommerceBlock',
-		);
-	}
-
-	/**
-	 * Returns the configurator config for default locations.
-	 *
-	 * @param Settings $settings The settings.
-	 * @param string   $location The location.
-	 * @param string[] $selected_locations The list of selected locations.
-	 * @return array{
-	 *     layout: string,
-	 *     logo-position: string,
-	 *     logo-type: string,
-	 *     text-color: string,
-	 *     text-size: string,
-	 *     status: "disabled"|"enabled",
-	 *     placement: string
-	 * } The configurator config map.
-	 */
-	private function for_default_location( Settings $settings, string $location, array $selected_locations ): array {
-		return array(
-			'layout'        => $this->get_or_default( $settings, "pay_later_{$location}_message_layout", 'text' ),
-			'logo-position' => $this->get_or_default( $settings, "pay_later_{$location}_message_position", 'left' ),
-			'logo-type'     => $this->get_or_default( $settings, "pay_later_{$location}_message_logo", 'inline' ),
-			'text-color'    => $this->get_or_default( $settings, "pay_later_{$location}_message_color", 'black' ),
-			'text-size'     => $this->get_or_default( $settings, "pay_later_{$location}_message_text_size", '12' ),
-			'status'        => in_array( $location, $selected_locations, true ) ? 'enabled' : 'disabled',
-			'placement'     => $location,
-		);
-	}
-
-	/**
-	 * Returns the settings value or default, if does not exist or not allowed value.
-	 *
-	 * @param Settings   $settings The settings.
-	 * @param string     $key The key.
-	 * @param mixed      $default The default value.
-	 * @param array|null $allowed_values The list of allowed values, or null if all values are allowed.
-	 * @return string
-	 */
-	private function get_or_default( Settings $settings, string $key, $default, ?array $allowed_values = null ): string {
-		if ( $settings->has( $key ) ) {
-			$value = $settings->get( $key );
-			if ( ! $allowed_values || in_array( $value, $allowed_values, true ) ) {
-				return $value;
-			}
-		}
-		return $default;
 	}
 }

--- a/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
+++ b/modules/ppcp-paylater-configurator/src/PayLaterConfiguratorModule.php
@@ -20,6 +20,8 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameI
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\PersistentMessage;
 
@@ -77,8 +79,11 @@ class PayLaterConfiguratorModule implements ServiceModule, ExtendingModule, Exec
 					$current_page_id
 				);
 
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
+				$settings_provider = $c->get( 'settings.settings-provider' );
+				assert( $settings_provider instanceof SettingsProvider );
+
+				$paylater_settings = $c->get( 'settings.data.paylater-messaging-settings' );
+				assert( $paylater_settings instanceof PayLaterMessagingSettings );
 
 				add_action(
 					'wc_ajax_' . SaveConfig::ENDPOINT,
@@ -148,8 +153,8 @@ class PayLaterConfiguratorModule implements ServiceModule, ExtendingModule, Exec
 								'nonce'    => wp_create_nonce( GetConfig::nonce() ),
 							),
 						),
-						'config'                 => $config_factory->from_settings( $settings ),
-						'merchantClientId'       => $settings->get( 'client_id' ),
+						'config'                 => $config_factory->from_settings( $paylater_settings ),
+						'merchantClientId'       => $settings_provider->merchant_data()->client_id,
 						'partnerClientId'        => $c->get( 'api.partner_merchant_id' ),
 						'bnCode'                 => $partner_attribution->get_bn_code(),
 						'publishButtonClassName' => 'ppcp-paylater-configurator-publishButton',

--- a/modules/ppcp-paylater-wc-blocks/services.php
+++ b/modules/ppcp-paylater-wc-blocks/services.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\PayLaterWCBlocks;
 
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
@@ -22,32 +23,36 @@ return array(
 	},
 
 	'paylater-wc-blocks.cart-renderer'     => static function ( ContainerInterface $container ): PayLaterWCBlocksRenderer {
-		$settings = $container->get( 'wcgateway.settings' );
+		$paylater_settings = $container->get( 'settings.data.paylater-messaging-settings' );
+		assert( $paylater_settings instanceof PayLaterMessagingSettings );
+		$cart = $paylater_settings->get_cart();
 		return new PayLaterWCBlocksRenderer(
 			array(
 				'placement'  => 'cart',
-				'layout'     => $settings->has( 'pay_later_cart_message_layout' ) ? $settings->get( 'pay_later_cart_message_layout' ) : '',
-				'position'   => $settings->has( 'pay_later_cart_message_position' ) ? $settings->get( 'pay_later_cart_message_position' ) : '',
-				'logo'       => $settings->has( 'pay_later_cart_message_logo' ) ? $settings->get( 'pay_later_cart_message_logo' ) : '',
-				'text_size'  => $settings->has( 'pay_later_cart_message_text_size' ) ? $settings->get( 'pay_later_cart_message_text_size' ) : '',
-				'color'      => $settings->has( 'pay_later_cart_message_color' ) ? $settings->get( 'pay_later_cart_message_color' ) : '',
-				'flex_color' => $settings->has( 'pay_later_cart_message_flex_color' ) ? $settings->get( 'pay_later_cart_message_flex_color' ) : '',
-				'flex_ratio' => $settings->has( 'pay_later_cart_message_flex_ratio' ) ? $settings->get( 'pay_later_cart_message_flex_ratio' ) : '',
+				'layout'     => $cart->layout,
+				'position'   => $cart->logo_position,
+				'logo'       => $cart->logo_type,
+				'text_size'  => $cart->text_size,
+				'color'      => $cart->text_color,
+				'flex_color' => $cart->flex_color,
+				'flex_ratio' => $cart->flex_ratio,
 			)
 		);
 	},
 	'paylater-wc-blocks.checkout-renderer' => static function ( ContainerInterface $container ): PayLaterWCBlocksRenderer {
-		$settings = $container->get( 'wcgateway.settings' );
+		$paylater_settings = $container->get( 'settings.data.paylater-messaging-settings' );
+		assert( $paylater_settings instanceof PayLaterMessagingSettings );
+		$checkout = $paylater_settings->get_checkout();
 		return new PayLaterWCBlocksRenderer(
 			array(
-				'payment',
-				'layout'     => $settings->has( 'pay_later_checkout_message_layout' ) ? $settings->get( 'pay_later_checkout_message_layout' ) : '',
-				'position'   => $settings->has( 'pay_later_checkout_message_position' ) ? $settings->get( 'pay_later_checkout_message_position' ) : '',
-				'logo'       => $settings->has( 'pay_later_checkout_message_logo' ) ? $settings->get( 'pay_later_checkout_message_logo' ) : '',
-				'text_size'  => $settings->has( 'pay_later_checkout_message_text_size' ) ? $settings->get( 'pay_later_checkout_message_text_size' ) : '',
-				'color'      => $settings->has( 'pay_later_checkout_message_color' ) ? $settings->get( 'pay_later_checkout_message_color' ) : '',
-				'flex_color' => $settings->has( 'pay_later_checkout_message_flex_color' ) ? $settings->get( 'pay_later_checkout_message_flex_color' ) : '',
-				'flex_ratio' => $settings->has( 'pay_later_checkout_message_flex_ratio' ) ? $settings->get( 'pay_later_checkout_message_flex_ratio' ) : '',
+				'placement'  => 'payment',
+				'layout'     => $checkout->layout,
+				'position'   => $checkout->logo_position,
+				'logo'       => $checkout->logo_type,
+				'text_size'  => $checkout->text_size,
+				'color'      => $checkout->text_color,
+				'flex_color' => $checkout->flex_color,
+				'flex_ratio' => $checkout->flex_ratio,
 			)
 		);
 	},

--- a/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php
+++ b/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php
@@ -12,6 +12,8 @@ namespace WooCommerce\PayPalCommerce\PayLaterWCBlocks;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Endpoint\CartScriptParamsEndpoint;
 use WooCommerce\PayPalCommerce\PayLaterConfigurator\Factory\ConfigFactory;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -19,7 +21,6 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 
 /**
  * Class PayLaterWCBlocksModule
@@ -103,8 +104,12 @@ class PayLaterWCBlocksModule implements ServiceModule, ExtendingModule, Executab
 		add_action(
 			'init',
 			function () use ( $c ): void {
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof Settings );
+				$paylater_settings = $c->get( 'settings.data.paylater-messaging-settings' );
+				assert( $paylater_settings instanceof PayLaterMessagingSettings );
+
+				$settings_provider = $c->get( 'settings.settings-provider' );
+				assert( $settings_provider instanceof SettingsProvider );
+
 				$config_factory = $c->get( 'paylater-configurator.factory.config' );
 				assert( $config_factory instanceof ConfigFactory );
 
@@ -130,9 +135,9 @@ class PayLaterWCBlocksModule implements ServiceModule, ExtendingModule, Executab
 								'endpoint' => \WC_AJAX::get_endpoint( CartScriptParamsEndpoint::ENDPOINT ),
 							),
 						),
-						'config'                      => $config_factory->from_settings( $settings ),
+						'config'                      => $config_factory->from_settings( $paylater_settings ),
 						'settingsUrl'                 => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'vaultingEnabled'             => $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' ),
+						'vaultingEnabled'             => $settings_provider->save_paypal_and_venmo(),
 						'placementEnabled'            => self::is_placement_enabled( $c->get( 'wcgateway.settings.status' ), 'cart' ),
 						'payLaterSettingsUrl'         => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' ),
 						'underTotalsPlacementEnabled' => self::is_under_cart_totals_placement_enabled(),
@@ -158,9 +163,9 @@ class PayLaterWCBlocksModule implements ServiceModule, ExtendingModule, Executab
 								'endpoint' => \WC_AJAX::get_endpoint( CartScriptParamsEndpoint::ENDPOINT ),
 							),
 						),
-						'config'              => $config_factory->from_settings( $settings ),
+						'config'              => $config_factory->from_settings( $paylater_settings ),
 						'settingsUrl'         => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'vaultingEnabled'     => $settings->has( 'vault_enabled' ) && $settings->get( 'vault_enabled' ),
+						'vaultingEnabled'     => $settings_provider->save_paypal_and_venmo(),
 						'placementEnabled'    => self::is_placement_enabled( $c->get( 'wcgateway.settings.status' ), 'checkout' ),
 						'payLaterSettingsUrl' => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway&ppcp-tab=ppcp-pay-later' ),
 					)

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -36,6 +36,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\FastlaneSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\TodosDefinition;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\AuthenticationRestEndpoint;
@@ -100,7 +101,8 @@ return array(
 			$container->get( 'settings.data.payment' ),
 			$container->get( 'settings.data.settings' ),
 			$container->get( 'settings.data.styling' ),
-			$container->get( 'settings.data.fastlane' )
+			$container->get( 'settings.data.fastlane' ),
+			$container->get( 'settings.data.paylater-messaging-settings' )
 		);
 	},
 	'settings.data.onboarding'                            => static function ( ContainerInterface $container ): OnboardingProfile {
@@ -141,6 +143,11 @@ return array(
 	'settings.data.fastlane'                              => static function (): FastlaneSettings {
 		return new FastlaneSettings();
 	},
+	'settings.data.paylater-messaging-settings'           => static function ( ContainerInterface $container ): PayLaterMessagingSettings {
+		return new PayLaterMessagingSettings(
+			$container->get( 'settings.service.sanitizer' )
+		);
+	},
 	'settings.data.settings'                              => static function ( ContainerInterface $container ): SettingsModel {
 		$environment = $container->get( 'settings.environment' );
 		assert( $environment instanceof Environment );
@@ -151,18 +158,16 @@ return array(
 		);
 	},
 	'settings.data.paylater-messaging'                    => static function ( ContainerInterface $container ): array {
-		// TODO: Create an AbstractDataModel wrapper for this configuration!
-
-		$config_factors = $container->get( 'paylater-configurator.factory.config' );
-		assert( $config_factors instanceof ConfigFactory );
+		$config_factory = $container->get( 'paylater-configurator.factory.config' );
+		assert( $config_factory instanceof ConfigFactory );
 
 		$save_config = $container->get( 'paylater-configurator.endpoint.save-config' );
 		assert( $save_config instanceof SaveConfig );
 
-		$settings = $container->get( 'wcgateway.settings' );
-		assert( $settings instanceof Settings );
+		$paylater_settings = $container->get( 'settings.data.paylater-messaging-settings' );
+		assert( $paylater_settings instanceof PayLaterMessagingSettings );
 
-		$pay_later_config = $config_factors->from_settings( $settings );
+		$pay_later_config = $config_factory->from_settings( $paylater_settings );
 
 		return array(
 			'read' => $pay_later_config,

--- a/modules/ppcp-settings/src/DTO/PayLaterMessagingDTO.php
+++ b/modules/ppcp-settings/src/DTO/PayLaterMessagingDTO.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Data transfer object. Stores Pay Later messaging details for a single location.
- *
- * @package WooCommerce\PayPalCommerce\Settings\DTO;
- */
-
 declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\DTO;

--- a/modules/ppcp-settings/src/DTO/PayLaterMessagingDTO.php
+++ b/modules/ppcp-settings/src/DTO/PayLaterMessagingDTO.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Data transfer object. Stores Pay Later messaging details for a single location.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\DTO;
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\DTO;
+
+/**
+ * DTO that collects all Pay Later messaging details of a single location.
+ */
+class PayLaterMessagingDTO {
+	public string $location;
+	public bool $enabled;
+	public string $layout;
+	public string $logo_type;
+	public string $logo_position;
+	public string $text_color;
+	public string $text_size;
+	public string $flex_color;
+	public string $flex_ratio;
+
+	public function __construct(
+		string $location = '',
+		bool $enabled = false,
+		string $layout = 'text',
+		string $logo_type = 'inline',
+		string $logo_position = 'left',
+		string $text_color = 'black',
+		string $text_size = '12',
+		string $flex_color = 'black',
+		string $flex_ratio = '8x1'
+	) {
+		$this->location      = $location;
+		$this->enabled       = $enabled;
+		$this->layout        = $layout;
+		$this->logo_type     = $logo_type;
+		$this->logo_position = $logo_position;
+		$this->text_color    = $text_color;
+		$this->text_size     = $text_size;
+		$this->flex_color    = $flex_color;
+		$this->flex_ratio    = $flex_ratio;
+	}
+}

--- a/modules/ppcp-settings/src/Data/PayLaterMessagingSettings.php
+++ b/modules/ppcp-settings/src/Data/PayLaterMessagingSettings.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Pay Later Messaging Settings class
- *
- * @package WooCommerce\PayPalCommerce\Settings\Data
- */
-
 declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Data;
@@ -13,11 +7,6 @@ use RuntimeException;
 use WooCommerce\PayPalCommerce\Settings\DTO\PayLaterMessagingDTO;
 use WooCommerce\PayPalCommerce\Settings\Service\DataSanitizer;
 
-/**
- * Class PayLaterMessagingSettings
- *
- * Stores and manages the Pay Later messaging settings for different locations.
- */
 class PayLaterMessagingSettings extends AbstractDataModel {
 
 	protected const OPTION_KEY = 'woocommerce-ppcp-data-paylater-messaging';

--- a/modules/ppcp-settings/src/Data/PayLaterMessagingSettings.php
+++ b/modules/ppcp-settings/src/Data/PayLaterMessagingSettings.php
@@ -162,7 +162,7 @@ class PayLaterMessagingSettings extends AbstractDataModel {
 	 * Updates a location's settings from configurator config array.
 	 *
 	 * @param string $location The location name.
-	 * @param array  $config   The configurator config.
+	 * @param array  $config The configurator config.
 	 */
 	public function set_location_from_config( string $location, array $config ): void {
 		$method = "get_{$location}";
@@ -201,7 +201,7 @@ class PayLaterMessagingSettings extends AbstractDataModel {
 	/**
 	 * Sanitizes Pay Later messaging data.
 	 *
-	 * @param mixed   $data     The messaging data to sanitize.
+	 * @param mixed   $data The messaging data to sanitize.
 	 * @param ?string $location Name of the location.
 	 * @return PayLaterMessagingDTO Sanitized messaging data.
 	 */

--- a/modules/ppcp-settings/src/Data/PayLaterMessagingSettings.php
+++ b/modules/ppcp-settings/src/Data/PayLaterMessagingSettings.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Pay Later Messaging Settings class
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Data
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Data;
+
+use RuntimeException;
+use WooCommerce\PayPalCommerce\Settings\DTO\PayLaterMessagingDTO;
+use WooCommerce\PayPalCommerce\Settings\Service\DataSanitizer;
+
+/**
+ * Class PayLaterMessagingSettings
+ *
+ * Stores and manages the Pay Later messaging settings for different locations.
+ */
+class PayLaterMessagingSettings extends AbstractDataModel {
+
+	protected const OPTION_KEY = 'woocommerce-ppcp-data-paylater-messaging';
+
+	private const LEGACY_OPTION_KEY = 'woocommerce-ppcp-settings';
+
+	protected DataSanitizer $sanitizer;
+
+	/**
+	 * @throws RuntimeException If the OPTION_KEY is not defined in the child class.
+	 */
+	public function __construct( DataSanitizer $sanitizer ) {
+		$this->sanitizer = $sanitizer;
+
+		parent::__construct();
+
+		$this->maybe_migrate_from_legacy();
+	}
+
+	protected function get_defaults(): array {
+		return array(
+			'messaging_enabled'    => false,
+			'styling_per_location' => true,
+			'messaging_locations'  => array(),
+			'cart'                 => new PayLaterMessagingDTO( 'cart' ),
+			'checkout'             => new PayLaterMessagingDTO( 'checkout' ),
+			'product'              => new PayLaterMessagingDTO( 'product' ),
+			'shop'                 => new PayLaterMessagingDTO( 'shop', false, 'flex' ),
+			'home'                 => new PayLaterMessagingDTO( 'home', false, 'flex' ),
+			'custom_placement'     => new PayLaterMessagingDTO( 'custom_placement' ),
+		);
+	}
+
+	public function get_messaging_enabled(): bool {
+		return (bool) $this->data['messaging_enabled'];
+	}
+
+	public function set_messaging_enabled( bool $enabled ): void {
+		$this->data['messaging_enabled'] = $enabled;
+	}
+
+	public function get_styling_per_location(): bool {
+		return (bool) $this->data['styling_per_location'];
+	}
+
+	public function set_styling_per_location( bool $enabled ): void {
+		$this->data['styling_per_location'] = $enabled;
+	}
+
+	public function get_messaging_locations(): array {
+		return (array) $this->data['messaging_locations'];
+	}
+
+	public function set_messaging_locations( array $locations ): void {
+		$this->data['messaging_locations'] = $this->sanitizer->sanitize_array(
+			$locations,
+			array( $this->sanitizer, 'sanitize_text' )
+		);
+	}
+
+	public function get_cart(): PayLaterMessagingDTO {
+		return $this->data['cart'];
+	}
+
+	public function set_cart( $styles ): void {
+		$this->data['cart'] = $this->sanitize_paylater_messaging( $styles, 'cart' );
+	}
+
+	public function get_checkout(): PayLaterMessagingDTO {
+		return $this->data['checkout'];
+	}
+
+	public function set_checkout( $styles ): void {
+		$this->data['checkout'] = $this->sanitize_paylater_messaging( $styles, 'checkout' );
+	}
+
+	public function get_product(): PayLaterMessagingDTO {
+		return $this->data['product'];
+	}
+
+	public function set_product( $styles ): void {
+		$this->data['product'] = $this->sanitize_paylater_messaging( $styles, 'product' );
+	}
+
+	public function get_shop(): PayLaterMessagingDTO {
+		return $this->data['shop'];
+	}
+
+	public function set_shop( $styles ): void {
+		$this->data['shop'] = $this->sanitize_paylater_messaging( $styles, 'shop' );
+	}
+
+	public function get_home(): PayLaterMessagingDTO {
+		return $this->data['home'];
+	}
+
+	public function set_home( $styles ): void {
+		$this->data['home'] = $this->sanitize_paylater_messaging( $styles, 'home' );
+	}
+
+	public function get_custom_placement(): PayLaterMessagingDTO {
+		return $this->data['custom_placement'];
+	}
+
+	public function set_custom_placement( $styles ): void {
+		$this->data['custom_placement'] = $this->sanitize_paylater_messaging( $styles, 'custom_placement' );
+	}
+
+	/**
+	 * Returns an array representation of a location's messaging config in configurator format.
+	 *
+	 * @param string $location The location name.
+	 * @return array The configurator-compatible config array.
+	 */
+	public function get_location_config( string $location ): array {
+		$method = "get_{$location}";
+		if ( ! method_exists( $this, $method ) ) {
+			return array();
+		}
+
+		$dto               = $this->$method();
+		$enabled_locations = $this->get_messaging_locations();
+
+		if ( 'shop' === $location || 'home' === $location ) {
+			return array(
+				'layout'    => $dto->layout,
+				'color'     => $dto->flex_color,
+				'ratio'     => $dto->flex_ratio,
+				'status'    => in_array( $location, $enabled_locations, true ) ? 'enabled' : 'disabled',
+				'placement' => $location,
+			);
+		}
+
+		if ( 'custom_placement' === $location ) {
+			return array(
+				'status'            => in_array( 'custom_placement', $enabled_locations, true ) ? 'enabled' : 'disabled',
+				'message_reference' => 'woocommerceBlock',
+			);
+		}
+
+		return array(
+			'layout'        => $dto->layout,
+			'logo-position' => $dto->logo_position,
+			'logo-type'     => $dto->logo_type,
+			'text-color'    => $dto->text_color,
+			'text-size'     => $dto->text_size,
+			'status'        => in_array( $location, $enabled_locations, true ) ? 'enabled' : 'disabled',
+			'placement'     => $location,
+		);
+	}
+
+	/**
+	 * Updates a location's settings from configurator config array.
+	 *
+	 * @param string $location The location name.
+	 * @param array  $config   The configurator config.
+	 */
+	public function set_location_from_config( string $location, array $config ): void {
+		$method = "get_{$location}";
+		if ( ! method_exists( $this, $method ) ) {
+			return;
+		}
+
+		$dto = $this->$method();
+
+		if ( isset( $config['layout'] ) ) {
+			$dto->layout = $this->sanitizer->sanitize_text( $config['layout'], 'text' );
+		}
+		if ( isset( $config['logo-position'] ) ) {
+			$dto->logo_position = $this->sanitizer->sanitize_text( $config['logo-position'], 'left' );
+		}
+		if ( isset( $config['logo-type'] ) ) {
+			$dto->logo_type = $this->sanitizer->sanitize_text( $config['logo-type'], 'inline' );
+		}
+		if ( isset( $config['text-color'] ) || isset( $config['logo-color'] ) ) {
+			$dto->text_color = $this->sanitizer->sanitize_text( $config['text-color'] ?? $config['logo-color'] ?? 'black', 'black' );
+		}
+		if ( isset( $config['text-size'] ) ) {
+			$dto->text_size = $this->sanitizer->sanitize_text( $config['text-size'], '12' );
+		}
+		if ( isset( $config['color'] ) ) {
+			$dto->flex_color = $this->sanitizer->sanitize_text( $config['color'], 'black' );
+		}
+		if ( isset( $config['ratio'] ) ) {
+			$dto->flex_ratio = $this->sanitizer->sanitize_text( $config['ratio'], '8x1' );
+		}
+
+		$setter = "set_{$location}";
+		$this->$setter( $dto );
+	}
+
+	/**
+	 * Sanitizes Pay Later messaging data.
+	 *
+	 * @param mixed   $data     The messaging data to sanitize.
+	 * @param ?string $location Name of the location.
+	 * @return PayLaterMessagingDTO Sanitized messaging data.
+	 */
+	private function sanitize_paylater_messaging( $data, ?string $location = null ): PayLaterMessagingDTO {
+		if ( $data instanceof PayLaterMessagingDTO ) {
+			if ( $location ) {
+				$data->location = $location;
+			}
+			return $data;
+		}
+
+		if ( is_object( $data ) ) {
+			$data = (array) $data;
+		}
+
+		if ( ! is_array( $data ) ) {
+			return new PayLaterMessagingDTO( $location ?? '' );
+		}
+
+		if ( null === $location ) {
+			$location = $data['location'] ?? '';
+		}
+
+		$enabled_locations = $this->get_messaging_locations();
+
+		return new PayLaterMessagingDTO(
+			$location,
+			in_array( $location, $enabled_locations, true ),
+			$this->sanitizer->sanitize_text( $data['layout'] ?? 'text' ),
+			$this->sanitizer->sanitize_text( $data['logo_type'] ?? $data['logo-type'] ?? 'inline' ),
+			$this->sanitizer->sanitize_text( $data['logo_position'] ?? $data['logo-position'] ?? 'left' ),
+			$this->sanitizer->sanitize_text( $data['text_color'] ?? $data['text-color'] ?? 'black' ),
+			$this->sanitizer->sanitize_text( $data['text_size'] ?? $data['text-size'] ?? '12' ),
+			$this->sanitizer->sanitize_text( $data['flex_color'] ?? $data['color'] ?? 'black' ),
+			$this->sanitizer->sanitize_text( $data['flex_ratio'] ?? $data['ratio'] ?? '8x1' )
+		);
+	}
+
+	private function maybe_migrate_from_legacy(): void {
+		$has_new_data = get_option( static::OPTION_KEY );
+		if ( false !== $has_new_data && ! empty( $has_new_data ) ) {
+			return;
+		}
+
+		$legacy_settings = (array) get_option( self::LEGACY_OPTION_KEY, array() );
+		if ( empty( $legacy_settings ) ) {
+			return;
+		}
+
+		$this->data['messaging_enabled']    = ! empty( $legacy_settings['pay_later_messaging_enabled'] );
+		$this->data['styling_per_location'] = ! empty( $legacy_settings['pay_later_enable_styling_per_messaging_location'] );
+
+		$locations = $legacy_settings['pay_later_messaging_locations'] ?? array();
+		if ( is_array( $locations ) ) {
+			$this->data['messaging_locations'] = $locations;
+		}
+
+		$location_map = array(
+			'cart'             => 'cart',
+			'checkout'         => 'checkout',
+			'product'          => 'product',
+			'shop'             => 'shop',
+			'home'             => 'home',
+			'custom_placement' => 'custom_placement',
+		);
+
+		foreach ( $location_map as $location => $key ) {
+			$prefix = "pay_later_{$location}_message";
+
+			$this->data[ $key ] = new PayLaterMessagingDTO(
+				$location,
+				in_array( $location, $this->data['messaging_locations'], true ),
+				$legacy_settings[ "{$prefix}_layout" ] ?? ( in_array( $location, array( 'shop', 'home' ), true ) ? 'flex' : 'text' ),
+				$legacy_settings[ "{$prefix}_logo" ] ?? 'inline',
+				$legacy_settings[ "{$prefix}_position" ] ?? 'left',
+				$legacy_settings[ "{$prefix}_color" ] ?? 'black',
+				$legacy_settings[ "{$prefix}_text_size" ] ?? '12',
+				$legacy_settings[ "{$prefix}_flex_color" ] ?? 'black',
+				$legacy_settings[ "{$prefix}_flex_ratio" ] ?? '8x1'
+			);
+		}
+
+		$this->save();
+	}
+}

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -23,6 +23,7 @@ class SettingsProvider {
 	private SettingsModel $settings_model;
 	private StylingSettings $styling_settings;
 	private FastlaneSettings $fastlane_settings;
+	private PayLaterMessagingSettings $paylater_messaging_settings;
 
 	public function __construct(
 		GeneralSettings $general_settings,
@@ -30,14 +31,16 @@ class SettingsProvider {
 		PaymentSettings $payment_settings,
 		SettingsModel $settings_model,
 		StylingSettings $styling_settings,
-		FastlaneSettings $fastlane_settings
+		FastlaneSettings $fastlane_settings,
+		PayLaterMessagingSettings $paylater_messaging_settings
 	) {
-		$this->general_settings   = $general_settings;
-		$this->onboarding_profile = $onboarding_profile;
-		$this->payment_settings   = $payment_settings;
-		$this->settings_model     = $settings_model;
-		$this->styling_settings   = $styling_settings;
-		$this->fastlane_settings  = $fastlane_settings;
+		$this->general_settings            = $general_settings;
+		$this->onboarding_profile          = $onboarding_profile;
+		$this->payment_settings            = $payment_settings;
+		$this->settings_model              = $settings_model;
+		$this->styling_settings            = $styling_settings;
+		$this->fastlane_settings           = $fastlane_settings;
+		$this->paylater_messaging_settings = $paylater_messaging_settings;
 	}
 
 	/**
@@ -638,17 +641,46 @@ class SettingsProvider {
 	 * @return array The messaging style settings.
 	 */
 	public function pay_later_messaging_style( string $location ): array {
-		$settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
-		$prefix   = "pay_later_{$location}_message";
+		$method_map = array(
+			'cart'             => 'get_cart',
+			'checkout'         => 'get_checkout',
+			'product'          => 'get_product',
+			'shop'             => 'get_shop',
+			'home'             => 'get_home',
+			'custom_placement' => 'get_custom_placement',
+		);
+
+		if ( isset( $method_map[ $location ] ) ) {
+			$method = $method_map[ $location ];
+			$dto    = $this->paylater_messaging_settings->$method();
+
+			return array(
+				'layout'        => $dto->layout,
+				'logo_type'     => $dto->logo_type,
+				'logo_position' => $dto->logo_position,
+				'text_color'    => $dto->text_color,
+				'flex_color'    => $dto->flex_color,
+				'ratio'         => $dto->flex_ratio,
+				'text_size'     => $dto->text_size,
+			);
+		}
 
 		return array(
-			'layout'        => $settings[ "{$prefix}_layout" ] ?? 'text',
-			'logo_type'     => $settings[ "{$prefix}_logo" ] ?? 'primary',
-			'logo_position' => $settings[ "{$prefix}_position" ] ?? 'left',
-			'text_color'    => $settings[ "{$prefix}_color" ] ?? 'black',
-			'flex_color'    => $settings[ "{$prefix}_flex_color" ] ?? 'blue',
-			'ratio'         => $settings[ "{$prefix}_flex_ratio" ] ?? '1x1',
-			'text_size'     => $settings[ "{$prefix}_text_size" ] ?? '12',
+			'layout'        => 'text',
+			'logo_type'     => 'primary',
+			'logo_position' => 'left',
+			'text_color'    => 'black',
+			'flex_color'    => 'blue',
+			'ratio'         => '1x1',
+			'text_size'     => '12',
 		);
+	}
+
+	public function pay_later_messaging_locations(): array {
+		return $this->paylater_messaging_settings->get_messaging_locations();
+	}
+
+	public function pay_later_messaging_settings(): PayLaterMessagingSettings {
+		return $this->paylater_messaging_settings;
 	}
 }

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -679,8 +679,4 @@ class SettingsProvider {
 	public function pay_later_messaging_locations(): array {
 		return $this->paylater_messaging_settings->get_messaging_locations();
 	}
-
-	public function pay_later_messaging_settings(): PayLaterMessagingSettings {
-		return $this->paylater_messaging_settings;
-	}
 }

--- a/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
+++ b/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
@@ -9,6 +9,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\FastlaneSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
@@ -29,15 +30,16 @@ class SettingsProviderTest extends TestCase {
 	private SettingsModel $settings_model;
 	private StylingSettings $styling_settings;
 	private FastlaneSettings $fastlane_settings;
+	private PayLaterMessagingSettings $paylater_messaging_settings;
 
 	public function setUp(): void {
-		// Mock Models
-		$this->general_settings   = Mockery::mock( GeneralSettings::class );
-		$this->onboarding_profile = Mockery::mock( OnboardingProfile::class );
-		$this->payment_settings   = Mockery::mock( PaymentSettings::class );
-		$this->settings_model     = Mockery::mock( SettingsModel::class );
-		$this->styling_settings   = Mockery::mock( StylingSettings::class );
-		$this->fastlane_settings  = Mockery::mock( FastlaneSettings::class );
+		$this->general_settings            = Mockery::mock( GeneralSettings::class );
+		$this->onboarding_profile          = Mockery::mock( OnboardingProfile::class );
+		$this->payment_settings            = Mockery::mock( PaymentSettings::class );
+		$this->settings_model              = Mockery::mock( SettingsModel::class );
+		$this->styling_settings            = Mockery::mock( StylingSettings::class );
+		$this->fastlane_settings           = Mockery::mock( FastlaneSettings::class );
+		$this->paylater_messaging_settings = Mockery::mock( PayLaterMessagingSettings::class );
 
 		$this->provider = new SettingsProvider(
 			$this->general_settings,
@@ -45,7 +47,8 @@ class SettingsProviderTest extends TestCase {
 			$this->payment_settings,
 			$this->settings_model,
 			$this->styling_settings,
-			$this->fastlane_settings
+			$this->fastlane_settings,
+			$this->paylater_messaging_settings
 		);
 	}
 
@@ -88,6 +91,7 @@ class SettingsProviderTest extends TestCase {
 			$this->get_model_data( $this->get_settings_model_data(), 'settings_model' ),
 			$this->get_model_data( $this->get_styling_settings_data(), 'styling_settings' ),
 			$this->get_model_data( $this->get_fastlane_settings_data(), 'fastlane_settings' ),
+			$this->get_model_data( $this->get_paylater_messaging_settings_data(), 'paylater_messaging_settings' ),
 		);
 	}
 
@@ -422,6 +426,21 @@ class SettingsProviderTest extends TestCase {
 			array(
 				'provider_method' => 'fastlane_input_styles',
 				'model_method'    => 'get_input_styles',
+				'expected_value'  => self::EXPECTED_VALUE_ARRAY,
+			),
+		);
+	}
+
+	/**
+	 * Test data for the PayLaterMessagingSettings model.
+	 * @return array
+	 * @see PayLaterMessagingSettings
+	 */
+	private function get_paylater_messaging_settings_data(): array {
+		return array(
+			array(
+				'provider_method' => 'pay_later_messaging_locations',
+				'model_method'    => 'get_messaging_locations',
 				'expected_value'  => self::EXPECTED_VALUE_ARRAY,
 			),
 		);


### PR DESCRIPTION
This PR migrates the Pay Later modules (`ppcp-paylater-block`, `ppcp-paylater-configurator` and `ppcp-paylater-wc-blocks`) from the legacy `wcgateway.settings` to the new `SettingsProvider` and introduces a dedicated `PayLaterMessagingSettings` data class.

> Note: psalm errors are already fixed in #4016

### PR Changes

  ppcp-settings
  - Added `PayLaterMessagingDTO` for storing messaging styles per location
  - Added `PayLaterMessagingSettings` data class with automatic migration from legacy settings
  - Extended `SettingsProvider` with Pay Later messaging getters

  ppcp-paylater-block
  - Replaced `wcgateway.settings` with `SettingsProvider` for messaging location checks

  ppcp-paylater-configurator
  - Replaced legacy settings with `PayLaterMessagingSettings` in `GetConfig` and `SaveConfig` endpoints
  - Simplified `ConfigFactory` by delegating config generation to `PayLaterMessagingSettings::get_location_config()`
  - Removed redundant legacy setting reads

  ppcp-paylater-wc-blocks
  - Replaced `wcgateway.settings` with `PayLaterMessagingSettings` DTO for cart/checkout renderers
  - Fixed missing placement key in checkout-renderer config