### PR TITLE
Simplify checkout validation rules (6404)

### DIFF
--- a/modules/ppcp-store-sync/src/Endpoint/CheckoutEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/CheckoutEndpoint.php
@@ -18,11 +18,7 @@ use WP_REST_Response;
 use Psr\Log\LoggerInterface;
 
 use WooCommerce\PayPalCommerce\StoreSync\Errors\AgenticError;
-use WooCommerce\PayPalCommerce\StoreSync\Errors\Http\InternalServerError;
 use WooCommerce\PayPalCommerce\StoreSync\Validation\Context\PaymentErrorContext;
-use WooCommerce\PayPalCommerce\StoreSync\Validation\StoreValidation;
-use WooCommerce\PayPalCommerce\StoreSync\Validation\ValidationIssue;
-use WooCommerce\PayPalCommerce\StoreSync\Schema\PaymentMethod;
 use WooCommerce\PayPalCommerce\StoreSync\Helper\AgenticSessionManager;
 use WooCommerce\PayPalCommerce\StoreSync\Helper\AgenticCheckoutProcessor;
 use WooCommerce\PayPalCommerce\StoreSync\Helper\PayPalOrderManager;
@@ -120,14 +116,14 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 		$order = $this->create_wc_order( $store_cart, $session['ec_token'] );
 
 		if ( is_wp_error( $order ) ) {
-			$store_cart->validation()->add_payment_error( $order->get_error_message() )
+			$store_cart->validation()
+				->add_payment_error( $order->get_error_message() )
 				->add_context(
 					PaymentErrorContext::create_payment_declined()
 						->decline_reason( (string) $order->get_error_code() )
 				);
 
-			// TODO: this should return an UnprocessableEntityError.
-			return $this->cart_details( $this->response_factory->from_cart( $store_cart, $cart_id ), 200 );
+			return $this->cart_details( $this->response_factory->from_cart( $store_cart, $cart_id ), 422 );
 		}
 
 		$this->flush_local_cart( $cart_id );

--- a/modules/ppcp-store-sync/src/Endpoint/CheckoutEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/CheckoutEndpoint.php
@@ -120,14 +120,13 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 		$order = $this->create_wc_order( $store_cart, $session['ec_token'] );
 
 		if ( is_wp_error( $order ) ) {
-			// TODO: Refactor this to use $validation->add_payment_error().
-			$issue = ValidationIssue::create_payment_error( $order->get_error_message() )
+			$store_cart->validation()->add_payment_error( $order->get_error_message() )
 				->add_context(
 					PaymentErrorContext::create_payment_declined()
 						->decline_reason( (string) $order->get_error_code() )
 				);
-			$store_cart->validation()->add( $issue );
 
+			// TODO: this should return an UnprocessableEntityError.
 			return $this->cart_details( $this->response_factory->from_cart( $store_cart, $cart_id ), 200 );
 		}
 

--- a/modules/ppcp-store-sync/src/Endpoint/CheckoutEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/CheckoutEndpoint.php
@@ -101,22 +101,6 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 			return $this->error( $data );
 		}
 
