### PR TITLE
Migration - PayPal title and description not saved after migration (6068)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/PaymentSettingsMigration.php
@@ -125,6 +125,19 @@ class PaymentSettingsMigration implements SettingsMigrationInterface {
 			$this->payment_settings->set_cardholder_name( $this->settings['dcc_name_on_card'] === 'yes' );
 		}
 
+		if ( ! empty( $this->settings['title'] ) ) {
+			$this->payment_settings->set_method_title( 'ppcp-gateway', $this->settings['title'] );
+		}
+		if ( ! empty( $this->settings['description'] ) ) {
+			$this->payment_settings->set_method_description( 'ppcp-gateway', $this->settings['description'] );
+		}
+		if ( ! empty( $this->settings['dcc_gateway_title'] ) ) {
+			$this->payment_settings->set_method_title( CreditCardGateway::ID, $this->settings['dcc_gateway_title'] );
+		}
+		if ( ! empty( $this->settings['dcc_gateway_description'] ) ) {
+			$this->payment_settings->set_method_description( CreditCardGateway::ID, $this->settings['dcc_gateway_description'] );
+		}
+
 		$this->payment_settings->save();
 	}
 


### PR DESCRIPTION
Custom PayPal and Credit Card gateway titles/descriptions set by merchants were lost when upgrading from legacy UI, because the settings migration didn't copy `title/description/dcc_gateway_title/dcc_gateway_description` from the legacy `woocommerce-ppcp-settings` option to the new WooCommerce gateway options.

This PR adds `title` and `description` migration for both gateways in `PaymentSettingsMigration::migrate()`, so custom values are now preserved during upgrade.     