### PR TITLE
Filter ineligible gateways from registration and checkout (6004)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -110,7 +110,19 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 
 				$payment_methods = apply_filters( 'woocommerce_paypal_payments_local_apm_payment_methods', $payment_methods );
 
+				// Only register eligible gateways when the merchant is connected.
+				$is_connected       = $c->get( 'settings.flag.is-connected' );
+				$eligibility_checks = array();
+				if ( $is_connected ) {
+					$eligibility_service = $c->get( 'settings.service.payment_methods_eligibilities' );
+					$eligibility_checks  = $eligibility_service->get_eligibility_checks();
+				}
+
 				foreach ( $payment_methods as $key => $value ) {
+					$gateway_id = $value['id'];
+					if ( isset( $eligibility_checks[ $gateway_id ] ) && ! $eligibility_checks[ $gateway_id ]() ) {
+						continue;
+					}
 					$methods[] = $c->get( 'ppcp-local-apms.' . $key . '.wc-gateway' );
 				}
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -377,6 +377,17 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					$methods[] = $axo_gateway;
 				}
 
+				// Remove gateways where the merchant is not eligible.
+				$eligibility_service = $container->get( 'settings.service.payment_methods_eligibilities' );
+				$eligibility_checks  = $eligibility_service->get_eligibility_checks();
+				$methods             = array_filter(
+					$methods,
+					static function ( $gateway ) use ( $eligibility_checks ) {
+						$id = $gateway instanceof WC_Payment_Gateway ? $gateway->id : '';
+						return ! isset( $eligibility_checks[ $id ] ) || $eligibility_checks[ $id ]();
+					}
+				);
+
 				return $methods;
 			},
 			99


### PR DESCRIPTION
### Description

Add merchant eligibility filtering to gateway registration so that ineligible gateways (PWC, Apple Pay, Google Pay, etc.) no longer appear on the WooCommerce Payments screen or frontend checkout when the connected merchant lacks the required capabilities.                                                                                                                                                                                                                    
                                                        
Uses the existing `PaymentMethodsEligibilityService` — the same service the settings page already relies on — in two places:                                                                                                               
   - `LocalAlternativePaymentMethodsModule`: skips registering ineligible local APM gateways via `woocommerce_payment_gateways`.                                                                                                            
   - `SettingsModule`: filters all gateways added at priority 99 through eligibility checks.

### Steps to Test

   1. Connect a US sandbox merchant and enable Pay with Crypto, Apple Pay, and Google Pay.
   2. Disconnect the US merchant and connect a non-US merchant that lacks crypto/Apple Pay/Google Pay capabilities.
   3. Go to **WooCommerce → Settings → Payments** — previously enabled but now ineligible gateways should not appear.
   4. Go to the frontend checkout — those gateways should not appear as payment options.