### PR TITLE
Agentic: Extract shared totals calculation for PayPal order updates (5863)

### DIFF
--- a/modules/ppcp-agentic-commerce/src/Helper/CartHelper.php
+++ b/modules/ppcp-agentic-commerce/src/Helper/CartHelper.php
@@ -12,6 +12,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Helper;
 
+use WC_Cart;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\PayPalCart;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\CartItem;
 use WooCommerce\PayPalCommerce\AgenticCommerce\Schema\Address;
@@ -149,6 +150,52 @@ class CartHelper {
 			'admin_area_1'   => $address->admin_area_1() ?? '',
 			'postal_code'    => $address->postal_code() ?? '',
 			'country_code'   => $address->country_code() ?? '',
+		);
+	}
+
+	/**
+	 * Calculate cart totals from WooCommerce cart.
+	 *
+	 * @param WC_Cart $wc_cart       The WooCommerce cart.
+	 * @param string  $currency_code The currency code.
+	 * @return array|null The totals array, or null if not calculable.
+	 */
+	public static function calculate_totals( WC_Cart $wc_cart, string $currency_code ): ?array {
+		$item_total     = (float) $wc_cart->get_cart_contents_total();
+		$discount_total = (float) $wc_cart->get_discount_total();
+		$shipping_total = (float) $wc_cart->get_shipping_total();
+		$tax_total      = (float) $wc_cart->get_total_tax();
+		$cart_total     = (float) $wc_cart->get_total( 'edit' );
+
+		if ( ! $currency_code || $item_total <= 0 || $cart_total <= 0 ) {
+			return null;
+		}
+
+		$totals = array(
+			'item_total' => self::money( $currency_code, $item_total ),
+			'shipping'   => self::money( $currency_code, $shipping_total ),
+			'tax_total'  => self::money( $currency_code, $tax_total ),
+			'amount'     => self::money( $currency_code, $cart_total ),
+		);
+
+		if ( $discount_total > 0 ) {
+			$totals['discount'] = self::money( $currency_code, $discount_total );
+		}
+
+		return $totals;
+	}
+
+	/**
+	 * Format a money value for API responses.
+	 *
+	 * @param string $currency_code The currency code.
+	 * @param float  $value         The money value.
+	 * @return array Money object with currency_code and value.
+	 */
+	public static function money( string $currency_code, float $value ): array {
+		return array(
+			'currency_code' => $currency_code,
+			'value'         => number_format( $value, 2 ),
 		);
 	}
 }

--- a/modules/ppcp-agentic-commerce/src/Helper/PayPalOrderManager.php
+++ b/modules/ppcp-agentic-commerce/src/Helper/PayPalOrderManager.php
@@ -12,6 +12,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AgenticCommerce\Helper;
 
 use RuntimeException;
