### PR TITLE
fix(working-capital): only show promotions when PayPal is connected (5483)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2219,6 +2219,9 @@ return array(
 		$messages_apply = $container->get( 'button.helper.messages-apply' );
 		assert( $messages_apply instanceof MessagesApply );
 
+		$state = $container->get( 'settings.connection-state' );
+		assert( $state instanceof ConnectionState );
+
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
@@ -2228,6 +2231,8 @@ return array(
 		$stay_updated = SettingsModule::should_use_the_old_ui()
 			? $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' )
 			: $settings_model->get_stay_updated();
+
+		$is_working_capital_eligible = $container->get( 'api.merchant.country' ) === 'US' && $stay_updated;
 
 		$message = sprintf(
 		// translators: %1$s is the URL for the startup guide.
@@ -2245,7 +2250,7 @@ return array(
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-working-capital-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
-				$is_working_capital_feature_flag_enabled && $container->get( 'api.merchant.country' ) === 'US' && $stay_updated,
+				$state->is_connected() && $is_working_capital_feature_flag_enabled && $is_working_capital_eligible,
 				new InboxNoteAction(
 					'learn_more',
 					__( 'Learn More', 'woocommerce-paypal-payments' ),

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -2113,6 +2113,9 @@ return array(
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
+		$state = $container->get( 'settings.connection-state' );
+		assert( $state instanceof ConnectionState );
+
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
 			'woocommerce.feature-flags.woocommerce_paypal_payments.working_capital_enabled',
@@ -2121,7 +2124,7 @@ return array(
 
 		$is_working_capital_eligible = $container->get( 'api.merchant.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
 
-		if ( ! $is_working_capital_feature_flag_enabled || ! $is_working_capital_eligible ) {
+		if ( ! $state->is_connected() || ! $is_working_capital_feature_flag_enabled || ! $is_working_capital_eligible ) {
 			return array();
 		}
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -31,6 +31,7 @@ use WooCommerce\PayPalCommerce\Onboarding\Render\OnboardingOptionsRenderer;
 use WooCommerce\PayPalCommerce\Onboarding\State;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\SettingsModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\FeesRenderer;
@@ -2113,8 +2114,8 @@ return array(
 		$settings = $container->get( 'wcgateway.settings' );
 		assert( $settings instanceof Settings );
 
-		$state = $container->get( 'settings.connection-state' );
-		assert( $state instanceof ConnectionState );
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
 
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
@@ -2124,7 +2125,7 @@ return array(
 
 		$is_working_capital_eligible = $container->get( 'api.merchant.country' ) === 'US' && $settings->has( 'stay_updated' ) && $settings->get( 'stay_updated' );
 
-		if ( ! $state->is_connected() || ! $is_working_capital_feature_flag_enabled || ! $is_working_capital_eligible ) {
+		if ( ! $settings_provider->merchant_connected() || ! $is_working_capital_feature_flag_enabled || ! $is_working_capital_eligible ) {
 			return array();
 		}
 
@@ -2219,8 +2220,8 @@ return array(
 		$messages_apply = $container->get( 'button.helper.messages-apply' );
 		assert( $messages_apply instanceof MessagesApply );
 
-		$state = $container->get( 'settings.connection-state' );
-		assert( $state instanceof ConnectionState );
+		$settings_provider = $container->get( 'settings.settings-provider' );
+		assert( $settings_provider instanceof SettingsProvider );
 
 		$is_working_capital_feature_flag_enabled = apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores -- feature flags use this convention
@@ -2250,7 +2251,7 @@ return array(
 				Note::E_WC_ADMIN_NOTE_INFORMATIONAL,
 				'ppcp-working-capital-inbox-note',
 				Note::E_WC_ADMIN_NOTE_UNACTIONED,
-				$state->is_connected() && $is_working_capital_feature_flag_enabled && $is_working_capital_eligible,
+				$settings_provider->merchant_connected() && $is_working_capital_feature_flag_enabled && $is_working_capital_eligible,
 				new InboxNoteAction(
 					'learn_more',
 					__( 'Learn More', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
## Issue Description

Working Capital promotional items (Woo task and inbox note) were being displayed to all merchants, including those who haven't connected their PayPal accounts yet. Since Working Capital is only accessible to merchants with active PayPal connections, showing these promotions to unconnected merchants is misleading and creates a poor user experience.

## PR Description

Added connection state checks to ensure Working Capital promotions are only shown to merchants who have already connected their PayPal accounts:

- W00 task configuration (`wcgateway.settings.wc-tasks.working-capital-config`)
- Inbox note display logic (`wcgateway.settings.inbox-notes`)

Both now check `$settings_provider->merchant_connected()` before displaying Working Capital promotional content.

This ensures merchants only see Working Capital promotions when they have an active PayPal connection and can actually access the feature, preventing confusion and improving the overall user experience.