### PR TITLE
Fix BCDC override flag (6024)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/DCCProductStatus.php
@@ -35,8 +35,6 @@ class DCCProductStatus extends ProductStatus {
 	}
 
 	public function check_local_state( bool $skip_filters = false ): ?bool {
-		$state = null;
-
 		if ( ! $skip_filters ) {
 			/**
 			 * Force BCDC (Standard Cards) for merchants migrated from legacy UI.
@@ -45,10 +43,15 @@ class DCCProductStatus extends ProductStatus {
 			 * in the legacy UI to maintain BCDC functionality in the new UI, regardless
 			 * of ACDC eligibility API responses.
 			 */
-			$state = apply_filters( 'woocommerce_paypal_payments_override_acdc_status_with_bcdc', null );
+			$bcdc_override = apply_filters( 'woocommerce_paypal_payments_override_acdc_status_with_bcdc', null );
+
+			if ( $bcdc_override === true ) {
+				// When overriding, short-circuit and mark ACDC as not available.
+				return false;
+			}
 		}
 
-		return is_bool( $state ) ? $state : parent::check_local_state();
+		return parent::check_local_state();
 	}
 
 	protected function check_api_response( SellerStatus $seller_status ): bool {

--- a/tests/PHPUnit/WcGateway/Helper/BCDCOverrideFlagTest.php
+++ b/tests/PHPUnit/WcGateway/Helper/BCDCOverrideFlagTest.php
@@ -1,0 +1,194 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\ProductStatusResultCache;
+use WooCommerce\PayPalCommerce\TestCase;
+
+use function Brain\Monkey\Filters\expectApplied;
+
+/**
+ * This test suite only covers the BCDC-Override-flag logic of the DCCProductStatus.
+ *
+ * @covers \WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus
+ */
+class BCDCOverrideFlagTest extends TestCase {
+
+	private const OVERRIDE_FLAG_KEY = 'woocommerce_paypal_payments_override_acdc_status_with_bcdc';
+
+	private PartnersEndpoint $partners_endpoint;
+	private FailureRegistry $api_failure_registry;
+	private ProductStatusResultCache $result_cache;
+	private DccApplies $dcc_applies;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->partners_endpoint    = Mockery::mock( PartnersEndpoint::class );
+		$this->api_failure_registry = Mockery::mock( FailureRegistry::class );
+		$this->result_cache         = Mockery::mock( ProductStatusResultCache::class );
+		$this->dcc_applies          = Mockery::mock( DccApplies::class );
+
+		defined( 'MONTH_IN_SECONDS' ) || define( 'MONTH_IN_SECONDS', 30 * 24 * 60 * 60 );
+	}
+
+	private function create_testee( bool $is_connected = true ): DCCProductStatus {
+		return new DCCProductStatus(
+			$is_connected,
+			$this->partners_endpoint,
+			$this->api_failure_registry,
+			$this->result_cache,
+			$this->dcc_applies
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// check_local_state() — filter active (skip_filters = false, default)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @scenario BCDC override is active (filter returns true)
+	 *
+	 * Given the BCDC migration override flag is set
+	 * When check_local_state() is called
+	 * Then it must return false — ACDC is NOT active for this merchant
+	 */
+	public function test_check_local_state_returns_false_when_bcdc_override_is_active(): void {
+		expectApplied( self::OVERRIDE_FLAG_KEY )
+			->once()
+			->with( null )
+			->andReturn( true );
+
+		// Cache should not be consulted when the filter short-circuits.
+		$this->result_cache->shouldNotReceive( 'get' );
+
+		$result = $this->create_testee()->check_local_state();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @scenario No BCDC override — filter returns null (default pass-through)
+	 *
+	 * Given no BCDC override is in place
+	 * And the result cache is empty
+	 * When check_local_state() is called
+	 * Then it falls through to the parent cache check and returns null
+	 */
+	public function test_check_local_state_returns_null_when_no_override_and_cache_is_empty(): void {
+		expectApplied( self::OVERRIDE_FLAG_KEY )
+			->once()
+			->with( null )
+			->andReturn( null );
+
+		$this->result_cache->shouldReceive( 'get' )
+			->with( DCCProductStatus::KEY )
+			->once()
+			->andReturn( '' );
+
+		$result = $this->create_testee()->check_local_state();
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @scenario No BCDC override — filter returns null, cache contains a positive result
+	 *
+	 * Given no BCDC override is in place
+	 * And the result cache holds a previously stored "yes" value
+	 * When check_local_state() is called
+	 * Then it returns true (ACDC eligible, sourced from cache)
+	 */
+	public function test_check_local_state_returns_true_when_no_override_and_cache_is_yes(): void {
+		expectApplied( self::OVERRIDE_FLAG_KEY )
+			->once()
+			->andReturn( null );
+
+		$this->result_cache->shouldReceive( 'get' )
+			->with( DCCProductStatus::KEY )
+			->once()
+			->andReturn( 'yes' );
+
+		$result = $this->create_testee()->check_local_state();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * @scenario No BCDC override — filter returns null, cache contains a negative result
+	 *
+	 * Given no BCDC override is in place
+	 * And the result cache holds a previously stored "no" value
+	 * When check_local_state() is called
+	 * Then it returns false (ACDC not eligible, sourced from cache)
+	 */
+	public function test_check_local_state_returns_false_when_no_override_and_cache_is_no(): void {
+		expectApplied( self::OVERRIDE_FLAG_KEY )
+			->once()
+			->andReturn( null );
+
+		$this->result_cache->shouldReceive( 'get' )
+			->with( DCCProductStatus::KEY )
+			->once()
+			->andReturn( 'no' );
+
+		$result = $this->create_testee()->check_local_state();
+
+		$this->assertFalse( $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// check_local_state() — filter skipped (skip_filters = true)
+	// -------------------------------------------------------------------------
+
+	/**
+	 * @scenario Filters are skipped explicitly — cache is empty
+	 *
+	 * Given skip_filters is true
+	 * And the result cache is empty
+	 * When check_local_state(true) is called
+	 * Then the override filter is never applied
+	 * And null is returned (no cached state available)
+	 */
+	public function test_check_local_state_skips_filter_and_returns_null_when_cache_is_empty(): void {
+		expectApplied( self::OVERRIDE_FLAG_KEY )
+			->never();
+
+		$this->result_cache->shouldReceive( 'get' )
+			->with( DCCProductStatus::KEY )
+			->once()
+			->andReturn( '' );
+
+		$result = $this->create_testee()->check_local_state( true );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * @scenario Filters are skipped explicitly — cache contains a positive result
+	 *
+	 * Given skip_filters is true
+	 * And the result cache holds "yes"
+	 * When check_local_state(true) is called
+	 * Then the override filter is never applied
+	 * And true is returned (ACDC eligible, from cache)
+	 */
+	public function test_check_local_state_skips_filter_and_returns_true_when_cache_is_yes(): void {
+		expectApplied( self::OVERRIDE_FLAG_KEY )
+			->never();
+
+		$this->result_cache->shouldReceive( 'get' )
+			->with( DCCProductStatus::KEY )
+			->once()
+			->andReturn( 'yes' );
+
+		$result = $this->create_testee()->check_local_state( true );
+
+		$this->assertTrue( $result );
+	}
+}


### PR DESCRIPTION
### Description

In a recent preparation to drop the legacy Settings class, we introduced a regression concerning the BCDC override flag.

#### Bug

The BCDC override flag should mean "Do not use ACDC, but only display BCDC" - due to a this bug, the decision was inverted, resulting in the flag being completely ignored:

- Flag present: Incorrectly treated as "Use ACDC, not BCDC"
- Flag absent: Correctly treated as "Use ACDC"

#### Steps to Test

Add the BCDC override flag to the DB and verify that no "Online Card Payments" are displayed in the plugins "Payment Methods" settings tab

The official way:
1. Onboard in the legacy UI with an ACDC merchant
2. Add the standard card payment button (the black button) and ensure to keep the ACDC checkbox unchecked
3. Update to the new UI → during migration, the BCDC Override flag is written to the DB

The fast way:
`wp option add "woocommerce_paypal_payments_override_acdc_status_with_bcdc" "1"`