### PR TITLE
[QA] Temporarily disable transaction-googlepay in e2e-tests.yml

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ on:
           - shard:settings
           - shard:transaction-usa
           - shard:transaction-mexico
-          - shard:transaction-googlepay
+          # - shard:transaction-googlepay - temporarily disabled due to instability in CI
           - shard:refund
           - shard:vaulting
           - shard:subscription
@@ -72,7 +72,7 @@ jobs:
             settings
             transaction-usa
             transaction-mexico
-            transaction-googlepay
+            # transaction-googlepay - temporarily disabled due to instability in CI
             refund
             vaulting
             subscription


### PR DESCRIPTION
### Description

Had to push additional commit for GPay test temporarily removed from CI:
Commented transaction-googlepay in e2e-tests.yml to prevent failing job because of missing tests.

 ✅ See successful [CI run](https://github.com/woocommerce/woocommerce-paypal-payments/actions/runs/26823951396)