### PR TITLE
[QA] Add E2E Tests for PCP Settings Overview Tab (Todos + Features)

### DIFF
--- a/tests/qa/tests/03-plugin-settings/overview-features.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/overview-features.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Internal dependencies
+ */
+import { expect, test } from '../../utils';
+import { merchants, storeConfigDefault } from '../../resources';
+
+test.beforeAll( async ( { utils, pcpApi } ) => {
+	await utils.configureStore( storeConfigDefault );
+	await utils.installAndActivatePcp();
+	await pcpApi.resetDb();
+	await pcpApi.connectMerchant(
+		merchants.usa.client_id,
+		merchants.usa.client_secret
+	);
+} );
+
+test(
+	'PCP-6234 | Settings - Overview - Features card shows items with Active badges @Critical',
+	async ( { pcpOverview } ) => {
+		await pcpOverview.visit();
+		await pcpOverview.waitForOverview();
+
+		await test.step( 'Assert Features card title and description', async () => {
+			await expect(
+				pcpOverview.featuresCard(),
+				'Assert Features card is visible'
+			).toBeVisible();
+
+			await expect(
+				pcpOverview.featuresCardTitle(),
+				'Assert Features card title reads "Features"'
+			).toContainText( 'Features' );
+
+			await expect(
+				pcpOverview.featuresCardDescription(),
+				'Assert Features description mentions enabling features'
+			).toContainText( 'Enable additional features' );
+
+			await expect(
+				pcpOverview.featuresCardDescription(),
+				'Assert Features description mentions Refresh action'
+			).toContainText( 'Refresh' );
+		} );
+
+		await test.step(
+			'Assert feature items are rendered with Active badges for enabled features',
+			async () => {
+				const featureCount = await pcpOverview.featureItems().count();
+				expect(
+					featureCount,
+					'Assert at least one feature item is visible'
+				).toBeGreaterThan( 0 );
+
+				const activeCount = await pcpOverview
+					.activeFeatureBadges()
+					.count();
+				expect
+					.soft(
+						activeCount,
+						'Assert at least one feature shows an Active badge'
+					)
+					.toBeGreaterThan( 0 );
+			}
+		);
+
+		await test.step( 'Assert Refresh button is visible in Features card', async () => {
+			await expect(
+				pcpOverview.refreshButton(),
+				'Assert Refresh button is visible'
+			).toBeVisible();
+		} );
+	}
+);
+
+test(
+	'PCP-6233 | Settings - Overview - Features Refresh button triggers success notice @Critical',
+	async ( { pcpOverview } ) => {
+		await pcpOverview.visit();
+		await pcpOverview.waitForOverview();
+
+		await expect(
+			pcpOverview.refreshButton(),
+			'Assert Refresh button is visible before click'
+		).toBeVisible();
+
+		await pcpOverview.refreshButton().click();
+
+		await expect(
+			pcpOverview.successNotice( 'Features refreshed successfully.' ),
+			'Assert success notice "Features refreshed successfully." appears'
+		).toBeAttached( { timeout: 15_000 } );
+	}
+);
+
+test(
+	'PCP-6232 | Settings - Overview - Feature Configure buttons navigate to correct tabs @Critical',
+	async ( { pcpOverview } ) => {
+		await pcpOverview.visit();
+		await pcpOverview.waitForOverview();
+
+		await test.step(
+			'ACDC Configure navigates to Payment Methods tab',
+			async () => {
+				// "Configure" buttons render as <button>
+				const acdcConfigure = pcpOverview.configureButtonFor(
+					'Advanced Credit and Debit Cards'
+				);
+
+				await expect(
+					acdcConfigure,
+					'Assert ACDC Configure button is visible'
+				).toBeVisible();
+
+				await acdcConfigure.click();
+
+				await expect(
+					pcpOverview.paymentMethodsTab(),
+					'Assert Payment Methods tab is selected after clicking ACDC Configure'
+				).toHaveAttribute( 'aria-selected', 'true', {
+					timeout: 5_000,
+				} );
+			}
+		);
+
+		await test.step(
+			'Save PayPal and Venmo Configure navigates to Settings tab',
+			async () => {
+				await pcpOverview.overviewTab().click();
+				await pcpOverview
+					.featuresCard()
+					.waitFor( { state: 'visible', timeout: 10_000 } );
+
+				const spvConfigure = pcpOverview.configureButtonFor(
+					'Save PayPal and Venmo'
+				);
+
+				await expect(
+					spvConfigure,
+					'Assert Save PayPal and Venmo Configure button is visible'
+				).toBeVisible();
+
+				await spvConfigure.click();
+
+				await expect(
+					pcpOverview.settingsTab(),
+					'Assert Settings tab is selected after clicking Save PayPal and Venmo Configure'
+				).toHaveAttribute( 'aria-selected', 'true', {
+					timeout: 5_000,
+				} );
+			}
+		);
+
+	}
+);

