### PR TITLE
Derive card-fields country matrix from DCC matrix (5840)

### DIFF
--- a/modules/ppcp-card-fields/services.php
+++ b/modules/ppcp-card-fields/services.php
@@ -31,50 +31,9 @@ return array(
 	'card-fields.supported-country-matrix'             => static function ( ContainerInterface $container ): array {
 		return apply_filters(
 			'woocommerce_paypal_payments_card_fields_supported_country_matrix',
-			array(
-				'AU',
-				'AT',
-				'BE',
-				'BG',
-				'CA',
-				'CN',
-				'C2',
-				'CY',
-				'CZ',
-				'DK',
-				'EE',
-				'FI',
-				'FR',
-				'DE',
-				'GR',
-				'HK',
-				'HU',
-				'IE',
-				'IT',
-				'LV',
-				'LI',
-				'LT',
-				'LU',
-				'MT',
-				'MX',
-				'NL',
-				'PL',
-				'PT',
-				'RO',
-				'SK',
-				'SG',
-				'SI',
-				'ES',
-				'SE',
-				'GB',
-				'US',
-				'NO',
-				'YT',
-				'RE',
-				'GP',
-				'GF',
-				'MQ',
-			)
+			// Since Vault v3, country coverage is identical to ACDC countries.
+			// TODO: Replace the card-fields.supported-country-matrix service dependency with api.dcc-supported-country-currency-matrix.
+			array_keys( $container->get( 'api.dcc-supported-country-currency-matrix' ) )
 		);
 	},
 	'card-fields.service.card-capture-validator'       => static function ( ContainerInterface $container ): CardCaptureValidator {


### PR DESCRIPTION
### Description

Derive `card-fields.supported-country-matrix` from `api.dcc-supported-country-currency-matrix` instead of maintaining a separate hardcoded country list. Since Vault v3, card fields country coverage is identical to ACDC countries, so this eliminates the duplicate list and ensures new ACDC countries (e.g. JP) automatically get card fields support.

This fixes Fastlane and Card Fields not appearing in onboarding for countries present in the DCC matrix but missing from the card-fields list.

### Steps to Test

1. Go to **WooCommerce → Settings → General** and set store country to Japan, currency to JPY
2. Go to **WooCommerce → PayPal Payments** onboarding wizard
3. Verify that Fastlane and Card Fields options appear in the payment methods step
4. Repeat for other DCC-supported countries (e.g. CN with USD) and confirm they also show card payment options