### PR TITLE
Fix missing Online Card Payments section after upgrade from 2.9.x

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -76,12 +76,27 @@ class MigrationManager implements SettingsMigrationInterface {
 		$this->onboarding_profile->set_gateways_synced( true, true );
 		$this->onboarding_profile->save();
 
+		// General settings migration is critical — it resolves the seller type
+		// via the PayPal API. If it fails, abort so migration retries on next load.
+		try {
+			$this->general_settings_migration->migrate();
+		} catch ( Exception $error ) {
+			$this->logger->warning(
+				'Settings migration aborted: seller status API call failed. Will retry on next page load.',
+				array(
+					'error_message' => $error->getMessage(),
+					'error_code'    => $error->getCode(),
+				)
+			);
+
+			return;
+		}
+
 		$migrations = array(
-			'general_settings' => $this->general_settings_migration,
-			'settings_tab'     => $this->settings_tab_migration,
-			'styling'          => $this->styling_settings_migration,
-			'payment'          => $this->payment_settings_migration,
-			'fastlane'         => $this->fastlane_settings_migration,
+			'settings_tab' => $this->settings_tab_migration,
+			'styling'      => $this->styling_settings_migration,
+			'payment'      => $this->payment_settings_migration,
+			'fastlane'     => $this->fastlane_settings_migration,
 		);
 
 		foreach ( $migrations as $name => $migration ) {

--- a/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
@@ -9,7 +9,6 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
 
-use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
@@ -54,30 +53,30 @@ class SettingsMigration implements SettingsMigrationInterface {
 			return;
 		}
 
-		$country     = '';
-		$seller_type = SellerTypeEnum::UNKNOWN;
-
-		try {
-			$seller_status = $this->partners_endpoint->seller_status();
-			$country       = $seller_status->country();
-			$seller_type   = $this->seller_type_resolver->resolve( $seller_status );
-		} catch ( Exception $exception ) {
-			$this->logger->warning(
-				'Seller status API call failed during settings migration; using defaults.',
-				array( 'error' => $exception->getMessage() )
-			);
-		}
-
+		// Save credentials first so they persist even if the API call fails.
 		$connection = new MerchantConnectionDTO(
 			! empty( $this->settings['sandbox_on'] ),
 			$this->settings['client_id'],
 			$this->settings['client_secret'],
 			$this->settings['merchant_id'],
 			$this->settings['merchant_email'] ?? '',
-			$country,
-			$seller_type
+			'',
+			SellerTypeEnum::UNKNOWN
 		);
+		$this->general_settings->set_merchant_data( $connection );
+		$this->general_settings->save();
 
+		// Resolve seller type — exception propagates so migration can retry.
+		$seller_status = $this->partners_endpoint->seller_status();
+		$connection    = new MerchantConnectionDTO(
+			! empty( $this->settings['sandbox_on'] ),
+			$this->settings['client_id'],
+			$this->settings['client_secret'],
+			$this->settings['merchant_id'],
+			$this->settings['merchant_email'] ?? '',
+			$seller_status->country(),
+			$this->seller_type_resolver->resolve( $seller_status )
+		);
 		$this->general_settings->set_merchant_data( $connection );
 		$this->general_settings->save();
 	}

--- a/modules/ppcp-settings/src/Service/SellerTypeResolver.php
+++ b/modules/ppcp-settings/src/Service/SellerTypeResolver.php
@@ -88,6 +88,8 @@ class SellerTypeResolver {
 				$general_settings->save();
 
 				do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
+
+				return;
 			}
 		} catch ( Exception $e ) {
 			$logger->debug(
@@ -95,6 +97,9 @@ class SellerTypeResolver {
 				array( 'error' => $e->getMessage() )
 			);
 		}
+
+		// Seller type still unknown — throttle retries to once per hour.
+		$failure_registry->add_failure( FailureRegistry::SELLER_STATUS_KEY );
 	}
 
 	/**
@@ -113,7 +118,7 @@ class SellerTypeResolver {
 			return false;
 		}
 
-		return ! $general_settings->is_business_seller() && ! $general_settings->is_casual_seller();
+		return SellerTypeEnum::UNKNOWN === $general_settings->get_merchant_data()->seller_type;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -118,15 +118,36 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		add_action(
 			'admin_init',
 			function () use ( $container ): void {
-				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) !== '1' ) {
-					$legacy_settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
-					if ( ! empty( $legacy_settings['client_id'] ) ) {
-						self::pre_populate_credentials( $container );
+				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) === '1' ) {
+					return;
+				}
 
-						$migration_manager = $container->get( 'settings.service.data-migration' );
-						assert( $migration_manager instanceof MigrationManager );
-						$migration_manager->migrate();
-					}
+				$legacy_settings = (array) get_option( 'woocommerce-ppcp-settings', array() );
+				if ( empty( $legacy_settings['client_id'] ) ) {
+					return;
+				}
+
+				self::pre_populate_credentials( $container );
+
+				$migration_manager = $container->get( 'settings.service.data-migration' );
+				assert( $migration_manager instanceof MigrationManager );
+				$migration_manager->migrate();
+
+				$migration_done = get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE );
+
+				if ( (string) $migration_done !== '1' ) {
+					add_action(
+						'admin_notices',
+						static function (): void {
+							printf(
+								'<div class="notice notice-warning"><p>%s</p></div>',
+								esc_html__(
+									'PayPal Payments: Settings migration could not be completed because the PayPal API is temporarily unavailable. It will retry automatically on the next page load.',
+									'woocommerce-paypal-payments'
+								)
+							);
+						}
+					);
 				}
 			}
 		);


### PR DESCRIPTION
When upgrading from `2.9.6` to `4.0.2` (or from any 3.x using legacy UI), the `seller_status` API call fails silently during migration, saving `seller_type = 'unknown'`. The 4.0.2 change to `is_casual_seller()` treats `UNKNOWN` as casual, which permanently disables the retry mechanism that would resolve it. This hides the "Online Card Payments" and "APMs" sections since they require isBusinessSeller = true.
                                                                                                                                                                                                      
This PR decouples the retry mechanism from is_casual_seller(), check for UNKNOWN directly, with hourly throttling to prevent excessive API calls.  It also stops silently swallowing API failures during migration, save credentials first, let the exception propagate so migration retries on next page load, and show an admin notice to the merchant. 