### PR TITLE
Fix early country access (5713)

### DIFF
--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -14,12 +14,6 @@ use WooCommerce\PayPalCommerce\CardFields\Service\CardCaptureValidator;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
-	// @deprecated - use `card-fields.eligibility.check` instead.
-	'card-fields.eligible'                             => static function ( ContainerInterface $container ): bool {
-		$eligibility_check = $container->get( 'card-fields.eligibility.check' );
-
-		return $eligibility_check();
-	},
 	'card-fields.eligibility.check'                    => static function ( ContainerInterface $container ): callable {
 		$save_payment_methods_applies = $container->get( 'card-fields.helpers.save-payment-methods-applies' );
 		assert( $save_payment_methods_applies instanceof CardFieldsApplies );

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -39,10 +39,27 @@ class CardFieldsModule implements ServiceModule, ExecutableModule {
 	 * {@inheritDoc}
 	 */
 	public function run( ContainerInterface $c ): bool {
-		if ( ! $c->get( 'card-fields.eligible' ) ) {
-			return true;
-		}
+		add_action(
+			'init',
+			function () use ( $c ): void {
+				$eligibility_check = $c->get( 'card-fields.eligibility.check' );
+				if ( ! $eligibility_check() ) {
+					return;
+				}
 
+				$this->register_hooks( $c );
+			}
+		);
+
+		return true;
+	}
+
+	/**
+	 * Registers all hooks that require card-fields eligibility.
+	 *
+	 * @param ContainerInterface $c The DI container.
+	 */
+	private function register_hooks( ContainerInterface $c ): void {
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
 			static function ( array $components ) use ( $c ) {
@@ -203,7 +220,5 @@ class CardFieldsModule implements ServiceModule, ExecutableModule {
 				}
 			}
 		);
-
-		return true;
 	}
 }

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -108,9 +108,9 @@ return array(
 	'settings.data.onboarding'                            => static function ( ContainerInterface $container ): OnboardingProfile {
 		$can_use_casual_selling      = $container->get( 'settings.casual-selling.eligible' );
 		$can_use_vaulting            = $container->has( 'save-payment-methods.eligible' ) && $container->get( 'save-payment-methods.eligible' );
-		$can_use_card_payments       = $container->has( 'card-fields.eligible' ) && $container->get( 'card-fields.eligible' );
-		$can_use_subscriptions       = $container->has( 'wc-subscriptions.helper' ) && $container->get( 'wc-subscriptions.helper' )
-																								->plugin_is_active();
+		$can_use_card_payments       = $container->has( 'card-fields.eligibility.check' ) && $container->get( 'card-fields.eligibility.check' )();
+		$can_use_subscriptions       = $container->has( 'wc-subscriptions.helper' ) &&
+			$container->get( 'wc-subscriptions.helper' )->plugin_is_active();
 		$should_skip_payment_methods = class_exists( '\WC_Payments' );
 		$can_use_fastlane            = $container->get( 'axo.eligibility.check' );
 		$can_use_pay_later           = $container->get( 'button.helper.messages-apply' );

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -109,8 +109,8 @@ return array(
 		$can_use_casual_selling      = $container->get( 'settings.casual-selling.eligible' );
 		$can_use_vaulting            = $container->has( 'save-payment-methods.eligible' ) && $container->get( 'save-payment-methods.eligible' );
 		$can_use_card_payments       = $container->has( 'card-fields.eligibility.check' ) && $container->get( 'card-fields.eligibility.check' )();
-		$can_use_subscriptions       = $container->has( 'wc-subscriptions.helper' ) &&
-			$container->get( 'wc-subscriptions.helper' )->plugin_is_active();
+		$can_use_subscriptions       = $container->has( 'wc-subscriptions.helper' ) && $container->get( 'wc-subscriptions.helper' )
+																								->plugin_is_active();
 		$should_skip_payment_methods = class_exists( '\WC_Payments' );
 		$can_use_fastlane            = $container->get( 'axo.eligibility.check' );
 		$can_use_pay_later           = $container->get( 'button.helper.messages-apply' );


### PR DESCRIPTION
### Description

`CardFieldsModule::run()` previously resolved `card-fields.eligible` immediately during `plugins_loaded`, which eagerly called `wc_get_base_location()` before themes and late-loading plugins had a chance to filter the base country.
                           
The eligibility check is now deferred to `init` using the `card-fields.eligibility.check` callable, ensuring WooCommerce and the theme are fully initialized before the country is read.