### PR TITLE
PayPal Subscriptions renewals incorrectly processed (5580)

### DIFF
--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -202,7 +202,8 @@ class RenewalHandler {
 	 */
 	public function renew( \WC_Order $wc_order ): void {
 		try {
-			$subscription = wcs_get_subscription( $wc_order->get_id() );
+			$subscriptions = wcs_get_subscriptions_for_renewal_order( $wc_order );
+			$subscription  = end( $subscriptions );
 			if ( $subscription instanceof WC_Subscription ) {
 				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';
 				if ( $subscription_id ) {


### PR DESCRIPTION
Fixes #4191.

`RenewalHandler::renew()` receives a renewal order but passes its ID to `wcs_get_subscription()`, which expects a subscription ID. This causes `wcs_get_subscription()` to return `false`, silently skipping the PayPal Subscriptions API check and failing renewals with "Subscription could not be loaded."                                                                                                                         
                                                                                                                                                                                                                       
This PR replaces `wcs_get_subscription($wc_order->get_id())` with `wcs_get_subscriptions_for_renewal_order($wc_order)`, which is the correct WooCommerce Subscriptions API for retrieving subscriptions from a renewal order.                                                                                                                                    
                                                                                 