### PR TITLE
Reduce JWKS cache TTL (6398)

### DIFF
--- a/modules/ppcp-store-sync/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-store-sync/src/Auth/JwtAuthService.php
@@ -4,9 +4,12 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\StoreSync\Auth;
 
+use DomainException;
 use Exception;
+use InvalidArgumentException;
 use WP_Error;
 use Firebase\JWT\JWT;
+use Firebase\JWT\SignatureInvalidException;
 
 use WooCommerce\PayPalCommerce\StoreSync\Merchant\MerchantMetadataProvider;
 
@@ -46,8 +49,12 @@ class JwtAuthService {
 
 		try {
 			return JWT::decode( $jwt, $keys );
-		} catch ( Exception $exception ) {
-			return new WP_Error( 'invalid_jwt', $exception->getMessage(), array( 'status' => 401 ) );
+		} catch ( InvalidArgumentException $e ) {
+			return $this->key_unavailable( $e->getMessage() );
+		} catch ( DomainException $e ) {
+			return $this->malformed_token( $e->getMessage() );
+		} catch ( SignatureInvalidException | Exception $e ) {
+			return $this->invalid_jwt( $e->getMessage() );
 		}
 	}
 

--- a/modules/ppcp-store-sync/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-store-sync/src/Auth/JwtAuthService.php
@@ -41,7 +41,7 @@ class JwtAuthService {
 
 		$keys = $this->jwk_provider->keys();
 		if ( ! $keys ) {
-			return new WP_Error( 'key_unavailable', 'Could not retrieve public JWT key', array( 'status' => 503 ) );
+			return $this->key_unavailable( 'Could not retrieve public JWT key' );
 		}
 
 		try {
@@ -61,60 +61,36 @@ class JwtAuthService {
 	public function verify_claims( object $context, array $required_scopes ) {
 		// Verify issuer.
 		if ( ! isset( $context->iss ) || $context->iss !== self::EXPECTED_ISSUER ) {
-			return new WP_Error(
-				'invalid_issuer',
-				'Token issuer is not recognized',
-				array( 'status' => 401 )
-			);
+			return $this->invalid_payload( 'Token issuer is not recognized' );
 		}
 
 		// Verify required scopes are present.
 		$token_scopes = $context->scope ?? array();
 		if ( ! is_array( $token_scopes ) ) {
-			return new WP_Error(
-				'invalid_token',
-				'Token scopes are malformed',
-				array( 'status' => 401 )
-			);
+			return $this->invalid_payload( 'Token scopes are malformed' );
 		}
 
 		$missing_scopes = array_diff( $required_scopes, $token_scopes );
 		if ( ! empty( $missing_scopes ) ) {
-			return new WP_Error(
-				'insufficient_scope',
-				'Token does not have required permissions',
-				array( 'status' => 403 )
-			);
+			return $this->insufficient_scope( 'Token does not have required permissions' );
 		}
 
 		// Verify merchant ID matches.
 		$metadata = $this->metadata_provider->get_metadata();
 		if ( ! $metadata->paypal_merchant_id ) {
-			return new WP_Error(
-				'merchant_not_configured',
-				'Merchant ID is not configured',
-				array( 'status' => 500 )
-			);
+			return $this->merchant_not_configured( 'Merchant ID is not configured' );
 		}
 
 		$external_ids = $context->external_id ?? array();
 		if ( ! is_array( $external_ids ) ) {
-			return new WP_Error(
-				'invalid_token',
-				'Token merchant identifiers are malformed',
-				array( 'status' => 401 )
-			);
+			return $this->invalid_payload( 'Token merchant identifiers are malformed' );
 		}
 
 		$expected_id     = 'PayPal:' . $metadata->paypal_merchant_id;
 		$has_merchant_id = in_array( $expected_id, $external_ids, true );
 
 		if ( ! $has_merchant_id ) {
-			return new WP_Error(
-				'merchant_mismatch',
-				'Token is not valid for this merchant',
-				array( 'status' => 403 )
-			);
+			return $this->merchant_mismatch( 'Token is not valid for this merchant' );
 		}
 
 		return true;
@@ -128,22 +104,54 @@ class JwtAuthService {
 		$string_token = trim( $auth_header ?? '' );
 
 		if ( $string_token === '' ) {
-			return new WP_Error( 'missing_token', 'Please provide a valid token', array( 'status' => 401 ) );
+			return $this->missing_token( 'Please provide a valid token' );
 		}
 
 		if ( 0 !== stripos( $string_token, 'Bearer' ) ) {
-			return new WP_Error( 'invalid_jwt', 'Please provide a valid token', array( 'status' => 401 ) );
+			return $this->malformed_token( 'Please provide a valid token' );
 		}
 
 		$jwt = trim( (string) substr( $string_token, 6 ) );
 		if ( empty( $jwt ) ) {
-			return new WP_Error( 'missing_token', 'Bearer prefix without token found', array( 'status' => 401 ) );
+			return $this->missing_token( 'Bearer prefix without token found' );
 		}
 
 		if ( 2 !== substr_count( $jwt, '.' ) ) {
-			return new WP_Error( 'invalid_jwt', 'Wrong number of segments in the token', array( 'status' => 401 ) );
+			return $this->malformed_token( 'Wrong number of segments in the token' );
 		}
 
 		return $jwt;
+	}
+
+	private function missing_token( string $message ): WP_Error {
+		return new WP_Error( 'missing_token', $message, array( 'status' => 401 ) );
+	}
+
+	private function malformed_token( string $message ): WP_Error {
+		return new WP_Error( 'malformed_token', $message, array( 'status' => 401 ) );
+	}
+
+	private function invalid_jwt( string $message ): WP_Error {
+		return new WP_Error( 'invalid_jwt', $message, array( 'status' => 401 ) );
+	}
+
+	private function invalid_payload( string $message ): WP_Error {
+		return new WP_Error( 'invalid_payload', $message, array( 'status' => 401 ) );
+	}
+
+	private function merchant_mismatch( string $message ): WP_Error {
+		return new WP_Error( 'merchant_mismatch', $message, array( 'status' => 403 ) );
+	}
+
+	private function insufficient_scope( string $message ): WP_Error {
+		return new WP_Error( 'insufficient_scope', $message, array( 'status' => 403 ) );
+	}
+
+	private function merchant_not_configured( string $message ): WP_Error {
+		return new WP_Error( 'merchant_not_configured', $message, array( 'status' => 500 ) );
+	}
+
+	private function key_unavailable( string $message ): WP_Error {
+		return new WP_Error( 'key_unavailable', $message, array( 'status' => 503 ) );
 	}
 }

--- a/modules/ppcp-store-sync/src/Auth/JwtAuthService.php
+++ b/modules/ppcp-store-sync/src/Auth/JwtAuthService.php
@@ -50,6 +50,9 @@ class JwtAuthService {
 		try {
 			return JWT::decode( $jwt, $keys );
 		} catch ( InvalidArgumentException $e ) {
+			// Key object was empty or malformed — corrupt cache.
+			PayPalJwkProvider::flush();
+
 			return $this->key_unavailable( $e->getMessage() );
 		} catch ( DomainException $e ) {
 			return $this->malformed_token( $e->getMessage() );

--- a/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
@@ -111,6 +111,14 @@ class PayPalJwkProvider {
 	protected function fetch_jwks_from_remote(): ?array {
 		$remove_user_agent =
 			/**
+			 * Removes the user agent string from the remote request that fetches the
+			 * JWKS metadata from PayPal's domain.
+			 *
+			 * We discovered this requirement by trial and error:
+			 * The user-agent `WordPress/*` is rejected by PayPal's firewall, which returns
+			 * a 403 response. Instead of mocking a browser user agent, we decided to simply
+			 * send an empty user agent to bypass the firewall.
+			 *
 			 * @param mixed|array  $args
 			 * @param mixed|string $url
 			 * @return mixed|array

--- a/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
@@ -37,18 +37,26 @@ class PayPalJwkProvider {
 	private const EXPECTED_KEY_TYPE = 'RSA';
 
 	/**
-	 * Returns the first public key from PayPal's JWKS.
+	 * Returns all public keys from PayPal's JWKS, keyed by kid.
 	 *
-	 * @return Key|null The public key, or null on failure.
+	 * Returning the full set (not just the first key) allows JWT::decode to match
+	 * tokens by kid during key rotation, when PayPal publishes old and new keys
+	 * simultaneously.
+	 *
+	 * @return array<string, Key> Parsed keys, or empty array on failure.
 	 */
-	public function keys(): ?Key {
+	public function keys(): array {
 		$jwks = $this->get_jwks_data();
 
 		if ( ! $jwks ) {
-			return null;
+			return array();
 		}
 
-		return $this->parse_first_key( $jwks );
+		try {
+			return JWK::parseKeySet( $jwks, self::EXPECTED_ALGORITHM );
+		} catch ( Exception $e ) {
+			return array();
+		}
 	}
 
 	/**
@@ -166,44 +174,23 @@ class PayPalJwkProvider {
 	 * @return array Filtered entries.
 	 */
 	private function filter_jwks_keys( array $keys ): array {
-		return array_values(
-			array_filter(
-				$keys,
-				function ( $key ): bool {
-					if ( ! is_array( $key ) ) {
-						return false;
-					}
-					if ( ( $key['kty'] ?? '' ) !== self::EXPECTED_KEY_TYPE ) {
-						return false;
-					}
-					if ( isset( $key['alg'] ) && $key['alg'] !== self::EXPECTED_ALGORITHM ) {
-						return false;
-					}
-					return true;
+		$filtered_keys = array_filter(
+			$keys,
+			static function ( $key ): bool {
+				if ( ! is_array( $key ) ) {
+					return false;
 				}
-			)
-		);
-	}
-
-	/**
-	 * Parses the first key from the JWKS data.
-	 *
-	 * @param array $jwks The JWKS data containing keys array.
-	 * @return Key|null The first key, or null if parsing fails.
-	 */
-	private function parse_first_key( array $jwks ): ?Key {
-		try {
-			$keys = JWK::parseKeySet( $jwks, self::EXPECTED_ALGORITHM );
-
-			foreach ( $keys as $key ) {
-				if ( $key->getAlgorithm() === self::EXPECTED_ALGORITHM ) {
-					return $key;
+				if ( ( $key['kty'] ?? '' ) !== self::EXPECTED_KEY_TYPE ) {
+					return false;
 				}
+				if ( isset( $key['alg'] ) && $key['alg'] !== self::EXPECTED_ALGORITHM ) {
+					return false;
+				}
+
+				return true;
 			}
+		);
 
-			return null;
-		} catch ( Exception $exception ) {
-			return null;
-		}
+		return array_values( $filtered_keys );
 	}
 }

--- a/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
@@ -20,10 +20,10 @@ class PayPalJwkProvider {
 
 	/**
 	 * The JWKS endpoint is lightweight, returning a small JSON object.
-	 * We keep the TTL low (30 min) for safety: In case the JSON changes, the
+	 * We keep the TTL low (one hour) for safety: In case the JSON changes, the
 	 * agentic endpoint is not blocked for too long.
 	 */
-	private const TRANSIENT_TTL = 30 * MINUTE_IN_SECONDS;
+	private const TRANSIENT_TTL = 60 * MINUTE_IN_SECONDS;
 
 	private const JWKS_URL = 'https://www.paypal.ai/.well-known/jwks.json';
 

--- a/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
@@ -18,7 +18,12 @@ use Exception;
 class PayPalJwkProvider {
 	private const TRANSIENT_NAME = 'ppcp-ai-jwks';
 
-	private const TRANSIENT_TTL = 24 * HOUR_IN_SECONDS;
+	/**
+	 * The JWKS endpoint is lightweight, returning a small JSON object.
+	 * We keep the TTL low (one hour) for safety: In case the JSON changes, the
+	 * agentic endpoint is not blocked for too long.
+	 */
+	private const TRANSIENT_TTL = 30 * MINUTE_IN_SECONDS;
 
 	private const JWKS_URL = 'https://www.paypal.ai/.well-known/jwks.json';
 

--- a/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
@@ -20,7 +20,7 @@ class PayPalJwkProvider {
 
 	/**
 	 * The JWKS endpoint is lightweight, returning a small JSON object.
-	 * We keep the TTL low (one hour) for safety: In case the JSON changes, the
+	 * We keep the TTL low (30 min) for safety: In case the JSON changes, the
 	 * agentic endpoint is not blocked for too long.
 	 */
 	private const TRANSIENT_TTL = 30 * MINUTE_IN_SECONDS;

--- a/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
+++ b/modules/ppcp-store-sync/src/Auth/PayPalJwkProvider.php
@@ -23,7 +23,7 @@ class PayPalJwkProvider {
 	 * We keep the TTL low (one hour) for safety: In case the JSON changes, the
 	 * agentic endpoint is not blocked for too long.
 	 */
-	private const TRANSIENT_TTL = 60 * MINUTE_IN_SECONDS;
+	private const TRANSIENT_TTL = HOUR_IN_SECONDS;
 
 	private const JWKS_URL = 'https://www.paypal.ai/.well-known/jwks.json';
 

--- a/tests/PHPUnit/StoreSync/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/StoreSync/Auth/JwtAuthServiceTest.php
@@ -138,11 +138,11 @@ class JwtAuthServiceTest extends TestCase {
 			'bearer whitespace'      => array( 'Bearer   ', 'missing_token', 401, false ),
 
 			// Format and validation errors (401).
-			'not bearer format'      => array( 'NotBearerFormat', 'invalid_jwt', 401, false ),
+			'not bearer format'      => array( 'NotBearerFormat', 'malformed_token', 401, false ),
 			'invalid signature'      => array( 'Bearer ' . $invalid_jwt, 'invalid_jwt', 401, true ),
-			'malformed (1 segment)'  => array( 'Bearer randomgarbage', 'invalid_jwt', 401, true ),
-			'malformed (2 segments)' => array( 'Bearer invalid.token', 'invalid_jwt', 401, true ),
-			'malformed (4 segments)' => array( 'Bearer a.b.c.d', 'invalid_jwt', 401, true ),
+			'malformed (1 segment)'  => array( 'Bearer randomgarbage', 'malformed_token', 401, true ),
+			'malformed (2 segments)' => array( 'Bearer invalid.token', 'malformed_token', 401, true ),
+			'malformed (4 segments)' => array( 'Bearer a.b.c.d', 'malformed_token', 401, true ),
 			'expired token'          => array( 'Bearer ' . $expired_jwt, 'invalid_jwt', 401, true ),
 			'not yet valid token'    => array( 'Bearer ' . $future_jwt, 'invalid_jwt', 401, true ),
 		);
@@ -245,19 +245,19 @@ class JwtAuthServiceTest extends TestCase {
 			'wrong issuer'            => array(
 				'token_data'  => array( 'iss' => 'evil.com' ),
 				'merchant_id' => null,
-				'error_code'  => 'invalid_issuer',
+				'error_code'  => 'invalid_payload',
 				'http_status' => 401,
 			),
 			'empty issuer'            => array(
 				'token_data'  => array( 'iss' => '' ),
 				'merchant_id' => null,
-				'error_code'  => 'invalid_issuer',
+				'error_code'  => 'invalid_payload',
 				'http_status' => 401,
 			),
 			'issuer subdomain'        => array(
 				'token_data'  => array( 'iss' => 'sub.paypal.com' ),
 				'merchant_id' => null,
-				'error_code'  => 'invalid_issuer',
+				'error_code'  => 'invalid_payload',
 				'http_status' => 401,
 			),
 
@@ -273,13 +273,13 @@ class JwtAuthServiceTest extends TestCase {
 			'scope not array'         => array(
 				'token_data'  => array( 'scope' => 'cart' ),
 				'merchant_id' => null,
-				'error_code'  => 'invalid_token',
+				'error_code'  => 'invalid_payload',
 				'http_status' => 401,
 			),
 			'external_id not array'   => array(
 				'token_data'  => array( 'external_id' => 'PayPal:MERCHANT123' ),
 				'merchant_id' => 'MERCHANT123',
-				'error_code'  => 'invalid_token',
+				'error_code'  => 'invalid_payload',
 				'http_status' => 401,
 			),
 

--- a/tests/PHPUnit/StoreSync/Auth/JwtAuthServiceTest.php
+++ b/tests/PHPUnit/StoreSync/Auth/JwtAuthServiceTest.php
@@ -32,8 +32,9 @@ class JwtAuthServiceTest extends TestCase {
 		$jwk_provider      = Mockery::mock( PayPalJwkProvider::class );
 		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
 
+		$keys = $jwk_key !== null ? array( 'test-key' => $jwk_key ) : array();
 		$jwk_provider->allows( 'keys' )
-			->andReturn( $jwk_key );
+			->andReturn( $keys );
 		$metadata_provider->allows( 'get_metadata' )
 			->andReturn( $metadata );
 
@@ -158,7 +159,7 @@ class JwtAuthServiceTest extends TestCase {
 		$metadata_provider = Mockery::mock( MerchantMetadataProvider::class );
 
 		$jwk_provider->allows( 'keys' )
-			->andReturn( null );
+			->andReturn( array() );
 
 		$service = new JwtAuthService( $jwk_provider, $metadata_provider );
 		$result  = $service->get_token( 'Bearer some.valid.token' );
@@ -183,7 +184,7 @@ class JwtAuthServiceTest extends TestCase {
 		$key     = new Key( 'test-secret-key', 'HS256' );
 		$service = $this->create_service( null, $key );
 
-		$valid_jwt = JWT::encode( (array) $expected_payload, 'test-secret-key', 'HS256' );
+		$valid_jwt = JWT::encode( (array) $expected_payload, 'test-secret-key', 'HS256', 'test-key' );
 		$token     = $prefix . ' ' . $valid_jwt;
 
 		$result = $service->get_token( $token );

--- a/tests/PHPUnit/StoreSync/Auth/PayPalJwkProviderTest.php
+++ b/tests/PHPUnit/StoreSync/Auth/PayPalJwkProviderTest.php
@@ -8,9 +8,31 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\StoreSync\Auth;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use Firebase\JWT\JWT;
+use Firebase\JWT\JWK;
 use Firebase\JWT\Key;
 use Mockery;
 use function Brain\Monkey\Functions\when;
+
+/**
+ * A testable subclass that injects a fixture JWKS instead of fetching from remote or cache.
+ */
+class FixtureJwkProvider extends PayPalJwkProvider {
+
+	/** @var array */
+	private $fixture_jwks;
+
+	/**
+	 * @param array $fixture_jwks
+	 */
+	public function __construct( array $fixture_jwks ) {
+		$this->fixture_jwks = $fixture_jwks;
+	}
+
+	protected function get_jwks_data(): ?array {
+		return $this->fixture_jwks;
+	}
+}
 
 /**
  * @covers \WooCommerce\PayPalCommerce\StoreSync\Auth\PayPalJwkProvider
@@ -53,7 +75,8 @@ class PayPalJwkProviderTest extends TestCase {
 
 		$result = $this->provider->keys();
 
-		$this->assertInstanceOf( Key::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
 	}
 
 	/**
@@ -76,14 +99,15 @@ class PayPalJwkProviderTest extends TestCase {
 
 		$result = $this->provider->keys();
 
-		$this->assertInstanceOf( Key::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result );
 	}
 
 	/**
 	 * GIVEN no cached data exists
 	 * AND remote fetch fails
 	 * WHEN keys() is called
-	 * THEN should return null without caching
+	 * THEN should return empty array without caching
 	 */
 	public function test_returns_null_when_remote_fetch_fails(): void {
 		$this->provider->shouldReceive( 'cache_get' )
@@ -98,13 +122,13 @@ class PayPalJwkProviderTest extends TestCase {
 
 		$result = $this->provider->keys();
 
-		$this->assertNull( $result );
+		$this->assertSame( array(), $result );
 	}
 
 	/**
 	 * GIVEN remote returns JWKS with invalid key structure
 	 * WHEN keys() is called
-	 * THEN should return null
+	 * THEN should return empty array
 	 */
 	public function test_returns_null_when_parsing_fails(): void {
 		when( 'set_transient' )->justReturn( true );
@@ -120,6 +144,154 @@ class PayPalJwkProviderTest extends TestCase {
 
 		$result = $this->provider->keys();
 
-		$this->assertNull( $result );
+		$this->assertSame( array(), $result );
+	}
+
+	// ---------------------------------------------------------------------------
+	// Full-keyset regression test
+	// ---------------------------------------------------------------------------
+
+	/**
+	 * Two pre-generated 2048-bit RSA private keys (PKCS#8 PEM).
+	 * Generated once; stored as static fixtures to avoid runtime key generation.
+	 */
+	private static function rsa_private_key_1(): string {
+		return "-----BEGIN PRIVATE KEY-----\n" .
+			"MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCVtnxFGqZVq5PB\n" .
+			"slsvYNbYdWUBgmWeRortCcL1Mp5mfUkPgSh8nQcL36lWk+Lh/0b8bTEhGUtK/O1y\n" .
+			"q2SbSlryaLzeN6aIVJ6NyPIk2WoE067GBrjy0gAnknG19//G3irOsSt9sJlEHUHZ\n" .
+			"sa8hcd0lQbXtblK9lVCOfGLkMZIbisOLOGOBINZIafzkrFbupfSJ5T9akqSklfTT\n" .
+			"soREAQ/3hQ16CHyINU18ERpaquYJE//wE3MC7Y2dkH2I1WErt4voHGyASG8ZrfFg\n" .
+			"7n27V9cObYKhNSl+5Dh7XehaDVTYMlKNEk/6FMeAyjUu2s0f44oPyxC1LTmbWCKo\n" .
+			"RMDsUjttAgMBAAECggEAMWu2BhHQCsPC2NQJqdAr2/SUzTTAWskqnyjzxIFbLLX6\n" .
+			"4jVeqhQj+VVxzvSulq/wPO/Gogh5hF2N/KZ7ZY/cCd1tS2XPgX19gYxt8qAakVFX\n" .
+			"hmM9tlqAVo/PHaSqOHmqY+S0WJ9tWMDXtgcjqsStndjdN22NvquFliOVeYKrmo9o\n" .
+			"w3jtjrHG+khlmoPF7NBrLEHrKGW1TFC2tm4xtHsIcblxSy/odrR2YeWqFz0uEU6X\n" .
+			"YCLHQCWOcz8LCPziXnP33o1h5Ih/Rn/1ACeWJ08u2YzxsDfJXTUGGJ0HX6rYCNeR\n" .
+			"ECKhShJWaXX2WXKaaQVi7nXLPaPVqauzaW894WUeOQKBgQDJeitlqy309BWqKUqM\n" .
+			"AYj28IiJ7sZv8ma7EdoijCJrYxVS7nkXiox9sCpzln8LjFI8rL4X9UkMgKwbZGl3\n" .
+			"mG9hJ3eXPwTGSUwCAEHRnuiPg4u1VvHuTrTlU5uSCYzSjuvtD2So4FkMCDG4mfJ4\n" .
+			"Aw3mzJr1L+8Ovr/xWQiYiQofIwKBgQC+OjXZ8C3WUuSkfR95XVvxi3sOVQtBwneD\n" .
+			"s4o7xd8a81ELgCmP1/KjXsxPkYKTVxiEEKNYCWWRdPYC9Jez9Hnc3C1DzUtIRElH\n" .
+			"0V4AWmCs5bFRgDRltH/YqXw8vxe9t2ZS2GU9fhVgBrtfjMdX1raWgg+kAvhP8+/p\n" .
+			"TX/mNXmsLwKBgCRPWzDYd9DUiG8BQAkZYbi3QrQxDxwvwGnoXrqpLK7TzY0Do1kl\n" .
+			"xAoGzK/GKKFJKaz7qMqijwaszdel8gf2teP5e+kLF24w2Xzm1PXVQK5Uk8IbqEA9\n" .
+			"eQZ3Wesow3NTBJvVkVuKCyJK+8L8I6GTU1cL+sVDXT74C5mQZScwU12nAoGAIhdK\n" .
+			"iVk6zbsjULs/xb9Od/ZYQlRJZSqVwpuNfXLTrf/HGXmJeUbpLBAUK3pXXVJxiVF2\n" .
+			"BJQCiNPeNt9gxJZetI8c6ZbEFBpwy5cg8o0/4Bx177Y7LbLwaoLNShGxDoXsp5Iy\n" .
+			"apfK+t+Z+uC+5OYM6OI8LVd+6s07xKLn9fjFam8CgYBUBN+H8Q8nTtSsUqDwoeFf\n" .
+			"kJWk56Zy5UN4t4twE1ThrS1q/x3mtwG1XrEZ5b9XNRZQ4abn0s4C1wyqxH2EAvPg\n" .
+			"SJtidLzNhThb/rc/U+Z/+3EzviAHLRkRJEKdn5W5w9ohow8sx0tgc5rBspONHdaU\n" .
+			"/Fg/Nk2+bNnApuumCNQDig==\n" .
+			"-----END PRIVATE KEY-----\n";
+	}
+
+	private static function rsa_private_key_2(): string {
+		return "-----BEGIN PRIVATE KEY-----\n" .
+			"MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC2a9X92HI1OIHU\n" .
+			"f78B0nq6+Kkp+NjXvQFTxOtlPp+XC0uAXTF+a4Ss+6JpS3bPhb7LCWR7hI0JXWxp\n" .
+			"fIgcFQdXogWDc1idPKmTRG81Ie3jEtqc8VF3mB4DNrPw0x3GvEdPUiLc2ngZMuFL\n" .
+			"Nfn3QZIoJlngf/FOONBhx6DGa3CKWzJbPIAiQ6Wx49YzZvL034HOmp4axUb1LK9v\n" .
+			"LVSD0pG3CZMxyn4SrquHKlmj6XfXGPbgxjsWHKAw5OEyNYu5L5Czy8T9WollJiLp\n" .
+			"EJLKEo0BdDTvQnDF9geFb7xnewWuHsKNRKH9gwJ5Q1gDnLNCyVLoXuBLtCfVo68g\n" .
+			"U7vSsHyPAgMBAAECggEAD3LGZn7j/RnR9Nr0pATdG+Re/wzx4CNDb4KnpKVPAo2U\n" .
+			"UUSTIm+chsGwmVYos55R8APVnJg3EWn1+mDvbeFiA8vWx7EG+hnfCnerK0a6TJaW\n" .
+			"KOBO09/v+rmxN13JkcD0EQWVqjpeHVQvvBzQFF5bMEc/KUHsf4FUNFOhi+whVbYK\n" .
+			"x6c4iVuBaBN1AhyKwrK40ONWT0Vy7gWnOjxX/CSV79wkBYCjniNV0seXyjw5jzBp\n" .
+			"I9sc5DU9TQf4GKjwBIHN3Wir1CqQ9EcJsMAJWu6SBPPgiPvgApbH+rl+Tbja33S6\n" .
+			"ti/bkGGjgLHEUKH1GaL8FmHHQ2FeujoUJe8hoRneQQKBgQDf+BgFjk4GC2r6g7dO\n" .
+			"P6BtwlGji8UP1xIAZuZckw+lBtnDBPKzR+jbGtKOtnGJVNy5d/6A/Gfpz0SlppZ2\n" .
+			"ZS5u74BrAchsKInL4DuIBO0ybL3eaXpXiAU5phpjEvxMQwZgXzweFxaPXfMWBhTA\n" .
+			"4QLs1fNpGQeU5DMNUArzSPMiEQKBgQDQgpm5AY2evz+E/TLgzJwu6VB8+afUECWy\n" .
+			"RCswvtOeWHOIJIJ/2O+DkmC3AlEaWweMdQm+vo39N/Yo4aUkBZklfkAKJVfCVFHk\n" .
+			"1gOIR97r5nPZBRIhnZHZtBdmd1AcBYs61o1HGEbQ6XBQo9lq+W8MbpYCoUFfNUzp\n" .
+			"xRARf7UUnwKBgQCEgu37g4moS+Mcmwe+VSjfJ8RTpiOOzqnI8RjElwH/msEGgIv0\n" .
+			"BMzBren8I/ei0EHTvionOK9mh4pPE/Qb0puZaTyqkyB41bdJl77BKGEKn4nq6K9I\n" .
+			"0KJ+zEb6bUY2/MTuCgqwpupjIqvrUOfAgqDPbXqZqQRyVF3cN4pzDKtFcQKBgDZy\n" .
+			"M+PMVQej1tlKKHPs2ceiIuNPaZSFVuKSzFhhK+8IF7rwFad+pSRNH7YKA9WG+ZSi\n" .
+			"pxXIuljpuPx5115tm8zfh6dekujqjavcenWmlr4wogWEPnTKqWAYl5epBiEbDX0i\n" .
+			"sydiXnOE0VAtSMOXOHkdk0xCgUh0KY5NZ+G54DXvAoGAZfjZM+KPXjN7GQcnbhKB\n" .
+			"uGO0IHLTmaO9Clyz7/SZI9jT0+rWerXkqMsKYTmZvnE6fzZV+5BQ8SoQdvAcE8/M\n" .
+			"zpizdg7ZszkMBFXKf80Q+22j2npNGcx7UGxalgeETCOuLOyoZhQqIfCZFW8FSWp2\n" .
+			"NGa5riyDj9G5TqejoCeL9xs=\n" .
+			"-----END PRIVATE KEY-----\n";
+	}
+
+	/**
+	 * Extracts the JWK n (modulus) and e (exponent) components from a PEM private key.
+	 *
+	 * @param string $pem PEM-encoded private key.
+	 * @return array Associative array with 'n' and 'e' as base64url strings.
+	 */
+	private static function jwk_components_from_pem( string $pem ): array {
+		$res     = openssl_pkey_get_private( $pem );
+		$details = openssl_pkey_get_details( $res );
+		return array(
+			'n' => rtrim( strtr( base64_encode( $details['rsa']['n'] ), '+/', '-_' ), '=' ),
+			'e' => rtrim( strtr( base64_encode( $details['rsa']['e'] ), '+/', '-_' ), '=' ),
+		);
+	}
+
+	/**
+	 * Returns a JWKS fixture containing two RSA keys.
+	 *
+	 * @return array
+	 */
+	private static function two_key_jwks(): array {
+		$key1_components = self::jwk_components_from_pem( self::rsa_private_key_1() );
+		$key2_components = self::jwk_components_from_pem( self::rsa_private_key_2() );
+
+		return array(
+			'keys' => array(
+				array(
+					'kty' => 'RSA',
+					'kid' => 'key-1',
+					'use' => 'sig',
+					'alg' => 'RS256',
+					'n'   => $key1_components['n'],
+					'e'   => $key1_components['e'],
+				),
+				array(
+					'kty' => 'RSA',
+					'kid' => 'key-2',
+					'use' => 'sig',
+					'alg' => 'RS256',
+					'n'   => $key2_components['n'],
+					'e'   => $key2_components['e'],
+				),
+			),
+		);
+	}
+
+	/**
+	 * GIVEN a JWKS endpoint that advertises two RSA keys
+	 * WHEN keys() is called
+	 * THEN both keys must be present in the returned keyset
+	 * AND a JWT signed with the second key must be decodable using the keyset
+	 */
+	public function test_keys_returns_full_keyset_allowing_jwt_signed_with_second_key(): void {
+		$jwks     = self::two_key_jwks();
+		$provider = new FixtureJwkProvider( $jwks );
+
+		// Encode a JWT using the second key's private key, with kid='key-2'.
+		$payload = array(
+			'sub'  => 'regression-test',
+			'name' => 'second-key',
+			'iat'  => 1700000000,
+		);
+
+		$private_key_2 = openssl_pkey_get_private( self::rsa_private_key_2() );
+		$token         = JWT::encode( $payload, $private_key_2, 'RS256', 'key-2' );
+
+		$result = $provider->keys();
+
+		// We assert the contract: any key in the keyset must allow decoding the JWT.
+		$this->assertIsArray( $result, 'keys() must return an array of Key objects, not a single Key' );
+		$this->assertCount( 2, $result, 'Both keys from the JWKS must be present in the returned keyset' );
+
+		$decoded = JWT::decode( $token, $result );
+
+		$this->assertSame( 'regression-test', $decoded->sub );
+		$this->assertSame( 'second-key', $decoded->name );
 	}
 }


### PR DESCRIPTION
### Description

We query a JWKS file served by PayPal to authenticate incoming Cart API calls.

#### What it is

`JWKS` stands for JSON Web Key Set

It provides the public key to verify the authenticity of a signed JWT (JSON Web Token).

#### Why reducing the TTL

Until now, we cached the JWKS for 24 hours. Because typically it does not change.

Two failure modes can happen due to JWKS changes:
1. Old key in cache + attacker with compromised private key → forged JWTs accepted
2. Old key in cache + PayPal rotates to a new key → legitimate new JWTs rejected, blocking the Cart API

The first is a highly unlikely worst-case scenario, but vase 2 (regular key rotation) could happen more frequently.

We reduced the **TTL to one hour** to mitigate the window for potential problems caused by JWKS rotation

#### Cache control

When the `JwtAuthService` fails due to an invalid or missing key, the JWKS cache is now automatically flushed.

Since those keys can only come from PayPal from the hardcoded source URL (and never by a caller), this is a safe mechanism to auto-refresh the cache in case it becomes stale due to a key rotation.