### PR TITLE
Set the default state for `enable payment_level_processing`

### DIFF
--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -106,7 +106,7 @@ class SettingsModel extends AbstractDataModel {
 			'enable_pay_now'           => false,
 			'enable_logging'           => false,
 			'stay_updated'             => true,
-			'payment_level_processing' => false,
+			'payment_level_processing' => true,
 
 			// Array of string values.
 			'disabled_cards'           => array(),

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -739,6 +739,39 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			/**
+			 * Migrates payment level processing setting during plugin update.
+			 *
+			 * For merchants updating from version 3.3.2 or older, disables Level 2/3
+			 * processing if they previously opted out of automatic updates (stay_updated=false).
+			 * Merchants who opted into updates inherit the default enabled state.
+			 *
+			 * @param false|string $previous_version The previously installed plugin version,
+			 *                                       or false on first installation.
+			 */
+			static function ( $previous_version ) use ( $container ): void {
+				// Only run this migration logic when updating from version 3.3.2 or older.
+				if ( $previous_version && version_compare( $previous_version, '3.3.2', 'gt' ) ) {
+					return;
+				}
+
+				try {
+					$settings_model = $container->get( 'settings.data.settings' );
+					assert( $settings_model instanceof SettingsModel );
+
+					if ( ! $settings_model->get_stay_updated() ) {
+						$settings_model->set_payment_level_processing( false );
+						$settings_model->save();
+					}
+				} catch ( Throwable $error ) {
+					// Something failed - ignore the error and assume there is no migration data.
+					return;
+				}
+			}
+		);
+
 		return true;
 	}
 


### PR DESCRIPTION
# Enable Level 2/3 Processing by Default for Eligible Merchants

## Overview
Changes `payment_level_processing` default from `false` to `true`, automatically enabling Level 2/3 card processing for eligible merchants. Includes migration logic to respect existing merchant preferences.

## Changes

**Default Setting:**
- Before: `payment_level_processing = false` (opt-in)
- After: `payment_level_processing = true` (opt-out)

**Migration Logic (3.3.2 → 3.4.0):**
- Stay Updated ON → inherit default `true` (Level 2/3 enabled)
- Stay Updated OFF → explicitly set `false` (Level 2/3 disabled)

## Why

**Problem:** Eligible merchants missed lower interchange rates because feature required manual opt-in.

**Solution:** Enable by default for eligible merchants while respecting conservative preferences via `stay_updated` flag.

## Eligibility Requirements

Level 2/3 only activates when ALL met:
- ✅ US merchant
- ✅ USD currency
- ✅ ACDC payment method
- ✅ Setting enabled

## Migration Scenarios

**Scenario 1: Update with Stay Updated ON**
- Result: Level 2/3 enabled automatically
- Benefit: Lower interchange rates on eligible transactions

**Scenario 2: Update with Stay Updated OFF**
- Result: Level 2/3 remains disabled
- Respects: Conservative merchant preference

**Scenario 3: Fresh Installation**
- Result: Level 2/3 enabled by default for eligible merchants

## Backward Compatibility
✅ Fully compatible - migration respects existing preferences and `stay_updated` flag

## Testing
- [x] Fresh install defaults to enabled
- [x] Migration with Stay Updated ON → enabled
- [x] Migration with Stay Updated OFF → disabled
- [x] Ineligible merchants don't see setting
- [x] Level 2/3 data only sent when eligible