### PR TITLE
Fix button style for GooglePay/Apple Pay (5789)

### DIFF
--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -221,14 +221,16 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 				$styles->label = PropertiesDictionary::map_type( $styles->label );
 
 				return $styles;
-			}
+			},
+			9999
 		);
 
 		add_filter(
 			'woocommerce_paypal_payments_applepay_button_language',
 			static function ( string $language ): string {
 				return PropertiesDictionary::map_language( $language );
-			}
+			},
+			9999
 		);
 
 		return true;

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -25,6 +25,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameI
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 
 /**
  * Class ApplepayModule
@@ -106,7 +107,7 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 			 *
 			 * @psalm-suppress MissingClosureParamType
 			 */
-			function ( $uid, $action ) {
+			static function ( $uid, $action ) {
 				if ( $action === PropertiesDictionary::NONCE_ACTION ) {
 					return 0;
 				}
@@ -211,6 +212,23 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 			},
 			10,
 			3
+		);
+
+		add_filter(
+			'woocommerce_paypal_payments_applepay_button_styles',
+			static function ( LocationStylingDTO $styles ): LocationStylingDTO {
+				$styles->color = PropertiesDictionary::map_color( $styles->color );
+				$styles->label = PropertiesDictionary::map_type( $styles->label );
+
+				return $styles;
+			}
+		);
+
+		add_filter(
+			'woocommerce_paypal_payments_applepay_button_language',
+			static function ( string $language ): string {
+				return PropertiesDictionary::map_language( $language );
+			}
 		);
 
 		return true;

--- a/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
+++ b/modules/ppcp-applepay/src/Assets/PropertiesDictionary.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * The Applepay module.
+ * The Apple Pay module.
  *
  * @package WooCommerce\PayPalCommerce\Applepay
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Applepay\Assets;
 
