### PR TITLE
Add pattern validation and improve error messages for client credentials (5888, 5889)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -231,7 +231,8 @@ $services = array(
 	'settings.rest.authentication'                        => static function ( ContainerInterface $container ): AuthenticationRestEndpoint {
 		return new AuthenticationRestEndpoint(
 			$container->get( 'settings.service.authentication_manager' ),
-			$container->get( 'settings.service.data-manager' )
+			$container->get( 'settings.service.data-manager' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 	'settings.rest.login_link'                            => static function ( ContainerInterface $container ): LoginLinkRestEndpoint {

--- a/modules/ppcp-settings/src/Endpoint/AuthenticationRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/AuthenticationRestEndpoint.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Settings\Endpoint;
 
 use Exception;
+use Psr\Log\LoggerInterface;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
@@ -48,6 +49,8 @@ class AuthenticationRestEndpoint extends RestEndpoint {
 	 */
 	private SettingsDataManager $data_manager;
 
+	private LoggerInterface $logger;
+
 	/**
 	 * Defines the JSON response format (when connection was successful).
 	 *
@@ -62,16 +65,14 @@ class AuthenticationRestEndpoint extends RestEndpoint {
 		),
 	);
 
-	/**
-	 * Constructor.
-	 *
-	 * @param AuthenticationManager $authentication_manager The authentication manager.
-	 * @param SettingsDataManager   $data_manager           Settings data manager, to reset
-	 *                                                      settings.
-	 */
-	public function __construct( AuthenticationManager $authentication_manager, SettingsDataManager $data_manager ) {
+	public function __construct(
+		AuthenticationManager $authentication_manager,
+		SettingsDataManager $data_manager,
+		LoggerInterface $logger
+	) {
 		$this->authentication_manager = $authentication_manager;
 		$this->data_manager           = $data_manager;
+		$this->logger                 = $logger;
 	}
 
 	/**
@@ -180,9 +181,17 @@ class AuthenticationRestEndpoint extends RestEndpoint {
 
 		try {
 			$this->authentication_manager->validate_id_and_secret( $client_id, $client_secret );
-			$this->authentication_manager->authenticate_via_direct_api( $use_sandbox, $client_id, $client_secret );
 		} catch ( Exception $exception ) {
 			return $this->return_error( $exception->getMessage() );
+		}
+
+		try {
+			$this->authentication_manager->authenticate_via_direct_api( $use_sandbox, $client_id, $client_secret );
+		} catch ( Exception $exception ) {
+			$this->logger->error( 'Direct API authentication failed: ' . $exception->getMessage() );
+			return $this->return_error(
+				__( 'Could not connect to PayPal. Please verify your credentials and try again.', 'woocommerce-paypal-payments' )
+			);
 		}
 
 		$account  = $this->authentication_manager->get_account_details();

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -180,12 +180,18 @@ class AuthenticationManager {
 			throw new RuntimeException( 'No client ID provided.' );
 		}
 
-		if ( false === preg_match( '/^A[\w-]{79}$/', $client_secret ) ) {
+		// Exactly 80 alphanumeric, underscore, or hyphen characters.
+		if ( 1 !== preg_match( '/^[\w-]{80}$/', $client_id ) ) {
 			throw new RuntimeException( 'Invalid client ID provided.' );
 		}
 
 		if ( empty( $client_secret ) ) {
 			throw new RuntimeException( 'No client secret provided.' );
+		}
+
+		// Starts with "A", followed by 79 alphanumeric, underscore, or hyphen characters.
+		if ( 1 !== preg_match( '/^A[\w-]{79}$/', $client_secret ) ) {
+			throw new RuntimeException( 'Invalid client secret provided.' );
 		}
 	}
 

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -466,11 +466,17 @@ class AuthenticationManager {
 			$order_response = $orders->order( $order_id );
 			$order_body     = json_decode( $order_response['body'], false, 512, JSON_THROW_ON_ERROR );
 		} catch ( JsonException $exception ) {
-			// Cast JsonException to a RuntimeException.
-			throw new RuntimeException( 'Could not decode JSON response: ' . $exception->getMessage() );
+			throw new RuntimeException(
+				'Failed to retrieve payee details.',
+				0,
+				$exception
+			);
 		} catch ( Throwable $exception ) {
-			// Cast any other Throwable to a RuntimeException.
-			throw new RuntimeException( $exception->getMessage() );
+			throw new RuntimeException(
+				'Failed to retrieve payee details.',
+				0,
+				$exception
+			);
 		}
 
 		$pu    = $order_body->purchase_units[0];

--- a/tests/PHPUnit/PpcpSettings/Service/AuthenticationManagerValidationTest.php
+++ b/tests/PHPUnit/PpcpSettings/Service/AuthenticationManagerValidationTest.php
@@ -1,0 +1,69 @@
+<?php
+declare( strict_types=1 );
+
+namespace PHPUnit\PpcpSettings\Service;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Repository\PartnerReferralsData;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\Service\AuthenticationManager;
+use WooCommerce\PayPalCommerce\Settings\Service\InternalRestService;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\ConnectionState;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\EnvironmentConfig;
+
+class AuthenticationManagerValidationTest extends TestCase {
+	private AuthenticationManager $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sut = new AuthenticationManager(
+			Mockery::mock( GeneralSettings::class ),
+			Mockery::mock( EnvironmentConfig::class ),
+			Mockery::mock( EnvironmentConfig::class ),
+			Mockery::mock( PartnerReferralsData::class ),
+			Mockery::mock( ConnectionState::class ),
+			Mockery::mock( InternalRestService::class )
+		);
+	}
+
+	public function test_empty_client_id_throws(): void {
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'No client ID provided.' );
+
+		$this->sut->validate_id_and_secret( '', 'Avalid_secret_that_is_exactly_eighty_characters_long_padded_to_meet_length_needed' );
+	}
+
+	public function test_invalid_client_id_pattern_throws(): void {
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Invalid client ID provided.' );
+
+		$this->sut->validate_id_and_secret( 'too-short', 'Avalid_secret_that_is_exactly_eighty_characters_long_padded_to_meet_length_needed' );
+	}
+
+	public function test_empty_client_secret_throws(): void {
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'No client secret provided.' );
+
+		$valid_id = str_repeat( 'a', 80 );
+		$this->sut->validate_id_and_secret( $valid_id, '' );
+	}
+
+	public function test_invalid_client_secret_pattern_throws(): void {
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Invalid client secret provided.' );
+
+		$valid_id = str_repeat( 'a', 80 );
+		$this->sut->validate_id_and_secret( $valid_id, 'invalid' );
+	}
+
+	public function test_valid_credentials_pass(): void {
+		$valid_id     = str_repeat( 'a', 80 );
+		$valid_secret = 'A' . str_repeat( 'b', 79 );
+
+		$this->sut->validate_id_and_secret( $valid_id, $valid_secret );
+		$this->addToAssertionCount( 1 );
+	}
+}


### PR DESCRIPTION
This PR fixes `client_secret` error message and add `client_id` pattern validation. It also adds exception chaining and generic error messages for direct API authentication.