### PR TITLE
Update stable tag to 4.0.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: woocommerce, paypal, payments, ecommerce, credit card
 Requires at least: 6.5
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 4.0.0
+Stable tag: 4.0.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
This PR updates the stable tag to 4.0.1 in the `dev/release/4.0.1` branch, as it was not updated correctly during the automated release process.

This change was applied to the WordPress.org plugin directory earlier in https://plugins.trac.wordpress.org/changeset/3495642/, so this PR is mostly to ensure we have the same data across both sets of code.