### PR TITLE
fix(tests): restore missing `wp_functions.php` bootstrap file

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f454a4dc4519aa3bafab294be971ae9b",
+    "content-hash": "a39f67516f6df923b6f79368c7def9e4",
     "packages": [
         {
             "name": "psr/log",
@@ -1863,11 +1863,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.39",
+            "version": "2.1.46",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
-                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
+                "reference": "a193923fc2d6325ef4e741cf3af8c3e8f54dbf25",
                 "shasum": ""
             },
             "require": {
@@ -1912,7 +1912,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-11T14:48:56+00:00"
+            "time": "2026-04-01T09:25:14+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/tests/inc/wp_functions.php
+++ b/tests/inc/wp_functions.php
@@ -1,0 +1,41 @@
+<?php
+
+if ( ! file_exists( 'wp_normalize_path' ) ) {
+	function wp_is_stream( $path ) {
+		$scheme_separator = strpos( $path, '://' );
+
+		if ( false === $scheme_separator ) {
+			// $path isn't a stream.
+			return false;
+		}
+
+		$stream = substr( $path, 0, $scheme_separator );
+
+		return in_array( $stream, stream_get_wrappers(), true );
+	}
+}
+
+if ( ! file_exists( 'wp_normalize_path' ) ) {
+	function wp_normalize_path( $path ) {
+		$wrapper = '';
+
+		if ( wp_is_stream( $path ) ) {
+			list( $wrapper, $path ) = explode( '://', $path, 2 );
+
+			$wrapper .= '://';
+		}
+
+		// Standardize all paths to use '/'.
+		$path = str_replace( '\\', '/', $path );
+
+		// Replace multiple slashes down to a singular, allowing for network shares having two slashes.
+		$path = preg_replace( '|(?<=.)/+|', '/', $path );
+
+		// Windows paths should uppercase the drive letter.
+		if ( ':' === substr( $path, 1, 1 ) ) {
+			$path = ucfirst( $path );
+		}
+
+		return $wrapper . $path;
+	}
+}

--- a/tests/inc/wp_functions.php
+++ b/tests/inc/wp_functions.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( ! function_exists( 'wp_normalize_path' ) ) {
+if ( ! function_exists( 'wp_is_stream' ) ) {
 	function wp_is_stream( $path ) {
 		$scheme_separator = strpos( $path, '://' );
 

--- a/tests/inc/wp_functions.php
+++ b/tests/inc/wp_functions.php
@@ -1,6 +1,6 @@
 <?php
 
-if ( ! file_exists( 'wp_normalize_path' ) ) {
+if ( ! function_exists( 'wp_normalize_path' ) ) {
 	function wp_is_stream( $path ) {
 		$scheme_separator = strpos( $path, '://' );
 
@@ -15,7 +15,7 @@ if ( ! file_exists( 'wp_normalize_path' ) ) {
 	}
 }
 
-if ( ! file_exists( 'wp_normalize_path' ) ) {
+if ( ! function_exists( 'wp_normalize_path' ) ) {
 	function wp_normalize_path( $path ) {
 		$wrapper = '';
 


### PR DESCRIPTION
### Issue Description

`tests/inc/wp_functions.php` was accidentally removed in PR #4206, causing CI failures on all PRs targeting `dev/develop`. This PR restores it.

### PR Description

Restores `tests/inc/wp_functions.php` from `dev/release/4.0.0`. The file is still required by the test suite and should not have been removed.

### Acceptance criteria covered

- [x] `tests/inc/wp_functions.php` exists on `dev/develop`
- [x] CI passes on `dev/develop`