### PR TITLE
Dev/pcp 6566 vaulted frictionless payments

### DIFF
--- a/docs/testing-card-vaulting.md
+++ b/docs/testing-card-vaulting.md
@@ -1,0 +1,36 @@
+# Card vaulting & vaulted checkout: testing notes
+
+PayPal publishes separate test-card tables for "**purchase flow**" and "**save payment methods**" (vaulting). They are **not interchangeable**.
+
+Vaulting a purchase-flow card can mint a token PayPal will not honor: every request returns `2xx`, but a later charge fails with `403 PERMISSION_DENIED`. Always vault with the "Save payment methods" cards.
+
+Reference:
+- [Cards for "Purchase flow"](https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/#test-cases-and-card-details-for-purchase-flows)
+- [Cards for "Save payment methods"](https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/#test-cases-and-card-details-for-save-payment-methods)
+
+## Sandbox setup
+
+To exercise the 3DS path at all, set the plugin's **3D Secure** option to **ALWAYS**. The sandbox does not require 3DS by default, so with any other setting the test cards below authenticate without triggering the flow you want to test.
+
+## Cards to use for vaulting tests
+
+Current "Save payment methods" table (expiry = `01/current year + 3`).
+
+| Network    | No-challenge (frictionless) | Challenge (step-up) |
+|------------|-----------------------------|---------------------|
+| Visa       | `4000000000002701`          | `4000000000002503`  |
+| Mastercard | `5200000000002235`          | `5200000000002151`  |
+
+Do **not** use purchase-flow cards (e.g. `4868719196829038`,
+`4868719166101368`, `5329879707824603`) for vaulting.
+
+## Test coverage
+
+The 3DS authentication itself runs in the browser SDK and on PayPal's servers, so the end-to-end save + 3DS + charge flow can only be verified **manually** (real browser, with the sandbox setup and save-flow cards above). A live-API integration test would be non-deterministic.
+
+The surrounding plugin logic is covered by automated tests that mock the PayPal HTTP boundary and assert what our code sends and does with responses:
+
+- `tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php`: resume-nonce / capture / authorize state machine (uses a `payer-action` link to represent "3DS required").
+- `tests/integration/PHPUnit/Vaulting/WooCommercePaymentTokensTest.php`: response → `WC_Payment_Token_CC` persistence.
+- `tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php`: vaulted-charge order-body construction.
+- `tests/PHPUnit/SavePaymentMethods/Endpoint/CreateSetupTokenTest.php` and `CreatePaymentTokenTest.php`: vault-token setup-request body and exchange-response handling.

--- a/docs/testing-card-vaulting.md
+++ b/docs/testing-card-vaulting.md
@@ -1,16 +1,8 @@
 # Card vaulting & vaulted checkout: testing notes
 
-PayPal publishes separate test-card tables for "**purchase flow**" and "**save payment methods**" (
-vaulting). They are **not interchangeable**.
-
-Vaulting a purchase-flow card can mint a token PayPal will not honor: every request returns `2xx`,
-but a later charge fails with `403 PERMISSION_DENIED`. Always vault with the "Save payment methods"
-cards.
-
-Reference:
-
-- [Cards for "Purchase flow"](https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/#test-cases-and-card-details-for-purchase-flows)
-- [Cards for "Save payment methods"](https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/#test-cases-and-card-details-for-save-payment-methods)
+Vaulting tests need PayPal's "**save payment methods**" test cards, which are **not
+interchangeable** with the "purchase flow" cards. Using the wrong table is the most common mistake
+here.
 
 ## Sandbox setup
 
@@ -42,8 +34,16 @@ Current "Save payment methods" table (expiry = `01/current year + 3`).
 | Visa       | `4000000000002701` | `4000000000002503` |
 | Mastercard | `5200000000002235` | `5200000000002151` |
 
-Do **not** use purchase-flow cards (e.g. `4868719196829038`,
-`4868719166101368`, `5329879707824603`) for vaulting.
+Do **not** use purchase-flow cards (e.g. `4868719196829038`, `4868719166101368`,
+`5329879707824603`) for vaulting. They mint a token that looks valid (every request returns `2xx`),
+but the later charge fails with a very visible `403 PERMISSION_DENIED`.
+
+## References
+
+- [Cards for "Save payment methods"](https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/#test-cases-and-card-details-for-save-payment-methods) ←
+  *what we need for vaulting!*
+- [Cards for "Purchase flow"](https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/#test-cases-and-card-details-for-purchase-flows) -
+  *not usable for vaulting, added for distinction*
 
 ## Test coverage
 
@@ -54,11 +54,13 @@ save-flow cards above). A live-API integration test would be non-deterministic.
 The surrounding plugin logic is covered by automated tests that mock the PayPal HTTP boundary and
 assert what our code sends and does with responses:
 
-- `tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php`: resume-nonce /
-  capture / authorize state machine (uses a `payer-action` link to represent "3DS required").
-- `tests/integration/PHPUnit/Vaulting/WooCommercePaymentTokensTest.php`: response →
-  `WC_Payment_Token_CC` persistence.
-- `tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php`: vaulted-charge order-body
-  construction.
-- `tests/PHPUnit/SavePaymentMethods/Endpoint/CreateSetupTokenTest.php` and
-  `CreatePaymentTokenTest.php`: vault-token setup-request body and exchange-response handling.
+- [Integration: VaultedCard3dsTransactionTest.php](../tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php):
+  resume-nonce / capture / authorize state machine (uses a `payer-action` link to represent
+  "3DS required").
+- [Integration: WooCommercePaymentTokensTest.php](../tests/integration/PHPUnit/Vaulting/WooCommercePaymentTokensTest.php):
+  response → `WC_Payment_Token_CC` persistence.
+- [Unit: CaptureCardPaymentTest.php](../tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php):
+  vaulted-charge order-body construction.
+- [Unit: CreateSetupTokenTest.php](../tests/PHPUnit/SavePaymentMethods/Endpoint/CreateSetupTokenTest.php)
+  and [Unit: CreatePaymentTokenTest.php](../tests/PHPUnit/SavePaymentMethods/Endpoint/CreatePaymentTokenTest.php):
+  vault-token setup-request body and exchange-response handling.

--- a/docs/testing-card-vaulting.md
+++ b/docs/testing-card-vaulting.md
@@ -1,36 +1,64 @@
 # Card vaulting & vaulted checkout: testing notes
 
-PayPal publishes separate test-card tables for "**purchase flow**" and "**save payment methods**" (vaulting). They are **not interchangeable**.
+PayPal publishes separate test-card tables for "**purchase flow**" and "**save payment methods**" (
+vaulting). They are **not interchangeable**.
 
-Vaulting a purchase-flow card can mint a token PayPal will not honor: every request returns `2xx`, but a later charge fails with `403 PERMISSION_DENIED`. Always vault with the "Save payment methods" cards.
+Vaulting a purchase-flow card can mint a token PayPal will not honor: every request returns `2xx`,
+but a later charge fails with `403 PERMISSION_DENIED`. Always vault with the "Save payment methods"
+cards.
 
 Reference:
+
 - [Cards for "Purchase flow"](https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/#test-cases-and-card-details-for-purchase-flows)
 - [Cards for "Save payment methods"](https://developer.paypal.com/docs/checkout/advanced/customize/3d-secure/test/#test-cases-and-card-details-for-save-payment-methods)
 
 ## Sandbox setup
 
-To exercise the 3DS path at all, set the plugin's **3D Secure** option to **ALWAYS**. The sandbox does not require 3DS by default, so with any other setting the test cards below authenticate without triggering the flow you want to test.
+To exercise the 3DS path at all, set the plugin's **3D Secure** option to **ALWAYS**. The sandbox
+does not require 3DS by default, so with any other setting the test cards below authenticate without
+triggering the flow you want to test.
+
+## 3DS modes
+
+3D Secure authentication has two possible behaviors. Both must work identically; the only difference
+is whether the shopper has to enter an OTP.
+
+|                  | Frictionless ("no challenge")             | Step-up ("challenge")                |
+|------------------|-------------------------------------------|--------------------------------------|
+| **What it is**   | No user input; the bank approves silently | A manual OTP step is required        |
+| **New card**     | Overlay closes itself after a few seconds | Overlay expands into an OTP form     |
+| **Vaulted card** | Redirects out, then back to the shop      | Redirects out, returns after the OTP |
+
+- "New card" = entering card details at checkout or adding one in My Account.
+- "Vaulted card" = paying with a saved card at checkout.
+- "Checkout" = Block checkout or Classic checkout, both are identical in this aspect.
 
 ## Cards to use for vaulting tests
 
 Current "Save payment methods" table (expiry = `01/current year + 3`).
 
-| Network    | No-challenge (frictionless) | Challenge (step-up) |
-|------------|-----------------------------|---------------------|
-| Visa       | `4000000000002701`          | `4000000000002503`  |
-| Mastercard | `5200000000002235`          | `5200000000002151`  |
+| Network    | Frictionless       | Step-up            |
+|------------|--------------------|--------------------|
+| Visa       | `4000000000002701` | `4000000000002503` |
+| Mastercard | `5200000000002235` | `5200000000002151` |
 
 Do **not** use purchase-flow cards (e.g. `4868719196829038`,
 `4868719166101368`, `5329879707824603`) for vaulting.
 
 ## Test coverage
 
-The 3DS authentication itself runs in the browser SDK and on PayPal's servers, so the end-to-end save + 3DS + charge flow can only be verified **manually** (real browser, with the sandbox setup and save-flow cards above). A live-API integration test would be non-deterministic.
+The 3DS authentication itself runs in the browser SDK and on PayPal's servers, so the end-to-end
+save + 3DS + charge flow can only be verified **manually** (real browser, with the sandbox setup and
+save-flow cards above). A live-API integration test would be non-deterministic.
 
-The surrounding plugin logic is covered by automated tests that mock the PayPal HTTP boundary and assert what our code sends and does with responses:
+The surrounding plugin logic is covered by automated tests that mock the PayPal HTTP boundary and
+assert what our code sends and does with responses:
 
-- `tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php`: resume-nonce / capture / authorize state machine (uses a `payer-action` link to represent "3DS required").
-- `tests/integration/PHPUnit/Vaulting/WooCommercePaymentTokensTest.php`: response → `WC_Payment_Token_CC` persistence.
-- `tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php`: vaulted-charge order-body construction.
-- `tests/PHPUnit/SavePaymentMethods/Endpoint/CreateSetupTokenTest.php` and `CreatePaymentTokenTest.php`: vault-token setup-request body and exchange-response handling.
+- `tests/integration/PHPUnit/Transaction/VaultedCard3dsTransactionTest.php`: resume-nonce /
+  capture / authorize state machine (uses a `payer-action` link to represent "3DS required").
+- `tests/integration/PHPUnit/Vaulting/WooCommercePaymentTokensTest.php`: response →
+  `WC_Payment_Token_CC` persistence.
+- `tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php`: vaulted-charge order-body
+  construction.
+- `tests/PHPUnit/SavePaymentMethods/Endpoint/CreateSetupTokenTest.php` and
+  `CreatePaymentTokenTest.php`: vault-token setup-request body and exchange-response handling.

--- a/tests/PHPUnit/SavePaymentMethods/Endpoint/CreatePaymentTokenTest.php
+++ b/tests/PHPUnit/SavePaymentMethods/Endpoint/CreatePaymentTokenTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint;
+
+use Exception;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentMethodTokensEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcPaymentTokens\WooCommercePaymentTokens;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class CreatePaymentTokenTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var RequestData&\Mockery\MockInterface */
+	private $request_data;
+
+	/** @var PaymentMethodTokensEndpoint&\Mockery\MockInterface */
+	private $tokens_endpoint;
+
+	/** @var WooCommercePaymentTokens&\Mockery\MockInterface */
+	private $wc_payment_tokens;
+
+	/** @var CreatePaymentToken */
+	private $sut;
+
+	/**
+	 * Real captured exchange (VISA card vault token response from PayPal sandbox).
+	 */
+	private function card_result_fixture(): \stdClass {
+		return json_decode( '{"id":"72k37380cm2997353","customer":{"id":"LYraJLIEfz"},"payment_source":{"card":{"name":"Frictionless","last_digits":"9038","brand":"VISA","expiry":"2029-01","verification_status":"VERIFIED","verification":{"network_transaction_id":"841006768893514","three_d_secure":{"eci_flag":"FULLY_AUTHENTICATED_TRANSACTION","cavv":"AAABAWFlmQAAAABjRWWZEEFgFz+=","enrolled":"Y","pares_status":"Y","three_ds_version":"2.2.0"}},"authentication_result":{"three_d_secure":{"authentication_status":"Y","enrollment_status":"Y","authentication_id":"22674300069036246"}}}},"links":[{"href":"https://api.sandbox.paypal.com/v3/vault/payment-tokens/72k37380cm2997353","rel":"self","method":"GET"}]}' );
+	}
+
+	/**
+	 * A minimal PayPal result that carries a paypal payment_source.
+	 */
+	private function paypal_result_fixture( string $email = 'buyer@paypal.com' ): \stdClass {
+		return (object) array(
+			'id'             => 'paypal-token-id-999',
+			'customer'       => (object) array( 'id' => 'CustPayPal01' ),
+			'payment_source' => (object) array(
+				'paypal' => (object) array( 'email_address' => $email ),
+			),
+		);
+	}
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->request_data      = Mockery::mock( RequestData::class );
+		$this->tokens_endpoint   = Mockery::mock( PaymentMethodTokensEndpoint::class );
+		$this->wc_payment_tokens = Mockery::mock( WooCommercePaymentTokens::class );
+
+		$this->sut = new CreatePaymentToken(
+			$this->request_data,
+			$this->tokens_endpoint,
+			$this->wc_payment_tokens
+		);
+
+		// Common WP stubs.
+		when( 'get_current_user_id' )->justReturn( 42 );
+		when( 'get_user_meta' )->justReturn( 'cust-existing' );
+		when( 'is_user_logged_in' )->justReturn( true );
+	}
+
+	// -------------------------------------------------------------------------
+	// Tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GIVEN a logged-in user and create_payment_token() returns a card vault result
+	 * WHEN handle_request() is called with a vault_setup_token
+	 * THEN create_payment_token_card() is called with the current user id and result
+	 * AND update_user_meta() persists the PayPal customer id from the result
+	 * AND wp_send_json_success() receives the WC token id returned by create_payment_token_card()
+	 */
+	public function test_card_success_calls_create_card_token_and_sends_wc_token_id(): void {
+		$this->request_data
+			->shouldReceive( 'read_request' )
+			->once()
+			->with( CreatePaymentToken::ENDPOINT )
+			->andReturn( array( 'vault_setup_token' => 'setup-tok-001' ) );
+
+		$fixture = $this->card_result_fixture();
+
+		$this->tokens_endpoint
+			->shouldReceive( 'create_payment_token' )
+			->once()
+			->andReturn( $fixture );
+
+		$this->wc_payment_tokens
+			->shouldReceive( 'create_payment_token_card' )
+			->once()
+			->with( 42, $fixture )
+			->andReturn( 4242 );
+
+		$this->wc_payment_tokens->shouldNotReceive( 'create_payment_token_paypal' );
+
+		// Capture the value sent to wp_send_json_success.
+		$sent_value = null;
+		expect( 'wp_send_json_success' )
+			->once()
+			->andReturnUsing( function ( $value ) use ( &$sent_value ): void {
+				$sent_value = $value;
+			} );
+
+		// update_user_meta must be called with the customer id from the result.
+		expect( 'update_user_meta' )
+			->once()
+			->with( 42, '_ppcp_target_customer_id', 'LYraJLIEfz' );
+
+		$this->sut->handle_request();
+
+		$this->assertSame( 4242, $sent_value, 'wp_send_json_success should receive the WC token id from create_payment_token_card()' );
+	}
+
+	/**
+	 * GIVEN a logged-in user and create_payment_token() returns a PayPal vault result
+	 * WHEN handle_request() is called
+	 * THEN create_payment_token_paypal() is called with user id, result id, and email
+	 * AND create_payment_token_card() is NOT called
+	 * AND wp_send_json_success() receives the WC token id returned by create_payment_token_paypal()
+	 */
+	public function test_paypal_success_calls_create_paypal_token_not_card(): void {
+		$this->request_data
+			->shouldReceive( 'read_request' )
+			->once()
+			->andReturn( array( 'vault_setup_token' => 'setup-tok-002' ) );
+
+		$fixture = $this->paypal_result_fixture( 'buyer@paypal.com' );
+
+		$this->tokens_endpoint
+			->shouldReceive( 'create_payment_token' )
+			->once()
+			->andReturn( $fixture );
+
+		$this->wc_payment_tokens
+			->shouldReceive( 'create_payment_token_paypal' )
+			->once()
+			->with( 42, 'paypal-token-id-999', 'buyer@paypal.com' )
+			->andReturn( 7777 );
+
+		$this->wc_payment_tokens->shouldNotReceive( 'create_payment_token_card' );
+
+		$sent_value = null;
+		expect( 'wp_send_json_success' )
+			->once()
+			->andReturnUsing( function ( $value ) use ( &$sent_value ): void {
+				$sent_value = $value;
+			} );
+
+		expect( 'update_user_meta' )
+			->once()
+			->with( 42, '_ppcp_target_customer_id', 'CustPayPal01' );
+
+		$this->sut->handle_request();
+
+		$this->assertSame( 7777, $sent_value );
+	}
+
+	/**
+	 * GIVEN read_request() throws a NonceValidationException
+	 * WHEN handle_request() is called
+	 * THEN wp_send_json_error() is called with a message array and HTTP 400
+	 * AND no token is persisted
+	 */
+	public function test_nonce_failure_returns_400_and_no_token_persisted(): void {
+		$this->request_data
+			->shouldReceive( 'read_request' )
+			->once()
+			->andThrow( new NonceValidationException( 'Invalid nonce.' ) );
+
+		$this->tokens_endpoint->shouldNotReceive( 'create_payment_token' );
+		$this->wc_payment_tokens->shouldNotReceive( 'create_payment_token_card' );
+		$this->wc_payment_tokens->shouldNotReceive( 'create_payment_token_paypal' );
+
+		$error_data   = null;
+		$error_status = null;
+		expect( 'wp_send_json_error' )
+			->once()
+			->andReturnUsing( function ( $data, $status ) use ( &$error_data, &$error_status ): void {
+				$error_data   = $data;
+				$error_status = $status;
+			} );
+
+		$this->sut->handle_request();
+
+		$this->assertIsArray( $error_data );
+		$this->assertArrayHasKey( 'message', $error_data );
+		$this->assertSame( 400, $error_status );
+	}
+
+	/**
+	 * GIVEN create_payment_token() throws a PayPalApiException
+	 * WHEN handle_request() is called
+	 * THEN wp_send_json_error() is called with no arguments
+	 * AND no WC token is persisted
+	 */
+	public function test_api_exception_calls_wp_send_json_error_with_no_args(): void {
+		$this->request_data
+			->shouldReceive( 'read_request' )
+			->once()
+			->andReturn( array( 'vault_setup_token' => 'setup-tok-003' ) );
+
+		$this->tokens_endpoint
+			->shouldReceive( 'create_payment_token' )
+			->once()
+			->andThrow( new PayPalApiException() );
+
+		$this->wc_payment_tokens->shouldNotReceive( 'create_payment_token_card' );
+		$this->wc_payment_tokens->shouldNotReceive( 'create_payment_token_paypal' );
+
+		expect( 'wp_send_json_error' )->once()->withNoArgs();
+
+		$this->sut->handle_request();
+	}
+}

--- a/tests/PHPUnit/SavePaymentMethods/Endpoint/CreateSetupTokenTest.php
+++ b/tests/PHPUnit/SavePaymentMethods/Endpoint/CreateSetupTokenTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentMethodTokensEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PaymentSource;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class CreateSetupTokenTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	/** @var RequestData&\Mockery\MockInterface */
+	private $request_data;
+
+	/** @var PaymentMethodTokensEndpoint&\Mockery\MockInterface */
+	private $tokens_endpoint;
+
+	/** @var CreateSetupToken */
+	private $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->request_data    = Mockery::mock( RequestData::class );
+		$this->tokens_endpoint = Mockery::mock( PaymentMethodTokensEndpoint::class );
+
+		$this->sut = new CreateSetupToken(
+			$this->request_data,
+			$this->tokens_endpoint
+		);
+
+		// Common WP stubs used by handle_request(). get_user_meta is intentionally
+		// NOT stubbed here: a shared when() stub would shadow the per-test
+		// expect( 'get_user_meta' ) in test_customer_id_comes_from_user_meta. Each
+		// test that reaches it stubs it locally instead.
+		when( 'get_current_user_id' )->justReturn( 7 );
+		when( 'wc_get_account_endpoint_url' )->justReturn( 'https://example.com/my-account/' );
+		when( 'wp_send_json_success' )->justReturn( null );
+	}
+
+	// -------------------------------------------------------------------------
+	// Data provider
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Scenarios for payment_method and verification_method combinations.
+	 *
+	 * Columns: request_data array, expected PaymentSource name, expected properties check callable.
+	 */
+	public function payment_source_scenarios(): array {
+		$cc_id = CreditCardGateway::ID;
+
+		return [
+			'credit card with SCA_ALWAYS sets verification_method and usage_type' => [
+				'request'              => array(
+					'payment_method'     => $cc_id,
+					'verification_method' => 'SCA_ALWAYS',
+				),
+				'expected_name'        => 'card',
+				'has_verification'     => true,
+				'verification_method'  => 'SCA_ALWAYS',
+			],
+			'credit card with SCA_WHEN_REQUIRED sets verification_method and usage_type' => [
+				'request'              => array(
+					'payment_method'     => $cc_id,
+					'verification_method' => 'SCA_WHEN_REQUIRED',
+				),
+				'expected_name'        => 'card',
+				'has_verification'     => true,
+				'verification_method'  => 'SCA_WHEN_REQUIRED',
+			],
+			'credit card with empty verification_method produces empty properties object' => [
+				'request'              => array(
+					'payment_method'     => $cc_id,
+					'verification_method' => '',
+				),
+				'expected_name'        => 'card',
+				'has_verification'     => false,
+				'verification_method'  => '',
+			],
+			'paypal payment method produces paypal source with usage_type and experience_context' => [
+				'request'              => array(
+					'payment_method' => 'ppcp-gateway',
+				),
+				'expected_name'        => 'paypal',
+				'has_verification'     => false,
+				'verification_method'  => '',
+			],
+		];
+	}
+
+	// -------------------------------------------------------------------------
+	// Tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * GIVEN a logged-in user with a stored PayPal customer ID
+	 * WHEN handle_request() is called with various payment_method / verification_method combos
+	 * THEN setup_tokens() receives a PaymentSource with the correct name and properties
+	 * AND the customer_id passed comes from get_user_meta(..., '_ppcp_target_customer_id', ...)
+	 *
+	 * @dataProvider payment_source_scenarios
+	 */
+	public function test_setup_tokens_receives_correct_payment_source(
+		array $request,
+		string $expected_name,
+		bool $has_verification,
+		string $verification_method
+	): void {
+		$this->request_data
+			->shouldReceive( 'read_request' )
+			->once()
+			->with( CreateSetupToken::ENDPOINT )
+			->andReturn( $request );
+
+		when( 'get_user_meta' )->justReturn( 'cust-abc123' );
+
+		/** @var PaymentSource|null $captured_source */
+		$captured_source = null;
+
+		$this->tokens_endpoint
+			->shouldReceive( 'setup_tokens' )
+			->once()
+			->withArgs( function ( PaymentSource $source, string $customer_id ) use ( &$captured_source ): bool {
+				$captured_source = $source;
+				return true;
+			} )
+			->andReturn( new \stdClass() );
+
+		$this->sut->handle_request();
+
+		$this->assertNotNull( $captured_source, 'setup_tokens() was not called' );
+		$this->assertSame( $expected_name, $captured_source->name() );
+
+		$props = $captured_source->properties();
+
+		if ( $has_verification ) {
+			$this->assertSame(
+				$verification_method,
+				$props->verification_method,
+				'verification_method property should match the value passed in'
+			);
+			$this->assertSame( 'MERCHANT', $props->usage_type );
+			$this->assertTrue(
+				property_exists( $props, 'experience_context' ),
+				'experience_context property should be set'
+			);
+		} else {
+			// For empty/non-SCA credit card: no properties set.
+			// For paypal: usage_type + experience_context are set but no verification_method.
+			if ( $expected_name === 'card' ) {
+				// Empty properties object (no verification_method, no usage_type).
+				$this->assertFalse(
+					isset( $props->verification_method ),
+					'Empty-verification card should produce no verification_method property'
+				);
+				$this->assertFalse(
+					isset( $props->usage_type ),
+					'Empty-verification card should produce no usage_type property'
+				);
+			} else {
+				// paypal source always gets usage_type + experience_context.
+				$this->assertSame( 'MERCHANT', $props->usage_type );
+				$this->assertTrue(
+				property_exists( $props, 'experience_context' ),
+				'experience_context property should be set'
+			);
+			}
+		}
+	}
+
+	/**
+	 * GIVEN a logged-in user with customer ID 'cust-abc123' stored in user meta
+	 * WHEN handle_request() is called
+	 * THEN setup_tokens() receives 'cust-abc123' as the customer_id argument
+	 */
+	public function test_customer_id_comes_from_user_meta(): void {
+		$this->request_data
+			->shouldReceive( 'read_request' )
+			->once()
+			->andReturn( array( 'payment_method' => 'ppcp-gateway' ) );
+
+		$captured_customer_id = null;
+
+		$this->tokens_endpoint
+			->shouldReceive( 'setup_tokens' )
+			->once()
+			->withArgs( function ( PaymentSource $source, string $customer_id ) use ( &$captured_customer_id ): bool {
+				$captured_customer_id = $customer_id;
+				return true;
+			} )
+			->andReturn( new \stdClass() );
+
+		// Override the default stub to verify the exact meta key used.
+		expect( 'get_user_meta' )
+			->once()
+			->with( 7, '_ppcp_target_customer_id', true )
+			->andReturn( 'cust-abc123' );
+
+		$this->sut->handle_request();
+
+		$this->assertSame( 'cust-abc123', $captured_customer_id );
+	}
+
+	/**
+	 * GIVEN a nonce validation failure
+	 * WHEN handle_request() is called
+	 * THEN wp_send_json_error() is called with a message array and HTTP 400 status
+	 * AND setup_tokens() is never called
+	 */
+	public function test_nonce_failure_returns_400_error(): void {
+		$this->request_data
+			->shouldReceive( 'read_request' )
+			->once()
+			->andThrow( new NonceValidationException( 'Invalid nonce.' ) );
+
+		$this->tokens_endpoint->shouldNotReceive( 'setup_tokens' );
+
+		expect( 'wp_send_json_error' )
+			->once()
+			->with(
+				Mockery::on( function ( $arg ): bool {
+					return is_array( $arg ) && isset( $arg['message'] );
+				} ),
+				400
+			);
+
+		$this->sut->handle_request();
+	}
+}


### PR DESCRIPTION
# Description

Add unit test coverage and manual-testing documentation for card vaulting.

## 🎯 The goal

The 3DS authentication step in vaulted card payments runs in the browser SDK and on PayPal's servers, so the full save + 3DS + charge flow can only be exercised manually. This PR documents how to run that manual test correctly and adds automated coverage for the plugin logic that surrounds it.

## ✅ What this adds

- `docs/testing-card-vaulting.md`: which PayPal test-card table to use for vaulting (the "Save payment methods" cards, not the purchase-flow ones), the sandbox prerequisite of setting 3DS to ALWAYS, and where the automated coverage lives.
- Unit coverage for the two vault-token AJAX endpoints: `CreateSetupToken` (setup-request body construction across payment-method and verification-method combinations) and `CreatePaymentToken` (exchange-response handling and WooCommerce token persistence).

## 🔍 What to review

- **No production code changes.** Docs and tests only; nothing in the runtime path moves.
- **The 3DS path itself stays manually verified.** A live-API integration test would be non-deterministic, so the new unit tests deliberately stop at the PayPal HTTP boundary and assert only what our code sends and does with responses.
