### PR TITLE
fix(settings): Restrict Venmo, Google Pay and Apple Pay to locations enabled in styling settings (6079)

### DIFF
--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -157,7 +157,6 @@ return array(
 			$container->get( 'applepay.asset_getter' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'applepay.data_to_scripts' ),
-			$container->get( 'wcgateway.settings.status' ),
 			$container->get( 'button.helper.cart-products' ),
 			$container->get( 'button.helper.context' )
 		);

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -158,7 +158,8 @@ return array(
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'applepay.data_to_scripts' ),
 			$container->get( 'wcgateway.settings.status' ),
-			$container->get( 'button.helper.cart-products' )
+			$container->get( 'button.helper.cart-products' ),
+			$container->get( 'button.helper.context' )
 		);
 	},
 	'applepay.blocks-payment-method'           => static function ( ContainerInterface $container ): PaymentMethodTypeInterface {
@@ -167,7 +168,9 @@ return array(
 			$container->get( 'applepay.asset_getter' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'applepay.button' ),
-			$container->get( 'blocks.method' )
+			$container->get( 'blocks.method' ),
+			$container->get( 'button.helper.context' ),
+			$container->get( 'settings.settings-provider' )
 		);
 	},
 

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\Applepay\Assets\PropertiesDictionary;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\Applepay\Helper\AvailabilityNotice;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -132,12 +132,23 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 				$settings = $c->get( 'settings.settings-provider' );
 				assert( $settings instanceof SettingsProvider );
 
-				if ( $settings->applepay_enabled() ) {
-					$applepay_gateway = $c->get( 'applepay.wc-gateway' );
-					assert( $applepay_gateway instanceof WC_Payment_Gateway );
-
-					$methods[] = $applepay_gateway;
+				if ( ! $settings->applepay_enabled() ) {
+					return $methods;
 				}
+
+				$context = $c->get( 'button.helper.context' );
+				assert( $context instanceof Context );
+
+				$page_methods = $settings->button_styling( $context->context() )->methods;
+
+				if ( ! in_array( ApplePayGateway::ID, $page_methods, true ) ) {
+					return $methods;
+				}
+
+				$applepay_gateway = $c->get( 'applepay.wc-gateway' );
+				assert( $applepay_gateway instanceof WC_Payment_Gateway );
+
+				$methods[] = $applepay_gateway;
 
 				return $methods;
 			}

--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -154,6 +154,41 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		/**
+		 * Filters the available payment gateways to remove the Apple Pay gateway
+		 * when the button is disabled for the current location (e.g., classic checkout) in the styling settings.
+		 * This is necessary because WooCommerce automatically includes the gateway when it is enabled,
+		 * even if the button is hidden via settings.
+		 */
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			static function ( $methods ) use ( $c ) {
+				if ( ! is_array( $methods ) ) {
+					return $methods;
+				}
+
+				$context = $c->get( 'button.helper.context' );
+				assert( $context instanceof Context );
+
+				$current_context = $context->context();
+
+				if ( $current_context !== 'checkout' ) {
+					return $methods;
+				}
+
+				$settings = $c->get( 'settings.settings-provider' );
+				assert( $settings instanceof SettingsProvider );
+
+				$page_methods = $settings->button_styling( $current_context )->methods;
+
+				if ( ! in_array( ApplePayGateway::ID, $page_methods, true ) ) {
+					unset( $methods[ ApplePayGateway::ID ] );
+				}
+
+				return $methods;
+			}
+		);
+
 		add_action(
 			'woocommerce_review_order_after_submit',
 			function () {

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -767,14 +767,8 @@ class ApplePayButton implements ButtonInterface {
 	 */
 	public function render(): bool {
 		if ( ! $this->is_enabled() ) {
-			return true;
+			return false;
 		}
-
-		$button_enabled_product  = $this->settings_status->is_smart_button_enabled_for_location( 'product' );
-		$button_enabled_cart     = $this->settings_status->is_smart_button_enabled_for_location( 'cart' );
-		$button_enabled_checkout = true;
-		$button_enabled_payorder = true;
-		$button_enabled_minicart = $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' );
 
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
@@ -783,67 +777,49 @@ class ApplePayButton implements ButtonInterface {
 				return $components;
 			}
 		);
-		if ( $button_enabled_product ) {
-			$default_hookname   = 'woocommerce_paypal_payments_single_product_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_applepay_render_hook_product', $default_hookname );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hookname;
-			add_action(
-				$render_placeholder,
-				function () {
-					$this->applepay_button();
-				}
-			);
-		}
-		if ( $button_enabled_cart ) {
-			$default_hook_name  = 'woocommerce_paypal_payments_cart_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_applepay_cart_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
-					$this->applepay_button();
-				}
-			);
-		}
 
