### PR TITLE
Add filters to AmountFactory

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AmountFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AmountFactory.php
@@ -113,7 +113,7 @@ class AmountFactory {
 			null, // shipping discounts?
 			$discount
 		);
-		return new Amount( $total, $breakdown );
+		return apply_filters( 'woocommerce_paypal_payments_amount_from_wc_cart', new Amount( $total, $breakdown ), $breakdown, $cart );
 	}
 
 	/**
@@ -146,18 +146,16 @@ class AmountFactory {
 			return ( new StoreApiMoney( (string) $minor, $currency, $minor_unit ) )->to_paypal();
 		};
 
-		return new Amount(
-			$make( $total_minor ),
-			new AmountBreakdown(
-				$make( $items_minor ),
-				$make( $shipping_minor ),
-				$make( $tax_minor ),
-				null,
-				null,
-				null,
-				$discount_minor > 0 ? $make( $discount_minor ) : null,
-			)
+		$breakdown = new AmountBreakdown(
+			$make( $items_minor ),
+			$make( $shipping_minor ),
+			$make( $tax_minor ),
+			null,
+			null,
+			null,
+			$discount_minor > 0 ? $make( $discount_minor ) : null,
 		);
+		return apply_filters( 'woocommerce_paypal_payments_amount_from_api_cart', new Amount( $make( $total_minor ), $breakdown ), $breakdown, $cart_totals );
 	}
 
 	/**
@@ -234,7 +232,7 @@ class AmountFactory {
 			null, // shipping discounts?
 			$discount
 		);
-		return new Amount( $total, $breakdown );
+		return apply_filters( 'woocommerce_paypal_payments_amount_from_order', new Amount( $total, $breakdown ), $breakdown, $order );
 	}
 
 	/**
@@ -251,7 +249,7 @@ class AmountFactory {
 
 		$money     = $this->money_factory->from_paypal_response( $data );
 		$breakdown = ( isset( $data->breakdown ) ) ? $this->break_down( $data->breakdown ) : null;
-		return new Amount( $money, $breakdown );
+		return apply_filters( 'woocommerce_paypal_payments_amount_from_paypal', new Amount( $money, $breakdown ), $breakdown, $data );
 	}
 
 	/**


### PR DESCRIPTION
### Description
I have a plugin that adds additional options to the shipping rate(s). This includes the feature to add additional cost. This is added to the WooCommerce cart total and has worked in the past. 

In version 4 (I think) of the plugin the code was changed to no longer use/read the `WC()->cart->get_total()`, but instead calculate this in the PayPal code directly through the breakdown. 

This caused my plugin (and possibly others) to break as the cost is not in the breakdown.
Through this filter the amount and breakdown can be adjusted to make sure the correct amount is passed to PayPal. 

Hope that explanation makes sense. Let me know if there are any questions.