### PR TITLE
[QA] fix: error handling and authorization token API requests

### DIFF
--- a/tests/qa/utils/paypal-api.ts
+++ b/tests/qa/utils/paypal-api.ts
@@ -30,20 +30,21 @@ export class PayPalApi {
 		data?: any
 	) => {
 		try {
+			const token = await this.getToken( merchant );
 			const response = await this.request[ requestType ](
 				this.apiBaseUrl + endPoint,
 				{
-					headers: createAuthHeader(
-						merchant.client_id,
-						merchant.client_secret
-					),
+					headers: {
+						Authorization: `Bearer ${ token }`,
+					},
 					data,
 				}
 			);
 
 			if ( ! ( await response.ok() ) ) {
+				const body = await response.text();
 				throw new Error(
-					`Request failed with status ${ await response.status() }`
+					`Request failed with status ${ await response.status() } for ${ endPoint }: ${ body }`
 				);
 			}
 
@@ -70,7 +71,11 @@ export class PayPalApi {
 				form: { grant_type: 'client_credentials' },
 			}
 		);
-		return ( await response.json() ).access_token;
+		const json = await response.json();
+		if ( ! response.ok() ) {
+			throw new Error( `getToken failed with status ${ response.status() }: ${ JSON.stringify( json ) }` );
+		}
+		return json.access_token;
 	};
 
 	/**


### PR DESCRIPTION
Switches from Basic auth to Bearer token for API requests, and improves error messages to include the endpoint name and response body when requests fail.