### PR TITLE
Validate PayPal response in card-vault order creation

### DIFF
--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -11,6 +11,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\RequestTrait;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
@@ -120,6 +121,22 @@ class CaptureCardPayment {
 		}
 
 		$decoded_response = json_decode( $response['body'] );
+		$status_code      = (int) wp_remote_retrieve_response_code( $response );
+		if ( ! in_array( $status_code, array( 200, 201 ), true ) ) {
+			$error = new PayPalApiException(
+				$decoded_response,
+				$status_code
+			);
+
+			$this->logger->warning(
+				sprintf(
+					'Failed to create order from card vault. PayPal API response: %1$s',
+					$error->getMessage()
+				)
+			);
+
+			throw $error;
+		}
 
 		return $this->order_factory->from_paypal_response( $decoded_response );
 	}

--- a/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Requests_Utility_CaseInsensitiveDictionary;
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class CaptureCardPaymentTest extends TestCase
+{
+	/**
+	 * Regression test for #4353: when PayPal's v2/checkout/orders response is an
+	 * error (non-2xx, no `id`), create_order() must surface a PayPalApiException
+	 * with PayPal's actual error, not the opaque "Order does not contain an id."
+	 * RuntimeException raised by OrderFactory when it parses an error body.
+	 */
+	public function testCreateOrderThrowsPayPalApiExceptionOnErrorResponse(): void
+	{
+		when('wp_json_encode')->alias('json_encode');
+		when('trailingslashit')->returnArg();
+		when('wp_remote_retrieve_response_code')->justReturn(422);
+
+		$host = 'https://example.com/';
+
+		$token = Mockery::mock(Token::class);
+		$token->shouldReceive('token')->andReturn('bearer');
+		$bearer = Mockery::mock(Bearer::class);
+		$bearer->shouldReceive('bearer')->andReturn($token);
+
+		$purchaseUnit = Mockery::mock(PurchaseUnit::class);
+		$purchaseUnit->shouldReceive('to_array')->andReturn([]);
+		$purchaseUnitFactory = Mockery::mock(PurchaseUnitFactory::class);
+		$purchaseUnitFactory->shouldReceive('from_wc_order')->andReturn($purchaseUnit);
+
+		// If the response validation is missing, the error body falls through to
+		// the factory; we let it "succeed" here so the only way the test passes
+		// is the new PayPalApiException guard firing first.
+		$orderFactory = Mockery::mock(OrderFactory::class);
+		$orderFactory->shouldReceive('from_paypal_response')->andReturn(Mockery::mock(Order::class));
+
+		$settingsProvider = Mockery::mock(SettingsProvider::class);
+		$settingsProvider->shouldReceive('payment_intent')->andReturn('CAPTURE');
+
+		$logger = Mockery::mock(LoggerInterface::class);
+		$logger->shouldReceive('debug');
+		$logger->shouldReceive('warning');
+
+		$headers = Mockery::mock(Requests_Utility_CaseInsensitiveDictionary::class);
+		$headers->shouldReceive('getAll')->andReturn([]);
+
+		$rawResponse = [
+			'body'    => '{"name":"UNPROCESSABLE_ENTITY","message":"The requested action could not be performed."}',
+			'headers' => $headers,
+		];
+
+		expect('wp_remote_get')->andReturn($rawResponse);
+
+		$testee = new CaptureCardPayment(
+			$host,
+			$bearer,
+			$orderFactory,
+			$purchaseUnitFactory,
+			$settingsProvider,
+			$logger
+		);
+
+		$this->expectException(PayPalApiException::class);
+
+		$testee->create_order('vault-123', Mockery::mock(WC_Order::class));
+	}
+}


### PR DESCRIPTION
**Issue**: #4353

### Description

`CaptureCardPayment::create_order()` (Advanced Card Processing with a saved card / vault id) only guarded against a `WP_Error` transport failure, then decoded the body and handed it straight to `OrderFactory::from_paypal_response()` with no HTTP status check. When PayPal's `v2/checkout/orders` call returns a non-2xx error response (which has no `id`), `OrderFactory` throws the misleading `RuntimeException('Order does not contain an id.')`, the order is marked Failed, and the real PayPal error is lost. Retrying the same payment then succeeds, which matches the intermittent reports in #4353.

This mirrors the response handling already used throughout `OrderEndpoint`: check `wp_remote_retrieve_response_code()` and, on a non-2xx status, throw a `PayPalApiException` built from the decoded body (so PayPal's `name` / `message` / `debug_id` are surfaced and logged) before attempting to parse it as an order.

### Steps to Test

1. Configure Advanced Card Processing with vaulting and a saved card.
2. Force the `v2/checkout/orders` call in `CaptureCardPayment::create_order()` to receive a non-2xx PayPal response (e.g. a 422 `UNPROCESSABLE_ENTITY` body with no `id`).
3. Before this change: the order fails with `Order does not contain an id.` and the actual PayPal error is not logged.
4. After this change: a `PayPalApiException` is thrown carrying PayPal's actual error, and a warning with the PayPal response is logged.
5. `composer unit` passes, including the new `CaptureCardPaymentTest`.

### Documentation

- [ ] This PR needs documentation.

### Changelog Entry

Fix - Advanced Card Processing: surface the actual PayPal API error instead of a misleading "Order does not contain an id" when creating an order from a saved card returns an error response.

Closes #4353
