### PR TITLE
fix(settings): coerce stored values in typed-bool getters and vault_enabled migration

### DIFF
--- a/modules/ppcp-settings/src/Data/SettingsModel.php
+++ b/modules/ppcp-settings/src/Data/SettingsModel.php
@@ -306,7 +306,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if authorize only is enabled, false otherwise.
 	 */
 	public function get_authorize_only(): bool {
-		return $this->data['authorize_only'];
+		return $this->sanitizer->sanitize_bool( $this->data['authorize_only'] ?? false );
 	}
 
 	/**
@@ -324,7 +324,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if capturing virtual orders is enabled, false otherwise.
 	 */
 	public function get_capture_virtual_orders(): bool {
-		return $this->data['capture_virtual_orders'];
+		return $this->sanitizer->sanitize_bool( $this->data['capture_virtual_orders'] ?? false );
 	}
 
 	/**
@@ -342,7 +342,9 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if saving PayPal and Venmo is enabled, false otherwise.
 	 */
 	public function get_save_paypal_and_venmo(): bool {
-		return $this->data[ FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO ];
+		return $this->sanitizer->sanitize_bool(
+			$this->data[ FeaturesDefinition::FEATURE_SAVE_PAYPAL_AND_VENMO ] ?? false
+		);
 	}
 
 	/**
@@ -360,7 +362,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if instant payments only setting is enabled, false otherwise.
 	 */
 	public function get_instant_payments_only(): bool {
-		return $this->data['instant_payments_only'] ?? false;
+		return $this->sanitizer->sanitize_bool( $this->data['instant_payments_only'] ?? false );
 	}
 
 	/**
@@ -378,7 +380,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if the contact module feature is enabled, false otherwise.
 	 */
 	public function get_enable_contact_module(): bool {
-		return $this->data['enable_contact_module'];
+		return $this->sanitizer->sanitize_bool( $this->data['enable_contact_module'] ?? true );
 	}
 
 	/**
@@ -396,7 +398,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if saving card details is enabled, false otherwise.
 	 */
 	public function get_save_card_details(): bool {
-		return $this->data['save_card_details'];
+		return $this->sanitizer->sanitize_bool( $this->data['save_card_details'] ?? false );
 	}
 
 	/**
@@ -414,7 +416,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if Pay Now is enabled, false otherwise.
 	 */
 	public function get_enable_pay_now(): bool {
-		return $this->data['enable_pay_now'];
+		return $this->sanitizer->sanitize_bool( $this->data['enable_pay_now'] ?? false );
 	}
 
 	/**
@@ -432,7 +434,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if logging is enabled, false otherwise.
 	 */
 	public function get_enable_logging(): bool {
-		return $this->data['enable_logging'];
+		return $this->sanitizer->sanitize_bool( $this->data['enable_logging'] ?? false );
 	}
 
 	/**
@@ -492,7 +494,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool True if Stay Updated is enabled, false otherwise.
 	 */
 	public function get_stay_updated(): bool {
-		return $this->data['stay_updated'];
+		return $this->sanitizer->sanitize_bool( $this->data['stay_updated'] ?? true );
 	}
 
 	/**
@@ -510,7 +512,7 @@ class SettingsModel extends AbstractDataModel {
 	 * @return bool
 	 */
 	public function get_payment_level_processing(): bool {
-		return (bool) $this->data['payment_level_processing'];
+		return $this->sanitizer->sanitize_bool( $this->data['payment_level_processing'] ?? true );
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
@@ -80,6 +80,21 @@ class SettingsTabMigration implements SettingsMigrationInterface {
 					$old_to_new_3d_secure_map = array_flip( self::THREE_D_SECURE_VALUES_MAP );
 					$data[ $new_key ]         = $old_to_new_3d_secure_map[ $value ] ?? 'NO_3D_SECURE';
 					break;
+				case 'vault_enabled':
+					/*
+					 * Legacy classic-WooCommerce settings stored vault_enabled as
+					 * the string "yes" or "no". The new target slot
+					 * SettingsModel::save_paypal_and_venmo is typed bool and its
+					 * setter declares `bool $save`, so any non-bool value flowing
+					 * through from_array() either throws a TypeError (strict
+					 * mode) or persists the wrong value (weak mode, where every
+					 * non-empty non-"0" string casts to true -- including "no").
+					 *
+					 * Coerce explicitly here so the migration is correct
+					 * regardless of how the legacy option was stored.
+					 */
+					$data[ $new_key ] = filter_var( $this->settings[ $old_key ], FILTER_VALIDATE_BOOLEAN );
+					break;
 				default:
 					$data[ $new_key ] = $this->settings[ $old_key ];
 			}

--- a/tests/PHPUnit/Settings/Data/SettingsModelTest.php
+++ b/tests/PHPUnit/Settings/Data/SettingsModelTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace PHPUnit\Settings\Data;
+
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\Service\DataSanitizer;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+/**
+ * Tests defensive bool coercion in SettingsModel typed-bool getters.
+ *
+ * Background: the typed-bool getters used to return $this->data[ $key ]
+ * directly, trusting that whatever was stored under that key was a real
+ * bool. On PHP 8.x this throws "Return value must be of type bool, string
+ * returned" whenever the stored option contains a string -- which happens
+ * after the legacy migration if the legacy option was stored in classic-WC
+ * "yes"/"no" format, after a direct DB write, or after a third-party
+ * import/export tool that re-serialises options without preserving types.
+ *
+ * The getters are now wrapped with DataSanitizer::sanitize_bool() which
+ * uses filter_var( ..., FILTER_VALIDATE_BOOLEAN ) under the hood. This
+ * preserves correct values, accepts every legacy on/off shape, and
+ * falls back to the declared per-field default when the key is missing
+ * entirely.
+ */
+class SettingsModelTest extends TestCase {
+
+	/**
+	 * Builds a SettingsModel where the persisted option contains exactly
+	 * the value-under-test for $key, with no other keys present. This
+	 * forces every other field to fall back to its declared default and
+	 * isolates the getter under test from incidental coupling.
+	 *
+	 * @param string $key   The settings key under test.
+	 * @param mixed  $value The persisted value to inject for that key.
+	 */
+	private function build_model_with( string $key, $value ): SettingsModel {
+		expect( 'get_option' )
+			->once()
+			->with( 'woocommerce-ppcp-data-settings', array() )
+			->andReturn( array( $key => $value ) );
+
+		return new SettingsModel( new DataSanitizer(), 'wc-' );
+	}
+
+	/**
+	 * Builds a SettingsModel where the persisted option is empty, so every
+	 * getter falls back to the per-field default declared in get_defaults().
+	 */
+	private function build_model_with_empty_option(): SettingsModel {
+		expect( 'get_option' )
+			->once()
+			->with( 'woocommerce-ppcp-data-settings', array() )
+			->andReturn( array() );
+
+		return new SettingsModel( new DataSanitizer(), 'wc-' );
+	}
+
+	// ------------------------------------------------------------------
+	// The customer-reported regression: get_save_paypal_and_venmo
+	// ------------------------------------------------------------------
+
+	/**
+	 * Regression test for the customer-reported TypeError.
+	 *
+	 * Reproduces the exact failure mode: a stored option containing the
+	 * legacy WooCommerce "yes"/"no" string instead of a real bool. Before
+	 * the fix, this getter would throw "Return value must be of type bool,
+	 * string returned" on PHP 8.x.
+	 *
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value Any of the shapes the option has
+	 *                            historically been observed to hold.
+	 * @param bool  $expected     Expected getter return value.
+	 */
+	public function test_get_save_paypal_and_venmo_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'save_paypal_and_venmo', $stored_value );
+
+		$this->assertSame( $expected, $model->get_save_paypal_and_venmo() );
+	}
+
+	// ------------------------------------------------------------------
+	// Same defensive behaviour applied uniformly to every bool getter
+	// ------------------------------------------------------------------
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_authorize_only_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'authorize_only', $stored_value );
+
+		$this->assertSame( $expected, $model->get_authorize_only() );
+	}
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_capture_virtual_orders_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'capture_virtual_orders', $stored_value );
+
+		$this->assertSame( $expected, $model->get_capture_virtual_orders() );
+	}
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_instant_payments_only_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'instant_payments_only', $stored_value );
+
+		$this->assertSame( $expected, $model->get_instant_payments_only() );
+	}
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_enable_contact_module_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'enable_contact_module', $stored_value );
+
+		$this->assertSame( $expected, $model->get_enable_contact_module() );
+	}
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_save_card_details_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'save_card_details', $stored_value );
+
+		$this->assertSame( $expected, $model->get_save_card_details() );
+	}
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_enable_pay_now_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'enable_pay_now', $stored_value );
+
+		$this->assertSame( $expected, $model->get_enable_pay_now() );
+	}
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_enable_logging_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'enable_logging', $stored_value );
+
+		$this->assertSame( $expected, $model->get_enable_logging() );
+	}
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_stay_updated_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'stay_updated', $stored_value );
+
+		$this->assertSame( $expected, $model->get_stay_updated() );
+	}
+
+	/**
+	 * @dataProvider bool_like_value_provider
+	 *
+	 * @param mixed $stored_value
+	 * @param bool  $expected
+	 */
+	public function test_get_payment_level_processing_coerces_stored_value( $stored_value, bool $expected ): void {
+		$model = $this->build_model_with( 'payment_level_processing', $stored_value );
+
+		$this->assertSame( $expected, $model->get_payment_level_processing() );
+	}
+
+	// ------------------------------------------------------------------
+	// Per-field defaults when the option is absent
+	//
+	// Different fields have different declared defaults in get_defaults().
+	// Verify each one falls back to that default when the stored option
+	// is empty -- the path third-party migration tools take when they
+	// clear or recreate the option mid-process.
+	// ------------------------------------------------------------------
+
+	/**
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public function default_value_provider(): array {
+		return array(
+			'authorize_only defaults to false'           => array( 'get_authorize_only', false ),
+			'capture_virtual_orders defaults to false'   => array( 'get_capture_virtual_orders', false ),
+			'save_paypal_and_venmo defaults to false'    => array( 'get_save_paypal_and_venmo', false ),
+			'instant_payments_only defaults to false'    => array( 'get_instant_payments_only', false ),
+			'enable_contact_module defaults to true'     => array( 'get_enable_contact_module', true ),
+			'save_card_details defaults to false'        => array( 'get_save_card_details', false ),
+			'enable_pay_now defaults to false'           => array( 'get_enable_pay_now', false ),
+			'enable_logging defaults to false'           => array( 'get_enable_logging', false ),
+			'stay_updated defaults to true'              => array( 'get_stay_updated', true ),
+			'payment_level_processing defaults to true'  => array( 'get_payment_level_processing', true ),
+		);
+	}
+
+	/**
+	 * @dataProvider default_value_provider
+	 *
+	 * @param string $getter   The bool getter under test.
+	 * @param bool   $expected The declared per-field default.
+	 */
+	public function test_getter_returns_declared_default_when_option_is_empty( string $getter, bool $expected ): void {
+		$model = $this->build_model_with_empty_option();
+
+		$this->assertSame( $expected, $model->$getter() );
+	}
+
+	// ------------------------------------------------------------------
+	// Shared data provider for the coercion test family
+	// ------------------------------------------------------------------
+
+	/**
+	 * Covers every shape the stored value has been observed to take in
+	 * production, plus the boundary cases for filter_var(FILTER_VALIDATE_BOOLEAN).
+	 *
+	 * @return array<string, array{0: mixed, 1: bool}>
+	 */
+	public function bool_like_value_provider(): array {
+		return array(
+			// Real booleans -- the happy path. Must round-trip unchanged.
+			'real bool true'                  => array( true, true ),
+			'real bool false'                 => array( false, false ),
+
+			// Legacy classic-WooCommerce "yes"/"no" storage. This is the
+			// shape that produced the customer's TypeError.
+			'legacy string yes'               => array( 'yes', true ),
+			'legacy string no'                => array( 'no', false ),
+
+			// Numeric-string storage common in form-posted settings.
+			'string 1'                        => array( '1', true ),
+			'string 0'                        => array( '0', false ),
+
+			// Word forms accepted by filter_var FILTER_VALIDATE_BOOLEAN.
+			'string true'                     => array( 'true', true ),
+			'string false'                    => array( 'false', false ),
+			'string on'                       => array( 'on', true ),
+			'string off'                      => array( 'off', false ),
+
+			// Empty / unrecognised string -- treat as falsey rather than
+			// fatal.
+			'empty string'                    => array( '', false ),
+			'unrecognised string is falsy'    => array( 'maybe', false ),
+
+			// Integers.
+			'integer 1'                       => array( 1, true ),
+			'integer 0'                       => array( 0, false ),
+		);
+	}
+}

