### PR TITLE
 fix: replace infinite spinner with static placeholder in Pay Later block editor preview (5801)

### DIFF
--- a/modules/ppcp-paylater-block/resources/js/components/preview-placeholder.js
+++ b/modules/ppcp-paylater-block/resources/js/components/preview-placeholder.js
@@ -1,0 +1,16 @@
+import { __ } from '@wordpress/i18n';
+import { Spinner } from '@wordpress/components';
+
+export function PreviewPlaceholder( { timedOut } ) {
+	if ( ! timedOut ) {
+		return <Spinner />;
+	}
+	return (
+		<p className="ppcp-paylater-preview-placeholder">
+			{ __(
+				'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
+				'woocommerce-paypal-payments'
+			) }
+		</p>
+	);
+}

--- a/modules/ppcp-paylater-block/resources/js/edit.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.js
@@ -1,9 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, SelectControl, Spinner } from '@wordpress/components';
+import { PanelBody, SelectControl } from '@wordpress/components';
 import { PayPalScriptProvider, PayPalMessages } from '@paypal/react-paypal-js';
 import { useScriptParams } from './hooks/script-params';
+import { usePreviewTimeout } from './hooks/use-preview-timeout';
+import { PreviewPlaceholder } from './components/preview-placeholder';
 
 export default function Edit( { attributes, clientId, setAttributes } ) {
 	const {
@@ -20,7 +22,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	const isFlex = layout === 'flex';
 
 	const [ loaded, setLoaded ] = useState( false );
-	const [ timedOut, setTimedOut ] = useState( false );
+	const timedOut = usePreviewTimeout( loaded );
 
 	let amount;
 	const postContent = String(
@@ -61,14 +63,6 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 			setAttributes( { id: `ppcp-${ clientId }` } );
 		}
 	}, [ id, clientId ] );
-
-	useEffect( () => {
-		if ( loaded ) {
-			return;
-		}
-		const timer = setTimeout( () => setTimedOut( true ), 5000 );
-		return () => clearTimeout( timer );
-	}, [ loaded ] );
 
 	if ( PcpPayLaterBlock.vaultingEnabled ) {
 		return (
@@ -169,16 +163,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	if ( scriptParams === null ) {
 		return (
 			<div { ...props }>
-				{ timedOut ? (
-					<p>
-						{ __(
-							'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
-							'woocommerce-paypal-payments'
-						) }
-					</p>
-				) : (
-					<Spinner />
-				) }
+				<PreviewPlaceholder timedOut={ timedOut } />
 			</div>
 		);
 	}
@@ -516,17 +501,9 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 				<div className="ppcp-overlay-child ppcp-unclicable-overlay">
 					{ ' ' }
 					{ /* make the message not clickable */ }
-					{ ! loaded &&
-						( timedOut ? (
-							<p>
-								{ __(
-									'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
-									'woocommerce-paypal-payments'
-								) }
-							</p>
-						) : (
-							<Spinner />
-						) ) }
+					{ ! loaded && (
+						<PreviewPlaceholder timedOut={ timedOut } />
+					) }
 				</div>
 			</div>
 		</>

--- a/modules/ppcp-paylater-block/resources/js/edit.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.js
@@ -20,6 +20,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	const isFlex = layout === 'flex';
 
 	const [ loaded, setLoaded ] = useState( false );
+	const [ timedOut, setTimedOut ] = useState( false );
 
 	let amount;
 	const postContent = String(
@@ -60,6 +61,14 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 			setAttributes( { id: `ppcp-${ clientId }` } );
 		}
 	}, [ id, clientId ] );
