### PR TITLE
Free trial vaulting subscription - Unsuccessfully payment with acdc and PayPal (6528)

### DIFF
--- a/modules/ppcp-api-client/src/ApiModule.php
+++ b/modules/ppcp-api-client/src/ApiModule.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient;
 
 use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\PayPalBearer;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PartnersEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
@@ -134,6 +136,41 @@ class ApiModule implements ServiceModule, FactoryModule, ExecutableModule {
 
 					$cache->flush();
 				}
+			}
+		);
+
+		/**
+		 * Refreshes the access token before a request is retried after an
+		 * authentication failure (see {@see RequestTrait::should_retry_after_auth_failure()}).
+		 *
+		 * A cached bearer token can outlive a change in the merchant's granted
+		 * scopes (e.g. vaulting enabled after the token was issued), causing
+		 * Vault and other calls to fail with 401 / 403 NOT_AUTHORIZED for up to
+		 * the token's lifetime. Discarding the cached token here forces a fresh
+		 * one to be issued with the current scopes for the retry.
+		 */
+		add_filter(
+			'ppcp_retry_request_args',
+			static function ( array $args ) use ( $c ): array {
+				$authorization = $args['headers']['Authorization'] ?? '';
+				if ( ! is_string( $authorization ) || 0 !== strpos( $authorization, 'Bearer ' ) ) {
+					return $args;
+				}
+
+				$bearer_cache = $c->get( 'api.paypal-bearer-cache' );
+				assert( $bearer_cache instanceof Cache );
+				$bearer_cache->delete( PayPalBearer::CACHE_KEY );
+
+				try {
+					$bearer                           = $c->get( 'api.bearer' );
+					$args['headers']['Authorization'] = 'Bearer ' . $bearer->bearer()->token();
+				} catch ( RuntimeException $exception ) {
+					$logger = $c->get( 'woocommerce.logger.woocommerce' );
+					assert( $logger instanceof LoggerInterface );
+					$logger->warning( 'Could not refresh the access token for request retry: ' . $exception->getMessage() );
+				}
+
+				return $args;
 			}
 		);
 

