### PR TITLE
Fix migration logic on plugin update (6380)

### DIFF
--- a/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
+++ b/modules/ppcp-settings/src/Service/Migration/MigrationManager.php
@@ -71,11 +71,6 @@ class MigrationManager implements SettingsMigrationInterface {
 		 * - "woocommerce-ppcp-is-new-merchant"
 		 */
 
-		$this->onboarding_profile->set_completed( true );
-		$this->onboarding_profile->set_gateways_refreshed( true );
-		$this->onboarding_profile->set_gateways_synced( true, true );
-		$this->onboarding_profile->save();
-
 		// General settings migration is critical — it resolves the seller type
 		// via the PayPal API. If it fails, abort so migration retries on next load.
 		try {
@@ -112,6 +107,13 @@ class MigrationManager implements SettingsMigrationInterface {
 					)
 				);
 			}
+		}
+
+		if ( $this->general_settings_migration->is_merchant_connected() ) {
+			$this->onboarding_profile->set_completed( true );
+			$this->onboarding_profile->set_gateways_refreshed( true );
+			$this->onboarding_profile->set_gateways_synced( true, true );
+			$this->onboarding_profile->save();
 		}
 
 		update_option( self::OPTION_NAME_MIGRATION_IS_DONE, true );

--- a/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsMigration.php
@@ -46,6 +46,10 @@ class SettingsMigration implements SettingsMigrationInterface {
 		$this->seller_type_resolver = $seller_type_resolver;
 	}
 
