### PR TITLE
Enable Working Capital via feature flag (5818)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -553,7 +553,7 @@ $services = array(
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
-			getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
+			true
 		);
 
 		$is_working_capital_eligible = $container->get( 'settings.data.general' )->get_merchant_country() === 'US' && $settings_model->get_stay_updated();

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2116,7 +2116,7 @@ return array(
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
-			getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
+			true
 		);
 
 		$is_working_capital_eligible = $container->get( 'api.shop.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
@@ -2219,7 +2219,7 @@ return array(
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
-			getenv( 'PCP_WORKING_CAPITAL_ENABLED' ) === '1'
+			true
 		);
 
 		$stay_updated = SettingsModule::should_use_the_old_ui()


### PR DESCRIPTION
This PR enables Working Capital by default via:
`woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled` filter.