### PR TITLE
SDK v6 module foundation & infrastructure (5779)

### DIFF
--- a/modules.php
+++ b/modules.php
@@ -93,5 +93,12 @@ return static function ( string $root_dir ): iterable {
 		$modules[] = ( require "$modules_dir/ppcp-store-sync/module.php" )();
 	}
 
+	if ( apply_filters(
+		'woocommerce.feature-flags.woocommerce_paypal_payments.sdk_v6_enabled',
+		getenv( 'PCP_SDK_V6_ENABLED' ) === '1'
+	) ) {
+		$modules[] = ( require "$modules_dir/ppcp-sdk-v6/module.php" )();
+	}
+
 	return $modules;
 };

--- a/modules/ppcp-sdk-v6/composer.json
+++ b/modules/ppcp-sdk-v6/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "woocommerce/ppcp-sdk-v6",
+    "type": "dhii-mod",
+    "description": "PayPal JS SDK v6 integration module for PPCP",
+    "license": "GPL-2.0",
+    "require": {
+        "php": "^7.4 | ^8.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "WooCommerce\\PayPalCommerce\\SdkV6\\": "src"
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/modules/ppcp-sdk-v6/module.php
+++ b/modules/ppcp-sdk-v6/module.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * The SDK v6 module.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6;
+
+return static function (): SdkV6Module {
+	return new SdkV6Module();
+};

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -1,5 +1,108 @@
 /**
- * PayPal SDK v6 Bootstrap -- placeholder.
+ * PayPal SDK v6 Bootstrap.
  *
- * @package WooCommerce\PayPalCommerce\SdkV6
+ * Loads the PayPal JS SDK v6 core, fetches a browser-safe client token
+ * from the backend, and creates the SDK instance.
+ *
+ * @package
  */
+
+/**
+ * @param {Object} config Localized script data from wc_ppcp_sdk_v6.
+ */
+( function ( config ) {
+	'use strict';
+
+	if ( ! config ) {
+		return;
+	}
+
+	/**
+	 * Fetches the browser-safe client token from the WC AJAX endpoint.
+	 *
+	 * @return {Promise<string>} Resolves to the client token string.
+	 */
+	async function fetchClientToken() {
+		const response = await fetch( config.ajax.client_token.endpoint, {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify( {
+				nonce: config.ajax.client_token.nonce,
+			} ),
+		} );
+
+		const json = await response.json();
+
+		if ( ! json.success ) {
+			throw new Error(
+				json.data?.message || 'Failed to fetch client token.'
+			);
+		}
+
+		return json.data.client_token;
+	}
+
+	/**
+	 * Dynamically loads the PayPal SDK v6 core script.
+	 *
+	 * @return {Promise<void>} Resolves when the script is loaded.
+	 */
+	function loadSdkScript() {
+		return new Promise( ( resolve, reject ) => {
+			if ( document.querySelector( 'script[src*="web-sdk/v6/core"]' ) ) {
+				resolve();
+				return;
+			}
+
+			const script = document.createElement( 'script' );
+			script.src = config.sdk_url;
+			script.async = true;
+			script.onload = resolve;
+			script.onerror = () =>
+				reject( new Error( 'Failed to load PayPal SDK v6 script.' ) );
+			document.head.appendChild( script );
+		} );
+	}
+
+	/**
+	 * Initializes the PayPal SDK v6 instance.
+	 */
+	async function init() {
+		try {
+			const [ , clientToken ] = await Promise.all( [
+				loadSdkScript(),
+				fetchClientToken(),
+			] );
+
+			if ( ! window.paypal?.createInstance ) {
+				throw new Error(
+					'PayPal SDK v6 global not found after script load.'
+				);
+			}
+
+			const sdkInstance = await window.paypal.createInstance( {
+				clientToken,
+			} );
+
+			window.ppcpSdkV6Instance = sdkInstance;
+
+			document.dispatchEvent(
+				new CustomEvent( 'ppcp-sdk-v6-ready', {
+					detail: { sdkInstance },
+				} )
+			);
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( '[PPCP SDK v6]', error );
+		}
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )( window.wc_ppcp_sdk_v6 );

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -1,0 +1,5 @@
+/**
+ * PayPal SDK v6 Bootstrap -- placeholder.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6
+ */

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * The SDK v6 module services.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6;
+
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
+use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
+use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RateLimiter;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+return array(
+
+	'sdk-v6.asset-getter'          => static function ( ContainerInterface $container ): AssetGetter {
+		$factory = $container->get( 'assets.asset_getter_factory' );
+		assert( $factory instanceof AssetGetterFactory );
+
+		return $factory->for_module( 'ppcp-sdk-v6' );
+	},
+
+	'sdk-v6.manager'               => static function ( ContainerInterface $container ): SdkV6Manager {
+		return new SdkV6Manager(
+			$container->get( 'sdk-v6.asset-getter' ),
+			$container->get( 'ppcp.asset-version' ),
+			$container->get( 'settings.environment' )
+		);
+	},
+
+	'sdk-v6.endpoint.client-token' => static function ( ContainerInterface $container ): ClientTokenEndpoint {
+		return new ClientTokenEndpoint(
+			$container->get( 'button.request-data' ),
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'api.sdk-client-token' ),
+			$container->get( 'sdk-v6.rate-limiter' )
+		);
+	},
+
+	'sdk-v6.rate-limiter'          => static function ( ContainerInterface $container ): RateLimiter {
+		return new RateLimiter(
+			'ppcp_sdk_v6_rl_',
+			10,
+			60
+		);
+	},
+
+);

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\SdkV6\Assets;
 
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 
 /**
@@ -22,21 +23,21 @@ class SdkV6Manager {
 	 *
 	 * @var AssetGetter
 	 */
-	private AssetGetter $asset_getter; // @phpstan-ignore property.onlyWritten
+	private AssetGetter $asset_getter;
 
 	/**
 	 * The assets version.
 	 *
 	 * @var string
 	 */
-	private string $version; // @phpstan-ignore property.onlyWritten
+	private string $version;
 
 	/**
 	 * The environment object.
 	 *
 	 * @var Environment
 	 */
-	private Environment $environment; // @phpstan-ignore property.onlyWritten
+	private Environment $environment;
 
 	/**
 	 * SdkV6Manager constructor.
@@ -61,5 +62,54 @@ class SdkV6Manager {
 	 * @return void
 	 */
 	public function enqueue(): void {
+		if ( ! $this->should_enqueue() ) {
+			return;
+		}
+
+		wp_register_script(
+			'wc-ppcp-sdk-v6-boot',
+			$this->asset_getter->get_asset_url( 'boot.js' ),
+			array(),
+			$this->version,
+			true
+		);
+
+		wp_localize_script(
+			'wc-ppcp-sdk-v6-boot',
+			'wc_ppcp_sdk_v6',
+			$this->script_data()
+		);
+
+		wp_enqueue_script( 'wc-ppcp-sdk-v6-boot' );
+	}
+
+	/**
+	 * Whether the scripts should be enqueued on the current page.
+	 *
+	 * @return bool
+	 */
+	private function should_enqueue(): bool {
+		return is_checkout() || is_cart();
+	}
+
+	/**
+	 * The configuration data for the SDK v6 bootstrap script.
+	 *
+	 * @return array
+	 */
+	private function script_data(): array {
+		$base_url = $this->environment->is_sandbox()
+			? 'https://www.sandbox.paypal.com'
+			: 'https://www.paypal.com';
+
+		return array(
+			'sdk_url' => $base_url . '/web-sdk/v6/core',
+			'ajax'    => array(
+				'client_token' => array(
+					'endpoint' => \WC_AJAX::get_endpoint( ClientTokenEndpoint::ENDPOINT ),
+					'nonce'    => wp_create_nonce( ClientTokenEndpoint::nonce() ),
+				),
+			),
+		);
 	}
 }

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Manages the SDK v6 frontend assets.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Assets
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Assets;
+
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
+
+/**
+ * Class SdkV6Manager
+ */
+class SdkV6Manager {
+
+	/**
+	 * The asset getter.
+	 *
+	 * @var AssetGetter
+	 */
+	private AssetGetter $asset_getter; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * The assets version.
+	 *
+	 * @var string
+	 */
+	private string $version; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * The environment object.
+	 *
+	 * @var Environment
+	 */
+	private Environment $environment; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * SdkV6Manager constructor.
+	 *
+	 * @param AssetGetter $asset_getter The asset getter.
+	 * @param string      $version The assets version.
+	 * @param Environment $environment The environment object.
+	 */
+	public function __construct(
+		AssetGetter $asset_getter,
+		string $version,
+		Environment $environment
+	) {
+		$this->asset_getter = $asset_getter;
+		$this->version      = $version;
+		$this->environment  = $environment;
+	}
+
+	/**
+	 * Enqueues scripts/styles.
+	 *
+	 * @return void
+	 */
+	public function enqueue(): void {
+	}
+}

--- a/modules/ppcp-sdk-v6/src/Endpoint/ClientTokenEndpoint.php
+++ b/modules/ppcp-sdk-v6/src/Endpoint/ClientTokenEndpoint.php
@@ -11,8 +11,11 @@ namespace WooCommerce\PayPalCommerce\SdkV6\Endpoint;
 
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\RateLimiter;
 
 /**
@@ -27,28 +30,28 @@ class ClientTokenEndpoint implements EndpointInterface {
 	 *
 	 * @var RequestData
 	 */
-	private RequestData $request_data; // @phpstan-ignore property.onlyWritten
+	private RequestData $request_data;
 
 	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
 	 */
-	private LoggerInterface $logger; // @phpstan-ignore property.onlyWritten
+	private LoggerInterface $logger;
 
 	/**
 	 * The SDK client token generator.
 	 *
 	 * @var SdkClientToken
 	 */
-	private SdkClientToken $sdk_client_token; // @phpstan-ignore property.onlyWritten
+	private SdkClientToken $sdk_client_token;
 
 	/**
 	 * The rate limiter.
 	 *
 	 * @var RateLimiter
 	 */
-	private RateLimiter $rate_limiter; // @phpstan-ignore property.onlyWritten
+	private RateLimiter $rate_limiter;
 
 	/**
 	 * ClientTokenEndpoint constructor.
@@ -81,6 +84,36 @@ class ClientTokenEndpoint implements EndpointInterface {
 	 * {@inheritDoc}
 	 */
 	public function handle_request(): void {
-		wp_send_json_error( 'Not implemented.', 501 );
+		try {
+			$this->request_data->read_request( $this->nonce() );
+		} catch ( NonceValidationException $error ) {
+			wp_send_json_error( array( 'message' => $error->getMessage() ), 400 );
+		}
+
+		if ( $this->rate_limiter->is_limited() ) {
+			$this->logger->warning( 'SDK v6 client token rate limit exceeded.' );
+			wp_send_json_error(
+				array( 'message' => 'Rate limit exceeded. Please try again later.' ),
+				429
+			);
+		}
+
+		$this->rate_limiter->hit();
+
+		try {
+			$token = $this->sdk_client_token->sdk_client_token();
+
+			wp_send_json_success(
+				array(
+					'client_token' => $token,
+				)
+			);
+		} catch ( PayPalApiException $exception ) {
+			$this->logger->error( 'SDK v6 client token PayPal API error: ' . $exception->getMessage() );
+			wp_send_json_error( array( 'message' => 'Failed to generate client token.' ), 500 );
+		} catch ( RuntimeException $exception ) {
+			$this->logger->error( 'SDK v6 client token runtime error: ' . $exception->getMessage() );
+			wp_send_json_error( array( 'message' => 'Failed to generate client token.' ), 500 );
+		}
 	}
 }

