### PR TITLE
fix(settings): detect US shipping coverage for Everywhere zones, NA continent, and US states (6408)

### DIFF
--- a/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
+++ b/modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php
@@ -100,8 +100,19 @@ class AgenticBetaBannerEligibility {
 			if ( empty( $zone->get_shipping_methods( true ) ) ) {
 				continue;
 			}
-			foreach ( $zone->get_zone_locations() as $location ) {
-				if ( $location->type === 'country' && $location->code === 'US' ) {
+
+			$locations = $zone->get_zone_locations();
+
+			if ( empty( $locations ) ) {
+				return true;
+			}
+
+			foreach ( $locations as $location ) {
+				if (
+					( $location->type === 'continent' && $location->code === 'NA' ) ||
+					( $location->type === 'country' && $location->code === 'US' ) ||
+					( $location->type === 'state' && strncmp( $location->code, 'US:', 3 ) === 0 )
+				) {
 					return true;
 				}
 			}


### PR DESCRIPTION
## Problem

`AgenticBetaBannerEligibility::has_us_shipping_zone()` failed to recognise US shipping coverage in three valid WooCommerce configurations:

- **Named zone with no locations** — WooCommerce shows these as "Everywhere". `get_zone_locations()` returns `[]`, so the location loop was a no-op and the zone was silently skipped.
- **North America continent zone** — a zone set to continent `NA` covers the US but the code only checked for `type === 'country' && code === 'US'`.
- **US state zones** — zones covering individual US states (e.g. `US:CA`) were not matched.

In all three cases the agentic beta banner was not shown even when it should be. Zone 0 (WooCommerce's built-in "Rest of the World" fallback) was already handled correctly and is unchanged.

## Changes
  
- `modules/ppcp-settings/src/Service/AgenticBetaBannerEligibility.php`
- Return `true` immediately when `get_zone_locations()` is empty
- Also match `type === 'continent' && code === 'NA'`
- Also match `type === 'state'` with code prefixed `US:`

## Testing

- Create a named shipping zone with **no locations** and an active shipping method → banner eligibility should be `true`
- Create a zone set to the **North America continent** with an active method → eligible
- Create a zone with a **US state** (e.g. United States / California) and an active method → eligible
- Create a zone covering only a **non-US country** (e.g. Germany) → not eligible
- Zone 0 (Everywhere/Rest of the World) with active methods → still eligible