### PR TITLE
Gift cards ignored on paypal payment page (PCP-6447) 

### DIFF
--- a/docs/extra-discount-filters.md
+++ b/docs/extra-discount-filters.md
@@ -1,0 +1,82 @@
+# Extra Discount Filters
+
+## Overview
+
+Some plugins apply discounts by calling `WC_Cart::set_total()` or `WC_Order::set_total()` directly,
+bypassing WooCommerce's standard coupon and fee mechanisms. Because `AmountFactory` derives the
+PayPal order amount from the standard breakdown getters (`get_subtotal()`, `get_discount_total()`,
+etc.), such discounts are invisible to it and the customer would be charged the full amount on the
+PayPal payment page.
+
+Three filters allow third-party plugins to surface these amounts so they are correctly reflected in
+the PayPal order.
+
+## Filters
+
+### `woocommerce_paypal_payments_cart_extra_discount`
+
+Contributes an extra discount amount when a PayPal order is created from the WC cart
+(`AmountFactory::from_wc_cart()`). The value is added to the `discount` field of the PayPal
+amount breakdown.
+
+```php
+add_filter(
+    'woocommerce_paypal_payments_cart_extra_discount',
+    function ( float $discount, WC_Cart $cart ): float {
+        // Return the additional discount amount that was applied to the cart
+        // outside of WooCommerce's standard coupon/fee system.
+        return $discount + my_plugin_get_cart_discount( $cart );
+    },
+    10,
+    2
+);
+```
+
+### `woocommerce_paypal_payments_order_extra_discount`
+
+Contributes an extra discount amount when a PayPal order is created from a WC order
+(`AmountFactory::from_wc_order()`).
+
+```php
+add_filter(
+    'woocommerce_paypal_payments_order_extra_discount',
+    function ( float $discount, WC_Order $order ): float {
+        // Return the additional discount amount stored on the order.
+        return $discount + my_plugin_get_order_discount( $order );
+    },
+    10,
+    2
+);
+```
+
+### `woocommerce_paypal_payments_store_api_cart_extra_discount`
+
+Same as `woocommerce_paypal_payments_cart_extra_discount` but for the WooCommerce Blocks (Store API)
+checkout path (`AmountFactory::from_store_api_cart()`). The second argument is a `CartTotals`
+object instead of `WC_Cart`. Because the Store API works entirely in **minor units** (e.g. cents),
+the returned value must also be in minor units — the filter user is responsible for any conversion.
+
+```php
+add_filter(
+    'woocommerce_paypal_payments_store_api_cart_extra_discount',
+    function ( int $discount, CartTotals $cart_totals ): int {
+        // Return cents (minor units), not dollars.
+        return $discount + my_plugin_get_cart_discount_cents();
+    },
+    10,
+    2
+);
+```
+
+## Notes
+
+- Each filter receives the currently accumulated extra discount as its first argument and must
+  return it unchanged if your plugin has nothing to contribute.
+- The cart and order filters return a `float` in the currency's major unit (e.g. dollars).
+  The Store API filter returns an `int` in minor units (e.g. cents) — the conversion is the
+  caller's responsibility.
+- Negative values are clamped to `0` by the factory.
+- The WooCommerce Gift Cards plugin (`woocommerce-gift-cards`) is handled automatically via
+  `WcGiftCardsCompat` for the classic cart/checkout and order paths. The Store API path
+  (`woocommerce_paypal_payments_store_api_cart_extra_discount`) is not hooked by
+  `WcGiftCardsCompat` because the Store API totals already reflect the gift card discount.

