### PR TITLE
Add `item_group_id` to ingestion (6551)

### DIFF
--- a/modules/ppcp-store-sync/src/Ingestion/ProductDTO.php
+++ b/modules/ppcp-store-sync/src/Ingestion/ProductDTO.php
@@ -1,0 +1,106 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
+
+/**
+ * Single product entry of the agentic-commerce ingestion payload.
+ *
+ * A passive value carrier: it defines the payload schema and serialises itself via
+ * {@see ProductDTO::to_array()}, which owns the wire-format contract — the
+ * camelCase `merchantStoreUrl` key and the omit-when-empty behaviour for optional
+ * fields. All extraction logic lives in {@see ProductsPayload}.
+ */
+class ProductDTO {
+	private string $id;
+	private string $item_group_id;
+	private string $title;
+	private string $link;
+	private string $image_link;
+	private string $description;
+	private string $price;
+	private string $availability;
+	private string $merchant_store_url;
+
+	private ?string $mpn;
+	private ?string $sale_price;
+	private ?string $product_type;
+	private ?string $color;
+	private ?string $size;
+	private ?string $gender;
+
+	public function __construct(
+		string $merchant_store_url,
+		string $id,
+		string $item_group_id,
+		string $title,
+		string $link,
+		string $image_link,
+		string $description,
+		string $price,
+		string $availability,
+		?string $mpn = null,
+		?string $sale_price = null,
+		?string $product_type = null,
+		?string $color = null,
+		?string $size = null,
+		?string $gender = null
+	) {
+		$this->merchant_store_url = $merchant_store_url;
+		$this->id                 = $id;
+		$this->item_group_id      = $item_group_id;
+		$this->title              = $title;
+		$this->link               = $link;
+		$this->image_link         = $image_link;
+		$this->description        = $description;
+		$this->price              = $price;
+		$this->availability       = $availability;
+		$this->mpn                = $mpn;
+		$this->sale_price         = $sale_price;
+		$this->product_type       = $product_type;
+		$this->color              = $color;
+		$this->size               = $size;
+		$this->gender             = $gender;
+	}
+
+	/**
+	 * Serialises the entry to the API wire format, omitting empty optional fields.
+	 *
+	 * @return array<string, string>
+	 */
+	public function to_array(): array {
+		$data = array(
+			'id'               => $this->id,
+			'item_group_id'    => $this->item_group_id,
+			'title'            => $this->title,
+			'link'             => $this->link,
+			'image_link'       => $this->image_link,
+			'description'      => $this->description,
+			'price'            => $this->price,
+			'availability'     => $this->availability,
+			'merchantStoreUrl' => $this->merchant_store_url,
+		);
+
+		if ( $this->color !== null ) {
+			$data['color'] = $this->color;
+		}
+		if ( $this->size !== null ) {
+			$data['size'] = $this->size;
+		}
+		if ( $this->gender !== null ) {
+			$data['gender'] = $this->gender;
+		}
+		if ( $this->mpn !== null ) {
+			$data['mpn'] = $this->mpn;
+		}
+		if ( $this->sale_price !== null ) {
+			$data['sale_price'] = $this->sale_price;
+		}
+		if ( $this->product_type !== null ) {
+			$data['product_type'] = $this->product_type;
+		}
+
+		return $data;
+	}
+}

--- a/modules/ppcp-store-sync/src/Ingestion/ProductsPayload.php
+++ b/modules/ppcp-store-sync/src/Ingestion/ProductsPayload.php
@@ -24,10 +24,16 @@ class ProductsPayload {
 		$this->product_manager    = $product_manager;
 	}
 
