### PR TITLE
Missing shipping address validation not triggering requires additional information status (5867)

### DIFF
--- a/modules/ppcp-store-sync/src/CartValidation/ShippingValidator.php
+++ b/modules/ppcp-store-sync/src/CartValidation/ShippingValidator.php
@@ -4,10 +4,10 @@
  *
  * Validates shipping addresses and restrictions according to WooCommerce settings.
  * Covers four main scenarios:
- * 0. Missing Shipping Address (physical products, no address provided)
- * 1. Invalid Shipping Address (completeness, format)
- * 2. PO Box Restriction (signature-required items)
- * 3. Region Restricted (country not allowed)
+ * 1. Missing Shipping Address (physical products, no address provided)
+ * 2. Invalid Shipping Address (completeness, format)
+ * 3. PO Box Restriction (signature-required items)
+ * 4. Region Restricted (country not allowed)
  *
  * @package WooCommerce\PayPalCommerce\StoreSync\CartValidation
  */
@@ -49,11 +49,7 @@ class ShippingValidator implements ValidatorInterface {
 						'',
 						array( 'specific_issue' => ShippingIssue::MISSING_SHIPPING_ADDRESS ),
 						array(
-							array(
-								'action'   => 'PROVIDE_SHIPPING_ADDRESS',
-								'label'    => 'Add shipping address',
-								'metadata' => array( 'priority' => 'HIGH' ),
-							),
+							ResolutionOption::provide_shipping_address(),
 						)
 					),
 				);

--- a/modules/ppcp-store-sync/src/CartValidation/ShippingValidator.php
+++ b/modules/ppcp-store-sync/src/CartValidation/ShippingValidator.php
@@ -38,7 +38,7 @@ class ShippingValidator implements ValidatorInterface {
 
 	public function validate( PayPalCart $cart ) {
 		$shipping_address = $cart->shipping_address();
-
+		// Scenario 1: Missing Shipping Address.
 		if ( ! $shipping_address ) {
 			if ( $this->cart_needs_shipping( $cart ) ) {
 				return array(
@@ -59,19 +59,19 @@ class ShippingValidator implements ValidatorInterface {
 
 		$issues = array();
 
-		// Scenario 1: Invalid Shipping Address.
+		// Scenario 2: Invalid Shipping Address.
 		$address_issues = $this->validate_address_completeness( $shipping_address );
 		if ( $address_issues ) {
 			$issues = array_merge( $issues, $address_issues );
 		}
 
-		// Scenario 2: PO Box Restriction.
+		// Scenario 3: PO Box Restriction.
 		$po_box_issue = $this->validate_po_box_restrictions( $cart, $shipping_address );
 		if ( $po_box_issue ) {
 			$issues[] = $po_box_issue;
 		}
 
-		// Scenario 3: Region Restricted.
+		// Scenario 4: Region Restricted.
 		$country_issue = $this->validate_country( $shipping_address->country_code() );
 		if ( $country_issue ) {
 			$issues[] = $country_issue;

--- a/modules/ppcp-store-sync/src/CartValidation/ShippingValidator.php
+++ b/modules/ppcp-store-sync/src/CartValidation/ShippingValidator.php
@@ -3,7 +3,8 @@
  * Shipping Validator for Agentic Commerce.
  *
  * Validates shipping addresses and restrictions according to WooCommerce settings.
- * Covers three main scenarios:
+ * Covers four main scenarios:
+ * 0. Missing Shipping Address (physical products, no address provided)
  * 1. Invalid Shipping Address (completeness, format)
  * 2. PO Box Restriction (signature-required items)
  * 3. Region Restricted (country not allowed)
@@ -17,11 +18,13 @@ namespace WooCommerce\PayPalCommerce\StoreSync\CartValidation;
 
 use WC_Countries;
 use WooCommerce\PayPalCommerce\StoreSync\Enums\Priority;
+use WooCommerce\PayPalCommerce\StoreSync\Enums\ShippingIssue;
 use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\PayPalCart;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\ResolutionOption;
 use WooCommerce\PayPalCommerce\StoreSync\Validation\InvalidAddress;
 use WooCommerce\PayPalCommerce\StoreSync\Validation\ShippingUnavailable;
+use WooCommerce\PayPalCommerce\StoreSync\Validation\MissingField;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\Address;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\CartItem;
 
@@ -37,6 +40,24 @@ class ShippingValidator implements ValidatorInterface {
 		$shipping_address = $cart->shipping_address();
 
 		if ( ! $shipping_address ) {
+			if ( $this->cart_needs_shipping( $cart ) ) {
+				return array(
+					new MissingField(
+						'Shipping address is required',
+						'Please provide a shipping address to continue.',
+						'shipping_address',
+						'',
+						array( 'specific_issue' => ShippingIssue::MISSING_SHIPPING_ADDRESS ),
+						array(
+							array(
+								'action'   => 'PROVIDE_SHIPPING_ADDRESS',
+								'label'    => 'Add shipping address',
+								'metadata' => array( 'priority' => 'HIGH' ),
+							),
+						)
+					),
+				);
+			}
 			return null;
 		}
 
@@ -61,6 +82,22 @@ class ShippingValidator implements ValidatorInterface {
 		}
 
 		return $issues ?: null;
+	}
+
+	/**
+	 * Checks if any item in the cart requires shipping.
+	 *
+	 * @param PayPalCart $cart The cart to check.
+	 * @return bool True if at least one item needs shipping.
+	 */
+	private function cart_needs_shipping( PayPalCart $cart ): bool {
+		foreach ( $cart->items() as $item ) {
+			$product = $this->product_manager->find_product( $item );
+			if ( $product && $product->needs_shipping() ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/modules/ppcp-store-sync/src/Schema/ResolutionOption.php
+++ b/modules/ppcp-store-sync/src/Schema/ResolutionOption.php
@@ -172,6 +172,12 @@ class ResolutionOption {
 		);
 	}
 
+	public static function provide_shipping_address(): self {
+		return self::provide_missing_field( 'shipping_address', 'Add shipping address' )->with(
+			array( 'metadata' => array( 'priority' => Priority::HIGH ) )
+		);
+	}
+
 	/**
 	 * Factory: Wait for product restock.
 	 *

--- a/modules/ppcp-store-sync/src/Schema/ResolutionOption.php
+++ b/modules/ppcp-store-sync/src/Schema/ResolutionOption.php
@@ -172,12 +172,16 @@ class ResolutionOption {
 		);
 	}
 
+    /**
+     * Factory: Provide shipping address.
+     *
+     * @return self
+     */
 	public static function provide_shipping_address(): self {
 		return self::provide_missing_field( 'shipping_address', 'Add shipping address' )->with(
 			array( 'metadata' => array( 'priority' => Priority::HIGH ) )
 		);
 	}
-
 	/**
 	 * Factory: Wait for product restock.
 	 *


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

### Steps to Test

1. Create a new  simple cart via postman, with no address
2. See that the response has a Status invalid, and the validation issues shows the defect

This PR takes https://github.com/woocommerce/woocommerce-paypal-payments/tree/dev/PCP-5707-rename-to-store-sync as reference

