### PR TITLE
CreateCartEndpoint always returns the generated cart ID (6285)

### DIFF
--- a/modules/ppcp-store-sync/src/Response/CartResponse.php
+++ b/modules/ppcp-store-sync/src/Response/CartResponse.php
@@ -181,7 +181,9 @@ class CartResponse {
 			$data['applied_coupons'] = $this->applied_coupons;
 		}
 
-		$data   = array_merge( $data, $this->cart->to_array() );
+		$data       = array_merge( $data, $this->cart->to_array() );
+		$data['id'] = $this->cart_id;
+
 		$totals = $this->calculate_totals();
 
 		if ( $totals ) {

--- a/tests/PHPUnit/StoreSync/Response/CartResponseTest.php
+++ b/tests/PHPUnit/StoreSync/Response/CartResponseTest.php
@@ -643,7 +643,8 @@ class CartResponseTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * @scenario Server-generated cart ID is not overwritten by a caller-supplied ID in the request body
+	 * @scenario Server-generated cart ID is not overwritten by a caller-supplied ID in the request
+	 *           body
 	 *
 	 * Given a PayPal cart built from request body data that already contains an "id" key
 	 * When the response is built via create_new() with a distinct server-generated cart ID
@@ -651,10 +652,10 @@ class CartResponseTest extends TestCase {
 	 * And the caller-supplied ID from the request body is ignored
 	 */
 	public function test_create_new_id_is_not_overwritten_by_caller_supplied_id(): void {
-		$cart_data         = $this->make_cart_data();
-		$cart_data['id']   = 'client-supplied-id';
-		$cart              = PayPalCart::from_array( $cart_data );
-		$response          = CartResponse::create_new( $cart, 'server-generated-id', 'tok_test' );
+		$cart_data       = $this->make_cart_data();
+		$cart_data['id'] = 'client-supplied-id';
+		$cart            = PayPalCart::from_array( $cart_data );
+		$response        = CartResponse::create_new( $cart, 'server-generated-id', 'tok_test' );
 
 		$result = $response->to_array();
 

--- a/tests/PHPUnit/StoreSync/Response/CartResponseTest.php
+++ b/tests/PHPUnit/StoreSync/Response/CartResponseTest.php
@@ -643,6 +643,25 @@ class CartResponseTest extends TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
+	 * @scenario Server-generated cart ID is not overwritten by a caller-supplied ID in the request body
+	 *
+	 * Given a PayPal cart built from request body data that already contains an "id" key
+	 * When the response is built via create_new() with a distinct server-generated cart ID
+	 * Then to_array()['id'] equals the server-generated ID
+	 * And the caller-supplied ID from the request body is ignored
+	 */
+	public function test_create_new_id_is_not_overwritten_by_caller_supplied_id(): void {
+		$cart_data         = $this->make_cart_data();
+		$cart_data['id']   = 'client-supplied-id';
+		$cart              = PayPalCart::from_array( $cart_data );
+		$response          = CartResponse::create_new( $cart, 'server-generated-id', 'tok_test' );
+
+		$result = $response->to_array();
+
+		$this->assertSame( 'server-generated-id', $result['id'] );
+	}
+
+	/**
 	 * @scenario Completed checkout sets status to COMPLETED
 	 *
 	 * Given a cart that has been paid and a corresponding WC_Order


### PR DESCRIPTION
### Description

All cart endpoints returned a copy of the incoming payload with additional details - status, validation, totals, ...

**An edge case that was not considered:**

The incoming payload can include a cart ID, and that exact ID is included in the API response - this is expected for most endpoints, like "GetCartEndpoint."

However, when creating a new cart, this ID is generated by the endpoint, and must always be returned, regardless of whether the incoming payload included an ID or not.

We address this bug here