### PR TITLE
feat(fraud-protection): Add Fastlane to reCAPTCHA protected payment methods (5650)

### DIFF
--- a/modules/ppcp-fraud-protection/services.php
+++ b/modules/ppcp-fraud-protection/services.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\FraudProtection;
 
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
+use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\FraudProtection\Recaptcha\Recaptcha;
 use WooCommerce\PayPalCommerce\FraudProtection\Recaptcha\RecaptchaIntegration;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -41,6 +42,7 @@ return array(
 				PayPalGateway::ID,
 				CreditCardGateway::ID,
 				CardButtonGateway::ID,
+				AxoGateway::ID,
 			)
 		);
 	},


### PR DESCRIPTION
# Add Fastlane to reCAPTCHA protected payment methods

### Issue Description

Fastlane (`AxoGateway`) was missing from the list of payment gateways protected by reCAPTCHA in `ppcp-fraud-protection/services.php`. This left Fastlane checkouts without the fraud protection applied to other card-based gateways.

### PR Description

Adds `AxoGateway::ID` to the `fraud-protection.recaptcha.payment-methods` service definition, bringing Fastlane in line with the other card-based gateways (`PayPalGateway`, `CreditCardGateway`, `CardButtonGateway`) that are already covered by reCAPTCHA.