--- a/tests/PHPUnit/Settings/Service/Migration/SettingsTabMigrationTest.php
+++ b/tests/PHPUnit/Settings/Service/Migration/SettingsTabMigrationTest.php
@@ -89,4 +89,68 @@ class SettingsTabMigrationTest extends TestCase {
 			),
 		);
 	}
+
+	/**
+	 * Legacy classic-WooCommerce settings stored the vault_enabled flag as the
+	 * string "yes" or "no". The new SettingsModel slot is a typed bool, so the
+	 * migration must coerce the value before it reaches the typed setter.
+	 *
+	 * Without coercion the migration either throws a TypeError (strict mode)
+	 * or persists "no" as true (weak mode), which downstream causes
+	 * SettingsModel::get_save_paypal_and_venmo() -- declared `: bool` -- to
+	 * fatal on PHP 8.x with "Return value must be of type bool, string
+	 * returned" the next time the setting is read.
+	 *
+	 * @dataProvider vault_enabled_cases
+	 *
+	 * @param mixed     $legacy_value Legacy vault_enabled value, in any of the
+	 *                                shapes the option has historically held.
+	 * @param bool|null $expected     Expected save_paypal_and_venmo after
+	 *                                migration, or null if the key should be
+	 *                                absent from the captured payload.
+	 */
+	public function test_vault_enabled_migration( $legacy_value, ?bool $expected ): void {
+		$legacy_settings = ( $legacy_value === '__missing__' )
+			? array()
+			: array( 'vault_enabled' => $legacy_value );
+
+		$captured_data  = null;
+		$settings_model = Mockery::mock( SettingsModel::class );
+		$settings_model->shouldReceive( 'from_array' )
+			->once()
+			->withArgs( function ( array $data ) use ( &$captured_data ) {
+				$captured_data = $data;
+
+				return true;
+			} );
+		$settings_model->shouldReceive( 'save' )->once();
+
+		$migration = new SettingsTabMigration( $legacy_settings, $settings_model );
+		$migration->migrate();
+
+		if ( $expected === null ) {
+			$this->assertArrayNotHasKey( 'save_paypal_and_venmo', $captured_data );
+
+			return;
+		}
+
+		$this->assertArrayHasKey( 'save_paypal_and_venmo', $captured_data );
+		$this->assertSame( $expected, $captured_data['save_paypal_and_venmo'] );
+		$this->assertIsBool( $captured_data['save_paypal_and_venmo'] );
+	}
+
+	public function vault_enabled_cases(): array {
+		return array(
+			'legacy string yes coerces to true'  => array( 'yes', true ),
+			'legacy string no coerces to false'  => array( 'no', false ),
+			'legacy string 1 coerces to true'    => array( '1', true ),
+			'legacy string 0 coerces to false'   => array( '0', false ),
+			'empty string coerces to false'      => array( '', false ),
+			'real boolean true passes through'   => array( true, true ),
+			'real boolean false passes through'  => array( false, false ),
+			'integer 1 coerces to true'          => array( 1, true ),
+			'integer 0 coerces to false'         => array( 0, false ),
+			'missing legacy key is not migrated' => array( '__missing__', null ),
+		);
+	}
 }


