### PR TITLE
ACDC - For unsupported countries for save payment method check box toggle visible for ACDC (5629)

### DIFF
--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -53,7 +53,8 @@ return array(
 				return $container->get( 'button.smart-button' );
 			},
 			$container->get( 'settings.settings-provider' ),
-			$container->get( 'wcgateway.configuration.card-configuration' )
+			$container->get( 'wcgateway.configuration.card-configuration' ),
+			$container->get( 'save-payment-methods.eligible' )
 		);
 	},
 	'blocks.settings.final_review_enabled' => static function ( ContainerInterface $container ): bool {

--- a/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
+++ b/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
@@ -52,6 +52,8 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 
 	protected CardPaymentsConfiguration $card_payments_configuration;
 
+	protected bool $save_payment_methods_eligible;
+
 	/**
 	 * @param AssetGetter                   $asset_getter
 	 * @param string                        $version The assets version.
@@ -59,6 +61,7 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 	 * @param SmartButtonInterface|callable $smart_button The smart button script loading handler.
 	 * @param SettingsProvider              $settings_provider The settings provider.
 	 * @param CardPaymentsConfiguration     $card_payments_configuration
+	 * @param bool                          $save_payment_methods_eligible Whether save payment methods is eligible for the current country.
 	 */
 	public function __construct(
 		AssetGetter $asset_getter,
@@ -66,15 +69,17 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 		CreditCardGateway $gateway,
 		$smart_button,
 		SettingsProvider $settings_provider,
-		CardPaymentsConfiguration $card_payments_configuration
+		CardPaymentsConfiguration $card_payments_configuration,
+		bool $save_payment_methods_eligible
 	) {
-		$this->name                        = CreditCardGateway::ID;
-		$this->asset_getter                = $asset_getter;
-		$this->version                     = $version;
-		$this->gateway                     = $gateway;
-		$this->smart_button                = $smart_button;
-		$this->plugin_settings             = $settings_provider;
-		$this->card_payments_configuration = $card_payments_configuration;
+		$this->name                          = CreditCardGateway::ID;
+		$this->asset_getter                  = $asset_getter;
+		$this->version                       = $version;
+		$this->gateway                       = $gateway;
+		$this->smart_button                  = $smart_button;
+		$this->plugin_settings               = $settings_provider;
+		$this->card_payments_configuration   = $card_payments_configuration;
+		$this->save_payment_methods_eligible = $save_payment_methods_eligible;
 	}
 
 	/**
@@ -123,7 +128,7 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 			'scriptData'          => $script_data,
 			'supports'            => $this->gateway->supports,
 			'save_card_text'      => esc_html__( 'Save your card', 'woocommerce-paypal-payments' ),
-			'is_vaulting_enabled' => $this->plugin_settings->save_card_details(),
+			'is_vaulting_enabled' => $this->save_payment_methods_eligible && $this->plugin_settings->save_card_details(),
 			'card_icons'          => $this->plugin_settings->card_icons(),
 			'name_on_card'        => $this->card_payments_configuration->show_name_on_card(),
 		);

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -347,6 +347,7 @@ class SmartButton implements SmartButtonInterface {
 				if (
 					CreditCardGateway::ID === $id
 					&& is_user_logged_in()
+					&& $this->vault_v3_enabled
 					&& $this->settings_provider->save_card_details()
 					&& apply_filters( 'woocommerce_paypal_payments_should_render_card_custom_fields', true )
 				) {

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -419,6 +419,10 @@ class SavePaymentMethodsModule implements ServiceModule, ExecutableModule {
 				add_filter(
 					'woocommerce_paypal_payments_credit_card_gateway_supports',
 					function ( array $supports ) use ( $c ): array {
+						if ( ! $c->get( 'save-payment-methods.eligible' ) ) {
+							return $supports;
+						}
+
 						$settings_provider = $c->get( 'settings.settings-provider' );
 						assert( $settings_provider instanceof SettingsProvider );
 


### PR DESCRIPTION
The "Save your card" checkbox appeared in ACDC checkout for countries ineligible for vaulting (e.g. Mexico). Both blocks and classic checkout paths only checked the DB setting, not country eligibility.            

### PR Changes                                                                                                                                                                                                      
  - Gate `is_vaulting_enabled` on `save-payment-methods.eligible` in `AdvancedCardPaymentMethod` (blocks).
  - Add `vault_v3_enabled` check in `SmartButton::render_dcc_wrapper()` (classic).
