### PR TITLE
Remove dummy logic from agentic orders (6405)

### DIFF
--- a/modules/ppcp-store-sync/src/Helper/PayPalOrderManager.php
+++ b/modules/ppcp-store-sync/src/Helper/PayPalOrderManager.php
@@ -98,9 +98,7 @@ class PayPalOrderManager {
 			// Create PayPal Order (application_context filter is registered in StoreSyncModule).
 			$paypal_order = $this->order_endpoint->create(
 				array( $purchase_unit ),
-				ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING,
-				null,               // payer.
-				'agentic-commerce'  // payment_method identifier.
+				ExperienceContext::SHIPPING_PREFERENCE_NO_SHIPPING
 			);
 		} catch ( PayPalApiException $error ) {
 			$details = $error->details();

--- a/modules/ppcp-store-sync/src/StoreSyncModule.php
+++ b/modules/ppcp-store-sync/src/StoreSyncModule.php
@@ -102,28 +102,6 @@ class StoreSyncModule implements ServiceModule, ExecutableModule {
 			$this->ensure_registered( $registration_handler );
 		}
 
-		// Add filter for agentic commerce application context.
-		add_filter(
-			'ppcp_create_order_request_body_data',
-			static function ( array $data, string $payment_method ): array {
-				if ( $payment_method === 'agentic-commerce' ) {
-					$data['application_context'] = array(
-						'brand_name'          => get_bloginfo( 'name' ),
-						'locale'              => 'en-US',
-						'landing_page'        => 'NO_PREFERENCE',
-						'shipping_preference' => 'NO_SHIPPING',
-						'user_action'         => 'PAY_NOW',
-						'return_url'          => home_url( '/paypal-return' ),
-						'cancel_url'          => home_url( '/paypal-cancel' ),
-					);
-				}
-
-				return $data;
-			},
-			10,
-			2
-		);
-
 		// Public REST endpoints.
 		add_action(
 			'rest_api_init',

--- a/modules/ppcp-store-sync/src/StoreSyncModule.php
+++ b/modules/ppcp-store-sync/src/StoreSyncModule.php
@@ -128,60 +128,6 @@ class StoreSyncModule implements ServiceModule, ExecutableModule {
 		// Product ingestion.
 		add_action( 'init', static fn() => $ingestion_manager->init() );
 
-		// Handle PayPal return/cancel URLs for approval flow.
-		// In agentic commerce, these are typically not used by AI agents.
-		add_action(
-			'template_redirect',
-			/**
-			 * TODO: Temporary test code. This code will be removed soon.
-			 *
-			 * @psalm-suppress MixedArgument, MixedArrayAccess, MixedAssignment, PossiblyInvalidArgument
-			 */
-			static function (): void {
-				$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-
-				// Handle PayPal return (approval completed).
-				if ( strpos( $request_uri, '/paypal-return' ) !== false ) {
-					// phpcs:disable WordPress.Security.NonceVerification.Recommended
-					$token    = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : '';
-					$payer_id = isset( $_GET['PayerID'] ) ? sanitize_text_field( wp_unslash( $_GET['PayerID'] ) ) : '';
-					// phpcs:enable WordPress.Security.NonceVerification.Recommended
-
-					wp_die(
-						sprintf(
-							'<h1>Payment Approved</h1>
-							<p>Your PayPal payment has been approved.</p>
-							<p><strong>Order ID:</strong> %s</p>
-							<p><strong>Payer ID:</strong> %s</p>
-							<p>This transaction is being handled by the AI agent. You can close this window.</p>',
-							esc_html( $token ),
-							esc_html( $payer_id )
-						),
-						'Payment Approved',
-						array( 'response' => 200 )
-					);
-				}
-
-				// Handle PayPal cancel.
-				if ( strpos( $request_uri, '/paypal-cancel' ) !== false ) {
-					// phpcs:disable WordPress.Security.NonceVerification.Recommended
-					$token = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : '';
-					// phpcs:enable WordPress.Security.NonceVerification.Recommended
-
-					wp_die(
-						sprintf(
-							'<h1>Payment Cancelled</h1>
-							<p>The PayPal payment was cancelled.</p>
-							<p><strong>Order ID:</strong> %s</p>',
-							esc_html( $token )
-						),
-						'Payment Cancelled',
-						array( 'response' => 200 )
-					);
-				}
-			}
-		);
-
 		return true;
 	}
 


### PR DESCRIPTION
### Description

The store sync module processes orders via server side requests. In contrast to regular payments, the user never approves the order via JS or a page redirect - instead, the PayPal order is created by our plugin and later approved directly by the agent before allowing us to capture the payment.

This flow has a significant gap for our tests: The approval step is not part of the plugin experience, but an external event.

As a workaround, we had an early dummy page to display relevant information that we can then feed into the agentic API (eg via Postman tests) to simulate that approval step.

This PR removes that dummy page and cleans up the codebase, as it's not relevant for production usage.