### PR TITLE
Fix AddressFactory::from_wc_order billing address

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AddressFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AddressFactory.php
@@ -1,20 +1,13 @@
 <?php
-/**
- * The Address factory.
- *
- * @package WooCommerce\PayPalCommerce\ApiClient\Factory
- */
 
 declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
 
+use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Address;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 
-/**
- * Class AddressFactory
- */
 class AddressFactory {
 
 	/**
@@ -45,18 +38,25 @@ class AddressFactory {
 	/**
 	 * Returns an Address object based of a WooCommerce order.
 	 *
-	 * @param \WC_Order $order The order.
+	 * @param WC_Order $order The order.
+	 * @param string   $type Either 'shipping' or 'billing'.
 	 *
 	 * @return Address
 	 */
-	public function from_wc_order( \WC_Order $order ): Address {
+	public function from_wc_order( WC_Order $order, string $type = 'shipping' ): Address {
 		return new Address(
-			$order->get_shipping_country(),
-			$order->get_shipping_address_1(),
-			$order->get_shipping_address_2(),
-			$order->get_shipping_state(),
-			$order->get_shipping_city(),
-			$order->get_shipping_postcode()
+			( 'shipping' === $type ) ?
+				$order->get_shipping_country() : $order->get_billing_country(),
+			( 'shipping' === $type ) ?
+				$order->get_shipping_address_1() : $order->get_billing_address_1(),
+			( 'shipping' === $type ) ?
+				$order->get_shipping_address_2() : $order->get_billing_address_2(),
+			( 'shipping' === $type ) ?
+				$order->get_shipping_state() : $order->get_billing_state(),
+			( 'shipping' === $type ) ?
+				$order->get_shipping_city() : $order->get_billing_city(),
+			( 'shipping' === $type ) ?
+				$order->get_shipping_postcode() : $order->get_billing_postcode()
 		);
 	}
 

--- a/modules/ppcp-api-client/src/Factory/PayerFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PayerFactory.php
@@ -70,7 +70,7 @@ class PayerFactory {
 			),
 			$wc_order->get_billing_email(),
 			$payer_id,
-			$this->address_factory->from_wc_order( $wc_order ),
+			$this->address_factory->from_wc_order( $wc_order, 'billing' ),
 			$birthdate,
 			$phone
 		);

--- a/modules/ppcp-api-client/src/Factory/ShippingFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ShippingFactory.php
@@ -79,7 +79,7 @@ class ShippingFactory {
 	 */
 	public function from_wc_order( \WC_Order $order ): Shipping {
 		$full_name = $order->get_formatted_shipping_full_name();
-		$address   = $this->address_factory->from_wc_order( $order );
+		$address   = $this->address_factory->from_wc_order( $order, 'shipping' );
 
 		return new Shipping(
 			$full_name,

--- a/tests/PHPUnit/ApiClient/Factory/AddressFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AddressFactoryTest.php
@@ -106,6 +106,38 @@ class AddressFactoryTest extends TestCase
         $this->assertEquals('shipping_postcode', $result->postal_code());
     }
 
+    public function testFromWcOrderBillingAddress()
+    {
+        $testee = new AddressFactory();
+        $order = Mockery::mock(\WC_Order::class);
+        $order
+            ->expects('get_billing_country')
+            ->andReturn('billing_country');
+        $order
+            ->expects('get_billing_address_1')
+            ->andReturn('billing_address_1');
+        $order
+            ->expects('get_billing_address_2')
+            ->andReturn('billing_address_2');
+        $order
+            ->expects('get_billing_state')
+            ->andReturn('billing_state');
+        $order
+            ->expects('get_billing_city')
+            ->andReturn('billing_city');
+        $order
+            ->expects('get_billing_postcode')
+            ->andReturn('billing_postcode');
+
+        $result = $testee->from_wc_order($order, 'billing');
+        $this->assertEquals('billing_country', $result->country_code());
+        $this->assertEquals('billing_address_1', $result->address_line_1());
+        $this->assertEquals('billing_address_2', $result->address_line_2());
+        $this->assertEquals('billing_state', $result->admin_area_1());
+        $this->assertEquals('billing_city', $result->admin_area_2());
+        $this->assertEquals('billing_postcode', $result->postal_code());
+    }
+
     /**
      * @dataProvider dataFromPayPalRequest
      */

--- a/tests/PHPUnit/ApiClient/Factory/PayerFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PayerFactoryTest.php
@@ -148,6 +148,43 @@ class PayerFactoryTest extends TestCase
         $this->assertEquals($expectedPhone, $result->phone()->phone()->national_number());
     }
 
+    public function testFromWcOrderUsesBillingAddress()
+    {
+        $expectedPhone = '012345678901';
+        $expectedEmail = 'test@example.com';
+        $expectedFirstName = 'John';
+        $expectedLastName = 'Locke';
+        $address = Mockery::mock(Address::class);
+        $order = Mockery::mock(\WC_Order::class);
+        $order
+            ->shouldReceive('get_billing_phone')
+            ->andReturn($expectedPhone);
+        $order
+            ->shouldReceive('get_billing_email')
+            ->andReturn($expectedEmail);
+        $order
+            ->shouldReceive('get_billing_last_name')
+            ->andReturn($expectedLastName);
+        $order
+            ->shouldReceive('get_billing_first_name')
+            ->andReturn($expectedFirstName);
+        $addressFactory = Mockery::mock(AddressFactory::class);
+        $addressFactory
+            ->expects('from_wc_order')
+            ->with($order, 'billing')
+            ->andReturn($address);
+        $testee = new PayerFactory($addressFactory);
+        $result = $testee->from_wc_order($order);
+
+        $this->assertEquals($expectedEmail, $result->email_address());
+        $this->assertEquals($expectedLastName, $result->name()->surname());
+        $this->assertEquals($expectedFirstName, $result->name()->given_name());
+        $this->assertEquals($address, $result->address());
+        $this->assertEquals($expectedPhone, $result->phone()->phone()->national_number());
+        $this->assertNull($result->birthdate());
+        $this->assertEmpty($result->payer_id());
+    }
+
     /**
      * @dataProvider dataForTestFromPayPalResponse
      */


### PR DESCRIPTION
The `PayerFactory` needed the billing address, but `AddressFactory::from_wc_order()` actually did not support the `billing`/`shipping` `type` parameter (like other methods there) always returning the shipping address.

Now it is fixed and it is possible to retrieve billing and shipping addresses similarly to other `PayerFactory` methods. 