### PR TITLE
Merchant not onboarded when upgrading from previous version (5994)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -66,6 +66,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\Migration\SettingsTabMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\StylingSettingsMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\FastlaneSettingsMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\OnboardingUrlManager;
+use WooCommerce\PayPalCommerce\Settings\Service\SellerTypeResolver;
 use WooCommerce\PayPalCommerce\Settings\Service\PaymentMethodsEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\ScriptDataHandler;
 use WooCommerce\PayPalCommerce\Settings\Service\TodosEligibilityService;
@@ -425,11 +426,13 @@ return array(
 		$c->get( 'wcgateway.configuration.card-configuration' ),
 		$c->get( 'ppcp-local-apms.payment-methods' ),
 	),
+	'settings.service.seller-type-resolver'               => static fn(): SellerTypeResolver => new SellerTypeResolver(),
 	'settings.service.data-migration.general-settings'    => static fn( ContainerInterface $c ): SettingsMigration => new SettingsMigration(
 		(array) get_option( 'woocommerce-ppcp-settings', array() ),
 		$c->get( 'settings.data.general' ),
 		$c->get( 'api.endpoint.partners' ),
 		$c->get( 'woocommerce.logger.woocommerce' ),
+		$c->get( 'settings.service.seller-type-resolver' ),
 	),
 	'settings.service.data-migration.fastlane'            => static fn( ContainerInterface $c ): FastlaneSettingsMigration => new FastlaneSettingsMigration(
 		(array) get_option( 'woocommerce-ppcp-settings', array() ),
@@ -525,14 +528,14 @@ return array(
 		assert( $general_settings instanceof GeneralSettings );
 
 		return array(
-			FeaturesDefinition::FEATURE_APPLE_PAY       => ( $features[ FeaturesDefinition::FEATURE_APPLE_PAY ]['enabled'] ?? false ) && ! $general_settings->own_brand_only(),
-			FeaturesDefinition::FEATURE_GOOGLE_PAY      => ( $features[ FeaturesDefinition::FEATURE_GOOGLE_PAY ]['enabled'] ?? false ) && ! $general_settings->own_brand_only(),
+			FeaturesDefinition::FEATURE_APPLE_PAY        => ( $features[ FeaturesDefinition::FEATURE_APPLE_PAY ]['enabled'] ?? false ) && ! $general_settings->own_brand_only(),
+			FeaturesDefinition::FEATURE_GOOGLE_PAY       => ( $features[ FeaturesDefinition::FEATURE_GOOGLE_PAY ]['enabled'] ?? false ) && ! $general_settings->own_brand_only(),
 			FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS => ( $features[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ]['enabled'] ?? false ) && ! $general_settings->own_brand_only(),
 			FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO => $features[ FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS => $features[ FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING => $features[ FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING ]['enabled'] ?? false,
-			FeaturesDefinition::FEATURE_INSTALLMENTS    => $features[ FeaturesDefinition::FEATURE_INSTALLMENTS ]['enabled'] ?? false,
-			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => $features[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ]['enabled'] ?? false,
+			FeaturesDefinition::FEATURE_INSTALLMENTS     => $features[ FeaturesDefinition::FEATURE_INSTALLMENTS ]['enabled'] ?? false,
+			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO  => $features[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_PAY_UPON_INVOICE => $features[ FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ]['enabled'] ?? false,
 		);
 	},
@@ -641,13 +644,13 @@ return array(
 		);
 		// Merchant capabilities serve to show active or inactive badge and buttons.
 		$capabilities = array(
-			FeaturesDefinition::FEATURE_APPLE_PAY       => $features[ FeaturesDefinition::FEATURE_APPLE_PAY ]['enabled'] ?? false,
-			FeaturesDefinition::FEATURE_GOOGLE_PAY      => $features[ FeaturesDefinition::FEATURE_GOOGLE_PAY ]['enabled'] ?? false,
+			FeaturesDefinition::FEATURE_APPLE_PAY        => $features[ FeaturesDefinition::FEATURE_APPLE_PAY ]['enabled'] ?? false,
+			FeaturesDefinition::FEATURE_GOOGLE_PAY       => $features[ FeaturesDefinition::FEATURE_GOOGLE_PAY ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS => $features[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO => $features[ FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS => $features[ FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS ]['enabled'] ?? false,
-			FeaturesDefinition::FEATURE_INSTALLMENTS    => $features[ FeaturesDefinition::FEATURE_INSTALLMENTS ]['enabled'] ?? false,
-			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => $features[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ]['enabled'] ?? false,
+			FeaturesDefinition::FEATURE_INSTALLMENTS     => $features[ FeaturesDefinition::FEATURE_INSTALLMENTS ]['enabled'] ?? false,
+			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO  => $features[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING => $features[ FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING ]['enabled'] ?? false,
 			FeaturesDefinition::FEATURE_PAY_UPON_INVOICE => $features[ FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ]['enabled'] ?? false,
 		);
@@ -659,15 +662,15 @@ return array(
 			// Advanced credit and debit cards eligibility.
 			FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS => $capabilities[ FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS ],
 			// Alternative payment methods eligibility.
-			FeaturesDefinition::FEATURE_GOOGLE_PAY      => $capabilities[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ] && $capabilities[ FeaturesDefinition::FEATURE_GOOGLE_PAY ],
+			FeaturesDefinition::FEATURE_GOOGLE_PAY       => $capabilities[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ] && $capabilities[ FeaturesDefinition::FEATURE_GOOGLE_PAY ],
 			// Google Pay eligibility.
-			FeaturesDefinition::FEATURE_APPLE_PAY       => $capabilities[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ] && $capabilities[ FeaturesDefinition::FEATURE_APPLE_PAY ],
+			FeaturesDefinition::FEATURE_APPLE_PAY        => $capabilities[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ] && $capabilities[ FeaturesDefinition::FEATURE_APPLE_PAY ],
 			// Apple Pay eligibility.
 			FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING => $capabilities[ FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING ] && $capabilities[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ] && ! $gateways['card-button'],
 			// Pay Later eligibility.
-			FeaturesDefinition::FEATURE_INSTALLMENTS    => $capabilities[ FeaturesDefinition::FEATURE_INSTALLMENTS ],
+			FeaturesDefinition::FEATURE_INSTALLMENTS     => $capabilities[ FeaturesDefinition::FEATURE_INSTALLMENTS ],
 			// Installments eligibility.
-			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => $capabilities[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ], // Pay with Crypto eligibility.
+			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO  => $capabilities[ FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO ], // Pay with Crypto eligibility.
 			FeaturesDefinition::FEATURE_PAY_UPON_INVOICE => $capabilities[ FeaturesDefinition::FEATURE_PAY_UPON_INVOICE ], // Pay upon Invoice eligibility.
 		);
 

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -429,6 +429,7 @@ return array(
 		(array) get_option( 'woocommerce-ppcp-settings', array() ),
 		$c->get( 'settings.data.general' ),
 		$c->get( 'api.endpoint.partners' ),
+		$c->get( 'woocommerce.logger.woocommerce' ),
 	),
 	'settings.service.data-migration.fastlane'            => static fn( ContainerInterface $c ): FastlaneSettingsMigration => new FastlaneSettingsMigration(
 		(array) get_option( 'woocommerce-ppcp-settings', array() ),

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -49,41 +49,37 @@ class MigrationManager implements SettingsMigrationInterface {
 	}
 
 	public function migrate(): void {
-		try {
-			/**
-			 * Clean up legacy UI toggle options that are no longer needed.
-			 *
-			 * These options were used to control whether merchants saw the old or new settings UI:
-			 * - OPTION_NAME_SHOULD_USE_OLD_UI: Stored merchant's preference to use the old UI
-			 * - woocommerce-ppcp-is-new-merchant: Flagged new merchants to bypass the old UI
-			 *
-			 * With the new settings UI now being the only interface, these options serve no purpose
-			 * and are removed during the final migration to prevent confusion and reduce database bloat.
-			 */
-			delete_option( 'woocommerce_ppcp-settings-should-use-old-ui' );
-			delete_option( 'woocommerce-ppcp-is-new-merchant' );
+		delete_option( 'woocommerce_ppcp-settings-should-use-old-ui' );
+		delete_option( 'woocommerce-ppcp-is-new-merchant' );
 
-			$this->onboarding_profile->set_completed( true );
-			$this->onboarding_profile->set_gateways_refreshed( true );
-			$this->onboarding_profile->set_gateways_synced( true );
-			$this->onboarding_profile->save();
+		$this->onboarding_profile->set_completed( true );
+		$this->onboarding_profile->set_gateways_refreshed( true );
+		$this->onboarding_profile->set_gateways_synced( true );
+		$this->onboarding_profile->save();
 
-			$this->general_settings_migration->migrate();
-			$this->settings_tab_migration->migrate();
-			$this->styling_settings_migration->migrate();
-			$this->payment_settings_migration->migrate();
-			$this->fastlane_settings_migration->migrate();
+		$migrations = array(
+			'general_settings' => $this->general_settings_migration,
+			'settings_tab'     => $this->settings_tab_migration,
+			'styling'          => $this->styling_settings_migration,
+			'payment'          => $this->payment_settings_migration,
+			'fastlane'         => $this->fastlane_settings_migration,
+		);
 
-			update_option( self::OPTION_NAME_MIGRATION_IS_DONE, true );
-		} catch ( Exception $error ) {
-			$this->logger->warning(
-				'Settings migration failed during transition to new UI',
-				array(
-					'error_message' => $error->getMessage(),
-					'error_code'    => $error->getCode(),
-					'trace'         => $error->getTraceAsString(),
-				)
-			);
+		foreach ( $migrations as $name => $migration ) {
+			try {
+				$migration->migrate();
+			} catch ( Exception $error ) {
+				$this->logger->warning(
+					"Settings migration failed for '{$name}' during transition to new UI",
+					array(
+						'error_message' => $error->getMessage(),
+						'error_code'    => $error->getCode(),
+						'trace'         => $error->getTraceAsString(),
+					)
+				);
+			}
 		}
+
+		update_option( self::OPTION_NAME_MIGRATION_IS_DONE, true );
 	}
 }

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -49,6 +49,16 @@ class MigrationManager implements SettingsMigrationInterface {
 	}
 
 	public function migrate(): void {
+		/**
+		 * Clean up legacy UI toggle options that are no longer needed.
+		 *
+		 * These options were used to control whether merchants saw the old or new settings UI:
+		 * - OPTION_NAME_SHOULD_USE_OLD_UI: Stored merchant's preference to use the old UI
+		 * - woocommerce-ppcp-is-new-merchant: Flagged new merchants to bypass the old UI
+		 *
+		 * With the new settings UI now being the only interface, these options serve no purpose
+		 * and are removed during the final migration to prevent confusion and reduce database bloat.
+		 */
 		delete_option( 'woocommerce_ppcp-settings-should-use-old-ui' );
 		delete_option( 'woocommerce-ppcp-is-new-merchant' );
 

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -81,5 +81,14 @@ class MigrationManager implements SettingsMigrationInterface {
 		}
 
 		update_option( self::OPTION_NAME_MIGRATION_IS_DONE, true );
+
+		/**
+		 * Clear product status caches that may have been poisoned during migration.
+		 *
+		 * The PartnersEndpoint call in SettingsMigration may use the wrong environment
+		 * (production instead of sandbox) before sandbox_merchant is set, causing
+		 * stale false values in reference_transaction and other caches.
+		 */
+		do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 	}
 }

--- a/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
@@ -11,10 +11,10 @@ namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
 
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
+use WooCommerce\PayPalCommerce\Settings\Service\SellerTypeResolver;
 
 /**
  * Class SettingsMigration
@@ -30,17 +30,20 @@ class SettingsMigration implements SettingsMigrationInterface {
 	protected GeneralSettings $general_settings;
 	protected PartnersEndpoint $partners_endpoint;
 	protected LoggerInterface $logger;
+	protected SellerTypeResolver $seller_type_resolver;
 
 	public function __construct(
 		array $settings,
 		GeneralSettings $general_settings,
 		PartnersEndpoint $partners_endpoint,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		SellerTypeResolver $seller_type_resolver
 	) {
-		$this->settings          = $settings;
-		$this->general_settings  = $general_settings;
-		$this->partners_endpoint = $partners_endpoint;
-		$this->logger            = $logger;
+		$this->settings             = $settings;
+		$this->general_settings     = $general_settings;
+		$this->partners_endpoint    = $partners_endpoint;
+		$this->logger               = $logger;
+		$this->seller_type_resolver = $seller_type_resolver;
 	}
 
 	public function migrate(): void {
@@ -56,7 +59,7 @@ class SettingsMigration implements SettingsMigrationInterface {
 		try {
 			$seller_status = $this->partners_endpoint->seller_status();
 			$country       = $seller_status->country();
-			$seller_type   = $this->merchant_account_type( $seller_status );
+			$seller_type   = $this->seller_type_resolver->resolve( $seller_status );
 		} catch ( \Exception $exception ) {
 			$this->logger->warning(
 				'Seller status API call failed during settings migration; using defaults.',
@@ -76,60 +79,5 @@ class SettingsMigration implements SettingsMigrationInterface {
 
 		$this->general_settings->set_merchant_data( $connection );
 		$this->general_settings->save();
-	}
-
-	/**
-	 * Determines the merchant account type based on seller status capabilities.
-	 *
-	 * Analyzes PayPal seller capabilities to determine if the account is a business
-	 * account or falls back to unknown.
-	 *
-	 * @param SellerStatus $seller_status
-	 * @return 'business' | 'unknown' The merchant account type (SellerTypeEnum constant).
-	 */
-	protected function merchant_account_type( SellerStatus $seller_status ): string {
-		if ( $this->has_capability_active( $seller_status, 'COMMERCIAL_ENTITY' ) ) {
-			return SellerTypeEnum::BUSINESS;
-		}
-
-		$business_capabilities = array(
-			'CUSTOM_CARD_PROCESSING',
-			'CARD_PROCESSING_VIRTUAL_TERMINAL',
-			'FRAUD_TOOL_ACCESS',
-			'PAY_UPON_INVOICE',
-			'SEND_INVOICE',
-		);
-
-		foreach ( $business_capabilities as $capability ) {
-			if ( $this->has_capability_active( $seller_status, $capability ) ) {
-				return SellerTypeEnum::BUSINESS;
-			}
-		}
-
-		foreach ( $seller_status->products() as $product ) {
-			if ( $product->name() === 'PPCP_CUSTOM' &&
-				$product->vetting_status() === 'SUBSCRIBED' ) {
-				return SellerTypeEnum::BUSINESS;
-			}
-		}
-
-		return SellerTypeEnum::UNKNOWN;
-	}
-
-	/**
-	 * Checks if a specific capability is active for the seller.
-	 *
-	 * @param SellerStatus $seller_status
-	 * @param string       $capability_name
-	 * @return bool True if the capability is active, false otherwise.
-	 */
-	private function has_capability_active( SellerStatus $seller_status, string $capability_name ): bool {
-		foreach ( $seller_status->capabilities() as $capability ) {
-			if ( $capability->name() === $capability_name &&
-				$capability->status() === 'ACTIVE' ) {
-				return true;
-			}
-		}
-		return false;
 	}
 }

--- a/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
 
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
@@ -28,15 +29,18 @@ class SettingsMigration implements SettingsMigrationInterface {
 	protected array $settings;
 	protected GeneralSettings $general_settings;
 	protected PartnersEndpoint $partners_endpoint;
+	protected LoggerInterface $logger;
 
 	public function __construct(
 		array $settings,
 		GeneralSettings $general_settings,
-		PartnersEndpoint $partners_endpoint
+		PartnersEndpoint $partners_endpoint,
+		LoggerInterface $logger
 	) {
 		$this->settings          = $settings;
 		$this->general_settings  = $general_settings;
 		$this->partners_endpoint = $partners_endpoint;
+		$this->logger            = $logger;
 	}
 
 	public function migrate(): void {
@@ -46,14 +50,28 @@ class SettingsMigration implements SettingsMigrationInterface {
 			return;
 		}
 
+		$country     = '';
+		$seller_type = SellerTypeEnum::UNKNOWN;
+
+		try {
+			$seller_status = $this->partners_endpoint->seller_status();
+			$country       = $seller_status->country();
+			$seller_type   = $this->merchant_account_type( $seller_status );
+		} catch ( \Exception $exception ) {
+			$this->logger->warning(
+				'Seller status API call failed during settings migration; using defaults.',
+				array( 'error' => $exception->getMessage() )
+			);
+		}
+
 		$connection = new MerchantConnectionDTO(
 			! empty( $this->settings['sandbox_on'] ),
 			$this->settings['client_id'],
 			$this->settings['client_secret'],
 			$this->settings['merchant_id'],
 			$this->settings['merchant_email'] ?? '',
-			$this->partners_endpoint->seller_status()->country(),
-			$this->merchant_account_type( $this->partners_endpoint->seller_status() )
+			$country,
+			$seller_type
 		);
 
 		$this->general_settings->set_merchant_data( $connection );

--- a/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
@@ -9,6 +9,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
@@ -60,7 +61,7 @@ class SettingsMigration implements SettingsMigrationInterface {
 			$seller_status = $this->partners_endpoint->seller_status();
 			$country       = $seller_status->country();
 			$seller_type   = $this->seller_type_resolver->resolve( $seller_status );
-		} catch ( \Exception $exception ) {
+		} catch ( Exception $exception ) {
 			$this->logger->warning(
 				'Seller status API call failed during settings migration; using defaults.',
 				array( 'error' => $exception->getMessage() )

--- a/modules/ppcp-settings/src/Service/SellerTypeResolver.php
+++ b/modules/ppcp-settings/src/Service/SellerTypeResolver.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Resolves the merchant seller type from PayPal seller status.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service;
+
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
+
+/**
+ * Class SellerTypeResolver
+ */
+class SellerTypeResolver {
+
+	/**
+	 * Determines the merchant account type based on seller status capabilities.
+	 *
+	 * @param SellerStatus $seller_status The seller status from PayPal API.
+	 * @return string A SellerTypeEnum value.
+	 */
+	public function resolve( SellerStatus $seller_status ): string {
+		if ( $this->has_capability_active( $seller_status, 'COMMERCIAL_ENTITY' ) ) {
+			return SellerTypeEnum::BUSINESS;
+		}
+
+		$business_capabilities = array(
+			'CUSTOM_CARD_PROCESSING',
+			'CARD_PROCESSING_VIRTUAL_TERMINAL',
+			'FRAUD_TOOL_ACCESS',
+			'PAY_UPON_INVOICE',
+			'SEND_INVOICE',
+		);
+
+		foreach ( $business_capabilities as $capability ) {
+			if ( $this->has_capability_active( $seller_status, $capability ) ) {
+				return SellerTypeEnum::BUSINESS;
+			}
+		}
+
+		foreach ( $seller_status->products() as $product ) {
+			if ( $product->name() === 'PPCP_CUSTOM' &&
+				$product->vetting_status() === 'SUBSCRIBED' ) {
+				return SellerTypeEnum::BUSINESS;
+			}
+		}
+
+		return SellerTypeEnum::UNKNOWN;
+	}
+
+	/**
+	 * Checks if a specific capability is active for the seller.
+	 *
+	 * @param SellerStatus $seller_status  The seller status.
+	 * @param string       $capability_name The capability name to check.
+	 * @return bool True if the capability is active, false otherwise.
+	 */
+	private function has_capability_active( SellerStatus $seller_status, string $capability_name ): bool {
+		foreach ( $seller_status->capabilities() as $capability ) {
+			if ( $capability->name() === $capability_name &&
+				$capability->status() === 'ACTIVE' ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/modules/ppcp-settings/src/Service/SellerTypeResolver.php
+++ b/modules/ppcp-settings/src/Service/SellerTypeResolver.php
@@ -3,7 +3,13 @@ declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service;
 
+use Exception;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
 
 class SellerTypeResolver {
@@ -41,6 +47,73 @@ class SellerTypeResolver {
 		}
 
 		return SellerTypeEnum::UNKNOWN;
+	}
+
+	/**
+	 * For merchants that migrated with an unknown seller type (e.g. API was down
+	 * during migration), this retries the seller status call and persists the
+	 * resolved type. Also backfills empty merchant_country.
+	 *
+	 * @param FailureRegistry  $failure_registry  The failure registry.
+	 * @param GeneralSettings  $general_settings  The general settings.
+	 * @param PartnersEndpoint $partners_endpoint The partners endpoint.
+	 * @param LoggerInterface  $logger            The logger.
+	 */
+	public function resolve_unknown_seller_type(
+		FailureRegistry $failure_registry,
+		GeneralSettings $general_settings,
+		PartnersEndpoint $partners_endpoint,
+		LoggerInterface $logger
+	): void {
+		if ( ! $this->needs_seller_type_resolution( $failure_registry, $general_settings ) ) {
+			return;
+		}
+
+		try {
+			$seller_status = $partners_endpoint->seller_status();
+			$seller_type   = $this->resolve( $seller_status );
+
+			if ( $seller_type !== SellerTypeEnum::UNKNOWN ) {
+				$current    = $general_settings->get_merchant_data();
+				$connection = new MerchantConnectionDTO(
+					$current->is_sandbox,
+					$current->client_id,
+					$current->client_secret,
+					$current->merchant_id,
+					$current->merchant_email,
+					empty( $current->merchant_country ) ? $seller_status->country() : $current->merchant_country,
+					$seller_type
+				);
+				$general_settings->set_merchant_data( $connection );
+				$general_settings->save();
+
+				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
+			}
+		} catch ( Exception $e ) {
+			$logger->debug(
+				'Seller type resolution deferred; will retry in 1 hour.',
+				array( 'error' => $e->getMessage() )
+			);
+		}
+	}
+
+	/**
+	 * Checks whether seller type resolution is needed.
+	 *
+	 * @param FailureRegistry $failure_registry The failure registry.
+	 * @param GeneralSettings $general_settings The general settings.
+	 * @return bool True if the merchant is connected but has an unknown seller type.
+	 */
+	public function needs_seller_type_resolution( FailureRegistry $failure_registry, GeneralSettings $general_settings ): bool {
+		if ( $failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, HOUR_IN_SECONDS ) ) {
+			return false;
+		}
+
+		if ( ! $general_settings->is_merchant_connected() ) {
+			return false;
+		}
+
+		return ! $general_settings->is_business_seller() && ! $general_settings->is_casual_seller();
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/SellerTypeResolver.php
+++ b/modules/ppcp-settings/src/Service/SellerTypeResolver.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Resolves the merchant seller type from PayPal seller status.
- *
- * @package WooCommerce\PayPalCommerce\Settings\Service
- */
-
 declare( strict_types=1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service;
@@ -12,9 +6,6 @@ namespace WooCommerce\PayPalCommerce\Settings\Service;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
 
-/**
- * Class SellerTypeResolver
- */
 class SellerTypeResolver {
 
 	/**

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -41,7 +41,9 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WooCommerce\PayPalCommerce\Settings\Service\SettingsDataManager;
+use Exception;
 use WooCommerce\PayPalCommerce\Settings\DTO\ConfigurationFlagsDTO;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\Settings\Enum\ProductChoicesEnum;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
@@ -908,17 +910,22 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			$seller_type   = $seller_type_resolver->resolve( $seller_status );
 
 			if ( $seller_type !== SellerTypeEnum::UNKNOWN ) {
-				$connection              = $general_settings->get_merchant_data();
-				$connection->seller_type = $seller_type;
-				if ( empty( $connection->merchant_country ) ) {
-					$connection->merchant_country = $seller_status->country();
-				}
+				$current    = $general_settings->get_merchant_data();
+				$connection = new MerchantConnectionDTO(
+					$current->is_sandbox,
+					$current->client_id,
+					$current->client_secret,
+					$current->merchant_id,
+					$current->merchant_email,
+					empty( $current->merchant_country ) ? $seller_status->country() : $current->merchant_country,
+					$seller_type
+				);
 				$general_settings->set_merchant_data( $connection );
 				$general_settings->save();
 
 				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 			}
-		} catch ( \Exception $e ) {
+		} catch ( Exception $e ) {
 			set_transient( 'ppcp_seller_type_resolve_cooldown', '1', HOUR_IN_SECONDS );
 
 			$logger = $container->get( 'woocommerce.logger.woocommerce' );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -100,6 +100,24 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		add_action(
+			'admin_init',
+			static function () use ( $container ): void {
+				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) === '1' ) {
+					return;
+				}
+
+				$legacy_settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
+				if ( empty( $legacy_settings['client_id'] ) ) {
+					return;
+				}
+
+				$migration_manager = $container->get( 'settings.service.data-migration' );
+				assert( $migration_manager instanceof MigrationManager );
+				$migration_manager->migrate();
+			}
+		);
+
 		/**
 		 * Override ACDC status with BCDC for eligible merchants.
 		 *

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -919,10 +919,12 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 			}
 		} catch ( \Exception $e ) {
+			set_transient( 'ppcp_seller_type_resolve_cooldown', '1', HOUR_IN_SECONDS );
+
 			$logger = $container->get( 'woocommerce.logger.woocommerce' );
 			assert( $logger instanceof LoggerInterface );
 			$logger->debug(
-				'Seller type resolution deferred; will retry on next admin page load.',
+				'Seller type resolution deferred; will retry in 1 hour.',
 				array( 'error' => $e->getMessage() )
 			);
 		}
@@ -935,6 +937,10 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * @return bool True if the merchant is connected but has an unknown seller type.
 	 */
 	protected function needs_seller_type_resolution( ContainerInterface $container ): bool {
+		if ( get_transient( 'ppcp_seller_type_resolve_cooldown' ) ) {
+			return false;
+		}
+
 		$general_settings = $container->get( 'settings.data.general' );
 		assert( $general_settings instanceof GeneralSettings );
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -147,8 +147,13 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					if ( $seller_type !== SellerTypeEnum::UNKNOWN ) {
 						$connection              = $general_settings->get_merchant_data();
 						$connection->seller_type = $seller_type;
+						if ( empty( $connection->merchant_country ) ) {
+							$connection->merchant_country = $seller_status->country();
+						}
 						$general_settings->set_merchant_data( $connection );
 						$general_settings->save();
+
+						do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 					}
 				} catch ( \Exception $e ) {
 					$logger = $container->get( 'woocommerce.logger.woocommerce' );

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -890,17 +890,14 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * @param ContainerInterface $container The DI container.
 	 */
 	protected function resolve_unknown_seller_type( ContainerInterface $container ): void {
-		$general_settings = $container->get( 'settings.data.general' );
-		assert( $general_settings instanceof GeneralSettings );
-
-		if ( ! $general_settings->is_merchant_connected() ) {
-			return;
-		}
-		if ( $general_settings->is_business_seller() || $general_settings->is_casual_seller() ) {
+		if ( ! $this->needs_seller_type_resolution( $container ) ) {
 			return;
 		}
 
 		try {
+			$general_settings = $container->get( 'settings.data.general' );
+			assert( $general_settings instanceof GeneralSettings );
+
 			$partners_endpoint = $container->get( 'api.endpoint.partners' );
 			assert( $partners_endpoint instanceof PartnersEndpoint );
 
@@ -929,5 +926,22 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				array( 'error' => $e->getMessage() )
 			);
 		}
+	}
+
+	/**
+	 * Checks whether seller type resolution is needed.
+	 *
+	 * @param ContainerInterface $container The DI container.
+	 * @return bool True if the merchant is connected but has an unknown seller type.
+	 */
+	protected function needs_seller_type_resolution( ContainerInterface $container ): bool {
+		$general_settings = $container->get( 'settings.data.general' );
+		assert( $general_settings instanceof GeneralSettings );
+
+		if ( ! $general_settings->is_merchant_connected() ) {
+			return false;
+		}
+
+		return ! $general_settings->is_business_seller() && ! $general_settings->is_casual_seller();
 	}
 }

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -11,7 +11,6 @@ namespace WooCommerce\PayPalCommerce\Settings;
 
 use WC_Payment_Gateway;
 use Psr\Log\LoggerInterface;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
@@ -30,8 +29,6 @@ use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigrati
 use WooCommerce\PayPalCommerce\Settings\Service\PaymentMethodsEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\ScriptDataHandler;
 use WooCommerce\PayPalCommerce\Settings\Service\SellerTypeResolver;
-use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
-use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
@@ -42,9 +39,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WooCommerce\PayPalCommerce\Settings\Service\SettingsDataManager;
-use Exception;
 use WooCommerce\PayPalCommerce\Settings\DTO\ConfigurationFlagsDTO;
-use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\Settings\Enum\ProductChoicesEnum;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
@@ -118,22 +113,15 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					}
 				}
 
-				$failure_registry = $container->get( 'api.helper.failure-registry' );
-				assert( $failure_registry instanceof FailureRegistry );
-
-				$general_settings = $container->get( 'settings.data.general' );
-				assert( $general_settings instanceof GeneralSettings );
-
-				$partners_endpoint = $container->get( 'api.endpoint.partners' );
-				assert( $partners_endpoint instanceof PartnersEndpoint );
-
 				$seller_type_resolver = $container->get( 'settings.service.seller-type-resolver' );
 				assert( $seller_type_resolver instanceof SellerTypeResolver );
 
-				$logger = $container->get( 'woocommerce.logger.woocommerce' );
-				assert( $logger instanceof LoggerInterface );
-
-				$this->resolve_unknown_seller_type( $failure_registry, $general_settings, $partners_endpoint, $seller_type_resolver, $logger );
+				$seller_type_resolver->resolve_unknown_seller_type(
+					$container->get( 'api.helper.failure-registry' ),
+					$container->get( 'settings.data.general' ),
+					$container->get( 'api.endpoint.partners' ),
+					$container->get( 'woocommerce.logger.woocommerce' )
+				);
 			}
 		);
 
@@ -887,76 +875,5 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$gateway_enabled  = $gateway_settings['enabled'] ?? false;
 
 		return $gateway_enabled === 'yes';
-	}
-
-	/**
-	 * Resolves unknown seller type for connected merchants via PayPal API.
-	 *
-	 * For merchants that migrated with an unknown seller type (e.g. API was down
-	 * during migration), this retries the seller status call and persists the
-	 * resolved type. Also backfills empty merchant_country.
-	 *
-	 * @param FailureRegistry    $failure_registry    The failure registry.
-	 * @param GeneralSettings    $general_settings    The general settings.
-	 * @param PartnersEndpoint   $partners_endpoint   The partners endpoint.
-	 * @param SellerTypeResolver $seller_type_resolver The seller type resolver.
-	 * @param LoggerInterface    $logger              The logger.
-	 */
-	private function resolve_unknown_seller_type(
-		FailureRegistry $failure_registry,
-		GeneralSettings $general_settings,
-		PartnersEndpoint $partners_endpoint,
-		SellerTypeResolver $seller_type_resolver,
-		LoggerInterface $logger
-	): void {
-		if ( ! $this->needs_seller_type_resolution( $failure_registry, $general_settings ) ) {
-			return;
-		}
-
-		try {
-			$seller_status = $partners_endpoint->seller_status();
-			$seller_type   = $seller_type_resolver->resolve( $seller_status );
-
-			if ( $seller_type !== SellerTypeEnum::UNKNOWN ) {
-				$current    = $general_settings->get_merchant_data();
-				$connection = new MerchantConnectionDTO(
-					$current->is_sandbox,
-					$current->client_id,
-					$current->client_secret,
-					$current->merchant_id,
-					$current->merchant_email,
-					empty( $current->merchant_country ) ? $seller_status->country() : $current->merchant_country,
-					$seller_type
-				);
-				$general_settings->set_merchant_data( $connection );
-				$general_settings->save();
-
-				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
-			}
-		} catch ( Exception $e ) {
-			$logger->debug(
-				'Seller type resolution deferred; will retry in 1 hour.',
-				array( 'error' => $e->getMessage() )
-			);
-		}
-	}
-
-	/**
-	 * Checks whether seller type resolution is needed.
-	 *
-	 * @param FailureRegistry $failure_registry The failure registry.
-	 * @param GeneralSettings $general_settings The general settings.
-	 * @return bool True if the merchant is connected but has an unknown seller type.
-	 */
-	private function needs_seller_type_resolution( FailureRegistry $failure_registry, GeneralSettings $general_settings ): bool {
-		if ( $failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, HOUR_IN_SECONDS ) ) {
-			return false;
-		}
-
-		if ( ! $general_settings->is_merchant_connected() ) {
-			return false;
-		}
-
-		return ! $general_settings->is_business_seller() && ! $general_settings->is_casual_seller();
 	}
 }

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -123,46 +123,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'admin_init',
-			static function () use ( $container ): void {
-				$general_settings = $container->get( 'settings.data.general' );
-				assert( $general_settings instanceof GeneralSettings );
-
-				if ( ! $general_settings->is_merchant_connected() ) {
-					return;
-				}
-				if ( $general_settings->is_business_seller() || $general_settings->is_casual_seller() ) {
-					return;
-				}
-
-				try {
-					$partners_endpoint = $container->get( 'api.endpoint.partners' );
-					assert( $partners_endpoint instanceof PartnersEndpoint );
-
-					$seller_type_resolver = $container->get( 'settings.service.seller-type-resolver' );
-					assert( $seller_type_resolver instanceof SellerTypeResolver );
-
-					$seller_status = $partners_endpoint->seller_status();
-					$seller_type   = $seller_type_resolver->resolve( $seller_status );
-
-					if ( $seller_type !== SellerTypeEnum::UNKNOWN ) {
-						$connection              = $general_settings->get_merchant_data();
-						$connection->seller_type = $seller_type;
-						if ( empty( $connection->merchant_country ) ) {
-							$connection->merchant_country = $seller_status->country();
-						}
-						$general_settings->set_merchant_data( $connection );
-						$general_settings->save();
-
-						do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
-					}
-				} catch ( \Exception $e ) {
-					$logger = $container->get( 'woocommerce.logger.woocommerce' );
-					assert( $logger instanceof LoggerInterface );
-					$logger->debug(
-						'Seller type resolution deferred; will retry on next admin page load.',
-						array( 'error' => $e->getMessage() )
-					);
-				}
+			function () use ( $container ): void {
+				$this->resolve_unknown_seller_type( $container );
 			}
 		);
 
@@ -916,5 +878,56 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		$gateway_enabled  = $gateway_settings['enabled'] ?? false;
 
 		return $gateway_enabled === 'yes';
+	}
+
+	/**
+	 * Resolves unknown seller type for connected merchants via PayPal API.
+	 *
+	 * For merchants that migrated with an unknown seller type (e.g. API was down
+	 * during migration), this retries the seller status call and persists the
+	 * resolved type. Also backfills empty merchant_country.
+	 *
+	 * @param ContainerInterface $container The DI container.
+	 */
+	protected function resolve_unknown_seller_type( ContainerInterface $container ): void {
+		$general_settings = $container->get( 'settings.data.general' );
+		assert( $general_settings instanceof GeneralSettings );
+
+		if ( ! $general_settings->is_merchant_connected() ) {
+			return;
+		}
+		if ( $general_settings->is_business_seller() || $general_settings->is_casual_seller() ) {
+			return;
+		}
+
+		try {
+			$partners_endpoint = $container->get( 'api.endpoint.partners' );
+			assert( $partners_endpoint instanceof PartnersEndpoint );
+
+			$seller_type_resolver = $container->get( 'settings.service.seller-type-resolver' );
+			assert( $seller_type_resolver instanceof SellerTypeResolver );
+
+			$seller_status = $partners_endpoint->seller_status();
+			$seller_type   = $seller_type_resolver->resolve( $seller_status );
+
+			if ( $seller_type !== SellerTypeEnum::UNKNOWN ) {
+				$connection              = $general_settings->get_merchant_data();
+				$connection->seller_type = $seller_type;
+				if ( empty( $connection->merchant_country ) ) {
+					$connection->merchant_country = $seller_status->country();
+				}
+				$general_settings->set_merchant_data( $connection );
+				$general_settings->save();
+
+				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
+			}
+		} catch ( \Exception $e ) {
+			$logger = $container->get( 'woocommerce.logger.woocommerce' );
+			assert( $logger instanceof LoggerInterface );
+			$logger->debug(
+				'Seller type resolution deferred; will retry on next admin page load.',
+				array( 'error' => $e->getMessage() )
+			);
+		}
 	}
 }

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Settings;
 
 use WC_Payment_Gateway;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
@@ -944,7 +945,9 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * @return bool True if the merchant is connected but has an unknown seller type.
 	 */
 	protected function needs_seller_type_resolution( ContainerInterface $container ): bool {
-		if ( get_transient( 'ppcp_seller_type_resolve_cooldown' ) ) {
+		$failure_registry = $container->get( 'api.helper.failure-registry' );
+		assert( $failure_registry instanceof FailureRegistry );
+		if ( $failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, HOUR_IN_SECONDS ) ) {
 			return false;
 		}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -28,6 +28,9 @@ use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
 use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
 use WooCommerce\PayPalCommerce\Settings\Service\PaymentMethodsEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\ScriptDataHandler;
+use WooCommerce\PayPalCommerce\Settings\Service\SellerTypeResolver;
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
@@ -115,6 +118,46 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				$migration_manager = $container->get( 'settings.service.data-migration' );
 				assert( $migration_manager instanceof MigrationManager );
 				$migration_manager->migrate();
+			}
+		);
+
+		add_action(
+			'admin_init',
+			static function () use ( $container ): void {
+				$general_settings = $container->get( 'settings.data.general' );
+				assert( $general_settings instanceof GeneralSettings );
+
+				if ( ! $general_settings->is_merchant_connected() ) {
+					return;
+				}
+				if ( $general_settings->is_business_seller() || $general_settings->is_casual_seller() ) {
+					return;
+				}
+
+				try {
+					$partners_endpoint = $container->get( 'api.endpoint.partners' );
+					assert( $partners_endpoint instanceof PartnersEndpoint );
+
+					$seller_type_resolver = $container->get( 'settings.service.seller-type-resolver' );
+					assert( $seller_type_resolver instanceof SellerTypeResolver );
+
+					$seller_status = $partners_endpoint->seller_status();
+					$seller_type   = $seller_type_resolver->resolve( $seller_status );
+
+					if ( $seller_type !== SellerTypeEnum::UNKNOWN ) {
+						$connection              = $general_settings->get_merchant_data();
+						$connection->seller_type = $seller_type;
+						$general_settings->set_merchant_data( $connection );
+						$general_settings->save();
+					}
+				} catch ( \Exception $e ) {
+					$logger = $container->get( 'woocommerce.logger.woocommerce' );
+					assert( $logger instanceof LoggerInterface );
+					$logger->debug(
+						'Seller type resolution deferred; will retry on next admin page load.',
+						array( 'error' => $e->getMessage() )
+					);
+				}
 			}
 		);
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -108,26 +108,32 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'admin_init',
-			static function () use ( $container ): void {
-				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) === '1' ) {
-					return;
-				}
-
-				$legacy_settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
-				if ( empty( $legacy_settings['client_id'] ) ) {
-					return;
-				}
-
-				$migration_manager = $container->get( 'settings.service.data-migration' );
-				assert( $migration_manager instanceof MigrationManager );
-				$migration_manager->migrate();
-			}
-		);
-
-		add_action(
-			'admin_init',
 			function () use ( $container ): void {
-				$this->resolve_unknown_seller_type( $container );
+				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) !== '1' ) {
+					$legacy_settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
+					if ( ! empty( $legacy_settings['client_id'] ) ) {
+						$migration_manager = $container->get( 'settings.service.data-migration' );
+						assert( $migration_manager instanceof MigrationManager );
+						$migration_manager->migrate();
+					}
+				}
+
+				$failure_registry = $container->get( 'api.helper.failure-registry' );
+				assert( $failure_registry instanceof FailureRegistry );
+
+				$general_settings = $container->get( 'settings.data.general' );
+				assert( $general_settings instanceof GeneralSettings );
+
+				$partners_endpoint = $container->get( 'api.endpoint.partners' );
+				assert( $partners_endpoint instanceof PartnersEndpoint );
+
+				$seller_type_resolver = $container->get( 'settings.service.seller-type-resolver' );
+				assert( $seller_type_resolver instanceof SellerTypeResolver );
+
+				$logger = $container->get( 'woocommerce.logger.woocommerce' );
+				assert( $logger instanceof LoggerInterface );
+
+				$this->resolve_unknown_seller_type( $failure_registry, $general_settings, $partners_endpoint, $seller_type_resolver, $logger );
 			}
 		);
 
@@ -890,23 +896,24 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	 * during migration), this retries the seller status call and persists the
 	 * resolved type. Also backfills empty merchant_country.
 	 *
-	 * @param ContainerInterface $container The DI container.
+	 * @param FailureRegistry    $failure_registry    The failure registry.
+	 * @param GeneralSettings    $general_settings    The general settings.
+	 * @param PartnersEndpoint   $partners_endpoint   The partners endpoint.
+	 * @param SellerTypeResolver $seller_type_resolver The seller type resolver.
+	 * @param LoggerInterface    $logger              The logger.
 	 */
-	protected function resolve_unknown_seller_type( ContainerInterface $container ): void {
-		if ( ! $this->needs_seller_type_resolution( $container ) ) {
+	private function resolve_unknown_seller_type(
+		FailureRegistry $failure_registry,
+		GeneralSettings $general_settings,
+		PartnersEndpoint $partners_endpoint,
+		SellerTypeResolver $seller_type_resolver,
+		LoggerInterface $logger
+	): void {
+		if ( ! $this->needs_seller_type_resolution( $failure_registry, $general_settings ) ) {
 			return;
 		}
 
 		try {
-			$general_settings = $container->get( 'settings.data.general' );
-			assert( $general_settings instanceof GeneralSettings );
-
-			$partners_endpoint = $container->get( 'api.endpoint.partners' );
-			assert( $partners_endpoint instanceof PartnersEndpoint );
-
-			$seller_type_resolver = $container->get( 'settings.service.seller-type-resolver' );
-			assert( $seller_type_resolver instanceof SellerTypeResolver );
-
 			$seller_status = $partners_endpoint->seller_status();
 			$seller_type   = $seller_type_resolver->resolve( $seller_status );
 
@@ -927,10 +934,6 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 			}
 		} catch ( Exception $e ) {
-			set_transient( 'ppcp_seller_type_resolve_cooldown', '1', HOUR_IN_SECONDS );
-
-			$logger = $container->get( 'woocommerce.logger.woocommerce' );
-			assert( $logger instanceof LoggerInterface );
 			$logger->debug(
 				'Seller type resolution deferred; will retry in 1 hour.',
 				array( 'error' => $e->getMessage() )
@@ -941,18 +944,14 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 	/**
 	 * Checks whether seller type resolution is needed.
 	 *
-	 * @param ContainerInterface $container The DI container.
+	 * @param FailureRegistry $failure_registry The failure registry.
+	 * @param GeneralSettings $general_settings The general settings.
 	 * @return bool True if the merchant is connected but has an unknown seller type.
 	 */
-	protected function needs_seller_type_resolution( ContainerInterface $container ): bool {
-		$failure_registry = $container->get( 'api.helper.failure-registry' );
-		assert( $failure_registry instanceof FailureRegistry );
+	private function needs_seller_type_resolution( FailureRegistry $failure_registry, GeneralSettings $general_settings ): bool {
 		if ( $failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, HOUR_IN_SECONDS ) ) {
 			return false;
 		}
-
-		$general_settings = $container->get( 'settings.data.general' );
-		assert( $general_settings instanceof GeneralSettings );
 
 		if ( ! $general_settings->is_merchant_connected() ) {
 			return false;


### PR DESCRIPTION
Upgrading from older plugin versions (e.g. v3.0.3) leaves merchants stuck as "Not Connected" because:                                                                                                                
                                                                                                                                                                                                                       
- Migration fails silently: The `seller_status()` API call fails, the exception bubbles up, and the migration-done flag never gets set — so migration never retries.
- Seller type stays "unknown": The frontend hides Card Processing and APM groups since it checks `isBusinessSeller`.
- Cache poisoning: The API call during migration uses the wrong environment (production instead of sandbox), caching `false` for vaulting eligibility for 1 hour.

### PR Changes

- Resilient migration — Try-catch around the API call with fallback defaults; each sub-migration isolated so one failure doesn't block others; done-flag always set; admin_init retry for stuck merchants.
- Deferred seller type resolution — New `SellerTypeResolver` service + `admin_init` hook that re-queries the API for connected merchants with unknown seller type, also backfills empty merchant_country.
- Cache clearing — Fires `woocommerce_paypal_payments_clear_apm_product_status` after migration and after successful seller type resolution to flush stale entries.