### PR TITLE
Vaulting subscriptions fail with 100% discount coupons (CANNOT_BE_ZERO_OR_NEGATIVE) (6553)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/paypal-saved-token.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal-saved-token.js
@@ -38,8 +38,15 @@ export const PayPalSavedToken = ( {
 	const vaultData = config?.scriptData?.vault_component;
 	const isVaultEligible = vaultData?.is_eligible === true;
 	const isSavedTokenSelected = token && token !== '0' && token !== 0;
+	// A zero-total subscription cart (free trial or 100% coupon) must use the
+	// save-without-purchase flow. The Vault Component is order-based and would
+	// create a $0 order, which PayPal rejects with CANNOT_BE_ZERO_OR_NEGATIVE.
+	const isFreeTrial = config?.scriptData?.is_free_trial_cart === true;
 	const shouldShowVaultComponent =
-		isVaultEligible && isSavedTokenSelected && ! vaultRenderFailed;
+		isVaultEligible &&
+		isSavedTokenSelected &&
+		! isFreeTrial &&
+		! vaultRenderFailed;
 
 	const handleVaultRenderError = useCallback( () => {
 		setVaultRenderFailed( true );

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstrap.js
@@ -247,6 +247,12 @@ class CheckoutBootstrap {
 		setVisibleByClass(
 			this.standardOrderButtonSelector,
 			( isPaypal && isFreeTrial && hasVaultedPaypal ) ||
+				// On a zero-total cart the Vault Component is disabled, so selecting a
+				// saved PayPal token must show the standard "Place order" button. The
+				// saved token completes via process_payment's free-trial short-circuit.
+				( isPaypal &&
+					isFreeTrial &&
+					this.isSavedPayPalTokenSelected() ) ||
 				isNotOurGateway ||
 				isSavedCard ||
 				( isPaypal && ! useSmartButtons ) ||

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstrap.js
@@ -229,7 +229,11 @@ class CheckoutBootstrap {
 		const hasVaultedPaypal =
 			!! PayPalCommerceGateway.vaulted_paypal_email;
 		const useSmartButtons = this.renderer.useSmartButtons ?? true;
-		const showVaultComponent = !! this.vaultRenderer && isPaypal;
+		// A zero-total subscription cart (free trial or 100% coupon) must use the
+		// save-without-purchase flow. The Vault Component is order-based and would
+		// create a $0 order, which PayPal rejects with CANNOT_BE_ZERO_OR_NEGATIVE.
+		const showVaultComponent =
+			!! this.vaultRenderer && isPaypal && ! isFreeTrial;
 
 		const paypalButtonWrappers = {
 			...Object.entries( PayPalCommerceGateway.separate_buttons ).reduce(

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CheckoutBootstrap.js
@@ -61,6 +61,12 @@ class CheckoutBootstrap {
 			this.render();
 			this.handleButtonStatus();
 
+			// The free-trial flag is localized once at page load. Applying a coupon that
+			// turns a subscription cart into a $0 total (or removing it) happens via AJAX
+			// without a reload, leaving the flag stale and the button on the wrong flow.
+			// Re-fetch it and re-render the button when it changed.
+			this.refreshFreeTrialState();
+
 			if (
 				this.shouldShowMessages() &&
 				document.querySelector( this.gateway.messages.wrapper )
@@ -360,6 +366,38 @@ class CheckoutBootstrap {
 		);
 		jQuery( '#ppcp-credit-card-vault' ).attr( 'disabled', true );
 		this.renderer.disableCreditCardFields();
+	}
+
+	/**
+	 * Re-fetches the free-trial state for the current cart and, if it changed since the
+	 * page loaded (e.g. a 100% coupon zeroed a subscription cart, or was removed),
+	 * updates the flag and re-renders the PayPal button so it switches between the
+	 * normal order flow and the save-without-purchase (setup-token) flow.
+	 */
+	refreshFreeTrialState() {
+		const endpoint = this.gateway?.ajax?.cart_script_params?.endpoint;
+		if ( ! endpoint ) {
+			return;
+		}
+
+		fetch( endpoint, { method: 'GET', credentials: 'same-origin' } )
+			.then( ( result ) => result.json() )
+			.then( ( result ) => {
+				if ( ! result.success ) {
+					return;
+				}
+
+				const fresh = result.data?.is_free_trial_cart === true;
+				if ( fresh === ( PayPalCommerceGateway.is_free_trial_cart === true ) ) {
+					return;
+				}
+
+				PayPalCommerceGateway.is_free_trial_cart = fresh;
+				this.renderer.resetRenderedButtons( this.gateway.button.wrapper );
+				this.render();
+				this.updateUi();
+			} )
+			.catch( () => {} );
 	}
 
 	isSavedPayPalTokenSelected() {

--- a/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/Renderer.js
@@ -264,6 +264,27 @@ class Renderer {
 		return this.renderedSources.has( wrapper + ( fundingSource ?? '' ) );
 	}
 
+	/**
+	 * Clears the rendered state for a wrapper (across all funding sources) and empties
+	 * its DOM so a subsequent render() rebuilds the buttons with a fresh configuration.
+	 * Used when the cart changes the button flow, e.g. a coupon turning a subscription
+	 * cart into a $0 total that must switch to the save-without-purchase flow.
+	 *
+	 * @param {string} wrapper The wrapper selector.
+	 */
+	resetRenderedButtons( wrapper ) {
+		for ( const key of [ ...this.renderedSources ] ) {
+			if ( key === wrapper || key.startsWith( wrapper ) ) {
+				this.renderedSources.delete( key );
+			}
+		}
+		widgetBuilder.removeButtons( wrapper );
+		const element = document.querySelector( wrapper );
+		if ( element ) {
+			element.innerHTML = '';
+		}
+	}
+
 	disableCreditCardFields() {
 		this.creditCardRenderer.disableFields();
 	}

--- a/modules/ppcp-button/resources/js/modules/Renderer/WidgetBuilder.js
+++ b/modules/ppcp-button/resources/js/modules/Renderer/WidgetBuilder.js
@@ -77,6 +77,24 @@ class WidgetBuilder {
 		}
 	}
 
+	/**
+	 * Forgets every registered button belonging to the given wrapper so it can be
+	 * re-registered with a different configuration (e.g. switching the checkout
+	 * button between the order and the save-without-purchase flow).
+	 *
+	 * @param {string} wrapper The wrapper selector.
+	 */
+	removeButtons( wrapper ) {
+		for ( const [ key, entry ] of this.buttons ) {
+			const entryWrapper = Array.isArray( entry.wrapper )
+				? entry.wrapper[ 0 ]
+				: entry.wrapper;
+			if ( entryWrapper === wrapper ) {
+				this.buttons.delete( key );
+			}
+		}
+	}
+
 	registerMessages( wrapper, options ) {
 		this.messages.set( wrapper, {
 			wrapper,

--- a/modules/ppcp-button/src/Endpoint/CartScriptParamsEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CartScriptParamsEndpoint.php
@@ -88,15 +88,20 @@ class CartScriptParamsEndpoint implements EndpointInterface {
 			$currency_code     = get_woocommerce_currency();
 
 			$response = array(
-				'url_params'    => $script_data['url_params'],
-				'button'        => $script_data['button'],
-				'messages'      => $script_data['messages'],
-				'amount'        => WC()->cart->get_total( 'raw' ),
+				'url_params'         => $script_data['url_params'],
+				'button'             => $script_data['button'],
+				'messages'           => $script_data['messages'],
+				'amount'             => WC()->cart->get_total( 'raw' ),
 
-				'total'         => $total,
-				'total_str'     => ( new Money( $total, $currency_code ) )->value_str(),
-				'currency_code' => $currency_code,
-				'country_code'  => $shop_country_code,
+				// Recomputed against the current cart so the client can re-route the
+				// button to the save-without-purchase flow when a coupon turns a
+				// subscription cart into a $0 total after the page has loaded.
+				'is_free_trial_cart' => (bool) ( $script_data['is_free_trial_cart'] ?? false ),
+
+				'total'              => $total,
+				'total_str'          => ( new Money( $total, $currency_code ) )->value_str(),
+				'currency_code'      => $currency_code,
+				'country_code'       => $shop_country_code,
 			);
 
 			if ( $include_shipping ) {

--- a/modules/ppcp-vault-component/services.php
+++ b/modules/ppcp-vault-component/services.php
@@ -11,6 +11,7 @@ use WooCommerce\PayPalCommerce\VaultComponent\Authentication\VaultClientToken;
 use WooCommerce\PayPalCommerce\VaultComponent\Endpoint\CreateVaultOrderEndpoint;
 use WooCommerce\PayPalCommerce\VaultComponent\Helper\VaultComponentApplies;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 return array(
@@ -21,8 +22,16 @@ return array(
 		$settings_provider = $container->get( 'settings.settings-provider' );
 		assert( $settings_provider instanceof SettingsProvider );
 
-		return static function () use ( $vault_component_applies, $settings_provider ): bool {
+		$free_trial_helper = $container->get( 'wc-subscriptions.free-trial-subscription-helper' );
+		assert( $free_trial_helper instanceof FreeTrialSubscriptionHelper );
+
+		return static function () use ( $vault_component_applies, $settings_provider, $free_trial_helper ): bool {
+			// A zero-total subscription cart (free trial or 100% coupon) uses the
+			// save-without-purchase flow. The order-based Vault Component would
+			// create a $0 order (rejected by PayPal with CANNOT_BE_ZERO_OR_NEGATIVE)
+			// and only renders an empty paysheet, so disable it entirely here.
 			return $settings_provider->save_paypal_and_venmo()
+				&& ! $free_trial_helper->is_free_trial_cart()
 				&& $vault_component_applies->for_country()
 				&& $vault_component_applies->for_merchant();
 		};


### PR DESCRIPTION
When Vaulting is enabled for PayPal/Venmo and a subscription product is fully discounted using a 100% coupon, checkout fails with a PayPal API validation error instead of allowing the order to be placed.

Error Message:
```
CANNOT_BE_ZERO_OR_NEGATIVE
Must be greater than zero. If the currency supports decimals, only two decimal place precision is support
```

### Steps To Reproduce
- Enable Vaulting (Save PayPal and Venmo).
- Add a subscription product to the cart.
- Apply a 100% discount coupon.
- Proceed to checkout.
- Attempt to complete checkout.