### PR TITLE
New UI - As ACDC is not enable by default and after enabling, saving and reloading page setting is not preserved (5907)

### DIFF
--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -87,6 +87,11 @@ class PaymentSettings extends AbstractDataModel {
 					$gateway->enabled = wc_bool_to_string( $is_enabled );
 
 					$this->modified_gateway( $gateway );
+				} else {
+					$option_key          = 'woocommerce_' . $method_id . '_settings';
+					$settings            = get_option( $option_key, array() );
+					$settings['enabled'] = wc_bool_to_string( $is_enabled );
+					update_option( $option_key, $settings );
 				}
 		}
 	}
@@ -127,6 +132,11 @@ class PaymentSettings extends AbstractDataModel {
 			$gateway->title = $title;
 
 			$this->modified_gateway( $gateway );
+		} else {
+			$option_key        = 'woocommerce_' . $method_id . '_settings';
+			$settings          = get_option( $option_key, array() );
+			$settings['title'] = $title;
+			update_option( $option_key, $settings );
 		}
 	}
 
@@ -140,6 +150,11 @@ class PaymentSettings extends AbstractDataModel {
 			$gateway->description = $description;
 
 			$this->modified_gateway( $gateway );
+		} else {
+			$option_key              = 'woocommerce_' . $method_id . '_settings';
+			$settings                = get_option( $option_key, array() );
+			$settings['description'] = $description;
+			update_option( $option_key, $settings );
 		}
 	}
 


### PR DESCRIPTION
`PaymentSettings::toggle_method_state()` (and `set_method_title/set_method_description`) rely on `WC()->payment_gateways()` to find the gateway object. But gateways like CreditCardGateway are only registered             conditionally when `wcgateway.is-plugin-settings-page` is true. During REST API saves (`POST wc/v3/wc_paypal/payment`), that flag is false, so `get_gateway()` returns `null` and the write silently does nothing.

### Steps To Reproduce
- Onboard with merchant from US
- Navigate to Payment tab and enable ACDC, save settings and reload
  - Observe setting are not saved

This PR adds a fallback when the gateway object isn't available and writes directly to the `woocommerce_{id}_settings option`.