### PR TITLE
fix(pay-later-messaging): resolve merchant_identifier error after manual connection (6286)

### DIFF
--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPayLaterMessaging.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Tabs/TabPayLaterMessaging.js
@@ -1,4 +1,4 @@
-import { PayLaterMessagingHooks } from '@ppcp-settings/data';
+import { PayLaterMessagingHooks, CommonHooks } from '@ppcp-settings/data';
 import { useEffect } from '@wordpress/element';
 
 const TabPayLaterMessaging = () => {
@@ -11,6 +11,7 @@ const TabPayLaterMessaging = () => {
 		setHome,
 		setCustom_placement,
 	} = PayLaterMessagingHooks.usePayLaterMessaging();
+	const { clientId: merchantClientId } = CommonHooks.useMerchant();
 	const PcpPayLaterConfigurator =
 		window.ppcpSettings?.PcpPayLaterConfigurator;
 
@@ -18,7 +19,7 @@ const TabPayLaterMessaging = () => {
 		if ( window.merchantConfigurators && PcpPayLaterConfigurator ) {
 			window.merchantConfigurators.Messaging( {
 				config,
-				merchantClientId: PcpPayLaterConfigurator.merchantClientId,
+				merchantClientId,
 				partnerClientId: PcpPayLaterConfigurator.partnerClientId,
 				partnerName: 'WooCommerce',
 				bnCode: PcpPayLaterConfigurator.bnCode,
@@ -45,7 +46,7 @@ const TabPayLaterMessaging = () => {
 				},
 			} );
 		}
-	}, [ PcpPayLaterConfigurator, config ] );
+	}, [ PcpPayLaterConfigurator, config, merchantClientId ] );
 
 	return (
 		<div


### PR DESCRIPTION
## Problem

After manually connecting via Client ID + Secret, the Pay Later Messaging tab shows a `merchant_identifier` error from the PayPal configurator library. The error disappears on page reload.

**Root cause:** `merchantClientId` was read from `window.ppcpSettings.PcpPayLaterConfigurator.merchantClientId`, a static PHP-localized value set at page render time. When the page loads for an unconnected merchant, this value is an empty string and is never updated in memory after a successful connection.

The Redux store, by contrast, is explicitly refreshed after manual connection (`verifyLoginStatus()` →  `refreshMerchantData()` → `hydrate()`), so `merchant.clientId` always reflects the current state.

## Solution

Read `merchantClientId` from the Redux store via `CommonHooks.useMerchant()` instead of the static  `window.ppcpSettings` object. `merchantClientId` is also added to the `useEffect` dependency array so the configurator reinitialises as soon as the value becomes available after connection.

## How to test

1. Set up a US store with no vaulting enabled (Pay Later tab should be visible).
2. Ensure the merchant is disconnected.
3. Go to **Settings** and manually connect with valid sandbox Client ID + Secret.
4. After connection, navigate to the **Pay Later Messaging** tab — **without reloading the page**.
5. Confirm the `merchant_identifier` error is no longer shown and the configurator renders correctly.
6. Reload the page and confirm the tab still works as expected.