### PR TITLE
feat(onboarding): add `PAYMENT_METHODS` and `PAY_UPON_INVOICE` for PUI-eligible merchants (5942)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -339,9 +339,10 @@ return array(
 		);
 	},
 	'api.repository.partner-referrals-data'          => static function ( ContainerInterface $container ): PartnerReferralsData {
-
-		$dcc_applies    = $container->get( 'api.helpers.dccapplies' );
-		return new PartnerReferralsData( $dcc_applies );
+		return new PartnerReferralsData(
+			$container->get( 'api.helpers.dccapplies' ),
+			$container->get( 'ppcp-local-apms.pui.eligibility.check' )
+		);
 	},
 	'api.repository.payee'                           => static function ( ContainerInterface $container ): PayeeRepository {
 		$merchant_email = $container->get( 'api.merchant_email' );

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -11,9 +11,6 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Repository;
 
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 
-/**
- * Class PartnerReferralsData
- */
 class PartnerReferralsData {
 	/**
 	 * The DCC Applies Helper object.
@@ -25,14 +22,11 @@ class PartnerReferralsData {
 	 * @var DccApplies
 	 */
 	private DccApplies $dcc_applies;
+	protected bool $is_pui_eligible;
 
-	/**
-	 * PartnerReferralsData constructor.
-	 *
-	 * @param DccApplies $dcc_applies The DCC Applies helper.
-	 */
-	public function __construct( DccApplies $dcc_applies ) {
-		$this->dcc_applies = $dcc_applies; // @phpstan-ignore property.deprecated
+	public function __construct( DccApplies $dcc_applies, bool $is_pui_eligible ) {
+		$this->dcc_applies     = $dcc_applies; // @phpstan-ignore property.deprecated
+		$this->is_pui_eligible = $is_pui_eligible;
 	}
 
 	/**
@@ -104,6 +98,11 @@ class PartnerReferralsData {
 		if ( $use_card_payments !== false ) {
 			$first_party_features[] = 'VAULT';
 			$first_party_features[] = 'FUTURE_PAYMENT';
+		}
+
+		if ( $this->is_pui_eligible ) {
+			$products[]     = 'PAYMENT_METHODS';
+			$capabilities[] = 'PAY_UPON_INVOICE';
 		}
 
 		$payload = array(


### PR DESCRIPTION
### Issue Description

During the initial onboarding flow, DE/EUR merchants eligible for Pay Upon Invoice (PUI) were not having the required PayPal products and capabilities requested. As a result, the `PAY_UPON_INVOICE` capability was never granted during signup.

### PR Description

Updated `PartnerReferralsData::data()` to include the `PAYMENT_METHODS` product and `PAY_UPON_INVOICE` capability in the partner referrals payload when the merchant is PUI-eligible.

The `$is_pui_eligible` flag is already resolved at construction time (injected via the constructor), so the change is a minimal, targeted addition inside `data()`:

```php
if ( $this->is_pui_eligible ) {
    $products[]     = 'PAYMENT_METHODS';
    $capabilities[] = 'PAY_UPON_INVOICE';
}
```

No logic changes to eligibility detection — that responsibility remains upstream. This change only ensures the correct products/capabilities are forwarded to PayPal when eligibility is already confirmed.