### PR TITLE
Fix smart button locations being disabled after updating (6096)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
@@ -34,7 +34,7 @@ class StylingSettingsMigration implements SettingsMigrationInterface {
 	}
 
 	public function migrate(): void {
-		if ( empty( $this->settings ) ) {
+		if ( empty( $this->settings ) || ! isset( $this->settings['smart_button_locations'] ) ) {
 			return;
 		}
 

--- a/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/StylingSettingsMigration.php
@@ -34,6 +34,10 @@ class StylingSettingsMigration implements SettingsMigrationInterface {
 	}
 
 	public function migrate(): void {
+		if ( empty( $this->settings ) ) {
+			return;
+		}
+
 		$location_styles = array();
 
 		$styling_per_location = ! empty( $this->settings['smart_button_enable_styling_per_location'] );


### PR DESCRIPTION
### Description                                                                                                                                                                                                   
  When upgrading from 4.0.1 to a higher version, the styling migration was incorrectly wiping Smart Button locations on the Style tab, leaving all locations disabled.                                              
                                                                                                                                                                                                                    
  **Root cause:** Fresh 4.0.1 installs never used the legacy UI, so `woocommerce-ppcp-settings` has credentials/account data but no button location keys (`smart_button_locations`, etc.). The migration-done flag  
  (`woocommerce_ppcp-settings-migration-is-done`) was never set for these merchants. On the next version bump, the migration ran and — with no `smart_button_locations` key present — every location was treated as
  disabled, overwriting the merchant's working config.                                                                                                                                                              
                                                                                                                                                                                                                  
  **Fix:** If `$this->settings` is empty or the `smart_button_locations` key is absent (no legacy button data to migrate), skip the migration entirely. In the old UI, saving settings always persisted             
  `smart_button_locations`, so its absence means the merchant never used the legacy UI. `StylingSettings` already holds the correct defaults — there's nothing to migrate and nothing to overwrite.
                                                                                                                                                                                                                                                     
  
  ### Steps to Test                                                                                                                                                                                                 
                                                                                                                                                                                                                  
  1. Install 4.0.1 on a clean WordPress site                                                                                                                                                                        
  2. Go to PayPal Payments → Settings → Style tab and confirm button locations are enabled
  3. Install 4.0.2 (the build with this fix) as an update                                                                                          
  4. Go back to Style tab                                                                                                                                                                                           
  5. Verify button locations are still enabled                                                                                                                                                                      
                                                   