+use WC_Cart;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
@@ -140,8 +141,30 @@ class PayPalOrderManager {
 	 * @throws RuntimeException If the update fails.
 	 */
 	public function update_order( string $order_id, PayPalCart $cart, float $discount = 0.0 ): void {
-		$totals = $this->calculate_cart_totals( $cart, $discount );
-		$items  = $this->build_items_for_patch( $cart );
+		$wc_cart = $this->cart_builder->paypal_cart_to_wc_cart( $cart );
+
+		if ( is_wp_error( $wc_cart ) ) {
+			$this->logger->warning(
+				'[ORDER] Cannot update PayPal Order: failed to build WC_Cart',
+				array(
+					'order_id' => $order_id,
+					'error'    => $wc_cart->get_error_message(),
+				)
+			);
+			return;
+		}
+
+		$currency_code = CartHelper::currency( $cart );
+		$totals        = CartHelper::calculate_totals( $wc_cart, $currency_code );
+		$items         = $this->build_items_for_patch( $cart );
+
+		if ( ! $totals ) {
+			$this->logger->warning(
+				'[ORDER] Cannot update PayPal Order: totals not calculable',
+				array( 'order_id' => $order_id )
+			);
+			return;
+		}
 
 		$this->logger->info(
 			'[ORDER] Updating PayPal Order',
@@ -161,7 +184,7 @@ class PayPalOrderManager {
 		);
 
 		// Only include discount in breakdown if there's a discount.
-		if ( $discount > 0 ) {
+		if ( isset( $totals['discount'] ) ) {
 			$breakdown['discount'] = $totals['discount'];
 		}
 
@@ -196,7 +219,6 @@ class PayPalOrderManager {
 				array(
 					'order_id'   => $order_id,
 					'amount'     => $cart_amount['value'],
-					'discount'   => $discount,
 					'item_count' => count( $items ),
 				)
 			);
@@ -383,60 +405,6 @@ class PayPalOrderManager {
 			// Return null - payment can be handled manually or via webhook.
 			return null;
 		}
-	}
-
-	/**
-	 * Calculate cart totals from items.
-	 *
-	 * @param PayPalCart $cart     The cart.
-	 * @param float      $discount The total discount amount.
-	 * @return array The totals array with currency_code and value for each total.
-	 */
-	private function calculate_cart_totals( PayPalCart $cart, float $discount = 0.0 ): array {
-		$currency_code = CartHelper::currency( $cart );
-		$item_total    = CartHelper::cart_item_total( $cart );
-
-		// Cap discount to prevent order amount from reaching $0.
-		// PayPal requires order amount > 0, while WooCommerce allows $0 orders.
-		// TODO: Confirm how $0 orders should be handled in agentic context.
-		if ( $discount >= $item_total ) {
-			$discount = max( 0, $item_total - 0.01 );
-		}
-
-		// Calculate final amount: item_total - discount (+ shipping + tax when implemented).
-		// Ensure amount is at least $0.01 for PayPal.
-		/** @psalm-suppress InvalidOperand */
-		$net_total = $item_total - $discount;
-		$amount    = max( 0.01, $net_total );
-
-		$totals = array(
-			'item_total' => array(
-				'currency_code' => $currency_code,
-				'value'         => $this->format_money( $item_total ),
-			),
-			'shipping'   => array(
-				'currency_code' => $currency_code,
-				'value'         => $this->format_money( 0.00 ),
-			),
-			'tax_total'  => array(
-				'currency_code' => $currency_code,
-				'value'         => $this->format_money( 0.00 ),
-			),
-			'amount'     => array(
-				'currency_code' => $currency_code,
-				'value'         => $this->format_money( $amount ),
-			),
-		);
-
-		// Only include discount if there is one.
-		if ( $discount > 0 ) {
-			$totals['discount'] = array(
-				'currency_code' => $currency_code,
-				'value'         => $this->format_money( $discount ),
-			);
-		}
-
-		return $totals;
 	}
 
 	/**

--- a/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
+++ b/modules/ppcp-agentic-commerce/src/Response/CartResponse.php
@@ -116,45 +116,16 @@ class CartResponse {
 	/**
 	 * Calculate cart totals.
 	 *
-	 * @return array The cart-totals array, or null if not calculatable.
+	 * @return array|null The cart-totals array, or null if not calculable.
 	 */
 	private function calculate_totals(): ?array {
-		// Cart items have invalid prices or currency: do not calculate totals.
 		if ( ! $this->wc_cart || $this->cart->has_validation_issue( ErrorCode::PRICING_ERROR ) ) {
 			return null;
 		}
 
-		$currency_code  = CartHelper::currency( $this->cart );
-		$item_total     = (float) $this->wc_cart->get_cart_contents_total();
-		$discount_total = (float) $this->wc_cart->get_discount_total();
-		$shipping_total = $this->wc_cart->get_shipping_total();
-		$tax_total      = $this->wc_cart->get_total_tax();
-		$cart_total     = (float) $this->wc_cart->get_total( 'edit' );
+		$currency_code = CartHelper::currency( $this->cart );
 
-		// Cart has no items, no currency, no quantity: nothing to calculate.
-		if ( ! $currency_code || $item_total <= 0 || $cart_total <= 0 ) {
-			return null;
-		}
-
-		$totals = array(
-			'item_total' => $this->money( $currency_code, $item_total ),
-			'shipping'   => $this->money( $currency_code, (float) $shipping_total ),
-			'tax_total'  => $this->money( $currency_code, (float) $tax_total ),
-			'amount'     => $this->money( $currency_code, $cart_total ),
-		);
-
-		if ( $discount_total > 0 ) {
-			$totals['discount'] = $this->money( $currency_code, $discount_total );
-		}
-
-		return $totals;
-	}
-
-	private function money( string $currency_code, float $value ): array {
-		return array(
-			'currency_code' => $currency_code,
-			'value'         => number_format( $value, 2 ),
-		);
+		return CartHelper::calculate_totals( $this->wc_cart, $currency_code );
 	}
 
 	private function status(): string {


### PR DESCRIPTION
### Description
Extract `calculate_totals()` and `money()` helper methods from `CartResponse` to `CartHelper` so both `CartResponse` and `PayPalOrderManager` use the same calculation logic for shipping, tax, and discount totals.                                                                                                      
                                                                                                                                                                                                                                                                                        
                                                                                                                                                                  
### Steps to Test                                                                                                                                                   
                                                                                                                                                                  
  1. Create an agentic cart with items that have shipping and/or tax                                                                                              
  2. Update the cart via PUT `/merchant-cart/{cart_id}`                                                                                                             
  3. Verify PayPal order totals include accurate shipping/tax values (not 0.00)                                                                                   
  4. Complete checkout and verify amounts match between WooCommerce and PayPal    