### PR TITLE
fix(applepay): include payment_source for Apple Pay express checkout orders (4107)

### DIFF
--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -240,7 +240,8 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 			'ppcp_create_order_request_body_data',
 			static function ( array $data, string $payment_method, array $request ) use ( $c ): array {
 
-				if ( $payment_method !== ApplePayGateway::ID ) {
+				$funding_source = $request['funding_source'] ?? '';
+				if ( $payment_method !== ApplePayGateway::ID && $funding_source !== 'apple_pay' ) {
 					return $data;
 				}
 


### PR DESCRIPTION
## Summary

When Apple Pay is used via express checkout (product or cart page), the WooCommerce payment method is set to `ppcp-gateway` rather than `ppcp-applepay`. The `ppcp_create_order_request_body_data` filter in `ApplepayModule` was gating on `payment_method === ApplePayGateway::ID` only, so `payment_source.apple_pay` was never added to the PayPal order creation request for express checkout flows.

This resulted in the PayPal order not carrying the Apple Pay payment source context (return/cancel URLs), which could cause the payment to not be recognized as an Apple Pay transaction in the  PayPal order.

The fix adds a `funding_source` fallback check. The Apple Pay JS sets `window.ppcpFundingSource = 'apple_pay'` before triggering order creation, so the backend receives `funding_source = 'apple_pay'` — this is used as the secondary condition to ensure `payment_source.apple_pay.experience_context` is injected for both flows.
