### PR TITLE
Add PHP 7.4 compatibility (6398)

### DIFF
--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -143,7 +143,7 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		add_filter(
 			'woocommerce_paypal_payments_sdk_components_hook',
 			function ( array $components, string $context ) {
-				if ( str_ends_with( $context, '-block' ) ) {
+				if ( substr( $context, -6 ) === '-block' ) {
 					$components[] = 'buttons';
 				}
 

--- a/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CreateOrderEndpoint.php
@@ -563,7 +563,7 @@ class CreateOrderEndpoint implements EndpointInterface {
 				&& array_filter(
 					$exception->details(),
 					function ( stdClass $detail ): bool {
-						return isset( $detail->field ) && str_contains( (string) $detail->field, 'shipping/address' );
+						return isset( $detail->field ) && strpos( (string) $detail->field, 'shipping/address' ) !== false;
 					}
 				) ) {
 				$this->logger->info( 'Invalid shipping address for order creation, retrying without it.' );

--- a/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/LocalAlternativePaymentMethodsModule.php
@@ -542,7 +542,7 @@ class LocalAlternativePaymentMethodsModule implements ServiceModule, ExecutableM
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_uri = wp_unslash( $_SERVER['REQUEST_URI'] ?? '' );
 
-		return str_contains( $request_uri, '/wp-json/wc/' );
+		return strpos( $request_uri, '/wp-json/wc/' ) !== false;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Data/AbstractDataModel.php
+++ b/modules/ppcp-settings/src/Data/AbstractDataModel.php
@@ -121,7 +121,7 @@ abstract class AbstractDataModel {
 		$stripped_key      = $field_key;
 
 		foreach ( $prefixes_to_strip as $prefix ) {
-			if ( str_starts_with( $field_key, $prefix ) ) {
+			if ( 0 === strpos( $field_key, $prefix ) ) {
 				$stripped_key = substr( $field_key, strlen( $prefix ) );
 				break;
 			}

--- a/modules/ppcp-wc-gateway/src/Helper/CartCheckoutDetector.php
+++ b/modules/ppcp-wc-gateway/src/Helper/CartCheckoutDetector.php
@@ -149,6 +149,6 @@ class CartCheckoutDetector {
 		$page         = get_post( $page_id );
 		$page_content = is_object( $page ) ? $page->post_content : '';
 
-		return str_contains( $page_content, $shortcode );
+		return strpos( $page_content, $shortcode ) !== false;
 	}
 }


### PR DESCRIPTION
### Description

Not related to agentic/store sync, but discovered during code review of this module:

Several modules in the codebase already use PHP 8.0 string comparison functions. This PR converts those string functions to valid PHP 7.4 expressions to maintain the expected backwards compatibility.

| PHP 8 (found) | PHP 7.4 (expected) |
|--|--|
| `str_starts_with( $haystack, $needle )` | `strpos( $haystack, $needle ) === 0` |
| `str_ends_with( $haystack, $needle )` |  `substr( $haystack, - len($needle) ) === $needle )` |
| `str_contains( $haystack, $needle )` |  `strpos( $haystack, $needle ) !== false` |
