### PR TITLE
PUI: Add Pay Upon Invoice support to the new settings UI (5916)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/services.php
+++ b/modules/ppcp-local-alternative-payment-methods/services.php
@@ -238,4 +238,13 @@ return array(
 	'ppcp-local-apms.pwc.eligibility.check'     => static function ( ContainerInterface $container ): bool {
 		return $container->get( 'ppcp-local-apms.eligibility.check' ) && $container->get( 'ppcp-local-apms.pwc.currency.check' );
 	},
+	'ppcp-local-apms.pui.country.check'         => static function ( ContainerInterface $container ): bool {
+		return 'DE' === $container->get( 'api.merchant.country' );
+	},
+	'ppcp-local-apms.pui.currency.check'        => static function ( ContainerInterface $container ): bool {
+		return 'EUR' === $container->get( 'api.shop.currency.getter' )->get();
+	},
+	'ppcp-local-apms.pui.eligibility.check'     => static function ( ContainerInterface $container ): bool {
+		return $container->get( 'ppcp-local-apms.pui.country.check' ) && $container->get( 'ppcp-local-apms.pui.currency.check' );
+	},
 );

--- a/modules/ppcp-settings/resources/css/components/reusable-components/_payment-method-item.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_payment-method-item.scss
@@ -291,6 +291,10 @@
 		visibility: visible;
 		pointer-events: auto;
 	}
