### PR TITLE
Enhanced order decline reason detection via processor response object integration (6061)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -345,9 +345,18 @@ class OrderEndpoint {
 
 		$order = $this->order_factory->from_paypal_response( $json );
 
-		$capture_status = $order->purchase_units()[0]->payments()->captures()[0]->status() ?? null;
+		$first_capture  = $order->purchase_units()[0]->payments()->captures()[0] ?? null;
+		$capture_status = $first_capture ? $first_capture->status() : null;
 		if ( $capture_status && $capture_status->is( CaptureStatus::DECLINED ) ) {
-			throw new RuntimeException( __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' ) );
+			$fraud           = $first_capture->fraud_processor_response();
+			$decline_message = ( $fraud && $fraud->response_code() )
+				? sprintf(
+					/* translators: %s - processor response code and description */
+					__( 'Payment declined by card processor: %s. Please use a different payment method or contact your bank.', 'woocommerce-paypal-payments' ),
+					$fraud->get_response_code_message()
+				)
+				: __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' );
+			throw new RuntimeException( $decline_message );
 		}
 
 		return $order;

--- a/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/OrderEndpoint.php
@@ -349,12 +349,8 @@ class OrderEndpoint {
 		$capture_status = $first_capture ? $first_capture->status() : null;
 		if ( $capture_status && $capture_status->is( CaptureStatus::DECLINED ) ) {
 			$fraud           = $first_capture->fraud_processor_response();
-			$decline_message = ( $fraud && $fraud->response_code() )
-				? sprintf(
-					/* translators: %s - processor response code and description */
-					__( 'Payment declined by card processor: %s. Please use a different payment method or contact your bank.', 'woocommerce-paypal-payments' ),
-					$fraud->get_response_code_message()
-				)
+			$decline_message = $fraud
+				? $fraud->get_customer_decline_message()
 				: __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' );
 			throw new RuntimeException( $decline_message );
 		}

--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -29,14 +29,23 @@ class FraudProcessorResponse {
 	protected string $cvv2_code;
 
 	/**
+	 * The processor response code (e.g. 9500, 9100).
+	 *
+	 * @var string
+	 */
+	protected string $response_code;
+
+	/**
 	 * FraudProcessorResponse constructor.
 	 *
 	 * @param string|null $avs_code The AVS response code.
 	 * @param string|null $cvv2_code The CVV response code.
+	 * @param string|null $response_code The processor response code.
 	 */
-	public function __construct( ?string $avs_code, ?string $cvv2_code ) {
-		$this->avs_code  = (string) $avs_code;
-		$this->cvv2_code = (string) $cvv2_code;
+	public function __construct( ?string $avs_code, ?string $cvv2_code, ?string $response_code = null ) {
+		$this->avs_code      = (string) $avs_code;
+		$this->cvv2_code     = (string) $cvv2_code;
+		$this->response_code = (string) $response_code;
 	}
 
 	/**
@@ -58,14 +67,24 @@ class FraudProcessorResponse {
 	}
 
 	/**
+	 * Returns the processor response code.
+	 *
+	 * @return string
+	 */
+	public function response_code(): string {
+		return $this->response_code;
+	}
+
+	/**
 	 * Returns the object as array.
 	 *
 	 * @return array
 	 */
 	public function to_array(): array {
 		return array(
-			'avs_code'  => $this->avs_code(),
-			'cvv2_code' => $this->cvv_code(),
+			'avs_code'      => $this->avs_code(),
+			'cvv2_code'     => $this->cvv_code(),
+			'response_code' => $this->response_code(),
 		);
 	}
 
@@ -154,5 +173,71 @@ class FraudProcessorResponse {
 		 * @psalm-suppress PossiblyNullArgument
 		 */
 		return $messages[ $this->cvv_code() ] ?? sprintf( '%s: Error', $this->cvv_code() );
+	}
+
+	/**
+	 * Returns the human-readable description for the processor response code.
+	 *
+	 * @return string
+	 */
+	public function get_response_code_message(): string {
+		if ( ! $this->response_code() ) {
+			return '';
+		}
+		$messages = array(
+			'0000' => '0000: Approved',
+			'00N7' => '00N7: Decline CVV2 Failure',
+			'0100' => '0100: Refer to card issuer',
+			'0390' => '0390: No credit account',
+			'0500' => '0500: Do not honor',
+			'0580' => '0580: Transaction not permitted to cardholder',
+			'0800' => '0800: Bad response reversal amount',
+			'0880' => '0880: Cryptographic failure',
+			'0890' => '0890: Unavailable',
+			'0960' => '0960: System malfunction',
+			'1000' => '1000: Partial Approval',
+			'10BR' => '10BR: 3DS Authentication Failure',
+			'1300' => '1300: Invalid data format',
+			'1310' => '1310: Invalid amount',
+			'1312' => '1312: Invalid transaction card issuer acquirer',
+			'1317' => '1317: Invalid capture date',
+			'1320' => '1320: Invalid currency code',
+			'1330' => '1330: Invalid account',
+			'1335' => '1335: Invalid account type',
+			'1340' => '1340: Invalid terminal id',
+			'1350' => '1350: Invalid merchant/terminal city',
+			'1360' => '1360: Bad or malformed request',
+			'1370' => '1370: Issuer unavailable',
+			'1380' => '1380: Updates not allowed',
+			'1382' => '1382: Bad CVV2',
+			'1384' => '1384: Similar transaction recently submitted',
+			'1390' => '1390: Trace number error',
+			'1393' => '1393: Transaction amount range error',
+			'5100' => '5100: Generic Decline',
+			'5110' => '5110: CVV2 Failure',
+			'5120' => '5120: Insufficient funds',
+			'5130' => '5130: Invalid PIN',
+			'5140' => '5140: Card closed',
+			'5150' => '5150: Pick up card (fraud)',
+			'5160' => '5160: Unauthorized user',
+			'5170' => '5170: Card blocked',
+			'5180' => '5180: Declined by the issuer',
+			'5200' => '5200: Account closed',
+			'5400' => '5400: Expired card',
+			'5910' => '5910: Issuer not available, return to issuer',
+			'5920' => '5920: Issuer not available, return to issuer',
+			'5930' => '5930: Card not activated',
+			'6300' => '6300: Account blocked',
+			'9100' => '9100: Declined, Please Retry',
+			'9500' => '9500: Suspected Fraud',
+			'9510' => '9510: Security Violation',
+			'9520' => '9520: Lost or Stolen Card',
+			'9530' => '9530: Hold - Call issuer',
+			'9540' => '9540: Refused Card',
+			'9600' => '9600: Unacceptable PIN - Transaction Declined - Retry',
+			'PCNF' => 'PCNF: Purchase Confirmation Not Received',
+			'PCOM' => 'PCOM: Purchase Confirmation Received',
+		);
+		return $messages[ $this->response_code() ] ?? sprintf( '%s: Unknown response code', $this->response_code() );
 	}
 }

--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -176,6 +176,23 @@ class FraudProcessorResponse {
 	}
 
 	/**
+	 * Returns the customer-facing decline message, including the processor response code when available.
+	 *
+	 * @return string
+	 */
+	public function get_customer_decline_message(): string {
+		if ( $this->response_code() ) {
+			return sprintf(
+				/* translators: %s - processor response code and description */
+				__( 'Payment declined by card processor: %s. Please use a different payment method or contact your bank.', 'woocommerce-paypal-payments' ),
+				$this->get_response_code_message()
+			);
+		}
+
+		return __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' );
+	}
+
+	/**
 	 * Returns the human-readable description for the processor response code.
 	 *
 	 * @return string

--- a/modules/ppcp-api-client/src/Factory/FraudProcessorResponseFactory.php
+++ b/modules/ppcp-api-client/src/Factory/FraudProcessorResponseFactory.php
@@ -25,9 +25,10 @@ class FraudProcessorResponseFactory {
 	 * @return FraudProcessorResponse
 	 */
 	public function from_paypal_response( stdClass $data ): FraudProcessorResponse {
-		$avs_code = ( $data->avs_code ?? null ) ?: null;
-		$cvv_code = ( $data->cvv_code ?? null ) ?: null;
+		$avs_code      = ( $data->avs_code ?? null ) ?: null;
+		$cvv_code      = ( $data->cvv_code ?? null ) ?: null;
+		$response_code = ( $data->response_code ?? null ) ?: null;
 
-		return new FraudProcessorResponse( $avs_code, $cvv_code );
+		return new FraudProcessorResponse( $avs_code, $cvv_code, $response_code );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/CreditCardOrderInfoHandlingTrait.php
@@ -106,7 +106,18 @@ trait CreditCardOrderInfoHandlingTrait {
             <li>%1$s</li>
             <li>%2$s</li>
             <li>%3$s</li>
+            %4$s
         </ul>';
+		$response_code_item                = $fraud->response_code()
+			? sprintf(
+				'<li>%s</li>',
+				sprintf(
+					/* translators: %s is processor response code and description */
+					esc_html__( 'Response Code: %s', 'woocommerce-paypal-payments' ),
+					esc_html( $fraud->get_response_code_message() )
+				)
+			)
+			: '';
 		$response_order_note_result        = sprintf(
 			$response_order_note_result_format,
 			/* translators: %1$s is card brand and %2$s card last 4 digits */
@@ -115,6 +126,7 @@ trait CreditCardOrderInfoHandlingTrait {
 			sprintf( __( 'AVS: %s', 'woocommerce-paypal-payments' ), $fraud->get_avs_code_message() ),
 			/* translators: %s is fraud CVV message */
 			sprintf( __( 'CVV: %s', 'woocommerce-paypal-payments' ), $fraud->get_cvv2_code_message() ),
+			$response_code_item,
 		);
 		$response_order_note = sprintf(
 			$response_order_note_format,

--- a/modules/ppcp-wc-gateway/src/Processor/PaymentsStatusHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/PaymentsStatusHandlingTrait.php
@@ -87,11 +87,28 @@ trait PaymentsStatusHandlingTrait {
 			// It is checked in the capture endpoint already, but there are other ways to capture,
 			// such as when paid via saved card.
 			case CaptureStatus::DECLINED:
+				$fraud = $capture->fraud_processor_response();
+				if ( $fraud && $fraud->response_code() ) {
+					$wc_order->add_order_note(
+						sprintf(
+							/* translators: %s - processor response code and description */
+							__( 'PayPal payment declined. Processor response: %s', 'woocommerce-paypal-payments' ),
+							$fraud->get_response_code_message()
+						)
+					);
+				}
 				$wc_order->update_status(
 					'failed',
 					__( 'Could not capture the payment.', 'woocommerce-paypal-payments' )
 				);
-				throw new RuntimeException( __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' ) );
+				$decline_message = ( $fraud && $fraud->response_code() )
+					? sprintf(
+						/* translators: %s - processor response code and description */
+						__( 'Payment declined by card processor: %s. Please use a different payment method or contact your bank.', 'woocommerce-paypal-payments' ),
+						$fraud->get_response_code_message()
+					)
+					: __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' );
+				throw new RuntimeException( $decline_message );
 			case CaptureStatus::PENDING:
 			case CaptureStatus::FAILED:
 				$wc_order->update_status(

--- a/modules/ppcp-wc-gateway/src/Processor/PaymentsStatusHandlingTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/PaymentsStatusHandlingTrait.php
@@ -87,26 +87,17 @@ trait PaymentsStatusHandlingTrait {
 			// It is checked in the capture endpoint already, but there are other ways to capture,
 			// such as when paid via saved card.
 			case CaptureStatus::DECLINED:
-				$fraud = $capture->fraud_processor_response();
-				if ( $fraud && $fraud->response_code() ) {
-					$wc_order->add_order_note(
-						sprintf(
-							/* translators: %s - processor response code and description */
-							__( 'PayPal payment declined. Processor response: %s', 'woocommerce-paypal-payments' ),
-							$fraud->get_response_code_message()
-						)
-					);
-				}
-				$wc_order->update_status(
-					'failed',
-					__( 'Could not capture the payment.', 'woocommerce-paypal-payments' )
-				);
-				$decline_message = ( $fraud && $fraud->response_code() )
+				$fraud        = $capture->fraud_processor_response();
+				$status_note  = ( $fraud && $fraud->response_code() )
 					? sprintf(
 						/* translators: %s - processor response code and description */
-						__( 'Payment declined by card processor: %s. Please use a different payment method or contact your bank.', 'woocommerce-paypal-payments' ),
+						__( 'Could not capture the payment. Processor response: %s', 'woocommerce-paypal-payments' ),
 						$fraud->get_response_code_message()
 					)
+					: __( 'Could not capture the payment.', 'woocommerce-paypal-payments' );
+				$wc_order->update_status( 'failed', $status_note );
+				$decline_message = $fraud
+					? $fraud->get_customer_decline_message()
 					: __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' );
 				throw new RuntimeException( $decline_message );
 			case CaptureStatus::PENDING:

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -17,6 +17,7 @@ use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\FraudProcessorResponse;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
@@ -163,6 +164,30 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				echo $fees_renderer->render( $wc_order );
+			}
+		);
+
+		add_action(
+			'woocommerce_admin_order_totals_after_total',
+			function ( int $order_id ) {
+				$wc_order = wc_get_order( $order_id );
+				if ( ! $wc_order instanceof WC_Order ) {
+					return;
+				}
+				$fraud_result = $wc_order->get_meta( PayPalGateway::FRAUD_RESULT_META_KEY );
+				if ( empty( $fraud_result['response_code'] ) ) {
+					return;
+				}
+				$fraud = new FraudProcessorResponse(
+					$fraud_result['avs_code'] ?? null,
+					$fraud_result['cvv2_code'] ?? null,
+					$fraud_result['response_code']
+				);
+				printf(
+					'<tr><td class="label">%s:</td><td width="1%%"></td><td class="total">%s</td></tr>',
+					esc_html__( 'Processor Response', 'woocommerce-paypal-payments' ),
+					esc_html( $fraud->get_response_code_message() )
+				);
 			}
 		);
 

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -17,7 +17,6 @@ use WooCommerce\PayPalCommerce\AdminNotices\Entity\Message;
 use WooCommerce\PayPalCommerce\AdminNotices\Repository\Repository;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
-use WooCommerce\PayPalCommerce\ApiClient\Entity\FraudProcessorResponse;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\ReferenceTransactionStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
@@ -169,7 +168,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 
 		add_action(
 			'woocommerce_admin_order_totals_after_total',
-			function ( int $order_id ) {
+			function ( int $order_id ) use ( $c ) {
 				$wc_order = wc_get_order( $order_id );
 				if ( ! $wc_order instanceof WC_Order ) {
 					return;
@@ -178,11 +177,8 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				if ( empty( $fraud_result['response_code'] ) ) {
 					return;
 				}
-				$fraud = new FraudProcessorResponse(
-					$fraud_result['avs_code'] ?? null,
-					$fraud_result['cvv2_code'] ?? null,
-					$fraud_result['response_code']
-				);
+				$fraud = $c->get( 'api.factory.fraud-processor-response' )
+					->from_paypal_response( (object) $fraud_result );
 				printf(
 					'<tr><td class="label">%s:</td><td width="1%%"></td><td class="total">%s</td></tr>',
 					esc_html__( 'Processor Response', 'woocommerce-paypal-payments' ),

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
@@ -9,6 +9,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Address;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\FraudProcessorResponse;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
@@ -1201,6 +1202,188 @@ class OrderEndpointTest extends TestCase
         $payer->expects('email_address')->andReturn('email@email.com');
         $payer->expects('to_array')->andReturn(['payer']);
         $testee->create([$purchaseUnit], ExperienceContext::SHIPPING_PREFERENCE_GET_FROM_FILE, $payer);
+    }
+
+    public function testCaptureDeclinedWithFraudResponseCodeThrowsDetailedMessage(): void
+    {
+        expect('wp_json_encode')->andReturnUsing('json_encode');
+        $orderId = 'id';
+        $orderToCaptureStatus = Mockery::mock(OrderStatus::class);
+        $orderToCaptureStatus->expects('is')->with('COMPLETED')->andReturn(false);
+        $orderToCapture = Mockery::mock(Order::class);
+        $orderToCapture->expects('status')->andReturn($orderToCaptureStatus);
+        $orderToCapture->expects('id')->andReturn($orderId);
+        $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+        $headers->shouldReceive('getAll');
+        $rawResponse = [
+            'body'    => '{"id":"order123"}',
+            'headers' => $headers,
+        ];
+        $expectedOrder = Mockery::mock(Order::class);
+        $host          = 'https://example.com/';
+        $token         = Mockery::mock(Token::class);
+        $token->expects('token')->andReturn('bearer');
+        $bearer = Mockery::mock(Bearer::class);
+        $bearer->expects('bearer')->andReturn($token);
+        $orderFactory = Mockery::mock(OrderFactory::class);
+        $orderFactory->expects('from_paypal_response')->andReturn($expectedOrder);
+        $patchCollectionFactory = Mockery::mock(PatchCollectionFactory::class);
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('warning');
+        $logger->shouldReceive('debug');
+        $subscription_helper = Mockery::mock(SubscriptionHelper::class);
+        $fraudnet            = Mockery::mock(FraudNet::class);
+
+        $testee = new OrderEndpoint(
+            $host,
+            $bearer,
+            $orderFactory,
+            $patchCollectionFactory,
+            'CAPTURE',
+            $logger,
+            $subscription_helper,
+            false,
+            $fraudnet
+        );
+
+        expect('wp_remote_get')->andReturn($rawResponse);
+        expect('is_wp_error')->with($rawResponse)->andReturn(false);
+        expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(201);
+
+        $fraud        = new FraudProcessorResponse(null, null, '9500');
+        $purchaseUnit = Mockery::mock(PurchaseUnit::class);
+        $payment      = Mockery::mock(Payments::class);
+        $capture      = Mockery::mock(Capture::class);
+        $expectedOrder->shouldReceive('purchase_units')->once()->andReturn([$purchaseUnit]);
+        $purchaseUnit->shouldReceive('payments')->once()->andReturn($payment);
+        $payment->shouldReceive('captures')->once()->andReturn([$capture]);
+        $capture->shouldReceive('status')->once()->andReturn(new CaptureStatus(CaptureStatus::DECLINED));
+        $capture->shouldReceive('fraud_processor_response')->once()->andReturn($fraud);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageMatches('/9500: Suspected Fraud/');
+        $testee->capture($orderToCapture);
+    }
+
+    public function testCaptureDeclinedWithNullFraudThrowsGenericMessage(): void
+    {
+        expect('wp_json_encode')->andReturnUsing('json_encode');
+        $orderId = 'id';
+        $orderToCaptureStatus = Mockery::mock(OrderStatus::class);
+        $orderToCaptureStatus->expects('is')->with('COMPLETED')->andReturn(false);
+        $orderToCapture = Mockery::mock(Order::class);
+        $orderToCapture->expects('status')->andReturn($orderToCaptureStatus);
+        $orderToCapture->expects('id')->andReturn($orderId);
+        $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+        $headers->shouldReceive('getAll');
+        $rawResponse = [
+            'body'    => '{"id":"order123"}',
+            'headers' => $headers,
+        ];
+        $expectedOrder = Mockery::mock(Order::class);
+        $host          = 'https://example.com/';
+        $token         = Mockery::mock(Token::class);
+        $token->expects('token')->andReturn('bearer');
+        $bearer = Mockery::mock(Bearer::class);
+        $bearer->expects('bearer')->andReturn($token);
+        $orderFactory = Mockery::mock(OrderFactory::class);
+        $orderFactory->expects('from_paypal_response')->andReturn($expectedOrder);
+        $patchCollectionFactory = Mockery::mock(PatchCollectionFactory::class);
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('warning');
+        $logger->shouldReceive('debug');
+        $subscription_helper = Mockery::mock(SubscriptionHelper::class);
+        $fraudnet            = Mockery::mock(FraudNet::class);
+
+        $testee = new OrderEndpoint(
+            $host,
+            $bearer,
+            $orderFactory,
+            $patchCollectionFactory,
+            'CAPTURE',
+            $logger,
+            $subscription_helper,
+            false,
+            $fraudnet
+        );
+
+        expect('wp_remote_get')->andReturn($rawResponse);
+        expect('is_wp_error')->with($rawResponse)->andReturn(false);
+        expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(201);
+
+        $purchaseUnit = Mockery::mock(PurchaseUnit::class);
+        $payment      = Mockery::mock(Payments::class);
+        $capture      = Mockery::mock(Capture::class);
+        $expectedOrder->shouldReceive('purchase_units')->once()->andReturn([$purchaseUnit]);
+        $purchaseUnit->shouldReceive('payments')->once()->andReturn($payment);
+        $payment->shouldReceive('captures')->once()->andReturn([$capture]);
+        $capture->shouldReceive('status')->once()->andReturn(new CaptureStatus(CaptureStatus::DECLINED));
+        $capture->shouldReceive('fraud_processor_response')->once()->andReturn(null);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Payment provider declined the payment, please use a different payment method.');
+        $testee->capture($orderToCapture);
+    }
+
+    public function testCaptureDeclinedWithEmptyResponseCodeThrowsGenericMessage(): void
+    {
+        expect('wp_json_encode')->andReturnUsing('json_encode');
+        $orderId = 'id';
+        $orderToCaptureStatus = Mockery::mock(OrderStatus::class);
+        $orderToCaptureStatus->expects('is')->with('COMPLETED')->andReturn(false);
+        $orderToCapture = Mockery::mock(Order::class);
+        $orderToCapture->expects('status')->andReturn($orderToCaptureStatus);
+        $orderToCapture->expects('id')->andReturn($orderId);
+        $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+        $headers->shouldReceive('getAll');
+        $rawResponse = [
+            'body'    => '{"id":"order123"}',
+            'headers' => $headers,
+        ];
+        $expectedOrder = Mockery::mock(Order::class);
+        $host          = 'https://example.com/';
+        $token         = Mockery::mock(Token::class);
+        $token->expects('token')->andReturn('bearer');
+        $bearer = Mockery::mock(Bearer::class);
+        $bearer->expects('bearer')->andReturn($token);
+        $orderFactory = Mockery::mock(OrderFactory::class);
+        $orderFactory->expects('from_paypal_response')->andReturn($expectedOrder);
+        $patchCollectionFactory = Mockery::mock(PatchCollectionFactory::class);
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('warning');
+        $logger->shouldReceive('debug');
+        $subscription_helper = Mockery::mock(SubscriptionHelper::class);
+        $fraudnet            = Mockery::mock(FraudNet::class);
+
+        $testee = new OrderEndpoint(
+            $host,
+            $bearer,
+            $orderFactory,
+            $patchCollectionFactory,
+            'CAPTURE',
+            $logger,
+            $subscription_helper,
+            false,
+            $fraudnet
+        );
+
+        expect('wp_remote_get')->andReturn($rawResponse);
+        expect('is_wp_error')->with($rawResponse)->andReturn(false);
+        expect('wp_remote_retrieve_response_code')->with($rawResponse)->andReturn(201);
+
+        $fraud        = new FraudProcessorResponse(null, null, null);
+        $purchaseUnit = Mockery::mock(PurchaseUnit::class);
+        $payment      = Mockery::mock(Payments::class);
+        $capture      = Mockery::mock(Capture::class);
+        $expectedOrder->shouldReceive('purchase_units')->once()->andReturn([$purchaseUnit]);
+        $purchaseUnit->shouldReceive('payments')->once()->andReturn($payment);
+        $payment->shouldReceive('captures')->once()->andReturn([$capture]);
+        $capture->shouldReceive('status')->once()->andReturn(new CaptureStatus(CaptureStatus::DECLINED));
+        $capture->shouldReceive('fraud_processor_response')->once()->andReturn($fraud);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Payment provider declined the payment, please use a different payment method.');
+        $testee->capture($orderToCapture);
     }
 }
 

--- a/tests/PHPUnit/ApiClient/Entity/FraudProcessorResponseTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/FraudProcessorResponseTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
+
+use WooCommerce\PayPalCommerce\TestCase;
+
+class FraudProcessorResponseTest extends TestCase
+{
+	public function testResponseCodeGetter(): void
+	{
+		$testee = new FraudProcessorResponse('A', 'M', '9500');
+		$this->assertSame('9500', $testee->response_code());
+	}
+
+	public function testNullResponseCodeStoredAsEmptyString(): void
+	{
+		$testee = new FraudProcessorResponse('A', 'M', null);
+		$this->assertSame('', $testee->response_code());
+	}
+
+	public function testToArrayIncludesResponseCode(): void
+	{
+		$testee = new FraudProcessorResponse('A', 'M', '9500');
+		$array  = $testee->to_array();
+
+		$this->assertArrayHasKey('response_code', $array);
+		$this->assertSame('9500', $array['response_code']);
+	}
+
+	public function testToArrayWithoutResponseCodeHasEmptyString(): void
+	{
+		$testee = new FraudProcessorResponse('A', 'M', null);
+		$array  = $testee->to_array();
+
+		$this->assertArrayHasKey('response_code', $array);
+		$this->assertSame('', $array['response_code']);
+	}
+
+	public function testGetResponseCodeMessageForKnownCode9500(): void
+	{
+		$testee = new FraudProcessorResponse(null, null, '9500');
+		$this->assertSame('9500: Suspected Fraud', $testee->get_response_code_message());
+	}
+
+	public function testGetResponseCodeMessageForKnownCode0000(): void
+	{
+		$testee = new FraudProcessorResponse(null, null, '0000');
+		$this->assertSame('0000: Approved', $testee->get_response_code_message());
+	}
+
+	public function testGetResponseCodeMessageForKnownCode9100(): void
+	{
+		$testee = new FraudProcessorResponse(null, null, '9100');
+		$this->assertSame('9100: Declined, Please Retry', $testee->get_response_code_message());
+	}
+
+	public function testGetResponseCodeMessageForUnknownCode(): void
+	{
+		$testee = new FraudProcessorResponse(null, null, 'ZZZZ');
+		$this->assertSame('ZZZZ: Unknown response code', $testee->get_response_code_message());
+	}
+
+	public function testGetResponseCodeMessageForEmptyCodeReturnsEmptyString(): void
+	{
+		$testee = new FraudProcessorResponse(null, null, null);
+		$this->assertSame('', $testee->get_response_code_message());
+	}
+}

--- a/tests/PHPUnit/ApiClient/Entity/FraudProcessorResponseTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/FraudProcessorResponseTest.php
@@ -67,4 +67,22 @@ class FraudProcessorResponseTest extends TestCase
 		$testee = new FraudProcessorResponse(null, null, null);
 		$this->assertSame('', $testee->get_response_code_message());
 	}
+
+	public function testGetCustomerDeclineMessageWithKnownCode(): void
+	{
+		$testee = new FraudProcessorResponse(null, null, '9500');
+		$this->assertSame(
+			'Payment declined by card processor: 9500: Suspected Fraud. Please use a different payment method or contact your bank.',
+			$testee->get_customer_decline_message()
+		);
+	}
+
+	public function testGetCustomerDeclineMessageWithEmptyCodeReturnsGenericMessage(): void
+	{
+		$testee = new FraudProcessorResponse(null, null, null);
+		$this->assertSame(
+			'Payment provider declined the payment, please use a different payment method.',
+			$testee->get_customer_decline_message()
+		);
+	}
 }

--- a/tests/PHPUnit/ApiClient/Factory/FraudProcessorResponseFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/FraudProcessorResponseFactoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Factory;
+
+use WooCommerce\PayPalCommerce\ApiClient\Entity\FraudProcessorResponse;
+use WooCommerce\PayPalCommerce\TestCase;
+
+class FraudProcessorResponseFactoryTest extends TestCase
+{
+	public function testFromPaypalResponseParsesAllFields(): void
+	{
+		$data = (object) [
+			'avs_code'      => 'Y',
+			'cvv_code'      => 'M',
+			'response_code' => '9500',
+		];
+
+		$testee = new FraudProcessorResponseFactory();
+		$result = $testee->from_paypal_response($data);
+
+		$this->assertInstanceOf(FraudProcessorResponse::class, $result);
+		$this->assertSame('Y', $result->avs_code());
+		$this->assertSame('M', $result->cvv_code());
+		$this->assertSame('9500', $result->response_code());
+	}
+
+	public function testFromPaypalResponseWithMissingResponseCode(): void
+	{
+		$data = (object) [
+			'avs_code' => 'Y',
+			'cvv_code' => 'M',
+		];
+
+		$testee = new FraudProcessorResponseFactory();
+		$result = $testee->from_paypal_response($data);
+
+		$this->assertSame('', $result->response_code());
+	}
+
+	public function testFromPaypalResponseWithEmptyResponseCode(): void
+	{
+		$data = (object) [
+			'avs_code'      => 'Y',
+			'cvv_code'      => 'M',
+			'response_code' => '',
+		];
+
+		$testee = new FraudProcessorResponseFactory();
+		$result = $testee->from_paypal_response($data);
+
+		// Empty string is falsy; the factory coerces it to null, stored as empty string.
+		$this->assertSame('', $result->response_code());
+	}
+}

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Authorization;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\AuthorizationStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Capture;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\CaptureStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\FraudProcessorResponse;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payments;
@@ -257,6 +258,56 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 
 	private function createAuthorization(string $id, string $status): Authorization {
 		return new Authorization($id, new AuthorizationStatus($status), null);
+	}
+
+	public function testCaptureAuthorizedPaymentDeclinedWithFraudResponseCodeAddsOrderNoteAndThrows(): void
+	{
+		$this->orderEndpoint->shouldReceive('order')->andReturn($this->paypalOrder);
+
+		$fraud   = new FraudProcessorResponse(null, null, '9500');
+		$capture = Mockery::mock(Capture::class);
+		$capture->shouldReceive('id')->andReturn($this->captureId);
+		$capture->shouldReceive('status')->andReturn(new CaptureStatus(CaptureStatus::DECLINED));
+		$capture->shouldReceive('fraud_processor_response')->andReturn($fraud);
+
+		$this->paymentsEndpoint
+			->expects('capture')
+			->with($this->authorizationId, equalTo(new Money($this->amount, $this->currency)))
+			->andReturn($capture);
+
+		$this->wcOrder->shouldReceive('update_status');
+		$this->wcOrder
+			->shouldReceive('add_order_note')
+			->once()
+			->with(Mockery::on(function (string $note): bool {
+				return strpos($note, '9500: Suspected Fraud') !== false;
+			}));
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessageMatches('/9500: Suspected Fraud/');
+		$this->testee->capture_authorized_payment($this->wcOrder);
+	}
+
+	public function testCaptureAuthorizedPaymentDeclinedWithoutFraudCodeThrowsGenericMessage(): void
+	{
+		$this->orderEndpoint->shouldReceive('order')->andReturn($this->paypalOrder);
+
+		$capture = Mockery::mock(Capture::class);
+		$capture->shouldReceive('id')->andReturn($this->captureId);
+		$capture->shouldReceive('status')->andReturn(new CaptureStatus(CaptureStatus::DECLINED));
+		$capture->shouldReceive('fraud_processor_response')->andReturn(null);
+
+		$this->paymentsEndpoint
+			->expects('capture')
+			->with($this->authorizationId, equalTo(new Money($this->amount, $this->currency)))
+			->andReturn($capture);
+
+		$this->wcOrder->shouldReceive('update_status');
+		$this->wcOrder->shouldNotReceive('add_order_note');
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Payment provider declined the payment, please use a different payment method.');
+		$this->testee->capture_authorized_payment($this->wcOrder);
 	}
 
 	private function createCapture(string $id, string $status): Capture {

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -260,7 +260,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 		return new Authorization($id, new AuthorizationStatus($status), null);
 	}
 
-	public function testCaptureAuthorizedPaymentDeclinedWithFraudResponseCodeAddsOrderNoteAndThrows(): void
+	public function testCaptureAuthorizedPaymentDeclinedWithFraudResponseCodePassesCodeToStatusNote(): void
 	{
 		$this->orderEndpoint->shouldReceive('order')->andReturn($this->paypalOrder);
 
@@ -275,13 +275,13 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 			->with($this->authorizationId, equalTo(new Money($this->amount, $this->currency)))
 			->andReturn($capture);
 
-		$this->wcOrder->shouldReceive('update_status');
 		$this->wcOrder
-			->shouldReceive('add_order_note')
+			->shouldReceive('update_status')
 			->once()
-			->with(Mockery::on(function (string $note): bool {
+			->with('failed', Mockery::on(function (string $note): bool {
 				return strpos($note, '9500: Suspected Fraud') !== false;
 			}));
+		$this->wcOrder->shouldNotReceive('add_order_note');
 
 		$this->expectException(RuntimeException::class);
 		$this->expectExceptionMessageMatches('/9500: Suspected Fraud/');
@@ -302,7 +302,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 			->with($this->authorizationId, equalTo(new Money($this->amount, $this->currency)))
 			->andReturn($capture);
 
-		$this->wcOrder->shouldReceive('update_status');
+		$this->wcOrder->shouldReceive('update_status')->with('failed', 'Could not capture the payment.');
 		$this->wcOrder->shouldNotReceive('add_order_note');
 
 		$this->expectException(RuntimeException::class);


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Issue**: #

**Ticket**:

**Slack Thread**:

---

### Description

Adds response_code support to FraudProcessorResponse, parsing it from PayPal's capture response and mapping it  
  to human-readable descriptions. When a capture is declined, the processor response code is now      
  surfaced in the customer-facing exception message, the WC order note —     
  replacing the previous generic "payment declined" message wherever a specific code is available.   

### Steps to Test

Pay with creditcard failed transaction test numbers 
Observe message in checkout indicating failure reason
Observe order note indicating failure reason

### Changelog Entry

Added - enhanced order decline reason detection via processor response object integration

Closes # .