+
+	useEffect( () => {
+		if ( loaded ) {
+			return;
+		}
+		const timer = setTimeout( () => setTimedOut( true ), 5000 );
+		return () => clearTimeout( timer );
+	}, [ loaded ] );
 
 	if ( PcpPayLaterBlock.vaultingEnabled ) {
 		return (
@@ -160,7 +169,16 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	if ( scriptParams === null ) {
 		return (
 			<div { ...props }>
-				<Spinner />
+				{ timedOut ? (
+					<p>
+						{ __(
+							'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
+							'woocommerce-paypal-payments'
+						) }
+					</p>
+				) : (
+					<Spinner />
+				) }
 			</div>
 		);
 	}
@@ -498,7 +516,17 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 				<div className="ppcp-overlay-child ppcp-unclicable-overlay">
 					{ ' ' }
 					{ /* make the message not clickable */ }
-					{ ! loaded && <Spinner /> }
+					{ ! loaded &&
+						( timedOut ? (
+							<p>
+								{ __(
+									'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
+									'woocommerce-paypal-payments'
+								) }
+							</p>
+						) : (
+							<Spinner />
+						) ) }
 				</div>
 			</div>
 		</>

--- a/modules/ppcp-paylater-block/resources/js/edit.test.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.test.js
@@ -1,0 +1,144 @@
+import { render, act, screen } from '@testing-library/react';
+import { useEffect } from '@wordpress/element';
+import '@testing-library/jest-dom';
+import Edit from './edit';
+
+jest.useFakeTimers();
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children } ) => children,
+	useBlockProps: () => ( {} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { children } ) => children,
+	SelectControl: () => null,
+	Spinner: () => <div className="components-spinner" />,
+} ) );
+
+jest.mock( './hooks/script-params', () => ( {
+	useScriptParams: jest.fn(),
+} ) );
+
+jest.mock( '@paypal/react-paypal-js', () => ( {
+	PayPalScriptProvider: ( { children } ) => children,
+	PayPalMessages: jest.fn( () => null ),
+} ) );
+
+const { useScriptParams } = require( './hooks/script-params' );
+
+const defaultConfig = {
+	vaultingEnabled: false,
+	placementEnabled: true,
+	payLaterSettingsUrl: '/wp-admin/paylater-settings',
+	ajax: { cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' } },
+};
+
+const defaultProps = {
+	attributes: {
+		id: 'ppcp-test',
+		layout: 'text',
+		logo: 'primary',
+		position: 'left',
+		color: 'black',
+		size: '14',
+		flexColor: 'blue',
+		flexRatio: '8x1',
+		placement: 'auto',
+	},
+	clientId: 'test-client-id',
+	setAttributes: jest.fn(),
+};
+
+beforeEach( () => {
+	global.PcpPayLaterBlock = { ...defaultConfig };
+	global.wp = {
+		data: {
+			select: () => ( { getEditedPostContent: () => '' } ),
+			dispatch: () => ( { removeBlock: jest.fn() } ),
+		},
+	};
+	jest.clearAllMocks();
+	jest.clearAllTimers();
+} );
+
+test( 'shows spinner while script params are loading', () => {
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect( document.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+} );
+
+test( 'shows placeholder after 5 seconds when script params never resolve', () => {
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.getByText(
+			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
+		)
+	).toBeInTheDocument();
+	expect( document.querySelector( '.components-spinner' ) ).not.toBeInTheDocument();
+} );
+
+test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () => {
+	useScriptParams.mockReturnValue( {
+		url_params: { 'client-id': 'test' },
+	} );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.getByText(
+			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
+		)
+	).toBeInTheDocument();
+} );
+
+test( 'does not show placeholder when PayPalMessages renders within 5 seconds', () => {
+	useScriptParams.mockReturnValue( {
+		url_params: { 'client-id': 'test' },
+	} );
+
+	const { PayPalMessages } = require( '@paypal/react-paypal-js' );
+	PayPalMessages.mockImplementation( ( { onRender } ) => {
+		useEffect( () => onRender(), [] );
+		return null;
+	} );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.queryByText( /Pay Later messaging preview unavailable/ )
+	).not.toBeInTheDocument();
+} );
+
+test( 'shows vaulting warning when vaulting is enabled', () => {
+	global.PcpPayLaterBlock = { ...defaultConfig, vaultingEnabled: true };
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect(
+		screen.getByText( /cannot be used while PayPal Vaulting is active/ )
+	).toBeInTheDocument();
+} );
+
+test( 'shows placement warning when placement is disabled', () => {
+	global.PcpPayLaterBlock = { ...defaultConfig, placementEnabled: false };
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect(
+		screen.getByText( /messaging placement is disabled/ )
+	).toBeInTheDocument();
+} );

