### PR TITLE
Clarify cardholder name field placeholder

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/card-fields.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.js
@@ -101,7 +101,7 @@ export function CardFields( { config, eventRegistration, emitResponse } ) {
 					{ config.name_on_card === 'yes' && (
 						<PayPalNameField
 							placeholder={ __(
-								'Cardholder Name (optional)',
+								'Cardholder Name as shown on card',
 								'woocommerce-paypal-payments'
 							) }
 						/>

--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -101,7 +101,7 @@ class CardFieldsModule implements ServiceModule, ExecutableModule {
 				if ( CreditCardGateway::ID === $id && $should_show_card_holder_name ) {
 					$default_fields['card-name-field'] = '<p class="form-row form-row-wide">
 						<label for="ppcp-credit-card-gateway-card-name">' . esc_attr__( 'Cardholder Name', 'woocommerce-paypal-payments' ) . '</label>
-						<input id="ppcp-credit-card-gateway-card-name" class="input-text wc-credit-card-form-card-expiry" type="text" placeholder="' . esc_attr__( 'Cardholder Name (optional)', 'woocommerce-paypal-payments' ) . '" name="ppcp-credit-card-gateway-card-name">
+						<input id="ppcp-credit-card-gateway-card-name" class="input-text wc-credit-card-form-card-expiry" type="text" placeholder="' . esc_attr__( 'Cardholder Name as shown on card', 'woocommerce-paypal-payments' ) . '" name="ppcp-credit-card-gateway-card-name">
 					</p>';
 
 					// Moves new item to first position.


### PR DESCRIPTION
## Description

This updates the cardholder name placeholder from "Cardholder Name (optional)" to "Cardholder Name as shown on card" in both classic checkout and block checkout card fields.

Although the PayPal Card Fields name field can be rendered as an optional SDK field, merchants may rely on the cardholder name as part of Advanced Card Processing authorization flows. In particular, cardholder/billing details can help with 3D Secure/SCA authentication and issuer risk checks. When the field is displayed as optional, shoppers may skip it or enter a value that does not match the card, which can surface as a generic invalid card details error.

This wording avoids implying that the field is safe to ignore while keeping the UI concise and consistent across checkout implementations.

## Changes

- Update classic checkout cardholder name placeholder.
- Update block checkout cardholder name placeholder.

## Testing

- Not run locally. This is a copy-only change; generated assets were not edited manually.