### PR TITLE
Remove test entry from the cart response (6085)

### DIFF
--- a/modules/ppcp-store-sync/src/Response/NewCartResponse.php
+++ b/modules/ppcp-store-sync/src/Response/NewCartResponse.php
@@ -51,13 +51,6 @@ class NewCartResponse extends CartResponse {
 			'token' => $this->token,
 		);
 
-		// Add sandbox approval URL for testing.
-		// In production, PayPal Commerce Platform handles approval automatically.
-		$data['_testing'] = array(
-			'sandbox_approval_url' => 'https://www.sandbox.paypal.com/checkoutnow?token=' . $this->token,
-			'instructions'         => 'For sandbox testing: Open this URL in browser, login as buyer, and approve payment before checkout.',
-		);
-
 		return $data;
 	}
 }


### PR DESCRIPTION
### Description

The Cart API responses contained a test-object with details we used for debugging and testing.

To prepare the integration into the main develop branch, we're cleaning up this test code. It's not part of the schema that PayPal expects from the endpoint