### PR TITLE
Migration - When APM-S are part of PayPal gateway - What to expect after switching to New UI (5694)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -61,22 +61,17 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	}
 
 	public function migrate(): void {
-		if ( isset( $this->settings['disable_funding'] ) ) {
-			$disable_funding = (array) $this->settings['disable_funding'];
-			if ( ! in_array( 'venmo', $disable_funding, true ) ) {
-				$this->payment_settings->toggle_method_state( 'venmo', true );
-			}
+		$disable_funding = (array) ( $this->settings['disable_funding'] ?? array() );
+		if ( ! in_array( 'venmo', $disable_funding, true ) ) {
+			$this->payment_settings->toggle_method_state( 'venmo', true );
+		}
 
-			if ( ! empty( $this->settings['allow_local_apm_gateways'] ) ) {
-				foreach ( $this->local_apms as $apm ) {
-					if ( ! in_array( $apm['id'], $disable_funding, true ) ) {
-						$this->payment_settings->toggle_method_state( $apm['id'], true );
-					}
-				}
+		foreach ( $this->local_apms as $apm ) {
+			if ( ! in_array( $apm['id'], $disable_funding, true ) ) {
+				$this->payment_settings->toggle_method_state( $apm['id'], true );
 			}
 		}
 
-		$disable_funding         = (array) ( $this->settings['disable_funding'] ?? array() );
 		$card_funding_was_active = ! in_array( 'card', $disable_funding, true );
 
 		if ( $this->is_bcdc_enabled_for_acdc_merchant() ) {

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -716,6 +716,59 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
 			/**
+			 * Retroactive fix for local APMs not enabled after migration when
+			 * allow_local_apm_gateways was false.
+			 *
+			 * In versions up to 3.4.1, the migration only enabled local APMs when
+			 * allow_local_apm_gateways was truthy. When it was false, APMs were shown
+			 * inside the PayPal button, not as separate gateways. The new UI always
+			 * treats APMs as separate gateways, so skipping them left them invisible.
+			 *
+			 * @param false|string $previous_version The previously installed plugin version,
+			 *                                       or false on first installation.
+			 */
+			static function ( $previous_version ) use ( $container ): void {
+				if ( $previous_version && version_compare( $previous_version, '3.4.1', 'gt' ) ) {
+					return;
+				}
+
+				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) !== '1' ) {
+					return;
+				}
+
+				$legacy_settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
+
+				// Only fix merchants who had allow_local_apm_gateways falsy.
+				// Truthy merchants were migrated correctly.
+				if ( ! empty( $legacy_settings['allow_local_apm_gateways'] ) ) {
+					return;
+				}
+
+				$payment_settings = $container->get( 'settings.data.payment' );
+				assert( $payment_settings instanceof PaymentSettings );
+
+				$local_apms      = $container->get( 'ppcp-local-apms.payment-methods' );
+				$disable_funding = (array) ( $legacy_settings['disable_funding'] ?? array() );
+				$changed         = false;
+
+				foreach ( $local_apms as $apm ) {
+					if ( ! in_array( $apm['id'], $disable_funding, true )
+						&& ! $payment_settings->is_method_enabled( $apm['id'] )
+					) {
+						$payment_settings->toggle_method_state( $apm['id'], true );
+						$changed = true;
+					}
+				}
+
+				if ( $changed ) {
+					$payment_settings->save();
+				}
+			}
+		);
+
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			/**
 			 * Migrates payment level processing setting during plugin update.
 			 *
 			 * For merchants updating from version 3.3.2 or older, disables Level 2/3

--- a/tests/integration/PHPUnit/Settings/Service/Migration/PaymentSettingsMigrationTest.php
+++ b/tests/integration/PHPUnit/Settings/Service/Migration/PaymentSettingsMigrationTest.php
@@ -1,0 +1,164 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Settings\Service\Migration;
+
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager;
+use WooCommerce\PayPalCommerce\Settings\Service\Migration\PaymentSettingsMigration;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
+use WooCommerce\PayPalCommerce\Tests\Integration\TestCase;
+
+/**
+ * Tests for PaymentSettingsMigration, specifically the allow_local_apm_gateways fix.
+ */
+class PaymentSettingsMigrationTest extends TestCase {
+
+	protected const OLD_SETTINGS_OPTION = 'woocommerce-ppcp-settings';
+
+	/**
+	 * @var PaymentSettings
+	 */
+	private PaymentSettings $payment_settings;
+
+	/**
+	 * @var array
+	 */
+	private array $local_apms;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$container              = $this->getContainer();
+		$this->payment_settings = $container->get( 'settings.data.payment' );
+		$this->local_apms       = $container->get( 'ppcp-local-apms.payment-methods' );
+		$this->cleanUp();
+	}
+
+	protected function tearDown(): void {
+		$this->cleanUp();
+		parent::tearDown();
+	}
+
+	private function cleanUp(): void {
+		delete_option( self::OLD_SETTINGS_OPTION );
+		delete_option( 'woocommerce-ppcp-data-payment' );
+		delete_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE );
+
+		foreach ( $this->local_apms as $apm ) {
+			delete_option( 'woocommerce_' . $apm['id'] . '_settings' );
+		}
+	}
+
+	private function createMigration( array $settings ): PaymentSettingsMigration {
+		$container = $this->getContainer();
+
+		return new PaymentSettingsMigration(
+			$settings,
+			$this->payment_settings,
+			$container->get( 'api.helpers.dccapplies' ),
+			$container->get( 'wcgateway.helper.dcc-product-status' ),
+			$container->get( 'wcgateway.configuration.card-configuration' ),
+			$this->local_apms
+		);
+	}
+
+	/**
+	 * APMs should be enabled after migration even when allow_local_apm_gateways was false.
+	 */
+	public function testApmsEnabledWhenAllowLocalApmGatewaysFalse(): void {
+		$settings = array(
+			'allow_local_apm_gateways' => false,
+			'disable_funding'          => array(),
+		);
+
+		$migration = $this->createMigration( $settings );
+		$migration->migrate();
+
+		foreach ( $this->local_apms as $apm ) {
+			$this->assertTrue(
+				$this->payment_settings->is_method_enabled( $apm['id'] ),
+				"APM {$apm['id']} should be enabled when allow_local_apm_gateways is false and not in disable_funding."
+			);
+		}
+	}
+
+	/**
+	 * APMs should be enabled after migration when allow_local_apm_gateways was true (existing behavior).
+	 */
+	public function testApmsEnabledWhenAllowLocalApmGatewaysTrue(): void {
+		$settings = array(
+			'allow_local_apm_gateways' => true,
+			'disable_funding'          => array(),
+		);
+
+		$migration = $this->createMigration( $settings );
+		$migration->migrate();
+
+		foreach ( $this->local_apms as $apm ) {
+			$this->assertTrue(
+				$this->payment_settings->is_method_enabled( $apm['id'] ),
+				"APM {$apm['id']} should be enabled when allow_local_apm_gateways is true."
+			);
+		}
+	}
+
+	/**
+	 * APMs in disable_funding should remain disabled regardless of allow_local_apm_gateways.
+	 */
+	public function testApmsInDisableFundingStillExcluded(): void {
+		$first_apm = reset( $this->local_apms );
+
+		$settings = array(
+			'allow_local_apm_gateways' => false,
+			'disable_funding'          => array( $first_apm['id'] ),
+		);
+
+		$migration = $this->createMigration( $settings );
+		$migration->migrate();
+
+		$this->assertFalse(
+			$this->payment_settings->is_method_enabled( $first_apm['id'] ),
+			"APM {$first_apm['id']} should remain disabled when in disable_funding."
+		);
+
+		$remaining_apms = array_slice( $this->local_apms, 1 );
+		foreach ( $remaining_apms as $apm ) {
+			$this->assertTrue(
+				$this->payment_settings->is_method_enabled( $apm['id'] ),
+				"APM {$apm['id']} should be enabled when not in disable_funding."
+			);
+		}
+	}
+
+	/**
+	 * Venmo should still be enabled when not in disable_funding.
+	 */
+	public function testVenmoEnabledWhenNotInDisableFunding(): void {
+		$settings = array(
+			'allow_local_apm_gateways' => false,
+			'disable_funding'          => array(),
+		);
+
+		$migration = $this->createMigration( $settings );
+		$migration->migrate();
+
+		$this->assertTrue( $this->payment_settings->is_method_enabled( 'venmo' ) );
+	}
+
+	/**
+	 * Venmo should not be enabled when in disable_funding.
+	 */
+	public function testVenmoDisabledWhenInDisableFunding(): void {
+		$settings = array(
+			'allow_local_apm_gateways' => false,
+			'disable_funding'          => array( 'venmo' ),
+		);
+
+		$migration = $this->createMigration( $settings );
+		$migration->migrate();
+
+		$this->assertFalse( $this->payment_settings->is_method_enabled( 'venmo' ) );
+	}
+}


### PR DESCRIPTION
When merchants had `allow_local_apm_gateways` set to false in the legacy UI (APMs rendered inside the PayPal Smart Button), the migration to the new UI skipped enabling them as separate gateways. Since the new UI has no "inside PayPal" mode, those APMs ended up disabled everywhere,  invisible on checkout.

This PR removes the `allow_local_apm_gateways` guard from the migration so APMs are always enabled based on disable_funding. Added a retroactive fix hook for merchants who already migrated with the bug.  