--- a/modules/ppcp-api-client/src/Endpoint/RequestTrait.php
+++ b/modules/ppcp-api-client/src/Endpoint/RequestTrait.php
@@ -46,7 +46,70 @@ trait RequestTrait {
 		if ( $this->is_request_logging_enabled ) {
 			$this->logger->debug( $this->request_response_string( $url, $args, $response ) );
 		}
+
+		if ( $this->should_retry_after_auth_failure( $url, $args, $response ) ) {
+			/**
+			 * Filters the request args before a single retry that follows an
+			 * authentication failure. Listeners are expected to refresh the
+			 * cached access token and rebuild the `Authorization` header so the
+			 * retry uses a token with the current scopes.
+			 *
+			 * @param array  $args The request arguments.
+			 * @param string $url  The request URL.
+			 */
+			$args = apply_filters( 'ppcp_retry_request_args', $args, $url );
+
+			$response = wp_remote_get( $url, $args );
+			if ( $this->is_request_logging_enabled ) {
+				$this->logger->debug( $this->request_response_string( $url, $args, $response ) );
+			}
+		}
+
 		return $response;
+	}
+
+	/**
+	 * Determines whether a request should be retried once after an
+	 * authentication failure.
+	 *
+	 * A cached access token can outlive a change in the merchant's granted
+	 * scopes (for example, vaulting being enabled after the token was issued),
+	 * which surfaces as HTTP 401, or HTTP 403 with `NOT_AUTHORIZED`. Retrying
+	 * once with a freshly issued token recovers from that state instead of
+	 * failing for up to the token's lifetime.
+	 *
+	 * @param string         $url The request URL.
+	 * @param array          $args The request arguments.
+	 * @param array|WP_Error $response The response.
+	 * @return bool
+	 */
+	private function should_retry_after_auth_failure( string $url, array $args, $response ): bool {
+		if ( $response instanceof WP_Error ) {
+			return false;
+		}
+
+		// Never retry the token request itself; that would risk a request loop.
+		if ( false !== strpos( $url, 'v1/oauth2/token' ) ) {
+			return false;
+		}
+
+		// Only Bearer-authenticated requests can be recovered by a token refresh.
+		$authorization = $args['headers']['Authorization'] ?? '';
+		if ( ! is_string( $authorization ) || 0 !== strpos( $authorization, 'Bearer ' ) ) {
+			return false;
+		}
+
+		$status_code = (int) ( $response['response']['code'] ?? 0 );
+		if ( 401 === $status_code ) {
+			return true;
+		}
+
+		if ( 403 === $status_code ) {
+			$body = json_decode( (string) ( $response['body'] ?? '' ) );
+			return isset( $body->name ) && 'NOT_AUTHORIZED' === $body->name;
+		}
+
+		return false;
 	}
 
 	/**

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -107,6 +107,14 @@ class SavePaymentMethodsModule implements ServiceModule, ExecutableModule {
 						$settings_provider = $c->get( 'settings.settings-provider' );
 						assert( $settings_provider instanceof SettingsProvider );
 
+						// If the merchant's access token lacks the vault scope, PayPal rejects
+						// any store-in-vault request with 403 NOT_AUTHORIZED. Skip adding vault
+						// attributes so the payment can still be captured without a hard
+						// checkout failure (renewals then fail gracefully with a clear message).
+						if ( ! $c->get( 'wcgateway.helper.vaulting-scope' ) ) {
+							return $data;
+						}
+
 						$new_attributes = array(
 							'vault' => array(
 								'store_in_vault' => 'ON_SUCCESS',

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -107,14 +107,6 @@ class SavePaymentMethodsModule implements ServiceModule, ExecutableModule {
 						$settings_provider = $c->get( 'settings.settings-provider' );
 						assert( $settings_provider instanceof SettingsProvider );
 
-						// If the merchant's access token lacks the vault scope, PayPal rejects
-						// any store-in-vault request with 403 NOT_AUTHORIZED. Skip adding vault
-						// attributes so the payment can still be captured without a hard
-						// checkout failure (renewals then fail gracefully with a clear message).
-						if ( ! $c->get( 'wcgateway.helper.vaulting-scope' ) ) {
-							return $data;
-						}
-
 						$new_attributes = array(
 							'vault' => array(
 								'store_in_vault' => 'ON_SUCCESS',

--- a/modules/ppcp-settings/src/Endpoint/RefreshFeatureStatusEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/RefreshFeatureStatusEndpoint.php
@@ -102,6 +102,15 @@ class RefreshFeatureStatusEndpoint extends RestEndpoint {
 
 		do_action( 'woocommerce_paypal_payments_clear_apm_product_status' );
 
+		/**
+		 * Flush the API caches so a fresh access token is issued with the
+		 * merchant's current scopes. Refreshing features is exactly when newly
+		 * granted capabilities (e.g. Advanced Vaulting) should take effect, and
+		 * a token cached before the change would otherwise keep failing Vault
+		 * calls with 403 NOT_AUTHORIZED until it expires.
+		 */
+		do_action( 'woocommerce_paypal_payments_flush_api_cache' );
+
 		$this->logger->info( 'Feature status refreshed successfully' );
 
 		return $this->return_success(

--- a/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
+++ b/modules/ppcp-settings/src/Service/Migration/SettingsTabMigration.php
@@ -81,14 +81,16 @@ class SettingsTabMigration implements SettingsMigrationInterface {
 					$data[ $new_key ]         = $old_to_new_3d_secure_map[ $value ] ?? 'NO_3D_SECURE';
 					break;
 				case 'vault_enabled':
+				case 'vault_enabled_dcc':
 					/*
-					 * Legacy classic-WooCommerce settings stored vault_enabled as
-					 * the string "yes" or "no". The new target slot
-					 * SettingsModel::save_paypal_and_venmo is typed bool and its
-					 * setter declares `bool $save`, so any non-bool value flowing
-					 * through from_array() either throws a TypeError (strict
-					 * mode) or persists the wrong value (weak mode, where every
-					 * non-empty non-"0" string casts to true -- including "no").
+					 * Legacy classic-WooCommerce settings stored vault_enabled and
+					 * vault_enabled_dcc as the string "yes" or "no". The new target
+					 * slots SettingsModel::save_paypal_and_venmo / save_card_details
+					 * are typed bool and their setters declare `bool $save`, so any
+					 * non-bool value flowing through from_array() either throws a
+					 * TypeError (strict mode) or persists the wrong value (weak mode,
+					 * where every non-empty non-"0" string casts to true -- including
+					 * "no").
 					 *
 					 * Coerce explicitly here so the migration is correct
 					 * regardless of how the legacy option was stored.

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -493,7 +493,21 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 			$customer_id = get_user_meta( $wc_order->get_customer_id(), '_ppcp_target_customer_id', true );
 			if ( $customer_id ) {
-				$customer_tokens = $this->payment_tokens_endpoint->payment_tokens_for_customer( $customer_id );
+				try {
+					$customer_tokens = $this->payment_tokens_endpoint->payment_tokens_for_customer( $customer_id );
+				} catch ( RuntimeException $exception ) {
+					// A failure here (e.g. the access token lacks the vault scope and
+					// PayPal returns 403 NOT_AUTHORIZED) must not bubble up as a fatal
+					// error; fall through to the "no saved PayPal account" failure below.
+					$this->logger->error(
+						sprintf(
+							'Could not retrieve saved payment methods for customer %1$s: %2$s',
+							$customer_id,
+							$exception->getMessage()
+						)
+					);
+					$customer_tokens = array();
+				}
 				foreach ( $customer_tokens as $token ) {
 					$payment_source_name = $token['payment_source']->name() ?? '';
 					if ( $payment_source_name === 'paypal' || $payment_source_name === 'venmo' ) {

--- a/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
+++ b/modules/ppcp-wc-subscriptions/src/RenewalHandler.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
@@ -227,7 +228,7 @@ class RenewalHandler {
 	 *
 	 * @param \WC_Order $wc_order The WooCommerce order.
 	 *
-	 * @throws \Exception If customer cannot be read/found.
+	 * @throws RuntimeException When no saved payment method is available to process the renewal.
 	 */
 	private function process_order( \WC_Order $wc_order ): void {
 		$user_id  = (int) $wc_order->get_customer_id();
@@ -405,8 +406,19 @@ class RenewalHandler {
 						$wc_order->get_id()
 					)
 				);
+
+				return;
 			}
 		}
