### PR TITLE
CC - Add skill to generate the PR description (6288)

### DIFF
--- a/.claude/skills/describe-pr/SKILL.md
+++ b/.claude/skills/describe-pr/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: describe-pr
+description: Draft a standardized, reviewer-focused pull request description and - only after explicit approval - update the PR. Optional first argument is a PR number (defaults to the current branch's open PR). Optional argument is a Jira issue ID (e.g. ABC-123).
+argument-hint: "[PR-number] [JIRA-ID]"
+invocation: user
+---
+
+You help the user write a helpful, standardized PR description and, **only after their final and explicit approval**, update the pull request via `gh pr edit`.
+
+The description exists to **introduce a reviewer to the problem and the reasoning behind the change** - not to summarize the diff. How something was done is already obvious in the code.
+
+## Argument Parsing
+
+Arguments after `/describe-pr` (both optional, order does not matter):
+- A bare integer is the **PR number**.
+- An identifier matching `[A-Z]+-\d+` is a **Jira issue ID**.
+
+## Steps
+
+### 1. Resolve the target PR
+
+If a PR number was passed, use it. Otherwise, resolve the current branch's open PR:
+
+```bash
+gh pr view --json number,title,body,url,headRefName,baseRefName,state
+```
+
+If no PR is found for the current branch and none was given, stop and tell the user - offer to proceed once they pass a PR number or push a branch with an open PR.
+
+### 2. Gather source material
+
+Collect context to ground the draft. Pull from all that apply:
+
+- **The current conversation** - if this session already investigated the bug or built the fix, that understanding is often the richest source of "the problem" and "why it happens." Use it.
+- **Existing PR body** - `gh pr view <n> --json body,title,baseRefName`. Treat it as a starting point to refine, not something to blindly discard.
+- **Optional Jira** - if a Jira ID was given, or one is embedded in the branch name (`[A-Z]+-\d+`), fetch it via the connected Atlassian MCP for problem framing. If the fetch fails, note it in one line and continue.
+- **Diff + commits** - `git diff <base>...HEAD` and `git log <base>..HEAD --oneline` (use the PR's `baseRefName`). This is the substance you reason *about* - do not transcribe it into the description.
+
+### 3. Draft the description
+
+Follow [guideline.md](guideline.md) for the heading catalog, tone, writing style, and a worked example. Read it before drafting.
+
+### 4. Present the draft and iterate
+
+Show the full draft to the user as a fenced markdown block. Invite edits. Iterate until they are satisfied.
+
+**Do not call `gh pr edit` yet.** Drafting and updating are separate steps.
+
+### 5. Update the PR - only after explicit approval
+
+Wait for the user's clear, explicit go-ahead (e.g. "approved", "update it", "yes, push it"). Silence, "looks good", or answering an unrelated question is **not** approval to write - if in doubt, ask.
+
+Once approved, write the body to a temp file and update the PR (avoids shell-escaping issues with multi-line markdown):
+
+```bash
+gh pr edit <number> --body-file <path>
+```
+
+Then confirm by re-fetching and report the PR URL back to the user:
+
+```bash
+gh pr view <number> --json body,url
+```

--- a/.claude/skills/describe-pr/SKILL.md
+++ b/.claude/skills/describe-pr/SKILL.md
@@ -5,7 +5,7 @@ argument-hint: "[PR-number] [JIRA-ID]"
 invocation: user
 ---
 
-You help the user write a helpful, standardized PR description and, **only after their final and explicit approval**, update the pull request via `gh pr edit`.
+You help the user write a helpful, standardized PR title and description and, **only after their final and explicit approval**, update the pull request via `gh pr edit`.
 
 The description exists to **introduce a reviewer to the problem and the reasoning behind the change** - not to summarize the diff. How something was done is already obvious in the code.
 
@@ -27,6 +27,8 @@ gh pr view --json number,title,body,url,headRefName,baseRefName,state
 
 If no PR is found for the current branch and none was given, stop and tell the user - offer to proceed once they pass a PR number or push a branch with an open PR.
 
+Also resolve the **Jira number** for the title suffix: the Jira ID (from the argument or the branch name `[A-Z]+-\d+`) with its letter prefix stripped, e.g. `PCP-6288` -> `6288`. If no Jira ID is found anywhere, ask the user for the number in step 4 rather than dropping the suffix.
+
 ### 2. Gather source material
 
 Collect context to ground the draft. Pull from all that apply:
@@ -36,24 +38,30 @@ Collect context to ground the draft. Pull from all that apply:
 - **Optional Jira** - if a Jira ID was given, or one is embedded in the branch name (`[A-Z]+-\d+`), fetch it via the connected Atlassian MCP for problem framing. If the fetch fails, note it in one line and continue.
 - **Diff + commits** - `git diff <base>...HEAD` and `git log <base>..HEAD --oneline` (use the PR's `baseRefName`). This is the substance you reason *about* - do not transcribe it into the description.
 
-### 3. Draft the description
+### 3. Draft the title and description
 
-Follow [guideline.md](guideline.md) for the heading catalog, tone, writing style, and a worked example. Read it before drafting.
+Follow [guideline.md](guideline.md) for the title rule, the mandatory changelog first line, the heading catalog, tone, writing style, and a worked example. Read it before drafting.
+
+Draft both: a reviewer-focused **title** ending in the Jira number in parentheses (e.g. `(6288)`), and the **body** starting with the mandatory `*Changelog:*` line above `# Description`.
+
+**Keep the first draft short.** Reviewers skim, and an over-long draft is the usual complaint. Include only sections that tell the reviewer something they cannot get from the title or the code - most PRs do not need a 50-line description.
 
 ### 4. Present the draft and iterate
 
-Show the full draft to the user as a fenced markdown block. Invite edits. Iterate until they are satisfied.
+Show the full draft to the user - the proposed **title** and the body as a fenced markdown block.
 
-**Do not call `gh pr edit` yet.** Drafting and updating are separate steps.
+Ask whether to include a **Visual proof** section. Only if they opt in, append the placeholder block from guideline.md for them to fill in manually. If no Jira number could be resolved in step 1, ask for it now so the title suffix is correct.
+
+**Never call `gh pr edit` yet.** Drafting and updating are separate steps.
 
 ### 5. Update the PR - only after explicit approval
 
 Wait for the user's clear, explicit go-ahead (e.g. "approved", "update it", "yes, push it"). Silence, "looks good", or answering an unrelated question is **not** approval to write - if in doubt, ask.
 
-Once approved, write the body to a temp file and update the PR (avoids shell-escaping issues with multi-line markdown):
+Once approved, write the body to a temp file (to avoid shell-escaping issues) and update the PR, setting the title in the same call:
 
 ```bash
-gh pr edit <number> --body-file <path>
+gh pr edit <number> --title "<title>" --body-file <path>
 ```
 
 Then confirm by re-fetching and report the PR URL back to the user:

--- a/.claude/skills/describe-pr/SKILL.md
+++ b/.claude/skills/describe-pr/SKILL.md
@@ -42,7 +42,7 @@ Collect context to ground the draft. Pull from all that apply:
 
 Follow [guideline.md](guideline.md) for the title rule, the mandatory changelog first line, the heading catalog, tone, writing style, and a worked example. Read it before drafting.
 
-Draft both: a reviewer-focused **title** ending in the Jira number in parentheses (e.g. `(6288)`), and the **body** starting with the mandatory `*Changelog:*` line above `# Description`.
+Draft both: a reviewer-focused **title** ending in the Jira number in parentheses (e.g. `(6288)`), and the **body** starting with the mandatory `*Changelog:*` line above `# Description`. For a PR with no plugin-user-facing change (tooling, CI, tests, build, docs), use the `*Changelog:* (none - <reason>)` form instead of inventing an entry - see guideline.md.
 
 **Keep the first draft short.** Reviewers skim, and an over-long draft is the usual complaint. Include only sections that tell the reviewer something they cannot get from the title or the code - most PRs do not need a 50-line description.
 

--- a/.claude/skills/describe-pr/guideline.md
+++ b/.claude/skills/describe-pr/guideline.md
@@ -1,12 +1,69 @@
 # PR description guide
 
-Reference for drafting in step 3. The goal is to introduce a reviewer to the problem and the reasoning - never to walk through the diff.
+Reference for drafting in step 3. The goal is to introduce a reviewer to the problem and the
+reasoning - never to walk through the diff.
+
+## Concision comes first
+
+**Default to the shortest draft that does the job.** A reviewer skims; every extra sentence costs
+their attention. The most common failure is a first draft that is too long, so bias hard toward
+less.
+
+Start from the **minimum** set of sections and add one only when it tells the reviewer something
+they cannot get from the code or the title. When unsure whether a section earns its place, leave
+it out.
+
+The example at the bottom is near the **upper bound** of acceptable length, not a target to fill.
+
+## Title
+
+Draft or refine the PR title as well as the body. The title is a clear, plain description of the
+change **for a reviewer** - what this PR does. It is not the changelog line and may be more
+technical or specific than the changelog.
+
+The title **must always end** with the Jira number in parentheses: the Jira ID with its letter
+prefix removed. `PCP-6288` becomes `(6288)`. Get the number from the Jira ID argument or the branch
+name (`[A-Z]+-\d+`). If no Jira ID can be found anywhere, ask the user for the number rather than
+guessing or dropping the suffix.
+
+Example: `Restore the "Proceed to PayPal" button label on block checkout (6288)`.
+
+## Changelog line
+
+The **first line** of the description, above the `# Description` title, is always a changelog line.
+It is mandatory. Exact format:
+
+```
+*Changelog:* `Type - the entry #PR`
+```
+
+The entry inside the backticks follows the project's `readme.txt` changelog format,
+`Type - short summary #PR`:
+
+- **Type** is one of `New` (a brand-new capability), `Enhancement` (improves existing behavior), or
+  `Fix` (corrects a defect). Derive it from the PR: a defect PR (`🐛 The problem`) is `Fix`; a
+  new-spec PR (`🎯 The goal`) is `New` or `Enhancement`.
+- **Summary** is very short and written for a **regular plugin user**, not a developer. Describe the
+  observable outcome or benefit, never the mechanism, class, method, or file. Plain English.
+- **#PR** is the resolved PR number. Append extra PRs as `, #1234`. Append `(author @handle)` only
+  for an external contributor.
+- Use a plain hyphen `-`.
+
+|                                               | Entry                                                                            |
+|-----------------------------------------------|----------------------------------------------------------------------------------|
+| Good (user-facing)                            | `Fix - Google Pay now correctly updates WooCommerce shipping address #3798`      |
+| Good                                          | `Enhancement - Improved error message for reCAPTCHA v2 challenge failures #4342` |
+| Bad (developer voice)                         | `Fix - AddressFactory::from_wc_order billing address #4279`                      |
+| Bad (describes the code, not the user impact) | `Fix - Do not increment step directly #4086`                                     |
 
 ## Heading catalog
 
-**Every section is optional.** Include a heading only when it adds something for the reviewer; omit the ones that do not apply. A trivial change might be one paragraph under `# Description`; a subtle fix warrants the full set.
+**Every section is optional, and omitting is the default.** This is a menu, not a form to fill in.
+Include a heading only when it adds something a reviewer cannot get elsewhere. Most PRs land on two
+or three sections; the full set is rare and reserved for a genuinely subtle change.
 
 ````template
+*Changelog:* `Type - the entry #PR`   mandatory first line, above the title
 # Description
 ## 🐛 The problem      a defect: the symptom in plain terms, not the stack trace
 ## 🎯 The goal         no defect: a spec that changed or scope not covered until now
@@ -15,39 +72,80 @@ Reference for drafting in step 3. The goal is to introduce a reviewer to the pro
 ## 🧪 Tests            what the change now covers and what it deliberately does not; reasoning, not a test-by-test list
 ## 🔍 What to review   fragile assumptions, blast radius, what tests can't catch; be honest about weak points
 ## 🧪 How to verify    numbered steps that exercise the change
+## 🖼️ Visual proof     user-supplied before/after media; only when the user opts in (see below)
 ````
 
-`The problem` and `The goal` are alternatives - pick one. Use `🐛 The problem` when something was broken; use `🎯 The goal` when nothing was defective and the change implements a new or revised spec.
+`The problem` and `The goal` are alternatives - pick one. Use `🐛 The problem` when something was
+broken; use `🎯 The goal` when nothing was defective and the change implements a new or revised spec.
 
-`Tests` and `How to verify` are distinct: **Tests** explains what coverage the change adds (and what it leaves uncovered, and why); **How to verify** lists the concrete steps a reviewer runs.
+`Visual proof` is never drafted automatically. Offer it in step 4, and only when the user opts in
+insert a placeholder block they fill in manually (see below).
 
-**The catalog is framed for bug fixes.** For other PR types (test additions, refactors, features, chores), keep the headings that carry meaning and drop the rest. A test-addition PR, for example, often needs only `# Description`, `🔍 What to review`, and `🧪 How to verify` - forcing "Why it happens" / "The fix" onto it produces filler.
+`Tests` and `How to verify` are distinct: **Tests** explains what coverage the change adds (and what
+it leaves uncovered, and why); **How to verify** lists the concrete steps a reviewer runs.
+
+**The catalog is framed for bug fixes.** For other PR types (test additions, refactors, features,
+chores), keep the headings that carry meaning and drop the rest. A test-addition PR, for example,
+often needs only `# Description`, `🔍 What to review`, and `🧪 How to verify` - forcing "Why it
+happens" / "The fix" onto it produces filler.
 
 ## Tone and content rules
 
 - **Reasoning over mechanics.** Explain the problem and the *why*; let the diff explain the *how*.
-- **Do not summarize the changes** file-by-file. If a reviewer wants the mechanics, they read the code.
-- **Be candid in "What to review"** - surface the one fragile assumption, the load-order dependency, the thing not covered by tests. This is the most valuable section.
+- **Do not summarize the changes** file-by-file. If a reviewer wants the mechanics, they read the
+  code.
+- **Be candid in "What to review"** - surface the one fragile assumption, the load-order dependency,
+  the thing not covered by tests. This is the most valuable section.
 - Keep the user's voice and the emoji headings. Drop headings that would only contain filler.
-- The PR description is public and must stand on its own: Never reference a Jira issue ID, Slack threads, developer names, or other sensitive details that should not be public.
-- **Write evergreen.** Describe the end state the reviewer sees when this merges, not transient or in-progress status ("currently failing", "WIP", "will be green once X"). If something is genuinely temporary, it does not belong in the description.
-- **"How to verify" lists actions, not narration.** Give the reviewer steps that exercise *this* change, using the project's real documented commands (check `CLAUDE.md` / `AGENTS.md` / `package.json`; never invent an invocation). Skip preconditions that already hold and environment boilerplate. Do not state expected pass/fail results - a test is expected to pass; saying so adds nothing.
+- The PR description is public and must stand on its own: Never reference a Jira issue ID, Slack
+  threads, developer names, or other sensitive details that should not be public.
+- **Write evergreen.** Describe the end state the reviewer sees when this merges, not transient or
+  in-progress status ("currently failing", "WIP", "will be green once X"). If something is genuinely
+  temporary, it does not belong in the description.
+- **"How to verify" lists actions, not narration.** Give the reviewer steps that exercise *this*
+  change, using the project's real documented commands (check `CLAUDE.md` / `AGENTS.md` /
+  `package.json`; never invent an invocation). Skip preconditions that already hold and environment
+  boilerplate. Do not state expected pass/fail results - a test is expected to pass; saying so adds
+  nothing.
 
 ## Writing style
 
 - **Paragraphs:** 1-3 sentences max. Break at natural pauses.
 - **Language:** plain English. No filler phrases ("it is worth noting", "in order to").
-- **Inline code:** backticks for file paths, class names, method names, hook names, config keys, JS globals.
+- **Inline code:** backticks for file paths, class names, method names, hook names, config keys, JS
+  globals.
 - **Bold:** one use per section max, for the single most important term or outcome.
 - **Lists:** prefer bullets over prose when there are 3+ parallel items.
 - **Avoid AI lingo** like "awkward", "scrutinize", "delve".
 - No em-dashes, direct and active tone.
 
+## Visual proof
+
+For UI changes a before/after helps, but the skill cannot capture media. In step 4, after the draft,
+ask the user whether to include a Visual proof section. Only if they opt in, append this placeholder
+for them to fill in manually after the PR is updated - never fabricate or attach media:
+
+````template
+## 🖼️ Visual proof
+
+| Before | After |
+|---|---|
+| _screenshot or video_ | _screenshot or video_ |
+````
+
 ## Reference example
 
-The canonical target style - note how it explains the problem and reasoning, names the single fragile assumption under "What to review", and never narrates the code:
+A subtle fix that justifies four body sections - this is roughly the **longest** a description
+should get, not the norm. Note the mandatory changelog first line, a reviewer-focused title ending
+in the Jira number, and how the body explains the problem and reasoning, names the single fragile
+assumption under "What to review", and never narrates the code. A routine PR would trim this to one
+or two sections:
 
 ````example
+Title: Restore the "Proceed to PayPal" button label on block checkout (6288)
+
+*Changelog:* `Fix - "Proceed to PayPal" button label restored on block checkout #4441`
+
 # Description
 
 ## 🐛 The problem

--- a/.claude/skills/describe-pr/guideline.md
+++ b/.claude/skills/describe-pr/guideline.md
@@ -1,0 +1,75 @@
+# PR description guide
+
+Reference for drafting in step 3. The goal is to introduce a reviewer to the problem and the reasoning - never to walk through the diff.
+
+## Heading catalog
+
+**Every section is optional.** Include a heading only when it adds something for the reviewer; omit the ones that do not apply. A trivial change might be one paragraph under `# Description`; a subtle fix warrants the full set.
+
+````template
+# Description
+## 🐛 The problem      a defect: the symptom in plain terms, not the stack trace
+## 🎯 The goal         no defect: a spec that changed or scope not covered until now
+## 💡 Why it happens   the root cause that explains the symptom or gap
+## ✅ The fix          what the change does conceptually and where it lives; never a code walkthrough
+## 🧪 Tests            what the change now covers and what it deliberately does not; reasoning, not a test-by-test list
+## 🔍 What to review   fragile assumptions, blast radius, what tests can't catch; be honest about weak points
+## 🧪 How to verify    numbered steps that exercise the change
+````
+
+`The problem` and `The goal` are alternatives - pick one. Use `🐛 The problem` when something was broken; use `🎯 The goal` when nothing was defective and the change implements a new or revised spec.
+
+`Tests` and `How to verify` are distinct: **Tests** explains what coverage the change adds (and what it leaves uncovered, and why); **How to verify** lists the concrete steps a reviewer runs.
+
+**The catalog is framed for bug fixes.** For other PR types (test additions, refactors, features, chores), keep the headings that carry meaning and drop the rest. A test-addition PR, for example, often needs only `# Description`, `🔍 What to review`, and `🧪 How to verify` - forcing "Why it happens" / "The fix" onto it produces filler.
+
+## Tone and content rules
+
+- **Reasoning over mechanics.** Explain the problem and the *why*; let the diff explain the *how*.
+- **Do not summarize the changes** file-by-file. If a reviewer wants the mechanics, they read the code.
+- **Be candid in "What to review"** - surface the one fragile assumption, the load-order dependency, the thing not covered by tests. This is the most valuable section.
+- Keep the user's voice and the emoji headings. Drop headings that would only contain filler.
+- The PR description is public and must stand on its own: Never reference a Jira issue ID, Slack threads, developer names, or other sensitive details that should not be public.
+- **Write evergreen.** Describe the end state the reviewer sees when this merges, not transient or in-progress status ("currently failing", "WIP", "will be green once X"). If something is genuinely temporary, it does not belong in the description.
+- **"How to verify" lists actions, not narration.** Give the reviewer steps that exercise *this* change, using the project's real documented commands (check `CLAUDE.md` / `AGENTS.md` / `package.json`; never invent an invocation). Skip preconditions that already hold and environment boilerplate. Do not state expected pass/fail results - a test is expected to pass; saying so adds nothing.
+
+## Writing style
+
+- **Paragraphs:** 1-3 sentences max. Break at natural pauses.
+- **Language:** plain English. No filler phrases ("it is worth noting", "in order to").
+- **Inline code:** backticks for file paths, class names, method names, hook names, config keys, JS globals.
+- **Bold:** one use per section max, for the single most important term or outcome.
+- **Lists:** prefer bullets over prose when there are 3+ parallel items.
+- **Avoid AI lingo** like "awkward", "scrutinize", "delve".
+- No em-dashes, direct and active tone.
+
+## Reference example
+
+The canonical target style - note how it explains the problem and reasoning, names the single fragile assumption under "What to review", and never narrates the code:
+
+````example
+# Description
+
+## 🐛 The problem
+
+On block checkout the PayPal place-order button is expected to read **"Proceed to PayPal"**. However, when a subscription product is in the cart, the button instead reads "Sign up now".
+
+## 💡 Why it happens
+
+WooCommerce Subscriptions registers a `placeOrderButtonLabel` checkout filter that *unconditionally rewrites the label* to its own text. PayPal only supplied its label through `registerPaymentMethod`, with no competing filter - so WCS always won.
+
+## ✅ The fix
+
+PayPal now registers its own `placeOrderButtonLabel` filter that restores "Proceed to PayPal" **only when PayPal is the active gateway**, and passes the value through untouched otherwise. One file: `modules/ppcp-blocks/resources/js/checkout-block.js`.
+
+## 🔍 What to review
+
+- **Load-order dependency.** Both filters run; the last one to register wins, and WCS's overwrites whatever it receives. This fix relies on PayPal's filter registering **after** WCS's, which holds because `checkout-block.js` enqueues later. If that ordering ever changes, the bug returns silently.
+- **Not unit-tested by design.** Correctness depends on filter execution order and the runtime presence of `window.wp.data`, neither of which a unit test can exercise. Verified manually instead (steps below).
+
+## 🧪 How to verify
+
+1. With **Save PayPal and Venmo** enabled, add a subscription product to the cart and open **Block Checkout**.
+2. Select the PayPal gateway → button reads **"Proceed to PayPal"** (not "Sign up now").
+3. Select a different gateway → its normal label is unaffected.
+````

--- a/.claude/skills/describe-pr/guideline.md
+++ b/.claude/skills/describe-pr/guideline.md
@@ -49,6 +49,11 @@ The entry inside the backticks follows the project's `readme.txt` changelog form
   for an external contributor.
 - Use a plain hyphen `-`.
 
+**No user-facing change?** For a PR that touches only internal tooling, CI, tests, build, or docs -
+nothing a plugin user would notice and nothing that lands in `readme.txt` - do not invent an entry.
+Write `*Changelog:* (none - <short reason>)` instead, e.g. `*Changelog:* (none - internal Claude
+tooling)`. Never dress up an internal change as a user-facing one just to fill the line.
+
 |                                               | Entry                                                                            |
 |-----------------------------------------------|----------------------------------------------------------------------------------|
 | Good (user-facing)                            | `Fix - Google Pay now correctly updates WooCommerce shipping address #3798`      |


### PR DESCRIPTION
*Changelog:* (none - internal Claude tooling, not shown in the plugin changelog)

# Description

Adds a `/describe-pr` skill under `.claude/skills/describe-pr/` that drafts a standardized, reviewer-focused PR title and description, then updates the PR only after explicit approval.

The skill encodes three team conventions: a title ending in the Jira number (e.g. `(6288)`), a `*Changelog:*` first line in the `readme.txt` format, and bodies that explain the problem and reasoning rather than narrate the diff. It offers a Visual proof placeholder on request.

## 🔍 What to review

`guideline.md` carries the substance (heading catalog, changelog formula, concision rules); `SKILL.md` is just the thin workflow around it.

## 🧪 How to verify

1. Run `/describe-pr <pr> <jira-id>` on an open PR.
2. Confirm the draft proposes a title ending in the Jira number, a `*Changelog:*` first line, and asks before adding a Visual proof section.
