### PR TITLE
fix(blocks): show PayPal redirect gateway for subscription carts when vaulting is enabled (6291)

### DIFF
--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -238,7 +238,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		$smart_buttons_enabled = ! $this->use_place_order
 			&& $this->settings_status->is_smart_button_enabled_for_location( $script_data['context'] ?? 'block-checkout' );
 		$place_order_enabled   = ( $this->use_place_order || $this->add_place_order_method )
-			&& ! $this->subscription_helper->cart_contains_subscription();
+			&& ( ! $this->subscription_helper->cart_contains_subscription() || $script_data['can_save_vault_token'] );
 		$cart                  = WC()->cart;
 
 		return array(


### PR DESCRIPTION
 ## Problem                                                                                                                                                                                         
                  
The PayPal redirect gateway ("Proceed to PayPal") was unconditionally hidden in Block Checkout whenever a subscription product was in the cart. This was a legacy restriction added before vaulting support existed for the redirect flow — the intent was to prevent subscription renewals from breaking, since tokens could not be saved via that flow at the time.                                                                                                                               
                                                                                                                                                                                                     
That restriction was never lifted after vaulting support for the redirect gateway was introduced, leaving merchants unable to use the feature for subscription checkouts.                                                                                                                                                                            
   
  ## Solution                                                                                                                                                                                        
                  
Allow `placeOrderEnabled` to be `true` when the cart contains a subscription and vaulting ("Save PayPal and Venmo") is enabled. The existing JS guard (`blockEnabled = false`) continues to hide the gateway when vaulting is disabled, preserving the original protection.
                                                                                                                                                                                                     
  ## Steps to reproduce
                                                                                                                                                                                                     
  1. Enable "Save PayPal and Venmo" in PayPal settings
  2. Add a subscription product to the cart
  3. Navigate to Block Checkout
  4. **Before:** PayPal redirect gateway not visible                                                                                                                                                 
  5. **After:** PayPal redirect gateway appears in the payment methods list
