### PR TITLE
Migration - Enable BCDC when merchant have it active and is not ACDC eligible (6010)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -76,8 +76,14 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			}
 		}
 
+		$disable_funding         = (array) ( $this->settings['disable_funding'] ?? array() );
+		$card_funding_was_active = ! in_array( 'card', $disable_funding, true );
+
 		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {
 			update_option( self::OPTION_NAME_BCDC_MIGRATION_OVERRIDE, true );
+		}
+
+		if ( $card_funding_was_active ) {
 			$this->payment_settings->toggle_method_state( CardButtonGateway::ID, true );
 		}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -677,6 +677,45 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
 			/**
+			 * Retroactive fix for CardButtonGateway not enabled after migration.
+			 *
+			 * In versions up to 3.4.1, the migration only enabled CardButtonGateway for
+			 * ACDC-eligible merchants using BCDC. Non-ACDC merchants who had the card
+			 * funding source active (the default) were missed, causing the card button
+			 * to disappear after upgrade.
+			 *
+			 * @param false|string $previous_version The previously installed plugin version,
+			 *                                       or false on first installation.
+			 */
+			static function ( $previous_version ) use ( $container ): void {
+				if ( $previous_version && version_compare( $previous_version, '3.4.1', 'gt' ) ) {
+					return;
+				}
+
+				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) !== '1' ) {
+					return;
+				}
+
+				$payment_settings = $container->get( 'settings.data.payment' );
+				assert( $payment_settings instanceof PaymentSettings );
+
+				if ( $payment_settings->is_method_enabled( CardButtonGateway::ID ) ) {
+					return;
+				}
+
+				$legacy_settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
+				$disable_funding = (array) ( $legacy_settings['disable_funding'] ?? array() );
+
+				if ( ! in_array( 'card', $disable_funding, true ) ) {
+					$payment_settings->toggle_method_state( CardButtonGateway::ID, true );
+					$payment_settings->save();
+				}
+			}
+		);
+
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			/**
 			 * Migrates payment level processing setting during plugin update.
 			 *
 			 * For merchants updating from version 3.3.2 or older, disables Level 2/3


### PR DESCRIPTION
After upgrading from v2.9.6, the "Credit and debit card payments" (CardButtonGateway) disappears for non-ACDC merchants. In the legacy version, the card button was part of PayPal Smart Buttons and shown by default. The migration only enabled CardButtonGateway for ACDC-eligible merchants using BCDC, leaving non-ACDC merchants without it.                                                                              
   
### PR Changes                                                                                                                                                                                          
  - Fixed the migration to enable CardButtonGateway for all merchants who had the card funding source active (not in `disable_funding`), regardless of ACDC eligibility
  - Added a retroactive fix for merchants who already migrated with the bug (versions ≤ 3.4.1)