### PR TITLE
New UI - Buttons not visible on block cart page (5955)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -104,6 +104,9 @@ class SettingsStatus {
 		if ( 'checkout-block' === $location ) {
 			$location = 'checkout-block-express';
 		}
+		if ( 'cart-block' === $location ) {
+			$location = 'cart';
+		}
 		return $location;
 	}
 


### PR DESCRIPTION
### Steps to reproduce
- Onboard with US merchant
- Create a product
- Add to cart and visit Cart page
  - Observe no PayPal buttons

This PR fixes it by adding `'cart-block' → 'cart'` mapping in `SettingsStatus::normalize_location()`.