### PR TITLE
Negative fee on manually created order influence on wrong total amount on PayPal side (6463)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -161,18 +161,25 @@ class AmountFactory {
 		$currency = $order->get_currency();
 		$items    = $this->item_factory->from_wc_order( $order );
 
+		$items_discount = $this->discounts_from_items( $items );
+
 		$discount_value = array_sum(
 			array(
 				(float) $order->get_total_discount(), // Only coupons.
-				$this->discounts_from_items( $items ),
+				$items_discount,
 			)
 		);
-		$discount = null;
+		$discount       = null;
 		if ( $discount_value ) {
 			$discount = new Money( (float) $discount_value, $currency );
 		}
 
-		$item_total_val = (float) $order->get_subtotal() + (float) $order->get_total_fees();
+		// Negative items (e.g. a negative fee) are surfaced as `discount`, and the
+		// negative-amount items are filtered out by PurchaseUnitFactory before being
+		// sent to PayPal. Add them back here so item_total reflects the positive items
+		// actually sent and the negative fee is not counted twice (once in get_total_fees()
+		// and again in discount), which would otherwise undercharge the PayPal total.
+		$item_total_val = (float) $order->get_subtotal() + (float) $order->get_total_fees() + $items_discount;
 		$shipping_val   = (float) $order->get_shipping_total();
 		$taxes_val      = (float) $order->get_total_tax();
 

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -401,6 +401,53 @@ class AmountFactoryTest extends TestCase
 		$this->assertNull( $result->breakdown()->discount() );
 	}
 
+	/**
+	 * A manually created order with a negative fee
+	 * must not be undercharged on the PayPal side. The negative fee is surfaced as
+	 * a discount AND filtered out of the items sent to PayPal, so it must not also
+	 * be netted out of item_total — otherwise it is counted twice.
+	 *
+	 * Order: product $100, fee -$10 → real total $90.
+	 */
+	public function testFromWcOrderNegativeFeeNotDoubleCounted(): void
+	{
+		$order = Mockery::mock( \WC_Order::class );
+
+		$positiveAmount = Mockery::mock( Money::class );
+		$positiveAmount->shouldReceive( 'value' )->andReturn( 100.0 );
+		$positiveItem = Mockery::mock( Item::class );
+		$positiveItem->shouldReceive( 'quantity' )->andReturn( 1 );
+		$positiveItem->shouldReceive( 'unit_amount' )->andReturn( $positiveAmount );
+
+		$negativeAmount = Mockery::mock( Money::class );
+		$negativeAmount->shouldReceive( 'value' )->andReturn( -10.0 );
+		$negativeItem = Mockery::mock( Item::class );
+		$negativeItem->shouldReceive( 'quantity' )->andReturn( 1 );
+		$negativeItem->shouldReceive( 'unit_amount' )->andReturn( $negativeAmount );
+
+		$this->itemFactory
+			->expects( 'from_wc_order' )
+			->with( $order )
+			->andReturn( [ $positiveItem, $negativeItem ] );
+
+		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
+		$order->shouldReceive( 'get_meta' )->andReturn( null );
+		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
+		$order->shouldReceive( 'get_subtotal' )->andReturn( 100.0 );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( -10.0 );
+		$order->shouldReceive( 'get_shipping_total' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_total_tax' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_total_discount' )->andReturn( 0.0 );
+
+		$result = $this->testee->from_wc_order( $order );
+
+		// item_total must match the positive item actually sent to PayPal ($100),
+		// the negative fee is represented solely as a $10 discount, total stays $90.
+		$this->assertSame( '100.00', $result->breakdown()->item_total()->value_str() );
+		$this->assertSame( '10.00', $result->breakdown()->discount()->value_str() );
+		$this->assertSame( '90.00', $result->value_str() );
+	}
+
     /**
      * @dataProvider dataFromPayPalResponse
      * @param $response


### PR DESCRIPTION
Fixes a regression from where a **negative fee** on a manually created order was counted twice (netted into `item_total` *and* added as a `discount`), undercharging the PayPal total (e.g. a $90 order sent as $80).

This PR adds the extracted item-discounts back into `item_total` in `AmountFactory::from_wc_order()` so the negative fee is represented only once. Orders without negative items are unaffected.