### PR TITLE
Performance issue in /v2/vault/payment-tokens/id (5918)

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
+++ b/modules/ppcp-wc-subscriptions/src/WcSubscriptionsModule.php
@@ -400,20 +400,20 @@ class WcSubscriptionsModule implements ServiceModule, ExtendingModule, Executabl
 					return $localized_script_data;
 				}
 
+				$free_trial_subscription_helper = $c->get( 'wc-subscriptions.free-trial-subscription-helper' );
+				assert( $free_trial_subscription_helper instanceof FreeTrialSubscriptionHelper );
+
+				if ( ! is_checkout() || ! $free_trial_subscription_helper->is_free_trial_cart() ) {
+					return $localized_script_data;
+				}
+
 				$vaulted_paypal_email = $c->get( 'wc-subscriptions.vault-v2.vaulted-paypal-email' );
 				assert( $vaulted_paypal_email instanceof VaultedPayPalEmail );
 
 				$vaulted_email = $vaulted_paypal_email->get_vaulted_paypal_email();
-				if ( ! $vaulted_email ) {
-					return $localized_script_data;
+				if ( $vaulted_email ) {
+					$localized_script_data['vaulted_paypal_email'] = $vaulted_email;
 				}
-
-				$free_trial_subscription_helper = $c->get( 'wc-subscriptions.free-trial-subscription-helper' );
-				assert( $free_trial_subscription_helper instanceof FreeTrialSubscriptionHelper );
-
-				$localized_script_data['vaulted_paypal_email'] = ( is_checkout() && $free_trial_subscription_helper->is_free_trial_cart() )
-				? $vaulted_paypal_email->get_vaulted_paypal_email()
-				: '';
 
 				return $localized_script_data;
 			}


### PR DESCRIPTION
This PR fixes the problem with reported performance issues with `/v2/vault/payment-tokens/id` endpoint, it moves the `is_checkout() && is_free_trial_cart()` check before the `get_vaulted_paypal_email()` API call.