--- a/docs/extra-discount-filters.md
+++ b/docs/extra-discount-filters.md
@@ -51,17 +51,18 @@ add_filter(
 
 ### `woocommerce_paypal_payments_store_api_cart_extra_discount`
 
-Same as `woocommerce_paypal_payments_cart_extra_discount` but for the WooCommerce Blocks (Store API)
-checkout path (`AmountFactory::from_store_api_cart()`). The second argument is a `CartTotals`
-object instead of `WC_Cart`. Because the Store API works entirely in **minor units** (e.g. cents),
-the returned value must also be in minor units — the filter user is responsible for any conversion.
+Same as `woocommerce_paypal_payments_cart_extra_discount` but for the Store API path
+(`AmountFactory::from_store_api_cart()`), used during the PayPal express button shipping callback.
+The second argument is a `CartTotals` object instead of `WC_Cart`. Unlike the other filters,
+the value must be in the currency's
+**minor unit** (e.g. cents for USD) because the Store API works entirely in minor units.
 
 ```php
 add_filter(
     'woocommerce_paypal_payments_store_api_cart_extra_discount',
     function ( int $discount, CartTotals $cart_totals ): int {
         // Return cents (minor units), not dollars.
-        return $discount + my_plugin_get_cart_discount_cents();
+        return $discount + my_plugin_get_cart_discount_cents( $cart_totals );
     },
     10,
     2
@@ -73,10 +74,9 @@ add_filter(
 - Each filter receives the currently accumulated extra discount as its first argument and must
   return it unchanged if your plugin has nothing to contribute.
 - The cart and order filters return a `float` in the currency's major unit (e.g. dollars).
-  The Store API filter returns an `int` in minor units (e.g. cents) — the conversion is the
-  caller's responsibility.
+  The Store API filter returns an `int` in minor units (e.g. cents for USD).
 - Negative values are clamped to `0` by the factory.
 - The WooCommerce Gift Cards plugin (`woocommerce-gift-cards`) is handled automatically via
-  `WcGiftCardsCompat` for the classic cart/checkout and order paths. The Store API path
-  (`woocommerce_paypal_payments_store_api_cart_extra_discount`) is not hooked by
-  `WcGiftCardsCompat` because the Store API totals already reflect the gift card discount.
+  `WcGiftCardsCompat` for the classic cart/checkout, express button shipping callback, and order
+  paths. No manual
+  integration is needed for that plugin.

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -80,11 +80,7 @@ class AmountFactory {
 		$taxes_val      = (float) $cart->get_total_tax();
 		$discount_val   = (float) $cart->get_discount_total();
 
-		/**
-		 * Some plugins (e.g. WooCommerce Gift Cards) reduce cart->total via WC_Cart::set_total()
-		 * without registering a coupon or fee. Allow them to contribute their discount amount here.
-		 */
-		$discount_val += (float) apply_filters( 'woocommerce_paypal_payments_cart_extra_discount', 0.0, $cart );
+		$discount_val += $this->extra_discount( 'woocommerce_paypal_payments_cart_extra_discount', $cart );
 
 		$item_total = new Money( $item_total_val, $this->currency->get() );
 		$shipping   = new Money( $shipping_val, $this->currency->get() );
@@ -175,6 +171,8 @@ class AmountFactory {
 				$items_discount,
 			)
 		);
+
+		$discount_value += $this->extra_discount( 'woocommerce_paypal_payments_order_extra_discount', $order );
 
 		$discount = null;
 		if ( $discount_value ) {
@@ -292,6 +290,25 @@ class AmountFactory {
 		}
 
 		return new AmountBreakdown( ...$money );
+	}
+
+	/**
+	 * Returns any extra discount contributed via a filter hook.
+	 *
+	 * Some plugins (e.g. WooCommerce Gift Cards) reduce the WC total directly via
+	 * WC_Cart::set_total() / WC_Order::set_total() without registering a coupon or fee,
+	 * making their discount invisible to the standard breakdown getters. This method
+	 * applies the given filter so those plugins can surface their amount here.
+	 *
+	 * @param string $filter_name The filter hook name.
+	 * @param mixed  $context     The cart or order passed as context to the filter.
+	 * @return float
+	 */
+	private function extra_discount( string $filter_name, $context ): float {
+		/**
+		 * Filters extra discount amounts not captured by standard WC discount/fee getters.
+		 */
+		return (float) apply_filters( $filter_name, 0.0, $context );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -80,7 +80,11 @@ class AmountFactory {
 		$taxes_val      = (float) $cart->get_total_tax();
 		$discount_val   = (float) $cart->get_discount_total();
 
-		$discount_val += $this->extra_discount( 'woocommerce_paypal_payments_cart_extra_discount', $cart );
+		/**
+		 * Some plugins (e.g. WooCommerce Gift Cards) reduce cart->total via WC_Cart::set_total()
+		 * without registering a coupon or fee. Allow them to contribute their discount amount here.
+		 */
+		$discount_val += (float) apply_filters( 'woocommerce_paypal_payments_cart_extra_discount', 0.0, $cart );
 
 		$item_total = new Money( $item_total_val, $this->currency->get() );
 		$shipping   = new Money( $shipping_val, $this->currency->get() );
@@ -171,8 +175,6 @@ class AmountFactory {
 				$items_discount,
 			)
 		);
-
-		$discount_value += $this->extra_discount( 'woocommerce_paypal_payments_order_extra_discount', $order );
 
 		$discount = null;
 		if ( $discount_value ) {
@@ -290,25 +292,6 @@ class AmountFactory {
 		}
 
 		return new AmountBreakdown( ...$money );
-	}
-
-	/**
-	 * Returns any extra discount contributed via a filter hook.
-	 *
-	 * Some plugins (e.g. WooCommerce Gift Cards) reduce the WC total directly via
-	 * WC_Cart::set_total() / WC_Order::set_total() without registering a coupon or fee,
-	 * making their discount invisible to the standard breakdown getters. This method
-	 * applies the given filter so those plugins can surface their amount here.
-	 *
-	 * @param string $filter_name The filter hook name.
-	 * @param mixed  $context     The cart or order passed as context to the filter.
-	 * @return float
-	 */
-	private function extra_discount( string $filter_name, $context ): float {
-		/**
-		 * Filters extra discount amounts not captured by standard WC discount/fee getters.
-		 */
-		return (float) apply_filters( $filter_name, 0.0, $context );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -308,7 +308,7 @@ class AmountFactory {
 		/**
 		 * Filters extra discount amounts not captured by standard WC discount/fee getters.
 		 */
-		return (float) apply_filters( $filter_name, 0.0, $context );
+		return max( 0.0, (float) apply_filters( $filter_name, 0.0, $context ) );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -80,6 +80,8 @@ class AmountFactory {
 		$taxes_val      = (float) $cart->get_total_tax();
 		$discount_val   = (float) $cart->get_discount_total();
 
+		$discount_val += $this->extra_discount( 'woocommerce_paypal_payments_cart_extra_discount', $cart );
+
 		$item_total = new Money( $item_total_val, $this->currency->get() );
 		$shipping   = new Money( $shipping_val, $this->currency->get() );
 		$taxes      = new Money( $taxes_val, $this->currency->get() );
@@ -169,7 +171,10 @@ class AmountFactory {
 				$items_discount,
 			)
 		);
-		$discount       = null;
+
+		$discount_value += $this->extra_discount( 'woocommerce_paypal_payments_order_extra_discount', $order );
+
+		$discount = null;
 		if ( $discount_value ) {
 			$discount = new Money( (float) $discount_value, $currency );
 		}
@@ -285,6 +290,25 @@ class AmountFactory {
 		}
 
 		return new AmountBreakdown( ...$money );
+	}
+
+	/**
+	 * Returns any extra discount contributed via a filter hook.
+	 *
+	 * Some plugins (e.g. WooCommerce Gift Cards) reduce the WC total directly via
+	 * WC_Cart::set_total() / WC_Order::set_total() without registering a coupon or fee,
+	 * making their discount invisible to the standard breakdown getters. This method
+	 * applies the given filter so those plugins can surface their amount here.
+	 *
+	 * @param string $filter_name The filter hook name.
+	 * @param mixed  $context     The cart or order passed as context to the filter.
+	 * @return float
+	 */
+	private function extra_discount( string $filter_name, $context ): float {
+		/**
+		 * Filters extra discount amounts not captured by standard WC discount/fee getters.
+		 */
+		return (float) apply_filters( $filter_name, 0.0, $context );
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -130,7 +130,15 @@ class AmountFactory {
 		$shipping_minor = (int) $cart_totals->total_shipping()->value();
 		$tax_minor      = (int) $cart_totals->total_tax()->value();
 		$discount_minor = (int) $cart_totals->total_discount()->value();
-		$total_minor    = $items_minor + $shipping_minor + $tax_minor - $discount_minor;
+
+		/**
+		 * Some plugins (e.g. WooCommerce Gift Cards) reduce cart->total via WC_Cart::set_total()
+		 * without registering a coupon or fee. Allow them to contribute their discount amount here.
+		 * The value must be an integer in the cart currency's minor unit (e.g. cents for USD).
+		 */
+		$discount_minor += max( 0, (int) apply_filters( 'woocommerce_paypal_payments_store_api_cart_extra_discount', 0, $cart_totals ) );
+
+		$total_minor = $items_minor + $shipping_minor + $tax_minor - $discount_minor;
 
 		$currency   = $cart_totals->total_price()->currency_code();
 		$minor_unit = $cart_totals->total_price()->currency_minor_unit();

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Compat\Assets\CompatAssets;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
 use WooCommerce\PayPalCommerce\WcGateway\Settings\Settings;

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -62,6 +62,8 @@ class CompatModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
+		( new WcGiftCardsCompat() )->register();
+
 		$this->migrate_pay_later_settings( $c );
 		$this->migrate_smart_button_settings( $c );
 		$this->migrate_three_d_secure_setting();

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -63,7 +63,11 @@ class CompatModule implements ServiceModule, ExecutableModule {
 			}
 		);
 
-		( new WcGiftCardsCompat() )->register();
+		if ( function_exists( 'WC_GC' ) ) {
+			$context = $c->get( 'button.helper.context' );
+			assert( $context instanceof Context );
+			( new WcGiftCardsCompat( $context ) )->register();
+		}
 
 		$this->migrate_pay_later_settings( $c );
 		$this->migrate_smart_button_settings( $c );

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -23,7 +23,7 @@ namespace WooCommerce\PayPalCommerce\Compat;
  */
 class WcGiftCardsCompat {
 
-	const SESSION_KEY = 'ppcp_gc_cart_discount';
+	private const SESSION_KEY = 'ppcp_gc_cart_discount';
 
 	/**
 	 * Registers the hooks.

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -71,6 +71,12 @@ class WcGiftCardsCompat {
 			10,
 			2
 		);
+		add_filter(
+			'woocommerce_paypal_payments_store_api_cart_extra_discount',
+			array( $this, 'store_api_cart_extra_discount' ),
+			10,
+			2
+		);
 	}
 
 	/**
@@ -139,6 +145,26 @@ class WcGiftCardsCompat {
 	 */
 	private function is_gc_disabled_on_cart(): bool {
 		return 'no' !== get_option( 'wc_gc_disable_cart_ui', 'yes' );
+	}
+
+	/**
+	 * Returns the WC Gift Cards discount for the Store API (shipping callback on address change).
+	 * Must return an integer in minor units (e.g. cents for USD) to match the filter contract.
+	 *
+	 * @param int $extra Current extra discount in minor units.
+	 * @return int
+	 */
+	public function store_api_cart_extra_discount( int $extra ): int {
+		if ( ! function_exists( 'WC_GC' ) || ! WC()->session ) {
+			return $extra;
+		}
+
+		$gc_discount = (float) ( WC()->session->get( self::SESSION_KEY ) ?? 0.0 );
+		if ( $gc_discount <= 0.0 ) {
+			return $extra;
+		}
+
+		return $extra + (int) round( $gc_discount * 10 ** wc_get_price_decimals() );
 	}
 
 	/**

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -40,12 +40,6 @@ class WcGiftCardsCompat {
 			10,
 			2
 		);
-		add_filter(
-			'woocommerce_paypal_payments_order_extra_discount',
-			array( $this, 'order_extra_discount' ),
-			10,
-			2
-		);
 	}
 
 	/**
@@ -81,23 +75,5 @@ class WcGiftCardsCompat {
 		$gc_discount = (float) ( WC()->session->get( self::SESSION_KEY ) ?? 0.0 );
 
 		return $extra + ( $gc_discount ?: 0.0 );
-	}
-
-	/**
-	 * Returns the total WC Gift Cards discount applied to the order.
-	 *
-	 * @param float     $extra Current extra discount accumulated by other hooks.
-	 * @param \WC_Order $order The WooCommerce order.
-	 * @return float
-	 */
-	public function order_extra_discount( float $extra, \WC_Order $order ): float {
-		if ( ! function_exists( 'WC_GC' ) || ! WC_GC()->order ) {
-			return $extra;
-		}
-
-		$gift_cards = WC_GC()->order->get_gift_cards( $order );
-		$extra     += (float) ( $gift_cards['total'] ?? 0.0 );
-
-		return $extra;
 	}
 }

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -19,9 +19,16 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
  * supplies the missing amounts to the PayPal order amount breakdown via the
  * extra-discount filters.
  *
- * For the cart, the discount is captured right after WC_GC sets the cart total
- * (priority 1000, after WC_GC at 999) and stored in the WC session so it is
- * available across AJAX requests.
+ * Two complementary hooks manage the WC session value:
+ *
+ * 1. clear_on_cart_page() via template_redirect — fires on every real page load
+ *    regardless of whether WC recalculates, guaranteeing the session is reset to 0
+ *    when the customer is on the cart page with WC_GC UI disabled.
+ *
+ * 2. store_cart_discount() via woocommerce_after_calculate_totals — runs only when
+ *    WC actually recalculates, stores the live discount from WC_GC.
+ * 	  Skipped in AJAX so the session always reflects the
+ *    last real page load.
  */
 class WcGiftCardsCompat {
 

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -44,6 +44,10 @@ class WcGiftCardsCompat {
 	 */
 	public function register(): void {
 		add_action(
+			'template_redirect',
+			array( $this, 'clear_on_cart_page' )
+		);
+		add_action(
 			'woocommerce_after_calculate_totals',
 			array( $this, 'store_cart_discount' ),
 			1000
@@ -60,6 +64,25 @@ class WcGiftCardsCompat {
 			10,
 			2
 		);
+	}
+
+	/**
+	 * Clears the stored discount on every cart page load (template_redirect fires
+	 * unconditionally, even when WC uses cached totals). This guarantees the session
+	 * reflects the full price the customer sees when WC_GC is configured to hide its
+	 * discount on the cart page.
+	 */
+	public function clear_on_cart_page(): void {
+		if ( ! function_exists( 'WC_GC' ) || ! WC()->session ) {
+			return;
+		}
+
+		$context = $this->context->context();
+		if ( in_array( $context, array( 'cart', 'cart-block' ), true )
+			&& 'no' !== get_option( 'wc_gc_disable_cart_ui', 'yes' )
+		) {
+			WC()->session->set( self::SESSION_KEY, 0.0 );
+		}
 	}
 
 	/**

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -25,10 +25,10 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
  *    regardless of whether WC recalculates, guaranteeing the session is reset to 0
  *    when the customer is on the cart page with WC_GC UI disabled.
  *
- * 2. store_cart_discount() via woocommerce_after_calculate_totals — runs only when
- *    WC actually recalculates, stores the live discount from WC_GC.
- *    Skipped in AJAX so the session always reflects the
- *    last real page load.
+ * 2. store_cart_discount() via woocommerce_after_calculate_totals — stores the live
+ *    discount from WC_GC when in a checkout context.
+ *    Skipped outside of checkout when the GC UI is disabled on the cart page,
+ *    since the discount is not shown there and should not be charged.
  */
 class WcGiftCardsCompat {
 

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat;
 
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+
 /**
  * Provides WooCommerce Gift Cards plugin compatibility.
  *
@@ -24,6 +26,18 @@ namespace WooCommerce\PayPalCommerce\Compat;
 class WcGiftCardsCompat {
 
 	private const SESSION_KEY = 'ppcp_gc_cart_discount';
+
+	/**
+	 * @var Context
+	 */
+	private Context $context;
+
+	/**
+	 * @param Context $context The button context helper.
+	 */
+	public function __construct( Context $context ) {
+		$this->context = $context;
+	}
 
 	/**
 	 * Registers the hooks.
@@ -57,6 +71,10 @@ class WcGiftCardsCompat {
 	 */
 	public function store_cart_discount( \WC_Cart $cart ): void {
 		if ( ! function_exists( 'WC_GC' ) || ! WC_GC()->cart || ! WC()->session ) {
+			return;
+		}
+
+		if ( ! $this->context->is_checkout() ) {
 			return;
 		}
 

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Compatibility layer for WooCommerce Gift Cards plugin.
+ *
+ * @package WooCommerce\PayPalCommerce\Compat
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat;
+
+/**
+ * Provides WooCommerce Gift Cards plugin compatibility.
+ *
+ * The WC Gift Cards plugin applies its discount directly via WC_Cart::set_total()
+ * and WC_Order::set_total(), bypassing the standard coupon/fee getters. This class
+ * supplies the missing amounts to the PayPal order amount breakdown via the
+ * extra-discount filters.
+ *
+ * For the cart, the discount is captured right after WC_GC sets the cart total
+ * (priority 1000, after WC_GC at 999) and stored in the WC session so it is
+ * available across AJAX requests.
+ */
+class WcGiftCardsCompat {
+
+	const SESSION_KEY = 'ppcp_gc_cart_discount';
+
+	/**
+	 * Registers the hooks.
+	 */
+	public function register(): void {
+		add_action(
+			'woocommerce_after_calculate_totals',
+			array( $this, 'store_cart_discount' ),
+			1000
+		);
+		add_filter(
+			'woocommerce_paypal_payments_cart_extra_discount',
+			array( $this, 'cart_extra_discount' ),
+			10,
+			2
+		);
+		add_filter(
+			'woocommerce_paypal_payments_order_extra_discount',
+			array( $this, 'order_extra_discount' ),
+			10,
+			2
+		);
+	}
+
+	/**
+	 * Runs after WC_GC (priority 999) has set the cart total. Computes the gap
+	 * between the standard breakdown total and the actual cart total and stores
+	 * it in the WC session so it is available in subsequent AJAX requests.
+	 *
+	 * @param \WC_Cart $cart The WooCommerce cart.
+	 */
+	public function store_cart_discount( \WC_Cart $cart ): void {
+		if ( ! function_exists( 'WC_GC' ) || ! WC_GC()->cart || ! WC()->session ) {
+			return;
+		}
+
+		$totals      = WC_GC()->cart->get_account_totals_breakdown();
+		$gc_discount = (float) ( $totals['cart_total'] ?? 0.0 ) - (float) ( $totals['remaining_total'] ?? 0.0 );
+
+		WC()->session->set( self::SESSION_KEY, $gc_discount ?: 0.0 );
+	}
+
+	/**
+	 * Returns the total WC Gift Cards discount applied to the cart.
+	 *
+	 * @param float    $extra Current extra discount accumulated by other hooks.
+	 * @param \WC_Cart $cart  The WooCommerce cart.
+	 * @return float
+	 */
+	public function cart_extra_discount( float $extra, \WC_Cart $cart ): float {
+		if ( ! function_exists( 'WC_GC' ) || ! WC()->session ) {
+			return $extra;
+		}
+
+		$gc_discount = (float) ( WC()->session->get( self::SESSION_KEY ) ?? 0.0 );
+
+		return $extra + ( $gc_discount ?: 0.0 );
+	}
+
+	/**
+	 * Returns the total WC Gift Cards discount applied to the order.
+	 *
+	 * @param float     $extra Current extra discount accumulated by other hooks.
+	 * @param \WC_Order $order The WooCommerce order.
+	 * @return float
+	 */
+	public function order_extra_discount( float $extra, \WC_Order $order ): float {
+		if ( ! function_exists( 'WC_GC' ) || ! WC_GC()->order ) {
+			return $extra;
+		}
+
+		$gift_cards = WC_GC()->order->get_gift_cards( $order );
+		$extra     += (float) ( $gift_cards['total'] ?? 0.0 );
+
+		return $extra;
+	}
+}

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -40,6 +40,12 @@ class WcGiftCardsCompat {
 			10,
 			2
 		);
+		add_filter(
+			'woocommerce_paypal_payments_order_extra_discount',
+			array( $this, 'order_extra_discount' ),
+			10,
+			2
+		);
 	}
 
 	/**
@@ -75,5 +81,23 @@ class WcGiftCardsCompat {
 		$gc_discount = (float) ( WC()->session->get( self::SESSION_KEY ) ?? 0.0 );
 
 		return $extra + ( $gc_discount ?: 0.0 );
+	}
+
+	/**
+	 * Returns the total WC Gift Cards discount applied to the order.
+	 *
+	 * @param float     $extra Current extra discount accumulated by other hooks.
+	 * @param \WC_Order $order The WooCommerce order.
+	 * @return float
+	 */
+	public function order_extra_discount( float $extra, \WC_Order $order ): float {
+		if ( ! function_exists( 'WC_GC' ) || ! WC_GC()->order ) {
+			return $extra;
+		}
+
+		$gift_cards = WC_GC()->order->get_gift_cards( $order );
+		$extra     += (float) ( $gift_cards['total'] ?? 0.0 );
+
+		return $extra;
 	}
 }

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -27,7 +27,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
  *
  * 2. store_cart_discount() via woocommerce_after_calculate_totals — runs only when
  *    WC actually recalculates, stores the live discount from WC_GC.
- * 	  Skipped in AJAX so the session always reflects the
+ *    Skipped in AJAX so the session always reflects the
  *    last real page load.
  */
 class WcGiftCardsCompat {
@@ -93,9 +93,8 @@ class WcGiftCardsCompat {
 	}
 
 	/**
-	 * Runs after WC_GC (priority 999) has set the cart total. Computes the gap
-	 * between the standard breakdown total and the actual cart total and stores
-	 * it in the WC session so it is available in subsequent AJAX requests.
+	 * Stores the applied gift card discount when WC recalculates on the checkout
+	 * page. Skips this outside of checkout when gift cards are disabled on cart.
 	 *
 	 * @param \WC_Cart $cart The WooCommerce cart.
 	 */

--- a/modules/ppcp-compat/src/WcGiftCardsCompat.php
+++ b/modules/ppcp-compat/src/WcGiftCardsCompat.php
@@ -86,7 +86,7 @@ class WcGiftCardsCompat {
 
 		$context = $this->context->context();
 		if ( in_array( $context, array( 'cart', 'cart-block' ), true )
-			&& 'no' !== get_option( 'wc_gc_disable_cart_ui', 'yes' )
+			&& $this->is_gc_disabled_on_cart()
 		) {
 			WC()->session->set( self::SESSION_KEY, 0.0 );
 		}
@@ -104,7 +104,7 @@ class WcGiftCardsCompat {
 			return;
 		}
 
-		if ( ! $this->context->is_checkout() ) {
+		if ( ! $this->context->is_checkout() && $this->is_gc_disabled_on_cart() ) {
 			return;
 		}
 
@@ -129,6 +129,17 @@ class WcGiftCardsCompat {
 		$gc_discount = (float) ( WC()->session->get( self::SESSION_KEY ) ?? 0.0 );
 
 		return $extra + ( $gc_discount ?: 0.0 );
+	}
+
+	/**
+	 * Whether the WC Gift Cards UI is disabled on the cart page (the default).
+	 * When disabled, the discount is not shown there and should not be applied
+	 * to a PayPal order created from the cart page.
+	 *
+	 * @return bool
+	 */
+	private function is_gc_disabled_on_cart(): bool {
+		return 'no' !== get_option( 'wc_gc_disable_cart_ui', 'yes' );
 	}
 
 	/**

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -448,6 +448,48 @@ class AmountFactoryTest extends TestCase
 		$this->assertSame( '90.00', $result->value_str() );
 	}
 
+	/**
+	 * Plugins like WooCommerce Gift Cards apply discounts via WC_Cart::set_total() rather
+	 * than coupons or fees. The filter lets them contribute the missing amount so the
+	 * PayPal order total matches the actual WC cart total.
+	 */
+	public function testFromWcCartAppliesExtraDiscountFilter(): void
+	{
+		$cart = Mockery::mock( \WC_Cart::class );
+		$cart->shouldReceive( 'get_subtotal' )->andReturn( 100.0 );
+		$cart->shouldReceive( 'get_fee_total' )->andReturn( 0.0 );
+		$cart->shouldReceive( 'get_discount_total' )->andReturn( 0.0 );
+		$cart->shouldReceive( 'get_shipping_total' )->andReturn( 10.0 );
+		$cart->shouldReceive( 'get_total_tax' )->andReturn( 0.0 );
+
+		$woocommerce          = Mockery::mock( \WooCommerce::class );
+		$session              = Mockery::mock( \WC_Session::class );
+		$woocommerce->session = $session;
+		when( 'WC' )->justReturn( $woocommerce );
+		$session->shouldReceive( 'get' )->andReturn( [] );
+
+		\Brain\Monkey\Filters\expectApplied( 'woocommerce_paypal_payments_cart_extra_discount' )
+			->once()
+			->with( 0.0, $cart )
+			->andReturn( 25.0 );
+
+		$result    = $this->testee->from_wc_cart( $cart );
+		$breakdown = $result->breakdown();
+
+		$this->assertSame( '85.00', $result->value_str() );
+		$this->assertSame( '25.00', $breakdown->discount()->value_str() );
+		$this->assertSame(
+			$result->value_str(),
+			number_format(
+				(float) $breakdown->item_total()->value_str()
+				+ (float) $breakdown->shipping()->value_str()
+				+ (float) $breakdown->tax_total()->value_str()
+				- (float) $breakdown->discount()->value_str(),
+				2, '.', ''
+			)
+		);
+	}
+
     /**
      * @dataProvider dataFromPayPalResponse
      * @param $response

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -490,6 +490,41 @@ class AmountFactoryTest extends TestCase
 		);
 	}
 
+	public function testFromWcOrderAppliesExtraDiscountFilter(): void
+	{
+		$order = Mockery::mock( \WC_Order::class );
+		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
+		$order->shouldReceive( 'get_meta' )->andReturn( null );
+		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
+		$order->shouldReceive( 'get_subtotal' )->andReturn( 100.0 );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_shipping_total' )->andReturn( 10.0 );
+		$order->shouldReceive( 'get_total_tax' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_total_discount' )->andReturn( 0.0 );
+		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
+
+		\Brain\Monkey\Filters\expectApplied( 'woocommerce_paypal_payments_order_extra_discount' )
+			->once()
+			->with( 0.0, $order )
+			->andReturn( 25.0 );
+
+		$result    = $this->testee->from_wc_order( $order );
+		$breakdown = $result->breakdown();
+
+		$this->assertSame( '85.00', $result->value_str() );
+		$this->assertSame( '25.00', $breakdown->discount()->value_str() );
+		$this->assertSame(
+			$result->value_str(),
+			number_format(
+				(float) $breakdown->item_total()->value_str()
+				+ (float) $breakdown->shipping()->value_str()
+				+ (float) $breakdown->tax_total()->value_str()
+				- (float) $breakdown->discount()->value_str(),
+				2, '.', ''
+			)
+		);
+	}
+
     /**
      * @dataProvider dataFromPayPalResponse
      * @param $response

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -615,6 +615,7 @@ class AmountFactoryTest extends TestCase
 		$order->shouldReceive( 'get_shipping_total' )->andReturn( 10.0 );
 		$order->shouldReceive( 'get_total_tax' )->andReturn( 0.0 );
 		$order->shouldReceive( 'get_total_discount' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_total' )->andReturn( 85.0 );
 		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
 
 		\Brain\Monkey\Filters\expectApplied( 'woocommerce_paypal_payments_order_extra_discount' )


### PR DESCRIPTION
**Ticket**: PCP-6447

---

### Description
Gift cards added by the Gift Cards for WooCommerce plugin are not reflected in the PayPal payment amount.

### Steps to reproduce the issue
1. Add a new product, select “Gift Card”, add the value of the gift card. Save the product.
2. Add the gift card to cart, complete purchase - email it to yourself - so that the code is sent to your email.
3. Now add another item to cart (where it exceeds the value of the giftcard). 
4. Copy the gift card code from your email, and apply it at checkout page. 
5. Pay with PayPal. 
6. Instead of the discounted value, it charges full value.

### Steps to Test
Pre-requisites:
1. Create a classic checkout page, a classic cart page, a block checkout page, and a block cart page.
2. Create a Gift Card product, add multiple of them to the cart (to have spare codes), and purchase.

Scenario *Gift cards on the cart page enabled*
1. Go to WooCommerce -> Settings -> Gift cards and make sure the 'Enable cart page features' checkbox is checked.
2. Add any product to the cart
3. Apply the gift cart code
4. Buy it on the classic cart, block cart, classic checkout, and block checkout, making sure that the gift cart amount is reduced from the PayPal total amount.


Scenario *Gift cards on the cart page disabled*
1. Go to WooCommerce -> Settings -> Gift cards and make sure the 'Enable cart page features' checkbox is unchecked.
2. Add any product to the cart
3. Go to the checkout page and use the gift cart code
4. Buy the product on the classic and block checkout, making sure that the gift cart amount is reduced from the PayPal total amount.
5. Go to the checkout and apply another gift card code.
6. Move to the classic cart and complete payment, making sure that the gift cart amount is NOT reduced from the PayPal account.


https://github.com/user-attachments/assets/28335232-1753-45b8-a083-621c58be3bdd



_Note: There is a problem with block checkout. When the gift cards are disabled on the cart page, the displayed total amount on the block cart page changes during payment. I left it out as a separate issue, only making sure that PayPal receives the correct amount in this case. See the video below for more details._

https://github.com/user-attachments/assets/89751394-24ae-4df6-92ce-6293e7137d86



### Documentation

<!-- Will this change require new documentation or changes to existing documentation? -->
<!-- A good way to answer it is to ask: will more than one customer ever need to know about this? -->
- [ ] This PR needs documentation (has the "Documentation" label).
<!-- For an extra 💯 include further details about which change requires documentation. -->

### Changelog Entry

* Added compatibility with the Gift Cards for Woocommerce plugin.
