### PR TITLE
Fix Javascript aliases resolution in PHPStorm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,12 @@
 	},
 	"rules": {
 		"no-console": ["error", { "allow": ["warn", "error"] }]
+	},
+	"settings": {
+		"import/resolver": {
+			"webpack": {
+				"config": "./webpack.config.js"
+			}
+		}
 	}
 }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,33 @@
+{
+	"compilerOptions": {
+		"baseUrl": ".",
+		"paths": {
+            "@ppcp-admin-notices/*": [ "modules/ppcp-admin-notices/resources/js/*" ],
+            "@ppcp-applepay/*": [ "modules/ppcp-applepay/resources/js/*" ],
+            "@ppcp-axo/*": [ "modules/ppcp-axo/resources/js/*" ],
+            "@ppcp-axo-block/*": [ "modules/ppcp-axo-block/resources/js/*" ],
+            "@ppcp-blocks/*": [ "modules/ppcp-blocks/resources/js/*" ],
+            "@ppcp-button/*": [ "modules/ppcp-button/resources/js/modules/*" ],
+            "@ppcp-card-fields/*": [ "modules/ppcp-card-fields/resources/js/*" ],
+            "@ppcp-compat/*": [ "modules/ppcp-compat/resources/js/*" ],
+            "@ppcp-fraud-protection/*": [ "modules/ppcp-fraud-protection/resources/js/*" ],
+            "@ppcp-googlepay/*": [ "modules/ppcp-googlepay/resources/js/*" ],
+            "@ppcp-local-alternative-payment-methods/*": [ "modules/ppcp-local-alternative-payment-methods/resources/js/*" ],
+            "@ppcp-onboarding/*": [ "modules/ppcp-onboarding/resources/js/*" ],
+            "@ppcp-order-tracking/*": [ "modules/ppcp-order-tracking/resources/js/*" ],
+            "@ppcp-paylater-block/*": [ "modules/ppcp-paylater-block/resources/js/*" ],
+            "@ppcp-paylater-configurator/*": [ "modules/ppcp-paylater-configurator/resources/js/*" ],
+            "@ppcp-paylater-wc-blocks/*": [ "modules/ppcp-paylater-wc-blocks/resources/js/*" ],
+            "@ppcp-paypal-subscriptions/*": [ "modules/ppcp-paypal-subscriptions/resources/js/*" ],
+            "@ppcp-save-payment-methods/*": [ "modules/ppcp-save-payment-methods/resources/js/*" ],
+            "@ppcp-settings/*": [ "modules/ppcp-settings/resources/js/*" ],
+            "@ppcp-uninstall/*": [ "modules/ppcp-uninstall/resources/js/*" ],
+            "@ppcp-wc-gateway/*": [ "modules/ppcp-wc-gateway/resources/js/*" ],
+            "@ppcp-webhooks/*": [ "modules/ppcp-webhooks/resources/js/*" ]
+		}
+	},
+	"exclude": [
+		"node_modules",
+		"assets"
+	]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-paypal-payments",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-paypal-payments",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "GPL-2.0",
       "dependencies": {
         "@paypal/paypal-js": "^8.1.3",
@@ -38,6 +38,7 @@
         "@wordpress/jest-preset-default": "^12.37.0",
         "@wordpress/scripts": "^31.2.0",
         "babel-plugin-explicit-exports-references": "^1.0.2",
+        "eslint-import-resolver-webpack": "^0.13.10",
         "jquery": "^3.7.1"
       }
     },
