### PR TITLE
docs: add minimal agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ Minimal instructions for coding agents working in this repository.
 - Use `ddev describe` for active URLs/ports.
 - If `.ddev.site` routing fails, use the direct host mapping shown in `ddev describe` for `web:80` (for example `http://127.0.0.1:60792`).
 - Admin defaults: `admin` / `admin` at `/wp-admin`.
+- Common DDEV issues and fixes are documented in the README under "Troubleshooting DDEV setup" (vmnetd/port errors, Docker CLI path, SSL trust, Mutagen warnings).
 
 ### Build
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# AGENTS.md
+
+Minimal instructions for coding agents working in this repository.
+
+## CRITICAL Rules
+
+- CRITICAL: Keep `CLAUDE.md` as a pointer to this file (`@AGENTS.md`).
+- CRITICAL: Maintain PHP `7.4+` compatibility unless project requirements change.
+- CRITICAL: Do not edit WordPress core, `vendor/`, or `node_modules/`.
+- CRITICAL: For frontend work, edit `modules/*/resources/*`; do not hand-edit built files in `/assets`.
+- CRITICAL: Never revert unrelated local changes.
+- MUST: Run relevant lint/tests before claiming completion.
+
+## Project Knowledge
+
+- This is a modular WooCommerce/WordPress plugin using Syde Modularity.
+- Key entry points:
+  - `woocommerce-paypal-payments.php` (plugin bootstrap/constants)
+  - `bootstrap.php` (container + module boot)
+  - `modules.php` (module registration and feature-flag loading)
+- Most feature code is in `modules/*`.
+- Service wiring is module-based (`services.php`, `factories.php`, `extensions.php`).
+- Architecture reference: `docs/plugin-architecture.md`.
+
+## Commands
+
+### Setup
+
+- Preferred local env: DDEV.
+- `npm run ddev:setup` (start + orchestrate).
+- If WP is missing after startup, run `ddev orchestrate`.
+- Use `ddev describe` for active URLs/ports.
+- If `.ddev.site` routing fails, use the direct host mapping shown in `ddev describe` for `web:80` (for example `http://127.0.0.1:60792`).
+- Admin defaults: `admin` / `admin` at `/wp-admin`.
+
+### Build
+
+- Non-DDEV setup: `composer install && npm ci && npm run build`.
+
+### Quality
+
+- `npm run lint` (PHPCS + PHPStan)
+- `npm run lint-js`
+- `npm run unit-tests`
+- `npm run test:unit-js`
+- `npm run integration-tests`
+- `npm run test` (full suite)
+- `npm run ddev:unit-tests:coverage` (coverage in DDEV)
+
+## Conventions
+
+- Add or extend behavior through module services/extensions, not ad-hoc globals.
+- If adding/removing a module, update `modules.php` and validate feature-flag behavior.
+- Keep i18n text domain as `woocommerce-paypal-payments`.
+- PRs should include reproducible test steps and a changelog summary.
+
+## Architectural Decisions
+
+- The plugin is intentionally modular; do not collapse it into a monolith.
+- Some modules are intentionally conditional via `PCP_*_ENABLED` and `woocommerce.feature-flags.*`.
+- JS/SCSS build output is intentionally centralized in root `/assets` via webpack.
+- WordPress hook-based integration and service registration are intentional patterns.
+
+## Common Pitfalls
+
+- Editing generated `/assets` files instead of module `resources`.
+- Forgetting to rebuild after JS/SCSS source changes.
+- Introducing PHP syntax that is not PHP 7.4 compatible.
+- Accessing plugin container/services before initialization.
+- Skipping integration tests for checkout, payment, onboarding, or webhook changes.
+- Changing module load order/feature flags without validating side effects.
+- Assuming `.ddev.site` URLs always resolve locally.
+
+## Verification Matrix
+
+- PHP-only change: `npm run unit-tests && npm run lint`
+- JS-only change: `npm run test:unit-js && npm run lint-js`
+- Checkout/payment/onboarding/webhook change: `npm run test`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Minimal instructions for coding agents working in this repository.
 - CRITICAL: Keep `CLAUDE.md` as a pointer to this file (`@AGENTS.md`).
 - CRITICAL: Maintain PHP `7.4+` compatibility unless project requirements change.
 - CRITICAL: Do not edit WordPress core, `vendor/`, or `node_modules/`.
-- CRITICAL: For frontend work, edit `modules/*/resources/*`; do not hand-edit built files in `/assets`.
+- CRITICAL: For frontend work, edit `modules/*/resources/*`.
 - CRITICAL: Never revert unrelated local changes.
 - MUST: Run relevant lint/tests before claiming completion.
 
