### PR TITLE
[QA] Fix Google Pay e2e test for headless/CI runs

### DIFF
--- a/tests/qa/.gitignore
+++ b/tests/qa/.gitignore
@@ -11,6 +11,7 @@ test-results
 .DS_Store
 /resources/files/woocommerce-paypal-payments*.zip
 /resources/files/woocommerce-subscriptions*.zip
+.google-session.json
 
 
 

--- a/tests/qa/utils/frontend/google-pay-popup.ts
+++ b/tests/qa/utils/frontend/google-pay-popup.ts
@@ -21,6 +21,49 @@ export class GooglePayPopup {
 		this.page = page;
 	}
 
+	/**
+	 * Path to the cached Google session cookies file
+	 */
+	private static readonly SESSION_PATH = path.join(
+		__dirname,
+		'../../.google-session.json'
+	);
+
+	/**
+	 * Loads previously saved Google cookies into the browser context
+	 */
+	private static loadGoogleSession = async (
+		context: BrowserContext
+	): Promise< void > => {
+		try {
+			if ( ! fs.existsSync( GooglePayPopup.SESSION_PATH ) ) return;
+			const { cookies } = JSON.parse(
+				fs.readFileSync( GooglePayPopup.SESSION_PATH, 'utf-8' )
+			) as { cookies: Cookie[] };
+			if ( Array.isArray( cookies ) && cookies.length > 0 ) {
+				await context.addCookies( cookies );
+			}
+		} catch {}
+	};
+
+	/**
+	 * Saves this popup's google.com cookies to disk so they can be reused later.
+	 */
+	private saveGoogleSession = async (): Promise< void > => {
+		try {
+			const all = await this.page.context().cookies();
+			const googleCookies = all.filter(
+				( c ) =>
+					c.domain === 'google.com' ||
+					c.domain.endsWith( '.google.com' )
+			);
+			fs.writeFileSync(
+				GooglePayPopup.SESSION_PATH,
+				JSON.stringify( { cookies: googleCookies }, null, 2 )
+			);
+		} catch {}
+	};
+
 	// -------------------------------------------------------------------------
 	// Browser-level patches — call once on the context before the test runs
 	// -------------------------------------------------------------------------
