### PR TITLE
Fix blueprint import fatal error and missing Fastlane/Pay Later options (5241)

### DIFF
--- a/modules/ppcp-compat/services.php
+++ b/modules/ppcp-compat/services.php
@@ -126,7 +126,9 @@ return array(
 		return new PayPalSettingsExporter();
 	},
 	'compat.blueprint.paypal_settings_importer'            => static function ( ContainerInterface $container ): PayPalSettingsImporter {
-		return new PayPalSettingsImporter();
+		return new PayPalSettingsImporter(
+			$container->get( 'settings.service.sanitizer' )
+		);
 	},
 	'compat.blueprint.bootstrap'                           => static function ( ContainerInterface $container ): PayPalBlueprintBootstrap {
 		return new PayPalBlueprintBootstrap(

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalBlueprintOptions.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalBlueprintOptions.php
@@ -28,14 +28,8 @@ class PayPalBlueprintOptions {
 		'woocommerce-ppcp-data-styling',
 		'woocommerce-ppcp-data-fastlane',
 		'woocommerce-ppcp-data-paylater-messaging',
-		// Legacy settings (maintained for backward compatibility during migration).
-		'woocommerce-ppcp-settings',
 		// Merchant state flags.
 		'woocommerce-ppcp-is-new-merchant',
-		// UI and migration state flags (prevent re-migration and control UI display).
-		'woocommerce_ppcp-settings-should-use-old-ui',
-		'woocommerce_ppcp-is_pay_later_settings_migrated',
-		'woocommerce_ppcp-is_smart_button_settings_migrated',
 		// Individual payment method settings (gateway titles/descriptions).
 		'woocommerce_venmo_settings',
 		'woocommerce_pay-later_settings',

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalBlueprintOptions.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalBlueprintOptions.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Shared list of PayPal options for Blueprint export/import.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
+
+/**
+ * Single source of truth for PayPal option names used in Blueprint export and import.
+ */
+class PayPalBlueprintOptions {
+
+	/**
+	 * PayPal-related options (excluding transients and plugin metadata).
+	 *
+	 * @var array<string>
+	 */
+	public const OPTION_NAMES = array(
+		// Core PPCP data settings (new settings).
+		'woocommerce-ppcp-data-common',
+		'woocommerce-ppcp-data-onboarding',
+		'woocommerce-ppcp-data-payment',
+		'woocommerce-ppcp-data-settings',
+		'woocommerce-ppcp-data-styling',
+		'woocommerce-ppcp-data-fastlane',
+		'woocommerce-ppcp-data-paylater-messaging',
+		// Legacy settings (maintained for backward compatibility during migration).
+		'woocommerce-ppcp-settings',
+		// Merchant state flags.
+		'woocommerce-ppcp-is-new-merchant',
+		// UI and migration state flags (prevent re-migration and control UI display).
+		'woocommerce_ppcp-settings-should-use-old-ui',
+		'woocommerce_ppcp-is_pay_later_settings_migrated',
+		'woocommerce_ppcp-is_smart_button_settings_migrated',
+		// Individual payment method settings (gateway titles/descriptions).
+		'woocommerce_venmo_settings',
+		'woocommerce_pay-later_settings',
+	);
+}

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
@@ -25,33 +25,6 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	private const OPTION_NOT_FOUND = '__PAYPAL_OPTION_NOT_FOUND__';
 
 	/**
-	 * PayPal-related options to export (excluding transients and plugin metadata).
-	 *
-	 * @var array<string>
-	 */
-	private const PAYPAL_OPTIONS = array(
-		// Core PPCP data settings (new settings).
-		'woocommerce-ppcp-data-common',
-		'woocommerce-ppcp-data-onboarding',
-		'woocommerce-ppcp-data-payment',
-		'woocommerce-ppcp-data-settings',
-		'woocommerce-ppcp-data-styling',
-		'woocommerce-ppcp-data-fastlane',
-		'woocommerce-ppcp-data-paylater-messaging',
-		// Legacy settings (maintained for backward compatibility during migration).
-		'woocommerce-ppcp-settings',
-		// Merchant state flags.
-		'woocommerce-ppcp-is-new-merchant',
-		// UI and migration state flags (prevent re-migration and control UI display).
-		'woocommerce_ppcp-settings-should-use-old-ui',
-		'woocommerce_ppcp-is_pay_later_settings_migrated',
-		'woocommerce_ppcp-is_smart_button_settings_migrated',
-		// Individual payment method settings (gateway titles/descriptions).
-		'woocommerce_venmo_settings',
-		'woocommerce_pay-later_settings',
-	);
-
-	/**
 	 * Export PayPal settings.
 	 *
 	 * @return Step
@@ -59,7 +32,7 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	public function export(): Step {
 		$paypal_options = array();
 
-		foreach ( self::PAYPAL_OPTIONS as $option_name ) {
+		foreach ( PayPalBlueprintOptions::OPTION_NAMES as $option_name ) {
 			$value = get_option( $option_name, self::OPTION_NOT_FOUND );
 			if ( self::OPTION_NOT_FOUND !== $value ) {
 				$paypal_options[ $option_name ] = $value;

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
@@ -36,6 +36,8 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 		'woocommerce-ppcp-data-payment',
 		'woocommerce-ppcp-data-settings',
 		'woocommerce-ppcp-data-styling',
+		'woocommerce-ppcp-data-fastlane',
+		'woocommerce-ppcp-data-paylater-messaging',
 		// Legacy settings (maintained for backward compatibility during migration).
 		'woocommerce-ppcp-settings',
 		// Merchant state flags.

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsExporter.php
@@ -11,7 +11,6 @@ namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
 
 use Automattic\WooCommerce\Blueprint\Exporters\StepExporter;
 use Automattic\WooCommerce\Blueprint\Exporters\HasAlias;
-use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
 use Automattic\WooCommerce\Blueprint\Steps\Step;
 
 /**
@@ -39,7 +38,7 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 			}
 		}
 
-		return new SetSiteOptions( $paypal_options );
+		return new SetPayPalSettings( $paypal_options );
 	}
 
 	/**
@@ -48,7 +47,7 @@ class PayPalSettingsExporter implements StepExporter, HasAlias {
 	 * @return string
 	 */
 	public function get_step_name(): string {
-		return SetSiteOptions::get_step_name();
+		return SetPayPalSettings::get_step_name();
 	}
 
 	/**

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
@@ -37,6 +37,8 @@ class PayPalSettingsImporter implements StepProcessor {
 		'woocommerce-ppcp-data-payment',
 		'woocommerce-ppcp-data-settings',
 		'woocommerce-ppcp-data-styling',
+		'woocommerce-ppcp-data-fastlane',
+		'woocommerce-ppcp-data-paylater-messaging',
 		// Legacy settings (maintained for backward compatibility during migration).
 		'woocommerce-ppcp-settings',
 		// Merchant state flags.

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
@@ -12,6 +12,8 @@ namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
 use Automattic\WooCommerce\Blueprint\StepProcessor;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
 use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\Settings\DTO\PayLaterMessagingDTO;
 
 /**
  * PayPal Settings Importer.
@@ -182,8 +184,11 @@ class PayPalSettingsImporter implements StepProcessor {
 	 * @return bool
 	 */
 	private function update_option_safely( string $option_name, $option_value ): bool {
-		// Convert objects to arrays recursively.
+		// Convert stdClass objects from JSON decode to arrays.
 		$option_value = $this->convert_objects_to_arrays( $option_value );
+
+		// Hydrate DTO-based options so typed objects are preserved in the database.
+		$option_value = $this->hydrate_dtos( $option_name, $option_value );
 
 		// Get the current value with a sentinel to distinguish between false and non-existent.
 		$current_value = get_option( $option_name, self::OPTION_NOT_FOUND );
@@ -194,6 +199,81 @@ class PayPalSettingsImporter implements StepProcessor {
 		}
 
 		return update_option( $option_name, $option_value );
+	}
+
+	/**
+	 * Hydrate DTO-based options so the data models can load them correctly.
+	 *
+	 * Some options store typed DTO objects (e.g. LocationStylingDTO). Blueprint
+	 * export serializes these to JSON objects, and on import they arrive as plain
+	 * arrays after convert_objects_to_arrays(). This method restores the proper
+	 * DTO instances before the value is written to the database.
+	 *
+	 * @param string $option_name  Option name.
+	 * @param mixed  $option_value Option value.
+	 * @return mixed
+	 */
+	private function hydrate_dtos( string $option_name, $option_value ) {
+		if ( 'woocommerce-ppcp-data-styling' === $option_name && is_array( $option_value ) ) {
+			$location_keys = array( 'cart', 'classic_checkout', 'express_checkout', 'mini_cart', 'product' );
+			foreach ( $location_keys as $key ) {
+				if ( isset( $option_value[ $key ] ) && is_array( $option_value[ $key ] ) ) {
+					$option_value[ $key ] = $this->array_to_location_styling_dto( $option_value[ $key ], $key );
+				}
+			}
+		}
+
+		if ( 'woocommerce-ppcp-data-paylater-messaging' === $option_name && is_array( $option_value ) ) {
+			$location_keys = array( 'cart', 'checkout', 'product', 'shop', 'home', 'custom_placement' );
+			foreach ( $location_keys as $key ) {
+				if ( isset( $option_value[ $key ] ) && is_array( $option_value[ $key ] ) ) {
+					$option_value[ $key ] = $this->array_to_pay_later_messaging_dto( $option_value[ $key ], $key );
+				}
+			}
+		}
+
+		return $option_value;
+	}
+
+	/**
+	 * Convert an array to a LocationStylingDTO instance.
+	 *
+	 * @param array  $data     The array data.
+	 * @param string $location The location key.
+	 * @return LocationStylingDTO
+	 */
+	private function array_to_location_styling_dto( array $data, string $location ): LocationStylingDTO {
+		return new LocationStylingDTO(
+			$data['location'] ?? $location,
+			(bool) ( $data['enabled'] ?? true ),
+			(array) ( $data['methods'] ?? array() ),
+			(string) ( $data['shape'] ?? 'rect' ),
+			(string) ( $data['label'] ?? 'pay' ),
+			(string) ( $data['color'] ?? 'gold' ),
+			(string) ( $data['layout'] ?? 'vertical' ),
+			(bool) ( $data['tagline'] ?? false )
+		);
+	}
+
+	/**
+	 * Convert an array to a PayLaterMessagingDTO instance.
+	 *
+	 * @param array  $data     The array data.
+	 * @param string $location The location key.
+	 * @return PayLaterMessagingDTO
+	 */
+	private function array_to_pay_later_messaging_dto( array $data, string $location ): PayLaterMessagingDTO {
+		return new PayLaterMessagingDTO(
+			$data['location'] ?? $location,
+			(bool) ( $data['enabled'] ?? false ),
+			(string) ( $data['layout'] ?? 'text' ),
+			(string) ( $data['logo_type'] ?? 'inline' ),
+			(string) ( $data['logo_position'] ?? 'left' ),
+			(string) ( $data['text_color'] ?? 'black' ),
+			(string) ( $data['text_size'] ?? '12' ),
+			(string) ( $data['flex_color'] ?? 'black' ),
+			(string) ( $data['flex_ratio'] ?? '8x1' )
+		);
 	}
 
 	/**

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
@@ -11,7 +11,6 @@ namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
 
 use Automattic\WooCommerce\Blueprint\StepProcessor;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
-use Automattic\WooCommerce\Blueprint\Steps\SetSiteOptions;
 use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 use WooCommerce\PayPalCommerce\Settings\DTO\PayLaterMessagingDTO;
 
@@ -32,7 +31,7 @@ class PayPalSettingsImporter implements StepProcessor {
 	 * @return StepProcessorResult
 	 */
 	public function process( $schema ): StepProcessorResult {
-		$result = StepProcessorResult::success( SetSiteOptions::get_step_name() );
+		$result = StepProcessorResult::success( SetPayPalSettings::get_step_name() );
 
 		if ( ! isset( $schema->options ) || ! is_object( $schema->options ) ) {
 			$result->add_error( 'Invalid PayPal options data' );
@@ -62,10 +61,8 @@ class PayPalSettingsImporter implements StepProcessor {
 				continue;
 			}
 
-			// Check if this is a PayPal-related option.
+			// Only accept options from our allowlist.
 			if ( ! $this->is_paypal_option( $option_name ) ) {
-				$sanitized_name = sanitize_text_field( $option_name );
-				$result->add_warn( "Skipped non-PayPal option: {$sanitized_name}" );
 				continue;
 			}
 
@@ -78,7 +75,7 @@ class PayPalSettingsImporter implements StepProcessor {
 			}
 		}
 
-		$result->add_info( "Successfully imported {$imported_count} PayPal options" );
+		$result->add_info( "Successfully imported {$imported_count} options" );
 		return $result;
 	}
 
@@ -88,7 +85,7 @@ class PayPalSettingsImporter implements StepProcessor {
 	 * @return string
 	 */
 	public function get_step_class(): string {
-		return SetSiteOptions::class;
+		return SetPayPalSettings::class;
 	}
 
 	/**

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
@@ -26,33 +26,6 @@ class PayPalSettingsImporter implements StepProcessor {
 	private const OPTION_NOT_FOUND = '__PAYPAL_OPTION_NOT_FOUND__';
 
 	/**
-	 * Explicit list of PayPal options that can be imported.
-	 *
-	 * @var array<string>
-	 */
-	private const PAYPAL_OPTIONS = array(
-		// Core PPCP data settings (new settings).
-		'woocommerce-ppcp-data-common',
-		'woocommerce-ppcp-data-onboarding',
-		'woocommerce-ppcp-data-payment',
-		'woocommerce-ppcp-data-settings',
-		'woocommerce-ppcp-data-styling',
-		'woocommerce-ppcp-data-fastlane',
-		'woocommerce-ppcp-data-paylater-messaging',
-		// Legacy settings (maintained for backward compatibility during migration).
-		'woocommerce-ppcp-settings',
-		// Merchant state flags.
-		'woocommerce-ppcp-is-new-merchant',
-		// UI and migration state flags (prevent re-migration and control UI display).
-		'woocommerce_ppcp-settings-should-use-old-ui',
-		'woocommerce_ppcp-is_pay_later_settings_migrated',
-		'woocommerce_ppcp-is_smart_button_settings_migrated',
-		// Individual payment method settings (gateway titles/descriptions).
-		'woocommerce_venmo_settings',
-		'woocommerce_pay-later_settings',
-	);
-
-	/**
 	 * Process PayPal settings import.
 	 *
 	 * @param object $schema Schema object.
@@ -175,7 +148,7 @@ class PayPalSettingsImporter implements StepProcessor {
 	 * @return bool
 	 */
 	private function is_paypal_option( string $option_name ): bool {
-		return in_array( $option_name, self::PAYPAL_OPTIONS, true );
+		return in_array( $option_name, PayPalBlueprintOptions::OPTION_NAMES, true );
 	}
 
 	/**

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/PayPalSettingsImporter.php
@@ -11,8 +11,7 @@ namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
 
 use Automattic\WooCommerce\Blueprint\StepProcessor;
 use Automattic\WooCommerce\Blueprint\StepProcessorResult;
-use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
-use WooCommerce\PayPalCommerce\Settings\DTO\PayLaterMessagingDTO;
+use WooCommerce\PayPalCommerce\Settings\Service\DataSanitizer;
 
 /**
  * PayPal Settings Importer.
@@ -23,6 +22,22 @@ class PayPalSettingsImporter implements StepProcessor {
 	 * Sentinel value to detect if option doesn't exist.
 	 */
 	private const OPTION_NOT_FOUND = '__PAYPAL_OPTION_NOT_FOUND__';
+
+	/**
+	 * Data sanitizer for DTO hydration.
+	 *
+	 * @var DataSanitizer
+	 */
+	private DataSanitizer $sanitizer;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param DataSanitizer $sanitizer Data sanitizer.
+	 */
+	public function __construct( DataSanitizer $sanitizer ) {
+		$this->sanitizer = $sanitizer;
+	}
 
 	/**
 	 * Process PayPal settings import.
@@ -178,8 +193,17 @@ class PayPalSettingsImporter implements StepProcessor {
 	 *
 	 * Some options store typed DTO objects (e.g. LocationStylingDTO). Blueprint
 	 * export serializes these to JSON objects, and on import they arrive as plain
-	 * arrays after convert_objects_to_arrays(). This method restores the proper
-	 * DTO instances before the value is written to the database.
+	 * arrays after convert_objects_to_arrays(). This method uses DataSanitizer to
+	 * restore the proper DTO instances before writing to the database.
+	 *
+	 * @todo The blueprint importer currently hardcodes which options contain
+	 *       DTOs and which keys within them need hydration. This couples the
+	 *       importer to the internal structure of StylingSettings and
+	 *       PayLaterMessagingSettings. Consider having AbstractDataModel
+	 *       subclasses register their own hydration/sanitization logic so
+	 *       the importer can delegate without knowing the details. This
+	 *       would also make adding new DTO-based options automatic rather
+	 *       than requiring importer changes.
 	 *
 	 * @param string $option_name  Option name.
 	 * @param mixed  $option_value Option value.
@@ -189,8 +213,8 @@ class PayPalSettingsImporter implements StepProcessor {
 		if ( 'woocommerce-ppcp-data-styling' === $option_name && is_array( $option_value ) ) {
 			$location_keys = array( 'cart', 'classic_checkout', 'express_checkout', 'mini_cart', 'product' );
 			foreach ( $location_keys as $key ) {
-				if ( isset( $option_value[ $key ] ) && is_array( $option_value[ $key ] ) ) {
-					$option_value[ $key ] = $this->array_to_location_styling_dto( $option_value[ $key ], $key );
+				if ( isset( $option_value[ $key ] ) ) {
+					$option_value[ $key ] = $this->sanitizer->sanitize_location_style( $option_value[ $key ], $key );
 				}
 			}
 		}
@@ -198,54 +222,13 @@ class PayPalSettingsImporter implements StepProcessor {
 		if ( 'woocommerce-ppcp-data-paylater-messaging' === $option_name && is_array( $option_value ) ) {
 			$location_keys = array( 'cart', 'checkout', 'product', 'shop', 'home', 'custom_placement' );
 			foreach ( $location_keys as $key ) {
-				if ( isset( $option_value[ $key ] ) && is_array( $option_value[ $key ] ) ) {
-					$option_value[ $key ] = $this->array_to_pay_later_messaging_dto( $option_value[ $key ], $key );
+				if ( isset( $option_value[ $key ] ) ) {
+					$option_value[ $key ] = $this->sanitizer->sanitize_paylater_messaging( $option_value[ $key ], $key );
 				}
 			}
 		}
 
 		return $option_value;
-	}
-
-	/**
-	 * Convert an array to a LocationStylingDTO instance.
-	 *
-	 * @param array  $data     The array data.
-	 * @param string $location The location key.
-	 * @return LocationStylingDTO
-	 */
-	private function array_to_location_styling_dto( array $data, string $location ): LocationStylingDTO {
-		return new LocationStylingDTO(
-			$data['location'] ?? $location,
-			(bool) ( $data['enabled'] ?? true ),
-			(array) ( $data['methods'] ?? array() ),
-			(string) ( $data['shape'] ?? 'rect' ),
-			(string) ( $data['label'] ?? 'pay' ),
-			(string) ( $data['color'] ?? 'gold' ),
-			(string) ( $data['layout'] ?? 'vertical' ),
-			(bool) ( $data['tagline'] ?? false )
-		);
-	}
-
-	/**
-	 * Convert an array to a PayLaterMessagingDTO instance.
-	 *
-	 * @param array  $data     The array data.
-	 * @param string $location The location key.
-	 * @return PayLaterMessagingDTO
-	 */
-	private function array_to_pay_later_messaging_dto( array $data, string $location ): PayLaterMessagingDTO {
-		return new PayLaterMessagingDTO(
-			$data['location'] ?? $location,
-			(bool) ( $data['enabled'] ?? false ),
-			(string) ( $data['layout'] ?? 'text' ),
-			(string) ( $data['logo_type'] ?? 'inline' ),
-			(string) ( $data['logo_position'] ?? 'left' ),
-			(string) ( $data['text_color'] ?? 'black' ),
-			(string) ( $data['text_size'] ?? '12' ),
-			(string) ( $data['flex_color'] ?? 'black' ),
-			(string) ( $data['flex_ratio'] ?? '8x1' )
-		);
 	}
 
 	/**

--- a/modules/ppcp-compat/src/WooCommerceBlueprint/SetPayPalSettings.php
+++ b/modules/ppcp-compat/src/WooCommerceBlueprint/SetPayPalSettings.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Custom Blueprint step for PayPal settings.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat\WooCommerceBlueprint;
+
+use Automattic\WooCommerce\Blueprint\Steps\Step;
+
+/**
+ * Custom step that carries PayPal-specific options under its own step name,
+ * so it never collides with the core setSiteOptions processor.
+ */
+class SetPayPalSettings extends Step {
+
+	/**
+	 * PayPal options to export/import.
+	 *
+	 * @var array
+	 */
+	private array $options;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $options PayPal options.
+	 */
+	public function __construct( array $options = array() ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Get the step name.
+	 *
+	 * @return string
+	 */
+	public static function get_step_name(): string {
+		return 'setPayPalSettings';
+	}
+
+	/**
+	 * Get the schema for the step.
+	 *
+	 * @param int $version Schema version.
+	 * @return array
+	 */
+	public static function get_schema( int $version = 1 ): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'step'    => array(
+					'type' => 'string',
+					'enum' => array( static::get_step_name() ),
+				),
+				'options' => array(
+					'type'                 => 'object',
+					'additionalProperties' => new \stdClass(),
+				),
+			),
+			'required'   => array( 'step', 'options' ),
+		);
+	}
+
+	/**
+	 * Prepare the JSON array for the step.
+	 *
+	 * @return array
+	 */
+	public function prepare_json_array(): array {
+		return array(
+			'step'    => static::get_step_name(),
+			'options' => $this->options,
+		);
+	}
+}

--- a/modules/ppcp-settings/src/Data/PayLaterMessagingSettings.php
+++ b/modules/ppcp-settings/src/Data/PayLaterMessagingSettings.php
@@ -199,45 +199,19 @@ class PayLaterMessagingSettings extends AbstractDataModel {
 	}
 
 	/**
-	 * Sanitizes Pay Later messaging data.
+	 * Sanitizes Pay Later messaging data, overriding the enabled flag
+	 * based on the current messaging locations list.
 	 *
 	 * @param mixed   $data The messaging data to sanitize.
 	 * @param ?string $location Name of the location.
 	 * @return PayLaterMessagingDTO Sanitized messaging data.
 	 */
 	private function sanitize_paylater_messaging( $data, ?string $location = null ): PayLaterMessagingDTO {
-		if ( $data instanceof PayLaterMessagingDTO ) {
-			if ( $location ) {
-				$data->location = $location;
-			}
-			return $data;
-		}
+		$dto = $this->sanitizer->sanitize_paylater_messaging( $data, $location );
 
-		if ( is_object( $data ) ) {
-			$data = (array) $data;
-		}
+		$dto->enabled = in_array( $dto->location, $this->get_messaging_locations(), true );
 
-		if ( ! is_array( $data ) ) {
-			return new PayLaterMessagingDTO( $location ?? '' );
-		}
-
-		if ( null === $location ) {
-			$location = $data['location'] ?? '';
-		}
-
-		$enabled_locations = $this->get_messaging_locations();
-
-		return new PayLaterMessagingDTO(
-			$location,
-			in_array( $location, $enabled_locations, true ),
-			$this->sanitizer->sanitize_text( $data['layout'] ?? 'text' ),
-			$this->sanitizer->sanitize_text( $data['logo_type'] ?? $data['logo-type'] ?? 'inline' ),
-			$this->sanitizer->sanitize_text( $data['logo_position'] ?? $data['logo-position'] ?? 'left' ),
-			$this->sanitizer->sanitize_text( $data['text_color'] ?? $data['text-color'] ?? 'black' ),
-			$this->sanitizer->sanitize_text( $data['text_size'] ?? $data['text-size'] ?? '12' ),
-			$this->sanitizer->sanitize_text( $data['flex_color'] ?? $data['color'] ?? 'black' ),
-			$this->sanitizer->sanitize_text( $data['flex_ratio'] ?? $data['ratio'] ?? '8x1' )
-		);
+		return $dto;
 	}
 
 	private function maybe_migrate_from_legacy(): void {

--- a/modules/ppcp-settings/src/Service/DataSanitizer.php
+++ b/modules/ppcp-settings/src/Service/DataSanitizer.php
@@ -10,6 +10,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\Settings\Service;
 
 use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\Settings\DTO\PayLaterMessagingDTO;
 
 /**
  * DataSanitizer service. Generally used by REST endpoints (sanitize input data)
@@ -64,6 +65,47 @@ class DataSanitizer {
 			$color,
 			$layout,
 			$tagline
+		);
+	}
+
+	/**
+	 * Sanitizes the provided Pay Later messaging data.
+	 *
+	 * @param mixed   $data     The messaging data to sanitize.
+	 * @param ?string $location Name of the location.
+	 * @return PayLaterMessagingDTO Messaging data.
+	 */
+	public function sanitize_paylater_messaging( $data, ?string $location = null ): PayLaterMessagingDTO {
+		if ( $data instanceof PayLaterMessagingDTO ) {
+			if ( $location ) {
+				$data->location = $location;
+			}
+
+			return $data;
+		}
+
+		if ( is_object( $data ) ) {
+			$data = (array) $data;
+		}
+
+		if ( ! is_array( $data ) ) {
+			return new PayLaterMessagingDTO( $location ?? '' );
+		}
+
+		if ( null === $location ) {
+			$location = $data['location'] ?? '';
+		}
+
+		return new PayLaterMessagingDTO(
+			$location,
+			$this->sanitize_bool( $data['enabled'] ?? false ),
+			$this->sanitize_text( $data['layout'] ?? 'text' ),
+			$this->sanitize_text( $data['logo_type'] ?? $data['logo-type'] ?? 'inline' ),
+			$this->sanitize_text( $data['logo_position'] ?? $data['logo-position'] ?? 'left' ),
+			$this->sanitize_text( $data['text_color'] ?? $data['text-color'] ?? 'black' ),
+			$this->sanitize_text( $data['text_size'] ?? $data['text-size'] ?? '12' ),
+			$this->sanitize_text( $data['flex_color'] ?? $data['color'] ?? 'black' ),
+			$this->sanitize_text( $data['flex_ratio'] ?? $data['ratio'] ?? '8x1' )
 		);
 	}
 


### PR DESCRIPTION
### Description

Fixes blueprint import issues in the WooCommerce Blueprint integration:

1. **Fatal error on import** — Importing a blueprint caused `StylingSettings::get_mini_cart()` to return a plain array instead of `LocationStylingDTO`, crashing the site. The blueprint importer's `convert_objects_to_arrays()` stripped DTO type information before writing to the database. The importer now hydrates `LocationStylingDTO` and `PayLaterMessagingDTO` instances from raw arrays before storing.
2. **Fastlane and Pay Later Messaging not restored** — `woocommerce-ppcp-data-fastlane` and `woocommerce-ppcp-data-paylater-messaging` were missing from the export/import allowlist, so their settings were silently skipped.
3. **Duplicated options list** — The exporter and importer each maintained their own copy of the allowed options list. Extracted into a shared `PayPalBlueprintOptions::OPTION_NAMES` constant to prevent future drift.
4. **Removed legacy settings from blueprint** — Removed `woocommerce-ppcp-settings` and related migration flags (`woocommerce_ppcp-settings-should-use-old-ui`, `woocommerce_ppcp-is_pay_later_settings_migrated`, `woocommerce_ppcp-is_smart_button_settings_migrated`) from the export/import list, as legacy settings have been removed from the plugin.
5. **Custom blueprint step to avoid overriding core handler** — The exporter/importer previously used the `setSiteOptions` step name, which caused our importer to replace the core `ImportSetSiteOptions` processor via `Util::index_array` (last-wins). This silently broke import of all non-PayPal `setSiteOptions` entries (e.g. gateway enabled states, other WC settings). Introduced a custom `SetPayPalSettings` step so PayPal settings use their own step name (`setPayPalSettings`) and the core `setSiteOptions` handler remains intact.
6. **Centralized DTO sanitization** — Moved `PayLaterMessagingDTO` array-to-DTO conversion from `PayLaterMessagingSettings` into `DataSanitizer::sanitize_paylater_messaging()`, alongside the existing `sanitize_location_style()`. The blueprint importer now delegates to `DataSanitizer` instead of duplicating DTO construction logic.

### Steps to Test

1. Go to a site with PayPal Payments connected, Fastlane enabled, and WooCommerce Blueprint feature enabled
2. Go to WooCommerce > Settings > PayPal Payments > Expert Settings
3. Click Export in the Blueprint Export & Import block
4. Verify the downloaded JSON includes a `setPayPalSettings` step with `woocommerce-ppcp-data-fastlane` and `woocommerce-ppcp-data-styling` entries
5. Disable all PayPal payment gateways
6. Import the previously exported blueprint via WooCommerce > Settings > Advanced > Blueprint
7. Verify the site loads without fatal errors
8. Verify payment gateways are re-enabled after import
9. Verify PayPal Payments > Expert Settings reflects the imported configuration (Fastlane enabled, styling preserved)