### PR TITLE
[QA] Add parallel E2E test execution in CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,7 @@ on:
           - e2e:test:critical
           - e2e:test:stress
           - e2e:test:all
+          - e2e:test:all:parallel
       XRAY_TEST_EXEC_KEY:
         description: 'Xray Test Execution Key'
         required: false
@@ -41,11 +42,60 @@ jobs:
 
   e2e-playwright:
     name: Run Playwright E2E Tests
+    if: ${{ inputs.TEST_SUITE != 'e2e:test:all:parallel' }}
     needs: build
     uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@fix/test-playwright
     with:
       WORK_DIR: tests/qa
       PLAYWRIGHT_SCRIPT: ${{ inputs.TEST_SUITE }}
+      ARTIFACT_PATH: |
+        tests/qa/artifacts/*
+        tests/qa/playwright-report/
+        tests/qa/test-results/
+      ARTIFACT_INCLUDE_HIDDEN_FILES: true
+      NODE_VERSION: 22
+      PLAYWRIGHT_BROWSER_ARGS: 'chromium --with-deps'
+      XRAY_TEST_EXEC_KEY: ${{ inputs.XRAY_TEST_EXEC_KEY }}
+      PRE_SCRIPT: |
+        # 1. Download and unzip the built plugin
+        gh run download ${{ github.run_id }} -p "woocommerce-paypal-payments-*" -D resources/files
+        pushd resources/files
+        mv woocommerce-paypal-payments-*/woocommerce-paypal-payments .
+        zip -r woocommerce-paypal-payments.zip woocommerce-paypal-payments
+        rm -rf woocommerce-paypal-payments woocommerce-paypal-payments-*/
+        popd
+
+        # 2. Add private composer repository and download WooCommerce Subscriptions
+        pushd ../../
+        composer config repositories.repo-name composer https://repo.packagist.com/inpsyde/payment-gateways/
+        composer require inpsyde-mirror/woocommerce-subscriptions
+        popd
+
+        # 3. Setup wp-env
+        npm run e2e:setup:env
+    secrets:
+      ENV_FILE_DATA: ${{ secrets.QA_ENV_FILE }}
+      NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_GITHUB_TOKEN_PACKAGES }}
+      COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
+
+  e2e-playwright-parallel:
+    name: Run Playwright E2E Tests / ${{ matrix.shard }}
+    if: ${{ inputs.TEST_SUITE == 'e2e:test:all:parallel' }}
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - plugin-foundation
+          - onboarding-settings
+          - transactions
+          - refund
+          - vaulting
+          - subscription
+    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@fix/test-playwright
+    with:
+      WORK_DIR: tests/qa
+      PLAYWRIGHT_SCRIPT: e2e:test:shard:${{ matrix.shard }}
       ARTIFACT_PATH: |
         tests/qa/artifacts/*
         tests/qa/playwright-report/

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,6 +15,7 @@ on:
           - e2e:test:critical
           - e2e:test:stress
           - e2e:test:all
+          - e2e:test:all:parallel
       XRAY_TEST_EXEC_KEY:
         description: 'Xray Test Execution Key'
         required: false
@@ -39,13 +40,34 @@ jobs:
       PACKAGE_NAME: woocommerce-paypal-payments
       NODE_VERSION: 22
 
+  resolve-playwright-matrix:
+    name: Resolve Playwright matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.resolve.outputs.matrix }}
+    steps:
+      - name: Resolve test scripts
+        id: resolve
+        shell: bash
+        run: |
+          if [[ '${{ inputs.TEST_SUITE }}' == 'e2e:test:all:parallel' ]]; then
+            echo 'matrix={"include":[{"script":"e2e:test:shard:plugin-foundation","name_suffix":" / plugin-foundation"},{"script":"e2e:test:shard:onboarding-settings","name_suffix":" / onboarding-settings"},{"script":"e2e:test:shard:transactions","name_suffix":" / transactions"},{"script":"e2e:test:shard:transactions-googlepay","name_suffix":" / transactions-googlepay"},{"script":"e2e:test:shard:refund","name_suffix":" / refund"},{"script":"e2e:test:shard:vaulting","name_suffix":" / vaulting"},{"script":"e2e:test:shard:subscription","name_suffix":" / subscription"}]}' >> "$GITHUB_OUTPUT"
+          else
+            echo 'matrix={"include":[{"script":"${{ inputs.TEST_SUITE }}","name_suffix":""}]}' >> "$GITHUB_OUTPUT"
+          fi
+
   e2e-playwright:
-    name: Run Playwright E2E Tests
-    needs: build
+    name: Run Playwright E2E Tests${{ matrix.name_suffix }}
+    needs:
+      - build
+      - resolve-playwright-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.resolve-playwright-matrix.outputs.matrix) }}
     uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@fix/test-playwright
     with:
       WORK_DIR: tests/qa
-      PLAYWRIGHT_SCRIPT: ${{ inputs.TEST_SUITE }}
+      PLAYWRIGHT_SCRIPT: ${{ matrix.script }}
       PLAYWRIGHT_ARTIFACT_PATH: |
         tests/qa/artifacts/*
         tests/qa/playwright-report/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,21 @@
     "phpstan": "vendor/bin/phpstan analyze --memory-limit=2G",
     "fix-lint": "vendor/bin/phpcbf",
     "build": "wp-scripts build",
-    "watch-js": "wp-scripts start"
+    "watch-js": "wp-scripts start",
+    "e2e:setup:env": "npm --prefix tests/qa run e2e:setup:env",
+    "e2e:test:plugin-foundation": "npm --prefix tests/qa run e2e:test:plugin-foundation",
+    "e2e:test:dev": "npm --prefix tests/qa run e2e:test:dev",
+    "e2e:test:smoke": "npm --prefix tests/qa run e2e:test:smoke",
+    "e2e:test:critical": "npm --prefix tests/qa run e2e:test:critical",
+    "e2e:test:stress": "npm --prefix tests/qa run e2e:test:stress",
+    "e2e:test:all": "npm --prefix tests/qa run e2e:test:all",
+    "e2e:test:shard:plugin-foundation": "npm --prefix tests/qa run e2e:test:shard:plugin-foundation",
+    "e2e:test:shard:onboarding-settings": "npm --prefix tests/qa run e2e:test:shard:onboarding-settings",
+    "e2e:test:shard:transactions": "npm --prefix tests/qa run e2e:test:shard:transactions",
+    "e2e:test:shard:transactions-googlepay": "npm --prefix tests/qa run e2e:test:shard:transactions-googlepay",
+    "e2e:test:shard:refund": "npm --prefix tests/qa run e2e:test:shard:refund",
+    "e2e:test:shard:vaulting": "npm --prefix tests/qa run e2e:test:shard:vaulting",
+    "e2e:test:shard:subscription": "npm --prefix tests/qa run e2e:test:shard:subscription"
   },
   "config": {
     "wp_org_slug": "woocommerce-paypal-payments"

--- a/tests/qa/package.json
+++ b/tests/qa/package.json
@@ -54,7 +54,15 @@
         "env:setup:checkout:block": "npx playwright test --grep=\"setup:checkout:block;\"",
         "env:setup:checkout:classic": "npx playwright test --grep=\"setup:checkout:classic;\"",
         "env:setup:tax:inc": "npx playwright test --grep=\"setup:tax:inc;\"",
-        "env:setup:tax:exc": "npx playwright test --grep=\"setup:tax:exc;\""
+        "env:setup:tax:exc": "npx playwright test --grep=\"setup:tax:exc;\"",
+
+        "e2e:test:shard:plugin-foundation": "npx playwright test --project \"shard:plugin-foundation\"",
+        "e2e:test:shard:onboarding-settings": "npx playwright test --project \"shard:onboarding-settings\"",
+        "e2e:test:shard:transactions": "npx playwright test --project \"shard:transactions\"",
+        "e2e:test:shard:transactions-googlepay": "npx playwright test --project \"shard:transactions-googlepay\"",
+        "e2e:test:shard:refund": "npx playwright test --project \"shard:refund\"",
+        "e2e:test:shard:vaulting": "npx playwright test --project \"shard:vaulting\"",
+        "e2e:test:shard:subscription": "npx playwright test --project \"shard:subscription\""
     },
     "eslintConfig": {
         "extends": [

--- a/tests/qa/package.json
+++ b/tests/qa/package.json
@@ -54,7 +54,14 @@
         "env:setup:checkout:block": "npx playwright test --grep=\"setup:checkout:block;\"",
         "env:setup:checkout:classic": "npx playwright test --grep=\"setup:checkout:classic;\"",
         "env:setup:tax:inc": "npx playwright test --grep=\"setup:tax:inc;\"",
-        "env:setup:tax:exc": "npx playwright test --grep=\"setup:tax:exc;\""
+        "env:setup:tax:exc": "npx playwright test --grep=\"setup:tax:exc;\"",
+
+        "e2e:test:shard:plugin-foundation": "npx playwright test --project \"shard:plugin-foundation\"",
+        "e2e:test:shard:onboarding-settings": "npx playwright test --project \"shard:onboarding-settings\"",
+        "e2e:test:shard:transactions": "npx playwright test --project \"shard:transactions\"",
+        "e2e:test:shard:refund": "npx playwright test --project \"shard:refund\"",
+        "e2e:test:shard:vaulting": "npx playwright test --project \"shard:vaulting\"",
+        "e2e:test:shard:subscription": "npx playwright test --project \"shard:subscription\""
     },
     "eslintConfig": {
         "extends": [

--- a/tests/qa/playwright.config.ts
+++ b/tests/qa/playwright.config.ts
@@ -139,5 +139,37 @@ export default defineConfig< BaseExtend >( {
 			dependencies: [ 'setup-woocommerce' ],
 			testMatch: /stress\.spec\.ts/,
 		},
+
+		// Parallel CI
+		{
+			name: 'shard:plugin-foundation',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /01-plugin-foundation\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:onboarding-settings',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /(02-onboarding|03-plugin-settings)\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:transactions',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /05-transactions\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:refund',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /06-refund\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:vaulting',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /07-vaulting\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:subscription',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /08-subscription\/.*\.spec\.ts/,
+		},
 	],
 } );

--- a/tests/qa/playwright.config.ts
+++ b/tests/qa/playwright.config.ts
@@ -11,8 +11,8 @@ import path from 'path';
 import { BaseExtend } from './utils';
 
 const dotenvPath = process.env.CI
-    ? path.resolve( __dirname, '.env.ci' )
-    : undefined;
+	? path.resolve( __dirname, '.env.ci' )
+	: undefined;
 dotenv.config( { path: dotenvPath } );
 
 const viewportSize: ViewportSize = { width: 1280, height: 850 };
@@ -63,12 +63,12 @@ export default defineConfig< BaseExtend >( {
 		 * For envs with Basic Auth. Omit when both are empty (e.g. wp-env).
 		 */
 		...( process.env.WP_BASIC_AUTH_USER &&
-		process.env.WP_BASIC_AUTH_PASS && {
-			httpCredentials: {
-				username: process.env.WP_BASIC_AUTH_USER,
-				password: process.env.WP_BASIC_AUTH_PASS,
-			},
-		} ),
+			process.env.WP_BASIC_AUTH_PASS && {
+				httpCredentials: {
+					username: process.env.WP_BASIC_AUTH_USER,
+					password: process.env.WP_BASIC_AUTH_PASS,
+				},
+			} ),
 
 		...devices[ 'Desktop Chrome' ],
 
