### PR TITLE
Map negative fee amounts to discount in PayPal amount breakdown (6705)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/class-amountfactory.php
+++ b/modules/ppcp-api-client/src/Factory/class-amountfactory.php
@@ -94,39 +94,62 @@ class AmountFactory {
 		$currency   = $order->get_currency();
 		$items      = $this->item_factory->from_wc_order( $order );
 		$total      = new Money( (float) $order->get_total(), $currency );
-		$item_total = new Money(
-			(float) array_reduce(
-				$items,
-				static function ( float $total, Item $item ): float {
-					return $total + $item->quantity() * $item->unit_amount()->value();
-				},
-				0
-			),
-			$currency
+	
+		$item_total_value = (float) array_reduce(
+			$items,
+			static function ( float $total, Item $item ): float {
+				return $total + $item->quantity() * $item->unit_amount()->value();
+			},
+			0
 		);
-		$shipping   = new Money(
+	
+		$taxes_value = (float) array_reduce(
+			$items,
+			static function ( float $total, Item $item ): float {
+				return $total + $item->quantity() * $item->tax()->value();
+			},
+			0
+		);
+	
+		$shipping = new Money(
 			(float) $order->get_shipping_total() + (float) $order->get_shipping_tax(),
 			$currency
 		);
-		$taxes      = new Money(
-			(float) array_reduce(
-				$items,
-				static function ( float $total, Item $item ): float {
-					return $total + $item->quantity() * $item->tax()->value();
-				},
-				0
-			),
+	
+		$discount_value = (float) $order->get_total_discount( false );
+	
+		foreach ( $order->get_fees() as $fee_item ) {
+			$fee_total = (float) $fee_item->get_total();
+			$fee_tax   = (float) $fee_item->get_total_tax();
+			$fee_gross = $fee_total + $fee_tax;
+	
+			if ( $fee_gross < 0 ) {
+				$discount_value += abs( $fee_gross );
+				continue;
+			}
+	
+			$item_total_value += $fee_total;
+			$taxes_value      += $fee_tax;
+		}
+	
+		$item_total = new Money(
+			$item_total_value,
 			$currency
 		);
-
+	
+		$taxes = new Money(
+			$taxes_value,
+			$currency
+		);
+	
 		$discount = null;
-		if ( (float) $order->get_total_discount( false ) ) {
+		if ( $discount_value > 0 ) {
 			$discount = new Money(
-				(float) $order->get_total_discount( false ),
+				$discount_value,
 				$currency
 			);
 		}
-
+	
 		$breakdown = new AmountBreakdown(
 			$item_total,
 			$shipping,
@@ -136,11 +159,11 @@ class AmountFactory {
 			null, // shipping discounts?
 			$discount
 		);
-		$amount    = new Amount(
+	
+		return new Amount(
 			$total,
 			$breakdown
 		);
-		return $amount;
 	}
 
 	/**


### PR DESCRIPTION
### Description

This change adjusts the PayPal amount breakdown handling for orders containing negative fees.

At the moment, coupon discounts are added to the PayPal `discount` amount, but negative fees are not handled separately. This can lead to incorrect amount breakdowns when negative fees are used as discounts, especially if they are taxable.

In such cases, the negative fee gross amount should be represented as `discount` instead of being treated like a regular fee line. Otherwise, the resulting breakdown may produce `AMOUNT_MISMATCH` errors because `amount.value` no longer matches the expected sum of `item_total + tax_total + shipping - discount`.

This patch keeps the existing item calculation intact and only adjusts fee handling:
positive fees are still added to `item_total` / `tax_total`, while negative fees are added as gross discount amounts.

This is a minimal change that improves compatibility with payment sources that strictly validate the PayPal amount breakdown.

Since this changes amount breakdown handling, an additional review would be appreciated to confirm the behavior across supported payment flows and edge cases.

### Steps to Test

1. Create or use an order/cart with at least one negative fee used as a discount.
2. Make sure the negative fee is taxable, so the gross discount amount differs from the net fee amount.
3. Select a PayPal payment method that validates the amount breakdown strictly, for example Pay upon Invoice / RatePay.
4. Attempt checkout before the patch and verify that an `AMOUNT_MISMATCH` can occur.
5. Apply this patch.
6. Repeat the same checkout with the same cart/order conditions.
7. Confirm that the PayPal amount breakdown now maps negative fee gross amounts to `discount`.
8. Confirm that checkout succeeds and no `AMOUNT_MISMATCH` is returned.
9. Confirm that positive fees, if present, are still included in `item_total` / `tax_total` as before.

### Documentation

- [X] This PR needs documentation

### Changelog Entry

> Fix PayPal amount breakdown handling for negative fee discounts by mapping negative fee gross amounts to `discount` instead of treating them as regular fees.
