### PR TITLE
fix(ACDC):Update default gateway title for Fastlane, ACDC and BCDC (6002)

### DIFF
--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -712,7 +712,7 @@ class SettingsProvider {
 	public function acdc_gateway_title(): string {
 		return $this->payment_settings->get_method_title(
 			CreditCardGateway::ID,
-			__( 'Credit Cards', 'woocommerce-paypal-payments' )
+			__( 'Debit & Credit Cards', 'woocommerce-paypal-payments' )
 		);
 	}
 


### PR DESCRIPTION
## Issue Description

The default gateway title for the Fastlane, ACDC, and BCDC payment methods was set to "Credit Cards", which is inaccurate — all three gateways also accept debit cards. 

## PR Description

Updates the default `title` for the Fastlane, ACDC, and BCDC gateways from `Credit Cards` to `Debit & Credit Cards` to accurately reflect the accepted payment instruments.