### PR TITLE
Show account or card last digits in payment method title

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -62,6 +62,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\FeesUpdater;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\InstallmentsProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\MerchantDetails;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\PaymentMethodTitleEnricher;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PayUponInvoice\PayUponInvoiceHelper;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PayUponInvoice\PayUponInvoiceProductStatus;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\PWCProductStatus;
@@ -695,6 +696,10 @@ return array(
 				$container->get( 'wcgateway.extra-funding-sources' )
 			)
 		);
+	},
+
+	'wcgateway.payment-method-title-enricher'              => static function ( ContainerInterface $container ): PaymentMethodTitleEnricher {
+		return new PaymentMethodTitleEnricher();
 	},
 
 	'wcgateway.checkout-helper'                            => static function ( ContainerInterface $container ): CheckoutHelper {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -61,6 +61,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	public const THREE_D_AUTH_RESULT_META_KEY  = '_ppcp_paypal_3DS_auth_result';
 	public const FRAUD_RESULT_META_KEY         = '_ppcp_paypal_fraud_result';
 
+	// Used to enrich the payment method title.
+	public const ORDER_CARD_BRAND_META_KEY       = '_ppcp_paypal_card_brand';
+	public const ORDER_CARD_LAST_DIGITS_META_KEY = '_ppcp_paypal_card_last_digits';
+
 	// Used by the Contact Module integration.
 	public const CONTACT_EMAIL_META_KEY = '_ppcp_paypal_contact_email';
 	public const CONTACT_PHONE_META_KEY = '_ppcp_paypal_contact_phone';

--- a/modules/ppcp-wc-gateway/src/Helper/PaymentMethodTitleEnricher.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PaymentMethodTitleEnricher.php
@@ -86,12 +86,7 @@ class PaymentMethodTitleEnricher {
 			return $title;
 		}
 
-		return sprintf(
-			/* translators: %1$s: payment method title, %2$s: contextual detail (payer email or card). */
-			__( '%1$s (%2$s)', 'woocommerce-paypal-payments' ),
-			$title,
-			$detail
-		);
+		return sprintf( '%1$s (%2$s)', $title, $detail );
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Helper/PaymentMethodTitleEnricher.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PaymentMethodTitleEnricher.php
@@ -1,0 +1,140 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+/**
+ * Enriches the payment method title with contextual payment details
+ * (payer email or card brand + last 4 digits) for supported gateways.
+ */
+class PaymentMethodTitleEnricher {
+
+	/**
+	 * Gateways for which the title is enriched.
+	 *
+	 * @var string[]
+	 */
+	private const SUPPORTED_GATEWAYS = array(
+		PayPalGateway::ID,
+		CreditCardGateway::ID,
+		ApplePayGateway::ID,
+		GooglePayGateway::ID,
+	);
+
+	/**
+	 * Payment source names that carry card details.
+	 *
+	 * @var string[]
+	 */
+	private const CARD_SOURCES = array( 'card', 'apple_pay', 'google_pay' );
+
+	/**
+	 * Maps PayPal card brand identifiers to display labels.
+	 *
+	 * @var array<string, string>
+	 */
+	private const BRAND_LABELS = array(
+		'VISA'             => 'Visa',
+		'MASTERCARD'       => 'Mastercard',
+		'AMEX'             => 'American Express',
+		'AMERICAN_EXPRESS' => 'American Express',
+		'DISCOVER'         => 'Discover',
+		'DINERS'           => 'Diners Club',
+		'JCB'              => 'JCB',
+		'MAESTRO'          => 'Maestro',
+		'SOLO'             => 'Solo',
+		'SWITCH'           => 'Switch',
+		'UNIONPAY'         => 'UnionPay',
+	);
+
+	/**
+	 * Returns the payment method title enriched with contextual payment details,
+	 * or the original title when enrichment is disabled or no details are available.
+	 *
+	 * @param string   $title The current payment method title.
+	 * @param WC_Order $order The order the title belongs to.
+	 */
+	public function enrich( string $title, WC_Order $order ): string {
+		/**
+		 * Whether to enrich the payment method title with contextual payment details.
+		 *
+		 * @param bool     $enrich Whether to enrich the title. Default true.
+		 * @param WC_Order $order  The order the title belongs to.
+		 */
+		if ( ! apply_filters( 'woocommerce_paypal_payments_enrich_payment_method_title', true, $order ) ) {
+			return $title;
+		}
+
+		if ( ! in_array( $order->get_payment_method(), self::SUPPORTED_GATEWAYS, true ) ) {
+			return $title;
+		}
+
+		$detail = $this->build_detail( $order );
+		if ( '' === $detail ) {
+			return $title;
+		}
+
+		// Avoid appending the detail twice if it is already present in the title.
+		if ( false !== strpos( $title, $detail ) ) {
+			return $title;
+		}
+
+		return sprintf(
+			/* translators: %1$s: payment method title, %2$s: contextual detail (payer email or card). */
+			__( '%1$s (%2$s)', 'woocommerce-paypal-payments' ),
+			$title,
+			$detail
+		);
+	}
+
+	/**
+	 * Builds the contextual detail string for the order, or an empty string when unavailable.
+	 */
+	private function build_detail( WC_Order $order ): string {
+		$source = (string) $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY );
+
+		if ( 'paypal' === $source ) {
+			$email = sanitize_email( (string) $order->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) );
+			return $email;
+		}
+
+		if ( in_array( $source, self::CARD_SOURCES, true ) ) {
+			$brand       = (string) $order->get_meta( PayPalGateway::ORDER_CARD_BRAND_META_KEY );
+			$last_digits = (string) $order->get_meta( PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY );
+
+			if ( '' === $brand || '' === $last_digits ) {
+				return '';
+			}
+
+			return sprintf(
+				/* translators: %1$s: card brand, %2$s: card last 4 digits. */
+				__( '%1$s ending in %2$s', 'woocommerce-paypal-payments' ),
+				$this->normalize_brand( $brand ),
+				$last_digits
+			);
+		}
+
+		return '';
+	}
+
+	/**
+	 * Normalizes a PayPal card brand identifier to a display label.
+	 *
+	 * @param string $brand The brand identifier, e.g. "VISA".
+	 */
+	private function normalize_brand( string $brand ): string {
+		$key = strtoupper( $brand );
+		if ( isset( self::BRAND_LABELS[ $key ] ) ) {
+			return self::BRAND_LABELS[ $key ];
+		}
+
+		return ucfirst( strtolower( str_replace( '_', ' ', $brand ) ) );
+	}
+}

