### PR TITLE
fix(compat): disable legacy WC PayPal Standard gateway on PPCP merchant connect

### DIFF
--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -612,6 +612,36 @@ class CompatModule implements ServiceModule, ExecutableModule {
 	}
 
 	/**
+	 * Returns the total count of active/pending-cancel PayPal Standard subscriptions via WCS.
+	 *
+	 * Checks both the native WPS gateway ID and the restoration plugin gateway ID.
+	 * Returns null when WooCommerce Subscriptions is not installed, so callers can
+	 * distinguish "WCS absent" from "WCS present but zero subscriptions".
+	 *
+	 * @return int|null  null = WCS not installed; int = total active subscription count.
+	 */
+	protected function count_wps_active_subscriptions(): ?int {
+		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
+			return null;
+		}
+
+		$total = 0;
+		foreach ( array( 'paypal', 'restore_paypal_standard' ) as $gateway_id ) {
+			$total += count(
+				wcs_get_subscriptions(
+					array(
+						'payment_method'         => $gateway_id,
+						'subscription_status'    => array( 'active', 'pending-cancel' ),
+						'subscriptions_per_page' => -1,
+					)
+				)
+			);
+		}
+
+		return $total;
+	}
+
+	/**
 	 * Disables the WC core PayPal Standard gateway when a merchant successfully connects PPCP.
 	 *
 	 * PayPal Standard has a '_should_load' persistence flag that survives the enabled toggle —
@@ -625,33 +655,19 @@ class CompatModule implements ServiceModule, ExecutableModule {
 	 * next admin page load via maybe_show_wps_subscriptions_notice().
 	 */
 	protected function disable_legacy_paypal_standard_on_connect(): void {
-		if ( function_exists( 'wcs_get_subscriptions' ) ) {
-			// Check both native WPS and the restoration plugin gateway for active subscriptions.
-			$total_count = 0;
-			foreach ( array( 'paypal', 'restore_paypal_standard' ) as $gateway_id ) {
-				$total_count += count(
-					wcs_get_subscriptions(
-						array(
-							'payment_method'         => $gateway_id,
-							'subscription_status'    => array( 'active', 'pending-cancel' ),
-							'subscriptions_per_page' => -1,
-						)
-					)
-				);
-			}
+		$sub_count = $this->count_wps_active_subscriptions();
 
-			if ( $total_count > 0 ) {
-				// Persist count to a transient so the notice survives the AJAX connect request
-				// and appears on the next admin page load.
-				set_transient( 'ppcp_wps_standard_subs_notice', $total_count, 30 * DAY_IN_SECONDS );
-				return;
-			}
+		if ( $sub_count !== null && $sub_count > 0 ) {
+			// Persist count to a transient so the notice survives the AJAX connect request
+			// and appears on the next admin page load.
+			set_transient( 'ppcp_wps_standard_subs_notice', $sub_count, 30 * DAY_IN_SECONDS );
+			return;
 		}
 
 		// Safe to disable — no active PayPal Standard subscriptions detected.
-		$settings               = get_option( 'woocommerce_paypal_settings', array() );
+		$settings                 = get_option( 'woocommerce_paypal_settings', array() );
 		$settings['enabled']      = 'no';
-		$settings['_should_load'] = 'no'; // clears the permanent latch; enabled=no alone is insufficient
+		$settings['_should_load'] = 'no'; // Clears the permanent latch; enabled=no alone is insufficient.
 		update_option( 'woocommerce_paypal_settings', $settings );
 
 		// Also disable restore-paypal-standard-for-woocommerce if installed.

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -86,6 +86,7 @@ class CompatModule implements ServiceModule, ExecutableModule {
 			'woocommerce_paypal_payments_authenticated_merchant',
 			array( $this, 'disable_legacy_paypal_standard_on_connect' )
 		);
+		add_action( 'admin_notices', array( $this, 'maybe_show_wps_subscriptions_notice' ) );
 
 		$this->legacy_ui_card_payment_mapping( $c );
 
@@ -586,45 +587,31 @@ class CompatModule implements ServiceModule, ExecutableModule {
 	 * keeps the IPN handler dormant by clearing _should_load, which prevents residual
 	 * WOOTHEMES_CART BN code volume from appearing in PayPal partner reporting.
 	 *
-	 * Skips the disable (and shows an admin notice instead) when WooCommerce Subscriptions
-	 * detects active subscriptions still billed through PayPal Standard — those renewals
-	 * depend on the IPN endpoint and cannot be silently migrated.
+	 * When WooCommerce Subscriptions detects active subscriptions billed through PayPal Standard
+	 * or the restoration plugin, stores a transient instead of disabling — those renewals
+	 * depend on the IPN endpoint and cannot be silently migrated. The notice is rendered on the
+	 * next admin page load via maybe_show_wps_subscriptions_notice().
 	 */
-	private function disable_legacy_paypal_standard_on_connect(): void {
-		// If WCS is active and the merchant has live PayPal Standard subscriptions,
-		// disabling would break their renewal flow. Show a notice instead.
+	protected function disable_legacy_paypal_standard_on_connect(): void {
 		if ( function_exists( 'wcs_get_subscriptions' ) ) {
-			$active_paypal_subs = wcs_get_subscriptions(
-				array(
-					'payment_method'      => 'paypal',
-					'subscription_status' => array( 'active', 'pending-cancel' ),
-				)
-			);
-
-			if ( ! empty( $active_paypal_subs ) ) {
-				$count = count( $active_paypal_subs );
-				add_action(
-					'admin_notices',
-					static function () use ( $count ) {
-						$subscriptions_url = admin_url( 'edit.php?post_type=shop_subscription&_payment_method=paypal' );
-						printf(
-							'<div class="notice notice-warning"><p>%s</p></div>',
-							wp_kses_post(
-								sprintf(
-									/* translators: 1: number of subscriptions, 2: URL to subscription list */
-									_n(
-										'PayPal Payments is now your active checkout gateway, but <a href="%2$s">%1$d subscription</a> is still billed through the legacy PayPal Standard gateway. Migrate or cancel these subscriptions before disabling PayPal Standard to avoid missed renewals.',
-										'PayPal Payments is now your active checkout gateway, but <a href="%2$s">%1$d subscriptions</a> are still billed through the legacy PayPal Standard gateway. Migrate or cancel these subscriptions before disabling PayPal Standard to avoid missed renewals.',
-										$count,
-										'woocommerce-paypal-payments'
-									),
-									$count,
-									esc_url( $subscriptions_url )
-								)
-							)
-						);
-					}
+			// Check both native WPS and the restoration plugin gateway for active subscriptions.
+			$total_count = 0;
+			foreach ( array( 'paypal', 'restore_paypal_standard' ) as $gateway_id ) {
+				$total_count += count(
+					wcs_get_subscriptions(
+						array(
+							'payment_method'         => $gateway_id,
+							'subscription_status'    => array( 'active', 'pending-cancel' ),
+							'subscriptions_per_page' => -1,
+						)
+					)
 				);
+			}
+
+			if ( $total_count > 0 ) {
+				// Persist count to a transient so the notice survives the AJAX connect request
+				// and appears on the next admin page load.
+				set_transient( 'ppcp_wps_standard_subs_notice', $total_count, 30 * DAY_IN_SECONDS );
 				return;
 			}
 		}
@@ -645,5 +632,37 @@ class CompatModule implements ServiceModule, ExecutableModule {
 			$rpsfw['enabled'] = 'no';
 			update_option( 'woocommerce_restore_paypal_standard_settings', $rpsfw );
 		}
+	}
+
+	/**
+	 * Renders an admin notice when disable_legacy_paypal_standard_on_connect() detected active
+	 * PayPal Standard subscriptions and stored a transient instead of disabling the gateway.
+	 *
+	 * Fires on admin_notices. Uses a transient to bridge the AJAX merchant-connect request
+	 * and the next admin page load.
+	 */
+	protected function maybe_show_wps_subscriptions_notice(): void {
+		$count = get_transient( 'ppcp_wps_standard_subs_notice' );
+		if ( false === $count ) {
+			return;
+		}
+		delete_transient( 'ppcp_wps_standard_subs_notice' );
+		$subscriptions_url = admin_url( 'edit.php?post_type=shop_subscription&payment_method=paypal' );
+		printf(
+			'<div class="notice notice-warning"><p>%s</p></div>',
+			wp_kses_post(
+				sprintf(
+					/* translators: 1: number of subscriptions, 2: URL to subscription list */
+					_n(
+						'PayPal Payments is now your active checkout gateway, but <a href="%2$s">%1$d subscription</a> is still billed through the legacy PayPal Standard gateway. Migrate or cancel these subscriptions before disabling PayPal Standard to avoid missed renewals.',
+						'PayPal Payments is now your active checkout gateway, but <a href="%2$s">%1$d subscriptions</a> are still billed through the legacy PayPal Standard gateway. Migrate or cancel these subscriptions before disabling PayPal Standard to avoid missed renewals.',
+						(int) $count,
+						'woocommerce-paypal-payments'
+					),
+					(int) $count,
+					esc_url( $subscriptions_url )
+				)
+			)
+		);
 	}
 }

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -634,5 +634,16 @@ class CompatModule implements ServiceModule, ExecutableModule {
 		$settings['enabled']      = 'no';
 		$settings['_should_load'] = 'no'; // clears the permanent latch; enabled=no alone is insufficient
 		update_option( 'woocommerce_paypal_settings', $settings );
+
+		// Also disable restore-paypal-standard-for-woocommerce if installed.
+		// That plugin registers gateway ID `restore_paypal_standard` with option key
+		// `woocommerce_restore_paypal_standard_settings` — a dark pool that sends no BN code.
+		// enable-standard-paypal-for-woocommerce uses the native `woocommerce_paypal_settings` key
+		// above, so it is already covered by the write above.
+		$rpsfw = get_option( 'woocommerce_restore_paypal_standard_settings', array() );
+		if ( ! empty( $rpsfw ) ) {
+			$rpsfw['enabled'] = 'no';
+			update_option( 'woocommerce_restore_paypal_standard_settings', $rpsfw );
+		}
 	}
 }

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -82,6 +82,11 @@ class CompatModule implements ServiceModule, ExecutableModule {
 
 		add_action( 'woocommerce_paypal_payments_gateway_migrate', static fn() => delete_transient( 'ppcp_has_ppec_subscriptions' ) );
 
+		add_action(
+			'woocommerce_paypal_payments_authenticated_merchant',
+			array( $this, 'disable_legacy_paypal_standard_on_connect' )
+		);
+
 		$this->legacy_ui_card_payment_mapping( $c );
 
 		/**
@@ -571,5 +576,63 @@ class CompatModule implements ServiceModule, ExecutableModule {
 				}
 			}
 		);
+	}
+
+	/**
+	 * Disables the WC core PayPal Standard gateway when a merchant successfully connects PPCP.
+	 *
+	 * PayPal Standard has a '_should_load' persistence flag that survives the enabled toggle —
+	 * both keys must be set to 'no' for the gateway to fully stop loading. This method also
+	 * keeps the IPN handler dormant by clearing _should_load, which prevents residual
+	 * WOOTHEMES_CART BN code volume from appearing in PayPal partner reporting.
+	 *
+	 * Skips the disable (and shows an admin notice instead) when WooCommerce Subscriptions
+	 * detects active subscriptions still billed through PayPal Standard — those renewals
+	 * depend on the IPN endpoint and cannot be silently migrated.
+	 */
+	private function disable_legacy_paypal_standard_on_connect(): void {
+		// If WCS is active and the merchant has live PayPal Standard subscriptions,
+		// disabling would break their renewal flow. Show a notice instead.
+		if ( function_exists( 'wcs_get_subscriptions' ) ) {
+			$active_paypal_subs = wcs_get_subscriptions(
+				array(
+					'payment_method'      => 'paypal',
+					'subscription_status' => array( 'active', 'pending-cancel' ),
+				)
+			);
+
+			if ( ! empty( $active_paypal_subs ) ) {
+				$count = count( $active_paypal_subs );
+				add_action(
+					'admin_notices',
+					static function () use ( $count ) {
+						$subscriptions_url = admin_url( 'edit.php?post_type=shop_subscription&_payment_method=paypal' );
+						printf(
+							'<div class="notice notice-warning"><p>%s</p></div>',
+							wp_kses_post(
+								sprintf(
+									/* translators: 1: number of subscriptions, 2: URL to subscription list */
+									_n(
+										'PayPal Payments is now your active checkout gateway, but <a href="%2$s">%1$d subscription</a> is still billed through the legacy PayPal Standard gateway. Migrate or cancel these subscriptions before disabling PayPal Standard to avoid missed renewals.',
+										'PayPal Payments is now your active checkout gateway, but <a href="%2$s">%1$d subscriptions</a> are still billed through the legacy PayPal Standard gateway. Migrate or cancel these subscriptions before disabling PayPal Standard to avoid missed renewals.',
+										$count,
+										'woocommerce-paypal-payments'
+									),
+									$count,
+									esc_url( $subscriptions_url )
+								)
+							)
+						);
+					}
+				);
+				return;
+			}
+		}
+
+		// Safe to disable — no active PayPal Standard subscriptions detected.
+		$settings               = get_option( 'woocommerce_paypal_settings', array() );
+		$settings['enabled']      = 'no';
+		$settings['_should_load'] = 'no'; // clears the permanent latch; enabled=no alone is insufficient
+		update_option( 'woocommerce_paypal_settings', $settings );
 	}
 }

--- a/modules/ppcp-compat/src/CompatModule.php
+++ b/modules/ppcp-compat/src/CompatModule.php
@@ -93,9 +93,16 @@ class CompatModule implements ServiceModule, ExecutableModule {
 
 		add_action(
 			'woocommerce_paypal_payments_authenticated_merchant',
-			array( $this, 'disable_legacy_paypal_standard_on_connect' )
+			function () {
+				$this->disable_legacy_paypal_standard_on_connect();
+			}
 		);
-		add_action( 'admin_notices', array( $this, 'maybe_show_wps_subscriptions_notice' ) );
+		add_action(
+			'admin_notices',
+			function () {
+				$this->maybe_show_wps_subscriptions_notice();
+			}
+		);
 
 		$this->legacy_ui_card_payment_mapping( $c );
 

--- a/tests/PHPUnit/Compat/DisableLegacyPaypalStandardTest.php
+++ b/tests/PHPUnit/Compat/DisableLegacyPaypalStandardTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Compat\Tests;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use WooCommerce\PayPalCommerce\Compat\CompatModule;
+
+/**
+ * Testable subclass exposing protected methods for unit testing.
+ */
+class TestableCompatModule extends CompatModule {
+	public function call_disable_legacy_paypal_standard_on_connect(): void {
+		$this->disable_legacy_paypal_standard_on_connect();
+	}
+
+	public function call_maybe_show_wps_subscriptions_notice(): string {
+		ob_start();
+		$this->maybe_show_wps_subscriptions_notice();
+		return ob_get_clean() ?: '';
+	}
+}
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Compat\CompatModule::disable_legacy_paypal_standard_on_connect
+ * @covers \WooCommerce\PayPalCommerce\Compat\CompatModule::maybe_show_wps_subscriptions_notice
+ */
+class DisableLegacyPaypalStandardTest extends TestCase {
+
+	/** @var TestableCompatModule */
+	private TestableCompatModule $sut;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->sut = new TestableCompatModule();
+
+		// Reset option state between tests.
+		delete_option( 'woocommerce_paypal_settings' );
+		delete_option( 'woocommerce_restore_paypal_standard_settings' );
+		delete_transient( 'ppcp_wps_standard_subs_notice' );
+	}
+
+	// ── disable_legacy_paypal_standard_on_connect ──────────────────────────
+
+	/**
+	 * @test
+	 *
+	 * GIVEN WooCommerce Subscriptions is not installed
+	 * WHEN  the merchant connects PPCP
+	 * THEN  WPS is disabled unconditionally (both enabled and _should_load set to 'no')
+	 */
+	public function test_disables_wps_when_wcs_not_installed(): void {
+		// function_exists('wcs_get_subscriptions') returns false in this env.
+		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
+
+		$this->sut->call_disable_legacy_paypal_standard_on_connect();
+
+		$settings = get_option( 'woocommerce_paypal_settings' );
+		$this->assertSame( 'no', $settings['enabled'] );
+		$this->assertSame( 'no', $settings['_should_load'] );
+		$this->assertFalse( get_transient( 'ppcp_wps_standard_subs_notice' ) );
+	}
+
+	/**
+	 * @test
+	 *
+	 * GIVEN WooCommerce Subscriptions is active with zero active PayPal Standard subscriptions
+	 * WHEN  the merchant connects PPCP
+	 * THEN  WPS is disabled (WCS guard does not block)
+	 */
+	public function test_disables_wps_when_wcs_has_no_active_paypal_subs(): void {
+		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
+			$this->markTestSkipped( 'WooCommerce Subscriptions not available.' );
+		}
+
+		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
+
+		// wcs_get_subscriptions returns empty for both gateway IDs.
+		$this->sut->call_disable_legacy_paypal_standard_on_connect();
+
+		$settings = get_option( 'woocommerce_paypal_settings' );
+		$this->assertSame( 'no', $settings['enabled'] );
+		$this->assertSame( 'no', $settings['_should_load'] );
+	}
+
+	/**
+	 * @test
+	 *
+	 * GIVEN WCS is active with at least one active native PayPal Standard subscription
+	 * WHEN  the merchant connects PPCP
+	 * THEN  WPS is NOT disabled and a transient is stored for the notice
+	 *
+	 * @dataProvider active_native_paypal_sub_counts
+	 */
+	public function test_stores_transient_and_skips_disable_when_native_paypal_subs_exist( int $count ): void {
+		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
+			$this->markTestSkipped( 'WooCommerce Subscriptions not available.' );
+		}
+
+		// Seed WCS with active native PayPal subscriptions.
+		$this->seed_wcs_subscriptions( 'paypal', $count );
+		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
+
+		$this->sut->call_disable_legacy_paypal_standard_on_connect();
+
+		// Transient must be set.
+		$stored = get_transient( 'ppcp_wps_standard_subs_notice' );
+		$this->assertSame( $count, (int) $stored );
+
+		// Options must NOT be touched.
+		$settings = get_option( 'woocommerce_paypal_settings' );
+		$this->assertSame( 'yes', $settings['enabled'] );
+	}
+
+	/** @return array<string, array{int}> */
+	public static function active_native_paypal_sub_counts(): array {
+		return array(
+			'one subscription'      => array( 1 ),
+			'multiple subscriptions' => array( 5 ),
+		);
+	}
+
+	/**
+	 * @test
+	 *
+	 * GIVEN WCS is active with an active restore_paypal_standard subscription (no native WPS subs)
+	 * WHEN  the merchant connects PPCP
+	 * THEN  WPS is NOT disabled and a transient is stored
+	 */
+	public function test_stores_transient_when_restoration_plugin_subs_exist(): void {
+		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
+			$this->markTestSkipped( 'WooCommerce Subscriptions not available.' );
+		}
+
+		$this->seed_wcs_subscriptions( 'restore_paypal_standard', 2 );
+		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
+
+		$this->sut->call_disable_legacy_paypal_standard_on_connect();
+
+		$stored = get_transient( 'ppcp_wps_standard_subs_notice' );
+		$this->assertSame( 2, (int) $stored );
+
+		$settings = get_option( 'woocommerce_paypal_settings' );
+		$this->assertSame( 'yes', $settings['enabled'] );
+	}
+
+	/**
+	 * @test
+	 *
+	 * GIVEN the restore-paypal-standard-for-woocommerce plugin is installed (option exists)
+	 * WHEN  the merchant connects PPCP with no active subscriptions
+	 * THEN  both woocommerce_paypal_settings and woocommerce_restore_paypal_standard_settings
+	 *       have enabled set to 'no'
+	 */
+	public function test_also_disables_restoration_plugin_option_when_present(): void {
+		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
+		update_option( 'woocommerce_restore_paypal_standard_settings', array( 'enabled' => 'yes' ) );
+
+		$this->sut->call_disable_legacy_paypal_standard_on_connect();
+
+		$wps   = get_option( 'woocommerce_paypal_settings' );
+		$rpsfw = get_option( 'woocommerce_restore_paypal_standard_settings' );
+		$this->assertSame( 'no', $wps['enabled'] );
+		$this->assertSame( 'no', $wps['_should_load'] );
+		$this->assertSame( 'no', $rpsfw['enabled'] );
+	}
+
+	/**
+	 * @test
+	 *
+	 * GIVEN WPS is already fully disabled
+	 * WHEN  the merchant re-connects PPCP
+	 * THEN  the operation is idempotent (safe to write 'no' to already-'no' keys)
+	 */
+	public function test_disable_is_idempotent(): void {
+		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'no', '_should_load' => 'no' ) );
+
+		$this->sut->call_disable_legacy_paypal_standard_on_connect();
+		$this->sut->call_disable_legacy_paypal_standard_on_connect();
+
+		$settings = get_option( 'woocommerce_paypal_settings' );
+		$this->assertSame( 'no', $settings['enabled'] );
+		$this->assertSame( 'no', $settings['_should_load'] );
+	}
+
+	// ── maybe_show_wps_subscriptions_notice ───────────────────────────────
+
+	/**
+	 * @test
+	 *
+	 * GIVEN no transient has been set
+	 * WHEN  admin_notices fires
+	 * THEN  no output is produced
+	 */
+	public function test_no_output_when_transient_absent(): void {
+		$output = $this->sut->call_maybe_show_wps_subscriptions_notice();
+
+		$this->assertSame( '', $output );
+	}
+
+	/**
+	 * @test
+	 *
+	 * GIVEN a subscription count transient is set
+	 * WHEN  admin_notices fires
+	 * THEN  a notice div is rendered and the transient is deleted
+	 *
+	 * @dataProvider subscription_count_notice_cases
+	 */
+	public function test_renders_notice_and_clears_transient( int $count, string $expected_fragment ): void {
+		set_transient( 'ppcp_wps_standard_subs_notice', $count, 30 * DAY_IN_SECONDS );
+
+		$output = $this->sut->call_maybe_show_wps_subscriptions_notice();
+
+		$this->assertStringContainsString( 'notice notice-warning', $output );
+		$this->assertStringContainsString( $expected_fragment, $output );
+		// Transient must be deleted after display.
+		$this->assertFalse( get_transient( 'ppcp_wps_standard_subs_notice' ) );
+	}
+
+	/** @return array<string, array{int, string}> */
+	public static function subscription_count_notice_cases(): array {
+		return array(
+			'singular — 1 subscription'  => array( 1, '1 subscription</a> is still billed' ),
+			'plural — 5 subscriptions'   => array( 5, '5 subscriptions</a> are still billed' ),
+		);
+	}
+
+	// ── helpers ───────────────────────────────────────────────────────────
+
+	/**
+	 * Seeds WCS with the given number of active subscriptions for a gateway.
+	 * No-op if WCS is not installed; callers should markTestSkipped() first.
+	 */
+	private function seed_wcs_subscriptions( string $gateway_id, int $count ): void {
+		for ( $i = 0; $i < $count; $i++ ) {
+			$order = wc_create_order();
+			$sub   = wcs_create_subscription(
+				array(
+					'order_id'         => $order->get_id(),
+					'status'           => 'active',
+					'billing_interval' => 1,
+					'billing_period'   => 'month',
+				)
+			);
+			$sub->set_payment_method( $gateway_id );
+			$sub->save();
+		}
+	}
+}

