### PR TITLE
Infinite loop while trying to change payment method for subscription (5900)

### DIFF
--- a/modules/ppcp-button/src/Helper/Context.php
+++ b/modules/ppcp-button/src/Helper/Context.php
@@ -74,12 +74,12 @@ class Context {
 	 * @return array<string, mixed>|null
 	 */
 	protected function find_classic_shortcode_block(): ?array {
-		$post = get_the_content();
-		if ( ! $post ) {
+		$post = get_post();
+		if ( ! $post || empty( $post->post_content ) ) {
 			return null;
 		}
 
-		$blocks = parse_blocks( $post );
+		$blocks = parse_blocks( $post->post_content );
 		foreach ( $blocks as $block ) {
 			if ( $block['blockName'] === 'woocommerce/classic-shortcode' ) {
 				return $block;


### PR DESCRIPTION
When accessing the Change Payment Method page for a subscription (via My Account > Subscriptions), an infinite loop is triggered, causing a crash or white screen.

### Steps to reproduce
- create a page with classic checkout shortcode 
- Set it as Checkout page in WC advanced settings 
- Purchase a subscription and try to change payment from My Account / Subscriptions / Subscription / Change payment button

### PR Changes
`get_the_content()` internally calls `the_title_attribute()`, which applies the `the_title` filter. When WooCommerce Subscriptions hooks that filter and calls is_checkout(), it triggers our `woocommerce_is_checkout` handler, which calls back into `find_classic_shortcode_block()` creating infinite recursion. 

This PR uses `get_post()->post_content` bypassing all filters, which is safe here since we only need the raw block markup.