+
+	&--error svg {
+		color: $color-error-red;
+	}
 }
 
 // For RTL support

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlocks/PaymentMethodItemBlock.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlocks/PaymentMethodItemBlock.js
@@ -13,6 +13,7 @@ const PaymentMethodItemBlock = ( {
 	isDisabled,
 	disabledMessage,
 	warningMessages,
+	warningSeverity,
 } ) => {
 	const hasWarning =
 		warningMessages && Object.keys( warningMessages ).length > 0;
@@ -71,6 +72,7 @@ const PaymentMethodItemBlock = ( {
 						{ hasWarning && ! isDisabled && isSelected && (
 							<WarningMessages
 								warningMessages={ warningMessages }
+								severity={ warningSeverity }
 							/>
 						) }
 					</div>

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlocks/PaymentMethodsBlock.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/SettingsBlocks/PaymentMethodsBlock.js
@@ -35,6 +35,7 @@ const PaymentMethodsBlock = ( { paymentMethods = [], onTriggerModal } ) => {
 								onTriggerModal?.( paymentMethod.id )
 							}
 							warningMessages={ paymentMethod.warningMessages }
+							warningSeverity={ paymentMethod.warningSeverity }
 						/>
 					);
 				} ) }

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/Modal.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/Modal.js
@@ -12,50 +12,61 @@ import { PaymentHooks } from '@ppcp-settings/data';
 
 const Modal = ( { method, setModalIsVisible, onSave } ) => {
 	const { all: paymentMethods } = PaymentHooks.usePaymentMethods();
-	const { paypalShowLogo, cardholderName, fastlaneDisplayWatermark } =
-		PaymentHooks.usePaymentMethodsModal();
+	const persistentValues = PaymentHooks.usePaymentMethodsModal();
+
+	const methodConfig = paymentMethods.find( ( i ) => i.id === method?.id );
+
+	// Build a unified value map from all sources.
+	// Persistent store values cover fields like paypalShowLogo, puiBrandName, etc.
+	// Method-level values cover checkout page title and description.
+	const currentValues = {
+		...persistentValues,
+		checkoutPageTitle: methodConfig?.title,
+		checkoutPageDescription: methodConfig?.description,
+	};
 
 	const [ settings, setSettings ] = useState( () => {
-		if ( ! method?.id ) {
-			return {};
-		}
-
-		const methodConfig = paymentMethods.find( ( i ) => i.id === method.id );
 		if ( ! methodConfig?.fields ) {
 			return {};
 		}
 
-		const initialSettings = {};
+		const initial = {};
 		Object.entries( methodConfig.fields ).forEach( ( [ key, field ] ) => {
-			switch ( key ) {
-				case 'checkoutPageTitle':
-					initialSettings[ key ] = methodConfig.title;
-					break;
-				case 'checkoutPageDescription':
-					initialSettings[ key ] = methodConfig.description;
-					break;
-				default:
-					initialSettings[ key ] = field.default;
-			}
+			initial[ key ] = currentValues[ key ] ?? field.default;
 		} );
-
-		initialSettings.paypalShowLogo = paypalShowLogo;
-		initialSettings.cardholderName = cardholderName;
-		initialSettings.fastlaneDisplayWatermark = fastlaneDisplayWatermark;
-
-		return initialSettings;
+		return initial;
 	} );
 
-	if ( ! method?.id ) {
+	if ( ! method?.id || ! methodConfig?.fields ) {
 		return null;
 	}
 
-	const methodConfig = paymentMethods.find( ( i ) => i.id === method.id );
-	if ( ! methodConfig?.fields ) {
-		return null;
-	}
+	/**
+	 * Check if all required fields have non-empty values.
+	 *
+	 * @return {boolean} True if all required fields are filled.
+	 */
+	const areRequiredFieldsValid = () => {
+		return Object.entries( methodConfig.fields ).every(
+			( [ key, field ] ) => {
+				if ( ! field.required ) {
+					return true;
+				}
+				const value = settings[ key ];
+				return typeof value === 'string'
+					? value.trim() !== ''
+					: value != null;
+			}
+		);
+	};
+
+	const updateSetting = ( key, value ) => {
+		setSettings( ( prev ) => ( { ...prev, [ key ]: value } ) );
+	};
 
 	const renderField = ( key, field ) => {
+		const fieldLabel = field.required ? `${ field.label } *` : field.label;
+
 		switch ( field.type ) {
 			case 'text':
 				return (
@@ -63,13 +74,11 @@ const Modal = ( { method, setModalIsVisible, onSave } ) => {
 						<TextControl
 							__nextHasNoMarginBottom
 							className="ppcp-r-vertical-text-control"
-							label={ field.label }
+							label={ fieldLabel }
+							help={ field.description }
 							value={ settings[ key ] }
 							onChange={ ( value ) =>
-								setSettings( ( prev ) => ( {
-									...prev,
-									[ key ]: value,
-								} ) )
+								updateSetting( key, value )
 							}
 						/>
 					</div>
@@ -83,10 +92,7 @@ const Modal = ( { method, setModalIsVisible, onSave } ) => {
 							label={ field.label }
 							checked={ settings[ key ] }
 							onChange={ ( value ) =>
-								setSettings( ( prev ) => ( {
-									...prev,
-									[ key ]: value,
-								} ) )
+								updateSetting( key, value )
 							}
 						/>
 					</div>
@@ -110,10 +116,7 @@ const Modal = ( { method, setModalIsVisible, onSave } ) => {
 								selected={ settings[ key ] }
 								options={ field.options }
 								onChange={ ( value ) =>
-									setSettings( ( prev ) => ( {
-										...prev,
-										[ key ]: value,
-									} ) )
+									updateSetting( key, value )
 								}
 							/>
 						</div>
@@ -126,6 +129,9 @@ const Modal = ( { method, setModalIsVisible, onSave } ) => {
 	};
 
 	const handleSave = () => {
+		if ( ! areRequiredFieldsValid() ) {
+			return;
+		}
 		onSave?.( method.id, settings );
 		setModalIsVisible( false );
 	};
@@ -142,7 +148,11 @@ const Modal = ( { method, setModalIsVisible, onSave } ) => {
 				) }
 
 				<div className="ppcp-r-modal__field-row ppcp-r-modal__field-row--save">
-					<Button variant="primary" onClick={ handleSave }>
+					<Button
+						variant="primary"
+						onClick={ handleSave }
+						disabled={ ! areRequiredFieldsValid() }
+					>
 						{ __( 'Save changes', 'woocommerce-paypal-payments' ) }
 					</Button>
 				</div>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/PaymentMethodCard.js
@@ -5,6 +5,7 @@ import usePaymentDependencyState from '@ppcp-settings/hooks/usePaymentDependency
 import useSettingDependencyState from '@ppcp-settings/hooks/useSettingDependencyState';
 import usePaymentMethodsToggle from '@ppcp-settings/hooks/usePaymentMethodsToggle';
 import useDependencyMessages from '@ppcp-settings/hooks/useDependencyMessages';
+import useMethodWarnings from '@ppcp-settings/hooks/useMethodWarnings';
 import BulkPaymentToggle from './BulkPaymentToggle';
 import SpinnerOverlay from '@ppcp-settings/Components/ReusableComponents/SpinnerOverlay';
 import {
@@ -78,6 +79,9 @@ const PaymentMethodCard = ( {
 			groupName,
 		} );
 
+	// Evaluate reactive warning visibility conditions against store data.
+	const methodsWithWarnings = useMethodWarnings( methods );
+
 	useEffect( () => {
 		if ( isPaymentStoreReady && isSettingsStoreReady ) {
 			handleHighlightFromUrl();
@@ -93,7 +97,7 @@ const PaymentMethodCard = ( {
 	}
 
 	// Process methods with dependencies from the pre-computed map.
-	const processedMethods = methods.map( ( method ) => {
+	const processedMethods = methodsWithWarnings.map( ( method ) => {
 		const dependencyInfo = dependencyMessagesMap[ method.id ] || {};
 
 		return {

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/WarningMessages.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Payment/WarningMessages.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { Icon } from '@wordpress/components';
 import { warning } from '@wordpress/icons';
 
@@ -6,9 +7,10 @@ import { warning } from '@wordpress/icons';
  *
  * @param {Object} props                 - Component props
  * @param {Object} props.warningMessages - The warning messages to display
+ * @param {string} [props.severity]      - The severity level: 'warning' (yellow) or 'error' (red)
  * @return {JSX.Element|null} The formatted warning messages or null
  */
-const WarningMessages = ( { warningMessages } ) => {
+const WarningMessages = ( { warningMessages, severity = 'warning' } ) => {
 	const messages = Object.values( warningMessages || {} );
 
 	if ( messages.length === 0 ) {
@@ -16,7 +18,11 @@ const WarningMessages = ( { warningMessages } ) => {
 	}
 
 	return (
-		<span className="ppcp--method-warning">
+		<span
+			className={ classNames( 'ppcp--method-warning', {
+				'ppcp--method-warning--error': severity === 'error',
+			} ) }
+		>
 			<Icon icon={ warning } />
 			<div className="ppcp--method-warning-message">
 				{ messages.map( ( message, index ) => (

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -46,6 +46,9 @@ const TabPaymentMethods = () => {
 				'threeDSecure',
 				'cardholderName',
 				'fastlaneDisplayWatermark',
+				'puiBrandName',
+				'puiLogoUrl',
+				'puiCustomerServiceInstructions',
 			];
 
 			persistentSettings.forEach( ( setting ) => {

--- a/modules/ppcp-settings/resources/js/data/payment/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/payment/hooks.js
@@ -135,10 +135,18 @@ export const usePaymentMethodsModal = () => {
 	const [ fastlaneDisplayWatermark ] = usePersistent(
 		'fastlaneDisplayWatermark'
 	);
+	const [ puiBrandName ] = usePersistent( 'puiBrandName' );
+	const [ puiLogoUrl ] = usePersistent( 'puiLogoUrl' );
+	const [ puiCustomerServiceInstructions ] = usePersistent(
+		'puiCustomerServiceInstructions'
+	);
 
 	return {
 		paypalShowLogo,
 		cardholderName,
 		fastlaneDisplayWatermark,
+		puiBrandName,
+		puiLogoUrl,
+		puiCustomerServiceInstructions,
 	};
 };

--- a/modules/ppcp-settings/resources/js/data/payment/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/payment/reducer.js
@@ -45,6 +45,9 @@ const defaultPersistent = Object.freeze( {
 	threeDSecure: 'no-3d-secure',
 	cardholderName: false,
 	fastlaneDisplayWatermark: false,
+	puiBrandName: '',
+	puiLogoUrl: '',
+	puiCustomerServiceInstructions: '',
 	__meta: false,
 } );
 

--- a/modules/ppcp-settings/resources/js/hooks/useMethodWarnings.js
+++ b/modules/ppcp-settings/resources/js/hooks/useMethodWarnings.js
@@ -1,0 +1,195 @@
+/**
+ * Custom hook to evaluate payment method warnings based on reactive store data.
+ *
+ * Warning messages can be either:
+ * - A plain string: always displayed (supports HTML content).
+ * - An object with { message, visibleWhen }: displayed only when the visibleWhen
+ *   condition evaluates to true. Reactively shown or hidden as store data changes.
+ *
+ * The visibleWhen object follows the same pattern as setting dependencies:
+ * - store:     Which store to read from ('payment' or 'settings').
+ * - field:     The persistent field name to evaluate (single-field conditions).
+ * - fields:    Map of field names to labels (for 'any_empty' condition).
+ * - condition: The evaluation rule ('not_empty', 'empty', 'equals', 'not_equals', 'any_empty').
+ * - value:     (Optional) Expected value for 'equals'/'not_equals' conditions.
+ *
+ * The 'any_empty' condition checks multiple fields and builds a dynamic message
+ * by replacing %s in the message template with a comma-separated list of labels
+ * for fields that are currently empty.
+ */
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { _x, sprintf } from '@wordpress/i18n';
+
+const STORE_MAP = {
+	payment: 'wc/paypal/payment',
+	settings: 'wc/paypal/settings',
+};
+
+const isEmpty = ( fieldValue ) =>
+	typeof fieldValue === 'string'
+		? fieldValue.trim().length === 0
+		: ! fieldValue;
+
+const CONDITION_EVALUATORS = {
+	not_empty: ( fieldValue ) => ! isEmpty( fieldValue ),
+	empty: ( fieldValue ) => isEmpty( fieldValue ),
+	equals: ( fieldValue, expected ) => fieldValue === expected,
+	not_equals: ( fieldValue, expected ) => fieldValue !== expected,
+};
+
+/**
+ * Joins a list of labels into a human-readable string.
+ *
+ * @param {string[]} labels Array of label strings.
+ * @return {string} Joined string (e.g. "A, B, and C").
+ */
+const joinLabels = ( labels ) => {
+	if ( labels.length <= 1 ) {
+		return labels[ 0 ] || '';
+	}
+	if ( labels.length === 2 ) {
+		return labels.join(
+			' ' +
+				/* translators: joins two items, e.g. "Brand name and Logo URL" */
+				_x(
+					'and',
+					'joining two items',
+					'woocommerce-paypal-payments'
+				) +
+				' '
+		);
+	}
+	const last = labels[ labels.length - 1 ];
+	const rest = labels.slice( 0, -1 );
+	return (
+		rest.join( ', ' ) +
+		', ' +
+		/* translators: before the last item in a list, e.g. "A, B, and C" */
+		_x( 'and', 'before last list item', 'woocommerce-paypal-payments' ) +
+		' ' +
+		last
+	);
+};
+
+/**
+ * Evaluates an 'any_empty' condition against store data.
+ *
+ * @param {Object} visibleWhen The visibleWhen config with fields map.
+ * @param {Object} store       The persistent store data for the referenced store.
+ * @return {string|null} The built label string if any fields are empty, or null.
+ */
+const evaluateAnyEmpty = ( visibleWhen, store ) => {
+	const { fields } = visibleWhen;
+	if ( ! fields ) {
+		return null;
+	}
+
+	const emptyLabels = Object.entries( fields )
+		.filter( ( [ fieldName ] ) => isEmpty( store?.[ fieldName ] ) )
+		.map( ( [ , label ] ) => label );
+
+	return emptyLabels.length > 0 ? joinLabels( emptyLabels ) : null;
+};
+
+/**
+ * Evaluates payment method warnings based on reactive store data.
+ *
+ * @param {Array} methods Array of payment method objects.
+ * @return {Array} Methods with warnings evaluated and normalized to { key: string }.
+ */
+const useMethodWarnings = ( methods ) => {
+	const referencedStores = useMemo( () => {
+		const stores = new Set();
+		methods?.forEach( ( method ) => {
+			if ( ! method?.warningMessages ) {
+				return;
+			}
+			Object.values( method.warningMessages ).forEach( ( warning ) => {
+				if (
+					typeof warning === 'object' &&
+					warning?.visibleWhen?.store
+				) {
+					stores.add( warning.visibleWhen.store );
+				}
+			} );
+		} );
+		return [ ...stores ];
+	}, [ methods ] );
+
+	const storeData = useSelect(
+		( select ) => {
+			const data = {};
+			referencedStores.forEach( ( storeKey ) => {
+				const storeName = STORE_MAP[ storeKey ];
+				if ( ! storeName ) {
+					return;
+				}
+				const store = select( storeName );
+				if ( store?.persistentData ) {
+					data[ storeKey ] = store.persistentData();
+				}
+			} );
+			return data;
+		},
+		[ referencedStores ]
+	);
+
+	return useMemo(
+		() =>
+			methods?.map( ( method ) => {
+				if ( ! method?.warningMessages ) {
+					return method;
+				}
+
+				const evaluatedWarnings = {};
+				Object.entries( method.warningMessages ).forEach(
+					( [ key, warning ] ) => {
+						if ( typeof warning === 'string' ) {
+							if ( warning ) {
+								evaluatedWarnings[ key ] = warning;
+							}
+							return;
+						}
+
+						const { message, visibleWhen } = warning;
+						if ( ! visibleWhen ) {
+							evaluatedWarnings[ key ] = message;
+							return;
+						}
+
+						const { store, condition } = visibleWhen;
+
+						// Multi-field condition: visible when any field is empty.
+						if ( condition === 'any_empty' ) {
+							const labelText = evaluateAnyEmpty(
+								visibleWhen,
+								storeData[ store ]
+							);
+							if ( labelText ) {
+								evaluatedWarnings[ key ] = sprintf(
+									message,
+									labelText
+								);
+							}
+							return;
+						}
+
+						// Single-field conditions.
+						const { field, value } = visibleWhen;
+						const evaluator = CONDITION_EVALUATORS[ condition ];
+						const fieldValue = storeData[ store ]?.[ field ];
+
+						if ( evaluator && evaluator( fieldValue, value ) ) {
+							evaluatedWarnings[ key ] = message;
+						}
+					}
+				);
+
+				return { ...method, warningMessages: evaluatedWarnings };
+			} ) || [],
+		[ methods, storeData ]
+	);
+};
+
+export default useMethodWarnings;

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -532,6 +532,7 @@ return array(
 			FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING => $features[ FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_INSTALLMENTS    => $features[ FeaturesDefinition::FEATURE_INSTALLMENTS ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => $features[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ]['enabled'] ?? false,
+			FeaturesDefinition::FEATURE_PAY_UPON_INVOICE => $features[ FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ]['enabled'] ?? false,
 		);
 	},
 
@@ -647,6 +648,7 @@ return array(
 			FeaturesDefinition::FEATURE_INSTALLMENTS    => $features[ FeaturesDefinition::FEATURE_INSTALLMENTS ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => $features[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING => $features[ FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING ]['enabled'] ?? false,
+			FeaturesDefinition::FEATURE_PAY_UPON_INVOICE => $features[ FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ]['enabled'] ?? false,
 		);
 
 		$merchant_capabilities = array(
@@ -665,6 +667,7 @@ return array(
 			FeaturesDefinition::FEATURE_INSTALLMENTS    => $capabilities[ FeaturesDefinition::FEATURE_INSTALLMENTS ],
 			// Installments eligibility.
 			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => $capabilities[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ], // Pay with Crypto eligibility.
+			FeaturesDefinition::FEATURE_PAY_UPON_INVOICE => $capabilities[ FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ], // Pay Upon Invoice eligibility.
 		);
 
 		return new FeaturesDefinition(
@@ -690,7 +693,8 @@ return array(
 			$container->get( 'applepay.eligibility.check' ), // Apple Pay eligibility.
 			$pay_later_eligible, // Pay Later eligibility.
 			'MX' === $container->get( 'api.merchant.country' ), // Installments eligibility.
-			$container->get( 'ppcp-local-apms.pwc.eligibility.check' ) // Pay with Crypto eligibility.
+			$container->get( 'ppcp-local-apms.pwc.eligibility.check' ), // Pay with Crypto eligibility.
+			$container->get( 'ppcp-local-apms.pui.eligibility.check' ) // Pay Upon Invoice eligibility.
 		);
 	},
 	'settings.service.payment_methods_eligibilities'      => static function ( ContainerInterface $container ): PaymentMethodsEligibilityService {

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -453,21 +453,11 @@ return array(
 		);
 	},
 	'settings.data.definition.methods'                    => static function ( ContainerInterface $container ): PaymentMethodsDefinition {
-		$axo_checkout_config_notice      = $container->get( 'axo.checkout-config-notice.raw' );
-		$axo_incompatible_plugins_notice = $container->get( 'axo.incompatible-plugins-notice.raw' );
-
-		// Combine the notices - only include non-empty ones.
-		$axo_notices = array_filter(
-			array(
-				$axo_checkout_config_notice,
-				$axo_incompatible_plugins_notice,
-			)
-		);
-
 		return new PaymentMethodsDefinition(
 			$container->get( 'settings.data.payment' ),
 			$container->get( 'settings.data.general' ),
-			$axo_notices
+			$container->get( 'axo.checkout-config-notice.raw' ),
+			$container->get( 'axo.incompatible-plugins-notice.raw' )
 		);
 	},
 	'settings.data.definition.method_dependencies'        => static function ( ContainerInterface $container ): PaymentMethodsDependenciesDefinition {

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -70,6 +70,11 @@ class FeaturesDefinition {
 	public const FEATURE_PAY_WITH_CRYPTO = 'pwc';
 
 	/**
+	 * Whether Pay Upon Invoice (PUI) is supported. Available for merchants in Germany.
+	 */
+	public const FEATURE_PAY_UPON_INVOICE = 'pay_upon_invoice';
+
+	/**
 	 * The features eligibility service.
 	 *
 	 * @var FeaturesEligibilityService
@@ -421,6 +426,41 @@ class FeaturesDefinition {
 						'type'  => 'tertiary',
 						'text'  => __( 'Learn more', 'woocommerce-paypal-payments' ),
 						'url'   => 'https://www.paypal.com/us/digital-wallet/manage-money/crypto',
+						'class' => 'small-button',
+					),
+				),
+			),
+			self::FEATURE_PAY_UPON_INVOICE                => array(
+				'title'       => __( 'Pay Upon Invoice', 'woocommerce-paypal-payments' ),
+				'description' => __( 'Offer Pay upon Invoice (Rechnungskauf) for customers in Germany. Buyers receive goods first and pay within 30 days — no PayPal account needed. Powered by Ratepay.', 'woocommerce-paypal-payments' ),
+				'enabled'     => $this->merchant_capabilities[ self::FEATURE_PAY_UPON_INVOICE ],
+				'buttons'     => array(
+					array(
+						'type'     => 'secondary',
+						'text'     => __( 'Configure', 'woocommerce-paypal-payments' ),
+						'action'   => array(
+							'type'    => 'tab',
+							'tab'     => 'payment_methods',
+							'section' => 'ppcp-pay-upon-invoice-gateway',
+							'modal'   => 'ppcp-pay-upon-invoice-gateway',
+						),
+						'showWhen' => 'enabled',
+						'class'    => 'small-button',
+					),
+					array(
+						'type'     => 'secondary',
+						'text'     => __( 'Sign up', 'woocommerce-paypal-payments' ),
+						'urls'     => array(
+							'sandbox' => 'https://www.sandbox.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE',
+							'live'    => 'https://www.paypal.com/bizsignup/entry?country.x=DE&product=payment_methods&capabilities=PAY_UPON_INVOICE',
+						),
+						'showWhen' => 'disabled',
+						'class'    => 'small-button',
+					),
+					array(
+						'type'  => 'tertiary',
+						'text'  => __( 'Learn more', 'woocommerce-paypal-payments' ),
+						'url'   => 'https://developer.paypal.com/docs/checkout/apm/pay-upon-invoice/',
 						'class' => 'small-button',
 					),
 				),

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -51,11 +51,18 @@ class PaymentMethodsDefinition {
 	private GeneralSettings $general_settings;
 
 	/**
-	 * Conflict notices for Axo gateway.
+	 * Axo checkout configuration conflict notice.
 	 *
-	 * @var array
+	 * @var string
 	 */
-	private array $axo_conflicts_notices;
+	private string $axo_checkout_config_notice;
+
+	/**
+	 * Axo incompatible plugins conflict notice.
+	 *
+	 * @var string
+	 */
+	private string $axo_incompatible_plugins_notice;
 
 	/**
 	 * List of WooCommerce payment gateways.
@@ -67,18 +74,21 @@ class PaymentMethodsDefinition {
 	/**
 	 * Constructor.
 	 *
-	 * @param PaymentSettings $settings              Payment methods data model.
-	 * @param GeneralSettings $general_settings      General plugin settings model.
-	 * @param array           $axo_conflicts_notices Conflicts notices for Axo.
+	 * @param PaymentSettings $settings                        Payment methods data model.
+	 * @param GeneralSettings $general_settings                General plugin settings model.
+	 * @param string          $axo_checkout_config_notice      Axo checkout config conflict notice.
+	 * @param string          $axo_incompatible_plugins_notice Axo incompatible plugins notice.
 	 */
 	public function __construct(
 		PaymentSettings $settings,
 		GeneralSettings $general_settings,
-		array $axo_conflicts_notices = array()
+		string $axo_checkout_config_notice = '',
+		string $axo_incompatible_plugins_notice = ''
 	) {
-		$this->settings              = $settings;
-		$this->general_settings      = $general_settings;
-		$this->axo_conflicts_notices = $axo_conflicts_notices;
+		$this->settings                        = $settings;
+		$this->general_settings                = $general_settings;
+		$this->axo_checkout_config_notice      = $axo_checkout_config_notice;
+		$this->axo_incompatible_plugins_notice = $axo_incompatible_plugins_notice;
 	}
 
 	/**
@@ -105,6 +115,7 @@ class PaymentMethodsDefinition {
 				$method['icon'],
 				$method['fields'] ?? array(),
 				$method['warningMessages'] ?? array(),
+				$method['warningSeverity'] ?? 'warning',
 			);
 		}
 
@@ -124,6 +135,8 @@ class PaymentMethodsDefinition {
 	 *                                                fields.
 	 * @param array       $warning_messages           Optional. Warning messages to display in the
 	 *                                                UI.
+	 * @param string      $warning_severity           Optional. Severity level: 'warning' (yellow)
+	 *                                                or 'error' (red).
 	 * @return array Payment method definition.
 	 */
 	private function build_method_definition(
@@ -132,7 +145,8 @@ class PaymentMethodsDefinition {
 		string $description,
 		string $icon,
 		$fields = array(),
-		array $warning_messages = array()
+		array $warning_messages = array(),
+		string $warning_severity = 'warning'
 	): array {
 		$gateway = $this->wc_gateways[ $gateway_id ] ?? null;
 
@@ -148,6 +162,7 @@ class PaymentMethodsDefinition {
 			'itemTitle'       => $title,
 			'itemDescription' => $description,
 			'warningMessages' => $warning_messages,
+			'warningSeverity' => $warning_severity,
 		);
 
 		if ( is_array( $fields ) ) {
@@ -234,7 +249,8 @@ class PaymentMethodsDefinition {
 	 * @return array
 	 */
 	public function group_card_methods(): array {
-		$group = array();
+		$group    = array();
+		$warnings = $this->get_warning_messages();
 
 		if ( ! $this->general_settings->own_brand_only() ) {
 			$group[] = array(
@@ -268,7 +284,7 @@ class PaymentMethodsDefinition {
 						),
 					),
 				),
-				'warningMessages' => $this->axo_conflicts_notices,
+				'warningMessages' => $warnings[ AxoGateway::ID ] ?? array(),
 			);
 			$group[] = array(
 				'id'          => ApplePayGateway::ID,
@@ -372,6 +388,7 @@ class PaymentMethodsDefinition {
 	 */
 	public function group_apms(): array {
 		$defaults = self::get_apm_defaults();
+		$warnings = $this->get_warning_messages();
 
 		$group = array(
 			array(
@@ -429,10 +446,32 @@ class PaymentMethodsDefinition {
 				'icon'        => 'payment-method-multibanco',
 			),
 			array(
-				'id'          => PayUponInvoiceGateway::ID,
-				'title'       => $defaults[ PayUponInvoiceGateway::ID ]['title'],
-				'description' => $defaults[ PayUponInvoiceGateway::ID ]['method_description'],
-				'icon'        => '',
+				'id'              => PayUponInvoiceGateway::ID,
+				'title'           => $defaults[ PayUponInvoiceGateway::ID ]['title'],
+				'description'     => $defaults[ PayUponInvoiceGateway::ID ]['method_description'],
+				'icon'            => 'payment-method-ratepay',
+				'fields'          => array(
+					'puiBrandName'                   => array(
+						'type'     => 'text',
+						'default'  => $this->settings->get_pui_brand_name(),
+						'label'    => __( 'Brand name', 'woocommerce-paypal-payments' ),
+						'required' => true,
+					),
+					'puiLogoUrl'                     => array(
+						'type'     => 'text',
+						'default'  => $this->settings->get_pui_logo_url(),
+						'label'    => __( 'Logo URL', 'woocommerce-paypal-payments' ),
+						'required' => true,
+					),
+					'puiCustomerServiceInstructions' => array(
+						'type'     => 'text',
+						'default'  => $this->settings->get_pui_customer_service_instructions(),
+						'label'    => __( 'Customer service instructions', 'woocommerce-paypal-payments' ),
+						'required' => true,
+					),
+				),
+				'warningMessages' => $warnings[ PayUponInvoiceGateway::ID ] ?? array(),
+				'warningSeverity' => 'error',
 			),
 			array(
 				'id'          => OXXO::ID,
@@ -443,5 +482,47 @@ class PaymentMethodsDefinition {
 		);
 
 		return apply_filters( 'woocommerce_paypal_payments_gateway_group_apm', $group );
+	}
+
+	/**
+	 * Returns warning definitions keyed by gateway ID.
+	 *
+	 * Each gateway can have multiple warnings. Each warning can be either:
+	 * - A plain string: always displayed.
+	 * - An object with { message, visibleWhen }: displayed only when the
+	 *   visibleWhen condition evaluates to true.
+	 *
+	 * @return array Warning definitions keyed by gateway ID.
+	 */
+	private function get_warning_messages(): array {
+		$warnings = array();
+
+		// Pay upon Invoice warnings.
+		$warnings[ PayUponInvoiceGateway::ID ] = array(
+			'pui_required_fields' => array(
+				/* translators: %s: comma-separated list of missing field names. */
+				'message'     => __(
+					'Pay upon Invoice requires %s to be configured. Click the settings icon to configure.',
+					'woocommerce-paypal-payments'
+				),
+				'visibleWhen' => array(
+					'store'     => 'payment',
+					'condition' => 'any_empty',
+					'fields'    => array(
+						'puiBrandName'                   => __( 'Brand name', 'woocommerce-paypal-payments' ),
+						'puiLogoUrl'                     => __( 'Logo URL', 'woocommerce-paypal-payments' ),
+						'puiCustomerServiceInstructions' => __( 'Customer service instructions', 'woocommerce-paypal-payments' ),
+					),
+				),
+			),
+		);
+
+		// Fastlane (Axo) conflict warnings.
+		$warnings[ AxoGateway::ID ] = array(
+			'axo_checkout_config'      => $this->axo_checkout_config_notice,
+			'axo_incompatible_plugins' => $this->axo_incompatible_plugins_notice,
+		);
+
+		return $warnings;
 	}
 }

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -37,13 +37,16 @@ class PaymentSettings extends AbstractDataModel {
 	 */
 	protected function get_defaults(): array {
 		return array(
-			'paypal_show_logo'            => false,
-			'cardholder_name'             => false,
-			'fastlane_display_watermark'  => false,
-			'venmo_enabled'               => false,
-			'paylater_enabled'            => false,
-			'applepay_validated'          => false,
-			'applepay_checkout_data_mode' => 'use_wc',
+			'paypal_show_logo'                  => false,
+			'cardholder_name'                   => false,
+			'fastlane_display_watermark'        => false,
+			'venmo_enabled'                     => false,
+			'paylater_enabled'                  => false,
+			'applepay_validated'                => false,
+			'applepay_checkout_data_mode'       => 'use_wc',
+			'pui_brand_name'                    => '',
+			'pui_logo_url'                      => '',
+			'pui_customer_service_instructions' => '',
 		);
 	}
 
@@ -305,5 +308,58 @@ class PaymentSettings extends AbstractDataModel {
 	 */
 	public function set_applepay_checkout_data_mode( string $value ): void {
 		$this->data['applepay_checkout_data_mode'] = $value;
+	}
+
+	/**
+	 * Get Pay upon Invoice brand name.
+	 */
+	public function get_pui_brand_name(): string {
+		return (string) $this->data['pui_brand_name'];
+	}
+
+	/**
+	 * Set Pay upon Invoice brand name.
+	 */
+	public function set_pui_brand_name( string $value ): void {
+		$this->data['pui_brand_name'] = $value;
+	}
+
+	/**
+	 * Get Pay upon Invoice logo URL.
+	 */
+	public function get_pui_logo_url(): string {
+		return (string) $this->data['pui_logo_url'];
+	}
+
+	/**
+	 * Set Pay upon Invoice logo URL.
+	 */
+	public function set_pui_logo_url( string $value ): void {
+		$this->data['pui_logo_url'] = $value;
+	}
+
+	/**
+	 * Get Pay upon Invoice customer service instructions.
+	 */
+	public function get_pui_customer_service_instructions(): string {
+		return (string) $this->data['pui_customer_service_instructions'];
+	}
+
+	/**
+	 * Set Pay upon Invoice customer service instructions.
+	 */
+	public function set_pui_customer_service_instructions( string $value ): void {
+		$this->data['pui_customer_service_instructions'] = $value;
+	}
+
+	/**
+	 * Check if Pay upon Invoice has all required fields configured.
+	 *
+	 * @return bool True if all required fields are configured.
+	 */
+	public function is_pui_configured(): bool {
+		return ! empty( $this->get_pui_brand_name() )
+			&& ! empty( $this->get_pui_logo_url() )
+			&& ! empty( $this->get_pui_customer_service_instructions() );
 	}
 }

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -352,14 +352,4 @@ class PaymentSettings extends AbstractDataModel {
 		$this->data['pui_customer_service_instructions'] = $value;
 	}
 
-	/**
-	 * Check if Pay upon Invoice has all required fields configured.
-	 *
-	 * @return bool True if all required fields are configured.
-	 */
-	public function is_pui_configured(): bool {
-		return ! empty( $this->get_pui_brand_name() )
-			&& ! empty( $this->get_pui_logo_url() )
-			&& ! empty( $this->get_pui_customer_service_instructions() );
-	}
 }

--- a/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
@@ -85,6 +85,18 @@ class PaymentRestEndpoint extends RestEndpoint {
 			'js_name'  => 'fastlaneDisplayWatermark',
 			'sanitize' => 'to_boolean',
 		),
+		'pui_brand_name'             => array(
+			'js_name'  => 'puiBrandName',
+			'sanitize' => 'sanitize_text_field',
+		),
+		'pui_logo_url'               => array(
+			'js_name'  => 'puiLogoUrl',
+			'sanitize' => 'esc_url_raw',
+		),
+		'pui_customer_service_instructions' => array(
+			'js_name'  => 'puiCustomerServiceInstructions',
+			'sanitize' => 'sanitize_text_field',
+		),
 	);
 
 	/**
@@ -183,6 +195,7 @@ class PaymentRestEndpoint extends RestEndpoint {
 				'itemTitle'       => $payment_method['itemTitle'],
 				'itemDescription' => $payment_method['itemDescription'],
 				'warningMessages' => $payment_method['warningMessages'],
+				'warningSeverity' => $payment_method['warningSeverity'] ?? 'warning',
 			);
 
 			if ( isset( $payment_method['fields'] ) ) {
@@ -202,9 +215,12 @@ class PaymentRestEndpoint extends RestEndpoint {
 			}
 		}
 
-		$gateway_settings['paypalShowLogo']           = $this->payment_settings->get_paypal_show_logo();
-		$gateway_settings['cardholderName']           = $this->payment_settings->get_cardholder_name();
-		$gateway_settings['fastlaneDisplayWatermark'] = $this->payment_settings->get_fastlane_display_watermark();
+		$gateway_settings['paypalShowLogo']              = $this->payment_settings->get_paypal_show_logo();
+		$gateway_settings['cardholderName']              = $this->payment_settings->get_cardholder_name();
+		$gateway_settings['fastlaneDisplayWatermark']    = $this->payment_settings->get_fastlane_display_watermark();
+		$gateway_settings['puiBrandName']                = $this->payment_settings->get_pui_brand_name();
+		$gateway_settings['puiLogoUrl']                  = $this->payment_settings->get_pui_logo_url();
+		$gateway_settings['puiCustomerServiceInstructions'] = $this->payment_settings->get_pui_customer_service_instructions();
 
 		return $this->return_success( apply_filters( 'woocommerce_paypal_payments_payment_methods', $gateway_settings ) );
 	}
@@ -219,6 +235,13 @@ class PaymentRestEndpoint extends RestEndpoint {
 	public function update_details( WP_REST_Request $request ): WP_REST_Response {
 		$request_data = $request->get_params();
 		$all_methods  = $this->gateways();
+
+		// Process field_map values first so PUI fields are available for validation.
+		$wp_data = $this->sanitize_for_wordpress(
+			$request->get_params(),
+			$this->field_map
+		);
+		$this->payment_settings->from_array( $wp_data );
 
 		foreach ( $all_methods as $key => $value ) {
 			$new_data = $request_data[ $key ] ?? null;
@@ -239,12 +262,6 @@ class PaymentRestEndpoint extends RestEndpoint {
 			}
 		}
 
-		$wp_data = $this->sanitize_for_wordpress(
-			$request->get_params(),
-			$this->field_map
-		);
-
-		$this->payment_settings->from_array( $wp_data );
 		$this->payment_settings->save();
 
 		return $this->get_details();

--- a/modules/ppcp-settings/src/Service/FeaturesEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/FeaturesEligibilityService.php
@@ -76,6 +76,13 @@ class FeaturesEligibilityService {
 	private bool $is_pwc_eligibility_checked;
 
 	/**
+	 * Whether Pay Upon Invoice is eligible.
+	 *
+	 * @var bool
+	 */
+	private bool $is_pui_eligible;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param bool     $is_save_paypal_eligible If saving PayPal and Venmo is eligible.
@@ -86,6 +93,7 @@ class FeaturesEligibilityService {
 	 * @param bool     $is_pay_later_eligible If Pay Later is eligible.
 	 * @param bool     $is_installments_eligible If Installments is eligible.
 	 * @param bool     $is_pwc_eligibility_checked If Pay With Crypto eligibility has been checked.
+	 * @param bool     $is_pui_eligible If Pay Upon Invoice is eligible.
 	 */
 	public function __construct(
 		bool $is_save_paypal_eligible,
@@ -95,7 +103,8 @@ class FeaturesEligibilityService {
 		callable $check_apple_pay_eligible,
 		bool $is_pay_later_eligible,
 		bool $is_installments_eligible,
-		bool $is_pwc_eligibility_checked
+		bool $is_pwc_eligibility_checked,
+		bool $is_pui_eligible
 	) {
 		$this->is_save_paypal_eligible    = $is_save_paypal_eligible;
 		$this->check_acdc_eligible        = $check_acdc_eligible;
@@ -105,6 +114,7 @@ class FeaturesEligibilityService {
 		$this->is_pay_later_eligible      = $is_pay_later_eligible;
 		$this->is_installments_eligible   = $is_installments_eligible;
 		$this->is_pwc_eligibility_checked = $is_pwc_eligibility_checked;
+		$this->is_pui_eligible            = $is_pui_eligible;
 	}
 
 	/**
@@ -122,6 +132,7 @@ class FeaturesEligibilityService {
 			FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING => fn() => $this->is_pay_later_eligible,
 			FeaturesDefinition::FEATURE_INSTALLMENTS    => fn() => $this->is_installments_eligible,
 			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => fn() => $this->is_pwc_eligibility_checked,
+			FeaturesDefinition::FEATURE_PAY_UPON_INVOICE => fn() => $this->is_pui_eligible,
 		);
 	}
 }

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -85,6 +85,19 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			}
 		}
 
+		$pui_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings', array() );
+		if ( is_array( $pui_settings ) ) {
+			if ( ! empty( $pui_settings['brand_name'] ) ) {
+				$this->payment_settings->set_pui_brand_name( $pui_settings['brand_name'] );
+			}
+			if ( ! empty( $pui_settings['logo_url'] ) ) {
+				$this->payment_settings->set_pui_logo_url( $pui_settings['logo_url'] );
+			}
+			if ( ! empty( $pui_settings['customer_service_instructions'] ) ) {
+				$this->payment_settings->set_pui_customer_service_instructions( $pui_settings['customer_service_instructions'] );
+			}
+		}
+
 		$this->payment_settings->save();
 	}
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -686,7 +686,9 @@ return array(
 		);
 	},
 	'wcgateway.pay-upon-invoice-payment-source-factory'    => static function ( ContainerInterface $container ): PaymentSourceFactory {
-		return new PaymentSourceFactory();
+		return new PaymentSourceFactory(
+			$container->get( 'settings.data.payment' )
+		);
 	},
 	'wcgateway.pay-upon-invoice-gateway'                   => static function ( ContainerInterface $container ): PayUponInvoiceGateway {
 		return new PayUponInvoiceGateway(
@@ -716,7 +718,8 @@ return array(
 	'wcgateway.pay-upon-invoice-helper'                    => static function ( ContainerInterface $container ): PayUponInvoiceHelper {
 		return new PayUponInvoiceHelper(
 			$container->get( 'wcgateway.checkout-helper' ),
-			$container->get( 'api.shop.country' )
+			$container->get( 'api.shop.country' ),
+			$container->get( 'settings.data.payment' )
 		);
 	},
 	'wcgateway.pay-upon-invoice-product-status'            => static function ( ContainerInterface $container ): PayUponInvoiceProductStatus {
@@ -752,7 +755,8 @@ return array(
 			$container->get( 'wcgateway.pay-upon-invoice-product-status' ),
 			$container->get( 'wcgateway.pay-upon-invoice-helper' ),
 			$container->get( 'wcgateway.checkout-helper' ),
-			$container->get( 'api.factory.capture' )
+			$container->get( 'api.factory.capture' ),
+			$container->get( 'settings.data.payment' )
 		);
 	},
 	'wcgateway.oxxo'                                       => static function ( ContainerInterface $container ): OXXO {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PayUponInvoice.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\CaptureFactory;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CheckoutHelper;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\TransactionIdHandlingTrait;
@@ -46,6 +47,8 @@ class PayUponInvoice {
 
 	protected CaptureFactory $capture_factory;
 
+	protected PaymentSettings $payment_settings;
+
 	/**
 	 * PayUponInvoice constructor.
 	 *
@@ -57,6 +60,7 @@ class PayUponInvoice {
 	 * @param PayUponInvoiceHelper        $pui_helper The PUI helper.
 	 * @param CheckoutHelper              $checkout_helper The checkout helper.
 	 * @param CaptureFactory              $capture_factory The capture factory.
+	 * @param PaymentSettings             $payment_settings The payment settings.
 	 */
 	public function __construct(
 		PayUponInvoiceOrderEndpoint $pui_order_endpoint,
@@ -66,7 +70,8 @@ class PayUponInvoice {
 		PayUponInvoiceProductStatus $pui_product_status,
 		PayUponInvoiceHelper $pui_helper,
 		CheckoutHelper $checkout_helper,
-		CaptureFactory $capture_factory
+		CaptureFactory $capture_factory,
+		PaymentSettings $payment_settings
 	) {
 		$this->pui_order_endpoint = $pui_order_endpoint;
 		$this->logger             = $logger;
@@ -76,6 +81,7 @@ class PayUponInvoice {
 		$this->pui_helper         = $pui_helper;
 		$this->checkout_helper    = $checkout_helper;
 		$this->capture_factory    = $capture_factory;
+		$this->payment_settings   = $payment_settings;
 	}
 
 	/**
@@ -148,8 +154,7 @@ class PayUponInvoice {
 
 					$instructions = $order->get_meta( 'ppcp_ratepay_payment_instructions_payment_reference' );
 
-					$gateway_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
-					$merchant_name    = $gateway_settings['brand_name'] ?? '';
+					$merchant_name = $this->payment_settings->get_pui_brand_name();
 
 					$order_total = wc_price( $order->get_total(), array( 'currency' => $order->get_currency() ) );
 
@@ -357,62 +362,6 @@ class PayUponInvoice {
 				$gateway = WC()->payment_gateways()->payment_gateways()[ PayUponInvoiceGateway::ID ];
 				if ( $gateway && $gateway->get_option( 'customer_service_instructions' ) === '' ) {
 					$gateway->update_option( 'enabled', 'no' );
-				}
-			}
-		);
-
-		add_action(
-			'woocommerce_settings_checkout',
-			function () {
-				// Todo: Possibly needs to be optimized or migrated for the #react-ui.
-
-				if ( ! $this->is_settings_page ) {
-					return;
-				}
-
-				if ( ! $this->pui_product_status->is_active() ) {
-					$pui_gateway = WC()->payment_gateways->payment_gateways()[ PayUponInvoiceGateway::ID ];
-					if ( 'yes' === $pui_gateway->get_option( 'enabled' ) ) {
-						$pui_gateway->update_option( 'enabled', 'no' );
-						$redirect_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-pay-upon-invoice-gateway' );
-						wp_safe_redirect( $redirect_url );
-						exit;
-					}
-
-					printf(
-						'<div class="notice notice-error"><p>%1$s</p></div>',
-						esc_html__( 'Could not enable gateway because the connected PayPal account is not activated for Pay upon Invoice. Reconnect your account while Onboard with Pay upon Invoice is selected to try again.', 'woocommerce-paypal-payments' )
-					);
-
-					return;
-				}
-
-				$error_messages = array();
-				$pui_gateway    = WC()->payment_gateways->payment_gateways()[ PayUponInvoiceGateway::ID ];
-				if ( $pui_gateway->get_option( 'brand_name' ) === '' ) {
-					$error_messages[] = esc_html__( 'Could not enable gateway because "Brand name" field is empty.', 'woocommerce-paypal-payments' );
-				}
-				if ( $pui_gateway->get_option( 'logo_url' ) === '' ) {
-					$error_messages[] = esc_html__( 'Could not enable gateway because "Logo URL" field is empty.', 'woocommerce-paypal-payments' );
-				}
-				if ( $pui_gateway->get_option( 'customer_service_instructions' ) === '' ) {
-					$error_messages[] = esc_html__( 'Could not enable gateway because "Customer service instructions" field is empty.', 'woocommerce-paypal-payments' );
-				}
-				if ( count( $error_messages ) > 0 ) {
-					$pui_gateway->update_option( 'enabled', 'no' );
-					?>
-					<div class="notice notice-error">
-						<?php
-						array_map(
-							static function ( $message ) {
-								// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-								echo '<p>' . $message . '</p>';
-							},
-							$error_messages
-						)
-						?>
-					</div>
-					<?php
 				}
 			}
 		);

--- a/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PaymentSourceFactory.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayUponInvoice/PaymentSourceFactory.php
@@ -10,11 +10,28 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice;
 
 use WC_Order;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 
 /**
  * Class PaymentSourceFactory.
  */
 class PaymentSourceFactory {
+
+	/**
+	 * The payment settings.
+	 *
+	 * @var PaymentSettings
+	 */
+	private PaymentSettings $payment_settings;
+
+	/**
+	 * PaymentSourceFactory constructor.
+	 *
+	 * @param PaymentSettings $payment_settings The payment settings.
+	 */
+	public function __construct( PaymentSettings $payment_settings ) {
+		$this->payment_settings = $payment_settings;
+	}
 
 	/**
 	 * Create a PUI payment source from a WC order.
@@ -38,10 +55,9 @@ class PaymentSourceFactory {
 			$phone_country_code = '';
 		}
 
-		$gateway_settings              = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
-		$merchant_name                 = $gateway_settings['brand_name'] ?? '';
-		$logo_url                      = $gateway_settings['logo_url'] ?? '';
-		$customer_service_instructions = $gateway_settings['customer_service_instructions'] ?? '';
+		$merchant_name                 = $this->payment_settings->get_pui_brand_name();
+		$logo_url                      = $this->payment_settings->get_pui_logo_url();
+		$customer_service_instructions = $this->payment_settings->get_pui_customer_service_instructions();
 
 		return new PaymentSource(
 			$address['first_name'] ?? '',

--- a/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PayUponInvoiceHelper.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 use WC_Customer;
 use WC_Order;
 use WC_Order_Item_Product;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 
 /**
  * Class PayUponInvoiceHelper
@@ -33,14 +34,23 @@ class PayUponInvoiceHelper {
 	protected $api_shop_country;
 
 	/**
+	 * The payment settings.
+	 *
+	 * @var PaymentSettings
+	 */
+	protected PaymentSettings $payment_settings;
+
+	/**
 	 * PayUponInvoiceHelper constructor.
 	 *
-	 * @param CheckoutHelper $checkout_helper The checkout helper.
-	 * @param string         $api_shop_country The api shop country.
+	 * @param CheckoutHelper  $checkout_helper The checkout helper.
+	 * @param string          $api_shop_country The api shop country.
+	 * @param PaymentSettings $payment_settings The payment settings.
 	 */
-	public function __construct( CheckoutHelper $checkout_helper, string $api_shop_country ) {
+	public function __construct( CheckoutHelper $checkout_helper, string $api_shop_country, PaymentSettings $payment_settings ) {
 		$this->checkout_helper  = $checkout_helper;
 		$this->api_shop_country = $api_shop_country;
+		$this->payment_settings = $payment_settings;
 	}
 
 	/**
@@ -50,8 +60,10 @@ class PayUponInvoiceHelper {
 	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
 	public function is_checkout_ready_for_pui(): bool {
-		$gateway_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
-		if ( $gateway_settings && '' === $gateway_settings['customer_service_instructions'] ) {
+		if ( '' === $this->payment_settings->get_pui_brand_name()
+			|| '' === $this->payment_settings->get_pui_logo_url()
+			|| '' === $this->payment_settings->get_pui_customer_service_instructions()
+		) {
 			return false;
 		}
 
@@ -88,8 +100,7 @@ class PayUponInvoiceHelper {
 	 * @return bool True if PUI gateway is enabled, otherwise false.
 	 */
 	public function is_pui_gateway_enabled(): bool {
-		$gateway_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings' );
-		return isset( $gateway_settings['enabled'] ) && $gateway_settings['enabled'] === 'yes' && 'DE' === $this->api_shop_country;
+		return $this->payment_settings->is_method_enabled( 'ppcp-pay-upon-invoice-gateway' ) && 'DE' === $this->api_shop_country;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -655,8 +655,8 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 				if ( 'DE' === $shop_country &&
 					( $is_our_page ||
-						( $is_gateways_list_page && $pui_product_status->is_active() ) ||
-						( $settings->has( 'products_pui_enabled' ) && $settings->get( 'products_pui_enabled' ) )
+						$is_gateways_list_page ||
+						$pui_product_status->is_active()
 					)
 				) {
 					$methods[] = $container->get( 'wcgateway.pay-upon-invoice-gateway' );

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -521,8 +521,12 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				$contact_module_check = $c->get( 'wcgateway.contact-module.eligibility.check' );
 				assert( is_callable( $contact_module_check ) );
 
+				$pui_product_status = $c->get( 'wcgateway.pay-upon-invoice-product-status' );
+				assert( $pui_product_status instanceof PayUponInvoiceProductStatus );
+
 				$save_payment_methods_check = $c->get( 'save-payment-methods.eligibility.check' );
 				assert( is_callable( $save_payment_methods_check ) );
+
 				$features[ FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO ] = array(
 					'enabled' => $reference_transaction_status->reference_transaction_enabled() && $save_payment_methods_check(),
 				);
@@ -550,6 +554,10 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 				$features[ FeaturesDefinition::FEATURE_CONTACT_MODULE ] = array(
 					'enabled' => $contact_module_check(),
+				);
+
+				$features[ FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ] = array(
+					'enabled' => $pui_product_status->is_active(),
 				);
 
 				return $features;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3319,12 +3319,6 @@ parameters:
 			path: modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
 
 		-
-			message: '#^Method WooCommerce\\PayPalCommerce\\Settings\\Data\\Definition\\PaymentMethodsDefinition\:\:__construct\(\) has parameter \$axo_conflicts_notices with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
-
-		-
 			message: '#^Method WooCommerce\\PayPalCommerce\\Settings\\Data\\Definition\\PaymentMethodsDefinition\:\:build_method_definition\(\) has parameter \$fields with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -3368,12 +3362,6 @@ parameters:
 
 		-
 			message: '#^Method WooCommerce\\PayPalCommerce\\Settings\\Data\\Definition\\PaymentMethodsDefinition\:\:group_paypal_methods\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
-
-		-
-			message: '#^Property WooCommerce\\PayPalCommerce\\Settings\\Data\\Definition\\PaymentMethodsDefinition\:\:\$axo_conflicts_notices type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php


### PR DESCRIPTION
Adds full Pay Upon Invoice support to the new settings UI. This includes the PUI feature card in `Overview > Features`, the PUI gateway migration to the new data model, required field validation, and warning severity support.                                                                                                                                   
                                                                                                                                                                                                    
  **Feature card (Overview > Features):**                                                                                                                                                           
  - Added PUI eligibility check services (DE country + EUR currency) in the local APMs module                                                                                                       
  - Registered PUI product status in the merchant features filter for Active/Inactive badge                                                                                                         
  - Added PUI feature card with Configure, Sign up, and Learn more buttons
  - Wired PUI capabilities and eligibility through `FeaturesEligibilityService` and settings services                                                                                               
                                                                                                                                                                                                    
  **PUI gateway settings migration:**                                                                                                                                                               
  - Migrated legacy PUI gateway settings to the new `PaymentSettings` data model                                                                                                                    
  - Refactored PUI gateway to use `PaymentSettings` instead of legacy options                                                                                                                       
                                                                                                                                                                                                    
  **Validation and warnings:**                                                                                                                                                                      
  - Added required field validation to the payment method modal                                                                                                                                     
  - Added warning severity support with reactive store-based evaluation                                                                                                                             
  - Fixed warning icon display in payment method cards     

  ### Screenshots                                                                                                                                                                                   
                                                                                                                                                                                                    
  **PUI Feature Card (Active / Inactive)**                                                                                                                                                          
  | Active | Inactive |                                                                                                                                                                             
  | :--- | :--- |                                                                                                                                                                                   
  |<img width="1091" height="699" alt="puio_feature" src="https://github.com/user-attachments/assets/58208e73-ac15-4950-946f-86398d2779ed" />| <img width="1284" height="696" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress-14" src="https://github.com/user-attachments/assets/fb3f26d0-6fe1-46e0-841b-959b1d71cc93" />|                                                                                                         

  **PUI Payment Method Card with Warning**
  | Warning |
  | :--- |
  |<img width="1017" height="871" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress-12" src="https://github.com/user-attachments/assets/91464102-7cdd-463a-813d-d26f96ce5b31" />|

  **PUI Modal Fields**
  | Modal |
  | :--- |
  |<img width="1287" height="820" alt="WooCommerce_settings_‹_WooCommerce_PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/d571264d-e7a1-4338-b670-84ced3896bb9" />|


  ### Steps to Test

  1. Set WooCommerce store country to Germany (DE) and currency to EUR
  2. Go to WooCommerce > Settings > Payments > PayPal Payments
  3. On the Overview tab, scroll down to the Features section
  4. Verify "Pay Upon Invoice" appears as the last feature card
  5. If the merchant has PUI capability, verify the "Active" badge and "Configure" button are shown
  6. If the merchant does not have PUI capability, verify "Sign up" button is shown instead
  7. Verify the "Learn more" link points to `https://developer.paypal.com/docs/checkout/apm/pay-upon-invoice/`
  8. Change store country to a non-DE country and verify the PUI card is no longer visible