--- a/modules/ppcp-paylater-block/resources/js/hooks/use-preview-timeout.js
+++ b/modules/ppcp-paylater-block/resources/js/hooks/use-preview-timeout.js
@@ -1,0 +1,22 @@
+import { useState, useEffect } from '@wordpress/element';
+
+export const PREVIEW_TIMEOUT_MS = 5000;
+
+/**
+ * Flips to `true` once `timeoutMs` has elapsed without `loaded` becoming truthy.
+ * Returns `false` if the preview loaded in time. Cleans up on unmount or when
+ * `loaded` flips, so no setState-on-unmounted warnings.
+ */
+export function usePreviewTimeout( loaded, timeoutMs = PREVIEW_TIMEOUT_MS ) {
+	const [ timedOut, setTimedOut ] = useState( false );
+
+	useEffect( () => {
+		if ( loaded ) {
+			return;
+		}
+		const timer = setTimeout( () => setTimedOut( true ), timeoutMs );
+		return () => clearTimeout( timer );
+	}, [ loaded, timeoutMs ] );
+
+	return timedOut;
+}

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.js
@@ -1,15 +1,17 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, Spinner } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { PayPalScriptProvider, PayPalMessages } from '@paypal/react-paypal-js';
 import { useScriptParams } from '@ppcp-paylater-block/hooks/script-params';
+import { usePreviewTimeout } from '@ppcp-paylater-block/hooks/use-preview-timeout';
+import { PreviewPlaceholder } from '@ppcp-paylater-block/components/preview-placeholder';
 
 export default function Edit( { attributes, clientId, setAttributes } ) {
 	const { ppcpId } = attributes;
 
 	const [ loaded, setLoaded ] = useState( false );
-	const [ timedOut, setTimedOut ] = useState( false );
+	const timedOut = usePreviewTimeout( loaded );
 
 	let amount;
 	const postContent = String(
@@ -64,14 +66,6 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 			setAttributes( { ppcpId: `ppcp-${ clientId }` } );
 		}
 	}, [ ppcpId, clientId ] );
-
-	useEffect( () => {
-		if ( loaded ) {
-			return;
-		}
-		const timer = setTimeout( () => setTimedOut( true ), 5000 );
-		return () => clearTimeout( timer );
-	}, [ loaded ] );
 
 	if ( PcpCartPayLaterBlock.vaultingEnabled ) {
 		return (
@@ -143,16 +137,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	if ( scriptParams === null ) {
 		return (
 			<div { ...props }>
-				{ timedOut ? (
-					<p>
-						{ __(
-							'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
-							'woocommerce-paypal-payments'
-						) }
-					</p>
-				) : (
-					<Spinner />
-				) }
+				<PreviewPlaceholder timedOut={ timedOut } />
 			</div>
 		);
 	}
@@ -204,17 +189,9 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 				<div className="ppcp-overlay-child ppcp-unclicable-overlay">
 					{ ' ' }
 					{ /* make the message not clickable */ }
-					{ ! loaded &&
-						( timedOut ? (
-							<p>
-								{ __(
-									'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
-									'woocommerce-paypal-payments'
-								) }
-							</p>
-						) : (
-							<Spinner />
-						) ) }
+					{ ! loaded && (
+						<PreviewPlaceholder timedOut={ timedOut } />
+					) }
 				</div>
 			</div>
 		</>

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.js
@@ -9,6 +9,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	const { ppcpId } = attributes;
 
 	const [ loaded, setLoaded ] = useState( false );
+	const [ timedOut, setTimedOut ] = useState( false );
 
 	let amount;
 	const postContent = String(
@@ -63,6 +64,14 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 			setAttributes( { ppcpId: `ppcp-${ clientId }` } );
 		}
 	}, [ ppcpId, clientId ] );
