### PR TITLE
Migration - PUI and OXXO do not persist after upgrade from 2.9.6 to 4.0.0 (6046 v2)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -46,6 +46,10 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 	 */
 	protected array $local_apms;
 
+	protected bool $legacy_pui_enabled;
+
+	protected bool $legacy_oxxo_enabled;
+
 	public function __construct(
 		array $settings,
 		PaymentSettings $payment_settings,
@@ -60,6 +64,12 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 		$this->dcc_status        = $dcc_status;
 		$this->local_apms        = $local_apms;
 		$this->dcc_configuration = $dcc_configuration;
+
+		$pui_option               = get_option( 'woocommerce_' . PayUponInvoiceGateway::ID . '_settings', array() );
+		$this->legacy_pui_enabled = is_array( $pui_option ) && ( $pui_option['enabled'] ?? 'no' ) === 'yes';
+
+		$oxxo_option               = get_option( 'woocommerce_' . OXXO::ID . '_settings', array() );
+		$this->legacy_oxxo_enabled = is_array( $oxxo_option ) && ( $oxxo_option['enabled'] ?? 'no' ) === 'yes';
 	}
 
 	public function migrate(): void {
@@ -103,11 +113,11 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			}
 		}
 
-		if ( $this->payment_settings->is_method_enabled( PayUponInvoiceGateway::ID ) ) {
+		if ( $this->legacy_pui_enabled ) {
 			$this->payment_settings->toggle_method_state( PayUponInvoiceGateway::ID, true );
 		}
 
-		if ( $this->payment_settings->is_method_enabled( OXXO::ID ) ) {
+		if ( $this->legacy_oxxo_enabled ) {
 			$this->payment_settings->toggle_method_state( OXXO::ID, true );
 		}
 


### PR DESCRIPTION
This PR reverts #4194 to the first commit changes which fixed the issue,  the initial fix works because the `PaymentSettingsMigration` object is constructed before `MigrationManager::migrate()` is called. So `get_option()` in the constructor captures the real value before the sync overwrites it.