### PR TITLE
BCDC button under PayPal buttons not active after migration (5667)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
@@ -77,6 +78,7 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 
 		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {
 			update_option( self::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
+			$this->payment_settings->toggle_method_state( CardButtonGateway::ID, true );
 		}
 
 		foreach ( $this->map() as $old_key => $method_name ) {


### PR DESCRIPTION
When migrating from legacy settings with BCDC configured under PayPal buttons (not as a separate gateway), the BCDC gateway is not activated. Merchants must manually enable it on the Payment Methods page.         
                                                            
This PR adds `toggle_method_state( CardButtonGateway::ID, true )` in `PaymentSettingsMigration::migrate()` alongside the existing override flag.