### PR TITLE
feat(acdc): add "Show logos of supported cards" setting (4533)

### DIFF
--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -54,7 +54,9 @@ return array(
 			},
 			$container->get( 'settings.settings-provider' ),
 			$container->get( 'wcgateway.configuration.card-configuration' ),
-			$container->get( 'save-payment-methods.eligible' )
+			$container->get( 'save-payment-methods.eligible' ),
+			$container->get( 'settings.data.payment' ),
+			$container->get( 'wcgateway.credit-card-icons' )
 		);
 	},
 	'blocks.settings.final_review_enabled' => static function ( ContainerInterface $container ): bool {

--- a/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
+++ b/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
@@ -58,8 +58,15 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 	private array $credit_card_icons;
 
 	/**
-	 * @param SmartButtonInterface|callable                               $smart_button The smart button script loading handler.
-	 * @param array<int, array{type: string, title: string, url: string}> $credit_card_icons Pre-built card icon data.
+	 * @param AssetGetter                   $asset_getter
+	 * @param string                        $version
+	 * @param CreditCardGateway             $gateway
+	 * @param SmartButtonInterface|callable $smart_button The smart button script loading handler.
+	 * @param SettingsProvider              $settings_provider
+	 * @param CardPaymentsConfiguration     $card_payments_configuration
+	 * @param bool                          $save_payment_methods_eligible
+	 * @param PaymentSettings               $payment_settings
+	 * @param array                         $credit_card_icons Pre-built card icon data.
 	 */
 	public function __construct(
 		AssetGetter $asset_getter,

--- a/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
+++ b/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
@@ -57,6 +57,10 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 	 */
 	private array $credit_card_icons;
 
+	/**
+	 * @param SmartButtonInterface|callable                               $smart_button The smart button script loading handler.
+	 * @param array<int, array{type: string, title: string, url: string}> $credit_card_icons Pre-built card icon data.
+	 */
 	public function __construct(
 		AssetGetter $asset_getter,
 		string $version,

--- a/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
+++ b/modules/ppcp-blocks/src/AdvancedCardPaymentMethod.php
@@ -12,6 +12,7 @@ namespace WooCommerce\PayPalCommerce\Blocks;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
@@ -43,26 +44,19 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 	 */
 	private $smart_button;
 
-	/**
-	 * The settings provider.
-	 *
-	 * @var SettingsProvider
-	 */
 	protected SettingsProvider $plugin_settings;
 
 	protected CardPaymentsConfiguration $card_payments_configuration;
 
 	protected bool $save_payment_methods_eligible;
 
+	private PaymentSettings $payment_settings;
+
 	/**
-	 * @param AssetGetter                   $asset_getter
-	 * @param string                        $version The assets version.
-	 * @param CreditCardGateway             $gateway
-	 * @param SmartButtonInterface|callable $smart_button The smart button script loading handler.
-	 * @param SettingsProvider              $settings_provider The settings provider.
-	 * @param CardPaymentsConfiguration     $card_payments_configuration
-	 * @param bool                          $save_payment_methods_eligible Whether save payment methods is eligible for the current country.
+	 * @var array<int, array{type: string, title: string, url: string}>
 	 */
+	private array $credit_card_icons;
+
 	public function __construct(
 		AssetGetter $asset_getter,
 		string $version,
@@ -70,7 +64,9 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 		$smart_button,
 		SettingsProvider $settings_provider,
 		CardPaymentsConfiguration $card_payments_configuration,
-		bool $save_payment_methods_eligible
+		bool $save_payment_methods_eligible,
+		PaymentSettings $payment_settings,
+		array $credit_card_icons
 	) {
 		$this->name                          = CreditCardGateway::ID;
 		$this->asset_getter                  = $asset_getter;
@@ -80,6 +76,8 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 		$this->plugin_settings               = $settings_provider;
 		$this->card_payments_configuration   = $card_payments_configuration;
 		$this->save_payment_methods_eligible = $save_payment_methods_eligible;
+		$this->payment_settings              = $payment_settings;
+		$this->credit_card_icons             = $credit_card_icons;
 	}
 
 	/**
@@ -129,8 +127,31 @@ class AdvancedCardPaymentMethod extends AbstractPaymentMethodType {
 			'supports'            => $this->gateway->supports,
 			'save_card_text'      => esc_html__( 'Save your card', 'woocommerce-paypal-payments' ),
 			'is_vaulting_enabled' => $this->save_payment_methods_eligible && $this->plugin_settings->save_card_details(),
-			'card_icons'          => $this->plugin_settings->card_icons(),
+			'card_icons'          => $this->build_card_icons(),
 			'name_on_card'        => $this->card_payments_configuration->show_name_on_card(),
+		);
+	}
+
+	/**
+	 * Returns card icons in the {id, alt, src} format expected by PaymentMethodIcons,
+	 * or an empty array when the merchant has disabled logo display.
+	 *
+	 * @return array<int, array{id: string, alt: string, src: string}>
+	 */
+	private function build_card_icons(): array {
+		if ( ! $this->payment_settings->get_show_card_logos() ) {
+			return array();
+		}
+
+		return array_map(
+			static function ( array $icon ): array {
+				return array(
+					'id'  => $icon['type'],
+					'alt' => $icon['title'],
+					'src' => $icon['url'],
+				);
+			},
+			$this->credit_card_icons
 		);
 	}
 

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPaymentMethods.js
@@ -42,6 +42,7 @@ const TabPaymentMethods = () => {
 				'paypalShowLogo',
 				'threeDSecure',
 				'cardholderName',
+				'showCardLogos',
 				'fastlaneDisplayWatermark',
 				'puiBrandName',
 				'puiLogoUrl',

--- a/modules/ppcp-settings/resources/js/data/payment/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/payment/hooks.js
@@ -132,6 +132,7 @@ export const usePaymentMethodsModal = () => {
 
 	const [ paypalShowLogo ] = usePersistent( 'paypalShowLogo' );
 	const [ cardholderName ] = usePersistent( 'cardholderName' );
+	const [ showCardLogos ] = usePersistent( 'showCardLogos' );
 	const [ fastlaneDisplayWatermark ] = usePersistent(
 		'fastlaneDisplayWatermark'
 	);
@@ -144,6 +145,7 @@ export const usePaymentMethodsModal = () => {
 	return {
 		paypalShowLogo,
 		cardholderName,
+		showCardLogos,
 		fastlaneDisplayWatermark,
 		puiBrandName,
 		puiLogoUrl,

--- a/modules/ppcp-settings/resources/js/data/payment/reducer.js
+++ b/modules/ppcp-settings/resources/js/data/payment/reducer.js
@@ -44,6 +44,7 @@ const defaultPersistent = Object.freeze( {
 	paypalShowLogo: false,
 	threeDSecure: 'no-3d-secure',
 	cardholderName: false,
+	showCardLogos: false,
 	fastlaneDisplayWatermark: false,
 	puiBrandName: '',
 	puiLogoUrl: '',

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -267,6 +267,14 @@ class PaymentMethodsDefinition {
 							'woocommerce-paypal-payments'
 						),
 					),
+					'showCardLogos'  => array(
+						'type'    => 'toggle',
+						'default' => $this->settings->get_show_card_logos(),
+						'label'   => __(
+							'Show logos of supported cards',
+							'woocommerce-paypal-payments'
+						),
+					),
 				),
 			);
 			$group[] = array(

--- a/modules/ppcp-settings/src/Data/PaymentSettings.php
+++ b/modules/ppcp-settings/src/Data/PaymentSettings.php
@@ -39,6 +39,7 @@ class PaymentSettings extends AbstractDataModel {
 		return array(
 			'paypal_show_logo'                  => false,
 			'cardholder_name'                   => false,
+			'show_card_logos'                   => false,
 			'fastlane_display_watermark'        => false,
 			'venmo_enabled'                     => false,
 			'paylater_enabled'                  => false,
@@ -214,6 +215,13 @@ class PaymentSettings extends AbstractDataModel {
 	}
 
 	/**
+	 * Whether to show card brand logos in the checkout payment method label.
+	 */
+	public function get_show_card_logos(): bool {
+		return (bool) $this->data['show_card_logos'];
+	}
+
+	/**
 	 * Get Fastlane display watermark.
 	 */
 	public function get_fastlane_display_watermark(): bool {
@@ -246,6 +254,13 @@ class PaymentSettings extends AbstractDataModel {
 	 */
 	public function set_cardholder_name( bool $value ): void {
 		$this->data['cardholder_name'] = $value;
+	}
+
+	/**
+	 * @see self::get_show_card_logos()
+	 */
+	public function set_show_card_logos( bool $value ): void {
+		$this->data['show_card_logos'] = $value;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/PaymentRestEndpoint.php
@@ -65,6 +65,10 @@ class PaymentRestEndpoint extends RestEndpoint {
 			'js_name'  => 'cardholderName',
 			'sanitize' => 'to_boolean',
 		),
+		'show_card_logos'                   => array(
+			'js_name'  => 'showCardLogos',
+			'sanitize' => 'to_boolean',
+		),
 		'fastlane_display_watermark'        => array(
 			'js_name'  => 'fastlaneDisplayWatermark',
 			'sanitize' => 'to_boolean',
@@ -201,6 +205,7 @@ class PaymentRestEndpoint extends RestEndpoint {
 
 		$gateway_settings['paypalShowLogo']                 = $this->payment_settings->get_paypal_show_logo();
 		$gateway_settings['cardholderName']                 = $this->payment_settings->get_cardholder_name();
+		$gateway_settings['showCardLogos']                  = $this->payment_settings->get_show_card_logos();
 		$gateway_settings['fastlaneDisplayWatermark']       = $this->payment_settings->get_fastlane_display_watermark();
 		$gateway_settings['puiBrandName']                   = $this->payment_settings->get_pui_brand_name();
 		$gateway_settings['puiLogoUrl']                     = $this->payment_settings->get_pui_logo_url();

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -26,6 +26,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Button\Helper\MessagesDisclaimers;
 use WooCommerce\PayPalCommerce\Common\Pattern\SingletonDecorator;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\FeaturesDefinition;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -185,6 +186,13 @@ return array(
 		);
 	},
 	'wcgateway.credit-card-icons'                          => static function ( ContainerInterface $container ): array {
+		$payment_settings = $container->get( 'settings.data.payment' );
+		assert( $payment_settings instanceof PaymentSettings );
+
+		if ( ! $payment_settings->get_show_card_logos() ) {
+			return array();
+		}
+
 		$settings_provider = $container->get( 'settings.settings-provider' );
 		assert( $settings_provider instanceof SettingsProvider );
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -194,7 +194,22 @@ return array(
 		$asset_getter = $container->get( 'wcgateway.asset_getter' );
 		assert( $asset_getter instanceof AssetGetter );
 
-		$url_root   = $asset_getter->get_static_asset_url( 'images/' );
+		$url_root = $asset_getter->get_static_asset_url( 'images/' );
+
+		// Default to all known card types when none are explicitly configured.
+		if ( empty( $icons ) ) {
+			$icons = array_keys( $labels );
+		}
+
+		$disabled = $settings_provider->disabled_cards();
+		if ( ! empty( $disabled ) ) {
+			$icons = array_filter(
+				$icons,
+				static function ( string $icon ) use ( $disabled ): bool {
+					return ! in_array( str_replace( '-dark', '', $icon ), $disabled, true );
+				}
+			);
+		}
 
 		$icons_with_label = array();
 		foreach ( $icons as $icon ) {


### PR DESCRIPTION
## Summary

Card brand logos were never displayed for Advanced Credit and Debit Card Processing in either the block checkout or the classic checkout.

  **Root cause:** 

The `show_card_logos` setting did not exist, so there was no way to enable logos. Additionally, the `wcgateway.credit-card-icons` service always returned an empty list and the block checkout received raw strings instead of the `{id, alt, src}` objects that WooCommerce's `PaymentMethodIcons` component requires.
  
  **Changes:**

- Adds a **"Show logos of supported cards"** toggle to the ACDC settings modal (below "Display cardholder name"), backed by a new `show_card_logos` boolean in `PaymentSettings` and exposed via the payment REST endpoint
<img width="782" height="478" alt="Screenshot 2026-05-18 at 16 57 22" src="https://github.com/user-attachments/assets/b2918279-bf7f-4791-976d-aa3e90139c3e" />
 
- `wcgateway.credit-card-icons` now defaults to all known card types when none are explicitly configured, and filters out any card disabled via "Disable specific credit cards"
- When the toggle is on, `AdvancedCardPaymentMethod` passes correctly formatted `{id, alt, src}` icon objects to the block checkout's `PaymentMethodIcons`
- Both block checkout and classic checkout (`CreditCardGateway::get_icon()`) respect the toggle — logos are hidden in both when it is off

<table>
  <tr>
    <th>Classic Checkout</th>
    <th>Block Checkout</th>
  </tr>
  <tr>
    <td><img width="922" height="534" alt="Screenshot 2026-05-18 at 16 47 33" src="https://github.com/user-attachments/assets/65f402be-aab1-4300-bc10-e38586dbac33" /></td>
    <td><img width="891" height="639" alt="Screenshot 2026-05-18 at 16 57 10" src="https://github.com/user-attachments/assets/2757451b-cacc-45db-aed5-b002d68eac80" /></td>
  </tr>
</table>


  ## How to test

1. Go to **WooCommerce → Settings → Payments → Payment methods tab**
2. Click the settings icon next to **Advanced Credit and Debit Card Payments**
3. Confirm the **"Show logos of supported cards"** toggle appears below "Display cardholder name" and defaults to **off**
4. Enable the toggle and save — card logos (Visa, Mastercard, Amex, Discover, etc.) should appear next to the payment method label in both the **block checkout** and the **classic shortcode checkout**
5. Disable specific cards via **"Disable specific credit cards"** — verify their logos are also hidden
6. Turn the toggle back off — verify logos disappear from both checkout types.