### PR TITLE
fix(local-apms): stop gateway.css loading on every frontend page

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/PWCPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/PWCPaymentMethod.php
@@ -73,13 +73,6 @@ class PWCPaymentMethod extends AbstractPaymentMethodType {
 			true
 		);
 
-		wp_enqueue_style(
-			'ppcp-pwc-payment-method',
-			$this->asset_getter->get_asset_url( 'gateway.css' ),
-			array(),
-			$this->version
-		);
-
 		return array( 'ppcp-pwc-payment-method' );
 	}
 


### PR DESCRIPTION
## Problem
  
`ppcp-local-alternative-payment-methods-css-gateway.css` was loading on every frontend page, even pages with no  PayPal buttons. On cart and classic checkout pages it was also loading twice.

## Root Cause
  
`PWCPaymentMethod::get_payment_method_script_handles()` called `wp_enqueue_style()` for `gateway.css` without any page condition. WooCommerce Blocks calls this method globally during payment method type registration (on every frontend request), so the style was enqueued unconditionally.

The module already enqueues `gateway.css` correctly via a `wp_enqueue_scripts` hook in  `LocalAlternativePaymentMethodsModule` that is gated to `is_checkout() || is_cart() || is_wc_endpoint_url('order-pay')`.

## Fix

Remove the `wp_enqueue_style` call from `get_payment_method_script_handles()` in `PWCPaymentMethod`. The existing module-level hook already covers all pages where this style is needed.

## Testing
  
1. Connect a merchant to the plugin
2. Visit any frontend page that is not cart/checkout/order-pay (e.g. homepage, product page)
3. Confirm `ppcp-local-alternative-payment-methods-css-gateway.css` is absent in the Network tab
4. Visit cart and checkout — confirm the file loads exactly once