### PR TITLE
New UI - ACDC not visible on frontend for eligible countries (5954)

### DIFF
--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -197,6 +197,9 @@ class SettingsDataManager {
 		// Apply defaults for the "Settings" tab.
 		$this->apply_payment_settings( $flags );
 
+		// Enable/disable payment gateways based on onboarding choices.
+		$this->toggle_payment_gateways( $flags );
+
 		// Assign defaults for the "Styling" tab.
 		$this->apply_location_styles( $flags );
 


### PR DESCRIPTION
### Steps to reproduce
- Onboard as US merchant
- Visit Settings / Payment methods tab
  - Notice ACDC is disabled by default

This PR adds missing `toggle_payment_gateways()` call in `SettingsDataManager::apply_configuration()` so payment gateways are enabled server-side during onboarding.