### PR TITLE
New UI - Crypto visible on Feature tab on fresh site when flag not enabled (5953)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -61,12 +61,12 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 	private function run_with_translations( ContainerInterface $c ): void {
 		$this->payment_methods = $c->get( 'ppcp-local-apms.payment-methods' );
 
+		$this->register_pwc_feature_flag_filters();
+
 		// When Local APMs are disabled, none of the following hooks are needed.
 		if ( ! $this->should_add_local_apm_gateways( $c ) ) {
 			return;
 		}
-
-		$this->register_pwc_feature_flag_filters();
 
 		add_action(
 			'wp_enqueue_scripts',


### PR DESCRIPTION
### Steps to reproduce
- Onboard with US merchant
- Visit Settings / Overview tab
  -  Notice Pay with Crypto is visible despite feature flag is disabled

This PR moves `register_pwc_feature_flag_filters()` before the `should_add_local_apm_gateways()` early return in `LocalAlternativePaymentMethodsModule`, so the PWC feature flag filters are always registered regardless of gateway status.   