### PR TITLE
[QA] Remove PCP-2655 from Smoke tests

### DIFF
--- a/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-checkout.data.ts
@@ -8,7 +8,7 @@ const customer = customers.usa;
 export const googlePayCheckout: ShopOrder[] = [
 	{
 		// https://inpsyde.atlassian.net/browse/PCP-2655
-		title: 'PCP-2655 | Transaction - Checkout - Google Pay - Order by customer @Smoke',
+		title: 'PCP-2655 | Transaction - Checkout - Google Pay - Order by customer @Critical',
 		...orders.default,
 		payment: payments.googlePay,
 		customer,


### PR DESCRIPTION
### Description

Remove PCP-2655 - Google Pay from Smoke tests since it never passes in CI. Has to be fixed.
