### PR TITLE
API rate limiting fix (6101)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -160,8 +160,12 @@ return array(
 			$container->get( 'api.factory.sellerstatus' ),
 			$container->get( 'api.partner_merchant_id' ),
 			$container->get( 'api.merchant_id' ),
-			$container->get( 'api.helper.failure-registry' )
+			$container->get( 'api.helper.failure-registry' ),
+			$container->get( 'api.partners-seller-status-cache' )
 		);
+	},
+	'api.partners-seller-status-cache'               => static function ( ContainerInterface $container ): Cache {
+		return new Cache( 'ppcp-seller-status-' );
 	},
 	'api.factory.sellerstatus'                       => static function ( ContainerInterface $container ): SellerStatusFactory {
 		return new SellerStatusFactory();

--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\ApiClient;
 
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderTransient;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\PartnerAttribution;
@@ -98,6 +99,12 @@ class ApiModule implements ServiceModule, FactoryModule, ExecutableModule {
 
 				if ( $failure_registry instanceof FailureRegistry ) {
 					$failure_registry->clear_failures( FailureRegistry::SELLER_STATUS_KEY );
+				}
+
+				$partners_endpoint = $c->has( 'api.endpoint.partners' ) ? $c->get( 'api.endpoint.partners' ) : null;
+
+				if ( $partners_endpoint instanceof PartnersEndpoint ) {
+					$partners_endpoint->clear_seller_status_cache();
 				}
 			},
 			10,

--- a/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\SellerStatusFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
 
 /**
@@ -74,6 +75,23 @@ class PartnersEndpoint {
 	private $failure_registry;
 
 	/**
+	 * The cache for seller status responses.
+	 *
+	 * @var Cache
+	 */
+	private $cache;
+
+	/**
+	 * Cache lifetime for seller status responses, in seconds.
+	 */
+	const SELLER_STATUS_CACHE_TTL = 600; // 10 minutes.
+
+	/**
+	 * Cache key for the seller status response.
+	 */
+	const SELLER_STATUS_CACHE_KEY = 'seller_status';
+
+	/**
 	 * PartnersEndpoint constructor.
 	 *
 	 * @param string              $host The host.
@@ -83,6 +101,7 @@ class PartnersEndpoint {
 	 * @param string              $partner_id The partner ID.
 	 * @param string              $merchant_id The merchant ID.
 	 * @param FailureRegistry     $failure_registry The API failure registry.
+	 * @param Cache               $cache The cache for seller status responses.
 	 */
 	public function __construct(
 		string $host,
@@ -91,7 +110,8 @@ class PartnersEndpoint {
 		SellerStatusFactory $seller_status_factory,
 		string $partner_id,
 		string $merchant_id,
-		FailureRegistry $failure_registry
+		FailureRegistry $failure_registry,
+		Cache $cache
 	) {
 		$this->host                  = $host;
 		$this->bearer                = $bearer;
@@ -100,15 +120,24 @@ class PartnersEndpoint {
 		$this->partner_id            = $partner_id;
 		$this->merchant_id           = $merchant_id;
 		$this->failure_registry      = $failure_registry;
+		$this->cache                 = $cache;
 	}
 
 	/**
 	 * Returns the current seller status.
 	 *
+	 * Uses a transient cache to avoid redundant API calls. The cached response
+	 * is returned for up to 10 minutes before a fresh request is made.
+	 *
 	 * @return SellerStatus
 	 * @throws RuntimeException When request could not be fulfilled.
 	 */
 	public function seller_status(): SellerStatus {
+		$cached = $this->cache->get( self::SELLER_STATUS_CACHE_KEY );
+		if ( $cached instanceof SellerStatus ) {
+			return $cached;
+		}
+
 		$url      = trailingslashit( $this->host ) . 'v1/customer/partners/' . $this->partner_id . '/merchant-integrations/' . $this->merchant_id;
 		$bearer   = $this->bearer->bearer();
 		$args     = array(
@@ -161,6 +190,9 @@ class PartnersEndpoint {
 		$this->failure_registry->clear_failures( FailureRegistry::SELLER_STATUS_KEY );
 
 		$status = $this->seller_status_factory->from_paypal_response( $json );
+
+		$this->cache->set( self::SELLER_STATUS_CACHE_KEY, $status, self::SELLER_STATUS_CACHE_TTL );
+
 		return $status;
 	}
 }

--- a/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
@@ -195,4 +195,14 @@ class PartnersEndpoint {
 
 		return $status;
 	}
+
+	/**
+	 * Clears the cached seller status response, forcing a fresh API call
+	 * on the next invocation of seller_status().
+	 *
+	 * @return void
+	 */
+	public function clear_seller_status_cache(): void {
+		$this->cache->delete( self::SELLER_STATUS_CACHE_KEY );
+	}
 }

--- a/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
@@ -79,17 +79,17 @@ class PartnersEndpoint {
 	 *
 	 * @var Cache
 	 */
-	private $cache;
+	private Cache $cache;
 
 	/**
 	 * Cache lifetime for seller status responses, in seconds.
 	 */
-	const SELLER_STATUS_CACHE_TTL = 600; // 10 minutes.
+	public const SELLER_STATUS_CACHE_TTL = 600; // 10 minutes.
 
 	/**
 	 * Cache key for the seller status response.
 	 */
-	const SELLER_STATUS_CACHE_KEY = 'seller_status';
+	public const SELLER_STATUS_CACHE_KEY = 'seller_status';
 
 	/**
 	 * PartnersEndpoint constructor.

--- a/modules/ppcp-settings/src/Data/GeneralSettings.php
+++ b/modules/ppcp-settings/src/Data/GeneralSettings.php
@@ -231,15 +231,17 @@ class GeneralSettings extends AbstractDataModel {
 	}
 
 	/**
-	 * Whether the merchant is a casual seller using a personal account.
+	 * Whether the merchant is a casual seller (i.e., not a confirmed business).
 	 *
-	 * Note: It's possible that the seller type is unknown, and both methods,
-	 * `is_casual_seller()` and `is_business_seller()` return false.
+	 * Returns true for both explicitly personal accounts and unknown seller
+	 * types. This prevents unresolvable UNKNOWN types from triggering
+	 * repeated API calls in the seller-type resolution loop, while keeping
+	 * the persisted value unchanged.
 	 *
 	 * @return bool
 	 */
 	public function is_casual_seller(): bool {
-		return SellerTypeEnum::PERSONAL === $this->data['seller_type'];
+		return SellerTypeEnum::BUSINESS !== $this->data['seller_type'];
 	}
 
 	/**

--- a/tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
@@ -1,0 +1,259 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Endpoint;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Requests_Utility_CaseInsensitiveDictionary;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\SellerStatusFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class PartnersEndpointTest extends TestCase
+{
+	private const HOST        = 'https://api.sandbox.paypal.com/';
+	private const PARTNER_ID  = 'partner-abc';
+	private const MERCHANT_ID = 'merchant-xyz';
+
+	/**
+	 * @var Bearer&\Mockery\MockInterface
+	 */
+	private $bearer;
+
+	/**
+	 * @var LoggerInterface&\Mockery\MockInterface
+	 */
+	private $logger;
+
+	/**
+	 * @var SellerStatusFactory&\Mockery\MockInterface
+	 */
+	private $seller_status_factory;
+
+	/**
+	 * @var FailureRegistry&\Mockery\MockInterface
+	 */
+	private $failure_registry;
+
+	/**
+	 * @var Cache&\Mockery\MockInterface
+	 */
+	private $cache;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$token = Mockery::mock(Token::class);
+		$token->shouldReceive('token')->andReturn('test-token');
+
+		$this->bearer = Mockery::mock(Bearer::class);
+		$this->bearer->shouldReceive('bearer')->andReturn($token);
+
+		$this->logger = Mockery::mock(LoggerInterface::class);
+		$this->logger->shouldReceive('debug')->andReturnNull();
+		$this->logger->shouldReceive('log')->andReturnNull();
+
+		$this->seller_status_factory = Mockery::mock(SellerStatusFactory::class);
+		$this->failure_registry      = Mockery::mock(FailureRegistry::class);
+		$this->cache                 = Mockery::mock(Cache::class);
+
+		when('trailingslashit')->alias(function (string $url): string {
+			return rtrim($url, '/') . '/';
+		});
+		when('wp_remote_retrieve_body')->alias(function (array $response): string {
+			return $response['body'] ?? '';
+		});
+	}
+
+	// -----------------------------------------------------------------------
+	// Factory helper
+	// -----------------------------------------------------------------------
+
+	private function make_endpoint(): PartnersEndpoint
+	{
+		return new PartnersEndpoint(
+			self::HOST,
+			$this->bearer,
+			$this->logger,
+			$this->seller_status_factory,
+			self::PARTNER_ID,
+			self::MERCHANT_ID,
+			$this->failure_registry,
+			$this->cache
+		);
+	}
+
+	private function make_raw_response(int $status_code = 200): array
+	{
+		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+		$headers->shouldReceive('getAll')->andReturn([]);
+
+		return [
+			'body'     => '{}',
+			'headers'  => $headers,
+			'response' => ['code' => $status_code, 'message' => 'OK'],
+		];
+	}
+
+	// -----------------------------------------------------------------------
+	// Tests: seller_status() caching behaviour
+	// -----------------------------------------------------------------------
+
+	/**
+	 * GIVEN a SellerStatus result is stored in the transient cache
+	 * WHEN seller_status() is called
+	 * THEN the cached value is returned immediately
+	 * AND no HTTP request is made to the PayPal API
+	 */
+	public function testSellerStatusReturnsCachedValueWithoutHttpCall(): void
+	{
+		$cached_status = Mockery::mock(SellerStatus::class);
+
+		$this->cache
+			->shouldReceive('get')
+			->once()
+			->with(PartnersEndpoint::SELLER_STATUS_CACHE_KEY)
+			->andReturn($cached_status);
+
+		// wp_remote_get must not be called — any invocation will cause the
+		// Brain Monkey expectation to fail with an unexpected call.
+		expect('wp_remote_get')->never();
+
+		$result = $this->make_endpoint()->seller_status();
+
+		$this->assertSame($cached_status, $result);
+	}
+
+	/**
+	 * GIVEN the transient cache contains no seller status entry
+	 * WHEN seller_status() is called
+	 * THEN the PayPal API is queried
+	 * AND the response is stored in the cache with the correct key and TTL
+	 * AND the resulting SellerStatus is returned
+	 */
+	public function testSellerStatusOnCacheMissFetchesAndStoresResult(): void
+	{
+		$seller_status = Mockery::mock(SellerStatus::class);
+		$raw_response  = $this->make_raw_response(200);
+
+		$this->cache
+			->shouldReceive('get')
+			->once()
+			->with(PartnersEndpoint::SELLER_STATUS_CACHE_KEY)
+			->andReturn(false);
+
+		$this->cache
+			->shouldReceive('set')
+			->once()
+			->with(
+				PartnersEndpoint::SELLER_STATUS_CACHE_KEY,
+				$seller_status,
+				PartnersEndpoint::SELLER_STATUS_CACHE_TTL
+			);
+
+		$this->seller_status_factory
+			->shouldReceive('from_paypal_response')
+			->once()
+			->andReturn($seller_status);
+
+		$this->failure_registry
+			->shouldReceive('clear_failures')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY);
+
+		$this->stub_successful_http_round_trip($raw_response);
+
+		$result = $this->make_endpoint()->seller_status();
+
+		$this->assertSame($seller_status, $result);
+	}
+
+	/**
+	 * GIVEN the transient cache is empty
+	 * AND the PayPal API returns a non-200 status code
+	 * WHEN seller_status() is called
+	 * THEN the failure is registered in the failure registry
+	 * AND the result is NOT stored in the cache
+	 * AND a PayPalApiException is thrown
+	 */
+	public function testSellerStatusOnApiErrorRegistersFailureAndThrows(): void
+	{
+		$raw_response = $this->make_raw_response(500);
+
+		$this->cache
+			->shouldReceive('get')
+			->once()
+			->with(PartnersEndpoint::SELLER_STATUS_CACHE_KEY)
+			->andReturn(false);
+
+		$this->cache
+			->shouldReceive('set')
+			->never();
+
+		$this->failure_registry
+			->shouldReceive('add_failure')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY);
+
+		$this->stub_failed_http_round_trip($raw_response, 500);
+
+		$this->expectException(PayPalApiException::class);
+
+		$this->make_endpoint()->seller_status();
+	}
+
+	// -----------------------------------------------------------------------
+	// Tests: clear_seller_status_cache()
+	// -----------------------------------------------------------------------
+
+	/**
+	 * GIVEN a cached seller status entry exists
+	 * WHEN clear_seller_status_cache() is called
+	 * THEN the cache entry is deleted using the correct key
+	 */
+	public function testClearSellerStatusCacheDeletesCacheEntry(): void
+	{
+		$this->cache
+			->shouldReceive('delete')
+			->once()
+			->with(PartnersEndpoint::SELLER_STATUS_CACHE_KEY);
+
+		$this->make_endpoint()->clear_seller_status_cache();
+
+		// Mockery will assert the expectation above during tearDown.
+		$this->addToAssertionCount(1);
+	}
+
+	// -----------------------------------------------------------------------
+	// HTTP stubs — allow (not assert) internal HTTP mechanics
+	// -----------------------------------------------------------------------
+
+	private function stub_successful_http_round_trip(array $raw_response): void
+	{
+		when('apply_filters')->alias(function (string $hook, ...$args) {
+			return $args[0] ?? null;
+		});
+		when('wp_remote_get')->justReturn($raw_response);
+		when('is_wp_error')->justReturn(false);
+		when('wp_remote_retrieve_response_code')->justReturn(200);
+	}
+
+	private function stub_failed_http_round_trip(array $raw_response, int $status_code): void
+	{
+		when('apply_filters')->alias(function (string $hook, ...$args) {
+			return $args[0] ?? null;
+		});
+		when('wp_remote_get')->justReturn($raw_response);
+		when('is_wp_error')->justReturn(false);
+		when('wp_remote_retrieve_response_code')->justReturn($status_code);
+	}
+}

