### PR TITLE
[QA] Update method name for deleting page in PLM Configurator test

### DIFF
--- a/tests/qa/tests/03-plugin-settings/pay-later-messaging-configurator.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/pay-later-messaging-configurator.spec.ts
@@ -178,7 +178,7 @@ test.describe( 'PLM Configurator', () => {
 				'Assert PLM is visible on WooCommerce Block page'
 			).toBeVisible();
 		} finally {
-			await requestUtils.deletePageById( page.id );
+			await requestUtils.deletePage( page.id );
 		}
 	} );
 


### PR DESCRIPTION
Updates the PLM Configurator e2e test to use the correct method for deleting pages.
Changes:
Replaces `deletePageById()` `with deletePage()` from `@inpsyde/playwright-utils`
Uses the `deletePage` method exposed by the `playwright-utils` package (see playwright-utils PR #253)
This change follows the playwright-utils update that exposes Gutenberg’s deletePage from `@wordpress/e2e-test-utils-playwright`. 