-		if ( $button_enabled_checkout ) { // @phpstan-ignore if.alwaysTrue
-			$default_hook_name  = 'woocommerce_paypal_payments_checkout_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_applepay_checkout_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
+		$button_hooks = array(
+			array(
+				'hook'     => 'woocommerce_paypal_payments_single_product_button_render',
+				'filter'   => 'woocommerce_paypal_payments_applepay_render_hook_product',
+				'callback' => fn() => $this->applepay_button(),
+			),
+			array(
+				'hook'     => 'woocommerce_paypal_payments_cart_button_render',
+				'filter'   => 'woocommerce_paypal_payments_applepay_cart_button_render_hook',
+				'callback' => fn() => $this->applepay_button(),
+			),
+			array(
+				'hook'     => 'woocommerce_paypal_payments_checkout_button_render',
+				'filter'   => 'woocommerce_paypal_payments_applepay_checkout_button_render_hook',
+				'callback' => function () {
 					$this->applepay_button();
 					$this->hide_gateway_until_eligible();
 				},
-				21
-			);
-		}
-		if ( $button_enabled_payorder ) { // @phpstan-ignore if.alwaysTrue
-			$default_hook_name  = 'woocommerce_paypal_payments_payorder_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_applepay_payorder_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
+				'priority' => 21,
+			),
+			array(
+				'hook'     => 'woocommerce_paypal_payments_payorder_button_render',
+				'filter'   => 'woocommerce_paypal_payments_applepay_payorder_button_render_hook',
+				'callback' => function () {
 					$this->applepay_button();
 					$this->hide_gateway_until_eligible();
 				},
-				21
-			);
-		}
+				'priority' => 21,
+			),
+			array(
+				'hook'     => 'woocommerce_paypal_payments_minicart_button_render',
+				'filter'   => 'woocommerce_paypal_payments_applepay_minicart_button_render_hook',
+				'callback' => fn() => print( '<span id="ppc-button-applepay-container-minicart" class="ppcp-button-apm ppcp-button-applepay ppcp-button-minicart"></span>' ),
+				'priority' => 21,
+			),
+		);
 
-		if ( $button_enabled_minicart ) {
-			$default_hook_name  = 'woocommerce_paypal_payments_minicart_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_applepay_minicart_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
-					echo '<span id="ppc-button-applepay-container-minicart" class="ppcp-button-apm ppcp-button-applepay ppcp-button-minicart"></span>';
-				},
-				21
-			);
+		foreach ( $button_hooks as $entry ) {
+			$hook = apply_filters( $entry['filter'], $entry['hook'] );
+			$hook = is_string( $hook ) ? $hook : $entry['hook'];
+
+			add_action( $hook, $entry['callback'], $entry['priority'] ?? 21 );
 		}
 
 		return true;

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -19,7 +19,6 @@ use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\RequestHandlerTrait;
 
