### PR TITLE
Fix bool (false) in transients

### DIFF
--- a/modules/ppcp-api-client/src/Helper/Cache.php
+++ b/modules/ppcp-api-client/src/Helper/Cache.php
@@ -66,9 +66,9 @@ class Cache {
 	/**
 	 * Caches a value.
 	 *
-	 * @param string $key        The key under which the value should be cached.
-	 * @param mixed  $value      The value to cache.
-	 * @param int    $expiration Time until expiration in seconds.
+	 * @param string                  $key        The key under which the value should be cached.
+	 * @param string|array|int|object $value      The value to cache. Must be scalar or serializable, cannot be bool.
+	 * @param int                     $expiration Time until expiration in seconds.
 	 *
 	 * @return bool
 	 */

--- a/modules/ppcp-api-client/src/Helper/ReferenceTransactionStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ReferenceTransactionStatus.php
@@ -40,7 +40,10 @@ class ReferenceTransactionStatus {
 	 */
 	public function reference_transaction_enabled(): bool {
 		if ( $this->cache->has( self::CACHE_KEY ) ) {
-			return (bool) $this->cache->get( self::CACHE_KEY );
+			$cached = $this->cache->get( self::CACHE_KEY );
+			if ( is_string( $cached ) || is_bool( $cached ) ) {
+				return wc_string_to_bool( $cached );
+			}
 		}
 
 		try {
@@ -49,16 +52,16 @@ class ReferenceTransactionStatus {
 					$capability->name() === 'PAYPAL_WALLET_VAULTING_ADVANCED' &&
 					$capability->status() === 'ACTIVE'
 				) {
-					$this->cache->set( self::CACHE_KEY, true, MONTH_IN_SECONDS );
+					$this->cache->set( self::CACHE_KEY, wc_bool_to_string( true ), MONTH_IN_SECONDS );
 					return true;
 				}
 			}
 		} catch ( RuntimeException $exception ) {
-			$this->cache->set( self::CACHE_KEY, false, HOUR_IN_SECONDS );
+			$this->cache->set( self::CACHE_KEY, wc_bool_to_string( false ), HOUR_IN_SECONDS );
 			return false;
 		}
 
-		$this->cache->set( self::CACHE_KEY, false, HOUR_IN_SECONDS );
+		$this->cache->set( self::CACHE_KEY, wc_bool_to_string( false ), HOUR_IN_SECONDS );
 		return false;
 	}
 }


### PR DESCRIPTION
Fixes #4221 

Now using `wc_string_to_bool`/`wc_bool_to_string` for caching in `ReferenceTransactionStatus` to avoid the issue about the `false` value being confused with the missing transient.

Also changed the `Cache::set` value type from `mixed` to `string|array|int|object`, so that such issues are caught by PHPStan and avoided in the future. 