### PR TITLE
fix: correct asset path for PayPalInsightsLoader.js in AxoBlockModule (6246)

### DIFF
--- a/modules/ppcp-axo-block/src/AxoBlockModule.php
+++ b/modules/ppcp-axo-block/src/AxoBlockModule.php
@@ -147,7 +147,7 @@ class AxoBlockModule implements ServiceModule, ExecutableModule {
 
 		wp_register_script(
 			'wc-ppcp-paypal-insights',
-			$asset_getter->get_asset_url( 'PayPalInsightsLoader.js' ),
+			$asset_getter->get_asset_url( 'plugins/PayPalInsightsLoader.js' ),
 			array( 'wp-plugins', 'wp-data', 'wp-element', 'wc-blocks-registry' ),
 			$asset_version,
 			true


### PR DESCRIPTION
## Summary

- The `wc-ppcp-paypal-insights` script was registered in `AxoBlockModule::enqueue_paypal_insights_script()` using `get_asset_url( 'PayPalInsightsLoader.js' )`, which resolved to the non-existent path `ppcp-axo-block-js-PayPalInsightsLoader.js`.
- The webpack entry for this file is `js/plugins/PayPalInsightsLoader.js`, so the actual built asset is `ppcp-axo-block-js-plugins-PayPalInsightsLoader.js`.
- Fixed by passing `'plugins/PayPalInsightsLoader.js'` to `get_asset_url()`, which causes `AssetGetter::get_compiled_asset_name()` to correctly produce the `plugins-` prefix in the output filename.

## Test Steps

1. Enable Fastlane (Axo block) in the PayPal Payments settings.
2. Add an item to the cart and navigate to the block-based checkout page.
3. Open browser devtools and confirm no 404 or failed script load error for `PayPalInsightsLoader`.
4. Confirm the `wc-ppcp-paypal-insights` script loads successfully.