-		// TODO: Move this into a validator to add a PAYMENT_ERROR, which we can check here.
-		$pm_validation  = new StoreValidation();
-		$payment_method = PaymentMethod::from_array(
-			(array) ( $data['payment_method'] ?? array() ),
-			$pm_validation
-		);
-
-		if ( ! $pm_validation->is_empty() ) {
-			return $this->error(
-				new InternalServerError(
-					'Payment method is required for checkout',
-					$pm_validation->all()
-				)
-			);
-		}
-
 		$session = $this->get_stored_cart( $cart_id );
 		if ( $session instanceof AgenticError ) {
 			return $this->error( $session );
@@ -127,17 +111,13 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 		if ( $store_cart instanceof AgenticError ) {
 			return $this->error( $store_cart );
 		}
-
 		$store_cart->set_paypal_order( $session['ec_token'] );
 
-		$validation = $store_cart->validation();
-
-		// If the cart has _any_ validation issue, stop here.
-		if ( ! $validation->is_empty() ) {
+		if ( ! $store_cart->is_ready_for_payment() ) {
 			return $this->cart_details( $this->response_factory->from_cart( $store_cart, $cart_id ), 200 );
 		}
 
-		$order = $this->create_wc_order( $store_cart, $payment_method, $session['ec_token'] );
+		$order = $this->create_wc_order( $store_cart, $session['ec_token'] );
 
 		if ( is_wp_error( $order ) ) {
 			// TODO: Refactor this to use $validation->add_payment_error().
@@ -146,7 +126,7 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 					PaymentErrorContext::create_payment_declined()
 						->decline_reason( (string) $order->get_error_code() )
 				);
-			$validation->add( $issue );
+			$store_cart->validation()->add( $issue );
 
 			return $this->cart_details( $this->response_factory->from_cart( $store_cart, $cart_id ), 200 );
 		}
@@ -170,11 +150,14 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 	 * 6. Cleaning up temporary cart
 	 *
 	 * @param StorePayPalCart $store_cart      The enriched cart data.
-	 * @param PaymentMethod   $payment_method  The payment method data.
 	 * @param string          $paypal_order_id The PayPal Order ID (ec_token).
 	 * @return WC_Order|WP_Error The created order or error.
 	 */
-	private function create_wc_order( StorePayPalCart $store_cart, PaymentMethod $payment_method, string $paypal_order_id ) {
-		return $this->checkout_processor->process( $store_cart, $payment_method, $paypal_order_id );
+	private function create_wc_order( StorePayPalCart $store_cart, string $paypal_order_id ) {
+		return $this->checkout_processor->process(
+			$store_cart,
+			$store_cart->paypal_cart()->payment_method(),
+			$paypal_order_id
+		);
 	}
 }

--- a/modules/ppcp-store-sync/src/StoreData/StorePayPalCart.php
+++ b/modules/ppcp-store-sync/src/StoreData/StorePayPalCart.php
@@ -106,19 +106,33 @@ class StorePayPalCart {
 	 * Verifies if cart items and payment token are present, and no validation issues exist.
 	 */
 	public function is_ready_for_payment(): bool {
-		// An empty cart cannot be paid.
-		if ( empty( $this->store_items ) ) {
-			return false;
-		}
-
 		// Any validation issue is a blocker that must be resolved before payment attempt.
 		if ( ! $this->validation->is_empty() ) {
 			return false;
 		}
 
-		// Missing payment token, cart is not ready.
-		if ( ! $this->paypal_cart->payment_method()->token() ) {
+		// An empty cart cannot be paid.
+		if ( empty( $this->store_items ) ) {
+			$this->validation->add_missing_field( 'items', 'Cannot pay cart: It is empty.' );
+
 			return false;
+		}
+
+		$method = $this->paypal_cart()->payment_method();
+
+		// Cart not reads: missing payment type (expected "paypal").
+		if ( ! $method->type() ) {
+			$this->validation->add_missing_field( 'payment_method.type', 'Cannot pay cart: Payment type is not defined.' );
+
+			return false;
+		}
+
+		// Cart not reads: missing payment token.
+		if ( ! $method->token() ) {
+			$this->validation->add_missing_field( 'payment_method.token', 'Cannot pay cart: PayPal order is missing.' );
+
+			return false;
+
 		}
 
 		return true;

--- a/modules/ppcp-store-sync/src/Validation/StoreValidation.php
+++ b/modules/ppcp-store-sync/src/Validation/StoreValidation.php
@@ -23,7 +23,10 @@ class StoreValidation {
 	private array $issues = array();
 
 	public function add( ValidationIssue $issue ): ValidationIssue {
-		$this->issues[] = $issue;
+		// Prevent duplicate field-level issues.
+		if ( ! $issue->field() || ! $this->has_issue( $issue ) ) {
+			$this->issues[] = $issue;
+		}
 
 		return $issue;
 	}
@@ -105,6 +108,23 @@ class StoreValidation {
 
 	public function has_pricing_issue(): bool {
 		return $this->has_issue_with_code( ErrorCode::PRICING_ERROR );
+	}
+
+	/**
+	 * Tests, whether an issue with the same type, code, and field value exists.
+	 */
+	public function has_issue( ValidationIssue $issue ): bool {
+		foreach ( $this->issues as $known ) {
+			if (
+				$known->code() === $issue->code()
+				&& $known->type() === $issue->type()
+				&& $known->field() === $issue->field()
+			) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	public function has_issue_for_field( string $field ): bool {

--- a/modules/ppcp-store-sync/src/Validation/ValidationIssue.php
+++ b/modules/ppcp-store-sync/src/Validation/ValidationIssue.php
@@ -186,6 +186,14 @@ class ValidationIssue {
 	}
 
 	/**
+	 * Returns the field, which caused the issue, in a dot-notation.
+	 * For example "shipping_address.postal_code"
+	 */
+	public function field(): string {
+		return $this->field;
+	}
+
+	/**
 	 * Sets the field that triggered the issue.
 	 *
 	 * @param string $field Field path, e.g. "shipping_address.postal_code".

--- a/tests/PHPUnit/StoreSync/StoreData/StorePayPalCartTest.php
+++ b/tests/PHPUnit/StoreSync/StoreData/StorePayPalCartTest.php
@@ -292,6 +292,7 @@ class StorePayPalCartTest extends StoreSyncTestCase {
 	 */
 	public function test_is_ready_for_payment_true_when_all_conditions_met(): void {
 		$payment_method = Mockery::mock( PaymentMethod::class );
+		$payment_method->allows( 'type' )->andReturn( 'paypal' );
 		$payment_method->allows( 'token' )->andReturn( 'some-token' );
 		$paypal_cart    = $this->make_paypal_cart( array( 'payment_method' => $payment_method ) );
 		$schema         = $this->make_cart_item_schema( array( 'quantity' => 1 ) );
@@ -324,9 +325,11 @@ class StorePayPalCartTest extends StoreSyncTestCase {
 
 		if ( $has_payment_method ) {
 			$payment_method = Mockery::mock( PaymentMethod::class );
+			$payment_method->allows( 'type' )->andReturn( 'paypal' );
 			$payment_method->allows( 'token' )->andReturn( 'some-token' );
 		} else {
 			$payment_method = Mockery::mock( PaymentMethod::class );
+			$payment_method->allows( 'type' )->andReturn( 'paypal' );
 			$payment_method->allows( 'token' )->andReturn( null );
 		}
 		$paypal_cart    = $this->make_paypal_cart( array( 'payment_method' => $payment_method ) );


### PR DESCRIPTION
### Description

The agentic commerce `CheckoutEndpoint` still contained outdated validation checks that are not needed, or should be refactored to match the current module architecture.

This PR addresses the legacy code and ensures the checkout uses the correct methods and validation structures.