### PR TITLE
Fix DI service name for logger (6398)

### DIFF
--- a/modules/ppcp-store-sync/services.php
+++ b/modules/ppcp-store-sync/services.php
@@ -167,7 +167,7 @@ return array(
 			$c->get( 'agentic.helper.cart-builder' ),
 			$c->get( 'agentic.response.applied-coupons-builder' ),
 			$c->get( 'api.factory.shipping' ),
-			$c->get( 'agentic.logger' )
+			$c->get( 'agentic.logger.default' )
 		);
 	},
 


### PR DESCRIPTION
### Description

In a recent PR we renamed the DI service for the agentic logger, but another existing PR still introduced the old service name

Addressing this bug and renaming the logger service to use the now correct `agentic.logger.default` locator