+
+	useEffect( () => {
+		if ( loaded ) {
+			return;
+		}
+		const timer = setTimeout( () => setTimedOut( true ), 5000 );
+		return () => clearTimeout( timer );
+	}, [ loaded ] );
 
 	if ( PcpCartPayLaterBlock.vaultingEnabled ) {
 		return (
@@ -134,7 +143,16 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	if ( scriptParams === null ) {
 		return (
 			<div { ...props }>
-				<Spinner />
+				{ timedOut ? (
+					<p>
+						{ __(
+							'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
+							'woocommerce-paypal-payments'
+						) }
+					</p>
+				) : (
+					<Spinner />
+				) }
 			</div>
 		);
 	}
@@ -186,7 +204,17 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 				<div className="ppcp-overlay-child ppcp-unclicable-overlay">
 					{ ' ' }
 					{ /* make the message not clickable */ }
-					{ ! loaded && <Spinner /> }
+					{ ! loaded &&
+						( timedOut ? (
+							<p>
+								{ __(
+									'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
+									'woocommerce-paypal-payments'
+								) }
+							</p>
+						) : (
+							<Spinner />
+						) ) }
 				</div>
 			</div>
 		</>

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.test.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.test.js
@@ -1,0 +1,140 @@
+import { render, act, screen } from '@testing-library/react';
+import { useEffect } from '@wordpress/element';
+import '@testing-library/jest-dom';
+import Edit from './edit';
+
+jest.useFakeTimers();
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children } ) => children,
+	useBlockProps: () => ( {} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { children } ) => children,
+	Spinner: () => <div className="components-spinner" />,
+} ) );
+
+jest.mock( '@ppcp-paylater-block/hooks/script-params', () => ( {
+	useScriptParams: jest.fn(),
+} ) );
+
+jest.mock( '@paypal/react-paypal-js', () => ( {
+	PayPalScriptProvider: ( { children } ) => children,
+	PayPalMessages: jest.fn( () => null ),
+} ) );
+
+const { useScriptParams } = require( '@ppcp-paylater-block/hooks/script-params' );
+
+const defaultConfig = {
+	vaultingEnabled: false,
+	placementEnabled: true,
+	settingsUrl: '/wp-admin/settings',
+	payLaterSettingsUrl: '/wp-admin/paylater-settings',
+	ajax: { cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' } },
+	config: {
+		cart: {
+			layout: 'text',
+			'logo-position': 'left',
+			'logo-type': 'primary',
+			'text-color': 'black',
+			'text-size': '14',
+		},
+	},
+};
+
+const defaultProps = {
+	attributes: { ppcpId: 'ppcp-test' },
+	clientId: 'test-client-id',
+	setAttributes: jest.fn(),
+};
+
+beforeEach( () => {
+	global.PcpCartPayLaterBlock = { ...defaultConfig };
+	global.wp = {
+		data: { select: () => ( { getEditedPostContent: () => '' } ) },
+	};
+	jest.clearAllMocks();
+	jest.clearAllTimers();
+} );
+
+test( 'shows spinner while script params are loading', () => {
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect( document.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+} );
+
+test( 'shows placeholder after 5 seconds when script params never resolve', () => {
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.getByText(
+			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
+		)
+	).toBeInTheDocument();
+	expect( document.querySelector( '.components-spinner' ) ).not.toBeInTheDocument();
+} );
+
+test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () => {
+	useScriptParams.mockReturnValue( {
+		url_params: { 'client-id': 'test' },
+	} );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.getByText(
+			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
+		)
+	).toBeInTheDocument();
+} );
+
+test( 'does not show placeholder when PayPalMessages renders within 5 seconds', () => {
+	useScriptParams.mockReturnValue( {
+		url_params: { 'client-id': 'test' },
+	} );
+
+	const { PayPalMessages } = require( '@paypal/react-paypal-js' );
+	PayPalMessages.mockImplementation( ( { onRender } ) => {
+		useEffect( () => onRender(), [] );
+		return null;
+	} );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.queryByText( /Pay Later messaging preview unavailable/ )
+	).not.toBeInTheDocument();
+} );
+
+test( 'shows vaulting warning when vaulting is enabled', () => {
+	global.PcpCartPayLaterBlock = { ...defaultConfig, vaultingEnabled: true };
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect(
+		screen.getByText( /cannot be used while PayPal Vaulting is active/ )
+	).toBeInTheDocument();
+} );
+
+test( 'shows placement warning when placement is disabled', () => {
+	global.PcpCartPayLaterBlock = { ...defaultConfig, placementEnabled: false };
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect(
+		screen.getByText( /messaging placement is disabled/ )
+	).toBeInTheDocument();
+} );

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.js
@@ -1,15 +1,17 @@
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, Spinner } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 import { PayPalScriptProvider, PayPalMessages } from '@paypal/react-paypal-js';
 import { useScriptParams } from '@ppcp-paylater-block/hooks/script-params';
