### PR TITLE
fix(branded-only): disable ACDC, Apple Pay, Google Pay and keep BCDC functional (5897)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -804,9 +804,16 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		 */
 		add_filter(
 			'woocommerce_paypal_payments_sdk_disabled_funding_hook',
-			static function ( array $disable_funding, array $flags ): array {
+			static function ( array $disable_funding, array $flags ) use ( $container ) {
 				$allowed_context = array( 'checkout-block', 'checkout' );
 				if ( ! in_array( $flags['context'], $allowed_context, true ) ) {
+					return $disable_funding;
+				}
+
+				$payment_settings = $container->get( 'settings.data.payment' );
+				assert( $payment_settings instanceof PaymentSettings );
+
+				if ( ! $payment_settings->is_method_enabled( CardButtonGateway::ID ) ) {
 					return $disable_funding;
 				}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -792,6 +792,33 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			return;
 		}
 
+		/**
+		 * Ensure BCDC remains functional in branded-only mode.
+		 *
+		 * In branded-only mode, white-label payment methods (ACDC, Apple Pay, Google Pay)
+		 * are disabled, but the PayPal-branded card button (BCDC) should remain functional.
+		 *
+		 * BCDC requires the 'card' funding source to be enabled. This filter prevents 'card'
+		 * from being added to the disabled funding sources list on checkout pages, ensuring
+		 * the BCDC button remains clickable and functional for merchants using branded-only mode.
+		 */
+		add_filter(
+			'woocommerce_paypal_payments_sdk_disabled_funding_hook',
+			static function ( array $disable_funding, array $flags ): array {
+				$allowed_context = array( 'checkout-block', 'checkout' );
+				if ( ! in_array( $flags['context'], $allowed_context, true ) ) {
+					return $disable_funding;
+				}
+
+				return array_filter(
+					$disable_funding,
+					static fn( string $funding_source ) => $funding_source !== 'card'
+				);
+			},
+			10,
+			2
+		);
+
 		$payment_settings = $container->get( 'settings.data.payment' );
 		assert( $payment_settings instanceof PaymentSettings );
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -792,6 +792,24 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			return;
 		}
 
+		$payment_settings = $container->get( 'settings.data.payment' );
+		assert( $payment_settings instanceof PaymentSettings );
+
+		if ( $payment_settings->is_method_enabled( CreditCardGateway::ID ) ) {
+			$payment_settings->toggle_method_state( CreditCardGateway::ID, false );
+			$payment_settings->save();
+		}
+
+		if ( $payment_settings->is_method_enabled( ApplePayGateway::ID ) ) {
+			$payment_settings->toggle_method_state( ApplePayGateway::ID, false );
+			$payment_settings->save();
+		}
+
+		if ( $payment_settings->is_method_enabled( GooglePayGateway::ID ) ) {
+			$payment_settings->toggle_method_state( GooglePayGateway::ID, false );
+			$payment_settings->save();
+		}
+
 		/**
 		 * In branded-only mode, we completely disable all white label features.
 		 */


### PR DESCRIPTION
## Issue Description

During onboarding, when merchants configure their PayPal integration with branded-only mode enabled, white-label payment methods (ACDC, Apple Pay, Google Pay) were incorrectly being enabled in the payment settings for business sellers.

While eligibility filters were intended to prevent these methods from displaying, they were actually shown on the frontend despite being hidden in backend settings, creating confusion and issues:

1. **Frontend visibility**: White-label payment methods were visible and functional on checkout pages despite branded-only mode being active
2. **Settings inconsistency**: Methods appeared as "enabled" in WooCommerce payment settings when they shouldn't be available
3. **BCDC button disabled**: After properly disabling ACDC, the PayPal-branded card button (BCDC) became non-functional because the 'card' funding source remained in the disabled funding sources list

### Expected Behavior
In branded-only mode:
- White-label payment methods (ACDC, Apple Pay, Google Pay) should not be visible on the frontend
- These methods should be disabled in backend settings
- PayPal-branded card button (BCDC) should remain functional for card payments
- Settings state should accurately reflect the active payment methods

## PR Description

### Changes Made

**1. Disable white-label payment methods in settings**
- Added logic in `apply_branded_only_limitations()` to explicitly disable ACDC, Apple Pay, and Google Pay when branded-only mode is detected
- Methods are toggled off and settings are saved to ensure consistent state
- This prevents these methods from appearing on the frontend and ensures backend settings accurately reflect available payment options

**2. Keep BCDC functional in branded-only mode**
- Added filter on `woocommerce_paypal_payments_sdk_disabled_funding_hook` to prevent 'card' funding source from being disabled on checkout pages
- BCDC (PayPal-branded card button) requires the 'card' funding source to remain enabled
- Filter only applies in checkout contexts where BCDC is relevant

### Technical Details

The fix addresses the onboarding flow in `toggle_payment_gateways()` which enables ACDC, Apple Pay, and Google Pay for business sellers without checking branded-only mode settings. The new logic in `apply_branded_only_limitations()` runs after onboarding and corrects the payment method states.

The distinction between BCDC and ACDC is critical:
- **BCDC** = PayPal-branded card button (allowed in branded-only mode)
- **ACDC** = Advanced Credit and Debit Card fields (white-label, not allowed in branded-only mode)

Both use the 'card' funding source, but only BCDC should be available when branded-only mode is active.

### Testing

- [ ] Onboard a new merchant with branded-only mode enabled
- [ ] Verify ACDC, Apple Pay, and Google Pay are disabled in WooCommerce > Settings > Payments
- [ ] Verify these white-label methods do NOT appear on frontend checkout
- [ ] Verify BCDC button appears and is functional on checkout page
- [ ] Verify PayPal and Venmo buttons work as expected
- [ ] Test with both classic and block checkout