### PR TITLE
New actions for store sync reporting (6461)

### DIFF
--- a/modules/ppcp-store-sync/src/Endpoint/AgenticRestEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/AgenticRestEndpoint.php
@@ -45,6 +45,9 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 	 */
 	protected const REQUIRED_SCOPES = array( 'cart' );
 
+	protected const ACTION_NAME_SUCCESS = 'woocommerce_paypal_payments_store_sync';
+	protected const ACTION_NAME_ERROR   = 'woocommerce_paypal_payments_store_sync_error';
+
 	private AuthServiceProvider $auth_provider;
 
 	private AgenticSessionHandler $session_handler;
@@ -122,6 +125,8 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 	protected function cart_details( CartResponse $cart, int $status_code ): WP_REST_Response {
 		$this->logger->info( "[REST] $status_code Response", $cart->to_array() );
 
+		do_action( static::ACTION_NAME_SUCCESS, $cart->cart_id(), $cart->store_cart(), $status_code );
+
 		return new WP_REST_Response( $cart->to_array(), $status_code );
 	}
 
@@ -134,6 +139,8 @@ abstract class AgenticRestEndpoint extends WC_REST_Controller {
 	protected function error( AgenticError $error ): WP_REST_Response {
 		$error_id = $error->get_debug_id();
 		$this->logger->error( "[REST] Error - $error_id", $error->to_array() );
+
+		do_action( static::ACTION_NAME_ERROR, $error );
 
 		return new WP_REST_Response( $error->to_array(), $error->get_status_code() );
 	}

--- a/modules/ppcp-store-sync/src/Endpoint/CheckoutEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/CheckoutEndpoint.php
@@ -48,6 +48,9 @@ class CheckoutEndpoint extends AgenticRestEndpoint {
 	 */
 	protected const METHOD = 'POST';
 
+	protected const ACTION_NAME_SUCCESS = 'woocommerce_paypal_payments_store_sync_checkout';
+	protected const ACTION_NAME_ERROR   = 'woocommerce_paypal_payments_store_sync_checkout_error';
+
 	protected AgenticCheckoutProcessor $checkout_processor;
 
 	public function __construct(

--- a/modules/ppcp-store-sync/src/Endpoint/CreateCartEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/CreateCartEndpoint.php
@@ -31,6 +31,9 @@ class CreateCartEndpoint extends AgenticRestEndpoint {
 	 */
 	private const METHOD = 'POST';
 
+	protected const ACTION_NAME_SUCCESS = 'woocommerce_paypal_payments_store_sync_create';
+	protected const ACTION_NAME_ERROR   = 'woocommerce_paypal_payments_store_sync_create_error';
+
 	/**
 	 * Register REST API routes.
 	 *

--- a/modules/ppcp-store-sync/src/Endpoint/GetCartEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/GetCartEndpoint.php
@@ -31,6 +31,9 @@ class GetCartEndpoint extends AgenticRestEndpoint {
 	 */
 	private const METHOD = 'GET';
 
+	protected const ACTION_NAME_SUCCESS = 'woocommerce_paypal_payments_store_sync_get';
+	protected const ACTION_NAME_ERROR   = 'woocommerce_paypal_payments_store_sync_get_error';
+
 	/**
 	 * Register REST API routes.
 	 *

--- a/modules/ppcp-store-sync/src/Endpoint/ReplaceCartEndpoint.php
+++ b/modules/ppcp-store-sync/src/Endpoint/ReplaceCartEndpoint.php
@@ -33,6 +33,9 @@ class ReplaceCartEndpoint extends AgenticRestEndpoint {
 	 */
 	private const METHOD = 'PUT';
 
+	protected const ACTION_NAME_SUCCESS = 'woocommerce_paypal_payments_store_sync_replace';
+	protected const ACTION_NAME_ERROR   = 'woocommerce_paypal_payments_store_sync_replace_error';
+
 	/**
 	 * Register REST API routes.
 	 *

--- a/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
+++ b/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
@@ -16,6 +16,8 @@ use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
  * managing success/failure states for products.
  */
 class SyncJob {
+	private const ACTION_NAME_COMPLETED = 'woocommerce_paypal_payments_store_sync_ingestion_completed';
+
 	private array $product_ids;
 	private LoggerInterface $logger;
 	private string $batch_id;
@@ -68,6 +70,8 @@ class SyncJob {
 			$this->logger->info(
 				sprintf( 'Agentic Sync Job %s: No products', $this->batch_id )
 			);
+
+			$this->fire_completed_action( 'empty', 0, 0, 0 );
 
 			return;
 		}
@@ -149,11 +153,19 @@ class SyncJob {
 			return;
 		}
 
+		$validation_errors = array();
+
 		if ( $contains_errors && $error_message ) {
 			$validation_errors = $this->extract_product_errors( $error_message );
 
 			$this->mark_products_by_validation_result( $validation_errors );
 		}
+
+		$pushed = count( $this->product_ids );
+		$failed = count( $validation_errors );
+		$status = $failed > 0 ? 'validation_errors' : 'success';
+
+		$this->fire_completed_action( $status, $pushed, $pushed - $failed, $failed, $error_message );
 	}
 
 	/**
@@ -242,7 +254,33 @@ class SyncJob {
 			$product->save_meta_data();
 		}
 
+		$pushed = count( $product_ids );
+		$this->fire_completed_action( 'api_error', $pushed, 0, $pushed, $error_message );
+
 		throw new RuntimeException( sprintf( 'Agentic sync failed: %s', $error_message ) );
+	}
+
+	/**
+	 * Fires the ingestion-completed action so other modules/plugins can monitor sync activity.
+	 *
+	 * @param string $status        One of: success, validation_errors, api_error, empty.
+	 * @param int    $pushed        Number of products sent in the request payload.
+	 * @param int    $synced        Number of products successfully synced (no validation errors).
+	 * @param int    $failed        Number of products that failed (validation or API error).
+	 * @param string $error_message Optional error message for failure cases.
+	 */
+	private function fire_completed_action( string $status, int $pushed, int $synced, int $failed, string $error_message = '' ): void {
+		do_action(
+			self::ACTION_NAME_COMPLETED,
+			array(
+				'batch_id'      => $this->batch_id,
+				'status'        => $status,
+				'pushed'        => $pushed,
+				'synced'        => $synced,
+				'failed'        => $failed,
+				'error_message' => $error_message,
+			)
+		);
 	}
 
 	/**

--- a/modules/ppcp-store-sync/src/Response/CartResponse.php
+++ b/modules/ppcp-store-sync/src/Response/CartResponse.php
@@ -12,7 +12,6 @@ namespace WooCommerce\PayPalCommerce\StoreSync\Response;
 use WC_Order;
 
 use WooCommerce\PayPalCommerce\StoreSync\StoreData\StorePayPalCart;
-use WooCommerce\PayPalCommerce\StoreSync\Validation\ValidationIssue;
 
 class CartResponse {
 	private const ALLOWED_STATUS = array(
@@ -125,6 +124,14 @@ class CartResponse {
 		}
 
 		return $this;
+	}
+
+	public function cart_id(): string {
+		return $this->cart_id;
+	}
+
+	public function store_cart(): StorePayPalCart {
+		return $this->store_cart;
 	}
 
 	// === API RESPONSE FORMAT ===


### PR DESCRIPTION
### Description

Most store-sync processes run in the background without a user session on the server, which makes logging and reporting abilities critical.

**Gap:** Currently, we have a sufficient level of logging, but very few options to integrate more advanced reporting (eg user facing stats).

**Solution:** This PR adds a series of `do_action()` calls in relevant places to allow other plugins or future modules to track behavior of the Cart API and product ingestion.