### PR TITLE
Improve validation logic for filtered arrays (6398)

### DIFF
--- a/modules/ppcp-store-sync/src/CartValidation/CouponValidator/CouponValidator.php
+++ b/modules/ppcp-store-sync/src/CartValidation/CouponValidator/CouponValidator.php
@@ -147,8 +147,10 @@ class CouponValidator implements ValidatorInterface {
 		}
 
 		if ( ! wc_coupons_enabled() ) {
+			$first_coupon = reset( $coupons_to_apply );
+
 			return array(
-				$this->create_issue( 'COUPON_NOT_SUPPORTED', $coupons_to_apply[0]->code() ?? '', 'coupons', $store_cart, null ),
+				$this->create_issue( 'COUPON_NOT_SUPPORTED', $first_coupon->code() ?? '', 'coupons', $store_cart, null ),
 			);
 		}
 

--- a/modules/ppcp-store-sync/src/CartValidation/CurrencyValidator.php
+++ b/modules/ppcp-store-sync/src/CartValidation/CurrencyValidator.php
@@ -35,7 +35,7 @@ class CurrencyValidator implements ValidatorInterface {
 			return null;
 		}
 
-		$field = $mismatch[0];
+		$field = reset( $mismatch );
 
 		return ValidationIssue::create_currency_mismatch(
 			sprintf(


### PR DESCRIPTION
### Description

Addressed concern: **Array Index Crash on Filtered Array**

`array_filter()` preserves the original array keys. If index 0 was not the first mismatched element, `$mismatch[0]` is an undefined index, causing a notice or (in strict mode) a TypeError.