### PR TITLE
Add URL lookup from DDEV to ngrok share script

### DIFF
--- a/.ddev/bin/share
+++ b/.ddev/bin/share
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-PROJECT_HOST=$(ddev wp option get home | tr -d '\r' | awk -F'^http[s]?://' '{print $2}')
+pkill -f ngrok 2>/dev/null || true
+
+PROJECT_HOST=$(ddev describe -j | jq -r '.raw.hostnames[0]')
 ddev share >/dev/null &
 NGROK_PID=$!
 ngrok-url(){
@@ -25,4 +27,4 @@ wp-replace "${PROJECT_HOST}" "${NGROK_HOST}"
 echo "Your site is now reachable at https://${NGROK_HOST}"
 echo "ctrl-c to stop sharing and revert database changes"
 trap kill-ngrok INT
-wait -f "${NGROK_PID}"
+wait "${NGROK_PID}"


### PR DESCRIPTION
There is a script to automatically set up an ngrok tunnel to the local enviroment. 

Whenever the script was interrupted without reverting the local site to the DDEV URL, on subsequent runs, this reversal would not be possible, so I would have to manually run the search-replace command to switch from the ngrok URL to the DDEV URL.

This PR adjusts the script by obtaining the original DDEV URL from the environment variables rather than the database, as well as force-killing the existing ngrok process so the script always runs and reverts without issues.
