### PR TITLE
Fix 'Subscription could not be loaded' in PayPalSubscriptionsModule admin meta box (6706)

### DIFF
--- a/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
+++ b/modules/ppcp-paypal-subscriptions/src/PayPalSubscriptionsModule.php
@@ -558,7 +558,11 @@ class PayPalSubscriptionsModule implements ServiceModule, ExecutableModule {
 
 				$subscription = wcs_get_subscription( $order->get_id() );
 				if ( ! ( $subscription instanceof WC_Subscription ) ) {
-					return;
+					$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
+					$subscription  = reset( $subscriptions ) ?: null;
+					if ( ! ( $subscription instanceof WC_Subscription ) ) {
+						return;
+					}
 				}
 
 				$subscription_id = $subscription->get_meta( 'ppcp_subscription' ) ?? '';


### PR DESCRIPTION
Fixes the same root cause as #4220 (which fixed `RenewalHandler.php`), but in the second affected file.

## Problem

`PayPalSubscriptionsModule.php` calls `wcs_get_subscription( $order->get_id() )` inside the `add_meta_boxes` hook. When viewing a **renewal order** in WP admin, `$order->get_id()` returns the renewal order ID, not the subscription ID. `wcs_get_subscription()` expects a subscription ID, so it returns `false` and logs "Subscription could not be loaded."

This is the exact same bug pattern that PR #4220 fixed in `RenewalHandler::renew()`.

## Fix

Added a fallback: when `wcs_get_subscription()` fails (returns non-subscription), try `wcs_get_subscriptions_for_renewal_order( $order )` which is the correct WooCommerce Subscriptions API for retrieving subscriptions from a renewal order.

This approach is backward-compatible — it still works when viewing an actual subscription directly, and now also handles renewal orders correctly.

## Testing

1. Create a subscription with PayPal Checkout
2. Let it generate a renewal order
3. View the renewal order in WP admin
4. Confirm no "Subscription could not be loaded" debug log entries

Related: #4191