### PR TITLE
New UI - Standard card button gateway visible on Woocommerce Payment tab and on classic checkout without button (5906)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -384,6 +384,16 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 					unset( WC()->payment_gateways->payment_gateways[ $index ] );
 				}
+
+				$card_config   = $container->get( 'wcgateway.configuration.card-configuration' );
+				$store_country = $container->get( 'api.merchant.country' );
+				if ( $card_config->use_acdc() && $store_country !== 'MX' ) {
+					foreach ( WC()->payment_gateways->payment_gateways as $index => $gateway ) {
+						if ( $gateway->id === CardButtonGateway::ID ) {
+							unset( WC()->payment_gateways->payment_gateways[ $index ] );
+						}
+					}
+				}
 			},
 			5
 		);

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -221,12 +221,14 @@ return array(
 		);
 	},
 	'wcgateway.disabler'                                   => static function ( ContainerInterface $container ): DisableGateways {
-		$settings_provider   = $container->get( 'settings.settings-provider' );
-		$settings_status     = $container->get( 'wcgateway.settings.status' );
+		$settings_provider  = $container->get( 'settings.settings-provider' );
+		$settings_status    = $container->get( 'wcgateway.settings.status' );
 		$subscription_helper = $container->get( 'wc-subscriptions.helper' );
-		$context             = $container->get( 'button.helper.context' );
+		$context            = $container->get( 'button.helper.context' );
+		$card_configuration = $container->get( 'wcgateway.configuration.card-configuration' );
+		$store_country      = $container->get( 'api.merchant.country' );
 
-		return new DisableGateways( $settings_provider, $settings_status, $subscription_helper, $context );
+		return new DisableGateways( $settings_provider, $settings_status, $subscription_helper, $context, $card_configuration, $store_country );
 	},
 
 	'wcgateway.is-wc-settings-page'                        => static function ( ContainerInterface $container ): bool {

--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -15,44 +15,34 @@ use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 
 /**
  * Class DisableGateways
  */
 class DisableGateways {
-
-	/**
-	 * @var Context Context data provider.
-	 */
 	private Context $context;
-
 	private SettingsProvider $settings_provider;
-
-	/**
-	 * The Settings status helper.
-	 *
-	 * @var SettingsStatus
-	 */
-	protected $settings_status;
-
-	/**
-	 * The subscription helper.
-	 *
-	 * @var SubscriptionHelper
-	 */
-	private $subscription_helper;
+	protected SettingsStatus $settings_status;
+	private SubscriptionHelper $subscription_helper;
+	private CardPaymentsConfiguration $card_configuration;
+	private string $store_country;
 
 	public function __construct(
 		SettingsProvider $settings_provider,
 		SettingsStatus $settings_status,
 		SubscriptionHelper $subscription_helper,
-		Context $context
+		Context $context,
+		CardPaymentsConfiguration $card_configuration,
+		string $store_country
 	) {
 		$this->settings_provider   = $settings_provider;
 		$this->settings_status     = $settings_status;
 		$this->subscription_helper = $subscription_helper;
 		$this->context             = $context;
+		$this->card_configuration  = $card_configuration;
+		$this->store_country       = $store_country;
 	}
 
 	/**
@@ -83,6 +73,10 @@ class DisableGateways {
 			if ( $this->subscription_helper->cart_contains_subscription() ) {
 				unset( $methods[ PayPalGateway::ID ] );
 			}
+		}
+
+		if ( $this->card_configuration->use_acdc() && $this->store_country !== 'MX' ) {
+			unset( $methods[ CardButtonGateway::ID ] );
 		}
 
 		if ( ! $this->needs_to_disable_gateways() ) {


### PR DESCRIPTION
### Steps to reproduce
- Onboard with merchant from US 
  - Observe standard card button gateway in Payments page
- Navigate to classic checkout
  - Observe standard card button gateway

This PR prevents the Standard Card Button gateway from appearing when the merchant already has Advanced Card Payments (ACDC), since ACDC handles card payments. Mexico is exempted because ACDC works differently there.       