### PR TITLE
Duplicate WooCommerce orders created when buyer switches payment method at checkout (6189)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/BancontactGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/BancontactGateway.php
@@ -145,7 +145,7 @@ class BancontactGateway extends WC_Payment_Gateway {
 				'redirect' => wc_get_checkout_url(),
 			);
 		}
-		$wc_order->update_status( 'on-hold', __( 'Awaiting Bancontact to confirm the payment.', 'woocommerce-paypal-payments' ) );
+		$wc_order->update_status( 'pending', __( 'Awaiting Bancontact to confirm the payment.', 'woocommerce-paypal-payments' ) );
 
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$amount        = $purchase_unit->amount()->to_array();

--- a/modules/ppcp-local-alternative-payment-methods/src/BlikGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/BlikGateway.php
@@ -145,7 +145,7 @@ class BlikGateway extends WC_Payment_Gateway {
 				'redirect' => wc_get_checkout_url(),
 			);
 		}
-		$wc_order->update_status( 'on-hold', __( 'Awaiting Blik to confirm the payment.', 'woocommerce-paypal-payments' ) );
+		$wc_order->update_status( 'pending', __( 'Awaiting Blik to confirm the payment.', 'woocommerce-paypal-payments' ) );
 
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$amount        = $purchase_unit->amount()->to_array();

--- a/modules/ppcp-local-alternative-payment-methods/src/EPSGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/EPSGateway.php
@@ -145,7 +145,7 @@ class EPSGateway extends WC_Payment_Gateway {
 				'redirect' => wc_get_checkout_url(),
 			);
 		}
-		$wc_order->update_status( 'on-hold', __( 'Awaiting EPS to confirm the payment.', 'woocommerce-paypal-payments' ) );
+		$wc_order->update_status( 'pending', __( 'Awaiting EPS to confirm the payment.', 'woocommerce-paypal-payments' ) );
 
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$amount        = $purchase_unit->amount()->to_array();

--- a/modules/ppcp-local-alternative-payment-methods/src/IDealGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/IDealGateway.php
@@ -145,7 +145,7 @@ class IDealGateway extends WC_Payment_Gateway {
 				'redirect' => wc_get_checkout_url(),
 			);
 		}
-		$wc_order->update_status( 'on-hold', __( 'Awaiting iDeal to confirm the payment.', 'woocommerce-paypal-payments' ) );
+		$wc_order->update_status( 'pending', __( 'Awaiting iDeal to confirm the payment.', 'woocommerce-paypal-payments' ) );
 
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$amount        = $purchase_unit->amount()->to_array();

--- a/modules/ppcp-local-alternative-payment-methods/src/MyBankGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/MyBankGateway.php
@@ -145,7 +145,7 @@ class MyBankGateway extends WC_Payment_Gateway {
 				'redirect' => wc_get_checkout_url(),
 			);
 		}
-		$wc_order->update_status( 'on-hold', __( 'Awaiting MyBank to confirm the payment.', 'woocommerce-paypal-payments' ) );
+		$wc_order->update_status( 'pending', __( 'Awaiting MyBank to confirm the payment.', 'woocommerce-paypal-payments' ) );
 
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$amount        = $purchase_unit->amount()->to_array();

--- a/modules/ppcp-local-alternative-payment-methods/src/P24Gateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/P24Gateway.php
@@ -145,7 +145,7 @@ class P24Gateway extends WC_Payment_Gateway {
 				'redirect' => wc_get_checkout_url(),
 			);
 		}
-		$wc_order->update_status( 'on-hold', __( 'Awaiting Przelewy24 to confirm the payment.', 'woocommerce-paypal-payments' ) );
+		$wc_order->update_status( 'pending', __( 'Awaiting Przelewy24 to confirm the payment.', 'woocommerce-paypal-payments' ) );
 
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$amount        = $purchase_unit->amount()->to_array();

--- a/modules/ppcp-local-alternative-payment-methods/src/TrustlyGateway.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/TrustlyGateway.php
@@ -145,7 +145,7 @@ class TrustlyGateway extends WC_Payment_Gateway {
 				'redirect' => wc_get_checkout_url(),
 			);
 		}
-		$wc_order->update_status( 'on-hold', __( 'Awaiting Trustly to confirm the payment.', 'woocommerce-paypal-payments' ) );
+		$wc_order->update_status( 'pending', __( 'Awaiting Trustly to confirm the payment.', 'woocommerce-paypal-payments' ) );
 
 		$purchase_unit = $this->purchase_unit_factory->from_wc_order( $wc_order );
 		$amount        = $purchase_unit->amount()->to_array();


### PR DESCRIPTION
When a buyer starts checkout with one local APM payment method (e.g., iDEAL) and then goes back to complete with a different method (e.g., credit card), the plugin creates two separate WooCommerce orders for the same purchase attempt. The first order remains stuck in On-Hold status with stock locked, while the second order completes successfully.

### Steps To Reproduce
- Add product(s) to cart on a WooCommerce store with PPCP and iDEAL enabled.                                                                                                                                        
- Proceed to checkout and select iDEAL as the payment method.
- Initiate the iDEAL payment flow (PayPal order created with status PAYER_ACTION_REQUIRED).                                                                                                                         
- Before completing the iDEAL redirect, go back and switch to credit card.                                                                                                                                          
- Complete the purchase with credit card.    

This PR changes the order status from `on-hold` to `pending` before the APM redirect on all local APMs gateways.

The fix will also prevent premature emails, and allow payment retry in My Account page.