### PR TITLE
 Add missing meta when paying via vaulted ACDC

### DIFF
--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -16,6 +16,7 @@ use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
@@ -24,9 +25,6 @@ use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\RealTimeAccountUpdaterHelper;
 use WP_Error;
 
-/**
- * Class CaptureCardPayment
- */
 class CaptureCardPayment {
 
 	use RequestTrait;
@@ -94,19 +92,6 @@ class CaptureCardPayment {
 	 */
 	private $logger;
 
-	/**
-	 * CaptureCardPayment constructor.
-	 *
-	 * @param string                       $host The host.
-	 * @param Bearer                       $bearer The bearer.
-	 * @param OrderFactory                 $order_factory The order factory.
-	 * @param PurchaseUnitFactory          $purchase_unit_factory The purchase unit factory.
-	 * @param OrderEndpoint                $order_endpoint The order endpoint.
-	 * @param SessionHandler               $session_handler The session handler.
-	 * @param RealTimeAccountUpdaterHelper $real_time_account_updater_helper Real Time Account Updater helper.
-	 * @param Settings                     $settings The settings.
-	 * @param LoggerInterface              $logger The logger.
-	 */
 	public function __construct(
 		string $host,
 		Bearer $bearer,
@@ -132,14 +117,9 @@ class CaptureCardPayment {
 	/**
 	 * Creates PayPal order from the given card vault id.
 	 *
-	 * @param string   $vault_id Vault id.
-	 * @param string   $custom_id Custom id.
-	 * @param string   $invoice_id Invoice id.
-	 * @param WC_Order $wc_order The WC order.
-	 * @return stdClass
 	 * @throws RuntimeException When request fails.
 	 */
-	public function create_order( string $vault_id, string $custom_id, string $invoice_id, WC_Order $wc_order ): stdClass {
+	public function create_order( string $vault_id, string $custom_id, string $invoice_id, WC_Order $wc_order ): Order {
 		$intent = $this->settings->has( 'intent' ) && strtoupper( (string) $this->settings->get( 'intent' ) ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
 		$items  = array( $this->purchase_unit_factory->from_wc_cart() );
 
@@ -192,6 +172,6 @@ class CaptureCardPayment {
 
 		$decoded_response = json_decode( $response['body'] );
 
-		return $decoded_response;
+		return $this->order_factory->from_paypal_response( $decoded_response );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -191,9 +191,6 @@ class CaptureCardPayment {
 		}
 
 		$decoded_response = json_decode( $response['body'] );
-		if ( ! isset( $decoded_response->invoice_id ) ) {
-			$decoded_response->invoice_id = $invoice_id;
-		}
 
 		return $decoded_response;
 	}

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -28,6 +28,7 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CaptureCardPayment;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\GatewayGenericException;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderMetaTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\PaymentsStatusHandlingTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
@@ -47,6 +48,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	use TransactionIdHandlingTrait;
 	use PaymentsStatusHandlingTrait;
 	use FreeTrialHandlerTrait;
+	use OrderMetaTrait;
 
 	const ID = 'ppcp-credit-card-gateway';
 
@@ -518,7 +520,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 					}
 
 					$order = $this->order_endpoint->order( $created_order->id() );
-					$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
+					$this->add_paypal_meta( $wc_order, $created_order, $this->environment );
 					$wc_order->add_payment_token( $token );
 
 					if ( $order->intent() === 'AUTHORIZE' ) {

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -512,12 +512,12 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 					$invoice_id = $this->prefix . $wc_order->get_order_number();
 
 					try {
-						$create_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order );
+						$created_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order );
 					} catch ( RuntimeException $exception ) {
 						$this->logger->error( $exception->getMessage() );
 					}
 
-					$order = $this->order_endpoint->order( $create_order->id );
+					$order = $this->order_endpoint->order( $created_order->id() );
 					$wc_order->update_meta_data( PayPalGateway::INTENT_META_KEY, $order->intent() );
 					$wc_order->add_payment_token( $token );
 


### PR DESCRIPTION
  Looks like some common metadata was missing because we were never calling `add_paypal_meta` in this case.