### PR TITLE
Enable Pay with Crypto feature flag by default (5941)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -536,7 +536,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 		return apply_filters(
 		// phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 			'woocommerce.feature-flags.woocommerce_paypal_payments.pwc_enabled',
-			getenv( 'PCP_PWC_ENABLED' ) === '1'
+			getenv( 'PCP_PWC_ENABLED' ) !== '0'
 		);
 	}
 }


### PR DESCRIPTION
### Description                                                                                                                                                                                               
  Enable Pay with Crypto feature flag by default so eligible merchants (USD currency + APM eligibility) automatically see the payment method under existing APMs.                                               
                                                                                                                                                                                                                                                                                                                                                                                                       
  ### Steps to Test                                                                                                                                                                                           
                                                                                                                                                                                                                
  1. Ensure store currency is set to USD                                                                                                                                                                      
  2. Go to WooCommerce → Settings → Payments
  3. Verify "Pay with Crypto" appears as an available payment method
  4. Set env `PCP_PWC_ENABLED=0` and confirm the method is hidden

