### PR TITLE
Bump release date to today

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 4.0.0 - 2026-03-30 =
+= 4.0.0 - 2026-03-31 =
 * Enhancement – Removed legacy UI #4031
 * Enhancement – Added migration banner guiding BCDC merchants through upgrade to Advanced Card Processing #4192
 * Enhancement – Apple Pay and Google Pay can now be enabled independently, without requiring Advanced Card Processing (ACDC) to be active #4186

--- a/readme.txt
+++ b/readme.txt
@@ -161,7 +161,7 @@ If you encounter issues with the PayPal buttons not appearing after an update, p
 
 == Changelog ==
 
-= 4.0.0 - 2026-03-30 =
+= 4.0.0 - 2026-03-31 =
 * Enhancement – Removed legacy UI #4031
 * Enhancement – Added migration banner guiding BCDC merchants through upgrade to Advanced Card Processing #4192
 * Enhancement – Apple Pay and Google Pay can now be enabled independently, without requiring Advanced Card Processing (ACDC) to be active #4186


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->
We didn't end up releasing 4.0.0 to the WordPress.org plugin directory yesterday, so we want to update the release date to today.

### Steps to Test

<!-- Describe the steps to replicate the issue and confirm the fix. -->
<!-- Include as many details as possible. -->

Confirm that the dates in [changelog.txt](changelog.txt) and [readme.txt](readme.txt) have been changed from `2026-03-30` to `2026-03-31`.

### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->