### PR TITLE
BCDC - Mexico - BCDC not visible on block checkout  (6251)

### DIFF
--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -143,7 +143,7 @@ class DisabledFundingSources {
 	 * Decision table:
 	 *
 	 *  Non-checkout page              → disabled  (no card button/fields needed outside checkout)
-	 *  Block checkout + ACDC capable  → disabled  (ACDC uses WC Blocks card-fields, not this source)
+	 *  Block checkout + ACDC enabled  → disabled  (ACDC uses WC Blocks card-fields, not this source)
 	 *  Block checkout + BCDC          → enabled   (BCDC card button shown in blocks)
 	 *  Block checkout, neither        → disabled
 	 *  MX + BCDC + classic            → enabled   (country-specific override)
@@ -151,11 +151,8 @@ class DisabledFundingSources {
 	 *  Classic checkout + BCDC        → enabled   (card button needs this source)
 	 *  Classic checkout, neither      → disabled
 	 *
-	 * Note: uses is_acdc_enabled() rather than use_acdc() in the classic checkout path,
-	 * because use_acdc() only reflects merchant capability while is_acdc_enabled() also
-	 * checks that the gateway is actually enabled. This prevents 'card' from staying
-	 * enabled when ACDC capability exists but the gateway is off (e.g. after switching
-	 * from branded-only mode).
+	 * Note: uses is_acdc_enabled() (gateway actually on), not use_acdc() (capability only),
+	 * so a MX merchant with BCDC on but ACDC gateway off still gets the BCDC button.
 	 *
 	 * @param bool $is_block_context Whether the current render context is a block.
 	 * @return bool True when 'card' should be added to the disabled list.
@@ -169,8 +166,8 @@ class DisabledFundingSources {
 		if ( $is_block_context ) {
 			// In block checkout, ACDC is rendered via the WC Blocks integration —
 			// it does not use the 'card' PayPal SDK funding source.
-			// Only keep 'card' enabled when BCDC button is needed and ACDC is inactive.
-			return $this->dcc_configuration->use_acdc()
+			// Keep 'card' enabled only when BCDC is active and ACDC is not actually enabled.
+			return $this->dcc_configuration->is_acdc_enabled()
 				|| ! $this->dcc_configuration->is_bcdc_enabled();
 		}
 
@@ -184,10 +181,6 @@ class DisabledFundingSources {
 		}
 
 		// Classic checkout: keep 'card' enabled for ACDC (card-fields) or BCDC (card button).
-		// Use is_acdc_enabled() — not use_acdc() — because use_acdc() only reflects merchant
-		// capability, while is_acdc_enabled() also checks that the gateway is actually on.
-		// Without this distinction, a merchant with ACDC capability but the gateway disabled
-		// (e.g. after switching from branded-only mode) would incorrectly keep 'card' enabled.
 		return ! $this->dcc_configuration->is_acdc_enabled()
 			&& ! $this->dcc_configuration->is_bcdc_enabled();
 	}

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -63,8 +63,8 @@ class DisabledFundingSourcesTest extends TestCase
 
 	public function test_is_checkout_true_add_allowed_sources_when_checkout_block_context()
 	{
-		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
 		$sut = new DisabledFundingSources(
 			$this->settings_provider,
 			[
@@ -88,8 +88,7 @@ class DisabledFundingSourcesTest extends TestCase
 	 */
 	public function test_mexico_bcdc_enabled_does_not_disable_card_funding()
 	{
-		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(false);
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
 		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
 
 		$sut = new DisabledFundingSources($this->settings_provider, [], $this->dcc_configuration, 'MX');
@@ -106,8 +105,7 @@ class DisabledFundingSourcesTest extends TestCase
 	 */
 	public function test_mexico_bcdc_disabled_disables_card_funding()
 	{
-		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
 		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
 
 		$sut = new DisabledFundingSources($this->settings_provider, [], $this->dcc_configuration, 'MX');
@@ -124,8 +122,8 @@ class DisabledFundingSourcesTest extends TestCase
 	 */
 	public function test_non_mexico_country_behavior_unchanged()
 	{
-		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
 
 		$sut = new DisabledFundingSources($this->settings_provider, [], $this->dcc_configuration, 'CA');
 
@@ -146,8 +144,8 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->settings_provider->shouldReceive('button_styling')
 			->andReturn(new LocationStylingDTO('', true, ['venmo']));
 
-		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
 
 		$sut = new DisabledFundingSources($this->settings_provider, [], $this->dcc_configuration, 'US');
 
@@ -163,8 +161,8 @@ class DisabledFundingSourcesTest extends TestCase
 		$this->settings_provider->shouldReceive('button_styling')
 			->andReturn(new LocationStylingDTO('', true, []));
 
-		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
 
 		$sut = new DisabledFundingSources($this->settings_provider, [], $this->dcc_configuration, 'US');
 
@@ -179,8 +177,8 @@ class DisabledFundingSourcesTest extends TestCase
 	 */
 	public function test_venmo_enabled_when_setting_is_true()
 	{
-		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
 
 		$sut = new DisabledFundingSources($this->settings_provider, [], $this->dcc_configuration, 'US');
 

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -33,8 +33,8 @@ class DisabledFundingSourcesTest extends TestCase
 	 */
 	public function test_is_checkout_true_add_card_when_checkout_block_context()
 	{
-		$this->dcc_configuration->shouldReceive('is_enabled')->andReturn(true);
-		$this->dcc_configuration->shouldReceive('use_acdc')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
 		$sut = new DisabledFundingSources($this->settings_provider, [], $this->dcc_configuration, 'US');
 
 		$this->setWooCommerceFunctionMocks();


### PR DESCRIPTION
 On block checkout, the BCDC button was missing from the express-checkout section for MX merchants with BCDC enabled and ACDC disabled. The PayPal SDK was loaded with card in disable-funding.                       
   
`DisabledFundingSources::should_disable_card()` block branch used `use_acdc()` (ACDC capability) instead of `is_acdc_enabled()` (capability + gateway on). MX merchants can have both `use_acdc() == true` and `is_bcdc_enabled() == true` at the same time, so the block rule incorrectly disabled card.
                                                                                                                                                                                                                       
This PR uses `is_acdc_enabled()` in the block branch, matching the classic branch. MX merchants with BCDC selected now keep card enabled on block checkout and the BCDC button renders.    