### PR TITLE
fix(axo): respect "Display Fastlane Watermark" setting on checkout (5972)

### DIFF
--- a/modules/ppcp-axo-block/resources/js/components/Watermark/Watermark.js
+++ b/modules/ppcp-axo-block/resources/js/components/Watermark/Watermark.js
@@ -17,14 +17,13 @@ const Watermark = ( {
 } ) => {
 	const containerRef = useRef( null );
 	const watermarkRef = useRef( null );
-	const axoConfig = window.wc_ppcp_axo;
 
 	useEffect( () => {
 		/**
 		 * Renders the Fastlane watermark.
 		 */
 		const renderWatermark = async () => {
-			if ( ! containerRef.current || axoConfig.show_watermark !== '1' ) {
+			if ( ! containerRef.current ) {
 				return;
 			}
 

--- a/modules/ppcp-axo-block/resources/js/components/Watermark/Watermark.js
+++ b/modules/ppcp-axo-block/resources/js/components/Watermark/Watermark.js
@@ -17,13 +17,14 @@ const Watermark = ( {
 } ) => {
 	const containerRef = useRef( null );
 	const watermarkRef = useRef( null );
+	const axoConfig = window.wc_ppcp_axo;
 
 	useEffect( () => {
 		/**
 		 * Renders the Fastlane watermark.
 		 */
 		const renderWatermark = async () => {
-			if ( ! containerRef.current ) {
+			if ( ! containerRef.current || axoConfig.show_watermark !== '1' ) {
 				return;
 			}
 

--- a/modules/ppcp-axo-block/resources/js/components/Watermark/WatermarkManager.js
+++ b/modules/ppcp-axo-block/resources/js/components/Watermark/WatermarkManager.js
@@ -23,7 +23,13 @@ const WatermarkManager = ( { fastlaneSdk } ) => {
 		select( STORE_NAME ).getIsAxoScriptLoaded()
 	);
 
+	const axoConfig = window.wc_ppcp_axo;
+
 	useEffect( () => {
+		if ( axoConfig?.show_watermark !== '1' ) {
+			return;
+		}
+
 		if ( isAxoActive || ( ! isAxoActive && ! isAxoScriptLoaded ) ) {
 			// Create watermark container and update content when AXO is active or loading
 			createWatermarkContainer();

--- a/modules/ppcp-axo-block/resources/js/components/Watermark/utils.js
+++ b/modules/ppcp-axo-block/resources/js/components/Watermark/utils.js
@@ -1,5 +1,8 @@
 import { createElement, createRoot } from '@wordpress/element';
-import { Watermark, WatermarkManager } from '@ppcp-axo-block/components/Watermark';
+import {
+	Watermark,
+	WatermarkManager,
+} from '@ppcp-axo-block/components/Watermark';
 
 // Object to store references to the watermark container and root
 const watermarkReference = {
@@ -11,6 +14,12 @@ const watermarkReference = {
  * Creates a container for the watermark in the checkout contact information block.
  */
 export const createWatermarkContainer = () => {
+	const axoConfig = window.wc_ppcp_axo;
+
+	if ( axoConfig?.show_watermark !== '1' ) {
+		//return;
+	}
+
 	const textInputContainer = document.querySelector(
 		'.wp-block-woocommerce-checkout-contact-information-block .wc-block-components-text-input'
 	);

--- a/modules/ppcp-axo-block/resources/js/components/Watermark/utils.js
+++ b/modules/ppcp-axo-block/resources/js/components/Watermark/utils.js
@@ -14,12 +14,6 @@ const watermarkReference = {
  * Creates a container for the watermark in the checkout contact information block.
  */
 export const createWatermarkContainer = () => {
-	const axoConfig = window.wc_ppcp_axo;
-
-	if ( axoConfig?.show_watermark !== '1' ) {
-		//return;
-	}
-
 	const textInputContainer = document.querySelector(
 		'.wp-block-woocommerce-checkout-contact-information-block .wc-block-components-text-input'
 	);

--- a/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
+++ b/modules/ppcp-axo-block/src/AxoBlockPaymentMethod.php
@@ -187,6 +187,7 @@ class AxoBlockPaymentMethod extends AbstractPaymentMethodType {
 				'input' => $this->settings_provider->fastlane_input_styles(),
 			),
 			'name_on_card'               => $this->dcc_configuration->show_name_on_card(),
+			'show_watermark'             => $this->settings_provider->show_fastlane_watermark(),
 			'woocommerce'                => array(
 				'states' => array(
 					'US' => WC()->countries->get_states( 'US' ),

--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -6,10 +6,7 @@ import BillingView from './Views/BillingView';
 import CardView from './Views/CardView';
 import ButtonStateManager from './ButtonStateManager';
 import PayPalInsights from './Insights/PayPalInsights';
-import {
-	disable,
-	enable,
-} from '@ppcp-button/Helper/ButtonDisabler';
+import { disable, enable } from '@ppcp-button/Helper/ButtonDisabler';
 import { getCurrentPaymentMethod } from '@ppcp-button/Helper/CheckoutMethodState';
 
 /**
@@ -166,6 +163,15 @@ class AxoManager {
 	 */
 	get cardFormSelector() {
 		return this.el.paymentContainer.selector + '-form';
+	}
+
+	/**
+	 * Whether the Fastlane watermark should be displayed.
+	 *
+	 * @return {boolean}
+	 */
+	get isWatermarkEnabled() {
+		return this.axoConfig.show_watermark === '1';
 	}
 
 	registerEventHandlers() {
@@ -450,11 +456,11 @@ class AxoManager {
 			'.woocommerce-billing-fields .form-row:visible'
 		);
 		const $billingHeaders = this.$( '.woocommerce-billing-fields h3' );
-            if ( $billingFields.length ) {
-                $billingHeaders.show();
-            } else {
-                $billingHeaders.hide();
-            }
+		if ( $billingFields.length ) {
+			$billingHeaders.show();
+		} else {
+			$billingHeaders.hide();
+		}
 	}
 
 	ensureShippingFieldsConsistency() {
@@ -462,11 +468,11 @@ class AxoManager {
 			'.woocommerce-shipping-fields .form-row:visible'
 		);
 		const $shippingHeaders = this.$( '.woocommerce-shipping-fields h3' );
-            if ( $shippingFields.length ) {
-                $shippingHeaders.show();
-            } else {
-                $shippingHeaders.hide();
-            }
+		if ( $shippingFields.length ) {
+			$shippingHeaders.show();
+		} else {
+			$shippingHeaders.hide();
+		}
 	}
 
 	showAxoEmailField() {
@@ -744,6 +750,11 @@ class AxoManager {
 	}
 
 	async renderWatermark( includeAdditionalInfo = true ) {
+		if ( ! this.isWatermarkEnabled ) {
+			this.el.watermarkContainer.hide();
+			return;
+		}
+
 		(
 			await this.fastlane.FastlaneWatermarkComponent( {
 				includeAdditionalInfo,

--- a/modules/ppcp-axo/src/Assets/AxoManager.php
+++ b/modules/ppcp-axo/src/Assets/AxoManager.php
@@ -137,6 +137,7 @@ class AxoManager {
 				'input' => $this->settings_provider->fastlane_input_styles(),
 			),
 			'name_on_card'               => $this->settings_provider->fastlane_name_on_card(),
+			'show_watermark'             => $this->settings_provider->show_fastlane_watermark(),
 			'woocommerce'                => array(
 				'states' => array(
 					'US' => WC()->countries->get_states( 'US' ),


### PR DESCRIPTION
### Issue Description

When the "Display Fastlane Watermark" option was disabled in Fastlane settings, the watermark (including its spinner and container div) still appeared below the email field on the checkout page. The `show_watermark` setting was not being passed to the JS config, and there were no guards in the JS layer to respect it.

### PR Description

- Passes the `show_watermark` setting from PHP to the JS config for both classic and block checkout.
- Adds an `isWatermarkEnabled` getter to `AxoManager` as a single source of truth for the setting.
- Guards `renderWatermark()` in `AxoManager` with an early return when the watermark is disabled, preventing the Fastlane SDK component from being instantiated.
- Guards the watermark lifecycle in `WatermarkManager` (block checkout) with an early return when `show_watermark` is disabled, preventing the container from being created or any watermark content from being rendered.