+import { usePreviewTimeout } from '@ppcp-paylater-block/hooks/use-preview-timeout';
+import { PreviewPlaceholder } from '@ppcp-paylater-block/components/preview-placeholder';
 
 export default function Edit( { attributes, clientId, setAttributes } ) {
 	const { ppcpId } = attributes;
 
 	const [ loaded, setLoaded ] = useState( false );
-	const [ timedOut, setTimedOut ] = useState( false );
+	const timedOut = usePreviewTimeout( loaded );
 
 	let amount;
 	const postContent = String(
@@ -64,14 +66,6 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 			setAttributes( { ppcpId: 'ppcp-' + clientId } );
 		}
 	}, [ ppcpId, clientId ] );
-
-	useEffect( () => {
-		if ( loaded ) {
-			return;
-		}
-		const timer = setTimeout( () => setTimedOut( true ), 5000 );
-		return () => clearTimeout( timer );
-	}, [ loaded ] );
 
 	if ( PcpCheckoutPayLaterBlock.vaultingEnabled ) {
 		return (
@@ -143,16 +137,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	if ( scriptParams === null ) {
 		return (
 			<div { ...props }>
-				{ timedOut ? (
-					<p>
-						{ __(
-							'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
-							'woocommerce-paypal-payments'
-						) }
-					</p>
-				) : (
-					<Spinner />
-				) }
+				<PreviewPlaceholder timedOut={ timedOut } />
 			</div>
 		);
 	}
@@ -204,17 +189,9 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 				<div className={ 'ppcp-overlay-child ppcp-unclicable-overlay' }>
 					{ ' ' }
 					{ /* make the message not clickable */ }
-					{ ! loaded &&
-						( timedOut ? (
-							<p>
-								{ __(
-									'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
-									'woocommerce-paypal-payments'
-								) }
-							</p>
-						) : (
-							<Spinner />
-						) ) }
+					{ ! loaded && (
+						<PreviewPlaceholder timedOut={ timedOut } />
+					) }
 				</div>
 			</div>
 		</>

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.js
@@ -9,6 +9,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	const { ppcpId } = attributes;
 
 	const [ loaded, setLoaded ] = useState( false );
+	const [ timedOut, setTimedOut ] = useState( false );
 
 	let amount;
 	const postContent = String(
@@ -63,6 +64,14 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 			setAttributes( { ppcpId: 'ppcp-' + clientId } );
 		}
 	}, [ ppcpId, clientId ] );
