### PR TITLE
fix(pay-later-block): adjust placeholder timeout

### DIFF
--- a/modules/ppcp-paylater-block/resources/js/edit.test.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.test.js
@@ -31,7 +31,9 @@ const defaultConfig = {
 	vaultingEnabled: false,
 	placementEnabled: true,
 	payLaterSettingsUrl: '/wp-admin/paylater-settings',
-	ajax: { cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' } },
+	ajax: {
+		cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' },
+	},
 };
 
 const defaultProps = {
@@ -67,32 +69,36 @@ test( 'shows spinner while script params are loading', () => {
 
 	render( <Edit { ...defaultProps } /> );
 
-	expect( document.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+	expect(
+		document.querySelector( '.components-spinner' )
+	).toBeInTheDocument();
 } );
 
-test( 'shows placeholder after 5 seconds when script params never resolve', () => {
+test( 'shows placeholder after 10 seconds when script params never resolve', () => {
 	useScriptParams.mockReturnValue( null );
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.getByText(
 			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
 		)
 	).toBeInTheDocument();
-	expect( document.querySelector( '.components-spinner' ) ).not.toBeInTheDocument();
+	expect(
+		document.querySelector( '.components-spinner' )
+	).not.toBeInTheDocument();
 } );
 
-test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () => {
+test( 'shows placeholder after 10 seconds when PayPalMessages never renders', () => {
 	useScriptParams.mockReturnValue( {
 		url_params: { 'client-id': 'test' },
 	} );
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.getByText(
@@ -101,7 +107,7 @@ test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () 
 	).toBeInTheDocument();
 } );
 
-test( 'does not show placeholder when PayPalMessages renders within 5 seconds', () => {
+test( 'does not show placeholder when PayPalMessages renders within 10 seconds', () => {
 	useScriptParams.mockReturnValue( {
 		url_params: { 'client-id': 'test' },
 	} );
@@ -114,7 +120,7 @@ test( 'does not show placeholder when PayPalMessages renders within 5 seconds', 
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.queryByText( /Pay Later messaging preview unavailable/ )

--- a/modules/ppcp-paylater-block/resources/js/hooks/use-preview-timeout.js
+++ b/modules/ppcp-paylater-block/resources/js/hooks/use-preview-timeout.js
@@ -1,11 +1,13 @@
 import { useState, useEffect } from '@wordpress/element';
 
-export const PREVIEW_TIMEOUT_MS = 5000;
+export const PREVIEW_TIMEOUT_MS = 10000;
 
 /**
  * Flips to `true` once `timeoutMs` has elapsed without `loaded` becoming truthy.
  * Returns `false` if the preview loaded in time. Cleans up on unmount or when
  * `loaded` flips, so no setState-on-unmounted warnings.
+ * @param loaded
+ * @param timeoutMs
  */
 export function usePreviewTimeout( loaded, timeoutMs = PREVIEW_TIMEOUT_MS ) {
 	const [ timedOut, setTimedOut ] = useState( false );

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.test.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.test.js
@@ -24,14 +24,18 @@ jest.mock( '@paypal/react-paypal-js', () => ( {
 	PayPalMessages: jest.fn( () => null ),
 } ) );
 
-const { useScriptParams } = require( '@ppcp-paylater-block/hooks/script-params' );
+const {
+	useScriptParams,
+} = require( '@ppcp-paylater-block/hooks/script-params' );
 
 const defaultConfig = {
 	vaultingEnabled: false,
 	placementEnabled: true,
 	settingsUrl: '/wp-admin/settings',
 	payLaterSettingsUrl: '/wp-admin/paylater-settings',
-	ajax: { cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' } },
+	ajax: {
+		cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' },
+	},
 	config: {
 		cart: {
 			layout: 'text',
@@ -63,32 +67,36 @@ test( 'shows spinner while script params are loading', () => {
 
 	render( <Edit { ...defaultProps } /> );
 
-	expect( document.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+	expect(
+		document.querySelector( '.components-spinner' )
+	).toBeInTheDocument();
 } );
 
-test( 'shows placeholder after 5 seconds when script params never resolve', () => {
+test( 'shows placeholder after 10 seconds when script params never resolve', () => {
 	useScriptParams.mockReturnValue( null );
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.getByText(
 			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
 		)
 	).toBeInTheDocument();
-	expect( document.querySelector( '.components-spinner' ) ).not.toBeInTheDocument();
+	expect(
+		document.querySelector( '.components-spinner' )
+	).not.toBeInTheDocument();
 } );
 
-test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () => {
+test( 'shows placeholder after 10 seconds when PayPalMessages never renders', () => {
 	useScriptParams.mockReturnValue( {
 		url_params: { 'client-id': 'test' },
 	} );
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.getByText(
@@ -97,7 +105,7 @@ test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () 
 	).toBeInTheDocument();
 } );
 
-test( 'does not show placeholder when PayPalMessages renders within 5 seconds', () => {
+test( 'does not show placeholder when PayPalMessages renders within 10 seconds', () => {
 	useScriptParams.mockReturnValue( {
 		url_params: { 'client-id': 'test' },
 	} );
@@ -110,7 +118,7 @@ test( 'does not show placeholder when PayPalMessages renders within 5 seconds', 
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.queryByText( /Pay Later messaging preview unavailable/ )

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.test.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.test.js
@@ -24,14 +24,18 @@ jest.mock( '@paypal/react-paypal-js', () => ( {
 	PayPalMessages: jest.fn( () => null ),
 } ) );
 
-const { useScriptParams } = require( '@ppcp-paylater-block/hooks/script-params' );
+const {
+	useScriptParams,
+} = require( '@ppcp-paylater-block/hooks/script-params' );
 
 const defaultConfig = {
 	vaultingEnabled: false,
 	placementEnabled: true,
 	settingsUrl: '/wp-admin/settings',
 	payLaterSettingsUrl: '/wp-admin/paylater-settings',
-	ajax: { cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' } },
+	ajax: {
+		cart_script_params: { endpoint: '/wp-json/ppcp/cart-script-params' },
+	},
 	config: {
 		checkout: {
 			layout: 'text',
@@ -63,32 +67,36 @@ test( 'shows spinner while script params are loading', () => {
 
 	render( <Edit { ...defaultProps } /> );
 
-	expect( document.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+	expect(
+		document.querySelector( '.components-spinner' )
+	).toBeInTheDocument();
 } );
 
-test( 'shows placeholder after 5 seconds when script params never resolve', () => {
+test( 'shows placeholder after 10 seconds when script params never resolve', () => {
 	useScriptParams.mockReturnValue( null );
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.getByText(
 			'Pay Later messaging preview unavailable in editor. Messaging will display on the frontend when eligibility conditions are met.'
 		)
 	).toBeInTheDocument();
-	expect( document.querySelector( '.components-spinner' ) ).not.toBeInTheDocument();
+	expect(
+		document.querySelector( '.components-spinner' )
+	).not.toBeInTheDocument();
 } );
 
-test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () => {
+test( 'shows placeholder after 10 seconds when PayPalMessages never renders', () => {
 	useScriptParams.mockReturnValue( {
 		url_params: { 'client-id': 'test' },
 	} );
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.getByText(
@@ -97,7 +105,7 @@ test( 'shows placeholder after 5 seconds when PayPalMessages never renders', () 
 	).toBeInTheDocument();
 } );
 
-test( 'does not show placeholder when PayPalMessages renders within 5 seconds', () => {
+test( 'does not show placeholder when PayPalMessages renders within 10 seconds', () => {
 	useScriptParams.mockReturnValue( {
 		url_params: { 'client-id': 'test' },
 	} );
@@ -110,7 +118,7 @@ test( 'does not show placeholder when PayPalMessages renders within 5 seconds', 
 
 	render( <Edit { ...defaultProps } /> );
 
-	act( () => jest.advanceTimersByTime( 5000 ) );
+	act( () => jest.advanceTimersByTime( 10000 ) );
 
 	expect(
 		screen.queryByText( /Pay Later messaging preview unavailable/ )
@@ -118,7 +126,10 @@ test( 'does not show placeholder when PayPalMessages renders within 5 seconds', 
 } );
 
 test( 'shows vaulting warning when vaulting is enabled', () => {
-	global.PcpCheckoutPayLaterBlock = { ...defaultConfig, vaultingEnabled: true };
+	global.PcpCheckoutPayLaterBlock = {
+		...defaultConfig,
+		vaultingEnabled: true,
+	};
 	useScriptParams.mockReturnValue( null );
 
 	render( <Edit { ...defaultProps } /> );
@@ -129,7 +140,10 @@ test( 'shows vaulting warning when vaulting is enabled', () => {
 } );
 
 test( 'shows placement warning when placement is disabled', () => {
-	global.PcpCheckoutPayLaterBlock = { ...defaultConfig, placementEnabled: false };
+	global.PcpCheckoutPayLaterBlock = {
+		...defaultConfig,
+		placementEnabled: false,
+	};
 	useScriptParams.mockReturnValue( null );
 
 	render( <Edit { ...defaultProps } /> );


### PR DESCRIPTION
This PR increases the preview timeout for Pay Later messaging in the block checkout editor from 5 seconds to 10 seconds.

The preview placeholder was sometimes shown together with the actual Pay Later message, even when the merchant was connected and eligible. This happened because the PayPal message rendering could take longer than the existing 5-second timeout, causing the fallback placeholder to appear before the preview finished loading.