@@ -41,7 +41,8 @@ Minimal instructions for coding agents working in this repository.
 ### Quality
 
 - `npm run lint` (PHPCS + PHPStan)
-- `npm run lint-js`
+- `npm run lint-js` (currently unreliable for full-repo linting in this project)
+- `npx wp-scripts lint-js <file-or-dir>` (recommended; works for targeted JS/TS paths)
 - `npm run unit-tests`
 - `npm run test:unit-js`
 - `npm run integration-tests`
@@ -75,5 +76,5 @@ Minimal instructions for coding agents working in this repository.
 ## Verification Matrix
 
 - PHP-only change: `npm run unit-tests && npm run lint`
-- JS-only change: `npm run test:unit-js && npm run lint-js`
+- JS-only change: `npm run test:unit-js && npx wp-scripts lint-js <changed-js-files-or-dir>`
 - Checkout/payment/onboarding/webhook change: `npm run test`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -66,6 +66,30 @@ To set up the DDEV environment, follow these steps:
 Use `$ ddev reset` for reinstallation (will destroy all site data).
 You may also need `$ ddev restart` to apply the config changes.
 
+#### Troubleshooting DDEV setup
+
+**`vmnetd` / port 443 error** (`failed to connect to /var/run/com.docker.vmnetd.sock`):
+Docker Desktop's privileged helper isn't running. Open **Docker Desktop > Settings > General** and toggle "Allow privileged port mapping", then restart Docker Desktop. Alternatively, use non-privileged ports:
+```
+$ ddev config global --router-http-port=8080 --router-https-port=8443
+```
+
+**Mutagen can't find `docker`** (`unable to identify 'docker' command`):
+Docker Desktop may not symlink the CLI to `/usr/local/bin`. Either enable "Install Docker CLI in system PATH" in Docker Desktop settings, or create the symlink manually:
+```
+$ sudo ln -s /Applications/Docker.app/Contents/Resources/bin/docker /usr/local/bin/docker
+```
+Then run `ddev mutagen reset && ddev restart`.
+
+**Untrusted SSL / "Not Secure" in browser**:
+Install mkcert's root CA so your system and browsers trust DDEV's certificates:
+```
+$ brew install mkcert nss
+$ mkcert -install
+$ ddev restart
+```
+After installing the CA, fully quit Chrome (Cmd+Q) and reopen it — Chrome caches certificate trust state and won't pick up the new CA until restarted.
+
 #### Running tests and other tasks in the DDEV environment
 
 Tests and code style:

--- a/README.md
+++ b/README.md
@@ -25,16 +25,16 @@
 
 PayPal's latest complete payments processing solution. Accept PayPal, Pay Later, credit/debit cards, alternative digital wallets local payment types and bank accounts. Turn on only PayPal options or process a full suite of payment methods. Enable global transaction with extensive currency and country coverage.
 