-	public function get_array(): array {
+	/**
+	 * @return ProductDTO[]
+	 */
+	public function get_products(): array {
 		return $this->transform_products( $this->product_ids );
 	}
 
+	/**
+	 * @return ProductDTO[]
+	 */
 	private function transform_products( array $product_ids ): array {
 		$api_products = array();
 
@@ -53,37 +59,28 @@ class ProductsPayload {
 			}
 
 			// For all other product types (simple, grouped, etc.).
-			$api_product = array(
-				'id'               => (string) $product->get_id(),
-				'title'            => $this->product_manager->get_product_title( $product ),
-				'link'             => $this->product_manager->get_product_link( $product ),
-				'image_link'       => $this->product_manager->get_product_image( $product ),
-				'description'      => $this->product_manager->get_product_description( $product, $product->get_short_description() ),
-				'price'            => $this->product_manager->format_price( $product->get_price() ),
-				'availability'     => $this->product_manager->get_product_availability( $product ),
-				'merchantStoreUrl' => $this->merchant_store_url,
+			$api_products[] = new ProductDTO(
+				$this->merchant_store_url,
+				(string) $product->get_id(),
+				(string) $product->get_id(),
+				$this->product_manager->get_product_title( $product ),
+				$this->product_manager->get_product_link( $product ),
+				$this->product_manager->get_product_image( $product ),
+				$this->product_manager->get_product_description( $product, $product->get_short_description() ),
+				$this->product_manager->format_price( $product->get_price() ),
+				$this->product_manager->get_product_availability( $product ),
+				$product->get_sku() ?: null,
+				$product->get_sale_price() ? $this->product_manager->format_price( $product->get_sale_price() ) : null,
+				$this->product_manager->get_product_type( $product ) ?: null
 			);
-
-			// Add optional fields.
-			if ( $product->get_sku() ) {
-				$api_product['mpn'] = $product->get_sku();
-			}
-
-			if ( $product->get_sale_price() ) {
-				$api_product['sale_price'] = $this->product_manager->format_price( $product->get_sale_price() );
-			}
-
-			$product_type = $this->product_manager->get_product_type( $product );
-			if ( $product_type ) {
-				$api_product['product_type'] = $product_type;
-			}
-
-			$api_products[] = $api_product;
 		}
 
 		return $api_products;
 	}
 
+	/**
+	 * @return ProductDTO[]
+	 */
 	private function get_product_variants( WC_Product $variable_product ): array {
 		$variants      = array();
 		$variation_ids = $variable_product->get_children();
@@ -96,51 +93,56 @@ class ProductsPayload {
 				continue;
 			}
 
-			$variant = array(
-				'id'               => (string) $variation->get_id(),
-				'item_group_id'    => (string) $variable_product->get_id(),
-				'title'            => $this->product_manager->get_product_title( $variation ),
-				'link'             => $this->product_manager->get_product_link( $variation ),
-				'image_link'       => $this->product_manager->get_product_image(
+			$attributes = $this->extract_variant_attributes( $variation );
+
+			$variants[] = new ProductDTO(
+				$this->merchant_store_url,
+				(string) $variation->get_id(),
+				(string) $variable_product->get_id(),
+				$this->product_manager->get_product_title( $variation ),
+				$this->product_manager->get_product_link( $variation ),
+				$this->product_manager->get_product_image(
 					$variation,
 					wp_get_attachment_image_url( (int) $variable_product->get_image_id(), 'full' ) ?: ''
 				),
-				'description'      => $this->product_manager->get_product_description( $variation, $variable_product->get_description() ),
-				'price'            => $this->product_manager->format_price( $variation->get_price() ),
-				'availability'     => $this->product_manager->get_product_availability( $variation ),
-				'merchantStoreUrl' => $this->merchant_store_url,
+				$this->product_manager->get_product_description( $variation, $variable_product->get_description() ),
+				$this->product_manager->format_price( $variation->get_price() ),
+				$this->product_manager->get_product_availability( $variation ),
+				$variation->get_sku() ?: null,
+				$variation->get_sale_price() ? $this->product_manager->format_price( $variation->get_sale_price() ) : null,
+				$product_type ?: null,
+				$attributes['color'] ?? null,
+				$attributes['size'] ?? null,
+				$attributes['gender'] ?? null
 			);
-
-			// Add variant attributes using WooCommerce methods.
-			$attributes = $variation->get_variation_attributes();
-			foreach ( $attributes as $attribute => $value ) {
-				$clean_attr = str_replace(
-					array( 'attribute_pa_', 'attribute_' ),
-					'',
-					$attribute
-				);
-
-				if ( in_array( $clean_attr, array( 'color', 'size', 'gender' ), true ) ) {
-					$variant[ $clean_attr ] = $value;
-				}
-			}
-
-			if ( $variation->get_sku() ) {
-				$variant['mpn'] = $variation->get_sku();
-			}
-
-			if ( $variation->get_sale_price() ) {
-				$variant['sale_price'] = $this->product_manager->format_price( $variation->get_sale_price() );
-			}
-
-			// Add the parent product.
-			if ( $product_type ) {
-				$variant['product_type'] = $product_type;
-			}
-
-			$variants[] = $variant;
 		}
 
 		return $variants;
+	}
+
+	/**
+	 * Extracts the color/size/gender attributes from a variation.
+	 *
+	 * WooCommerce prefixes attribute keys with `attribute_pa_` (taxonomy) or
+	 * `attribute_` (custom); both are stripped before matching.
+	 *
+	 * @return array<string, string> Map of the recognised attribute names to their values.
+	 */
+	private function extract_variant_attributes( WC_Product_Variation $variation ): array {
+		$attributes = array();
+
+		foreach ( $variation->get_variation_attributes() as $attribute => $value ) {
+			$clean_attr = str_replace(
+				array( 'attribute_pa_', 'attribute_' ),
+				'',
+				$attribute
+			);
+
+			if ( in_array( $clean_attr, array( 'color', 'size', 'gender' ), true ) ) {
+				$attributes[ $clean_attr ] = (string) $value;
+			}
+		}
+
+		return $attributes;
 	}
 }

--- a/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
+++ b/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
@@ -58,15 +58,16 @@ class SyncJob {
 			sprintf( 'Agentic Sync Job %s: Started', $this->batch_id )
 		);
 
-		// Transform products for API using the factory.
-		$api_products = new ProductsPayload(
+		// Transform products into DTOs.
+		$payload_container = new ProductsPayload(
 			$this->merchant_store_url,
 			$this->product_ids,
 			$this->product_manager
 		);
-		$api_payload  = $api_products->get_array();
 
-		if ( empty( $api_payload ) ) {
+		$products = $payload_container->get_products();
+
+		if ( empty( $products ) ) {
 			$this->logger->info(
 				sprintf( 'Agentic Sync Job %s: No products', $this->batch_id )
 			);
@@ -76,9 +77,13 @@ class SyncJob {
 			return;
 		}
 
+		// Compose the API payload, serialising each product DTO to its wire format.
 		$body = array(
 			'merchant_url' => $this->merchant_store_url,
-			'products'     => $api_payload,
+			'products'     => array_map(
+				static fn ( ProductDTO $product ): array => $product->to_array(),
+				$products
+			),
 		);
 
 		// Send payload to API.

--- a/tests/PHPUnit/StoreSync/Ingestion/ProductDTOTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/ProductDTOTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
+
+use WooCommerce\PayPalCommerce\TestCase;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\StoreSync\Ingestion\ProductDTO
+ */
+class ProductDTOTest extends TestCase {
+
+	// -------------------------------------------------------------------------
+	// Helpers
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Returns a DTO constructed with all required fields and all optional fields null.
+	 */
+	private function make_minimal_dto(): ProductDTO {
+		return new ProductDTO(
+			'https://shop.example.com',
+			'10',
+			'10',
+			'Widget',
+			'https://shop.example.com/widget',
+			'https://shop.example.com/img.jpg',
+			'A widget description',
+			'9.99 USD',
+			'in stock'
+		);
+	}
+
+	/**
+	 * Returns a DTO with every argument supplied (required + all optional).
+	 */
+	private function make_full_dto(): ProductDTO {
+		return new ProductDTO(
+			'https://shop.example.com',
+			'10',
+			'5',
+			'Widget - Red Large',
+			'https://shop.example.com/widget-red-large',
+			'https://shop.example.com/img-red.jpg',
+			'A red large widget',
+			'12.00 USD',
+			'in stock',
+			'SKU-001',
+			'9.99 USD',
+			'Clothing',
+			'red',
+			'large',
+			'unisex'
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Wire-format contract: required keys
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GIVEN a DTO built with only required arguments (all optionals null)
+	 * WHEN to_array() is called
+	 * THEN all nine required keys are present with their exact values
+	 *
+	 * @dataProvider required_key_provider
+	 */
+	public function test_required_key_present_with_correct_value( string $key, string $expected ): void {
+		$result = $this->make_minimal_dto()->to_array();
+
+		$this->assertArrayHasKey( $key, $result );
+		$this->assertSame( $expected, $result[ $key ] );
+	}
+
+	public function required_key_provider(): array {
+		return array(
+			'id carries the product id'              => array( 'id', '10' ),
+			'item_group_id carries the group id'     => array( 'item_group_id', '10' ),
+			'title carries the product name'         => array( 'title', 'Widget' ),
+			'link carries the product permalink'     => array( 'link', 'https://shop.example.com/widget' ),
+			'image_link carries the image url'       => array( 'image_link', 'https://shop.example.com/img.jpg' ),
+			'description carries the description'    => array( 'description', 'A widget description' ),
+			'price carries the formatted price'      => array( 'price', '9.99 USD' ),
+			'availability carries the stock status'  => array( 'availability', 'in stock' ),
+			'merchantStoreUrl carries the store url' => array( 'merchantStoreUrl', 'https://shop.example.com' ),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Wire-format contract: camelCase outlier
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GIVEN a DTO
+	 * WHEN to_array() is called
+	 * THEN the store URL key is 'merchantStoreUrl' (camelCase), not 'merchant_store_url'
+	 */
+	public function test_merchant_store_url_key_is_camel_case_not_snake_case(): void {
+		$result = $this->make_minimal_dto()->to_array();
+
+		$this->assertArrayHasKey( 'merchantStoreUrl', $result );
+		$this->assertArrayNotHasKey( 'merchant_store_url', $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Wire-format contract: item_group_id carries whatever string was passed
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GIVEN a DTO whose item_group_id was set to '42' (e.g. the product's own id for a simple product)
+	 * WHEN to_array() is called
+	 * THEN item_group_id in the output is '42'
+	 */
+	public function test_item_group_id_reflects_value_passed_to_constructor(): void {
+		$dto    = new ProductDTO(
+			'https://example.com', '42', '42', 'T', 'u', 'v', 'w', '1.00', 'in stock'
+		);
+		$result = $dto->to_array();
+
+		$this->assertSame( '42', $result['item_group_id'] );
+	}
+
+	/**
+	 * GIVEN a DTO whose item_group_id was set to '99' (e.g. a parent id for a variation)
+	 * AND id was set to '200' (the variation's own id)
+	 * WHEN to_array() is called
+	 * THEN item_group_id is '99' and id is '200'
+	 */
+	public function test_item_group_id_can_differ_from_id(): void {
+		$dto    = new ProductDTO(
+			'https://example.com', '200', '99', 'T', 'u', 'v', 'w', '1.00', 'in stock'
+		);
+		$result = $dto->to_array();
+
+		$this->assertSame( '200', $result['id'] );
+		$this->assertSame( '99', $result['item_group_id'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// Wire-format contract: omit-when-empty for optional fields
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GIVEN a DTO where all optional arguments are null
+	 * WHEN to_array() is called
+	 * THEN none of the six optional keys appear in the output
+	 *
+	 * @dataProvider optional_key_absent_provider
+	 */
+	public function test_optional_key_absent_when_null( string $key ): void {
+		$result = $this->make_minimal_dto()->to_array();
+
+		$this->assertArrayNotHasKey( $key, $result );
+	}
+
+	public function optional_key_absent_provider(): array {
+		return array(
+			'mpn absent when null'          => array( 'mpn' ),
+			'sale_price absent when null'   => array( 'sale_price' ),
+			'product_type absent when null' => array( 'product_type' ),
+			'color absent when null'        => array( 'color' ),
+			'size absent when null'         => array( 'size' ),
+			'gender absent when null'       => array( 'gender' ),
+		);
+	}
+
+	/**
+	 * GIVEN a DTO where all optional arguments are provided with non-null values
+	 * WHEN to_array() is called
+	 * THEN all six optional keys appear in the output with the exact values passed
+	 *
+	 * @dataProvider optional_key_present_provider
+	 */
+	public function test_optional_key_present_when_non_null( string $key, string $expected ): void {
+		$result = $this->make_full_dto()->to_array();
+
+		$this->assertArrayHasKey( $key, $result );
+		$this->assertSame( $expected, $result[ $key ] );
+	}
+
+	public function optional_key_present_provider(): array {
+		return array(
+			'mpn present with sku value'             => array( 'mpn', 'SKU-001' ),
+			'sale_price present with formatted price' => array( 'sale_price', '9.99 USD' ),
+			'product_type present with category'     => array( 'product_type', 'Clothing' ),
+			'color present with color value'         => array( 'color', 'red' ),
+			'size present with size value'           => array( 'size', 'large' ),
+			'gender present with gender value'       => array( 'gender', 'unisex' ),
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Minimal case: exactly the 9 required keys and no others
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GIVEN a DTO with all optionals null
+	 * WHEN to_array() is called
+	 * THEN the output contains exactly 9 keys — no optional keys leaked in
+	 */
+	public function test_minimal_dto_contains_exactly_nine_keys(): void {
+		$result = $this->make_minimal_dto()->to_array();
+
+		$this->assertCount( 9, $result );
+	}
+
+	// -------------------------------------------------------------------------
+	// Fully populated case: all 15 keys present
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GIVEN a DTO where every constructor argument is supplied (required + all 6 optionals)
+	 * WHEN to_array() is called
+	 * THEN the output contains exactly 15 keys with the correct values
+	 */
+	public function test_fully_populated_dto_contains_all_fifteen_keys(): void {
+		$result = $this->make_full_dto()->to_array();
+
+		$this->assertCount( 15, $result );
+		$this->assertSame( '10', $result['id'] );
+		$this->assertSame( '5', $result['item_group_id'] );
+		$this->assertSame( 'Widget - Red Large', $result['title'] );
+		$this->assertSame( 'https://shop.example.com/widget-red-large', $result['link'] );
+		$this->assertSame( 'https://shop.example.com/img-red.jpg', $result['image_link'] );
+		$this->assertSame( 'A red large widget', $result['description'] );
+		$this->assertSame( '12.00 USD', $result['price'] );
+		$this->assertSame( 'in stock', $result['availability'] );
+		$this->assertSame( 'https://shop.example.com', $result['merchantStoreUrl'] );
+		$this->assertSame( 'SKU-001', $result['mpn'] );
+		$this->assertSame( '9.99 USD', $result['sale_price'] );
+		$this->assertSame( 'Clothing', $result['product_type'] );
+		$this->assertSame( 'red', $result['color'] );
+		$this->assertSame( 'large', $result['size'] );
+		$this->assertSame( 'unisex', $result['gender'] );
+	}
+}

--- a/tests/PHPUnit/StoreSync/Ingestion/ProductsPayloadTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/ProductsPayloadTest.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
 use WooCommerce\PayPalCommerce\StoreSync\Config\StoreCurrencyValue;
 use WooCommerce\PayPalCommerce\StoreSync\Helper\ProductManager;
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\StoreSync\Ingestion\ProductDTO;
 use WC_Product;
 use WC_Product_Simple;
 use WC_Product_Variable;
@@ -56,11 +57,17 @@ class ProductsPayloadTest extends TestCase {
 			array( $product_id ),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertCount( 1, $result );
 		$this->assertEquals( array(
 			'id'               => '123',
+			'item_group_id'    => '123',
 			'title'            => 'Test Product',
 			'link'             => 'https://example.com/product/test',
 			'image_link'       => 'https://example.com/image.jpg',
@@ -164,7 +171,12 @@ class ProductsPayloadTest extends TestCase {
 			array( $parent_id ),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertCount( 2, $result );
 
@@ -237,7 +249,12 @@ class ProductsPayloadTest extends TestCase {
 			array( $parent_id ),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertCount( 0, $result );
 	}
@@ -249,7 +266,12 @@ class ProductsPayloadTest extends TestCase {
 			array( 999 ),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertCount( 0, $result );
 	}
@@ -260,7 +282,12 @@ class ProductsPayloadTest extends TestCase {
 			array(),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertIsArray( $result );
 		$this->assertCount( 0, $result );
@@ -294,7 +321,12 @@ class ProductsPayloadTest extends TestCase {
 			array( $product_id ),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertCount( 1, $result );
 		// Based on the implementation, image_link is always set (empty string if no image)
@@ -333,7 +365,12 @@ class ProductsPayloadTest extends TestCase {
 			array( $product_id ),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertCount( 1, $result );
 		// Based on actual implementation, empty price returns empty string
@@ -376,7 +413,12 @@ class ProductsPayloadTest extends TestCase {
 				array( $product_id ),
 				$this->make_product_manager_stub()
 			);
-			$result  = $payload->get_array();
+			$result  = array_map(
+				static function ( ProductDTO $dto ): array {
+					return $dto->to_array();
+				},
+				$payload->get_products()
+			);
 
 			$this->assertEquals( $expected_availability, $result[0]['availability'] );
 		}
@@ -415,7 +457,12 @@ class ProductsPayloadTest extends TestCase {
 			array( $product_id ),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertCount( 1, $result );
 		$this->assertArrayHasKey( 'item_group_id', $result[0] );
@@ -450,7 +497,12 @@ class ProductsPayloadTest extends TestCase {
 			array( $product_id ),
 			$this->make_product_manager_stub()
 		);
-		$result  = $payload->get_array();
+		$result  = array_map(
+			static function ( ProductDTO $dto ): array {
+				return $dto->to_array();
+			},
+			$payload->get_products()
+		);
 
 		$this->assertCount( 1, $result );
 		// Check required fields are present

--- a/tests/PHPUnit/StoreSync/Ingestion/ProductsPayloadTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/ProductsPayloadTest.php
@@ -382,6 +382,46 @@ class ProductsPayloadTest extends TestCase {
 		}
 	}
 
+	/**
+	 * GIVEN a simple product (no variants) with id 123
+	 * WHEN its payload entry is built by ProductsPayload
+	 * THEN the entry MUST contain an `item_group_id` key equal to the product's own id ('123')
+	 */
+	public function test_simple_product_includes_item_group_id_equal_to_id(): void {
+		$product_id = 123;
+		$product    = Mockery::mock( WC_Product_Simple::class );
+
+		$product->shouldReceive( 'get_id' )->andReturn( $product_id );
+		$product->shouldReceive( 'get_type' )->andReturn( 'simple' );
+		$product->shouldReceive( 'is_type' )->with( 'variable' )->andReturn( false );
+		$product->shouldReceive( 'get_name' )->andReturn( 'Test Product' );
+		$product->shouldReceive( 'get_permalink' )->andReturn( 'https://example.com/product/test' );
+		$product->shouldReceive( 'get_image_id' )->andReturn( 456 );
+		$product->shouldReceive( 'get_description' )->andReturn( 'Full description' );
+		$product->shouldReceive( 'get_short_description' )->andReturn( 'Short description' );
+		$product->shouldReceive( 'get_price' )->andReturn( '29.99' );
+		$product->shouldReceive( 'get_stock_status' )->andReturn( 'instock' );
+		$product->shouldReceive( 'get_sku' )->andReturn( 'SKU-123' );
+		$product->shouldReceive( 'get_sale_price' )->andReturn( '19.99' );
+
+		when( 'wc_get_product' )->justReturn( $product );
+		when( 'wp_get_attachment_image_url' )->justReturn( 'https://example.com/image.jpg' );
+		when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		when( 'wc_get_product_category_list' )->justReturn( 'Electronics, Gadgets' );
+		when( 'wp_strip_all_tags' )->returnArg( 1 );
+
+		$payload = new ProductsPayload(
+			'https://example.com',
+			array( $product_id ),
+			$this->make_product_manager_stub()
+		);
+		$result  = $payload->get_array();
+
+		$this->assertCount( 1, $result );
+		$this->assertArrayHasKey( 'item_group_id', $result[0] );
+		$this->assertSame( '123', $result[0]['item_group_id'] );
+	}
+
 	public function test_product_with_all_optional_fields_missing(): void {
 		$product_id = 123;
 		$product    = Mockery::mock( WC_Product_Simple::class );


### PR DESCRIPTION
# Description

## 🎯 The goal

PayPal's product ingestion API now requires `item_group_id` on **every** product entry. Variations already carried it (the parent product's id), but simple and other non-variant products were sent without it, so those entries are now rejected.

Per the new spec, a product with no variants sends its own `id` in both the `id` and `item_group_id` fields.

## ✅ The fix

Non-variant entries now set `item_group_id` to the product's own id; variations keep sending the parent id. This closes the gap that left simple products without the field.

Alongside the field addition, the inline array-building in `ProductsPayload` is replaced by a `ProductDTO` value object. The DTO owns the wire-format contract in one place:

- the camelCase `merchantStoreUrl` key (the lone outlier in an otherwise snake_case payload),
- the omit-when-empty behaviour for the six optional fields (`mpn`, `sale_price`, `product_type`, `color`, `size`, `gender`).

`ProductsPayload::get_array()` becomes `get_products()` and returns `ProductDTO[]`; `SyncJob` serialises each via `to_array()` when composing the request body. All extraction logic stays in `ProductsPayload`.

## 🧪 Tests

`ProductDTOTest` covers the wire-format contract directly: required keys always present, the `merchantStoreUrl` camelCase outlier, optionals omitted when null and present when set, and `item_group_id` carrying whatever was passed (so a simple product's own id and a variation's parent id are both exercised).

`ProductsPayloadTest` is updated to the new `get_products()` return type and adds a case asserting a simple product's `item_group_id` equals its `id`.