@@ -31,6 +74,9 @@ export class GooglePayPopup {
 	 * Call this in beforeEach, before any page navigation.
 	 */
 	static applyBrowserPatches = async ( context: BrowserContext ) => {
+		// Restore a cached Google session from disk
+		await GooglePayPopup.loadGoogleSession( context );
+
 		await context.addInitScript( () => {
 			// Google Pay requires a secure context. On a local http:// dev site it
 			// throws DEVELOPER_ERROR without this patch.
@@ -178,6 +224,9 @@ export class GooglePayPopup {
 			{ timeout: 30_000 }
 		);
 		await this.page.waitForLoadState();
+
+		// Save login cookies so the next test run can skip Google sign-in.
+		await this.saveGoogleSession();
 	};
 
 	/**
@@ -226,6 +275,8 @@ export class GooglePayPopup {
 
 		await expect( this.confirmButton(), 'Google Pay confirm button is visible' )
 			.toBeVisible( { timeout: 30_000 } );
+
+		await this.saveGoogleSession();
 
 		await Promise.all( [
 			this.page.waitForEvent( 'close' ),

--- a/tests/qa/utils/frontend/google-pay-popup.ts
+++ b/tests/qa/utils/frontend/google-pay-popup.ts
@@ -197,24 +197,6 @@ export class GooglePayPopup {
 			.catch( () => {} );
 
 		await this.page.waitForLoadState( 'domcontentloaded' ).catch( () => {} );
-
-		// In headed mode the popup occasionally loads blank on the first attempt —
-		// one reload is usually enough to get the real content.
-		for ( let attempt = 0; attempt < 2; attempt++ ) {
-			const hasContent = await this.page
-				.locator( 'input, button, iframe' )
-				.first()
-				.isVisible()
-				.catch( () => false );
-			if ( hasContent ) return;
-			await this.page.reload( { waitUntil: 'domcontentloaded' } );
-			await this.page.waitForTimeout( 1_000 );
-		}
-
-		await expect(
-			this.page.locator( 'body' ),
-			'Google Pay popup stayed blank after retries'
-		).not.toHaveText( /^\s*$/, { timeout: 10_000 } );
 	};
 
 	private signInToGoogle = async () => {

--- a/tests/qa/utils/frontend/google-pay-popup.ts
+++ b/tests/qa/utils/frontend/google-pay-popup.ts
@@ -1,7 +1,9 @@
 /**
  * External dependencies
  */
-import { expect, BrowserContext, Page } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import { expect, BrowserContext, Cookie, Page } from '@playwright/test';
 
 /**
  * Handles the Google Pay TEST-environment popup.
@@ -177,6 +179,23 @@ export class GooglePayPopup {
 		await this.page
 			.waitForURL( ( url ) => url.href !== 'about:blank', { timeout: 15_000 } )
 			.catch( () => {} );
+
+		// Reload only when still on about:blank; reloading during Google's redirect can break sign-in.
+		if ( this.page.url() === 'about:blank' || this.page.url() === '' ) {
+			await this.page.reload( { waitUntil: 'domcontentloaded' } ).catch( () => {} );
+		}
+
+		// Wait until the pay.google loading step finishes so we land on sign-in or the pay screen before other checks run.
+		await this.page
+			.waitForURL(
+				( url ) =>
+					url.hostname.includes( 'accounts.google.com' ) ||
+					( url.hostname.includes( 'pay.google.com' ) &&
+						! url.pathname.startsWith( '/gp/p/loading' ) ),
+				{ timeout: 20_000 }
+			)
+			.catch( () => {} );
+
 		await this.page.waitForLoadState( 'domcontentloaded' ).catch( () => {} );
 
 		// In headed mode the popup occasionally loads blank on the first attempt —

--- a/tests/qa/utils/test.ts
+++ b/tests/qa/utils/test.ts
@@ -100,7 +100,7 @@ const test = base.extend< BaseExtend >( {
 	pcpApi: async ( { request, requestUtils }, use ) => {
 		await use( new PcpApi( { request, requestUtils } ) );
 	},
-	visitorPage: async ( { browser, recordVideoOptions }, use, testInfo ) => {
+	visitorPage: async ( { browser, recordVideoOptions, httpCredentials }, use, testInfo ) => {
 		// check if visitor is specified in test otherwise use guest
 		const storageStateName =
 			testInfo.annotations?.find( ( el ) => el.type === 'visitor' )
@@ -109,6 +109,8 @@ const test = base.extend< BaseExtend >( {
 		// apply current visitor's storage state to the context
 		const context = await browser.newContext( {
 			...testInfo.project.use, // Spread project's use config
+			// Allow per-test overrides (e.g. `test.use({ httpCredentials: undefined })`)
+			httpCredentials,
 			storageState: fs.existsSync( storageStatePath )
 				? storageStatePath
 				: undefined,


### PR DESCRIPTION
The Google Pay transaction test (PCP-26555) was failing in headless mode.
Three areas were fixed:

- `httpCredentials` not stripped from visitor context - `test.use({ httpCredentials: undefined })` had no effect because `visitorPage` reads credentials from `testInfo.project.use` project-level only). It sometimes might broke Playwright's popup tracking.

- Sign-in missed on first run - `waitForContent` returned as soon as the popup left `about:blank`, before Google's redirect to accounts.google.com had fired. The sign-in check  was skipped, and the payment sheet loaded without an authenticated account.

- Every test run started with a fresh browser context and no Google cookies, requiring a full sign-in each time. During reruns, Google's  detection closed the popup before finished auth.