--- a/tests/PHPUnit/Compat/DisableLegacyPaypalStandardTest.php
+++ b/tests/PHPUnit/Compat/DisableLegacyPaypalStandardTest.php
@@ -2,26 +2,11 @@
 
 declare( strict_types = 1 );
 
-namespace WooCommerce\PayPalCommerce\Compat\Tests;
+namespace WooCommerce\PayPalCommerce\Compat;
 
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
-use WooCommerce\PayPalCommerce\Compat\CompatModule;
-
-/**
- * Testable subclass exposing protected methods for unit testing.
- */
-class TestableCompatModule extends CompatModule {
-	public function call_disable_legacy_paypal_standard_on_connect(): void {
-		$this->disable_legacy_paypal_standard_on_connect();
-	}
-
-	public function call_maybe_show_wps_subscriptions_notice(): string {
-		ob_start();
-		$this->maybe_show_wps_subscriptions_notice();
-		return ob_get_clean() ?: '';
-	}
-}
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\Compat\CompatModule::disable_legacy_paypal_standard_on_connect
@@ -29,224 +14,170 @@ class TestableCompatModule extends CompatModule {
  */
 class DisableLegacyPaypalStandardTest extends TestCase {
 
-	/** @var TestableCompatModule */
-	private TestableCompatModule $sut;
+	/** @var object Anonymous subclass of CompatModule */
+	private object $sut;
 
-	protected function setUp(): void {
+	public function setUp(): void {
 		parent::setUp();
-		$this->sut = new TestableCompatModule();
 
-		// Reset option state between tests.
-		delete_option( 'woocommerce_paypal_settings' );
-		delete_option( 'woocommerce_restore_paypal_standard_settings' );
-		delete_transient( 'ppcp_wps_standard_subs_notice' );
-	}
-
-	// ── disable_legacy_paypal_standard_on_connect ──────────────────────────
-
-	/**
-	 * @test
-	 *
-	 * GIVEN WooCommerce Subscriptions is not installed
-	 * WHEN  the merchant connects PPCP
-	 * THEN  WPS is disabled unconditionally (both enabled and _should_load set to 'no')
-	 */
-	public function test_disables_wps_when_wcs_not_installed(): void {
-		// function_exists('wcs_get_subscriptions') returns false in this env.
-		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
-
-		$this->sut->call_disable_legacy_paypal_standard_on_connect();
-
-		$settings = get_option( 'woocommerce_paypal_settings' );
-		$this->assertSame( 'no', $settings['enabled'] );
-		$this->assertSame( 'no', $settings['_should_load'] );
-		$this->assertFalse( get_transient( 'ppcp_wps_standard_subs_notice' ) );
-	}
-
-	/**
-	 * @test
-	 *
-	 * GIVEN WooCommerce Subscriptions is active with zero active PayPal Standard subscriptions
-	 * WHEN  the merchant connects PPCP
-	 * THEN  WPS is disabled (WCS guard does not block)
-	 */
-	public function test_disables_wps_when_wcs_has_no_active_paypal_subs(): void {
-		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
-			$this->markTestSkipped( 'WooCommerce Subscriptions not available.' );
+		if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+			define( 'DAY_IN_SECONDS', 86400 );
 		}
 
-		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
+		$this->sut = new class extends CompatModule {
+			private ?int $wcs_count = null;
 
-		// wcs_get_subscriptions returns empty for both gateway IDs.
-		$this->sut->call_disable_legacy_paypal_standard_on_connect();
+			public function set_wcs_count( ?int $count ): void {
+				$this->wcs_count = $count;
+			}
 
-		$settings = get_option( 'woocommerce_paypal_settings' );
-		$this->assertSame( 'no', $settings['enabled'] );
-		$this->assertSame( 'no', $settings['_should_load'] );
+			protected function count_wps_active_subscriptions(): ?int {
+				return $this->wcs_count;
+			}
+
+			public function call_disable(): void {
+				$this->disable_legacy_paypal_standard_on_connect();
+			}
+
+			public function call_notice(): string {
+				ob_start();
+				$this->maybe_show_wps_subscriptions_notice();
+				return ob_get_clean() ?: '';
+			}
+		};
+	}
+
+	// ── disable_legacy_paypal_standard_on_connect ──────────────────────────────
+
+	/**
+	 * WPS is disabled when WCS is absent (null) or has no active subscriptions (0).
+	 *
+	 * @test
+	 * @dataProvider wcs_absent_or_empty_counts
+	 */
+	public function test_disables_wps_when_no_active_subscriptions( ?int $count ): void {
+		$this->sut->set_wcs_count( $count );
+
+		when( 'get_option' )->alias(
+			static function ( string $key, $default = array() ) {
+				if ( $key === 'woocommerce_paypal_settings' ) {
+					return array( 'enabled' => 'yes', '_should_load' => 'yes' );
+				}
+				return $default;
+			}
+		);
+		expect( 'update_option' )
+			->once()
+			->with( 'woocommerce_paypal_settings', array( 'enabled' => 'no', '_should_load' => 'no' ) );
+		expect( 'set_transient' )->never();
+
+		$this->sut->call_disable();
+		$this->addToAssertionCount( 1 );
+	}
+
+	/** @return array<string, array{?int}> */
+	public static function wcs_absent_or_empty_counts(): array {
+		return array(
+			'WCS not installed' => array( null ),
+			'WCS has zero subs' => array( 0 ),
+		);
 	}
 
 	/**
+	 * WPS is NOT disabled and a transient is stored when active subscriptions exist.
+	 *
 	 * @test
-	 *
-	 * GIVEN WCS is active with at least one active native PayPal Standard subscription
-	 * WHEN  the merchant connects PPCP
-	 * THEN  WPS is NOT disabled and a transient is stored for the notice
-	 *
-	 * @dataProvider active_native_paypal_sub_counts
+	 * @dataProvider active_subscription_counts
 	 */
-	public function test_stores_transient_and_skips_disable_when_native_paypal_subs_exist( int $count ): void {
-		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
-			$this->markTestSkipped( 'WooCommerce Subscriptions not available.' );
-		}
+	public function test_stores_transient_and_skips_disable_when_subscriptions_exist( int $count ): void {
+		$this->sut->set_wcs_count( $count );
 
-		// Seed WCS with active native PayPal subscriptions.
-		$this->seed_wcs_subscriptions( 'paypal', $count );
-		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
+		expect( 'set_transient' )
+			->once()
+			->with( 'ppcp_wps_standard_subs_notice', $count, 30 * DAY_IN_SECONDS );
+		expect( 'update_option' )->never();
 
-		$this->sut->call_disable_legacy_paypal_standard_on_connect();
-
-		// Transient must be set.
-		$stored = get_transient( 'ppcp_wps_standard_subs_notice' );
-		$this->assertSame( $count, (int) $stored );
-
-		// Options must NOT be touched.
-		$settings = get_option( 'woocommerce_paypal_settings' );
-		$this->assertSame( 'yes', $settings['enabled'] );
+		$this->sut->call_disable();
+		$this->addToAssertionCount( 1 );
 	}
 
 	/** @return array<string, array{int}> */
-	public static function active_native_paypal_sub_counts(): array {
+	public static function active_subscription_counts(): array {
 		return array(
-			'one subscription'      => array( 1 ),
+			'one subscription'       => array( 1 ),
 			'multiple subscriptions' => array( 5 ),
 		);
 	}
 
 	/**
-	 * @test
+	 * Both native WPS and the restoration plugin option are disabled when the restore option exists.
 	 *
-	 * GIVEN WCS is active with an active restore_paypal_standard subscription (no native WPS subs)
-	 * WHEN  the merchant connects PPCP
-	 * THEN  WPS is NOT disabled and a transient is stored
+	 * @test
 	 */
-	public function test_stores_transient_when_restoration_plugin_subs_exist(): void {
-		if ( ! function_exists( 'wcs_get_subscriptions' ) ) {
-			$this->markTestSkipped( 'WooCommerce Subscriptions not available.' );
-		}
+	public function test_also_disables_restoration_plugin_when_option_present(): void {
+		when( 'get_option' )->alias(
+			static function ( string $key, $default = array() ) {
+				if ( $key === 'woocommerce_paypal_settings' ) {
+					return array( 'enabled' => 'yes', '_should_load' => 'yes' );
+				}
+				if ( $key === 'woocommerce_restore_paypal_standard_settings' ) {
+					return array( 'enabled' => 'yes' );
+				}
+				return $default;
+			}
+		);
+		expect( 'update_option' )
+			->once()
+			->with( 'woocommerce_paypal_settings', array( 'enabled' => 'no', '_should_load' => 'no' ) );
+		expect( 'update_option' )
+			->once()
+			->with( 'woocommerce_restore_paypal_standard_settings', array( 'enabled' => 'no' ) );
 
-		$this->seed_wcs_subscriptions( 'restore_paypal_standard', 2 );
-		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
-
-		$this->sut->call_disable_legacy_paypal_standard_on_connect();
-
-		$stored = get_transient( 'ppcp_wps_standard_subs_notice' );
-		$this->assertSame( 2, (int) $stored );
-
-		$settings = get_option( 'woocommerce_paypal_settings' );
-		$this->assertSame( 'yes', $settings['enabled'] );
+		$this->sut->call_disable();
+		$this->addToAssertionCount( 1 );
 	}
 
-	/**
-	 * @test
-	 *
-	 * GIVEN the restore-paypal-standard-for-woocommerce plugin is installed (option exists)
-	 * WHEN  the merchant connects PPCP with no active subscriptions
-	 * THEN  both woocommerce_paypal_settings and woocommerce_restore_paypal_standard_settings
-	 *       have enabled set to 'no'
-	 */
-	public function test_also_disables_restoration_plugin_option_when_present(): void {
-		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'yes', '_should_load' => 'yes' ) );
-		update_option( 'woocommerce_restore_paypal_standard_settings', array( 'enabled' => 'yes' ) );
-
-		$this->sut->call_disable_legacy_paypal_standard_on_connect();
-
-		$wps   = get_option( 'woocommerce_paypal_settings' );
-		$rpsfw = get_option( 'woocommerce_restore_paypal_standard_settings' );
-		$this->assertSame( 'no', $wps['enabled'] );
-		$this->assertSame( 'no', $wps['_should_load'] );
-		$this->assertSame( 'no', $rpsfw['enabled'] );
-	}
+	// ── maybe_show_wps_subscriptions_notice ────────────────────────────────────
 
 	/**
-	 * @test
+	 * No output when the transient is absent.
 	 *
-	 * GIVEN WPS is already fully disabled
-	 * WHEN  the merchant re-connects PPCP
-	 * THEN  the operation is idempotent (safe to write 'no' to already-'no' keys)
-	 */
-	public function test_disable_is_idempotent(): void {
-		update_option( 'woocommerce_paypal_settings', array( 'enabled' => 'no', '_should_load' => 'no' ) );
-
-		$this->sut->call_disable_legacy_paypal_standard_on_connect();
-		$this->sut->call_disable_legacy_paypal_standard_on_connect();
-
-		$settings = get_option( 'woocommerce_paypal_settings' );
-		$this->assertSame( 'no', $settings['enabled'] );
-		$this->assertSame( 'no', $settings['_should_load'] );
-	}
-
-	// ── maybe_show_wps_subscriptions_notice ───────────────────────────────
-
-	/**
 	 * @test
-	 *
-	 * GIVEN no transient has been set
-	 * WHEN  admin_notices fires
-	 * THEN  no output is produced
 	 */
 	public function test_no_output_when_transient_absent(): void {
-		$output = $this->sut->call_maybe_show_wps_subscriptions_notice();
+		when( 'get_transient' )->justReturn( false );
+
+		$output = $this->sut->call_notice();
 
 		$this->assertSame( '', $output );
 	}
 
 	/**
+	 * A warning notice is rendered with the correct singular/plural count.
+	 *
 	 * @test
-	 *
-	 * GIVEN a subscription count transient is set
-	 * WHEN  admin_notices fires
-	 * THEN  a notice div is rendered and the transient is deleted
-	 *
 	 * @dataProvider subscription_count_notice_cases
 	 */
-	public function test_renders_notice_and_clears_transient( int $count, string $expected_fragment ): void {
-		set_transient( 'ppcp_wps_standard_subs_notice', $count, 30 * DAY_IN_SECONDS );
+	public function test_renders_notice_with_correct_count( int $count, string $expected_fragment ): void {
+		when( 'get_transient' )->justReturn( $count );
+		when( 'admin_url' )->returnArg();
+		when( '_n' )->alias(
+			static function ( string $single, string $plural, int $number ): string {
+				return $number === 1 ? $single : $plural;
+			}
+		);
 
-		$output = $this->sut->call_maybe_show_wps_subscriptions_notice();
+		$output = $this->sut->call_notice();
 
 		$this->assertStringContainsString( 'notice notice-warning', $output );
 		$this->assertStringContainsString( $expected_fragment, $output );
-		// Transient must be deleted after display.
-		$this->assertFalse( get_transient( 'ppcp_wps_standard_subs_notice' ) );
 	}
 
 	/** @return array<string, array{int, string}> */
 	public static function subscription_count_notice_cases(): array {
 		return array(
-			'singular — 1 subscription'  => array( 1, '1 subscription</a> is still billed' ),
-			'plural — 5 subscriptions'   => array( 5, '5 subscriptions</a> are still billed' ),
+			'singular — 1 subscription' => array( 1, '1 subscription</a> is still billed' ),
+			'plural — 5 subscriptions'  => array( 5, '5 subscriptions</a> are still billed' ),
 		);
-	}
-
-	// ── helpers ───────────────────────────────────────────────────────────
-
-	/**
-	 * Seeds WCS with the given number of active subscriptions for a gateway.
-	 * No-op if WCS is not installed; callers should markTestSkipped() first.
-	 */
-	private function seed_wcs_subscriptions( string $gateway_id, int $count ): void {
-		for ( $i = 0; $i < $count; $i++ ) {
-			$order = wc_create_order();
-			$sub   = wcs_create_subscription(
-				array(
-					'order_id'         => $order->get_id(),
-					'status'           => 'active',
-					'billing_interval' => 1,
-					'billing_period'   => 'month',
-				)
-			);
-			$sub->set_payment_method( $gateway_id );
-			$sub->save();
-		}
 	}
 }


### PR DESCRIPTION
## Summary

- Hooks into `woocommerce_paypal_payments_authenticated_merchant` (fired after successful PPCP onboarding) to automatically disable the WC core PayPal Standard gateway.
- Sets both `enabled = 'no'` and `_should_load = 'no'` on `woocommerce_paypal_settings` — the only complete disable path (UI toggle alone is insufficient; see Problem section).
- Also disables `restore-paypal-standard-for-woocommerce` if installed (`woocommerce_restore_paypal_standard_settings['enabled'] = 'no'`) — a plugin (4,000+ installs) that sends no BN code and is not covered by the native WPS disable.
- WCS guard checks both `paypal` and `restore_paypal_standard` gateway IDs — if either has active subscriptions, stores a transient instead of disabling and renders a notice on the next admin page load.

---

## Proposed Change

Two additions to `modules/ppcp-compat/src/CompatModule.php`:

**1. Hook registration in `run()` method:**

```php
add_action(
    'woocommerce_paypal_payments_authenticated_merchant',
    array( $this, 'disable_legacy_paypal_standard_on_connect' )
);
add_action( 'admin_notices', array( $this, 'maybe_show_wps_subscriptions_notice' ) );
```

**2. New method `disable_legacy_paypal_standard_on_connect()`:**

```php
protected function disable_legacy_paypal_standard_on_connect(): void {
    if ( function_exists( 'wcs_get_subscriptions' ) ) {
        $total_count = 0;
        foreach ( array( 'paypal', 'restore_paypal_standard' ) as $gateway_id ) {
            $total_count += count(
                wcs_get_subscriptions(
                    array(
                        'payment_method'         => $gateway_id,
                        'subscription_status'    => array( 'active', 'pending-cancel' ),
                        'subscriptions_per_page' => -1,
                    )
                )
            );
        }

        if ( $total_count > 0 ) {
            set_transient( 'ppcp_wps_standard_subs_notice', $total_count, 30 * DAY_IN_SECONDS );
            return;
        }
    }

    $settings               = get_option( 'woocommerce_paypal_settings', array() );
    $settings['enabled']      = 'no';
    $settings['_should_load'] = 'no';
    update_option( 'woocommerce_paypal_settings', $settings );

    $rpsfw = get_option( 'woocommerce_restore_paypal_standard_settings', array() );
    if ( ! empty( $rpsfw ) ) {
        $rpsfw['enabled'] = 'no';
        update_option( 'woocommerce_restore_paypal_standard_settings', $rpsfw );
    }
}
```

**3. New method `maybe_show_wps_subscriptions_notice()`:**

```php
protected function maybe_show_wps_subscriptions_notice(): void {
    $count = get_transient( 'ppcp_wps_standard_subs_notice' );
    if ( false === $count ) {
        return;
    }
    delete_transient( 'ppcp_wps_standard_subs_notice' );
    $subscriptions_url = admin_url( 'edit.php?post_type=shop_subscription&payment_method=paypal' );
    printf(
        '<div class="notice notice-warning"><p>%s</p></div>',
        wp_kses_post(
            sprintf(
                _n( '...singular...', '...plural...', (int) $count, 'woocommerce-paypal-payments' ),
                (int) $count,
                esc_url( $subscriptions_url )
            )
        )
    );
}
```

The `_should_load = 'no'` write is the critical line — it clears the permanent latch that `enabled = 'no'` alone cannot clear.

The notice uses a transient (`ppcp_wps_standard_subs_notice`) to bridge the AJAX merchant-connect request and the next admin page load — a direct `add_action('admin_notices')` during the connect AJAX call would be in-memory only and never fire.

---

## Safety: WCS Guard

The WCS subscription check covers both `payment_method = 'paypal'` (native WPS) and `payment_method = 'restore_paypal_standard'` (restoration plugin). If either has active or pending-cancel subscriptions:

- Those subscriptions generate automatic renewal orders via PayPal IPN callbacks.
- The IPN endpoint is provided by `WC_Gateway_Paypal_IPN_Handler` (or the restoration plugin's equivalent).
- Disabling the gateway silently breaks those renewals — the merchant's subscribers would stop being billed with no error surfaced in WooCommerce.

The safe path is a persistent admin notice (via transient): tell the merchant how many subscriptions are still on PayPal Standard and link them to the subscription list. They can then migrate those subscriptions to PPCP or let them expire naturally before re-connecting.

---

## Test Plan

**Native WPS:**
- [ ] Fresh PPCP onboard on a site with no prior PayPal Standard orders → after connect: `woocommerce_paypal_settings['enabled'] = 'no'` and `woocommerce_paypal_settings['_should_load'] = 'no'`
- [ ] PPCP onboard on a site where WPS was previously enabled → same result: both keys set to `'no'`
- [ ] PPCP onboard on a site with active WCS PayPal Standard subscriptions (`payment_method = 'paypal'`) → transient `ppcp_wps_standard_subs_notice` set; on next admin page load, notice renders with correct subscription count and link; WPS NOT disabled
- [ ] PPCP onboard on a site with WCS installed but zero active PayPal Standard subscriptions → WPS disabled unconditionally
- [ ] PPCP onboard on a site without WCS installed → WPS disabled unconditionally (`function_exists` check passes silently)
- [ ] Confirm `WOOTHEMES_CART` BN code no longer appears in PayPal SDK calls after the change (check network requests during checkout on a post-connect site)
- [ ] Confirm IPN endpoint no longer responds after disable (verify `WC_Gateway_Paypal_IPN_Handler` is not instantiated)
- [ ] Re-connect / re-authenticate merchant → method runs again without side effects (idempotent: setting already-disabled keys to `'no'` is safe)