### PR TITLE
Avoid spamming OAuth requests when auth fails

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Authentication\ClientCredentials;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\ConnectBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\SdkClientToken;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\TokenRateLimiter;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingPlans;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\BillingSubscriptions;
@@ -146,8 +147,18 @@ return array(
 			$container->get( 'api.key' ),
 			$container->get( 'api.secret' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
-			$container->get( 'settings.settings-provider' )
+			$container->get( 'settings.settings-provider' ),
+			$container->get( 'api.token-rate-limiter' )
 		);
+	},
+	'api.token-rate-limiter'                         => static function ( ContainerInterface $container ): TokenRateLimiter {
+		return new TokenRateLimiter(
+			$container->get( 'api.token-rate-limiter-cache' ),
+			$container->get( 'woocommerce.logger.woocommerce' )
+		);
+	},
+	'api.token-rate-limiter-cache'                   => static function ( ContainerInterface $container ): Cache {
+		return new Cache( 'ppcp-token-rate-limiter' );
 	},
 	'api.endpoint.partners'                          => static function ( ContainerInterface $container ): PartnersEndpoint {
 		return new PartnersEndpoint(
@@ -870,7 +881,8 @@ return array(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'api.client-credentials' ),
-			$container->get( 'api.user-id-token-cache' )
+			$container->get( 'api.user-id-token-cache' ),
+			$container->get( 'api.token-rate-limiter' )
 		);
 	},
 	'api.sdk-client-token'                           => static function ( ContainerInterface $container ): SdkClientToken {
@@ -878,7 +890,8 @@ return array(
 			$container->get( 'api.host' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'api.client-credentials' ),
-			$container->get( 'api.client-credentials-cache' )
+			$container->get( 'api.client-credentials-cache' ),
+			$container->get( 'api.token-rate-limiter' )
 		);
 	},
 	'api.paypal-host-production'                     => static function ( ContainerInterface $container ): string {

--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -120,6 +120,7 @@ class ApiModule implements ServiceModule, FactoryModule, ExecutableModule {
 				$caches = array(
 					'api.paypal-bearer-cache',
 					'api.client-credentials-cache',
+					'api.token-rate-limiter-cache',
 					'settings.service.signup-link-cache',
 				);
 

--- a/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
+++ b/modules/ppcp-api-client/src/Authentication/ClientCredentials.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * The client credentials.
- *
- * @package WooCommerce\PayPalCommerce\ApiClient\Authentication
- */
 
 declare(strict_types=1);
 
@@ -12,31 +7,16 @@ namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 
-/**
- * Class ClientCredentials
- */
 class ClientCredentials {
 
-	/**
-	 * The settings.
-	 *
-	 * @var SettingsProvider
-	 */
-	protected $settings;
+	protected SettingsProvider $settings;
 
-	/**
-	 * ClientCredentials constructor.
-	 *
-	 * @param SettingsProvider $settings The settings.
-	 */
 	public function __construct( SettingsProvider $settings ) {
 		$this->settings = $settings;
 	}
 
 	/**
 	 * Returns encoded client credentials.
-	 *
-	 * @return string
 	 */
 	public function credentials(): string {
 		$merchant_data = $this->settings->merchant_data();
@@ -45,5 +25,14 @@ class ClientCredentials {
 
 		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 		return 'Basic ' . base64_encode( $client_id . ':' . $client_secret );
+	}
+
+	/**
+	 * Whether the client ID or secret is missing.
+	 */
+	public function is_empty(): bool {
+		$merchant_data = $this->settings->merchant_data();
+
+		return '' === $merchant_data->client_id || '' === $merchant_data->client_secret;
 	}
 }

--- a/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
@@ -26,6 +26,11 @@ class PayPalBearer implements Bearer {
 	const CACHE_KEY = 'ppcp-bearer';
 
 	/**
+	 * The rate-limiter scope key for the client-credentials token.
+	 */
+	const RATE_LIMIT_SCOPE = 'bearer';
+
+	/**
 	 * The settings.
 	 *
 	 * @var ?SettingsProvider
@@ -67,31 +72,25 @@ class PayPalBearer implements Bearer {
 	 */
 	private $logger;
 
-	/**
-	 * PayPalBearer constructor.
-	 *
-	 * @param Cache             $cache The cache.
-	 * @param string            $host The host.
-	 * @param string            $key The key.
-	 * @param string            $secret The secret.
-	 * @param LoggerInterface   $logger The logger.
-	 * @param ?SettingsProvider $settings The settings.
-	 */
+	private TokenRateLimiter $rate_limiter;
+
 	public function __construct(
 		Cache $cache,
 		string $host,
 		string $key,
 		string $secret,
 		LoggerInterface $logger,
-		?SettingsProvider $settings
+		?SettingsProvider $settings,
+		TokenRateLimiter $rate_limiter
 	) {
 
-		$this->cache    = $cache;
-		$this->host     = $host;
-		$this->key      = $key;
-		$this->secret   = $secret;
-		$this->logger   = $logger;
-		$this->settings = $settings;
+		$this->cache        = $cache;
+		$this->host         = $host;
+		$this->key          = $key;
+		$this->secret       = $secret;
+		$this->logger       = $logger;
+		$this->settings     = $settings;
+		$this->rate_limiter = $rate_limiter;
 	}
 
 	/**
@@ -147,7 +146,21 @@ class PayPalBearer implements Bearer {
 	private function newBearer(): Token {
 		$key    = $this->get_key();
 		$secret = $this->get_secret();
-		$url    = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials';
+
+		if ( '' === $key || '' === $secret ) {
+			throw new RuntimeException(
+				'Cannot request a PayPal access token without a client ID and secret.'
+			);
+		}
+
+		$wait = $this->rate_limiter->retry_after_seconds( self::RATE_LIMIT_SCOPE );
+		if ( null !== $wait ) {
+			throw new RuntimeException(
+				sprintf( 'PayPal token requests are paused for %d more seconds after a previous failure.', $wait )
+			);
+		}
+
+		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials';
 
 		$args     = array(
 			'method'  => 'POST',
@@ -159,9 +172,10 @@ class PayPalBearer implements Bearer {
 		$response = $this->request( $url, $args );
 
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
-			$error = new RuntimeException(
-				__( 'Could not create token.', 'woocommerce-paypal-payments' )
-			);
+			$status_code = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
+			$this->rate_limiter->register_failure( self::RATE_LIMIT_SCOPE, $status_code, $response );
+
+			$error = new RuntimeException( 'Could not create token.' );
 			$this->logger->warning(
 				$error->getMessage(),
 				array(
@@ -174,6 +188,7 @@ class PayPalBearer implements Bearer {
 
 		$token = Token::from_json( $response['body'] );
 		$this->cache->set( self::CACHE_KEY, $token->as_json() );
+		$this->rate_limiter->clear( self::RATE_LIMIT_SCOPE );
 
 		return $token;
 	}

--- a/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
@@ -109,8 +109,8 @@ class PayPalBearer implements Bearer {
 					return $bearer;
 				}
 			} catch ( RuntimeException $error ) {
-				// Cached token is corrupt/unparseable; discard it and fetch a fresh one.
-				$this->logger->debug( 'Discarding unparseable cached PayPal bearer token: ' . $error->getMessage() );
+				// Cached token is corrupt/unparsable; discard it and fetch a fresh one.
+				$this->logger->debug( 'Discarding unparsable cached PayPal bearer token: ' . $error->getMessage() );
 			}
 		}
 

--- a/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
@@ -100,13 +100,21 @@ class PayPalBearer implements Bearer {
 	 * @throws RuntimeException When request fails.
 	 */
 	public function bearer(): Token {
-		try {
-			$bearer = Token::from_json( (string) $this->cache->get( self::CACHE_KEY ) );
+		$cached = (string) $this->cache->get( self::CACHE_KEY );
 
-			return ( $bearer->is_valid() ) ? $bearer : $this->newBearer();
-		} catch ( RuntimeException $error ) {
-			return $this->newBearer();
+		if ( '' !== $cached ) {
+			try {
+				$bearer = Token::from_json( $cached );
+				if ( $bearer->is_valid() ) {
+					return $bearer;
+				}
+			} catch ( RuntimeException $error ) {
+				// Cached token is corrupt/unparseable; discard it and fetch a fresh one.
+				$this->logger->debug( 'Discarding unparseable cached PayPal bearer token: ' . $error->getMessage() );
+			}
 		}
+
+		return $this->newBearer();
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
+++ b/modules/ppcp-api-client/src/Authentication/PayPalBearer.php
@@ -179,6 +179,12 @@ class PayPalBearer implements Bearer {
 		);
 		$response = $this->request( $url, $args );
 
+		// A connection error (no response received) may be a momentary blip; retry
+		// once so a single network hiccup doesn't arm the cool-down.
+		if ( is_wp_error( $response ) ) {
+			$response = $this->request( $url, $args );
+		}
+
 		if ( is_wp_error( $response ) || wp_remote_retrieve_response_code( $response ) !== 200 ) {
 			$status_code = is_wp_error( $response ) ? 0 : (int) wp_remote_retrieve_response_code( $response );
 			$this->rate_limiter->register_failure( self::RATE_LIMIT_SCOPE, $status_code, $response );

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -24,51 +24,32 @@ class SdkClientToken {
 	const CACHE_KEY = 'sdk-client-token-key';
 
 	/**
-	 * The host.
-	 *
-	 * @var string
+	 * The rate-limiter scope key for the SDK client token.
 	 */
-	private $host;
+	const RATE_LIMIT_SCOPE = 'sdk-client-token';
 
-	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
-	private $logger;
+	private string $host;
 
-	/**
-	 * The client credentials.
-	 *
-	 * @var ClientCredentials
-	 */
-	private $client_credentials;
+	private LoggerInterface $logger;
 
-	/**
-	 * The cache.
-	 *
-	 * @var Cache
-	 */
-	private $cache;
+	private ClientCredentials $client_credentials;
 
-	/**
-	 * SdkClientToken constructor.
-	 *
-	 * @param string            $host The host.
-	 * @param LoggerInterface   $logger The logger.
-	 * @param ClientCredentials $client_credentials The client credentials.
-	 * @param Cache             $cache The cache.
-	 */
+	private Cache $cache;
+
+	private TokenRateLimiter $rate_limiter;
+
 	public function __construct(
 		string $host,
 		LoggerInterface $logger,
 		ClientCredentials $client_credentials,
-		Cache $cache
+		Cache $cache,
+		TokenRateLimiter $rate_limiter
 	) {
 		$this->host               = $host;
 		$this->logger             = $logger;
 		$this->client_credentials = $client_credentials;
 		$this->cache              = $cache;
+		$this->rate_limiter       = $rate_limiter;
 	}
 
 	/**
@@ -82,6 +63,11 @@ class SdkClientToken {
 	public function sdk_client_token(): string {
 		if ( $this->cache->has( self::CACHE_KEY ) ) {
 			return $this->cache->get( self::CACHE_KEY );
+		}
+
+		$wait = $this->rate_limiter->retry_after_seconds( self::RATE_LIMIT_SCOPE );
+		if ( null !== $wait ) {
+			throw new RuntimeException( sprintf( 'PayPal token requests are paused for %d more seconds after a previous failure.', $wait ) );
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
@@ -100,12 +86,14 @@ class SdkClientToken {
 
 		$response = $this->request( $url, $args );
 		if ( $response instanceof WP_Error ) {
+			$this->rate_limiter->register_failure( self::RATE_LIMIT_SCOPE, 0, $response );
 			throw new RuntimeException( $response->get_error_message() );
 		}
 
 		$json        = json_decode( $response['body'] );
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
+			$this->rate_limiter->register_failure( self::RATE_LIMIT_SCOPE, $status_code, $response );
 			throw new PayPalApiException( $json, $status_code );
 		}
 
@@ -113,6 +101,7 @@ class SdkClientToken {
 		$expires_in   = (int) $json->expires_in;
 
 		$this->cache->set( self::CACHE_KEY, $access_token, $expires_in );
+		$this->rate_limiter->clear( self::RATE_LIMIT_SCOPE );
 
 		return $access_token;
 	}

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -65,6 +65,10 @@ class SdkClientToken {
 			return $this->cache->get( self::CACHE_KEY );
 		}
 
+		if ( $this->client_credentials->is_empty() ) {
+			throw new RuntimeException( 'Cannot request a PayPal client token without a client ID and secret.' );
+		}
+
 		$wait = $this->rate_limiter->retry_after_seconds( self::RATE_LIMIT_SCOPE );
 		if ( null !== $wait ) {
 			throw new RuntimeException( sprintf( 'PayPal token requests are paused for %d more seconds after a previous failure.', $wait ) );

--- a/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
+++ b/modules/ppcp-api-client/src/Authentication/SdkClientToken.php
@@ -89,6 +89,13 @@ class SdkClientToken {
 		);
 
 		$response = $this->request( $url, $args );
+
+		// Retry once on a connection error (a momentary blip) before giving up, so a
+		// single network hiccup doesn't arm the cool-down.
+		if ( $response instanceof WP_Error ) {
+			$response = $this->request( $url, $args );
+		}
+
 		if ( $response instanceof WP_Error ) {
 			$this->rate_limiter->register_failure( self::RATE_LIMIT_SCOPE, 0, $response );
 			throw new RuntimeException( $response->get_error_message() );

--- a/modules/ppcp-api-client/src/Authentication/TokenRateLimiter.php
+++ b/modules/ppcp-api-client/src/Authentication/TokenRateLimiter.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WP_Error;
+
+/**
+ * Circuit breaker / backoff guard for PayPal token-endpoint requests.
+ *
+ * Prevents the plugin from hammering `/v1/oauth2/token` after a failure.
+ * On a failed token request it stores a short-lived "cool-down" in the cache,
+ * so subsequent callers fail fast without performing another network request
+ * until the cool-down expires.
+ */
+class TokenRateLimiter {
+
+	/**
+	 * Base backoff applied to the first failure (in seconds).
+	 */
+	const BASE_BACKOFF_SECONDS = 30;
+
+	/**
+	 * Maximum backoff / cool-down (in seconds). Caps the exponential growth and
+	 * any `Retry-After` value we honor.
+	 */
+	const MAX_BACKOFF_SECONDS = 900;
+
+	/**
+	 * Cool-down applied when the credentials are rejected (401 / invalid_client).
+	 * These normally do not self-heal until the merchant reconnects, so we wait longer.
+	 */
+	const DEAD_CREDENTIALS_COOLDOWN = 1800;
+
+	/**
+	 * Added to the cool-down when storing the state, so the failure counter
+	 * survives just past the cool-down to allow backoff to grow, while still
+	 * self-healing on a quiet site.
+	 */
+	const STATE_TTL_PADDING = 300;
+
+	/**
+	 * Suffix for the cool-down state cache key.
+	 */
+	const STATE_KEY_SUFFIX = '-circuit-state';
+
+	private Cache $cache;
+
+	private LoggerInterface $logger;
+
+	public function __construct( Cache $cache, LoggerInterface $logger ) {
+		$this->cache  = $cache;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Returns the number of seconds left in the current cool-down for the given
+	 * scope, or null when a token request is allowed.
+	 *
+	 * @param string $scope The token-type key (e.g. "bearer").
+	 */
+	public function retry_after_seconds( string $scope ): ?int {
+		$state = $this->read_state( $scope );
+		if ( ! isset( $state['retry_at'] ) ) {
+			return null;
+		}
+
+		$remaining = (int) $state['retry_at'] - time();
+		return $remaining > 0 ? $remaining : null;
+	}
+
+	/**
+	 * Whether token requests for the given scope are currently blocked.
+	 *
+	 * @param string $scope The token-type key.
+	 */
+	public function is_blocked( string $scope ): bool {
+		return $this->retry_after_seconds( $scope ) !== null;
+	}
+
+	/**
+	 * Records a failed token request and computes/stores the next cool-down.
+	 *
+	 * @param string         $scope The token-type key.
+	 * @param int            $status_code The HTTP status code (0 for WP_Error / network failure).
+	 * @param array|WP_Error $response The raw response, used to read Retry-After and the error body.
+	 * @return int The cool-down in seconds that was applied.
+	 */
+	public function register_failure( string $scope, int $status_code, $response ): int {
+		$state = $this->read_state( $scope );
+		$count = isset( $state['count'] ) ? (int) $state['count'] : 0;
+
+		$retry_after = $this->parse_retry_after( $response );
+
+		if ( $this->is_dead_credentials( $status_code, $response ) ) {
+			$cooldown = self::DEAD_CREDENTIALS_COOLDOWN;
+			$reason   = 'dead_credentials';
+		} elseif ( 429 === $status_code && null !== $retry_after ) {
+			$cooldown = max( 1, min( $retry_after, self::MAX_BACKOFF_SECONDS ) );
+			$reason   = 'rate_limited_retry_after';
+			++$count;
+		} elseif ( 429 === $status_code ) {
+			$cooldown = $this->backoff( $count );
+			$reason   = 'rate_limited_backoff';
+			++$count;
+		} elseif ( $status_code >= 500 ) {
+			$cooldown = $this->backoff( $count );
+			$reason   = 'server_error';
+			++$count;
+		} elseif ( 0 === $status_code ) {
+			$cooldown = $this->backoff( $count );
+			$reason   = 'network_error';
+			++$count;
+		} else {
+			$cooldown = self::BASE_BACKOFF_SECONDS;
+			$reason   = 'client_error';
+			++$count;
+		}
+
+		$this->write_state( $scope, time() + $cooldown, $count, $reason );
+
+		if ( 429 === $status_code ) {
+			$this->logger->warning(
+				sprintf(
+					'PayPal token endpoint returned 429 for "%1$s". Retry-After: %2$s. Pausing token requests for %3$d seconds.',
+					$scope,
+					null === $retry_after ? 'absent' : (string) $retry_after,
+					$cooldown
+				),
+				array(
+					'scope'       => $scope,
+					'status'      => $status_code,
+					'retry_after' => $retry_after,
+					'cooldown'    => $cooldown,
+				)
+			);
+		} elseif ( 'dead_credentials' === $reason ) {
+			$this->logger->warning(
+				sprintf(
+					'PayPal rejected the credentials for "%1$s" (status %2$d). Pausing token requests for %3$d seconds; the merchant likely needs to reconnect.',
+					$scope,
+					$status_code,
+					$cooldown
+				),
+				array(
+					'scope'    => $scope,
+					'status'   => $status_code,
+					'cooldown' => $cooldown,
+				)
+			);
+		}
+
+		return $cooldown;
+	}
+
+	/**
+	 * Clears the cool-down state for the given scope after a successful request.
+	 *
+	 * @param string $scope The token-type key.
+	 */
+	public function clear( string $scope ): void {
+		$this->cache->delete( $scope . self::STATE_KEY_SUFFIX );
+	}
+
+	/**
+	 * Parses the `Retry-After` response header into seconds-from-now.
+	 *
+	 * Handles both the integer-seconds form and the HTTP-date form. Returns null
+	 * when the header is absent or unparseable.
+	 *
+	 * @param array|WP_Error $response The response.
+	 */
+	private function parse_retry_after( $response ): ?int {
+		$raw = wp_remote_retrieve_header( $response, 'retry-after' );
+		if ( ! is_string( $raw ) || $raw === '' ) {
+			return null;
+		}
+
+		if ( is_numeric( $raw ) ) {
+			return max( 0, (int) $raw );
+		}
+
+		$timestamp = strtotime( $raw );
+		if ( false === $timestamp ) {
+			return null;
+		}
+
+		return max( 0, $timestamp - time() );
+	}
+
+	/**
+	 * Computes the exponential backoff (with jitter) for a given failure count.
+	 *
+	 * @param int $count The number of consecutive failures so far.
+	 */
+	private function backoff( int $count ): int {
+		$exponent = min( $count, 16 );
+		$base     = (int) min( self::BASE_BACKOFF_SECONDS * ( 2 ** $exponent ), self::MAX_BACKOFF_SECONDS );
+		$jitter   = random_int( 0, (int) max( 1, $base / 4 ) );
+
+		return (int) min( self::MAX_BACKOFF_SECONDS, $base + $jitter );
+	}
+
+	/**
+	 * Whether the failure indicates rejected credentials that will not self-heal.
+	 *
+	 * @param int            $status_code The HTTP status code.
+	 * @param array|WP_Error $response The response.
+	 */
+	private function is_dead_credentials( int $status_code, $response ): bool {
+		if ( 401 === $status_code ) {
+			return true;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( ! is_string( $body ) || '' === $body ) {
+			return false;
+		}
+
+		$json = json_decode( $body );
+		return is_object( $json ) && isset( $json->error ) && 'invalid_client' === $json->error;
+	}
+
+	/**
+	 * Reads the stored cool-down state for the given scope.
+	 *
+	 * @param string $scope The token-type key.
+	 */
+	private function read_state( string $scope ): array {
+		$value = $this->cache->get( $scope . self::STATE_KEY_SUFFIX );
+		return is_array( $value ) ? $value : array();
+	}
+
+	/**
+	 * Writes the cool-down state for the given scope.
+	 *
+	 * @param string $scope The token-type key.
+	 * @param int    $retry_at The timestamp at which requests are allowed again.
+	 * @param int    $count The consecutive failure count.
+	 * @param string $reason The failure reason (for diagnostics).
+	 */
+	private function write_state( string $scope, int $retry_at, int $count, string $reason ): void {
+		$cooldown = max( 0, $retry_at - time() );
+		$this->cache->set(
+			$scope . self::STATE_KEY_SUFFIX,
+			array(
+				'retry_at' => $retry_at,
+				'count'    => $count,
+				'reason'   => $reason,
+			),
+			$cooldown + self::STATE_TTL_PADDING
+		);
+	}
+}

--- a/modules/ppcp-api-client/src/Authentication/TokenRateLimiter.php
+++ b/modules/ppcp-api-client/src/Authentication/TokenRateLimiter.php
@@ -169,7 +169,7 @@ class TokenRateLimiter {
 	 * Parses the `Retry-After` response header into seconds-from-now.
 	 *
 	 * Handles both the integer-seconds form and the HTTP-date form. Returns null
-	 * when the header is absent or unparseable.
+	 * when the header is absent or unparsable.
 	 *
 	 * @param array|WP_Error $response The response.
 	 */

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -95,6 +95,13 @@ class UserIdToken {
 		);
 
 		$response = $this->request( $url, $args );
+
+		// Retry once on a connection error (a momentary blip) before giving up, so a
+		// single network hiccup doesn't arm the cool-down.
+		if ( $response instanceof WP_Error ) {
+			$response = $this->request( $url, $args );
+		}
+
 		if ( $response instanceof WP_Error ) {
 			$this->rate_limiter->register_failure( self::RATE_LIMIT_SCOPE, 0, $response );
 			throw new RuntimeException( $response->get_error_message() );

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -67,6 +67,10 @@ class UserIdToken {
 			return $this->cache->get( self::CACHE_KEY . (string) $session_customer_id );
 		}
 
+		if ( $this->client_credentials->is_empty() ) {
+			throw new RuntimeException( 'Cannot request a PayPal user ID token without a client ID and secret.' );
+		}
+
 		$wait = $this->rate_limiter->retry_after_seconds( self::RATE_LIMIT_SCOPE );
 		if ( null !== $wait ) {
 			throw new RuntimeException( sprintf( 'PayPal token requests are paused for %d more seconds after a previous failure.', $wait ) );

--- a/modules/ppcp-api-client/src/Authentication/UserIdToken.php
+++ b/modules/ppcp-api-client/src/Authentication/UserIdToken.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Generates user ID token for payer.
- *
- * @package WooCommerce\PayPalCommerce\ApiClient\Authentication
- */
 
 namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
 
@@ -15,7 +10,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WP_Error;
 
 /**
- * Class UserIdToken
+ * Generates user ID token for payer.
  */
 class UserIdToken {
 
@@ -24,51 +19,32 @@ class UserIdToken {
 	const CACHE_KEY = 'id-token-key';
 
 	/**
-	 * The host.
-	 *
-	 * @var string
+	 * The rate-limiter scope key for the user ID token.
 	 */
-	private $host;
+	const RATE_LIMIT_SCOPE = 'id-token';
 
-	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
-	private $logger;
+	private string $host;
 
-	/**
-	 * The client credentials.
-	 *
-	 * @var ClientCredentials
-	 */
-	private $client_credentials;
+	private LoggerInterface $logger;
 
-	/**
-	 * The cache.
-	 *
-	 * @var Cache
-	 */
-	private $cache;
+	private ClientCredentials $client_credentials;
 
-	/**
-	 * UserIdToken constructor.
-	 *
-	 * @param string            $host The host.
-	 * @param LoggerInterface   $logger The logger.
-	 * @param ClientCredentials $client_credentials The client credentials.
-	 * @param Cache             $cache The cache.
-	 */
+	private Cache $cache;
+
+	private TokenRateLimiter $rate_limiter;
+
 	public function __construct(
 		string $host,
 		LoggerInterface $logger,
 		ClientCredentials $client_credentials,
-		Cache $cache
+		Cache $cache,
+		TokenRateLimiter $rate_limiter
 	) {
 		$this->host               = $host;
 		$this->logger             = $logger;
 		$this->client_credentials = $client_credentials;
 		$this->cache              = $cache;
+		$this->rate_limiter       = $rate_limiter;
 	}
 
 	/**
@@ -91,6 +67,11 @@ class UserIdToken {
 			return $this->cache->get( self::CACHE_KEY . (string) $session_customer_id );
 		}
 
+		$wait = $this->rate_limiter->retry_after_seconds( self::RATE_LIMIT_SCOPE );
+		if ( null !== $wait ) {
+			throw new RuntimeException( sprintf( 'PayPal token requests are paused for %d more seconds after a previous failure.', $wait ) );
+		}
+
 		$url = trailingslashit( $this->host ) . 'v1/oauth2/token?grant_type=client_credentials&response_type=id_token';
 		if ( $target_customer_id ) {
 			$url = add_query_arg(
@@ -111,12 +92,14 @@ class UserIdToken {
 
 		$response = $this->request( $url, $args );
 		if ( $response instanceof WP_Error ) {
+			$this->rate_limiter->register_failure( self::RATE_LIMIT_SCOPE, 0, $response );
 			throw new RuntimeException( $response->get_error_message() );
 		}
 
 		$json        = json_decode( $response['body'] );
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		if ( 200 !== $status_code ) {
+			$this->rate_limiter->register_failure( self::RATE_LIMIT_SCOPE, $status_code, $response );
 			throw new PayPalApiException( $json, $status_code );
 		}
 
@@ -125,6 +108,8 @@ class UserIdToken {
 		if ( $session_customer_id ) {
 			$this->cache->set( self::CACHE_KEY . (string) $session_customer_id, $id_token, 5 );
 		}
+
+		$this->rate_limiter->clear( self::RATE_LIMIT_SCOPE );
 
 		return $id_token;
 	}

--- a/modules/ppcp-api-client/src/Entity/Token.php
+++ b/modules/ppcp-api-client/src/Entity/Token.php
@@ -17,6 +17,13 @@ use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 class Token {
 
 	/**
+	 * Safety margin (in seconds) subtracted from the real expiry, so a token that
+	 * is about to expire is refreshed proactively instead of being used for a
+	 * request that would race the expiry and fail with a 401.
+	 */
+	const EXPIRATION_SAFETY_MARGIN = 60;
+
+	/**
 	 * The Token data.
 	 *
 	 * @var object
@@ -71,7 +78,7 @@ class Token {
 	 * @return bool
 	 */
 	public function is_valid(): bool {
-		return time() < $this->json->created + $this->json->expires_in;
+		return time() < $this->json->created + $this->json->expires_in - self::EXPIRATION_SAFETY_MARGIN;
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -612,15 +612,15 @@ class AuthenticationManager {
 			// Update the connection status and set the environment flags.
 			$this->connection_state->connect( $connection->is_sandbox );
 
-			// At this point, we can use the PayPal API to get more details about the seller.
-			$this->enrich_merchant_details();
-
 			/**
 			 * Request to flush caches before authenticating the merchant, to
 			 * ensure the new merchant does not use stale data from previous
 			 * connections.
 			 */
 			do_action( 'woocommerce_paypal_payments_flush_api_cache' );
+
+			// At this point, we can use the PayPal API to get more details about the seller.
+			$this->enrich_merchant_details();
 
 			/**
 			 * Broadcast that the plugin connected to a new PayPal merchant account.

--- a/modules/ppcp-settings/src/Service/AuthenticationManager.php
+++ b/modules/ppcp-settings/src/Service/AuthenticationManager.php
@@ -14,6 +14,7 @@ use JsonException;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\TokenRateLimiter;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\LoginSeller;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\Orders;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\InMemoryCache;
@@ -439,7 +440,8 @@ class AuthenticationManager {
 			$client_id,
 			$client_secret,
 			$this->logger,
-			null
+			null,
+			new TokenRateLimiter( new InMemoryCache(), $this->logger )
 		);
 
 		$orders = new Orders(

--- a/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
@@ -369,4 +369,39 @@ class PayPalBearerTest extends TestCase
         $token = $bearer->bearer();
         $this->assertEquals('abc', $token->token());
     }
+
+    public function testRetriesOnceOnConnectionError()
+    {
+        expect('wp_json_encode')->andReturnUsing('json_encode');
+        $json = '{"access_token":"abc","expires_in":100, "created":' . time() . '}';
+        $cache = Mockery::mock(Cache::class);
+        $cache->expects('get')->andReturn('');
+        $cache->expects('set');
+        $host = 'https://example.com';
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('debug');
+        $settings = $this->settings();
+        $headers = $this->headers();
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $rateLimiter->shouldReceive('clear');
+        // A blip that recovers on retry must NOT arm the cool-down.
+        $rateLimiter->shouldNotReceive('register_failure');
+
+        $bearer = new PayPalBearer($cache, $host, 'key', 'secret', $logger, $settings, $rateLimiter);
+
+        // First attempt: connection error; retry: success.
+        $wpError = Mockery::mock('WP_Error');
+        $wpError->shouldReceive('get_error_messages')->andReturn(['blip']);
+        expect('is_wp_error')->twice()->andReturn(true, false);
+        expect('trailingslashit')->andReturn($host . '/');
+        expect('wp_remote_retrieve_response_code')->andReturn(200);
+        expect('wp_remote_get')->twice()->andReturn(
+            $wpError,
+            ['body' => $json, 'headers' => $headers]
+        );
+
+        $token = $bearer->bearer();
+        $this->assertEquals('abc', $token->token());
+    }
 }

--- a/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/PayPalBearerTest.php
@@ -11,11 +11,30 @@ use Mockery;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\TestCase;
-use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;
 use function Brain\Monkey\Functions\expect;
 
 class PayPalBearerTest extends TestCase
 {
+    private function settings(string $clientId = 'key', string $clientSecret = 'secret'): SettingsProvider
+    {
+        $settings = Mockery::mock(SettingsProvider::class);
+        $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
+            true,
+            $clientId,
+            $clientSecret,
+            '123'
+        ));
+
+        return $settings;
+    }
+
+    private function headers()
+    {
+        $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+        $headers->shouldReceive('getAll');
+
+        return $headers;
+    }
 
 	public function testDefault()
     {
@@ -32,17 +51,13 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('debug');
-        $settings = Mockery::mock(SettingsProvider::class);
-        $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
-			true,
-	        'key',
-	        'secret',
-	        '123'
-        ));
-        $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
-        $headers->shouldReceive('getAll');
+        $settings = $this->settings();
+        $headers = $this->headers();
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $rateLimiter->shouldReceive('clear');
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings, $rateLimiter);
 
         expect('trailingslashit')
             ->with($host)
@@ -91,17 +106,13 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('debug');
-	    $settings = Mockery::mock(SettingsProvider::class);
-	    $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
-		    true,
-		    'key',
-		    'secret',
-		    '123'
-	    ));
-		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
-		$headers->shouldReceive('getAll');
+	    $settings = $this->settings();
+		$headers = $this->headers();
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $rateLimiter->shouldReceive('clear');
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings, $rateLimiter);
 
         expect('trailingslashit')
             ->with($host)
@@ -147,15 +158,13 @@ class PayPalBearerTest extends TestCase
         $secret = 'secret';
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldNotReceive('warning');
-	    $settings = Mockery::mock(SettingsProvider::class);
-	    $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
-		    true,
-		    'key',
-		    'secret',
-		    '123'
-	    ));
+	    $settings = $this->settings();
+        // A valid cached token must never touch the network or the rate limiter.
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings, $rateLimiter);
+
+        expect('wp_remote_get')->never();
 
         $token = $bearer->bearer();
         $this->assertEquals("abc", $token->token());
@@ -175,17 +184,13 @@ class PayPalBearerTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('warning');
         $logger->shouldReceive('debug');
-	    $settings = Mockery::mock(SettingsProvider::class);
-	    $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
-		    true,
-		    'key',
-		    'secret',
-		    '123'
-	    ));
-		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
-		$headers->shouldReceive('getAll');
+	    $settings = $this->settings();
+		$headers = $this->headers();
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $rateLimiter->shouldReceive('register_failure')->with('bearer', 0, Mockery::any());
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings, $rateLimiter);
 
         expect('trailingslashit')
             ->with($host)
@@ -229,17 +234,13 @@ class PayPalBearerTest extends TestCase
         $logger = Mockery::mock(LoggerInterface::class);
         $logger->shouldReceive('warning');
         $logger->shouldReceive('debug');
-	    $settings = Mockery::mock(SettingsProvider::class);
-	    $settings->shouldReceive('merchant_data')->andReturn(new MerchantConnectionDTO(
-		    true,
-		    'key',
-		    'secret',
-		    '123'
-	    ));
-		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
-		$headers->shouldReceive('getAll');
+	    $settings = $this->settings();
+		$headers = $this->headers();
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $rateLimiter->shouldReceive('register_failure')->with('bearer', 500, Mockery::any());
 
-        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings);
+        $bearer = new PayPalBearer($cache, $host, $key, $secret, $logger, $settings, $rateLimiter);
 
         expect('trailingslashit')
             ->with($host)
@@ -270,5 +271,102 @@ class PayPalBearerTest extends TestCase
 
         $this->expectException(RuntimeException::class);
         $bearer->bearer();
+    }
+
+    public function testNoRequestWhileInCooldown()
+    {
+        $cache = Mockery::mock(Cache::class);
+        $cache->expects('get')->andReturn('');
+        $host = 'https://example.com';
+        $logger = Mockery::mock(LoggerInterface::class);
+        $settings = $this->settings();
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $rateLimiter->shouldReceive('retry_after_seconds')->with('bearer')->andReturn(120);
+
+        $bearer = new PayPalBearer($cache, $host, 'key', 'secret', $logger, $settings, $rateLimiter);
+
+        expect('wp_remote_get')->never();
+
+        $this->expectException(RuntimeException::class);
+        $bearer->bearer();
+    }
+
+    /**
+     * A failing refresh of an expired-but-cached token must request a token only
+     * ONCE. The previous implementation called newBearer() in both the try and
+     * the catch, producing two requests per call.
+     */
+    public function testNoDoubleFetch()
+    {
+        $expired = '{"access_token":"abc","expires_in":100, "created":' . (time() - 1000) . '}';
+        $cache = Mockery::mock(Cache::class);
+        $cache->expects('get')->andReturn($expired);
+        $host = 'https://example.com';
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('warning');
+        $logger->shouldReceive('debug');
+        $settings = $this->settings();
+        $headers = $this->headers();
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $rateLimiter->shouldReceive('register_failure')->with('bearer', 500, Mockery::any());
+
+        $bearer = new PayPalBearer($cache, $host, 'key', 'secret', $logger, $settings, $rateLimiter);
+
+        expect('trailingslashit')->andReturn($host . '/');
+        expect('is_wp_error')->andReturn(false);
+        expect('wp_remote_retrieve_response_code')->andReturn(500);
+        // Exactly one HTTP request despite the failure.
+        expect('wp_remote_get')
+            ->once()
+            ->andReturn(['body' => '{}', 'headers' => $headers]);
+
+        $this->expectException(RuntimeException::class);
+        $bearer->bearer();
+    }
+
+	public function testEmptyCredentialsShortCircuit()
+	{
+		$cache = Mockery::mock(Cache::class);
+		$cache->expects('get')->andReturn('');
+		$host = 'https://example.com';
+		$logger = Mockery::mock(LoggerInterface::class);
+		$settings = $this->settings('', '');
+		// Nothing on the rate limiter should be called.
+		$rateLimiter = Mockery::mock(TokenRateLimiter::class);
+
+		$bearer = new PayPalBearer($cache, $host, '', '', $logger, $settings, $rateLimiter);
+
+		expect('wp_remote_get')->never();
+
+		$this->expectException(RuntimeException::class);
+		$bearer->bearer();
+	}
+
+    public function testSuccessClearsCooldown()
+    {
+        expect('wp_json_encode')->andReturnUsing('json_encode');
+        $json = '{"access_token":"abc","expires_in":100, "created":' . time() . '}';
+        $cache = Mockery::mock(Cache::class);
+        $cache->expects('get')->andReturn('');
+        $cache->expects('set');
+        $host = 'https://example.com';
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('debug');
+        $settings = $this->settings();
+        $headers = $this->headers();
+        $rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $rateLimiter->expects('clear')->with('bearer');
+
+        $bearer = new PayPalBearer($cache, $host, 'key', 'secret', $logger, $settings, $rateLimiter);
+
+        expect('trailingslashit')->andReturn($host . '/');
+        expect('is_wp_error')->andReturn(false);
+        expect('wp_remote_retrieve_response_code')->andReturn(200);
+        expect('wp_remote_get')->andReturn(['body' => $json, 'headers' => $headers]);
+
+        $token = $bearer->bearer();
+        $this->assertEquals('abc', $token->token());
     }
 }

--- a/tests/PHPUnit/ApiClient/Authentication/SdkClientTokenTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/SdkClientTokenTest.php
@@ -114,4 +114,29 @@ class SdkClientTokenTest extends TestCase
 
         $this->assertSame('tok', $this->sut->sdk_client_token());
     }
+
+    public function testRetriesOnceOnConnectionError()
+    {
+        $this->cache->shouldReceive('has')->andReturn(false);
+        $this->credentials->shouldReceive('is_empty')->andReturn(false);
+        $this->credentials->shouldReceive('credentials')->andReturn('Basic xxx');
+        $this->rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $this->rateLimiter->expects('clear')->with('sdk-client-token');
+        // A blip that recovers on retry must NOT arm the cool-down.
+        $this->rateLimiter->shouldNotReceive('register_failure');
+        $this->cache->expects('set')->with(SdkClientToken::CACHE_KEY, 'tok', 3600);
+
+        $headers = $this->headers();
+        $wpError = Mockery::mock('WP_Error');
+        $wpError->shouldReceive('get_error_messages')->andReturn(['blip']);
+        expect('trailingslashit')->andReturn($this->host . '/');
+        // First attempt: connection error; retry: success.
+        expect('wp_remote_get')->twice()->andReturn(
+            $wpError,
+            ['body' => '{"access_token":"tok","expires_in":3600}', 'headers' => $headers]
+        );
+        expect('wp_remote_retrieve_response_code')->andReturn(200);
+
+        $this->assertSame('tok', $this->sut->sdk_client_token());
+    }
 }

--- a/tests/PHPUnit/ApiClient/Authentication/SdkClientTokenTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/SdkClientTokenTest.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Requests_Utility_CaseInsensitiveDictionary;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+class SdkClientTokenTest extends TestCase
+{
+    private $host;
+    private $logger;
+    private $credentials;
+    private $cache;
+    private $rateLimiter;
+    private $sut;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->host = 'https://example.com';
+        $this->logger = Mockery::mock(LoggerInterface::class);
+        $this->logger->shouldReceive('debug');
+        $this->credentials = Mockery::mock(ClientCredentials::class);
+        $this->cache = Mockery::mock(Cache::class);
+        $this->rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $this->sut = new SdkClientToken(
+            $this->host,
+            $this->logger,
+            $this->credentials,
+            $this->cache,
+            $this->rateLimiter
+        );
+    }
+
+    private function headers()
+    {
+        $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+        $headers->shouldReceive('getAll');
+
+        return $headers;
+    }
+
+    public function testCachedTokenReturnedWithoutRequest()
+    {
+        $this->cache->shouldReceive('has')->with(SdkClientToken::CACHE_KEY)->andReturn(true);
+        $this->cache->shouldReceive('get')->with(SdkClientToken::CACHE_KEY)->andReturn('cached-token');
+
+        expect('wp_remote_get')->never();
+
+        $this->assertSame('cached-token', $this->sut->sdk_client_token());
+    }
+
+    public function testEmptyCredentialsShortCircuit()
+    {
+        $this->cache->shouldReceive('has')->andReturn(false);
+        $this->credentials->shouldReceive('is_empty')->andReturn(true);
+
+        expect('wp_remote_get')->never();
+
+        $this->expectException(RuntimeException::class);
+        $this->sut->sdk_client_token();
+    }
+
+    public function testBlockedReturnsFastWithoutRequest()
+    {
+        $this->cache->shouldReceive('has')->andReturn(false);
+        $this->credentials->shouldReceive('is_empty')->andReturn(false);
+        $this->rateLimiter->shouldReceive('retry_after_seconds')->with('sdk-client-token')->andReturn(60);
+
+        expect('wp_remote_get')->never();
+
+        $this->expectException(RuntimeException::class);
+        $this->sut->sdk_client_token();
+    }
+
+    public function test429RegistersFailureAndThrows()
+    {
+        $this->cache->shouldReceive('has')->andReturn(false);
+        $this->credentials->shouldReceive('is_empty')->andReturn(false);
+        $this->credentials->shouldReceive('credentials')->andReturn('Basic xxx');
+        $this->rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $this->rateLimiter->expects('register_failure')->with('sdk-client-token', 429, Mockery::any());
+
+        $headers = $this->headers();
+        expect('trailingslashit')->andReturn($this->host . '/');
+        expect('wp_remote_get')->once()->andReturn(['body' => '{"error":"rate"}', 'headers' => $headers]);
+        expect('wp_remote_retrieve_response_code')->andReturn(429);
+
+        $this->expectException(PayPalApiException::class);
+        $this->sut->sdk_client_token();
+    }
+
+    public function testSuccess()
+    {
+        $this->cache->shouldReceive('has')->andReturn(false);
+        $this->credentials->shouldReceive('is_empty')->andReturn(false);
+        $this->credentials->shouldReceive('credentials')->andReturn('Basic xxx');
+        $this->rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $this->rateLimiter->expects('clear')->with('sdk-client-token');
+        $this->cache->expects('set')->with(SdkClientToken::CACHE_KEY, 'tok', 3600);
+
+        $headers = $this->headers();
+        expect('trailingslashit')->andReturn($this->host . '/');
+        expect('wp_remote_get')->andReturn(['body' => '{"access_token":"tok","expires_in":3600}', 'headers' => $headers]);
+        expect('wp_remote_retrieve_response_code')->andReturn(200);
+
+        $this->assertSame('tok', $this->sut->sdk_client_token());
+    }
+}

--- a/tests/PHPUnit/ApiClient/Authentication/TokenRateLimiterTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/TokenRateLimiterTest.php
@@ -1,0 +1,194 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class TokenRateLimiterTest extends TestCase
+{
+    private $cache;
+    private $logger;
+    private $sut;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cache = Mockery::mock(Cache::class);
+        $this->logger = Mockery::mock(LoggerInterface::class);
+        $this->sut = new TokenRateLimiter($this->cache, $this->logger);
+    }
+
+    public function testNotBlockedWhenNoState()
+    {
+        $this->cache->shouldReceive('get')->andReturn(false);
+
+        $this->assertNull($this->sut->retry_after_seconds('bearer'));
+        $this->assertFalse($this->sut->is_blocked('bearer'));
+    }
+
+    public function testBlockedWithinCooldown()
+    {
+        $this->cache->shouldReceive('get')->andReturn(
+            ['retry_at' => time() + 120, 'count' => 1, 'reason' => 'rate_limited_backoff']
+        );
+
+        $remaining = $this->sut->retry_after_seconds('bearer');
+        $this->assertNotNull($remaining);
+        $this->assertGreaterThan(0, $remaining);
+        $this->assertLessThanOrEqual(120, $remaining);
+        $this->assertTrue($this->sut->is_blocked('bearer'));
+    }
+
+    public function testNotBlockedAfterCooldownExpires()
+    {
+        $this->cache->shouldReceive('get')->andReturn(
+            ['retry_at' => time() - 1, 'count' => 1, 'reason' => 'rate_limited_backoff']
+        );
+
+        $this->assertNull($this->sut->retry_after_seconds('bearer'));
+    }
+
+    public function testRegisterFailure429WithNumericRetryAfter()
+    {
+        when('wp_remote_retrieve_header')->justReturn('90');
+        when('wp_remote_retrieve_body')->justReturn('{"error":"RATE_LIMIT_REACHED"}');
+        $this->cache->shouldReceive('get')->andReturn(false);
+        $this->cache->shouldReceive('set')->once();
+        $this->logger->shouldReceive('warning')->once();
+
+        $cooldown = $this->sut->register_failure('bearer', 429, []);
+
+        $this->assertSame(90, $cooldown);
+    }
+
+    public function testRegisterFailure429WithHttpDateRetryAfter()
+    {
+        $future = gmdate('D, d M Y H:i:s', time() + 30) . ' GMT';
+        when('wp_remote_retrieve_header')->justReturn($future);
+        when('wp_remote_retrieve_body')->justReturn('');
+        $this->cache->shouldReceive('get')->andReturn(false);
+        $this->cache->shouldReceive('set')->once();
+        $this->logger->shouldReceive('warning');
+
+        $cooldown = $this->sut->register_failure('bearer', 429, []);
+
+        $this->assertGreaterThanOrEqual(25, $cooldown);
+        $this->assertLessThanOrEqual(31, $cooldown);
+    }
+
+    public function testRegisterFailure429WithoutRetryAfterUsesBackoff()
+    {
+        when('wp_remote_retrieve_header')->justReturn('');
+        when('wp_remote_retrieve_body')->justReturn('');
+        $this->cache->shouldReceive('get')->andReturn(false);
+        $this->cache->shouldReceive('set')->once();
+        $this->logger->shouldReceive('warning');
+
+        $cooldown = $this->sut->register_failure('bearer', 429, []);
+
+        // backoff(0): base 30 + jitter [0, 7].
+        $this->assertGreaterThanOrEqual(30, $cooldown);
+        $this->assertLessThanOrEqual(38, $cooldown);
+    }
+
+	public function testUnparseableRetryAfterFallsBackToBackoff()
+	{
+		when('wp_remote_retrieve_header')->justReturn('not-a-date');
+		when('wp_remote_retrieve_body')->justReturn('');
+		$this->cache->shouldReceive('get')->andReturn(false);
+		$this->cache->shouldReceive('set')->once();
+		$this->logger->shouldReceive('warning');
+
+		$cooldown = $this->sut->register_failure('bearer', 429, []);
+
+		$this->assertGreaterThanOrEqual(30, $cooldown);
+		$this->assertLessThanOrEqual(38, $cooldown);
+	}
+
+    public function testBackoffGrowsWithFailureCount()
+    {
+        when('wp_remote_retrieve_header')->justReturn('');
+        when('wp_remote_retrieve_body')->justReturn('');
+        $this->cache->shouldReceive('get')->andReturn(
+            ['retry_at' => time() - 1, 'count' => 2, 'reason' => 'rate_limited_backoff']
+        );
+        $this->cache->shouldReceive('set')->once();
+        $this->logger->shouldReceive('warning');
+
+        $cooldown = $this->sut->register_failure('bearer', 429, []);
+
+        // backoff(2): base = 30 * 2^2 = 120, jitter [0, 30].
+        $this->assertGreaterThanOrEqual(120, $cooldown);
+        $this->assertLessThanOrEqual(151, $cooldown);
+    }
+
+    public function testBackoffCapsAtMax()
+    {
+        when('wp_remote_retrieve_header')->justReturn('');
+        when('wp_remote_retrieve_body')->justReturn('');
+        $this->cache->shouldReceive('get')->andReturn(
+            ['retry_at' => time() - 1, 'count' => 30, 'reason' => 'server_error']
+        );
+        $this->cache->shouldReceive('set')->once();
+        $this->logger->shouldNotReceive('warning');
+
+        $cooldown = $this->sut->register_failure('bearer', 500, []);
+
+        $this->assertSame(900, $cooldown);
+    }
+
+    public function testRegisterFailure401UsesDeadCredentialsCooldown()
+    {
+        when('wp_remote_retrieve_header')->justReturn('');
+        when('wp_remote_retrieve_body')->justReturn('');
+        $this->cache->shouldReceive('get')->andReturn(false);
+        $this->cache->shouldReceive('set')->once();
+        $this->logger->shouldReceive('warning')->once();
+
+        $cooldown = $this->sut->register_failure('bearer', 401, []);
+
+        $this->assertSame(1800, $cooldown);
+    }
+
+    public function testRegisterFailureInvalidClientBodyUsesDeadCredentials()
+    {
+        when('wp_remote_retrieve_header')->justReturn('');
+        when('wp_remote_retrieve_body')->justReturn('{"error":"invalid_client"}');
+        $this->cache->shouldReceive('get')->andReturn(false);
+        $this->cache->shouldReceive('set')->once();
+        $this->logger->shouldReceive('warning')->once();
+
+        $cooldown = $this->sut->register_failure('sdk-client-token', 400, []);
+
+        $this->assertSame(1800, $cooldown);
+    }
+
+    public function testRegisterFailureNetworkUsesBackoff()
+    {
+        when('wp_remote_retrieve_header')->justReturn('');
+        when('wp_remote_retrieve_body')->justReturn('');
+        $this->cache->shouldReceive('get')->andReturn(false);
+        $this->cache->shouldReceive('set')->once();
+        $this->logger->shouldNotReceive('warning');
+
+        $cooldown = $this->sut->register_failure('id-token', 0, []);
+
+        $this->assertGreaterThanOrEqual(30, $cooldown);
+        $this->assertLessThanOrEqual(38, $cooldown);
+    }
+
+    public function testClearDeletesState()
+    {
+        $this->cache->expects('delete')->with('bearer-circuit-state');
+
+        $this->sut->clear('bearer');
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/PHPUnit/ApiClient/Authentication/UserIdTokenTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/UserIdTokenTest.php
@@ -102,4 +102,27 @@ class UserIdTokenTest extends TestCase
 
         $this->assertSame('idtok', $this->sut->id_token());
     }
+
+    public function testRetriesOnceOnConnectionError()
+    {
+        $this->credentials->shouldReceive('is_empty')->andReturn(false);
+        $this->credentials->shouldReceive('credentials')->andReturn('Basic xxx');
+        $this->rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $this->rateLimiter->expects('clear')->with('id-token');
+        // A blip that recovers on retry must NOT arm the cool-down.
+        $this->rateLimiter->shouldNotReceive('register_failure');
+
+        $headers = $this->headers();
+        $wpError = Mockery::mock('WP_Error');
+        $wpError->shouldReceive('get_error_messages')->andReturn(['blip']);
+        expect('trailingslashit')->andReturn($this->host . '/');
+        // First attempt: connection error; retry: success.
+        expect('wp_remote_get')->twice()->andReturn(
+            $wpError,
+            ['body' => '{"id_token":"idtok"}', 'headers' => $headers]
+        );
+        expect('wp_remote_retrieve_response_code')->andReturn(200);
+
+        $this->assertSame('idtok', $this->sut->id_token());
+    }
 }

--- a/tests/PHPUnit/ApiClient/Authentication/UserIdTokenTest.php
+++ b/tests/PHPUnit/ApiClient/Authentication/UserIdTokenTest.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Authentication;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Requests_Utility_CaseInsensitiveDictionary;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class UserIdTokenTest extends TestCase
+{
+    private $host;
+    private $logger;
+    private $credentials;
+    private $cache;
+    private $rateLimiter;
+    private $sut;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        when('WC')->justReturn((object) ['session' => null]);
+
+        $this->host = 'https://example.com';
+        $this->logger = Mockery::mock(LoggerInterface::class);
+        $this->logger->shouldReceive('debug');
+        $this->credentials = Mockery::mock(ClientCredentials::class);
+        $this->cache = Mockery::mock(Cache::class);
+        $this->rateLimiter = Mockery::mock(TokenRateLimiter::class);
+        $this->sut = new UserIdToken(
+            $this->host,
+            $this->logger,
+            $this->credentials,
+            $this->cache,
+            $this->rateLimiter
+        );
+    }
+
+    private function headers()
+    {
+        $headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+        $headers->shouldReceive('getAll');
+
+        return $headers;
+    }
+
+    public function testEmptyCredentialsShortCircuit()
+    {
+        $this->credentials->shouldReceive('is_empty')->andReturn(true);
+
+        expect('wp_remote_get')->never();
+
+        $this->expectException(RuntimeException::class);
+        $this->sut->id_token();
+    }
+
+    public function testBlockedReturnsFastWithoutRequest()
+    {
+        $this->credentials->shouldReceive('is_empty')->andReturn(false);
+        $this->rateLimiter->shouldReceive('retry_after_seconds')->with('id-token')->andReturn(60);
+
+        expect('wp_remote_get')->never();
+
+        $this->expectException(RuntimeException::class);
+        $this->sut->id_token();
+    }
+
+    public function test429RegistersFailureAndThrows()
+    {
+        $this->credentials->shouldReceive('is_empty')->andReturn(false);
+        $this->credentials->shouldReceive('credentials')->andReturn('Basic xxx');
+        $this->rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $this->rateLimiter->expects('register_failure')->with('id-token', 429, Mockery::any());
+
+        $headers = $this->headers();
+        expect('trailingslashit')->andReturn($this->host . '/');
+        expect('wp_remote_get')->once()->andReturn(['body' => '{"error":"rate"}', 'headers' => $headers]);
+        expect('wp_remote_retrieve_response_code')->andReturn(429);
+
+        $this->expectException(PayPalApiException::class);
+        $this->sut->id_token();
+    }
+
+    public function testSuccess()
+    {
+        $this->credentials->shouldReceive('is_empty')->andReturn(false);
+        $this->credentials->shouldReceive('credentials')->andReturn('Basic xxx');
+        $this->rateLimiter->shouldReceive('retry_after_seconds')->andReturn(null);
+        $this->rateLimiter->expects('clear')->with('id-token');
+
+        $headers = $this->headers();
+        expect('trailingslashit')->andReturn($this->host . '/');
+        expect('wp_remote_get')->andReturn(['body' => '{"id_token":"idtok"}', 'headers' => $headers]);
+        expect('wp_remote_retrieve_response_code')->andReturn(200);
+
+        $this->assertSame('idtok', $this->sut->id_token());
+    }
+}

--- a/tests/PHPUnit/ApiClient/Entity/TokenTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/TokenTest.php
@@ -52,6 +52,26 @@ class TokenTest extends TestCase
         $this->assertFalse($token->is_valid());
     }
 
+    public function testIsValidAppliesSafetyMargin()
+    {
+        // Within the safety margin of true expiry: treated as already invalid,
+        // so it is refreshed proactively instead of racing the expiry.
+        $within_margin = new Token((object) [
+            'created' => time(),
+            'expires_in' => Token::EXPIRATION_SAFETY_MARGIN - 30,
+            'token' => 'abc',
+        ]);
+        $this->assertFalse($within_margin->is_valid());
+
+        // Comfortably before expiry: still valid.
+        $beyond_margin = new Token((object) [
+            'created' => time(),
+            'expires_in' => Token::EXPIRATION_SAFETY_MARGIN + 60,
+            'token' => 'abc',
+        ]);
+        $this->assertTrue($beyond_margin->is_valid());
+    }
+
     public function testFromBearerJson()
     {
         $data = json_encode([


### PR DESCRIPTION
Added rate-limiting for the failed auth token requests as well as some other small improvements related to that (checking empty credentials, adding expiration safety margin). 
The retry request on exception in `bearer()` was replaced with more explicit and limited retries (not 429 etc.). 