### PR TITLE
fix: Add Fastlane "Learn More" link for GB and AU locales (5903)

### DIFF
--- a/modules/ppcp-settings/resources/js/utils/countryInfoLinks.js
+++ b/modules/ppcp-settings/resources/js/utils/countryInfoLinks.js
@@ -26,6 +26,8 @@ export const learnMoreLinks = {
 			'https://www.paypal.com/uk/business/accept-payments/checkout',
 		PayInThree:
 			'https://www.paypal.com/uk/business/accept-payments/checkout/installments',
+		Fastlane:
+			'https://www.paypal.com/us/enterprise/payment-processing/guest-checkout',
 	},
 	FR: {
 		PaymentDetails:

--- a/modules/ppcp-settings/resources/js/utils/countryInfoLinks.js
+++ b/modules/ppcp-settings/resources/js/utils/countryInfoLinks.js
@@ -66,5 +66,7 @@ export const learnMoreLinks = {
 			'https://www.paypal.com/au/business/accept-payments/checkout',
 		PayLater:
 			'https://www.paypal.com/au/business/accept-payments/checkout/installments',
+		Fastlane:
+			'https://www.paypal.com/us/enterprise/payment-processing/guest-checkout',
 	},
 };


### PR DESCRIPTION
## Description

The Fastlane "Learn More" link was missing for GB (UK) and AU (Australia) locales in `learnMoreLinks`, causing the Fastlane section to render without a link on the onboarding screen and the four-step flow for merchants in those countries.

## Changes

Added `Fastlane` link entry to the `GB` and `AU` locale configurations in `learnMoreLinks`.

## Testing

1. Set store country to **UK** / currency to **GBP** → verify Fastlane "Learn More" link appears on the onboarding screen and four-step flow
2. Set store country to **Australia** / currency to **AUD** → same verification
3. Set store country to **US** → verify no regression