### PR TITLE
feat(order-endpoint): Add BN code to` confirm_payment_source` requests (6099)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -302,10 +302,14 @@ return array(
 		);
 	},
 	'api.endpoint.orders'                            => static function ( ContainerInterface $container ): Orders {
+		$session_handler = $container->get( 'session.handler' );
+		assert( $session_handler instanceof SessionHandler );
+
 		return new Orders(
 			$container->get( 'api.host' ),
 			$container->get( 'api.bearer' ),
-			$container->get( 'woocommerce.logger.woocommerce' )
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$session_handler->bn_code()
 		);
 	},
 	'api.reference-transaction-status'               => static fn ( ContainerInterface $container ): ReferenceTransactionStatus => new ReferenceTransactionStatus(

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -601,6 +601,10 @@ class OrderEndpoint {
 			'body'    => wp_json_encode( $data ),
 		);
 
+		if ( $this->bn_code ) {
+			$args['headers']['PayPal-Partner-Attribution-Id'] = $this->bn_code;
+		}
+
 		$response = $this->request( $url, $args );
 		if ( $response instanceof WP_Error ) {
 			throw new RuntimeException( $response->get_error_message() );

--- a/modules/ppcp-api-client/src/Endpoint/Orders.php
+++ b/modules/ppcp-api-client/src/Endpoint/Orders.php
@@ -23,42 +23,21 @@ class Orders {
 
 	use RequestTrait;
 
-	/**
-	 * The host.
-	 *
-	 * @var string
-	 */
-	private $host;
+	private string $host;
+	private Bearer $bearer;
+	private LoggerInterface $logger;
+	private string $bn_code;
 
-	/**
-	 * The bearer.
-	 *
-	 * @var Bearer
-	 */
-	private $bearer;
-
-	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
-	private $logger;
-
-	/**
-	 * Orders constructor.
-	 *
-	 * @param string          $host The host.
-	 * @param Bearer          $bearer The bearer.
-	 * @param LoggerInterface $logger The logger.
-	 */
 	public function __construct(
 		string $host,
 		Bearer $bearer,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		string $bn_code = ''
 	) {
-		$this->host   = $host;
-		$this->bearer = $bearer;
-		$this->logger = $logger;
+		$this->host    = $host;
+		$this->bearer  = $bearer;
+		$this->logger  = $logger;
+		$this->bn_code = $bn_code;
 	}
 
 	/**
@@ -137,6 +116,10 @@ class Orders {
 			),
 			'body'    => wp_json_encode( $request_body ),
 		);
+
+		if ( $this->bn_code ) {
+			$args['headers']['PayPal-Partner-Attribution-Id'] = $this->bn_code;
+		}
 
 		$response = $this->request( $url, $args );
 		if ( $response instanceof WP_Error ) {


### PR DESCRIPTION
### Issue Description

`confirm_payment_source` was the only method in `OrderEndpoint` not explicitly setting the `PayPal-Partner-Attribution-Id` header, causing gaps in PayPal partnership reporting and revenue attribution.

### PR Description

Adds the BN code header to `confirm_payment_source` requests in `OrderEndpoint`, aligning it with the established pattern used in all other API methods (`create`, `capture`, `authorize`, `order`, `patch`).

```php
if ( $this->bn_code ) {
    $args['headers']['PayPal-Partner-Attribution-Id'] = $this->bn_code;
}
```

### Acceptance criteria covered

- [x] All `confirm_payment_source` requests include the `PayPal-Partner-Attribution-Id` header
- [x] No regression in existing payment method behaviour (Multibanco, OXXO, etc.)