### PR TITLE
APM-S - Transaction link open paypal.com instead of sandbox.paypal.com (6487)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -647,7 +647,11 @@ return array(
 		$sandbox_url_base = $container->get( 'wcgateway.transaction-url-sandbox' );
 		$live_url_base    = $container->get( 'wcgateway.transaction-url-live' );
 
-		return new TransactionUrlProvider( $sandbox_url_base, $live_url_base );
+		return new TransactionUrlProvider(
+			$sandbox_url_base,
+			$live_url_base,
+			$container->get( 'settings.environment' )
+		);
 	},
 
 	'wcgateway.configuration.card-configuration'           => static function ( ContainerInterface $container ): CardPaymentsConfiguration {

--- a/modules/ppcp-wc-gateway/src/Gateway/TransactionUrlProvider.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/TransactionUrlProvider.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
+use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
+
 /**
  * Class TransactionUrlProvider
  */
@@ -30,18 +32,28 @@ class TransactionUrlProvider {
 	protected $transaction_url_base_live;
 
 	/**
+	 * The environment.
+	 *
+	 * @var Environment
+	 */
+	protected $environment;
+
+	/**
 	 * TransactionUrlProvider constructor.
 	 *
-	 * @param string $transaction_url_base_sandbox URL for sandbox orders.
-	 * @param string $transaction_url_base_live URL for live orders.
+	 * @param string      $transaction_url_base_sandbox URL for sandbox orders.
+	 * @param string      $transaction_url_base_live URL for live orders.
+	 * @param Environment $environment The environment.
 	 */
 	public function __construct(
 		string $transaction_url_base_sandbox,
-		string $transaction_url_base_live
+		string $transaction_url_base_live,
+		Environment $environment
 	) {
 
 		$this->transaction_url_base_sandbox = $transaction_url_base_sandbox;
 		$this->transaction_url_base_live    = $transaction_url_base_live;
+		$this->environment                  = $environment;
 	}
 
 	/**
@@ -53,6 +65,12 @@ class TransactionUrlProvider {
 	 */
 	public function get_transaction_url_base( \WC_Order $order ): string {
 		$order_payment_mode = $order->get_meta( PayPalGateway::ORDER_PAYMENT_MODE_META_KEY, true );
+
+		// Some gateways (e.g. local APMs) do not store the payment mode on the order,
+		// so fall back to the current environment to avoid defaulting to the live URL.
+		if ( ! $order_payment_mode ) {
+			$order_payment_mode = $this->environment->is_sandbox() ? 'sandbox' : 'live';
+		}
 
 		return 'sandbox' === $order_payment_mode ? $this->transaction_url_base_sandbox : $this->transaction_url_base_live;
 	}

--- a/tests/PHPUnit/WcGateway/Gateway/TransactionUrlProviderTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/TransactionUrlProviderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 
 class TransactionUrlProviderTest extends TestCase
 {
@@ -14,9 +15,10 @@ class TransactionUrlProviderTest extends TestCase
         string $sandboxUrl,
         string $liveUrl,
         string $orderPaymentMode,
+        bool $isSandbox,
         $expectedResult
     ) {
-        $testee = new TransactionUrlProvider($sandboxUrl, $liveUrl);
+        $testee = new TransactionUrlProvider($sandboxUrl, $liveUrl, new Environment($isSandbox));
 
         $wcOrder = \Mockery::mock(\WC_Order::class);
 
@@ -33,15 +35,20 @@ class TransactionUrlProviderTest extends TestCase
         $liveUrl = 'example.com';
 
         return [
+            // Order payment mode takes precedence over the environment when present.
             [
-                $sandboxUrl, $liveUrl, 'sandbox', $sandboxUrl
+                $sandboxUrl, $liveUrl, 'sandbox', false, $sandboxUrl
             ],
             [
-                $sandboxUrl, $liveUrl, 'live', $liveUrl
+                $sandboxUrl, $liveUrl, 'live', true, $liveUrl
+            ],
+            // No stored payment mode (e.g. local APMs): fall back to the environment.
+            [
+                $sandboxUrl, $liveUrl, '', true, $sandboxUrl
             ],
             [
-                $sandboxUrl, $liveUrl, '', $liveUrl
-            ]
+                $sandboxUrl, $liveUrl, '', false, $liveUrl
+            ],
         ];
     }
 }


### PR DESCRIPTION
`TransactionUrlProvider` picked sandbox vs. live solely from the `_ppcp_paypal_payment_mode` order meta. That meta is set via OrderProcessor but the local APM gateways build orders directly and never set it, so the provider defaulted to the live URL.

`TransactionUrlProvider` now falls back to the current Environment (`is_sandbox()`) when the order meta is absent. When the meta is present it still takes precedence. 