### PR TITLE
Vaulting subscription - PayPal - Free trial order renewal (4913)

### DIFF
--- a/modules/ppcp-button/resources/js/button.js
+++ b/modules/ppcp-button/resources/js/button.js
@@ -366,7 +366,7 @@ document.addEventListener( 'DOMContentLoaded', () => {
 			) ||
 			isChangePaymentPage() ||
 			( PayPalCommerceGateway.is_free_trial_cart &&
-				PayPalCommerceGateway.vaulted_paypal_email !== '' )
+				!! PayPalCommerceGateway.vaulted_paypal_email )
 		) {
 			return;
 		}

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstrap.js
@@ -210,7 +210,7 @@ class CheckoutBootstrap {
 			! isApplePayMethod;
 		const isFreeTrial = PayPalCommerceGateway.is_free_trial_cart;
 		const hasVaultedPaypal =
-			PayPalCommerceGateway.vaulted_paypal_email !== '';
+			!! PayPalCommerceGateway.vaulted_paypal_email;
 		const useSmartButtons = this.renderer.useSmartButtons ?? true;
 
 		const paypalButtonWrappers = {

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -396,8 +396,10 @@ class WcSubscriptionsModule implements ServiceModule, ExtendingModule, Executabl
 		add_filter(
 			'woocommerce_paypal_payments_localized_script_data',
 			function ( array $localized_script_data ) use ( $c ) {
-				// Return early if save payment methods (Vault v3) is enabled.
+				// When Vault v3 is enabled, set empty vaulted_paypal_email to prevent
+				// undefined JS property from affecting button visibility logic.
 				if ( $c->has( 'save-payment-methods.eligible' ) && $c->get( 'save-payment-methods.eligible' ) ) {
+					$localized_script_data['vaulted_paypal_email'] = '';
 					return $localized_script_data;
 				}
 

--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -396,10 +396,7 @@ class WcSubscriptionsModule implements ServiceModule, ExtendingModule, Executabl
 		add_filter(
 			'woocommerce_paypal_payments_localized_script_data',
 			function ( array $localized_script_data ) use ( $c ) {
-				// When Vault v3 is enabled, set empty vaulted_paypal_email to prevent
-				// undefined JS property from affecting button visibility logic.
 				if ( $c->has( 'save-payment-methods.eligible' ) && $c->get( 'save-payment-methods.eligible' ) ) {
-					$localized_script_data['vaulted_paypal_email'] = '';
 					return $localized_script_data;
 				}
 


### PR DESCRIPTION
The localized script data filter returned early without setting `vaulted_paypal_email`, leaving it as undefined in JavaScript. Since undefined `!== ''` evaluates to `true`, the JS incorrectly treated guest users as having a vaulted PayPal account, which hid the smart button and showed the standard "Proceed to PayPal" button instead.                                                                       
                                                                                                                                                                                                                       
This PR changes the JS checks from `!== ''` to `!!` so that `undefined`, `null`, and `''` are all treated as false. 