@@ -27,7 +27,6 @@ class PropertiesDictionary {
 
 	public const BILLING_DATA_MODE_USE_WC       = 'use_wc';
 	public const BILLING_DATA_MODE_USE_APPLEPAY = 'use_applepay';
-	public const BILLING_DATA_MODE_DEFAULT      = self::BILLING_DATA_MODE_USE_WC;
 
 	public const CREATE_ORDER_SINGLE_PROD_REQUIRED_FIELDS =
 		array(
@@ -87,7 +86,6 @@ class PropertiesDictionary {
 	public const SHIPPING_CONTACT_INVALID = 'shipping Contact Invalid';
 	public const BILLING_CONTACT          = 'billing_contact';
 
-	public const NONCE        = 'nonce';
 	public const NONCE_ACTION = 'woocommerce-process_checkout';
 	public const WCNONCE      = 'woocommerce-process-checkout-nonce';
 
@@ -105,98 +103,131 @@ class PropertiesDictionary {
 	public const UPDATE_SHIPPING_CONTACT = 'ppcp_update_shipping_contact';
 	public const UPDATE_SHIPPING_METHOD  = 'ppcp_update_shipping_method';
 	public const CREATE_ORDER            = 'ppcp_create_order';
-	public const CREATE_ORDER_CART       = 'ppcp_create_order_cart';
-	public const REDIRECT                = 'ppcp_redirect';
 	public const VALIDATE                = 'ppcp_validate';
 
+	private const VALID_COLORS = array(
+		'white',
+		'black',
+		'white-outline',
+	);
+
+	private const VALID_TYPES = array(
+		'book',
+		'buy',
+		'check-out',
+		'donate',
+		'order',
+		'pay',
+		'plain',
+		'subscribe',
+		'add-money',
+		'continue',
+		'contribute',
+		'reload',
+		'rent',
+		'setup',
+		'support',
+		'tip',
+		'top-up',
+	);
+
+	private const VALID_LANGUAGES = array(
+		'',
+		'ar-AB',
+		'ca-ES',
+		'cs-CZ',
+		'da-DK',
+		'de-DE',
+		'el-GR',
+		'en-AU',
+		'en-GB',
+		'en-US',
+		'es-ES',
+		'es-MX',
+		'fi-FI',
+		'fr-CA',
+		'fr-FR',
+		'he-IL',
+		'hi-IN',
+		'hr-HR',
+		'hu-HU',
+		'id-ID',
+		'it-IT',
+		'ja-JP',
+		'ko-KR',
+		'ms-MY',
+		'nb-NO',
+		'nl-NL',
+		'pl-PL',
+		'pt-BR',
+		'pt-PT',
+		'ro-RO',
+		'ru-RU',
+		'sk-SK',
+		'sv-SE',
+		'th-TH',
+		'tr-TR',
+		'uk-UA',
+		'vi-VN',
+		'zh-CN',
+		'zh-HK',
+		'zh-TW',
+	);
+
 	/**
-	 * Returns the possible list of button colors.
-	 *
-	 * @return array
+	 * Maps a color value from the React settings UI's "Styling" tab to a color-key
+	 * that is supported by the Apple Pay button.
 	 */
-	public static function button_colors(): array {
-		return array(
-			'white'         => __( 'White', 'woocommerce-paypal-payments' ),
-			'black'         => __( 'Black', 'woocommerce-paypal-payments' ),
-			'white-outline' => __( 'White with outline', 'woocommerce-paypal-payments' ),
-		);
+	public static function map_color( string $color ): string {
+		if ( in_array( $color, self::VALID_COLORS, true ) ) {
+			return $color;
+		}
+
+		switch ( $color ) {
+			case 'silver':
+				return 'white';
+
+			case 'gold':
+			case 'blue':
+			default:
+				return 'black';
+		}
 	}
 
 	/**
-	 * Returns the possible list of button types.
-	 *
-	 * @return array
+	 * Maps the "label" string from the React settings UI's "Styling" tab to a button type
+	 * that is supported by the Apple Pay button.
 	 */
-	public static function button_types(): array {
-		return array(
-			'book'       => __( 'Book', 'woocommerce-paypal-payments' ),
-			'buy'        => __( 'Buy', 'woocommerce-paypal-payments' ),
-			'check-out'  => __( 'Checkout', 'woocommerce-paypal-payments' ),
-			'donate'     => __( 'Donate', 'woocommerce-paypal-payments' ),
-			'order'      => __( 'Order', 'woocommerce-paypal-payments' ),
-			'pay'        => __( 'Pay', 'woocommerce-paypal-payments' ),
-			'plain'      => __( 'Plain', 'woocommerce-paypal-payments' ),
-			'subscribe'  => __( 'Book', 'woocommerce-paypal-payments' ),
-			'add-money'  => __( 'Add money', 'woocommerce-paypal-payments' ),
-			'continue'   => __( 'Continue', 'woocommerce-paypal-payments' ),
-			'contribute' => __( 'Contribute', 'woocommerce-paypal-payments' ),
-			'reload'     => __( 'Reload', 'woocommerce-paypal-payments' ),
-			'rent'       => __( 'Rent', 'woocommerce-paypal-payments' ),
-			'setup'      => __( 'Setup', 'woocommerce-paypal-payments' ),
-			'support'    => __( 'Support', 'woocommerce-paypal-payments' ),
-			'tip'        => __( 'Tip', 'woocommerce-paypal-payments' ),
-			'top-up'     => __( 'Top up', 'woocommerce-paypal-payments' ),
-		);
+	public static function map_type( string $label ): string {
+		if ( in_array( $label, self::VALID_TYPES, true ) ) {
+			return $label;
+		}
+
+		switch ( $label ) {
+			case 'checkout':
+				return 'check-out';
+
+			case 'buynow':
+				return 'buy';
+
+			case 'paypal':
+			default:
+				return 'plain';
+		}
 	}
 
 	/**
-	 * Returns the possible list of button languages.
-	 *
-	 * @return array
+	 * Translates the plugin's "language" setting to a valid language identifier that
+	 * the Apple Pay button understands.
 	 */
-	public static function button_languages(): array {
-		return array(
-			''      => __( 'Browser language', 'woocommerce-paypal-payments' ),
-			'ar-AB' => __( 'Arabic', 'woocommerce-paypal-payments' ),
-			'ca-ES' => __( 'Catalan', 'woocommerce-paypal-payments' ),
-			'cs-CZ' => __( 'Czech', 'woocommerce-paypal-payments' ),
-			'da-DK' => __( 'Danish', 'woocommerce-paypal-payments' ),
-			'de-DE' => __( 'German', 'woocommerce-paypal-payments' ),
-			'el-GR' => __( 'Greek', 'woocommerce-paypal-payments' ),
-			'en-AU' => __( 'English (Australia)', 'woocommerce-paypal-payments' ),
-			'en-GB' => __( 'English (United Kingdom)', 'woocommerce-paypal-payments' ),
-			'en-US' => __( 'English (United States)', 'woocommerce-paypal-payments' ),
-			'es-ES' => __( 'Spanish (Spain)', 'woocommerce-paypal-payments' ),
-			'es-MX' => __( 'Spanish (Mexico)', 'woocommerce-paypal-payments' ),
-			'fi-FI' => __( 'Finnish', 'woocommerce-paypal-payments' ),
-			'fr-CA' => __( 'French (Canada)', 'woocommerce-paypal-payments' ),
-			'fr-FR' => __( 'French (France)', 'woocommerce-paypal-payments' ),
-			'he-IL' => __( 'Hebrew', 'woocommerce-paypal-payments' ),
-			'hi-IN' => __( 'Hindi', 'woocommerce-paypal-payments' ),
-			'hr-HR' => __( 'Croatian', 'woocommerce-paypal-payments' ),
-			'hu-HU' => __( 'Hungarian', 'woocommerce-paypal-payments' ),
-			'id-ID' => __( 'Indonesian', 'woocommerce-paypal-payments' ),
-			'it-IT' => __( 'Italian', 'woocommerce-paypal-payments' ),
-			'ja-JP' => __( 'Japanese', 'woocommerce-paypal-payments' ),
-			'ko-KR' => __( 'Korean', 'woocommerce-paypal-payments' ),
-			'ms-MY' => __( 'Malay', 'woocommerce-paypal-payments' ),
-			'nb-NO' => __( 'Norwegian', 'woocommerce-paypal-payments' ),
-			'nl-NL' => __( 'Dutch', 'woocommerce-paypal-payments' ),
-			'pl-PL' => __( 'Polish', 'woocommerce-paypal-payments' ),
-			'pt-BR' => __( 'Portuguese (Brazil)', 'woocommerce-paypal-payments' ),
-			'pt-PT' => __( 'Portuguese (Portugal)', 'woocommerce-paypal-payments' ),
-			'ro-RO' => __( 'Romanian', 'woocommerce-paypal-payments' ),
-			'ru-RU' => __( 'Russian', 'woocommerce-paypal-payments' ),
-			'sk-SK' => __( 'Slovak', 'woocommerce-paypal-payments' ),
-			'sv-SE' => __( 'Swedish', 'woocommerce-paypal-payments' ),
-			'th-TH' => __( 'Thai', 'woocommerce-paypal-payments' ),
-			'tr-TR' => __( 'Turkish', 'woocommerce-paypal-payments' ),
-			'uk-UA' => __( 'Ukrainian', 'woocommerce-paypal-payments' ),
-			'vi-VN' => __( 'Vietnamese', 'woocommerce-paypal-payments' ),
-			'zh-CN' => __( 'Chinese (Simplified)', 'woocommerce-paypal-payments' ),
-			'zh-HK' => __( 'Chinese (Hong Kong)', 'woocommerce-paypal-payments' ),
-			'zh-TW' => __( 'Chinese (Traditional)', 'woocommerce-paypal-payments' ),
-		);
+	public static function map_language( string $language ): string {
+		$language = str_replace( '_', '-', $language );
+
+		if ( in_array( $language, self::VALID_LANGUAGES, true ) ) {
+			return $language;
+		}
+
+		return '';
 	}
 
 	/**

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce\Googlepay
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Googlepay;
 
@@ -23,6 +23,8 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameI
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\Googlepay\Helper\PropertiesDictionary;
 
 /**
  * Class GooglepayModule
@@ -281,6 +283,23 @@ class GooglepayModule implements ServiceModule, ExecutableModule {
 			},
 			10,
 			3
+		);
+
+		add_filter(
+			'woocommerce_paypal_payments_googlepay_button_styles',
+			static function ( LocationStylingDTO $styles ): LocationStylingDTO {
+				$styles->color = PropertiesDictionary::map_color( $styles->color );
+				$styles->label = PropertiesDictionary::map_type( $styles->label );
+
+				return $styles;
+			}
+		);
+
+		add_filter(
+			'woocommerce_paypal_payments_googlepay_button_language',
+			static function ( string $language ): string {
+				return PropertiesDictionary::map_language( $language );
+			}
 		);
 
 		return true;

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -292,14 +292,16 @@ class GooglepayModule implements ServiceModule, ExecutableModule {
 				$styles->label = PropertiesDictionary::map_type( $styles->label );
 
 				return $styles;
-			}
+			},
+			9999
 		);
 
 		add_filter(
 			'woocommerce_paypal_payments_googlepay_button_language',
 			static function ( string $language ): string {
 				return PropertiesDictionary::map_language( $language );
-			}
+			},
+			9999
 		);
 
 		return true;

--- a/modules/ppcp-googlepay/src/Helper/PropertiesDictionary.php
+++ b/modules/ppcp-googlepay/src/Helper/PropertiesDictionary.php
@@ -2,10 +2,11 @@
 /**
  * Properties of the GooglePay module.
  *
+ * @see     https://developers.google.com/pay/api/web/guides/resources/customize
  * @package WooCommerce\PayPalCommerce\Googlepay\Helper
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Googlepay\Helper;
 
@@ -13,76 +14,110 @@ namespace WooCommerce\PayPalCommerce\Googlepay\Helper;
  * Class Button
  */
 class PropertiesDictionary {
+	private const VALID_COLORS = array(
+		'',
+		'black',
+		'white',
+	);
+
+	private const VALID_TYPES = array(
+		'book',
+		'buy',
+		'checkout',
+		'donate',
+		'order',
+		'pay',
+		'plain',
+		'subscribe',
+	);
+
+	private const VALID_LANGUAGES = array(
+		'',
+		'ar',
+		'bg',
+		'ca',
+		'zh',
+		'hr',
+		'cs',
+		'da',
+		'nl',
+		'en',
+		'et',
+		'fi',
+		'fr',
+		'de',
+		'el',
+		'id',
+		'it',
+		'ja',
+		'ko',
+		'ms',
+		'no',
+		'pl',
+		'pt',
+		'ru',
+		'sr',
+		'sk',
+		'sl',
+		'es',
+		'sv',
+		'th',
+		'tr',
+		'uk',
+	);
 
 	/**
-	 * Returns the possible list of button colors.
-	 *
-	 * @return array
+	 * Maps a color value from the React settings UI's "Styling" tab to a color-key
+	 * that is supported by Google button.
 	 */
-	public static function button_colors(): array {
-		return array(
-			'white' => __( 'White', 'woocommerce-paypal-payments' ),
-			'black' => __( 'Black', 'woocommerce-paypal-payments' ),
-		);
+	public static function map_color( string $color ): string {
+		if ( in_array( $color, self::VALID_COLORS, true ) ) {
+			return $color;
+		}
+
+		switch ( $color ) {
+			case 'silver':
+				return 'white';
+
+			case 'gold':
+			case 'blue':
+			default:
+				return 'black';
+		}
 	}
 
 	/**
-	 * Returns the possible list of button types.
-	 *
-	 * @return array
+	 * Maps the "label" string from the React settings UI's "Styling" tab to a button type
+	 * that is supported by Google button.
 	 */
-	public static function button_types(): array {
-		return array(
-			'book'      => __( 'Book', 'woocommerce-paypal-payments' ),
-			'buy'       => __( 'Buy', 'woocommerce-paypal-payments' ),
-			'checkout'  => __( 'Checkout', 'woocommerce-paypal-payments' ),
-			'donate'    => __( 'Donate', 'woocommerce-paypal-payments' ),
-			'order'     => __( 'Order', 'woocommerce-paypal-payments' ),
-			'pay'       => __( 'Pay', 'woocommerce-paypal-payments' ),
-			'plain'     => __( 'Plain', 'woocommerce-paypal-payments' ),
-			'subscribe' => __( 'Subscribe', 'woocommerce-paypal-payments' ),
-		);
+	public static function map_type( string $label ): string {
+		if ( in_array( $label, self::VALID_TYPES, true ) ) {
+			return $label;
+		}
+
+		switch ( $label ) {
+			case 'buynow':
+				return 'buy';
+
+			case 'paypal':
+			default:
+				return 'plain';
+		}
 	}
 
 	/**
-	 * Returns the possible list of button languages.
-	 *
-	 * @return array
+	 * Translates the plugin's "language" setting to a valid language identifier that
+	 * the Google button understands.
 	 */
-	public static function button_languages(): array {
-		return array(
-			''   => __( 'Browser language', 'woocommerce-paypal-payments' ),
-			'ar' => __( 'Arabic', 'woocommerce-paypal-payments' ),
-			'bg' => __( 'Bulgarian', 'woocommerce-paypal-payments' ),
-			'ca' => __( 'Catalan', 'woocommerce-paypal-payments' ),
-			'zh' => __( 'Chinese', 'woocommerce-paypal-payments' ),
-			'hr' => __( 'Croatian', 'woocommerce-paypal-payments' ),
-			'cs' => __( 'Czech', 'woocommerce-paypal-payments' ),
-			'da' => __( 'Danish', 'woocommerce-paypal-payments' ),
-			'nl' => __( 'Dutch', 'woocommerce-paypal-payments' ),
-			'en' => __( 'English', 'woocommerce-paypal-payments' ),
-			'et' => __( 'Estonian', 'woocommerce-paypal-payments' ),
-			'fi' => __( 'Finnish', 'woocommerce-paypal-payments' ),
-			'fr' => __( 'French', 'woocommerce-paypal-payments' ),
-			'de' => __( 'German', 'woocommerce-paypal-payments' ),
-			'el' => __( 'Greek', 'woocommerce-paypal-payments' ),
-			'id' => __( 'Indonesian', 'woocommerce-paypal-payments' ),
-			'it' => __( 'Italian', 'woocommerce-paypal-payments' ),
-			'ja' => __( 'Japanese', 'woocommerce-paypal-payments' ),
-			'ko' => __( 'Korean', 'woocommerce-paypal-payments' ),
-			'ms' => __( 'Malay', 'woocommerce-paypal-payments' ),
-			'no' => __( 'Norwegian', 'woocommerce-paypal-payments' ),
-			'pl' => __( 'Polish', 'woocommerce-paypal-payments' ),
-			'pt' => __( 'Portuguese', 'woocommerce-paypal-payments' ),
-			'ru' => __( 'Russian', 'woocommerce-paypal-payments' ),
-			'sr' => __( 'Serbian', 'woocommerce-paypal-payments' ),
-			'sk' => __( 'Slovak', 'woocommerce-paypal-payments' ),
-			'sl' => __( 'Slovenian', 'woocommerce-paypal-payments' ),
-			'es' => __( 'Spanish', 'woocommerce-paypal-payments' ),
-			'sv' => __( 'Swedish', 'woocommerce-paypal-payments' ),
-			'th' => __( 'Thai', 'woocommerce-paypal-payments' ),
-			'tr' => __( 'Turkish', 'woocommerce-paypal-payments' ),
-			'uk' => __( 'Ukrainian', 'woocommerce-paypal-payments' ),
-		);
+	public static function map_language( string $language ): string {
+		if ( strlen( $language ) > 2 ) {
+			$language = substr( $language, 0, 2 );
+		}
+
+		if ( in_array( $language, self::VALID_LANGUAGES, true ) ) {
+			return $language;
+		}
+
+		return '';
 	}
 }


### PR DESCRIPTION
### Description

After dropping the legacy UI, the GooglePay and Apple Pay buttons were incorrectly styled.

The new React settings UI does not support the fine-grained styling of those two buttons anymore, and this PR introduces a filter-based mapping that translates the new styling settings to props that are understood by the two payment buttons.

#### Customization

**GooglePay sample**
```php
add_filter(
	'woocommerce_paypal_payments_googlepay_button_styles',
	static function ( LocationStylingDTO $styles ): LocationStylingDTO {
		$styles->color = 'black';
		$styles->label = 'donate';

		return $styles;
	}
);

add_filter(
	'woocommerce_paypal_payments_googlepay_button_language',
	static function ( string $language ): string {
		return 'en';
	}
);
```

**Apple Pay sample**
```php
add_filter(
	'woocommerce_paypal_payments_applepay_button_styles',
	static function ( LocationStylingDTO $styles ): LocationStylingDTO {
		$styles->color = 'white-outline';
		$styles->label = 'tip';

		return $styles;
	}
);

add_filter(
	'woocommerce_paypal_payments_applepay_button_language',
	static function ( string $language ): string {
		return 'en-US';
	}
);
```