### PR TITLE
Google Pay not rendered on variable product page (6452)

### DIFF
--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
@@ -42,21 +42,17 @@ class SingleProductHandler extends BaseHandler {
 			? actionHandler.getSubscriptionProducts()
 			: actionHandler.getProducts();
 
-		return new Promise( ( resolve, reject ) => {
-			new SimulateCart(
-				this.ppcpConfig.ajax.simulate_cart.endpoint,
-				this.ppcpConfig.ajax.simulate_cart.nonce
-			).simulate( ( data ) => {
-				const transaction = new TransactionInfo(
-					data.total,
-					data.shipping_fee,
-					data.currency_code,
-					data.country_code
-				);
-
-				resolve( transaction );
-			}, products );
-		} );
+		return new SimulateCart(
+			this.ppcpConfig.ajax.simulate_cart.endpoint,
+			this.ppcpConfig.ajax.simulate_cart.nonce
+		).simulate( ( data ) => {
+			return new TransactionInfo(
+				data.total,
+				data.shipping_fee,
+				data.currency_code,
+				data.country_code
+			);
+		}, products );
 	}
 
 	validateForm() {

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
@@ -14,6 +14,14 @@ class SingleProductHandler extends BaseHandler {
 	}
 
 	transactionInfo() {
+		const variationIdInput = form()?.querySelector(
+			'input[name="variation_id"]'
+		);
+		if ( variationIdInput && ! parseInt( variationIdInput.value ) ) {
+			return Promise.reject( new Error( 'No variation selected.' ) );
+		}
+
+
 		const errorHandler = new ErrorHandler(
 			this.ppcpConfig.labels.error.generic,
 			document.querySelector( '.woocommerce-notices-wrapper' )

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
@@ -14,27 +14,23 @@ class SingleProductHandler extends BaseHandler {
 	}
 
 	transactionInfo() {
-		const variationIdInput = form()?.querySelector(
+		const form = document.querySelector( 'form.cart' );
+		const variationIdInput = form?.querySelector(
 			'input[name="variation_id"]'
 		);
 		if ( variationIdInput && ! parseInt( variationIdInput.value ) ) {
 			return Promise.reject( new Error( 'No variation selected.' ) );
 		}
 
-
 		const errorHandler = new ErrorHandler(
 			this.ppcpConfig.labels.error.generic,
 			document.querySelector( '.woocommerce-notices-wrapper' )
 		);
 
-		function form() {
-			return document.querySelector( 'form.cart' );
-		}
-
 		const actionHandler = new SingleProductActionHandler(
 			null,
 			null,
-			form(),
+			form,
 			errorHandler
 		);
 

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.test.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.test.js
@@ -1,0 +1,201 @@
+/* global describe, test, expect, jest, beforeEach */
+
+jest.mock( '@ppcp-button/ActionHandler/SingleProductActionHandler' );
+jest.mock( '@ppcp-button/Helper/SimulateCart' );
+jest.mock( '@ppcp-button/ErrorHandler', () => jest.fn() );
+jest.mock( '@ppcp-button/Helper/UpdateCart', () => jest.fn() );
+jest.mock( '@ppcp-googlepay/Helper/TransactionInfo' );
+
+import SingleProductHandler from './SingleProductHandler';
+import SimulateCart from '@ppcp-button/Helper/SimulateCart';
+import SingleProductActionHandler from '@ppcp-button/ActionHandler/SingleProductActionHandler';
+import TransactionInfo from '@ppcp-googlepay/Helper/TransactionInfo';
+
+describe( 'SingleProductHandler', () => {
+	let handler;
+	let mockSimulate;
+	let mockGetProducts;
+	let mockGetSubscriptionProducts;
+	const mockProducts = [ { id: 64, quantity: 1 } ];
+
+	const ppcpConfig = {
+		labels: { error: { generic: 'An error occurred.' } },
+		ajax: {
+			simulate_cart: {
+				endpoint: '/ppcp/simulate-cart',
+				nonce: 'test-nonce',
+			},
+		},
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		document.body.innerHTML = '';
+
+		global.PayPalCommerceGateway = {
+			data_client_id: {
+				has_subscriptions: false,
+				paypal_subscriptions_enabled: false,
+			},
+		};
+
+		mockGetProducts = jest.fn().mockReturnValue( mockProducts );
+		mockGetSubscriptionProducts = jest.fn().mockReturnValue( [] );
+		SingleProductActionHandler.mockImplementation( () => ( {
+			getProducts: mockGetProducts,
+			getSubscriptionProducts: mockGetSubscriptionProducts,
+		} ) );
+
+		mockSimulate = jest.fn();
+		SimulateCart.mockImplementation( () => ( {
+			simulate: mockSimulate,
+		} ) );
+
+		handler = new SingleProductHandler( {}, ppcpConfig, null );
+	} );
+
+	describe( 'validateContext()', () => {
+		test( 'returns true when no subscription product is present', () => {
+			expect( handler.validateContext() ).toBe( true );
+		} );
+
+		test( 'returns false when a subscription product is present', () => {
+			const subscriptionHandler = new SingleProductHandler(
+				{},
+				{
+					...ppcpConfig,
+					locations_with_subscription_product: { product: true },
+				},
+				null
+			);
+
+			expect( subscriptionHandler.validateContext() ).toBe( false );
+		} );
+	} );
+
+	describe( 'transactionInfo()', () => {
+		describe( 'variation_id guard', () => {
+			test( 'rejects immediately when variation_id is empty', async () => {
+				document.body.innerHTML = `
+					<form class="cart">
+						<input type="hidden" name="variation_id" value="" />
+					</form>
+				`;
+
+				await expect( handler.transactionInfo() ).rejects.toThrow(
+					'No variation selected.'
+				);
+				expect( mockSimulate ).not.toHaveBeenCalled();
+			} );
+
+			test( 'rejects immediately when variation_id is "0"', async () => {
+				document.body.innerHTML = `
+					<form class="cart">
+						<input type="hidden" name="variation_id" value="0" />
+					</form>
+				`;
+
+				await expect( handler.transactionInfo() ).rejects.toThrow(
+					'No variation selected.'
+				);
+				expect( mockSimulate ).not.toHaveBeenCalled();
+			} );
+
+			test( 'calls simulate_cart when variation_id is set', async () => {
+				document.body.innerHTML = `
+					<form class="cart">
+						<input type="hidden" name="variation_id" value="87" />
+					</form>
+				`;
+				mockSimulate.mockResolvedValue( {} );
+
+				await handler.transactionInfo();
+
+				expect( mockSimulate ).toHaveBeenCalledWith(
+					expect.any( Function ),
+					mockProducts
+				);
+			} );
+
+			test( 'calls simulate_cart when no variation_id input exists (non-variable product)', async () => {
+				document.body.innerHTML = `<form class="cart"></form>`;
+				mockSimulate.mockResolvedValue( {} );
+
+				await handler.transactionInfo();
+
+				expect( mockSimulate ).toHaveBeenCalled();
+			} );
+
+			test( 'calls simulate_cart when no form.cart exists', async () => {
+				mockSimulate.mockResolvedValue( {} );
+
+				await handler.transactionInfo();
+
+				expect( mockSimulate ).toHaveBeenCalled();
+			} );
+		} );
+
+		describe( 'simulate_cart integration', () => {
+			beforeEach( () => {
+				document.body.innerHTML = `
+					<form class="cart">
+						<input type="hidden" name="variation_id" value="87" />
+					</form>
+				`;
+			} );
+
+			test( 'resolves with TransactionInfo built from response data', async () => {
+				const mockTransactionInstance = { totalPrice: '45.00' };
+				TransactionInfo.mockImplementation( () => mockTransactionInstance );
+
+				mockSimulate.mockImplementation( ( onResolve ) =>
+					Promise.resolve(
+						onResolve( {
+							total: 45,
+							shipping_fee: 5,
+							currency_code: 'USD',
+							country_code: 'US',
+						} )
+					)
+				);
+
+				const result = await handler.transactionInfo();
+
+				expect( TransactionInfo ).toHaveBeenCalledWith( 45, 5, 'USD', 'US' );
+				expect( result ).toBe( mockTransactionInstance );
+			} );
+
+			test( 'propagates rejection from simulate_cart', async () => {
+				const serverError = { message: 'Error adding products to cart.' };
+				mockSimulate.mockRejectedValue( serverError );
+
+				await expect( handler.transactionInfo() ).rejects.toEqual(
+					serverError
+				);
+			} );
+
+			test( 'passes subscription products to simulate_cart when subscriptions are enabled', async () => {
+				const mockSubscriptionProducts = [ { id: 155, quantity: 1 } ];
+				mockGetSubscriptionProducts.mockReturnValue(
+					mockSubscriptionProducts
+				);
+				global.PayPalCommerceGateway = {
+					data_client_id: {
+						has_subscriptions: true,
+						paypal_subscriptions_enabled: true,
+					},
+				};
+				mockSimulate.mockResolvedValue( {} );
+
+				await handler.transactionInfo();
+
+				expect( mockGetSubscriptionProducts ).toHaveBeenCalled();
+				expect( mockGetProducts ).not.toHaveBeenCalled();
+				expect( mockSimulate ).toHaveBeenCalledWith(
+					expect.any( Function ),
+					mockSubscriptionProducts
+				);
+			} );
+		} );
+	} );
+} );

--- a/modules/ppcp-googlepay/resources/js/GooglepayButton.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayButton.js
@@ -299,11 +299,6 @@ class GooglepayButton extends PaymentButton {
 		);
 
 		invalidIf(
-			() => ! this.transactionInfo,
-			'No transactionInfo - missing configure() call?'
-		);
-
-		invalidIf(
 			() => ! this.contextHandler?.validateContext(),
 			`Invalid context handler.`
 		);

--- a/modules/ppcp-googlepay/resources/js/GooglepayManager.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayManager.js
@@ -74,11 +74,7 @@ class GooglepayManager {
 			}
 
 			if ( ! this.transactionInfo ) {
-				try {
-					this.transactionInfo = await this.fetchTransactionInfo();
-				} catch ( error ) {
-					console.debug( 'Failed to fetch transaction info:', error );
-				}
+				this.transactionInfo = await this.fetchTransactionInfo();
 			}
 
 			if ( ! this.googlePayConfig ) {
@@ -100,9 +96,14 @@ class GooglepayManager {
 
 	async fetchTransactionInfo() {
 		if ( ! this.contextHandler ) {
-			throw new Error( 'ContextHandler is not initialized' );
+			return null;
 		}
-		return await this.contextHandler.transactionInfo();
+		try {
+			return await this.contextHandler.transactionInfo();
+		} catch ( error ) {
+			console.debug( 'Failed to fetch transaction info:', error );
+			return null;
+		}
 	}
 
 	reinit() {

--- a/modules/ppcp-googlepay/resources/js/GooglepayManager.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayManager.js
@@ -51,13 +51,13 @@ class GooglepayManager {
 				button.init();
 			};
 
-			// Initialize button only if googlePayConfig and transactionInfo are already fetched.
-			if ( this.googlePayConfig && this.transactionInfo ) {
+			// Initialize button only if googlePayConfig is already fetched.
+			if ( this.googlePayConfig ) {
 				initButton();
 			} else {
 				await this.init();
 
-				if ( this.googlePayConfig && this.transactionInfo ) {
+				if ( this.googlePayConfig ) {
 					initButton();
 				}
 			}
@@ -74,13 +74,15 @@ class GooglepayManager {
 			}
 
 			if ( ! this.transactionInfo ) {
-				this.transactionInfo = await this.fetchTransactionInfo();
+				try {
+					this.transactionInfo = await this.fetchTransactionInfo();
+				} catch ( error ) {
+					console.error( 'Failed to fetch transaction info:', error );
+				}
 			}
 
 			if ( ! this.googlePayConfig ) {
 				console.error( 'No GooglePayConfig received during init' );
-			} else if ( ! this.transactionInfo ) {
-				console.error( 'No transactionInfo found during init' );
 			} else {
 				for ( const button of this.buttons ) {
 					button.configure(

--- a/modules/ppcp-googlepay/resources/js/GooglepayManager.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayManager.js
@@ -77,7 +77,7 @@ class GooglepayManager {
 				try {
 					this.transactionInfo = await this.fetchTransactionInfo();
 				} catch ( error ) {
-					console.error( 'Failed to fetch transaction info:', error );
+					console.debug( 'Failed to fetch transaction info:', error );
 				}
 			}
 
@@ -99,15 +99,10 @@ class GooglepayManager {
 	}
 
 	async fetchTransactionInfo() {
-		try {
-			if ( ! this.contextHandler ) {
-				throw new Error( 'ContextHandler is not initialized' );
-			}
-			return await this.contextHandler.transactionInfo();
-		} catch ( error ) {
-			console.error( 'Error fetching transaction info:', error );
-			throw error;
+		if ( ! this.contextHandler ) {
+			throw new Error( 'ContextHandler is not initialized' );
 		}
+		return await this.contextHandler.transactionInfo();
 	}
 
 	reinit() {

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -9,7 +9,8 @@
         "^@ppcp-settings/(.*)$": "<rootDir>/modules/ppcp-settings/resources/js/$1",
         "^@ppcp-blocks/(.*)$": "<rootDir>/modules/ppcp-blocks/resources/js/$1",
         "^@ppcp-card-fields/(.*)$": "<rootDir>/modules/ppcp-card-fields/resources/js/$1",
-        "^@ppcp-paylater-block/(.*)$": "<rootDir>/modules/ppcp-paylater-block/resources/js/$1"
+        "^@ppcp-paylater-block/(.*)$": "<rootDir>/modules/ppcp-paylater-block/resources/js/$1",
+        "^@ppcp-googlepay/(.*)$": "<rootDir>/modules/ppcp-googlepay/resources/js/$1"
     },
     "testPathIgnorePatterns": [
         "<rootDir>/tests/",


### PR DESCRIPTION
### Description
1. Let Google Pay button be rendered even when transactionInfo is not available. This is ok when the page is rendered initially.
2. Remove transactionInfo from button validation rules, since it is fetched fresh on every button click, and it will fail anyway until the variation is selected
3. Check WooCommerce's hidden input to get the selected variation ID
4. Remove extra wrapping Promise

### Steps to Test

1. Enable Google Pay in the plugin settings
2. Enable Google Pay button in the plugin's Styling settings
3. Go to the variable products page (make sure you have no default variation configured)
4.  Observe that the Google Pay button is visible on the page
5. Without selecting a variation, click the Google Pay button - confirm the payment does not happen
6. Select a variation and observe that the Google Pay button is now enabled, and clicking it opens the payment sheet
7. Complete the payment with Google Pay to make sure it works properly


### Documentation
- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry
Fixed: Google Pay button on the variable product page
