### PR TITLE
Migration banner — remove Fastlane US-only text (6056)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/screens/settings/_migration-banner.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/settings/_migration-banner.scss
@@ -36,7 +36,7 @@
 
 	.ppcp-r-settings-migration-banner__icon {
 		text-align: center;
-		flex: 0.6;
+		width: 35%;
 		height: 100%;
 		position: relative;
 

--- a/modules/ppcp-settings/resources/css/components/screens/settings/_migration-banner.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/settings/_migration-banner.scss
@@ -36,7 +36,7 @@
 
 	.ppcp-r-settings-migration-banner__icon {
 		text-align: center;
-		flex: 0.7;
+		flex: 0.6;
 		height: 100%;
 		position: relative;
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -124,7 +124,7 @@ const TabPaymentMethods = () => {
 						'woocommerce-paypal-payments'
 					) }
 					description={ __(
-						'Upgrade your card payments with embedded card fields for faster checkout, Apple Pay and Google Pay support, and Fastlane one-click checkout (US only).',
+						'Your card payments can do more. Unlock lower processing fees, advanced fraud protection, and a faster checkout with Apple Pay, Google Pay, and Fastlane one-click checkout.',
 						'woocommerce-paypal-payments'
 					) }
 					actionProps={ {
@@ -132,7 +132,7 @@ const TabPaymentMethods = () => {
 							{
 								type: 'secondary',
 								text: __(
-									'Upgrade now',
+									'Unlock now',
 									'woocommerce-paypal-payments'
 								),
 							},


### PR DESCRIPTION
### Issue Description

Since v4.0.0, Fastlane is available for all ACDC countries, not just the US. The migration banner text still referenced "US only", which is no longer accurate and should be removed.

### PR Description

- Updated the migration banner description to remove the Fastlane US-only qualifier
- Minor CSS improvement to better align the description text

**New banner text:**

> Your card payments can do more. Unlock lower processing fees, advanced fraud protection, and a faster checkout with Apple Pay, Google Pay, and Fastlane one-click checkout.

<img width="1067" height="704" alt="Screenshot 2026-03-18 at 14 46 30" src="https://github.com/user-attachments/assets/dcddd7e4-9e83-4a18-9c2d-14ff4c599889" />