### PR TITLE
fix(settings): disable L2/L3 when `stay_updated` is false during legacy migration (5943)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
@@ -85,6 +85,10 @@ class SettingsTabMigration implements SettingsMigrationInterface {
 			}
 		}
 
+		if ( isset( $this->settings['stay_updated'] ) && ! $this->settings['stay_updated'] ) {
+			$this->settings_tab->set_payment_level_processing( false );
+		}
+
 		$this->settings_tab->from_array( $data );
 		$this->settings_tab->save();
 	}


### PR DESCRIPTION
### Issue Description

When a merchant upgrades from a legacy version (≤3.3.2) while still on the old UI, and then later migrates to the new UI, Level 2/3 processing would always be enabled by default, even if the merchant had explicitly disabled "Stay Updated" in their legacy settings. This is because the `gateway_migrate` action (which handles the plugin update path) had already run before the legacy→new-UI migration, leaving the `stay_updated` preference unread during `SettingsTabMigration`.

### PR Description

Read the legacy `stay_updated` value during `SettingsTabMigration::migrate()` and call `set_payment_level_processing( false )` when it is explicitly set to false. This mirrors the logic already present in the `gateway_migrate` action hook, which covers the complementary case where the merchant was already on the new UI when the plugin updated.