### PR TITLE
Fix(Apple Pay): Hide Apple Pay “Register Domain” TODO when domain is already validated (6080)

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -625,7 +625,7 @@ return array(
 			! $button_locations['cart_enabled'],                                                          // Add PayPal buttons to cart.
 			! $button_locations['block_checkout_enabled'],                                                // Add PayPal buttons to block checkout.
 			! $button_locations['product_enabled'],                                                       // Add PayPal buttons to product.
-			$container->get( 'applepay.eligible' ) && $capabilities[ FeaturesDefinition::FEATURE_APPLE_PAY ],  // Register Domain for Apple Pay.
+			$container->get( 'applepay.eligible' ) && $capabilities[ FeaturesDefinition::FEATURE_APPLE_PAY ] && ! $container->get( 'applepay.is_validated' ),  // Register Domain for Apple Pay.
 			$capabilities[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ] && ! ( $capabilities[ FeaturesDefinition::FEATURE_APPLE_PAY ] && $capabilities[ FeaturesDefinition::FEATURE_GOOGLE_PAY ] ),     // Add digital wallets to your account.
 			$container->get( 'applepay.eligible' ) && $capabilities[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ] && ! $capabilities[ FeaturesDefinition::FEATURE_APPLE_PAY ],                                        // Add Apple Pay to your account.
 			$container->get( 'googlepay.eligible' ) && $capabilities[ FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS ] && ! $capabilities[ FeaturesDefinition::FEATURE_GOOGLE_PAY ],                                       // Add Google Pay to your account.


### PR DESCRIPTION
**PR Description**

Adds an additional condition to prevent showing the “Register Domain” TODO item for Apple Pay when the domain has already been validated:

**Why**

the “Register Domain” prompt is still displayed even if the domain was already registered.

The `applepay.is_validated` service reflects the correct state, but only after the Apple Pay button is triggered on the frontend. By adding this condition, we ensure that:

Once the domain is validated via frontend interaction, the TODO item disappears
No additional API request  is needed

**Limitations**

This is a partial fix: the TODO item will still appear until the Apple Pay button is triggered at least once on the frontend
A fully accurate solution would require an additional API call, which we are intentionally avoiding for performance reasons

**Result**

Improves UX after migration without introducing extra API calls or added complexity.