### PR TITLE
fix(button): always apply per-location Pay Later messaging styles (6077)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -880,9 +880,6 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			$amount = WC()->cart->get_total( 'raw' );
 		}
 
-		$styling_per_location = $this->settings_provider->pay_later_styling_per_location();
-		$location             = $styling_per_location ? $location : 'general';
-
 		// Map checkout-block and cart-block message options to checkout and cart options.
 		switch ( $location ) {
 			case 'checkout-block':

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -634,13 +634,6 @@ class SettingsProvider {
 	// ----- PAY LATER -----
 
 	/**
-	 * Whether Pay Later messaging styling should be customized per location.
-	 */
-	public function pay_later_styling_per_location(): bool {
-		return $this->styling_settings->get_pay_later_styling_per_location();
-	}
-
-	/**
 	 * Whether the given gateway is enabled.
 	 */
 	public function gateway_enabled( string $method_id ): bool {

--- a/modules/ppcp-settings/src/Data/StylingSettings.php
+++ b/modules/ppcp-settings/src/Data/StylingSettings.php
@@ -53,12 +53,11 @@ class StylingSettings extends AbstractDataModel {
 	 */
 	protected function get_defaults(): array {
 		return array(
-			'cart'                           => new LocationStylingDTO( 'cart' ),
-			'classic_checkout'               => new LocationStylingDTO( 'classic_checkout' ),
-			'express_checkout'               => new LocationStylingDTO( 'express_checkout' ),
-			'mini_cart'                      => new LocationStylingDTO( 'mini_cart', false ),
-			'product'                        => new LocationStylingDTO( 'product' ),
-			'pay_later_styling_per_location' => false,
+			'cart'             => new LocationStylingDTO( 'cart' ),
+			'classic_checkout' => new LocationStylingDTO( 'classic_checkout' ),
+			'express_checkout' => new LocationStylingDTO( 'express_checkout' ),
+			'mini_cart'        => new LocationStylingDTO( 'mini_cart', false ),
+			'product'          => new LocationStylingDTO( 'product' ),
 		);
 	}
 
@@ -155,14 +154,6 @@ class StylingSettings extends AbstractDataModel {
 	 */
 	public function set_product( $styles ): void {
 		$this->data['product'] = $this->sanitizer->sanitize_location_style( $styles );
-	}
-
-	public function get_pay_later_styling_per_location(): bool {
-		return (bool) $this->data['pay_later_styling_per_location'];
-	}
-
-	public function set_pay_later_styling_per_location( bool $enabled ): void {
-		$this->data['pay_later_styling_per_location'] = $enabled;
 	}
 
 	/**


### PR DESCRIPTION
### Issue Description

Pay Later messaging styles (text color, banner style, etc.) were not being applied on the frontend for any page location — product, cart, checkout, home, shop — both on fresh installs and after migrating from older plugin versions.

The root cause was the `pay_later_styling_per_location` toggle. When this setting was `false` (the default), `SmartButton::message_values()` fell back to `'general'` as the location key for all pages, which does not correspond to any stored messaging style. This meant per-location settings were ignored entirely regardless of what the merchant configured.

On migration the same issue occurred, as the toggle was not carried over, defaulting to `false` and causing the fallback.

### PR Description

Removes the `pay_later_styling_per_location` setting entirely, as per-location Pay Later messaging styles are always applied in the new UI. The legacy toggle was only meaningful in the old settings context, which is being removed.

**`StylingSettings`:**
- Removes `pay_later_styling_per_location` from `get_defaults()`
- Removes `get_pay_later_styling_per_location()` and `set_pay_later_styling_per_location()` methods

**`SettingsProvider`:**
- Removes `pay_later_styling_per_location()` method

**`SmartButton`:**
- Removes the `$styling_per_location` conditional in `message_values()`
- Location is now always passed directly to `pay_later_messaging_style()`, ensuring per-location styles are always respected