### PR TITLE
Fix: Return HTTP 400 on nonce validation failures instead of 500 (6028)

### DIFF
--- a/modules/ppcp-admin-notices/src/Endpoint/MuteMessageEndpoint.php
+++ b/modules/ppcp-admin-notices/src/Endpoint/MuteMessageEndpoint.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\AdminNotices\Endpoint;
 
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\AdminNotices\Entity\PersistentMessage;
 
@@ -34,6 +35,14 @@ class MuteMessageEndpoint {
 	public function handle_request(): void {
 		try {
 			$data = $this->request_data->read_request( $this->nonce() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error(
+				array(
+					'message' => $error->getMessage(),
+					'code'    => $error->getCode(),
+				),
+				400
+			);
 		} catch ( RuntimeException $ex ) {
 			wp_send_json_error();
 		}

--- a/modules/ppcp-admin-notices/src/Endpoint/MuteMessageEndpoint.php
+++ b/modules/ppcp-admin-notices/src/Endpoint/MuteMessageEndpoint.php
@@ -36,13 +36,7 @@ class MuteMessageEndpoint {
 		try {
 			$data = $this->request_data->read_request( $this->nonce() );
 		} catch ( NonceValidationException $error ) {
-			wp_send_json_error(
-				array(
-					'message' => $error->getMessage(),
-					'code'    => $error->getCode(),
-				),
-				400
-			);
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( RuntimeException $ex ) {
 			wp_send_json_error();
 		}

--- a/modules/ppcp-axo/src/Endpoint/AxoScriptAttributes.php
+++ b/modules/ppcp-axo/src/Endpoint/AxoScriptAttributes.php
@@ -46,7 +46,6 @@ class AxoScriptAttributes implements EndpointInterface {
 			$this->request_data->read_request( $this->nonce() );
 		} catch ( NonceValidationException $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
-			return;
 		}
 
 		if (

--- a/modules/ppcp-axo/src/Endpoint/AxoScriptAttributes.php
+++ b/modules/ppcp-axo/src/Endpoint/AxoScriptAttributes.php
@@ -7,6 +7,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 
 /**
@@ -41,7 +42,12 @@ class AxoScriptAttributes implements EndpointInterface {
 	}
 
 	public function handle_request(): void {
-		$this->request_data->read_request( $this->nonce() );
+		try {
+			$this->request_data->read_request( $this->nonce() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
+			return;
+		}
 
 		if (
 			! $this->axo_eligible

--- a/modules/ppcp-axo/src/Endpoint/FrontendLogger.php
+++ b/modules/ppcp-axo/src/Endpoint/FrontendLogger.php
@@ -66,7 +66,6 @@ class FrontendLogger implements EndpointInterface {
 			$data = $this->request_data->read_request( $this->nonce() );
 		} catch ( NonceValidationException $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
-			return;
 		}
 
 		$level = $data['log']['level'] ?? 'info';

--- a/modules/ppcp-axo/src/Endpoint/FrontendLogger.php
+++ b/modules/ppcp-axo/src/Endpoint/FrontendLogger.php
@@ -13,6 +13,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 
 /**
  * Class FrontendLoggerEndpoint
@@ -61,7 +62,13 @@ class FrontendLogger implements EndpointInterface {
 	 * @throws Exception On Error.
 	 */
 	public function handle_request(): void {
-		$data  = $this->request_data->read_request( $this->nonce() );
+		try {
+			$data = $this->request_data->read_request( $this->nonce() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
+			return;
+		}
+
 		$level = $data['log']['level'] ?? 'info';
 
 		switch ( $level ) {

--- a/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
+++ b/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
@@ -112,14 +112,7 @@ class UpdateShippingEndpoint implements EndpointInterface {
 
 			wp_send_json_success();
 		} catch ( NonceValidationException $error ) {
-			wp_send_json_error(
-				array(
-					'message' => $error->getMessage(),
-					'code'    => $error->getCode(),
-				),
-				400
-			);
-
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			wp_send_json_error(
 				array(

--- a/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
+++ b/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
@@ -17,6 +17,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\PatchCollection;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 
 /**
  * Class UpdateShippingEndpoint
@@ -110,6 +111,15 @@ class UpdateShippingEndpoint implements EndpointInterface {
 			$this->order_endpoint->patch( $order_id, $patches );
 
 			wp_send_json_success();
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error(
+				array(
+					'message' => $error->getMessage(),
+					'code'    => $error->getCode(),
+				),
+				400
+			);
+
 		} catch ( Exception $error ) {
 			wp_send_json_error(
 				array(

--- a/modules/ppcp-button/src/Endpoint/AbstractCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/AbstractCartEndpoint.php
@@ -10,6 +10,7 @@ namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 
 /**
@@ -151,7 +152,13 @@ abstract class AbstractCartEndpoint implements EndpointInterface {
 	 * @return array|false
 	 */
 	protected function products_from_request() {
-		$data     = $this->request_data->read_request( $this->nonce() );
+		try {
+			$data = $this->request_data->read_request( $this->nonce() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
+			return false;
+		}
+
 		$products = $this->cart_products->products_from_data( $data );
 		if ( ! $products ) {
 			wp_send_json_error(

--- a/modules/ppcp-button/src/Endpoint/AbstractCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/AbstractCartEndpoint.php
@@ -156,7 +156,6 @@ abstract class AbstractCartEndpoint implements EndpointInterface {
 			$data = $this->request_data->read_request( $this->nonce() );
 		} catch ( NonceValidationException $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
-			return false;
 		}
 
 		$products = $this->cart_products->products_from_data( $data );

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -255,14 +255,7 @@ class ApproveOrderEndpoint implements EndpointInterface {
 			wp_send_json_success();
 
 		} catch ( NonceValidationException $error ) {
-			wp_send_json_error(
-				array(
-					'message' => $error->getMessage(),
-					'code'    => $error->getCode(),
-				),
-				400
-			);
-
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			$this->logger->error( 'Order approve failed: ' . $error->getMessage() );
 

--- a/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveOrderEndpoint.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\OrderHelper;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Button\Helper\ThreeDSecure;
@@ -252,6 +253,15 @@ class ApproveOrderEndpoint implements EndpointInterface {
 				wp_send_json_success( array( 'order_received_url' => $order_received_url ) );
 			}
 			wp_send_json_success();
+
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error(
+				array(
+					'message' => $error->getMessage(),
+					'code'    => $error->getCode(),
+				),
+				400
+			);
 
 		} catch ( Exception $error ) {
 			$this->logger->error( 'Order approve failed: ' . $error->getMessage() );

--- a/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
@@ -14,6 +14,7 @@ use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingSubscriptions;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Button\Helper\WooCommerceOrderCreator;
@@ -149,6 +150,14 @@ class ApproveSubscriptionEndpoint implements EndpointInterface {
 
 			wp_send_json_success();
 
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error(
+				array(
+					'message' => $error->getMessage(),
+					'code'    => $error->getCode(),
+				),
+				400
+			);
 		} catch ( Exception $error ) {
 			$this->logger->error( 'Subscription approve failed: ' . $error->getMessage() );
 

--- a/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
@@ -151,13 +151,7 @@ class ApproveSubscriptionEndpoint implements EndpointInterface {
 			wp_send_json_success();
 
 		} catch ( NonceValidationException $error ) {
-			wp_send_json_error(
-				array(
-					'message' => $error->getMessage(),
-					'code'    => $error->getCode(),
-				),
-				400
-			);
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			$this->logger->error( 'Subscription approve failed: ' . $error->getMessage() );
 

--- a/modules/ppcp-button/src/Endpoint/ChangeCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ChangeCartEndpoint.php
@@ -75,7 +75,6 @@ class ChangeCartEndpoint extends AbstractCartEndpoint {
 			$data = $this->request_data->read_request( $this->nonce() );
 		} catch ( NonceValidationException $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
-			return;
 		}
 
 		$this->cart_products->set_cart( $this->cart );

--- a/modules/ppcp-button/src/Endpoint/ChangeCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ChangeCartEndpoint.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
 
 /**
@@ -70,7 +71,12 @@ class ChangeCartEndpoint extends AbstractCartEndpoint {
 	 * @throws Exception On error.
 	 */
 	protected function handle_data(): void {
-		$data = $this->request_data->read_request( $this->nonce() );
+		try {
+			$data = $this->request_data->read_request( $this->nonce() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
+			return;
+		}
 
 		$this->cart_products->set_cart( $this->cart );
 

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -413,7 +413,6 @@ class CreateOrderEndpoint implements EndpointInterface {
 
 		} catch ( NonceValidationException $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
-			return;
 		} catch ( ValidationException $error ) {
 			$response = array(
 				'message' => $error->getMessage(),

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -29,6 +29,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ReturnUrlFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingPreferenceFactory;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Exception\ValidationException;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataFactory;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataTransientStorage;
@@ -410,6 +411,9 @@ class CreateOrderEndpoint implements EndpointInterface {
 
 			wp_send_json_success( $this->make_response( $order ) );
 
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
+			return;
 		} catch ( ValidationException $error ) {
 			$response = array(
 				'message' => $error->getMessage(),

--- a/modules/ppcp-button/src/Endpoint/DataClientIdEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/DataClientIdEndpoint.php
@@ -14,6 +14,7 @@ use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\IdentityToken;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 
 /**
  * Class DataClientIdEndpoint
@@ -86,6 +87,8 @@ class DataClientIdEndpoint implements EndpointInterface {
 					'user'       => $user_id,
 				)
 			);
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			$this->logger->error( 'Client ID retrieval failed: ' . $error->getMessage() );
 

--- a/modules/ppcp-button/src/Endpoint/GetOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/GetOrderEndpoint.php
@@ -14,6 +14,7 @@ use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataTransientStorage;
 
 /**
@@ -81,6 +82,8 @@ class GetOrderEndpoint implements EndpointInterface {
 			$order = $this->api_endpoint->order( $order_id );
 
 			wp_send_json_success( $order->to_array() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( RuntimeException $error ) {
 			$this->logger->error( 'Get order failed: ' . $error->getMessage() );
 

--- a/modules/ppcp-button/src/Endpoint/RequestData.php
+++ b/modules/ppcp-button/src/Endpoint/RequestData.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
-use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 
 /**
  * Class RequestData
@@ -36,7 +36,7 @@ class RequestData {
 	 * @param string $nonce The nonce.
 	 *
 	 * @return array
-	 * @throws RuntimeException When nonce validation fails.
+	 * @throws NonceValidationException When nonce validation fails.
 	 */
 	public function read_request( string $nonce ): array {
 		$stream = file_get_contents( 'php://input' );
@@ -47,7 +47,7 @@ class RequestData {
 			|| ! wp_verify_nonce( $json['nonce'], $nonce )
 		) {
 			remove_filter( 'nonce_user_logged_out', array( $this, 'nonce_fix' ), 100 );
-			throw new RuntimeException( 'Could not validate nonce.' );
+			throw new NonceValidationException( 'Could not validate nonce.' );
 		}
 		$this->dequeue_nonce_fix();
 

--- a/modules/ppcp-button/src/Endpoint/SaveCheckoutFormEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SaveCheckoutFormEndpoint.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
 use Exception;
 use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Helper\CheckoutFormSaver;
 
 /**
@@ -77,6 +78,8 @@ class SaveCheckoutFormEndpoint implements EndpointInterface {
 			$this->checkout_form_saver->save( $data['form'] );
 
 			wp_send_json_success();
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			$this->logger->error( 'Checkout form saving failed: ' . $error->getMessage() );
 

--- a/modules/ppcp-button/src/Endpoint/ValidateCheckoutEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ValidateCheckoutEndpoint.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Button\Endpoint;
 
 use Psr\Log\LoggerInterface;
 use Throwable;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Exception\ValidationException;
 use WooCommerce\PayPalCommerce\Button\Validation\CheckoutFormValidator;
 
@@ -81,6 +82,8 @@ class ValidateCheckoutEndpoint implements EndpointInterface {
 			$this->checkout_form_validator->validate( $form_fields );
 
 			wp_send_json_success();
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( ValidationException $exception ) {
 			$response = array(
 				'message' => $exception->getMessage(),

--- a/modules/ppcp-button/src/Exception/NonceValidationException.php
+++ b/modules/ppcp-button/src/Exception/NonceValidationException.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * NonceValidationException.
+ *
+ * @package WooCommerce\PayPalCommerce\Button\Exception
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Button\Exception;
+
+/**
+ * Thrown when nonce validation fails on an AJAX endpoint request.
+ */
+class NonceValidationException extends RuntimeException {
+
+}

--- a/modules/ppcp-googlepay/src/Endpoint/UpdatePaymentDataEndpoint.php
+++ b/modules/ppcp-googlepay/src/Endpoint/UpdatePaymentDataEndpoint.php
@@ -13,6 +13,7 @@ use Psr\Log\LoggerInterface;
 use Throwable;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Button\Exception\RuntimeException;
 
 /**
@@ -106,6 +107,8 @@ class UpdatePaymentDataEndpoint {
 					'shipping_options' => $this->get_shipping_options(),
 				)
 			);
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Throwable $error ) {
 			$this->logger->error( "UpdatePaymentDataEndpoint execution failed. {$error->getMessage()} {$error->getFile()}:{$error->getLine()}" );
 

--- a/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
+++ b/modules/ppcp-order-tracking/src/Endpoint/OrderTrackingEndpoint.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\OrderTracking\OrderTrackingModule;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentFactoryInterface;
 use WooCommerce\PayPalCommerce\OrderTracking\Shipment\ShipmentInterface;
@@ -161,6 +162,8 @@ class OrderTrackingEndpoint {
 					'shipment' => $shipment_html,
 				)
 			);
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 500 );
 		}

--- a/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
+++ b/modules/ppcp-paylater-configurator/src/Endpoint/SaveConfig.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\PayLaterConfigurator\Endpoint;
 use Psr\Log\LoggerInterface;
 use Throwable;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Settings\Data\PayLaterMessagingSettings;
 
 /**
@@ -52,6 +53,8 @@ class SaveConfig {
 			$this->save_config( $data['config']['config'] );
 
 			wp_send_json_success();
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Throwable $error ) {
 			$this->logger->error( "SaveConfig execution failed. {$error->getMessage()} {$error->getFile()}:{$error->getLine()}" );
 

--- a/modules/ppcp-paypal-subscriptions/src/DeactivatePlanEndpoint.php
+++ b/modules/ppcp-paypal-subscriptions/src/DeactivatePlanEndpoint.php
@@ -14,6 +14,7 @@ use WC_Product;
 use WC_Subscriptions_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingPlans;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 
 /**
  * Class DeactivatePlanEndpoint
@@ -78,6 +79,8 @@ class DeactivatePlanEndpoint {
 			}
 
 			wp_send_json_success( array( 'product_id' => (string) $product_id ) );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			wp_send_json_error();
 		}

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentToken.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentMethodTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\WcPaymentTokens\WooCommercePaymentTokens;
 
 /**
@@ -125,6 +126,8 @@ class CreatePaymentToken implements EndpointInterface {
 			}
 
 			wp_send_json_success( $wc_token_id );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $exception ) {
 			wp_send_json_error();
 		}

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentTokenForGuest.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentTokenForGuest.php
@@ -69,14 +69,7 @@ class CreatePaymentTokenForGuest implements EndpointInterface {
 		try {
 			$data = $this->request_data->read_request( $this->nonce() );
 		} catch ( NonceValidationException $error ) {
-			wp_send_json_error(
-				array(
-					'message' => $error->getMessage(),
-					'code'    => $error->getCode(),
-				),
-				400
-			);
-			return;
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		}
 
 		/**

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentTokenForGuest.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreatePaymentTokenForGuest.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentMethodTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 
 /**
  * Class UpdateCustomerId
@@ -65,7 +66,18 @@ class CreatePaymentTokenForGuest implements EndpointInterface {
 	 * @throws Exception On Error.
 	 */
 	public function handle_request(): void {
-		$data = $this->request_data->read_request( $this->nonce() );
+		try {
+			$data = $this->request_data->read_request( $this->nonce() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error(
+				array(
+					'message' => $error->getMessage(),
+					'code'    => $error->getCode(),
+				),
+				400
+			);
+			return;
+		}
 
 		/**
 		 * Suppress ArgumentTypeCoercion

--- a/modules/ppcp-save-payment-methods/src/Endpoint/CreateSetupToken.php
+++ b/modules/ppcp-save-payment-methods/src/Endpoint/CreateSetupToken.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentMethodTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 
 /**
@@ -107,6 +108,8 @@ class CreateSetupToken implements EndpointInterface {
 			$result = $this->payment_method_tokens_endpoint->setup_tokens( $payment_source, (string) $customer_id );
 
 			wp_send_json_success( $result );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $exception ) {
 			wp_send_json_error();
 		}

--- a/modules/ppcp-wc-gateway/src/Endpoint/VoidOrderEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/VoidOrderEndpoint.php
@@ -17,6 +17,7 @@ use WC_Order_Item_Product;
 use WC_Order_Item_Shipping;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\RefundProcessor;
 
@@ -86,7 +87,12 @@ class VoidOrderEndpoint {
 	 * Handles the incoming request.
 	 */
 	public function handle_request(): void {
-		$request = $this->request_data->read_request( self::nonce() );
+		try {
+			$request = $this->request_data->read_request( self::nonce() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
+			return;
+		}
 
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
 			wp_send_json_error(

--- a/modules/ppcp-wc-gateway/src/Endpoint/VoidOrderEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/VoidOrderEndpoint.php
@@ -91,7 +91,6 @@ class VoidOrderEndpoint {
 			$request = $this->request_data->read_request( self::nonce() );
 		} catch ( NonceValidationException $error ) {
 			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
-			return;
 		}
 
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {

--- a/modules/ppcp-wc-subscriptions/src/Endpoint/SubscriptionChangePaymentMethod.php
+++ b/modules/ppcp-wc-subscriptions/src/Endpoint/SubscriptionChangePaymentMethod.php
@@ -14,6 +14,7 @@ use WC_Order;
 use WC_Payment_Tokens;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 
 /**
  * Class SubscriptionChangePaymentMethod
@@ -70,6 +71,8 @@ class SubscriptionChangePaymentMethod implements EndpointInterface {
 			}
 
 			wp_send_json_error();
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $exception ) {
 			wp_send_json_error();
 		}

--- a/modules/ppcp-webhooks/src/Endpoint/ResubscribeEndpoint.php
+++ b/modules/ppcp-webhooks/src/Endpoint/ResubscribeEndpoint.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Webhooks\Endpoint;
 
 use Exception;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar;
 
 /**
@@ -71,6 +72,8 @@ class ResubscribeEndpoint {
 			}
 
 			wp_send_json_success();
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			wp_send_json_error( $error->getMessage(), 403 );
 		}

--- a/modules/ppcp-webhooks/src/Endpoint/SimulateEndpoint.php
+++ b/modules/ppcp-webhooks/src/Endpoint/SimulateEndpoint.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Webhooks\Endpoint;
 
 use Exception;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
 
 /**
@@ -72,6 +73,8 @@ class SimulateEndpoint {
 			$this->simulation->start();
 
 			wp_send_json_success();
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
 		} catch ( Exception $error ) {
 			wp_send_json_error( $error->getMessage(), 500 );
 		}


### PR DESCRIPTION
Fixes #4174.

## Problem

When nonce validation failed in AJAX endpoints, a `RuntimeException` was thrown and either went uncaught (returning HTTP 500) or was caught by a generic `Exception` handler that returned the wrong status code.

## Solution

- Added `NonceValidationException` extending `RuntimeException` to distinguish nonce failures from other errors.
- Updated `RequestData::read_request()` to throw `NonceValidationException` instead of `RuntimeException`.
- Added a dedicated `catch ( NonceValidationException $error )` block **before** the generic catch in all 23 affected endpoints, returning HTTP 400 with the error message.

## Affected endpoints

| Module | Endpoints |
|---|---|
| `ppcp-button` | `ApproveOrderEndpoint`, `ApproveSubscriptionEndpoint`, `CreateOrderEndpoint`, `GetOrderEndpoint`, `SaveCheckoutFormEndpoint`, `DataClientIdEndpoint`, `ValidateCheckoutEndpoint`, `AbstractCartEndpoint` |
| `ppcp-axo` | `AxoScriptAttributes`, `FrontendLogger` |
| `ppcp-save-payment-methods` | `CreatePaymentToken`, `CreatePaymentTokenForGuest`, `CreateSetupToken` |
| `ppcp-webhooks` | `ResubscribeEndpoint`, `SimulateEndpoint` |
| `ppcp-blocks` | `UpdateShippingEndpoint` |
| `ppcp-wc-subscriptions` | `SubscriptionChangePaymentMethod` |
| `ppcp-order-tracking` | `OrderTrackingEndpoint` |
| `ppcp-googlepay` | `UpdatePaymentDataEndpoint` |
| `ppcp-admin-notices` | `MuteMessageEndpoint` |
| `ppcp-paylater-configurator` | `SaveConfig` |
| `ppcp-paypal-subscriptions` | `DeactivatePlanEndpoint` |
| `ppcp-wc-gateway` | `VoidOrderEndpoint` |

## Testing

Trigger a nonce validation failure on any AJAX endpoint (e.g. send a request with an invalid or missing nonce) and verify the response status is `400` instead of `500`.