--- a/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
+++ b/modules/ppcp-wc-gateway/src/Processor/OrderMetaTrait.php
@@ -58,6 +58,8 @@ trait OrderMetaTrait {
 			}
 		}
 
+		$this->add_card_details_meta( $wc_order, $order );
+
 		$this->add_contact_details_to_wc_order( $wc_order, $order );
 
 		$wc_order->save();
@@ -141,5 +143,29 @@ trait OrderMetaTrait {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Persists the card brand and last 4 digits for card-backed payment sources.
+	 */
+	private function add_card_details_meta( WC_Order $wc_order, Order $order ): void {
+		$payment_source = $order->payment_source();
+		if ( ! $payment_source ) {
+			return;
+		}
+
+		$properties = $payment_source->properties();
+		// Wallets nest the card details under "card"; the direct card source exposes them at the top level.
+		$card = isset( $properties->card ) ? $properties->card : $properties;
+
+		$brand       = isset( $card->brand ) ? (string) $card->brand : '';
+		$last_digits = isset( $card->last_digits ) ? (string) $card->last_digits : '';
+
+		if ( $brand !== '' ) {
+			$wc_order->update_meta_data( PayPalGateway::ORDER_CARD_BRAND_META_KEY, $brand );
+		}
+		if ( $last_digits !== '' ) {
+			$wc_order->update_meta_data( PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY, $last_digits );
+		}
 	}
 }

--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -87,6 +87,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 	public function run( ContainerInterface $c ): bool {
 		$this->register_payment_gateways( $c );
 		$this->register_order_functionality( $c );
+		$this->register_payment_method_title_enrichment( $c );
 		$this->register_contact_handlers();
 		$this->register_block_express_payment_method_handler( $c );
 		$this->register_columns( $c );
@@ -882,6 +883,26 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 		}
 
 		return false === strpos( $order->get_payment_method_title(), '(via PayPal)' );
