### PR TITLE
APMS - Order with apms stay in pending status (iDeal, ...) (6266)

### DIFF
--- a/modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php
+++ b/modules/ppcp-webhooks/src/Handler/PaymentCaptureCompleted.php
@@ -109,7 +109,7 @@ class PaymentCaptureCompleted implements RequestHandler {
 		 */
 		do_action( 'woocommerce_paypal_payments_payment_capture_completed_webhook_handler', $wc_order, $order_id );
 
-		if ( $wc_order->get_status() !== 'on-hold' ) {
+		if ( ! in_array( $wc_order->get_status(), array( 'pending', 'on-hold' ), true ) ) {
 			return $this->success_response();
 		}
 		$wc_order->add_order_note(


### PR DESCRIPTION
APM orders (iDeal, Trustly, Bancontact, Blik, EPS, MyBank, P24) stay stuck in Pending status in WooCommerce even though PayPal reports the order as COMPLETED.                                                       
                                                                                                                                                                                                                       
Root cause: commit `258e06eb5` intentionally changed the pre-redirect WC status from `on-hold` → `pending, however, the `PAYMENT.CAPTURE.COMPLETED` webhook handler only completed orders in on-hold status, so after that change APM orders were silently skipped and never transitioned out of pending.
                                                                                                                                                                                                                       
This PR relaxes the guard in `PaymentCaptureCompleted::handle_request()` to also accept `pending`, so the webhook reconciles the order regardless of whether it started in pending (new APM flow) or on-hold (legacy/standard flow). Other statuses (processing, completed, failed, cancelled, refunded) remain correctly skipped.