### PR TITLE
Credit cards not saved when Save credit card is enabled (6410)

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -217,6 +217,17 @@ class SavePaymentMethodsModule implements ServiceModule, ExecutableModule {
 												$token_id
 											);
 											break;
+										case 'card':
+											$wc_payment_tokens->create_payment_token_card(
+												$wc_order->get_customer_id(),
+												(object) array(
+													'id' => $token_id,
+													'payment_source' => (object) array(
+														'card' => $payment_source->properties(),
+													),
+												)
+											);
+											break;
 										case 'paypal':
 										default:
 											$wc_payment_tokens->create_payment_token_paypal(

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -1044,7 +1044,8 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				if ( ! $order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) ) {
 					return;
 				}
-				if ( $order->get_payment_method() === PayPalGateway::ID ) {
+				$payment_method = $order->get_payment_method();
+				if ( $payment_method && strpos( $payment_method, 'ppcp-' ) === 0 ) {
 					return;
 				}
 				$order->set_payment_method( PayPalGateway::ID );


### PR DESCRIPTION
ACDC saved cards showed up under PayPal at `/my-account/payment-methods/` because the vault token was created with `gateway_id = ppcp-gateway` instead of `ppcp-credit-card-gateway`. 

Two causes: `SavePaymentMethodsModule` lacked a 'card' case in its payment-source switch, and WCGatewayModule's `before_order_object_save` hook rewrote any order with `_ppcp_paypal_order_id` meta to `PayPalGateway::ID`.

### PR changes
- Added case 'card': in `SavePaymentMethodsModule` calling `create_payment_token_card()`.
- Narrowed the `WCGatewayModule` hook to skip orders whose payment method already starts with `ppcp-`.
