### PR TITLE
Fix(settings-migration): Cardholder name migration (5675)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -106,6 +106,10 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			}
 		}
 
+		if ( isset( $this->settings[ 'dcc_name_on_card' ] ) ) {
+			$this->payment_settings->set_cardholder_name( $this->settings[ 'dcc_name_on_card' ] === 'yes' );
+		}
+
 		$this->payment_settings->save();
 	}
 

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -106,8 +106,8 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			}
 		}
 
-		if ( isset( $this->settings[ 'dcc_name_on_card' ] ) ) {
-			$this->payment_settings->set_cardholder_name( $this->settings[ 'dcc_name_on_card' ] === 'yes' );
+		if ( isset( $this->settings['dcc_name_on_card'] ) ) {
+			$this->payment_settings->set_cardholder_name( $this->settings['dcc_name_on_card'] === 'yes' );
 		}
 
 		$this->payment_settings->save();


### PR DESCRIPTION
### Issue Description

During migration from the legacy settings format, the `dcc_name_on_card` option was not being carried over to the new `PaymentSettings` model. As a result, the cardholder name field always appeared on the classic checkout frontend regardless of what the merchant had configured and toggling the setting in the new UI had no effect either, since the migrated value was never written in the first place.

### PR Description

Read the legacy `dcc_name_on_card` option during migration and persist it via `PaymentSettings::set_cardholder_name()`, so the merchant's previous preference is correctly reflected in both the new settings UI and on the checkout page after upgrading.