### PR TITLE
Migration - Capture virtual only orders when enabled not preserved when we migrate to new ui (5952)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
@@ -69,9 +69,8 @@ class SettingsTabMigration implements SettingsMigrationInterface {
 						);
 					break;
 				case 'intent':
-					$value                          = $this->settings[ $old_key ];
-					$data['authorize_only']         = $value === 'authorize';
-					$data['capture_virtual_orders'] = $value === 'capture';
+					$value                  = $this->settings[ $old_key ];
+					$data['authorize_only'] = $value === 'authorize';
 					break;
 				case 'blocks_final_review_enabled':
 					$data[ $new_key ] = ! $this->settings[ $old_key ];
@@ -106,6 +105,7 @@ class SettingsTabMigration implements SettingsMigrationInterface {
 			'smart_button_language'       => 'button_language',
 			'prefix'                      => 'invoice_prefix',
 			'intent'                      => '',
+			'capture_for_virtual_only'    => 'capture_virtual_orders',
 			'vault_enabled_dcc'           => 'save_card_details',
 			'blocks_final_review_enabled' => 'enable_pay_now',
 			'logging_enabled'             => 'enable_logging',


### PR DESCRIPTION
When migrating from the legacy settings UI to the new one, the "Capture Virtual-Only Orders" setting was always lost. The `intent` case in the migration switch was deriving `capture_virtual_orders` from the intent value (`$value === 'capture'`), which is always `false` when intent is `'authorize'`, the only scenario where the setting matters. Additionally, the actual legacy key `capture_for_virtual_only` was never included in the migration map, so its value was never read.                                                                                                                                                                   
                                                                                                                                                                                                                       
This PR adds `capture_for_virtual_only` to the migration key map so it gets migrated directly via the default case, and removed the incorrect derivation from the intent case.