+	}
+
+	/**
+	 * Enriches the payment method title with payment details
+	 * (payer email or card brand + last 4 digits) for supported gateways.
+	 */
+	private function register_payment_method_title_enrichment( ContainerInterface $c ): void {
+		add_filter(
+			'woocommerce_order_get_payment_method_title',
+			static function ( $title, $order ) use ( $c ) {
+				if ( ! is_string( $title ) || ! $order instanceof WC_Order ) {
+					return $title;
+				}
+
+				$enricher = $c->get( 'wcgateway.payment-method-title-enricher' );
+				return $enricher->enrich( $title, $order );
+			},
+			10,
+			2
+		);
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Helper/PaymentMethodTitleEnricherTest.php
+++ b/tests/PHPUnit/WcGateway/Helper/PaymentMethodTitleEnricherTest.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
+
+use Mockery;
+use WC_Order;
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use function Brain\Monkey\Functions\when;
+
+class PaymentMethodTitleEnricherTest extends TestCase
+{
+	private $testee;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		when('sanitize_email')->returnArg();
+
+		$this->testee = new PaymentMethodTitleEnricher();
+	}
+
+	public function testAppendsPayerEmailForPayPal(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		self::assertSame(
+			'PayPal (john@example.com)',
+			$this->testee->enrich('PayPal', $order)
+		);
+	}
+
+	public function testPayPalWithoutEmailIsUnchanged(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal' )
+		);
+
+		self::assertSame( 'PayPal', $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	public function testAppendsCardDetailsForAcdc(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		self::assertSame(
+			'Debit & Credit Cards (Visa ending in 1234)',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	/**
+	 * @dataProvider brandProvider
+	 */
+	public function testNormalizesCardBrand( string $raw_brand, string $expected_label ): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => $raw_brand,
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '0005',
+			)
+		);
+
+		self::assertSame(
+			"Card ($expected_label ending in 0005)",
+			$this->testee->enrich( 'Card', $order )
+		);
+	}
+
+	public function brandProvider(): array
+	{
+		return array(
+			'visa'             => array( 'VISA', 'Visa' ),
+			'mastercard'       => array( 'MASTERCARD', 'Mastercard' ),
+			'amex'             => array( 'AMEX', 'American Express' ),
+			'american_express' => array( 'AMERICAN_EXPRESS', 'American Express' ),
+			'unknown'          => array( 'FOO_BAR', 'Foo bar' ),
+		);
+	}
+
+	public function testAppendsCardDetailsForApplePay(): void
+	{
+		$order = $this->makeOrder(
+			ApplePayGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'apple_pay',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'MASTERCARD',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '5678',
+			)
+		);
+
+		self::assertSame(
+			'Apple Pay (Mastercard ending in 5678)',
+			$this->testee->enrich( 'Apple Pay', $order )
+		);
+	}
+
+	public function testAppendsCardDetailsForGooglePay(): void
+	{
+		$order = $this->makeOrder(
+			GooglePayGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'google_pay',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '4242',
+			)
+		);
+
+		self::assertSame(
+			'Google Pay (Visa ending in 4242)',
+			$this->testee->enrich( 'Google Pay', $order )
+		);
+	}
+
+	public function testPartialCardDataIsUnchanged(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY     => 'VISA',
+			)
+		);
+
+		self::assertSame(
+			'Debit & Credit Cards',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	public function testMissingCardMetaIsUnchanged(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'card' )
+		);
+
+		self::assertSame(
+			'Debit & Credit Cards',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	public function testUnsupportedGatewayIsUnchanged(): void
+	{
+		$order = $this->makeOrder(
+			'ppcp-card-button-gateway',
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		self::assertSame(
+			'Debit & Credit Cards',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	public function testOptOutFilterDisablesEnrichment(): void
+	{
+		when('apply_filters')->justReturn(false);
+
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		self::assertSame( 'PayPal', $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	public function testDoesNotAppendDetailTwice(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		$already_enriched = 'Debit & Credit Cards (Visa ending in 1234)';
+
+		self::assertSame(
+			$already_enriched,
+			$this->testee->enrich( $already_enriched, $order )
+		);
+	}
+
+	/**
+	 * @param string                $gateway The order payment method id.
+	 * @param array<string, string> $meta    Map of meta key => value.
+	 * @return WC_Order&Mockery\MockInterface
+	 */
+	private function makeOrder( string $gateway, array $meta )
+	{
+		$order = Mockery::mock( \WC_Order::class );
+		$order->shouldReceive( 'get_payment_method' )->andReturn( $gateway );
+		$order->shouldReceive( 'get_meta' )->andReturnUsing(
+			static function ( $key ) use ( $meta ) {
+				return $meta[ $key ] ?? '';
+			}
+		);
+
+		return $order;
+	}
+}

--- a/tests/PHPUnit/WcGateway/Processor/OrderMetaTraitTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/OrderMetaTraitTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Processor;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use ReflectionMethod;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+class OrderMetaTraitTest extends TestCase
+{
+	use MockeryPHPUnitIntegration;
+
+	public function testStoresFlatCardDetails(): void
+	{
+		$order = $this->orderWithPaymentSource(
+			new PaymentSource( 'card', (object) array( 'brand' => 'VISA', 'last_digits' => '1234' ) )
+		);
+
+		$wc_order = Mockery::mock( \WC_Order::class );
+		$wc_order->shouldReceive( 'update_meta_data' )
+			->once()
+			->with( PayPalGateway::ORDER_CARD_BRAND_META_KEY, 'VISA' );
+		$wc_order->shouldReceive( 'update_meta_data' )
+			->once()
+			->with( PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY, '1234' );
+
+		$this->invoke( $wc_order, $order );
+	}
+
+	public function testStoresNestedWalletCardDetails(): void
+	{
+		$order = $this->orderWithPaymentSource(
+			new PaymentSource(
+				'apple_pay',
+				(object) array( 'card' => (object) array( 'brand' => 'MASTERCARD', 'last_digits' => '5678' ) )
+			)
+		);
+
+		$wc_order = Mockery::mock( \WC_Order::class );
+		$wc_order->shouldReceive( 'update_meta_data' )
+			->once()
+			->with( PayPalGateway::ORDER_CARD_BRAND_META_KEY, 'MASTERCARD' );
+		$wc_order->shouldReceive( 'update_meta_data' )
+			->once()
+			->with( PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY, '5678' );
+
+		$this->invoke( $wc_order, $order );
+	}
+
+	public function testPayPalSourceStoresNoCardDetails(): void
+	{
+		$order = $this->orderWithPaymentSource(
+			new PaymentSource( 'paypal', (object) array( 'email_address' => 'john@example.com' ) )
+		);
+
+		$wc_order = Mockery::mock( \WC_Order::class );
+		$wc_order->shouldNotReceive( 'update_meta_data' );
+
+		$this->invoke( $wc_order, $order );
+	}
+
+	public function testPartialCardDetailsStoresOnlyAvailableKey(): void
+	{
+		$order = $this->orderWithPaymentSource(
+			new PaymentSource( 'card', (object) array( 'brand' => 'VISA' ) )
+		);
+
+		$wc_order = Mockery::mock( \WC_Order::class );
+		$wc_order->shouldReceive( 'update_meta_data' )
+			->once()
+			->with( PayPalGateway::ORDER_CARD_BRAND_META_KEY, 'VISA' );
+
+		$this->invoke( $wc_order, $order );
+	}
+
+	public function testNoPaymentSourceStoresNothing(): void
+	{
+		$order = Mockery::mock( Order::class );
+		$order->shouldReceive( 'payment_source' )->andReturnNull();
+
+		$wc_order = Mockery::mock( \WC_Order::class );
+		$wc_order->shouldNotReceive( 'update_meta_data' );
+
+		$this->invoke( $wc_order, $order );
+	}
+
+	/**
+	 * @param PaymentSource $payment_source The payment source the order should return.
+	 * @return Order&Mockery\MockInterface
+	 */
+	private function orderWithPaymentSource( PaymentSource $payment_source )
+	{
+		$order = Mockery::mock( Order::class );
+		$order->shouldReceive( 'payment_source' )->andReturn( $payment_source );
+
+		return $order;
+	}
+
+	private function invoke( $wc_order, $order ): void
+	{
+		$fixture = new class() {
+			use OrderMetaTrait;
+		};
+
+		$method = new ReflectionMethod( $fixture, 'add_card_details_meta' );
+		$method->setAccessible( true );
+		$method->invoke( $fixture, $wc_order, $order );
+	}
+}


### PR DESCRIPTION
Addef saving of the card brand and last digits into the order meta, similar to other info that we save when finishing orders. 

And now the account or account info is displayed in the payment method title, for example, on the order received page and emails.

I'm not sure if it fully works for subscriptions, it seems to work for the first order, but maybe there are some issues with renewals in some cases. 