### PR TITLE
fix(uninstall): clear `woocommerce_paypal_branded` flag on plugin uninstall (6299)

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -42,6 +42,13 @@ require $main_plugin_file;
 	$general_settings = $app_container->get( 'settings.data.general' );
 	assert( $general_settings instanceof GeneralSettings );
 
+	/**
+	 * Delete the branded flag unconditionally so reinstalling from a different
+	 * source (e.g. WordPress.org) does not silently re-enter branded-only mode.
+	 * Unlike most settings, this flag must be cleared on every uninstall — even
+	 * when the full-reset filter is off — because keeping it prevents merchants
+	 * from ever escaping branded-only mode without direct DB intervention.
+	 */
 	delete_option( 'woocommerce_paypal_branded' );
 
 	if ( $general_settings->reset_installation_path( 'plugin_uninstall' ) ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -42,6 +42,8 @@ require $main_plugin_file;
 	$general_settings = $app_container->get( 'settings.data.general' );
 	assert( $general_settings instanceof GeneralSettings );
 
+	delete_option( 'woocommerce_paypal_branded' );
+
 	if ( $general_settings->reset_installation_path( 'plugin_uninstall' ) ) {
 		$general_settings->save();
 	}


### PR DESCRIPTION
## Problem

When the plugin is installed via the WooCommerce Settings page, WooCommerce sets the `woocommerce_paypal_branded` option, which enables branded-only mode. On uninstall, this option is only removed when the full-reset filter (`woocommerce_paypal_payments_uninstall_full_reset`) is set to `true` — which defaults to `false` to preserve merchant settings.

As a result, reinstalling the plugin from the WordPress.org directory silently re-enters branded-only mode, with no way out short of direct DB intervention.

## Solution

Delete `woocommerce_paypal_branded` unconditionally in `uninstall.php`, outside the full-reset guard. This mirrors the existing unconditional `reset_installation_path` call and follows the same rationale: certain flags must always be cleared on uninstall regardless of whether settings are preserved.

## Steps to reproduce

1. Install the plugin via the WooCommerce Settings page (branded-only mode is activated)
2. Uninstall the plugin (no filter override)
3. Reinstall from the WordPress.org directory
4. Visit the plugin settings — branded-only mode should no longer be active