### PR TITLE
Dev/pcp 6500 fix vaulted card payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ modules/*/assets/*
 !tests/qa-legacy-ui/resources/files/*.zip
 .env*
 !.env.example*
-auth.json
 .DS_Store
 tests/.DS_Store
 .composer_compiled_assets
@@ -32,3 +31,7 @@ test-results
 /tests/qa/resources/files/woocommerce-paypal-payments*.zip
 /tests/qa/resources/files/woocommerce-subscriptions*.zip
 .google-session.json
+
+# Do not track private authentication details
+auth.json
+.npmrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,34 @@
+# Do not track private authentication details
+auth.json
+.npmrc
+.env*
+
+# Exclude runtime artifacts by file types
+*.cache
+*.bak
+*.log
+*.zip
+.DS_Store
+
+# Ignore IDE settings
+/.idea/
+.vscode
+
 /vendor/
 /build/
-/.idea/
 node_modules
-.phpunit.result.cache
-phpunit.xml.dist.bak
-yarn-error.log
 modules/*/vendor/*
 modules/*/assets/*
 !modules/ppcp-wc-gateway/assets/images
-*.zip
 !tests/qa/resources/files/*.zip
 !tests/qa-legacy-ui/resources/files/*.zip
-.env*
 !.env.example*
-.DS_Store
-tests/.DS_Store
 .composer_compiled_assets
 /coverage/
 /assets
 !modules/ppcp-local-alternative-payment-methods/assets/images
 tests/inc/inpsyde/
 
-.vscode
 playwright-utils
 playwright-report*
 snapshots
@@ -31,7 +38,3 @@ test-results
 /tests/qa/resources/files/woocommerce-paypal-payments*.zip
 /tests/qa/resources/files/woocommerce-subscriptions*.zip
 .google-session.json
-
-# Do not track private authentication details
-auth.json
-.npmrc

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -1186,6 +1186,7 @@ return array(
 			$container->get( 'api.factory.order' ),
 			$container->get( 'api.factory.purchase-unit' ),
 			$container->get( 'settings.settings-provider' ),
+			$container->get( 'wcgateway.builder.experience-context' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -118,6 +118,8 @@ class CaptureCardPayment {
 				'usage'             => 'SUBSEQUENT',
 			),
 			'experience_context' => $this->experience_context_builder
+				->with_current_locale()
+				->with_current_brand_name()
 				->with_custom_return_url( $card_3ds_return_url )
 				->with_custom_cancel_url( wc_get_checkout_url() )
 				->build()

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -52,12 +52,7 @@ class CaptureCardPayment {
 
 	private SettingsProvider $settings_provider;
 
-	/**
-	 * The experience context builder.
-	 *
-	 * @var ExperienceContextBuilder
-	 */
-	private $experience_context_builder;
+	private ExperienceContextBuilder $experience_context_builder;
 
 	/**
 	 * The logger.

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -97,10 +97,8 @@ class CaptureCardPayment {
 		 * PayPal's vaulted-card 3D Secure return hits the return URL WITHOUT the
 		 * order token (it appends liability_shift/code/state instead), so
 		 * ReturnUrlEndpoint cannot identify the order by token. Encode the WC order
-		 * id plus a per-order resume nonce in the return URL: the order id locates
-		 * the order, and the nonce (matched against the order meta on return)
-		 * prevents the resume from being triggered by a manually crafted URL. A
-		 * cancelled challenge returns to the checkout URL and the order stays unpaid.
+		 * id plus a per-order resume nonce in the return URL so the return handler
+		 * can locate and authenticate the order.
 		 */
 		$card_3ds_return_url = add_query_arg(
 			array(

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -89,7 +89,7 @@ class CaptureCardPayment {
 	 *
 	 * @throws RuntimeException When request fails.
 	 */
-	public function create_order( string $vault_id, WC_Order $wc_order ): Order {
+	public function create_order( string $vault_id, WC_Order $wc_order, string $resume_nonce = '' ): Order {
 		$intent = strtoupper( $this->settings_provider->payment_intent() ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
 		$items  = array( $this->purchase_unit_factory->from_wc_order( $wc_order ) );
 
@@ -97,12 +97,16 @@ class CaptureCardPayment {
 		 * PayPal's vaulted-card 3D Secure return hits the return URL WITHOUT the
 		 * order token (it appends liability_shift/code/state instead), so
 		 * ReturnUrlEndpoint cannot identify the order by token. Encode the WC order
-		 * id in the return URL so the capture can be resumed on return. A cancelled
-		 * challenge returns to the checkout URL and the order stays unpaid.
+		 * id plus a per-order resume nonce in the return URL: the order id locates
+		 * the order, and the nonce (matched against the order meta on return)
+		 * prevents the resume from being triggered by a manually crafted URL. A
+		 * cancelled challenge returns to the checkout URL and the order stays unpaid.
 		 */
 		$card_3ds_return_url = add_query_arg(
-			'ppcp_resume_wc_order',
-			$wc_order->get_id(),
+			array(
+				'ppcp_resume_wc_order' => $wc_order->get_id(),
+				'ppcp_resume_nonce'    => $resume_nonce,
+			),
 			home_url( WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ) )
 		);
 

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -82,6 +82,34 @@ class CaptureCardPayment {
 		$intent = strtoupper( $this->settings_provider->payment_intent() ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
 		$items  = array( $this->purchase_unit_factory->from_wc_order( $wc_order ) );
 
+		$card = array(
+			'vault_id'          => $vault_id,
+			'stored_credential' => array(
+				'payment_initiator' => 'CUSTOMER',
+				'payment_type'      => 'UNSCHEDULED',
+				'usage'             => 'SUBSEQUENT',
+			),
+		);
+
+		/**
+		 * Request 3D Secure for the vaulted card charge so cards whose issuer
+		 * mandates Strong Customer Authentication can authenticate and produce a
+		 * liability shift. Without it such captures are rejected. Mirrors the
+		 * contingency the fresh-card flow applies via
+		 * `ppcp_create_order_request_body_data`.
+		 */
+		$three_d_secure_contingency = $this->settings_provider->three_d_secure_enum()
+			? apply_filters( 'woocommerce_paypal_payments_three_d_secure_contingency', $this->settings_provider->three_d_secure_enum() )
+			: '';
+
+		if ( in_array( $three_d_secure_contingency, array( 'SCA_ALWAYS', 'SCA_WHEN_REQUIRED' ), true ) ) {
+			$card['attributes'] = array(
+				'verification' => array(
+					'method' => $three_d_secure_contingency,
+				),
+			);
+		}
+
 		$data = array(
 			'intent'         => $intent,
 			'purchase_units' => array_map(
@@ -91,14 +119,7 @@ class CaptureCardPayment {
 				$items
 			),
 			'payment_source' => array(
-				'card' => array(
-					'vault_id'          => $vault_id,
-					'stored_credential' => array(
-						'payment_initiator' => 'CUSTOMER',
-						'payment_type'      => 'UNSCHEDULED',
-						'usage'             => 'SUBSEQUENT',
-					),
-				),
+				'card' => $card,
 			),
 		);
 

--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -6,11 +6,13 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
 
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use WC_AJAX;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
@@ -51,6 +53,13 @@ class CaptureCardPayment {
 	private SettingsProvider $settings_provider;
 
 	/**
+	 * The experience context builder.
+	 *
+	 * @var ExperienceContextBuilder
+	 */
+	private $experience_context_builder;
+
+	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -63,14 +72,16 @@ class CaptureCardPayment {
 		OrderFactory $order_factory,
 		PurchaseUnitFactory $purchase_unit_factory,
 		SettingsProvider $settings_provider,
+		ExperienceContextBuilder $experience_context_builder,
 		LoggerInterface $logger
 	) {
-		$this->host                  = $host;
-		$this->bearer                = $bearer;
-		$this->order_factory         = $order_factory;
-		$this->purchase_unit_factory = $purchase_unit_factory;
-		$this->settings_provider     = $settings_provider;
-		$this->logger                = $logger;
+		$this->host                       = $host;
+		$this->bearer                     = $bearer;
+		$this->order_factory              = $order_factory;
+		$this->purchase_unit_factory      = $purchase_unit_factory;
+		$this->settings_provider          = $settings_provider;
+		$this->experience_context_builder = $experience_context_builder;
+		$this->logger                     = $logger;
 	}
 
 	/**
@@ -82,13 +93,31 @@ class CaptureCardPayment {
 		$intent = strtoupper( $this->settings_provider->payment_intent() ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
 		$items  = array( $this->purchase_unit_factory->from_wc_order( $wc_order ) );
 
+		/**
+		 * PayPal's vaulted-card 3D Secure return hits the return URL WITHOUT the
+		 * order token (it appends liability_shift/code/state instead), so
+		 * ReturnUrlEndpoint cannot identify the order by token. Encode the WC order
+		 * id in the return URL so the capture can be resumed on return. A cancelled
+		 * challenge returns to the checkout URL and the order stays unpaid.
+		 */
+		$card_3ds_return_url = add_query_arg(
+			'ppcp_resume_wc_order',
+			$wc_order->get_id(),
+			home_url( WC_AJAX::get_endpoint( ReturnUrlEndpoint::ENDPOINT ) )
+		);
+
 		$card = array(
-			'vault_id'          => $vault_id,
-			'stored_credential' => array(
+			'vault_id'           => $vault_id,
+			'stored_credential'  => array(
 				'payment_initiator' => 'CUSTOMER',
 				'payment_type'      => 'UNSCHEDULED',
 				'usage'             => 'SUBSEQUENT',
 			),
+			'experience_context' => $this->experience_context_builder
+				->with_custom_return_url( $card_3ds_return_url )
+				->with_custom_cancel_url( wc_get_checkout_url() )
+				->build()
+				->to_array(),
 		);
 
 		/**

--- a/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
@@ -181,14 +181,20 @@ class ReturnUrlEndpoint {
 	 *
 	 * PayPal returns from a vaulted-card 3DS challenge without the order token, so
 	 * the order is identified by the WC order id that CaptureCardPayment encoded
-	 * in the return URL. Re-runs the gateway's payment processing, which
-	 * captures the now-authenticated order and completes it. Exits on a handled
-	 * success; returns so the caller can fall back to the error redirect otherwise.
+	 * in the return URL. The accompanying one-time nonce must match the value
+	 * stored on the order, otherwise the request is ignored — both the order id
+	 * and the nonce travel in public query arguments, so the nonce is what makes a
+	 * manually crafted return URL unable to trigger processing. Re-runs the
+	 * gateway's payment processing, which captures the now-authenticated order and
+	 * completes it. Exits on a handled success; returns so the caller can fall
+	 * back to the error redirect otherwise.
 	 */
 	private function maybe_resume_card_3ds(): void {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$wc_order_id = isset( $_GET['ppcp_resume_wc_order'] ) ? absint( wp_unslash( $_GET['ppcp_resume_wc_order'] ) ) : 0;
-		if ( ! $wc_order_id ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$wc_order_id    = isset( $_GET['ppcp_resume_wc_order'] ) ? absint( wp_unslash( $_GET['ppcp_resume_wc_order'] ) ) : 0;
+		$provided_nonce = isset( $_GET['ppcp_resume_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['ppcp_resume_nonce'] ) ) : '';
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		if ( ! $wc_order_id || ! $provided_nonce ) {
 			return;
 		}
 
@@ -197,10 +203,11 @@ class ReturnUrlEndpoint {
 			return;
 		}
 
-		// Only orders explicitly flagged as awaiting a vaulted-card 3DS resume may
-		// be processed here; the WC order id arrives from a public, guessable query
-		// argument, so an order without the flag must not trigger payment handling.
-		if ( ! $wc_order->get_meta( CreditCardGateway::THREE_DS_RESUME_META ) ) {
+		// The order id arrives from a public, guessable query argument; require the
+		// one-time nonce stored on the order to match before any payment handling,
+		// so a hand-crafted return URL cannot trigger a resume.
+		$stored_nonce = (string) $wc_order->get_meta( CreditCardGateway::THREE_DS_RESUME_META );
+		if ( ! $stored_nonce || ! hash_equals( $stored_nonce, $provided_nonce ) ) {
 			return;
 		}
 

--- a/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
@@ -17,6 +17,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 /**
@@ -80,6 +81,8 @@ class ReturnUrlEndpoint {
 	public function handle_request(): void {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET['token'] ) ) {
+			$this->maybe_resume_card_3ds();
+
 			wc_add_notice( __( 'Payment session expired. Please try placing your order again.', 'woocommerce-paypal-payments' ), 'error' );
 			wp_safe_redirect( $this->get_checkout_url_with_error() );
 			exit();
@@ -171,6 +174,52 @@ class ReturnUrlEndpoint {
 		wc_add_notice( __( 'Payment processing failed. Please try again or contact support.', 'woocommerce-paypal-payments' ), 'error' );
 		wp_safe_redirect( $this->get_checkout_url_with_error() );
 		exit();
+	}
+
+	/**
+	 * Resumes a vaulted-card payment after a 3D Secure challenge.
+	 *
+	 * PayPal returns from a vaulted-card 3DS challenge without the order token, so
+	 * the order is identified by the WC order id that CaptureCardPayment encoded
+	 * in the return URL. Re-runs the gateway's payment processing, which
+	 * captures the now-authenticated order and completes it. Exits on a handled
+	 * success; returns so the caller can fall back to the error redirect otherwise.
+	 */
+	private function maybe_resume_card_3ds(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$wc_order_id = isset( $_GET['ppcp_resume_wc_order'] ) ? absint( wp_unslash( $_GET['ppcp_resume_wc_order'] ) ) : 0;
+		if ( ! $wc_order_id ) {
+			return;
+		}
+
+		$wc_order = wc_get_order( $wc_order_id );
+		if ( ! ( $wc_order instanceof \WC_Order ) ) {
+			return;
+		}
+
+		// Only orders explicitly flagged as awaiting a vaulted-card 3DS resume may
+		// be processed here; the WC order id arrives from a public, guessable query
+		// argument, so an order without the flag must not trigger payment handling.
+		if ( ! $wc_order->get_meta( CreditCardGateway::THREE_DS_RESUME_META ) ) {
+			return;
+		}
+
+		$gateway = $this->get_payment_gateway( $wc_order->get_payment_method() );
+		if ( ! $gateway ) {
+			return;
+		}
+
+		try {
+			$result = $gateway->process_payment( $wc_order_id );
+		} catch ( Exception $exception ) {
+			$this->logger->warning( "Card 3DS resume failed for WC order $wc_order_id: " . $exception->getMessage() );
+			return;
+		}
+
+		if ( isset( $result['result'] ) && 'success' === $result['result'] ) {
+			wp_safe_redirect( $result['redirect'] );
+			exit();
+		}
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
@@ -191,9 +191,14 @@ class ReturnUrlEndpoint {
 	 */
 	private function maybe_resume_card_3ds(): void {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$wc_order_id    = isset( $_GET['ppcp_resume_wc_order'] ) ? absint( wp_unslash( $_GET['ppcp_resume_wc_order'] ) ) : 0;
-		$provided_nonce = isset( $_GET['ppcp_resume_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['ppcp_resume_nonce'] ) ) : '';
+		$wc_order_id = isset( $_GET['ppcp_resume_wc_order'] ) ? absint( wp_unslash( $_GET['ppcp_resume_wc_order'] ) ) : 0;
+
+		// wp_unslash() can return an array, so the value is sanitized on the next line behind an is_string() guard.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$provided_nonce = wp_unslash( $_GET['ppcp_resume_nonce'] ?? '' );
+		$provided_nonce = is_string( $provided_nonce ) ? sanitize_text_field( $provided_nonce ) : '';
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
 		if ( ! $wc_order_id || ! $provided_nonce ) {
 			return;
 		}

--- a/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ReturnUrlEndpoint.php
@@ -181,13 +181,9 @@ class ReturnUrlEndpoint {
 	 *
 	 * PayPal returns from a vaulted-card 3DS challenge without the order token, so
 	 * the order is identified by the WC order id that CaptureCardPayment encoded
-	 * in the return URL. The accompanying one-time nonce must match the value
-	 * stored on the order, otherwise the request is ignored — both the order id
-	 * and the nonce travel in public query arguments, so the nonce is what makes a
-	 * manually crafted return URL unable to trigger processing. Re-runs the
-	 * gateway's payment processing, which captures the now-authenticated order and
-	 * completes it. Exits on a handled success; returns so the caller can fall
-	 * back to the error redirect otherwise.
+	 * in the return URL. Re-runs the gateway's payment processing, which captures
+	 * the now-authenticated order and completes it. Exits on a handled success;
+	 * returns so the caller can fall back to the error redirect otherwise.
 	 */
 	private function maybe_resume_card_3ds(): void {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -461,10 +461,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 
 		/**
 		 * Resume a vaulted-card payment after the buyer completed a 3D Secure
-		 * challenge and returned via the PayPal return URL (ppc-return-url). The
-		 * resume only proceeds when the one-time nonce in the return URL matches
-		 * the nonce stored on the order, so a manually crafted return URL cannot
-		 * trigger it. The nonce is cleared immediately, making it single-use.
+		 * challenge. The one-time nonce in the return URL must match the value
+		 * stored on the order; it is cleared on use, so the resume is single-use.
 		 */
 		// wp_unslash() can return an array, so the value is sanitized on the next line behind an is_string() guard.
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -466,9 +466,12 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		 * the nonce stored on the order, so a manually crafted return URL cannot
 		 * trigger it. The nonce is cleared immediately, making it single-use.
 		 */
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$provided_resume_nonce = isset( $_GET['ppcp_resume_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['ppcp_resume_nonce'] ) ) : '';
+		// wp_unslash() can return an array, so the value is sanitized on the next line behind an is_string() guard.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$provided_resume_nonce = wp_unslash( $_GET['ppcp_resume_nonce'] ?? '' );
+		$provided_resume_nonce = is_string( $provided_resume_nonce ) ? sanitize_text_field( $provided_resume_nonce ) : '';
 		$stored_resume_nonce   = (string) $wc_order->get_meta( self::THREE_DS_RESUME_META );
+
 		if ( $stored_resume_nonce && $provided_resume_nonce && hash_equals( $stored_resume_nonce, $provided_resume_nonce ) ) {
 			$wc_order->delete_meta_data( self::THREE_DS_RESUME_META );
 			$wc_order->save();

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -497,8 +497,6 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 						$resume_nonce  = wp_generate_password( 20, false );
 						$created_order = $this->capture_card_payment->create_order( $token->get_token(), $wc_order, $resume_nonce );
 
-						$order = $this->order_endpoint->order( $created_order->id() );
-
 						$this->add_paypal_meta( $wc_order, $created_order, $this->environment );
 						$wc_order->add_payment_token( $token );
 
@@ -522,6 +520,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 								'redirect' => $payer_action,
 							);
 						}
+
+						$order = $this->order_endpoint->order( $created_order->id() );
 
 						return $this->finalize_vaulted_card_order( $wc_order, $order );
 					} catch ( RuntimeException $exception ) {

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -15,6 +15,7 @@ use WC_Order;
 use WC_Payment_Tokens;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentsEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
@@ -47,6 +48,14 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	use OrderMetaTrait;
 
 	const ID = 'ppcp-credit-card-gateway';
+
+	/**
+	 * Order meta flag marking a vaulted-card payment that is awaiting the buyer
+	 * to complete a 3D Secure challenge before it can be captured.
+	 *
+	 * @var string
+	 */
+	const THREE_DS_RESUME_META = '_ppcp_card_3ds_resume';
 
 	/**
 	 * The processor for orders.
@@ -449,6 +458,28 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		}
 
 		/**
+		 * Resume a vaulted-card payment after the buyer completed a 3D Secure
+		 * challenge and returned via the PayPal return URL (ppc-return-url). At
+		 * this point no payment token is posted; the PayPal order id is read from
+		 * the meta stored before the redirect.
+		 */
+		if ( $wc_order->get_meta( self::THREE_DS_RESUME_META ) && ! $card_payment_token_id ) {
+			$wc_order->delete_meta_data( self::THREE_DS_RESUME_META );
+			$wc_order->save();
+
+			try {
+				$order = $this->order_endpoint->order(
+					(string) $wc_order->get_meta( PayPalGateway::ORDER_ID_META_KEY )
+				);
+
+				return $this->finalize_vaulted_card_order( $wc_order, $order );
+			} catch ( RuntimeException $exception ) {
+				$this->logger->error( $exception->getMessage() );
+				return $this->handle_payment_failure( $wc_order, $exception );
+			}
+		}
+
+		/**
 		 * Vault v3 (save payment methods).
 		 * If customer has chosen a saved credit card payment from checkout page.
 		 */
@@ -464,56 +495,31 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 						$this->add_paypal_meta( $wc_order, $created_order, $this->environment );
 						$wc_order->add_payment_token( $token );
 
-						if ( $order->intent() === 'AUTHORIZE' ) {
-							$order = $this->order_endpoint->authorize( $order );
+						/**
+						 * Step-up: when PayPal returns a payer-action link the buyer must
+						 * complete a 3D Secure challenge before this vaulted card can be
+						 * charged. PayPal returns the order in CREATED (or
+						 * PAYER_ACTION_REQUIRED) status with that link; a frictionless
+						 * charge has no such link. Persist the resume flag and redirect to
+						 * the payer-action URL; the capture resumes when the buyer returns
+						 * via the PayPal return URL.
+						 */
+						$payer_action = $this->payer_action_url( $created_order );
+						if ( $payer_action ) {
+							$wc_order->update_meta_data( self::THREE_DS_RESUME_META, '1' );
+							$wc_order->save();
 
-							$wc_order->update_meta_data( AuthorizedPaymentsProcessor::CAPTURED_META_KEY, 'false' );
-
-							if ( $this->subscription_helper->has_subscription( $wc_order->get_id() ) ) {
-								$wc_order->update_meta_data( '_ppcp_captured_vault_webhook', 'false' );
-							}
-						} elseif ( $order->status()->is( OrderStatus::APPROVED ) || $order->status()->is( OrderStatus::CREATED ) ) {
-							// A vaulted-card order is created in CREATED status and must be
-							// captured explicitly; without this it never leaves "pending payment".
-							$order = $this->order_endpoint->capture( $order );
+							return array(
+								'result'   => 'success',
+								'redirect' => $payer_action,
+							);
 						}
 
-						$transaction_id = $this->get_paypal_order_transaction_id( $order );
-						if ( $transaction_id ) {
-							$this->update_transaction_id( $transaction_id, $wc_order );
-						}
-
-						$this->handle_new_order_status( $order, $wc_order );
+						return $this->finalize_vaulted_card_order( $wc_order, $order );
 					} catch ( RuntimeException $exception ) {
 						$this->logger->error( $exception->getMessage() );
 						return $this->handle_payment_failure( $wc_order, $exception );
 					}
-
-					/**
-					 * Safety net: if nothing transitioned the order into a handled state
-					 * (e.g. PayPal returned PAYER_ACTION_REQUIRED and produced no capture or
-					 * authorization), fail cleanly instead of leaving the order silently
-					 * stuck in "pending payment".
-					 */
-					if ( ! $wc_order->has_status( array( 'processing', 'completed', 'on-hold' ) ) ) {
-						$this->logger->error(
-							sprintf(
-								'Vaulted card payment for WC order %1$d did not reach a handled state (PayPal order %2$s, status %3$s); failing the payment.',
-								$wc_order->get_id(),
-								$created_order->id(),
-								$order->status()->name()
-							)
-						);
-
-						return $this->handle_payment_failure(
-							$wc_order,
-							new RuntimeException(
-								__( 'This saved card could not be charged. Please try another payment method.', 'woocommerce-paypal-payments' )
-							)
-						);
-					}
-
-					return $this->handle_payment_success( $wc_order );
 				}
 			}
 		}
@@ -556,6 +562,89 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 		} catch ( Exception $error ) {
 			return $this->handle_payment_failure( $wc_order, $error );
 		}
+	}
+
+	/**
+	 * Authorizes or captures a vaulted-card PayPal order, records the transaction
+	 * id, transitions the WC order and returns the WC payment result. Shared by
+	 * the initial saved-card charge and the resume step after a 3D Secure
+	 * challenge; the status checks keep it idempotent whether or not the order
+	 * was already captured during the return.
+	 *
+	 * @param WC_Order $wc_order The WC order.
+	 * @param Order    $order    The PayPal order to finalize.
+	 * @return array The WC payment result.
+	 * @throws RuntimeException When an API request fails.
+	 */
+	private function finalize_vaulted_card_order( WC_Order $wc_order, Order $order ): array {
+		if ( $order->intent() === 'AUTHORIZE' ) {
+			$order = $this->order_endpoint->authorize( $order );
+
+			$wc_order->update_meta_data( AuthorizedPaymentsProcessor::CAPTURED_META_KEY, 'false' );
+
+			if ( $this->subscription_helper->has_subscription( $wc_order->get_id() ) ) {
+				$wc_order->update_meta_data( '_ppcp_captured_vault_webhook', 'false' );
+			}
+		} elseif ( $order->status()->is( OrderStatus::APPROVED ) || $order->status()->is( OrderStatus::CREATED ) ) {
+			// A vaulted-card order is created in CREATED status and must be
+			// captured explicitly; without this it never leaves "pending payment".
+			$order = $this->order_endpoint->capture( $order );
+		}
+
+		$transaction_id = $this->get_paypal_order_transaction_id( $order );
+		if ( $transaction_id ) {
+			$this->update_transaction_id( $transaction_id, $wc_order );
+		}
+
+		$this->handle_new_order_status( $order, $wc_order );
+
+		/**
+		 * Safety net: if nothing transitioned the order into a handled state
+		 * (e.g. PayPal returned PAYER_ACTION_REQUIRED and produced no capture or
+		 * authorization), fail cleanly instead of leaving the order silently
+		 * stuck in "pending payment".
+		 */
+		if ( ! $wc_order->has_status( array( 'processing', 'completed', 'on-hold' ) ) ) {
+			$this->logger->error(
+				sprintf(
+					'Vaulted card payment for WC order %1$d did not reach a handled state (PayPal order %2$s, status %3$s); failing the payment.',
+					$wc_order->get_id(),
+					$order->id(),
+					$order->status()->name()
+				)
+			);
+
+			return $this->handle_payment_failure(
+				$wc_order,
+				new RuntimeException(
+					__( 'This saved card could not be charged. Please try another payment method.', 'woocommerce-paypal-payments' )
+				)
+			);
+		}
+
+		return $this->handle_payment_success( $wc_order );
+	}
+
+	/**
+	 * Returns the payer-action URL from a PayPal order's HATEOAS links, or an
+	 * empty string when none is present.
+	 *
+	 * @param Order $order The PayPal order.
+	 * @return string
+	 */
+	private function payer_action_url( Order $order ): string {
+		$links = $order->links();
+		if ( ! is_array( $links ) ) {
+			return '';
+		}
+
+		foreach ( $links as $link ) {
+			if ( is_object( $link ) && isset( $link->rel, $link->href ) && 'payer-action' === $link->rel ) {
+				return (string) $link->href;
+			}
+		}
+
+		return '';
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/CreditCardGateway.php
@@ -50,8 +50,10 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 	const ID = 'ppcp-credit-card-gateway';
 
 	/**
-	 * Order meta flag marking a vaulted-card payment that is awaiting the buyer
-	 * to complete a 3D Secure challenge before it can be captured.
+	 * Order meta key holding the one-time, per-attempt random nonce for a
+	 * vaulted-card payment that is awaiting the buyer to complete a 3D Secure
+	 * challenge. The same value is embedded in the PayPal return URL and must
+	 * match on return before the capture is resumed; it is cleared once used.
 	 *
 	 * @var string
 	 */
@@ -459,11 +461,15 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 
 		/**
 		 * Resume a vaulted-card payment after the buyer completed a 3D Secure
-		 * challenge and returned via the PayPal return URL (ppc-return-url). At
-		 * this point no payment token is posted; the PayPal order id is read from
-		 * the meta stored before the redirect.
+		 * challenge and returned via the PayPal return URL (ppc-return-url). The
+		 * resume only proceeds when the one-time nonce in the return URL matches
+		 * the nonce stored on the order, so a manually crafted return URL cannot
+		 * trigger it. The nonce is cleared immediately, making it single-use.
 		 */
-		if ( $wc_order->get_meta( self::THREE_DS_RESUME_META ) && ! $card_payment_token_id ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$provided_resume_nonce = isset( $_GET['ppcp_resume_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['ppcp_resume_nonce'] ) ) : '';
+		$stored_resume_nonce   = (string) $wc_order->get_meta( self::THREE_DS_RESUME_META );
+		if ( $stored_resume_nonce && $provided_resume_nonce && hash_equals( $stored_resume_nonce, $provided_resume_nonce ) ) {
 			$wc_order->delete_meta_data( self::THREE_DS_RESUME_META );
 			$wc_order->save();
 
@@ -488,7 +494,8 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 			foreach ( $tokens as $token ) {
 				if ( $token->get_id() === (int) $card_payment_token_id ) {
 					try {
-						$created_order = $this->capture_card_payment->create_order( $token->get_token(), $wc_order );
+						$resume_nonce  = wp_generate_password( 20, false );
+						$created_order = $this->capture_card_payment->create_order( $token->get_token(), $wc_order, $resume_nonce );
 
 						$order = $this->order_endpoint->order( $created_order->id() );
 
@@ -500,13 +507,14 @@ class CreditCardGateway extends \WC_Payment_Gateway_CC {
 						 * complete a 3D Secure challenge before this vaulted card can be
 						 * charged. PayPal returns the order in CREATED (or
 						 * PAYER_ACTION_REQUIRED) status with that link; a frictionless
-						 * charge has no such link. Persist the resume flag and redirect to
-						 * the payer-action URL; the capture resumes when the buyer returns
-						 * via the PayPal return URL.
+						 * charge has no such link. Store this attempt's one-time nonce and
+						 * redirect to the payer-action URL; the capture resumes when the
+						 * buyer returns with the matching nonce. A later attempt overwrites
+						 * the nonce, so only the most recent challenge can be confirmed.
 						 */
 						$payer_action = $this->payer_action_url( $created_order );
 						if ( $payer_action ) {
-							$wc_order->update_meta_data( self::THREE_DS_RESUME_META, '1' );
+							$wc_order->update_meta_data( self::THREE_DS_RESUME_META, $resume_nonce );
 							$wc_order->save();
 
 							return array(

--- a/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
+++ b/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
@@ -59,4 +59,58 @@ class CardCaptureValidatorTest extends TestCase {
 
 		$this->assertTrue( $validator->is_valid( $order ) );
 	}
+
+	/**
+	 * GIVEN a card payment source with status CREATED
+	 * WHEN is_valid is called for a given liability_shift value
+	 * THEN the validator allows capture only for a POSSIBLE or YES liability_shift
+	 *
+	 * @dataProvider card_liability_shift_provider
+	 */
+	public function test_is_valid_card_payment_source_with_liability_shift(
+		string $liability_shift,
+		bool $expected
+	): void {
+		$validator     = new CardCaptureValidator();
+		$order         = Mockery::mock( Order::class );
+		$orderStatus   = Mockery::mock( OrderStatus::class );
+		$paymentSource = Mockery::mock( PaymentSource::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
+		$order->shouldReceive( 'payment_source' )->andReturn( $paymentSource );
+		$paymentSource->shouldReceive( 'name' )->andReturn( 'card' );
+		$paymentSource->shouldReceive( 'properties' )->andReturn( (object) [
+			'authentication_result' => (object) [
+				'liability_shift' => $liability_shift,
+			],
+		] );
+
+		$this->assertSame( $expected, $validator->is_valid( $order ) );
+	}
+
+	public function card_liability_shift_provider(): array {
+		return [
+			'empty liability_shift blocks capture' => [ '', false ],
+			'NO liability_shift blocks capture'    => [ 'NO', false ],
+			'YES liability_shift allows capture'   => [ 'YES', true ],
+		];
+	}
+
+	/**
+	 * GIVEN an order with status CREATED and no payment source (null)
+	 * WHEN is_valid is called
+	 * THEN the validator returns false
+	 */
+	public function test_is_valid_returns_false_when_payment_source_is_null(): void {
+		$validator   = new CardCaptureValidator();
+		$order       = Mockery::mock( Order::class );
+		$orderStatus = Mockery::mock( OrderStatus::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
+		$order->shouldReceive( 'payment_source' )->andReturn( null );
+
+		$this->assertFalse( $validator->is_valid( $order ) );
+	}
 }

--- a/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
+++ b/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
@@ -91,9 +91,10 @@ class CardCaptureValidatorTest extends TestCase {
 
 	public function card_liability_shift_provider(): array {
 		return [
-			'empty liability_shift blocks capture' => [ '', false ],
-			'NO liability_shift blocks capture'    => [ 'NO', false ],
-			'YES liability_shift allows capture'   => [ 'YES', true ],
+			'empty liability_shift blocks capture'    => [ '', false ],
+			'NO liability_shift blocks capture'       => [ 'NO', false ],
+			'YES liability_shift allows capture'      => [ 'YES', true ],
+			'POSSIBLE liability_shift allows capture' => [ 'POSSIBLE', true ],
 		];
 	}
 

--- a/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
@@ -32,7 +32,7 @@ class CaptureCardPaymentTest extends TestCase {
 		$bearer->shouldReceive( 'bearer' )->andReturn( $token );
 
 		$purchase_unit = Mockery::mock( PurchaseUnit::class );
-		$purchase_unit->shouldReceive( 'to_array' )->andReturn( [] );
+		$purchase_unit->shouldReceive( 'to_array' )->andReturn( array() );
 
 		$purchase_unit_factory = Mockery::mock( PurchaseUnitFactory::class );
 		$purchase_unit_factory->shouldReceive( 'from_wc_order' )->andReturn( $purchase_unit );
@@ -59,7 +59,7 @@ class CaptureCardPaymentTest extends TestCase {
 
 		// RequestTrait::request_response_string() calls $response['headers']->getAll(), so headers must be an object.
 		$headers_stub = Mockery::mock( \Requests_Utility_CaseInsensitiveDictionary::class );
-		$headers_stub->shouldReceive( 'getAll' )->andReturn( [] );
+		$headers_stub->shouldReceive( 'getAll' )->andReturn( array() );
 
 		expect( 'wp_remote_get' )->andReturnUsing(
 			function ( string $url, array $args ) use ( &$captured_body, $headers_stub ): array {
@@ -93,7 +93,7 @@ class CaptureCardPaymentTest extends TestCase {
 	public function test_create_order_includes_vault_id_and_stored_credential(
 		string $three_d_secure_enum
 	): void {
-		$captured_body = [];
+		$captured_body = array();
 		$testee        = $this->make_testee( $three_d_secure_enum, $captured_body );
 		$wc_order      = Mockery::mock( WC_Order::class );
 
@@ -122,7 +122,7 @@ class CaptureCardPaymentTest extends TestCase {
 		string $three_d_secure_enum,
 		string $expected_method
 	): void {
-		$captured_body = [];
+		$captured_body = array();
 		$testee        = $this->make_testee( $three_d_secure_enum, $captured_body );
 		$wc_order      = Mockery::mock( WC_Order::class );
 
@@ -141,7 +141,7 @@ class CaptureCardPaymentTest extends TestCase {
 	 * THEN payment_source.card has no 'attributes' key (no verification sent)
 	 */
 	public function test_create_order_omits_attributes_when_3ds_disabled(): void {
-		$captured_body = [];
+		$captured_body = array();
 		$testee        = $this->make_testee( '', $captured_body );
 		$wc_order      = Mockery::mock( WC_Order::class );
 
@@ -178,17 +178,17 @@ class CaptureCardPaymentTest extends TestCase {
 	}
 
 	public function three_d_secure_enum_provider(): array {
-		return [
-			'SCA_WHEN_REQUIRED setting' => [ 'SCA_WHEN_REQUIRED' ],
-			'SCA_ALWAYS setting'        => [ 'SCA_ALWAYS' ],
-			'No 3DS setting'            => [ '' ],
-		];
+		return array(
+			'SCA_WHEN_REQUIRED setting' => array( 'SCA_WHEN_REQUIRED' ),
+			'SCA_ALWAYS setting'        => array( 'SCA_ALWAYS' ),
+			'No 3DS setting'            => array( '' ),
+		);
 	}
 
 	public function three_d_secure_enum_with_verification_provider(): array {
-		return [
-			'SCA_WHEN_REQUIRED maps to verification method SCA_WHEN_REQUIRED' => [ 'SCA_WHEN_REQUIRED', 'SCA_WHEN_REQUIRED' ],
-			'SCA_ALWAYS maps to verification method SCA_ALWAYS'               => [ 'SCA_ALWAYS', 'SCA_ALWAYS' ],
-		];
+		return array(
+			'SCA_WHEN_REQUIRED maps to verification method SCA_WHEN_REQUIRED' => array( 'SCA_WHEN_REQUIRED', 'SCA_WHEN_REQUIRED' ),
+			'SCA_ALWAYS maps to verification method SCA_ALWAYS'               => array( 'SCA_ALWAYS', 'SCA_ALWAYS' ),
+		);
 	}
 }

--- a/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
@@ -67,8 +67,8 @@ class CaptureCardPaymentTest extends TestCase {
 		when( 'home_url' )->alias( function ( string $path = '' ): string {
 			return 'https://example.com' . $path;
 		} );
-		when( 'add_query_arg' )->alias( function ( string $key, $value, string $url ): string {
-			return $url . '&' . $key . '=' . $value;
+		when( 'add_query_arg' )->alias( function ( $args, string $url ): string {
+			return $url;
 		} );
 		when( 'wc_get_checkout_url' )->justReturn( 'https://example.com/checkout/' );
 		when( 'trailingslashit' )->alias( function ( string $value ): string {

--- a/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
@@ -1,0 +1,171 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class CaptureCardPaymentTest extends TestCase {
+
+	/**
+	 * Build a fully-wired CaptureCardPayment instance.
+	 *
+	 * @param string $three_d_secure_enum Value returned by settings_provider->three_d_secure_enum().
+	 * @param array  &$captured_body      Passed by reference; populated with the decoded request body inside the wp_remote_get stub.
+	 */
+	private function make_testee( string $three_d_secure_enum, array &$captured_body ): CaptureCardPayment {
+		$token = Mockery::mock( \WooCommerce\PayPalCommerce\ApiClient\Entity\Token::class );
+		$token->shouldReceive( 'token' )->andReturn( 'test-bearer-token' );
+
+		$bearer = Mockery::mock( Bearer::class );
+		$bearer->shouldReceive( 'bearer' )->andReturn( $token );
+
+		$purchase_unit = Mockery::mock( PurchaseUnit::class );
+		$purchase_unit->shouldReceive( 'to_array' )->andReturn( [] );
+
+		$purchase_unit_factory = Mockery::mock( PurchaseUnitFactory::class );
+		$purchase_unit_factory->shouldReceive( 'from_wc_order' )->andReturn( $purchase_unit );
+
+		$returned_order = Mockery::mock( Order::class );
+
+		$order_factory = Mockery::mock( OrderFactory::class );
+		$order_factory->shouldReceive( 'from_paypal_response' )->andReturn( $returned_order );
+
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+		$settings_provider->shouldReceive( 'payment_intent' )->andReturn( 'capture' );
+		$settings_provider->shouldReceive( 'three_d_secure_enum' )->andReturn( $three_d_secure_enum );
+
+		$logger = Mockery::mock( LoggerInterface::class );
+		$logger->shouldReceive( 'debug' )->zeroOrMoreTimes();
+
+		when( 'trailingslashit' )->alias( function ( string $value ): string {
+			return rtrim( $value, '/' ) . '/';
+		} );
+		expect( 'wp_json_encode' )->andReturnUsing( 'json_encode' );
+		when( 'apply_filters' )->alias( function ( string $hook, ...$args ) {
+			return $args[0] ?? null;
+		} );
+
+		// RequestTrait::request_response_string() calls $response['headers']->getAll(), so headers must be an object.
+		$headers_stub = Mockery::mock( \Requests_Utility_CaseInsensitiveDictionary::class );
+		$headers_stub->shouldReceive( 'getAll' )->andReturn( [] );
+
+		expect( 'wp_remote_get' )->andReturnUsing(
+			function ( string $url, array $args ) use ( &$captured_body, $headers_stub ): array {
+				$captured_body = (array) json_decode( $args['body'], true );
+				return array(
+					'body'     => '{}',
+					'response' => array( 'code' => 200 ),
+					'headers'  => $headers_stub,
+				);
+			}
+		);
+
+		return new CaptureCardPayment(
+			'https://api.paypal.com',
+			$bearer,
+			$order_factory,
+			$purchase_unit_factory,
+			$settings_provider,
+			$logger
+		);
+	}
+
+	/**
+	 * GIVEN a vaulted card vault_id is passed to create_order
+	 * WHEN the HTTP request body is built
+	 * THEN payment_source.card.vault_id in the body equals the passed vault_id
+	 * AND stored_credential.payment_initiator equals 'CUSTOMER'
+	 *
+	 * @dataProvider three_d_secure_enum_provider
+	 */
+	public function test_create_order_includes_vault_id_and_stored_credential(
+		string $three_d_secure_enum
+	): void {
+		$captured_body = [];
+		$testee        = $this->make_testee( $three_d_secure_enum, $captured_body );
+		$wc_order      = Mockery::mock( WC_Order::class );
+
+		$testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertSame(
+			'vault-abc-123',
+			$captured_body['payment_source']['card']['vault_id'],
+			'vault_id must be forwarded verbatim into the request body'
+		);
+		$this->assertSame(
+			'CUSTOMER',
+			$captured_body['payment_source']['card']['stored_credential']['payment_initiator'],
+			'stored_credential.payment_initiator must be CUSTOMER for vaulted card charges'
+		);
+	}
+
+	/**
+	 * GIVEN the merchant has configured a 3DS setting (SCA_WHEN_REQUIRED or SCA_ALWAYS)
+	 * WHEN create_order builds the PayPal API request for a vaulted card
+	 * THEN payment_source.card.attributes.verification.method equals the configured enum value
+	 *
+	 * @dataProvider three_d_secure_enum_with_verification_provider
+	 */
+	public function test_create_order_includes_3ds_verification_when_configured(
+		string $three_d_secure_enum,
+		string $expected_method
+	): void {
+		$captured_body = [];
+		$testee        = $this->make_testee( $three_d_secure_enum, $captured_body );
+		$wc_order      = Mockery::mock( WC_Order::class );
+
+		$testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertSame(
+			$expected_method,
+			$captured_body['payment_source']['card']['attributes']['verification']['method'] ?? null,
+			"Request body must include payment_source.card.attributes.verification.method={$expected_method} for 3DS setting '{$three_d_secure_enum}'"
+		);
+	}
+
+	/**
+	 * GIVEN the merchant has disabled 3DS (empty enum value)
+	 * WHEN create_order builds the PayPal API request for a vaulted card
+	 * THEN payment_source.card has no 'attributes' key (no verification sent)
+	 */
+	public function test_create_order_omits_attributes_when_3ds_disabled(): void {
+		$captured_body = [];
+		$testee        = $this->make_testee( '', $captured_body );
+		$wc_order      = Mockery::mock( WC_Order::class );
+
+		$testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertArrayNotHasKey(
+			'attributes',
+			$captured_body['payment_source']['card'],
+			'When 3DS is disabled the request body must not contain payment_source.card.attributes'
+		);
+	}
+
+	public function three_d_secure_enum_provider(): array {
+		return [
+			'SCA_WHEN_REQUIRED setting' => [ 'SCA_WHEN_REQUIRED' ],
+			'SCA_ALWAYS setting'        => [ 'SCA_ALWAYS' ],
+			'No 3DS setting'            => [ '' ],
+		];
+	}
+
+	public function three_d_secure_enum_with_verification_provider(): array {
+		return [
+			'SCA_WHEN_REQUIRED maps to verification method SCA_WHEN_REQUIRED' => [ 'SCA_WHEN_REQUIRED', 'SCA_WHEN_REQUIRED' ],
+			'SCA_ALWAYS maps to verification method SCA_ALWAYS'               => [ 'SCA_ALWAYS', 'SCA_ALWAYS' ],
+		];
+	}
+}

--- a/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
@@ -7,8 +7,10 @@ use Mockery;
 use Psr\Log\LoggerInterface;
 use WC_Order;
 use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ExperienceContext;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\ExperienceContextBuilder;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
@@ -46,9 +48,29 @@ class CaptureCardPaymentTest extends TestCase {
 		$settings_provider->shouldReceive( 'payment_intent' )->andReturn( 'capture' );
 		$settings_provider->shouldReceive( 'three_d_secure_enum' )->andReturn( $three_d_secure_enum );
 
+		$experience_context = Mockery::mock( ExperienceContext::class );
+		$experience_context->shouldReceive( 'to_array' )->andReturn(
+			array(
+				'return_url' => 'https://example.com/return',
+				'cancel_url' => 'https://example.com/cancel',
+			)
+		);
+
+		$experience_context_builder = Mockery::mock( ExperienceContextBuilder::class );
+		$experience_context_builder->shouldReceive( 'with_custom_return_url' )->andReturnSelf();
+		$experience_context_builder->shouldReceive( 'with_custom_cancel_url' )->andReturnSelf();
+		$experience_context_builder->shouldReceive( 'build' )->andReturn( $experience_context );
+
 		$logger = Mockery::mock( LoggerInterface::class );
 		$logger->shouldReceive( 'debug' )->zeroOrMoreTimes();
 
+		when( 'home_url' )->alias( function ( string $path = '' ): string {
+			return 'https://example.com' . $path;
+		} );
+		when( 'add_query_arg' )->alias( function ( string $key, $value, string $url ): string {
+			return $url . '&' . $key . '=' . $value;
+		} );
+		when( 'wc_get_checkout_url' )->justReturn( 'https://example.com/checkout/' );
 		when( 'trailingslashit' )->alias( function ( string $value ): string {
 			return rtrim( $value, '/' ) . '/';
 		} );
@@ -78,6 +100,7 @@ class CaptureCardPaymentTest extends TestCase {
 			$order_factory,
 			$purchase_unit_factory,
 			$settings_provider,
+			$experience_context_builder,
 			$logger
 		);
 	}
@@ -96,6 +119,7 @@ class CaptureCardPaymentTest extends TestCase {
 		$captured_body = array();
 		$testee        = $this->make_testee( $three_d_secure_enum, $captured_body );
 		$wc_order      = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'get_id' )->andReturn( 1 );
 
 		$testee->create_order( 'vault-abc-123', $wc_order );
 
@@ -125,6 +149,7 @@ class CaptureCardPaymentTest extends TestCase {
 		$captured_body = array();
 		$testee        = $this->make_testee( $three_d_secure_enum, $captured_body );
 		$wc_order      = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'get_id' )->andReturn( 1 );
 
 		$testee->create_order( 'vault-abc-123', $wc_order );
 
@@ -144,6 +169,7 @@ class CaptureCardPaymentTest extends TestCase {
 		$captured_body = array();
 		$testee        = $this->make_testee( '', $captured_body );
 		$wc_order      = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'get_id' )->andReturn( 1 );
 
 		$testee->create_order( 'vault-abc-123', $wc_order );
 
@@ -164,6 +190,7 @@ class CaptureCardPaymentTest extends TestCase {
 		$captured_body = array();
 		$testee        = $this->make_testee( 'SCA_WHEN_REQUIRED', $captured_body );
 		$wc_order      = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'get_id' )->andReturn( 1 );
 
 		$testee->create_order( 'vault-abc-123', $wc_order );
 

--- a/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
@@ -57,12 +57,14 @@ class CaptureCardPaymentTest extends TestCase {
 		);
 
 		$experience_context_builder = Mockery::mock( ExperienceContextBuilder::class );
-		$experience_context_builder->shouldReceive( 'with_custom_return_url' )->andReturnSelf();
-		$experience_context_builder->shouldReceive( 'with_custom_cancel_url' )->andReturnSelf();
-		$experience_context_builder->shouldReceive( 'build' )->andReturn( $experience_context );
+		$experience_context_builder->allows( 'with_custom_return_url' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_custom_cancel_url' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_current_locale' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_current_brand_name' )->andReturnSelf();
+		$experience_context_builder->allows( 'build' )->andReturn( $experience_context );
 
 		$logger = Mockery::mock( LoggerInterface::class );
-		$logger->shouldReceive( 'debug' )->zeroOrMoreTimes();
+		$logger->allows( 'debug' );
 
 		when( 'home_url' )->alias( function ( string $path = '' ): string {
 			return 'https://example.com' . $path;

--- a/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
@@ -154,6 +154,29 @@ class CaptureCardPaymentTest extends TestCase {
 		);
 	}
 
+	/**
+	 * GIVEN a vaulted card charge is built by create_order
+	 * WHEN the request body is inspected
+	 * THEN payment_source.card.experience_context exists and is a non-empty array
+	 * AND experience_context.return_url is a non-empty string
+	 */
+	public function test_create_order_includes_experience_context_with_return_url(): void {
+		$captured_body = array();
+		$testee        = $this->make_testee( 'SCA_WHEN_REQUIRED', $captured_body );
+		$wc_order      = Mockery::mock( WC_Order::class );
+
+		$testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertTrue(
+			array_key_exists( 'experience_context', $captured_body['payment_source']['card'] ),
+			'create_order() must include payment_source.card.experience_context with a return_url'
+		);
+		$this->assertNotEmpty(
+			$captured_body['payment_source']['card']['experience_context']['return_url'] ?? null,
+			'create_order() must include payment_source.card.experience_context with a return_url'
+		);
+	}
+
 	public function three_d_secure_enum_provider(): array {
 		return [
 			'SCA_WHEN_REQUIRED setting' => [ 'SCA_WHEN_REQUIRED' ],

--- a/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/CreditCardGatewayTest.php
@@ -88,6 +88,7 @@ class CreditCardGatewayTest extends TestCase
 	public function testProcessPayment()
 	{
 		$wc_order = Mockery::mock(WC_Order::class);
+		$wc_order->shouldReceive('get_meta')->andReturn('');
 		when('wc_get_order')->justReturn($wc_order);
 
 		$woocommerce = Mockery::mock(\WooCommerce::class);

--- a/tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php
+++ b/tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Transaction;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\Tests\Integration\IntegrationMockedTestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CaptureCardPayment;
+use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+
+/**
+ * @group transactions
+ */
+class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
+{
+	/**
+	 * @var callable|null Filter registered to expose the credit-card gateway; removed in tearDown.
+	 */
+	private $register_cc_gateway_filter = null;
+
+	/**
+	 * GIVEN a saved card whose issuer requires 3D Secure
+	 * AND PayPal returns the created order with a payer-action link
+	 * WHEN the saved card is charged through the credit card gateway
+	 * THEN the buyer is redirected to the payer-action URL
+	 * AND the order stores a resume nonce and the PayPal order id
+	 */
+	public function test_saved_card_requiring_3ds_redirects_to_payer_action()
+	{
+		wp_set_current_user($this->customer_id);
+
+		// WC core's get_tokens() only returns tokens whose gateway_id is a
+		// registered payment gateway. In a live DCC checkout the credit-card
+		// gateway is registered; this test env does not enable it, so register
+		// it here or the saved token would be filtered out before the vault
+		// branch can match it.
+		$this->registerCreditCardGateway();
+
+		$token = $this->createAPaymentTokenForTheCustomer($this->customer_id, 'ppcp-credit-card-gateway');
+
+		$order = $this->getConfiguredOrder(
+			$this->customer_id,
+			'ppcp-credit-card-gateway',
+			['simple'],
+			[],
+			false
+		);
+
+		$payer_action_url = 'https://www.sandbox.paypal.com/checkoutnow?token=PP-ORDER-3DS';
+
+		$created_order = Mockery::mock(Order::class)->shouldIgnoreMissing();
+		$created_order->shouldReceive('id')->andReturn('PP-ORDER-3DS');
+		$created_order->shouldReceive('intent')->andReturn('CAPTURE');
+		$created_order->shouldReceive('payment_source')->andReturn(null);
+		$created_order->shouldReceive('payer')->andReturn(null);
+		$created_order->shouldReceive('purchase_units')->andReturn([]);
+		$created_order->shouldReceive('links')->andReturn([
+			(object) ['rel' => 'self', 'href' => 'https://api.paypal.com/v2/checkout/orders/PP-ORDER-3DS'],
+			(object) ['rel' => 'payer-action', 'href' => $payer_action_url],
+		]);
+
+		$captureCardPayment = Mockery::mock(CaptureCardPayment::class);
+		$captureCardPayment->shouldReceive('create_order')->andReturn($created_order);
+
+		$orderEndpoint = Mockery::mock(OrderEndpoint::class);
+		$orderEndpoint->shouldReceive('order')->andReturn($created_order);
+
+		$c = $this->bootstrapModule([
+			'wcgateway.endpoint.capture-card-payment' => function () use ($captureCardPayment) {
+				return $captureCardPayment;
+			},
+			'api.endpoint.order' => function () use ($orderEndpoint) {
+				return $orderEndpoint;
+			},
+		]);
+
+		$_POST['wc-ppcp-credit-card-gateway-payment-token'] = (string) $token->get_id();
+
+		$gateway = $c->get('wcgateway.credit-card-gateway');
+		$result = $gateway->process_payment($order->get_id());
+
+		$this->assertSame('success', $result['result']);
+		$this->assertSame($payer_action_url, $result['redirect']);
+
+		$order = wc_get_order($order->get_id());
+		$this->assertNotEmpty($order->get_meta(CreditCardGateway::THREE_DS_RESUME_META));
+		$this->assertSame('PP-ORDER-3DS', $order->get_meta(PayPalGateway::ORDER_ID_META_KEY));
+
+		unset($_POST['wc-ppcp-credit-card-gateway-payment-token']);
+	}
+
+	/**
+	 * GIVEN an order with a stored resume nonce and PayPal order id
+	 * AND the buyer returns with the matching nonce in the URL
+	 * AND PayPal reports the order as capturable and the capture completes
+	 * WHEN the payment is processed
+	 * THEN the order is captured and reaches the processing status
+	 * AND the resume nonce is cleared
+	 */
+	public function test_returning_from_3ds_captures_and_completes_the_order()
+	{
+		$order = $this->getConfiguredOrder(
+			$this->customer_id,
+			'ppcp-credit-card-gateway',
+			['simple'],
+			[],
+			false
+		);
+		$resume_nonce = 'test-resume-nonce-abc123';
+		$order->update_meta_data(CreditCardGateway::THREE_DS_RESUME_META, $resume_nonce);
+		$order->update_meta_data(PayPalGateway::ORDER_ID_META_KEY, 'PP-ORDER-3DS');
+		$order->save();
+
+		$orderEndpoint = $this->mockOrderEndpoint('CAPTURE', true, true);
+
+		$sessionHandler = Mockery::mock(SessionHandler::class);
+		$sessionHandler->shouldReceive('order')->andReturn(null);
+		$sessionHandler->shouldReceive('destroy_session_data')->andReturnSelf();
+
+		$c = $this->bootstrapModule([
+			'api.endpoint.order' => function () use ($orderEndpoint) {
+				return $orderEndpoint;
+			},
+			'session.handler' => function () use ($sessionHandler) {
+				return $sessionHandler;
+			},
+		]);
+
+		$_GET['ppcp_resume_wc_order'] = (string) $order->get_id();
+		$_GET['ppcp_resume_nonce']    = $resume_nonce;
+
+		$gateway = $c->get('wcgateway.credit-card-gateway');
+		$result = $gateway->process_payment($order->get_id());
+
+		unset($_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce']);
+
+		$this->assertSame('success', $result['result']);
+
+		$order = wc_get_order($order->get_id());
+		$this->assertSame('processing', $order->get_status());
+		$this->assertNotEmpty($order->get_transaction_id());
+		$this->assertEmpty($order->get_meta(CreditCardGateway::THREE_DS_RESUME_META));
+	}
+
+	/**
+	 * GIVEN a resume request whose ppcp_resume_wc_order points to an order that has
+	 * NO stored resume nonce (e.g. a guessed/arbitrary order id)
+	 * AND a nonce is supplied in the URL
+	 * WHEN the return endpoint handles it
+	 * THEN payment processing is not invoked and the order is left untouched
+	 */
+	public function test_resume_ignores_order_without_stored_nonce()
+	{
+		$order = $this->getConfiguredOrder(
+			$this->customer_id,
+			PayPalGateway::ID,
+			['simple'],
+			[],
+			false
+		);
+		$status_before = $order->get_status();
+
+		$_GET['ppcp_resume_wc_order'] = (string) $order->get_id();
+		$_GET['ppcp_resume_nonce']    = 'any-nonce';
+
+		$this->invokeResume();
+
+		unset($_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce']);
+
+		$this->assertSame($status_before, wc_get_order($order->get_id())->get_status());
+	}
+
+	/**
+	 * GIVEN an order that is awaiting a 3D Secure resume (a nonce is stored)
+	 * AND the buyer/attacker returns with a nonce that does NOT match
+	 * WHEN the return endpoint handles it
+	 * THEN payment processing is not invoked and the order is left untouched
+	 */
+	public function test_resume_rejects_mismatched_nonce()
+	{
+		$order = $this->getConfiguredOrder(
+			$this->customer_id,
+			PayPalGateway::ID,
+			['simple'],
+			[],
+			false
+		);
+		$order->update_meta_data(CreditCardGateway::THREE_DS_RESUME_META, 'the-real-nonce');
+		$order->save();
+		$status_before = $order->get_status();
+
+		$_GET['ppcp_resume_wc_order'] = (string) $order->get_id();
+		$_GET['ppcp_resume_nonce']    = 'a-guessed-nonce';
+
+		$this->invokeResume();
+
+		unset($_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce']);
+
+		$this->assertSame($status_before, wc_get_order($order->get_id())->get_status());
+		$this->assertSame('the-real-nonce', wc_get_order($order->get_id())->get_meta(CreditCardGateway::THREE_DS_RESUME_META));
+	}
+
+	public function tearDown(): void
+	{
+		if (null !== $this->register_cc_gateway_filter) {
+			remove_filter('woocommerce_payment_gateways', $this->register_cc_gateway_filter);
+			$this->register_cc_gateway_filter = null;
+			WC()->payment_gateways()->init();
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Registers a minimal stub gateway under the credit-card gateway id so WC
+	 * core's WC_Payment_Token_Data_Store::get_tokens() does not filter out the
+	 * saved card token (it keeps only tokens whose gateway is registered).
+	 */
+	private function registerCreditCardGateway(): void
+	{
+		$stub     = new class extends \WC_Payment_Gateway {
+			public function __construct()
+			{
+				$this->id = CreditCardGateway::ID;
+			}
+		};
+		$this->register_cc_gateway_filter = function (array $gateways) use ($stub): array {
+			$gateways[] = $stub;
+			return $gateways;
+		};
+		add_filter('woocommerce_payment_gateways', $this->register_cc_gateway_filter);
+		WC()->payment_gateways()->init();
+	}
+
+	/**
+	 * Invokes the private ReturnUrlEndpoint::maybe_resume_card_3ds() with a gateway
+	 * that must never be asked to process a payment, so a rejected resume is proven
+	 * by process_payment not being called and the order being left untouched.
+	 */
+	private function invokeResume(): void
+	{
+		$gateway = Mockery::mock(PayPalGateway::class);
+		$gateway->id = PayPalGateway::ID;
+		$gateway->shouldNotReceive('process_payment');
+
+		$endpoint = new ReturnUrlEndpoint(
+			$gateway,
+			Mockery::mock(OrderEndpoint::class),
+			Mockery::mock(SessionHandler::class),
+			Mockery::mock(LoggerInterface::class)
+		);
+
+		$method = new \ReflectionMethod(ReturnUrlEndpoint::class, 'maybe_resume_card_3ds');
+		$method->setAccessible(true);
+		$method->invoke($endpoint);
+	}
+}

--- a/tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php
+++ b/tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php
@@ -4,6 +4,7 @@ namespace WooCommerce\PayPalCommerce\Tests\Integration\Transaction;
 
 use Mockery;
 use Psr\Log\LoggerInterface;
+use WC_Payment_Gateway;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -12,16 +13,26 @@ use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CaptureCardPayment;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\ReturnUrlEndpoint;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\AuthorizedPaymentsProcessor;
 
 /**
  * @group transactions
  */
-class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
-{
+class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase {
 	/**
 	 * @var callable|null Filter registered to expose the credit-card gateway; removed in tearDown.
 	 */
 	private $register_cc_gateway_filter = null;
+
+	public function tearDown(): void {
+		if ( null !== $this->register_cc_gateway_filter ) {
+			remove_filter( 'woocommerce_payment_gateways', $this->register_cc_gateway_filter );
+			$this->register_cc_gateway_filter = null;
+			WC()->payment_gateways()->init();
+		}
+
+		parent::tearDown();
+	}
 
 	/**
 	 * GIVEN a saved card whose issuer requires 3D Secure
@@ -30,9 +41,8 @@ class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
 	 * THEN the buyer is redirected to the payer-action URL
 	 * AND the order stores a resume nonce and the PayPal order id
 	 */
-	public function test_saved_card_requiring_3ds_redirects_to_payer_action()
-	{
-		wp_set_current_user($this->customer_id);
+	public function test_saved_card_requiring_3ds_redirects_to_payer_action() {
+		wp_set_current_user( $this->customer_id );
 
 		// WC core's get_tokens() only returns tokens whose gateway_id is a
 		// registered payment gateway. In a live DCC checkout the credit-card
@@ -41,57 +51,59 @@ class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
 		// branch can match it.
 		$this->registerCreditCardGateway();
 
-		$token = $this->createAPaymentTokenForTheCustomer($this->customer_id, 'ppcp-credit-card-gateway');
+		$token = $this->createAPaymentTokenForTheCustomer(
+			$this->customer_id,
+			'ppcp-credit-card-gateway'
+		);
 
 		$order = $this->getConfiguredOrder(
 			$this->customer_id,
 			'ppcp-credit-card-gateway',
-			['simple'],
-			[],
+			array( 'simple' ),
+			array(),
 			false
 		);
 
 		$payer_action_url = 'https://www.sandbox.paypal.com/checkoutnow?token=PP-ORDER-3DS';
 
-		$created_order = Mockery::mock(Order::class)->shouldIgnoreMissing();
-		$created_order->shouldReceive('id')->andReturn('PP-ORDER-3DS');
-		$created_order->shouldReceive('intent')->andReturn('CAPTURE');
-		$created_order->shouldReceive('payment_source')->andReturn(null);
-		$created_order->shouldReceive('payer')->andReturn(null);
-		$created_order->shouldReceive('purchase_units')->andReturn([]);
-		$created_order->shouldReceive('links')->andReturn([
-			(object) ['rel' => 'self', 'href' => 'https://api.paypal.com/v2/checkout/orders/PP-ORDER-3DS'],
-			(object) ['rel' => 'payer-action', 'href' => $payer_action_url],
-		]);
+		$created_order = Mockery::mock( Order::class )->shouldIgnoreMissing();
+		$created_order->shouldReceive( 'id' )->andReturn( 'PP-ORDER-3DS' );
+		$created_order->shouldReceive( 'intent' )->andReturn( 'CAPTURE' );
+		$created_order->shouldReceive( 'payment_source' )->andReturn( null );
+		$created_order->shouldReceive( 'payer' )->andReturn( null );
+		$created_order->shouldReceive( 'purchase_units' )->andReturn( [] );
+		$created_order->shouldReceive( 'links' )->andReturn( [
+			(object) array(
+				'rel'  => 'self',
+				'href' => 'https://api.paypal.com/v2/checkout/orders/PP-ORDER-3DS',
+			),
+			(object) array( 'rel' => 'payer-action', 'href' => $payer_action_url ),
+		] );
 
-		$captureCardPayment = Mockery::mock(CaptureCardPayment::class);
-		$captureCardPayment->shouldReceive('create_order')->andReturn($created_order);
+		$captureCardPayment = Mockery::mock( CaptureCardPayment::class );
+		$captureCardPayment->shouldReceive( 'create_order' )->andReturn( $created_order );
 
-		$orderEndpoint = Mockery::mock(OrderEndpoint::class);
-		$orderEndpoint->shouldReceive('order')->andReturn($created_order);
+		$orderEndpoint = Mockery::mock( OrderEndpoint::class );
+		$orderEndpoint->shouldReceive( 'order' )->andReturn( $created_order );
 
-		$c = $this->bootstrapModule([
-			'wcgateway.endpoint.capture-card-payment' => function () use ($captureCardPayment) {
-				return $captureCardPayment;
-			},
-			'api.endpoint.order' => function () use ($orderEndpoint) {
-				return $orderEndpoint;
-			},
-		]);
+		$c = $this->bootstrapModule( array(
+			'wcgateway.endpoint.capture-card-payment' => fn() => $captureCardPayment,
+			'api.endpoint.order'                      => fn() => $orderEndpoint,
+		) );
 
 		$_POST['wc-ppcp-credit-card-gateway-payment-token'] = (string) $token->get_id();
 
-		$gateway = $c->get('wcgateway.credit-card-gateway');
-		$result = $gateway->process_payment($order->get_id());
+		$gateway = $c->get( 'wcgateway.credit-card-gateway' );
+		$result  = $gateway->process_payment( $order->get_id() );
 
-		$this->assertSame('success', $result['result']);
-		$this->assertSame($payer_action_url, $result['redirect']);
+		$this->assertSame( 'success', $result['result'] );
+		$this->assertSame( $payer_action_url, $result['redirect'] );
 
-		$order = wc_get_order($order->get_id());
-		$this->assertNotEmpty($order->get_meta(CreditCardGateway::THREE_DS_RESUME_META));
-		$this->assertSame('PP-ORDER-3DS', $order->get_meta(PayPalGateway::ORDER_ID_META_KEY));
+		$order = wc_get_order( $order->get_id() );
+		$this->assertNotEmpty( $order->get_meta( CreditCardGateway::THREE_DS_RESUME_META ) );
+		$this->assertSame( 'PP-ORDER-3DS', $order->get_meta( PayPalGateway::ORDER_ID_META_KEY ) );
 
-		unset($_POST['wc-ppcp-credit-card-gateway-payment-token']);
+		unset( $_POST['wc-ppcp-credit-card-gateway-payment-token'] );
 	}
 
 	/**
@@ -102,49 +114,45 @@ class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
 	 * THEN the order is captured and reaches the processing status
 	 * AND the resume nonce is cleared
 	 */
-	public function test_returning_from_3ds_captures_and_completes_the_order()
-	{
+	public function test_returning_from_3ds_captures_and_completes_the_order() {
 		$order = $this->getConfiguredOrder(
 			$this->customer_id,
 			'ppcp-credit-card-gateway',
-			['simple'],
-			[],
+			array( 'simple' ),
+			array(),
 			false
 		);
+
 		$resume_nonce = 'test-resume-nonce-abc123';
-		$order->update_meta_data(CreditCardGateway::THREE_DS_RESUME_META, $resume_nonce);
-		$order->update_meta_data(PayPalGateway::ORDER_ID_META_KEY, 'PP-ORDER-3DS');
+		$order->update_meta_data( CreditCardGateway::THREE_DS_RESUME_META, $resume_nonce );
+		$order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, 'PP-ORDER-3DS' );
 		$order->save();
 
-		$orderEndpoint = $this->mockOrderEndpoint('CAPTURE', true, true);
+		$orderEndpoint = $this->mockOrderEndpoint( 'CAPTURE', true, true );
 
-		$sessionHandler = Mockery::mock(SessionHandler::class);
-		$sessionHandler->shouldReceive('order')->andReturn(null);
-		$sessionHandler->shouldReceive('destroy_session_data')->andReturnSelf();
+		$sessionHandler = Mockery::mock( SessionHandler::class )->shouldIgnoreMissing();
+		$sessionHandler->shouldReceive( 'order' )->andReturn( null );
+		$sessionHandler->shouldReceive( 'destroy_session_data' )->andReturnSelf();
 
-		$c = $this->bootstrapModule([
-			'api.endpoint.order' => function () use ($orderEndpoint) {
-				return $orderEndpoint;
-			},
-			'session.handler' => function () use ($sessionHandler) {
-				return $sessionHandler;
-			},
-		]);
+		$c = $this->bootstrapModule( array(
+			'api.endpoint.order' => fn() => $orderEndpoint,
+			'session.handler'    => fn() => $sessionHandler,
+		) );
 
 		$_GET['ppcp_resume_wc_order'] = (string) $order->get_id();
 		$_GET['ppcp_resume_nonce']    = $resume_nonce;
 
-		$gateway = $c->get('wcgateway.credit-card-gateway');
-		$result = $gateway->process_payment($order->get_id());
+		$gateway = $c->get( 'wcgateway.credit-card-gateway' );
+		$result  = $gateway->process_payment( $order->get_id() );
 
-		unset($_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce']);
+		unset( $_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce'] );
 
-		$this->assertSame('success', $result['result']);
+		$this->assertSame( 'success', $result['result'] );
 
-		$order = wc_get_order($order->get_id());
-		$this->assertSame('processing', $order->get_status());
-		$this->assertNotEmpty($order->get_transaction_id());
-		$this->assertEmpty($order->get_meta(CreditCardGateway::THREE_DS_RESUME_META));
+		$order = wc_get_order( $order->get_id() );
+		$this->assertSame( 'processing', $order->get_status() );
+		$this->assertNotEmpty( $order->get_transaction_id() );
+		$this->assertEmpty( $order->get_meta( CreditCardGateway::THREE_DS_RESUME_META ) );
 	}
 
 	/**
@@ -154,15 +162,15 @@ class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
 	 * WHEN the return endpoint handles it
 	 * THEN payment processing is not invoked and the order is left untouched
 	 */
-	public function test_resume_ignores_order_without_stored_nonce()
-	{
+	public function test_resume_ignores_order_without_stored_nonce() {
 		$order = $this->getConfiguredOrder(
 			$this->customer_id,
 			PayPalGateway::ID,
-			['simple'],
-			[],
+			array( 'simple' ),
+			array(),
 			false
 		);
+
 		$status_before = $order->get_status();
 
 		$_GET['ppcp_resume_wc_order'] = (string) $order->get_id();
@@ -170,9 +178,9 @@ class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
 
 		$this->invokeResume();
 
-		unset($_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce']);
+		unset( $_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce'] );
 
-		$this->assertSame($status_before, wc_get_order($order->get_id())->get_status());
+		$this->assertSame( $status_before, wc_get_order( $order->get_id() )->get_status() );
 	}
 
 	/**
@@ -181,16 +189,16 @@ class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
 	 * WHEN the return endpoint handles it
 	 * THEN payment processing is not invoked and the order is left untouched
 	 */
-	public function test_resume_rejects_mismatched_nonce()
-	{
+	public function test_resume_rejects_mismatched_nonce() {
 		$order = $this->getConfiguredOrder(
 			$this->customer_id,
 			PayPalGateway::ID,
-			['simple'],
-			[],
+			array( 'simple' ),
+			array(),
 			false
 		);
-		$order->update_meta_data(CreditCardGateway::THREE_DS_RESUME_META, 'the-real-nonce');
+
+		$order->update_meta_data( CreditCardGateway::THREE_DS_RESUME_META, 'the-real-nonce' );
 		$order->save();
 		$status_before = $order->get_status();
 
@@ -199,21 +207,136 @@ class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
 
 		$this->invokeResume();
 
-		unset($_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce']);
+		unset( $_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce'] );
 
-		$this->assertSame($status_before, wc_get_order($order->get_id())->get_status());
-		$this->assertSame('the-real-nonce', wc_get_order($order->get_id())->get_meta(CreditCardGateway::THREE_DS_RESUME_META));
+		$this->assertSame( $status_before, wc_get_order( $order->get_id() )->get_status() );
+		$this->assertSame( 'the-real-nonce', wc_get_order( $order->get_id() )->get_meta( CreditCardGateway::THREE_DS_RESUME_META ) );
 	}
 
-	public function tearDown(): void
-	{
-		if (null !== $this->register_cc_gateway_filter) {
-			remove_filter('woocommerce_payment_gateways', $this->register_cc_gateway_filter);
-			$this->register_cc_gateway_filter = null;
-			WC()->payment_gateways()->init();
-		}
+	/**
+	 * GIVEN an order with a matching stored resume nonce
+	 * AND the order's payment_method is not the injected gateway's id
+	 *     and is not registered as a WC payment gateway in this test environment
+	 * WHEN maybe_resume_card_3ds runs
+	 * THEN it returns early without invoking payment processing
+	 * AND the order status is unchanged and the stored nonce is still present
+	 */
+	public function test_resume_returns_when_gateway_not_found(): void {
+		$order = $this->getConfiguredOrder(
+			$this->customer_id,
+			'ppcp-credit-card-gateway',
+			array( 'simple' ),
+			array(),
+			false
+		);
 
-		parent::tearDown();
+		$resume_nonce = 'test-nonce-no-gateway';
+		$order->update_meta_data( CreditCardGateway::THREE_DS_RESUME_META, $resume_nonce );
+		$order->save();
+		$status_before = $order->get_status();
+
+		$_GET['ppcp_resume_wc_order'] = (string) $order->get_id();
+		$_GET['ppcp_resume_nonce']    = $resume_nonce;
+
+		$no_process_gateway     = Mockery::mock( PayPalGateway::class );
+		$no_process_gateway->id = PayPalGateway::ID;
+		$no_process_gateway->shouldNotReceive( 'process_payment' );
+
+		$this->invokeResume( $no_process_gateway );
+
+		unset( $_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce'] );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( $status_before, $refreshed->get_status() );
+		$this->assertSame( $resume_nonce, $refreshed->get_meta( CreditCardGateway::THREE_DS_RESUME_META ) );
+	}
+
+	/**
+	 * GIVEN an order with a matching stored resume nonce
+	 * AND the order's payment_method equals the injected gateway's id
+	 * AND the gateway's process_payment() returns a failure result (not a success array)
+	 * WHEN maybe_resume_card_3ds runs
+	 * THEN it returns without redirecting or exiting
+	 * AND the order is left untouched
+	 */
+	public function test_resume_returns_when_process_payment_fails(): void {
+		$order = $this->getConfiguredOrder(
+			$this->customer_id,
+			PayPalGateway::ID,
+			array( 'simple' ),
+			array(),
+			false
+		);
+
+		$resume_nonce = 'test-nonce-failure-result';
+		$order->update_meta_data( CreditCardGateway::THREE_DS_RESUME_META, $resume_nonce );
+		$order->save();
+		$status_before = $order->get_status();
+
+		$_GET['ppcp_resume_wc_order'] = (string) $order->get_id();
+		$_GET['ppcp_resume_nonce']    = $resume_nonce;
+
+		$failing_gateway     = Mockery::mock( PayPalGateway::class );
+		$failing_gateway->id = PayPalGateway::ID;
+		$failing_gateway->allows( 'process_payment' )->andReturn( [ 'result' => 'failure' ] );
+
+		$this->invokeResume( $failing_gateway );
+
+		unset( $_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce'] );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( $status_before, $refreshed->get_status() );
+	}
+
+	/**
+	 * GIVEN an order with a stored resume nonce and PayPal order id
+	 * AND the buyer returns with the matching nonce in the URL
+	 * AND PayPal returns an AUTHORIZE-intent order
+	 * WHEN the payment is processed via the resume path
+	 * THEN finalize_vaulted_card_order takes the AUTHORIZE branch:
+	 *      order_endpoint->authorize() is called and the order reaches on-hold status
+	 * AND the CAPTURED_META_KEY is set to 'false' on the WC order
+	 * AND the resume nonce is cleared
+	 */
+	public function test_returning_from_3ds_authorizes_the_order(): void {
+		$order = $this->getConfiguredOrder(
+			$this->customer_id,
+			'ppcp-credit-card-gateway',
+			array( 'simple' ),
+			array(),
+			false
+		);
+
+		$resume_nonce = 'test-resume-nonce-authorize';
+		$order->update_meta_data( CreditCardGateway::THREE_DS_RESUME_META, $resume_nonce );
+		$order->update_meta_data( PayPalGateway::ORDER_ID_META_KEY, 'PP-ORDER-AUTH' );
+		$order->save();
+
+		$orderEndpoint = $this->mockOrderEndpoint( 'AUTHORIZE', true, true );
+
+		$sessionHandler = Mockery::mock( SessionHandler::class )->shouldIgnoreMissing();
+		$sessionHandler->shouldReceive( 'order' )->andReturn( null );
+		$sessionHandler->shouldReceive( 'destroy_session_data' )->andReturnSelf();
+
+		$c = $this->bootstrapModule( array(
+			'api.endpoint.order' => fn() => $orderEndpoint,
+			'session.handler'    => fn() => $sessionHandler,
+		) );
+
+		$_GET['ppcp_resume_wc_order'] = (string) $order->get_id();
+		$_GET['ppcp_resume_nonce']    = $resume_nonce;
+
+		$gateway = $c->get( 'wcgateway.credit-card-gateway' );
+		$result  = $gateway->process_payment( $order->get_id() );
+
+		unset( $_GET['ppcp_resume_wc_order'], $_GET['ppcp_resume_nonce'] );
+
+		$this->assertSame( 'success', $result['result'] );
+
+		$refreshed = wc_get_order( $order->get_id() );
+		$this->assertSame( 'on-hold', $refreshed->get_status() );
+		$this->assertSame( 'false', $refreshed->get_meta( AuthorizedPaymentsProcessor::CAPTURED_META_KEY ) );
+		$this->assertEmpty( $refreshed->get_meta( CreditCardGateway::THREE_DS_RESUME_META ) );
 	}
 
 	/**
@@ -221,42 +344,49 @@ class VaultedCard3dsTransactionTest extends IntegrationMockedTestCase
 	 * core's WC_Payment_Token_Data_Store::get_tokens() does not filter out the
 	 * saved card token (it keeps only tokens whose gateway is registered).
 	 */
-	private function registerCreditCardGateway(): void
-	{
-		$stub     = new class extends \WC_Payment_Gateway {
-			public function __construct()
-			{
+	private function registerCreditCardGateway(): void {
+		$stub = new class extends WC_Payment_Gateway {
+			public function __construct() {
 				$this->id = CreditCardGateway::ID;
 			}
 		};
-		$this->register_cc_gateway_filter = function (array $gateways) use ($stub): array {
-			$gateways[] = $stub;
-			return $gateways;
-		};
-		add_filter('woocommerce_payment_gateways', $this->register_cc_gateway_filter);
+
+		$this->register_cc_gateway_filter =
+			static function ( array $gateways ) use ( $stub ): array {
+				$gateways[] = $stub;
+
+				return $gateways;
+			};
+
+		add_filter( 'woocommerce_payment_gateways', $this->register_cc_gateway_filter );
 		WC()->payment_gateways()->init();
 	}
 
 	/**
-	 * Invokes the private ReturnUrlEndpoint::maybe_resume_card_3ds() with a gateway
-	 * that must never be asked to process a payment, so a rejected resume is proven
-	 * by process_payment not being called and the order being left untouched.
+	 * Invokes the private ReturnUrlEndpoint::maybe_resume_card_3ds() with the
+	 * supplied gateway. Defaults to a gateway that must never be asked to process
+	 * a payment, so a rejected resume is proven by process_payment not being
+	 * called and the order being left untouched.
+	 *
+	 * @param WC_Payment_Gateway|null $gateway  Gateway to inject; null uses the default no-process
+	 *                                          mock.
 	 */
-	private function invokeResume(): void
-	{
-		$gateway = Mockery::mock(PayPalGateway::class);
-		$gateway->id = PayPalGateway::ID;
-		$gateway->shouldNotReceive('process_payment');
+	private function invokeResume( $gateway = null ): void {
+		if ( $gateway === null ) {
+			$gateway     = Mockery::mock( PayPalGateway::class );
+			$gateway->id = PayPalGateway::ID;
+			$gateway->shouldNotReceive( 'process_payment' );
+		}
 
 		$endpoint = new ReturnUrlEndpoint(
 			$gateway,
-			Mockery::mock(OrderEndpoint::class),
-			Mockery::mock(SessionHandler::class),
-			Mockery::mock(LoggerInterface::class)
+			Mockery::mock( OrderEndpoint::class ),
+			Mockery::mock( SessionHandler::class ),
+			Mockery::mock( LoggerInterface::class )
 		);
 
-		$method = new \ReflectionMethod(ReturnUrlEndpoint::class, 'maybe_resume_card_3ds');
-		$method->setAccessible(true);
-		$method->invoke($endpoint);
+		$method = new \ReflectionMethod( ReturnUrlEndpoint::class, 'maybe_resume_card_3ds' );
+		$method->setAccessible( true );
+		$method->invoke( $endpoint );
 	}
 }


### PR DESCRIPTION
# Description

## 🐛 The problem

Saved (vaulted) card payments failed consistently at checkout, while a fresh manually entered card always worked. Affected orders never left **"pending payment"**, or failed outright with a generic error.

## 💡 Why it happens

When a vaulted card's issuer mandates Strong Customer Authentication, PayPal does not charge the card immediately. It returns the order in `CREATED` / `PAYER_ACTION_REQUIRED` status together with a `payer-action` link the buyer must visit to complete a 3D Secure challenge.

The saved-card path never handled that step. It assumed the charge was always frictionless: it tried to capture right away and, when PayPal had instead handed back a challenge link, there was nothing to capture. The order was left stuck.

Two pieces were missing:
- The request never asked PayPal to run 3D Secure, so SCA-required cards had no path to authenticate.
- There was no return handling to resume the capture after the buyer completed the challenge.

## ✅ The fix

The vaulted-card charge now drives the full 3D Secure round trip.

- **Request the challenge.** `CaptureCardPayment::create_order()` adds the merchant's configured 3DS contingency (`SCA_WHEN_REQUIRED` / `SCA_ALWAYS`) and an `experience_context` (locale, brand name, return and cancel URLs) so PayPal can present a branded, localized challenge and return the buyer to the right place.
- **Redirect on step-up.** When PayPal returns a `payer-action` link, `CreditCardGateway` stores a one-time nonce on the order and redirects the buyer to the challenge instead of trying to capture.
- **Resume on return.** `ReturnUrlEndpoint::maybe_resume_card_3ds()` handles the return (which arrives without the PayPal order token), matches the nonce, and re-runs payment processing to capture the now-authenticated order.
- **Shared finalize.** Authorize/capture, transaction-id recording, status transition and the stuck-order safety net are extracted into `finalize_vaulted_card_order()`, used by both the initial charge and the resume so the two paths stay identical and idempotent.

A frictionless saved card (no `payer-action` link) charges directly, exactly as before, and now skips a redundant order fetch on that path.

## 🔍 What to review

- **The nonce is the only thing guarding the resume.** The WC order id travels in a public, guessable query argument on the return URL; the PayPal order token does not come back. Authorization rests entirely on the one-time `_ppcp_card_3ds_resume` nonce stored on the order, compared with `hash_equals` and cleared on first use. Please scrutinize that a crafted return URL cannot trigger a capture, and that the nonce is genuinely single-use (a new attempt overwrites it, so only the latest challenge is resumable).
- **Resume re-enters `process_payment`.** The return handler calls the gateway's `process_payment` again rather than capturing directly. Worth confirming this is safe to run twice and that `finalize_vaulted_card_order`'s status checks keep it idempotent if PayPal already advanced the order during the return.
- **3DS only fires when the merchant enabled it.** If the 3DS setting is empty, no verification is requested and behavior is unchanged. The new flow is only exercised for merchants with 3DS configured.

## 🧪 Tests

Unit tests cover the request-body construction (vault id, stored-credential, 3DS verification method present/absent, experience context). A new integration test, `VaultedCard3dsTransactionTest`, exercises the end-to-end flow: redirect to the challenge, resume-and-capture, resume-and-authorize, and the rejection branches (unknown gateway, nonce mismatch, failed re-processing). The CAPTURE and AUTHORIZE intents are both covered.

## 🧪 How to verify

1. In **PayPal Payments → Settings**:
   - **Common Settings:** enable "Save PayPal and Venmo" and "Save Credit and Debit Cards".
   - **Other Payment Method Settings:** set **3D Secure: ALWAYS**.
2. As a logged-in user, check out on classic checkout, enter card `4000 0000 0000 2503` (a PayPal 3DS test card), and tick **Save Card** to vault it.
3. Check out again using that saved card → you are redirected to the 3DS challenge.
4. Complete the challenge → you return to the shop and the order reaches **processing/completed** (or **on-hold** for AUTHORIZE intent).
5. Cancel the challenge instead → the order stays unpaid and you land back on checkout.

### Sample
https://github.com/user-attachments/assets/0d1b1fe0-5e94-4e70-966b-765c1b119324