### PR DESCRIPTION
**Issue**: #4388 (related — same module, distinct symptom; this PR does not close it)

**Ticket**: n/a (community contribution from production triage)

**Slack Thread**: n/a

---

### Description

`SettingsModel` exposes ten typed-bool getters that return `$this->data[$key]` directly, trusting that whatever is stored under that key is a real `bool`. On PHP 8.x this throws

```
Return value must be of type bool, string returned
```

whenever the stored option holds a non-bool value. We hit this in production for `get_save_paypal_and_venmo()`, which fatals during `WcSubscriptionsModule` boot and prevents PPCP's REST routes (including the webhook endpoint at `/wp-json/paypal/v1/incoming`) from registering. The user-visible effect is that PayPal webhook events stop reaching the site silently — order/subscription state desyncs without any obvious error to the merchant.

Observed shapes of the stored value that produce the fatal:

- Legacy classic-WooCommerce `'yes'`/`'no'` strings (`vault_enabled` lineage).
- `'1'`/`'0'` from form-posted settings via paths that bypass the typed setter.
- Direct DB writes by import/export tools that re-serialise options without preserving scalar types.

The same defect pattern exists on all ten typed-bool getters; only `get_save_paypal_and_venmo()` has been observed firing in the wild, but the surface is identical and the fix is a uniform one-liner per getter.

