### PR TITLE
ACDC eligible merchant onboarded as BCDC on fresh install (6055)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -168,7 +168,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 			 */
 			static function ( $previous_version ) use ( $container ): void {
 				// Only run this migration logic when updating from version 3.1.1 or older.
-				if ( $previous_version && version_compare( $previous_version, '3.1.1', 'gt' ) ) {
+				// Skip on fresh installs (no previous version) since there's nothing to migrate.
+				if ( ! $previous_version || version_compare( $previous_version, '3.1.1', 'gt' ) ) {
 					return;
 				}
 


### PR DESCRIPTION
After a fresh install and onboarding, ACDC is not visible, BCDC shows instead. Disconnecting and reconnecting fixes it.                                                            

The `woocommerce_paypal_payments_gateway_migrate` handler runs on fresh installs because its version guard (`$previous_version && ...`) evaluates to false when there's no previous version. The fallback legacy-settings check then interprets empty settings as "card was active + DCC not enabled" = BCDC merchant, and sets the `BCDC_MIGRATION_OVERRIDE` option. This forces ACDC off via the `override_acdc_status_with_bcdc` filter.

This PR changes the condition from `$previous_version && version_compare(...)` to `! $previous_version || version_compare(...)` so fresh installs (where `$previous_version` is false) are properly skipped.