### PR TITLE
fix(wc-gateway): don't reassign ACDC orders to PayPal gateway on save (6420)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -1047,6 +1047,9 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 				if ( $order->get_payment_method() === PayPalGateway::ID ) {
 					return;
 				}
+				if ( $order->get_payment_method() === CreditCardGateway::ID ) {
+					return;
+				}
 				$order->set_payment_method( PayPalGateway::ID );
 			},
 			10,


### PR DESCRIPTION
## Problem

When an order is paid via ACDC (`ppcp-credit-card-gateway`), the admin order page shows **"Refund via PayPal"** instead of the correct "Refund via Debit & Credit Cards".

### Root cause

`WCGatewayModule::register_block_express_payment_method_handler()` registers a `woocommerce_before_order_object_save` hook that reassigns any order carrying `_ppcp_paypal_order_id` meta to `ppcp-gateway`, unless the payment method is already `ppcp-gateway`.

This hook exists to handle a specific block-checkout edge case: when the PayPal express button is used but WooCommerce routes the payment to the wrong PCP gateway (because another PCP gateway is sorted first in WC Settings → Payments).

ACDC orders have `_ppcp_paypal_order_id` set (PayPal processes card payments behind the scenes), so they were silently reassigned to `ppcp-gateway` on every save. Once on `ppcp-gateway`, `PayPalGateway::get_title()` falls back to "PayPal" when `_payment_method_title` is empty (common for API-created/Pay-by-Link orders), causing WooCommerce to render "Refund via PayPal".

  ## Fix

Skip the payment method override when the order belongs to `CreditCardGateway::ID`. The block-checkout express-button edge case is already handled correctly by the `woocommerce_rest_checkout_process_payment_with_context` hook that runs first — the `woocommerce_before_order_object_save` hook is a secondary safety net that was cast too wide.

  ## Testing

  1. Enable ACDC in plugin settings
  2. Place an order using ACDC (both classic and block checkout)
  3. Open the order in WooCommerce admin
  4. Click **Refund** — confirm the button reads **"Refund via Debit & Credit Cards"** (not "Refund via PayPal")
  5. Repeat with a Pay-by-Link (API-created) order paid via ACDC
  6. Also verify a standard PayPal express button order still processes correctly end-to-end
  7. Verify if the refund works correctly - no regression