### PR TITLE
Apple Pay - When coupon is applied on total and we click on Apple Pay it is not visible on popup (5824)

### DIFF
--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -412,6 +412,13 @@ class ApplePayButton implements ButtonInterface {
 			return;
 		}
 		$applepay_request_data_object->order_data( $context );
+		if ( $applepay_request_data_object->has_errors() ) {
+			$this->response_templates->response_with_data_errors(
+				$applepay_request_data_object->errors()
+			);
+
+			return;
+		}
 
 		$this->update_posted_data( $applepay_request_data_object );
 

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -705,7 +705,7 @@ class ApplePayButton implements ButtonInterface {
 				'amount' => $cart->needs_shipping()
 					? $cart->get_shipping_total() : null,
 				'label'  => $cart->needs_shipping()
-					? $selected_shipping_method['label'] : null,
+					? ( $selected_shipping_method['label'] ?? null ) : null,
 			),
 			'shippingMethods' => $cart->needs_shipping()
 				? $shipping_methods_array : null,

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -647,7 +647,7 @@ class ApplePayButton implements ButtonInterface {
 			}
 		}
 
-		$selected_shipping_method = $shipping_methods_array[0];
+		$selected_shipping_method = $shipping_methods_array[0] ?? array();
 		if ( $shipping_method ) {
 			$selected_shipping_method = $shipping_method;
 		}

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -691,17 +691,22 @@ class ApplePayButton implements ButtonInterface {
 		$selected_shipping_method,
 		$shipping_methods_array
 	): array {
-		$total = (float) $cart->get_total( 'edit' );
-		$total = round( $total, 2 );
+		$total          = (float) $cart->get_total( 'edit' );
+		$total          = round( $total, 2 );
+		$discount_total = (float) $cart->get_discount_total();
+
 		return array(
 			'subtotal'        => $cart->get_subtotal(),
+			'discount'        => $discount_total > 0 ? array(
+				'amount' => $discount_total,
+				'label'  => __( 'Discount', 'woocommerce-paypal-payments' ),
+			) : null,
 			'shipping'        => array(
 				'amount' => $cart->needs_shipping()
 					? $cart->get_shipping_total() : null,
 				'label'  => $cart->needs_shipping()
 					? $selected_shipping_method['label'] : null,
 			),
-
 			'shippingMethods' => $cart->needs_shipping()
 				? $shipping_methods_array : null,
 			'taxes'           => $cart->get_total_tax(),

--- a/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
@@ -351,14 +351,34 @@ class ApplePayDataObjectHttp {
 	 * @param array $data The data.
 	 */
 	protected function assign_data_object_values( array $data ): void {
+		$class_properties = array(
+			'nonce',
+			'simplified_contact',
+			'need_shipping',
+			'caller_page',
+			'product_id',
+			'product_quantity',
+			'product_variations',
+			'product_extra',
+			'product_booking',
+			'shipping_method',
+			'billing_contact',
+			'shipping_contact',
+		);
+
 		foreach ( $data as $key => $value ) {
-			// Null values may give origin to type errors. If necessary replace this condition with a specialized field filter.
 			if ( null === $value ) {
 				continue;
 			}
+
 			if ( $key === 'woocommerce-process-checkout-nonce' ) {
 				$key = 'nonce';
 			}
+
+			if ( ! in_array( $key, $class_properties, true ) ) {
+				continue;
+			}
+
 			$this->$key = $value;
 		}
 	}

--- a/modules/ppcp-applepay/src/Assets/ResponsesToApple.php
+++ b/modules/ppcp-applepay/src/Assets/ResponsesToApple.php
@@ -163,6 +163,15 @@ class ResponsesToApple {
 			$type
 		);
 
+		$has_discount = $payment_details['discount']['amount'] ?? null;
+		if ( $has_discount ) {
+			$response[] = $this->apple_item_format(
+				$payment_details['discount']['label'] ?: __( 'Discount', 'woocommerce-paypal-payments' ),
+				-round( floatval( $payment_details['discount']['amount'] ), 2 ),
+				$type
+			);
+		}
+
 		if ( $payment_details['shipping']['amount'] ) {
 			$response[] = $this->apple_item_format(
 				$payment_details['shipping']['label'] ?: '',


### PR DESCRIPTION
A fix was included in v3.4.0 but was not completely fixed the issue, the discount line item is not visible in the Apple Pay payment sheet. 
 
### Steps To Reproduce
- Navigate to shop, add product to cart
- Navigate to cart/classic cart/checkout/block chekcout
- Apply coupon and click on Apple Pay
  - Observe total is correct but no line about applied coupon