### PR TITLE
On fresh site after payment with PUI orders stuck on status on hold as webhook are not registered (6062)

### DIFF
--- a/modules/ppcp-webhooks/src/WebhookModule.php
+++ b/modules/ppcp-webhooks/src/WebhookModule.php
@@ -74,6 +74,13 @@ class WebhookModule implements ServiceModule, FactoryModule, ExecutableModule {
 			}
 		);
 
+		/**
+		 * Auto-recover missing webhook registration on admin pages.
+		 *
+		 * Registers webhooks when a connected merchant has no active subscription,
+		 * e.g. after a fresh install or if the webhook was lost. Throttled to once
+		 * every 5 minutes.
+		 */
 		add_action(
 			'admin_init',
 			static function () use ( $container ) {
@@ -95,15 +102,20 @@ class WebhookModule implements ServiceModule, FactoryModule, ExecutableModule {
 			}
 		);
 
+		/**
+		 * Force webhook re-registration for PUI/OXXO merchants on plugin upgrade.
+		 *
+		 * Clears the stored webhook so the auto-recovery hook above re-registers it
+		 * with the full event list required by PUI/OXXO. Only runs on upgrades (not
+		 * fresh installs) when PUI or OXXO is enabled.
+		 */
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
 			static function ( $installed_plugin_version ) {
-				// Skip fresh installs.
 				if ( ! $installed_plugin_version ) {
 					return;
 				}
 
-				// Only resubscribe for PUI or OXXO merchants.
 				$pui_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings', array() );
 				$pui_enabled  = is_array( $pui_settings ) && ( $pui_settings['enabled'] ?? 'no' ) === 'yes';
 
@@ -114,7 +126,6 @@ class WebhookModule implements ServiceModule, FactoryModule, ExecutableModule {
 					return;
 				}
 
-				// Clear stored webhook to force re-registration via self-healing.
 				delete_option( WebhookRegistrar::KEY );
 			}
 		);

--- a/modules/ppcp-webhooks/src/WebhookModule.php
+++ b/modules/ppcp-webhooks/src/WebhookModule.php
@@ -75,6 +75,51 @@ class WebhookModule implements ServiceModule, FactoryModule, ExecutableModule {
 		);
 
 		add_action(
+			'admin_init',
+			static function () use ( $container ) {
+				$is_connected  = $container->get( 'settings.flag.is-connected' );
+				$is_registered = $container->get( 'webhook.is-registered' );
+				if ( ! $is_connected || $is_registered ) {
+					return;
+				}
+
+				$throttle_key = 'ppcp_webhook_auto_register_throttle';
+				if ( get_transient( $throttle_key ) ) {
+					return;
+				}
+				set_transient( $throttle_key, true, 5 * MINUTE_IN_SECONDS );
+
+				$registrar = $container->get( 'webhook.registrar' );
+				assert( $registrar instanceof WebhookRegistrar );
+				$registrar->register();
+			}
+		);
+
+		add_action(
+			'woocommerce_paypal_payments_gateway_migrate',
+			static function ( $installed_plugin_version ) use ( $container ) {
+				// Skip fresh installs.
+				if ( ! $installed_plugin_version ) {
+					return;
+				}
+
+				// Only resubscribe for PUI or OXXO merchants.
+				$pui_settings = get_option( 'woocommerce_ppcp-pay-upon-invoice-gateway_settings', array() );
+				$pui_enabled  = is_array( $pui_settings ) && ( $pui_settings['enabled'] ?? 'no' ) === 'yes';
+
+				$oxxo_settings = get_option( 'woocommerce_ppcp-oxxo-gateway_settings', array() );
+				$oxxo_enabled  = is_array( $oxxo_settings ) && ( $oxxo_settings['enabled'] ?? 'no' ) === 'yes';
+
+				if ( ! $pui_enabled && ! $oxxo_enabled ) {
+					return;
+				}
+
+				// Clear stored webhook to force re-registration via self-healing.
+				delete_option( WebhookRegistrar::KEY );
+			}
+		);
+
+		add_action(
 			'wc_ajax_' . ResubscribeEndpoint::ENDPOINT,
 			static function () use ( $container ) {
 				$endpoint = $container->get( 'webhook.endpoint.resubscribe' );

--- a/modules/ppcp-webhooks/src/WebhookModule.php
+++ b/modules/ppcp-webhooks/src/WebhookModule.php
@@ -97,7 +97,7 @@ class WebhookModule implements ServiceModule, FactoryModule, ExecutableModule {
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',
-			static function ( $installed_plugin_version ) use ( $container ) {
+			static function ( $installed_plugin_version ) {
 				// Skip fresh installs.
 				if ( ! $installed_plugin_version ) {
 					return;


### PR DESCRIPTION
This PR ensures webhooks are registered on new plugin installs, also resubscribes on plugin upgrades for PUI and OXXO.