-## Features  
-  
-- **Multiple Payment Options**: PayPal, credit/debit cards, Pay Later, digital wallets (Apple Pay, Google Pay), and localized payment methods  
-- **Subscription Support**: Supports WooCommerce Subscriptions with PayPal Vaulting and PayPal Subscriptions  
-- **Customizable Experience**: Flexible button placement and styling options  
-- **Enhanced Security**: PCI compliance, 3D Secure, and fraud protection tools  
-- **Global Compliance**: Meets international standards (PSD2, SCA)  
-  
-## Documentation  
-  
+## Features
+
+- **Multiple Payment Options**: PayPal, credit/debit cards, Pay Later, digital wallets (Apple Pay, Google Pay), and localized payment methods
+- **Subscription Support**: Supports WooCommerce Subscriptions with PayPal Vaulting and PayPal Subscriptions
+- **Customizable Experience**: Flexible button placement and styling options
+- **Enhanced Security**: PCI compliance, 3D Secure, and fraud protection tools
+- **Global Compliance**: Meets international standards (PSD2, SCA)
+
+## Documentation
+
 Visit our [official documentation](https://woocommerce.com/document/woocommerce-paypal-payments/) for detailed guides and setup instructions.
 
 ## Dependencies
@@ -43,11 +43,11 @@ Visit our [official documentation](https://woocommerce.com/document/woocommerce-
 * WordPress >= 6.5
 * WooCommerce >= 9.6
 
-## Quick Installation  
-  
-1. Go to **Plugins > Add New** in your WordPress admin  
-2. Search for "WooCommerce PayPal Payments"  
-3. Click "Install Now" and then "Activate"  
+## Quick Installation
+
+1. Go to **Plugins > Add New** in your WordPress admin
+2. Search for "WooCommerce PayPal Payments"
+3. Click "Install Now" and then "Activate"
 4. Go to **WooCommerce > Settings > Payments** to configure PayPal Payments
 
 ## Development
@@ -59,9 +59,9 @@ You can install WooCommerce PayPal Payments locally using the dev environment of
 To set up the DDEV environment, follow these steps:
 
 0. Install Docker and [DDEV](https://ddev.readthedocs.io/en/stable/).
-1. Edit the [configuration](https://docs.ddev.com/en/stable/users/configuration/config/#managing-configuration) in the `.ddev/config.local.yml` file if needed. 
+1. Edit the [configuration](https://docs.ddev.com/en/stable/users/configuration/config/#managing-configuration) in the `.ddev/config.local.yml` file if needed.
 2. Run `$ ddev start && ddev orchestrate` to setup and orchestrate the plugin, WooCommerce and WordPress (you can also use `$ npm run ddev:setup`)
-3. Open https://woocommerce-paypal-payments.ddev.site 
+3. Open https://woocommerce-paypal-payments.ddev.site
 
 Use `$ ddev reset` for reinstallation (will destroy all site data).
 You may also need `$ ddev restart` to apply the config changes.
@@ -75,7 +75,7 @@ $ ddev config global --router-http-port=8080 --router-https-port=8443
 ```
 
 **Mutagen can't find `docker`** (`unable to identify 'docker' command`):
-Docker Desktop may not symlink the CLI to `/usr/local/bin`. Either enable "Install Docker CLI in system PATH" in Docker Desktop settings, or create the symlink manually:
+Docker Desktop may not symlink the CLI to `/usr/local/bin`. Either enable "Install Docker CLI in system PATH" in Docker Desktop settings, or create the symlink manually. Here's an example:
 ```
 $ sudo ln -s /Applications/Docker.app/Contents/Resources/bin/docker /usr/local/bin/docker
 ```
@@ -133,7 +133,7 @@ This command generates a full test coverage report, available at the URL https:/
 
 If you want to build a release package, use the **Build package (New)** in GitHub Actions.
 
-Currently, there is no script for building a proper release package locally, but you may try to run GHA locally via [nektos/act](https://github.com/nektos/act). 
+Currently, there is no script for building a proper release package locally, but you may try to run GHA locally via [nektos/act](https://github.com/nektos/act).
 
 ## Test account setup
 


### PR DESCRIPTION
Across Automattic, we're attempting to improve the agent experience of our codebases. At a high level, this includes the following:

- **Guidelines**: The repo tells agents what they need to know: project structure, conventions, gotchas, and explicit instructions via AGENTS.md, CLAUDE.md, and skills. A developer can point an agent at the repo and it understands how to work in it. See the Field Guide article linked above the table.
- **Build & Tests**: An agent can build the project and run tests on its own. It can verify its code compiles and doesn't break existing functionality without human hand-holding.
- **E2E Verification**: An agent can check that its changes actually work — not just that tests pass, but that the feature behaves correctly from a user's perspective (e.g. local dev server, preview URL).
- **Isolated ENV**: An agent can work in a sandboxed environment where it's safe to experiment. Mistakes don't touch production or shared state, so developers can let agents run with less supervision.

### Description

This PR adds repository-level coding agent guidance in a minimal, high-signal format aligned with Automattic guidelines.

Changes included:
- Added `AGENTS.md` with concise sections for:
  - project knowledge
  - setup/build/test commands
  - conventions
  - architectural decisions
  - common pitfalls
  - verification matrix
- Added `CLAUDE.md` as a single-line pointer to `@AGENTS.md` to keep one source of truth.

<img width="2618" height="1522" alt="Screenshot 2026-02-18 at 11 16 30 AM" src="https://github.com/user-attachments/assets/e025443a-2096-40d1-afcb-e7f4237aedde" />

<img width="1536" height="1108" alt="CleanShot 2026-02-18 at 11 23 03@2x" src="https://github.com/user-attachments/assets/109cedda-b8ec-43e7-83eb-89c1dd0839a5" />


### Steps to Test

1. Check out branch `update/agents-md-minimal-fg`.
2. Open `AGENTS.md` and verify it contains the minimal guidance sections above.
3. Open `CLAUDE.md` and verify it contains exactly `@AGENTS.md`.
4. Ask the agent (such as Codex) to build and run tests.
5. Ask the agent to browse the local test environment.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Add minimal repository instructions for coding agents via `AGENTS.md`, with `CLAUDE.md` pointing to it.