--- a/tests/PHPUnit/PpcpSettings/Data/GeneralSettingsTest.php
+++ b/tests/PHPUnit/PpcpSettings/Data/GeneralSettingsTest.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPUnit\PpcpSettings\Data;
+
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\Enum\SellerTypeEnum;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+class GeneralSettingsTest extends TestCase
+{
+	// -----------------------------------------------------------------------
+	// Factory helper
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Instantiate GeneralSettings with a specific seller_type persisted in the DB.
+	 *
+	 * AbstractDataModel::__construct() calls get_option() once, so we set that
+	 * expectation here and return an options array containing only the key under
+	 * test.  All other settings fall back to their declared defaults.
+	 *
+	 * @param string $seller_type One of SellerTypeEnum::BUSINESS / PERSONAL / UNKNOWN.
+	 */
+	private function make_general_settings(string $seller_type): GeneralSettings
+	{
+		expect('get_option')
+			->once()
+			->with('woocommerce-ppcp-data-common', [])
+			->andReturn(['seller_type' => $seller_type]);
+
+		return new GeneralSettings('US', 'USD', false);
+	}
+
+	// -----------------------------------------------------------------------
+	// Data provider
+	// -----------------------------------------------------------------------
+
+	/**
+	 * @return array<string, array{seller_type: string, is_business: bool, is_casual: bool}>
+	 */
+	public function seller_type_provider(): array
+	{
+		return [
+			'business seller: confirmed business account' => [
+				'seller_type' => SellerTypeEnum::BUSINESS,
+				'is_business' => true,
+				'is_casual'   => false,
+			],
+			'personal seller: casual individual account' => [
+				'seller_type' => SellerTypeEnum::PERSONAL,
+				'is_business' => false,
+				'is_casual'   => true,
+			],
+			'unknown seller type: treated as casual to prevent retry loop' => [
+				'seller_type' => SellerTypeEnum::UNKNOWN,
+				'is_business' => false,
+				'is_casual'   => true,
+			],
+		];
+	}
+
+	// -----------------------------------------------------------------------
+	// Tests
+	// -----------------------------------------------------------------------
+
+	/**
+	 * GIVEN a merchant whose seller_type is stored in the database
+	 * WHEN is_business_seller() and is_casual_seller() are queried
+	 * THEN each method returns the value that matches the merchant's account type
+	 * AND unknown seller types are treated as casual (not business) to avoid
+	 *     triggering an unresolvable seller-type detection retry loop
+	 *
+	 * @dataProvider seller_type_provider
+	 */
+	public function testSellerTypeClassificationMatchesStoredValue(
+		string $seller_type,
+		bool $is_business,
+		bool $is_casual
+	): void {
+		$settings = $this->make_general_settings($seller_type);
+
+		$this->assertSame(
+			$is_business,
+			$settings->is_business_seller(),
+			"is_business_seller() should return {$this->bool_label($is_business)} for seller_type '{$seller_type}'"
+		);
+
+		$this->assertSame(
+			$is_casual,
+			$settings->is_casual_seller(),
+			"is_casual_seller() should return {$this->bool_label($is_casual)} for seller_type '{$seller_type}'"
+		);
+	}
+
+	// -----------------------------------------------------------------------
+	// Helpers
+	// -----------------------------------------------------------------------
+
+	private function bool_label(bool $value): string
+	{
+		return $value ? 'true' : 'false';
+	}
+}


### PR DESCRIPTION
## Description

**Fix excessive API calls to merchant-integrations endpoint:**

Merchants with `seller_type = 'unknown'` triggered an API call on every page load.
The resolver retries on every `init` hook when the type is unresolved, but the throttle only kicks in on failed requests - successful calls that return `UNKNOWN` were never throttled.

### Fix

1. **Treat unknown as casual** - `GeneralSettings::is_casual_seller()` returns `true` for any non-business type, breaking the retry loop without changing the stored DB value.
2. **Cache at the endpoint** - `PartnersEndpoint::seller_status()` caches responses for 10 minutes. Cleared on plugin update and "Refresh features".

### Test plan

- Added 7 new unit tests covering both changes