--- a/tests/qa/tests/03-plugin-settings/overview-tab.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/overview-tab.spec.ts
@@ -61,14 +61,7 @@ test(
 		await pcpOverview.visit();
 		await pcpOverview.waitForOverview();
 
-		const todosVisible = await pcpOverview.todosCard().isVisible();
-		if ( ! todosVisible ) {
-			test.skip(
-				true,
-				'Todos card not visible — no eligible todos for this merchant/store state'
-			);
-			return;
-		}
+		await pcpOverview.todosCard().waitFor( { state: 'visible' } );
 
 		let initialCount = 0;
 
@@ -93,15 +86,8 @@ test(
 			initialCount = await pcpOverview.todoItems().count();
 			expect(
 				initialCount,
-				'Assert at least one todo item is rendered'
-			).toBeGreaterThan( 0 );
-
-			expect
-				.soft(
-					initialCount,
-					'Assert todo items do not exceed the cap of 5'
-				)
-				.toBeLessThanOrEqual( 5 );
+				'Assert todo items are rendered at the cap of 5'
+			).toBe( 5 );
 
 			const firstTitle = await pcpOverview
 				.todoItemTitle()
@@ -162,14 +148,7 @@ test(
 		await pcpOverview.visit();
 		await pcpOverview.waitForOverview();
 
-		const todosVisible = await pcpOverview.todosCard().isVisible();
-		if ( ! todosVisible ) {
-			test.skip(
-				true,
-				'Todos card not visible — no eligible todos for this merchant/store state'
-			);
-			return;
-		}
+		await pcpOverview.todosCard().waitFor( { state: 'visible' } );
 
 		// Target the "Enable Fastlane" todo
 		const fastlaneTodo = pcpOverview
@@ -177,18 +156,10 @@ test(
 			.filter( { hasText: 'Enable Fastlane' } )
 			.first();
 
-		const isTodoVisible = await fastlaneTodo
-			.waitFor( { state: 'visible', timeout: 3_000 } )
-			.then( () => true )
-			.catch( () => false );
-
-		if ( ! isTodoVisible ) {
-			test.skip(
-				true,
-				'"Enable Fastlane" todo not visible — ACDC capability may not be active or Fastlane is already enabled'
-			);
-			return;
-		}
+		await expect(
+			fastlaneTodo,
+			'Assert "Enable Fastlane" todo is present'
+		).toBeVisible();
 
 		// Click the title area of the todo item (avoids the dismiss button)
 		await fastlaneTodo

--- a/tests/qa/tests/03-plugin-settings/overview-tab.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/overview-tab.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * Internal dependencies
+ */
+import { expect, test } from '../../utils';
+import { merchants, storeConfigDefault } from '../../resources';
+
+test.beforeAll( async ( { utils, pcpApi } ) => {
+	await utils.configureStore( storeConfigDefault );
+	await utils.installAndActivatePcp();
+	await pcpApi.resetDb();
+	await pcpApi.connectMerchant(
+		merchants.usa.client_id,
+		merchants.usa.client_secret
+	);
+} );
+
+test(
+	'PCP-6237 | Settings - Overview - Tab loads and all navigation tabs are visible @Critical',
+	async ( { pcpOverview } ) => {
+		await pcpOverview.visit();
+		await pcpOverview.waitForOverview();
+
+		await expect(
+			pcpOverview.overviewTab(),
+			'Assert Overview tab is visible in navigation'
+		).toBeVisible();
+
+		await expect(
+			pcpOverview.overviewTab(),
+			'Assert Overview tab is the active tab on load'
+		).toHaveAttribute( 'aria-selected', 'true' );
+
+		await expect(
+			pcpOverview.overviewContainer(),
+			'Assert overview container is rendered'
+		).toBeVisible();
+
+		// All settings tabs are reachable from the Overview tab
+		await expect(
+			pcpOverview.paymentMethodsTab(),
+			'Assert Payment Methods tab is present'
+		).toBeVisible();
+		await expect(
+			pcpOverview.settingsTab(),
+			'Assert Settings tab is present'
+		).toBeVisible();
+		await expect(
+			pcpOverview.stylingTab(),
+			'Assert Styling tab is present'
+		).toBeVisible();
+		await expect(
+			pcpOverview.payLaterMessagingTab(),
+			'Assert Pay Later Messaging tab is present'
+		).toBeVisible();
+	}
+);
+
+test(
+	'PCP-6236 | Settings - Overview - Todos card structure, dismiss, and restore @Critical',
+	async ( { pcpOverview } ) => {
+		await pcpOverview.visit();
+		await pcpOverview.waitForOverview();
+
+		const todosVisible = await pcpOverview.todosCard().isVisible();
+		if ( ! todosVisible ) {
+			test.skip(
+				true,
+				'Todos card not visible — no eligible todos for this merchant/store state'
+			);
+			return;
+		}
+
+		let initialCount = 0;
+
+		await test.step( 'Assert Todos card title, description, and restore button', async () => {
+			await expect(
+				pcpOverview.todosCardTitle(),
+				'Assert Todos card title reads "Things to do next"'
+			).toContainText( 'Things to do next' );
+
+			await expect(
+				pcpOverview.todosCardDescription(),
+				'Assert Todos card description mentions completing tasks'
+			).toContainText( 'Complete these tasks' );
+
+			await expect(
+				pcpOverview.restoreButton(),
+				'Assert Restore button is present in Todos card'
+			).toBeVisible();
+		} );
+
+		await test.step( 'Assert item count, titles, and dismiss buttons', async () => {
+			initialCount = await pcpOverview.todoItems().count();
+			expect(
+				initialCount,
+				'Assert at least one todo item is rendered'
+			).toBeGreaterThan( 0 );
+
+			expect
+				.soft(
+					initialCount,
+					'Assert todo items do not exceed the cap of 5'
+				)
+				.toBeLessThanOrEqual( 5 );
+
+			const firstTitle = await pcpOverview
+				.todoItemTitle()
+				.first()
+				.textContent();
+			expect(
+				firstTitle?.trim(),
+				'Assert first todo item has a non-empty title'
+			).toBeTruthy();
+
+			const dismissCount = await pcpOverview
+				.todoDismissButtons()
+				.count();
+			expect(
+				dismissCount,
+				'Assert every visible todo item has a dismiss button'
+			).toBe( initialCount );
+		} );
+
+		await test.step(
+			'Dismiss first todo item and assert it is removed from the list',
+			async () => {
+				// Capture the title of the first item so we can assert it is gone
+				const firstTitle = (
+					await pcpOverview.todoItemTitle().first().textContent()
+				)?.trim() ?? '';
+
+				await pcpOverview.todoDismissButtons().first().click();
+
+				await expect(
+					pcpOverview
+						.todoItems()
+						.filter( { hasText: firstTitle } )
+						.first(),
+					'Assert the dismissed todo item is removed from the list'
+				).not.toBeAttached( { timeout: 5_000 } );
+			}
+		);
+
+		await test.step(
+			'Restore dismissed items and assert success notice',
+			async () => {
+				await pcpOverview.restoreButton().click();
+				await expect(
+					pcpOverview.successNotice(
+						'Dismissed items restored successfully.'
+					),
+					'Assert success notice "Dismissed items restored successfully." appears'
+				).toBeAttached( { timeout: 15_000 } );
+			}
+		);
+	}
+);
+
+test(
+	'PCP-6235 | Settings - Overview - Clicking a todo item navigates to its associated tab @Critical',
+	async ( { pcpOverview } ) => {
+		await pcpOverview.visit();
+		await pcpOverview.waitForOverview();
+
+		const todosVisible = await pcpOverview.todosCard().isVisible();
+		if ( ! todosVisible ) {
+			test.skip(
+				true,
+				'Todos card not visible — no eligible todos for this merchant/store state'
+			);
+			return;
+		}
+
+		// Target the "Enable Fastlane" todo
+		const fastlaneTodo = pcpOverview
+			.todoItems()
+			.filter( { hasText: 'Enable Fastlane' } )
+			.first();
+
+		const isTodoVisible = await fastlaneTodo
+			.waitFor( { state: 'visible', timeout: 3_000 } )
+			.then( () => true )
+			.catch( () => false );
+
+		if ( ! isTodoVisible ) {
+			test.skip(
+				true,
+				'"Enable Fastlane" todo not visible — ACDC capability may not be active or Fastlane is already enabled'
+			);
+			return;
+		}
+
+		// Click the title area of the todo item (avoids the dismiss button)
+		await fastlaneTodo
+			.locator( '.ppcp-r-todo-item__description' )
+			.click();
+
+		await expect(
+			pcpOverview.paymentMethodsTab(),
+			'Assert Payment Methods tab is selected after clicking the Enable Fastlane todo'
+		).toHaveAttribute( 'aria-selected', 'true', { timeout: 5_000 } );
+	}
+);

--- a/tests/qa/utils/admin/pcp-overview.ts
+++ b/tests/qa/utils/admin/pcp-overview.ts
@@ -7,10 +7,67 @@ import urls from '../urls';
 export class PcpOverview extends PcpAdminPage {
 	url = urls.admin.pcp.overview;
 
-	// Locators
+	// Locators — container
 	overviewContainer = () => this.page.locator( '.ppcp-r-tab-overview' );
+
+	// Locators — Todos section
+	todosCard = () => this.page.locator( '.ppcp-r-tab-overview-todo' );
+	todosCardTitle = () =>
+		this.todosCard().locator( '.ppcp-r-settings-card__title' );
+	todosCardDescription = () =>
+		this.todosCard().locator( '.ppcp-r-settings-card__description' );
+	todoItems = () => this.todosCard().locator( '.ppcp-r-todo-item' );
+	todoItemTitle = () =>
+		this.todosCard().locator( '.ppcp-r-todo-item__description' );
+	todoDismissButtons = () =>
+		this.todosCard().locator( 'button.ppcp-r-todo-item__dismiss' );
+	restoreButton = () =>
+		this.todosCard().getByRole( 'button', {
+			name: 'Restore dismissed Things To Do',
+		} );
+
+	// Locators — Features section
+	featuresCard = () => this.page.locator( '.ppcp-r-tab-overview-features' );
+	featuresCardTitle = () =>
+		this.featuresCard().locator( '.ppcp-r-settings-card__title' );
+	featuresCardDescription = () =>
+		this.featuresCard().locator( '.ppcp-r-settings-card__description' );
+	featureItems = () =>
+		this.featuresCard().locator( '.ppcp-r-settings-block__feature' );
+	activeFeatureBadges = () =>
+		this.featuresCard().locator( '.ppcp-r-title-badge--positive' );
+	refreshButton = () =>
+		this.featuresCard().getByRole( 'button', { name: /Refresh/ } );
+	configureButtonFor = ( featureName: string ) =>
+		this.featureItems()
+			.filter( { hasText: featureName } )
+			.getByRole( 'button', { name: 'Configure' } );
+
+	// Locators — Notices (WordPress snackbar rendered by WooCommerce admin layout)
+	successNotice = ( text: string ) =>
+		this.page
+			.locator( '.components-snackbar' )
+			.filter( { hasText: text } );
 
 	// Actions
 
-	// Assertions
+	/**
+	 * Waits for the overview container to be visible after load.
+	 * Reloads once if the container does not appear within 3s
+	 */
+	waitForOverview = async () => {
+		await this.waitForLoadingMaskRemoved();
+		const isContainerVisible = await this.overviewContainer()
+			.waitFor( { state: 'visible', timeout: 3_000 } )
+			.then( () => true )
+			.catch( () => false );
+		if ( ! isContainerVisible ) {
+			await this.page.reload();
+			await this.waitForLoadingMaskRemoved();
+		}
+		await this.overviewContainer().waitFor( {
+			state: 'visible',
+			timeout: 20_000,
+		} );
+	};
 }


### PR DESCRIPTION
**Description**

Solves [PCP-5991](https://inpsyde.atlassian.net/browse/PCP-5991).
This PR adds end-to-end test coverage for the **Overview** tab in PCP Settings. 

Before this, the Overview tab was only checked for visibility.  
Now we test the two main sections in this tab:

- **Things to do next** (Todos)
- **Features**

**Changes**
- Extended the Overview page object with locators for Todos and Features sections.
- Added tests for the Overview tab behaviour and content.
- Added tests for Features card

**Test coverage**

- Overview tab renders.
- Things To Do card shows at least one item.
- Restore dismissed Things To Do works (click + success notice).
- Features card shows at least one item.
- Refresh works (click + success notice).
- One feature navigates correctly

**Run tests**

command:
`npx playwright test tests/03-plugin-settings/overview-tab.spec.ts tests/03-plugin-settings/overview-features.spec.ts`