### PR TITLE
Docs: add npm run build after npm ci in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Optionally, change the `PAYPAL_INTEGRATION_DATE` constant to `gmdate( 'Y-m-d' )`
 
 1. `$ ./vendor/bin/phpunit`
 2. `$ ./vendor/bin/phpcs`
-3. `$ ./vendor/bin/psalm`
+3. `$ ./vendor/bin/phpstan`
 4. `$ npm run lint-js`
 5. `$ npm run test:unit-js` - Ensure node version is `18` or above
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Check [this article](https://docs.ddev.com/en/stable/users/debugging-profiling/s
 
 - `$ composer install`
 - `$ npm ci`
+- `$ npm run build`
 
 Optionally, change the `PAYPAL_INTEGRATION_DATE` constant to `gmdate( 'Y-m-d' )` to run the latest PayPal JavaScript SDK
 


### PR DESCRIPTION
Adds `npm run build` to the instructions for setting up the environment.