### PR TITLE
Fix type casting for customer unique ID in session MD5 hash

### DIFF
--- a/modules/ppcp-axo/services.php
+++ b/modules/ppcp-axo/services.php
@@ -111,7 +111,7 @@ return array(
 		$session_id = '';
 		if ( isset( WC()->session ) && method_exists( WC()->session, 'get_customer_unique_id' ) ) {
 			$session_id = substr(
-				md5( WC()->session->get_customer_unique_id() ),
+				md5( (string) WC()->session->get_customer_unique_id() ),
 				0,
 				16
 			);


### PR DESCRIPTION



**Issue**: #

**Ticket**:

**Slack Thread**:

---

### Description

Fix PHP 8.0+ fatal error in `ppcp-axo/services.php` where `WC()->session->get_customer_unique_id()` returns an `int`, which is passed directly to `md5()`. PHP 8.0 made `md5()` strict — it no longer silently coerces non-string arguments — causing an uncaught `TypeError` that crashes the entire page on any request that boots WordPress (including WP-GraphQL product queries).



**Fix:** Cast the return value of `get_customer_unique_id()` to `string` before passing to `md5()`:

```php
// Before
$session_id = substr(md5(WC()->session->get_customer_unique_id()), 0, 16);

// After
$session_id = substr(md5((string) WC()->session->get_customer_unique_id()), 0, 16);
```
Version:  4.0.3

**File:** `modules/ppcp-axo/services.php`, line 70

**Error:**
```
PHP Fatal error: Uncaught TypeError: md5(): Argument #1 ($string) must be of type string, int given
in .../modules/ppcp-axo/services.php:70
Stack trace:
#0 .../services.php(70): md5()
#1 .../ReadOnlyContainer.php(46): WooCommerce\PayPalCommerce\Axo\AxoModule::WooCommerce\PayPalCommerce\Axo\{closure}()
#2 .../services.php(57): ReadOnlyContainer->get()
...
#8 wp-settings.php(764): do_action()
```

### Steps to Test

1. Set up a WordPress site running PHP 8.0 or higher with WooCommerce and this plugin active.
2. Ensure a WooCommerce session exists (e.g., visit any product page or the shop).
3. Trigger a page load that boots WordPress (e.g., visit any frontend page, or execute a WP-GraphQL product query).
4. Confirm the fatal error no longer appears in the PHP error log.
5. Verify checkout and Fastlane/AXO functionality is unaffected.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix PHP 8.0+ fatal `TypeError` in AXO/Fastlane insights service caused by passing an `int` return value of `get_customer_unique_id()` to `md5()`. Added explicit `(string)` cast to restore PHP 8 compatibility.

Closes # .