#### Two-part defence

**1. Defensive coercion in every typed-bool getter.** Wrap each getter with the existing `DataSanitizer::sanitize_bool()` (which is `filter_var( ..., FILTER_VALIDATE_BOOLEAN )`). Pure pass-through for real bools; correctly handles `'yes'`/`'no'`/`'1'`/`'0'`/`'true'`/`'false'`/`'on'`/`'off'` strings. Each getter also gets a per-field default via `??` so a missing key falls back to the value declared in `get_defaults()` instead of producing a PHP warning.

Affected getters (all in `modules/ppcp-settings/src/Data/SettingsModel.php`):

- `get_authorize_only()`
- `get_capture_virtual_orders()`
- `get_save_paypal_and_venmo()`
- `get_instant_payments_only()`
- `get_enable_contact_module()`
- `get_save_card_details()`
- `get_enable_pay_now()`
- `get_enable_logging()`
- `get_stay_updated()`
- `get_payment_level_processing()` — note this one previously had a weak `(bool)` cast which incorrectly returns `true` for `'no'` (every non-empty, non-`'0'` string casts to true).

**2. Explicit `vault_enabled` arm in `SettingsTabMigration`.** Legacy classic-WooCommerce settings stored `vault_enabled` as `'yes'` / `'no'`. The migration currently routes unknown keys through a `default:` arm that copies the raw string into the new typed slot. From there, `from_array()` hands it to `set_save_paypal_and_venmo( bool $save )`, which either TypeErrors (strict mode) or silently persists `'no'` as `true` (weak mode, where every non-empty non-`'0'` string casts to true — including `'no'`). The new `case 'vault_enabled':` arm coerces explicitly via `filter_var( ..., FILTER_VALIDATE_BOOLEAN )` before assignment.

