### PR TITLE
Make cart simulation disabling filter work for Apple Pay and Google Pay (4438)

### DIFF
--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
@@ -43,19 +43,17 @@ class SingleProductHandler extends BaseHandler {
 			? actionHandler.getSubscriptionProducts()
 			: actionHandler.getProducts();
 
-		return new Promise( ( resolve, reject ) => {
-			new SimulateCart(
-				this.ppcpConfig.ajax.simulate_cart.endpoint,
-				this.ppcpConfig.ajax.simulate_cart.nonce
-			).simulate( ( data ) => {
-				resolve( {
-					countryCode: data.country_code,
-					currencyCode: data.currency_code,
-					totalPriceStatus: 'FINAL',
-					totalPrice: data.total,
-				} );
-			}, products );
-		} );
+		return new SimulateCart(
+			this.ppcpConfig.ajax?.simulate_cart?.endpoint,
+			this.ppcpConfig.ajax?.simulate_cart?.nonce
+		).simulate( ( data ) => {
+			return {
+				countryCode: data.country_code,
+				currencyCode: data.currency_code,
+				totalPriceStatus: 'FINAL',
+				totalPrice: data.total,
+			};
+		}, products );
 	}
 
 	createOrder() {

--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
@@ -1,5 +1,5 @@
 import SingleProductActionHandler from '@ppcp-button/ActionHandler/SingleProductActionHandler';
-import SimulateCart from '@ppcp-button/Helper/SimulateCart';
+import SimulateCart, { isSimulateCartEnabled } from '@ppcp-button/Helper/SimulateCart';
 import ErrorHandler from '@ppcp-button/ErrorHandler';
 import UpdateCart from '@ppcp-button/Helper/UpdateCart';
 import BaseHandler from '@ppcp-applepay/Context/BaseHandler';
@@ -13,6 +13,12 @@ class SingleProductHandler extends BaseHandler {
 	}
 
 	transactionInfo() {
+		// Simulation is this method's only mechanism for fetching product data;
+		// reject early to avoid a pointless AJAX call.
+		if ( ! isSimulateCartEnabled( this.ppcpConfig ) ) {
+			return Promise.reject( new Error( 'Cart simulation is disabled.' ) );
+		}
+
 		const errorHandler = new ErrorHandler(
 			this.ppcpConfig.labels.error.generic,
 			document.querySelector( '.woocommerce-notices-wrapper' )

--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.test.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.test.js
@@ -1,0 +1,170 @@
+/* global describe, test, expect, jest, beforeEach */
+
+jest.mock( '@ppcp-button/ActionHandler/SingleProductActionHandler' );
+jest.mock( '@ppcp-button/Helper/SimulateCart', () => {
+	const { isSimulateCartEnabled } = jest.requireActual(
+		'@ppcp-button/Helper/SimulateCart'
+	);
+	return { __esModule: true, default: jest.fn(), isSimulateCartEnabled };
+} );
+jest.mock( '@ppcp-button/ErrorHandler', () => jest.fn() );
+jest.mock( '@ppcp-button/Helper/UpdateCart', () => jest.fn() );
+
+import SingleProductHandler from './SingleProductHandler';
+import SimulateCart from '@ppcp-button/Helper/SimulateCart';
+import SingleProductActionHandler from '@ppcp-button/ActionHandler/SingleProductActionHandler';
+
+describe( 'SingleProductHandler', () => {
+	let handler;
+	let mockSimulate;
+	let mockGetProducts;
+	let mockGetSubscriptionProducts;
+	const mockProducts = [ { id: 64, quantity: 1 } ];
+
+	const ppcpConfig = {
+		labels: { error: { generic: 'An error occurred.' } },
+		simulate_cart: {
+			enabled: true,
+		},
+		ajax: {
+			simulate_cart: {
+				endpoint: '/ppcp/simulate-cart',
+				nonce: 'test-nonce',
+			},
+		},
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		global.PayPalCommerceGateway = {
+			data_client_id: {
+				has_subscriptions: false,
+				paypal_subscriptions_enabled: false,
+			},
+		};
+
+		mockGetProducts = jest.fn().mockReturnValue( mockProducts );
+		mockGetSubscriptionProducts = jest.fn().mockReturnValue( [] );
+		SingleProductActionHandler.mockImplementation( () => ( {
+			getProducts: mockGetProducts,
+			getSubscriptionProducts: mockGetSubscriptionProducts,
+		} ) );
+
+		mockSimulate = jest.fn();
+		SimulateCart.mockImplementation( () => ( {
+			simulate: mockSimulate,
+		} ) );
+
+		handler = new SingleProductHandler( {}, ppcpConfig );
+	} );
+
+	describe( 'validateContext()', () => {
+		test( 'returns true by default', () => {
+			expect( handler.validateContext() ).toBe( true );
+		} );
+	} );
+
+	describe( 'transactionInfo()', () => {
+		describe( 'simulate_cart.enabled guard', () => {
+			test( 'rejects immediately when simulate_cart is disabled', async () => {
+				const disabledHandler = new SingleProductHandler(
+					{},
+					{ ...ppcpConfig, simulate_cart: { enabled: false } }
+				);
+
+				await expect( disabledHandler.transactionInfo() ).rejects.toThrow(
+					'Cart simulation is disabled.'
+				);
+				expect( mockSimulate ).not.toHaveBeenCalled();
+			} );
+
+			test( 'proceeds when simulate_cart key is absent (defaults to enabled)', async () => {
+				const { simulate_cart: _, ...configWithoutKey } = ppcpConfig;
+				const defaultHandler = new SingleProductHandler(
+					{},
+					configWithoutKey
+				);
+				mockSimulate.mockResolvedValue( {} );
+
+				await defaultHandler.transactionInfo();
+
+				expect( mockSimulate ).toHaveBeenCalled();
+			} );
+		} );
+
+		test( 'calls simulate_cart with products when enabled', async () => {
+			mockSimulate.mockImplementation( ( onResolve ) => {
+				return Promise.resolve(
+					onResolve( {
+						total: 45,
+						country_code: 'US',
+						currency_code: 'USD',
+					} )
+				);
+			} );
+
+			await handler.transactionInfo();
+
+			expect( mockSimulate ).toHaveBeenCalledWith(
+				expect.any( Function ),
+				mockProducts
+			);
+		} );
+
+		test( 'maps simulation response to Apple Pay transaction info format', async () => {
+			mockSimulate.mockImplementation( ( onResolve ) => {
+				return Promise.resolve(
+					onResolve( {
+						total: 45,
+						country_code: 'US',
+						currency_code: 'USD',
+					} )
+				);
+			} );
+
+			const result = await handler.transactionInfo();
+
+			expect( result ).toEqual( {
+				countryCode: 'US',
+				currencyCode: 'USD',
+				totalPriceStatus: 'FINAL',
+				totalPrice: 45,
+			} );
+		} );
+
+		test( 'propagates rejection from simulate_cart', async () => {
+			const serverError = { message: 'Server error.' };
+			mockSimulate.mockRejectedValue( serverError );
+
+			await expect( handler.transactionInfo() ).rejects.toEqual(
+				serverError
+			);
+		} );
+
+		test( 'passes subscription products when subscriptions are enabled', async () => {
+			const mockSubscriptionProducts = [ { id: 155, quantity: 1 } ];
+			mockGetSubscriptionProducts.mockReturnValue( mockSubscriptionProducts );
+			global.PayPalCommerceGateway = {
+				data_client_id: {
+					has_subscriptions: true,
+					paypal_subscriptions_enabled: true,
+				},
+			};
+			mockSimulate.mockImplementation( ( onResolve ) => {
+				return Promise.resolve(
+					onResolve( { total: 0, country_code: 'US', currency_code: 'USD' } )
+				);
+			} );
+
+			await handler.transactionInfo();
+
+			expect( mockGetSubscriptionProducts ).toHaveBeenCalled();
+			expect( mockGetProducts ).not.toHaveBeenCalled();
+			expect( mockSimulate ).toHaveBeenCalledWith(
+				expect.any( Function ),
+				mockSubscriptionProducts
+			);
+		} );
+	} );
+} );

--- a/modules/ppcp-button/resources/js/modules/Helper/SimulateCart.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/SimulateCart.js
@@ -1,3 +1,7 @@
+export const isSimulateCartEnabled = ( ppcpConfig ) =>
+    //Fallback to true because it preserves behavior existing earlier, and misconfigured state fails loudly at the AJAX call.
+	ppcpConfig?.simulate_cart?.enabled ?? true;
+
 class SimulateCart {
 	constructor( endpoint, nonce ) {
 		this.endpoint = endpoint;

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
@@ -14,6 +14,12 @@ class SingleProductHandler extends BaseHandler {
 	}
 
 	transactionInfo() {
+		// Simulation is this method's only mechanism for fetching product data;
+		// reject early to avoid a pointless AJAX call.
+		if ( ! isSimulateCartEnabled( this.ppcpConfig ) ) {
+			return Promise.reject( new Error( 'Cart simulation is disabled.' ) );
+		}
+
 		const form = document.querySelector( 'form.cart' );
 		const variationIdInput = form?.querySelector(
 			'input[name="variation_id"]'

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.js
@@ -1,5 +1,5 @@
 import SingleProductActionHandler from '@ppcp-button/ActionHandler/SingleProductActionHandler';
-import SimulateCart from '@ppcp-button/Helper/SimulateCart';
+import SimulateCart, { isSimulateCartEnabled } from '@ppcp-button/Helper/SimulateCart';
 import ErrorHandler from '@ppcp-button/ErrorHandler';
 import UpdateCart from '@ppcp-button/Helper/UpdateCart';
 import BaseHandler from './BaseHandler';

--- a/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.test.js
+++ b/modules/ppcp-googlepay/resources/js/Context/SingleProductHandler.test.js
@@ -1,7 +1,12 @@
 /* global describe, test, expect, jest, beforeEach */
 
 jest.mock( '@ppcp-button/ActionHandler/SingleProductActionHandler' );
-jest.mock( '@ppcp-button/Helper/SimulateCart' );
+jest.mock( '@ppcp-button/Helper/SimulateCart', () => {
+	const { isSimulateCartEnabled } = jest.requireActual(
+		'@ppcp-button/Helper/SimulateCart'
+	);
+	return { __esModule: true, default: jest.fn(), isSimulateCartEnabled };
+} );
 jest.mock( '@ppcp-button/ErrorHandler', () => jest.fn() );
 jest.mock( '@ppcp-button/Helper/UpdateCart', () => jest.fn() );
 jest.mock( '@ppcp-googlepay/Helper/TransactionInfo' );
@@ -20,6 +25,9 @@ describe( 'SingleProductHandler', () => {
 
 	const ppcpConfig = {
 		labels: { error: { generic: 'An error occurred.' } },
+		simulate_cart: {
+			enabled: true,
+		},
 		ajax: {
 			simulate_cart: {
 				endpoint: '/ppcp/simulate-cart',
@@ -74,6 +82,36 @@ describe( 'SingleProductHandler', () => {
 	} );
 
 	describe( 'transactionInfo()', () => {
+		describe( 'simulate_cart.enabled guard', () => {
+			test( 'rejects immediately when simulate_cart is disabled', async () => {
+				const disabledHandler = new SingleProductHandler(
+					{},
+					{ ...ppcpConfig, simulate_cart: { enabled: false } },
+					null
+				);
+
+				await expect( disabledHandler.transactionInfo() ).rejects.toThrow(
+					'Cart simulation is disabled.'
+				);
+				expect( mockSimulate ).not.toHaveBeenCalled();
+			} );
+
+			test( 'proceeds when simulate_cart key is absent (defaults to enabled)', async () => {
+				const { simulate_cart: _, ...configWithoutKey } = ppcpConfig;
+				const defaultHandler = new SingleProductHandler(
+					{},
+					configWithoutKey,
+					null
+				);
+				document.body.innerHTML = `<form class="cart"></form>`;
+				mockSimulate.mockResolvedValue( {} );
+
+				await defaultHandler.transactionInfo();
+
+				expect( mockSimulate ).toHaveBeenCalled();
+			} );
+		} );
+
 		describe( 'variation_id guard', () => {
 			test( 'rejects immediately when variation_id is empty', async () => {
 				document.body.innerHTML = `

--- a/modules/ppcp-googlepay/resources/js/GooglepayManager.js
+++ b/modules/ppcp-googlepay/resources/js/GooglepayManager.js
@@ -51,13 +51,13 @@ class GooglepayManager {
 				button.init();
 			};
 
-			// Initialize button only if googlePayConfig is already fetched.
-			if ( this.googlePayConfig ) {
+			// Initialize button only if googlePayConfig and transactionInfo are already fetched.
+			if ( this.googlePayConfig && this.transactionInfo ) {
 				initButton();
 			} else {
 				await this.init();
 
-				if ( this.googlePayConfig ) {
+				if ( this.googlePayConfig && this.transactionInfo ) {
 					initButton();
 				}
 			}
@@ -79,6 +79,8 @@ class GooglepayManager {
 
 			if ( ! this.googlePayConfig ) {
 				console.error( 'No GooglePayConfig received during init' );
+			} else if ( ! this.transactionInfo ) {
+				console.warn( 'No transaction info available, skipping button init.' );
 			} else {
 				for ( const button of this.buttons ) {
 					button.configure(

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -10,7 +10,8 @@
         "^@ppcp-blocks/(.*)$": "<rootDir>/modules/ppcp-blocks/resources/js/$1",
         "^@ppcp-card-fields/(.*)$": "<rootDir>/modules/ppcp-card-fields/resources/js/$1",
         "^@ppcp-paylater-block/(.*)$": "<rootDir>/modules/ppcp-paylater-block/resources/js/$1",
-        "^@ppcp-googlepay/(.*)$": "<rootDir>/modules/ppcp-googlepay/resources/js/$1"
+        "^@ppcp-googlepay/(.*)$": "<rootDir>/modules/ppcp-googlepay/resources/js/$1",
+        "^@ppcp-applepay/(.*)$": "<rootDir>/modules/ppcp-applepay/resources/js/$1"
     },
     "testPathIgnorePatterns": [
         "<rootDir>/tests/",


### PR DESCRIPTION
**Ticket**: PCP-4438
---

### Description

There is a way to disable cart simulation with a filter. The problem was that Apple Pay and Google Pay buttons ignored it, failing when the button is clicked, and the payment process starts.

Now, the Apple Pay and Google Pay buttons are not rendered on a product page when cart simulation is disabled.

### Steps to Test
1. Make sure payment buttons are visible on the product page.
2. Disable cart simulation by returning false from the filter `woocommerce_paypal_payments_simulate_cart_enabled` (_there is a plugin somewhere doing this, or just ping me if help is needed_).
3. Go to the same product page and make sure payment buttons are not rendered.

Note: I couldn't test it myself as I have neither Apple Pay nor Google Pay configured, and it would be too much effort for a relatively small fix. Sorry about that.
UPD: tested with Google Pay, works fine for me. When the filter returns false, no button is rendered on the product page.

### Documentation
- [x] This PR needs documentation (has the "Documentation" label).

If there is documentation about that filter, it needs to be updated to mention that not all buttons are rendered on the product page when simulation is disabled. If there is no such documentation, the filter and its effects should be documented.

### Changelog Entry
Fix: Make Apple Pay and Google Pay buttons respect the `woocommerce_paypal_payments_simulate_cart_enabled` filter