+	public function is_merchant_connected(): bool {
+		return $this->general_settings->is_merchant_connected();
+	}
+
 	public function migrate(): void {
 		if ( empty( $this->settings['client_id'] )
 			|| empty( $this->settings['client_secret'] )

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -74,24 +74,20 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		add_action( 'init', fn() => $this->apply_branded_only_limitations( $container ), 1 );
 
 		add_action(
-			'woocommerce_paypal_payments_gateway_migrate_on_update',
+			'woocommerce_paypal_payments_gateway_migrate',
 			/**
-			 * Auto-trigger settings migration to new UI on plugin update.
+			 * Auto-trigger settings migration to new UI when upgrading from a legacy (pre-4.0) version.
 			 *
-			 * This hook executes during plugin updates to automatically migrate existing merchants
-			 * from the legacy settings interface to the new settings UI. The migration runs once
-			 * per installation.
-			 *
-			 * Migration process includes:
-			 * - Cleaning up legacy UI toggle options (old/new UI preference flags)
-			 * - Marking onboarding as completed for existing merchants
-			 * - Migrating general settings, styling settings, and payment method configurations
-			 * - Syncing gateway states to reflect current settings
-			 *
-			 * The migration is skipped if:
+			 * Migration is skipped when:
+			 * - No previous version exists (fresh install — nothing to migrate)
+			 * - Previous version is 4.0 or newer (already on the new UI)
 			 * - OPTION_NAME_MIGRATION_IS_DONE flag is already set (migration completed previously)
 			 */
-			static function () use ( $container ): void {
+			static function ( $previous_version ) use ( $container ): void {
+				if ( ! $previous_version || version_compare( (string) $previous_version, '4.0', '>=' ) ) {
+					return;
+				}
+
 				if ( get_option( MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ) === '1' ) {
 					return;
 				}

--- a/tests/PHPUnit/Settings/Service/Migration/MigrationManagerTest.php
+++ b/tests/PHPUnit/Settings/Service/Migration/MigrationManagerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Settings\Service\Migration;
+
+use Exception;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Settings\Service\Migration\MigrationManager
+ */
+class MigrationManagerTest extends TestCase {
+
+	/**
+	 * GIVEN a general_settings_migration that throws / succeeds
+	 * AND   is_merchant_connected() returning true or false
+	 * WHEN  migrate() is called
+	 * THEN  set_completed(true) is called only when migration succeeds AND merchant is connected
+	 * AND   OPTION_NAME_MIGRATION_IS_DONE is written only when migration does not abort early
+	 *
+	 * @dataProvider set_completed_behavior_provider
+	 */
+	public function test_set_completed_reflects_migration_outcome(
+		bool $general_migration_throws,
+		bool $merchant_connected,
+		int $expected_set_completed_calls,
+		bool $expect_migration_done_written
+	): void {
+		// Stub get_option so is-new-merchant returns false (simulate missing option entry).
+		when( 'get_option' )->justReturn( false );
+
+		$written_options = array();
+		when( 'update_option' )->alias(
+			function ( string $key, $value ) use ( &$written_options ): bool {
+				$written_options[ $key ] = $value;
+
+				return true;
+			}
+		);
+
+		when( 'do_action' )->justReturn( null );
+		when( 'did_action' )->justReturn( 0 );
+		when( 'add_action' )->justReturn( null );
+
+		// General settings migration: either a clean no-op or a throw to simulate failed API call.
+		$general_migration = $this->createStub( SettingsMigration::class );
+		if ( $general_migration_throws ) {
+			$general_migration->method( 'migrate' )
+				->willThrowException( new Exception( 'API call failed' ) );
+		} else {
+			$general_migration->method( 'is_merchant_connected' )
+				->willReturn( $merchant_connected );
+		}
+
+		// All other migrations are plain no-ops.
+		$tab_migration      = $this->createStub( SettingsTabMigration::class );
+		$styling_migration  = $this->createStub( StylingSettingsMigration::class );
+		$payment_migration  = $this->createStub( PaymentSettingsMigration::class );
+		$fastlane_migration = $this->createStub( FastlaneSettingsMigration::class );
+
+		// Logger stub — we are not asserting on it.
+		$logger = $this->createStub( LoggerInterface::class );
+
+		// OnboardingProfile: mock because the assertion IS about whether set_completed is called.
+		$onboarding_profile = Mockery::mock( OnboardingProfile::class );
+		$onboarding_profile->shouldReceive( 'set_completed' )
+			->with( true )
+			->times( $expected_set_completed_calls );
+
+		// Allow set_completed(false) — called when migration succeeds but merchant is not connected.
+		$onboarding_profile->shouldReceive( 'set_completed' )
+			->with( false )
+			->zeroOrMoreTimes();
+
+		// Allow any other OnboardingProfile calls that may occur on the happy path.
+		$onboarding_profile->shouldReceive( 'set_gateways_refreshed' )->zeroOrMoreTimes();
+		$onboarding_profile->shouldReceive( 'set_gateways_synced' )->zeroOrMoreTimes();
+		$onboarding_profile->shouldReceive( 'save' )->zeroOrMoreTimes();
+
+		$manager = new MigrationManager(
+			$general_migration,
+			$tab_migration,
+			$styling_migration,
+			$payment_migration,
+			$fastlane_migration,
+			$onboarding_profile,
+			$logger
+		);
+
+		$manager->migrate();
+
+		if ( $expect_migration_done_written ) {
+			$this->assertArrayHasKey(
+				MigrationManager::OPTION_NAME_MIGRATION_IS_DONE,
+				$written_options,
+				'OPTION_NAME_MIGRATION_IS_DONE must be written when migration completes successfully.'
+			);
+			$this->assertTrue( $written_options[ MigrationManager::OPTION_NAME_MIGRATION_IS_DONE ] );
+		} else {
+			$this->assertArrayNotHasKey(
+				MigrationManager::OPTION_NAME_MIGRATION_IS_DONE,
+				$written_options,
+				'OPTION_NAME_MIGRATION_IS_DONE must NOT be written when migration aborts.'
+			);
+		}
+	}
+
+	public function set_completed_behavior_provider(): array {
+		return array(
+			'general migration throws — set_completed must not be called' => array(
+				'general_migration_throws'      => true,
+				'merchant_connected'            => false,
+				'expected_set_completed_calls'  => 0,
+				'expect_migration_done_written' => false,
+			),
+
+			'migration succeeds but merchant not connected — set_completed(false)' => array(
+				'general_migration_throws'      => false,
+				'merchant_connected'            => false,
+				'expected_set_completed_calls'  => 0,
+				'expect_migration_done_written' => true,
+			),
+
+			'happy path — merchant connected — set_completed(true)' => array(
+				'general_migration_throws'      => false,
+				'merchant_connected'            => true,
+				'expected_set_completed_calls'  => 1,
+				'expect_migration_done_written' => true,
+			),
+		);
+	}
+}


### PR DESCRIPTION
### Description

When upgrading from a 3.x plugin version to the latest version, we run an automated settings migration to convert the legacy settings to the new format.

This auto migration is fired on every plugin update action, and has two side effects that caused a rare bug:

1. When upgrading from 4.0.3 to 4.0.4, the migration was triggered. This is invalid, as version 4.0.3 always comes with correct settings and migration is not relevant here.
2. When entering the migration logic, the first action was to unconditionally mark the onboarding wizard as "completed", without checking if legacy settings exist or if the merchant was onboarded.

#### Fix 1: Restrict auto migration

This PR limits the cases where auto migrate is triggered. The migration action is only invoked when upgrading from a plugin version `< 4.0`, ie skipping migration on a fresh installation or when upgrading from a 4.x or later version.

#### Fix 2: Migration checks onboarding state

The onboarding profile was updated at the very start of `migrate()`, before any legacy settings were read or migrated. This meant that even if the migration aborted (e.g. due to a failed PayPal API call) or the legacy settings were empty, onboarding was already marked as completed.

The fix moves this logic to the end of migration process, and only changes onboarding status after verifying that we have valid merchant connection details. This decision is made by the `GeneralSettings::is_merchant_connected()` method, which verifies that relevant merchant details are known (email, PayPal ID, Client ID, Client Secret - all needed for certain API calls)