### PR TITLE
[QA] Fix Payment Methods UI E2E tests

### DIFF
--- a/tests/qa/resources/pcp-gateways.ts
+++ b/tests/qa/resources/pcp-gateways.ts
@@ -55,6 +55,7 @@ const acdc: Pcp.Gateway = {
 	description: '',
 	title: 'Debit & Credit Cards',
 	titleInPcpSettings: 'Advanced Credit and Debit Card Payments',
+	titleInModal: 'Debit & Credit Cards',
 	titleInWcSettings: 'Advanced Card Processing',
 	hasSettingsButton: true,
 	enabled: false,
@@ -76,6 +77,7 @@ const fastlane: Pcp.Gateway = {
 	description: '',
 	title: 'Fastlane',
 	titleInPcpSettings: 'Fastlane by PayPal',
+	titleInModal: 'Debit & Credit Cards',
 	titleInWcSettings: 'Fastlane Debit & Credit Cards',
 	hasSettingsButton: true,
 	dependsOn: 'acdc',
@@ -127,7 +129,8 @@ const bancontact: Pcp.Gateway = {
 	titleInPcpSettings: 'Bancontact',
 	titleInWcSettings: 'Bancontact (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const blik: Pcp.Gateway = {
@@ -138,11 +141,12 @@ const blik: Pcp.Gateway = {
 
 	id: 'ppcp-blik',
 	description: '',
-	title: 'BLIK',
-	titleInPcpSettings: 'BLIK',
+	title: 'Blik',
+	titleInPcpSettings: 'Blik',
 	titleInWcSettings: ' (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const eps: Pcp.Gateway = {
@@ -153,11 +157,12 @@ const eps: Pcp.Gateway = {
 
 	id: 'ppcp-eps',
 	description: '',
-	title: 'eps',
-	titleInPcpSettings: 'eps',
+	title: 'EPS',
+	titleInPcpSettings: 'EPS',
 	titleInWcSettings: 'EPS (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const ideal: Pcp.Gateway = {
@@ -168,11 +173,12 @@ const ideal: Pcp.Gateway = {
 
 	id: 'ppcp-ideal',
 	description: '',
-	title: 'iDEAL',
-	titleInPcpSettings: 'iDEAL',
+	title: 'iDeal',
+	titleInPcpSettings: 'iDeal',
 	titleInWcSettings: ' (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const mybank: Pcp.Gateway = {
@@ -186,7 +192,8 @@ const mybank: Pcp.Gateway = {
 	titleInPcpSettings: 'MyBank',
 	titleInWcSettings: ' (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const przelewy24: Pcp.Gateway = {
@@ -200,7 +207,8 @@ const przelewy24: Pcp.Gateway = {
 	titleInPcpSettings: 'Przelewy24',
 	titleInWcSettings: ' (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const trustly: Pcp.Gateway = {
@@ -215,7 +223,8 @@ const trustly: Pcp.Gateway = {
 	titleInPcpSettings: 'Trustly',
 	titleInWcSettings: 'Trustly (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const multibanco: Pcp.Gateway = {
@@ -229,7 +238,8 @@ const multibanco: Pcp.Gateway = {
 	titleInPcpSettings: 'Multibanco',
 	titleInWcSettings: 'Multibanco (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const oxxo: Pcp.Gateway = {
@@ -243,7 +253,8 @@ const oxxo: Pcp.Gateway = {
 	titleInPcpSettings: 'OXXO',
 	titleInWcSettings: 'OXXO (via PayPal)',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const payUponInvoice: Pcp.Gateway = {
@@ -259,7 +270,8 @@ const payUponInvoice: Pcp.Gateway = {
 	titleInPcpSettings: 'Pay upon Invoice',
 	titleInWcSettings: 'Pay upon Invoice',
 	hasSettingsButton: true,
-	enabled: true,
+	// Disabled by default after a fresh connect; enabled only in country-specific test setups.
+	enabled: false,
 };
 
 const debitOrCreditCard: Pcp.Gateway = {

--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -84,7 +84,8 @@ export namespace Pcp {
 			minAmount?: string;
 			maxAmount?: string;
 			titleInWcSettings?: string; // gateway title on WooCommerce > Settings > Payments tab
-			titleInPcpSettings?: string; // gateway title on PCP Settings > Payment Methods tab
+			titleInPcpSettings?: string; // gateway title in PCP Settings > Payment Methods
+			titleInModal?: string; // title shown in the PCP Settings > Payment Methods modal
 			hasSettingsButton?: boolean; // gateway has Settings icon on PCP Settings > Payment Methods tab
 			dependsOn?: GatewayShortcut; // gateway can be enabled if leading gateway is enabled on PCP Settings > Payment Methods tab
 		};

--- a/tests/qa/tests/03-plugin-settings/_test-data/payment-methods-ui.data.ts
+++ b/tests/qa/tests/03-plugin-settings/_test-data/payment-methods-ui.data.ts
@@ -1,7 +1,34 @@
-const defaultUi = [
+// expectedGatewayCount: approximate total number of .ppcp--method-item elements (soft assertion).
+// expectedGroupCounts: expected count per section for easier debugging (soft assertions).
+//   PayPal Checkout:          payPal + venmo + payLater = 3
+//   Online Card Payments:     acdc + fastlane + applepay + googlepay = 4
+//   Alternative Payments:     bancontact + blik + eps + ideal + mybank +
+//                             przelewy24 + trustly + multibanco = 8
+//   (OXXO, PayUponInvoice, and Pay with Crypto are not shown for this merchant/env right now)
+
+export type PaymentMethodsUiTestData = {
+	testKey: string;
+	country: string;
+	expectedGatewayCount: number;
+	expectedGroupCounts: {
+		paypalCheckout: number;
+		onlineCardPayments: number;
+		alternativePaymentMethods: number;
+	};
+	testGateways: string[];
+};
+
+const defaultUi: PaymentMethodsUiTestData[] = [
 	{
-		testKey: 'PCP-0000',
+		// https://inpsyde.atlassian.net/browse/PCP-6228
+		testKey: 'PCP-6228',
 		country: 'usa',
+		expectedGatewayCount: 15,
+		expectedGroupCounts: {
+			paypalCheckout: 3,
+			onlineCardPayments: 4,
+			alternativePaymentMethods: 8,
+		},
 		testGateways: [
 			'payPal',
 			'venmo',

--- a/tests/qa/tests/03-plugin-settings/payment-methods-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/payment-methods-ui.spec.ts
@@ -25,7 +25,7 @@ for ( const testData of paymentMethodsData.defaultUi ) {
 	} = testData;
 
 	test(
-		`${ testKey } | Settings - US - Payment Methods - Default UI — groups, toggles, modals, live PayPal buttons`,
+		`${ testKey } | Settings - US - Payment Methods - Default UI — groups, toggles, modals, live PayPal buttons @Critical`,
 		async (
 			{
 				utils,

--- a/tests/qa/tests/03-plugin-settings/payment-methods-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/payment-methods-ui.spec.ts
@@ -16,10 +16,16 @@ test.beforeAll( async ( { utils, pcpApi } ) => {
 } );
 
 for ( const testData of paymentMethodsData.defaultUi ) {
-	const { testKey, country, testGateways } = testData;
+	const {
+		testKey,
+		country,
+		testGateways,
+		expectedGatewayCount,
+		expectedGroupCounts,
+	} = testData;
 
-	test.fixme(
-		`${ testKey } | Settings - ${ country } - Payment Methods - Default UI`,
+	test(
+		`${ testKey } | Settings - US - Payment Methods - Default UI — groups, toggles, modals, live PayPal buttons`,
 		async (
 			{
 				utils,
@@ -35,27 +41,56 @@ for ( const testData of paymentMethodsData.defaultUi ) {
 		) => {
 			const simpleProduct = products.simple100;
 
+			// ── Settings page ────────────────────────────────────────────────────────
+
 			await pcpPaymentMethods.visit();
 			await expect(
 				pcpPaymentMethods.onlineCardPaymentsContainer(),
 				`Assert online card payments container is visible for ${ country }`
 			).toBeVisible();
+
+			// Total item count (soft — continues on mismatch)
 			await expect
 				.soft(
 					pcpPaymentMethods.paymentMethodContainers(),
-					`Assert payment methods count is ${ testGateways.length } for ${ country }`
+					`Assert total payment methods count is ${ expectedGatewayCount } for ${ country }`
 				)
-				.toHaveCount( testGateways.length );
+				.toHaveCount( expectedGatewayCount );
 
-			// Assert expected gateways one by one
+			// Per-group item counts (soft — targeted diagnostics on count drift)
+			await expect
+				.soft(
+					pcpPaymentMethods.payPalCheckoutMethodItems(),
+					`Assert PayPal Checkout group has ${ expectedGroupCounts.paypalCheckout } items`
+				)
+				.toHaveCount( expectedGroupCounts.paypalCheckout );
+			await expect
+				.soft(
+					pcpPaymentMethods.onlineCardPaymentMethodItems(),
+					`Assert Online Card Payments group has ${ expectedGroupCounts.onlineCardPayments } items`
+				)
+				.toHaveCount( expectedGroupCounts.onlineCardPayments );
+			await expect
+				.soft(
+					pcpPaymentMethods.alternativePaymentMethodItems(),
+					`Assert Alternative Payment Methods group has ${ expectedGroupCounts.alternativePaymentMethods } items`
+				)
+				.toHaveCount( expectedGroupCounts.alternativePaymentMethods );
+
+			// ── Per-gateway assertions ────────────────────────────────────────────────
+
 			for ( const testGateway of testGateways ) {
 				const gateway = gateways[ testGateway ];
 				const {
+					title,
 					titleInPcpSettings,
+					titleInModal,
 					hasSettingsButton,
 					enabled: isGatewayEnabled,
 					dependsOn,
 				} = gateway;
+
+				const expectedModalTitle = titleInModal ?? title;
 
 				const gatewayToggle =
 					pcpPaymentMethods.paymentMethodToggle( titleInPcpSettings );
@@ -70,12 +105,12 @@ for ( const testData of paymentMethodsData.defaultUi ) {
 				);
 				await expect(
 					gatewayContainer,
-					`Assert gateway container for ${ titleInPcpSettings } is visible for ${ country }`
+					`Assert gateway container for ${ titleInPcpSettings } is visible`
 				).toBeVisible();
 				const gatewayTitle = await gatewayContainer.textContent();
 				expect(
 					gatewayTitle,
-					`Assert gateway ${ titleInPcpSettings } title is displayed for ${ country }`
+					`Assert gateway ${ titleInPcpSettings } title is displayed`
 				).toContain( titleInPcpSettings );
 
 				await expect(
@@ -88,15 +123,27 @@ for ( const testData of paymentMethodsData.defaultUi ) {
 				).toBeChecked( { checked: isGatewayEnabled } );
 
 				if ( hasSettingsButton ) {
+					// Track which toggles are being enabled
+					const dependencyTitle = dependsOn
+						? gateways[ dependsOn ].titleInPcpSettings
+						: null;
+					let enabledDependency = false;
+					let enabledGateway = false;
+
 					if ( ! isGatewayEnabled ) {
-						if ( dependsOn ) {
-							await pcpPaymentMethods
-								.paymentMethodToggle(
-									gateways[ dependsOn ].titleInPcpSettings
-								)
-								.check();
+						// Enable parent dependency if it is not yet on.
+						if ( dependencyTitle ) {
+							const depToggle =
+								pcpPaymentMethods.paymentMethodToggle(
+									dependencyTitle
+								);
+							if ( ! ( await depToggle.isChecked() ) ) {
+								await depToggle.check();
+								enabledDependency = true;
+							}
 						}
 						await gatewayToggle.check();
+						enabledGateway = true;
 					}
 
 					await gatewaySettingsButton.click();
@@ -104,50 +151,51 @@ for ( const testData of paymentMethodsData.defaultUi ) {
 						pcpPaymentMethods.modalWindow(),
 						`Assert modal window is visible for ${ titleInPcpSettings }`
 					).toBeVisible();
+					await expect(
+						pcpPaymentMethods.modalTitle(),
+						`Assert modal title contains "${ expectedModalTitle }"`
+					).toContainText( expectedModalTitle );
 					await pcpPaymentMethods.modalCloseButton().click();
+
+					// Restore toggle state (gateway first, then dependency).
+					if ( enabledGateway ) {
+						await gatewayToggle.uncheck();
+					}
+					if ( enabledDependency && dependencyTitle ) {
+						await pcpPaymentMethods
+							.paymentMethodToggle( dependencyTitle )
+							.uncheck();
+					}
 				}
 			}
+
+			// ── Live-site PayPal button visibility ───────────────────────────────────
 
 			await utils.fillVisitorsCart( [ simpleProduct ] );
 
 			await product.visit( simpleProduct.slug );
-			await expect(
-				product.payPalUi.payPalButtonsBlockContainer(),
-				'Assert PayPal button container is visible on product page'
-			).toBeVisible();
+			await product.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
 
 			await product.minicartContainer().hover();
 			await expect
 				.soft(
 					payPalUiClassic.miniCartButtonContainer(),
-					'Assert mini cart PayPal button is not visible when not expected'
+					'Assert mini cart PayPal button is not visible in default settings'
 				)
 				.not.toBeVisible();
 
 			await cart.visit();
-			await expect(
-				cart.payPalUi.payPalButtonsBlockContainer(),
-				'Assert PayPal button container is visible on cart'
-			).toBeVisible();
+			await cart.payPalUi.assertPayPalButtonsBlockVisibleWithContent();
 
 			await classicCart.visit();
-			await expect(
-				classicCart.payPalUi.payPalButtonsBlockContainer(),
-				'Assert PayPal button container is visible on classic cart'
-			).toBeVisible();
+			await classicCart.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
 
 			await checkout.visit();
-			await expect(
-				checkout.payPalUi.payPalButtonsBlockContainer(),
-				'Assert PayPal button container is visible on checkout'
-			).toBeVisible();
+			await checkout.payPalUi.assertPayPalButtonsBlockVisibleWithContent();
 
 			await classicCheckout.visit();
 			await classicCheckout.paymentOption( 'PayPal' ).click();
-			await expect(
-				classicCheckout.payPalUi.payPalButtonsBlockContainer(),
-				'Assert PayPal button container is visible on classic checkout'
-			).toBeVisible();
+			await classicCheckout.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
 		}
 	);
 }

--- a/tests/qa/tests/03-plugin-settings/payment-methods-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/payment-methods-ui.spec.ts
@@ -41,161 +41,170 @@ for ( const testData of paymentMethodsData.defaultUi ) {
 		) => {
 			const simpleProduct = products.simple100;
 
-			// ── Settings page ────────────────────────────────────────────────────────
+			await test.step(
+				'Verify payment method groups and counts in settings',
+				async () => {
+					await pcpPaymentMethods.visit();
+					await expect(
+						pcpPaymentMethods.onlineCardPaymentsContainer(),
+						`Assert online card payments container is visible for ${ country }`
+					).toBeVisible();
 
-			await pcpPaymentMethods.visit();
-			await expect(
-				pcpPaymentMethods.onlineCardPaymentsContainer(),
-				`Assert online card payments container is visible for ${ country }`
-			).toBeVisible();
+					// Total item count (soft — continues on mismatch)
+					await expect
+						.soft(
+							pcpPaymentMethods.paymentMethodContainers(),
+							`Assert total payment methods count is ${ expectedGatewayCount } for ${ country }`
+						)
+						.toHaveCount( expectedGatewayCount );
 
-			// Total item count (soft — continues on mismatch)
-			await expect
-				.soft(
-					pcpPaymentMethods.paymentMethodContainers(),
-					`Assert total payment methods count is ${ expectedGatewayCount } for ${ country }`
-				)
-				.toHaveCount( expectedGatewayCount );
+					// Per-group item counts (soft — targeted diagnostics on count drift)
+					await expect
+						.soft(
+							pcpPaymentMethods.payPalCheckoutMethodItems(),
+							`Assert PayPal Checkout group has ${ expectedGroupCounts.paypalCheckout } items`
+						)
+						.toHaveCount( expectedGroupCounts.paypalCheckout );
+					await expect
+						.soft(
+							pcpPaymentMethods.onlineCardPaymentMethodItems(),
+							`Assert Online Card Payments group has ${ expectedGroupCounts.onlineCardPayments } items`
+						)
+						.toHaveCount( expectedGroupCounts.onlineCardPayments );
+					await expect
+						.soft(
+							pcpPaymentMethods.alternativePaymentMethodItems(),
+							`Assert Alternative Payment Methods group has ${ expectedGroupCounts.alternativePaymentMethods } items`
+						)
+						.toHaveCount( expectedGroupCounts.alternativePaymentMethods );
+				}
+			);
 
-			// Per-group item counts (soft — targeted diagnostics on count drift)
-			await expect
-				.soft(
-					pcpPaymentMethods.payPalCheckoutMethodItems(),
-					`Assert PayPal Checkout group has ${ expectedGroupCounts.paypalCheckout } items`
-				)
-				.toHaveCount( expectedGroupCounts.paypalCheckout );
-			await expect
-				.soft(
-					pcpPaymentMethods.onlineCardPaymentMethodItems(),
-					`Assert Online Card Payments group has ${ expectedGroupCounts.onlineCardPayments } items`
-				)
-				.toHaveCount( expectedGroupCounts.onlineCardPayments );
-			await expect
-				.soft(
-					pcpPaymentMethods.alternativePaymentMethodItems(),
-					`Assert Alternative Payment Methods group has ${ expectedGroupCounts.alternativePaymentMethods } items`
-				)
-				.toHaveCount( expectedGroupCounts.alternativePaymentMethods );
+			await test.step(
+				'Verify each gateway toggle and settings modal behavior',
+				async () => {
+					for ( const testGateway of testGateways ) {
+						const gateway = gateways[ testGateway ];
+						const {
+							title,
+							titleInPcpSettings,
+							titleInModal,
+							hasSettingsButton,
+							enabled: isGatewayEnabled,
+							dependsOn,
+						} = gateway;
 
-			// ── Per-gateway assertions ────────────────────────────────────────────────
+						const expectedModalTitle = titleInModal ?? title;
 
-			for ( const testGateway of testGateways ) {
-				const gateway = gateways[ testGateway ];
-				const {
-					title,
-					titleInPcpSettings,
-					titleInModal,
-					hasSettingsButton,
-					enabled: isGatewayEnabled,
-					dependsOn,
-				} = gateway;
+						const gatewayToggle =
+							pcpPaymentMethods.paymentMethodToggle( titleInPcpSettings );
+						const gatewaySettingsButton =
+							pcpPaymentMethods.paymentMethodSettingsButton(
+								titleInPcpSettings
+							);
 
-				const expectedModalTitle = titleInModal ?? title;
+						// Assert gateway title is displayed correctly
+						const gatewayContainer = pcpPaymentMethods.paymentMethodContainer(
+							titleInPcpSettings
+						);
+						await expect(
+							gatewayContainer,
+							`Assert gateway container for ${ titleInPcpSettings } is visible`
+						).toBeVisible();
+						const gatewayTitle = await gatewayContainer.textContent();
+						expect(
+							gatewayTitle,
+							`Assert gateway ${ titleInPcpSettings } title is displayed`
+						).toContain( titleInPcpSettings );
 
-				const gatewayToggle =
-					pcpPaymentMethods.paymentMethodToggle( titleInPcpSettings );
-				const gatewaySettingsButton =
-					pcpPaymentMethods.paymentMethodSettingsButton(
-						titleInPcpSettings
-					);
+						await expect(
+							gatewaySettingsButton,
+							`Assert settings button visibility is ${ hasSettingsButton } for ${ titleInPcpSettings }`
+						).toBeVisible( { visible: hasSettingsButton } );
+						await expect(
+							gatewayToggle,
+							`Assert gateway ${ titleInPcpSettings } checked state is ${ isGatewayEnabled }`
+						).toBeChecked( { checked: isGatewayEnabled } );
 
-				// Assert gateway title is displayed correctly
-				const gatewayContainer = pcpPaymentMethods.paymentMethodContainer(
-					titleInPcpSettings
-				);
-				await expect(
-					gatewayContainer,
-					`Assert gateway container for ${ titleInPcpSettings } is visible`
-				).toBeVisible();
-				const gatewayTitle = await gatewayContainer.textContent();
-				expect(
-					gatewayTitle,
-					`Assert gateway ${ titleInPcpSettings } title is displayed`
-				).toContain( titleInPcpSettings );
+						if ( hasSettingsButton ) {
+							// Track which toggles are being enabled
+							const dependencyTitle = dependsOn
+								? gateways[ dependsOn ].titleInPcpSettings
+								: null;
+							let enabledDependency = false;
+							let enabledGateway = false;
 
-				await expect(
-					gatewaySettingsButton,
-					`Assert settings button visibility is ${ hasSettingsButton } for ${ titleInPcpSettings }`
-				).toBeVisible( { visible: hasSettingsButton } );
-				await expect(
-					gatewayToggle,
-					`Assert gateway ${ titleInPcpSettings } checked state is ${ isGatewayEnabled }`
-				).toBeChecked( { checked: isGatewayEnabled } );
+							if ( ! isGatewayEnabled ) {
+								// Enable parent dependency if it is not yet on.
+								if ( dependencyTitle ) {
+									const depToggle =
+										pcpPaymentMethods.paymentMethodToggle(
+											dependencyTitle
+										);
+									if ( ! ( await depToggle.isChecked() ) ) {
+										await depToggle.check();
+										enabledDependency = true;
+									}
+								}
+								await gatewayToggle.check();
+								enabledGateway = true;
+							}
 
-				if ( hasSettingsButton ) {
-					// Track which toggles are being enabled
-					const dependencyTitle = dependsOn
-						? gateways[ dependsOn ].titleInPcpSettings
-						: null;
-					let enabledDependency = false;
-					let enabledGateway = false;
+							await gatewaySettingsButton.click();
+							await expect(
+								pcpPaymentMethods.modalWindow(),
+								`Assert modal window is visible for ${ titleInPcpSettings }`
+							).toBeVisible();
+							await expect(
+								pcpPaymentMethods.modalTitle(),
+								`Assert modal title contains "${ expectedModalTitle }"`
+							).toContainText( expectedModalTitle );
+							await pcpPaymentMethods.modalCloseButton().click();
 
-					if ( ! isGatewayEnabled ) {
-						// Enable parent dependency if it is not yet on.
-						if ( dependencyTitle ) {
-							const depToggle =
-								pcpPaymentMethods.paymentMethodToggle(
-									dependencyTitle
-								);
-							if ( ! ( await depToggle.isChecked() ) ) {
-								await depToggle.check();
-								enabledDependency = true;
+							// Restore toggle state (gateway first, then dependency).
+							if ( enabledGateway ) {
+								await gatewayToggle.uncheck();
+							}
+							if ( enabledDependency && dependencyTitle ) {
+								await pcpPaymentMethods
+									.paymentMethodToggle( dependencyTitle )
+									.uncheck();
 							}
 						}
-						await gatewayToggle.check();
-						enabledGateway = true;
-					}
-
-					await gatewaySettingsButton.click();
-					await expect(
-						pcpPaymentMethods.modalWindow(),
-						`Assert modal window is visible for ${ titleInPcpSettings }`
-					).toBeVisible();
-					await expect(
-						pcpPaymentMethods.modalTitle(),
-						`Assert modal title contains "${ expectedModalTitle }"`
-					).toContainText( expectedModalTitle );
-					await pcpPaymentMethods.modalCloseButton().click();
-
-					// Restore toggle state (gateway first, then dependency).
-					if ( enabledGateway ) {
-						await gatewayToggle.uncheck();
-					}
-					if ( enabledDependency && dependencyTitle ) {
-						await pcpPaymentMethods
-							.paymentMethodToggle( dependencyTitle )
-							.uncheck();
 					}
 				}
-			}
+			);
 
-			// ── Live-site PayPal button visibility ───────────────────────────────────
+			await test.step(
+				'Verify live PayPal button visibility on frontend',
+				async () => {
+					await utils.fillVisitorsCart( [ simpleProduct ] );
 
-			await utils.fillVisitorsCart( [ simpleProduct ] );
+					await product.visit( simpleProduct.slug );
+					await product.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
 
-			await product.visit( simpleProduct.slug );
-			await product.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
+					await product.minicartContainer().hover();
+					await expect
+						.soft(
+							payPalUiClassic.miniCartButtonContainer(),
+							'Assert mini cart PayPal button is not visible in default settings'
+						)
+						.not.toBeVisible();
 
-			await product.minicartContainer().hover();
-			await expect
-				.soft(
-					payPalUiClassic.miniCartButtonContainer(),
-					'Assert mini cart PayPal button is not visible in default settings'
-				)
-				.not.toBeVisible();
+					await cart.visit();
+					await cart.payPalUi.assertPayPalButtonsBlockVisibleWithContent();
 
-			await cart.visit();
-			await cart.payPalUi.assertPayPalButtonsBlockVisibleWithContent();
+					await classicCart.visit();
+					await classicCart.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
 
-			await classicCart.visit();
-			await classicCart.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
+					await checkout.visit();
+					await checkout.payPalUi.assertPayPalButtonsBlockVisibleWithContent();
 
-			await checkout.visit();
-			await checkout.payPalUi.assertPayPalButtonsBlockVisibleWithContent();
-
-			await classicCheckout.visit();
-			await classicCheckout.paymentOption( 'PayPal' ).click();
-			await classicCheckout.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
+					await classicCheckout.visit();
+					await classicCheckout.paymentOption( 'PayPal' ).click();
+					await classicCheckout.payPalUi.assertPayPalButtonsGatewayVisibleWithContent();
+				}
+			);
 		}
 	);
 }

--- a/tests/qa/utils/admin/pcp-payment-methods.ts
+++ b/tests/qa/utils/admin/pcp-payment-methods.ts
@@ -17,8 +17,24 @@ export class PcpPaymentMethods extends PcpAdminPage {
 			has: this.paymentMethodTitle( title ),
 		} );
 	paymentMethodContainers = () => this.page.locator( '.ppcp--method-item' );
+
+	// Group containers — IDs come from TabPaymentMethods.js PaymentMethodCard `id` props
+	payPalCheckoutContainer = () =>
+		this.page.locator( '#ppcp-paypal-checkout-card' );
 	onlineCardPaymentsContainer = () =>
 		this.page.locator( '#ppcp-card-payments-card' );
+	alternativePaymentMethodsContainer = () =>
+		this.page.locator( '#ppcp-alternative-payments-card' );
+
+	// Per-group item counts (scoped to each section)
+	payPalCheckoutMethodItems = () =>
+		this.payPalCheckoutContainer().locator( '.ppcp--method-item' );
+	onlineCardPaymentMethodItems = () =>
+		this.onlineCardPaymentsContainer().locator( '.ppcp--method-item' );
+	alternativePaymentMethodItems = () =>
+		this.alternativePaymentMethodsContainer().locator(
+			'.ppcp--method-item'
+		);
 	paymentMethodContainer = ( title: string ) =>
 		this.paymentMethodContainers().filter( {
 			has: this.paymentMethodTitleContainer( title ),


### PR DESCRIPTION
**Ticket:** [PCP-5990](https://inpsyde.atlassian.net/browse/PCP-5990)

**Description** 

The Payment Methods screen tests were turned off (`test.fixme`). This PR turns them back on and fixes them so they match what a USA store really sees in the plugin settings.

**Changes in the code**

- The test runs again instead of being skipped.
- Test data and gateway lists match the USA case (not every country’s payment method).
- We check payment method groups and counts in a softer way so small UI changes are easier to debug.
- We check modal titles and handle gateways that depend on another gateway (turn on parent if needed, then turn things back off).
- On the shop side, we check PayPal buttons more clearly (not only “something is on the page”).
- Small updates to test types, gateway test data, and page helpers (selectors for each section).

**How to run**

Run the Payment Methods UI Playwright test (or the plugin settings QA group). Make sure other settings tests still pass.

`npx playwright test tests/03-plugin-settings/payment-methods-ui.spec.ts --workers=1`