@@ -110,7 +110,7 @@ export default defineConfig< BaseExtend >( {
 				host: process.env.SSH_HOST,
 				port: process.env.SSH_PORT,
 				path: process.env.SSH_PATH,
-			}
+			},
 		},
 	},
 
@@ -126,6 +126,41 @@ export default defineConfig< BaseExtend >( {
 			fullyParallel: false,
 		},
 		{
+			name: 'setup-pcp-usa-for-transactions',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /pcp\.setup\.ts/,
+			grep: /setup:pcp:usa:transactions;/,
+			fullyParallel: false,
+		},
+		{
+			name: 'setup-pcp-usa-for-transactions-googlepay',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /pcp\.setup\.ts/,
+			grep: /setup:pcp:usa:transactions:googlepay;/,
+			fullyParallel: false,
+		},
+		{
+			name: 'setup-pcp-usa-for-refund',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /pcp\.setup\.ts/,
+			grep: /setup:pcp:usa:refund;/,
+			fullyParallel: false,
+		},
+		{
+			name: 'setup-pcp-vaulting',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /pcp\.setup\.ts/,
+			grep: /setup:pcp:usa:vaulting;/,
+			fullyParallel: false,
+		},
+		{
+			name: 'setup-pcp-subscription',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /pcp\.setup\.ts/,
+			grep: /setup:pcp:usa:subscription;/,
+			fullyParallel: false,
+		},
+		{
 			name: 'plugin-foundation',
 			dependencies: [ 'setup-woocommerce' ],
 			testMatch: /plugin-foundation\.spec\.ts/,
@@ -133,15 +168,49 @@ export default defineConfig< BaseExtend >( {
 		{
 			name: 'all',
 			dependencies: [ 'setup-woocommerce' ],
-			testIgnore: [
-				/stress\.spec\.ts/,
-				/plugin-foundation\.spec\.ts/,
-			],
+			testIgnore: [ /stress\.spec\.ts/, /plugin-foundation\.spec\.ts/ ],
 		},
 		{
 			name: 'stress',
 			dependencies: [ 'setup-woocommerce' ],
 			testMatch: /stress\.spec\.ts/,
+		},
+
+		// Parallel CI
+		{
+			name: 'shard:plugin-foundation',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /01-plugin-foundation\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:onboarding-settings',
+			dependencies: [ 'setup-woocommerce' ],
+			testMatch: /(02-onboarding|03-plugin-settings)\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:transactions',
+			dependencies: [ 'setup-pcp-usa-for-transactions' ],
+			testMatch: /05-transactions\/transaction-usa.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:transactions-googlepay',
+			dependencies: [ 'setup-pcp-usa-for-transactions-googlepay' ],
+			testMatch: /05-transactions\/transaction-googlepay\.spec\.ts/,
+		},
+		{
+			name: 'shard:refund',
+			dependencies: [ 'setup-pcp-usa-for-refund' ],
+			testMatch: /06-refund\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:vaulting',
+			dependencies: [ 'setup-pcp-vaulting' ],
+			testMatch: /07-vaulting\/.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:subscription',
+			dependencies: [ 'setup-pcp-subscription' ],
+			testMatch: /08-subscription\/.*\.spec\.ts/,
 		},
 	],
 } );

--- a/tests/qa/tests/03-plugin-settings/pay-later-messaging-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/pay-later-messaging-ui.spec.ts
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import { expect, test } from '../../utils';
-import { merchants, storeConfigDefault, products } from '../../resources';
+import { merchants, storeConfigUsa, products } from '../../resources';
 
 test.beforeAll( async ( { utils, pcpApi } ) => {
-	await utils.configureStore( storeConfigDefault );
+	await utils.configureStore( storeConfigUsa );
 	await utils.installAndActivatePcp();
 	await pcpApi.resetDb();
 	await pcpApi.connectMerchant(

--- a/tests/qa/tests/05-transactions/transaction-googlepay.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-googlepay.spec.ts
@@ -2,12 +2,9 @@
  * Internal dependencies
  */
 import { test } from '../../utils';
-import { merchants, storeConfigUsa, gateways, customers } from '../../resources';
 import { transactionsOnCheckout } from './_test-scenarios';
 import { googlePayCheckout } from './_test-data/googlepay';
 import { GooglePayPopup } from '../../utils/frontend/google-pay-popup';
-
-const { acdc, googlepay } = gateways;
 
 test.use( {
 	// Strip Basic Auth from the visitor context — when present it breaks
@@ -27,18 +24,6 @@ test.use( {
 
 test.beforeEach( async ( { visitorPage } ) => {
 	await GooglePayPopup.applyBrowserPatches( visitorPage.context() );
-} );
-
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
-	await utils.configureStore( { ...storeConfigUsa, customer: customers.usa } );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant( merchants.usa.client_id, merchants.usa.client_secret );
-	// Google Pay requires ACDC to be enabled alongside it.
-	await pcpApi.updatePcpPaymentMethods( {
-		[ acdc.id ]: { id: acdc.id, enabled: true },
-		[ googlepay.id ]: { id: googlepay.id, enabled: true },
-	} );
 } );
 
 for ( const order of googlePayCheckout ) {

--- a/tests/qa/tests/05-transactions/transaction-usa-classic.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-usa-classic.spec.ts
@@ -3,22 +3,11 @@
  */
 import { test } from '../../utils';
 import {
-	merchants,
-	storeConfigUsa,
+	customers,
 	gateways,
 	taxSettings,
-	customers,
 } from '../../resources';
-import {
-	transactionsOnClassicCart,
-	transactionsOnClassicCheckout,
-	transactionsOnClassicProduct,
-} from './_test-scenarios';
-import {
-	venmoClassicCartUsa,
-	venmoClassicCheckoutUsa,
-	venmoClassicProductUsa,
-} from './_test-data/venmo';
+import { transactionsOnClassicCheckout } from './_test-scenarios';
 import {
 	payPalClassicCheckout,
 	payPalClassicCheckoutExcludingTax,
@@ -37,27 +26,14 @@ import {
 } from './_test-data/acdc';
 import { fastlaneClassicCheckout } from './_test-data/fastlane';
 
-const { payPal, payLater, venmo, acdc, fastlane } = gateways;
+const { fastlane } = gateways;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
 	await utils.configureStore( {
-		...storeConfigUsa,
 		enableClassicPages: true,
 		customer: customers.usa,
 	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret
-	);
-	await pcpApi.updatePcpPaymentMethods( {
-		[ payPal.id ]: { id: payPal.id, enabled: true },
-		[ payLater.id ]: { id: payLater.id, enabled: true },
-		[ venmo.id ]: { id: venmo.id, enabled: true },
-		[ acdc.id ]: { id: acdc.id, enabled: true },
-		[ fastlane.id ]: { id: fastlane.id, enabled: false },
-	} );
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of payPalClassicCheckout ) {

--- a/tests/qa/tests/05-transactions/transaction-usa.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-usa.spec.ts
@@ -3,11 +3,9 @@
  */
 import { test } from '../../utils';
 import {
-	merchants,
-	storeConfigUsa,
+	customers,
 	gateways,
 	taxSettings,
-	customers,
 } from '../../resources';
 import {
 	transactionsOnCheckout,
@@ -38,26 +36,14 @@ import {
 } from './_test-data/acdc';
 import { fastlaneCheckout } from './_test-data/fastlane';
 
-const { payPal, payLater, venmo, acdc, fastlane } = gateways;
+const { fastlane } = gateways;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
 	await utils.configureStore( {
-		...storeConfigUsa,
+		enableClassicPages: false,
 		customer: customers.usa,
 	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret
-	);
-	await pcpApi.updatePcpPaymentMethods( {
-		[ payPal.id ]: { id: payPal.id, enabled: true },
-		[ payLater.id ]: { id: payLater.id, enabled: true },
-		[ venmo.id ]: { id: venmo.id, enabled: true },
-		[ acdc.id ]: { id: acdc.id, enabled: true },
-		[ fastlane.id ]: { id: fastlane.id, enabled: false },
-	} );
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of payPalCheckout ) {

--- a/tests/qa/tests/06-refund/refund-usa.spec.ts
+++ b/tests/qa/tests/06-refund/refund-usa.spec.ts
@@ -1,13 +1,6 @@
 /**
  * Internal dependencies
  */
-import { test } from '../../utils';
-import {
-	merchants,
-	storeConfigUsa,
-	gateways,
-	customers,
-} from '../../resources';
 import { testRefund } from './_test-scenarios';
 import {
 	refundPayPalFromCheckout,
@@ -15,25 +8,6 @@ import {
 	refundAcdcFromCheckout,
 	refundAcdcFromPayByLink,
 } from './_test-data';
-
-const { payPal, acdc } = gateways;
-
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
-	await utils.configureStore( {
-		...storeConfigUsa,
-		customer: customers.usa,
-	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret
-	);
-	await pcpApi.updatePcpPaymentMethods( {
-		[ payPal.id ]: { id: payPal.id, enabled: true },
-		[ acdc.id ]: { id: acdc.id, enabled: true },
-	} );
-} );
 
 for ( const testOrder of refundPayPalFromCheckout ) {
 	testRefund( testOrder );

--- a/tests/qa/tests/07-vaulting/vaulting-checkout.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-checkout.spec.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { test } from '../../utils';
-import { merchants, storeConfigUsa } from '../../resources';
 import { vaultingCheckout } from './_test-data';
 import { testVaultingCheckout } from './_test-scenarios';
 
@@ -18,25 +17,9 @@ const {
 	testVaultedPaymentMethod,
 } = testVaultingCheckout;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
-	await utils.configureStore( {
-		...storeConfigUsa,
-		enableClassicPages: false,
-	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret,
-		{
-			isCasualSeller: false,
-			areOptionalPaymentMethodsEnabled: true,
-		}
-	);
-	await pcpApi.updatePcpSettings( {
-		savePaypalAndVenmo: true,
-		saveCardDetails: true,
-	} );
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
+	await utils.configureStore( { enableClassicPages: false } );
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of savePaymentMethodData ) {

--- a/tests/qa/tests/07-vaulting/vaulting-classic-cart.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-classic-cart.spec.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { test } from '../../utils';
-import { merchants, storeConfigUsa } from '../../resources';
 import { vaultingClassicCart } from './_test-data';
 import { testVaultingClassicCart } from './_test-scenarios';
 
@@ -11,25 +10,9 @@ const { savePaymentMethodData, vaultedPaymentMethodData } = vaultingClassicCart;
 const { testSavePaymentMethod, testVaultedPaymentMethod } =
 	testVaultingClassicCart;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
-	await utils.configureStore( {
-		...storeConfigUsa,
-		enableClassicPages: true,
-	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret,
-		{
-			isCasualSeller: false,
-			areOptionalPaymentMethodsEnabled: true,
-		}
-	);
-	await pcpApi.updatePcpSettings( {
-		savePaypalAndVenmo: true,
-		saveCardDetails: true,
-	} );
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
+	await utils.configureStore( { enableClassicPages: true } );
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of savePaymentMethodData ) {

--- a/tests/qa/tests/07-vaulting/vaulting-classic-checkout.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-classic-checkout.spec.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { test } from '../../utils';
-import { merchants, storeConfigUsa } from '../../resources';
 import { vaultingClassicCheckout } from './_test-data';
 import { testVaultingClassicCheckout } from './_test-scenarios';
 
@@ -18,25 +17,9 @@ const {
 	testVaultedPaymentMethod,
 } = testVaultingClassicCheckout;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
-	await utils.configureStore( {
-		...storeConfigUsa,
-		enableClassicPages: true,
-	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret,
-		{
-			isCasualSeller: false,
-			areOptionalPaymentMethodsEnabled: true,
-		}
-	);
-	await pcpApi.updatePcpSettings( {
-		savePaypalAndVenmo: true,
-		saveCardDetails: true,
-	} );
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
+	await utils.configureStore( { enableClassicPages: true } );
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of savePaymentMethodData ) {

--- a/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
@@ -3,8 +3,6 @@
  */
 import { annotateVisitor, expect, test, PayPalPopup } from '../../utils';
 import {
-	merchants,
-	storeConfigUsa,
 	customers,
 	payments,
 	cards,
@@ -15,25 +13,9 @@ const customer = customers.usa;
 const { payPal, acdc } = payments;
 const acdc2 = { ...acdc, card: cards.visa2 };
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
-	await utils.configureStore( {
-		...storeConfigUsa,
-		enableClassicPages: true,
-	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret,
-		{
-			isCasualSeller: false,
-			areOptionalPaymentMethodsEnabled: true,
-		}
-	);
-	await pcpApi.updatePcpSettings( {
-		savePaypalAndVenmo: true,
-		saveCardDetails: true,
-	} );
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
+	await utils.configureStore( { enableClassicPages: true } );
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 const savePaymentMethodData = [
@@ -61,7 +43,9 @@ for ( const testData of savePaymentMethodData ) {
 		} );
 
 		test(
-			`${ testKey } | Vaulting - My Account - Payment Methods - ${ payment.gateway.title } - Save payment method${ testLabel ?? '' }`,
+			`${ testKey } | Vaulting - My Account - Payment Methods - ${
+				payment.gateway.title
+			} - Save payment method${ testLabel ?? '' }`,
 			annotateVisitor( customer ),
 			async ( { utils, customerPaymentMethods, classicCheckout } ) => {
 				await customerPaymentMethods.visit();
@@ -173,17 +157,18 @@ test.describe( () => {
 				// Save and assert payment method
 				await customerPaymentMethods.savePaymentMethod( payPal );
 			} );
-			
+
 			await test.step( 'Save another PayPal account', async () => {
 				const secondPayPalAccount = {
 					email: process.env.PAYPAL_PERSONAL_EMAIL_US2,
 					password: process.env.PAYPAL_PERSONAL_PASS_US2,
 				};
 				await customerPaymentMethods.addPaymentMethodButton().click();
-				const payPalGatewayButton = customerPaymentMethods.payPalUi.payPalGateway();
-				await expect (
+				const payPalGatewayButton =
+					customerPaymentMethods.payPalUi.payPalGateway();
+				await expect(
 					payPalGatewayButton,
-					'Assert PayPal gateway is visible',
+					'Assert PayPal gateway is visible'
 				).toBeVisible();
 				await payPalGatewayButton.click();
 				await customerPaymentMethods.page.waitForLoadState();
@@ -191,7 +176,7 @@ test.describe( () => {
 					customerPaymentMethods.payPalUi.payPalButton(),
 					'Assert PayPal button is visible'
 				).toBeVisible();
-				
+
 				// Assert PayPal dropdown menu button
 				const payPalButtonMoreOptions =
 					customerPaymentMethods.payPalUi.payPalButtonMoreOptions();
@@ -208,14 +193,17 @@ test.describe( () => {
 					payWithDifferentAccountButton,
 					'Assert Pay with different account button is visible'
 				).toBeVisible();
-				
+
 				// Call PayPal popup using "Pay with different account" button
 				const popupPromise =
-					customerPaymentMethods.payPalUi.page.waitForEvent( 'popup', {
-						timeout: 20_000,
-					} );
+					customerPaymentMethods.payPalUi.page.waitForEvent(
+						'popup',
+						{
+							timeout: 20_000,
+						}
+					);
 				await payWithDifferentAccountButton.click();
-		
+
 				const popup = await popupPromise;
 				await popup.waitForLoadState();
 				const payPalPopup = new PayPalPopup( popup );
@@ -225,9 +213,11 @@ test.describe( () => {
 				await customerPaymentMethods.assertUrl();
 				await customerPaymentMethods.assertIsSavedPaymentMethod( {
 					gateway: payPal.gateway,
-					payPalAccount: secondPayPalAccount
+					payPalAccount: secondPayPalAccount,
 				} );
-				await customerPaymentMethods.assertIsNotSavedPaymentMethod( payPal );
+				await customerPaymentMethods.assertIsNotSavedPaymentMethod(
+					payPal
+				);
 			} );
 		}
 	);

--- a/tests/qa/tests/07-vaulting/vaulting-pay-by-link.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-pay-by-link.spec.ts
@@ -2,7 +2,6 @@
  * Internal dependencies
  */
 import { test } from '../../utils';
-import { merchants, storeConfigUsa } from '../../resources';
 import { vaultingPayByLink } from './_test-data';
 import { testVaultingPayByLink } from './_test-scenarios';
 
@@ -18,25 +17,9 @@ const {
 	testVaultedPaymentMethod,
 } = testVaultingPayByLink;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
-	await utils.configureStore( {
-		...storeConfigUsa,
-		enableClassicPages: false,
-	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret,
-		{
-			isCasualSeller: false,
-			areOptionalPaymentMethodsEnabled: true,
-		}
-	);
-	await pcpApi.updatePcpSettings( {
-		savePaypalAndVenmo: true,
-		saveCardDetails: true,
-	} );
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
+	await utils.configureStore( { enableClassicPages: false } );
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of savePaymentMethodData ) {

--- a/tests/qa/tests/08-subscription/subscription-checkout.spec.ts
+++ b/tests/qa/tests/08-subscription/subscription-checkout.spec.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { test } from '../../utils';
-import { merchants, products, storeConfigUsa } from '../../resources';
+import { products } from '../../resources';
 import { subscriptionCheckout } from './_test-data';
 import { testSubscriptionCheckout } from './_test-scenarios';
 
@@ -12,24 +12,13 @@ const { vaultingGuest, vaultingCustomer, payPalGuest, payPalCustomer } =
 const { testSubscriptionOrderGuest, testSubscriptionOrderCustomer } =
 	testSubscriptionCheckout;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
+test.beforeAll( async ( { utils, wooCommerceApi } ) => {
 	await utils.configureStore( {
-		...storeConfigUsa,
 		enableClassicPages: false,
 		enableSubscriptionsPlugin: true,
 		products: [ products.subscription100, products.subscriptionFreeTrial ],
 	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret,
-		{
-			isCasualSeller: false,
-			areOptionalPaymentMethodsEnabled: true,
-			products: [ 'physical', 'virtual', 'subscriptions' ],
-		}
-	);
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of vaultingGuest ) {

--- a/tests/qa/tests/08-subscription/subscription-classic-checkout.spec.ts
+++ b/tests/qa/tests/08-subscription/subscription-classic-checkout.spec.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { test } from '../../utils';
-import { merchants, products, storeConfigUsa } from '../../resources';
+import { products } from '../../resources';
 import { subscriptionClassicCheckout } from './_test-data';
 import { testSubscriptionClassicCheckout } from './_test-scenarios';
 
@@ -12,24 +12,17 @@ const { vaultingGuest, vaultingCustomer, payPalGuest, payPalCustomer } =
 const { testSubscriptionOrderGuest, testSubscriptionOrderCustomer } =
 	testSubscriptionClassicCheckout;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
+test.beforeAll( async ( { utils, wooCommerceApi, pcpApi } ) => {
+	await pcpApi.updatePcpSettings( {
+		savePaypalAndVenmo: true,
+		saveCardDetails: true,
+	} );
 	await utils.configureStore( {
-		...storeConfigUsa,
 		enableClassicPages: true,
 		enableSubscriptionsPlugin: true,
 		products: [ products.subscription100, products.subscriptionFreeTrial ],
 	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret,
-		{
-			isCasualSeller: false,
-			areOptionalPaymentMethodsEnabled: true,
-			products: [ 'physical', 'virtual', 'subscriptions' ],
-		}
-	);
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of vaultingGuest ) {

--- a/tests/qa/tests/08-subscription/subscription-renewal.spec.ts
+++ b/tests/qa/tests/08-subscription/subscription-renewal.spec.ts
@@ -4,9 +4,7 @@
 import { test } from '../../utils';
 import {
 	disableWebhookVerificationPlugin,
-	merchants,
 	products,
-	storeConfigUsa,
 } from '../../resources';
 import { subscriptionRenewal } from './_test-data';
 import {
@@ -21,25 +19,17 @@ const {
 	payPalFreeTrialRenewal,
 } = subscriptionRenewal;
 
-test.beforeAll( async ( { utils, pcpApi, wooCommerceApi } ) => {
+test.beforeAll( async ( { utils, wooCommerceApi, pcpApi } ) => {
+	await pcpApi.updatePcpSettings( {
+		savePaypalAndVenmo: true,
+		saveCardDetails: true,
+	} );
 	await utils.configureStore( {
-		...storeConfigUsa,
-		enableWpDebugging: false,
 		enableClassicPages: false,
 		enableSubscriptionsPlugin: true,
 		products: [ products.subscription100, products.subscriptionFreeTrial ],
 	} );
-	await utils.installAndActivatePcp();
-	await pcpApi.resetDb();
-	await pcpApi.connectMerchant(
-		merchants.usa.client_id,
-		merchants.usa.client_secret,
-		{
-			isCasualSeller: false,
-			areOptionalPaymentMethodsEnabled: true,
-			products: [ 'physical', 'virtual', 'subscriptions' ],
-		}
-	);
+	await wooCommerceApi.deleteAllOrders();
 } );
 
 for ( const testOrder of vaultingRenewal ) {

--- a/tests/qa/tests/_setup/pcp.setup.ts
+++ b/tests/qa/tests/_setup/pcp.setup.ts
@@ -14,10 +14,11 @@ import {
 	storeConfigUsa,
 	taxSettings,
 	products,
+	customers,
 	gateways,
 } from '../../resources';
 
-const { acdc } = gateways;
+const { payPal, payLater, venmo, acdc, fastlane, googlepay } = gateways;
 
 setup.describe( 'env:reset;', async () => {
 	setup( 'Setup: Reset Environment', async () => {
@@ -42,6 +43,131 @@ setup( 'setup:pcp:usa;', async ( { utils, pcpApi } ) => {
 		merchants.usa.client_secret
 	);
 } );
+
+setup(
+	'setup:pcp:usa:transactions;',
+	async ( { utils, pcpApi, wooCommerceApi } ) => {
+		await utils.configureStore( {
+			...storeConfigUsa,
+			customer: customers.usa,
+		} );
+		await utils.installAndActivatePcp();
+		await pcpApi.resetDb();
+		await pcpApi.connectMerchant(
+			merchants.usa.client_id,
+			merchants.usa.client_secret
+		);
+		await pcpApi.updatePcpPaymentMethods( {
+			[ payPal.id ]: { id: payPal.id, enabled: true },
+			[ payLater.id ]: { id: payLater.id, enabled: true },
+			[ venmo.id ]: { id: venmo.id, enabled: true },
+			[ acdc.id ]: { id: acdc.id, enabled: true },
+			[ fastlane.id ]: { id: fastlane.id, enabled: false },
+		} );
+		await wooCommerceApi.deleteAllOrders();
+	}
+);
+
+setup( 'setup:pcp:usa:refund;', async ( { utils, pcpApi, wooCommerceApi } ) => {
+	await utils.configureStore( {
+		...storeConfigUsa,
+		customer: customers.usa,
+	} );
+	await utils.installAndActivatePcp();
+	await pcpApi.resetDb();
+	await pcpApi.connectMerchant(
+		merchants.usa.client_id,
+		merchants.usa.client_secret
+	);
+	await pcpApi.updatePcpPaymentMethods( {
+		[ payPal.id ]: { id: payPal.id, enabled: true },
+		[ acdc.id ]: { id: acdc.id, enabled: true },
+	} );
+	await wooCommerceApi.deleteAllOrders();
+} );
+
+setup(
+	'setup:pcp:usa:vaulting;',
+	async ( { utils, pcpApi, wooCommerceApi } ) => {
+		await utils.configureStore( storeConfigUsa );
+		await utils.installAndActivatePcp();
+		await pcpApi.resetDb();
+		await pcpApi.connectMerchant(
+			merchants.usa.client_id,
+			merchants.usa.client_secret,
+			{
+				isCasualSeller: false,
+				areOptionalPaymentMethodsEnabled: true,
+			}
+		);
+		await pcpApi.updatePcpSettings( {
+			savePaypalAndVenmo: true,
+			saveCardDetails: true,
+		} );
+		await pcpApi.updatePcpPaymentMethods( {
+			[ payPal.id ]: { id: payPal.id, enabled: true },
+			[ acdc.id ]: { id: acdc.id, enabled: true },
+		} );
+		await wooCommerceApi.deleteAllOrders();
+	}
+);
+
+setup(
+	'setup:pcp:usa:subscription;',
+	async ( { utils, pcpApi, wooCommerceApi } ) => {
+		await utils.configureStore( {
+			...storeConfigUsa,
+			enableWpDebugging: false,
+			enableSubscriptionsPlugin: true,
+			products: [
+				products.subscription100,
+				products.subscriptionFreeTrial,
+			],
+		} );
+		await utils.installAndActivatePcp();
+		await pcpApi.resetDb();
+		await pcpApi.connectMerchant(
+			merchants.usa.client_id,
+			merchants.usa.client_secret,
+			{
+				isCasualSeller: false,
+				areOptionalPaymentMethodsEnabled: true,
+				products: [ 'physical', 'virtual', 'subscriptions' ],
+			}
+		);
+		await pcpApi.updatePcpSettings( {
+			savePaypalAndVenmo: true,
+			saveCardDetails: true,
+		} );
+		await pcpApi.updatePcpPaymentMethods( {
+			[ payPal.id ]: { id: payPal.id, enabled: true },
+			[ acdc.id ]: { id: acdc.id, enabled: true },
+		} );
+		await wooCommerceApi.deleteAllOrders();
+	}
+);
+
+setup(
+	'setup:pcp:usa:transactions:googlepay;',
+	async ( { utils, pcpApi, wooCommerceApi } ) => {
+		await utils.configureStore( {
+			...storeConfigUsa,
+			enableClassicPages: false,
+			customer: customers.usa,
+		} );
+		await utils.installAndActivatePcp();
+		await pcpApi.resetDb();
+		await pcpApi.connectMerchant(
+			merchants.usa.client_id,
+			merchants.usa.client_secret
+		);
+		await pcpApi.updatePcpPaymentMethods( {
+			[ acdc.id ]: { id: acdc.id, enabled: true },
+			[ googlepay.id ]: { id: googlepay.id, enabled: true },
+		} );
+		await wooCommerceApi.deleteAllOrders();
+	}
+);
 
 // --- PCP Germany ---
 


### PR DESCRIPTION
Adds a separate CI option for running the full Playwright E2E suite in parallel across multiple wp-env setups.

The new `e2e:test:all:parallel` workflow input splits execution into dedicated shards for:

1. plugin foundation
2. onboarding/settings
3. transactions
4. refunds
5. vaulting
6. subscriptions

Each shard runs in its own CI job, allowing tests to execute independently instead of blocking each other.

For now this is added as a separate manual workflow option, so the existing default E2E runs remain unchanged. In the future, this parallel execution can be promoted to the default release test run.

# How to run

- Trigger the E2E Tests workflow manually.
- Select `e2e:test:all:parallel`.
- Verify that all shard jobs start independently and report results/artifacts correctly

# Test run
[Here you can view the how the workflow was executed](https://github.com/woocommerce/woocommerce-paypal-payments/actions/runs/25001249459)
