### PR TITLE
[QA] Refactor of Pay Later Messages and Styling autotests

### DIFF
--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -202,13 +202,14 @@ export namespace Pcp {
 			export type ButtonShape = 'Rectangle' | 'Pill';
 
 			export type ButtonLabel =
-				| 'Paypal'
+				| 'PayPal'
 				| 'Checkout'
 				| 'PayPal Buy Now'
 				| 'Pay with PayPal';
 
 			export type ButtonColor =
 				| 'Gold (recommended)'
+				| 'Gold (Recommended)'
 				| 'Blue'
 				| 'Silver'
 				| 'Black'
@@ -232,10 +233,11 @@ export namespace Pcp {
 				| 'Cart'
 				| 'Checkout'
 				| 'Home'
-				| 'Shop';
+				| 'Shop'
+				| 'WooCommerce Block';
 
 			export type LogoType =
-				| 'Full Logo'
+				| 'Full logo'
 				| 'Monogram'
 				| 'Inline'
 				| 'Message only';

--- a/tests/qa/tests/03-plugin-settings/_test-data/pay-later-messaging.data.ts
+++ b/tests/qa/tests/03-plugin-settings/_test-data/pay-later-messaging.data.ts
@@ -3,119 +3,62 @@
  */
 import { Pcp } from '../../../resources';
 
-const checkoutLocations: Pcp.Admin.Plm.Location[] = [
-	'Product page',
-	'Cart',
-	'Checkout',
-];
-const logoTypes: Pcp.Admin.Plm.LogoType[] = [
-	'Full Logo',
-	'Monogram',
-	'Inline',
-	'Message only',
-];
-const textColors: Pcp.Admin.Plm.TextColor[] = [
-	'Black / Blue logo',
-	'White / White logo',
-	'Monochrome',
-	'Black / Gray logo',
-];
-const logoPositions: Pcp.Admin.Plm.LogoPosition[] = [ 'Left', 'Right', 'Top' ];
-const textSizes: Pcp.Admin.Plm.TextSize[] = [ 'Small', 'Medium', 'Large' ];
-
-const bannerLocations: Pcp.Admin.Plm.Location[] = [ 'Home', 'Shop' ];
-const bannerColors: Pcp.Admin.Plm.BannerColor[] = [
-	'Blue',
-	'Black',
-	'White',
-	'White (no border)',
-];
-const bannerSizes: Pcp.Admin.Plm.BannerSize[] = [ '20 x 1', '8 x 1' ];
-
 /**
- * Builds data combinations for pages with payment buttons (Procuct, Cart, Checkout) in the following format:
- * {
- *     "Product page": {
- *         location: "Product page",
- *         settings: {
- *             "logoType": "Full Logo",
- *             "textColor": "Black / Blue logo",
- *             "logoPosition": "Left",
- *             "textSize": "Small",
- *         }
- *     },
- *     ...
- * }
+ * One variant per location (per plan).
  */
-const checkoutLocationTests = Object.fromEntries(
-	checkoutLocations.map( ( location ) => [
-		location,
-		{
-			location,
-			settings: logoTypes
-				.map( ( logoType ) => {
-					const settings = {
-						logoType,
-						textColor: 'Black / Blue logo', // Default, replaced later
-						logoPosition: 'Left' as Pcp.Admin.Plm.LogoPosition,
-						textSize: 'Medium' as Pcp.Admin.Plm.TextSize,
-					};
-
-					if ( logoType === 'Full Logo' ) {
-						return textColors.flatMap( ( textColor ) =>
-							logoPositions.flatMap( ( logoPosition ) =>
-								textSizes.map( ( textSize ) => ( {
-									...settings,
-									textColor,
-									logoPosition,
-									textSize,
-								} ) )
-							)
-						);
-					}
-
-					return textColors.flatMap( ( textColor ) =>
-						textSizes.map( ( textSize ) => ( {
-							...settings,
-							textColor,
-							textSize,
-						} ) )
-					);
-				} )
-				.flat(),
-		},
-	] )
-);
-
-/**
- * Builds data combinations for pages with banners (Home, Shop) in the following format:
- * {
- *     "Home": {
- *         location: "Home",
- *         settings: {
- *             "bannerColor": "Blue",
- *             "bannerSize": "20 x 1",
- *         }
- *     },
- *     ...
- * }
- */
-const bannerLocationTests = Object.fromEntries(
-	bannerLocations.map( ( location ) => [
-		location,
-		{
-			location,
-			settings: bannerColors.flatMap( ( bannerColor ) =>
-				bannerSizes.map( ( bannerSize ) => ( {
-					bannerColor,
-					bannerSize,
-				} ) )
-			),
-		},
-	] )
-);
-
 export const payLaterMessagingData = {
-	checkoutLocationSettings: checkoutLocationTests,
-	bannerLocationSettings: bannerLocationTests,
+	checkoutLocationSettings: {
+		'Product page': {
+			location: 'Product page' as Pcp.Admin.Plm.Location,
+			settings: [
+				{
+					logoType: 'Full logo' as Pcp.Admin.Plm.LogoType,
+					textColor: 'Black / Blue logo' as Pcp.Admin.Plm.TextColor,
+					logoPosition: 'Left' as Pcp.Admin.Plm.LogoPosition,
+					textSize: 'Medium' as Pcp.Admin.Plm.TextSize,
+				},
+			],
+		},
+		Cart: {
+			location: 'Cart' as Pcp.Admin.Plm.Location,
+			settings: [
+				{
+					logoType: 'Monogram' as Pcp.Admin.Plm.LogoType,
+					textColor: 'Black / Blue logo' as Pcp.Admin.Plm.TextColor,
+					textSize: 'Medium' as Pcp.Admin.Plm.TextSize,
+				},
+			],
+		},
+		Checkout: {
+			location: 'Checkout' as Pcp.Admin.Plm.Location,
+			settings: [
+				{
+					logoType: 'Full logo' as Pcp.Admin.Plm.LogoType,
+					textColor: 'Black / Blue logo' as Pcp.Admin.Plm.TextColor,
+					logoPosition: 'Right' as Pcp.Admin.Plm.LogoPosition,
+					textSize: 'Medium' as Pcp.Admin.Plm.TextSize,
+				},
+			],
+		},
+	},
+	bannerLocationSettings: {
+		Home: {
+			location: 'Home' as Pcp.Admin.Plm.Location,
+			settings: [
+				{
+					bannerColor: 'Blue' as Pcp.Admin.Plm.BannerColor,
+					bannerSize: '20 x 1' as Pcp.Admin.Plm.BannerSize,
+				},
+			],
+		},
+		Shop: {
+			location: 'Shop' as Pcp.Admin.Plm.Location,
+			settings: [
+				{
+					bannerColor: 'White' as Pcp.Admin.Plm.BannerColor,
+					bannerSize: '20 x 1' as Pcp.Admin.Plm.BannerSize,
+				},
+			],
+		},
+	},
 };

--- a/tests/qa/tests/03-plugin-settings/_test-data/pay-later-messaging.data.ts
+++ b/tests/qa/tests/03-plugin-settings/_test-data/pay-later-messaging.data.ts
@@ -3,60 +3,81 @@
  */
 import { Pcp } from '../../../resources';
 
+type PlmCheckoutPageData = {
+	location: Pcp.Admin.Plm.Location;
+	settings: {
+		logoType?: Pcp.Admin.Plm.LogoType;
+		textColor?: Pcp.Admin.Plm.TextColor;
+		logoPosition?: Pcp.Admin.Plm.LogoPosition;
+		textSize?: Pcp.Admin.Plm.TextSize;
+	}[];
+};
+
+type PlmBannerPageData = {
+	location: Pcp.Admin.Plm.Location;
+	settings: {
+		bannerColor?: Pcp.Admin.Plm.BannerColor;
+		bannerSize?: Pcp.Admin.Plm.BannerSize;
+	}[];
+};
+
 /**
  * One variant per location (per plan).
  */
-export const payLaterMessagingData = {
+export const payLaterMessagingData: {
+	checkoutLocationSettings: Record<string, PlmCheckoutPageData>;
+	bannerLocationSettings: Record<string, PlmBannerPageData>;
+} = {
 	checkoutLocationSettings: {
 		'Product page': {
-			location: 'Product page' as Pcp.Admin.Plm.Location,
+			location: 'Product page',
 			settings: [
 				{
-					logoType: 'Full logo' as Pcp.Admin.Plm.LogoType,
-					textColor: 'Black / Blue logo' as Pcp.Admin.Plm.TextColor,
-					logoPosition: 'Left' as Pcp.Admin.Plm.LogoPosition,
-					textSize: 'Medium' as Pcp.Admin.Plm.TextSize,
+					logoType: 'Full logo',
+					textColor: 'Black / Blue logo',
+					logoPosition: 'Left',
+					textSize: 'Medium',
 				},
 			],
 		},
 		Cart: {
-			location: 'Cart' as Pcp.Admin.Plm.Location,
+			location: 'Cart',
 			settings: [
 				{
-					logoType: 'Monogram' as Pcp.Admin.Plm.LogoType,
-					textColor: 'Black / Blue logo' as Pcp.Admin.Plm.TextColor,
-					textSize: 'Medium' as Pcp.Admin.Plm.TextSize,
+					logoType: 'Monogram',
+					textColor: 'Black / Blue logo',
+					textSize: 'Medium',
 				},
 			],
 		},
 		Checkout: {
-			location: 'Checkout' as Pcp.Admin.Plm.Location,
+			location: 'Checkout',
 			settings: [
 				{
-					logoType: 'Full logo' as Pcp.Admin.Plm.LogoType,
-					textColor: 'Black / Blue logo' as Pcp.Admin.Plm.TextColor,
-					logoPosition: 'Right' as Pcp.Admin.Plm.LogoPosition,
-					textSize: 'Medium' as Pcp.Admin.Plm.TextSize,
+					logoType: 'Full logo',
+					textColor: 'Black / Blue logo',
+					logoPosition: 'Right',
+					textSize: 'Medium',
 				},
 			],
 		},
 	},
 	bannerLocationSettings: {
 		Home: {
-			location: 'Home' as Pcp.Admin.Plm.Location,
+			location: 'Home',
 			settings: [
 				{
-					bannerColor: 'Blue' as Pcp.Admin.Plm.BannerColor,
-					bannerSize: '20 x 1' as Pcp.Admin.Plm.BannerSize,
+					bannerColor: 'Blue',
+					bannerSize: '20 x 1',
 				},
 			],
 		},
 		Shop: {
-			location: 'Shop' as Pcp.Admin.Plm.Location,
+			location: 'Shop',
 			settings: [
 				{
-					bannerColor: 'White' as Pcp.Admin.Plm.BannerColor,
-					bannerSize: '20 x 1' as Pcp.Admin.Plm.BannerSize,
+					bannerColor: 'White',
+					bannerSize: '20 x 1',
 				},
 			],
 		},

--- a/tests/qa/tests/03-plugin-settings/pay-later-messaging-configurator.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/pay-later-messaging-configurator.spec.ts
@@ -1,129 +1,11 @@
 /**
  * Internal dependencies
  */
-import {
-	expect,
-	getTestResultsFromFile,
-	PayPalUi,
-	PayPalUiClassic,
-	PcpPayLaterMessaging,
-	saveTestResultsToFile,
-	test,
-} from '../../utils';
-import { merchants, storeConfigDefault, products, Pcp } from '../../resources';
+import { expect, test } from '../../utils';
+import { merchants, storeConfigDefault, products } from '../../resources';
 import { payLaterMessagingData } from './_test-data';
 
-const TEST_RESULTS_FILE = 'plm-test-results.json';
-
-/**
- * Adds settings values to test name.
- *
- * @param  settings
- * @param  settings.logoType
- * @param  settings.textColor
- * @param  settings.logoPosition
- * @param  settings.textSize
- * @param  settings.bannerColor
- * @param  settings.bannerSize
- * @return { string } Example: (PCP-000) PLM - Product page - Full Logo - Black / Gray logo - Left - Small
- */
-const summarizeSettings = ( settings: {
-	logoType?: Pcp.Admin.Plm.LogoType;
-	textColor?: Pcp.Admin.Plm.TextColor;
-	logoPosition?: Pcp.Admin.Plm.LogoPosition;
-	textSize?: Pcp.Admin.Plm.TextSize;
-	bannerColor?: Pcp.Admin.Plm.BannerColor;
-	bannerSize?: Pcp.Admin.Plm.BannerSize;
-} ): string => {
-	const {
-		logoType,
-		textColor,
-		logoPosition,
-		textSize,
-		bannerColor,
-		bannerSize,
-	} = settings;
-	let title = '';
-
-	if ( logoType ) {
-		title += ` - ${ logoType }`;
-	}
-
-	if ( textColor ) {
-		title += ` - ${ textColor }`;
-	}
-
-	if ( logoPosition && logoType === 'Full Logo' ) {
-		title += ` - ${ logoPosition }`;
-	}
-
-	if ( textSize ) {
-		title += ` - ${ textSize }`;
-	}
-
-	if ( bannerColor ) {
-		title += ` - ${ bannerColor }`;
-	}
-
-	if ( bannerSize ) {
-		title += ` - ${ bannerSize }`;
-	}
-
-	return title;
-};
-
-/**
- * Takes percy snapshot for each preview variant (text, desktop, mobile + light/dark):
- * - Switches previews
- * - Switches Light/Dark modes
- * - Takes snapshot
- *
- * @param pcpPayLaterMessaging
- * @param snapshotName
- */
-const takePreviewSnapshots = async (
-	pcpPayLaterMessaging: PcpPayLaterMessaging,
-	snapshotName: string
-) => {
-	for ( const layout of [ 'Text', 'Desktop', 'Mobile' ] ) {
-		if ( layout === 'Text' ) {
-			await pcpPayLaterMessaging.previewTextButton().click();
-		}
-		if ( layout === 'Desktop' ) {
-			await pcpPayLaterMessaging.previewDesktopButton().click();
-		}
-		if ( layout === 'Mobile' ) {
-			await pcpPayLaterMessaging.previewMobileButton().click();
-		}
-		for ( const togglePosition of [ 'Dark', 'Light' ] ) {
-			const isDark = togglePosition === 'Dark';
-			const previewSnapshotName = `${ snapshotName } - ${ layout } - Preview - ${ togglePosition }`;
-			await pcpPayLaterMessaging.setDarkModeToggleState( isDark );
-			await pcpPayLaterMessaging.snapshotPlmConfigurator(
-				previewSnapshotName
-			);
-		}
-		break;
-	}
-};
-
-/**
- * Asserts Pay Later Messaging container is visible on the frontend.
- *
- * @param payPalUi
- * @param assertContext - description for the Assert message
- */
-const assertPlmContainerVisible = async (
-	payPalUi: PayPalUi | PayPalUiClassic,
-	assertContext: string
-) => {
-	await expect(
-		payPalUi.payLaterMessageContainer(),
-		`Assert Pay Later Messaging container is visible - ${ assertContext }`
-	).toBeVisible();
-};
-
-test.describe( 'Subtests', () => {
+test.describe( 'PLM Configurator', () => {
 	test.beforeAll( async ( { utils, pcpApi } ) => {
 		await utils.configureStore( storeConfigDefault );
 		await utils.installAndActivatePcp();
@@ -134,244 +16,214 @@ test.describe( 'Subtests', () => {
 		);
 	} );
 
-	const productPlm =
-		payLaterMessagingData.checkoutLocationSettings[ 'Product page' ];
+	test( 'PCP-0001 | PLM - Product page', async ( {
+		pcpPayLaterMessaging,
+		product,
+	} ) => {
+		const { location } = payLaterMessagingData.checkoutLocationSettings[
+			'Product page'
+		];
+		const settings =
+			payLaterMessagingData.checkoutLocationSettings[ 'Product page' ]
+				.settings[ 0 ];
 
-	for ( const settings of productPlm.settings ) {
-		test.fixme(
-			`(PCP-0001) PLM - Product page${ summarizeSettings( settings ) }`,
-			async ( { pcpPayLaterMessaging, product }, testInfo ) => {
-				const snapshotName = testInfo.title;
-				const { location } = productPlm;
-				await pcpPayLaterMessaging.visit();
-				await pcpPayLaterMessaging.enableMessagingForLocation(
-					location
-				);
-				await pcpPayLaterMessaging.updateLocationSettings(
-					location,
-					settings
-				);
-				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
-				await pcpPayLaterMessaging.saveChanges();
-				await pcpPayLaterMessaging.page.reload();
-				await pcpPayLaterMessaging.expandAccordionSection( location );
-				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
-				await expect(
-					pcpPayLaterMessaging.configContainer(),
-					`Assert PLM configurator is visible after save for Product page`
-				).toBeVisible();
+		await pcpPayLaterMessaging.visit();
+		await pcpPayLaterMessaging.enableMessagingForLocation( location );
+		await pcpPayLaterMessaging.updateLocationSettings( location, settings );
+		await pcpPayLaterMessaging.saveChanges();
+		await pcpPayLaterMessaging.page.reload();
+		await pcpPayLaterMessaging.expandAccordionSection( location );
+		await pcpPayLaterMessaging.assertPreviewShowsMessage();
 
-				await product.visit( products.simple100.slug );
-				await assertPlmContainerVisible(
-					product.payPalUi,
-					'Product page frontend'
-				);
-			}
-		);
-	}
+		await product.visit( products.simple100.slug );
+		await expect(
+			product.payPalUi.payLaterMessageContainer(),
+			'Assert PLM is visible on product page'
+		).toBeVisible();
+	} );
 
-	const cartPlm = payLaterMessagingData.checkoutLocationSettings.Cart;
+	test( 'PCP-0002 | PLM - Cart (block and classic)', async ( {
+		utils,
+		pcpPayLaterMessaging,
+		cart,
+		classicCart,
+	} ) => {
+		await utils.fillVisitorsCart( [ products.simple100 ] );
 
-	for ( const settings of cartPlm.settings ) {
-		test.fixme(
-			`(PCP-0002) PLM - Cart${ summarizeSettings( settings ) }`,
-			async (
-				{ utils, pcpPayLaterMessaging, cart, classicCart },
-				testInfo
-			) => {
-				const snapshotName = testInfo.title;
-				const { location } = cartPlm;
-				await utils.fillVisitorsCart( [ products.simple100 ] );
+		const { location } = payLaterMessagingData.checkoutLocationSettings.Cart;
+		const settings =
+			payLaterMessagingData.checkoutLocationSettings.Cart.settings[ 0 ];
 
-				await pcpPayLaterMessaging.visit();
-				await pcpPayLaterMessaging.enableMessagingForLocation(
-					location
-				);
-				await pcpPayLaterMessaging.updateLocationSettings(
-					location,
-					settings
-				);
-				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
-				await pcpPayLaterMessaging.saveChanges();
-				await pcpPayLaterMessaging.page.reload();
-				await pcpPayLaterMessaging.expandAccordionSection( location );
-				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
-				await expect(
-					pcpPayLaterMessaging.configContainer(),
-					'Assert PLM configurator is visible after save for Cart'
-				).toBeVisible();
-				// Block cart
-				await cart.visit();
-				await assertPlmContainerVisible(
-					cart.payPalUi,
-					'Block cart frontend'
-				);
-				// Classic cart
-				await classicCart.visit();
-				await assertPlmContainerVisible(
-					classicCart.payPalUi,
-					'Classic cart frontend'
-				);
-			}
-		);
-	}
+		await pcpPayLaterMessaging.visit();
+		await pcpPayLaterMessaging.enableMessagingForLocation( location );
+		await pcpPayLaterMessaging.updateLocationSettings( location, settings );
+		await pcpPayLaterMessaging.saveChanges();
+		await pcpPayLaterMessaging.page.reload();
+		await pcpPayLaterMessaging.expandAccordionSection( location );
+		await pcpPayLaterMessaging.assertPreviewShowsMessage();
 
-	const checkoutPlm = payLaterMessagingData.checkoutLocationSettings.Checkout;
+		await cart.visit();
+		await expect(
+			cart.payPalUi.payLaterMessageContainer(),
+			'Assert PLM is visible on cart'
+		).toBeVisible();
 
-	for ( const settings of checkoutPlm.settings ) {
-		test.fixme(
-			`(PCP-0003) PLM - Checkout${ summarizeSettings( settings ) }`,
-			async (
-				{ utils, pcpPayLaterMessaging, checkout, classicCheckout },
-				testInfo
-			) => {
-				const snapshotName = testInfo.title;
-				const { location } = checkoutPlm;
-				await utils.fillVisitorsCart( [ products.simple100 ] );
+		await classicCart.visit();
+		await expect(
+			classicCart.payPalUi.payLaterMessageContainer(),
+			'Assert PLM is visible on classic cart'
+		).toBeVisible();
+	} );
 
-				await pcpPayLaterMessaging.visit();
-				await pcpPayLaterMessaging.enableMessagingForLocation(
-					location
-				);
-				await pcpPayLaterMessaging.updateLocationSettings(
-					location,
-					settings
-				);
-				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
-				await pcpPayLaterMessaging.saveChanges();
-				await pcpPayLaterMessaging.page.reload();
-				await pcpPayLaterMessaging.expandAccordionSection( location );
-				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
-				await expect(
-					pcpPayLaterMessaging.configContainer(),
-					'Assert PLM configurator is visible after save for Checkout'
-				).toBeVisible();
-				// Block checkout
-				await checkout.visit();
-				await assertPlmContainerVisible(
-					checkout.payPalUi,
-					'Block checkout frontend'
-				);
-				// Classic checkout
-				await classicCheckout.visit();
-				await assertPlmContainerVisible(
-					classicCheckout.payPalUi,
-					'Classic checkout frontend'
-				);
-			}
-		);
-	}
+	test( 'PCP-0003 | PLM - Checkout (block and classic)', async ( {
+		utils,
+		pcpPayLaterMessaging,
+		checkout,
+		classicCheckout,
+	} ) => {
+		await utils.fillVisitorsCart( [ products.simple100 ] );
 
-	const homePlm = payLaterMessagingData.bannerLocationSettings.Home;
+		const { location } =
+			payLaterMessagingData.checkoutLocationSettings.Checkout;
+		const settings =
+			payLaterMessagingData.checkoutLocationSettings.Checkout.settings[ 0 ];
 
-	for ( const settings of homePlm.settings ) {
-		test.fixme(
-			`(PCP-0004) PLM - Home${ summarizeSettings( settings ) }`,
-			async ( { pcpPayLaterMessaging, payPalUiClassic }, testInfo ) => {
-				const snapshotName = testInfo.title;
-				const { location } = homePlm;
-				await pcpPayLaterMessaging.visit();
-				await pcpPayLaterMessaging.enableMessagingForLocation(
-					location
-				);
-				await pcpPayLaterMessaging.updateLocationSettings(
-					location,
-					settings
-				);
-				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
-				await pcpPayLaterMessaging.saveChanges();
-				await pcpPayLaterMessaging.page.reload();
-				await pcpPayLaterMessaging.expandAccordionSection( location );
-				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
-				await expect(
-					pcpPayLaterMessaging.configContainer(),
-					'Assert PLM configurator is visible after save for Home'
-				).toBeVisible();
+		await pcpPayLaterMessaging.visit();
+		await pcpPayLaterMessaging.enableMessagingForLocation( location );
+		await pcpPayLaterMessaging.updateLocationSettings( location, settings );
+		await pcpPayLaterMessaging.saveChanges();
+		await pcpPayLaterMessaging.page.reload();
+		await pcpPayLaterMessaging.expandAccordionSection( location );
+		await pcpPayLaterMessaging.assertPreviewShowsMessage();
 
-				await payPalUiClassic.page.goto( '/' );
-				await assertPlmContainerVisible(
-					payPalUiClassic,
-					'Home page frontend'
-				);
-			}
-		);
-	}
+		await checkout.visit();
+		await expect(
+			checkout.payPalUi.payLaterMessageContainer(),
+			'Assert PLM is visible on checkout'
+		).toBeVisible();
 
-	const shopPlm = payLaterMessagingData.bannerLocationSettings.Shop;
+		await classicCheckout.visit();
+		await expect(
+			classicCheckout.payPalUi.payLaterMessageContainer(),
+			'Assert PLM is visible on classic checkout'
+		).toBeVisible();
+	} );
 
-	for ( const settings of shopPlm.settings ) {
-		test.fixme(
-			`(PCP-0005) PLM - Shop${ summarizeSettings( settings ) }`,
-			async ( { pcpPayLaterMessaging, shop }, testInfo ) => {
-				const snapshotName = testInfo.title;
-				const { location } = shopPlm;
-				await pcpPayLaterMessaging.visit();
-				await pcpPayLaterMessaging.enableMessagingForLocation(
-					location
-				);
-				await pcpPayLaterMessaging.updateLocationSettings(
-					location,
-					settings
-				);
-				// await takePreviewSnapshots( pcpPayLaterMessaging, snapshotName ); // TODO: uncomment when fixed
-				await pcpPayLaterMessaging.saveChanges();
-				await pcpPayLaterMessaging.page.reload();
-				await pcpPayLaterMessaging.expandAccordionSection( location );
-				// await pcpPayLaterMessaging.assertLocationSettings( settings ); // TODO: uncomment when fixed
-				await expect(
-					pcpPayLaterMessaging.configContainer(),
-					'Assert PLM configurator is visible after save for Shop'
-				).toBeVisible();
+	test( 'PCP-0004 | PLM - Home page', async ( {
+		pcpPayLaterMessaging,
+		payPalUiClassic,
+	} ) => {
+		const { location } = payLaterMessagingData.bannerLocationSettings.Home;
+		const settings =
+			payLaterMessagingData.bannerLocationSettings.Home.settings[ 0 ];
 
-				await shop.visit();
-				await assertPlmContainerVisible(
-					shop.payPalUi,
-					'Shop page frontend'
-				);
-			}
-		);
-	}
+		await pcpPayLaterMessaging.visit();
+		await pcpPayLaterMessaging.enableMessagingForLocation( location );
+		await pcpPayLaterMessaging.updateLocationSettings( location, settings );
+		await pcpPayLaterMessaging.saveChanges();
+		await pcpPayLaterMessaging.page.reload();
+		await pcpPayLaterMessaging.expandAccordionSection( location );
+		await pcpPayLaterMessaging.assertPreviewShowsMessage();
 
-	test.afterEach( async ( {}, testInfo ) => {
-		saveTestResultsToFile(
-			testInfo.title,
-			testInfo.status,
-			TEST_RESULTS_FILE
-		);
+		await payPalUiClassic.page.goto( '/' );
+		await expect(
+			payPalUiClassic.payLaterMessageContainer(),
+			'Assert PLM is visible on home page'
+		).toBeVisible();
+	} );
+
+	test( 'PCP-0005 | PLM - Shop page', async ( {
+		pcpPayLaterMessaging,
+		shop,
+	} ) => {
+		const { location } = payLaterMessagingData.bannerLocationSettings.Shop;
+		const settings =
+			payLaterMessagingData.bannerLocationSettings.Shop.settings[ 0 ];
+
+		await pcpPayLaterMessaging.visit();
+		await pcpPayLaterMessaging.enableMessagingForLocation( location );
+		await pcpPayLaterMessaging.updateLocationSettings( location, settings );
+		await pcpPayLaterMessaging.saveChanges();
+		await pcpPayLaterMessaging.page.reload();
+		await pcpPayLaterMessaging.expandAccordionSection( location );
+		await pcpPayLaterMessaging.assertPreviewShowsMessage();
+
+		await shop.visit();
+		await expect(
+			shop.payPalUi.payLaterMessageContainer(),
+			'Assert PLM is visible on shop page'
+		).toBeVisible();
+	} );
+
+	test( 'PCP-0006 | PLM - WooCommerce Block', async ( {
+		pcpPayLaterMessaging,
+		product,
+		requestUtils,
+	} ) => {
+		await pcpPayLaterMessaging.visit();
+		await pcpPayLaterMessaging.enableMessagingForWooCommerceBlock();
+		await pcpPayLaterMessaging.saveChanges();
+
+		const page = await requestUtils.createPage( {
+			title: 'PLM Block Test Page',
+			status: 'publish',
+			content:
+				'<!-- wp:woocommerce-paypal-payments/paylater-messages /-->',
+		} );
+
+		try {
+			await product.visitByPageId( page.id );
+			await expect(
+				product.payPalUi.payLaterMessageContainer(),
+				'Assert PLM is visible on WooCommerce Block page'
+			).toBeVisible();
+		} finally {
+			await requestUtils.deletePageById( page.id );
+		}
+	} );
+
+	test( 'PCP-0007 | PLM - Preview layout buttons (Text/Desktop/Mobile)', async ( {
+		pcpPayLaterMessaging,
+	} ) => {
+		const { location } = payLaterMessagingData.checkoutLocationSettings[
+			'Product page'
+		];
+		const settings =
+			payLaterMessagingData.checkoutLocationSettings[ 'Product page' ]
+				.settings[ 0 ];
+
+		await pcpPayLaterMessaging.visit();
+		await pcpPayLaterMessaging.enableMessagingForLocation( location );
+		await pcpPayLaterMessaging.updateLocationSettings( location, settings );
+		await pcpPayLaterMessaging.saveChanges();
+		await pcpPayLaterMessaging.page.reload();
+		await pcpPayLaterMessaging.expandAccordionSection( location );
+
+		const previewIframe = pcpPayLaterMessaging
+			.previewContainer()
+			.locator( 'iframe' )
+			.first();
+		await expect(
+			previewIframe,
+			'Assert PLM preview iframe is visible'
+		).toBeVisible();
+
+		await pcpPayLaterMessaging.previewTextButton().click();
+		await expect(
+			previewIframe,
+			'Assert PLM preview iframe still visible after Text layout'
+		).toBeVisible();
+
+		await pcpPayLaterMessaging.previewDesktopButton().click();
+		await expect(
+			previewIframe,
+			'Assert PLM preview iframe still visible after Desktop layout'
+		).toBeVisible();
+
+		await pcpPayLaterMessaging.previewMobileButton().click();
+		await expect(
+			previewIframe,
+			'Assert PLM preview iframe still visible after Mobile layout'
+		).toBeVisible();
 	} );
 } );
-
-test.fixme(
-	'PCP-0001 | Pay Later Messaging - Customize on Product page',
-	async () => {
-		getTestResultsFromFile( 'PCP-0001', TEST_RESULTS_FILE );
-	}
-);
-
-test.fixme(
-	'PCP-0002 | Pay Later Messaging - Customize on Cart (block and classic)',
-	async () => {
-		getTestResultsFromFile( 'PCP-0002', TEST_RESULTS_FILE );
-	}
-);
-
-test.fixme(
-	'PCP-0003 | Pay Later Messaging - Customize on Checkout (block and classic)',
-	async () => {
-		getTestResultsFromFile( 'PCP-0003', TEST_RESULTS_FILE );
-	}
-);
-
-test.fixme(
-	'PCP-0004 | Pay Later Messaging - Customize on Home page',
-	async () => {
-		getTestResultsFromFile( 'PCP-0004', TEST_RESULTS_FILE );
-	}
-);
-
-test.fixme(
-	'PCP-0005 | Pay Later Messaging - Customize on Shop page',
-	async () => {
-		getTestResultsFromFile( 'PCP-0005', TEST_RESULTS_FILE );
-	}
-);

--- a/tests/qa/tests/03-plugin-settings/pay-later-messaging-configurator.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/pay-later-messaging-configurator.spec.ts
@@ -199,30 +199,26 @@ test.describe( 'PLM Configurator', () => {
 		await pcpPayLaterMessaging.page.reload();
 		await pcpPayLaterMessaging.expandAccordionSection( location );
 
-		const previewIframe = pcpPayLaterMessaging
-			.previewContainer()
-			.locator( 'iframe' )
-			.first();
 		await expect(
-			previewIframe,
+			pcpPayLaterMessaging.previewIframe(),
 			'Assert PLM preview iframe is visible'
 		).toBeVisible();
 
 		await pcpPayLaterMessaging.previewTextButton().click();
 		await expect(
-			previewIframe,
+			pcpPayLaterMessaging.previewIframe(),
 			'Assert PLM preview iframe still visible after Text layout'
 		).toBeVisible();
 
 		await pcpPayLaterMessaging.previewDesktopButton().click();
 		await expect(
-			previewIframe,
+			pcpPayLaterMessaging.previewIframe(),
 			'Assert PLM preview iframe still visible after Desktop layout'
 		).toBeVisible();
 
 		await pcpPayLaterMessaging.previewMobileButton().click();
 		await expect(
-			previewIframe,
+			pcpPayLaterMessaging.previewIframe(),
 			'Assert PLM preview iframe still visible after Mobile layout'
 		).toBeVisible();
 	} );

--- a/tests/qa/tests/03-plugin-settings/pay-later-messaging-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/pay-later-messaging-ui.spec.ts
@@ -14,7 +14,7 @@ test.beforeAll( async ( { utils, pcpApi } ) => {
 	);
 } );
 
-test.fixme(
+test(
 	'PCP-0000 | Settings - Pay Later Messaging - Default UI',
 	async (
 		{
@@ -27,9 +27,7 @@ test.fixme(
 			classicCart,
 			checkout,
 			classicCheckout,
-		},
-		testInfo
-	) => {
+		} ) => {
 		await utils.fillVisitorsCart( [ products.simple100 ] );
 
 		await pcpPayLaterMessaging.visit();
@@ -72,31 +70,31 @@ test.fixme(
 		await product.visit( products.simple100.slug );
 		await expect(
 			product.payPalUi.payLaterMessageContainer(),
-			'Assert PLM container is visible on product page'
+			'Assert PLM is visible on product page'
 		).toBeVisible();
 
 		await cart.visit();
 		await expect(
 			cart.payPalUi.payLaterMessageContainer(),
-			'Assert PLM container is visible on cart'
+			'Assert PLM is visible on cart'
 		).toBeVisible();
 
 		await classicCart.visit();
 		await expect(
 			classicCart.payPalUi.payLaterMessageContainer(),
-			'Assert PLM container is visible on classic cart'
+			'Assert PLM is visible on classic cart'
 		).toBeVisible();
 
 		await checkout.visit();
 		await expect(
 			checkout.payPalUi.payLaterMessageContainer(),
-			'Assert PLM container is visible on checkout'
+			'Assert PLM is visible on checkout'
 		).toBeVisible();
 
 		await classicCheckout.visit();
 		await expect(
 			classicCheckout.payPalUi.payLaterMessageContainer(),
-			'Assert PLM container is visible on classic checkout'
+			'Assert PLM is visible on classic checkout'
 		).toBeVisible();
 
 		await shop.visit();
@@ -113,7 +111,7 @@ test.fixme(
 	}
 );
 
-test.fixme(
+test(
 	'PCP-0000 | Settings - Pay Later Messaging - Disabled on all pages',
 	async ( {
 		utils,
@@ -129,6 +127,8 @@ test.fixme(
 		await utils.fillVisitorsCart( [ products.simple100 ] );
 
 		await pcpPayLaterMessaging.visit();
+		await pcpPayLaterMessaging.waitForLoadingMaskRemoved();
+
 		await pcpPayLaterMessaging.disableMessagingForLocation(
 			'Product page'
 		);
@@ -136,8 +136,10 @@ test.fixme(
 		await pcpPayLaterMessaging.disableMessagingForLocation( 'Checkout' );
 		await pcpPayLaterMessaging.disableMessagingForLocation( 'Home' );
 		await pcpPayLaterMessaging.disableMessagingForLocation( 'Shop' );
+
 		await pcpPayLaterMessaging.saveChanges();
 		await pcpPayLaterMessaging.page.reload();
+		await pcpPayLaterMessaging.waitForLoadingMaskRemoved();
 
 		expect
 			.soft(

--- a/tests/qa/tests/03-plugin-settings/styling-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/styling-ui.spec.ts
@@ -2,7 +2,20 @@
  * Internal dependencies
  */
 import { expect, test } from '../../utils';
-import { merchants, storeConfigDefault, Pcp, products } from '../../resources';
+import {
+	merchants,
+	storeConfigDefault,
+	Pcp,
+	products,
+} from '../../resources';
+
+const LOCATIONS: Pcp.Admin.Styling.Location[] = [
+	'Cart',
+	'Classic Checkout',
+	'Express Checkout',
+	// 'Mini Cart' skipped: minicart buttons unreliable in test env
+	'Product Page',
+];
 
 test.beforeAll( async ( { utils, pcpApi } ) => {
 	await utils.configureStore( storeConfigDefault );
@@ -14,24 +27,16 @@ test.beforeAll( async ( { utils, pcpApi } ) => {
 	);
 } );
 
-test.fixme(
+test(
 	'PCP-0000 | Settings - Styling - Default UI',
 	async ( {
 		utils,
 		pcpStyling,
 		product,
-		cart,
 		classicCart,
 		checkout,
 		classicCheckout,
 	} ) => {
-		const locations: Pcp.Admin.Styling.Location[] = [
-			'Cart',
-			'Classic Checkout',
-			'Express Checkout',
-			'Mini Cart',
-			'Product Page',
-		];
 		const simpleProduct = products.simple100;
 
 		await pcpStyling.visit();
@@ -44,51 +49,86 @@ test.fixme(
 			'Assert styling location selectbox is visible'
 		).toBeVisible();
 
-		for ( const location of locations ) {
+		await utils.fillVisitorsCart( [ simpleProduct ] );
+
+		for ( const location of LOCATIONS ) {
 			await pcpStyling.locationSelectbox().selectOption( location );
 			await expect(
 				pcpStyling.configContainer(),
 				`Assert styling config is visible for location ${ location }`
 			).toBeVisible();
+
+			await pcpStyling.enablePaymentMethodsOnLocationCheckbox().check();
+			await pcpStyling.assertPreviewHasPayPalButtons();
+			await pcpStyling.saveChanges();
+
+			await assertPayPalButtonsVisibleOnLiveSite( location, {
+				product,
+				classicCart,
+				checkout,
+				classicCheckout,
+				simpleProduct,
+			} );
 		}
-
-		await utils.fillVisitorsCart( [ simpleProduct ] );
-
-		await product.visit( simpleProduct.slug );
-		await expect(
-			product.payPalUi.payPalButtonsBlockContainer(),
-			'Assert PayPal buttons are visible on product page'
-		).toBeVisible();
-
-		await product.minicartContainer().hover();
-		await expect(
-			product.payPalUi.miniCartButtonContainer(),
-			'Assert PayPal minicart buttons are visible'
-		).toBeVisible();
-
-		await cart.visit();
-		await expect(
-			cart.payPalUi.payPalButtonsBlockContainer(),
-			'Assert PayPal buttons are visible on cart'
-		).toBeVisible();
-
-		await classicCart.visit();
-		await expect(
-			classicCart.payPalUi.payPalButtonsBlockContainer(),
-			'Assert PayPal buttons are visible on classic cart'
-		).toBeVisible();
-
-		await checkout.visit();
-		await expect(
-			checkout.payPalUi.payPalButtonsBlockContainer(),
-			'Assert PayPal buttons are visible on checkout'
-		).toBeVisible();
-
-		await classicCheckout.visit();
-		await classicCheckout.paymentOption( 'PayPal' ).click();
-		await expect(
-			classicCheckout.payPalUi.payPalButtonsBlockContainer(),
-			'Assert PayPal buttons are visible on classic checkout'
-		).toBeVisible();
 	}
 );
+
+/**
+ * Asserts PayPal buttons are visible on the live site for the given location.
+ * Uses standard/default appearance (no label or layout assertions).
+ */
+async function assertPayPalButtonsVisibleOnLiveSite(
+	location: Pcp.Admin.Styling.Location,
+	ctx: {
+		product: {
+			visit: ( slug: string ) => Promise< void >;
+			payPalUi: {
+				assertPayPalButtonsGatewayVisibleWithContent: () => Promise< void >;
+			};
+		};
+		classicCart: {
+			visit: () => Promise< void >;
+			payPalUi: {
+				assertPayPalButtonsGatewayVisibleWithContent: () => Promise< void >;
+			};
+		};
+		checkout: {
+			visit: () => Promise< void >;
+			payPalUi: {
+				assertPayPalButtonsBlockVisibleWithContent: () => Promise< void >;
+			};
+		};
+		classicCheckout: {
+			visit: () => Promise< void >;
+			paymentOption: ( name: string ) => { click: () => Promise< void > };
+			payPalUi: {
+				assertPayPalButtonsGatewayVisibleWithContent: () => Promise< void >;
+			};
+		};
+		simpleProduct: { slug?: string };
+	}
+) {
+	const { product, classicCart, checkout, classicCheckout, simpleProduct } =
+		ctx;
+	const slug = simpleProduct.slug ?? '';
+
+	switch ( location ) {
+		case 'Product Page':
+			await product.visit( slug );
+			await product.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
+			break;
+		case 'Cart':
+			await classicCart.visit();
+			await classicCart.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
+			break;
+		case 'Classic Checkout':
+			await classicCheckout.visit();
+			await classicCheckout.paymentOption( 'PayPal' ).click();
+			await classicCheckout.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
+			break;
+		case 'Express Checkout':
+			await checkout.visit();
+			await checkout.payPalUi.assertPayPalButtonsBlockVisibleWithContent();
+			break;
+	}
+}

--- a/tests/qa/tests/03-plugin-settings/styling-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/styling-ui.spec.ts
@@ -9,11 +9,11 @@ import {
 	products,
 } from '../../resources';
 
+// 'Mini Cart' skipped: minicart buttons unreliable in test env
 const LOCATIONS: Pcp.Admin.Styling.Location[] = [
 	'Cart',
 	'Classic Checkout',
 	'Express Checkout',
-	// 'Mini Cart' skipped: minicart buttons unreliable in test env
 	'Product Page',
 ];
 

--- a/tests/qa/utils/admin/pcp-pay-later-messaging.ts
+++ b/tests/qa/utils/admin/pcp-pay-later-messaging.ts
@@ -64,6 +64,8 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 	};
 	previewContainer = () =>
 		this.page.locator( '#configurator-previewSectionContainer' );
+	previewIframe = () =>
+		this.previewContainer().locator( 'iframe' ).first();
 	previewTextButton = () =>
 		this.page.locator(
 			'svg path[d="M5 5a1 1 0 0 0 0 2h14a1 1 0 1 0 0-2H5zm-1 7a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1zm0 6a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1z"]'
@@ -352,11 +354,8 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 	 */
 	assertPreviewShowsMessage = async () => {
 		// Assert preview iframe is visible (works for all layouts including banner)
-		const previewIframe = this.previewContainer()
-			.locator( 'iframe' )
-			.first();
 		await expect(
-			previewIframe,
+			this.previewIframe(),
 			'Assert PLM preview iframe is visible'
 		).toBeVisible();
 	};

--- a/tests/qa/utils/admin/pcp-pay-later-messaging.ts
+++ b/tests/qa/utils/admin/pcp-pay-later-messaging.ts
@@ -26,48 +26,44 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 	accordionCheckboxSvg = ( location: Pcp.Admin.Plm.Location ) =>
 		this.accordionCheckbox( location ).locator( 'svg' );
 
-	logoTypeCombobox = () =>
-		this.page.locator(
+	logoTypeCombobox = ( location: Pcp.Admin.Plm.Location ) =>
+		this.accordionContainer( location ).locator(
 			'button[aria-labelledby^="dropdownMenuButton_Logotype"]'
 		);
-	textColorCombobox = () =>
-		this.page.locator(
+	textColorCombobox = ( location: Pcp.Admin.Plm.Location ) =>
+		this.accordionContainer( location ).locator(
 			'button[aria-labelledby^="dropdownMenuButton_Textcolor"]'
 		);
-	logoPositionCombobox = () =>
-		this.page.locator(
+	logoPositionCombobox = ( location: Pcp.Admin.Plm.Location ) =>
+		this.accordionContainer( location ).locator(
 			'button[aria-labelledby^="dropdownMenuButton_Logoposition"]'
 		);
-	textSizeCombobox = () =>
-		this.page.locator(
+	textSizeCombobox = ( location: Pcp.Admin.Plm.Location ) =>
+		this.accordionContainer( location ).locator(
 			'button[aria-labelledby^="dropdownMenuButton_Textsize"]'
 		);
-	bannerColorCombobox = () =>
-		this.page.locator(
+	bannerColorCombobox = ( location: Pcp.Admin.Plm.Location ) =>
+		this.accordionContainer( location ).locator(
 			'button[aria-labelledby^="dropdownMenuButton_Bannercolor"]'
 		);
-	bannerSizeCombobox = () =>
-		this.page.locator(
+	bannerSizeCombobox = ( location: Pcp.Admin.Plm.Location ) =>
+		this.accordionContainer( location ).locator(
 			'button[aria-labelledby^="dropdownMenuButton_Bannersize"]'
 		);
-	comboboxOption = ( optionName: string ) =>
-		this.page
+	comboboxOption = ( optionName: string ) => {
+		const escaped = optionName.replace(
+			/[.*+?^${}()|[\]\\]/g,
+			'\\$&'
+		);
+		return this.page
 			.locator( 'li[id^="smenu_item_"]' )
-			.filter( { hasText: optionName } );
+			.filter( {
+				hasText: new RegExp( `^${ escaped }$`, 'i' ),
+			} )
+			.first();
+	};
 	previewContainer = () =>
 		this.page.locator( '#configurator-previewSectionContainer' );
-	previewIframe = () =>
-		this.previewContainer().locator( 'iframe' ).first().contentFrame();
-	previewIframeSpan = () =>
-		this.previewIframe().locator( '[id^="zoid-paypal-message-uid"]' );
-	previewMessageIframe = () =>
-		this.previewIframeSpan().frameLocator(
-			'iframe[name^="__zoid__paypal_message__"]'
-		);
-	previewMessageTextPart = () =>
-		this.previewMessageIframe().getByText(
-			'Pay in 4 interest-free payments'
-		);
 	previewTextButton = () =>
 		this.page.locator(
 			'svg path[d="M5 5a1 1 0 0 0 0 2h14a1 1 0 1 0 0-2H5zm-1 7a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1zm0 6a1 1 0 0 1 1-1h14a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1z"]'
@@ -109,7 +105,8 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 		if ( pathData === collapsedPath ) {
 			await this.accordionButton( location ).click();
 			await expect(
-				this.accordionButtonSvgPath( location )
+				this.accordionButtonSvgPath( location ),
+				`Assert accordion section ${ location } is expanded`
 			).toHaveAttribute( 'd', expandedPath );
 		}
 	};
@@ -134,6 +131,7 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 
 	/**
 	 * Enables/disabled messaging for location.
+	 * Waits for checkbox state to change after click (no hard timeouts).
 	 *
 	 * @param location
 	 * @param isChecked
@@ -145,6 +143,12 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 		const isEnabled = await this.isMessagingForLocationEnabled( location );
 		if ( isEnabled !== isChecked ) {
 			await this.accordionCheckbox( location ).click();
+			await expect
+				.poll(
+					() => this.isMessagingForLocationEnabled( location ),
+					`Assert ${ location } checkbox is ${ isChecked ? 'enabled' : 'disabled' }`
+				)
+				.toBe( isChecked );
 		}
 	};
 
@@ -163,6 +167,13 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 	 */
 	disableMessagingForLocation = async ( location: Pcp.Admin.Plm.Location ) =>
 		this.setMessagingCheckboxStateForLocation( location, false );
+
+	/**
+	 * Enables messaging for WooCommerce Block placement (custom_placement).
+	 * Required for the PLM block to render on custom pages.
+	 */
+	enableMessagingForWooCommerceBlock = async () =>
+		this.enableMessagingForLocation( 'WooCommerce Block' );
 
 	/**
 	 * Toggles dark mode on/off.
@@ -228,32 +239,32 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 		await this.expandAccordionSection( location );
 
 		if ( logoType ) {
-			await this.logoTypeCombobox().click();
+			await this.logoTypeCombobox( location ).click();
 			await this.comboboxOption( logoType ).click();
 		}
 
 		if ( textColor ) {
-			await this.textColorCombobox().click();
+			await this.textColorCombobox( location ).click();
 			await this.comboboxOption( textColor ).click();
 		}
 
-		if ( logoPosition && logoType === 'Full Logo' ) {
-			await this.logoPositionCombobox().click();
+		if ( logoPosition && logoType === 'Full logo' ) {
+			await this.logoPositionCombobox( location ).click();
 			await this.comboboxOption( logoPosition ).click();
 		}
 
 		if ( textSize ) {
-			await this.textSizeCombobox().click();
+			await this.textSizeCombobox( location ).click();
 			await this.comboboxOption( textSize ).click();
 		}
 
 		if ( bannerColor ) {
-			await this.bannerColorCombobox().click();
+			await this.bannerColorCombobox( location ).click();
 			await this.comboboxOption( bannerColor ).click();
 		}
 
 		if ( bannerSize ) {
-			await this.bannerSizeCombobox().click();
+			await this.bannerSizeCombobox( location ).click();
 			await this.comboboxOption( bannerSize ).click();
 		}
 	};
@@ -271,14 +282,17 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 	 * @param settings.bannerColor
 	 * @param settings.bannerSize
 	 */
-	assertLocationSettings = async ( settings: {
-		logoType?: Pcp.Admin.Plm.LogoType;
-		textColor?: Pcp.Admin.Plm.TextColor;
-		logoPosition?: Pcp.Admin.Plm.LogoPosition;
-		textSize?: Pcp.Admin.Plm.TextSize;
-		bannerColor?: Pcp.Admin.Plm.BannerColor;
-		bannerSize?: Pcp.Admin.Plm.BannerSize;
-	} ) => {
+	assertLocationSettings = async (
+		location: Pcp.Admin.Plm.Location,
+		settings: {
+			logoType?: Pcp.Admin.Plm.LogoType;
+			textColor?: Pcp.Admin.Plm.TextColor;
+			logoPosition?: Pcp.Admin.Plm.LogoPosition;
+			textSize?: Pcp.Admin.Plm.TextSize;
+			bannerColor?: Pcp.Admin.Plm.BannerColor;
+			bannerSize?: Pcp.Admin.Plm.BannerSize;
+		}
+	) => {
 		const {
 			logoType,
 			textColor,
@@ -289,43 +303,61 @@ export class PcpPayLaterMessaging extends PcpAdminPage {
 		} = settings;
 
 		if ( logoType ) {
-			await expect( this.logoTypeCombobox() ).toHaveText( logoType );
+			await expect(
+				this.logoTypeCombobox( location ),
+				`Assert logo type is ${ logoType }`
+			).toHaveText( logoType );
 		}
 
 		if ( textColor ) {
-			await expect( this.textColorCombobox() ).toHaveText( textColor );
+			await expect(
+				this.textColorCombobox( location ),
+				`Assert text color is ${ textColor }`
+			).toHaveText( textColor );
 		}
 
-		if ( logoPosition && logoType === 'Full Logo' ) {
-			await expect( this.logoPositionCombobox() ).toHaveText(
-				logoPosition
-			);
+		if ( logoPosition && logoType === 'Full logo' ) {
+			await expect(
+				this.logoPositionCombobox( location ),
+				`Assert logo position is ${ logoPosition }`
+			).toHaveText( logoPosition );
 		}
 
 		if ( textSize ) {
-			await expect( this.textSizeCombobox() ).toHaveText( textSize );
+			await expect(
+				this.textSizeCombobox( location ),
+				`Assert text size is ${ textSize }`
+			).toHaveText( textSize );
 		}
 
 		if ( bannerColor ) {
-			await expect( this.bannerColorCombobox() ).toHaveText(
-				bannerColor
-			);
+			await expect(
+				this.bannerColorCombobox( location ),
+				`Assert banner color is ${ bannerColor }`
+			).toHaveText( bannerColor );
 		}
 
 		if ( bannerSize ) {
-			await expect( this.bannerSizeCombobox() ).toHaveText( bannerSize );
+			await expect(
+				this.bannerSizeCombobox( location ),
+				`Assert banner size is ${ bannerSize }`
+			).toHaveText( bannerSize );
 		}
 	};
 
 	/**
-	 * Compares actual configurator screenshot to expected.
-	 *
-	 * @param snapshotName
+	 * Asserts the PLM configurator preview shows the message (element-based).
+	 * For banner layouts (Home/Shop), the message text may be hidden initially;
+	 * we assert the preview iframe is present instead.
 	 */
-	snapshotPlmConfigurator = async ( snapshotName: string ) => {
-		// Assert message is displayed
-		await expect.soft( this.previewMessageTextPart() ).toBeVisible();
-		// Screenshot configurator
-		this.snapshotLocator( this.configContainer(), snapshotName );
+	assertPreviewShowsMessage = async () => {
+		// Assert preview iframe is visible (works for all layouts including banner)
+		const previewIframe = this.previewContainer()
+			.locator( 'iframe' )
+			.first();
+		await expect(
+			previewIframe,
+			'Assert PLM preview iframe is visible'
+		).toBeVisible();
 	};
 }

--- a/tests/qa/utils/admin/pcp-styling.ts
+++ b/tests/qa/utils/admin/pcp-styling.ts
@@ -6,6 +6,39 @@ import { PcpAdminPage } from './pcp-admin-page';
 import urls from '../urls';
 import { Pcp } from '../../resources';
 
+/** Maps ButtonColor label to select value. */
+const COLOR_LABEL_TO_VALUE: Record<
+	Pcp.Admin.Styling.ButtonColor,
+	string
+> = {
+	'Gold (recommended)': 'gold',
+	'Gold (Recommended)': 'gold',
+	Blue: 'blue',
+	Silver: 'silver',
+	Black: 'black',
+	White: 'white',
+};
+
+/** Maps ButtonLabel to select value. */
+const LABEL_TO_VALUE: Record<Pcp.Admin.Styling.ButtonLabel, string> = {
+	PayPal: 'paypal',
+	Checkout: 'checkout',
+	'PayPal Buy Now': 'buynow',
+	'Pay with PayPal': 'pay',
+};
+
+/** Maps ButtonShape to radio value. */
+const SHAPE_TO_VALUE: Record<Pcp.Admin.Styling.ButtonShape, string> = {
+	Rectangle: 'rect',
+	Pill: 'pill',
+};
+
+/** Maps ButtonLayout to radio value. */
+const LAYOUT_TO_VALUE: Record<Pcp.Admin.Styling.ButtonLayout, string> = {
+	Vertical: 'vertical',
+	Horizontal: 'horizontal',
+};
+
 export class PcpStyling extends PcpAdminPage {
 	url = urls.admin.pcp.styling;
 
@@ -24,9 +57,9 @@ export class PcpStyling extends PcpAdminPage {
 	buttonShapeRadio = ( label: Pcp.Admin.Styling.ButtonShape ) =>
 		this.page.getByLabel( label );
 	buttonLabelSelectbox = () =>
-		this.page.locator( '#inspector-select-control-30' );
+		this.page.locator( '.ppcp-r-settings-block.button-label select' );
 	buttonColorSelectbox = () =>
-		this.page.locator( '#inspector-select-control-31' );
+		this.page.locator( '.ppcp-r-settings-block.button-color select' );
 
 	payPalButtonsPreviewIframe = () =>
 		this.page.frameLocator( 'iframe[name^="__zoid__paypal_buttons__"]' );
@@ -35,17 +68,62 @@ export class PcpStyling extends PcpAdminPage {
 
 	// Actions
 
+	applyButtonColor = async ( color: Pcp.Admin.Styling.ButtonColor ) => {
+		await this.buttonColorSelectbox().selectOption( { label: color } );
+	};
+
+	applyButtonLabel = async ( label: Pcp.Admin.Styling.ButtonLabel ) => {
+		await this.buttonLabelSelectbox().selectOption( { label } );
+	};
+
+	applyButtonShape = async ( shape: Pcp.Admin.Styling.ButtonShape ) => {
+		await this.buttonShapeRadio( shape ).click();
+	};
+
+	applyButtonLayout = async ( layout: Pcp.Admin.Styling.ButtonLayout ) => {
+		await this.buttonLayoutRadio( layout ).click();
+	};
+
 	// Assertions
 
 	/**
-	 * Compares actual configurator screenshot to expected.
-	 *
-	 * @param snapshotName
+	 * Asserts the admin preview shows PayPal buttons.
 	 */
-	snapshotStylingConfigurator = async ( snapshotName: string ) => {
-		// Assert message is displayed
-		await expect( this.payPalButtonsPreviewContainer() ).toBeVisible();
-		// Screenshot configurator
-		this.snapshotLocator( this.configContainer(), snapshotName );
+	assertPreviewHasPayPalButtons = async () => {
+		await expect(
+			this.payPalButtonsPreviewContainer(),
+			'Assert styling preview shows PayPal buttons'
+		).toBeVisible();
+	};
+
+	assertButtonColor = async ( color: Pcp.Admin.Styling.ButtonColor ) => {
+		const value = COLOR_LABEL_TO_VALUE[ color ];
+		await expect(
+			this.buttonColorSelectbox(),
+			`Assert button color is ${ color }`
+		).toHaveValue( value );
+	};
+
+	assertButtonLabel = async ( label: Pcp.Admin.Styling.ButtonLabel ) => {
+		const value = LABEL_TO_VALUE[ label ];
+		await expect(
+			this.buttonLabelSelectbox(),
+			`Assert button label is ${ label }`
+		).toHaveValue( value );
+	};
+
+	assertButtonShape = async ( shape: Pcp.Admin.Styling.ButtonShape ) => {
+		const value = SHAPE_TO_VALUE[ shape ];
+		await expect(
+			this.buttonShapeRadio( shape ),
+			`Assert button shape is ${ shape }`
+		).toBeChecked();
+	};
+
+	assertButtonLayout = async ( layout: Pcp.Admin.Styling.ButtonLayout ) => {
+		await expect(
+			this.buttonLayoutRadio( layout ),
+			`Assert button layout is ${ layout }`
+		).toBeChecked();
 	};
 }

--- a/tests/qa/utils/frontend/paypal-ui-classic.ts
+++ b/tests/qa/utils/frontend/paypal-ui-classic.ts
@@ -7,7 +7,6 @@ import { expect, getLast4CardDigits } from '@inpsyde/playwright-utils/build';
  */
 import { Pcp } from '../../resources';
 import { PayPalPopup } from './paypal-popup';
-import { PayPalApi } from '../paypal-api';
 import { PayPalUi } from './paypal-ui';
 
 /**
@@ -521,38 +520,82 @@ export class PayPalUiClassic extends PayPalUi {
 	// Assertions
 
 	/**
-	 * - Asserts PayPal buttons classic container is visible.
-	 * - Compares actual PayPal buttons container screenshot to expected.
-	 *
-	 * @param snapshotName
+	 * Asserts PayPal buttons gateway container is visible and contains PayPal button (product, classic cart, classic checkout).
 	 */
-	snapshotClassicPayPalButtons = async ( snapshotName: string ) => {
-		await expect.soft( this.payPalButtonsClassicContainer() ).toBeVisible();
-		await this.page.waitForTimeout( 500 );
-		expect
-			.soft(
-				await this.payPalButtonsClassicContainer().screenshot( {
-					animations: 'disabled',
-				} )
-			)
-			.toMatchSnapshot( `${ snapshotName }.png` );
+	assertPayPalButtonsGatewayVisibleWithContent = async () => {
+		await expect(
+			this.payPalButtonsHostElement(),
+			'Assert PayPal buttons gateway host is visible'
+		).toBeVisible();
+		await expect(
+			this.payPalButton(),
+			'Assert PayPal button is visible'
+		).toBeVisible();
+	};
+
+	/** Host element with paypal-buttons-label-* and paypal-buttons-layout-* classes (product, cart, checkout). */
+	payPalButtonsHostElement = () =>
+		this.page.locator( '#ppc-button-ppcp-gateway .paypal-buttons' );
+
+	/** Host element for mini cart PayPal buttons. */
+	minicartPayPalButtonsHostElement = () =>
+		this.page.locator( '#ppc-button-minicart .paypal-buttons' );
+
+	/**
+	 * Asserts PayPal buttons have the given label (pay, checkout, buynow, paypal).
+	 *
+	 * @param label   - Expected label value
+	 * @param context - 'gateway' for product/cart/checkout, 'minicart' for mini cart
+	 */
+	assertPayPalButtonsHaveLabel = async (
+		label: 'pay' | 'checkout' | 'buynow' | 'paypal',
+		context: 'gateway' | 'minicart' = 'gateway'
+	) => {
+		const host =
+			context === 'minicart'
+				? this.minicartPayPalButtonsHostElement()
+				: this.payPalButtonsHostElement();
+		await expect(
+			host,
+			`Assert PayPal buttons have label ${ label }`
+		).toHaveClass( new RegExp( `paypal-buttons-label-${ label }` ) );
 	};
 
 	/**
-	 * - Asserts Minicart PayPal buttons container is visible.
-	 * - Compares actual PayPal buttons container screenshot to expected.
+	 * Asserts PayPal buttons have the given layout (vertical, horizontal).
 	 *
-	 * @param snapshotName
+	 * @param layout  - Expected layout value
+	 * @param context - 'gateway' for product/cart/checkout, 'minicart' for mini cart
 	 */
-	snapshotMinicartPayPalButtons = async ( snapshotName: string ) => {
-		await expect.soft( this.miniCartButtonContainer() ).toBeVisible();
-		await this.page.waitForTimeout( 500 );
-		expect
-			.soft(
-				await this.miniCartButtonContainer().screenshot( {
-					animations: 'disabled',
-				} )
-			)
-			.toMatchSnapshot( `${ snapshotName }.png` );
+	assertPayPalButtonsHaveLayout = async (
+		layout: 'vertical' | 'horizontal',
+		context: 'gateway' | 'minicart' = 'gateway'
+	) => {
+		const host =
+			context === 'minicart'
+				? this.minicartPayPalButtonsHostElement()
+				: this.payPalButtonsHostElement();
+		await expect(
+			host,
+			`Assert PayPal buttons have layout ${ layout }`
+		).toHaveClass( new RegExp( `paypal-buttons-layout-${ layout }` ) );
+	};
+
+	/**
+	 * Asserts PayPal buttons are not visible.
+	 *
+	 * @param context - 'gateway' for product/cart/checkout, 'minicart' for mini cart
+	 */
+	assertPayPalButtonsNotVisible = async (
+		context: 'gateway' | 'minicart' = 'gateway'
+	) => {
+		const selector =
+			context === 'minicart'
+				? '#ppc-button-minicart .paypal-buttons'
+				: '#ppc-button-ppcp-gateway .paypal-buttons';
+		await expect(
+			this.page.locator( selector ),
+			`Assert PayPal buttons (${ context }) are not visible`
+		).toBeHidden();
 	};
 }

--- a/tests/qa/utils/frontend/paypal-ui-classic.ts
+++ b/tests/qa/utils/frontend/paypal-ui-classic.ts
@@ -308,6 +308,14 @@ export class PayPalUiClassic extends PayPalUi {
 	usingVaultedPayPalAccountText = ( payPalEmail: string ) =>
 		this.page.getByText( `Using ${ payPalEmail } PayPal.` );
 
+	/** Host element with paypal-buttons-label-* and paypal-buttons-layout-* classes (product, cart, checkout). */
+	payPalButtonsHostElement = () =>
+		this.page.locator( '#ppc-button-ppcp-gateway .paypal-buttons' );
+
+	/** Host element for mini cart PayPal buttons. */
+	minicartPayPalButtonsHostElement = () =>
+		this.page.locator( '#ppc-button-minicart .paypal-buttons' );
+
 	// Actions
 
 	/**
@@ -532,14 +540,6 @@ export class PayPalUiClassic extends PayPalUi {
 			'Assert PayPal button is visible'
 		).toBeVisible();
 	};
-
-	/** Host element with paypal-buttons-label-* and paypal-buttons-layout-* classes (product, cart, checkout). */
-	payPalButtonsHostElement = () =>
-		this.page.locator( '#ppc-button-ppcp-gateway .paypal-buttons' );
-
-	/** Host element for mini cart PayPal buttons. */
-	minicartPayPalButtonsHostElement = () =>
-		this.page.locator( '#ppc-button-minicart .paypal-buttons' );
 
 	/**
 	 * Asserts PayPal buttons have the given label (pay, checkout, buynow, paypal).

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { Page } from '@playwright/test';
-import { expect, getLast4CardDigits } from '@inpsyde/playwright-utils/build';
+import {
+	expect,
+	getLast4CardDigits,
+	assertIframeWithRetry,
+} from '@inpsyde/playwright-utils/build';
 /**
  * Internal dependencies
  */
@@ -38,7 +42,7 @@ export class PayPalUi {
 
 	payPalButtonsBlockContainer = () =>
 		this.page.locator(
-			'ul.wc-block-components-express-payment__event-buttons'
+			'.wc-block-components-express-payment__event-buttons'
 		);
 	blockSmartButtonListItem = () =>
 		this.payPalButtonsBlockContainer().locator(
@@ -76,13 +80,9 @@ export class PayPalUi {
 		} );
 
 	payLaterMessageIframe = () =>
-		this.page.frameLocator( 'iframe[name^="__zoid__paypal_message__"]' );
+		this.page.frameLocator( 'iframe[title^="PayPal Message"]' );
 	payLaterMessageContainer = () =>
-		this.payLaterMessageIframe().locator( '.message__container' );
-	payLaterMessageTextPart = () =>
-		this.payLaterMessageContainer().getByText(
-			'Pay in 4 interest-free payments on'
-		);
+		this.page.locator( 'iframe[title^="PayPal Message"]' ).first();
 
 	fastlaneContinueButton = () =>
 		this.page
@@ -540,20 +540,77 @@ export class PayPalUi {
 	};
 
 	/**
-	 * - Asserts PayPal buttons block container is visible.
-	 * - Compares actual PayPal buttons container screenshot to expected.
-	 *
-	 * @param snapshotName
+	 * Asserts Pay Later Messaging iframe is visible. Uses retry-with-reload for SDK-loaded content.
+	 * Returns false if not found after retry (caller should test.skip()).
 	 */
-	snapshotBlockPayPalButtons = async ( snapshotName: string ) => {
-		await expect.soft( this.payPalButtonsBlockContainer() ).toBeVisible();
-		await this.page.waitForTimeout( 500 );
-		expect
-			.soft(
-				await this.payPalButtonsBlockContainer().screenshot( {
-					animations: 'disabled',
-				} )
-			)
-			.toMatchSnapshot( `${ snapshotName }.png` );
+	assertPayLaterMessageVisibleWithContent = async (): Promise<boolean> =>
+		assertIframeWithRetry(
+			this.page,
+			'iframe[title^="PayPal Message"]',			
+		);
+
+	/**
+	 * Asserts Pay Later Messaging iframe is not visible.
+	 */
+	assertPayLaterMessageNotVisible = async () => {
+		await expect(
+			this.payLaterMessageContainer(),
+			'Assert PLM iframe is not visible'
+		).toBeHidden();
+	};
+
+	/**
+	 * Asserts PayPal buttons block container is visible and contains PayPal payment button.
+	 */
+	assertPayPalButtonsBlockVisibleWithContent = async () => {
+		const container = this.payPalButtonsBlockContainer();
+		await expect(
+			container,
+			'Assert PayPal buttons block container is visible'
+		).toBeVisible();
+		await expect(
+			container.locator( '#express-payment-method-ppcp-gateway-paypal' ),
+			'Assert PayPal express payment button is visible'
+		).toBeVisible();
+	};
+
+	/** Host element with paypal-buttons-label-* and paypal-buttons-layout-* classes (block cart/checkout). */
+	payPalButtonsHostElement = () =>
+		this.page.locator(
+			'#express-payment-method-ppcp-gateway-paypal .paypal-buttons'
+		);
+
+	/**
+	 * Asserts PayPal buttons have the given label (pay, checkout, buynow, paypal).
+	 */
+	assertPayPalButtonsHaveLabel = async (
+		label: 'pay' | 'checkout' | 'buynow' | 'paypal'
+	) => {
+		await expect(
+			this.payPalButtonsHostElement(),
+			`Assert PayPal buttons have label ${ label }`
+		).toHaveClass( new RegExp( `paypal-buttons-label-${ label }` ) );
+	};
+
+	/**
+	 * Asserts PayPal buttons have the given layout (vertical, horizontal).
+	 */
+	assertPayPalButtonsHaveLayout = async (
+		layout: 'vertical' | 'horizontal'
+	) => {
+		await expect(
+			this.payPalButtonsHostElement(),
+			`Assert PayPal buttons have layout ${ layout }`
+		).toHaveClass( new RegExp( `paypal-buttons-layout-${ layout }` ) );
+	};
+
+	/**
+	 * Asserts PayPal buttons are not visible (block cart/checkout).
+	 */
+	assertPayPalButtonsNotVisible = async () => {
+		await expect(
+			this.page.locator( '#express-payment-method-ppcp-gateway-paypal' ),
+			'Assert PayPal buttons block container is not visible'
+		).toBeHidden();
 	};
 }

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -178,6 +178,12 @@ export class PayPalUi {
 	threeDSSubmitButton = () =>
 		this.threeDSFrame2().locator( 'input.primary[type="submit"]' );
 
+	/** Host element with paypal-buttons-label-* and paypal-buttons-layout-* classes (block cart/checkout). */
+	payPalButtonsHostElement = () =>
+		this.page.locator(
+			'#express-payment-method-ppcp-gateway-paypal .paypal-buttons'
+		);
+
 	// Actions
 
 	/**
@@ -573,12 +579,6 @@ export class PayPalUi {
 			'Assert PayPal express payment button is visible'
 		).toBeVisible();
 	};
-
-	/** Host element with paypal-buttons-label-* and paypal-buttons-layout-* classes (block cart/checkout). */
-	payPalButtonsHostElement = () =>
-		this.page.locator(
-			'#express-payment-method-ppcp-gateway-paypal .paypal-buttons'
-		);
 
 	/**
 	 * Asserts PayPal buttons have the given label (pay, checkout, buynow, paypal).

--- a/tests/qa/utils/test.ts
+++ b/tests/qa/utils/test.ts
@@ -164,10 +164,12 @@ const test = base.extend< BaseExtend >( {
 		await use( new PcpSettings( { page } ) );
 	},
 	pcpStyling: async ( { page }, use ) => {
-		await use( new PcpStyling( { page } ) );
+		const pcpStyling = new PcpStyling( { page } );
+		await use( pcpStyling );
 	},
 	pcpPayLaterMessaging: async ( { page }, use ) => {
-		await use( new PcpPayLaterMessaging( { page } ) );
+		const pcpPayLaterMessaging = new PcpPayLaterMessaging( { page } );
+		await use( pcpPayLaterMessaging );
 	},
 
 	// WooCommerce dashboard


### PR DESCRIPTION
### Description

Summary of changes:

- **PLM tests** – refactor
- **Styling tests** – refactor
- Assert messages – Added "Assert …" as the second argument to expect() so Playwright reports show what is being asserted.
- Subtests – Removed subtests to simplify the structure.
- FIXMEs – Fixed and removed.
- Visual tests – Removed 
- Not marking as critical yet – These tests will be observed first. PLM and Styling rely on external content (PayPal SDK, iframes), which can cause flakiness.

playwright-utils – Changes are also committed and PR’d in the external playwright-utils library.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Closes # .
