### PR TITLE
fix(ACDC): hide Processor Response row for approved orders on edit order page (6429)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WCGatewayModule.php
+++ b/modules/ppcp-wc-gateway/src/WCGatewayModule.php
@@ -173,7 +173,7 @@ class WCGatewayModule implements ServiceModule, ExtendingModule, ExecutableModul
 					return;
 				}
 				$fraud_result = $wc_order->get_meta( PayPalGateway::FRAUD_RESULT_META_KEY );
-				if ( empty( $fraud_result['response_code'] ) ) {
+				if ( empty( $fraud_result['response_code'] ) || $fraud_result['response_code'] === '0000' ) {
 					return;
 				}
 				$fraud = $c->get( 'api.factory.fraud-processor-response' )

--- a/tests/qa/utils/admin/woocommerce-order-edit.ts
+++ b/tests/qa/utils/admin/woocommerce-order-edit.ts
@@ -25,6 +25,7 @@ export class WooCommerceOrderEdit extends WooCommerceOrderEditBase {
 
 	totalPayPalFee = () => this.totalsTableRow( 'PayPal Fee:' );
 	totalPayPalPayout = () => this.totalsTableRow( 'PayPal Payout' );
+	processorResponseRow = () => this.totalsTableRow( 'Processor Response:' );
 
 	refundViaButton = ( paymentMethod ) =>
 		this.page.locator( '.do-api-refund', {
@@ -192,6 +193,13 @@ export class WooCommerceOrderEdit extends WooCommerceOrderEditBase {
 					)
 				);
 			}
+		}
+
+		if ( fundingSource === 'acdc' ) {
+			await expect(
+				this.processorResponseRow(),
+				'Assert Processor Response row is not visible for approved ACDC orders'
+			).not.toBeVisible();
 		}
 
 		if ( fundingSource === 'oxxo' ) {


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
On the WooCommerce edit order page, ACDC orders were showing a **"Processor Response: 0000: Approved"** row in the order totals section. Code `0000` means the payment was approved — there is nothing actionable for the merchant, so the row should not be displayed.                                                                                                                                        
                                                                                                                                                                                                          
The display is rendered by a hook in `WCGatewayModule` that only checked `empty($fraud_result['response_code'])`. Since `'0000'` is non-empty, it passed the guard and was always printed for ACDC orders. The fix adds `|| $fraud_result['response_code'] === '0000'` to the early-return condition, suppressing the row for approved payments. Non-`0000` codes (declines, errors, etc.) continue to display as before.                                                                                                                                                                                      
                                                                                                                                                                                                          
A functional test assertion was added to `WooCommerceOrderEdit.assertOrderDetails` to verify the row is absent for all ACDC orders going forward.


<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img
          src="https://github.com/user-attachments/assets/39d9a6a2-cec5-4f60-b31e-97f16904d4e2"
          alt="Before - Screenshot 2026-05-18 at 12:53:04"
          width="100%"
        />
      </td>
      <td>
        <img
          src="https://github.com/user-attachments/assets/b99eddfa-43b2-4718-8aeb-51914d450539"
          alt="After - Screenshot 2026-06-26 at 14:23:44"
          width="100%"
        />
      </td>
    </tr>
  </tbody>
</table>
                                                       
                                                                                                                                                                                                          
### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
  1. Enable ACDC (Advanced Card Processing) in the plugin settings.                                                                                                                                       
  2. Complete a checkout using a test card (e.g. the default Visa test card).                                                                                                                             
  3. Navigate to **WooCommerce → Orders** and open the newly created order.                                                                                                                               
  4. Confirm the **"Processor Response"** row is **no longer visible** in the order totals section beneath the PayPal Payout line.