### PR TITLE
Fix merchant config broken after upgrade when frontend page loads first

### DIFF
--- a/modules/ppcp-settings/src/Data/OnboardingProfile.php
+++ b/modules/ppcp-settings/src/Data/OnboardingProfile.php
@@ -230,13 +230,16 @@ class OnboardingProfile extends AbstractDataModel {
 	/**
 	 * Set whether gateways have been synced.
 	 *
-	 * @param bool $synced Whether gateways have been synced.
+	 * @param bool $synced    Whether gateways have been synced.
+	 * @param bool $skip_sync When true, only updates the flag without triggering
+	 *                        the gateway sync action. Use during migration where
+	 *                        gateway states are already handled by the migration itself.
 	 */
-	public function set_gateways_synced( bool $synced ): void {
+	public function set_gateways_synced( bool $synced, bool $skip_sync = false ): void {
 		$this->data['gateways_synced'] = $synced;
 
 		// No sync = no action needed.
-		if ( ! $synced ) {
+		if ( ! $synced || $skip_sync ) {
 			return;
 		}
 

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -64,7 +64,7 @@ class MigrationManager implements SettingsMigrationInterface {
 
 		$this->onboarding_profile->set_completed( true );
 		$this->onboarding_profile->set_gateways_refreshed( true );
-		$this->onboarding_profile->set_gateways_synced( true );
+		$this->onboarding_profile->set_gateways_synced( true, true );
 		$this->onboarding_profile->save();
 
 		$migrations = array(

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -118,7 +118,14 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 						$migration_manager->migrate();
 					}
 				}
+			}
+		);
 
+		// Resolve unknown seller type on all pages (not just admin), so frontend
+		// page loads after migration also fix the seller_type saved as 'unknown'.
+		add_action(
+			'init',
+			static function () use ( $container ): void {
 				$seller_type_resolver = $container->get( 'settings.service.seller-type-resolver' );
 				assert( $seller_type_resolver instanceof SellerTypeResolver );
 

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -40,7 +40,9 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayUponInvoice\PayUponInvoiceGateway;
 use WooCommerce\PayPalCommerce\Settings\Service\SettingsDataManager;
 use WooCommerce\PayPalCommerce\Settings\DTO\ConfigurationFlagsDTO;
+use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\Settings\Enum\ProductChoicesEnum;
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Axo\Helper\CompatibilityChecker;
@@ -94,6 +96,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					return;
 				}
 
+				self::pre_populate_credentials( $container );
+
 				$migration_manager = $container->get( 'settings.service.data-migration' );
 				assert( $migration_manager instanceof MigrationManager );
 
@@ -107,6 +111,8 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) !== '1' ) {
 					$legacy_settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
 					if ( ! empty( $legacy_settings['client_id'] ) ) {
+						self::pre_populate_credentials( $container );
+
 						$migration_manager = $container->get( 'settings.service.data-migration' );
 						assert( $migration_manager instanceof MigrationManager );
 						$migration_manager->migrate();
@@ -870,6 +876,44 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		);
 
 		return true;
+	}
+
+	/**
+	 * Pre-populates GeneralSettings with legacy credentials before migration
+	 * DI services are resolved.
+	 *
+	 * DI services like api.key, api.secret, api.merchant_id are resolved from
+	 * SettingsProvider → GeneralSettings → woocommerce-ppcp-data-common.
+	 * This option does not exist before migration, so these DI services resolve
+	 * to empty strings. Pre-populating ensures PartnersEndpoint has working
+	 * credentials during migration so seller_status() API call succeeds.
+	 *
+	 * @param ContainerInterface $container The DI container.
+	 */
+	private static function pre_populate_credentials( ContainerInterface $container ): void {
+		$general = $container->get( 'settings.data.general' );
+		assert( $general instanceof GeneralSettings );
+
+		if ( $general->is_merchant_connected() ) {
+			return;
+		}
+
+		$legacy = (array) get_option( 'woocommerce-ppcp-settings', array() );
+		if ( empty( $legacy['client_id'] ) || empty( $legacy['merchant_id'] ) ) {
+			return;
+		}
+
+		$general->set_merchant_data(
+			new MerchantConnectionDTO(
+				! empty( $legacy['sandbox_on'] ),
+				$legacy['client_id'],
+				$legacy['client_secret'] ?? '',
+				$legacy['merchant_id'],
+				$legacy['merchant_email'] ?? '',
+				'',
+				SellerTypeEnum::UNKNOWN
+			)
+		);
 	}
 
 	/**

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 define('TESTS_ROOT_DIR', dirname(__DIR__));
 define('ROOT_DIR', dirname(TESTS_ROOT_DIR));
 
+require_once TESTS_ROOT_DIR . '/inc/wp_functions.php';
 require_once ROOT_DIR . '/vendor/autoload.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway_CC.php';

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 define('TESTS_ROOT_DIR', dirname(__DIR__));
 define('ROOT_DIR', dirname(TESTS_ROOT_DIR));
 
-require_once TESTS_ROOT_DIR . '/inc/wp_functions.php';
 require_once ROOT_DIR . '/vendor/autoload.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway_CC.php';


### PR DESCRIPTION
After upgrading from 2.9.6 to 4.0.0, loading a frontend page (e.g. blocks checkout) before visiting admin settings breaks merchant config: features disappear, wrong connection label, BCDC disabled. Admin visit first works fine because SellerTypeResolver only ran on admin_init.

### PR Changes
  - Pre-populate `GeneralSettings` with legacy credentials before migration so API calls have working credentials
  - Move `SellerTypeResolver` from `admin_init` to init so it also runs on frontend pages
  - Skip gateway sync during migration to prevent reset of payment method states