### PR TITLE
Fix Google Pay "Invalid label" error in blocks cart after legacy migration 

### DIFF
--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -600,7 +600,7 @@ class SettingsProvider {
 	}
 
 	public function applepay_styles( string $location = 'checkout' ): LocationStylingDTO {
-		return apply_filters( 'woocommerce_paypal_payments_applepay_button_styles', $this->button_styling( $location ) );
+		return apply_filters( 'woocommerce_paypal_payments_applepay_button_styles', clone $this->button_styling( $location ) );
 	}
 
 	public function applepay_button_language(): string {
@@ -624,7 +624,7 @@ class SettingsProvider {
 	}
 
 	public function googlepay_styles( string $location = 'checkout' ): LocationStylingDTO {
-		return apply_filters( 'woocommerce_paypal_payments_googlepay_button_styles', $this->button_styling( $location ) );
+		return apply_filters( 'woocommerce_paypal_payments_googlepay_button_styles', clone $this->button_styling( $location ) );
 	}
 
 	public function googlepay_button_language(): string {

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -495,25 +495,25 @@ class SettingsProvider {
 	public function button_styling( string $location ): LocationStylingDTO {
 		switch ( $location ) {
 			case 'product':
-				return $this->styling_product();
+				return clone $this->styling_product();
 
 			case 'cart':
 			case 'cart-block':
-				return $this->styling_cart();
+				return clone $this->styling_cart();
 
 			case 'mini-cart':
 			case 'mini_cart':
-				return $this->styling_mini_cart();
+				return clone $this->styling_mini_cart();
 
 			case 'checkout-block':
 			case 'express_checkout':
-				return $this->styling_express_checkout();
+				return clone $this->styling_express_checkout();
 
 			case 'checkout':
 			case 'classic_checkout':
 			case 'pay-now':
 			default:
-				return $this->styling_classic_checkout();
+				return clone $this->styling_classic_checkout();
 		}
 	}
 
@@ -600,7 +600,7 @@ class SettingsProvider {
 	}
 
 	public function applepay_styles( string $location = 'checkout' ): LocationStylingDTO {
-		return apply_filters( 'woocommerce_paypal_payments_applepay_button_styles', clone $this->button_styling( $location ) );
+		return apply_filters( 'woocommerce_paypal_payments_applepay_button_styles', $this->button_styling( $location ) );
 	}
 
 	public function applepay_button_language(): string {
@@ -624,7 +624,7 @@ class SettingsProvider {
 	}
 
 	public function googlepay_styles( string $location = 'checkout' ): LocationStylingDTO {
-		return apply_filters( 'woocommerce_paypal_payments_googlepay_button_styles', clone $this->button_styling( $location ) );
+		return apply_filters( 'woocommerce_paypal_payments_googlepay_button_styles', $this->button_styling( $location ) );
 	}
 
 	public function googlepay_button_language(): string {


### PR DESCRIPTION
After upgrading from legacy UI with Google Pay enabled, the blocks cart throws `Error: Invalid label: plain`. 

The Google Pay filter mutates the shared `LocationStylingDTO` instance in-place (converting label `paypal` to `plain`), so when PayPal Smart Buttons reads the same object, it receives an invalid label value.                                                                                                       
                                                                                                                                                                                                                       
This PR clones the DTO in `SettingsProvider::button_styling()` so every consumer gets an independent copy. This prevents any filter from mutating the shared instance and protects all current and future consumers.