### PR TITLE
Do not migrate New-UI-Only merchants (6096)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -50,6 +50,17 @@ class MigrationManager implements SettingsMigrationInterface {
 
 	public function migrate(): void {
 		/**
+		 * When this is a new merchant that never had the legacy UI we can simply
+		 * mark the migration as done (prevent future migration attempts) and
+		 * exit directly, as there are no legacy settings to convert.
+		 */
+		if ( 1 === (int) get_option( 'woocommerce-ppcp-is-new-merchant' ) ) {
+			update_option( self::OPTION_NAME_MIGRATION_IS_DONE, true );
+
+			return;
+		}
+
+		/**
 		 * Clean up legacy UI toggle options that are no longer needed.
 		 *
 		 * These options were used to control whether merchants saw the old or new settings UI:


### PR DESCRIPTION
### Description

The auto-migrate flow was not checking for the type of merchant, and simply migrate every environment that was not mgirated.

Problem with this: Environments that never had legacy settings do not need a migration.

This PR adds a condition to skip migration for those merchants