### PR TITLE
fix(todos): prevent dismissed items reappearing when dismissing multiple todos (6294)

### DIFF
--- a/modules/ppcp-settings/resources/js/data/todos/actions.js
+++ b/modules/ppcp-settings/resources/js/data/todos/actions.js
@@ -111,6 +111,15 @@ export function refresh() {
 	};
 }
 
+export function addDismissedTodo( todoId ) {
+	return async ( { select, dispatch } ) => {
+		const current = select.getDismissedTodos() || [];
+		if ( ! current.includes( todoId ) ) {
+			await dispatch.setDismissedTodos( [ ...current, todoId ] );
+		}
+	};
+}
+
 export function resetDismissedTodos() {
 	return async ( { dispatch } ) => {
 		try {

--- a/modules/ppcp-settings/resources/js/data/todos/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/todos/hooks.js
@@ -38,7 +38,7 @@ const useStoreData = () => {
 
 const useHooks = () => {
 	const { dispatch, select } = useStoreData();
-	const { fetchTodos, setDismissedTodos, setCompletedTodos } = dispatch;
+	const { fetchTodos, addDismissedTodo, setCompletedTodos } = dispatch;
 
 	// Get todos data from store
 	const todos = select.getTodos();
@@ -47,12 +47,7 @@ const useHooks = () => {
 
 	const dismissedSet = new Set( dismissedTodos );
 
-	const dismissTodo = async ( todoId ) => {
-		if ( ! dismissedSet.has( todoId ) ) {
-			const newDismissedTodos = [ ...dismissedTodos, todoId ];
-			await setDismissedTodos( newDismissedTodos );
-		}
-	};
+	const dismissTodo = ( todoId ) => addDismissedTodo( todoId );
 
 	const setTodoCompleted = async ( todoId, isCompleted ) => {
 		let newCompletedTodos;


### PR DESCRIPTION
## Summary

Investigated "Enable Installments" not visible in the *Things to do next* section on the Overview tab.

**Findings:**
- The item is intentionally hidden when Installments is already active — correct behavior.
- The section shows a maximum of 5 items at a time; "Enable Installments" has the lowest priority and only appears after higher-priority items are dismissed.
- A bug in the dismiss logic prevented it from ever appearing: dismissing a second item would overwrite the first dismissed entry instead of appending to it. This happened because `dismissTodo` closed over a stale `dismissedTodos = []` value (the parent component never re-rendered after the first dismiss). As a result, the first dismissed item would reappear stuck with the `is-dismissing` CSS class, blocking the list from updating.

**Fix:**
Replaced the inline dismiss logic with an `addDismissedTodo` thunk that reads the current dismissed list directly from the store at dispatch time, eliminating the stale closure entirely.

## Test steps

1. Go to Overview tab → *Things to do next*.
2. Confirm 5 items are visible.
3. Dismiss one — it disappears and a new item takes its place.
4. Dismiss another — it also disappears cleanly, no item stuck with animation.
5. Continue until all higher-priority items are dismissed and "Enable Installments" appears (requires MX store with Installments inactive).