--- a/modules/ppcp-sdk-v6/src/Endpoint/ClientTokenEndpoint.php
+++ b/modules/ppcp-sdk-v6/src/Endpoint/ClientTokenEndpoint.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Handles the request for the SDK v6 browser-safe client token.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Endpoint
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Endpoint;
+
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
+use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\RateLimiter;
+
+/**
+ * Class ClientTokenEndpoint
+ */
+class ClientTokenEndpoint implements EndpointInterface {
+
+	const ENDPOINT = 'ppc-sdk-v6-client-token';
+
+	/**
+	 * The request data helper.
+	 *
+	 * @var RequestData
+	 */
+	private RequestData $request_data; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * The logger.
+	 *
+	 * @var LoggerInterface
+	 */
+	private LoggerInterface $logger; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * The SDK client token generator.
+	 *
+	 * @var SdkClientToken
+	 */
+	private SdkClientToken $sdk_client_token; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * The rate limiter.
+	 *
+	 * @var RateLimiter
+	 */
+	private RateLimiter $rate_limiter; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * ClientTokenEndpoint constructor.
+	 *
+	 * @param RequestData     $request_data The request data helper.
+	 * @param LoggerInterface $logger The logger.
+	 * @param SdkClientToken  $sdk_client_token The SDK client token generator.
+	 * @param RateLimiter     $rate_limiter The rate limiter.
+	 */
+	public function __construct(
+		RequestData $request_data,
+		LoggerInterface $logger,
+		SdkClientToken $sdk_client_token,
+		RateLimiter $rate_limiter
+	) {
+		$this->request_data     = $request_data;
+		$this->logger           = $logger;
+		$this->sdk_client_token = $sdk_client_token;
+		$this->rate_limiter     = $rate_limiter;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function nonce(): string {
+		return self::ENDPOINT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function handle_request(): void {
+		wp_send_json_error( 'Not implemented.', 501 );
+	}
+}

--- a/modules/ppcp-sdk-v6/src/Helper/RateLimiter.php
+++ b/modules/ppcp-sdk-v6/src/Helper/RateLimiter.php
@@ -19,21 +19,21 @@ class RateLimiter {
 	 *
 	 * @var string
 	 */
-	private string $prefix; // @phpstan-ignore property.onlyWritten
+	private string $prefix;
 
 	/**
 	 * The maximum number of requests allowed per window.
 	 *
 	 * @var int
 	 */
-	private int $max_requests; // @phpstan-ignore property.onlyWritten
+	private int $max_requests;
 
 	/**
 	 * The time window in seconds.
 	 *
 	 * @var int
 	 */
-	private int $window_seconds; // @phpstan-ignore property.onlyWritten
+	private int $window_seconds;
 
 	/**
 	 * RateLimiter constructor.
@@ -54,7 +54,10 @@ class RateLimiter {
 	 * @return bool
 	 */
 	public function is_limited(): bool {
-		return false;
+		$key   = $this->get_key();
+		$count = (int) get_transient( $key );
+
+		return $count >= $this->max_requests;
 	}
 
 	/**
@@ -63,5 +66,33 @@ class RateLimiter {
 	 * @return void
 	 */
 	public function hit(): void {
+		$key   = $this->get_key();
+		$count = (int) get_transient( $key );
+
+		set_transient( $key, $count + 1, $this->window_seconds );
+	}
+
+	/**
+	 * Generates the transient key for the current client.
+	 *
+	 * Uses WC session customer ID if available, falls back to IP address.
+	 *
+	 * @return string
+	 */
+	private function get_key(): string {
+		$identifier = '';
+		if ( function_exists( 'WC' ) && isset( WC()->session ) && is_object( WC()->session ) ) {
+			$customer_id = WC()->session->get_customer_id();
+			if ( ! empty( $customer_id ) ) {
+				$identifier = $customer_id;
+			}
+		}
+		if ( empty( $identifier ) ) {
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$raw_ip     = wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0' );
+			$identifier = is_array( $raw_ip ) ? '0.0.0.0' : sanitize_text_field( $raw_ip );
+		}
+
+		return $this->prefix . md5( $identifier );
 	}
 }

--- a/modules/ppcp-sdk-v6/src/Helper/RateLimiter.php
+++ b/modules/ppcp-sdk-v6/src/Helper/RateLimiter.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Simple transient-based rate limiter.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+/**
+ * Class RateLimiter
+ */
+class RateLimiter {
+
+	/**
+	 * The transient key prefix.
+	 *
+	 * @var string
+	 */
+	private string $prefix; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * The maximum number of requests allowed per window.
+	 *
+	 * @var int
+	 */
+	private int $max_requests; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * The time window in seconds.
+	 *
+	 * @var int
+	 */
+	private int $window_seconds; // @phpstan-ignore property.onlyWritten
+
+	/**
+	 * RateLimiter constructor.
+	 *
+	 * @param string $prefix The transient key prefix.
+	 * @param int    $max_requests The maximum requests per window.
+	 * @param int    $window_seconds The time window in seconds.
+	 */
+	public function __construct( string $prefix, int $max_requests, int $window_seconds ) {
+		$this->prefix         = $prefix;
+		$this->max_requests   = $max_requests;
+		$this->window_seconds = $window_seconds;
+	}
+
+	/**
+	 * Checks if the current client has exceeded the rate limit.
+	 *
+	 * @return bool
+	 */
+	public function is_limited(): bool {
+		return false;
+	}
+
+	/**
+	 * Records a request hit for the current client.
+	 *
+	 * @return void
+	 */
+	public function hit(): void {
+	}
+}

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * The SDK v6 module.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6;
+
+use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
+use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
+use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Class SdkV6Module
+ */
+class SdkV6Module implements ServiceModule, ExecutableModule {
+	use ModuleClassNameIdTrait;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function services(): array {
+		return require __DIR__ . '/../services.php';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function run( ContainerInterface $c ): bool {
+		return true;
+	}
+}

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\SdkV6;
 
+use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
+use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
@@ -31,6 +33,26 @@ class SdkV6Module implements ServiceModule, ExecutableModule {
 	 * {@inheritDoc}
 	 */
 	public function run( ContainerInterface $c ): bool {
+		add_action(
+			'wc_ajax_' . ClientTokenEndpoint::ENDPOINT,
+			static function () use ( $c ) {
+				$endpoint = $c->get( 'sdk-v6.endpoint.client-token' );
+				assert( $endpoint instanceof ClientTokenEndpoint );
+
+				$endpoint->handle_request();
+			}
+		);
+
+		add_action(
+			'wp_enqueue_scripts',
+			static function () use ( $c ) {
+				$manager = $c->get( 'sdk-v6.manager' );
+				assert( $manager instanceof SdkV6Manager );
+
+				$manager->enqueue();
+			}
+		);
+
 		return true;
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,6 +68,7 @@ const modulesAssets = {
 	],
 	'ppcp-paypal-subscriptions': [ 'js/paypal-subscription.js' ],
 	'ppcp-save-payment-methods': [ 'js/add-payment-method.js' ],
+	'ppcp-sdk-v6': [ 'js/boot.js' ],
 	'ppcp-settings': [ 'js/index.js', 'css/styles.scss' ],
 	'ppcp-wc-gateway': [
 		'js/common.js',


### PR DESCRIPTION
### Description

PayPal JS SDK v6 module infrastructure behind `PCP_SDK_V6_ENABLED` feature flag.

- Client token endpoint with nonce validation and rate limiting
- Bootstrap script loads SDK v6 core + fetches token in parallel, creates SDK instance
- Exposes `window.ppcpSdkV6Instance` and `ppcp-sdk-v6-ready` event for downstream modules
- No impact on v5 when flag is off

### Steps to Test

1. Add `putenv( 'PCP_SDK_V6_ENABLED=1' );` to `wp-config.php`
2. Run `npm run build`
3. Go to cart or checkout page
4. Open DevTools Network tab — verify `ppcp-sdk-v6-js-boot.js`, SDK core, and `?wc-ajax=ppc-sdk-v6-client-token` all return 200
5. In Console, verify window.ppcpSdkV6Instance exists
