### PR TITLE
Migration - PUI and OXXO do not persist after upgrade from 2.9.6 to 4.0.0 (6046)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -65,11 +65,8 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		$this->local_apms        = $local_apms;
 		$this->dcc_configuration = $dcc_configuration;
 
-		$pui_option               = get_option( 'woocommerce_' . PayUponInvoiceGateway::ID . '_settings', array() );
-		$this->legacy_pui_enabled = is_array( $pui_option ) && ( $pui_option['enabled'] ?? 'no' ) === 'yes';
-
-		$oxxo_option               = get_option( 'woocommerce_' . OXXO::ID . '_settings', array() );
-		$this->legacy_oxxo_enabled = is_array( $oxxo_option ) && ( $oxxo_option['enabled'] ?? 'no' ) === 'yes';
+		$this->legacy_pui_enabled  = $this->payment_settings->is_method_enabled( PayUponInvoiceGateway::ID );
+		$this->legacy_oxxo_enabled = $this->payment_settings->is_method_enabled( OXXO::ID );
 	}
 
 	public function migrate(): void {

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -16,6 +16,8 @@ use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\OXXO\OXXO;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\DCCProductStatus;
 
@@ -44,6 +46,10 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	 */
 	protected array $local_apms;
 
+	protected bool $legacy_pui_enabled;
+
+	protected bool $legacy_oxxo_enabled;
+
 	public function __construct(
 		array $settings,
 		PaymentSettings $payment_settings,
@@ -58,6 +64,12 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		$this->dcc_status        = $dcc_status;
 		$this->local_apms        = $local_apms;
 		$this->dcc_configuration = $dcc_configuration;
+
+		$pui_option               = get_option( 'woocommerce_' . PayUponInvoiceGateway::ID . '_settings', array() );
+		$this->legacy_pui_enabled = is_array( $pui_option ) && ( $pui_option['enabled'] ?? 'no' ) === 'yes';
+
+		$oxxo_option               = get_option( 'woocommerce_' . OXXO::ID . '_settings', array() );
+		$this->legacy_oxxo_enabled = is_array( $oxxo_option ) && ( $oxxo_option['enabled'] ?? 'no' ) === 'yes';
 	}
 
 	public function migrate(): void {
@@ -99,6 +111,14 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			if ( ! empty( $pui_settings['customer_service_instructions'] ) ) {
 				$this->payment_settings->set_pui_customer_service_instructions( $pui_settings['customer_service_instructions'] );
 			}
+		}
+
+		if ( $this->legacy_pui_enabled ) {
+			$this->payment_settings->toggle_method_state( PayUponInvoiceGateway::ID, true );
+		}
+
+		if ( $this->legacy_oxxo_enabled ) {
+			$this->payment_settings->toggle_method_state( OXXO::ID, true );
 		}
 
 		if ( isset( $this->settings['dcc_name_on_card'] ) ) {

--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -46,10 +46,6 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	 */
 	protected array $local_apms;
 
-	protected bool $legacy_pui_enabled;
-
-	protected bool $legacy_oxxo_enabled;
-
 	public function __construct(
 		array $settings,
 		PaymentSettings $payment_settings,
@@ -64,9 +60,6 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		$this->dcc_status        = $dcc_status;
 		$this->local_apms        = $local_apms;
 		$this->dcc_configuration = $dcc_configuration;
-
-		$this->legacy_pui_enabled  = $this->payment_settings->is_method_enabled( PayUponInvoiceGateway::ID );
-		$this->legacy_oxxo_enabled = $this->payment_settings->is_method_enabled( OXXO::ID );
 	}
 
 	public function migrate(): void {
@@ -110,11 +103,11 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			}
 		}
 
-		if ( $this->legacy_pui_enabled ) {
+		if ( $this->payment_settings->is_method_enabled( PayUponInvoiceGateway::ID ) ) {
 			$this->payment_settings->toggle_method_state( PayUponInvoiceGateway::ID, true );
 		}
 
-		if ( $this->legacy_oxxo_enabled ) {
+		if ( $this->payment_settings->is_method_enabled( OXXO::ID ) ) {
 			$this->payment_settings->toggle_method_state( OXXO::ID, true );
 		}
 


### PR DESCRIPTION
This PR ensures PUI and OXXO are enabled after migrating from 2.9.6 to 4.0.0.