### PR TITLE
Defer branded-only limitations to wp_loaded to avoid early translation loading

### DIFF
--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -72,7 +72,11 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		assert( $loading_screen_service instanceof LoadingScreenService );
 		$loading_screen_service->register();
 
-		add_action( 'init', fn() => $this->apply_branded_only_limitations( $container ), 1 );
+		// Deferred to 'wp_loaded' (not 'init') so the store-currency resolution this
+		// performs cannot fire a third-party 'woocommerce_currency' filter before
+		// textdomains are loaded, which triggers "translation triggered too early"
+		// notices in WordPress 6.7+. See #4103.
+		add_action( 'wp_loaded', fn() => $this->apply_branded_only_limitations( $container ) );
 
 		add_action(
 			'woocommerce_paypal_payments_gateway_migrate',

--- a/tests/PHPUnit/Settings/SettingsModuleTest.php
+++ b/tests/PHPUnit/Settings/SettingsModuleTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Settings;
+
+use WooCommerce\PayPalCommerce\ModularTestCase;
+use function Brain\Monkey\Functions\when;
+
+class SettingsModuleTest extends ModularTestCase
+{
+	/**
+	 * Regression test for #4103.
+	 *
+	 * apply_branded_only_limitations() resolves the store currency, which can
+	 * trigger a third-party 'woocommerce_currency' filter (e.g. Aelia) that calls
+	 * translation functions. Registering it on 'init' (priority 1) runs it before
+	 * textdomains are loaded, producing "Translation loading was triggered too
+	 * early" notices in WordPress 6.7+. The work must be deferred to 'wp_loaded'.
+	 */
+	public function testBrandedOnlyLimitationsAreDeferredToWpLoaded(): void
+	{
+		$container = $this->bootstrapModule();
+
+		$actions = array();
+		when('add_action')->alias(
+			function ( string $hook, $callback = null, int $priority = 10, int $accepted_args = 1 ) use ( &$actions ): bool {
+				$actions[] = $hook;
+				return true;
+			}
+		);
+		when('add_filter')->justReturn(true);
+
+		( new SettingsModule() )->run( $container );
+
+		self::assertContains( 'wp_loaded', $actions, 'Branded-only limitations should be registered on wp_loaded.' );
+		self::assertNotContains( 'init', $actions, 'Branded-only limitations must not run on init (translations load too early).' );
+	}
+}


### PR DESCRIPTION
**Issue**: #4103

### Description

`SettingsModule::run()` registered `apply_branded_only_limitations()` on `init` priority 1. That method resolves the store currency (via the `settings.data.general` factory, which eagerly calls the currency getter). Resolving the currency fires the `woocommerce_currency` filter; third-party multi-currency plugins such as Aelia hook it and call translation functions (`__()`). Because `init` priority 1 runs before WooCommerce / third-party textdomains are loaded, this produces "Translation loading was triggered too early" notices in WordPress 6.7+.

This defers the callback to `wp_loaded`, which runs after textdomains are loaded. It mirrors the existing fix for the same class of "called too early" error in `AxoModule` (commit `acc0ac61d`, "Replace the init hook with wp_loaded to avoid getting 'called too early' errors"). The method's side effects (branded-only onboarding gateway limitations) are consumed during later request hooks — the `woocommerce_paypal_payments_toggle_payment_gateways_apms` action fires during onboarding REST requests — so moving from `init`/1 to `wp_loaded` does not change observable behaviour.

### Steps to Test

1. On WordPress 6.7+, install a multi-currency plugin that resolves currency on the `woocommerce_currency` filter (e.g. Aelia Currency Switcher) with PayPal Payments active.
2. Before this change: a "Translation loading was triggered too early" notice for the third-party plugin's textdomain appears (debug.log / Query Monitor) on front-end requests.
3. After this change: the notice is gone, and branded-only onboarding limitations still apply.
4. `composer unit` passes, including the new `SettingsModuleTest`.

### Documentation

- [ ] This PR needs documentation.

### Changelog Entry

Fix - Defer branded-only limitations to the `wp_loaded` hook so store-currency resolution no longer triggers third-party multi-currency translation loading before textdomains are ready (avoids "translation triggered too early" notices).

Closes #4103
