### PR TITLE
Fix bug in continuation mode (6558)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -121,7 +121,8 @@ return array(
 			$container->get( 'wcgateway.settings.admin-settings-enabled' ),
 			$container->get( 'wcgateway.endpoint.capture-paypal-payment' ),
 			$container->get( 'api.endpoint.order' ),
-			$container->get( 'api.prefix' )
+			$container->get( 'api.prefix' ),
+			$container->get( 'button.helper.context' )
 		);
 	},
 	'wcgateway.credit-card-gateway'                        => static function ( ContainerInterface $container ): CreditCardGateway {

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -353,7 +353,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		// methods must additionally be gated on the merchant's "save PayPal and Venmo"
 		// setting, mirroring how CreditCardGateway gates on `save_card_details()`.
 		$vaulting_enabled = $this->supports( 'tokenization' ) && $this->settings_provider->save_paypal_and_venmo();
-		if ( $vaulting_enabled && is_checkout() ) {
+		// During a PayPal continuation the payment source is already chosen on PayPal's
+		// side, so the saved-method selector must not be rendered (it would otherwise show
+		// stray radio buttons on the classic checkout).
+		if ( $vaulting_enabled && is_checkout() && ! $this->context->is_paypal_continuation() ) {
 			$this->tokenization_script();
 			$this->saved_payment_methods();
 		}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -122,11 +122,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 	private string $prefix;
 
-	/**
-	 * The context helper, used to detect the PayPal continuation flow.
-	 *
-	 * @var Context
-	 */
 	private Context $context;
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -349,14 +349,14 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * Renders payment fields including saved payment method radio buttons when tokenization is active.
 	 */
 	public function payment_fields(): void {
-		// `supports( 'tokenization' )` only reflects the static capability; saved PayPal
-		// methods must additionally be gated on the merchant's "save PayPal and Venmo"
-		// setting, mirroring how CreditCardGateway gates on `save_card_details()`.
+		// Saved methods require tokenization support plus the merchant's "save PayPal and Venmo" setting.
 		$vaulting_enabled = $this->supports( 'tokenization' ) && $this->settings_provider->save_paypal_and_venmo();
-		// During a PayPal continuation the payment source is already chosen on PayPal's
-		// side, so the saved-method selector must not be rendered (it would otherwise show
-		// stray radio buttons on the classic checkout).
-		if ( $vaulting_enabled && is_checkout() && ! $this->context->is_paypal_continuation() ) {
+
+		// In a continuation the payment source is already chosen on PayPal's side, so the saved-method
+		// selector would only render stray radio buttons on the classic checkout.
+		$is_continuation = $this->context->is_paypal_continuation();
+
+		if ( ! $is_continuation && $vaulting_enabled && is_checkout() ) {
 			$this->tokenization_script();
 			$this->saved_payment_methods();
 		}

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\WcPaymentTokens\WooCommercePaymentTokens;
@@ -122,6 +123,13 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	private string $prefix;
 
 	/**
+	 * The context helper, used to detect the PayPal continuation flow.
+	 *
+	 * @var Context
+	 */
+	private Context $context;
+
+	/**
 	 * ID of the class extending the settings API. Used in option names.
 	 *
 	 * @var string
@@ -206,6 +214,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @param CapturePayPalPayment     $capture_paypal_payment The PayPal vault payment capture endpoint.
 	 * @param OrderEndpoint            $order_endpoint The order endpoint.
 	 * @param string                   $prefix The invoice prefix.
+	 * @param Context                  $context The context helper.
 	 */
 	public function __construct(
 		FundingSourceRenderer $funding_source_renderer,
@@ -227,7 +236,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		bool $admin_settings_enabled,
 		CapturePayPalPayment $capture_paypal_payment,
 		OrderEndpoint $order_endpoint,
-		string $prefix
+		string $prefix,
+		Context $context
 	) {
 		$this->id                          = self::ID;
 		$this->funding_source_renderer     = $funding_source_renderer;
@@ -250,6 +260,7 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->capture_paypal_payment      = $capture_paypal_payment;
 		$this->order_endpoint              = $order_endpoint;
 		$this->prefix                      = $prefix;
+		$this->context                     = $context;
 
 		$default_support = array(
 			'products',

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -10,6 +10,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CapturePayPalPayment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -47,6 +48,7 @@ class WcGatewayTest extends TestCase
 	private $paymentTokensEndpoint;
 	private $wcPaymentTokens;
 	private $assetGetter;
+	private $context;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -94,6 +96,7 @@ class WcGatewayTest extends TestCase
 
 		$this->paymentTokensEndpoint = Mockery::mock(PaymentTokensEndpoint::class);
 		$this->wcPaymentTokens = Mockery::mock(WooCommercePaymentTokens::class);
+		$this->context = Mockery::mock(Context::class);
 	}
 
 	private function createGateway()
@@ -118,7 +121,35 @@ class WcGatewayTest extends TestCase
 			false,
 			Mockery::mock(CapturePayPalPayment::class),
 			Mockery::mock(OrderEndpoint::class),
-			'WC-'
+			'WC-',
+			$this->context
+		);
+	}
+
+	private function createSpyGateway(): SpyablePayPalGateway
+	{
+		return new SpyablePayPalGateway(
+			$this->funding_source_renderer,
+			$this->orderProcessor,
+			$this->settingsProvider,
+			$this->sessionHandler,
+			$this->refundProcessor,
+			$this->isConnected,
+			$this->transactionUrlProvider,
+			$this->subscriptionHelper,
+			$this->environment,
+			$this->logger,
+			$this->apiShopCountry,
+			static fn ($id) => 'checkoutnow=' . $id,
+			'Pay via PayPal',
+			$this->paymentTokensEndpoint,
+			$this->wcPaymentTokens,
+			$this->assetGetter,
+			false,
+			Mockery::mock(CapturePayPalPayment::class),
+			Mockery::mock(OrderEndpoint::class),
+			'WC-',
+			$this->context
 		);
 	}
 
@@ -301,4 +332,116 @@ class WcGatewayTest extends TestCase
     		['qwerty', 'PayPal', 'Pay via PayPal.'],
 	    ];
     }
+
+	/**
+	 * GIVEN a customer has already initiated PayPal payment (continuation flow)
+	 * WHEN payment_fields() is rendered on the checkout page
+	 * THEN the saved-method UI (tokenization_script + saved_payment_methods) must NOT be rendered
+	 * AND the payment fields render without the vault UI to avoid double-render during continuation
+	 */
+	public function test_payment_fields_during_continuation_flow_suppresses_saved_method_ui(): void
+	{
+		$this->context->shouldReceive('is_paypal_continuation')->andReturn(true);
+		$this->settingsProvider->shouldReceive('save_paypal_and_venmo')->andReturn(true);
+
+		when('is_checkout')->justReturn(true);
+		when('wp_kses_post')->returnArg();
+		when('wpautop')->returnArg();
+		when('wptexturize')->returnArg();
+		when('apply_filters')->returnArg(2);
+
+		$gateway = $this->createSpyGateway();
+		$gateway->set_test_supports(['tokenization']);
+
+		$gateway->payment_fields();
+
+		$this->assertSame(0, $gateway->tokenization_script_call_count, 'tokenization_script() must not be called during PayPal continuation flow');
+		$this->assertSame(0, $gateway->saved_payment_methods_call_count, 'saved_payment_methods() must not be called during PayPal continuation flow');
+	}
+
+	/**
+	 * GIVEN a normal checkout (no PayPal continuation in progress) with vaulting enabled
+	 * WHEN payment_fields() is rendered on the checkout page
+	 * THEN the saved-method UI (tokenization_script + saved_payment_methods) IS rendered
+	 */
+	public function test_payment_fields_on_normal_checkout_renders_saved_method_ui(): void
+	{
+		$this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+		$this->settingsProvider->shouldReceive('save_paypal_and_venmo')->andReturn(true);
+
+		when('is_checkout')->justReturn(true);
+		when('wp_kses_post')->returnArg();
+		when('wpautop')->returnArg();
+		when('wptexturize')->returnArg();
+		when('apply_filters')->returnArg(2);
+
+		$gateway = $this->createSpyGateway();
+		$gateway->set_test_supports(['tokenization']);
+
+		$gateway->payment_fields();
+
+		$this->assertSame(1, $gateway->tokenization_script_call_count, 'tokenization_script() must be called on a normal checkout with vaulting enabled');
+		$this->assertSame(1, $gateway->saved_payment_methods_call_count, 'saved_payment_methods() must be called on a normal checkout with vaulting enabled');
+	}
+
+	/**
+	 * GIVEN vaulting is disabled (save_paypal_and_venmo returns false)
+	 * WHEN payment_fields() is rendered on the checkout page
+	 * THEN the saved-method UI is NOT rendered regardless of continuation state
+	 */
+	public function test_payment_fields_with_vaulting_disabled_suppresses_saved_method_ui(): void
+	{
+		$this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+		$this->settingsProvider->shouldReceive('save_paypal_and_venmo')->andReturn(false);
+
+		when('is_checkout')->justReturn(true);
+		when('wp_kses_post')->returnArg();
+		when('wpautop')->returnArg();
+		when('wptexturize')->returnArg();
+		when('apply_filters')->returnArg(2);
+
+		$gateway = $this->createSpyGateway();
+		$gateway->set_test_supports(['tokenization']);
+
+		$gateway->payment_fields();
+
+		$this->assertSame(0, $gateway->tokenization_script_call_count, 'tokenization_script() must not be called when vaulting is disabled');
+		$this->assertSame(0, $gateway->saved_payment_methods_call_count, 'saved_payment_methods() must not be called when vaulting is disabled');
+	}
+}
+
+/**
+ * Testable subclass that replaces the WC parent's side-effectful
+ * saved-payment-method methods with simple call-count spies.
+ */
+class SpyablePayPalGateway extends PayPalGateway
+{
+	public int $saved_payment_methods_call_count = 0;
+	public int $tokenization_script_call_count   = 0;
+
+	/** @param string[] $supports */
+	public function set_test_supports(array $supports): void
+	{
+		$this->supports = $supports;
+	}
+
+	public function supports($feature): bool
+	{
+		return in_array($feature, $this->supports, true);
+	}
+
+	public function saved_payment_methods(): void
+	{
+		$this->saved_payment_methods_call_count++;
+	}
+
+	public function tokenization_script(): void
+	{
+		$this->tokenization_script_call_count++;
+	}
+
+	public function get_description(): string
+	{
+		return '';
+	}
 }