+
+		// Reaching this point means no saved payment method (vaulted token or legacy
+		// billing agreement) could be used. This commonly happens when the PayPal
+		// access token lacks the vault scope and the token lookup returned nothing.
+		// Throw so renew() marks the order failed with an actionable message instead
+		// of silently completing without taking a payment.
+		throw new RuntimeException(
+			'No saved payment method is available to process this renewal. The PayPal account may need to be reconnected with vaulting enabled.'
+		);
 	}
 
 	/**

--- a/tests/PHPUnit/Settings/Service/Migration/SettingsTabMigrationTest.php
+++ b/tests/PHPUnit/Settings/Service/Migration/SettingsTabMigrationTest.php
@@ -153,4 +153,64 @@ class SettingsTabMigrationTest extends TestCase {
 			'missing legacy key is not migrated' => array( '__missing__', null ),
 		);
 	}
+
+	/**
+	 * Same problem as vault_enabled: legacy classic-WooCommerce settings stored
+	 * vault_enabled_dcc as the string "yes" or "no", while the new
+	 * SettingsModel::save_card_details slot is a typed bool. The migration must
+	 * coerce the value before it reaches the typed setter, otherwise a stored
+	 * string aborts the whole migration with an uncaught TypeError.
+	 *
+	 * @dataProvider vault_enabled_dcc_cases
+	 *
+	 * @param mixed     $legacy_value Legacy vault_enabled_dcc value, in any of the
+	 *                                shapes the option has historically held.
+	 * @param bool|null $expected     Expected save_card_details after migration,
+	 *                                or null if the key should be absent from the
+	 *                                captured payload.
+	 */
+	public function test_vault_enabled_dcc_migration( $legacy_value, ?bool $expected ): void {
+		$legacy_settings = ( $legacy_value === '__missing__' )
+			? array()
+			: array( 'vault_enabled_dcc' => $legacy_value );
+
+		$captured_data  = null;
+		$settings_model = Mockery::mock( SettingsModel::class );
+		$settings_model->shouldReceive( 'from_array' )
+			->once()
+			->withArgs( function ( array $data ) use ( &$captured_data ) {
+				$captured_data = $data;
+
+				return true;
+			} );
+		$settings_model->shouldReceive( 'save' )->once();
+
+		$migration = new SettingsTabMigration( $legacy_settings, $settings_model );
+		$migration->migrate();
+
+		if ( $expected === null ) {
+			$this->assertArrayNotHasKey( 'save_card_details', $captured_data );
+
+			return;
+		}
+
+		$this->assertArrayHasKey( 'save_card_details', $captured_data );
+		$this->assertSame( $expected, $captured_data['save_card_details'] );
+		$this->assertIsBool( $captured_data['save_card_details'] );
+	}
+
+	public function vault_enabled_dcc_cases(): array {
+		return array(
+			'legacy string yes coerces to true'  => array( 'yes', true ),
+			'legacy string no coerces to false'  => array( 'no', false ),
+			'legacy string 1 coerces to true'    => array( '1', true ),
+			'legacy string 0 coerces to false'   => array( '0', false ),
+			'empty string coerces to false'      => array( '', false ),
+			'real boolean true passes through'   => array( true, true ),
+			'real boolean false passes through'  => array( false, false ),
+			'integer 1 coerces to true'          => array( 1, true ),
+			'integer 0 coerces to false'         => array( 0, false ),
+			'missing legacy key is not migrated' => array( '__missing__', null ),
+		);
+	}
 }


### PR DESCRIPTION
Vaulting/subscription payments (free-trial ACDC + PayPal, and admin renewals) intermittently failed with `403 NOT_AUTHORIZED "Authorization failed due to insufficient permissions"` on Vault v3 calls. 

The PayPal access token is cached for ~9h and only refreshed on connect/disconnect. If a merchant connects before Advanced Vaulting is provisioned (or scopes change afterward), the cached token lacks the vault scope and every vault call fails until it naturally expires. A renewal also surfaced this as an admin-ajax 500.

### PR Changes
  - **Self-healing retry** (`RequestTrait` + `ApiModule`): on a `401` or `403 NOT_AUTHORIZED`, flush the cached bearer token and retry the request once with a freshly issued token (with current scopes).
  - **Proactive refresh** (`RefreshFeatureStatusEndpoint`): flush the API cache when a merchant clicks "Refresh features", so newly granted vaulting takes effect immediately instead of after ≤9h.
  - **Graceful degradation**: the renewal/gateway paths no longer surface a raw 500, a vault failure fails the order cleanly with an actionable message.