### PR TITLE
fix(OXXO): add missing default checkout descriptio (6567)

### DIFF
--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -379,11 +379,11 @@ class PaymentMethodsDefinition {
 				'title'              => __( 'Pay upon Invoice', 'woocommerce-paypal-payments' ),
 				'description'        => '',
 			),
-			OXXOGateway::ID                  => array(
+			OXXOGateway::ID           => array(
 				'method_title'       => __( 'OXXO', 'woocommerce-paypal-payments' ),
 				'method_description' => __( 'OXXO is a Mexican chain of convenience stores. *Get PayPal account permission to use OXXO payment functionality by contacting us at (+52) 800–925–0304', 'woocommerce-paypal-payments' ),
 				'title'              => __( 'OXXO', 'woocommerce-paypal-payments' ),
-				'description'        => '',
+				'description'        => __( 'OXXO allows you to pay bills and online purchases in-store with cash.', 'woocommerce-paypal-payments' ),
 			),
 		);
 	}


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
The OXXO payment method had no default description, leaving the field blank in two places:                                                                                                              
  - PCP Settings → Payment methods → OXXO settings modal                                                                                                                                                  
  - WooCommerce checkout page when OXXO is selected                                                                                                                                               
                                                                                                                                                                                                          
The `description` key in `PaymentMethodsDefinition::get_apm_defaults()` for OXXO was set to an empty string. `OXXOGateway::init_apm_settings()` uses this as the fallback when no saved option exists, so both the admin form default and the checkout description were blank on fresh installs or new merchant connections.                                                                                   
                                                                                                                                                                                                          
Fixed by setting the default to the expected value: *"OXXO allows you to pay bills and online purchases in-store with cash."* 

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
<img width="817" height="466" alt="Screenshot 2026-06-26 at 14 49 32" src="https://github.com/user-attachments/assets/7163d7b0-0a98-494a-8393-ae92d1cddfc1" />
      </td>
      <td>
<img width="746" height="460" alt="Screenshot 2026-06-26 at 14 49 42" src="https://github.com/user-attachments/assets/9ccb8043-c077-4e65-9fc8-af36bc3a415a" />
      </td>
    </tr>
  </tbody>
</table>                                                 
                                                                                                                                                                                                          
  ### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Configure WooCommerce for Mexico / MXN currency.                                                                                                                                                     
2. Connect a Mexico merchant.                                                                                                                                                                           
3. Navigate to PCP Settings → Payment methods → click the OXXO settings icon.                                                                                                                           
4. Confirm the **Description** field shows *"OXXO allows you to pay bills and online purchases in-store with cash."* by default.                                                                        
5. Enable OXXO and save.                                                                                                                                                                                
6. On the classic checkout page, fill in Mexican customer details and select OXXO.                                                                                                                      
7. Confirm the description is visible beneath the OXXO gateway title. 