### PR TITLE
feat(onboarding): restore Firefox incompatibility notice (6076)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Components/ConnectionButton.js
@@ -8,6 +8,9 @@ import { OnboardingHooks } from '@ppcp-settings/data/onboarding/hooks';
 import BusyStateWrapper from '@ppcp-settings/Components/ReusableComponents/BusyStateWrapper';
 import { Notice } from '@ppcp-settings/Components/ReusableComponents/Elements';
 
+const isFirefox =
+	typeof window !== 'undefined' &&
+	window.navigator.userAgent.toLowerCase().includes( 'firefox' );
 /**
  * Button component that outputs a placeholder button when no onboardingUrl is present yet - the
  * placeholder button looks identical to the working button, but has no href, target, or
@@ -40,6 +43,20 @@ const ButtonOrPlaceholder = ( {
 		buttonProps.href = href;
 		buttonProps[ 'data-paypal-button' ] = 'true';
 		buttonProps[ 'data-paypal-onboard-button' ] = 'true';
+	}
+
+	if ( isFirefox ) {
+		return (
+			<>
+				<Button { ...buttonProps }>{ children }</Button>
+				<Notice type={ 'error' }>
+					{ __(
+						'This button may not work in Firefox. Please use another browser, like Chrome, to complete this step.',
+						'woocommerce-paypal-payments'
+					) }
+				</Notice>
+			</>
+		);
 	}
 
 	return <Button { ...buttonProps }>{ children }</Button>;


### PR DESCRIPTION
### Issue Description

The Firefox incompatibility notice was accidentally removed. This PR restores it.

### PR Description

Re-introduces the Firefox browser warning in the `ConnectionButton` component:

- Adds a `useIsFirefox` utility to detect Firefox via `userAgent`
- When Firefox is detected, renders an error `Notice` below the onboarding button informing the merchant to use a different browser to complete onboarding

<img width="1504" height="454" alt="Screenshot 2026-04-01 at 16 25 30" src="https://github.com/user-attachments/assets/c00ef4f4-34c9-4cd8-96a5-9433004b61c0" />

### Acceptance criteria covered

- [x] Given the plugin is not yet connected, when the onboarding wizard is visited in Firefox, there is a visible notice about Firefox being incompatible with the onboarding