### PR TITLE
Migrate "capture for virtual only" (6026)

### DIFF
--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -235,9 +235,16 @@ class OnboardingProfile extends AbstractDataModel {
 	public function set_gateways_synced( bool $synced ): void {
 		$this->data['gateways_synced'] = $synced;
 
-		// If enabling the flag, trigger the action.
-		if ( $synced ) {
+		// No sync = no action needed.
+		if ( ! $synced ) {
+			return;
+		}
+
+		// Timing is important - we can sync only on/after woocommerce_init fired.
+		if ( did_action( 'woocommerce_init' ) ) {
 			do_action( 'woocommerce_paypal_payments_sync_gateways' );
+		} else {
+			add_action( 'woocommerce_init', static fn() => do_action( 'woocommerce_paypal_payments_sync_gateways' ) );
 		}
 	}
 

--- a/tests/PHPUnit/Settings/Service/Migration/SettingsTabMigrationTest.php
+++ b/tests/PHPUnit/Settings/Service/Migration/SettingsTabMigrationTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\TestCase;
+
+/**
+ * Tests the capture_for_virtual_only → capture_virtual_orders migration
+ * in SettingsTabMigration.
+ */
+class SettingsTabMigrationTest extends TestCase {
+
+	/**
+	 * @dataProvider capture_for_virtual_only_cases
+	 *
+	 * @param array     $legacy_settings    Legacy woocommerce-ppcp-settings values.
+	 * @param bool|null $expected_authorize Expected authorize_only value, or null if absent.
+	 * @param bool|null $expected_capture   Expected capture_virtual_orders value, or null if
+	 *                                      absent.
+	 */
+	public function test_capture_for_virtual_only_migration(
+		array $legacy_settings,
+		?bool $expected_authorize,
+		?bool $expected_capture
+	): void {
+		$captured_data  = null;
+		$settings_model = Mockery::mock( SettingsModel::class );
+		$settings_model->shouldReceive( 'from_array' )
+			->once()
+			->withArgs( function ( array $data ) use ( &$captured_data ) {
+				$captured_data = $data;
+
+				return true;
+			} );
+		$settings_model->shouldReceive( 'save' )->once();
+
+		$migration = new SettingsTabMigration( $legacy_settings, $settings_model );
+		$migration->migrate();
+
+		if ( $expected_authorize !== null ) {
+			$this->assertArrayHasKey( 'authorize_only', $captured_data );
+			$this->assertSame( $expected_authorize, $captured_data['authorize_only'] );
+		}
+
+		if ( $expected_capture !== null ) {
+			$this->assertArrayHasKey( 'capture_virtual_orders', $captured_data );
+			$this->assertSame( $expected_capture, $captured_data['capture_virtual_orders'] );
+		} else {
+			$this->assertArrayNotHasKey( 'capture_virtual_orders', $captured_data );
+		}
+	}
+
+	public function capture_for_virtual_only_cases(): array {
+		return array(
+			'authorize + capture_for_virtual_only true'  => array(
+				'legacy_settings'    => array(
+					'intent'                   => 'authorize',
+					'capture_for_virtual_only' => true,
+				),
+				'expected_authorize' => true,
+				'expected_capture'   => true,
+			),
+			'authorize + capture_for_virtual_only false' => array(
+				'legacy_settings'    => array(
+					'intent'                   => 'authorize',
+					'capture_for_virtual_only' => false,
+				),
+				'expected_authorize' => true,
+				'expected_capture'   => false,
+			),
+			'capture intent without virtual-only flag'   => array(
+				'legacy_settings'    => array(
+					'intent' => 'capture',
+				),
+				'expected_authorize' => false,
+				'expected_capture'   => null,
+			),
+			'capture + capture_for_virtual_only true'    => array(
+				'legacy_settings'    => array(
+					'intent'                   => 'capture',
+					'capture_for_virtual_only' => true,
+				),
+				'expected_authorize' => false,
+				'expected_capture'   => true,
+			),
+		);
+	}
+}


### PR DESCRIPTION
### Description

Adds unit tests to confirm correct migration of the `capture_virtual_orders` flag from the legacy settings to the new React settings.

Note: The issue itself was already resolved in commit 2e5547a24 - this PR only adds unit tests to prevent future regressions

#### Timing Error

This PR also fixes a one-time fatal error that happened when auto migrating legacy to React. The issue was caused by accessing some WooCommerce functions too early (during `init` at prio `-1`, while WooCommerce initializes at `init` prio `10`)

Testing this issue is difficult, but basically follows those steps:
1. Start with plugin version 2.9.6, ensure there are NO react UI settings in the DB; i.e. a "clean legacy DB"
2. Install the latest plugin version to trigger the auto-migration during update
3. Directly after the plugin update you should see a fatal error, which disappears on page reload


https://github.com/user-attachments/assets/c9ca08ed-d5e3-48a9-b102-86ed24de05fa
