### PR TITLE
Use Classic Checkout styling settings on Pay for Order page

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1543,6 +1543,9 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 		if ( $context === 'checkout-block' ) {
 			$context = 'checkout-block-express';
 		}
+		if ( $context === 'pay-now' ) {
+			$context = 'checkout';
+		}
 
 		$defaults = array(
 			'layout'  => 'vertical',


### PR DESCRIPTION
Looks like currently we fail to retrieve any styling settings for the PayPal buttons on the Pay for Order page, and they use the default values. 

We do not have separate styling settings for this page so for now using  the Classic Checkout styling settings here.