### PR DESCRIPTION
# Description

## 🐛 The problem

On **classic checkout**, a logged-in customer in a PayPal continuation flow (started from the product page, "You are currently paying with PayPal") sees a stray saved-payment-method radio group under the PayPal option. It shouldn't appear: the payment source is already chosen on PayPal's side.

## 💡 Why it happens

The token filter in `WcPaymentTokensModule` already empties the saved tokens during a continuation, but `PayPalGateway::payment_fields()` still calls WooCommerce's `saved_payment_methods()`, which renders the "Use a new payment method" radio even with zero tokens.

## ✅ The fix

`payment_fields()` now skips the saved-method UI when `Context::is_paypal_continuation()` is true, reusing the same check the token filter trusts. The gateway gets the context helper via constructor injection.

## 🔍 What to review

- The guard keys solely on `is_paypal_continuation()`. The original report mentioned "Pay Now" disabled, but the continuation flow plus a logged-in session is the real trigger; the Pay Now setting is not consulted.
- Classic checkout only; block checkout uses a different path.

## 🧪 How to verify

1. As a logged-in customer with **Save PayPal and Venmo** enabled and classic checkout active, start payment from the product page via the PayPal button.
2. On the continuation page, confirm no saved-method radios appear under PayPal.
3. In a normal checkout, confirm the saved-method selector still appears.

### Screenshots

| Before | After |
|---|---|
| <img width="1440" height="1224" alt="2026-06-17 - pcp-6558-before" src="https://github.com/user-attachments/assets/d4098059-503c-4dfc-b6fc-2bde4cb21f6f" /> | <img width="1440" height="1044" alt="2026-06-17 - pcp-6558-fixed" src="https://github.com/user-attachments/assets/1d0d798a-bce5-4c7a-80fb-5338aaf8e388" /> |