### PR TITLE
Pay for order - wrong PayPal buttons style (5577)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -49,6 +49,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CartCheckoutDetector;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
@@ -1545,7 +1546,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			$context = 'checkout-block-express';
 		}
 		if ( $context === 'pay-now' ) {
-			$context = 'checkout';
+			$context = CartCheckoutDetector::has_block_checkout() ? 'checkout-block-express' : 'checkout';
 		}
 
 		$defaults = array(


### PR DESCRIPTION
PayPal buttons on the order-pay page always use classic checkout styling, even when the store uses block checkout, causing mismatched button styles.                                                        
                                         
This PR updates `style_for_context()` to detect the store's checkout type and apply the matching styling context.         