### PR TITLE
[QA] add: OXXO E2E tests (PCP-6324, PCP-6325)

### DIFF
--- a/tests/qa/tests/05-transactions/_test-data/oxxo/index.ts
+++ b/tests/qa/tests/05-transactions/_test-data/oxxo/index.ts
@@ -1,0 +1,1 @@
+export * from './oxxo-classic-checkout.data';

--- a/tests/qa/tests/05-transactions/_test-data/oxxo/oxxo-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/oxxo/oxxo-classic-checkout.data.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import {
+	payments,
+	orders,
+	customers,
+	guests,
+	merchants,
+	ShopOrder,
+} from '../../../../resources';
+
+const customer = customers.mexico;
+const guest = guests.mexico;
+const merchant = merchants.mexico;
+
+export const oxxoClassicCheckout: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-6324
+		title: 'PCP-6324 | Transaction - Classic checkout - OXXO - Default order @Critical',
+		...orders.default,
+		payment: payments.oxxo,
+		customer: guest,
+		merchant,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-6325
+		title: 'PCP-6325 | Transaction - Classic checkout - OXXO - Order by customer',
+		...orders.default,
+		payment: payments.oxxo,
+		customer,
+		merchant,
+	},
+];

--- a/tests/qa/tests/05-transactions/_test-scenarios/classic-checkout.scenario.ts
+++ b/tests/qa/tests/05-transactions/_test-scenarios/classic-checkout.scenario.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { ShopOrder } from '../../../resources';
-import { annotateVisitor, test } from '../../../utils';
+import { annotateVisitor, test, expect, OxxoVoucherPopup } from '../../../utils';
 
 export const transactionsOnClassicCheckout = ( testOrder: ShopOrder ) => {
 	const { title, payment, products, customer, merchant } = testOrder;
@@ -48,38 +48,66 @@ export const transactionsOnClassicCheckout = ( testOrder: ShopOrder ) => {
 };
 
 export const transactionsOnClassicCheckoutOxxo = ( testOrder: ShopOrder ) => {
-	const { title, payment, products, customer, merchant } = testOrder;
+	const { payment, merchant } = testOrder;
 
-	test.fixme(
-		title,
-		annotateVisitor( customer ),
+	test(
+		testOrder.title,
+		annotateVisitor( testOrder.customer ),
 		async ( {
 			classicCheckout,
-			// wooCommerceApi,
+			wooCommerceApi,
 			orderReceived,
-			// payPalApi,
-			// wooCommerceOrderEdit,
+			payPalApi,
+			wooCommerceOrderEdit,
 			utils,
 		} ) => {
-			await utils.fillVisitorsCart( products );
+			await utils.fillVisitorsCart( testOrder.products );
 			await classicCheckout.visit();
 			await classicCheckout.completeCheckoutDetails( testOrder );
 			await classicCheckout.payPalUi.makePayment( { merchant, payment } );
 			await orderReceived.assertOrderDetails( testOrder );
 
-			// const orderId = await orderReceived.getOrderNumber();
-			// const orderJson = await wooCommerceApi.getOrder( orderId );
+			const orderId = await orderReceived.getOrderNumber();
+			const orderJson = await wooCommerceApi.getOrder( orderId );
 
-			// const oxxoOrderId =
-			// 	await payPalApi.getOrderIdFromWooCommerce( orderJson );
-			// const oxxoOrder = await payPalApi.getOrder(
-			// 	oxxoOrderId,
-			// 	testOrder.merchant
-			// );
-			// const oxxoPaymentId = await payPalApi.getPaymentIdFromOrder(
-			// 	oxxoOrder,
-			// 	testOrder.payment
-			// );
+			const oxxoOrderId = await payPalApi.getOrderIdFromWooCommerce(
+				orderJson
+			);
+
+			await expect(
+				orderReceived.seeOXXOVoucherButton_1(),
+				'Assert OXXO voucher button is visible on order-received page'
+			).toBeVisible();
+			const popupPromise = orderReceived.page.waitForEvent( 'popup' );
+			await orderReceived.seeOXXOVoucherButton_1().click();
+			const voucherPopup = new OxxoVoucherPopup( await popupPromise );
+			await voucherPopup.simulate();
+
+			// Poll until the real webhook is processed and order status updates
+			await expect.poll(
+				async () => {
+					const order = await wooCommerceApi.getOrder( orderId );
+					return order.status;
+				},
+				{
+					message: 'Assert OXXO order status is processing after capture webhook',
+					timeout: 60_000,
+					intervals: [ 2_000, 3_000, 5_000 ],
+				}
+			).toEqual( 'processing' );
+
+			const oxxoOrder = await payPalApi.getOrder(
+				oxxoOrderId,
+				testOrder.merchant
+			);
+			const oxxoPaymentId = await payPalApi.getPaymentIdFromOrder(
+				oxxoOrder,
+				testOrder.payment
+			);
+			const pcpData = { transactionId: oxxoPaymentId };
+
+			await wooCommerceOrderEdit.visit( orderId );
+			await wooCommerceOrderEdit.assertOrderDetails( testOrder, pcpData );
 		}
 	);
 };

--- a/tests/qa/tests/05-transactions/transaction-mexico-classic.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-mexico-classic.spec.ts
@@ -6,12 +6,16 @@ import {
 	taxSettings,
 	customers,
 } from '../../resources';
-import { transactionsOnClassicCheckout } from './_test-scenarios';
+import {
+	transactionsOnClassicCheckout,
+	transactionsOnClassicCheckoutOxxo,
+} from './_test-scenarios';
 import {
 	bcdcClassicCheckout,
 	bcdcClassicCheckoutExcludingTax,
 	bcdcClassicCheckoutIntentAuthorized,
 } from './_test-data/bcdc';
+import { oxxoClassicCheckout } from './_test-data/oxxo';
 
 /**
  * BCDC is classic-checkout only — block checkout is not supported.
@@ -57,3 +61,10 @@ test.describe( () => {
 		await pcpApi.updatePcpSettings( { authorizeOnly: false } );
 	} );
 } );
+
+/**
+ * OXXO — Mexico cash payment via classic checkout
+ */
+for ( const testOrder of oxxoClassicCheckout ) {
+	transactionsOnClassicCheckoutOxxo( testOrder );
+}

--- a/tests/qa/tests/_setup/03-pcp.setup.ts
+++ b/tests/qa/tests/_setup/03-pcp.setup.ts
@@ -12,7 +12,7 @@ import {
 	gateways,
 } from '../../resources';
 
-const { payPal, payLater, venmo, acdc, bcdc, fastlane, googlepay } = gateways;
+const { payPal, payLater, venmo, acdc, bcdc, fastlane, googlepay, oxxo } = gateways;
 
 // =====================================================================
 // Layer 2 — PCP country: configureStore + installPcp + resetDb + connect
@@ -73,6 +73,7 @@ setup( 'setup:transaction:mexico;', async ( { utils, pcpApi } ) => {
 	await pcpApi.updatePcpPaymentMethods( {
 		[ payPal.id ]: { id: payPal.id, enabled: true },
 		[ bcdc.id ]: { id: bcdc.id, enabled: true },
+		[ oxxo.id ]: { id: oxxo.id, enabled: true },
 	} );
 } );
 

--- a/tests/qa/utils/admin/woocommerce-order-edit.ts
+++ b/tests/qa/utils/admin/woocommerce-order-edit.ts
@@ -198,13 +198,6 @@ export class WooCommerceOrderEdit extends WooCommerceOrderEditBase {
 			);
 		}
 
-		if ( orderData.payment.gateway.shortcut === 'oxxo' ) {
-			await expect(
-				this.seeOXXOVoucherButton(),
-				'Assert OXXO voucher button is visible'
-			).toBeVisible();
-		}
-
 		if (
 			[ 'paypal', 'paylater', 'venmo' ].includes(
 				orderData.payment.gateway.shortcut

--- a/tests/qa/utils/frontend/index.ts
+++ b/tests/qa/utils/frontend/index.ts
@@ -7,6 +7,7 @@ export * from './customer-account';
 export * from './customer-payment-methods';
 export * from './customer-subscriptions';
 export * from './order-received';
+export * from './oxxo-voucher-popup';
 export * from './pay-for-order';
 export * from './google-pay-popup';
 export * from './paypal-popup';

--- a/tests/qa/utils/frontend/oxxo-voucher-popup.ts
+++ b/tests/qa/utils/frontend/oxxo-voucher-popup.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { expect, Page } from '@playwright/test';
+
+export class OxxoVoucherPopup {
+	page: Page;
+
+	constructor( page: Page ) {
+		this.page = page;
+	}
+
+	// Locators
+
+	testSuccessfulPaymentButton = () =>
+		this.page.getByRole( 'button', { name: 'Test Successful Payment' } );
+
+	// Actions
+
+	simulate = async () => {
+		await this.page.waitForLoadState();
+
+		await this.page.evaluate( () => {
+			window.opener = null;
+		} );
+
+		await expect(
+			this.testSuccessfulPaymentButton(),
+			'Assert OXXO voucher popup loaded with test payment button'
+		).toBeVisible();
+		await this.testSuccessfulPaymentButton().click();
+
+		await this.page
+			.waitForEvent( 'close', { timeout: 15_000 } )
+			.catch( async () => {
+				console.warn(
+					'OXXO voucher popup did not auto-close — payment simulation may not have fired the webhook'
+				);
+				await this.page.close();
+			} );
+	};
+}

--- a/tests/qa/utils/frontend/paypal-ui-classic.ts
+++ b/tests/qa/utils/frontend/paypal-ui-classic.ts
@@ -435,13 +435,8 @@ export class PayPalUiClassic extends PayPalUi {
 		} );
 		await this.submitOrder();
 		const popup = await popupPromise;
-		const paypal = new PayPalPopup( popup );
-
-		await expect(
-			paypal.page.getByText( 'Successful Payment', { exact: true } ),
-			'Assert OXXO successful payment message is visible in PayPal popup'
-		).toBeVisible();
-
+		// Close without clicking — payment simulation happens from the thank-you page voucher button
+		await popup.waitForLoadState().catch( () => {} );
 		await popup.close();
 	};
 

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -138,6 +138,10 @@ export class PayPalUi {
 		this.page.locator(
 			'#radio-control-wc-payment-method-options-ppcp-credit-card-gateway__label'
 		);
+	oxxoGateway = () =>
+		this.page.locator(
+			'#radio-control-wc-payment-method-options-ppcp-oxxo-gateway__label'
+		);
 	acdcContainer = () =>
 		this.paymentOptionsContainers().filter( {
 			has: this.acdcGateway(),
@@ -567,10 +571,27 @@ export class PayPalUi {
 		await this.submitOrder();
 	};
 
-	completeOXXOPayment = async ( ...args ) =>
-		console.log(
-			`TODO: completeOXXOPayment for block pages ${ args.length }`
-		);
+	completeOXXOPayment = async () => {
+		await expect(
+			this.oxxoGateway(),
+			'Assert OXXO gateway is visible'
+		).toBeVisible();
+		await this.oxxoGateway().click();
+
+		const popupPromise = this.page.waitForEvent( 'popup', {
+			timeout: 20 * 1000,
+		} );
+		await this.submitOrder();
+		const popup = await popupPromise;
+
+		await expect(
+			popup.getByRole( 'button', { name: 'Test Successful Payment' } ),
+			'Assert OXXO PayPal popup loaded with payment simulation options'
+		).toBeVisible();
+
+		// Close without clicking — payment simulation happens from the thank-you page voucher button
+		await popup.close();
+	};
 
 	completeBcdcPayment = async ( ...args ) =>
 		console.log(


### PR DESCRIPTION
PR #4345 added OXXO tests but the last commit had a bad merge conflict resolution that broke `dev/develop`. PR #4392 reverted it,  which also removed the OXXO tests.

This PR brings the OXXO tests back.


Original description:

> Adds automated E2E tests for the OXXO payment method on classic checkout, covering guest (PCP-6324) and logged-in customer (PCP-6325) flows.
> 
> Closes PCP-5983.
> 
> What was added:
> 
> Two test cases: guest order and customer order via OXXO on classic checkout
> Full end-to-end flow: place order → voucher popup → PayPal fires real webhook → order transitions to Processing → admin order verified
> How it works
> 
> OXXO is an async payment — the order is placed as "Pending payment" first. The test then clicks the "See OXXO voucher" button on the thank-you page, which opens a PayPal sandbox popup. Clicking "Test Successful Payment" in that popup triggers a webhook from PayPal's servers to the WordPress instance.
> The test polls until the order status becomes "Processing" (up to 60 seconds).
> 
> Test plan
> 
> npx playwright test transaction-mexico-classic.spec.ts --workers=1 --grep "OXXO"
> PCP-6324 passes (guest)
> PCP-6325 passes (logged-in customer)