### PR TITLE
Plugin upgrade - Venmo (disabled in legacy) is enabled after upgrade to new version (6066)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1388,7 +1388,11 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 
 		$disabled_funding_sources = $this->disabled_funding_sources->sources( $current_context );
 
-		$enable_funding = array( 'venmo' );
+		$enable_funding = array();
+
+		if ( $this->settings_provider->venmo_enabled() ) {
+			$enable_funding[] = 'venmo';
+		}
 
 		if ( $this->is_pay_later_button_enabled_for_location( $current_context ) ) {
 			$enable_funding[] = 'paylater';


### PR DESCRIPTION
After upgrading , Venmo appeared on checkout even when the merchant had disabled it via "Disable Alternative Payment Methods" in legacy settings. The migration logic correctly set Venmo as disabled, but `SmartButton.php` unconditionally added `venmo` to the PayPal SDK's `enable-funding` parameter, which takes precedence over `disable-funding`.                     

This PR fixes it by conditionally adding Venmo to `enable-funding` only when `venmo_enabled()` returns `true`.       