### PR TITLE
Cache order requests

### DIFF
--- a/api/order-functions.php
+++ b/api/order-functions.php
@@ -34,16 +34,6 @@ use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
  * @throws Exception When the operation fails.
  */
 function ppcp_get_paypal_order( $paypal_id_or_wc_order ): Order {
-	if ( $paypal_id_or_wc_order instanceof WC_Order ) {
-		$paypal_id_or_wc_order = $paypal_id_or_wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
-		if ( ! $paypal_id_or_wc_order ) {
-			throw new InvalidArgumentException( 'PayPal order ID not found in meta.' );
-		}
-	}
-	if ( ! is_string( $paypal_id_or_wc_order ) ) {
-		throw new InvalidArgumentException( 'Invalid PayPal order ID, string expected.' );
-	}
-
 	$order_endpoint = PPCP::container()->get( 'api.endpoint.order' );
 	assert( $order_endpoint instanceof OrderEndpoint );
 

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -267,7 +267,7 @@ return array(
 			$bn_code
 		);
 	},
-	'api.endpoint.order.cached'                      => static function ( ContainerInterface $container ): OrderEndpoint {
+	'api.endpoint.order.cached'                      => static function ( ContainerInterface $container ): OrderEndpointCached {
 		$session_handler = $container->get( 'session.handler' );
 		assert( $session_handler instanceof SessionHandler );
 		$bn_code         = $session_handler->bn_code();

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\CatalogProducts;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\IdentityToken;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\LoginSeller;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpointCached;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnerReferrals;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
@@ -251,16 +252,39 @@ return array(
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
-		$intent                         = $settings->has( 'intent' ) && strtoupper( (string) $settings->get( 'intent' ) ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
-		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
+		$intent = $settings->has( 'intent' ) && strtoupper( (string) $settings->get( 'intent' ) ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
+
 		return new OrderEndpoint(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
-			$order_factory,
-			$patch_collection_factory,
+			$container->get( 'api.factory.order' ),
+			$container->get( 'api.factory.patch-collection-factory' ),
 			$intent,
-			$logger,
-			$subscription_helper,
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'wc-subscriptions.helper' ),
+			$container->get( 'wcgateway.is-fraudnet-enabled' ),
+			$container->get( 'wcgateway.fraudnet' ),
+			$bn_code
+		);
+	},
+	'api.endpoint.order.cached'                      => static function ( ContainerInterface $container ): OrderEndpoint {
+		$session_handler = $container->get( 'session.handler' );
+		assert( $session_handler instanceof SessionHandler );
+		$bn_code         = $session_handler->bn_code();
+
+		$settings = $container->get( 'wcgateway.settings' );
+		assert( $settings instanceof Settings );
+
+		$intent = $settings->has( 'intent' ) && strtoupper( (string) $settings->get( 'intent' ) ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
+
+		return new OrderEndpointCached(
+			$container->get( 'api.host' ),
+			$container->get( 'api.bearer' ),
+			$container->get( 'api.factory.order' ),
+			$container->get( 'api.factory.patch-collection-factory' ),
+			$intent,
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'wc-subscriptions.helper' ),
 			$container->get( 'wcgateway.is-fraudnet-enabled' ),
 			$container->get( 'wcgateway.fraudnet' ),
 			$bn_code

--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -244,10 +244,6 @@ return array(
 		);
 	},
 	'api.endpoint.order'                             => static function ( ContainerInterface $container ): OrderEndpoint {
-		$order_factory            = $container->get( 'api.factory.order' );
-		$patch_collection_factory = $container->get( 'api.factory.patch-collection-factory' );
-		$logger                   = $container->get( 'woocommerce.logger.woocommerce' );
-
 		$session_handler = $container->get( 'session.handler' );
 		assert( $session_handler instanceof SessionHandler );
 		$bn_code         = $session_handler->bn_code();

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -9,7 +9,9 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
 
+use InvalidArgumentException;
 use stdClass;
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
@@ -26,6 +28,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PatchCollectionFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ErrorResponse;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcGateway\FraudNet\FraudNet;
 use WP_Error;
@@ -425,14 +428,17 @@ class OrderEndpoint {
 	/**
 	 * Fetches an order for a given ID.
 	 *
-	 * @param string $id The ID.
+	 * @param string|WC_Order $paypal_id_or_wc_order The ID of PayPal order or a WC order (with the ID in meta).
 	 *
 	 * @return Order
 	 * @throws RuntimeException If the request fails.
+	 * @throws InvalidArgumentException If the ID is not a string or WC order with the ID in meta.
 	 */
-	public function order( string $id ): Order {
+	public function order( $paypal_id_or_wc_order ): Order {
+		$paypal_id = $this->resolve_paypal_id( $paypal_id_or_wc_order );
+
 		$bearer = $this->bearer->bearer();
-		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $id;
+		$url    = trailingslashit( $this->host ) . 'v2/checkout/orders/' . $paypal_id;
 		$args   = array(
 			'headers' => array(
 				'Authorization' => 'Bearer ' . $bearer->token(),
@@ -607,5 +613,29 @@ class OrderEndpoint {
 		}
 
 		return $json;
+	}
+
+	/**
+	 * Resolves the PayPal order ID from the given argument.
+	 *
+	 * @param string|WC_Order $paypal_id_or_wc_order The ID of PayPal order or a WC order (with the ID in meta).
+	 *
+	 * @return string The PayPal order ID.
+	 * @throws InvalidArgumentException If the ID cannot be resolved.
+	 */
+	protected function resolve_paypal_id( $paypal_id_or_wc_order ): string {
+		if ( $paypal_id_or_wc_order instanceof WC_Order ) {
+			$paypal_id = $paypal_id_or_wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY );
+			if ( ! $paypal_id ) {
+				throw new InvalidArgumentException( 'PayPal order ID not found in meta.' );
+			}
+			return $paypal_id;
+		}
+
+		if ( ! is_string( $paypal_id_or_wc_order ) ) {
+			throw new InvalidArgumentException( 'Invalid PayPal order ID, string expected.' );
+		}
+
+		return $paypal_id_or_wc_order;
 	}
 }

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpointCached.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpointCached.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+
+/**
+ * Extends OrderEndpoint to provide in-memory caching for order() calls.
+ */
+class OrderEndpointCached extends OrderEndpoint {
+
+	/**
+	 * In-memory cache for orders, keyed by PayPal order ID.
+	 *
+	 * @var array<string, Order>
+	 */
+	private array $order_cache = array();
+
+	/**
+	 * Fetches an order for a given ID, with in-memory caching.
+	 *
+	 * @param string|WC_Order $paypal_id_or_wc_order The ID of PayPal order or a WC order (with the ID in meta).
+	 *
+	 * @return Order
+	 */
+	public function order( $paypal_id_or_wc_order ): Order {
+		$paypal_id = $this->resolve_paypal_id( $paypal_id_or_wc_order );
+
+		if ( isset( $this->order_cache[ $paypal_id ] ) ) {
+			return $this->order_cache[ $paypal_id ];
+		}
+
+		$order = parent::order( $paypal_id );
+
+		$this->order_cache[ $paypal_id ] = $order;
+
+		return $order;
+	}
+}

--- a/modules/ppcp-order-tracking/services.php
+++ b/modules/ppcp-order-tracking/services.php
@@ -41,7 +41,8 @@ return array(
 			$container->get( 'button.request-data' ),
 			$container->get( 'order-tracking.shipment.factory' ),
 			$container->get( 'order-tracking.allowed-shipping-statuses' ),
-			$container->get( 'order-tracking.should-use-second-version-of-api' )
+			$container->get( 'order-tracking.should-use-second-version-of-api' ),
+			$container->get( 'api.endpoint.order.cached' )
 		);
 	},
 	'order-tracking.asset_getter'                     => static function ( ContainerInterface $container ): AssetGetter {

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -14,6 +14,7 @@ use Psr\Log\LoggerInterface;
 use stdClass;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
@@ -23,7 +24,6 @@ use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
-use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * The OrderTrackingEndpoint.
@@ -95,9 +95,9 @@ class OrderTrackingEndpoint {
 	 */
 	protected $should_use_new_api;
 
+	protected OrderEndpoint $order_endpoint;
+
 	/**
-	 * PartnersEndpoint constructor.
-	 *
 	 * @param string                   $host The host.
 	 * @param Bearer                   $bearer The bearer.
 	 * @param LoggerInterface          $logger The logger.
@@ -105,6 +105,7 @@ class OrderTrackingEndpoint {
 	 * @param ShipmentFactoryInterface $shipment_factory The ShipmentFactory.
 	 * @param string[]                 $allowed_statuses Allowed shipping statuses.
 	 * @param bool                     $should_use_new_api Whether new API should be used.
+	 * @param OrderEndpoint            $order_endpoint The OrderEndpoint.
 	 */
 	public function __construct(
 		string $host,
@@ -113,7 +114,8 @@ class OrderTrackingEndpoint {
 		RequestData $request_data,
 		ShipmentFactoryInterface $shipment_factory,
 		array $allowed_statuses,
-		bool $should_use_new_api
+		bool $should_use_new_api,
+		OrderEndpoint $order_endpoint
 	) {
 		$this->host               = $host;
 		$this->bearer             = $bearer;
@@ -122,6 +124,7 @@ class OrderTrackingEndpoint {
 		$this->shipment_factory   = $shipment_factory;
 		$this->allowed_statuses   = $allowed_statuses;
 		$this->should_use_new_api = $should_use_new_api;
+		$this->order_endpoint     = $order_endpoint;
 	}
 
 	/**
@@ -275,7 +278,7 @@ class OrderTrackingEndpoint {
 		}
 
 		$host         = trailingslashit( $this->host );
-		$paypal_order = ppcp_get_paypal_order( $wc_order );
+		$paypal_order = $this->order_endpoint->order( $wc_order );
 		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order ) ?? '';
 		$tracker_id   = $this->find_tracker_id( $capture_id, $tracking_number );
 		$url          = "{$host}v1/shipping/trackers/{$tracker_id}";
@@ -324,7 +327,7 @@ class OrderTrackingEndpoint {
 		}
 
 		$host         = trailingslashit( $this->host );
-		$paypal_order = ppcp_get_paypal_order( $wc_order );
+		$paypal_order = $this->order_endpoint->order( $wc_order );
 		$capture_id   = $this->get_paypal_order_transaction_id( $paypal_order );
 		$url          = "{$host}v1/shipping/trackers?transaction_id={$capture_id}";
 

--- a/modules/ppcp-order-tracking/src/OrderTrackingModule.php
+++ b/modules/ppcp-order-tracking/src/OrderTrackingModule.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\OrderTracking;
 use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 use Exception;
 use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -23,7 +24,6 @@ use WooCommerce\PayPalCommerce\OrderTracking\Endpoint\OrderTrackingEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
 use WP_Post;
-use function WooCommerce\PayPalCommerce\Api\ppcp_get_paypal_order;
 
 /**
  * Class OrderTrackingModule
@@ -109,8 +109,11 @@ class OrderTrackingModule implements ServiceModule, ExtendingModule, ExecutableM
 					return;
 				}
 
+				$order_endpoint = $c->get( 'api.endpoint.order.cached' );
+				assert( $order_endpoint instanceof OrderEndpoint );
+
 				try {
-					$paypal_order = ppcp_get_paypal_order( $wc_order );
+					$paypal_order = $order_endpoint->order( $wc_order );
 				} catch ( Exception $exception ) {
 					return;
 				}

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2273,7 +2273,7 @@ return array(
 		return new VoidButtonAssets(
 			$container->get( 'wcgateway.asset_getter' ),
 			$container->get( 'ppcp.asset-version' ),
-			$container->get( 'api.endpoint.order' ),
+			$container->get( 'api.endpoint.order.cached' ),
 			$container->get( 'wcgateway.processor.refunds' )
 		);
 	},

--- a/modules/ppcp-wc-gateway/src/Assets/VoidButtonAssets.php
+++ b/modules/ppcp-wc-gateway/src/Assets/VoidButtonAssets.php
@@ -96,13 +96,8 @@ class VoidButtonAssets {
 			return false;
 		}
 
-		$order_id = $theorder->get_meta( PayPalGateway::ORDER_ID_META_KEY );
-		if ( ! $order_id ) {
-			return false;
-		}
-
 		try {
-			$order = $this->order_endpoint->order( $order_id );
+			$order = $this->order_endpoint->order( $theorder );
 
 			if ( $this->refund_processor->determine_refund_mode( $order ) !== RefundProcessor::REFUND_MODE_VOID ) {
 				return false;

--- a/tests/PHPUnit/Api/GetOrderTest.php
+++ b/tests/PHPUnit/Api/GetOrderTest.php
@@ -39,13 +39,10 @@ class GetOrderTest extends ModularTestCase
 
 	public function testSuccessWithOrder(): void {
 		$wcOrder = Mockery::mock(WC_Order::class);
-		$wcOrder->expects('get_meta')
-			->with(PayPalGateway::ORDER_ID_META_KEY)
-			->andReturn('123abc');
 
 		$this->orderEndpoint
 			->expects('order')
-			->with('123abc')
+			->with($wcOrder)
 			->andReturn(Mockery::mock(Order::class))
 			->once();
 
@@ -54,9 +51,12 @@ class GetOrderTest extends ModularTestCase
 
 	public function testOrderWithoutId(): void {
 		$wcOrder = Mockery::mock(WC_Order::class);
-		$wcOrder->expects('get_meta')
-			->with(PayPalGateway::ORDER_ID_META_KEY)
-			->andReturn(false);
+
+		$this->orderEndpoint
+			->expects('order')
+			->with($wcOrder)
+			->andThrow(new InvalidArgumentException())
+			->once();
 
 		$this->expectException(InvalidArgumentException::class);
 
@@ -76,6 +76,12 @@ class GetOrderTest extends ModularTestCase
 	}
 
 	public function testInvalidId(): void {
+		$this->orderEndpoint
+			->expects('order')
+			->with(123)
+			->andThrow(new InvalidArgumentException())
+			->once();
+
 		$this->expectException(InvalidArgumentException::class);
 
 		ppcp_get_paypal_order(123);

--- a/tests/PHPUnit/Api/OrderRefundTest.php
+++ b/tests/PHPUnit/Api/OrderRefundTest.php
@@ -36,13 +36,10 @@ class OrderRefundTest extends ModularTestCase
 
 	public function testSuccess(): void {
 		$wcOrder = Mockery::mock(WC_Order::class);
-		$wcOrder->expects('get_meta')
-			->with(PayPalGateway::ORDER_ID_META_KEY)
-			->andReturn('123abc');
 
 		$this->orderEndpoint
 			->expects('order')
-			->with('123abc')
+			->with($wcOrder)
 			->andReturn(Mockery::mock(Order::class))
 			->once();
 
@@ -57,9 +54,12 @@ class OrderRefundTest extends ModularTestCase
 
 	public function testOrderWithoutId(): void {
 		$wcOrder = Mockery::mock(WC_Order::class);
-		$wcOrder->expects('get_meta')
-			->with(PayPalGateway::ORDER_ID_META_KEY)
-			->andReturn(false);
+
+		$this->orderEndpoint
+			->expects('order')
+			->with($wcOrder)
+			->andThrow(new InvalidArgumentException())
+			->once();
 
 		$this->expectException(InvalidArgumentException::class);
 
@@ -68,13 +68,10 @@ class OrderRefundTest extends ModularTestCase
 
 	public function testFailure(): void {
 		$wcOrder = Mockery::mock(WC_Order::class);
-		$wcOrder->expects('get_meta')
-			->with(PayPalGateway::ORDER_ID_META_KEY)
-			->andReturn('123abc');
 
 		$this->orderEndpoint
 			->expects('order')
-			->with('123abc')
+			->with($wcOrder)
 			->andReturn(Mockery::mock(Order::class))
 			->once();
 

--- a/tests/PHPUnit/Api/OrderVoidTest.php
+++ b/tests/PHPUnit/Api/OrderVoidTest.php
@@ -36,13 +36,10 @@ class OrderVoidTest extends ModularTestCase
 
 	public function testSuccess(): void {
 		$wcOrder = Mockery::mock(WC_Order::class);
-		$wcOrder->expects('get_meta')
-			->with(PayPalGateway::ORDER_ID_META_KEY)
-			->andReturn('123abc');
 
 		$this->orderEndpoint
 			->expects('order')
-			->with('123abc')
+			->with($wcOrder)
 			->andReturn(Mockery::mock(Order::class))
 			->once();
 
@@ -55,9 +52,12 @@ class OrderVoidTest extends ModularTestCase
 
 	public function testOrderWithoutId(): void {
 		$wcOrder = Mockery::mock(WC_Order::class);
-		$wcOrder->expects('get_meta')
-			->with(PayPalGateway::ORDER_ID_META_KEY)
-			->andReturn(false);
+
+		$this->orderEndpoint
+			->expects('order')
+			->with($wcOrder)
+			->andThrow(new InvalidArgumentException())
+			->once();
 
 		$this->expectException(InvalidArgumentException::class);
 
@@ -66,13 +66,10 @@ class OrderVoidTest extends ModularTestCase
 
 	public function testFailure(): void {
 		$wcOrder = Mockery::mock(WC_Order::class);
-		$wcOrder->expects('get_meta')
-			->with(PayPalGateway::ORDER_ID_META_KEY)
-			->andReturn('123abc');
 
 		$this->orderEndpoint
 			->expects('order')
-			->with('123abc')
+			->with($wcOrder)
 			->andReturn(Mockery::mock(Order::class))
 			->once();
 

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointCachedTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointCachedTest.php
@@ -1,0 +1,216 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PatchCollectionFactory;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use WooCommerce\PayPalCommerce\WcGateway\FraudNet\FraudNet;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+class OrderEndpointCachedTest extends TestCase
+{
+	private function createBearer(): Bearer
+	{
+		$token = Mockery::mock(Token::class);
+		$bearer = Mockery::mock(Bearer::class);
+
+		$token->shouldReceive('token')->andReturn('bearer');
+		$bearer->shouldReceive('bearer')->andReturn($token);
+
+		return $bearer;
+	}
+
+	private function setupHttpResponse(int $callCount = 1): void
+	{
+		expect('wp_json_encode')->andReturnUsing('json_encode');
+		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+		$headers->shouldReceive('getAll');
+		$rawResponse = [
+			'body' => '{}',
+			'headers' => $headers,
+		];
+
+		$expectation = expect('wp_remote_get');
+		$expectation->times($callCount);
+		$expectation->andReturn($rawResponse);
+
+		expect('is_wp_error')->with($rawResponse)->andReturn(false);
+		expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(200);
+	}
+
+	private function createTestee(OrderFactory $orderFactory): OrderEndpointCached
+	{
+		$logger = Mockery::mock(LoggerInterface::class);
+		$logger->shouldReceive('debug');
+
+		return new OrderEndpointCached(
+			'https://example.com/',
+			$this->createBearer(),
+			$orderFactory,
+			Mockery::mock(PatchCollectionFactory::class),
+			'CAPTURE',
+			$logger,
+			Mockery::mock(SubscriptionHelper::class),
+			false,
+			Mockery::mock(FraudNet::class)
+		);
+	}
+
+	public function testOrderReturnsCachedResultOnSecondCall()
+	{
+		$orderId = 'abc123';
+		$order = Mockery::mock(Order::class);
+		$orderFactory = Mockery::mock(OrderFactory::class);
+		$orderFactory
+			->expects('from_paypal_response')
+			->once()
+			->andReturn($order);
+
+		$testee = $this->createTestee($orderFactory);
+		$this->setupHttpResponse(1);
+
+		// First call should hit the API
+		$result1 = $testee->order($orderId);
+		$this->assertEquals($order, $result1);
+
+		// Second call should return cached result
+		$result2 = $testee->order($orderId);
+		$this->assertEquals($order, $result2);
+		$this->assertSame($result1, $result2);
+	}
+
+	public function testOrderWithWcOrderReturnsCachedResult()
+	{
+		$orderId = 'abc123';
+		$wcOrder = Mockery::mock(WC_Order::class);
+		$wcOrder
+			->shouldReceive('get_meta')
+			->with(PayPalGateway::ORDER_ID_META_KEY)
+			->andReturn($orderId);
+
+		$order = Mockery::mock(Order::class);
+		$orderFactory = Mockery::mock(OrderFactory::class);
+		$orderFactory
+			->expects('from_paypal_response')
+			->once()
+			->andReturn($order);
+
+		$testee = $this->createTestee($orderFactory);
+		$this->setupHttpResponse(1);
+
+		// First call with WC_Order should hit the API
+		$result1 = $testee->order($wcOrder);
+		$this->assertEquals($order, $result1);
+
+		// Second call with same WC_Order should return cached result
+		$result2 = $testee->order($wcOrder);
+		$this->assertEquals($order, $result2);
+		$this->assertSame($result1, $result2);
+	}
+
+	public function testOrderWithStringAndWcOrderReturnsSameCachedResult()
+	{
+		$orderId = 'abc123';
+		$wcOrder = Mockery::mock(WC_Order::class);
+		$wcOrder
+			->shouldReceive('get_meta')
+			->with(PayPalGateway::ORDER_ID_META_KEY)
+			->andReturn($orderId);
+
+		$order = Mockery::mock(Order::class);
+		$orderFactory = Mockery::mock(OrderFactory::class);
+		$orderFactory
+			->expects('from_paypal_response')
+			->once()
+			->andReturn($order);
+
+		$testee = $this->createTestee($orderFactory);
+		$this->setupHttpResponse(1);
+
+		// First call with string ID should hit the API
+		$result1 = $testee->order($orderId);
+		$this->assertEquals($order, $result1);
+
+		// Second call with WC_Order (same PayPal ID) should return cached result
+		$result2 = $testee->order($wcOrder);
+		$this->assertEquals($order, $result2);
+		$this->assertSame($result1, $result2);
+	}
+
+	public function testOrderWithDifferentIdsDoesNotReturnCachedResult()
+	{
+		$orderId1 = 'abc123';
+		$orderId2 = 'def456';
+		$order1 = Mockery::mock(Order::class);
+		$order2 = Mockery::mock(Order::class);
+		$orderFactory = Mockery::mock(OrderFactory::class);
+		$orderFactory
+			->expects('from_paypal_response')
+			->twice()
+			->andReturnUsing(function () use ($order1, $order2) {
+				static $callCount = 0;
+				$callCount++;
+				return $callCount === 1 ? $order1 : $order2;
+			});
+
+		$testee = $this->createTestee($orderFactory);
+		$this->setupHttpResponse(2);
+
+		// First call with first ID
+		$result1 = $testee->order($orderId1);
+		$this->assertEquals($order1, $result1);
+
+		// Second call with different ID should hit the API again
+		$result2 = $testee->order($orderId2);
+		$this->assertEquals($order2, $result2);
+		$this->assertNotSame($result1, $result2);
+	}
+
+	public function testOrderCachesMultipleOrders()
+	{
+		$orderId1 = 'abc123';
+		$orderId2 = 'def456';
+		$order1 = Mockery::mock(Order::class);
+		$order2 = Mockery::mock(Order::class);
+		$orderFactory = Mockery::mock(OrderFactory::class);
+		$orderFactory
+			->expects('from_paypal_response')
+			->twice()
+			->andReturnUsing(function () use ($order1, $order2) {
+				static $callCount = 0;
+				$callCount++;
+				return $callCount === 1 ? $order1 : $order2;
+			});
+
+		$testee = $this->createTestee($orderFactory);
+		$this->setupHttpResponse(2);
+
+		// Cache first order
+		$result1 = $testee->order($orderId1);
+		$this->assertEquals($order1, $result1);
+
+		// Cache second order
+		$result2 = $testee->order($orderId2);
+		$this->assertEquals($order2, $result2);
+
+		// Verify first order is still cached
+		$result1Again = $testee->order($orderId1);
+		$this->assertEquals($order1, $result1Again);
+		$this->assertSame($result1, $result1Again);
+
+		// Verify second order is still cached
+		$result2Again = $testee->order($orderId2);
+		$this->assertEquals($order2, $result2Again);
+		$this->assertSame($result2, $result2Again);
+	}
+}

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
@@ -3,8 +3,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
 
-use Hamcrest\Matchers;
-use Requests_Utility_CaseInsensitiveDictionary;
+use InvalidArgumentException;
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Address;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
@@ -14,7 +14,6 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PatchCollection;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\PayerName;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
@@ -25,6 +24,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\PatchCollectionFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ErrorResponse;
 use Mockery;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\FraudNet\FraudNet;
@@ -42,10 +42,26 @@ class OrderEndpointTest extends TestCase
 		$this->shipping = new Shipping('shipping', new Address('US', 'street', '', 'CA', '', '12345'));
 	}
 
-	public function testOrderDefault()
+	public static function orderValidInputsDataProvider(): array
+	{
+		$wcOrder = Mockery::mock(WC_Order::class);
+		$wcOrder
+			->shouldReceive('get_meta')
+			->with(PayPalGateway::ORDER_ID_META_KEY)
+			->andReturn('abc123');
+
+		return [
+			['abc123', 'abc123'],
+			[$wcOrder, 'abc123'],
+		];
+	}
+
+	/**
+	 * @dataProvider orderValidInputsDataProvider
+	 */
+	public function testOrderDefault($input, string $orderId)
     {
 	    expect('wp_json_encode')->andReturnUsing('json_encode');
-        $orderId = 'id';
         $host = 'https://example.com/';
         $token = Mockery::mock(Token::class);
         $token
@@ -103,8 +119,44 @@ class OrderEndpointTest extends TestCase
         expect('is_wp_error')->with($rawResponse)->andReturn(false);
         expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(200);
 
-        $result = $testee->order($orderId);
+        $result = $testee->order($input);
         $this->assertEquals($order, $result);
+    }
+
+	public static function orderInvalidInputsDataProvider(): array
+	{
+		$wcOrder = Mockery::mock(WC_Order::class);
+		$wcOrder
+			->shouldReceive('get_meta')
+			->with(PayPalGateway::ORDER_ID_META_KEY)
+			->andReturnFalse();
+
+		return [
+			[123],
+			[$wcOrder],
+		];
+	}
+
+	/**
+	 * @dataProvider orderInvalidInputsDataProvider
+	 */
+	public function testOrderInvalidInput($input)
+    {
+		$testee = new OrderEndpoint(
+			'https://example.com/',
+			Mockery::mock(Bearer::class),
+			Mockery::mock(OrderFactory::class),
+			Mockery::mock(PatchCollectionFactory::class),
+			'CAPTURE',
+			Mockery::mock(LoggerInterface::class),
+			Mockery::mock(SubscriptionHelper::class),
+			false,
+			Mockery::mock(FraudNet::class)
+		);
+
+		$this->expectException(InvalidArgumentException::class);
+
+        $testee->order($input);
     }
 
     public function testOrderResponseIsWpError()


### PR DESCRIPTION
Added `OrderEndpointCached` that caches the `order` calls in an array, so that we do not perform the same API requests at least during the same page request. Such as when visiting a WC order page, there were 3 order requests, now there is only 1.

Also, the `order` method now can accept a WC order (to retrieve the PayPal ID from the meta), because we seem to need to do it in many places and it does not make much sense to duplicate it every time.

Currently using the cached version only for the 3 WC order page requests, but it probably should be fine to use it in most (all?) other places.