### PR TITLE
fix(SettingsDataManager): guard Apple Pay and Google Pay behind ACDC eligibility check (5658)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -384,6 +384,7 @@ return array(
 			$container->get( 'settings.data.settings' ),
 			$container->get( 'settings.data.styling' ),
 			$container->get( 'settings.data.payment' ),
+			$container->get( 'wcgateway.configuration.card-configuration' ),
 			$container->get( 'settings.data.paylater-messaging' ),
 			$container->get( 'settings.data.todos' ),
 		);

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -384,7 +384,6 @@ return array(
 			$container->get( 'settings.data.settings' ),
 			$container->get( 'settings.data.styling' ),
 			$container->get( 'settings.data.payment' ),
-			$container->get( 'wcgateway.configuration.card-configuration' ),
 			$container->get( 'settings.data.paylater-messaging' ),
 			$container->get( 'settings.data.todos' ),
 		);

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -66,19 +66,10 @@ class SettingsDataManager {
 		PaymentSettings $payment_methods,
 		CardPaymentsConfiguration $dcc_configuration,
 		array $paylater_messaging, // TODO should be migrated to an AbstractDataModel.
-		...$data_models
+		AbstractDataModel ...$data_models
 	) {
 		foreach ( $data_models as $data_model ) {
-			/**
-			 * An instance extracted from the spread operator. We only process
-			 * AbstractDataModel instances.
-			 *
-			 * @var mixed|AbstractDataModel $data_model
-			 */
-
-			if ( $data_model instanceof AbstractDataModel ) {
-				$this->models_to_reset[] = $data_model;
-			}
+			$this->models_to_reset[] = $data_model;
 		}
 
 		$this->models_to_reset[] = $onboarding_profile;

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -24,6 +24,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDefinition;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 
 /**
  * Class SettingsDataManager
@@ -33,40 +34,12 @@ use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDefinition
  */
 class SettingsDataManager {
 
-	/**
-	 * The payment methods definition, provides a list of all available payment methods.
-	 *
-	 * @var PaymentMethodsDefinition
-	 */
 	private PaymentMethodsDefinition $methods_definition;
-
-	/**
-	 * The onboarding profile data model.
-	 *
-	 * @var OnboardingProfile
-	 */
 	private OnboardingProfile $onboarding_profile;
-
-	/**
-	 * Payment settings model.
-	 *
-	 * @var SettingsModel
-	 */
 	private SettingsModel $payment_settings;
-
-	/**
-	 * Data model that handles button styling on the front end.
-	 *
-	 * @var StylingSettings
-	 */
 	private StylingSettings $styling_settings;
-
-	/**
-	 * Model for handling payment methods.
-	 *
-	 * @var PaymentSettings
-	 */
 	private PaymentSettings $payment_methods;
+	private CardPaymentsConfiguration $dcc_configuration;
 
 	/**
 	 * Data accessors for pay later messaging settings.
@@ -84,18 +57,6 @@ class SettingsDataManager {
 	 */
 	private array $models_to_reset = array();
 
-	/**
-	 * Constructor.
-	 *
-	 * @param PaymentMethodsDefinition $methods_definition Access list of all payment methods.
-	 * @param OnboardingProfile        $onboarding_profile The onboarding profile model.
-	 * @param GeneralSettings          $general_settings   The general settings model.
-	 * @param SettingsModel            $payment_settings   The settings model.
-	 * @param StylingSettings          $styling_settings   The styling settings model.
-	 * @param PaymentSettings          $payment_methods    The payment settings model.
-	 * @param array                    $paylater_messaging Paylater Messaging accessor.
-	 * @param array                    ...$data_models     List of additional data models to reset.
-	 */
 	public function __construct(
 		PaymentMethodsDefinition $methods_definition,
 		OnboardingProfile $onboarding_profile,
@@ -103,6 +64,7 @@ class SettingsDataManager {
 		SettingsModel $payment_settings,
 		StylingSettings $styling_settings,
 		PaymentSettings $payment_methods,
+		CardPaymentsConfiguration $dcc_configuration,
 		array $paylater_messaging, // TODO should be migrated to an AbstractDataModel.
 		...$data_models
 	) {
@@ -130,6 +92,7 @@ class SettingsDataManager {
 		$this->payment_settings   = $payment_settings;
 		$this->styling_settings   = $styling_settings;
 		$this->payment_methods    = $payment_methods;
+		$this->dcc_configuration  = $dcc_configuration;
 		$this->paylater_messaging = $paylater_messaging;
 	}
 
@@ -253,12 +216,14 @@ class SettingsDataManager {
 
 		if ( $flags->is_business_seller ) {
 			if ( $flags->use_card_payments ) {
-				// Enable ACDC for business sellers.
-				$this->payment_methods->toggle_method_state( CreditCardGateway::ID, true );
+				if ( $this->dcc_configuration->use_acdc() ) {
+					// Enable ACDC for business sellers.
+					$this->payment_methods->toggle_method_state( CreditCardGateway::ID, true );
 
-				// Apple Pay and Google Pay depend on the ACDC gateway.
-				$this->payment_methods->toggle_method_state( ApplePayGateway::ID, true );
-				$this->payment_methods->toggle_method_state( GooglePayGateway::ID, true );
+					// Apple Pay and Google Pay depend on the ACDC gateway.
+					$this->payment_methods->toggle_method_state( ApplePayGateway::ID, true );
+					$this->payment_methods->toggle_method_state( GooglePayGateway::ID, true );
+				}
 
 				// Enable Pay Later for business sellers if subscriptions were not selected.
 				// Selecting subscriptions automatically enables the "Save PayPal and Venmo" option, which is incompatible with Pay Later.

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -24,7 +24,6 @@ use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDefinition;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 
 /**
  * Class SettingsDataManager
@@ -39,7 +38,6 @@ class SettingsDataManager {
 	private SettingsModel $payment_settings;
 	private StylingSettings $styling_settings;
 	private PaymentSettings $payment_methods;
-	private CardPaymentsConfiguration $dcc_configuration;
 
 	/**
 	 * Data accessors for pay later messaging settings.
@@ -64,7 +62,6 @@ class SettingsDataManager {
 		SettingsModel $payment_settings,
 		StylingSettings $styling_settings,
 		PaymentSettings $payment_methods,
-		CardPaymentsConfiguration $dcc_configuration,
 		array $paylater_messaging, // TODO should be migrated to an AbstractDataModel.
 		AbstractDataModel ...$data_models
 	) {
@@ -83,7 +80,6 @@ class SettingsDataManager {
 		$this->payment_settings   = $payment_settings;
 		$this->styling_settings   = $styling_settings;
 		$this->payment_methods    = $payment_methods;
-		$this->dcc_configuration  = $dcc_configuration;
 		$this->paylater_messaging = $paylater_messaging;
 	}
 
@@ -207,14 +203,12 @@ class SettingsDataManager {
 
 		if ( $flags->is_business_seller ) {
 			if ( $flags->use_card_payments ) {
-				if ( $this->dcc_configuration->use_acdc() ) {
-					// Enable ACDC for business sellers.
-					$this->payment_methods->toggle_method_state( CreditCardGateway::ID, true );
+				// Enable ACDC for business sellers.
+				$this->payment_methods->toggle_method_state( CreditCardGateway::ID, true );
 
-					// Apple Pay and Google Pay depend on the ACDC gateway.
-					$this->payment_methods->toggle_method_state( ApplePayGateway::ID, true );
-					$this->payment_methods->toggle_method_state( GooglePayGateway::ID, true );
-				}
+				// Apple Pay and Google Pay depend on the ACDC gateway.
+				$this->payment_methods->toggle_method_state( ApplePayGateway::ID, true );
+				$this->payment_methods->toggle_method_state( GooglePayGateway::ID, true );
 
 				// Enable Pay Later for business sellers if subscriptions were not selected.
 				// Selecting subscriptions automatically enables the "Save PayPal and Venmo" option, which is incompatible with Pay Later.

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -682,6 +682,30 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		/**
+		 * Disable ACDC-dependent gateways for merchants not eligible for ACDC
+		 * after onboarding is completed.
+		 *
+		 * Apple Pay and Google Pay depend on the ACDC, so they
+		 * must be disabled alongside ACDC when the merchant's country is not
+		 * eligible for Advanced Card Processing.
+		 */
+		add_action(
+			'woocommerce_paypal_payments_toggle_payment_gateways',
+			function ( PaymentSettings $payment_methods, ConfigurationFlagsDTO $flags ) use ( $container ) {
+				$dcc_configuration = $container->get( 'wcgateway.configuration.card-configuration' );
+				assert( $dcc_configuration instanceof CardPaymentsConfiguration );
+
+				if ( $flags->is_business_seller && $flags->use_card_payments && ! $dcc_configuration->use_acdc() ) {
+					$payment_methods->toggle_method_state( CreditCardGateway::ID, false );
+					$payment_methods->toggle_method_state( ApplePayGateway::ID, false );
+					$payment_methods->toggle_method_state( GooglePayGateway::ID, false );
+				}
+			},
+			10,
+			2
+		);
+
 		return true;
 	}
 


### PR DESCRIPTION
### Issue Description

Google Pay and Apple Pay buttons were visible on the classic checkout page for merchants in countries where ACDC is not supported (e.g. Vietnam). During onboarding, `sync_gateway_settings()` calls `toggle_payment_gateways()`, which was enabling ACDC, Apple Pay and Google Pay for any business seller that accepted card payments — without checking whether the merchant is actually eligible for ACDC in their country.

Since Apple Pay and Google Pay both depend on the ACD, they should only be enabled when ACDC is available for the merchant.

### PR Description

Added a hook on `woocommerce_paypal_payments_toggle_payment_gateways` that disables ACDC, Apple Pay and Google Pay after onboarding for merchants not eligible for Advanced Card Processing. This avoids injecting `CardPaymentsConfiguration` directly into `SettingsDataManager` and instead handles the eligibility check from the outside via the existing filter.

**Changes:**
- Added `woocommerce_paypal_payments_toggle_payment_gateways` action callback — disables ACDC, Apple Pay and Google Pay when `dcc_configuration->use_acdc()` returns `false` for business sellers with card payments enabled

### Testing

1. Connect with a merchant account from a country where ACDC is not supported (e.g. Vietnam)
2. Navigate to shop, add a product to cart, navigate to classic checkout
3. Confirm Google Pay and Apple Pay buttons are no longer visible
4. Connect with a merchant account from a country where ACDC is supported (e.g. US)
5. Confirm Google Pay, Apple Pay and ACDC are all enabled and visible as expected