### PR TITLE
Do not increment step directly

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
@@ -12,7 +12,7 @@ import WelcomeDocs from '../Components/WelcomeDocs';
 import AdvancedOptionsForm from '../Components/AdvancedOptionsForm';
 import { usePaymentConfig } from '../hooks/usePaymentConfig';
 
-const StepWelcome = ( { setStep, currentStep } ) => {
+const StepWelcome = ( { onNext } ) => {
 	const { storeCountry, ownBrandOnly } = CommonHooks.useWooSettings();
 	const { canUseCardPayments, canUseFastlane } = OnboardingHooks.useFlags();
 
@@ -35,8 +35,7 @@ const StepWelcome = ( { setStep, currentStep } ) => {
 			  );
 
 	const handleActivatePayPal = () => {
-		const nextStep = currentStep + 1;
-		setStep( nextStep, 'user' );
+		onNext();
 	};
 
 	return (

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepWelcome.js
@@ -34,10 +34,6 @@ const StepWelcome = ( { onNext } ) => {
 					'woocommerce-paypal-payments'
 			  );
 
-	const handleActivatePayPal = () => {
-		onNext();
-	};
-
 	return (
 		<div className="ppcp-r-page-welcome">
 			<OnboardingHeader
@@ -60,7 +56,7 @@ const StepWelcome = ( { onNext } ) => {
 					<Button
 						className="ppcp-r-button-activate-paypal"
 						variant="primary"
-						onClick={ handleActivatePayPal }
+						onClick={ onNext }
 					>
 						{ __(
 							'Activate PayPal Payments',

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/index.js
@@ -33,9 +33,8 @@ const OnboardingScreen = () => {
 			<Container page="onboarding">
 				<div className="ppcp-r-card">
 					<currentStep.StepComponent
-						setStep={ setStep }
-						currentStep={ step }
-						stepperOrder={ Steps }
+						onNext={ handleNext }
+						onPrev={ handlePrev }
 					/>
 				</div>
 			</Container>


### PR DESCRIPTION
Replaced the direct step increment via `setStep(currentStep + 1)` on the activation button click with `handleNext` from `OnboardingScreen` (which at least clamps the value), similar to the navigation component.

Hopefully this should fix #3707