### PR TITLE
Vaulted ACDC payments not captured + malformed order request custom_id/invoice_id misplaced (6293)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -140,7 +140,6 @@ return array(
 			$container->get( 'settings.environment' ),
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'wcgateway.endpoint.capture-card-payment' ),
-			$container->get( 'api.prefix' ),
 			$container->get( 'wc-payment-tokens.wc-payment-tokens' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -78,17 +78,9 @@ class CaptureCardPayment {
 	 *
 	 * @throws RuntimeException When request fails.
 	 */
-	public function create_order( string $vault_id, string $custom_id, string $invoice_id, WC_Order $wc_order ): Order {
+	public function create_order( string $vault_id, WC_Order $wc_order ): Order {
 		$intent = strtoupper( $this->settings_provider->payment_intent() ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
-		$items  = array( $this->purchase_unit_factory->from_wc_cart( null, false, $wc_order->get_payment_method() ) );
-
-		// phpcs:disable WordPress.Security.NonceVerification
-		$pay_for_order = wc_clean( wp_unslash( $_GET['pay_for_order'] ?? '' ) );
-		$order_key     = wc_clean( wp_unslash( $_GET['key'] ?? '' ) );
-		// phpcs:enable
-		if ( $pay_for_order && $order_key === $wc_order->get_order_key() ) {
-			$items = array( $this->purchase_unit_factory->from_wc_order( $wc_order ) );
-		}
+		$items  = array( $this->purchase_unit_factory->from_wc_order( $wc_order ) );
 
 		$data = array(
 			'intent'         => $intent,
@@ -108,8 +100,6 @@ class CaptureCardPayment {
 					),
 				),
 			),
-			'custom_id'      => $custom_id,
-			'invoice_id'     => $invoice_id,
 		);
 
 		$bearer = $this->bearer->bearer();

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -132,13 +132,6 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	private $capture_card_payment;
 
 	/**
-	 * The prefix.
-	 *
-	 * @var string
-	 */
-	private $prefix;
-
-	/**
 	 * WooCommerce payment tokens factory.
 	 *
 	 * @var WooCommercePaymentTokens
@@ -221,7 +214,6 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	 * @param Environment               $environment                 The environment.
 	 * @param OrderEndpoint             $order_endpoint              The order endpoint.
 	 * @param CaptureCardPayment        $capture_card_payment        Capture card payment.
-	 * @param string                    $prefix                      The prefix.
 	 * @param WooCommercePaymentTokens  $wc_payment_tokens           WooCommerce payment tokens factory.
 	 * @param LoggerInterface           $logger                      The logger.
 	 */
@@ -238,7 +230,6 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		Environment $environment,
 		OrderEndpoint $order_endpoint,
 		CaptureCardPayment $capture_card_payment,
-		string $prefix,
 		WooCommercePaymentTokens $wc_payment_tokens,
 		LoggerInterface $logger
 	) {
@@ -254,7 +245,6 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		$this->environment              = $environment;
 		$this->order_endpoint           = $order_endpoint;
 		$this->capture_card_payment     = $capture_card_payment;
-		$this->prefix                   = $prefix;
 		$this->wc_payment_tokens        = $wc_payment_tokens;
 		$this->logger                   = $logger;
 
@@ -465,11 +455,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			$tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id() );
 			foreach ( $tokens as $token ) {
 				if ( $token->get_id() === (int) $card_payment_token_id ) {
-					$custom_id  = (string) $wc_order->get_id();
-					$invoice_id = $this->prefix . $wc_order->get_order_number();
-
 					try {
-						$created_order = $this->capture_card_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order );
+						$created_order = $this->capture_card_payment->create_order( $token->get_token(), $wc_order );
 					} catch ( RuntimeException $exception ) {
 						$this->logger->error( $exception->getMessage() );
 						return $this->handle_payment_failure( $wc_order, $exception );
@@ -487,6 +474,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 						if ( $this->subscription_helper->has_subscription( $wc_order->get_id() ) ) {
 							$wc_order->update_meta_data( '_ppcp_captured_vault_webhook', 'false' );
 						}
+					} else {
+						$order = $this->order_endpoint->capture( $order );
 					}
 
 					$transaction_id = $this->get_paypal_order_transaction_id( $order );

--- a/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
@@ -32,7 +32,6 @@ class CreditCardGatewayTest extends TestCase
 	private $transactionUrlProvider;
 	private $subscriptionHelper;
 	private $captureCardPayment;
-	private $prefix;
 	private $wcPaymentTokens;
 	private $logger;
 	private $paymentsEndpoint;
@@ -53,7 +52,6 @@ class CreditCardGatewayTest extends TestCase
 		$this->transactionUrlProvider = Mockery::mock(TransactionUrlProvider::class);
 		$this->subscriptionHelper = Mockery::mock(SubscriptionHelper::class);
 		$this->captureCardPayment = Mockery::mock(CaptureCardPayment::class);
-		$this->prefix = 'some-prefix';
 		$this->wcPaymentTokens = Mockery::mock(WooCommercePaymentTokens::class);
 		$this->logger = Mockery::mock(LoggerInterface::class);
 		$this->paymentsEndpoint = Mockery::mock(PaymentsEndpoint::class);
@@ -82,7 +80,6 @@ class CreditCardGatewayTest extends TestCase
 			$this->environment,
 			$this->orderEndpoint,
 			$this->captureCardPayment,
-			$this->prefix,
 			$this->wcPaymentTokens,
 			$this->logger
 		);

--- a/tests/qa/utils/paypal-api.ts
+++ b/tests/qa/utils/paypal-api.ts
@@ -30,20 +30,21 @@ export class PayPalApi {
 		data?: any
 	) => {
 		try {
+			const token = await this.getToken( merchant );
 			const response = await this.request[ requestType ](
 				this.apiBaseUrl + endPoint,
 				{
-					headers: createAuthHeader(
-						merchant.client_id,
-						merchant.client_secret
-					),
+					headers: {
+						Authorization: `Bearer ${ token }`,
+					},
 					data,
 				}
 			);
 
 			if ( ! ( await response.ok() ) ) {
+				const body = await response.text();
 				throw new Error(
-					`Request failed with status ${ await response.status() }`
+					`Request failed with status ${ await response.status() } for ${ endPoint }: ${ body }`
 				);
 			}
 
@@ -70,7 +71,11 @@ export class PayPalApi {
 				form: { grant_type: 'client_credentials' },
 			}
 		);
-		return ( await response.json() ).access_token;
+		const json = await response.json();
+		if ( ! response.ok() ) {
+			throw new Error( `getToken failed with status ${ response.status() }: ${ JSON.stringify( json ) }` );
+		}
+		return json.access_token;
 	};
 
 	/**


### PR DESCRIPTION
Vaulted ACDC (saved card) orders were created but never captured, two bugs found in the vault v3 code path:

  1. `custom_id` and `invoice_id` were placed at the root of the PayPal order creation payload instead of inside `purchase_units[0]`.
  2. For `CAPTURE` intent, `POST /v2/checkout/orders/{id}/capture` was never called after order creation, leaving the order uncharged.

### PR changes
  - Switch `CaptureCardPayment::create_order()` from `from_wc_cart()` to `from_wc_order()` so custom_id/invoice_id are correctly embedded inside `purchase_units[0]`.
  - Add the missing `order_endpoint->capture()` call for `CAPTURE` intent in `CreditCardGateway::process_payment()`.
  - Remove the now-unused `$prefix` constructor parameter from `CreditCardGateway`.