+
+	useEffect( () => {
+		if ( loaded ) {
+			return;
+		}
+		const timer = setTimeout( () => setTimedOut( true ), 5000 );
+		return () => clearTimeout( timer );
+	}, [ loaded ] );
 
 	if ( PcpCheckoutPayLaterBlock.vaultingEnabled ) {
 		return (
@@ -134,7 +143,16 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 	if ( scriptParams === null ) {
 		return (
 			<div { ...props }>
-				<Spinner />
+				{ timedOut ? (
+					<p>
+						{ __(
+							'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
+							'woocommerce-paypal-payments'
+						) }
+					</p>
+				) : (
+					<Spinner />
+				) }
 			</div>
 		);
 	}
@@ -186,7 +204,17 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 				<div className={ 'ppcp-overlay-child ppcp-unclicable-overlay' }>
 					{ ' ' }
 					{ /* make the message not clickable */ }
-					{ ! loaded && <Spinner /> }
+					{ ! loaded &&
+						( timedOut ? (
+							<p>
+								{ __(
+									'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.',
+									'woocommerce-paypal-payments'
+								) }
+							</p>
+						) : (
+							<Spinner />
+						) ) }
 				</div>
 			</div>
 		</>

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.test.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.test.js
@@ -1,0 +1,140 @@
+import { render, act, screen } from '@testing-library/react';
+import { useEffect } from '@wordpress/element';
+import '@testing-library/jest-dom';
+import Edit from './edit';
+
+jest.useFakeTimers();
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	InspectorControls: ( { children } ) => children,
+	useBlockProps: () => ( {} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	PanelBody: ( { children } ) => children,
+	Spinner: () => <div className="components-spinner" />,
+} ) );
+
+jest.mock( '@ppcp-paylater-block/hooks/script-params', () => ( {
+	useScriptParams: jest.fn(),
+} ) );
+
+jest.mock( '@paypal/react-paypal-js', () => ( {
+	PayPalScriptProvider: ( { children } ) => children,
+	PayPalMessages: jest.fn( () => null ),
+} ) );
+
+const { useScriptParams } = require( '@ppcp-paylater-block/hooks/script-params' );
+
+const defaultConfig = {
+	vaultingEnabled: false,
+	placementEnabled: true,
+	settingsUrl: '/wp-admin/settings',
+	payLaterSettingsUrl: '/wp-admin/paylater-settings',
+	ajax: { cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' } },
+	config: {
+		checkout: {
+			layout: 'text',
+			'logo-position': 'left',
+			'logo-type': 'primary',
+			'text-color': 'black',
+			'text-size': '14',
+		},
+	},
+};
+
+const defaultProps = {
+	attributes: { ppcpId: 'ppcp-test' },
+	clientId: 'test-client-id',
+	setAttributes: jest.fn(),
+};
+
+beforeEach( () => {
+	global.PcpCheckoutPayLaterBlock = { ...defaultConfig };
+	global.wp = {
+		data: { select: () => ( { getEditedPostContent: () => '' } ) },
+	};
+	jest.clearAllMocks();
+	jest.clearAllTimers();
+} );
+
+test( 'shows spinner while script params are loading', () => {
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect( document.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+} );
+
+test( 'shows placeholder after 5 seconds when script params never resolve', () => {
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.getByText(
+			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
+		)
+	).toBeInTheDocument();
+	expect( document.querySelector( '.components-spinner' ) ).not.toBeInTheDocument();
+} );
+
+test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () => {
+	useScriptParams.mockReturnValue( {
+		url_params: { 'client-id': 'test' },
+	} );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.getByText(
+			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
+		)
+	).toBeInTheDocument();
+} );
+
+test( 'does not show placeholder when PayPalMessages renders within 5 seconds', () => {
+	useScriptParams.mockReturnValue( {
+		url_params: { 'client-id': 'test' },
+	} );
+
+	const { PayPalMessages } = require( '@paypal/react-paypal-js' );
+	PayPalMessages.mockImplementation( ( { onRender } ) => {
+		useEffect( () => onRender(), [] );
+		return null;
+	} );
+
+	render( <Edit { ...defaultProps } /> );
+
+	act( () => jest.advanceTimersByTime( 5000 ) );
+
+	expect(
+		screen.queryByText( /Pay Later messaging preview unavailable/ )
+	).not.toBeInTheDocument();
+} );
+
+test( 'shows vaulting warning when vaulting is enabled', () => {
+	global.PcpCheckoutPayLaterBlock = { ...defaultConfig, vaultingEnabled: true };
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect(
+		screen.getByText( /cannot be used while PayPal Vaulting is active/ )
+	).toBeInTheDocument();
+} );
+
+test( 'shows placement warning when placement is disabled', () => {
+	global.PcpCheckoutPayLaterBlock = { ...defaultConfig, placementEnabled: false };
+	useScriptParams.mockReturnValue( null );
+
+	render( <Edit { ...defaultProps } /> );
+
+	expect(
+		screen.getByText( /messaging placement is disabled/ )
+	).toBeInTheDocument();
+} );

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -8,7 +8,8 @@
         "^@ppcp-button/(.*)$": "<rootDir>/modules/ppcp-button/resources/js/modules/$1",
         "^@ppcp-settings/(.*)$": "<rootDir>/modules/ppcp-settings/resources/js/$1",
         "^@ppcp-blocks/(.*)$": "<rootDir>/modules/ppcp-blocks/resources/js/$1",
