### PR TITLE
Remove redundant cache from ReferenceTransactionStatus (6280)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -300,8 +300,7 @@ return array(
 		);
 	},
 	'api.reference-transaction-status'               => static fn ( ContainerInterface $container ): ReferenceTransactionStatus => new ReferenceTransactionStatus(
-		$container->get( 'api.endpoint.partners' ),
-		$container->get( 'api.reference-transaction-status-cache' )
+		$container->get( 'api.endpoint.partners' )
 	),
 	'api.endpoint.catalog-products'                  => static function ( ContainerInterface $container ): CatalogProducts {
 		return new CatalogProducts(
@@ -865,9 +864,6 @@ return array(
 	},
 	'api.user-id-token-cache'                        => static function ( ContainerInterface $container ): Cache {
 		return new Cache( 'ppcp-id-token-cache' );
-	},
-	'api.reference-transaction-status-cache'         => static function ( ContainerInterface $container ): Cache {
-		return new Cache( 'ppcp-reference-transaction-status-cache' );
 	},
 	'api.user-id-token'                              => static function ( ContainerInterface $container ): UserIdToken {
 		return new UserIdToken(

--- a/modules/ppcp-api-client/src/Helper/ReferenceTransactionStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ReferenceTransactionStatus.php
@@ -19,15 +19,10 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
  */
 class ReferenceTransactionStatus {
 
-	public const CACHE_KEY = 'ppcp_reference_transaction_enabled';
-
-
 	protected PartnersEndpoint $partners_endpoint;
-	protected Cache $cache;
 
-	public function __construct( PartnersEndpoint $partners_endpoint, Cache $cache ) {
+	public function __construct( PartnersEndpoint $partners_endpoint ) {
 		$this->partners_endpoint = $partners_endpoint;
-		$this->cache             = $cache;
 	}
 
 	/**
@@ -39,29 +34,19 @@ class ReferenceTransactionStatus {
 	 * @return bool True if reference transactions are enabled, false otherwise.
 	 */
 	public function reference_transaction_enabled(): bool {
-		if ( $this->cache->has( self::CACHE_KEY ) ) {
-			$cached = $this->cache->get( self::CACHE_KEY );
-			if ( is_string( $cached ) || is_bool( $cached ) ) {
-				return wc_string_to_bool( $cached );
-			}
-		}
-
 		try {
 			foreach ( $this->partners_endpoint->seller_status()->capabilities() as $capability ) {
 				if (
 					$capability->name() === 'PAYPAL_WALLET_VAULTING_ADVANCED' &&
 					$capability->status() === 'ACTIVE'
 				) {
-					$this->cache->set( self::CACHE_KEY, wc_bool_to_string( true ), MONTH_IN_SECONDS );
 					return true;
 				}
 			}
 		} catch ( RuntimeException $exception ) {
-			$this->cache->set( self::CACHE_KEY, wc_bool_to_string( false ), HOUR_IN_SECONDS );
 			return false;
 		}
 
-		$this->cache->set( self::CACHE_KEY, wc_bool_to_string( false ), HOUR_IN_SECONDS );
 		return false;
 	}
 }

--- a/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
+++ b/modules/ppcp-api-client/src/Repository/PartnerReferralsData.php
@@ -26,7 +26,7 @@ class PartnerReferralsData {
 	protected FeaturesDefinition $features_definition;
 
 	public function __construct( DccApplies $dcc_applies, FeaturesDefinition $features_definition ) {
-		$this->dcc_applies     = $dcc_applies; // @phpstan-ignore property.deprecated
+		$this->dcc_applies         = $dcc_applies; // @phpstan-ignore property.deprecated
 		$this->features_definition = $features_definition;
 	}
 

--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -336,7 +336,7 @@ return array(
 		$data_store = \WC_Data_Store::load( 'product' );
 		return new CartProductsHelper( $data_store );
 	},
-	'button.helper.isolated-cart-simulator'      => static function ( ContainerInterface $container ): IsolatedCartSimulator {
+	'button.helper.isolated-cart-simulator'       => static function ( ContainerInterface $container ): IsolatedCartSimulator {
 		return new IsolatedCartSimulator(
 			$container->get( 'button.helper.cart-products' ),
 			$container->get( 'woocommerce.logger.woocommerce' )

--- a/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/SimulateCartEndpoint.php
@@ -25,11 +25,11 @@ class SimulateCartEndpoint extends AbstractCartEndpoint {
 		IsolatedCartSimulator $cart_simulator,
 		LoggerInterface $logger
 	) {
-		$this->smart_button  = $smart_button;
-		$this->request_data  = $request_data;
-		$this->cart_products = $cart_products;
+		$this->smart_button   = $smart_button;
+		$this->request_data   = $request_data;
+		$this->cart_products  = $cart_products;
 		$this->cart_simulator = $cart_simulator;
-		$this->logger        = $logger;
+		$this->logger         = $logger;
 
 		$this->logger_tag = 'simulation';
 	}

--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -17,7 +17,7 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
 
-	'compat.ppec.mock-gateway'                       => static function ( $container ) {
+	'compat.ppec.mock-gateway'                             => static function ( $container ) {
 		$settings = $container->get( 'settings.settings-provider' );
 		assert( $settings instanceof SettingsProvider );
 
@@ -30,7 +30,7 @@ return array(
 		return new PPEC\MockGateway( $title );
 	},
 
-	'compat.ppec.billing-agreement-converter'        => static function ( ContainerInterface $container ) {
+	'compat.ppec.billing-agreement-converter'              => static function ( ContainerInterface $container ) {
 		return new PPEC\BillingAgreementTokenConverter(
 			$container->get( 'api.endpoint.payment-method-tokens' ),
 			$container->get( 'api.repository.customer' ),
@@ -38,7 +38,7 @@ return array(
 		);
 	},
 
-	'compat.ppec.subscriptions-handler'              => static function ( ContainerInterface $container ) {
+	'compat.ppec.subscriptions-handler'                    => static function ( ContainerInterface $container ) {
 		return new PPEC\SubscriptionsHandler(
 			$container->get( 'wc-subscriptions.renewal-handler' ),
 			$container->get( 'compat.ppec.mock-gateway' ),
@@ -47,7 +47,7 @@ return array(
 		);
 	},
 
-	'compat.plugin-script-names'                     => static function ( ContainerInterface $container ): array {
+	'compat.plugin-script-names'                           => static function ( ContainerInterface $container ): array {
 		return array(
 			'ppcp-smart-button',
 			'ppcp-oxxo',
@@ -61,7 +61,7 @@ return array(
 		);
 	},
 
-	'compat.plugin-script-file-names'                => static function ( ContainerInterface $container ): array {
+	'compat.plugin-script-file-names'                      => static function ( ContainerInterface $container ): array {
 		return array(
 			'button.js',
 			'gateway-settings.js',
@@ -71,7 +71,7 @@ return array(
 		);
 	},
 
-	'compat.shiptastic.is_supported_plugin_version_active'  => function (): bool {
+	'compat.shiptastic.is_supported_plugin_version_active' => function (): bool {
 		return function_exists( 'wc_stc_get_shipments' );
 	},
 
@@ -79,10 +79,10 @@ return array(
 		return class_exists( 'WC_Shipment_Tracking' );
 	},
 
-	'compat.ywot.is_supported_plugin_version_active' => function (): bool {
+	'compat.ywot.is_supported_plugin_version_active'       => function (): bool {
 		return function_exists( 'yith_ywot_init' );
 	},
-	'compat.dhl.is_supported_plugin_version_active'  => function (): bool {
+	'compat.dhl.is_supported_plugin_version_active'        => function (): bool {
 		return function_exists( 'PR_DHL' );
 	},
 	'compat.shipstation.is_supported_plugin_version_active' => function (): bool {
@@ -91,21 +91,21 @@ return array(
 	'compat.wc_shipping_tax.is_supported_plugin_version_active' => function (): bool {
 		return class_exists( 'WC_Connect_Loader' );
 	},
-	'compat.nyp.is_supported_plugin_version_active'  => function (): bool {
+	'compat.nyp.is_supported_plugin_version_active'        => function (): bool {
 		return function_exists( 'wc_nyp_init' );
 	},
 	'compat.wc_bookings.is_supported_plugin_version_active' => function (): bool {
 		return class_exists( 'WC_Bookings' );
 	},
 
-	'compat.asset_getter'                            => static function ( ContainerInterface $container ): AssetGetter {
+	'compat.asset_getter'                                  => static function ( ContainerInterface $container ): AssetGetter {
 		$factory = $container->get( 'assets.asset_getter_factory' );
 		assert( $factory instanceof AssetGetterFactory );
 
 		return $factory->for_module( 'ppcp-compat' );
 	},
 
-	'compat.assets'                                  => function ( ContainerInterface $container ): CompatAssets {
+	'compat.assets'                                        => function ( ContainerInterface $container ): CompatAssets {
 		return new CompatAssets(
 			$container->get( 'compat.asset_getter' ),
 			$container->get( 'ppcp.asset-version' ),

--- a/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
@@ -73,23 +73,23 @@ class PaymentRestEndpoint extends RestEndpoint {
 	 * @var array
 	 */
 	private array $field_map = array(
-		'paypal_show_logo'           => array(
+		'paypal_show_logo'                  => array(
 			'js_name'  => 'paypalShowLogo',
 			'sanitize' => 'to_boolean',
 		),
-		'cardholder_name'            => array(
+		'cardholder_name'                   => array(
 			'js_name'  => 'cardholderName',
 			'sanitize' => 'to_boolean',
 		),
-		'fastlane_display_watermark' => array(
+		'fastlane_display_watermark'        => array(
 			'js_name'  => 'fastlaneDisplayWatermark',
 			'sanitize' => 'to_boolean',
 		),
-		'pui_brand_name'             => array(
+		'pui_brand_name'                    => array(
 			'js_name'  => 'puiBrandName',
 			'sanitize' => 'sanitize_text_field',
 		),
-		'pui_logo_url'               => array(
+		'pui_logo_url'                      => array(
 			'js_name'  => 'puiLogoUrl',
 			'sanitize' => 'esc_url_raw',
 		),
@@ -215,11 +215,11 @@ class PaymentRestEndpoint extends RestEndpoint {
 			}
 		}
 
-		$gateway_settings['paypalShowLogo']              = $this->payment_settings->get_paypal_show_logo();
-		$gateway_settings['cardholderName']              = $this->payment_settings->get_cardholder_name();
-		$gateway_settings['fastlaneDisplayWatermark']    = $this->payment_settings->get_fastlane_display_watermark();
-		$gateway_settings['puiBrandName']                = $this->payment_settings->get_pui_brand_name();
-		$gateway_settings['puiLogoUrl']                  = $this->payment_settings->get_pui_logo_url();
+		$gateway_settings['paypalShowLogo']                 = $this->payment_settings->get_paypal_show_logo();
+		$gateway_settings['cardholderName']                 = $this->payment_settings->get_cardholder_name();
+		$gateway_settings['fastlaneDisplayWatermark']       = $this->payment_settings->get_fastlane_display_watermark();
+		$gateway_settings['puiBrandName']                   = $this->payment_settings->get_pui_brand_name();
+		$gateway_settings['puiLogoUrl']                     = $this->payment_settings->get_pui_logo_url();
 		$gateway_settings['puiCustomerServiceInstructions'] = $this->payment_settings->get_pui_customer_service_instructions();
 
 		return $this->return_success( apply_filters( 'woocommerce_paypal_payments_payment_methods', $gateway_settings ) );

--- a/modules/ppcp-settings/src/Service/FeaturesEligibilityService.php
+++ b/modules/ppcp-settings/src/Service/FeaturesEligibilityService.php
@@ -127,11 +127,11 @@ class FeaturesEligibilityService {
 			FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO => fn() => $this->is_save_paypal_eligible,
 			FeaturesDefinition::FEATURE_ADVANCED_CREDIT_AND_DEBIT_CARDS => $this->check_acdc_eligible,
 			FeaturesDefinition::FEATURE_ALTERNATIVE_PAYMENT_METHODS => fn() => $this->is_apm_eligible,
-			FeaturesDefinition::FEATURE_GOOGLE_PAY      => $this->check_google_pay_eligible,
-			FeaturesDefinition::FEATURE_APPLE_PAY       => $this->check_apple_pay_eligible,
+			FeaturesDefinition::FEATURE_GOOGLE_PAY       => $this->check_google_pay_eligible,
+			FeaturesDefinition::FEATURE_APPLE_PAY        => $this->check_apple_pay_eligible,
 			FeaturesDefinition::FEATURE_PAY_LATER_MESSAGING => fn() => $this->is_pay_later_eligible,
-			FeaturesDefinition::FEATURE_INSTALLMENTS    => fn() => $this->is_installments_eligible,
-			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO => fn() => $this->is_pwc_eligibility_checked,
+			FeaturesDefinition::FEATURE_INSTALLMENTS     => fn() => $this->is_installments_eligible,
+			FeaturesDefinition::FEATURE_PAY_WITH_CRYPTO  => fn() => $this->is_pwc_eligibility_checked,
 			FeaturesDefinition::FEATURE_PAY_UPON_INVOICE => fn() => $this->is_pui_eligible,
 		);
 	}

--- a/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
@@ -69,10 +69,10 @@ class ReturnUrlEndpoint {
 		SessionHandler $session_handler,
 		LoggerInterface $logger
 	) {
-		$this->gateway             = $gateway;
-		$this->order_endpoint      = $order_endpoint;
-		$this->session_handler     = $session_handler;
-		$this->logger              = $logger;
+		$this->gateway         = $gateway;
+		$this->order_endpoint  = $order_endpoint;
+		$this->session_handler = $session_handler;
+		$this->logger          = $logger;
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -448,7 +448,6 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				if ( $pwc_product_status instanceof PWCProductStatus ) {
 					$pwc_product_status->clear();
 				}
-
 			}
 		);
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -19,7 +19,6 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
-use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\DccApplies;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\LocalApmProductStatus;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
@@ -450,12 +449,6 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 					$pwc_product_status->clear();
 				}
 
-				$reference_transaction_status_cache = $c->get( 'api.reference-transaction-status-cache' );
-				assert( $reference_transaction_status_cache instanceof Cache );
-				// Clear Reference Transaction status.
-				if ( $reference_transaction_status_cache->has( ReferenceTransactionStatus::CACHE_KEY ) ) {
-					$reference_transaction_status_cache->delete( ReferenceTransactionStatus::CACHE_KEY );
-				}
 			}
 		);
 

--- a/tests/PHPUnit/ApiClient/Helper/ReferenceTransactionStatusTest.php
+++ b/tests/PHPUnit/ApiClient/Helper/ReferenceTransactionStatusTest.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Helper;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\TestCase;
+
+class ReferenceTransactionStatusTest extends TestCase
+{
+	public function testReferenceTransactionEnabledReturnsTrueWhenCapabilityIsActive(): void
+	{
+		$active_capability = new class() {
+			public function name(): string
+			{
+				return 'PAYPAL_WALLET_VAULTING_ADVANCED';
+			}
+
+			public function status(): string
+			{
+				return 'ACTIVE';
+			}
+		};
+
+		$seller_status = Mockery::mock(SellerStatus::class);
+		$seller_status->shouldReceive('capabilities')->once()->andReturn([$active_capability]);
+
+		$partners_endpoint = Mockery::mock(PartnersEndpoint::class);
+		$partners_endpoint->shouldReceive('seller_status')->once()->andReturn($seller_status);
+
+		$testee = new ReferenceTransactionStatus($partners_endpoint);
+
+		$this->assertTrue($testee->reference_transaction_enabled());
+	}
+
+	public function testReferenceTransactionEnabledReturnsFalseWhenCapabilityIsMissing(): void
+	{
+		$inactive_capability = new class() {
+			public function name(): string
+			{
+				return 'PAYPAL_WALLET_VAULTING_ADVANCED';
+			}
+
+			public function status(): string
+			{
+				return 'INACTIVE';
+			}
+		};
+
+		$seller_status = Mockery::mock(SellerStatus::class);
+		$seller_status->shouldReceive('capabilities')->once()->andReturn([$inactive_capability]);
+
+		$partners_endpoint = Mockery::mock(PartnersEndpoint::class);
+		$partners_endpoint->shouldReceive('seller_status')->once()->andReturn($seller_status);
+
+		$testee = new ReferenceTransactionStatus($partners_endpoint);
+
+		$this->assertFalse($testee->reference_transaction_enabled());
+	}
+
+	public function testReferenceTransactionEnabledReturnsFalseWhenSellerStatusFails(): void
+	{
+		$partners_endpoint = Mockery::mock(PartnersEndpoint::class);
+		$partners_endpoint->shouldReceive('seller_status')->once()->andThrow(new RuntimeException('failed'));
+
+		$testee = new ReferenceTransactionStatus($partners_endpoint);
+
+		$this->assertFalse($testee->reference_transaction_enabled());
+	}
+}


### PR DESCRIPTION
### Description
Remove the redundant cache from `ReferenceTransactionStatus` and rely on `PartnersEndpoint::seller_status()`, which already caches the `SellerStatus` object.

This cache is a leftover from the old `BillingAgreementsEndpoint` (removed in #3495), where it made sense because the check required an expensive `create_token()` API call.
                                                                                                                                                                                                                                 
Now that the class reads from `PartnersEndpoint::seller_status()`, which already caches the `SellerStatus` object in its own transient, the extra cache is redundant.         

This change:
- Removes the extra boolean cache and its service wiring
- Keeps `woocommerce_paypal_payments_seller_status` effective on repeated calls
- Removes the stale cache-clearing logic from `WCGatewayModule`
- Adds unit coverage for the updated helper behavior
