### PR TITLE
Failing ACDC payment for Free Trial subscription on classic checkout (6262)

### DIFF
--- a/modules/ppcp-button/src/Helper/DisabledFundingSources.php
+++ b/modules/ppcp-button/src/Helper/DisabledFundingSources.php
@@ -52,7 +52,7 @@ class DisabledFundingSources {
 		// Free trials have a shorter, special funding-source rule.
 		if ( $flags['is_free_trial'] ) {
 			return $this->sanitize_and_filter_sources(
-				$this->get_sources_for_free_trial(),
+				$this->get_sources_for_free_trial( $flags ),
 				$flags
 			);
 		}
@@ -97,14 +97,20 @@ class DisabledFundingSources {
 	 * Rule: Carts that include a free trial product can ONLY use the
 	 * funding source "card" - all other sources are disabled.
 	 *
+	 * The 'card' decision defers to {@see self::should_disable_card()} so the
+	 * same decision table applies to free-trial carts — notably: classic
+	 * checkout keeps 'card' enabled for ACDC (card-fields) or BCDC (card
+	 * button); block checkout keeps 'card' disabled because ACDC there is
+	 * rendered via the WC Blocks integration.
+	 *
+	 * @param array $flags Decision flags (context, is_block_context, …).
 	 * @return array
 	 */
-	private function get_sources_for_free_trial(): array {
+	private function get_sources_for_free_trial( array $flags ): array {
 		// Disable all sources.
 		$disable_funding = array_keys( $this->all_funding_sources );
 
-		if ( is_checkout() && $this->dcc_configuration->is_bcdc_enabled() ) {
-			// If BCDC is used, re-enable card payments.
+		if ( ! $this->should_disable_card( (bool) ( $flags['is_block_context'] ?? false ) ) ) {
 			$disable_funding = array_filter(
 				$disable_funding,
 				static fn( string $funding_source ) => $funding_source !== 'card'

--- a/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
+++ b/tests/PHPUnit/Button/Helper/DisabledFundingSourcesTest.php
@@ -190,6 +190,115 @@ class DisabledFundingSourcesTest extends TestCase
 	}
 
 	/**
+	 * Free-trial cart on classic checkout with ACDC enabled: 'card' must stay enabled
+	 * (otherwise paypal.CardFields() reports ineligible and the card iframes never
+	 * render over the stock WooCommerce inputs).
+	 */
+	public function test_free_trial_classic_checkout_with_acdc_keeps_card_enabled()
+	{
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
+
+		$sut = $this->makeFreeTrialSut(
+			[
+				'card' => 'Credit or debit cards',
+				'paypal' => 'PayPal',
+				'venmo' => 'Venmo',
+			],
+			'US'
+		);
+
+		$this->setWooCommerceFunctionMocks();
+		when('is_checkout')->justReturn(true);
+
+		$this->assertNotContains('card', $sut->sources('checkout'));
+	}
+
+	/**
+	 * Free-trial cart on classic checkout with BCDC enabled: 'card' stays enabled
+	 * (pre-existing behavior, kept intact by the refactor).
+	 */
+	public function test_free_trial_classic_checkout_with_bcdc_keeps_card_enabled()
+	{
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
+
+		$sut = $this->makeFreeTrialSut(
+			[
+				'card' => 'Credit or debit cards',
+				'paypal' => 'PayPal',
+			],
+			'US'
+		);
+
+		$this->setWooCommerceFunctionMocks();
+		when('is_checkout')->justReturn(true);
+
+		$this->assertNotContains('card', $sut->sources('checkout'));
+	}
+
+	/**
+	 * Free-trial cart on block checkout with ACDC enabled: 'card' stays disabled
+	 * (block ACDC uses the WC Blocks integration, not the 'card' SDK funding source).
+	 */
+	public function test_free_trial_block_checkout_with_acdc_disables_card()
+	{
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(true);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
+
+		$sut = $this->makeFreeTrialSut(
+			[
+				'card' => 'Credit or debit cards',
+				'paypal' => 'PayPal',
+			],
+			'US'
+		);
+
+		$this->setWooCommerceFunctionMocks();
+		when('is_checkout')->justReturn(true);
+
+		$this->assertContains('card', $sut->sources('checkout-block'));
+	}
+
+	/**
+	 * Free-trial cart on classic checkout with neither ACDC nor BCDC: 'card' disabled
+	 * (no card flow active).
+	 */
+	public function test_free_trial_classic_checkout_no_card_flow_disables_card()
+	{
+		$this->dcc_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+		$this->dcc_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
+
+		$sut = $this->makeFreeTrialSut(
+			[
+				'card' => 'Credit or debit cards',
+				'paypal' => 'PayPal',
+			],
+			'US'
+		);
+
+		$this->setWooCommerceFunctionMocks();
+		when('is_checkout')->justReturn(true);
+
+		$this->assertContains('card', $sut->sources('checkout'));
+	}
+
+	/**
+	 * Builds a DisabledFundingSources whose is_free_trial_cart() is forced to true,
+	 * so the free-trial branch can be tested without bootstrapping WooCommerce
+	 * Subscriptions and WC()->cart.
+	 */
+	private function makeFreeTrialSut(array $funding_sources, string $country): DisabledFundingSources
+	{
+		return new class($this->settings_provider, $funding_sources, $this->dcc_configuration, $country) extends DisabledFundingSources {
+			protected function is_free_trial_cart(): bool
+			{
+				return true;
+			}
+		};
+	}
+
+	/**
 	 * Set up common WooCommerce function mocks
 	 */
 	private function setWooCommerceFunctionMocks(): void


### PR DESCRIPTION
On classic checkout, adding a free-trial subscription product and selecting Debit & Credit Cards left users stuck: the PayPal CardFields never rendered over the stock WooCommerce card inputs, so clicking Place order submitted the form with no tokenized card and the order failed.

Root cause: `DisabledFundingSources::get_sources_for_free_trial()` disables all funding sources for free-trial carts and only re-enables card when BCDC is on. For classic + ACDC the card source stayed disabled in the PayPal SDK URL, so `paypal.CardFields().isEligible()` returned false and `renderFields()` short-circuited.

This PR delegates the card decision in the free-trial path to the existing `should_disable_card()` authority so the same classic/blocks + ACDC/BCDC decision table applies. Result: classic + ACDC + free-trial now keeps card enabled (bug fix); all other contexts (blocks, MX, BCDC-only, no-card-flow) retain their current behavior. 