### PR TITLE
AVS code mismatch (5960)

### DIFF
--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -64,12 +64,8 @@ class FraudProcessorResponse {
 	 */
 	public function to_array(): array {
 		return array(
-			'avs_code'      => $this->avs_code(),
-			'cvv2_code'     => $this->cvv_code(),
-			// For backwards compatibility.
-			'address_match' => $this->avs_code() === 'M' ? 'Y' : 'N',
-			'postal_match'  => $this->avs_code() === 'M' ? 'Y' : 'N',
-			'cvv_match'     => $this->cvv_code() === 'M' ? 'Y' : 'N',
+			'avs_code'  => $this->avs_code(),
+			'cvv2_code' => $this->cvv_code(),
 		);
 	}
 


### PR DESCRIPTION
PayPal response is passing an `S` but the plugin is showing an `N` which means not a match. Any code that is not exactly `M` (Match) gets mapped to `N` (No match), including `S` (Service not Supported), `U` (Unavailable), `Y` (Yes), `A` (Address only), etc. This is semantically incorrect.   

This PR removes the fraud processor response legacy  keys that were causing the problem.