### PR TITLE
fix: include payment level data for manually created orders (5836)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -112,7 +112,7 @@ class PurchaseUnitFactory {
 	 *
 	 * @return PurchaseUnit
 	 */
-	public function from_wc_order( \WC_Order $order ): PurchaseUnit {
+	public function from_wc_order( \WC_Order $order, string $payment_method = '' ): PurchaseUnit {
 		$amount = $this->amount_factory->from_wc_order( $order );
 		$items  = array_filter(
 			$this->item_factory->from_wc_order( $order ),
@@ -133,8 +133,9 @@ class PurchaseUnitFactory {
 		$invoice_id      = $this->prefix . $order->get_order_number();
 		$soft_descriptor = $this->sanitize_soft_descriptor( $this->soft_descriptor );
 		$payment_level   = null;
+		$payment_method  = ! empty( $payment_method ) ? $payment_method : $order->get_payment_method();
 
-		if ( $this->payment_level_eligibility->is_eligible( $order->get_payment_method() ) && $this->settings->is_payment_level_processing_enabled() ) {
+		if ( $this->payment_level_eligibility->is_eligible( $payment_method ) && $this->settings->is_payment_level_processing_enabled() ) {
 			$payment_level = $this->payment_level_helper->build( $amount, $items, $shipping );
 		}
 

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -310,7 +310,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 						)
 					);
 				}
-				$this->purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
+				$this->purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order, $payment_method );
 			} else {
 				$this->purchase_unit = $this->purchase_unit_factory->from_wc_cart( null, $this->should_handle_shipping_in_paypal( $funding_source ), $payment_method );
 


### PR DESCRIPTION
## Description

Fixes missing Level 2/3 payment data (`supplementary_data`) in PayPal Orders API requests when paying for manually created orders that don't have a payment method set.

## Problem

When merchants manually create orders in WooCommerce without selecting a payment method, `$order->get_payment_method()` returns an empty string. This caused the eligibility check for Level 2/3 processing to fail:
```php
// This would fail because get_payment_method() returns ''
if ( $this->payment_level_eligibility->is_eligible( $order->get_payment_method() ) 
     && $this->settings->is_payment_level_processing_enabled() ) {
    $payment_level = $this->payment_level_helper->build( $amount, $items, $shipping );
}
```

**Result:** `supplementary_data` was missing from PayPal API requests, preventing merchants from qualifying for lower Level 2/3 interchange rates.

## Solution

Updated `PurchaseUnitFactory::from_wc_order()` to accept an optional `$payment_method` parameter that can be passed from the request handler:
```php
public function from_wc_order( \WC_Order $order, string $payment_method = '' ): PurchaseUnit {
    // Prioritize request payment method, fall back to order's payment method
    $payment_method = ! empty( $payment_method ) ? $payment_method : $order->get_payment_method();
    
    if ( $this->payment_level_eligibility->is_eligible( $payment_method ) 
         && $this->settings->is_payment_level_processing_enabled() ) {
        $payment_level = $this->payment_level_helper->build( $amount, $items, $shipping );
    }
}
```

The request handler now passes the payment method from request data:
```php
if ( 'pay-now' === $data['context'] ) {
    $wc_order = wc_get_order( (int) $data['order_id'] );
    $this->purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order, $payment_method );
}
```

## Impact

- ✅ **Pay-now flow:** Level 2/3 data now included for manually created orders
- ✅ **Backward compatibility:** Existing code paths continue working without changes
- ✅ **Lower interchange rates:** Merchants can now qualify for Level 2/3 rates on all eligible orders

## Testing

### Prerequisites
1. Enable Level 2/3 processing in plugin settings
2. Configure store for US location with USD currency
3. Enable taxes and configure tax rate

### Test Cases

**Scenario 1: Manually created order without payment method**
1. Go to `WooCommerce → Orders → Add Order`
2. Add products, set billing/shipping address
3. Do NOT select a payment method in the order
4. Save order
5. Customer uses "Pay for order" link and pays with ACDC
6. Verify PayPal API request includes `supplementary_data` with Level 2/3 data

**Scenario 2: Manually created order with payment method**
1. Create order and select PayPal payment method
2. Customer uses "Pay for order" link
3. Verify PayPal API request includes `supplementary_data`

**Scenario 3: Regular checkout flow (unchanged)**
1. Customer goes through normal checkout
2. Verify PayPal API request includes `supplementary_data` as before

