### PR TITLE
[QA] PCP-6283 Disable video recording in CI to reduce artifact size

### DIFF
--- a/tests/qa/playwright.config.ts
+++ b/tests/qa/playwright.config.ts
@@ -93,10 +93,12 @@ export default defineConfig< BaseExtend >( {
 					size: viewportSize,
 			  },
 
-		recordVideoOptions: {
-			mode: 'retain-on-failure',
-			size: viewportSize,
-		},
+		recordVideoOptions: process.env.CI
+			? undefined
+			: {
+				mode: 'retain-on-failure',
+				size: viewportSize,
+			},
 
 		cliConfig: {
 			envType: process.env.WPCLI_ENV_TYPE as WpCliEnvType,


### PR DESCRIPTION
### Description

Disable video recording in CI tests to reduce artifact size, according to PCP-6283.
Tested with the following [job](https://github.com/woocommerce/woocommerce-paypal-payments/actions/runs/25312322205)