### PR TITLE
Fix ACDC gateway not visible on checkout after onboarding with new UI (5954)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -641,13 +641,9 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				assert( $dcc_product_status instanceof DCCProductStatus );
 
 				if ( $dcc_applies->for_country_currency() &&
-					// Show only if allowed in PayPal account, except when on our settings pages.
-					// Performing the full DCCProductStatus check only when on the gateway list page
-					// to avoid sending the API requests all the time.
-					( $is_our_page ||
-						( $is_gateways_list_page && $dcc_product_status->is_active() ) ||
-						( $settings->has( 'products_dcc_enabled' ) && $settings->get( 'products_dcc_enabled' ) )
-					)
+					// Always show on our settings pages.
+					// On other pages, check the cached product status.
+					( $is_our_page || $dcc_product_status->is_active() )
 				) {
 					$methods[] = $container->get( 'wcgateway.credit-card-gateway' );
 				}


### PR DESCRIPTION
### Description

After `DCCProductStatus` was refactored to use `ProductStatusResultCache` (transients) instead of the legacy `Settings` class (40d2a9a9f), the `products_dcc_enabled` key is no longer written to the `woocommerce-ppcp-settings` option. However, the gateway registration check in `WCGatewayModule.php` still relied on this legacy key to determine whether to register the ACDC gateway on checkout pages.

This meant the ACDC gateway was correctly enabled in the new UI (which reads from `woocommerce_ppcp-credit-card-gateway_settings`), but never registered with WooCommerce on the checkout page — so it was invisible to customers.

### Fix

The fix replaces the dead legacy settings check with `$dcc_product_status->is_active()`, which reads from the transient cache and only falls back to the PayPal API when the cache is empty or expired.

The original code had three branches to avoid expensive API calls on every page load:

1. **Settings pages** → always register
2. **Gateways list page** → check `$dcc_product_status->is_active()` (API call acceptable)
3. **Other pages (checkout)** → check cached legacy setting (no API call)

Since `DCCProductStatus` now uses `ProductStatusResultCache` (transient-backed), `is_active()` is cheap on all pages — it reads from the transient first and only hits the PayPal API on cache miss. This makes the page-type branching unnecessary, so the fix safely simplifies to `$is_our_page || $dcc_product_status->is_active()`.

Visibility of disabled gateways on the WC admin payments list is handled separately by `SettingsModule::woocommerce_admin_field_payment_gateways` (line 368), which unsets any PayPal gateway where `is_gateway_enabled()` returns false. This behavior is unchanged.

### Steps to Test

1. Start with a fresh site (no legacy `woocommerce-ppcp-settings` option in the database)
2. Complete the onboarding wizard as a business seller in an ACDC-eligible country (e.g., US) with card payments enabled
3. Verify that "Debit or Credit Cards" (ACDC) appears as enabled on the new UI Payment Methods tab
4. Go to the frontend checkout page with an item in the cart
5. Verify that the ACDC credit card fields are visible as a payment option