### PR TITLE
fix(crypto): checkout description copy (5992)

### DIFF
--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -315,7 +315,7 @@ class PaymentMethodsDefinition {
 				'method_title'       => __( 'Pay with Crypto', 'woocommerce-paypal-payments' ),
 				'method_description' => __( 'Accept cryptocurrency payments through PayPal, supporting various digital currencies for global customers.', 'woocommerce-paypal-payments' ),
 				'title'              => __( 'Pay with Crypto', 'woocommerce-paypal-payments' ),
-				'description'        => __( 'Clicking "Place order" will redirect you to PayPal\'s encrypted checkout to complete your cryptocurrency purchase.', 'woocommerce-paypal-payments' ),
+				'description'        => __( 'Clicking "Place order" will take you to PayPal to complete your payment using cryptocurrency.', 'woocommerce-paypal-payments' ),
 			),
 			BancontactGateway::ID     => array(
 				'method_title'       => __( 'Bancontact (via PayPal)', 'woocommerce-paypal-payments' ),


### PR DESCRIPTION
## Issue Description

Update the checkout description copy

## PR Description

Updates the `Place order` button description for the Pay with Crypto payment method to use clearer, simpler language.

**Before:**
> Clicking "Place order" will redirect you to PayPal's encrypted checkout to complete your cryptocurrency purchase.

**After:**
> Clicking "Place order" will take you to PayPal to complete your payment using cryptocurrency.