### PR TITLE
Throw when JSON body is not parseable (5957)

### DIFF
--- a/modules/ppcp-wc-gateway/src/StoreApi/Endpoint/CartEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/StoreApi/Endpoint/CartEndpoint.php
@@ -95,6 +95,10 @@ class CartEndpoint {
 		);
 	}
 
+	/**
+	 * @throws \JsonException If cannot decode JSON from the response.
+	 * @throws Exception If response contains error code or has empty body.
+	 */
 	protected function perform_cart_request( string $path, array $args ): CartResponse {
 		$response = $this->request( $this->cart_endpoint_url( $path ), $args );
 
@@ -110,7 +114,20 @@ class CartEndpoint {
 			throw $error;
 		}
 
-		$json = json_decode( $response['body'], true );
+		$json = json_decode( $response['body'], true, 512, JSON_THROW_ON_ERROR );
+
+		if ( ! $json ) {
+			$error = new Exception( 'Failed to parse response: ' . $response['body'] );
+			$this->logger->warning(
+				$error->getMessage(),
+				array(
+					'args'     => $args,
+					'response' => $response,
+				)
+			);
+
+			throw $error;
+		}
 
 		$error_code    = $json['code'] ?? null;
 		$error_message = $json['message'] ?? null;


### PR DESCRIPTION
Avoid a fatal error when the JSON body from the response cannot be decoded. 

Since the changed method already throws an exception, the new one will be caught and handled in the same way. This may fix the duplicated WC orders problem by catching the exception and handling it properly.

Although I cannot reproduce the issue, and hence, cannot confirm it is fixed, this is still an improvement - a code path ending in a fatal error has to be fixed anyway.