### PR TITLE
Migration - Case when BCDC is part of PayPal or as separated gateway Pay later messaging tab is not present (5929)

### DIFF
--- a/modules/ppcp-paylater-configurator/services.php
+++ b/modules/ppcp-paylater-configurator/services.php
@@ -55,7 +55,7 @@ return array(
 
 		$vault_enabled = $settings_provider->save_paypal_and_venmo();
 
-		return ! $vault_enabled && $messages_apply->for_country() && $dcc_product_status->is_active();
+		return ! $vault_enabled && $messages_apply->for_country();
 	},
 	'paylater-configurator.messaging-locations'  => static function ( ContainerInterface $container ): array {
 		$settings_provider = $container->get( 'settings.settings-provider' );


### PR DESCRIPTION
We were incorrectly checking for ACDC eligible on Pay Later Messaging, it should not rely on card eligibility but only on vault enabled and allowed countries.