### PR TITLE
Fix(button): Prevent WooCommerce notices leaking during cart simulation (6281)

### DIFF
--- a/modules/ppcp-button/src/Helper/IsolatedCartSimulator.php
+++ b/modules/ppcp-button/src/Helper/IsolatedCartSimulator.php
@@ -44,6 +44,7 @@ class IsolatedCartSimulator {
 		};
 
 		add_filter( 'woocommerce_paypal_payments_is_simulating_cart', $simulation_filter );
+		$existing_notices = wc_get_notices();
 
 		try {
 			$cart = $this->create_isolated_cart();
@@ -62,6 +63,15 @@ class IsolatedCartSimulator {
 			throw $e;
 		} finally {
 			remove_filter( 'woocommerce_paypal_payments_is_simulating_cart', $simulation_filter );
+			$current_notices = wc_get_notices();
+
+			/**
+			 * Simulation may add WooCommerce notices (stored in the global session, not the cart).
+			 * Snapshot + restore ensures simulation notices don't leak into the user session.
+			 */
+			if ( $current_notices !== $existing_notices ) {
+				wc_set_notices( $existing_notices );
+			}
 
 			if ( $cart instanceof WC_Cart ) {
 				$this->cleanup_cart( $cart );


### PR DESCRIPTION
## Problem

Cart simulation for PayPal buttons may trigger WooCommerce notices (e.g. "Please choose product options") when attempting to add variable products without a resolved variation.

Although the simulation uses an isolated `WC_Cart`, WooCommerce stores notices  in the global session (`WC()->session`), not on the cart instance. As a result,  notices generated during simulation persist and are displayed to the user.

This leads to confusing UX where an error message is shown even though the product is successfully added to the cart.

---

## Root cause

During simulation:
- `add_to_cart()` is called on an isolated cart
- For variable products without a resolved variation, WooCommerce calls `wc_add_notice()`
- Notices are stored in the global session
- Unlike the previous implementation, they are not cleared automatically
- The notice leaks into the real user session

---

## Solution

Snapshot existing WooCommerce notices before simulation and restore them afterward:

- Capture notices via `wc_get_notices()` before simulation
- Run simulation logic
- Restore original notices using `wc_set_notices()` in `finally`

Additionally:
- Only restore if notices changed to avoid unnecessary writes

This ensures:
- Notices generated during simulation are discarded
- Legitimate pre-existing notices are preserved
- No global session state is unintentionally modified

---

## Why not `wc_clear_notices()`?

`wc_clear_notices()` removes *all* notices, including legitimate ones (e.g. coupon errors),
which makes it too aggressive for this use case.

---

## Testing steps

1. Go to a variable product page
2. Select all required options
3. Trigger PayPal button flow (cart simulation runs)
4. Remove product from cart
5. Re-add the same product with selected options