### PR TITLE
Consolidate agentic product data extraction (6403)

### DIFF
--- a/modules/ppcp-store-sync/services.php
+++ b/modules/ppcp-store-sync/services.php
@@ -136,8 +136,10 @@ return array(
 	},
 
 	// Helper services.
-	'agentic.helper.product-manager'               => static function (): ProductManager {
-		return new ProductManager();
+	'agentic.helper.product-manager'               => static function ( ContainerInterface $c ): ProductManager {
+		return new ProductManager(
+			$c->get( 'agentic.config.store-currency' )
+		);
 	},
 
 	'agentic.helper.session-manager'               => static function ( ContainerInterface $c ): AgenticSessionManager {

--- a/modules/ppcp-store-sync/services.php
+++ b/modules/ppcp-store-sync/services.php
@@ -317,7 +317,7 @@ return array(
 			$c->get( 'agentic.config.webhook_urls' ),
 			$c->get( 'agentic.merchant.provider' ),
 			$c->get( 'agentic.logger.ingestion' ),
-			$c->get( 'agentic.config.store-currency' )
+			$c->get( 'agentic.helper.product-manager' )
 		);
 	},
 

--- a/modules/ppcp-store-sync/src/Helper/ProductManager.php
+++ b/modules/ppcp-store-sync/src/Helper/ProductManager.php
@@ -2,7 +2,7 @@
 /**
  * Responsibility: WooCommerce Products
  *
- * Unified helper for WooCommerce product resolution and stock checking.
+ * Unified helper for WooCommerce product resolution, stock checking, and data extraction.
  *
  * @package WooCommerce\PayPalCommerce\StoreSync\Helper
  */
@@ -13,10 +13,18 @@ namespace WooCommerce\PayPalCommerce\StoreSync\Helper;
 
 use WC_Product;
 
+use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\CartItem;
+use WooCommerce\PayPalCommerce\StoreSync\Schema\Money;
 
 class ProductManager {
 	protected static array $product_cache = array();
+
+	private StoreCurrencyValue $store_currency;
+
+	public function __construct( StoreCurrencyValue $store_currency ) {
+		$this->store_currency = $store_currency;
+	}
 
 	/**
 	 * Find a product by variant_id or item_id using multiple resolution strategies.
@@ -33,8 +41,8 @@ class ProductManager {
 	public function find_product( CartItem $item ): ?WC_Product {
 		$variant_id = $item->variant_id();
 		// @phpstan-ignore-next-line method.deprecated
-		$item_id    = $item->item_id();
-		$cache_key  = $this->build_cache_key( $variant_id, $item_id );
+		$item_id   = $item->item_id();
+		$cache_key = $this->build_cache_key( $variant_id, $item_id );
 
 		if ( array_key_exists( $cache_key, self::$product_cache ) ) {
 			return self::$product_cache[ $cache_key ];
@@ -95,6 +103,164 @@ class ProductManager {
 		}
 
 		return true;
+	}
+
+	/**
+	 * @param WC_Product $product  The WooCommerce product object.
+	 * @param string     $fallback Fallback description (e.g. short description for simple products,
+	 *                             parent description for variations).
+	 * @return string Plain-text description, passed through the filter hook.
+	 */
+	public function get_product_description( WC_Product $product, string $fallback = '' ): string {
+		$description = $product->get_description() ?: $fallback;
+		$plain_text  = wp_strip_all_tags( $description );
+		$plain_text  = html_entity_decode( $plain_text, ENT_QUOTES, 'UTF-8' );
+		$plain_text  = trim( preg_replace( '/\s+/', ' ', $plain_text ) ?? '' );
+
+		/**
+		 * Filters the product description for PayPal Agentic Commerce ingestion.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string     $plain_text The plain text description.
+		 * @param WC_Product $product    The WooCommerce product object.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_agentic_commerce_item_description',
+			$plain_text,
+			$product
+		);
+	}
+
+	/**
+	 * @param WC_Product $product The WooCommerce product object.
+	 * @return string The filtered product title.
+	 */
+	public function get_product_title( WC_Product $product ): string {
+		/**
+		 * Filters the product title for PayPal Agentic Commerce ingestion.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string     $title   The product title.
+		 * @param WC_Product $product The WooCommerce product object.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_agentic_commerce_item_title',
+			$product->get_name(),
+			$product
+		);
+	}
+
+	/**
+	 * @param WC_Product $product The WooCommerce product object.
+	 * @return string The filtered product permalink.
+	 */
+	public function get_product_link( WC_Product $product ): string {
+		/**
+		 * Filters the product link for PayPal Agentic Commerce ingestion.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string     $link    The product permalink.
+		 * @param WC_Product $product The WooCommerce product object.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_agentic_commerce_item_link',
+			$product->get_permalink(),
+			$product
+		);
+	}
+
+	/**
+	 * @param WC_Product $product  The WooCommerce product object.
+	 * @param string     $fallback Fallback image URL (e.g. parent product image for variations).
+	 * @return string The filtered image URL.
+	 */
+	public function get_product_image( WC_Product $product, string $fallback = '' ): string {
+		$image_id  = (int) $product->get_image_id();
+		$image_url = wp_get_attachment_image_url( $image_id, 'full' ) ?: $fallback;
+
+		/**
+		 * Filters the product image URL for PayPal Agentic Commerce ingestion.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string     $image_url The product image URL.
+		 * @param WC_Product $product   The WooCommerce product object.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_agentic_commerce_item_image',
+			$image_url,
+			$product
+		);
+	}
+
+	/**
+	 * @param WC_Product $product The WooCommerce product object.
+	 * @return string The filtered availability status.
+	 */
+	public function get_product_availability( WC_Product $product ): string {
+		$mapping = array(
+			'instock'     => 'in stock',
+			'outofstock'  => 'out of stock',
+			'onbackorder' => 'backorder',
+		);
+
+		$availability = $mapping[ $product->get_stock_status() ] ?? 'out of stock';
+
+		/**
+		 * Filters the product availability for PayPal Agentic Commerce usage.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string     $availability The mapped availability status.
+		 * @param WC_Product $product      The WooCommerce product object.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_agentic_commerce_item_availability',
+			$availability,
+			$product
+		);
+	}
+
+	/**
+	 * @param WC_Product $product The WooCommerce product object.
+	 * @return string Plain-text category list, passed through the filter hook, or empty string.
+	 */
+	public function get_product_type( WC_Product $product ): string {
+		$categories = wc_get_product_category_list( $product->get_id() );
+		$plain_text = wp_strip_all_tags( $categories );
+		$plain_text = html_entity_decode( $plain_text, ENT_QUOTES, 'UTF-8' );
+		$plain_text = trim( preg_replace( '/\s+/', ' ', $plain_text ) ?? '' );
+
+		/**
+		 * Filters the product type for PayPal Agentic Commerce usage.
+		 *
+		 * @since 3.4.0
+		 *
+		 * @param string     $plain_text The plain text category list.
+		 * @param WC_Product $product    The WooCommerce product object.
+		 */
+		return apply_filters(
+			'woocommerce_paypal_payments_agentic_commerce_item_product_type',
+			$plain_text,
+			$product
+		);
+	}
+
+	/**
+	 * @param string|mixed $price WooCommerce uses strings, but any numeric value is accepted.
+	 *                            Defends the method against plugins or future changes that use
+	 *                            a different data type.
+	 * @return string
+	 */
+	public function format_price( $price ): string {
+		if ( ! $price || ! is_numeric( $price ) ) {
+			return '';
+		}
+
+		return Money::create( $price, $this->store_currency->value() )->to_price();
 	}
 
 	private function build_cache_key( ?string $variant_id, ?string $item_id ): string {

--- a/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
+++ b/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
@@ -9,7 +9,7 @@ use Psr\Log\LoggerInterface;
 
 use WooCommerce\PayPalCommerce\StoreSync\Config\AgenticWebhookConfiguration;
 use WooCommerce\PayPalCommerce\StoreSync\Config\IngestionConfiguration;
-use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
+use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\StoreSync\Merchant\MerchantMetadataProvider;
 
 use function as_next_scheduled_action;
@@ -25,7 +25,7 @@ class IngestionManager {
 	private AgenticWebhookConfiguration $webhook_urls;
 	private MerchantMetadataProvider $metadata_provider;
 	private LoggerInterface $logger;
-	private StoreCurrencyValue $store_currency;
+	private ProductManager $product_manager;
 
 	public function __construct(
 		IngestionConfiguration $configuration,
@@ -33,7 +33,7 @@ class IngestionManager {
 		AgenticWebhookConfiguration $webhook_urls,
 		MerchantMetadataProvider $metadata_provider,
 		LoggerInterface $logger,
-		StoreCurrencyValue $store_currency
+		ProductManager $product_manager
 	) {
 
 		$this->configuration     = $configuration;
@@ -41,7 +41,7 @@ class IngestionManager {
 		$this->webhook_urls      = $webhook_urls;
 		$this->metadata_provider = $metadata_provider;
 		$this->logger            = $logger;
-		$this->store_currency    = $store_currency;
+		$this->product_manager   = $product_manager;
 	}
 
 	/**
@@ -143,7 +143,7 @@ class IngestionManager {
 			$metadata->store_url,
 			$product_ids,
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 	}
 }

--- a/modules/ppcp-store-sync/src/Ingestion/ProductsPayload.php
+++ b/modules/ppcp-store-sync/src/Ingestion/ProductsPayload.php
@@ -6,8 +6,7 @@ namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
 
 use WC_Product;
 use WC_Product_Variation;
-use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
-use WooCommerce\PayPalCommerce\StoreSync\Schema\Money;
+use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 
 class ProductsPayload {
 	private string $merchant_store_url;
@@ -17,12 +16,12 @@ class ProductsPayload {
 	 */
 	private array $product_ids;
 
-	private StoreCurrencyValue $store_currency;
+	private ProductManager $product_manager;
 
-	public function __construct( string $merchant_store_url, array $product_ids, StoreCurrencyValue $store_currency ) {
+	public function __construct( string $merchant_store_url, array $product_ids, ProductManager $product_manager ) {
 		$this->merchant_store_url = $merchant_store_url;
 		$this->product_ids        = $product_ids;
-		$this->store_currency     = $store_currency;
+		$this->product_manager    = $product_manager;
 	}
 
 	public function get_array(): array {
@@ -56,12 +55,12 @@ class ProductsPayload {
 			// For all other product types (simple, grouped, etc.).
 			$api_product = array(
 				'id'               => (string) $product->get_id(),
-				'title'            => $this->get_product_title( $product ),
-				'link'             => $this->get_product_link( $product ),
-				'image_link'       => $this->get_product_image( $product ),
-				'description'      => $this->get_product_description( $product, $product->get_short_description() ),
-				'price'            => $this->format_price( $product->get_price() ),
-				'availability'     => $this->get_product_availability( $product ),
+				'title'            => $this->product_manager->get_product_title( $product ),
+				'link'             => $this->product_manager->get_product_link( $product ),
+				'image_link'       => $this->product_manager->get_product_image( $product ),
+				'description'      => $this->product_manager->get_product_description( $product, $product->get_short_description() ),
+				'price'            => $this->product_manager->format_price( $product->get_price() ),
+				'availability'     => $this->product_manager->get_product_availability( $product ),
 				'merchantStoreUrl' => $this->merchant_store_url,
 			);
 
@@ -71,10 +70,10 @@ class ProductsPayload {
 			}
 
 			if ( $product->get_sale_price() ) {
-				$api_product['sale_price'] = $this->format_price( $product->get_sale_price() );
+				$api_product['sale_price'] = $this->product_manager->format_price( $product->get_sale_price() );
 			}
 
-			$product_type = $this->get_product_type( $product );
+			$product_type = $this->product_manager->get_product_type( $product );
 			if ( $product_type ) {
 				$api_product['product_type'] = $product_type;
 			}
@@ -89,7 +88,7 @@ class ProductsPayload {
 		$variants      = array();
 		$variation_ids = $variable_product->get_children();
 
-		$product_type = $this->get_product_type( $variable_product );
+		$product_type = $this->product_manager->get_product_type( $variable_product );
 
 		foreach ( $variation_ids as $variation_id ) {
 			$variation = wc_get_product( $variation_id );
@@ -100,15 +99,15 @@ class ProductsPayload {
 			$variant = array(
 				'id'               => (string) $variation->get_id(),
 				'item_group_id'    => (string) $variable_product->get_id(),
-				'title'            => $this->get_product_title( $variation ),
-				'link'             => $this->get_product_link( $variation ),
-				'image_link'       => $this->get_product_image(
+				'title'            => $this->product_manager->get_product_title( $variation ),
+				'link'             => $this->product_manager->get_product_link( $variation ),
+				'image_link'       => $this->product_manager->get_product_image(
 					$variation,
 					wp_get_attachment_image_url( (int) $variable_product->get_image_id(), 'full' ) ?: ''
 				),
-				'description'      => $this->get_product_description( $variation, $variable_product->get_description() ),
-				'price'            => $this->format_price( $variation->get_price() ),
-				'availability'     => $this->get_product_availability( $variation ),
+				'description'      => $this->product_manager->get_product_description( $variation, $variable_product->get_description() ),
+				'price'            => $this->product_manager->format_price( $variation->get_price() ),
+				'availability'     => $this->product_manager->get_product_availability( $variation ),
 				'merchantStoreUrl' => $this->merchant_store_url,
 			);
 
@@ -131,7 +130,7 @@ class ProductsPayload {
 			}
 
 			if ( $variation->get_sale_price() ) {
-				$variant['sale_price'] = $this->format_price( $variation->get_sale_price() );
+				$variant['sale_price'] = $this->product_manager->format_price( $variation->get_sale_price() );
 			}
 
 			// Add the parent product.
@@ -143,163 +142,5 @@ class ProductsPayload {
 		}
 
 		return $variants;
-	}
-
-	/**
-	 * @param WC_Product $product  The WooCommerce product object.
-	 * @param string     $fallback Fallback description (e.g. short description for simple products,
-	 *                             parent description for variations).
-	 * @return string Plain-text description, passed through the filter hook.
-	 */
-	private function get_product_description( WC_Product $product, string $fallback = '' ): string {
-		$description = $product->get_description() ?: $fallback;
-		$plain_text  = wp_strip_all_tags( $description );
-		$plain_text  = html_entity_decode( $plain_text, ENT_QUOTES, 'UTF-8' );
-		$plain_text  = trim( preg_replace( '/\s+/', ' ', $plain_text ) ?? '' );
-
-		/**
-		 * Filters the product description for PayPal Agentic Commerce ingestion.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string     $plain_text The plain text description.
-		 * @param WC_Product $product    The WooCommerce product object.
-		 */
-		return apply_filters(
-			'woocommerce_paypal_payments_agentic_commerce_item_description',
-			$plain_text,
-			$product
-		);
-	}
-
-	/**
-	 * @param WC_Product $product The WooCommerce product object.
-	 * @return string The filtered product title.
-	 */
-	private function get_product_title( WC_Product $product ): string {
-		/**
-		 * Filters the product title for PayPal Agentic Commerce ingestion.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string     $title   The product title.
-		 * @param WC_Product $product The WooCommerce product object.
-		 */
-		return apply_filters(
-			'woocommerce_paypal_payments_agentic_commerce_item_title',
-			$product->get_name(),
-			$product
-		);
-	}
-
-	/**
-	 * @param WC_Product $product The WooCommerce product object.
-	 * @return string The filtered product permalink.
-	 */
-	private function get_product_link( WC_Product $product ): string {
-		/**
-		 * Filters the product link for PayPal Agentic Commerce ingestion.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string     $link    The product permalink.
-		 * @param WC_Product $product The WooCommerce product object.
-		 */
-		return apply_filters(
-			'woocommerce_paypal_payments_agentic_commerce_item_link',
-			$product->get_permalink(),
-			$product
-		);
-	}
-
-	/**
-	 * @param WC_Product $product  The WooCommerce product object.
-	 * @param string     $fallback Fallback image URL (e.g. parent product image for variations).
-	 * @return string The filtered image URL.
-	 */
-	private function get_product_image( WC_Product $product, string $fallback = '' ): string {
-		$image_url =
-			wp_get_attachment_image_url( (int) $product->get_image_id(), 'full' ) ?: $fallback;
-
-		/**
-		 * Filters the product image URL for PayPal Agentic Commerce ingestion.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string     $image_url The product image URL.
-		 * @param WC_Product $product   The WooCommerce product object.
-		 */
-		return apply_filters(
-			'woocommerce_paypal_payments_agentic_commerce_item_image',
-			$image_url,
-			$product
-		);
-	}
-
-	/**
-	 * @param WC_Product $product The WooCommerce product object.
-	 * @return string The filtered availability status.
-	 */
-	private function get_product_availability( WC_Product $product ): string {
-		$mapping = array(
-			'instock'     => 'in stock',
-			'outofstock'  => 'out of stock',
-			'onbackorder' => 'backorder',
-		);
-
-		$availability = $mapping[ $product->get_stock_status() ] ?? 'out of stock';
-
-		/**
-		 * Filters the product availability for PayPal Agentic Commerce ingestion.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string     $availability The mapped availability status.
-		 * @param WC_Product $product      The WooCommerce product object.
-		 */
-		return apply_filters(
-			'woocommerce_paypal_payments_agentic_commerce_item_availability',
-			$availability,
-			$product
-		);
-	}
-
-	/**
-	 * @param WC_Product $product The WooCommerce product object.
-	 * @return string Plain-text category list, passed through the filter hook, or empty string.
-	 */
-	private function get_product_type( WC_Product $product ): string {
-		$categories = wc_get_product_category_list( $product->get_id() );
-		$plain_text = wp_strip_all_tags( $categories );
-		$plain_text = html_entity_decode( $plain_text, ENT_QUOTES, 'UTF-8' );
-		$plain_text = trim( preg_replace( '/\s+/', ' ', $plain_text ) ?? '' );
-
-		/**
-		 * Filters the product type for PayPal Agentic Commerce ingestion.
-		 *
-		 * @since 3.4.0
-		 *
-		 * @param string     $plain_text The plain text category list.
-		 * @param WC_Product $product    The WooCommerce product object.
-		 */
-		return apply_filters(
-			'woocommerce_paypal_payments_agentic_commerce_item_product_type',
-			$plain_text,
-			$product
-		);
-	}
-
-	/**
-	 * @param string|mixed $price WooCommerce uses strings, but any numeric value is accepted.
-	 *                            Defends the method against plugins or future changes that use
-	 *                            a different data type.
-	 * @return string
-	 */
-	private function format_price( $price ): string {
-		if ( ! $price || ! is_numeric( $price ) ) {
-			return '';
-		}
-
-		return Money::create( $price, $this->store_currency->value() )->to_price();
 	}
 }

--- a/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
+++ b/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
@@ -7,7 +7,7 @@ namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
 use RuntimeException;
 use Psr\Log\LoggerInterface;
 use JsonException;
-use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
+use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 
 /**
  * Represents a sync job for sending product data to the agentic commerce API.
@@ -21,23 +21,14 @@ class SyncJob {
 	private string $batch_id;
 	private string $api_endpoint;
 	private string $merchant_store_url;
-	private StoreCurrencyValue $store_currency;
+	private ProductManager $product_manager;
 
-	/**
-	 * Constructor.
-	 *
-	 * @param string             $api_endpoint       The API endpoint URL for product synchronization.
-	 * @param string             $merchant_store_url Primary key to identify the merchant.
-	 * @param array              $product_ids        The product IDs to be synced.
-	 * @param LoggerInterface    $logger             The logger instance for logging sync operations.
-	 * @param StoreCurrencyValue $store_currency     Store currency resolver.
-	 */
 	public function __construct(
 		string $api_endpoint,
 		string $merchant_store_url,
 		array $product_ids,
 		LoggerInterface $logger,
-		StoreCurrencyValue $store_currency
+		ProductManager $product_manager
 	) {
 
 		$this->api_endpoint       = $api_endpoint;
@@ -45,7 +36,7 @@ class SyncJob {
 		$this->product_ids        = $product_ids;
 		$this->logger             = $logger;
 		$this->batch_id           = wp_generate_uuid4();
-		$this->store_currency     = $store_currency;
+		$this->product_manager    = $product_manager;
 	}
 
 	/**
@@ -66,7 +57,11 @@ class SyncJob {
 		);
 
 		// Transform products for API using the factory.
-		$api_products = new ProductsPayload( $this->merchant_store_url, $this->product_ids, $this->store_currency );
+		$api_products = new ProductsPayload(
+			$this->merchant_store_url,
+			$this->product_ids,
+			$this->product_manager
+		);
 		$api_payload  = $api_products->get_array();
 
 		if ( empty( $api_payload ) ) {

--- a/modules/ppcp-store-sync/src/StoreData/StoreCartItem.php
+++ b/modules/ppcp-store-sync/src/StoreData/StoreCartItem.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\StoreSync\StoreData;
 
 use WC_Product;
 use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
+use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\CartItem;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\Money;
 
@@ -20,12 +21,21 @@ class StoreCartItem {
 	private CartItem $paypal_item;
 	private WC_Product $product;
 	private StoreCurrencyValue $store_currency;
+	private ProductManager $product_manager;
 
-	public function __construct( int $index, CartItem $schema_item, WC_Product $product, StoreCurrencyValue $store_currency ) {
-		$this->index          = $index;
-		$this->paypal_item    = $schema_item;
-		$this->product        = $product;
-		$this->store_currency = $store_currency;
+	public function __construct(
+		int $index,
+		CartItem $schema_item,
+		WC_Product $product,
+		StoreCurrencyValue $store_currency,
+		ProductManager $product_manager
+	) {
+
+		$this->index           = $index;
+		$this->paypal_item     = $schema_item;
+		$this->product         = $product;
+		$this->store_currency  = $store_currency;
+		$this->product_manager = $product_manager;
 	}
 
 	/**
@@ -127,19 +137,20 @@ class StoreCartItem {
 	public function to_array(): array {
 		$data = $this->paypal_item->to_array();
 
-		// WooCommerce always providees the price and product name/description.
+		// WooCommerce always provides the price and product name/description.
 		$data['price'] = $this->real_price_as_money()->to_array();
-		$data['name']  = $this->product->get_name();
+		$data['name']  = $this->product_manager->get_product_title( $this->product );
 
-		// todo: this logic is different from how Ingestion\ProductsPayload defined description.
-		$description = $this->product->get_short_description();
+		$description = $this->product_manager->get_product_description(
+			$this->product,
+			$this->product->get_short_description()
+		);
 		if ( $description ) {
 			$data['description'] = $description;
 		} else {
 			unset( $data['description'] );
 		}
 
-		// todo: Verify this logic matches the ingestion behavior. Extract a common data provider class.
 		$parent_id = $this->product->get_parent_id();
 		if ( $parent_id ) {
 			$data['parent_id'] = (string) $parent_id;

--- a/modules/ppcp-store-sync/src/StoreData/StoreData.php
+++ b/modules/ppcp-store-sync/src/StoreData/StoreData.php
@@ -48,7 +48,8 @@ class StoreData {
 					$index,
 					$item,
 					$product,
-					$this->store_currency
+					$this->store_currency,
+					$this->product_manager
 				);
 			}
 		}

--- a/tests/PHPUnit/StoreSync/Ingestion/ProductsPayloadTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/ProductsPayloadTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
 
 use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
+use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\TestCase;
 use WC_Product;
 use WC_Product_Simple;
@@ -17,16 +18,11 @@ use function Brain\Monkey\Functions\when;
  */
 class ProductsPayloadTest extends TestCase {
 
-	/**
-	 * Returns a StoreCurrencyValue stub that yields 'USD'.
-	 *
-	 * @return StoreCurrencyValue|Mockery\MockInterface
-	 */
-	private function make_currency_stub(): StoreCurrencyValue {
-		$stub = Mockery::mock( StoreCurrencyValue::class );
-		$stub->allows( 'value' )->andReturn( 'USD' );
+	private function make_product_manager_stub(): ProductManager {
+		$currency = Mockery::mock( StoreCurrencyValue::class );
+		$currency->allows( 'value' )->andReturn( 'USD' );
 
-		return $stub;
+		return new ProductManager( $currency );
 	}
 
 	public function test_transform_simple_product(): void {
@@ -58,7 +54,7 @@ class ProductsPayloadTest extends TestCase {
 		$payload = new ProductsPayload(
 			'https://example.com',
 			array( $product_id ),
-			$this->make_currency_stub()
+			$this->make_product_manager_stub()
 		);
 		$result  = $payload->get_array();
 
@@ -166,7 +162,7 @@ class ProductsPayloadTest extends TestCase {
 		$payload = new ProductsPayload(
 			'https://example.com',
 			array( $parent_id ),
-			$this->make_currency_stub()
+			$this->make_product_manager_stub()
 		);
 		$result  = $payload->get_array();
 
@@ -239,7 +235,7 @@ class ProductsPayloadTest extends TestCase {
 		$payload = new ProductsPayload(
 			'https://example.com',
 			array( $parent_id ),
-			$this->make_currency_stub()
+			$this->make_product_manager_stub()
 		);
 		$result  = $payload->get_array();
 
@@ -251,7 +247,7 @@ class ProductsPayloadTest extends TestCase {
 
 		$payload = new ProductsPayload( 'https://example.com',
 			array( 999 ),
-			$this->make_currency_stub()
+			$this->make_product_manager_stub()
 		);
 		$result  = $payload->get_array();
 
@@ -262,7 +258,7 @@ class ProductsPayloadTest extends TestCase {
 		$payload = new ProductsPayload(
 			'https://example.com',
 			array(),
-			$this->make_currency_stub()
+			$this->make_product_manager_stub()
 		);
 		$result  = $payload->get_array();
 
@@ -296,7 +292,7 @@ class ProductsPayloadTest extends TestCase {
 		$payload = new ProductsPayload(
 			'https://example.com',
 			array( $product_id ),
-			$this->make_currency_stub()
+			$this->make_product_manager_stub()
 		);
 		$result  = $payload->get_array();
 
@@ -335,7 +331,7 @@ class ProductsPayloadTest extends TestCase {
 		$payload = new ProductsPayload(
 			'https://example.com',
 			array( $product_id ),
-			$this->make_currency_stub()
+			$this->make_product_manager_stub()
 		);
 		$result  = $payload->get_array();
 
@@ -378,7 +374,7 @@ class ProductsPayloadTest extends TestCase {
 			$payload = new ProductsPayload(
 				'https://example.com',
 				array( $product_id ),
-				$this->make_currency_stub()
+				$this->make_product_manager_stub()
 			);
 			$result  = $payload->get_array();
 
@@ -412,7 +408,7 @@ class ProductsPayloadTest extends TestCase {
 		$payload = new ProductsPayload(
 			'https://example.com',
 			array( $product_id ),
-			$this->make_currency_stub()
+			$this->make_product_manager_stub()
 		);
 		$result  = $payload->get_array();
 

--- a/tests/PHPUnit/StoreSync/Ingestion/SyncJobTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/SyncJobTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
 
 use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
+use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\TestCase;
 use Psr\Log\LoggerInterface;
 use Exception;
@@ -22,9 +23,9 @@ class SyncJobTest extends TestCase {
 	private $logger;
 
 	/**
-	 * @var StoreCurrencyValue|Mockery\MockInterface
+	 * @var ProductManager
 	 */
-	private $store_currency;
+	private $product_manager;
 
 	/**
 	 * @var string
@@ -41,8 +42,9 @@ class SyncJobTest extends TestCase {
 
 		$this->logger = Mockery::mock( LoggerInterface::class );
 
-		$this->store_currency = Mockery::mock( StoreCurrencyValue::class );
-		$this->store_currency->allows( 'value' )->andReturn( 'USD' );
+		$store_currency = Mockery::mock( StoreCurrencyValue::class );
+		$store_currency->allows( 'value' )->andReturn( 'USD' );
+		$this->product_manager = new ProductManager( $store_currency );
 
 		// Stub WordPress functions with default values
 		when( 'wp_generate_uuid4' )->justReturn( 'test-batch-id-1234' );
@@ -216,7 +218,7 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 
 		$sync_job->execute();
@@ -247,7 +249,7 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 
 		$sync_job->execute();
@@ -304,7 +306,7 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 
 		$this->expectException( Exception::class );
@@ -361,7 +363,7 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 
 		$this->expectException( Exception::class );
@@ -422,7 +424,7 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 
 		$sync_job->execute();
@@ -485,7 +487,7 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$expectedProductIds,
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 
 		$sync_job->execute();
@@ -513,7 +515,7 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			array(),
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 
 		$sync_job->execute();
@@ -566,7 +568,7 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$expectedProductIds,
 			$this->logger,
-			$this->store_currency
+			$this->product_manager
 		);
 
 		$sync_job->execute();

--- a/tests/PHPUnit/StoreSync/StoreData/StoreCartItemTest.php
+++ b/tests/PHPUnit/StoreSync/StoreData/StoreCartItemTest.php
@@ -10,6 +10,7 @@ namespace WooCommerce\PayPalCommerce\StoreSync\StoreData;
 use Mockery;
 use WC_Product;
 use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
+use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\CartItem;
 use WooCommerce\PayPalCommerce\StoreSync\Schema\Money;
 use WooCommerce\PayPalCommerce\StoreSync\Validation\StoreValidation;
@@ -21,6 +22,8 @@ use function Brain\Monkey\Functions\when;
  */
 class StoreCartItemTest extends StoreSyncTestCase {
 
+	private ProductManager $product_manager;
+
 	public function setUp(): void {
 		parent::setUp();
 		when( 'wc_get_price_excluding_tax' )->alias(
@@ -28,6 +31,11 @@ class StoreCartItemTest extends StoreSyncTestCase {
 				return (float) $product->get_price();
 			}
 		);
+		when( 'wp_strip_all_tags' )->returnArg( 1 );
+
+		$currency              = Mockery::mock( StoreCurrencyValue::class );
+		$currency->allows( 'value' )->andReturn( 'USD' );
+		$this->product_manager = new ProductManager( $currency );
 	}
 
 	// -------------------------------------------------------------------------
@@ -65,6 +73,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 		$stub = Mockery::mock( WC_Product::class );
 		$stub->allows( 'get_price' )->andReturn( $price_string );
 		$stub->allows( 'get_name' )->andReturn( $name );
+		$stub->allows( 'get_description' )->andReturn( '' );
 		$stub->allows( 'get_short_description' )->andReturn( $short_description );
 		$stub->allows( 'get_parent_id' )->andReturn( $parent_id );
 
@@ -82,6 +91,10 @@ class StoreCartItemTest extends StoreSyncTestCase {
 		$stub->allows( 'value' )->andReturn( $currency );
 
 		return $stub;
+	}
+
+	private function make_product_manager(): ProductManager {
+		return $this->product_manager;
 	}
 
 	/**
@@ -110,7 +123,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_real_price_returns_float_from_product_get_price(): void {
 		$schema  = $this->make_cart_item_schema();
 		$product = $this->make_product( '19.99' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertSame( 19.99, $sut->real_price() );
 	}
@@ -127,7 +140,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_assumed_price_returns_null_when_schema_has_no_price(): void {
 		$schema  = $this->make_cart_item_schema( null );
 		$product = $this->make_product( '9.99' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertNull( $sut->assumed_price_as_money() );
 	}
@@ -141,7 +154,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 		$money   = $this->make_money( '9.99', 'USD' );
 		$schema  = $this->make_cart_item_schema( $money );
 		$product = $this->make_product( '9.99' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertSame( $money, $sut->assumed_price_as_money() );
 	}
@@ -158,7 +171,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_is_price_correct_returns_true_when_no_assumed_price(): void {
 		$schema  = $this->make_cart_item_schema( null );
 		$product = $this->make_product( '9.99' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertTrue( $sut->is_price_correct() );
 	}
@@ -180,7 +193,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 		$money   = $this->make_money( $assumed_value, 'USD' );
 		$schema  = $this->make_cart_item_schema( $money );
 		$product = $this->make_product( $product_price );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertTrue( $sut->is_price_correct() );
 	}
@@ -211,7 +224,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 		$money   = $this->make_money( $assumed_value, 'USD' );
 		$schema  = $this->make_cart_item_schema( $money );
 		$product = $this->make_product( $product_price );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertFalse( $sut->is_price_correct() );
 	}
@@ -236,7 +249,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 		$money   = $this->make_money( '0.30', 'USD' );
 		$schema  = $this->make_cart_item_schema( $money );
 		$product = $this->make_product( '0.30' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertTrue( $sut->is_price_correct() );
 	}
@@ -253,7 +266,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_is_currency_correct_returns_true_when_no_assumed_price(): void {
 		$schema  = $this->make_cart_item_schema( null );
 		$product = $this->make_product( '9.99' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertTrue( $sut->is_currency_correct() );
 	}
@@ -267,7 +280,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 		$money   = $this->make_money( '9.99', 'EUR' );
 		$schema  = $this->make_cart_item_schema( $money );
 		$product = $this->make_product( '9.99' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'EUR' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'EUR' ), $this->make_product_manager() );
 
 		$this->assertTrue( $sut->is_currency_correct() );
 	}
@@ -281,7 +294,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 		$money   = $this->make_money( '9.99', 'USD' );
 		$schema  = $this->make_cart_item_schema( $money );
 		$product = $this->make_product( '9.99' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'EUR' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'EUR' ), $this->make_product_manager() );
 
 		$this->assertFalse( $sut->is_currency_correct() );
 	}
@@ -298,7 +311,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_schema_returns_injected_cart_item(): void {
 		$schema  = $this->make_cart_item_schema();
 		$product = $this->make_product( '9.99' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$this->assertSame( $schema, $sut->paypal_item() );
 	}
@@ -322,7 +335,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 			new StoreValidation()
 		);
 		$product = $this->make_product( '12.50' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$result = $sut->to_array();
 
@@ -341,7 +354,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 			new StoreValidation()
 		);
 		$product = $this->make_product( '9.99', 'Real Product Name' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$result = $sut->to_array();
 
@@ -356,7 +369,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_to_array_description_present_when_product_has_short_description(): void {
 		$schema  = CartItem::from_array( array( 'quantity' => 1 ), new StoreValidation() );
 		$product = $this->make_product( '9.99', 'Product', 'A fine item.' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$result = $sut->to_array();
 
@@ -372,7 +385,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_to_array_description_absent_when_product_has_no_short_description(): void {
 		$schema  = CartItem::from_array( array( 'quantity' => 1 ), new StoreValidation() );
 		$product = $this->make_product( '9.99', 'Product', '' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$result = $sut->to_array();
 
@@ -387,7 +400,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_to_array_parent_id_present_as_string_when_product_has_parent(): void {
 		$schema  = CartItem::from_array( array( 'quantity' => 1 ), new StoreValidation() );
 		$product = $this->make_product( '9.99', 'Product', '', 42 );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$result = $sut->to_array();
 
@@ -403,7 +416,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 	public function test_to_array_parent_id_absent_when_product_has_no_parent(): void {
 		$schema  = CartItem::from_array( array( 'quantity' => 1 ), new StoreValidation() );
 		$product = $this->make_product( '9.99', 'Product', '', 0 );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'USD' ), $this->make_product_manager() );
 
 		$result = $sut->to_array();
 
@@ -429,7 +442,7 @@ class StoreCartItemTest extends StoreSyncTestCase {
 			new StoreValidation()
 		);
 		$product = $this->make_product( '20.00', 'T-Shirt' );
-		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'EUR' ) );
+		$sut     = new StoreCartItem( 0, $schema, $product, $this->make_currency( 'EUR' ), $this->make_product_manager() );
 
 		$result = $sut->to_array();
 


### PR DESCRIPTION
### Description

The store sync module has two places that extract product data:
1. The ingestion handler, which populates the product catalog via outbound webhooks
2. The store data handler, which interacts with the Cart API via inbound REST calls

Until now, both places had their own (slightly different) ways to extract product specs, like title or description.

This PR consolidates the logic, by moving the product data accessors into the helper class `ProductManager` and passing this helper into both handlers (ingestion and store data) to ensure the full agentic loop receives the same product details in an expected and identical format.