### PR TITLE
Prevent Advanced Card Fields submission when Blocks checkout fields are invalid

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/card-fields.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.js
@@ -19,8 +19,19 @@ import {
 import { cartHasSubscriptionProducts } from '../Helper/Subscription';
 import { __ } from '@wordpress/i18n';
 
+const CHECKOUT_FIELDS_NOT_VALID_MESSAGE = __(
+	'Please complete all required checkout fields before continuing with payment.',
+	'woocommerce-paypal-payments'
+);
+
+function hasCheckoutValidationErrors() {
+	const validationStore = wp?.data?.select?.( 'wc/store/validation' );
+
+	return validationStore?.hasValidationErrors?.() || false;
+}
+
 export function CardFields( { config, eventRegistration, emitResponse } ) {
-	const { onPaymentSetup } = eventRegistration;
+	const { onPaymentSetup, onCheckoutValidation } = eventRegistration;
 	const { responseTypes } = emitResponse;
 
 	const [ cardFieldsForm, setCardFieldsForm ] = useState();
@@ -44,9 +55,52 @@ export function CardFields( { config, eventRegistration, emitResponse } ) {
 	}, [ hasSubscriptionProducts ] );
 
 	useEffect(
+		() => {
+			if ( typeof onCheckoutValidation !== 'function' ) {
+				return undefined;
+			}
+
+			return onCheckoutValidation(
+				() => {
+					if ( hasCheckoutValidationErrors() ) {
+						return {
+							type: responseTypes.ERROR,
+							message: CHECKOUT_FIELDS_NOT_VALID_MESSAGE,
+						};
+					}
+
+					return true;
+				},
+				99
+			);
+		},
+		[ onCheckoutValidation, responseTypes.ERROR ]
+	);
+
+	useEffect(
 		() =>
 			onPaymentSetup( () => {
 				async function handlePaymentProcessing() {
+					if ( hasCheckoutValidationErrors() ) {
+						return {
+							type: responseTypes.ERROR,
+							message: CHECKOUT_FIELDS_NOT_VALID_MESSAGE,
+						};
+					}
+
+					if (
+						! cardFieldsForm ||
+						typeof cardFieldsForm.submit !== 'function'
+					) {
+						return {
+							type: responseTypes.ERROR,
+							message: __(
+								'Payment form is not ready. Please try again.',
+								'woocommerce-paypal-payments'
+							),
+						};
+					}
+
 					try {
 						await cardFieldsForm.submit();
 					} catch ( error ) {


### PR DESCRIPTION
## Description

This PR prevents PayPal Advanced Card Fields from submitting when the WooCommerce Blocks checkout has validation errors for missing or invalid required checkout fields.

Currently, the Advanced Card Fields payment flow can call `cardFieldsForm.submit()` even when WooCommerce Blocks has already marked required checkout fields as invalid. In that scenario, the card authentication flow, including 3DS, may start before the shopper has completed required checkout information.

This change uses the native WooCommerce Blocks checkout validation flow for Advanced Card Fields:

- registers an `onCheckoutValidation` callback
- checks the Blocks validation store via `wc/store/validation`
- returns a Blocks error response when validation errors are present
- keeps a final `onPaymentSetup` guard before `cardFieldsForm.submit()`

When invalid checkout fields are present, the shopper is asked to complete the required checkout fields before continuing with payment, and the PayPal card fields submission is not started.

## Why

Starting card authentication before required checkout fields are valid can create a confusing shopper experience:

1. The shopper enters card details.
2. 3DS/authentication starts.
3. WooCommerce Blocks still has required checkout fields missing.
4. The payment flow cannot complete cleanly.

This PR keeps the Advanced Card Fields flow aligned with the native Blocks checkout validation state before starting the PayPal card submission.

## Notes

WooCommerce Blocks remains responsible for rendering validation errors, focusing fields, and positioning the shopper in the checkout form.

A separate, translated error message is returned if the PayPal card fields form is not ready yet, so initialization/runtime readiness problems are not misreported as invalid card field input.

## Testing

Tested with a WooCommerce Blocks checkout using Advanced Card Fields:

- With required checkout fields missing, clicking place order no longer starts the 3DS/card authentication flow.
- WooCommerce Blocks validation errors remain visible.
- The shopper sees an error asking them to complete required checkout fields.
- After completing the required checkout fields, the card payment flow can proceed.

Build:

```bash
npm run build
```

Build completed successfully. Existing upstream webpack warnings remain unrelated to this change.

Related issue: #4434