### PR TITLE
Crypto: Fix query param parsing for local APM cancel/return URLs (5976)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -258,12 +258,14 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 			return;
 		}
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$cancelled = wc_clean( wp_unslash( $_GET['cancelled'] ?? '' ) );
-		$cancelled = is_array( $cancelled ) ? '' : (string) $cancelled;
-		$order_key = wc_clean( wp_unslash( $_GET['key'] ?? '' ) );
-		$order_key = is_array( $order_key ) ? '' : (string) $order_key;
-		// phpcs:enable
+		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$query_string = (string) wp_parse_url( $request_uri, PHP_URL_QUERY );
+		$params       = array();
+		wp_parse_str( str_replace( '?', '&', $query_string ), $params );
+		$params = array_map( 'sanitize_text_field', $params );
+
+		$cancelled = $params['cancelled'] ?? '';
+		$order_key = $params['key'] ?? '';
 
 		if (
 			! $this->is_local_apm( $order->get_payment_method(), $this->payment_methods )
@@ -278,7 +280,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 			return;
 		}
 
-		$this->handle_cancelled_standard_apm( $order );
+		$this->handle_cancelled_standard_apm( $order, $params );
 	}
 
 	/**
@@ -300,7 +302,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 			);
 
 			$order->add_order_note(
-				__( 'Payment was cancelled during the Pay with Crypto payment process.', 'woocommerce-paypal-payments' ),
+				__( 'Payment was cancelled or failed during the Pay with Crypto payment process.', 'woocommerce-paypal-payments' ),
 				1
 			);
 		}
@@ -320,11 +322,11 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 	 * Handle cancelled standard APM payments (non-crypto).
 	 *
 	 * @param WC_Order $order The WooCommerce order.
+	 * @param array    $params Parsed query parameters from the return URL.
 	 * @return void
 	 */
-	private function handle_cancelled_standard_apm( WC_Order $order ): void {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$error_code = wc_clean( wp_unslash( $_GET['errorcode'] ?? '' ) );
+	private function handle_cancelled_standard_apm( WC_Order $order, array $params = array() ): void {
+		$error_code = $params['errorcode'] ?? '';
 
 		if ( $error_code === 'processing_error' || $error_code === 'payment_error' ) {
 			$order->update_status(
@@ -500,9 +502,13 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 			return;
 		}
 
-		// Check if 'token' exists anywhere in the URL first.
-		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		if ( strpos( $request_uri, 'token=' ) === false ) {
+		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$query_string = (string) wp_parse_url( $request_uri, PHP_URL_QUERY );
+		$params       = array();
+		wp_parse_str( str_replace( '?', '&', $query_string ), $params );
+		$params = array_map( 'sanitize_text_field', $params );
+
+		if ( empty( $params['token'] ) || ! empty( $params['cancelled'] ) ) {
 			return;
 		}
 

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -258,7 +258,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 			return;
 		}
 
-		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( (string) wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( (string) $_SERVER['REQUEST_URI'] ) ) : '';
 		$query_string = (string) wp_parse_url( $request_uri, PHP_URL_QUERY );
 		$params       = array();
 		wp_parse_str( str_replace( '?', '&', $query_string ), $params );
@@ -502,7 +502,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 			return;
 		}
 
-		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( (string) wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( (string) $_SERVER['REQUEST_URI'] ) ) : '';
 		$query_string = (string) wp_parse_url( $request_uri, PHP_URL_QUERY );
 		$params       = array();
 		wp_parse_str( str_replace( '?', '&', $query_string ), $params );

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -258,7 +258,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 			return;
 		}
 
-		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( (string) wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		$query_string = (string) wp_parse_url( $request_uri, PHP_URL_QUERY );
 		$params       = array();
 		wp_parse_str( str_replace( '?', '&', $query_string ), $params );
@@ -502,7 +502,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 			return;
 		}
 
-		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		$request_uri  = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( (string) wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		$query_string = (string) wp_parse_url( $request_uri, PHP_URL_QUERY );
 		$params       = array();
 		wp_parse_str( str_replace( '?', '&', $query_string ), $params );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2805,7 +2805,7 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$url of function esc_url_raw expects string, array\|string given\.$#'
 			identifier: argument.type
-			count: 2
+			count: 3
 			path: modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
 
 		-


### PR DESCRIPTION
### Description                                                                                                                                                                          
                                                                                                                                                                                           
Fix query parameter parsing for local APM cancel and return URLs.                                                                                                                      
                                                                                                                                                                                           
PayPal appends `?token=<ORDER_ID>` to return/cancel URLs using `?` as delimiter instead of `&`, even when the URL already contains query parameters. This causes PHP to misparse the query string — for example, the `cancelled` parameter gets parsed as `"true?token=XXXXX"` instead of `"true"`, and `token` is lost entirely.                                             
                                                                                                                                                                                           
This also caused the token-stripping redirect in `handle_pwc_order_received_redirect` to fire before the cancel handler could process the request, silently preventing orders from transitioning to `failed` status.                                                                                                                                                        

### Steps to Test

  1. Enable Pay with Crypto gateway
  2. Add a product to cart and proceed to checkout, select "Pay with Crypto"
  3. On the PayPal crypto page, click failed/cancel
  4. Verify the order status transitions to `failed`
  5. Repeat steps 2-3, but complete the payment
  6. Verify the order completes via webhooks and the order-received page displays correctly
  7. Test a standard APM cancel flow (e.g. Bancontact/iDEAL) to confirm no regression

