### PR TITLE
[QA] Trigger smoke E2E tests after merge on dev/develop

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,10 @@
 name: E2E Tests
 
 on:
+  workflow_run:
+    workflows: [ "Build and distribute" ]
+    types: [ completed ]
+    branches: [ dev/develop ]
   workflow_dispatch:
     inputs:
       TEST_SUITE:
@@ -29,12 +33,15 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
     name: Build tested plugin package
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     uses: inpsyde/reusable-workflows/.github/workflows/build-and-distribute.yml@main
     secrets:
       GITHUB_USER_EMAIL: ${{ secrets.DEPLOYBOT_EMAIL }}
@@ -49,6 +56,9 @@ jobs:
   resolve-playwright-matrix:
     name: Resolve Playwright matrix
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     outputs:
       matrix: ${{ steps.resolve.outputs.matrix }}
     steps:
@@ -68,10 +78,11 @@ jobs:
             subscription
           )
 
-          if [[ '${{ inputs.TEST_SUITE }}' == *':parallel' ]]; then
-            TAG='${{ inputs.TEST_SUITE }}'
+          TEST_SUITE='${{ inputs.TEST_SUITE || 'smoke:parallel' }}'
+
+          if [[ "$TEST_SUITE" == *':parallel' ]]; then
             SUFFIX=""
-            [[ "$TAG" != "all:parallel" ]] && SUFFIX=":${TAG%:parallel}"
+            [[ "$TEST_SUITE" != "all:parallel" ]] && SUFFIX=":${TEST_SUITE%:parallel}"
 
             entry() { echo "{\"script\":\"e2e:test:shard:${1}${SUFFIX}\",\"name_suffix\":\" / ${1}\",\"artifact_name\":\"playwright-artifact-${1}\"}"; }
 
@@ -83,9 +94,8 @@ jobs:
 
             echo "matrix={\"include\":[${JOINED}]}" >> "$GITHUB_OUTPUT"
           else
-            SUITE='${{ inputs.TEST_SUITE }}'
-            NAME="${SUITE#shard:}"
-            echo "matrix={\"include\":[{\"script\":\"e2e:test:${SUITE}\",\"name_suffix\":\" / ${NAME}\",\"artifact_name\":\"playwright-artifact-${NAME}\"}]}" >> "$GITHUB_OUTPUT"
+            NAME="${TEST_SUITE#shard:}"
+            echo "matrix={\"include\":[{\"script\":\"e2e:test:${TEST_SUITE}\",\"name_suffix\":\" / ${NAME}\",\"artifact_name\":\"playwright-artifact-${NAME}\"}]}" >> "$GITHUB_OUTPUT"
           fi
 
   e2e-playwright:


### PR DESCRIPTION
**Ticket**: PCP-6437

### Description

Trigger smoke E2E tests after merge and B&D on `dev/develop`:
- Add `workflow_run` trigger to `e2e-tests.yml` that fires after "Build and distribute" completes on `dev/develop`.
- Defaults to `smoke:parallel` when no inputs are available.
- Skips E2E run if B&D failed.
