### PR TITLE
Exclude ddev/bin and tests from spell check

### DIFF
--- a/.github/workflows-config/typos.toml
+++ b/.github/workflows-config/typos.toml
@@ -11,6 +11,8 @@ extend-exclude = [
 	"vendor/",
 	"*.min.js",
 	"*.min.css",
+	".ddev/bin/"
+    "tests/"
 ]
 ignore-hidden = false
 

--- a/.github/workflows-config/typos.toml
+++ b/.github/workflows-config/typos.toml
@@ -11,8 +11,8 @@ extend-exclude = [
 	"vendor/",
 	"*.min.js",
 	"*.min.css",
-	".ddev/bin/"
-    "tests/"
+	".ddev/bin/",
+	"tests/",
 ]
 ignore-hidden = false
 


### PR DESCRIPTION
This PR excludes `ddev/bin` and `tests` from spell check GitHub workflow.