### PR TITLE
Harden plugin init to prevent errors during update (6063)

### DIFF
--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -35,9 +35,9 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 ! defined( 'CONNECT_WOO_URL' ) && define( 'CONNECT_WOO_URL', 'https://api.woocommerce.com/integrations/ppc' );
 ! defined( 'CONNECT_WOO_SANDBOX_URL' ) && define( 'CONNECT_WOO_SANDBOX_URL', 'https://api.woocommerce.com/integrations/ppcsandbox' );
 
-( function () {
+( static function () {
 	$autoload_filepath = __DIR__ . '/vendor/autoload.php';
-	if ( file_exists( $autoload_filepath ) && ! class_exists( '\WooCommerce\PayPalCommerce\PluginModule' ) ) {
+	if ( ! class_exists( '\WooCommerce\PayPalCommerce\PluginModule' ) && file_exists( $autoload_filepath ) ) {
 		require $autoload_filepath;
 	}
 
@@ -140,8 +140,8 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 	add_action(
 		'plugins_loaded',
-		function () {
-			// Skip full bootstrap during plugin upgrades to prevent class-mismatch
+		static function () {
+			// Skip full bootstrap during manual plugin updates to prevent class-mismatch
 			// fatals when old in-memory code autoloads new files from disk.
 			if ( 'update.php' === ( $GLOBALS['pagenow'] ?? '' ) ) {
 				return;
@@ -155,7 +155,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 			add_action(
 				'init',
-				function () {
+				static function () {
 					$current_plugin_version   = PPCP::container()->get( 'ppcp.plugin-version' );
 					$installed_plugin_version = get_option( 'woocommerce-ppcp-version' );
 					if ( $installed_plugin_version !== $current_plugin_version ) {
@@ -180,7 +180,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 	);
 	register_activation_hook(
 		__FILE__,
-		function () {
+		static function () {
 			init();
 			/**
 			 * The hook fired in register_activation_hook.
@@ -190,7 +190,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 	);
 	register_deactivation_hook(
 		__FILE__,
-		function () {
+		static function () {
 			init();
 			/**
 			 * The hook fired in register_deactivation_hook.
@@ -207,7 +207,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 		 * @param array $links
 		 * @return array
 		 */
-		function ( $links ) {
+		static function ( $links ) {
 			if ( ! is_woocommerce_activated() ) {
 				return $links;
 			}
@@ -234,7 +234,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 		 * @param string $file
 		 * @return array
 		 */
-		function ( $links, $file ) {
+		static function ( $links, $file ) {
 			if ( plugin_basename( __FILE__ ) !== $file ) {
 				return $links;
 			}
@@ -271,7 +271,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 
 	add_action(
 		'before_woocommerce_init',
-		function () {
+		static function () {
 			if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 				/**
 				 * Skip WC class check.

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -74,8 +74,8 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 	/**
 	 * Initialize the plugin and its modules.
 	 */
-	function init(): void {
-		$root_dir = __DIR__;
+	function init(): bool {
+		static $initialized = false;
 
 		if ( ! is_woocommerce_activated() ) {
 			show_admin_notice_and_deactivate(
@@ -105,7 +105,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 				)
 			);
 
-			return;
+			return $initialized;
 		}
 		if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
 			show_admin_notice_and_deactivate(
@@ -119,11 +119,11 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 				)
 			);
 
-			return;
+			return $initialized;
 		}
 
-		static $initialized;
 		if ( ! $initialized ) {
+			$root_dir  = __DIR__;
 			$bootstrap = require "$root_dir/bootstrap.php";
 
 			$app_container = $bootstrap( $root_dir );
@@ -136,6 +136,8 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 			 */
 			do_action( 'woocommerce_paypal_payments_built_container', $app_container );
 		}
+
+		return $initialized;
 	}
 
 	add_action(
@@ -147,9 +149,7 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 				return;
 			}
 
-			init();
-
-			if ( ! is_woocommerce_activated() ) {
+			if ( ! init() ) {
 				return;
 			}
 

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -141,6 +141,12 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 	add_action(
 		'plugins_loaded',
 		function () {
+			// Skip full bootstrap during plugin upgrades to prevent class-mismatch
+			// fatals when old in-memory code autoloads new files from disk.
+			if ( 'update.php' === ( $GLOBALS['pagenow'] ?? '' ) ) {
+				return;
+			}
+
 			init();
 
 			if ( ! is_woocommerce_activated() ) {


### PR DESCRIPTION
### Description

Skip plugin bootstrap on `update.php` to prevent fatal errors during manual zip uploads ("Upload Plugin").

When WordPress replaces plugin files mid-request, old in-memory hooks can autoload new class files that changed during the update (different constructor arguments, changed base class, etc) with an incompatible, old parent classes still in memory. The `$pagenow` guard prevents this by not initializing the plugin on that page.

Also contains a small refactor/clean-up of `init()` to return bool indicating whether the container is available, replacing the separate `is_woocommerce_activated()` re-check in `plugins_loaded`.
                                    
### How to test

Not possible to test with this release, it catches _future_ errors

Only verify that the plugin can be updated and initializes as expected