### PR TITLE
Agentic: Defer PayPal order sync from cart updates to checkout (5859)

### DIFF
--- a/modules/ppcp-agentic-commerce/services.php
+++ b/modules/ppcp-agentic-commerce/services.php
@@ -147,7 +147,8 @@ return array(
 		return new AgenticCheckoutProcessor(
 			$c->get( 'agentic.helper.paypal-order-manager' ),
 			$c->get( 'button.helper.wc-order-creator' ),
-			$c->get( 'agentic.helper.cart-builder' )
+			$c->get( 'agentic.helper.cart-builder' ),
+			$c->get( 'agentic.response.applied-coupons-builder' )
 		);
 	},
 
@@ -255,8 +256,7 @@ return array(
 			$c->get( 'agentic.response.factory' ),
 			$c->get( 'agentic.validation.processor' ),
 			$c->get( 'agentic.logger' ),
-			$c->get( 'agentic.helper.paypal-order-manager' ),
-			$c->get( 'agentic.response.applied-coupons-builder' )
+			$c->get( 'agentic.helper.paypal-order-manager' )
 		);
 	},
 	'agentic.rest.checkout'                        => static function ( ContainerInterface $c ): CheckoutEndpoint {

--- a/modules/ppcp-agentic-commerce/src/Endpoint/ReplaceCartEndpoint.php
+++ b/modules/ppcp-agentic-commerce/src/Endpoint/ReplaceCartEndpoint.php
@@ -11,20 +11,11 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Endpoint;
 
-use Psr\Log\LoggerInterface;
-use RuntimeException;
 use WP_REST_Request;
 use WP_REST_Response;
 
-use WooCommerce\PayPalCommerce\AgenticCommerce\Auth\AuthServiceProvider;
-use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\CartValidationProcessor;
-use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\CouponValidator\AppliedCouponsBuilder;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\Http\NotFoundError;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Errors\AgenticError;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\AgenticSessionManager;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Helper\PayPalOrderManager;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Response\ResponseFactory;
-use WooCommerce\PayPalCommerce\AgenticCommerce\Session\AgenticSessionHandler;
 
 /**
  * Replace Cart REST endpoint.
@@ -41,48 +32,6 @@ class ReplaceCartEndpoint extends AgenticRestEndpoint {
 	 * The expected HTTP method.
 	 */
 	private const METHOD = 'PUT';
-
-	/**
-	 * Applied coupons builder for discount calculation.
-	 *
-	 * @var AppliedCouponsBuilder
-	 */
-	private AppliedCouponsBuilder $applied_coupons_builder;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param AuthServiceProvider     $auth_provider Auth service provider.
-	 * @param AgenticSessionHandler   $session_handler Session handler.
-	 * @param AgenticSessionManager   $session_manager Session manager.
-	 * @param ResponseFactory         $response_factory Response factory.
-	 * @param CartValidationProcessor $validation_processor Validation processor.
-	 * @param LoggerInterface         $logger Logger.
-	 * @param PayPalOrderManager      $order_manager PayPal order manager.
-	 * @param AppliedCouponsBuilder   $applied_coupons_builder Applied coupons builder.
-	 */
-	public function __construct(
-		AuthServiceProvider $auth_provider,
-		AgenticSessionHandler $session_handler,
-		AgenticSessionManager $session_manager,
-		ResponseFactory $response_factory,
-		CartValidationProcessor $validation_processor,
-		LoggerInterface $logger,
-		PayPalOrderManager $order_manager,
-		AppliedCouponsBuilder $applied_coupons_builder
-	) {
-		parent::__construct(
-			$auth_provider,
-			$session_handler,
-			$session_manager,
-			$response_factory,
-			$validation_processor,
-			$logger,
-			$order_manager
-		);
-
-		$this->applied_coupons_builder = $applied_coupons_builder;
-	}
 
 	/**
 	 * Register REST API routes.
@@ -124,25 +73,6 @@ class ReplaceCartEndpoint extends AgenticRestEndpoint {
 
 		if ( $new_cart instanceof AgenticError ) {
 			return $this->error( $new_cart );
-		}
-
-		// Get the PayPal Order ID (ec_token).
-		$paypal_order_id = $session['ec_token'];
-
-		// Calculate total discount from applied coupons for PayPal order update.
-		$total_discount = $this->applied_coupons_builder->calculate_total_discount( $new_cart );
-
-		// Update the PayPal Order with new totals (including discount).
-		try {
-			$this->order_manager->update_order( $paypal_order_id, $new_cart, $total_discount );
-		} catch ( RuntimeException $e ) {
-			return $this->error_not_found(
-				'Failed to update PayPal Order: ' . $e->getMessage(),
-				array(
-					'issue'       => 'PAYPAL_ORDER_UPDATE_FAILED',
-					'description' => 'Could not synchronize cart changes with PayPal.',
-				)
-			);
 		}
 
 		// Replace the cart session (preserving ec_token).

--- a/modules/ppcp-agentic-commerce/src/Helper/AgenticCheckoutProcessor.php
+++ b/modules/ppcp-agentic-commerce/src/Helper/AgenticCheckoutProcessor.php
@@ -17,6 +17,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order as PayPalOrder;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;
 use WooCommerce\PayPalCommerce\Button\Helper\WooCommerceOrderCreator;
 
+use WooCommerce\PayPalCommerce\AgenticCommerce\CartValidation\CouponValidator\AppliedCouponsBuilder;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PaymentMethod;
 
@@ -25,6 +26,7 @@ use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PaymentMethod;
  *
  * This service coordinates the following steps:
  * - Fetches PayPal order
+ * - Syncs PayPal order with final cart totals
  * - Translates PayPalCart to CartData
  * - Creates WooCommerce order
  * - Links PayPal and WC orders
@@ -38,15 +40,19 @@ class AgenticCheckoutProcessor {
 
 	private AgenticCartBuilder $cart_builder;
 
+	private AppliedCouponsBuilder $applied_coupons_builder;
+
 	public function __construct(
 		PayPalOrderManager $order_manager,
 		WooCommerceOrderCreator $wc_order_creator,
-		AgenticCartBuilder $cart_builder
+		AgenticCartBuilder $cart_builder,
+		AppliedCouponsBuilder $applied_coupons_builder
 	) {
 
-		$this->order_manager    = $order_manager;
-		$this->wc_order_creator = $wc_order_creator;
-		$this->cart_builder     = $cart_builder;
+		$this->order_manager           = $order_manager;
+		$this->wc_order_creator        = $wc_order_creator;
+		$this->cart_builder            = $cart_builder;
+		$this->applied_coupons_builder = $applied_coupons_builder;
 	}
 
 	/**
@@ -54,10 +60,11 @@ class AgenticCheckoutProcessor {
 	 *
 	 * This orchestrates the complete checkout workflow:
 	 * 1. Fetches the PayPal Order using the token (order ID)
-	 * 2. Translates PayPalCart to CartData
-	 * 3. Creates WooCommerce order from PayPal Order and CartData
-	 * 4. Links PayPal order with WC order ID
-	 * 5. Captures the PayPal payment
+	 * 2. Syncs PayPal order with final cart totals
+	 * 3. Translates PayPalCart to CartData
+	 * 4. Creates WooCommerce order from PayPal Order and CartData
+	 * 5. Links PayPal order with WC order ID
+	 * 6. Captures the PayPal payment
 	 *
 	 * @param PayPalCart    $cart            The PayPal cart data.
 	 * @param PaymentMethod $payment_method  The payment method data.
@@ -72,7 +79,11 @@ class AgenticCheckoutProcessor {
 
 		try {
 			$paypal_order = $this->order_manager->fetch_order( $paypal_order_id );
-			$wc_cart      = $this->cart_builder->paypal_cart_to_wc_cart( $cart );
+
+			$total_discount = $this->applied_coupons_builder->calculate_total_discount( $cart );
+			$this->order_manager->update_order( $paypal_order_id, $cart, $total_discount );
+
+			$wc_cart = $this->cart_builder->paypal_cart_to_wc_cart( $cart );
 
 			if ( is_wp_error( $wc_cart ) ) {
 				return $wc_cart;


### PR DESCRIPTION
### Description

Moves PayPal order sync (`update_order()`) from `ReplaceCartEndpoint` (every PUT) to `AgenticCheckoutProcessor` (once at checkout). Cart updates now only modify the local session, and PayPal amounts are synced with final totals—including coupon discounts—right before capture.

### Steps to Test

1. Create an agentic cart and PUT updates (items, coupons) — confirm no PayPal API calls are made
2. Trigger checkout — verify PayPal order is synced with correct totals before capture
3. Confirm WooCommerce order amounts are correct
4. Simulate a PayPal sync failure at checkout — verify error is returned to the agent