### PR TITLE
fix(ACDC):Update default gateway title for Fastlane, ACDC and BCDC (6081)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -279,10 +279,7 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			apply_filters( 'woocommerce_paypal_payments_credit_card_gateway_supports', array() )
 		);
 
-		$this->method_title       = __(
-			'Advanced Card Processing',
-			'woocommerce-paypal-payments'
-		);
+		$this->method_title       = __( 'Debit & Credit Cards', 'woocommerce-paypal-payments' );
 		$this->method_description = __(
 			'Accept debit and credit cards, and local payment methods with PayPal’s latest solution.',
 			'woocommerce-paypal-payments'

--- a/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CardPaymentsConfiguration.php
@@ -339,7 +339,7 @@ class CardPaymentsConfiguration {
 			return $this->gateway_title;
 		}
 
-		return $fallback ?: __( 'Advanced Card Processing', 'woocommerce-paypal-payments' );
+		return $fallback ?: __( 'Debit & Credit Cards', 'woocommerce-paypal-payments' );
 	}
 
 	/**


### PR DESCRIPTION
## Issue Description

The default gateway title for the Fastlane, ACDC, and BCDC payment methods was set to "Advanced Card processing", which is inaccurate. 

## PR Description

Updates the default `title` for the Fastlane, ACDC, and BCDC gateways from `Advanced Card processing` to `Debit & Credit Cards` to accurately reflect the accepted payment instruments.