### PR TITLE
PayPal subscription - Debit & Credit Cards is not available for this order error (6323)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -79,12 +79,13 @@ class DisableGateways {
 			unset( $methods[ CardButtonGateway::ID ] );
 		}
 
+		$payment_gateways = WC()->payment_gateways;
 		if (
 			isset( $methods[ CreditCardGateway::ID ] )
 			&& $this->subscription_helper->cart_contains_paypal_subscription_product()
-			&& ! is_null( WC()->payment_gateways )
+			&& ! is_null( $payment_gateways )
 		) {
-			$cc_gateway = WC()->payment_gateways->payment_gateways()[ CreditCardGateway::ID ] ?? null;
+			$cc_gateway = $payment_gateways->payment_gateways()[ CreditCardGateway::ID ] ?? null;
 			if ( $cc_gateway && ! in_array( 'subscriptions', $cc_gateway->supports, true ) ) {
 				unset( $methods[ CreditCardGateway::ID ] );
 			}

--- a/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
+++ b/modules/ppcp-wc-gateway/src/Checkout/DisableGateways.php
@@ -79,6 +79,17 @@ class DisableGateways {
 			unset( $methods[ CardButtonGateway::ID ] );
 		}
 
+		if (
+			isset( $methods[ CreditCardGateway::ID ] )
+			&& $this->subscription_helper->cart_contains_paypal_subscription_product()
+			&& ! is_null( WC()->payment_gateways )
+		) {
+			$cc_gateway = WC()->payment_gateways->payment_gateways()[ CreditCardGateway::ID ] ?? null;
+			if ( $cc_gateway && ! in_array( 'subscriptions', $cc_gateway->supports, true ) ) {
+				unset( $methods[ CreditCardGateway::ID ] );
+			}
+		}
+
 		if ( ! $this->needs_to_disable_gateways() ) {
 			return $methods;
 		}

--- a/modules/ppcp-wc-payment-tokens/src/WcPaymentTokensModule.php
+++ b/modules/ppcp-wc-payment-tokens/src/WcPaymentTokensModule.php
@@ -20,6 +20,7 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 /**
  * Class WcPaymentTokensModule
@@ -102,6 +103,29 @@ class WcPaymentTokensModule implements ServiceModule, ExecutableModule {
 					foreach ( $tokens as $index => $token ) {
 						if ( $token instanceof PaymentTokenApplePay ) {
 							unset( $tokens[ $index ] );
+						}
+					}
+				}
+
+				// Exclude CC tokens when cart has a PayPal subscription product the CC gateway cannot support.
+				if (
+					( is_checkout() || is_cart() || is_product() )
+					&& ! $is_post
+					&& $container->has( 'wc-subscriptions.helper' )
+					&& ! is_null( WC()->payment_gateways )
+				) {
+					$subscription_helper = $container->get( 'wc-subscriptions.helper' );
+					if (
+						$subscription_helper instanceof SubscriptionHelper
+						&& $subscription_helper->cart_contains_paypal_subscription_product()
+					) {
+						$cc_gateway = WC()->payment_gateways->payment_gateways()[ CreditCardGateway::ID ] ?? null;
+						if ( $cc_gateway && ! in_array( 'subscriptions', $cc_gateway->supports, true ) ) {
+							foreach ( $tokens as $index => $token ) {
+								if ( $token->get_gateway_id() === CreditCardGateway::ID ) {
+									unset( $tokens[ $index ] );
+								}
+							}
 						}
 					}
 				}

--- a/modules/ppcp-wc-payment-tokens/src/WcPaymentTokensModule.php
+++ b/modules/ppcp-wc-payment-tokens/src/WcPaymentTokensModule.php
@@ -108,18 +108,19 @@ class WcPaymentTokensModule implements ServiceModule, ExecutableModule {
 				}
 
 				// Exclude CC tokens when cart has a PayPal subscription product the CC gateway cannot support.
+				$payment_gateways = WC()->payment_gateways;
 				if (
 					( is_checkout() || is_cart() || is_product() )
 					&& ! $is_post
 					&& $container->has( 'wc-subscriptions.helper' )
-					&& ! is_null( WC()->payment_gateways )
+					&& ! is_null( $payment_gateways )
 				) {
 					$subscription_helper = $container->get( 'wc-subscriptions.helper' );
 					if (
 						$subscription_helper instanceof SubscriptionHelper
 						&& $subscription_helper->cart_contains_paypal_subscription_product()
 					) {
-						$cc_gateway = WC()->payment_gateways->payment_gateways()[ CreditCardGateway::ID ] ?? null;
+						$cc_gateway = $payment_gateways->payment_gateways()[ CreditCardGateway::ID ] ?? null;
 						if ( $cc_gateway && ! in_array( 'subscriptions', $cc_gateway->supports, true ) ) {
 							foreach ( $tokens as $index => $token ) {
 								if ( $token->get_gateway_id() === CreditCardGateway::ID ) {

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -356,6 +356,38 @@ class SubscriptionHelper {
 	}
 
 	/**
+	 * Whether the cart contains a PayPal-subscription product (subscriptions_api mode).
+	 *
+	 * @return bool
+	 */
+	public function cart_contains_paypal_subscription_product(): bool {
+		if ( ! $this->plugin_is_active() ) {
+			return false;
+		}
+
+		$cart = WC()->cart;
+		if ( ! $cart || empty( $cart->cart_contents ) ) {
+			return false;
+		}
+
+		foreach ( $cart->get_cart() as $item ) {
+			if ( ! isset( $item['data'] ) || ! is_a( $item['data'], WC_Product::class ) ) {
+				continue;
+			}
+
+			$product = $item['data'];
+			if (
+				in_array( $product->get_type(), array( 'subscription', 'variable-subscription' ), true )
+				&& $product->get_meta( '_ppcp_enable_subscription_product', true ) === 'yes'
+			) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Checks if any subscription products exist.
 	 *
 	 * @return bool


### PR DESCRIPTION
Logged-in customers with saved credit card tokens see "Debit & Credit Cards is not available for this order" error when checking out with a PayPal subscription product and vaulting is disabled. This happens because the CC gateway no longer declares subscriptions support without vaulting, but the saved tokens cause block checkout to auto-select it anyway.

This PR unsets the CC gateway from available payment methods and strip saved CC tokens from the checkout page when the cart contains a PayPal subscription product that the CC gateway cannot support (i.e., vaulting is off).