### PR TITLE
Auto-capture on status change not working for Checkout flow  (6117)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1138,6 +1138,8 @@ return array(
 			CardButtonGateway::ID,
 			OXXOGateway::ID,
 			AxoGateway::ID,
+			GooglePayGateway::ID,
+			ApplePayGateway::ID,
 		);
 	},
 	'wcgateway.gateway-repository'                         => static function ( ContainerInterface $container ): GatewayRepository {


### PR DESCRIPTION
Orders placed via Google Pay or Apple Pay on the standard checkout page were not auto-captured when the order status changed, even with the `woocommerce_paypal_payments_auto_capture_statuses` filter configured. 

The status-change handler checks if the order's payment method belongs to a known PPCP gateway before proceeding, but `ppcp-googlepay` and `ppcp-applepay` were missing from that allowlist (`wcgateway.ppcp-gateways`). Express button flows were unaffected because they force `payment_method = ppcp-gateway` on the WC order.

This PR adds `GooglePayGateway::ID` and `ApplePayGateway::ID` to the `wcgateway.ppcp-gateways` service in modules/ppcp-wc-gateway/services.php.