### PR TITLE
Fix place order button label overridden by WC Subscriptions on block checkout (6442)

### DIFF
--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -84,6 +84,17 @@ if ( blockEnabled ) {
 				showSavedCards: true,
 			},
 		} );
+
+		const { registerCheckoutFilters } = window.wc.blocksCheckout;
+		registerCheckoutFilters( config.id, {
+			placeOrderButtonLabel: ( value ) => {
+				const store = window.wp?.data?.select( 'wc/store/payment' );
+				if ( store?.getActivePaymentMethod() === config.id ) {
+					return config.placeOrderButtonText;
+				}
+				return value;
+			},
+		} );
 	}
 
 	if ( config.scriptData.continuation ) {


### PR DESCRIPTION
# Description

## 🐛 The problem

On block checkout the PayPal place-order button es expected to read **"Proceed to PayPal"**. However, when a subscription product is in the cart, the button instead reads **"Sign up now"** - this is unexpected and should be changed to "Proceed to PayPal".

## 💡 Why it happens

WooCommerce Subscriptions registers a `placeOrderButtonLabel` checkout filter that *unconditionally rewrites the label* to its own text. PayPal only supplied its label through `registerPaymentMethod`, with no competing filter - so WCS always won.

## ✅ The fix

PayPal now registers its own `placeOrderButtonLabel` filter that restores "Proceed to PayPal" **only when PayPal is the active gateway**, and passes the value through untouched otherwise. One file: `modules/ppcp-blocks/resources/js/checkout-block.js`.

## 🔍 What to review

- **Load-order dependency.** Both filters run; the last one to register wins, and WCS's overwrites whatever it receives. This fix relies on PayPal's filter registering **after** WCS's, which holds because `checkout-block.js` enqueues later. If that ordering ever changes, the bug returns silently - this is the one fragile assumption in the change.
- **No collateral on other gateways.** The filter fires on every label render, including when another gateway is selected. The active-method guard makes it a no-op in those cases - worth confirming.
- **Not unit-tested by design.** Correctness depends on filter execution order and the runtime presence of `window.wp.data`, neither of which a unit test can exercise. Verified manually instead (steps below).

## 🧪 How to verify

1. Set up the plugin with **Save PayPal and Venmo** enabled.
2. Add a subscription product to the cart and go to **Block Checkout**.
3. Select the PayPal gateway → button reads **"Proceed to PayPal"** (not "Sign up now").
4. Select a different gateway → its normal label is unaffected.
5. Sanity check: a non-subscription cart with PayPal selected still shows "Proceed to PayPal".