### PR TITLE
fix(button-styling): use fundingKey for PayPal SDK disable-funding mapping (4839)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Styling/PreviewPanel.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Styling/PreviewPanel.js
@@ -30,7 +30,7 @@ const PreviewPanel = ( { location } ) => {
 			.filter( ( method ) => method.isFunding )
 			.filter( ( method ) => ! paymentMethods.includes( method.value ) )
 			.forEach( ( method ) => {
-				disabled.push( method.value );
+				disabled.push( method.fundingKey ?? method.value );
 			} );
 		return disabled;
 	}, [ paymentMethods ] );

--- a/modules/ppcp-settings/resources/js/data/styling/configuration.js
+++ b/modules/ppcp-settings/resources/js/data/styling/configuration.js
@@ -117,6 +117,7 @@ export const STYLING_PAYMENT_METHODS = {
 	},
 	'pay-later': {
 		value: 'pay-later',
+		fundingKey: 'paylater',
 		label: __( 'Pay Later', 'woocommerce-paypal-payments' ),
 		isFunding: true,
 	},


### PR DESCRIPTION
## Problem

Disabling Pay Later in the Cart location broke all button previews across all locations after a page reload.

The root cause: the PayPal SDK expects `paylater` as the funding source key, but we were passing `pay-later` (the internal payment method value). This caused the SDK to error silently, breaking the entire preview.

## Solution

Added an optional `fundingKey` property to `STYLING_PAYMENT_METHODS` for entries where the SDK key differs from the internal value. The `disableFunding` logic now uses `method.fundingKey ?? method.value` when building the `disable-funding` string passed to the PayPal SDK.

## Changes

- `STYLING_PAYMENT_METHODS`: added `fundingKey: 'paylater'` to the `pay-later` entry
- `PreviewPanel`: updated `disableFunding` to use `fundingKey` over `value` when present

## Testing

1. Navigate to **Payments > Settings > Button Styling**
2. Select **Cart** location
3. Disable **Pay Later**
4. Save and reload
5. Verify: Cart preview renders correctly, no other location previews are broken