### PR TITLE
Allow ReplaceCart endpoint to (re)create token (5866)

### DIFF
--- a/modules/ppcp-store-sync/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/AgenticRestEndpoint.php
@@ -207,8 +207,8 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 		return $this->session_handler->create_cart_session( $cart, $ec_token );
 	}
 
-	protected function store_local_cart( string $cart_id, PayPalCart $cart ): bool {
-		return $this->session_handler->update_cart_session( $cart_id, $cart );
+	protected function store_local_cart( string $cart_id, PayPalCart $cart, ?string $ec_token = null ): bool {
+		return $this->session_handler->update_cart_session( $cart_id, $cart, $ec_token );
 	}
 
 	protected function flush_local_cart( string $cart_id ): bool {

--- a/modules/ppcp-store-sync/src/Endpoint/ReplaceCartEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/ReplaceCartEndpoint.php
@@ -56,13 +56,17 @@ class ReplaceCartEndpoint extends AgenticRestEndpoint {
 	/**
 	 * Replace an existing cart with new data.
 	 *
+	 * Per PayPal specs, the PUT endpoint may create a new PayPal order when:
+	 * - The cart doesn't have an ec_token yet (POST validation failed)
+	 * - The existing ec_token has expired
+	 *
 	 * @param WP_REST_Request $request The REST request.
 	 * @return WP_REST_Response The REST response.
 	 */
 	public function replace_cart( WP_REST_Request $request ): WP_REST_Response {
 		$cart_id = $request->get_param( 'cart_id' );
 
-		// Verify cart exists.
+		// Verify cart exists and get current session data.
 		$session = $this->get_stored_cart( $cart_id );
 
 		if ( $session instanceof AgenticError ) {
@@ -75,8 +79,24 @@ class ReplaceCartEndpoint extends AgenticRestEndpoint {
 			return $this->error( $store_cart );
 		}
 
-		// Replace the cart session (preserving ec_token).
-		$update_result = $this->store_local_cart( $cart_id, $store_cart->paypal_cart() );
+		// Determine if we need to create a new PayPal order.
+		$existing_token = $session['ec_token'] ?? '';
+		$new_token      = null;
+
+		if ( empty( $existing_token ) && $store_cart->validation()->is_empty() ) {
+			$new_token = $this->order_manager->create_order( $store_cart->paypal_cart() ) ?: null;
+
+			$this->logger->info(
+				'[REST] PUT created new PayPal order',
+				array(
+					'cart_id'   => $cart_id,
+					'new_token' => $new_token ?? '(none - order creation failed)',
+				)
+			);
+		}
+
+		// Update the cart session, passing new token when one was created.
+		$update_result = $this->store_local_cart( $cart_id, $store_cart->paypal_cart(), $new_token );
 
 		if ( ! $update_result ) {
 			return $this->error_not_found(
@@ -88,7 +108,11 @@ class ReplaceCartEndpoint extends AgenticRestEndpoint {
 			);
 		}
 
-		$store_cart->set_paypal_order( $session['ec_token'] );
+		// Only inject the token into the response when a new one was created.
+		if ( $new_token ) {
+			$store_cart->set_paypal_order( $new_token );
+		}
+
 		$response = $this->response_factory->from_cart( $store_cart, $cart_id );
 
 		return $this->cart_details( $response, 200 );

--- a/modules/ppcp-store-sync/src/Session/AgenticSessionHandler.php
+++ b/modules/ppcp-store-sync/src/Session/AgenticSessionHandler.php
@@ -108,11 +108,12 @@ class AgenticSessionHandler {
 	/**
 	 * Update an existing cart session.
 	 *
-	 * @param string     $session_id The session ID.
-	 * @param PayPalCart $cart       The updated cart.
+	 * @param string      $session_id The session ID.
+	 * @param PayPalCart  $cart       The updated cart.
+	 * @param string|null $ec_token   Optional new token; when omitted the existing token is kept.
 	 * @return bool True on success.
 	 */
-	public function update_cart_session( string $session_id, PayPalCart $cart ): bool {
+	public function update_cart_session( string $session_id, PayPalCart $cart, ?string $ec_token = null ): bool {
 		// Load the session first.
 		$existing = $this->load_cart_session( $session_id );
 		if ( ! $existing ) {
@@ -121,7 +122,7 @@ class AgenticSessionHandler {
 
 		$data = array(
 			'cart'     => $cart->to_array(),
-			'ec_token' => $existing['ec_token'],
+			'ec_token' => $ec_token ?? $existing['ec_token'],
 			'created'  => $existing['created'],
 			'modified' => time(),
 		);

--- a/tests/PHPUnit/StoreSync/Endpoint/ReplaceCartEndpointTest.php
+++ b/tests/PHPUnit/StoreSync/Endpoint/ReplaceCartEndpointTest.php
@@ -278,4 +278,400 @@ class ReplaceCartEndpointTest extends AgenticEndpointTestCase {
 		$this->assertNotSame( 200, $response->get_status() );
 		$this->assert_error_response( $data );
 	}
+
+	/**
+	 * GIVEN a cart session that has no ec_token (POST order creation had previously failed)
+	 * WHEN a PUT /merchant-cart/{id} request is made with a valid, issue-free cart
+	 * THEN create_order() is called to recover the missing PayPal order token
+	 * AND the response is a 200 with the new token injected into the payment method data
+	 */
+	public function test_creates_paypal_order_when_session_has_no_token_and_cart_is_valid(): void {
+		$cart_id      = 't_mock_cart_id_recover';
+		$created_time = time();
+		$new_token    = 'EC-NEWTOKEN-001';
+
+		$cart_data = $this->cart()->with_item_fixture( 'new_item_2' )->to_array();
+
+		$mocks           = $this->create_mocks();
+		$session_handler = $mocks['session_handler'];
+		$order_manager   = $mocks['order_manager'];
+
+		$existing_cart = PayPalCart::from_array( $cart_data, new StoreValidation() );
+
+		// Session has no ec_token — the previous POST failed to create a PayPal order.
+		$session_handler->allows( 'load_cart_session' )
+			->with( $cart_id )
+			->andReturn(
+				array(
+					'cart'     => $existing_cart,
+					'ec_token' => '',
+					'created'  => $created_time,
+				)
+			);
+
+		$session_handler->allows( 'update_cart_session' )->andReturn( true );
+
+		// The cart has no validation issues, so create_order MUST be called once.
+		$order_manager->shouldReceive( 'create_order' )
+			->once()
+			->andReturn( $new_token );
+
+		$mocks['validation_processor']->allows( 'validate_cart' )->andReturnUsing( fn( $c ) => $c );
+		$mocks['response_factory']->allows( 'from_cart' )
+			->andReturnUsing( fn( $cart, $id ) => \WooCommerce\PayPalCommerce\StoreSync\Response\CartResponse::create( $cart, $id ) );
+
+		// Build a StorePayPalCart mock that captures set_paypal_order.
+		$store_cart_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StorePayPalCart::class );
+		$store_cart_mock->allows( 'paypal_cart' )->andReturn( $existing_cart );
+		$store_cart_mock->allows( 'validation' )->andReturn( new StoreValidation() );
+		$store_cart_mock->allows( 'get_validation_issues' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_items' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_customer' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_shipping_address' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_billing_address' )->andReturn( null );
+		$store_cart_mock->allows( 'get_totals' )->andReturn( null );
+		$store_cart_mock->allows( 'get_payment_method' )->andReturn( array( 'type' => 'paypal', 'token' => $new_token ) );
+		$store_cart_mock->shouldReceive( 'set_paypal_order' )->with( $new_token )->once();
+
+		$store_data_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StoreData::class );
+		$store_data_mock->allows( 'create_cart' )->andReturn( $store_cart_mock );
+		$mocks['store_data'] = $store_data_mock;
+
+		$endpoint = new ReplaceCartEndpoint(
+			$mocks['auth_provider'],
+			$session_handler,
+			$mocks['session_manager'],
+			$mocks['response_factory'],
+			$mocks['validation_processor'],
+			$mocks['logger'],
+			$order_manager,
+			$store_data_mock
+		);
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $cart_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * GIVEN a cart session that already has a valid ec_token from a previous successful POST
+	 * WHEN a PUT /merchant-cart/{id} request arrives
+	 * THEN create_order() is NOT called (the existing token must be preserved)
+	 * AND set_paypal_order() is NOT called on the cart (response must not mention existing tokens)
+	 */
+	public function test_does_not_create_paypal_order_when_session_already_has_token(): void {
+		$cart_id        = 't_mock_cart_id_has_token';
+		$existing_token = 'EC-EXISTING-TOKEN';
+		$created_time   = time();
+
+		$cart_data = $this->cart()->with_item_fixture( 'new_item_2' )->to_array();
+
+		$mocks           = $this->create_mocks();
+		$session_handler = $mocks['session_handler'];
+		$order_manager   = $mocks['order_manager'];
+
+		$existing_cart = PayPalCart::from_array( $cart_data, new StoreValidation() );
+
+		// Session already holds a valid token.
+		$session_handler->allows( 'load_cart_session' )
+			->with( $cart_id )
+			->andReturn(
+				array(
+					'cart'     => $existing_cart,
+					'ec_token' => $existing_token,
+					'created'  => $created_time,
+				)
+			);
+
+		$session_handler->allows( 'update_cart_session' )->andReturn( true );
+
+		// create_order must never be called when the session already has a token.
+		$order_manager->shouldNotReceive( 'create_order' );
+
+		$mocks['validation_processor']->allows( 'validate_cart' )->andReturnUsing( fn( $c ) => $c );
+		$mocks['response_factory']->allows( 'from_cart' )
+			->andReturnUsing( fn( $cart, $id ) => \WooCommerce\PayPalCommerce\StoreSync\Response\CartResponse::create( $cart, $id ) );
+
+		$store_cart_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StorePayPalCart::class );
+		$store_cart_mock->allows( 'paypal_cart' )->andReturn( $existing_cart );
+		$store_cart_mock->allows( 'validation' )->andReturn( new StoreValidation() );
+		$store_cart_mock->allows( 'get_validation_issues' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_items' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_customer' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_shipping_address' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_billing_address' )->andReturn( null );
+		$store_cart_mock->allows( 'get_totals' )->andReturn( null );
+		$store_cart_mock->allows( 'get_payment_method' )->andReturn( array( 'type' => 'paypal' ) );
+		// set_paypal_order must not be called — response must not mention the existing token.
+		$store_cart_mock->shouldNotReceive( 'set_paypal_order' );
+
+		$store_data_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StoreData::class );
+		$store_data_mock->allows( 'create_cart' )->andReturn( $store_cart_mock );
+
+		$endpoint = new ReplaceCartEndpoint(
+			$mocks['auth_provider'],
+			$session_handler,
+			$mocks['session_manager'],
+			$mocks['response_factory'],
+			$mocks['validation_processor'],
+			$mocks['logger'],
+			$order_manager,
+			$store_data_mock
+		);
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $cart_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * GIVEN a cart session with no ec_token
+	 * WHEN a PUT request arrives but the cart has validation issues (e.g. out-of-stock item)
+	 * THEN create_order() is NOT called (a broken cart must not create a PayPal order)
+	 * AND the response is still 200 (validation issues are surfaced in the payload, not as HTTP errors)
+	 */
+	public function test_does_not_create_paypal_order_when_cart_has_validation_issues(): void {
+		$cart_id      = 't_mock_cart_id_invalid';
+		$created_time = time();
+
+		$cart_data = $this->cart()->with_item_fixture( 'new_item_2' )->to_array();
+
+		$mocks           = $this->create_mocks();
+		$session_handler = $mocks['session_handler'];
+		$order_manager   = $mocks['order_manager'];
+
+		$existing_cart = PayPalCart::from_array( $cart_data, new StoreValidation() );
+
+		// Session has no ec_token.
+		$session_handler->allows( 'load_cart_session' )
+			->with( $cart_id )
+			->andReturn(
+				array(
+					'cart'     => $existing_cart,
+					'ec_token' => '',
+					'created'  => $created_time,
+				)
+			);
+
+		$session_handler->allows( 'update_cart_session' )->andReturn( true );
+
+		// Cart has a validation issue — create_order must never be called.
+		$order_manager->shouldNotReceive( 'create_order' );
+
+		$mocks['validation_processor']->allows( 'validate_cart' )->andReturnUsing( fn( $c ) => $c );
+		$mocks['response_factory']->allows( 'from_cart' )
+			->andReturnUsing( fn( $cart, $id ) => \WooCommerce\PayPalCommerce\StoreSync\Response\CartResponse::create( $cart, $id ) );
+
+		// Build a validation with at least one issue.
+		$validation_with_issue = new StoreValidation();
+		$validation_with_issue->add_invalid_product( 'Item is out of stock' );
+
+		$store_cart_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StorePayPalCart::class );
+		$store_cart_mock->allows( 'paypal_cart' )->andReturn( $existing_cart );
+		$store_cart_mock->allows( 'validation' )->andReturn( $validation_with_issue );
+		$store_cart_mock->allows( 'get_validation_issues' )->andReturn( $validation_with_issue->all() );
+		$store_cart_mock->allows( 'get_items' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_customer' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_shipping_address' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_billing_address' )->andReturn( null );
+		$store_cart_mock->allows( 'get_totals' )->andReturn( null );
+		$store_cart_mock->allows( 'get_payment_method' )->andReturn( array( 'type' => 'paypal' ) );
+		$store_cart_mock->shouldNotReceive( 'set_paypal_order' );
+
+		$store_data_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StoreData::class );
+		$store_data_mock->allows( 'create_cart' )->andReturn( $store_cart_mock );
+
+		$endpoint = new ReplaceCartEndpoint(
+			$mocks['auth_provider'],
+			$session_handler,
+			$mocks['session_manager'],
+			$mocks['response_factory'],
+			$mocks['validation_processor'],
+			$mocks['logger'],
+			$order_manager,
+			$store_data_mock
+		);
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $cart_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * GIVEN a cart session with no ec_token and a valid cart
+	 * WHEN create_order() succeeds and returns a new token
+	 * THEN update_cart_session() is called with that new token as the third argument
+	 * AND the new token is persisted in the session for future requests
+	 */
+	public function test_new_token_is_stored_in_session_when_created(): void {
+		$cart_id      = 't_mock_cart_id_persist';
+		$created_time = time();
+		$new_token    = 'EC-STORED-TOKEN-999';
+
+		$cart_data = $this->cart()->with_item_fixture( 'new_item_2' )->to_array();
+
+		$mocks           = $this->create_mocks();
+		$session_handler = $mocks['session_handler'];
+		$order_manager   = $mocks['order_manager'];
+
+		$existing_cart = PayPalCart::from_array( $cart_data, new StoreValidation() );
+
+		$session_handler->allows( 'load_cart_session' )
+			->with( $cart_id )
+			->andReturn(
+				array(
+					'cart'     => $existing_cart,
+					'ec_token' => '',
+					'created'  => $created_time,
+				)
+			);
+
+		// The new token must be forwarded to update_cart_session as the third argument.
+		$session_handler->shouldReceive( 'update_cart_session' )
+			->once()
+			->withArgs(
+				function ( $received_id, $received_cart, $received_token ) use ( $cart_id, $new_token ) {
+					return $received_id === $cart_id
+						&& $received_cart instanceof PayPalCart
+						&& $received_token === $new_token;
+				}
+			)
+			->andReturn( true );
+
+		$order_manager->allows( 'create_order' )->andReturn( $new_token );
+
+		$mocks['validation_processor']->allows( 'validate_cart' )->andReturnUsing( fn( $c ) => $c );
+		$mocks['response_factory']->allows( 'from_cart' )
+			->andReturnUsing( fn( $cart, $id ) => \WooCommerce\PayPalCommerce\StoreSync\Response\CartResponse::create( $cart, $id ) );
+
+		$store_cart_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StorePayPalCart::class );
+		$store_cart_mock->allows( 'paypal_cart' )->andReturn( $existing_cart );
+		$store_cart_mock->allows( 'validation' )->andReturn( new StoreValidation() );
+		$store_cart_mock->allows( 'get_validation_issues' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_items' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_customer' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_shipping_address' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_billing_address' )->andReturn( null );
+		$store_cart_mock->allows( 'get_totals' )->andReturn( null );
+		$store_cart_mock->allows( 'get_payment_method' )->andReturn( array( 'type' => 'paypal', 'token' => $new_token ) );
+		$store_cart_mock->allows( 'set_paypal_order' );
+
+		$store_data_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StoreData::class );
+		$store_data_mock->allows( 'create_cart' )->andReturn( $store_cart_mock );
+
+		$endpoint = new ReplaceCartEndpoint(
+			$mocks['auth_provider'],
+			$session_handler,
+			$mocks['session_manager'],
+			$mocks['response_factory'],
+			$mocks['validation_processor'],
+			$mocks['logger'],
+			$order_manager,
+			$store_data_mock
+		);
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $cart_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * GIVEN a cart session with no ec_token and a valid cart
+	 * WHEN create_order() fails and returns an empty/falsy value
+	 * THEN set_paypal_order() is NOT called on the cart (no broken token in response)
+	 * AND the session update proceeds without a token (null passed as third argument)
+	 * AND the response is still 200
+	 */
+	public function test_no_token_set_on_cart_when_order_creation_fails(): void {
+		$cart_id      = 't_mock_cart_id_fail_order';
+		$created_time = time();
+
+		$cart_data = $this->cart()->with_item_fixture( 'new_item_2' )->to_array();
+
+		$mocks           = $this->create_mocks();
+		$session_handler = $mocks['session_handler'];
+		$order_manager   = $mocks['order_manager'];
+
+		$existing_cart = PayPalCart::from_array( $cart_data, new StoreValidation() );
+
+		$session_handler->allows( 'load_cart_session' )
+			->with( $cart_id )
+			->andReturn(
+				array(
+					'cart'     => $existing_cart,
+					'ec_token' => '',
+					'created'  => $created_time,
+				)
+			);
+
+		// update_cart_session must receive null as token when order creation failed.
+		$session_handler->shouldReceive( 'update_cart_session' )
+			->once()
+			->withArgs(
+				function ( $received_id, $received_cart, $received_token ) use ( $cart_id ) {
+					return $received_id === $cart_id
+						&& $received_cart instanceof PayPalCart
+						&& $received_token === null;
+				}
+			)
+			->andReturn( true );
+
+		// create_order returns falsy — simulates API failure.
+		$order_manager->allows( 'create_order' )->andReturn( '' );
+
+		$mocks['validation_processor']->allows( 'validate_cart' )->andReturnUsing( fn( $c ) => $c );
+		$mocks['response_factory']->allows( 'from_cart' )
+			->andReturnUsing( fn( $cart, $id ) => \WooCommerce\PayPalCommerce\StoreSync\Response\CartResponse::create( $cart, $id ) );
+
+		$store_cart_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StorePayPalCart::class );
+		$store_cart_mock->allows( 'paypal_cart' )->andReturn( $existing_cart );
+		$store_cart_mock->allows( 'validation' )->andReturn( new StoreValidation() );
+		$store_cart_mock->allows( 'get_validation_issues' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_items' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_customer' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_shipping_address' )->andReturn( array() );
+		$store_cart_mock->allows( 'get_billing_address' )->andReturn( null );
+		$store_cart_mock->allows( 'get_totals' )->andReturn( null );
+		$store_cart_mock->allows( 'get_payment_method' )->andReturn( array( 'type' => 'paypal' ) );
+		// No token must be injected into the cart response when order creation failed.
+		$store_cart_mock->shouldNotReceive( 'set_paypal_order' );
+
+		$store_data_mock = Mockery::mock( \WooCommerce\PayPalCommerce\StoreSync\StoreData\StoreData::class );
+		$store_data_mock->allows( 'create_cart' )->andReturn( $store_cart_mock );
+
+		$endpoint = new ReplaceCartEndpoint(
+			$mocks['auth_provider'],
+			$session_handler,
+			$mocks['session_manager'],
+			$mocks['response_factory'],
+			$mocks['validation_processor'],
+			$mocks['logger'],
+			$order_manager,
+			$store_data_mock
+		);
+
+		$request = new WP_REST_Request( 'PUT', "/wp-json/paypal/v1/merchant-cart/{$cart_id}" );
+		$request->set_param( 'cart_id', $cart_id );
+		$request->set_body( json_encode( $cart_data ) );
+
+		$response = $endpoint->replace_cart( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
 }

--- a/tests/PHPUnit/StoreSync/Session/AgenticSessionHandlerTest.php
+++ b/tests/PHPUnit/StoreSync/Session/AgenticSessionHandlerTest.php
@@ -1,0 +1,144 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\StoreSync\Session;
+
+use Mockery;
+use ReflectionProperty;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\StoreSync\Schema\PayPalCart;
+use WooCommerce\PayPalCommerce\StoreSync\Validation\StoreValidation;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\StoreSync\Session\AgenticSessionHandler
+ */
+class AgenticSessionHandlerTest extends TestCase {
+
+	/**
+	 * Build a minimal PayPalCart from a single-item payload so tests have a
+	 * real object to pass into update_cart_session().
+	 *
+	 * @return PayPalCart
+	 */
+	private function make_cart(): PayPalCart {
+		$data = array(
+			'items'          => array(
+				array(
+					'item_id'  => 'ITEM-001',
+					'quantity' => 1,
+					'price'    => array(
+						'currency_code' => 'USD',
+						'value'         => '10.00',
+					),
+				),
+			),
+			'payment_method' => array( 'type' => 'paypal' ),
+		);
+
+		return PayPalCart::from_array( $data, new StoreValidation() );
+	}
+
+	/**
+	 * Build a partial mock of AgenticSessionHandler whose constructor is bypassed,
+	 * and inject a mock AgenticWcSession via reflection.
+	 *
+	 * @param array  $existing_session   Data returned by load_cart_session().
+	 * @param string $session_id         The session ID used in the stub.
+	 * @return array{handler: AgenticSessionHandler, session: AgenticWcSession&\Mockery\MockInterface}
+	 */
+	private function make_handler_with_session( array $existing_session, string $session_id ): array {
+		/** @var AgenticSessionHandler&\Mockery\MockInterface $handler */
+		$handler = Mockery::mock( AgenticSessionHandler::class )->makePartial();
+
+		$handler->allows( 'load_cart_session' )
+			->with( $session_id )
+			->andReturn( $existing_session );
+
+		/** @var AgenticWcSession&\Mockery\MockInterface $session_mock */
+		$session_mock = Mockery::mock( AgenticWcSession::class );
+		$session_mock->allows( 'save_data' );
+
+		$ref = new ReflectionProperty( AgenticSessionHandler::class, 'session' );
+		$ref->setAccessible( true );
+		$ref->setValue( $handler, $session_mock );
+
+		return array(
+			'handler' => $handler,
+			'session' => $session_mock,
+		);
+	}
+
+	/**
+	 * GIVEN a cart session that already holds an ec_token
+	 * WHEN update_cart_session() is called without supplying a new token (null)
+	 * THEN the existing token is preserved in the data written to the session store
+	 * AND save_data() is called to persist the change
+	 */
+	public function test_update_preserves_existing_token_when_no_new_token_given(): void {
+		$session_id     = 't_session_preserve_token';
+		$existing_token = 'EC-OLD-TOKEN-123';
+		$cart           = $this->make_cart();
+
+		$existing_session = array(
+			'cart'     => $cart,
+			'ec_token' => $existing_token,
+			'created'  => 12345,
+		);
+
+		$parts   = $this->make_handler_with_session( $existing_session, $session_id );
+		$handler = $parts['handler'];
+		$session = $parts['session'];
+
+		$session->shouldReceive( 'set' )
+			->once()
+			->withArgs(
+				function ( $key, $data ) use ( $existing_token ) {
+					return $key === 'ppcp_agentic'
+						&& is_array( $data )
+						&& $data['ec_token'] === $existing_token;
+				}
+			);
+
+		$result = $handler->update_cart_session( $session_id, $cart );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * GIVEN a cart session that already holds an ec_token
+	 * WHEN update_cart_session() is called with a new token string
+	 * THEN the new token replaces the old one in the data written to the session store
+	 * AND the old token is no longer present in the persisted data
+	 */
+	public function test_update_replaces_token_when_new_token_is_provided(): void {
+		$session_id    = 't_session_replace_token';
+		$old_token     = 'EC-OLD-TOKEN-456';
+		$new_token     = 'EC-NEW-TOKEN-789';
+		$cart          = $this->make_cart();
+
+		$existing_session = array(
+			'cart'     => $cart,
+			'ec_token' => $old_token,
+			'created'  => 67890,
+		);
+
+		$parts   = $this->make_handler_with_session( $existing_session, $session_id );
+		$handler = $parts['handler'];
+		$session = $parts['session'];
+
+		$session->shouldReceive( 'set' )
+			->once()
+			->withArgs(
+				function ( $key, $data ) use ( $new_token, $old_token ) {
+					return $key === 'ppcp_agentic'
+						&& is_array( $data )
+						&& $data['ec_token'] === $new_token
+						&& $data['ec_token'] !== $old_token;
+				}
+			);
+
+		$result = $handler->update_cart_session( $session_id, $cart, $new_token );
+
+		$this->assertTrue( $result );
+	}
+}


### PR DESCRIPTION
_Replaces #4136_

### Description

Until now, only the "Create Cart" endpoint could create a new PayPal order to inject a ec_token into the API response.

Problems:
- When order creation failed, the session was permanently left without a token
- When the session expired in the DB, the next replace-cart call would have no token

Here we add a new mechanism, allowing the "Replace Cart" endpoint to generate a new PayPal order, in case the current session has no token yet/anymore.