@@ -39,7 +38,6 @@ class ApplePayButton implements ButtonInterface {
 	private string $version;
 	private AssetGetter $asset_getter;
 	private DataToAppleButtonScripts $script_data;
-	private SettingsStatus $settings_status;
 	protected CartProductsHelper $cart_products;
 	private Context $context;
 
@@ -51,7 +49,6 @@ class ApplePayButton implements ButtonInterface {
 		AssetGetter $asset_getter,
 		string $version,
 		DataToAppleButtonScripts $data,
-		SettingsStatus $settings_status,
 		CartProductsHelper $cart_products,
 		Context $context
 	) {
@@ -65,7 +62,6 @@ class ApplePayButton implements ButtonInterface {
 		$this->asset_getter       = $asset_getter;
 		$this->version            = $version;
 		$this->script_data        = $data;
-		$this->settings_status    = $settings_status;
 		$this->cart_products      = $cart_products;
 		$this->context            = $context;
 	}

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -12,18 +12,17 @@ namespace WooCommerce\PayPalCommerce\Applepay\Assets;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WC_Cart;
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\RequestHandlerTrait;
 
-/**
- * Class ApplePayButton
- */
 class ApplePayButton implements ButtonInterface {
 	use RequestHandlerTrait;
 
@@ -42,20 +41,8 @@ class ApplePayButton implements ButtonInterface {
 	private DataToAppleButtonScripts $script_data;
 	private SettingsStatus $settings_status;
 	protected CartProductsHelper $cart_products;
+	private Context $context;
 
-	/**
-	 * PayPalPaymentMethod constructor.
-	 *
-	 * @param SettingsProvider         $settings_provider The settings provider.
-	 * @param PaymentSettings          $payment_settings The payment settings.
-	 * @param LoggerInterface          $logger The logger.
-	 * @param OrderProcessor           $order_processor The Order processor.
-	 * @param AssetGetter              $asset_getter
-	 * @param string                   $version The module version.
-	 * @param DataToAppleButtonScripts $data The data to send to the ApplePay button script.
-	 * @param SettingsStatus           $settings_status The settings status helper.
-	 * @param CartProductsHelper       $cart_products The cart products helper.
-	 */
 	public function __construct(
 		SettingsProvider $settings_provider,
 		PaymentSettings $payment_settings,
@@ -65,7 +52,8 @@ class ApplePayButton implements ButtonInterface {
 		string $version,
 		DataToAppleButtonScripts $data,
 		SettingsStatus $settings_status,
-		CartProductsHelper $cart_products
+		CartProductsHelper $cart_products,
+		Context $context
 	) {
 		$this->settings_provider  = $settings_provider;
 		$this->payment_settings   = $payment_settings;
@@ -79,6 +67,7 @@ class ApplePayButton implements ButtonInterface {
 		$this->script_data        = $data;
 		$this->settings_status    = $settings_status;
 		$this->cart_products      = $cart_products;
+		$this->context            = $context;
 	}
 
 	public function initialize(): void {
@@ -992,6 +981,12 @@ class ApplePayButton implements ButtonInterface {
 	 * @return bool
 	 */
 	public function is_enabled(): bool {
-		return $this->settings_provider->applepay_enabled();
+		if ( ! $this->settings_provider->applepay_enabled() ) {
+			return false;
+		}
+
+		$methods = $this->settings_provider->button_styling( $this->context->context() )->methods;
+
+		return in_array( ApplePayGateway::ID, $methods, true );
 	}
 }

--- a/modules/ppcp-applepay/src/Assets/BlocksPaymentMethod.php
+++ b/modules/ppcp-applepay/src/Assets/BlocksPaymentMethod.php
@@ -11,74 +11,50 @@ namespace WooCommerce\PayPalCommerce\Applepay\Assets;
 
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodTypeInterface;
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
-/**
- * Class BlocksPaymentMethod
- */
 class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	private AssetGetter $asset_getter;
+	private string $version;
+	private ButtonInterface $button;
+	private PaymentMethodTypeInterface $paypal_payment_method;
+	private Context $context;
+	private SettingsProvider $settings_provider;
 
-	/**
-	 * The assets version.
-	 *
-	 * @var string
-	 */
-	private $version;
-
-	/**
-	 * The button.
-	 *
-	 * @var ButtonInterface
-	 */
-	private $button;
-
-	/**
-	 * The paypal payment method.
-	 *
-	 * @var PaymentMethodTypeInterface
-	 */
-	private $paypal_payment_method;
-
-	/**
-	 * Assets constructor.
-	 *
-	 * @param string                     $name The name of this module.
-	 * @param AssetGetter                $asset_getter
-	 * @param string                     $version The assets version.
-	 * @param ButtonInterface            $button The button.
-	 * @param PaymentMethodTypeInterface $paypal_payment_method The paypal payment method.
-	 */
 	public function __construct(
 		string $name,
 		AssetGetter $asset_getter,
 		string $version,
 		ButtonInterface $button,
-		PaymentMethodTypeInterface $paypal_payment_method
+		PaymentMethodTypeInterface $paypal_payment_method,
+		Context $context,
+		SettingsProvider $settings_provider
 	) {
 		$this->name                  = $name;
 		$this->asset_getter          = $asset_getter;
 		$this->version               = $version;
 		$this->button                = $button;
 		$this->paypal_payment_method = $paypal_payment_method;
+		$this->context               = $context;
+		$this->settings_provider     = $settings_provider;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	public function initialize() {  }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function is_active() {
+	public function is_active(): bool {
+		$methods = $this->settings_provider->button_styling( $this->context->context() )->methods;
+
+		if ( ! in_array( ApplePayGateway::ID, $methods, true ) ) {
+			return false;
+		}
+
 		return $this->paypal_payment_method->is_active();
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	public function get_payment_method_script_handles() {
 		$handle = $this->name . '-block';
 
@@ -93,9 +69,6 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		return array( $handle );
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	public function get_payment_method_data() {
 		$paypal_data = $this->paypal_payment_method->get_payment_method_data();
 
@@ -109,7 +82,7 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $paypal_data['title'], // TODO : see if we should use another.
 			'description' => $paypal_data['description'], // TODO : see if we should use another.
-			'enabled'     => $paypal_data['smartButtonsEnabled'], // This button is enabled when PayPal buttons are.
+			'enabled'     => $this->is_active(),
 			'scriptData'  => $script_data,
 		);
 	}

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1387,7 +1387,8 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 
 		$enable_funding = array();
 
-		if ( $this->settings_provider->venmo_enabled() ) {
+		$methods = $this->settings_provider->button_styling( $current_context );
+		if ( $this->settings_provider->venmo_enabled() && in_array( 'venmo', $methods->methods, true ) ) {
 			$enable_funding[] = 'venmo';
 		}
 

--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -14,44 +14,15 @@ use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CartCheckoutDetector;
 
-/**
- * Class DisabledFundingSources
- */
 class DisabledFundingSources {
 
 	use FreeTrialHandlerTrait;
 
 	private SettingsProvider $settings_provider;
-
-	/**
-	 * All existing funding sources.
-	 *
-	 * @var array
-	 */
 	private array $all_funding_sources;
-
-	/**
-	 * Provides details about the DCC configuration.
-	 *
-	 * @var CardPaymentsConfiguration
-	 */
 	private CardPaymentsConfiguration $dcc_configuration;
-
-	/**
-	 * Merchant Country
-	 *
-	 * @var string
-	 */
 	private string $merchant_country;
 
-	/**
-	 * DisabledFundingSources constructor.
-	 *
-	 * @param SettingsProvider          $settings_provider   The settings provider.
-	 * @param array                     $all_funding_sources All existing funding sources.
-	 * @param CardPaymentsConfiguration $dcc_configuration   DCC gateway configuration.
-	 * @param string                    $merchant_country    Merchant country.
-	 */
 	public function __construct( SettingsProvider $settings_provider, array $all_funding_sources, CardPaymentsConfiguration $dcc_configuration, string $merchant_country ) {
 		$this->settings_provider   = $settings_provider;
 		$this->all_funding_sources = $all_funding_sources;
@@ -80,7 +51,7 @@ class DisabledFundingSources {
 			return $this->sanitize_and_filter_sources( $disable_funding, $flags );
 		}
 
-		$disable_funding = $this->get_sources_from_settings();
+		$disable_funding = $this->get_sources_from_settings( $context );
 
 		// Apply rules based on context and payment methods.
 		$disable_funding = $this->apply_context_rules( $disable_funding );
@@ -98,10 +69,11 @@ class DisabledFundingSources {
 	 *
 	 * @return array
 	 */
-	private function get_sources_from_settings(): array {
+	private function get_sources_from_settings( string $context ): array {
 		$disabled_funding = array();
+		$methods          = $this->settings_provider->button_styling( $context )->methods;
 
-		if ( ! $this->settings_provider->venmo_enabled() ) {
+		if ( ! $this->settings_provider->venmo_enabled() || ! in_array( 'venmo', $methods, true ) ) {
 			$disabled_funding[] = 'venmo';
 		}
 

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -202,7 +202,9 @@ return array(
 			$container->get( 'googlepay.asset_getter' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'googlepay.button' ),
-			$container->get( 'blocks.method' )
+			$container->get( 'blocks.method' ),
+			$container->get( 'button.helper.context' ),
+			$container->get( 'settings.settings-provider' )
 		);
 	},
 

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -191,7 +191,6 @@ return array(
 			$container->get( 'wc-subscriptions.helper' ),
 			$container->get( 'settings.settings-provider' ),
 			$container->get( 'settings.environment' ),
-			$container->get( 'wcgateway.settings.status' ),
 			$container->get( 'button.helper.context' )
 		);
 	},

--- a/modules/ppcp-googlepay/src/Assets/BlocksPaymentMethod.php
+++ b/modules/ppcp-googlepay/src/Assets/BlocksPaymentMethod.php
@@ -13,10 +13,10 @@ use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodTyp
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodTypeInterface;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
-/**
- * Class BlocksPaymentMethod
- */
 class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	private AssetGetter $asset_getter;
 
@@ -25,58 +25,42 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	 *
 	 * @var string
 	 */
-	private $version;
+	private string $version;
+	private ButtonInterface $button;
+	private PaymentMethodTypeInterface $paypal_payment_method;
+	private Context $context;
+	private SettingsProvider $settings_provider;
 
-	/**
-	 * The button.
-	 *
-	 * @var ButtonInterface
-	 */
-	private $button;
-
-	/**
-	 * The paypal payment method.
-	 *
-	 * @var PaymentMethodTypeInterface
-	 */
-	private $paypal_payment_method;
-
-	/**
-	 * @param string                     $name The name of this module.
-	 * @param AssetGetter                $asset_getter
-	 * @param string                     $version The assets version.
-	 * @param ButtonInterface            $button The button.
-	 * @param PaymentMethodTypeInterface $paypal_payment_method The paypal payment method.
-	 */
 	public function __construct(
 		string $name,
 		AssetGetter $asset_getter,
 		string $version,
 		ButtonInterface $button,
-		PaymentMethodTypeInterface $paypal_payment_method
+		PaymentMethodTypeInterface $paypal_payment_method,
+		Context $context,
+		SettingsProvider $settings_provider
 	) {
 		$this->name                  = $name;
 		$this->asset_getter          = $asset_getter;
 		$this->version               = $version;
 		$this->button                = $button;
 		$this->paypal_payment_method = $paypal_payment_method;
+		$this->context               = $context;
+		$this->settings_provider     = $settings_provider;
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	public function initialize() {  }
 
-	/**
-	 * {@inheritDoc}
-	 */
 	public function is_active() {
+		$methods = $this->settings_provider->button_styling( $this->context->context() )->methods;
+
+		if ( ! in_array( GooglePayGateway::ID, $methods, true ) ) {
+			return false;
+		}
+
 		return $this->paypal_payment_method->is_active();
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	public function get_payment_method_script_handles() {
 		$handle = $this->name . '-block';
 
@@ -91,9 +75,6 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 		return array( $handle );
 	}
 
-	/**
-	 * {@inheritDoc}
-	 */
 	public function get_payment_method_data() {
 		$paypal_data = $this->paypal_payment_method->get_payment_method_data();
 
@@ -101,7 +82,7 @@ class BlocksPaymentMethod extends AbstractPaymentMethodType {
 			'id'          => $this->name,
 			'title'       => $paypal_data['title'], // See if we should use another.
 			'description' => $paypal_data['description'], // See if we should use another.
-			'enabled'     => $paypal_data['smartButtonsEnabled'], // This button is enabled when PayPal buttons are.
+			'enabled'     => $this->is_active(),
 			'scriptData'  => $this->button->script_data(),
 		);
 	}

--- a/modules/ppcp-googlepay/src/Assets/BlocksPaymentMethod.php
+++ b/modules/ppcp-googlepay/src/Assets/BlocksPaymentMethod.php
@@ -19,12 +19,6 @@ use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 class BlocksPaymentMethod extends AbstractPaymentMethodType {
 	private AssetGetter $asset_getter;
-
-	/**
-	 * The assets version.
-	 *
-	 * @var string
-	 */
 	private string $version;
 	private ButtonInterface $button;
 	private PaymentMethodTypeInterface $paypal_payment_method;

--- a/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
+++ b/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
@@ -83,7 +83,13 @@ class GooglePayButton implements ButtonInterface {
 	 * Returns if Google Pay button is enabled
 	 */
 	public function is_enabled(): bool {
-		return $this->settings->googlepay_enabled();
+		if ( ! $this->settings->googlepay_enabled() ) {
+			return false;
+		}
+
+		$methods = $this->settings->button_styling( $this->context->context() )->methods;
+
+		return in_array( GooglePayGateway::ID, $methods, true );
 	}
 
 	/**
@@ -97,12 +103,6 @@ class GooglePayButton implements ButtonInterface {
 		if ( ! $this->is_enabled() ) {
 			return false;
 		}
-
-		$button_enabled_product  = $this->settings_status->is_smart_button_enabled_for_location( 'product' );
-		$button_enabled_cart     = $this->settings_status->is_smart_button_enabled_for_location( 'cart' );
-		$button_enabled_checkout = true; // todo - why is this hardcoded as true?
-		$button_enabled_payorder = true; // todo - why is this hardcoded as true?
-		$button_enabled_minicart = $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' );
 
 		if (
 			$this->subscription_helper->plugin_is_active()
@@ -128,76 +128,50 @@ class GooglePayButton implements ButtonInterface {
 			'woocommerce_paypal_payments_sdk_components_hook',
 			function ( $components ) {
 				$components[] = 'googlepay';
-
 				return $components;
 			}
 		);
 
-		if ( $button_enabled_product ) {
-			$default_hook_name  = 'woocommerce_paypal_payments_single_product_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_googlepay_single_product_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
-					$this->googlepay_button();
-				},
-				32
-			);
-		}
-
-		if ( $button_enabled_cart ) {
-			$default_hook_name  = 'woocommerce_paypal_payments_cart_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_googlepay_cart_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
-					$this->googlepay_button();
-				},
-				21
-			);
-		}
-
-		if ( $button_enabled_checkout ) { // @phpstan-ignore if.alwaysTrue
-			$default_hook_name  = 'woocommerce_paypal_payments_checkout_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_googlepay_checkout_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
+		$button_hooks = array(
+			array(
+				'hook'     => 'woocommerce_paypal_payments_single_product_button_render',
+				'filter'   => 'woocommerce_paypal_payments_googlepay_single_product_button_render_hook',
+				'callback' => fn() => $this->googlepay_button(),
+				'priority' => 32,
+			),
+			array(
+				'hook'     => 'woocommerce_paypal_payments_cart_button_render',
+				'filter'   => 'woocommerce_paypal_payments_googlepay_cart_button_render_hook',
+				'callback' => fn() => $this->googlepay_button(),
+			),
+			array(
+				'hook'     => 'woocommerce_paypal_payments_checkout_button_render',
+				'filter'   => 'woocommerce_paypal_payments_googlepay_checkout_button_render_hook',
+				'callback' => function () {
 					$this->googlepay_button();
 					$this->hide_gateway_until_eligible();
 				},
-				21
-			);
-		}
-
-		if ( $button_enabled_payorder ) { // @phpstan-ignore if.alwaysTrue
-			$default_hook_name  = 'woocommerce_paypal_payments_payorder_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_googlepay_payorder_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
+			),
+			array(
+				'hook'     => 'woocommerce_paypal_payments_payorder_button_render',
+				'filter'   => 'woocommerce_paypal_payments_googlepay_payorder_button_render_hook',
+				'callback' => function () {
 					$this->googlepay_button();
 					$this->hide_gateway_until_eligible();
 				},
-				21
-			);
-		}
+			),
+			array(
+				'hook'     => 'woocommerce_paypal_payments_minicart_button_render',
+				'filter'   => 'woocommerce_paypal_payments_googlepay_minicart_button_render_hook',
+				'callback' => fn() => print( '<span id="ppc-button-googlepay-container-minicart" class="ppcp-button-apm ppcp-button-googlepay ppcp-button-minicart"></span>' ),
+			),
+		);
 
-		if ( $button_enabled_minicart ) {
-			$default_hook_name  = 'woocommerce_paypal_payments_minicart_button_render';
-			$render_placeholder = apply_filters( 'woocommerce_paypal_payments_googlepay_minicart_button_render_hook', $default_hook_name );
-			$render_placeholder = is_string( $render_placeholder ) ? $render_placeholder : $default_hook_name;
-			add_action(
-				$render_placeholder,
-				function () {
-					echo '<span id="ppc-button-googlepay-container-minicart" class="ppcp-button-apm ppcp-button-googlepay ppcp-button-minicart"></span>';
-				},
-				21
-			);
+		foreach ( $button_hooks as $entry ) {
+			$hook = apply_filters( $entry['filter'], $entry['hook'] );
+			$hook = is_string( $hook ) ? $hook : $entry['hook'];
+
+			add_action( $hook, $entry['callback'], $entry['priority'] ?? 21 );
 		}
 
 		return true;

--- a/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
+++ b/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
@@ -25,37 +25,16 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
-/**
- * Class Button
- */
 class GooglePayButton implements ButtonInterface {
 
 	private Context $context;
-
 	private AssetGetter $asset_getter;
-
 	private string $sdk_url;
-
 	private string $version;
-
 	private SettingsProvider $settings;
-
 	private Environment $environment;
-
-	private SettingsStatus $settings_status;
-
 	private SubscriptionHelper $subscription_helper;
 
-	/**
-	 * @param AssetGetter        $asset_getter
-	 * @param string             $sdk_url             The URL to the SDK.
-	 * @param string             $version             The assets version.
-	 * @param SubscriptionHelper $subscription_helper The subscription helper.
-	 * @param SettingsProvider   $settings            The legacy settings.
-	 * @param Environment        $environment         The environment object.
-	 * @param SettingsStatus     $settings_status     The Settings status helper.
-	 * @param Context            $context             Context data provider.
-	 */
 	public function __construct(
 		AssetGetter $asset_getter,
 		string $sdk_url,
@@ -63,7 +42,6 @@ class GooglePayButton implements ButtonInterface {
 		SubscriptionHelper $subscription_helper,
 		SettingsProvider $settings,
 		Environment $environment,
-		SettingsStatus $settings_status,
 		Context $context
 	) {
 		$this->asset_getter        = $asset_getter;
@@ -72,7 +50,6 @@ class GooglePayButton implements ButtonInterface {
 		$this->subscription_helper = $subscription_helper;
 		$this->settings            = $settings;
 		$this->environment         = $environment;
-		$this->settings_status     = $settings_status;
 		$this->context             = $context;
 	}
 

--- a/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
+++ b/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
@@ -21,7 +21,6 @@ use WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
-use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -218,11 +218,6 @@ class GooglepayModule implements ServiceModule, ExecutableModule {
 		 */
 		add_filter(
 			'woocommerce_available_payment_gateways',
-			/**
-			 * Param types removed to avoid third-party issues.
-			 *
-			 * @psalm-suppress MissingClosureParamType
-			 */
 			static function ( $methods ) use ( $c ) {
 				if ( ! is_array( $methods ) ) {
 					return $methods;

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -14,6 +14,7 @@ use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
 use WooCommerce\PayPalCommerce\Button\Assets\ButtonInterface;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\GoogleProductStatus;
 use WooCommerce\PayPalCommerce\Googlepay\Helper\AvailabilityNotice;
@@ -187,12 +188,23 @@ class GooglepayModule implements ServiceModule, ExecutableModule {
 				$settings = $c->get( 'settings.settings-provider' );
 				assert( $settings instanceof SettingsProvider );
 
-				if ( $settings->googlepay_enabled() ) {
-					$googlepay_gateway = $c->get( 'googlepay.wc-gateway' );
-					assert( $googlepay_gateway instanceof WC_Payment_Gateway );
-
-					$methods[] = $googlepay_gateway;
+				if ( ! $settings->googlepay_enabled() ) {
+					return $methods;
 				}
+
+				$context = $c->get( 'button.helper.context' );
+				assert( $context instanceof Context );
+
+				$page_methods = $settings->button_styling( $context->context() )->methods;
+
+				if ( ! in_array( 'ppcp-googlepay', $page_methods, true ) ) {
+					return $methods;
+				}
+
+				$googlepay_gateway = $c->get( 'googlepay.wc-gateway' );
+				assert( $googlepay_gateway instanceof WC_Payment_Gateway );
+
+				$methods[] = $googlepay_gateway;
 
 				return $methods;
 			}

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -210,6 +210,46 @@ class GooglepayModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		/**
+		 * Filters the available payment gateways to remove the Google Pay gateway
+		 * when the button is disabled for the current location (e.g., classic checkout) in the styling settings.
+		 * This is necessary because WooCommerce automatically includes the gateway when it is enabled,
+		 * even if the button is hidden via settings.
+		 */
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			/**
+			 * Param types removed to avoid third-party issues.
+			 *
+			 * @psalm-suppress MissingClosureParamType
+			 */
+			static function ( $methods ) use ( $c ) {
+				if ( ! is_array( $methods ) ) {
+					return $methods;
+				}
+
+				$context = $c->get( 'button.helper.context' );
+				assert( $context instanceof Context );
+
+				$current_context = $context->context();
+
+				if ( $current_context !== 'checkout' ) {
+					return $methods;
+				}
+
+				$settings = $c->get( 'settings.settings-provider' );
+				assert( $settings instanceof SettingsProvider );
+
+				$page_methods = $settings->button_styling( $current_context )->methods;
+
+				if ( ! in_array( GooglePayGateway::ID, $page_methods, true ) ) {
+					unset( $methods[ GooglePayGateway::ID ] );
+				}
+
+				return $methods;
+			}
+		);
+
 		add_action(
 			'woocommerce_review_order_after_submit',
 			function () {

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\Button\Helper;
 
 use Mockery;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
@@ -20,6 +21,8 @@ class DisabledFundingSourcesTest extends TestCase
 
 		$this->settings_provider = Mockery::mock(SettingsProvider::class);
 		$this->settings_provider->shouldReceive('venmo_enabled')->andReturn(true)->byDefault();
+		$this->settings_provider->shouldReceive('button_styling')
+			->andReturn(new LocationStylingDTO('', true, ['venmo']))->byDefault();
 
 		$this->dcc_configuration = Mockery::mock(CardPaymentsConfiguration::class);
 	}
@@ -140,6 +143,8 @@ class DisabledFundingSourcesTest extends TestCase
 	{
 		$this->settings_provider = Mockery::mock(SettingsProvider::class);
 		$this->settings_provider->shouldReceive('venmo_enabled')->andReturn(false);
+		$this->settings_provider->shouldReceive('button_styling')
+			->andReturn(new LocationStylingDTO('', true, ['venmo']));
 
 		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
 		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
@@ -148,6 +153,22 @@ class DisabledFundingSourcesTest extends TestCase
 
 		$this->setWooCommerceFunctionMocks();
 
+		when('is_checkout')->justReturn(true);
+
+		$this->assertContains('venmo', $sut->sources('checkout-block'));
+	}
+
+	public function test_venmo_disabled_for_location_when_not_in_styling_methods()
+	{
+		$this->settings_provider->shouldReceive('button_styling')
+			->andReturn(new LocationStylingDTO('', true, []));
+
+		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+
+		$sut = new DisabledFundingSources($this->settings_provider, [], $this->dcc_configuration, 'US');
+
+		$this->setWooCommerceFunctionMocks();
 		when('is_checkout')->justReturn(true);
 
 		$this->assertContains('venmo', $sut->sources('checkout-block'));


### PR DESCRIPTION
## Description

Fixes per-location visibility of Venmo, Google Pay, and Apple Pay in the New UI. All three were visible on frontend pages even when disabled for specific locations in the styling tab.

## Root Cause

The per-location `button_styling()->methods` array was never consulted when deciding whether to render or register these payment methods. Each one only checked its global enabled toggle, causing them to appear on all pages regardless of styling tab configuration.

## Changes

**Venmo (SmartButton / DisabledFundingSources)**
- `DisabledFundingSources::get_sources_from_settings()` now adds venmo to disabled funding sources when it is not in the enabled methods for the current context
- `SmartButton::url_params()` gates venmo in `enable-funding` on the current context's methods array, not just the global toggle

**Google Pay**
- `GooglePayButton::is_enabled()` now checks `button_styling()` methods for the current context in addition to the global toggle
- `GooglePayButton::render()` refactored — removed per-location flags, replaced repeated hook registration blocks with a hook map and loop
- `GooglePayButton\BlocksPaymentMethod::is_active()` checks `button_styling()` for the current context; `enabled` in `get_payment_method_data()` now uses `is_active()` instead of `smartButtonsEnabled`
- `woocommerce_payment_gateways` filter skips Google Pay registration when disabled for the current location
- `woocommerce_available_payment_gateways` filter removes Google Pay from classic checkout when disabled for that location

**Apple Pay**
- Same fixes applied as Google Pay across `ApplePayButton::is_enabled()`, `render()`, `BlocksPaymentMethod`, and both gateway filters

## Testing

1. Onboard with a US merchant on New UI
2. In the styling tab, disable Google Pay / Apple Pay / Venmo for a specific page (e.g. product page)
3. Navigate to that page and confirm the button is not visible
4. Enable it again and confirm it reappears
5. Verify checkout and cart pages are unaffected when only product page is disabled
6. Repeat for block checkout and block cart