### PR TITLE
Fix ACDC error handling in blocks

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/card-fields.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.js
@@ -47,11 +47,17 @@ export function CardFields( { config, eventRegistration, emitResponse } ) {
 		() =>
 			onPaymentSetup( () => {
 				async function handlePaymentProcessing() {
-					await cardFieldsForm.submit().catch( ( error ) => {
+					try {
+						await cardFieldsForm.submit();
+					} catch ( error ) {
+						console.error( error );
 						return {
 							type: responseTypes.ERROR,
+							message:
+								config.scriptData.hosted_fields.labels
+									.fields_not_valid,
 						};
-					} );
+					}
 
 					return {
 						type: responseTypes.SUCCESS,


### PR DESCRIPTION
Looks like in block checkout the ACDC submission error handling was not correct:

- immediately returning the response, so the response from `catch()` never had any effect
- not setting any error message

So, now using `try catch` and returning the same generic error as in [classic checkout](https://github.com/woocommerce/woocommerce-paypal-payments/blob/58e27548ed7d983172fec1c2493ebdc6809edf78/modules/ppcp-button/resources/js/modules/Renderer/CardFieldsRenderer.js#L107-L114). 

<img width="1255" height="694" alt="image" src="https://github.com/user-attachments/assets/61fcf57d-1531-4e35-a176-811473930625" />
