### PR TITLE
fix: extract line item tax from cart and order items (5835)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -139,7 +139,7 @@ class ItemFactory {
 		$price_without_tax         = (float) $order->get_item_subtotal( $item, false );
 		$price_without_tax_rounded = round( $price_without_tax, 2 );
 		$image                     = $product instanceof WC_Product ? wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' ) : '';
-		$line_tax                  = $item->get_total_tax() ? (float) $item->get_total_tax() : null;
+		$line_tax                  = (float) $item->get_total_tax();
 
 		return new Item(
 			$this->prepare_item_string( $item->get_name() ),

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -60,13 +60,16 @@ class ItemFactory {
 				$quantity = (int) $item['quantity'];
 				$image    = wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' );
 
-				$price = (float) $item['line_subtotal'] / (float) $item['quantity'];
+				$price    = (float) $item['line_subtotal'] / (float) $item['quantity'];
+				$line_tax = isset( $item['line_tax'] ) ? (float) $item['line_tax'] : 0.0;
+				$unit_tax = $quantity > 0 ? $line_tax / $quantity : 0.0;
+
 				return new Item(
 					$this->prepare_item_string( $product->get_name() ),
 					new Money( $price, $this->currency->get() ),
 					$quantity,
 					$this->prepare_item_string( $product->get_description() ),
-					isset( $item['line_tax'] ) ? new Money( (float) $item['line_tax'], $this->currency->get() ) : null,
+					$unit_tax ? new Money( $unit_tax, $this->currency->get() ) : null,
 					$this->prepare_sku( $product->get_sku() ),
 					( $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
 					$product->get_permalink(),
@@ -140,13 +143,14 @@ class ItemFactory {
 		$price_without_tax_rounded = round( $price_without_tax, 2 );
 		$image                     = $product instanceof WC_Product ? wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' ) : '';
 		$line_tax                  = (float) $item->get_total_tax();
+		$unit_tax                  = $quantity > 0 ? $line_tax / $quantity : 0.0;
 
 		return new Item(
 			$this->prepare_item_string( $item->get_name() ),
 			new Money( $price_without_tax_rounded, $currency ),
 			$quantity,
 			$product instanceof WC_Product ? $this->prepare_item_string( $product->get_description() ) : '',
-			$line_tax ? new Money( $line_tax, $currency ) : null,
+			$unit_tax ? new Money( $unit_tax, $currency ) : null,
 			$product instanceof WC_Product ? $this->prepare_sku( $product->get_sku() ) : '',
 			( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
 			$product instanceof WC_Product ? $product->get_permalink() : '',

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -66,7 +66,7 @@ class ItemFactory {
 					new Money( $price, $this->currency->get() ),
 					$quantity,
 					$this->prepare_item_string( $product->get_description() ),
-					null,
+					isset( $item['line_tax'] ) ? new Money( (float) $item['line_tax'], $this->currency->get() ) : null,
 					$this->prepare_sku( $product->get_sku() ),
 					( $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
 					$product->get_permalink(),
@@ -74,10 +74,7 @@ class ItemFactory {
 					0,
 					$cart_item_key,
 					$product->get_id(),
-					new Money(
-						(float) $item['line_subtotal'] - (float) $item['line_total'],
-						get_woocommerce_currency()
-					)
+					new Money( (float) $item['line_subtotal'] - (float) $item['line_total'], $this->currency->get() )
 				);
 			},
 			$cart->get_cart_contents()
@@ -142,13 +139,14 @@ class ItemFactory {
 		$price_without_tax         = (float) $order->get_item_subtotal( $item, false );
 		$price_without_tax_rounded = round( $price_without_tax, 2 );
 		$image                     = $product instanceof WC_Product ? wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' ) : '';
+		$line_tax                  = $item->get_total_tax() ? (float) $item->get_total_tax() : null;
 
 		return new Item(
 			$this->prepare_item_string( $item->get_name() ),
 			new Money( $price_without_tax_rounded, $currency ),
 			$quantity,
 			$product instanceof WC_Product ? $this->prepare_item_string( $product->get_description() ) : '',
-			null,
+			$line_tax ? new Money( $line_tax, $currency ) : null,
 			$product instanceof WC_Product ? $this->prepare_sku( $product->get_sku() ) : '',
 			( $product instanceof WC_Product && $product->is_virtual() ) ? Item::DIGITAL_GOODS : Item::PHYSICAL_GOODS,
 			$product instanceof WC_Product ? $product->get_permalink() : '',
@@ -156,10 +154,7 @@ class ItemFactory {
 			0,
 			null,
 			$product instanceof WC_Product ? $product->get_id() : null,
-			new Money(
-				(float) $item->get_subtotal() - (float) $item->get_total(),
-				$order->get_currency()
-			)
+			new Money( (float) $item->get_subtotal() - (float) $item->get_total(), $currency )
 		);
 	}
 

--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -62,7 +62,7 @@ class ItemFactory {
 
 				$price    = (float) $item['line_subtotal'] / (float) $item['quantity'];
 				$line_tax = isset( $item['line_tax'] ) ? (float) $item['line_tax'] : 0.0;
-				$unit_tax = $quantity > 0 ? $line_tax / $quantity : 0.0;
+				$unit_tax = $quantity > 0 ? $line_tax / (float) $quantity : 0.0;
 
 				return new Item(
 					$this->prepare_item_string( $product->get_name() ),
@@ -143,7 +143,7 @@ class ItemFactory {
 		$price_without_tax_rounded = round( $price_without_tax, 2 );
 		$image                     = $product instanceof WC_Product ? wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' ) : '';
 		$line_tax                  = (float) $item->get_total_tax();
-		$unit_tax                  = $quantity > 0 ? $line_tax / $quantity : 0.0;
+		$unit_tax                  = $quantity > 0 ? $line_tax / (float) $quantity : 0.0;
 
 		return new Item(
 			$this->prepare_item_string( $item->get_name() ),

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -185,7 +185,7 @@ class ItemFactoryTest extends TestCase
         $order = Mockery::mock(\WC_Order::class);
 	    $order
 		    ->shouldReceive('get_currency')
-		    ->twice()
+		    ->once()
 		    ->andReturn($this->currency->get());
         $order
             ->expects('get_items')
@@ -200,6 +200,7 @@ class ItemFactoryTest extends TestCase
 	    $product->shouldReceive('get_id')->andReturn(123);
 	    $item->shouldReceive('get_subtotal')->andReturn(50.00);
 	    $item->shouldReceive('get_total')->andReturn(40.00);
+	    $item->shouldReceive('get_total_tax')->andReturn(1.00);
 
         $result = $testee->from_wc_order($order);
         $this->assertCount(1, $result);
@@ -247,7 +248,7 @@ class ItemFactoryTest extends TestCase
         $order = Mockery::mock(\WC_Order::class);
 	    $order
 		    ->shouldReceive('get_currency')
-		    ->twice()
+		    ->once()
 		    ->andReturn($this->currency->get());
         $order
             ->expects('get_items')
@@ -271,6 +272,7 @@ class ItemFactoryTest extends TestCase
 	    $product->shouldReceive('get_id')->andReturn(123);
 	    $item->shouldReceive('get_subtotal')->andReturn(50.00);
 	    $item->shouldReceive('get_total')->andReturn(40.00);
+	    $item->shouldReceive('get_total_tax')->andReturn(1.00);
 
 	    $result = $testee->from_wc_order($order);
         $item = current($result);
@@ -314,7 +316,7 @@ class ItemFactoryTest extends TestCase
         $order = Mockery::mock(\WC_Order::class);
 	    $order
 		    ->shouldReceive('get_currency')
-		    ->twice()
+		    ->once()
 		    ->andReturn('EUR');
         $order
             ->expects('get_items')
@@ -338,6 +340,7 @@ class ItemFactoryTest extends TestCase
 	    $product->shouldReceive('get_id')->andReturn(123);
 	    $item->shouldReceive('get_subtotal')->andReturn(50.00);
 	    $item->shouldReceive('get_total')->andReturn(40.00);
+	    $item->shouldReceive('get_total_tax')->andReturn(1.00);
 
 	    $result = $testee->from_wc_order($order);
         $item = current($result);


### PR DESCRIPTION
## Description

Fixes missing line item tax data in PayPal purchase units by properly extracting tax values from WooCommerce cart and order items in `ItemFactory`.

## Problem

Previously, `ItemFactory` was not extracting tax data from WooCommerce items:
- `from_wc_cart()` was passing `null` for the tax parameter
- `from_wc_order_line_item()` was also passing `null` for the tax parameter

This resulted in the `purchase_units[].items[].tax` field being missing or zero in PayPal Orders API requests, even when WooCommerce calculated taxes on the items.

## Solution

Updated `ItemFactory` to properly extract line item tax:

**Cart Items (`from_wc_cart`):**
```php
isset( $item['line_tax'] ) ? new Money( (float) $item['line_tax'], $this->currency->get() ) : null
```

**Order Items (`from_wc_order_line_item`):**
```php
$line_tax = $item->get_total_tax() ? (float) $item->get_total_tax() : null;
// Then create Money object only when tax exists
$line_tax ? new Money( $line_tax, $currency ) : null
```

## Impact

- ✅ **PayPal Orders API**: `purchase_units[].items[].tax` now includes accurate per-line-item tax amounts
- ✅ **Level 2/3 Card Processing**: Enables proper tax reporting required for lower interchange rates
- ✅ **Tax Reporting**: Merchants with tax-enabled stores now send complete tax data to PayPal

## Testing

### Prerequisites
1. Enable taxes: `WooCommerce → Settings → General` → Check "Enable tax rates and calculations"
2. Add tax rate: `WooCommerce → Settings → Tax → Standard rates`
   - Country: US
   - State: CA
   - Rate: 8.5%
3. Ensure product is taxable (Tax status: "Taxable", Tax class: "Standard")

### Test Cases

**Checkout Flow (Cart):**
1. Add taxable product to cart
2. Proceed to checkout
3. Verify PayPal order creation includes `items[].tax` with correct values

**Pay Now Flow (Order):**
1. Create order with taxable products
2. Use "Pay for order" link
3. Verify PayPal order creation includes `items[].tax` with correct values

**Expected Result:**
```json
{
  "purchase_units": [{
    "items": [{
      "name": "Product Name",
      "unit_amount": { "value": "100.00", "currency_code": "USD" },
      "quantity": "1",
      "tax": { "value": "8.50", "currency_code": "USD" }
    }]
  }]
}
```

## Related

Part of Level 2/3 card processing implementation
