### PR TITLE
Use merchant country instead of shop country (5842)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2242,7 +2242,7 @@ return array(
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-working-capital-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
-				$is_working_capital_feature_flag_enabled && $container->get( 'api.shop.country' ) === 'US' && $stay_updated,
+				$is_working_capital_feature_flag_enabled && $container->get( 'api.merchant.country' ) === 'US' && $stay_updated,
 				new InboxNoteAction(
 					'learn_more',
 					__( 'Learn More', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2119,7 +2119,7 @@ return array(
 			true
 		);
 
-		$is_working_capital_eligible = $container->get( 'api.shop.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
+		$is_working_capital_eligible = $container->get( 'api.merchant.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
 
 		if ( ! $is_working_capital_feature_flag_enabled || ! $is_working_capital_eligible ) {
 			return array();


### PR DESCRIPTION
## Issue Description

Working Capital promotional items (WOO task and inbox note) were using `api.shop.country` to determine eligibility, which checks the WooCommerce shop's base country. This is incorrect because Working Capital availability should be based on the merchant's PayPal account country, not their shop location.

This meant merchants with US PayPal accounts but non-US shops wouldn't see Working Capital promotions, and conversely, merchants with non-US PayPal accounts but US shops would incorrectly see them.

## PR Description

Updated Working Capital eligibility checks to use `api.merchant.country` instead of `api.shop.country` in both:
- Woo task configuration (`wcgateway.settings.wc-tasks.working-capital-config`)
- Inbox note display logic

The `api.merchant.country` service correctly returns:
- The connected merchant's PayPal account country when available
- Falls back to `api.shop.country` when not connected

This ensures Working Capital promotions are only shown to merchants with US-based PayPal accounts, regardless of their WooCommerce shop location, maintaining consistency across all promotional touchpoints.
