### PR TITLE
fix(amount-factory): derive total from breakdown sum to prevent PayPal PATCH rejection on shipping change (6279)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -149,7 +149,7 @@ class AmountFactory {
 				null,
 				null,
 				null,
-				$make( $discount_minor ),
+				$discount_minor > 0 ? $make( $discount_minor ) : null,
 			)
 		);
 	}

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -111,11 +111,7 @@ class AmountFactory {
 			null, // shipping discounts?
 			$discount
 		);
-		$amount    = new Amount(
-			$total,
-			$breakdown
-		);
-		return $amount;
+		return new Amount( $total, $breakdown );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -16,6 +16,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\CurrencyGetter;
 use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\CartTotals;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\Money as StoreApiMoney;
 use WooCommerce\PayPalCommerce\WcSubscriptions\FreeTrialHandlerTrait;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
@@ -92,11 +93,14 @@ class AmountFactory {
 		// using get_total(), which can diverge from the component sum by ±$0.01
 		// due to WooCommerce per-item tax rounding. PayPal requires amount.value to
 		// exactly equal the sum of its breakdown fields or it rejects the PATCH.
+		// Formatting through a string avoids floating-point representation issues
+		// when converting the integer-cent sum back to a decimal (e.g. 1001/100).
 		$total_cents = (int) round( $item_total_val * 100 )
 			+ (int) round( $shipping_val * 100 )
 			+ (int) round( $taxes_val * 100 )
 			- (int) round( $discount_val * 100 );
-		$total       = new Money( $total_cents / 100, $this->currency->get() );
+		$total_str   = number_format( $total_cents / 100, 2, '.', '' );
+		$total       = new Money( (float) $total_str, $this->currency->get() );
 
 		$breakdown = new AmountBreakdown(
 			$item_total,
@@ -133,11 +137,7 @@ class AmountFactory {
 		$currency   = $cart_totals->total_price()->currency_code();
 		$minor_unit = $cart_totals->total_price()->currency_minor_unit();
 		$make       = static function ( int $minor ) use ( $currency, $minor_unit ): Money {
-			return ( new \WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\Money(
-				(string) $minor,
-				$currency,
-				$minor_unit
-			) )->to_paypal();
+			return ( new StoreApiMoney( (string) $minor, $currency, $minor_unit ) )->to_paypal();
 		};
 
 		return new Amount(
@@ -171,37 +171,37 @@ class AmountFactory {
 				$this->discounts_from_items( $items ),
 			)
 		);
-		$discount       = null;
+		$discount = null;
 		if ( $discount_value ) {
-			$discount = new Money(
-				(float) $discount_value,
-				$currency
-			);
+			$discount = new Money( (float) $discount_value, $currency );
 		}
 
-		$total_value = (float) $order->get_total();
+		$item_total_val = (float) $order->get_subtotal() + (float) $order->get_total_fees();
+		$shipping_val   = (float) $order->get_shipping_total();
+		$taxes_val      = (float) $order->get_total_tax();
+
+		$item_total = new Money( $item_total_val, $currency );
+		$shipping   = new Money( $shipping_val, $currency );
+		$taxes      = new Money( $taxes_val, $currency );
+
+		// Free trial orders charge a fixed $1.00 regardless of cart contents —
+		// preserve that override. For all other orders derive the total from
+		// breakdown components so amount.value always equals the breakdown sum.
 		if ( (
 				in_array( $order->get_payment_method(), array( CreditCardGateway::ID, CardButtonGateway::ID ), true )
 				|| ( PayPalGateway::ID === $order->get_payment_method() && 'card' === $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) )
 			)
 			&& $this->is_free_trial_order( $order )
 		) {
-			$total_value = 1.0;
+			$total = new Money( 1.0, $currency );
+		} else {
+			$total_cents = (int) round( $item_total_val * 100 )
+				+ (int) round( $shipping_val * 100 )
+				+ (int) round( $taxes_val * 100 )
+				- (int) round( $discount_value * 100 );
+			$total_str   = number_format( $total_cents / 100, 2, '.', '' );
+			$total       = new Money( (float) $total_str, $currency );
 		}
-		$total = new Money( $total_value, $currency );
-
-		$item_total = new Money(
-			(float) $order->get_subtotal() + (float) $order->get_total_fees(),
-			$currency
-		);
-		$shipping   = new Money(
-			(float) $order->get_shipping_total(),
-			$currency
-		);
-		$taxes      = new Money(
-			(float) $order->get_total_tax(),
-			$currency
-		);
 
 		$breakdown = new AmountBreakdown(
 			$item_total,
@@ -212,11 +212,7 @@ class AmountFactory {
 			null, // shipping discounts?
 			$discount
 		);
-		$amount    = new Amount(
-			$total,
-			$breakdown
-		);
-		return $amount;
+		return new Amount( $total, $breakdown );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -74,27 +74,29 @@ class AmountFactory {
 	 * @return Amount
 	 */
 	public function from_wc_cart( \WC_Cart $cart ): Amount {
-		$total = new Money( (float) $cart->get_total( 'numeric' ), $this->currency->get() );
+		$item_total_val = (float) $cart->get_subtotal() + (float) $cart->get_fee_total();
+		$shipping_val   = (float) $cart->get_shipping_total();
+		$taxes_val      = (float) $cart->get_total_tax();
+		$discount_val   = (float) $cart->get_discount_total();
 
-		$item_total = (float) $cart->get_subtotal() + (float) $cart->get_fee_total();
-		$item_total = new Money( $item_total, $this->currency->get() );
-		$shipping   = new Money(
-			(float) $cart->get_shipping_total(),
-			$this->currency->get()
-		);
-
-		$taxes = new Money(
-			(float) $cart->get_total_tax(),
-			$this->currency->get()
-		);
+		$item_total = new Money( $item_total_val, $this->currency->get() );
+		$shipping   = new Money( $shipping_val, $this->currency->get() );
+		$taxes      = new Money( $taxes_val, $this->currency->get() );
 
 		$discount = null;
-		if ( $cart->get_discount_total() ) {
-			$discount = new Money(
-				(float) $cart->get_discount_total(),
-				$this->currency->get()
-			);
+		if ( $discount_val ) {
+			$discount = new Money( $discount_val, $this->currency->get() );
 		}
+
+		// Derive the total from breakdown components in integer cents rather than
+		// using get_total(), which can diverge from the component sum by ±$0.01
+		// due to WooCommerce per-item tax rounding. PayPal requires amount.value to
+		// exactly equal the sum of its breakdown fields or it rejects the PATCH.
+		$total_cents = (int) round( $item_total_val * 100 )
+			+ (int) round( $shipping_val * 100 )
+			+ (int) round( $taxes_val * 100 )
+			- (int) round( $discount_val * 100 );
+		$total       = new Money( $total_cents / 100, $this->currency->get() );
 
 		$breakdown = new AmountBreakdown(
 			$item_total,
@@ -116,16 +118,38 @@ class AmountFactory {
 	 *  Returns an Amount object based off a WooCommerce cart object from the Store API.
 	 */
 	public function from_store_api_cart( CartTotals $cart_totals ): Amount {
+		// Store API values are in integer minor units (e.g. cents), so integer
+		// arithmetic here is exact. Fees are included in items to match
+		// from_wc_cart() and to avoid a breakdown mismatch when fees are present.
+		// Total is derived from the breakdown sum rather than total_price() so
+		// PayPal's amount.value === sum(breakdown) invariant always holds.
+		$items_minor    = (int) $cart_totals->total_items()->value()
+			+ (int) $cart_totals->total_fees()->value();
+		$shipping_minor = (int) $cart_totals->total_shipping()->value();
+		$tax_minor      = (int) $cart_totals->total_tax()->value();
+		$discount_minor = (int) $cart_totals->total_discount()->value();
+		$total_minor    = $items_minor + $shipping_minor + $tax_minor - $discount_minor;
+
+		$currency   = $cart_totals->total_price()->currency_code();
+		$minor_unit = $cart_totals->total_price()->currency_minor_unit();
+		$make       = static function ( int $minor ) use ( $currency, $minor_unit ): Money {
+			return ( new \WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\Money(
+				(string) $minor,
+				$currency,
+				$minor_unit
+			) )->to_paypal();
+		};
+
 		return new Amount(
-			$cart_totals->total_price()->to_paypal(),
+			$make( $total_minor ),
 			new AmountBreakdown(
-				$cart_totals->total_items()->to_paypal(),
-				$cart_totals->total_shipping()->to_paypal(),
-				$cart_totals->total_tax()->to_paypal(),
+				$make( $items_minor ),
+				$make( $shipping_minor ),
+				$make( $tax_minor ),
 				null,
 				null,
 				null,
-				$cart_totals->total_discount()->to_paypal(),
+				$make( $discount_minor ),
 			)
 		);
 	}

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -10,6 +10,8 @@ use WooCommerce\PayPalCommerce\Helper\CurrencyGetterStub;
 use WooCommerce\PayPalCommerce\TestCase;
 use Mockery;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\CartTotals;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\Money as StoreApiMoney;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
@@ -35,10 +37,6 @@ class AmountFactoryTest extends TestCase
 	public function testFromWcCartDefault()
     {
         $cart = Mockery::mock(\WC_Cart::class);
-        $cart
-            ->shouldReceive('get_total')
-            ->withAnyArgs()
-            ->andReturn(13);
         $cart
             ->shouldReceive('get_subtotal')
             ->andReturn(5);
@@ -78,12 +76,8 @@ class AmountFactoryTest extends TestCase
     {
         $cart = Mockery::mock(\WC_Cart::class);
         $cart
-            ->shouldReceive('get_total')
-            ->withAnyArgs()
-            ->andReturn(11);
-		$cart
-			->shouldReceive('get_subtotal')
-			->andReturn(5);
+            ->shouldReceive('get_subtotal')
+            ->andReturn(5);
 		$cart
 			->shouldReceive('get_fee_total')
 			->andReturn(0);
@@ -110,6 +104,165 @@ class AmountFactoryTest extends TestCase
 		$this->assertEquals((float) 4, $result->breakdown()->tax_total()->value());
     }
 
+	/**
+	 * The critical invariant: amount.value must always equal the formatted sum of
+	 * its breakdown parts. This verifies the fix for the FCI PATCH rejection that
+	 * occurred when WC per-item tax rounding caused get_total() to diverge by ±$0.01.
+	 *
+	 * @dataProvider dataBreakdownRoundingCases
+	 */
+	public function testFromWcCartTotalAlwaysEqualsBreakdownSum(
+		float $subtotal,
+		float $fees,
+		float $shipping,
+		float $tax,
+		float $discount
+	): void {
+		$cart = Mockery::mock( \WC_Cart::class );
+		$cart->shouldReceive( 'get_subtotal' )->andReturn( $subtotal );
+		$cart->shouldReceive( 'get_fee_total' )->andReturn( $fees );
+		$cart->shouldReceive( 'get_shipping_total' )->andReturn( $shipping );
+		$cart->shouldReceive( 'get_total_tax' )->andReturn( $tax );
+		$cart->shouldReceive( 'get_discount_total' )->andReturn( $discount );
+
+		$woocommerce          = Mockery::mock( \WooCommerce::class );
+		$session              = Mockery::mock( \WC_Session::class );
+		$woocommerce->session = $session;
+		when( 'WC' )->justReturn( $woocommerce );
+		$session->shouldReceive( 'get' )->andReturn( [] );
+
+		$result    = $this->testee->from_wc_cart( $cart );
+		$breakdown = $result->breakdown();
+
+		$sum = (float) $breakdown->item_total()->value_str()
+			+ (float) $breakdown->shipping()->value_str()
+			+ (float) $breakdown->tax_total()->value_str();
+		if ( $breakdown->discount() ) {
+			$sum -= (float) $breakdown->discount()->value_str();
+		}
+		$expected_total_str = number_format( $sum, 2, '.', '' );
+
+		$this->assertSame(
+			$expected_total_str,
+			$result->value_str(),
+			"amount.value_str() must equal the formatted breakdown sum (PayPal PATCH invariant)"
+		);
+	}
+
+	public function dataBreakdownRoundingCases(): array
+	{
+		return [
+			// Classic WC tax-rounding edge case: 8% tax on $13.33 = $1.0664.
+			// WC rounds to $1.07 for tax but get_total() may accumulate differently.
+			'tax_rounding_edge_case'   => [ 13.33, 0.0, 5.00, 1.07, 0.0 ],
+			// Three items at $3.336 each: item total rounds differently at cart vs item level.
+			'multi_item_tax_rounding'  => [ 10.01, 0.0, 4.99, 1.50, 0.0 ],
+			// Discount present; all components interact.
+			'with_discount'            => [ 20.00, 2.00, 3.50, 2.25, 1.75 ],
+			// Fees and no discount.
+			'with_fees_no_discount'    => [ 15.50, 4.50, 6.00, 2.60, 0.0 ],
+			// Large order with all components.
+			'large_order'              => [ 199.99, 10.00, 12.95, 22.30, 15.00 ],
+			// Zero-value shipping (digital goods).
+			'digital_no_shipping'      => [ 49.99, 0.0, 0.0, 4.50, 0.0 ],
+		];
+	}
+
+	/**
+	 * Proves that the total is derived from breakdown components, not get_total().
+	 * When WC's get_total() is off by 1 cent, the PATCH total must still match
+	 * the breakdown so PayPal accepts it.
+	 */
+	public function testFromWcCartTotalDerivesFromComponentsNotWcGetTotal(): void
+	{
+		$cart = Mockery::mock( \WC_Cart::class );
+		// Components sum to $19.40 (1333 + 500 + 107 = 1940 cents).
+		$cart->shouldReceive( 'get_subtotal' )->andReturn( 13.33 );
+		$cart->shouldReceive( 'get_fee_total' )->andReturn( 0.0 );
+		$cart->shouldReceive( 'get_shipping_total' )->andReturn( 5.00 );
+		$cart->shouldReceive( 'get_total_tax' )->andReturn( 1.07 );
+		$cart->shouldReceive( 'get_discount_total' )->andReturn( 0.0 );
+		// get_total() deliberately returns a mismatched value to prove it is not used.
+		$cart->shouldReceive( 'get_total' )->withAnyArgs()->andReturn( 19.39 );
+
+		$woocommerce          = Mockery::mock( \WooCommerce::class );
+		$session              = Mockery::mock( \WC_Session::class );
+		$woocommerce->session = $session;
+		when( 'WC' )->justReturn( $woocommerce );
+		$session->shouldReceive( 'get' )->andReturn( [] );
+
+		$result = $this->testee->from_wc_cart( $cart );
+
+		// Total must be $19.40 (from breakdown), not $19.39 (from get_total()).
+		$this->assertSame( '19.40', $result->value_str() );
+		$this->assertSame( '13.33', $result->breakdown()->item_total()->value_str() );
+		$this->assertSame( '5.00', $result->breakdown()->shipping()->value_str() );
+		$this->assertSame( '1.07', $result->breakdown()->tax_total()->value_str() );
+	}
+
+	/**
+	 * @dataProvider dataFromStoreApiCart
+	 */
+	public function testFromStoreApiCart(
+		int $items,
+		int $fees,
+		int $shipping,
+		int $tax,
+		int $discount,
+		string $expected_total,
+		string $expected_items,
+		string $expected_shipping,
+		string $expected_tax,
+		?string $expected_discount
+	): void {
+		$currency   = 'USD';
+		$minor_unit = 2;
+		$make       = fn( int $v ) => new StoreApiMoney( (string) $v, $currency, $minor_unit );
+
+		$totals = Mockery::mock( CartTotals::class );
+		$totals->shouldReceive( 'total_items' )->andReturn( $make( $items ) );
+		$totals->shouldReceive( 'total_fees' )->andReturn( $make( $fees ) );
+		$totals->shouldReceive( 'total_shipping' )->andReturn( $make( $shipping ) );
+		$totals->shouldReceive( 'total_tax' )->andReturn( $make( $tax ) );
+		$totals->shouldReceive( 'total_discount' )->andReturn( $make( $discount ) );
+		$totals->shouldReceive( 'total_price' )->andReturn( $make( 0 ) ); // never used for value
+
+		$result    = $this->testee->from_store_api_cart( $totals );
+		$breakdown = $result->breakdown();
+
+		$this->assertSame( $expected_total, $result->value_str(), 'amount.value_str' );
+		$this->assertSame( $expected_items, $breakdown->item_total()->value_str(), 'item_total includes fees' );
+		$this->assertSame( $expected_shipping, $breakdown->shipping()->value_str(), 'shipping' );
+		$this->assertSame( $expected_tax, $breakdown->tax_total()->value_str(), 'tax_total' );
+		if ( null === $expected_discount ) {
+			$this->assertNull( $breakdown->discount(), 'discount should be null' );
+		} else {
+			$this->assertSame( $expected_discount, $breakdown->discount()->value_str(), 'discount' );
+		}
+		// Core invariant: value must equal breakdown sum.
+		$sum = (float) $breakdown->item_total()->value_str()
+			+ (float) $breakdown->shipping()->value_str()
+			+ (float) $breakdown->tax_total()->value_str();
+		if ( $breakdown->discount() ) {
+			$sum -= (float) $breakdown->discount()->value_str();
+		}
+		$this->assertSame( $result->value_str(), number_format( $sum, 2, '.', '' ), 'breakdown invariant' );
+	}
+
+	public function dataFromStoreApiCart(): array
+	{
+		return [
+			// items=1000¢, fees=0, shipping=500¢, tax=180¢, discount=0 → total=1680¢=$16.80
+			'no_fees_no_discount'  => [ 1000, 0, 500, 180, 0, '16.80', '10.00', '5.00', '1.80', null ],
+			// Fees included in item_total: items=1000¢ + fees=200¢ = 1200¢
+			'with_fees'            => [ 1000, 200, 500, 180, 0, '18.80', '12.00', '5.00', '1.80', null ],
+			// Discount reduces total: items=2000¢ + fees=0, shipping=500¢, tax=225¢, discount=150¢
+			'with_discount'        => [ 2000, 0, 500, 225, 150, '25.75', '20.00', '5.00', '2.25', '1.50' ],
+			// Fees + discount together.
+			'fees_and_discount'    => [ 1500, 300, 700, 250, 100, '26.50', '18.00', '7.00', '2.50', '1.00' ],
+		];
+	}
+
     public function testFromWcOrderDefault()
     {
         $order = Mockery::mock(\WC_Order::class);
@@ -134,9 +287,6 @@ class AmountFactoryTest extends TestCase
             ->shouldReceive('get_payment_method')
             ->andReturn(PayPalGateway::ID);
 
-        $order
-            ->shouldReceive('get_total')
-            ->andReturn(10);
         $order
             ->shouldReceive('get_subtotal')
             ->andReturn(6);
@@ -195,9 +345,6 @@ class AmountFactoryTest extends TestCase
 			->shouldReceive('get_payment_method')
 			->andReturn(PayPalGateway::ID);
 
-        $order
-            ->shouldReceive('get_total')
-            ->andReturn(100);
         $order
             ->shouldReceive('get_subtotal')
             ->andReturn(6);

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -182,8 +182,9 @@ class AmountFactoryTest extends TestCase
 		$cart->shouldReceive( 'get_shipping_total' )->andReturn( 5.00 );
 		$cart->shouldReceive( 'get_total_tax' )->andReturn( 1.07 );
 		$cart->shouldReceive( 'get_discount_total' )->andReturn( 0.0 );
-		// get_total() deliberately returns a mismatched value to prove it is not used.
-		$cart->shouldReceive( 'get_total' )->withAnyArgs()->andReturn( 19.39 );
+		// Enforce that get_total() is never consulted — the total is derived solely
+		// from breakdown components. If it were called, the test would fail.
+		$cart->shouldNotReceive( 'get_total' );
 
 		$woocommerce          = Mockery::mock( \WooCommerce::class );
 		$session              = Mockery::mock( \WC_Session::class );
@@ -225,7 +226,7 @@ class AmountFactoryTest extends TestCase
 		$totals->shouldReceive( 'total_shipping' )->andReturn( $make( $shipping ) );
 		$totals->shouldReceive( 'total_tax' )->andReturn( $make( $tax ) );
 		$totals->shouldReceive( 'total_discount' )->andReturn( $make( $discount ) );
-		$totals->shouldReceive( 'total_price' )->andReturn( $make( 0 ) ); // never used for value
+		$totals->shouldReceive( 'total_price' )->andReturn( $make( 0 ) ); // used for currency metadata only
 
 		$result    = $this->testee->from_store_api_cart( $totals );
 		$breakdown = $result->breakdown();
@@ -370,6 +371,35 @@ class AmountFactoryTest extends TestCase
         $result = $this->testee->from_wc_order($order);
         $this->assertNull($result->breakdown()->discount());
     }
+
+	/**
+	 * Proves that from_wc_order() derives the total from breakdown components
+	 * and never calls get_total(). Mirrors the equivalent from_wc_cart() test.
+	 */
+	public function testFromWcOrderTotalDerivesFromComponentsNotGetTotal(): void
+	{
+		$order = Mockery::mock( \WC_Order::class );
+		// Enforce get_total() is never consulted.
+		$order->shouldNotReceive( 'get_total' );
+		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
+		$order->shouldReceive( 'get_meta' )->andReturn( null );
+		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
+		// subtotal=$13.33, fees=0, shipping=$5.00, tax=$1.07 → total should be $19.40.
+		$order->shouldReceive( 'get_subtotal' )->andReturn( 13.33 );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_shipping_total' )->andReturn( 5.00 );
+		$order->shouldReceive( 'get_total_tax' )->andReturn( 1.07 );
+		$order->shouldReceive( 'get_total_discount' )->andReturn( 0.0 );
+		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
+
+		$result = $this->testee->from_wc_order( $order );
+
+		$this->assertSame( '19.40', $result->value_str() );
+		$this->assertSame( '13.33', $result->breakdown()->item_total()->value_str() );
+		$this->assertSame( '5.00', $result->breakdown()->shipping()->value_str() );
+		$this->assertSame( '1.07', $result->breakdown()->tax_total()->value_str() );
+		$this->assertNull( $result->breakdown()->discount() );
+	}
 
     /**
      * @dataProvider dataFromPayPalResponse


### PR DESCRIPTION
## Problem

Buyers using one-time pay (Fastlane guest checkout) are blocked from changing their shipping address. The failure affects approximately **10,683 requests / 2,882 unique orders in a 7-day window**.

When a buyer changes their shipping address, `UpdateShippingEndpoint` fires `ppc-update-shipping`, which calls `AmountFactory::from_wc_cart()` to build the PATCH payload. PayPal requires that `amount.value` exactly equals `item_total + shipping + tax_total − discount` in the breakdown. The current code uses `WC_Cart::get_total()` for `amount.value` but computes breakdown components from separate getters. Due to per-item tax rounding in WooCommerce, these two values can differ by ±$0.01 — enough for PayPal to reject the PATCH.

The same structural issue exists in `from_store_api_cart()`, used by the shipping callback endpoint, which also passes `total_price()` directly as `amount.value` without including fees in `item_total`.

## Fix

**`from_wc_cart()`**: compute the total in integer cents from the same component floats used for the breakdown, so `amount.value` is always the exact formatted sum of its parts.

**`from_store_api_cart()`**: use integer minor-unit arithmetic (Store API values are already in cents, so the sum is exact), and include `total_fees` in `item_total` to match `from_wc_cart()` and prevent a mismatch when WooCommerce fees are present.

## How to reproduce

1. Configure WooCommerce with a tax-exclusive rate (8–12%)
2. Add a product whose price × rate has a sub-cent remainder (e.g. $13.33 × 8% = $1.0664)
3. Add a non-zero shipping method
4. Open Fastlane (Axo) guest checkout
5. Change the shipping address or method
6. Observe the PATCH order request fail in the browser network tab or the WC PayPal debug log

## Verification

- The PATCH succeeds for the reproduction scenario above
- Buyer can change shipping address without error
- A unit test asserting `Amount::value_str() === formatted sum of breakdown parts` passes across carts with varied tax rates and product prices