### PR TITLE
Fix PayPal amount mismatch from inclusive-tax rounding

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -185,25 +185,30 @@ class AmountFactory {
 
 		$item_total = new Money( $item_total_val, $currency );
 		$shipping   = new Money( $shipping_val, $currency );
-		$taxes      = new Money( $taxes_val, $currency );
 
 		// Free trial orders charge a fixed $1.00 regardless of cart contents —
-		// preserve that override. For all other orders derive the total from
-		// breakdown components so amount.value always equals the breakdown sum.
+		// preserve that override. For all other orders use get_total() as the
+		// authoritative amount and adjust the tax breakdown by any rounding delta
+		// (typically ±1 cent from inclusive-tax rounding) so that PayPal's
+		// invariant — amount.value === sum(breakdown) — always holds while the
+		// total still matches what WooCommerce stored on the order.
 		if ( (
 				in_array( $order->get_payment_method(), array( CreditCardGateway::ID, CardButtonGateway::ID ), true )
 				|| ( PayPalGateway::ID === $order->get_payment_method() && 'card' === $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY ) )
 			)
 			&& $this->is_free_trial_order( $order )
 		) {
+			$taxes = new Money( $taxes_val, $currency );
 			$total = new Money( 1.0, $currency );
 		} else {
-			$total_cents = (int) round( $item_total_val * 100 )
+			$wc_total_cents        = (int) round( (float) $order->get_total() * 100 );
+			$component_total_cents = (int) round( $item_total_val * 100 )
 				+ (int) round( $shipping_val * 100 )
 				+ (int) round( $taxes_val * 100 )
 				- (int) round( $discount_value * 100 );
-			$total_str   = number_format( $total_cents / 100, 2, '.', '' );
-			$total       = new Money( (float) $total_str, $currency );
+			$taxes_cents           = (int) round( $taxes_val * 100 ) + ( $wc_total_cents - $component_total_cents );
+			$taxes                 = new Money( $taxes_cents / 100, $currency );
+			$total                 = new Money( (float) $order->get_total(), $currency );
 		}
 
 		$breakdown = new AmountBreakdown(

--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -201,14 +201,15 @@ class AmountFactory {
 			$taxes = new Money( $taxes_val, $currency );
 			$total = new Money( 1.0, $currency );
 		} else {
-			$wc_total_cents        = (int) round( (float) $order->get_total() * 100 );
+			$wc_total              = (float) $order->get_total();
+			$wc_total_cents        = (int) round( $wc_total * 100 );
 			$component_total_cents = (int) round( $item_total_val * 100 )
 				+ (int) round( $shipping_val * 100 )
 				+ (int) round( $taxes_val * 100 )
 				- (int) round( $discount_value * 100 );
 			$taxes_cents           = (int) round( $taxes_val * 100 ) + ( $wc_total_cents - $component_total_cents );
 			$taxes                 = new Money( $taxes_cents / 100, $currency );
-			$total                 = new Money( (float) $order->get_total(), $currency );
+			$total                 = new Money( $wc_total, $currency );
 		}
 
 		$breakdown = new AmountBreakdown(

--- a/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AmountFactoryTest.php
@@ -309,6 +309,9 @@ class AmountFactoryTest extends TestCase
         $order
             ->shouldReceive('get_meta')
             ->andReturn(null);
+        $order
+            ->shouldReceive('get_total')
+            ->andReturn(10.0);
 
         $result = $this->testee->from_wc_order($order);
         $this->assertEquals((float) 3, $result->breakdown()->discount()->value());
@@ -367,29 +370,32 @@ class AmountFactoryTest extends TestCase
 		$order
 			->shouldReceive('get_meta')
 			->andReturn(null);
+		$order
+			->shouldReceive('get_total')
+			->andReturn(9.0);
 
         $result = $this->testee->from_wc_order($order);
         $this->assertNull($result->breakdown()->discount());
     }
 
 	/**
-	 * Proves that from_wc_order() derives the total from breakdown components
-	 * and never calls get_total(). Mirrors the equivalent from_wc_cart() test.
+	 * When get_total() matches the component sum, amount.value equals both and the
+	 * breakdown is unchanged. get_total() must be called exactly once.
 	 */
-	public function testFromWcOrderTotalDerivesFromComponentsNotGetTotal(): void
+	public function testFromWcOrderUsesGetTotalWhenComponentsMatch(): void
 	{
 		$order = Mockery::mock( \WC_Order::class );
-		// Enforce get_total() is never consulted.
-		$order->shouldNotReceive( 'get_total' );
-		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
-		$order->shouldReceive( 'get_meta' )->andReturn( null );
-		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
-		// subtotal=$13.33, fees=0, shipping=$5.00, tax=$1.07 → total should be $19.40.
+		// Components sum to $19.40 (1333 + 500 + 107 = 1940 cents).
 		$order->shouldReceive( 'get_subtotal' )->andReturn( 13.33 );
 		$order->shouldReceive( 'get_total_fees' )->andReturn( 0.0 );
 		$order->shouldReceive( 'get_shipping_total' )->andReturn( 5.00 );
 		$order->shouldReceive( 'get_total_tax' )->andReturn( 1.07 );
 		$order->shouldReceive( 'get_total_discount' )->andReturn( 0.0 );
+		// get_total() matches the sum — no adjustment needed.
+		$order->shouldReceive( 'get_total' )->once()->andReturn( 19.40 );
+		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
+		$order->shouldReceive( 'get_meta' )->andReturn( null );
+		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
 		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
 
 		$result = $this->testee->from_wc_order( $order );
@@ -399,6 +405,113 @@ class AmountFactoryTest extends TestCase
 		$this->assertSame( '5.00', $result->breakdown()->shipping()->value_str() );
 		$this->assertSame( '1.07', $result->breakdown()->tax_total()->value_str() );
 		$this->assertNull( $result->breakdown()->discount() );
+	}
+
+	/**
+	 * The core regression fix: when get_total() differs from the component sum by
+	 * $0.01 (inclusive-tax rounding), amount.value must equal get_total() and the
+	 * tax breakdown component must absorb the delta so sum(breakdown) still holds.
+	 *
+	 * Concrete case: subtotal=13.90, tax=2.65 (components) → sum=16.55,
+	 * but WooCommerce stored get_total()=16.54. PayPal must capture 16.54 so that
+	 * a full refund of 16.54 is accepted without REFUND_AMOUNT_EXCEEDED.
+	 */
+	public function testFromWcOrderAdjustsTaxBreakdownWhenGetTotalDiffersFromComponentSum(): void
+	{
+		$order = Mockery::mock( \WC_Order::class );
+		$order->shouldReceive( 'get_subtotal' )->andReturn( 13.90 );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_shipping_total' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_total_tax' )->andReturn( 2.65 );  // component value
+		$order->shouldReceive( 'get_total_discount' )->andReturn( 0.0 );
+		// WooCommerce stored 16.54 — one cent less than the component sum.
+		$order->shouldReceive( 'get_total' )->once()->andReturn( 16.54 );
+		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
+		$order->shouldReceive( 'get_meta' )->andReturn( null );
+		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
+		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
+
+		$result    = $this->testee->from_wc_order( $order );
+		$breakdown = $result->breakdown();
+
+		// amount.value must be the WooCommerce total, not the component sum.
+		$this->assertSame( '16.54', $result->value_str(), 'amount.value must equal get_total()' );
+		// Tax absorbs the -1 cent delta (2.65 → 2.64).
+		$this->assertSame( '2.64', $breakdown->tax_total()->value_str(), 'tax adjusted down by 1 cent' );
+		// Other components unchanged.
+		$this->assertSame( '13.90', $breakdown->item_total()->value_str() );
+		$this->assertSame( '0.00', $breakdown->shipping()->value_str() );
+		// Breakdown invariant: sum must equal amount.value.
+		$sum = (float) $breakdown->item_total()->value_str()
+			+ (float) $breakdown->shipping()->value_str()
+			+ (float) $breakdown->tax_total()->value_str();
+		$this->assertSame( $result->value_str(), number_format( $sum, 2, '.', '' ), 'breakdown invariant' );
+	}
+
+	/**
+	 * Parametrised invariant: for any combination of components, sum(breakdown)
+	 * must always equal get_total() after the tax adjustment.
+	 *
+	 * @dataProvider dataOrderBreakdownInvariantCases
+	 */
+	public function testFromWcOrderBreakdownAlwaysSumsToGetTotal(
+		float $subtotal,
+		float $fees,
+		float $shipping,
+		float $tax,
+		float $discount,
+		float $wc_total
+	): void {
+		$order = Mockery::mock( \WC_Order::class );
+		$order->shouldReceive( 'get_subtotal' )->andReturn( $subtotal );
+		$order->shouldReceive( 'get_total_fees' )->andReturn( $fees );
+		$order->shouldReceive( 'get_shipping_total' )->andReturn( $shipping );
+		$order->shouldReceive( 'get_total_tax' )->andReturn( $tax );
+		$order->shouldReceive( 'get_total_discount' )->andReturn( $discount );
+		$order->shouldReceive( 'get_total' )->andReturn( $wc_total );
+		$order->shouldReceive( 'get_payment_method' )->andReturn( PayPalGateway::ID );
+		$order->shouldReceive( 'get_meta' )->andReturn( null );
+		$order->shouldReceive( 'get_currency' )->andReturn( $this->currency );
+		$this->itemFactory->shouldReceive( 'from_wc_order' )->andReturn( [] );
+
+		$result    = $this->testee->from_wc_order( $order );
+		$breakdown = $result->breakdown();
+
+		$this->assertSame(
+			number_format( $wc_total, 2, '.', '' ),
+			$result->value_str(),
+			'amount.value must equal get_total()'
+		);
+
+		$sum = (float) $breakdown->item_total()->value_str()
+			+ (float) $breakdown->shipping()->value_str()
+			+ (float) $breakdown->tax_total()->value_str();
+		if ( $breakdown->discount() ) {
+			$sum -= (float) $breakdown->discount()->value_str();
+		}
+		$this->assertSame(
+			$result->value_str(),
+			number_format( $sum, 2, '.', '' ),
+			'breakdown invariant: sum(breakdown) must equal amount.value'
+		);
+	}
+
+	public function dataOrderBreakdownInvariantCases(): array
+	{
+		return [
+			// Delta = 0: components already match get_total().
+			'no_delta'            => [ 13.33, 0.0, 5.00, 1.07, 0.0, 19.40 ],
+			// Delta = +1 cent: get_total() is 1 cent higher than component sum.
+			'delta_plus_one'      => [ 13.90, 0.0, 0.0, 2.65, 0.0, 16.56 ],
+			// Delta = -1 cent: get_total() is 1 cent lower than component sum.
+			'delta_minus_one'     => [ 13.90, 0.0, 0.0, 2.65, 0.0, 16.54 ],
+			// With discount, zero delta.
+			'with_discount'       => [ 20.00, 2.00, 3.50, 2.25, 1.75, 26.00 ],
+			// With discount, 1 cent delta.
+			'with_discount_delta' => [ 20.00, 2.00, 3.50, 2.26, 1.75, 26.00 ],
+			// Fees present, delta = -1 cent.
+			'with_fees_delta'     => [ 15.50, 4.50, 6.00, 2.60, 0.0, 28.59 ],
+		];
 	}
 
 	/**
@@ -438,6 +551,7 @@ class AmountFactoryTest extends TestCase
 		$order->shouldReceive( 'get_shipping_total' )->andReturn( 0.0 );
 		$order->shouldReceive( 'get_total_tax' )->andReturn( 0.0 );
 		$order->shouldReceive( 'get_total_discount' )->andReturn( 0.0 );
+		$order->shouldReceive( 'get_total' )->andReturn( 90.0 );
 
 		$result = $this->testee->from_wc_order( $order );
 


### PR DESCRIPTION
<!-- Source of this Pull Request. Remove any that are not applicable. -->

**Ticket**: PCP-6503
**Issue**: #4415

---

### Description

PR #4301 fixed a production regression where PayPal rejected PATCH requests during Fastlane shipping-address changes because `WC_Cart::get_total()` and the arithmetic sum of the breakdown components could differ by ±$0.01 due to per-item tax rounding. The fix — deriving `amount.value` from the component sum rather than from `get_total()` — was correct for `from_wc_cart()` and `from_store_api_cart()`, where no authoritative WooCommerce order total exists yet.

However, the same change was also applied to `from_wc_order()`, which introduced a new regression: when the component sum diverges from `$order->get_total()` (as it can in inclusive-tax stores), PayPal captures the component-sum amount while WooCommerce records a different total. A full refund then sends `$order->get_total()` to PayPal, which exceeds the captured amount and returns `REFUND_AMOUNT_EXCEEDED`.

**Root cause in `from_wc_order()`**

In inclusive-tax scenarios (e.g. 19% VAT) WooCommerce may store:

| Source | Subtotal | Tax | Total |
|---|---|---|---|
| `$order->get_total()` | 13.90 | 2.64 | **16.54** |
| Component sum via `get_total_tax()` | 13.90 | 2.65 | **16.55** |

Before PR #4301, `from_wc_order()` used `$order->get_total()` directly — correct for the refund path but technically violating PayPal's `amount.value === sum(breakdown)` invariant. PR #4301 inverted the priority: the invariant always holds, but the captured amount no longer matches what WooCommerce recorded.

**Fix**

Use `$order->get_total()` as the authoritative `amount.value` in `from_wc_order()`, and absorb any rounding delta (typically ±1 cent) into the tax breakdown component so that PayPal's invariant still holds:

```
adjusted_tax = round(get_total_tax() × 100) + (round(get_total() × 100) − component_sum_cents)
amount.value = get_total()                 ← WC-authoritative; refunds always match
sum(breakdown) = amount.value              ← PayPal invariant satisfied
```

The tax component is the right place to absorb the delta because the discrepancy always originates in inclusive-tax rounding.

`from_wc_cart()` and `from_store_api_cart()` are unchanged — the component approach remains correct there since no WC order total exists at cart time, and the pre-capture PATCH is the designed correction mechanism.

### Steps to Test

**REFUND_AMOUNT_EXCEEDED regression (main fix)**

1. Configure WooCommerce with an inclusive tax rate (e.g. 19% VAT, "prices include tax" enabled).
2. Add a product whose price produces a per-item rounding difference between the cart and the stored order (e.g. a product priced at €13.90 with 19% inclusive VAT).
3. Complete checkout using PayPal.
4. Confirm the order is captured successfully.
5. In the WooCommerce order admin, issue a full refund ("Refund via PayPal").
6. Confirm the refund succeeds without a `REFUND_AMOUNT_EXCEEDED` error.
7. Confirm the refunded amount matches `$order->get_total()` in the PayPal transaction record.

**PayPal invariant not broken (regression guard for PR #4301)**

1. Using the same inclusive-tax setup as above, open the Fastlane / Axo guest checkout.
2. Add a product to the cart and proceed to checkout.
3. Change the shipping address or shipping method during checkout.
4. Confirm the PATCH order request succeeds (no rejection in the browser network tab or WC PayPal debug log).
5. Complete the order.

**No unnecessary pre-capture PATCH (secondary improvement)**

1. Place an order where `$order->get_total()` matches the component sum (standard exclusive-tax store).
2. Monitor the WC PayPal debug log during payment capture.
3. Confirm no extra PATCH request is sent before capture.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

This is a bug fix with no user-visible behaviour change under normal operating conditions; no documentation update required.

### Changelog Entry

> Fix: `AmountFactory::from_wc_order()` now uses `$order->get_total()` as the authoritative PayPal `amount.value` and absorbs any inclusive-tax rounding delta (±$0.01) into the tax breakdown component. This prevents `REFUND_AMOUNT_EXCEEDED` errors when issuing full refunds on inclusive-tax orders, while preserving the `amount.value === sum(breakdown)` invariant required by the PayPal API.

Closes #4415 .
