### PR TITLE
Pay with Crypto: Fix token parameter remaining in order-received URL

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -219,8 +219,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 		);
 
 		add_action( 'woocommerce_before_thankyou', array( $this, 'handle_cancelled_local_apm' ) );
-
-		add_action( 'woocommerce_before_thankyou', array( $this, 'handle_pwc_order_received_redirect' ) );
+		add_action( 'template_redirect', array( $this, 'handle_pwc_order_received_redirect' ) );
 
 		add_action(
 			'woocommerce_paypal_payments_payment_capture_completed_webhook_handler',
@@ -486,22 +485,33 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 	 * When the 'token' parameter is present on the order-received page, WooCommerce displays
 	 * a minimal page instead of the full order details.
 	 *
-	 * This intercepts PWC orders on 'woocommerce_before_thankyou' and redirects to a clean
-	 * URL without the token, allowing WooCommerce to display the full order-received page.
+	 * This intercepts PWC orders on 'template_redirect' (before any output buffering)
+	 * and redirects to a clean URL without the token, allowing WooCommerce to display
+	 * the full order-received page.
 	 *
 	 * Note: PWC uses ORDER_COMPLETE_ON_PAYMENT_APPROVAL, so the token serves no purpose
 	 * but we can't prevent PayPal from appending it.
 	 *
-	 * @param int $order_id The order ID.
 	 * @return void
 	 */
-	public function handle_pwc_order_received_redirect( $order_id ): void {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		// Only intercept if 'token' parameter is present.
-		if ( ! isset( $_GET['token'] ) ) {
+	public function handle_pwc_order_received_redirect(): void {
+		// Only run on order-received endpoint.
+		if ( ! is_wc_endpoint_url( 'order-received' ) ) {
 			return;
 		}
-		// phpcs:enable
+
+		// Check if 'token' exists anywhere in the URL first.
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		if ( strpos( $request_uri, 'token=' ) === false ) {
+			return;
+		}
+
+		// Get order ID from the URL endpoint.
+		global $wp;
+		$order_id = isset( $wp->query_vars['order-received'] ) ? absint( $wp->query_vars['order-received'] ) : 0;
+		if ( ! $order_id ) {
+			return;
+		}
 
 		$order = wc_get_order( $order_id );
 		if ( ! $order instanceof WC_Order ) {
@@ -513,9 +523,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExtendingMo
 			return;
 		}
 
-		// Redirect to clean URL, allowing WooCommerce to display the full order-received page.
-		$clean_url = remove_query_arg( 'token', $order->get_checkout_order_received_url() );
-		wp_safe_redirect( $clean_url );
+		wp_safe_redirect( $order->get_checkout_order_received_url() );
 		exit;
 	}
 


### PR DESCRIPTION
### Description
Fix Pay with Crypto orders showing a truncated Order Received page.

Changed hook from `woocommerce_before_thankyou` to `template_redirect` to ensure redirect executes before output buffering.

### Screenshots

|Before|After|
|-|-|
|<img width="826" height="626" alt="pwc_before" src="https://github.com/user-attachments/assets/eef79190-2320-44a2-8ab4-f302ad29e5be" />|<img width="830" height="710" alt="after_pwc" src="https://github.com/user-attachments/assets/fcd73939-5dc6-4c3f-a15f-6833c3756797" />|

### Testing
1. Enable Pay with Crypto
2. Complete a crypto payment as a logged-in user
3. Verify the order-received page shows full order details (not minimal view)