### PR TITLE
Fix error caused by running migration too early (6078)

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -98,10 +98,20 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 
 				self::pre_populate_credentials( $container );
 
-				$migration_manager = $container->get( 'settings.service.data-migration' );
-				assert( $migration_manager instanceof MigrationManager );
+				$run_migration = static function () use ( $container ): void {
+					$migration_manager = $container->get( 'settings.service.data-migration' );
+					assert( $migration_manager instanceof MigrationManager );
 
-				$migration_manager->migrate();
+					$migration_manager->migrate();
+				};
+
+				// Timing is important - migration saves gateway options, which triggers WooCommerce
+				// hooks that require WC to be fully initialized.
+				if ( did_action( 'woocommerce_init' ) ) {
+					$run_migration();
+				} else {
+					add_action( 'woocommerce_init', $run_migration );
+				}
 			}
 		);
 


### PR DESCRIPTION
### Description

During plugin auto-migration, a legacy-to-react migration routine was called too early and ended in a WooCommerce error.

This PR adds a condition to postpone the migration to the earliest point when WooCommerce is fully initialized. This is a one time process, so delayed timing is not sensitive here, as it impacts a single request on wp-admin, likely directly after the plugin update.

### Steps to reproduce

**In 2.9.6:**

- Onboard as US merchant
- Enable the PayPal gateway
- Enable the Google Pay method
- Enable separate gateways for APMs
- Configure the Google Pay gateway - just enter a custom title

**Migrate to 4.0.0:**
- Install the new zip package
- After the update, visit any admin page, eg the "installed plugins" page

→ This first admin page load **displayed a fatal error** which disappeared after reloading the page.