### PR TITLE
Fix Pay Later check

### DIFF
--- a/modules/ppcp-settings/src/Data/StylingSettings.php
+++ b/modules/ppcp-settings/src/Data/StylingSettings.php
@@ -209,7 +209,7 @@ class StylingSettings extends AbstractDataModel {
 		foreach ( $location_map as $key => $location_name ) {
 			if ( isset( $this->data[ $key ] ) && $this->data[ $key ] instanceof LocationStylingDTO ) {
 				$dto = $this->data[ $key ];
-				if ( $dto->enabled && in_array( 'paylater', $dto->methods, true ) ) {
+				if ( $dto->enabled && in_array( 'pay-later', $dto->methods, true ) ) {
 					$locations[] = $location_name;
 				}
 			}


### PR DESCRIPTION
`StylingSettings::get_pay_later_button_locations` was checking for `paylater` method while it was actually saved as `pay-later`. Because of that, the Pay Later button was never appearing. 
So, changing the check to `pay-later`.