### PR TITLE
Capture on status change (6006)

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\PayPalCommerce\Compat
  */
 
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
@@ -65,6 +65,7 @@ class CompatModule implements ServiceModule, ExecutableModule {
 		$this->migrate_pay_later_settings( $c );
 		$this->migrate_smart_button_settings( $c );
 		$this->migrate_three_d_secure_setting();
+		$this->migrate_capture_on_status_change();
 
 		$this->fix_page_builders();
 		$this->exclude_cache_plugins_js_minification( $c );
@@ -320,6 +321,30 @@ class CompatModule implements ServiceModule, ExecutableModule {
 
 				// Save both.
 				update_option( 'woocommerce-ppcp-data-settings', $data_settings );
+				update_option( 'woocommerce-ppcp-data-payment', $payment_settings );
+			}
+		);
+	}
+
+	/**
+	 * Migrates the "capture on status change" setting from the legacy UI.
+	 *
+	 * The migration will be done on plugin update if it hasn't already done.
+	 */
+	protected function migrate_capture_on_status_change(): void {
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate_on_update',
+			static function () {
+				$legacy_settings  = (array) get_option( 'woocommerce-ppcp-settings' ) ?: array();
+				$payment_settings = (array) get_option( 'woocommerce-ppcp-data-payment' ) ?: array();
+
+				// Noop if the legacy setting does not exist, or the setting was already migrated.
+				if ( ! isset( $legacy_settings['capture_on_status_change'] ) || isset( $payment_settings['capture_on_status_change'] ) ) {
+					return;
+				}
+
+				$payment_settings['capture_on_status_change'] = $legacy_settings['capture_on_status_change'];
+
 				update_option( 'woocommerce-ppcp-data-payment', $payment_settings );
 			}
 		);

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -43,6 +43,7 @@ class PaymentSettings extends AbstractDataModel {
 			'venmo_enabled'                     => false,
 			'paylater_enabled'                  => false,
 			'applepay_validated'                => false,
+			'capture_on_status_change'          => true,
 			'applepay_checkout_data_mode'       => 'use_wc',
 			'pui_brand_name'                    => '',
 			'pui_logo_url'                      => '',
@@ -182,7 +183,7 @@ class PaymentSettings extends AbstractDataModel {
 	/**
 	 * Gets the payment method description.
 	 *
-	 * @param string $method_id ID of the payment method.
+	 * @param string $method_id           ID of the payment method.
 	 * @param string $default_description Default description to return if method not found.
 	 * @return string The method description, or an empty string if not found.
 	 */
@@ -365,5 +366,21 @@ class PaymentSettings extends AbstractDataModel {
 	 */
 	public function set_pui_customer_service_instructions( string $value ): void {
 		$this->data['pui_customer_service_instructions'] = $value;
+	}
+
+	/**
+	 * A legacy setting that has no React UI: Whether to capture an authorize-only payment
+	 * when the order is transitioned to "Processing". No setter.
+	 */
+	public function get_capture_on_status_change(): bool {
+		return $this->data['capture_on_status_change'];
+	}
+
+	/**
+	 * Changes the "capture on status change" legacy setting. No UI equivalent, only used by
+	 * the migration script.
+	 */
+	public function set_capture_on_status_change( bool $capture ): void {
+		$this->data['capture_on_status_change'] = $capture;
 	}
 }

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -375,12 +375,4 @@ class PaymentSettings extends AbstractDataModel {
 	public function get_capture_on_status_change(): bool {
 		return $this->data['capture_on_status_change'];
 	}
-
-	/**
-	 * Changes the "capture on status change" legacy setting. No UI equivalent, only used by
-	 * the migration script.
-	 */
-	public function set_capture_on_status_change( bool $capture ): void {
-		$this->data['capture_on_status_change'] = $capture;
-	}
 }

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -740,7 +740,8 @@ class SettingsProvider {
 	}
 
 	/**
-	 * Whether to show the cardholder name field in the ACDC (Advanced Card Processing) payment form.
+	 * Whether to show the cardholder name field in the ACDC (Advanced Card Processing) payment
+	 * form.
 	 *
 	 * @return string 'yes' to show the field, 'no' to hide it.
 	 */
@@ -751,5 +752,12 @@ class SettingsProvider {
 		}
 
 		return $this->payment_settings->get_cardholder_name() ? 'yes' : 'no';
+	}
+
+	public function capture_on_status_change(): bool {
+		return apply_filters(
+			'woocommerce_paypal_payments_capture_on_status_change',
+			$this->payment_settings->get_capture_on_status_change()
+		);
 	}
 }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -31,7 +31,6 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\FeesRenderer;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\OrderTablePaymentStatusColumn;
 use WooCommerce\PayPalCommerce\WcGateway\Admin\PaymentStatusOrderDetail;
-use WooCommerce\PayPalCommerce\WcGateway\Admin\RenderAuthorizeAction;
 use WooCommerce\PayPalCommerce\WcGateway\Assets\FraudNetAssets;
 use WooCommerce\PayPalCommerce\WcGateway\Assets\SettingsPageAssets;
 use WooCommerce\PayPalCommerce\WcGateway\Assets\VoidButtonAssets;
@@ -61,6 +60,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Processor\CreditCardOrderInfoHandlingTr
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use WooCommerce\PayPalCommerce\WcGateway\WcInboxNotes\InboxNoteRegistrar;
 use WooCommerce\PayPalCommerce\WcGateway\WcTasks\Registrar\TaskRegistrarInterface;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 /**
  * Class WcGatewayModule
@@ -377,17 +377,17 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 					return;
 				}
 
-				$settings = $c->get( 'wcgateway.settings' );
-				assert( $settings instanceof ContainerInterface );
+				$settings = $c->get( 'settings.settings-provider' );
+				assert( $settings instanceof SettingsProvider );
 
-				if ( ! $settings->has( 'capture_on_status_change' ) || ! $settings->get( 'capture_on_status_change' ) ) {
+				if ( ! $settings->capture_on_status_change() ) {
 					return;
 				}
 
 				$gateway_repository = $c->get( 'wcgateway.gateway-repository' );
 				assert( $gateway_repository instanceof GatewayRepository );
 
-				// Only allow to proceed if the payment method is one of our Gateways.
+				// Only allow proceeding if the payment method is one of our Gateways.
 				if ( ! $gateway_repository->exists( $wc_order->get_payment_method() ) ) {
 					return;
 				}


### PR DESCRIPTION
### Description

Migrates the legacy setting `capture_on_status_change` to the new settings data model.

#### Special notes

- This setting is code-level-only, it has no UI equivalent to toggle it.
- During plugin update, the missing setting is extracted from the legacy settings (if present)
- If no legacy settings exist, the setting defaults to `true`
- A new WP filter allows to override the flag programmatically

#### New Filter

Name: `woocommerce_paypal_payments_capture_on_status_change`

Sample:
```php
add_filter( 'woocommerce_paypal_payments_capture_on_status_change', '_return_true' );
```