### PR TITLE
Guest Cart appears empty when product is added from product page (6252)

### DIFF
--- a/modules/ppcp-button/src/Helper/IsolatedCartSimulator.php
+++ b/modules/ppcp-button/src/Helper/IsolatedCartSimulator.php
@@ -102,7 +102,6 @@ class IsolatedCartSimulator {
 	private function cleanup_cart( WC_Cart $cart ): void {
 		try {
 			$this->cart_products->remove_cart_items();
-			$cart->empty_cart( false );
 		} catch ( Exception $e ) {
 			$this->logger->warning( 'Cart simulation cleanup failed: ' . $e->getMessage() );
 		}

--- a/tests/integration/PHPUnit/Button/IsolatedCartSimulatorTest.php
+++ b/tests/integration/PHPUnit/Button/IsolatedCartSimulatorTest.php
@@ -41,6 +41,24 @@ class IsolatedCartSimulatorTest extends SimulateCartTestCase {
 		self::assertEquals( $original_total, (float) WC()->cart->get_total( 'numeric' ) );
 	}
 
+	public function testSimulateDoesNotClearSessionCart(): void {
+		$product = $this->createSimpleProduct( 25.00 );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+
+		// Force a session write so there is something to preserve.
+		WC()->cart->session->set_session();
+		self::assertNotEmpty( WC()->session->get( 'cart' ) );
+
+		$sim_product = $this->createSimpleProduct( 99.00 );
+		$this->cart_simulator->simulate( [ $this->productData( $sim_product ) ] );
+
+		self::assertNotEmpty(
+			WC()->session->get( 'cart' ),
+			'Real session cart must survive a simulate call (guests rely on this).'
+		);
+	}
+
 	public function testSimulateDoesNotRemoveShutdownHooks(): void {
 		$callback = function () {};
 


### PR DESCRIPTION
Guests lost their cart after adding a product from the product page. The `ppc-simulate-cart` was wiping the guest's WC session cart.   

`IsolatedCartSimulator::cleanup_cart()` was calling `$cart->empty_cart( false )` on the throwaway cart, which fires the global `woocommerce_cart_emptied` action.                                                                                                                         
                                                                                                                                                                                                                       
### PR Changes                                                                                                                                                                                                                                                                                                                                                                                                              
- Removed the `empty_cart()` call. `remove_cart_items()` still runs so third-party per-item reservations are released. 
- Added a regression test asserting `WC()->session->get( 'cart' )` survives a simulate call.
                                                                 