-        "^@ppcp-card-fields/(.*)$": "<rootDir>/modules/ppcp-card-fields/resources/js/$1"
+        "^@ppcp-card-fields/(.*)$": "<rootDir>/modules/ppcp-card-fields/resources/js/$1",
+        "^@ppcp-paylater-block/(.*)$": "<rootDir>/modules/ppcp-paylater-block/resources/js/$1"
     },
     "testPathIgnorePatterns": [
         "<rootDir>/tests/",


### PR DESCRIPTION
## Problem

When editing the checkout/cart page in the block editor, the Pay Later messaging block could display an infinite spinner that never resolves. This happens when eligibility requirements (merchant status, geolocation, store configuration) cannot be determined in the editor context, causing the PayPal SDK to silently skip rendering without calling `onRender`.

## Solution

Added a 5-second timeout mechanism to all three Pay Later block editor components. If the messaging preview has not loaded within 5 seconds, the spinner is replaced with a static placeholder:

> "Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met."

<table>
  <tr>
    <th>PayPal Pay Later messaging block (any page)</th>
    <th>WooCommerce Checkout/Cart block</th>
  </tr>
  <tr>
    <td><img width="1713" height="764" alt="Screenshot 2026-04-27 at 16 24 06" src="https://github.com/user-attachments/assets/6b3e577f-91b2-4106-a222-55e63e9d5e95" /></td>
    <td><img width="1718" height="753" alt="Screenshot 2026-04-27 at 16 24 21" src="https://github.com/user-attachments/assets/cca8eb4a-9517-4cd0-a639-ab90ef79ca6e" /></td>
  </tr>
</table>


If the preview loads successfully within 5 seconds, behavior is unchanged.

## Changes

- `CheckoutPayLaterMessagesBlock/edit.js` — timeout + placeholder
- `CartPayLaterMessagesBlock/edit.js` — timeout + placeholder
- `ppcp-paylater-block/resources/js/edit.js` — timeout + placeholder
- `tests/js/jest.config.json` — added `@ppcp-paylater-block` Jest alias
- Added unit tests for all three blocks (18 tests total)

## Testing

Switch the WooCommerce store currency to one where Pay Later messaging is not supported — the placeholder should appear after 5 seconds.

## Notes

- Frontend rendering is unaffected
- Block controls remain accessible during and after the timeout