### PR TITLE
Remove UI flag references (6067)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -50,18 +50,15 @@ class MigrationManager implements SettingsMigrationInterface {
 
 	public function migrate(): void {
 		/**
-		 * Clean up legacy UI toggle options that are no longer needed.
+		 * Note on UI toggles:
 		 *
-		 * These options were used to control whether merchants saw the old or new settings UI:
-		 * - OPTION_NAME_SHOULD_USE_OLD_UI: Stored merchant's preference to use the old UI
+		 * There are two options that control the UI experience in all 3.x versions. Both flags
+		 * are intentionally preserved during the migration, though they do not serve a purpose
+		 * in version 4.x; however, they must be intact to ensure a stable downgrade path.
 		 *
-		 * Do NOT delete
-		 * - woocommerce-ppcp-is-new-merchant: Must be present when downgrading to 3.x to preserve new UI
-		 *
-		 * With the new settings UI now being the only interface, these options serve no purpose
-		 * and are removed during the final migration to prevent confusion and reduce database bloat.
+		 * - "woocommerce_ppcp-settings-should-use-old-ui" (OPTION_NAME_SHOULD_USE_OLD_UI)
+		 * - "woocommerce-ppcp-is-new-merchant"
 		 */
-		delete_option( 'woocommerce_ppcp-settings-should-use-old-ui' );
 
 		$this->onboarding_profile->set_completed( true );
 		$this->onboarding_profile->set_gateways_refreshed( true );

--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -54,13 +54,14 @@ class MigrationManager implements SettingsMigrationInterface {
 		 *
 		 * These options were used to control whether merchants saw the old or new settings UI:
 		 * - OPTION_NAME_SHOULD_USE_OLD_UI: Stored merchant's preference to use the old UI
-		 * - woocommerce-ppcp-is-new-merchant: Flagged new merchants to bypass the old UI
+		 *
+		 * Do NOT delete
+		 * - woocommerce-ppcp-is-new-merchant: Must be present when downgrading to 3.x to preserve new UI
 		 *
 		 * With the new settings UI now being the only interface, these options serve no purpose
 		 * and are removed during the final migration to prevent confusion and reduce database bloat.
 		 */
 		delete_option( 'woocommerce_ppcp-settings-should-use-old-ui' );
-		delete_option( 'woocommerce-ppcp-is-new-merchant' );
 
 		$this->onboarding_profile->set_completed( true );
 		$this->onboarding_profile->set_gateways_refreshed( true );

--- a/tests/integration/PHPUnit/Settings/Service/Migration/MigrationManagerTest.php
+++ b/tests/integration/PHPUnit/Settings/Service/Migration/MigrationManagerTest.php
@@ -31,7 +31,6 @@ class MigrationManagerTest extends TestCase {
 	 */
 	public function tearDown(): void {
 		delete_option(MigrationManager::OPTION_NAME_MIGRATION_IS_DONE);
-		delete_option('woocommerce_ppcp-settings-should-use-old-ui');
 
 		parent::tearDown();
 	}
@@ -44,12 +43,7 @@ class MigrationManagerTest extends TestCase {
 	 * and NOT set the migration complete flag, allowing retry on next update.
 	 */
 	public function test_migration_handles_api_failures_gracefully(): void {
-		// Arrange: Set up legacy options
-		update_option('woocommerce_ppcp-settings-should-use-old-ui', 'yes');
-
 		// Assert pre-conditions
-		$this->assertSame('yes', get_option('woocommerce_ppcp-settings-should-use-old-ui'));
-
 		$this->assertNotSame('1', get_option(MigrationManager::OPTION_NAME_MIGRATION_IS_DONE));
 
 		// Act: Run migration (will fail due to missing API connection in tests)
@@ -61,28 +55,10 @@ class MigrationManagerTest extends TestCase {
 		// Assert: Migration did NOT complete due to API failure
 		$this->assertNotSame('1', get_option(MigrationManager::OPTION_NAME_MIGRATION_IS_DONE));
 
-		// Assert: Legacy options WERE cleaned up (happens before API calls)
-		$this->assertFalse(get_option('woocommerce_ppcp-settings-should-use-old-ui'));
-
 		// Assert: Onboarding profile WAS updated (happens before API calls)
 		$this->assertTrue($this->onboarding_profile->get_completed());
 		$this->assertTrue($this->onboarding_profile->is_gateways_refreshed());
 		$this->assertTrue($this->onboarding_profile->is_gateways_synced());
-	}
-
-
-	/**
-	 * Test legacy options cleanup specifically.
-	 */
-	public function test_legacy_options_cleanup(): void {
-		// Arrange: Create legacy options
-		update_option('woocommerce_ppcp-settings-should-use-old-ui', 'yes');
-
-		// Act: Run migration
-		$this->migration_manager->migrate();
-
-		// Assert: Legacy options deleted (this happens even if API calls fail later)
-		$this->assertFalse(get_option('woocommerce_ppcp-settings-should-use-old-ui'));
 	}
 
 	/**

--- a/tests/integration/PHPUnit/Settings/Service/Migration/MigrationManagerTest.php
+++ b/tests/integration/PHPUnit/Settings/Service/Migration/MigrationManagerTest.php
@@ -32,7 +32,6 @@ class MigrationManagerTest extends TestCase {
 	public function tearDown(): void {
 		delete_option(MigrationManager::OPTION_NAME_MIGRATION_IS_DONE);
 		delete_option('woocommerce_ppcp-settings-should-use-old-ui');
-		delete_option('woocommerce-ppcp-is-new-merchant');
 
 		parent::tearDown();
 	}
@@ -47,11 +46,9 @@ class MigrationManagerTest extends TestCase {
 	public function test_migration_handles_api_failures_gracefully(): void {
 		// Arrange: Set up legacy options
 		update_option('woocommerce_ppcp-settings-should-use-old-ui', 'yes');
-		update_option('woocommerce-ppcp-is-new-merchant', '0');
 
 		// Assert pre-conditions
 		$this->assertSame('yes', get_option('woocommerce_ppcp-settings-should-use-old-ui'));
-		$this->assertSame('0', get_option('woocommerce-ppcp-is-new-merchant'));
 
 		$this->assertNotSame('1', get_option(MigrationManager::OPTION_NAME_MIGRATION_IS_DONE));
 
@@ -66,7 +63,6 @@ class MigrationManagerTest extends TestCase {
 
 		// Assert: Legacy options WERE cleaned up (happens before API calls)
 		$this->assertFalse(get_option('woocommerce_ppcp-settings-should-use-old-ui'));
-		$this->assertFalse(get_option('woocommerce-ppcp-is-new-merchant'));
 
 		// Assert: Onboarding profile WAS updated (happens before API calls)
 		$this->assertTrue($this->onboarding_profile->get_completed());
@@ -81,14 +77,12 @@ class MigrationManagerTest extends TestCase {
 	public function test_legacy_options_cleanup(): void {
 		// Arrange: Create legacy options
 		update_option('woocommerce_ppcp-settings-should-use-old-ui', 'yes');
-		update_option('woocommerce-ppcp-is-new-merchant', '1');
 
 		// Act: Run migration
 		$this->migration_manager->migrate();
 
 		// Assert: Legacy options deleted (this happens even if API calls fail later)
 		$this->assertFalse(get_option('woocommerce_ppcp-settings-should-use-old-ui'));
-		$this->assertFalse(get_option('woocommerce-ppcp-is-new-merchant'));
 	}
 
 	/**

--- a/woocommerce-paypal-payments.php
+++ b/woocommerce-paypal-payments.php
@@ -291,22 +291,4 @@ define( 'PPCP_PAYPAL_BN_CODE', 'Woo_PPCP' );
 	function is_woocommerce_activated(): bool {
 		return class_exists( 'woocommerce' );
 	}
-
-	add_action(
-		'woocommerce_paypal_payments_gateway_migrate',
-		/**
-		 * Set new merchant flag on plugin install.
-		 *
-		 * When installing the plugin for the first time, we direct the user to
-		 * the new UI without a data migration, and fully hide the #legacy-ui.
-		 *
-		 * @param string|false $version String with previous installed plugin version.
-		 *                              Boolean false on first installation on a new site.
-		 */
-		static function ( $version ) {
-			if ( ! $version ) {
-				update_option( 'woocommerce-ppcp-is-new-merchant', '1' );
-			}
-		}
-	);
 } )();


### PR DESCRIPTION
Replaces #4213

### Issue Description

Two UI toggle flags are no longer needed but are still set in some places in the plugin, as well as referenced in unit tests.

### PR Description

Remove all code that changes, reads or deletes the two options `woocommerce-ppcp-is-new-merchant` and `woocommerce_ppcp-settings-should-use-old-ui`

The options are intentionally left in the database for backwards compatibility with any existing installations that may have it stored.