### PR TITLE
Add agentic beta banner for eligible US merchants (6057)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/screens/_settings.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_settings.scss
@@ -3,7 +3,7 @@
 @import './settings/tab-settings';
 @import './settings/tab-styling';
 @import './settings/tab-paylater-configurator';
-@import './settings/migration-banner';
+@import './settings/banner';
 
 // Container and Tab Settings
 .ppcp-r-tabs.settings,

--- a/modules/ppcp-settings/resources/css/components/screens/settings/_banner.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/settings/_banner.scss
@@ -52,6 +52,8 @@
 	}
 
 	@media screen and (max-width: 480px) {
+		margin-bottom: 24px;
+
 		.ppcp-r-settings-card__content-wrapper {
 			flex-direction: column;
 		}

--- a/modules/ppcp-settings/resources/css/components/screens/settings/_banner.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/settings/_banner.scss
@@ -65,3 +65,16 @@
 		}
 	}
 }
+
+#ppcp-agentic-beta-banner {
+	.ppcp-r-settings-banner__icon {
+		padding-right: 8%;
+		display: flex;
+		align-items: center;
+		justify-content: right;
+	}
+
+	.ppcp-r-settings-card__content-wrapper .ppcp--content:first-child {
+		flex: 1.1;
+	}
+}

--- a/modules/ppcp-settings/resources/css/components/screens/settings/_banner.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/settings/_banner.scss
@@ -1,4 +1,4 @@
-.ppcp-r-settings-migration-banner {
+.ppcp-r-settings-banner {
 
 	.ppcp-r-settings-card__content-wrapper {
 		display: flex;
@@ -34,7 +34,7 @@
 		margin-right: 16px;
 	}
 
-	.ppcp-r-settings-migration-banner__icon {
+	.ppcp-r-settings-banner__icon {
 		text-align: center;
 		width: 35%;
 		height: 100%;
@@ -56,11 +56,11 @@
 			flex-direction: column;
 		}
 
-		.ppcp--content:not(.ppcp-r-settings-migration-banner__icon) {
+		.ppcp--content:not(.ppcp-r-settings-banner__icon) {
 			order:2;
 		}
 
-		.ppcp-r-settings-migration-banner__icon-close {
+		.ppcp-r-settings-banner__icon-close {
 			display: none;
 		}
 	}

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -19,7 +19,8 @@ import {
 const BANNER_ID        = 'ppcp-agentic-beta-banner';
 const BANNER_CLASS     = 'ppcp-r-settings-banner';
 const BANNER_TITLE_ID  = `${ BANNER_ID }-title`;
-const APPLY_URL        = 'https://example.com';
+// TODO: Replace with the real beta sign-up URL once it is confirmed by the PayPal team.
+const APPLY_URL = 'https://example.com';
 
 let isBannerDismissed = false;
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -85,7 +85,7 @@ const AgenticBetaBanner = ( {
 					</Action>
 				</Content>
 				<Content asCard={ false } className={ `${ className }__icon` }>
-					<PPIcon imageName="icon-button-payment-method-advanced-cards-large.svg" />
+					<PPIcon imageName="icon-paypal-business-loan.svg" />
 					<button
 						className={ `${ className }__icon-close` }
 						aria-label={ __(

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -19,7 +19,8 @@ import {
 const BANNER_ID = 'ppcp-agentic-beta-banner';
 const BANNER_CLASS = 'ppcp-r-settings-banner';
 const BANNER_TITLE_ID = `${ BANNER_ID }-title`;
-const APPLY_URL = 'https://example.com'; // TODO: Replace with the real beta sign-up URL once it is known.
+const APPLY_URL =
+	'https://docs.google.com/forms/d/e/1FAIpQLSeSMEJii54f4GfofEsPt1TbKK40NnOvq_Rs9ezXA6Ck5ZEDvg/viewform';
 
 let isBannerDismissed = false;
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -19,7 +19,7 @@ import {
 const BANNER_ID = 'ppcp-agentic-beta-banner';
 const BANNER_CLASS = 'ppcp-r-settings-banner';
 const BANNER_TITLE_ID = `${ BANNER_ID }-title`;
-const APPLY_URL = 'https://example.com'; // TODO: Replace with the real beta sign-up URL once it is confirmed by the PayPal team.
+const APPLY_URL = 'https://example.com'; // TODO: Replace with the real beta sign-up URL once it is known.
 
 let isBannerDismissed = false;
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -16,15 +16,14 @@ import {
 	applyForAgenticBeta,
 } from '@ppcp-settings/data/agentic-beta/actions';
 
+const BANNER_ID        = 'ppcp-agentic-beta-banner';
+const BANNER_CLASS     = 'ppcp-r-settings-banner';
+const BANNER_TITLE_ID  = `${ BANNER_ID }-title`;
+const APPLY_URL        = 'https://example.com';
+
 let isBannerDismissed = false;
 
-const AgenticBetaBanner = ( {
-	id,
-	className,
-	title,
-	description,
-	actionProps,
-} ) => {
+const AgenticBetaBanner = () => {
 	const [ isDismissed, setIsDismissed ] = useState( () => isBannerDismissed );
 
 	const dismiss = () => {
@@ -43,66 +42,65 @@ const AgenticBetaBanner = ( {
 		return null;
 	}
 
-	const migrationBannerClassNames = classNames(
-		'ppcp-r-settings-card',
-		className
-	);
-	const props = {
-		className: migrationBannerClassNames,
-		id,
-	};
-
-	const titleId = id ? `${ id }-title` : undefined;
-
 	return (
-		<div { ...props } role="region" aria-labelledby={ titleId }>
+		<div
+			id={ BANNER_ID }
+			className={ classNames( 'ppcp-r-settings-card', BANNER_CLASS ) }
+			role="region"
+			aria-labelledby={ BANNER_TITLE_ID }
+		>
 			<ContentWrapper>
 				<Content asCard={ false }>
 					<Header>
 						<div className="ppcp--title-wrapper">
 							<h2
-								id={ titleId }
+								id={ BANNER_TITLE_ID }
 								className="ppcp-r-settings-card__title"
 							>
-								{ title }
+								{ __(
+									'Be among the first: Join the PayPal Store Sync Beta',
+									'woocommerce-paypal-payments'
+								) }
 							</h2>
 						</div>
-						<Description>{ description }</Description>
+						<Description>
+							{ __(
+								"AI-powered shopping agents are changing how customers discover and buy. We're looking for a small group of active US-based WooCommerce merchants to help shape this experience — get early access, direct input into the roadmap, and dedicated support from the PayPal & Syde team.",
+								'woocommerce-paypal-payments'
+							) }
+						</Description>
 					</Header>
 					<Action>
 						<div className="ppcp--action-buttons">
-							{ actionProps?.buttons.map(
-								( buttonData, index ) => {
-									const { type, text, url } = buttonData;
-									const isRemind = type === 'tertiary';
-
-									return (
-										<Button
-											key={ index }
-											className="small-button"
-											variant={ type }
-											href={ url }
-											target={
-												url ? '_blank' : undefined
-											}
-											onClick={
-												isRemind
-													? remind
-													: applyForAgenticBeta
-											}
-										>
-											{ text }
-										</Button>
-									);
-								}
-							) }
+							<Button
+								className="small-button"
+								variant="secondary"
+								href={ APPLY_URL }
+								target="_blank"
+								onClick={ applyForAgenticBeta }
+							>
+								{ __(
+									'Apply for Early Access',
+									'woocommerce-paypal-payments'
+								) }
+							</Button>
+							<Button
+								className="small-button"
+								variant="tertiary"
+								onClick={ remind }
+							>
+								{ __(
+									'Remind me later',
+									'woocommerce-paypal-payments'
+								) }
+							</Button>
 						</div>
 					</Action>
 				</Content>
-				<Content asCard={ false } className={ `${ className }__icon` }>
+				<Content asCard={ false } className={ `${ BANNER_CLASS }__icon` }>
 					<PPIcon imageName="icon-paypal-business-loan.svg" />
 					<button
-						className={ `${ className }__icon-close` }
+						className={ `${ BANNER_CLASS }__icon-close` }
 						aria-label={ __(
 							'Dismiss',
 							'woocommerce-paypal-payments'

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -10,6 +10,7 @@ import {
 import { PPIcon } from '../../../ReusableComponents/Icons';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
+import { dismissAgenticBetaBanner } from '@ppcp-settings/data/agentic-beta/actions';
 
 let isBannerDismissed = false;
 
@@ -21,11 +22,11 @@ const AgenticBetaBanner = ( {
 	actionProps,
 } ) => {
 	const [ isDismissed, setIsDismissed ] = useState( () => isBannerDismissed );
-	const [ isMigrating, setIsMigrating ] = useState( false );
 
 	const dismiss = () => {
 		isBannerDismissed = true;
 		setIsDismissed( true );
+		dismissAgenticBetaBanner();
 	};
 
 	if ( isDismissed ) {
@@ -69,12 +70,10 @@ const AgenticBetaBanner = ( {
 										<Button
 											key={ index }
 											className="small-button"
-											isBusy={
-												! isDismiss && isMigrating
-											}
 											variant={ type }
-											disabled={ isMigrating }
-											onClick={ isDismiss ? dismiss : '' }
+											onClick={
+												isDismiss ? dismiss : undefined
+											}
 										>
 											{ text }
 										</Button>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -16,11 +16,10 @@ import {
 	applyForAgenticBeta,
 } from '@ppcp-settings/data/agentic-beta/actions';
 
-const BANNER_ID        = 'ppcp-agentic-beta-banner';
-const BANNER_CLASS     = 'ppcp-r-settings-banner';
-const BANNER_TITLE_ID  = `${ BANNER_ID }-title`;
-// TODO: Replace with the real beta sign-up URL once it is confirmed by the PayPal team.
-const APPLY_URL = 'https://example.com';
+const BANNER_ID = 'ppcp-agentic-beta-banner';
+const BANNER_CLASS = 'ppcp-r-settings-banner';
+const BANNER_TITLE_ID = `${ BANNER_ID }-title`;
+const APPLY_URL = 'https://example.com'; // TODO: Replace with the real beta sign-up URL once it is confirmed by the PayPal team.
 
 let isBannerDismissed = false;
 
@@ -98,7 +97,10 @@ const AgenticBetaBanner = () => {
 						</div>
 					</Action>
 				</Content>
-				<Content asCard={ false } className={ `${ BANNER_CLASS }__icon` }>
+				<Content
+					asCard={ false }
+					className={ `${ BANNER_CLASS }__icon` }
+				>
 					<PPIcon imageName="icon-paypal-business-loan.svg" />
 					<button
 						className={ `${ BANNER_CLASS }__icon-close` }

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -12,6 +12,7 @@ import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import {
 	dismissAgenticBetaBanner,
+	remindLaterAgenticBeta,
 	applyForAgenticBeta,
 } from '@ppcp-settings/data/agentic-beta/actions';
 
@@ -30,6 +31,12 @@ const AgenticBetaBanner = ( {
 		isBannerDismissed = true;
 		setIsDismissed( true );
 		dismissAgenticBetaBanner();
+	};
+
+	const remind = () => {
+		isBannerDismissed = true;
+		setIsDismissed( true );
+		remindLaterAgenticBeta();
 	};
 
 	if ( isDismissed ) {
@@ -67,7 +74,7 @@ const AgenticBetaBanner = ( {
 							{ actionProps?.buttons.map(
 								( buttonData, index ) => {
 									const { type, text, url } = buttonData;
-									const isDismiss = type === 'tertiary';
+									const isRemind = type === 'tertiary';
 
 									return (
 										<Button
@@ -79,8 +86,8 @@ const AgenticBetaBanner = ( {
 												url ? '_blank' : undefined
 											}
 											onClick={
-												isDismiss
-													? dismiss
+												isRemind
+													? remind
 													: applyForAgenticBeta
 											}
 										>

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -1,0 +1,105 @@
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import {
+	Content,
+	ContentWrapper,
+	Header,
+	Action,
+	Description,
+} from '@ppcp-settings/Components/ReusableComponents/Elements';
+import { PPIcon } from '../../../ReusableComponents/Icons';
+import classNames from 'classnames';
+import { __ } from '@wordpress/i18n';
+
+let isBannerDismissed = false;
+
+const AgenticBetaBanner = ( {
+	id,
+	className,
+	title,
+	description,
+	actionProps,
+} ) => {
+	const [ isDismissed, setIsDismissed ] = useState( () => isBannerDismissed );
+	const [ isMigrating, setIsMigrating ] = useState( false );
+
+	const dismiss = () => {
+		isBannerDismissed = true;
+		setIsDismissed( true );
+	};
+
+	if ( isDismissed ) {
+		return null;
+	}
+
+	const migrationBannerClassNames = classNames(
+		'ppcp-r-settings-card',
+		className
+	);
+	const props = {
+		className: migrationBannerClassNames,
+		id,
+	};
+
+	const titleId = id ? `${ id }-title` : undefined;
+
+	return (
+		<div { ...props } role="region" aria-labelledby={ titleId }>
+			<ContentWrapper>
+				<Content asCard={ false }>
+					<Header>
+						<div className="ppcp--title-wrapper">
+							<h2
+								id={ titleId }
+								className="ppcp-r-settings-card__title"
+							>
+								{ title }
+							</h2>
+						</div>
+						<Description>{ description }</Description>
+					</Header>
+					<Action>
+						<div className="ppcp--action-buttons">
+							{ actionProps?.buttons.map(
+								( buttonData, index ) => {
+									const { type, text } = buttonData;
+									const isDismiss = type === 'tertiary';
+
+									return (
+										<Button
+											key={ index }
+											className="small-button"
+											isBusy={
+												! isDismiss && isMigrating
+											}
+											variant={ type }
+											disabled={ isMigrating }
+											onClick={ isDismiss ? dismiss : '' }
+										>
+											{ text }
+										</Button>
+									);
+								}
+							) }
+						</div>
+					</Action>
+				</Content>
+				<Content asCard={ false } className={ `${ className }__icon` }>
+					<PPIcon imageName="icon-button-payment-method-advanced-cards-large.svg" />
+					<button
+						className={ `${ className }__icon-close` }
+						aria-label={ __(
+							'Dismiss',
+							'woocommerce-paypal-payments'
+						) }
+						onClick={ dismiss }
+					>
+						<PPIcon imageName="icon-close.svg" />
+					</button>
+				</Content>
+			</ContentWrapper>
+		</div>
+	);
+};
+
+export default AgenticBetaBanner;

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/AgenticBetaBanner.js
@@ -10,7 +10,10 @@ import {
 import { PPIcon } from '../../../ReusableComponents/Icons';
 import classNames from 'classnames';
 import { __ } from '@wordpress/i18n';
-import { dismissAgenticBetaBanner } from '@ppcp-settings/data/agentic-beta/actions';
+import {
+	dismissAgenticBetaBanner,
+	applyForAgenticBeta,
+} from '@ppcp-settings/data/agentic-beta/actions';
 
 let isBannerDismissed = false;
 
@@ -63,7 +66,7 @@ const AgenticBetaBanner = ( {
 						<div className="ppcp--action-buttons">
 							{ actionProps?.buttons.map(
 								( buttonData, index ) => {
-									const { type, text } = buttonData;
+									const { type, text, url } = buttonData;
 									const isDismiss = type === 'tertiary';
 
 									return (
@@ -71,8 +74,14 @@ const AgenticBetaBanner = ( {
 											key={ index }
 											className="small-button"
 											variant={ type }
+											href={ url }
+											target={
+												url ? '_blank' : undefined
+											}
 											onClick={
-												isDismiss ? dismiss : undefined
+												isDismiss
+													? dismiss
+													: applyForAgenticBeta
 											}
 										>
 											{ text }

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -118,7 +118,7 @@ const TabPaymentMethods = () => {
 			{ isBcdcOverrideFlagEnabled && (
 				<MigrationBanner
 					id="ppcp-migration-banner"
-					className="ppcp-r-settings-migration-banner"
+					className="ppcp-r-settings-banner"
 					title={ __(
 						'Unlock Advanced Card Processing',
 						'woocommerce-paypal-payments'

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
@@ -35,6 +35,7 @@ const SettingsScreen = ( { activePanel, setActivePanel } ) => {
 								'Apply for Early Access',
 								'woocommerce-paypal-payments'
 							),
+							url: 'https://example.com',
 						},
 						{
 							type: 'tertiary',

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
@@ -3,7 +3,6 @@ import HelpSection from '@ppcp-settings/Components/ReusableComponents/HelpSectio
 import SettingsNavigation from './Components/Navigation';
 import AgenticBetaBanner from './Components/AgenticBetaBanner';
 import { getSettingsTabs } from './Tabs';
-import { __ } from '@wordpress/i18n';
 
 const SettingsScreen = ( { activePanel, setActivePanel } ) => {
 	const tabs = getSettingsTabs();
@@ -17,39 +16,7 @@ const SettingsScreen = ( { activePanel, setActivePanel } ) => {
 				activePanel={ activePanel }
 				setActivePanel={ setActivePanel }
 			/>
-			{ isAgenticBetaBannerEligible && (
-				<AgenticBetaBanner
-					id="ppcp-agentic-beta-banner"
-					className="ppcp-r-settings-banner"
-					title={ __(
-						'Be among the first: Join the PayPal Store Sync Beta',
-						'woocommerce-paypal-payments'
-					) }
-					description={ __(
-						"AI-powered shopping agents are changing how customers discover and buy. We're looking for a small group of active US-based WooCommerce merchants to help shape this experience — get early access, direct input into the roadmap, and dedicated support from the PayPal & Syde team.",
-						'woocommerce-paypal-payments'
-					) }
-					actionProps={ {
-						buttons: [
-							{
-								type: 'secondary',
-								text: __(
-									'Apply for Early Access',
-									'woocommerce-paypal-payments'
-								),
-								url: 'https://example.com',
-							},
-							{
-								type: 'tertiary',
-								text: __(
-									'Remind me later',
-									'woocommerce-paypal-payments'
-								),
-							},
-						],
-					} }
-				/>
-			) }
+			{ isAgenticBetaBannerEligible && <AgenticBetaBanner /> }
 			<Container page="settings">
 				{ Component }
 				<HelpSection />

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
 const SettingsScreen = ( { activePanel, setActivePanel } ) => {
 	const tabs = getSettingsTabs();
 	const { Component } = tabs.find( ( tab ) => tab.name === activePanel );
+	const isAgenticBetaBannerEligible = window.ppcpSettings?.isAgenticBetaBannerEligible;
 
 	return (
 		<>
@@ -16,37 +17,39 @@ const SettingsScreen = ( { activePanel, setActivePanel } ) => {
 				activePanel={ activePanel }
 				setActivePanel={ setActivePanel }
 			/>
-			<AgenticBetaBanner
-				id="ppcp-agentic-beta-banner"
-				className="ppcp-r-settings-banner"
-				title={ __(
-					'Be among the first: Join the PayPal Store Sync Beta',
-					'woocommerce-paypal-payments'
-				) }
-				description={ __(
-					"AI-powered shopping agents are changing how customers discover and buy. We're looking for a small group of active US-based WooCommerce merchants to help shape this experience — get early access, direct input into the roadmap, and dedicated support from the PayPal & Syde team.",
-					'woocommerce-paypal-payments'
-				) }
-				actionProps={ {
-					buttons: [
-						{
-							type: 'secondary',
-							text: __(
-								'Apply for Early Access',
-								'woocommerce-paypal-payments'
-							),
-							url: 'https://example.com',
-						},
-						{
-							type: 'tertiary',
-							text: __(
-								'Remind me later',
-								'woocommerce-paypal-payments'
-							),
-						},
-					],
-				} }
-			/>
+			{ isAgenticBetaBannerEligible && (
+				<AgenticBetaBanner
+					id="ppcp-agentic-beta-banner"
+					className="ppcp-r-settings-banner"
+					title={ __(
+						'Be among the first: Join the PayPal Store Sync Beta',
+						'woocommerce-paypal-payments'
+					) }
+					description={ __(
+						"AI-powered shopping agents are changing how customers discover and buy. We're looking for a small group of active US-based WooCommerce merchants to help shape this experience — get early access, direct input into the roadmap, and dedicated support from the PayPal & Syde team.",
+						'woocommerce-paypal-payments'
+					) }
+					actionProps={ {
+						buttons: [
+							{
+								type: 'secondary',
+								text: __(
+									'Apply for Early Access',
+									'woocommerce-paypal-payments'
+								),
+								url: 'https://example.com',
+							},
+							{
+								type: 'tertiary',
+								text: __(
+									'Remind me later',
+									'woocommerce-paypal-payments'
+								),
+							},
+						],
+					} }
+				/>
+			) }
 			<Container page="settings">
 				{ Component }
 				<HelpSection />

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/index.js
@@ -1,7 +1,9 @@
 import Container from '@ppcp-settings/Components/ReusableComponents/Container';
 import HelpSection from '@ppcp-settings/Components/ReusableComponents/HelpSection';
 import SettingsNavigation from './Components/Navigation';
+import AgenticBetaBanner from './Components/AgenticBetaBanner';
 import { getSettingsTabs } from './Tabs';
+import { __ } from '@wordpress/i18n';
 
 const SettingsScreen = ( { activePanel, setActivePanel } ) => {
 	const tabs = getSettingsTabs();
@@ -13,6 +15,36 @@ const SettingsScreen = ( { activePanel, setActivePanel } ) => {
 				tabs={ tabs }
 				activePanel={ activePanel }
 				setActivePanel={ setActivePanel }
+			/>
+			<AgenticBetaBanner
+				id="ppcp-agentic-beta-banner"
+				className="ppcp-r-settings-banner"
+				title={ __(
+					'Be among the first: Join the PayPal Store Sync Beta',
+					'woocommerce-paypal-payments'
+				) }
+				description={ __(
+					"AI-powered shopping agents are changing how customers discover and buy. We're looking for a small group of active US-based WooCommerce merchants to help shape this experience — get early access, direct input into the roadmap, and dedicated support from the PayPal & Syde team.",
+					'woocommerce-paypal-payments'
+				) }
+				actionProps={ {
+					buttons: [
+						{
+							type: 'secondary',
+							text: __(
+								'Apply for Early Access',
+								'woocommerce-paypal-payments'
+							),
+						},
+						{
+							type: 'tertiary',
+							text: __(
+								'Remind me later',
+								'woocommerce-paypal-payments'
+							),
+						},
+					],
+				} }
 			/>
 			<Container page="settings">
 				{ Component }

--- a/modules/ppcp-settings/resources/js/data/agentic-beta/actions.js
+++ b/modules/ppcp-settings/resources/js/data/agentic-beta/actions.js
@@ -16,6 +16,12 @@ export const dismissAgenticBetaBanner = () =>
 		method: 'POST',
 	} );
 
+export const remindLaterAgenticBeta = () =>
+	apiFetch( {
+		path: `${ REST_BASE_PATH }/remind`,
+		method: 'POST',
+	} );
+
 export const applyForAgenticBeta = () =>
 	apiFetch( {
 		path: `${ REST_BASE_PATH }/apply`,

--- a/modules/ppcp-settings/resources/js/data/agentic-beta/actions.js
+++ b/modules/ppcp-settings/resources/js/data/agentic-beta/actions.js
@@ -8,10 +8,16 @@
 
 import apiFetch from '@wordpress/api-fetch';
 
-const REST_DISMISS_PATH = '/wc/v3/wc_paypal/agentic-beta-banner-dismiss';
+const REST_BASE_PATH = '/wc/v3/wc_paypal/agentic-beta-banner';
 
 export const dismissAgenticBetaBanner = () =>
 	apiFetch( {
-		path: REST_DISMISS_PATH,
+		path: `${ REST_BASE_PATH }/dismiss`,
+		method: 'POST',
+	} );
+
+export const applyForAgenticBeta = () =>
+	apiFetch( {
+		path: `${ REST_BASE_PATH }/apply`,
 		method: 'POST',
 	} );

--- a/modules/ppcp-settings/resources/js/data/agentic-beta/actions.js
+++ b/modules/ppcp-settings/resources/js/data/agentic-beta/actions.js
@@ -1,0 +1,17 @@
+/**
+ * Agentic Beta Actions: Side-effect functions for the agentic beta banner.
+ *
+ * These functions trigger server-side operations via the REST API.
+ *
+ * @file
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+
+const REST_DISMISS_PATH = '/wc/v3/wc_paypal/agentic-beta-banner-dismiss';
+
+export const dismissAgenticBetaBanner = () =>
+	apiFetch( {
+		path: REST_DISMISS_PATH,
+		method: 'POST',
+	} );

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -58,6 +58,7 @@ use WooCommerce\PayPalCommerce\Settings\Service\AuthenticationManager;
 use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\ActivationDetector;
 use WooCommerce\PayPalCommerce\Settings\Service\BrandedExperience\PathRepository;
 use WooCommerce\PayPalCommerce\Settings\Service\ConnectionUrlGenerator;
+use WooCommerce\PayPalCommerce\Settings\Service\AgenticBetaBannerEligibility;
 use WooCommerce\PayPalCommerce\Settings\Service\FeaturesEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Service\GatewayRedirectService;
 use WooCommerce\PayPalCommerce\Settings\Service\LoadingScreenService;
@@ -404,6 +405,12 @@ return array(
 			$container->get( 'settings.data.todos' ),
 		);
 	},
+	'settings.service.agentic-beta-eligibility'           => static function ( ContainerInterface $container ): AgenticBetaBannerEligibility {
+		return new AgenticBetaBannerEligibility(
+			$container->get( 'settings.data.general' ),
+			$container->get( 'wcgateway.store-country' )
+		);
+	},
 	'settings.service.script-data-handler'                => static function ( ContainerInterface $container ): ScriptDataHandler {
 		$check_override = $container->get( 'settings.migration.bcdc-override-check' );
 		assert( is_callable( $check_override ) );
@@ -417,7 +424,8 @@ return array(
 			$container->get( 'api.helper.partner-attribution' ),
 			$container->get( 'settings.settings-provider' ),
 			$container->get( 'api.helpers.paymentLevelEligibility' ),
-			$check_override()
+			$check_override(),
+			$container->get( 'settings.service.agentic-beta-eligibility' )
 		);
 	},
 	'settings.service.data-migration'                     => static fn( ContainerInterface $c ): MigrationManager => new MigrationManager(

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -43,6 +43,7 @@ use WooCommerce\PayPalCommerce\Settings\Endpoint\AuthenticationRestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\CommonRestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\FeaturesRestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\LoginLinkRestEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Endpoint\AgenticBetaBannerEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\MigrateToAcdcRestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\OnboardingRestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\PayLaterMessagingEndpoint;
@@ -286,6 +287,9 @@ return array(
 		return new MigrateToAcdcRestEndpoint(
 			$container->get( 'settings.data.payment' )
 		);
+	},
+	'settings.rest.agentic_beta_banner'                   => static function ( ContainerInterface $container ): AgenticBetaBannerEndpoint {
+		return new AgenticBetaBannerEndpoint();
 	},
 	'settings.casual-selling.supported-countries'         => static function ( ContainerInterface $container ): array {
 		return array(

--- a/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
@@ -14,21 +14,34 @@ use WP_REST_Response;
 use WP_REST_Request;
 
 /**
- * Handles permanent dismissal of the agentic beta banner.
+ * Handles banner interactions for the agentic beta program:
+ * permanent dismissal and survey application.
  */
 class AgenticBetaBannerEndpoint extends RestEndpoint {
 
 	public const OPTION_DISMISSED = 'ppcp_agentic_banner_dismissed';
+	public const OPTION_STATUS    = 'ppcp_agentic_beta_status';
+	public const STATUS_PENDING   = 'pending';
 
-	protected $rest_base = 'agentic-beta-banner-dismiss';
+	protected $rest_base = 'agentic-beta-banner';
 
 	public function register_routes(): void {
 		register_rest_route(
 			static::NAMESPACE,
-			'/' . $this->rest_base,
+			'/' . $this->rest_base . '/dismiss',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_dismiss' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+
+		register_rest_route(
+			static::NAMESPACE,
+			'/' . $this->rest_base . '/apply',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_apply' ),
 				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
@@ -38,5 +51,11 @@ class AgenticBetaBannerEndpoint extends RestEndpoint {
 		update_option( self::OPTION_DISMISSED, true );
 
 		return $this->return_success( array( 'dismissed' => true ) );
+	}
+
+	public function handle_apply( WP_REST_Request $request ): WP_REST_Response {
+		update_option( self::OPTION_STATUS, self::STATUS_PENDING );
+
+		return $this->return_success( array( 'status' => self::STATUS_PENDING ) );
 	}
 }

--- a/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * REST endpoint to handle the agentic beta banner dismiss action.
+ * REST endpoint to handle agentic beta banner interactions.
  *
  * @package WooCommerce\PayPalCommerce\Settings\Endpoint
  */
@@ -15,14 +15,16 @@ use WP_REST_Request;
 
 /**
  * Handles banner interactions for the agentic beta program:
- * permanent dismissal, remind-me-later, and survey application.
+ * permanent dismissal, 7-day snooze (remind-me-later), and survey application.
  */
 class AgenticBetaBannerEndpoint extends RestEndpoint {
 
-	public const OPTION_DISMISSED = 'ppcp_agentic_banner_dismissed';
-	public const OPTION_STATUS    = 'ppcp_agentic_beta_status';
-	public const STATUS_PENDING   = 'pending';
-	public const STATUS_APPLIED   = 'applied';
+	public const OPTION_DISMISSED     = 'ppcp_agentic_banner_dismissed';
+	public const OPTION_STATUS        = 'ppcp_agentic_beta_status';
+	public const OPTION_SNOOZED_UNTIL = 'ppcp_agentic_banner_snoozed_until';
+	public const STATUS_PENDING       = 'pending';
+	public const STATUS_APPLIED       = 'applied';
+	public const SNOOZE_DAYS          = 7;
 
 	protected $rest_base = 'agentic-beta-banner';
 
@@ -58,18 +60,30 @@ class AgenticBetaBannerEndpoint extends RestEndpoint {
 		);
 	}
 
+	/**
+	 * Permanently dismisses the banner. Once dismissed it will never be shown again.
+	 */
 	public function handle_dismiss( WP_REST_Request $request ): WP_REST_Response {
 		update_option( self::OPTION_DISMISSED, true );
 
 		return $this->return_success( array( 'dismissed' => true ) );
 	}
 
+	/**
+	 * Snoozes the banner for {@see self::SNOOZE_DAYS} days and sets status to pending.
+	 * After the snooze period expires the banner becomes eligible to show again.
+	 */
 	public function handle_remind( WP_REST_Request $request ): WP_REST_Response {
+		$snoozed_until = time() + self::SNOOZE_DAYS * DAY_IN_SECONDS;
+		update_option( self::OPTION_SNOOZED_UNTIL, $snoozed_until );
 		update_option( self::OPTION_STATUS, self::STATUS_PENDING );
 
-		return $this->return_success( array( 'status' => self::STATUS_PENDING ) );
+		return $this->return_success( array( 'snoozed_until' => $snoozed_until ) );
 	}
 
+	/**
+	 * Records that the merchant has applied for the beta program.
+	 */
 	public function handle_apply( WP_REST_Request $request ): WP_REST_Response {
 		update_option( self::OPTION_STATUS, self::STATUS_APPLIED );
 

--- a/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * REST endpoint to handle the agentic beta banner dismiss action.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Endpoint
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Endpoint;
+
+use WP_REST_Server;
+use WP_REST_Response;
+use WP_REST_Request;
+
+/**
+ * Handles permanent dismissal of the agentic beta banner.
+ */
+class AgenticBetaBannerEndpoint extends RestEndpoint {
+
+	public const OPTION_DISMISSED = 'ppcp_agentic_banner_dismissed';
+
+	protected $rest_base = 'agentic-beta-banner-dismiss';
+
+	public function register_routes(): void {
+		register_rest_route(
+			static::NAMESPACE,
+			'/' . $this->rest_base,
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_dismiss' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+	}
+
+	public function handle_dismiss( WP_REST_Request $request ): WP_REST_Response {
+		update_option( self::OPTION_DISMISSED, true );
+
+		return $this->return_success( array( 'dismissed' => true ) );
+	}
+}

--- a/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
@@ -19,9 +19,9 @@ use WP_REST_Request;
  */
 class AgenticBetaBannerEndpoint extends RestEndpoint {
 
-	public const OPTION_DISMISSED     = 'ppcp_agentic_banner_dismissed';
-	public const OPTION_STATUS        = 'ppcp_agentic_beta_status';
-	public const OPTION_SNOOZED_UNTIL = 'ppcp_agentic_banner_snoozed_until';
+	public const OPTION_DISMISSED     = 'woocommerce-ppcp-agentic-banner-dismissed';
+	public const OPTION_STATUS        = 'woocommerce-ppcp-agentic-beta-status';
+	public const OPTION_SNOOZED_UNTIL = 'woocommerce-ppcp-agentic-banner-snoozed-until';
 	public const STATUS_PENDING       = 'pending';
 	public const STATUS_APPLIED       = 'applied';
 	public const SNOOZE_DAYS          = 7;

--- a/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/AgenticBetaBannerEndpoint.php
@@ -15,13 +15,14 @@ use WP_REST_Request;
 
 /**
  * Handles banner interactions for the agentic beta program:
- * permanent dismissal and survey application.
+ * permanent dismissal, remind-me-later, and survey application.
  */
 class AgenticBetaBannerEndpoint extends RestEndpoint {
 
 	public const OPTION_DISMISSED = 'ppcp_agentic_banner_dismissed';
 	public const OPTION_STATUS    = 'ppcp_agentic_beta_status';
 	public const STATUS_PENDING   = 'pending';
+	public const STATUS_APPLIED   = 'applied';
 
 	protected $rest_base = 'agentic-beta-banner';
 
@@ -32,6 +33,16 @@ class AgenticBetaBannerEndpoint extends RestEndpoint {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'handle_dismiss' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+
+		register_rest_route(
+			static::NAMESPACE,
+			'/' . $this->rest_base . '/remind',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_remind' ),
 				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
@@ -53,9 +64,15 @@ class AgenticBetaBannerEndpoint extends RestEndpoint {
 		return $this->return_success( array( 'dismissed' => true ) );
 	}
 
-	public function handle_apply( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_remind( WP_REST_Request $request ): WP_REST_Response {
 		update_option( self::OPTION_STATUS, self::STATUS_PENDING );
 
 		return $this->return_success( array( 'status' => self::STATUS_PENDING ) );
+	}
+
+	public function handle_apply( WP_REST_Request $request ): WP_REST_Response {
+		update_option( self::OPTION_STATUS, self::STATUS_APPLIED );
+
+		return $this->return_success( array( 'status' => self::STATUS_APPLIED ) );
 	}
 }

--- a/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
+++ b/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
@@ -19,17 +19,13 @@ use WooCommerce\PayPalCommerce\Settings\Endpoint\AgenticBetaBannerEndpoint;
  */
 class AgenticBetaBannerEligibility {
 
-	private const REQUIRED_PRODUCT_COUNT = 50;
-	private const REQUIRED_ORDER_COUNT   = 50;
-	private const ORDER_LOOKBACK_DAYS    = 90;
+	private const REQUIRED_PRODUCT_COUNT = 1;
+	private const REQUIRED_ORDER_COUNT   = 1;
+	private const ORDER_LOOKBACK_DAYS    = 900;
 
 	private GeneralSettings $general_settings;
 	private string $store_country;
 
-	/**
-	 * @param GeneralSettings $general_settings Used to verify the merchant is connected.
-	 * @param string          $store_country    WooCommerce base country (e.g. "US").
-	 */
 	public function __construct( GeneralSettings $general_settings, string $store_country ) {
 		$this->general_settings = $general_settings;
 		$this->store_country    = $store_country;
@@ -40,7 +36,7 @@ class AgenticBetaBannerEligibility {
 	 * merchant is connected, store country is US, a US shipping zone exists,
 	 * at least {@see self::REQUIRED_PRODUCT_COUNT} published products exist,
 	 * at least {@see self::REQUIRED_ORDER_COUNT} completed orders within the last
-	 * {@see self::ORDER_LOOKBACK_DAYS} days, the banner status is not pending,
+	 * {@see self::ORDER_LOOKBACK_DAYS} days, the banner is not snoozed,
 	 * and the banner has not been permanently dismissed.
 	 *
 	 * @return bool
@@ -51,7 +47,7 @@ class AgenticBetaBannerEligibility {
 			&& $this->has_us_shipping_zone()
 			&& $this->has_enough_products()
 			&& $this->has_enough_recent_orders()
-			&& get_option( AgenticBetaBannerEndpoint::OPTION_STATUS ) !== AgenticBetaBannerEndpoint::STATUS_PENDING
+			&& $this->is_not_snoozed()
 			&& ! get_option( AgenticBetaBannerEndpoint::OPTION_DISMISSED );
 	}
 
@@ -116,5 +112,16 @@ class AgenticBetaBannerEligibility {
 		);
 
 		return is_array( $orders ) && count( $orders ) >= self::REQUIRED_ORDER_COUNT;
+	}
+
+	/**
+	 * Returns true if no snooze is active or the snooze period has expired.
+	 *
+	 * @return bool
+	 */
+	private function is_not_snoozed(): bool {
+		$snoozed_until = get_option( AgenticBetaBannerEndpoint::OPTION_SNOOZED_UNTIL );
+
+		return ! $snoozed_until || (int) $snoozed_until < time();
 	}
 }

--- a/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
+++ b/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
@@ -14,14 +14,13 @@ use WooCommerce\PayPalCommerce\Settings\Endpoint\AgenticBetaBannerEndpoint;
 
 /**
  * Determines whether the agentic beta banner should be shown to the merchant.
- *
- * All seven conditions must be true for the banner to be eligible.
  */
 class AgenticBetaBannerEligibility {
 
 	private const REQUIRED_PRODUCT_COUNT = 50;
 	private const REQUIRED_ORDER_COUNT   = 50;
 	private const ORDER_LOOKBACK_DAYS    = 90;
+	private const TRANSIENT_KEY          = 'ppcp_agentic_banner_base_eligible';
 
 	private GeneralSettings $general_settings;
 	private string $store_country;
@@ -32,23 +31,51 @@ class AgenticBetaBannerEligibility {
 	}
 
 	/**
-	 * Returns true only when all seven conditions are met:
-	 * merchant is connected, store country is US, a US shipping zone exists,
-	 * at least {@see self::REQUIRED_PRODUCT_COUNT} published products exist,
-	 * at least {@see self::REQUIRED_ORDER_COUNT} completed orders within the last
-	 * {@see self::ORDER_LOOKBACK_DAYS} days, the banner is not snoozed,
-	 * and the banner has not been permanently dismissed.
+	 * Returns true only when all conditions are met. Checks user-preference
+	 * conditions first (cheap option reads) before falling through to the
+	 * store-level conditions, which are cached in a transient.
 	 *
 	 * @return bool
 	 */
 	public function is_eligible(): bool {
-		return $this->general_settings->is_merchant_connected()
+		if ( ! $this->should_display_banner() ) {
+			return false;
+		}
+
+		return $this->are_store_conditions_met();
+	}
+
+	/**
+	 * Returns false if the merchant has dismissed or snoozed the banner.
+	 *
+	 * @return bool
+	 */
+	private function should_display_banner(): bool {
+		return $this->is_not_snoozed()
+			&& ! get_option( AgenticBetaBannerEndpoint::OPTION_DISMISSED );
+	}
+
+	/**
+	 * Returns true when the store-level conditions are met. The result is cached
+	 * for 10 minutes to avoid running expensive DB queries on every admin load.
+	 *
+	 * @return bool
+	 */
+	private function are_store_conditions_met(): bool {
+		$cached = get_transient( self::TRANSIENT_KEY );
+		if ( $cached !== false ) {
+			return (bool) $cached;
+		}
+
+		$result = $this->general_settings->is_merchant_connected()
 			&& $this->store_country === 'US'
 			&& $this->has_us_shipping_zone()
 			&& $this->has_enough_products()
-			&& $this->has_enough_recent_orders()
-			&& $this->is_not_snoozed()
-			&& ! get_option( AgenticBetaBannerEndpoint::OPTION_DISMISSED );
+			&& $this->has_enough_recent_orders();
+
+		set_transient( self::TRANSIENT_KEY, (int) $result, 10 * MINUTE_IN_SECONDS );
+
+		return $result;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
+++ b/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
@@ -20,7 +20,6 @@ class AgenticBetaBannerEligibility {
 	private const REQUIRED_PRODUCT_COUNT = 50;
 	private const REQUIRED_ORDER_COUNT   = 50;
 	private const ORDER_LOOKBACK_DAYS    = 90;
-	private const MIN_PHP_VERSION        = '8.1';
 	private const TRANSIENT_KEY          = 'ppcp_agentic_banner_base_eligible';
 
 	private GeneralSettings $general_settings;
@@ -64,7 +63,7 @@ class AgenticBetaBannerEligibility {
 	 * @return bool
 	 */
 	private function are_store_conditions_met(): bool {
-		if ( ! version_compare( PHP_VERSION, self::MIN_PHP_VERSION, '>=' ) ) {
+		if ( ! version_compare( PHP_VERSION, '8.1', '>=' ) ) {
 			return false;
 		}
 

--- a/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
+++ b/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Eligibility check for the agentic beta program banner.
+ *
+ * @package WooCommerce\PayPalCommerce\Settings\Service
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service;
+
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\Endpoint\AgenticBetaBannerEndpoint;
+
+/**
+ * Determines whether the agentic beta banner should be shown to the merchant.
+ *
+ * All seven conditions must be true for the banner to be eligible.
+ */
+class AgenticBetaBannerEligibility {
+
+	private const REQUIRED_PRODUCT_COUNT = 50;
+	private const REQUIRED_ORDER_COUNT   = 50;
+	private const ORDER_LOOKBACK_DAYS    = 90;
+
+	private GeneralSettings $general_settings;
+	private string $store_country;
+
+	/**
+	 * @param GeneralSettings $general_settings Used to verify the merchant is connected.
+	 * @param string          $store_country    WooCommerce base country (e.g. "US").
+	 */
+	public function __construct( GeneralSettings $general_settings, string $store_country ) {
+		$this->general_settings = $general_settings;
+		$this->store_country    = $store_country;
+	}
+
+	/**
+	 * Returns true only when all seven conditions are met:
+	 * merchant is connected, store country is US, a US shipping zone exists,
+	 * at least {@see self::REQUIRED_PRODUCT_COUNT} published products exist,
+	 * at least {@see self::REQUIRED_ORDER_COUNT} completed orders within the last
+	 * {@see self::ORDER_LOOKBACK_DAYS} days, the banner status is not pending,
+	 * and the banner has not been permanently dismissed.
+	 *
+	 * @return bool
+	 */
+	public function is_eligible(): bool {
+		return $this->general_settings->is_merchant_connected()
+			&& $this->store_country === 'US'
+			&& $this->has_us_shipping_zone()
+			&& $this->has_enough_products()
+			&& $this->has_enough_recent_orders()
+			&& get_option( AgenticBetaBannerEndpoint::OPTION_STATUS ) !== AgenticBetaBannerEndpoint::STATUS_PENDING
+			&& ! get_option( AgenticBetaBannerEndpoint::OPTION_DISMISSED );
+	}
+
+	/**
+	 * Returns true if the default zone has active shipping methods, or if any
+	 * named zone covers the US country and has at least one active method.
+	 *
+	 * @return bool
+	 */
+	private function has_us_shipping_zone(): bool {
+		$default_zone = new \WC_Shipping_Zone( 0 );
+		if ( ! empty( $default_zone->get_shipping_methods( true ) ) ) {
+			return true;
+		}
+
+		foreach ( \WC_Shipping_Zones::get_zones() as $zone_data ) {
+			$zone = new \WC_Shipping_Zone( $zone_data['id'] );
+			if ( empty( $zone->get_shipping_methods( true ) ) ) {
+				continue;
+			}
+			foreach ( $zone->get_zone_locations() as $location ) {
+				if ( $location->type === 'country' && $location->code === 'US' ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns true if the store has at least {@see self::REQUIRED_PRODUCT_COUNT} published products.
+	 *
+	 * @return bool
+	 */
+	private function has_enough_products(): bool {
+		$products = wc_get_products(
+			array(
+				'status' => 'publish',
+				'limit'  => self::REQUIRED_PRODUCT_COUNT,
+				'return' => 'ids',
+			)
+		);
+
+		return is_array( $products ) && count( $products ) >= self::REQUIRED_PRODUCT_COUNT;
+	}
+
+	/**
+	 * Returns true if the store has at least {@see self::REQUIRED_ORDER_COUNT} completed orders
+	 * within the last {@see self::ORDER_LOOKBACK_DAYS} days.
+	 *
+	 * @return bool
+	 */
+	private function has_enough_recent_orders(): bool {
+		$orders = wc_get_orders(
+			array(
+				'status'       => 'wc-completed',
+				'date_created' => '>' . gmdate( 'Y-m-d', strtotime( '-' . self::ORDER_LOOKBACK_DAYS . ' days' ) ),
+				'limit'        => self::REQUIRED_ORDER_COUNT,
+				'return'       => 'ids',
+			)
+		);
+
+		return is_array( $orders ) && count( $orders ) >= self::REQUIRED_ORDER_COUNT;
+	}
+}

--- a/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
+++ b/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
@@ -19,9 +19,9 @@ use WooCommerce\PayPalCommerce\Settings\Endpoint\AgenticBetaBannerEndpoint;
  */
 class AgenticBetaBannerEligibility {
 
-	private const REQUIRED_PRODUCT_COUNT = 1;
-	private const REQUIRED_ORDER_COUNT   = 1;
-	private const ORDER_LOOKBACK_DAYS    = 900;
+	private const REQUIRED_PRODUCT_COUNT = 50;
+	private const REQUIRED_ORDER_COUNT   = 50;
+	private const ORDER_LOOKBACK_DAYS    = 90;
 
 	private GeneralSettings $general_settings;
 	private string $store_country;

--- a/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
+++ b/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
@@ -20,6 +20,7 @@ class AgenticBetaBannerEligibility {
 	private const REQUIRED_PRODUCT_COUNT = 50;
 	private const REQUIRED_ORDER_COUNT   = 50;
 	private const ORDER_LOOKBACK_DAYS    = 90;
+	private const MIN_PHP_VERSION        = '8.1';
 	private const TRANSIENT_KEY          = 'ppcp_agentic_banner_base_eligible';
 
 	private GeneralSettings $general_settings;
@@ -56,12 +57,17 @@ class AgenticBetaBannerEligibility {
 	}
 
 	/**
-	 * Returns true when the store-level conditions are met. The result is cached
-	 * for 10 minutes to avoid running expensive DB queries on every admin load.
+	 * Returns true when the store-level conditions are met: PHP >= 8.1, merchant
+	 * connected, US store with a US shipping zone, and sufficient product/order
+	 * counts. The result is cached for 10 minutes to avoid repeated DB queries.
 	 *
 	 * @return bool
 	 */
 	private function are_store_conditions_met(): bool {
+		if ( ! version_compare( PHP_VERSION, self::MIN_PHP_VERSION, '>=' ) ) {
+			return false;
+		}
+
 		$cached = get_transient( self::TRANSIENT_KEY );
 		if ( $cached !== false ) {
 			return (bool) $cached;

--- a/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
+++ b/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
@@ -78,7 +78,7 @@ class AgenticBetaBannerEligibility {
 			&& $this->has_enough_products()
 			&& $this->has_enough_recent_orders();
 
-		set_transient( self::TRANSIENT_KEY, (int) $result, 10 * MINUTE_IN_SECONDS );
+		set_transient( self::TRANSIENT_KEY, (int) $result, DAY_IN_SECONDS );
 
 		return $result;
 	}

--- a/modules/ppcp-settings/src/Service/ScriptDataHandler.php
+++ b/modules/ppcp-settings/src/Service/ScriptDataHandler.php
@@ -12,6 +12,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\PaymentLevelEligibility;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\Settings\Service\AgenticBetaBannerEligibility;
 
 /**
  * This class is responsible for localizing the scripts and styles for the settings page.
@@ -27,6 +28,7 @@ class ScriptDataHandler {
 	protected SettingsProvider $settings_provider;
 	protected PaymentLevelEligibility $payment_level_eligibility;
 	private bool $is_bcdc_override_flag_enabled;
+	private AgenticBetaBannerEligibility $agentic_beta_banner_eligibility;
 
 	public function __construct(
 		AssetGetter $asset_getter,
@@ -37,17 +39,19 @@ class ScriptDataHandler {
 		PartnerAttribution $partner_attribution,
 		SettingsProvider $settings_provider,
 		PaymentLevelEligibility $payment_level_eligibility,
-		bool $is_bcdc_override_flag_enabled
+		bool $is_bcdc_override_flag_enabled,
+		AgenticBetaBannerEligibility $agentic_beta_banner_eligibility
 	) {
-		$this->asset_getter                  = $asset_getter;
-		$this->paylater_is_available         = $paylater_is_available;
-		$this->store_country                 = $store_country;
-		$this->merchant_id                   = $merchant_id;
-		$this->button_language_choices       = $button_language_choices;
-		$this->partner_attribution           = $partner_attribution;
-		$this->settings_provider             = $settings_provider;
-		$this->payment_level_eligibility     = $payment_level_eligibility;
-		$this->is_bcdc_override_flag_enabled = $is_bcdc_override_flag_enabled;
+		$this->asset_getter                    = $asset_getter;
+		$this->paylater_is_available           = $paylater_is_available;
+		$this->store_country                   = $store_country;
+		$this->merchant_id                     = $merchant_id;
+		$this->button_language_choices         = $button_language_choices;
+		$this->partner_attribution             = $partner_attribution;
+		$this->settings_provider               = $settings_provider;
+		$this->payment_level_eligibility       = $payment_level_eligibility;
+		$this->is_bcdc_override_flag_enabled   = $is_bcdc_override_flag_enabled;
+		$this->agentic_beta_banner_eligibility = $agentic_beta_banner_eligibility;
 	}
 
 	/**
@@ -186,6 +190,7 @@ class ScriptDataHandler {
 			'threeDSecureOptions'                 => $three_d_secure_options,
 			'isEligibleForPaymentLevelProcessing' => $this->payment_level_eligibility->is_eligible( CreditCardGateway::ID ),
 			'isBcdcOverrideFlagEnabled'           => $this->is_bcdc_override_flag_enabled,
+			'isAgenticBetaBannerEligible'         => $this->agentic_beta_banner_eligibility->is_eligible(),
 		);
 
 		if ( $is_pay_later_configurator_available ) {

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -319,6 +319,7 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 					'pay_later_messaging'    => $container->get( 'settings.rest.pay_later_messaging' ),
 					'features'               => $container->get( 'settings.rest.features' ),
 					'migrate_to_acdc'        => $container->get( 'settings.rest.migrate_to_acdc' ),
+					'agentic_beta_banner'    => $container->get( 'settings.rest.agentic_beta_banner' ),
 				);
 
 				foreach ( $endpoints as $endpoint ) {


### PR DESCRIPTION
## Summary

Adds an invite banner for the PayPal Store Sync (agentic) beta program, visible on all PayPal Payments settings tabs to eligible US-based merchants.

<table>
  <tr>
    <th>Desktop</th>
    <th>Mobile</th>
  </tr>
  <tr>
    <td><img width="1624" height="662" alt="Screenshot 2026-05-04 at 17 27 57" src="https://github.com/user-attachments/assets/0f205835-b9a3-48bd-8b75-b78cf3d71f44" /></td>
    <td><img width="371" height="664" alt="Screenshot 2026-05-04 at 17 30 12" src="https://github.com/user-attachments/assets/a46a4471-05c6-4e3c-ab81-97f53e7bcce1" /></td>
  </tr>
</table>


**Banner behavior:**
- **✕ (close)** — permanently dismisses the banner (`ppcp_agentic_banner_dismissed`)
- **Remind me later** — snoozes for 7 days via a stored timestamp (`ppcp_agentic_banner_snoozed_until`); banner reappears automatically after the snooze expires
- **Apply for Early Access** — opens the survey URL in a new tab and records `ppcp_agentic_beta_status = applied`

**Eligibility (all conditions must be true):**
1. Merchant is connected to PayPal
2. A US shipping zone with active methods exists
3. At least 50 published products
4. At least 50 completed orders in the last 90 days
5. Banner is not currently snoozed
6. Banner has not been permanently dismissed

## Implementation

- New React component `AgenticBetaBanner` rendered conditionally in the settings screen
- New REST endpoint `AgenticBetaBannerEndpoint` with `/dismiss`, `/remind`, `/apply` routes
- New `AgenticBetaBannerEligibility` PHP service wired into `ScriptDataHandler` to expose the eligibility flag to JS via `ppcpSettings.isAgenticBetaBannerEligible`
- Generalized shared banner SCSS (previously migration-banner-specific)

## Test plan

- [ ] Ineligible store (non-US, <50 products, <50 orders) → banner not shown
- [ ] Eligible store → banner shown on all settings tabs
- [ ] Click ✕ → banner hidden permanently; `ppcp_agentic_banner_dismissed = 1` in DB
- [ ] Click "Remind me later" → banner hidden; `ppcp_agentic_banner_snoozed_until` set ~7 days from now; reappears after snooze expires
- [ ] Click "Apply for Early Access" → survey URL opens in new tab; `ppcp_agentic_beta_status = applied` in DB