### PR TITLE
Add upgrade notice for 4.0.0 major update (6088)

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -154,6 +154,11 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 5. Click "Connect to PayPal" to link your site to your PayPal account.
 6. Main settings screen.
 
+== Upgrade Notice ==
+
+= 4.0.0 =
+⚠️ Major Update — This release includes significant changes. Please back up your site before updating.
+
 == Changelog ==
 
 = 4.0.0 - XXXX-XX-XX =


### PR DESCRIPTION
### Description                                                                                                                                                                                                   
Add an Upgrade Notice field to the plugin's `readme.txt` header for version 4.0.0. The notice warns users that this is a major update and recommends creating a backup before updating.                         
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
### Steps to Test

1. Open `readme.txt` and verify the `== Upgrade Notice ==` section exists before the `== Changelog ==` section
2. Confirm the notice is associated with version `4.0.0`
3. Confirm the notice text reads: `⚠️  Major Update — This release includes significant changes. Please back up your site before updating.`
