### PR TITLE
PayPal Subscriptions - Unsuccessfully payment when paypal subscription in cart from block checkout (6321)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
+++ b/modules/ppcp-api-client/src/Factory/PurchaseUnitFactory.php
@@ -242,9 +242,9 @@ class PurchaseUnitFactory {
 	 * @throws RuntimeException When JSON object is malformed.
 	 */
 	public function from_paypal_response( \stdClass $data ): ?PurchaseUnit {
-		if ( ! isset( $data->reference_id ) || ! is_string( $data->reference_id ) ) {
-			throw new RuntimeException( 'No reference ID given.' );
-		}
+		$reference_id = ( isset( $data->reference_id ) && is_string( $data->reference_id ) )
+			? $data->reference_id
+			: 'default';
 
 		$amount_data = $data->amount ?? null;
 		$amount      = $this->amount_factory->from_paypal_response( $amount_data );
@@ -286,7 +286,7 @@ class PurchaseUnitFactory {
 			$amount,
 			$items,
 			$shipping,
-			$data->reference_id,
+			$reference_id,
 			$description,
 			$custom_id,
 			$invoice_id,

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -438,26 +438,26 @@ class PurchaseUnitFactoryTest extends TestCase
 		$this->assertNull($unit->shipping());
 	}
 
-	public function test_from_paypal_response_needs_reference_id()
+	public function test_from_paypal_response_uses_default_reference_id_as_fallback()
 	{
+		$raw_amount = (object) ['amount' => 1];
+		$amount = Mockery::mock(Amount::class);
+
 		$testee = $this->create_testee(
-			Mockery::mock(AmountFactory::class),
+			$this->create_amount_factory_mock($amount, 'from_paypal_response', $raw_amount),
 			Mockery::mock(ItemFactory::class),
 			Mockery::mock(ShippingFactory::class)
 		);
 
 		$response = (object) [
 			'description' => 'description',
-			'customId' => 'customId',
-			'invoiceId' => 'invoiceId',
-			'softDescriptor' => 'softDescriptor',
-			'amount' => '',
+			'amount' => $raw_amount,
 			'items' => [],
-			'shipping' => '',
 		];
 
-		$this->expectException(\WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException::class);
-		$testee->from_paypal_response($response);
+		$unit = $testee->from_paypal_response($response);
+		$this->assertInstanceOf(PurchaseUnit::class, $unit);
+		$this->assertEquals('default', $unit->reference_id());
 	}
 
 	public function test_from_paypal_response_payments_get_appended()


### PR DESCRIPTION
This PR adds `default` to `reference_id` as fallback on PayPal subscription approval flow used by blocks checkout, it prevents the "No reference ID given." error on `ppc-approve-subscription` ajax endpoint.

### Steps To Reproduce
- Create subscription connected to plan
- Add this to cart and navigate to block checkout
- Click on PayPal button
- Observe payment can not be finished 