### PR TITLE
Render gateway button wrapper at same hook as PayPal on Classic Checkout (4299)

### DIFF
--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -191,10 +191,19 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 		);
 
 		add_action(
-			'woocommerce_review_order_after_submit',
-			function () {
-				// Wrapper ID: #ppc-button-ppcp-applepay.
-				echo '<div id="ppc-button-' . esc_attr( ApplePayGateway::ID ) . '"></div>';
+			'wp',
+			static function () {
+				$checkout_hook = (string) apply_filters(
+					'woocommerce_paypal_payments_checkout_button_renderer_hook',
+					'woocommerce_review_order_after_payment'
+				);
+				add_action(
+					$checkout_hook,
+					static function () {
+						// Wrapper ID: #ppc-button-ppcp-applepay.
+						echo '<div id="ppc-button-' . esc_attr( ApplePayGateway::ID ) . '"></div>';
+					}
+				);
 			}
 		);
 

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -246,9 +246,18 @@ class GooglepayModule implements ServiceModule, ExecutableModule {
 		);
 
 		add_action(
-			'woocommerce_review_order_after_submit',
-			function () {
-				echo '<div id="ppc-button-' . esc_attr( GooglePayGateway::ID ) . '"></div>';
+			'wp',
+			static function () {
+				$checkout_hook = (string) apply_filters(
+					'woocommerce_paypal_payments_checkout_button_renderer_hook',
+					'woocommerce_review_order_after_payment'
+				);
+				add_action(
+					$checkout_hook,
+					static function () {
+						echo '<div id="ppc-button-' . esc_attr( GooglePayGateway::ID ) . '"></div>';
+					}
+				);
 			}
 		);
 


### PR DESCRIPTION
### Description

The #ppc-button-ppcp-applepay and #ppc-button-ppcp-googlepay divs (the
  "Gateway" wrappers used by the JS on Classic Checkout) were registered on
  woocommerce_review_order_after_submit, which fires inside #payment.
  PayPal's button renders at woocommerce_review_order_after_payment (outside
  #payment), causing a visible position mismatch when Apple Pay and Google Pay
  are enabled as separate gateways.

  Move the checkout wrapper registration to a wp-deferred callback that
  resolves the hook via the woocommerce_paypal_payments_checkout_button_renderer_hook
  filter, defaulting to woocommerce_review_order_after_payment — identical to
  the PayPal button. The pay-for-order hook (woocommerce_pay_order_after_submit)
  is unchanged, as PayPal uses the same hook on that page.


### Steps to Test

- enable Apple Pay & Google Pay as a separate gateway
- navigate to Classic Checkout
- → observe Apple Pay & Google Pay buttons and PayPal buttons have same render positions with [Storefront](https://wordpress.org/themes/storefront/) theme


### Changelog Entry

> Render gateway button wrapper at same hook as PayPal on Classic Checkout 

Closes # .
