### PR TITLE
refactor(settings): add `is_feature_eligible()` and rename `get()` to `eligible_features()` in `FeaturesDefinition` (5982)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -345,7 +345,7 @@ return array(
 	'api.repository.partner-referrals-data'          => static function ( ContainerInterface $container ): PartnerReferralsData {
 		return new PartnerReferralsData(
 			$container->get( 'api.helpers.dccapplies' ),
-			$container->get( 'ppcp-local-apms.pui.eligibility.check' )
+			$container->get( 'settings.data.definition.features' )
 		);
 	},
 	'api.repository.payee'                           => static function ( ContainerInterface $container ): PayeeRepository {

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\ApiClient\Repository;
 
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
+use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
 
 class PartnerReferralsData {
 	/**
@@ -22,11 +23,11 @@ class PartnerReferralsData {
 	 * @var DccApplies
 	 */
 	private DccApplies $dcc_applies;
-	protected bool $is_pui_eligible;
+	protected FeaturesDefinition $features_definition;
 
-	public function __construct( DccApplies $dcc_applies, bool $is_pui_eligible ) {
+	public function __construct( DccApplies $dcc_applies, FeaturesDefinition $features_definition ) {
 		$this->dcc_applies     = $dcc_applies; // @phpstan-ignore property.deprecated
-		$this->is_pui_eligible = $is_pui_eligible;
+		$this->features_definition = $features_definition;
 	}
 
 	/**
@@ -100,7 +101,7 @@ class PartnerReferralsData {
 			$first_party_features[] = 'FUTURE_PAYMENT';
 		}
 
-		if ( $this->is_pui_eligible ) {
+		if ( $this->features_definition->is_feature_eligible( FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ) ) {
 			$products[]     = 'PAYMENT_METHODS';
 			$capabilities[] = 'PAY_UPON_INVOICE';
 		}

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -674,7 +674,8 @@ return array(
 			$container->get( 'settings.service.features_eligibilities' ),
 			$container->get( 'settings.data.general' ),
 			$merchant_capabilities,
-			$container->get( 'settings.data.settings' )
+			$container->get( 'settings.data.settings' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
 	'settings.service.features_eligibilities'             => static function ( ContainerInterface $container ): FeaturesEligibilityService {

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Data\Definition;
 
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Service\FeaturesEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
@@ -101,6 +102,7 @@ class FeaturesDefinition {
 	 * @var SettingsModel
 	 */
 	protected SettingsModel $plugin_settings;
+	protected LoggerInterface $logger;
 
 	/**
 	 * Constructor.
@@ -114,12 +116,14 @@ class FeaturesDefinition {
 		FeaturesEligibilityService $eligibilities,
 		GeneralSettings $settings,
 		array $merchant_capabilities,
-		SettingsModel $plugin_settings
+		SettingsModel $plugin_settings,
+		LoggerInterface $logger
 	) {
 		$this->eligibilities         = $eligibilities;
 		$this->settings              = $settings;
 		$this->merchant_capabilities = $merchant_capabilities;
 		$this->plugin_settings       = $plugin_settings;
+		$this->logger                = $logger;
 	}
 
 	/**
@@ -140,6 +144,28 @@ class FeaturesDefinition {
 		}
 
 		return $eligible_features;
+	}
+
+	/**
+	 * Returns whether a specific feature is eligible.
+	 *
+	 * @param string $feature_name One of the FEATURE_* constants.
+	 * @return bool true if the feature is eligible, false otherwise or if unknown.
+	 */
+	public function is_feature_eligible( string $feature_name ): bool {
+		$eligibility_checks = $this->eligibilities->get_eligibility_checks();
+
+		if ( ! isset( $eligibility_checks[ $feature_name ] ) ) {
+			$this->logger->warning(
+				sprintf(
+					'No eligibility check registered for feature "%s".',
+					$feature_name
+				)
+			);
+			return false;
+		}
+
+		return (bool) $eligibility_checks[ $feature_name ]();
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -113,7 +113,7 @@ class FeaturesDefinition {
 		$eligible_features  = array();
 		$eligibility_checks = $this->eligibilities->get_eligibility_checks();
 		foreach ( $all_features as $feature_key => $feature ) {
-			if ( $eligibility_checks[ $feature_key ]() ) {
+			if ( isset( $eligibility_checks[ $feature_key ] ) && $eligibility_checks[ $feature_key ]() ) {
 				$eligible_features[ $feature_key ] = $feature;
 			}
 		}

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -125,9 +125,11 @@ class FeaturesDefinition {
 	/**
 	 * Returns the full list of feature definitions with their eligibility conditions.
 	 *
+	 * Only features whose eligibility check passes are included.
+	 *
 	 * @return array The array of feature definitions.
 	 */
-	public function get(): array {
+	public function eligible_features(): array {
 		$all_features       = $this->all_available_features();
 		$eligible_features  = array();
 		$eligibility_checks = $this->eligibilities->get_eligibility_checks();

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -75,18 +75,7 @@ class FeaturesDefinition {
 	 */
 	public const FEATURE_PAY_UPON_INVOICE = 'pay_upon_invoice';
 
-	/**
-	 * The features eligibility service.
-	 *
-	 * @var FeaturesEligibilityService
-	 */
 	protected FeaturesEligibilityService $eligibilities;
-
-	/**
-	 * The general settings service.
-	 *
-	 * @var GeneralSettings
-	 */
 	protected GeneralSettings $settings;
 
 	/**
@@ -95,23 +84,9 @@ class FeaturesDefinition {
 	 * @var array
 	 */
 	protected array $merchant_capabilities;
-
-	/**
-	 * The plugin settings.
-	 *
-	 * @var SettingsModel
-	 */
 	protected SettingsModel $plugin_settings;
 	protected LoggerInterface $logger;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param FeaturesEligibilityService $eligibilities The features eligibility service.
-	 * @param GeneralSettings            $settings The general settings service.
-	 * @param array                      $merchant_capabilities The merchant capabilities.
-	 * @param SettingsModel              $plugin_settings The plugin settings.
-	 */
 	public function __construct(
 		FeaturesEligibilityService $eligibilities,
 		GeneralSettings $settings,

--- a/modules/ppcp-settings/src/Endpoint/FeaturesRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/FeaturesRestEndpoint.php
@@ -83,7 +83,7 @@ class FeaturesRestEndpoint extends RestEndpoint {
 	 */
 	public function get_features(): WP_REST_Response {
 		$features = array();
-		foreach ( $this->features_definition->get() as $id => $feature ) {
+		foreach ( $this->features_definition->eligible_features() as $id => $feature ) {
 			$features[] = array_merge(
 				array( 'id' => $id ),
 				$feature


### PR DESCRIPTION
### Issue Description

`FeaturesDefinition::get()` had a generic name that didn't communicate intent, and the class had no way to check eligibility for a single feature. As a result, any code needing to check one feature had to retrieve the full eligibility checks array and resolve the callable manually:

```php
$eligibility_service = $container->get( 'settings.service.features_eligibilities' );
assert( $eligibility_service instanceof FeaturesEligibilityService );
$eligibilities = $eligibility_service->get_eligibility_checks();
$is_pui_eligible = $eligibilities[ FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ] ?? false;

// then use it like this
$is_pui_eligible ? $is_pui_eligible() : $is_pui_eligible;
```

This made `FeaturesDefinition` practically only usable in the REST endpoint context, pushing developers to fall back on individual eligibility services (e.g. `ppcp-local-apms.pui.eligibility.check`) instead of the intended centralized abstraction.

### PR Description

Refactors `FeaturesDefinition` in two steps and updates the `PartnerReferralsData` call site:

**1. Rename `get()` → `eligible_features()`**
Pure rename with no logic change. The new name reflects what the method actually returns — only the features whose eligibility check passes. Updates the existing call in `FeaturesRestEndpoint`.

**2. Add `is_feature_eligible(string $feature_name): bool`**
New method for checking individual feature eligibility directly on `FeaturesDefinition`. Resolves the eligibility callable internally so callers get a plain `bool` back. Returns `false` and logs a warning when an unregistered feature name is passed, since this always indicates a programming error rather than a runtime condition.

**3. Refactor `PartnerReferralsData` PUI eligibility check**
Replaces the verbose eligibility boilerplate with the new method:

```php
if ( $this->features_definition->is_feature_eligible( FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ) ) {
```