### PR TITLE
fix(button-styling): force PreviewPanel remount when disable-funding changes (4838)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Styling/PreviewPanel.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Styling/PreviewPanel.js
@@ -35,7 +35,7 @@ const PreviewPanel = ( { location } ) => {
 		return disabled;
 	}, [ paymentMethods ] );
 
-	// TODO: Changes in the providerOptions are not reflected on the page.
+	// PayPalScriptProvider ignores option changes after mount — key forces a full remount.
 	const providerOptions = useMemo(
 		() => ( {
 			clientId: PREVIEW_CLIENT_ID,
@@ -51,7 +51,10 @@ const PreviewPanel = ( { location } ) => {
 	return (
 		<div className="preview-panel">
 			<div className="preview-panel-inner">
-				<PayPalScriptProvider options={ providerOptions }>
+				<PayPalScriptProvider
+					options={ providerOptions }
+					key={ providerOptions[ 'disable-funding' ] }
+				>
 					<PayPalButtons style={ style } forceReRender={ [ style ] }>
 						Error
 					</PayPalButtons>


### PR DESCRIPTION
## Problem

Changing enabled payment methods in the Button Styling preview was not reflected — the PayPal buttons continued showing the previous state even after saving and reloading.

The root cause: `PayPalScriptProvider` only loads the SDK once and ignores subsequent `options` changes.

## Solution

Pass `key={ providerOptions[ 'disable-funding' ] }` to `PayPalScriptProvider`. When React sees a changed key it fully unmounts and remounts the component, causing the SDK to reload with the updated `disable-funding` option.

Also cleaned up:
- Removed the TODO comment that flagged this limitation

## Testing

1. Navigate to **Payments > Settings > Button Styling**
2. Select **Cart** location
3. Toggle Pay Later or Venmo off
4. Save and reload
5. Verify the preview reflects the updated button set
6. Switch locations — verify other previews are unaffected and working