#### Out of scope

Other legacy bool fields routed through the `default:` arm may share the same latent defect, but I have no production evidence for them. Happy to expand the migration patch in a follow-up if maintainers prefer.

### Steps to Test

**Reproduce the fatal (without this patch):**

1. On a site with PPCP active, run:
   ```bash
   wp option patch update woocommerce-ppcp-data-settings save_paypal_and_venmo yes
   ```
   (or use any other typed-bool key from the list above).
2. Load any page that boots `WcSubscriptionsModule`, or hit `/wp-json/paypal/v1/incoming`.
3. Observe `TypeError: SettingsModel::get_save_paypal_and_venmo(): Return value must be of type bool, string returned` in the error log; the webhook route returns `rest_no_route`.

**Verify the fix:**

1. Apply this branch.
2. Repeat the steps above — the getter now returns `true` (and `'no'` returns `false`), no fatal, webhook route registers normally.
3. Run `vendor/bin/phpunit tests/PHPUnit/Settings tests/PHPUnit/PpcpSettings` — 240 tests pass.

**Verify the migration arm:**

1. Set up a site with the legacy WooCommerce PPCP settings containing `vault_enabled = "yes"`.
2. Trigger the settings-tab migration.
3. Confirm `save_paypal_and_venmo` is stored as bool `true` in the new option, not the string `'yes'`.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

No user-facing behaviour change. Internal defensive coercion only.

### Changelog Entry

> Fix: defensively coerce stored values in `SettingsModel` typed-bool getters, and explicitly coerce `vault_enabled` during settings-tab migration, to prevent `TypeError: Return value must be of type bool, string returned` when the persisted option contains a non-bool value (legacy `'yes'`/`'no'` strings, direct DB writes, or third-party import/export tools).

Related: #4388.