@@ -5727,30 +5728,12 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/source-list-map": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.6.tgz",
-      "integrity": "sha512-5JcVt1u5HDmlXkwOD2nslZVllBBc7HDuOICfiZah2Z0is8M8g+ddAEawbmd3VjedfDHBzxCaXLs07QEmb7y54g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/tapable": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.12.tgz",
-      "integrity": "sha512-bTHG8fcxEqv1M9+TD14P8ok8hjxoOCkfKc8XXLaaD05kI7ohpeI956jtDOD3XHKBQrlyPughUtzm1jtVhHpA5Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
@@ -5768,73 +5751,6 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/uglify-js": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
-      "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@types/uglify-js/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@types/webpack": {
-      "version": "4.41.40",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.40.tgz",
-      "integrity": "sha512-u6kMFSBM9HcoTpUXnL6mt2HSzftqb3JgYV6oxIgL2dl6sX6aCa5k6SOkzv5DuZjBTPUE/dJltKtwwuqrkZHpfw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tapable": "^1",
-        "@types/uglify-js": "*",
-        "@types/webpack-sources": "*",
-        "anymatch": "^3.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/@types/webpack-sources": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.3.tgz",
-      "integrity": "sha512-4nZOdMwSPHZ4pTEZzSp0AsTM4K7Qmu40UKW4tJDiOVs20UzYF9l+qUe4s0ftfN0pin06n+5cWWDJXH+sbhAiDw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/source-list-map": "*",
-        "source-map": "^0.7.3"
-      }
-    },
-    "node_modules/@types/webpack/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -11104,6 +11020,104 @@
         "eslint-plugin-import-x": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack": {
+      "version": "0.13.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.13.10.tgz",
+      "integrity": "sha512-ciVTEg7sA56wRMR772PyjcBRmyBMLS46xgzQZqt6cWBEKc7cK65ZSSLCTLVRu2gGtKyXUb5stwf4xxLBfERLFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "enhanced-resolve": "^0.9.1",
+        "find-root": "^1.1.0",
+        "hasown": "^2.0.2",
+        "interpret": "^1.4.0",
+        "is-core-module": "^2.15.1",
+        "is-regex": "^1.2.0",
+        "lodash": "^4.17.21",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^5.7.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "eslint-plugin-import": ">=1.4.0",
+        "webpack": ">=1.11.0"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/enhanced-resolve": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "integrity": "sha512-kxpoMgrdtkXZ5h0SeraBS1iRntpTpQ3R8ussdb38+UAFnMGX5DDyJXePm+OCHOcoXvHDw7mc2erbJBpDnl7TPw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "memory-fs": "^0.2.0",
+        "tapable": "^0.1.8"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/interpret": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/resolve": {
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/eslint-import-resolver-webpack/node_modules/tapable": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz",
+      "integrity": "sha512-jX8Et4hHg57mug1/079yitEKWGB3LCwoxByLsNim89LABq8NqgiX+6iYVOsq0vX8uJHkU+DZ5fnq95f800bEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -16705,6 +16719,13 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
+    "node_modules/memory-fs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz",
+      "integrity": "sha512-+y4mDxU4rvXXu5UDSGCGNiesFmwCHuefGMoPCO1WYucNYj7DsLqrFaa2fXVI0H+NNiPTwwzKwspn9yTZqUGqng==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/meow": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@wordpress/jest-preset-default": "^12.37.0",
     "@wordpress/scripts": "^31.2.0",
     "babel-plugin-explicit-exports-references": "^1.0.2",
+    "eslint-import-resolver-webpack": "^0.13.10",
     "jquery": "^3.7.1"
   }
 }


### PR DESCRIPTION
After #3938 PHPStorm fails to resolve the imports with aliases correctly. 

I restored the `import/resolver` in `.eslintrc` similar to #3941 (it was removed in #3982 because it was not correct and causing issues). But it was not enough, so I also created `jsonfig.json` with all aliases. It's just a JSON file, so we cannot do anything automatically and have to duplicate the paths manually, but it should not be a huge problem since it's just one path per module and we do not create new modules often, so probably no reason to bother with something like a script for generating the JSON file. 

Now the PHPStorm errors have disappeared, and Go To Definition, function parameters hints etc. work fine.

<img width="684" height="97" alt="image" src="https://github.com/user-attachments/assets/c0ad96b3-c6be-4804-96d0-36ba50d85370" />
