### PR TITLE
fix(blocks): validate PayPal order ownership before patching shipping (6393)

### DIFF
--- a/modules/ppcp-blocks/services.php
+++ b/modules/ppcp-blocks/services.php
@@ -71,6 +71,7 @@ return array(
 			$container->get( 'button.request-data' ),
 			$container->get( 'api.endpoint.order' ),
 			$container->get( 'api.factory.purchase-unit' ),
+			$container->get( 'session.handler' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},

--- a/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
+++ b/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
@@ -21,57 +21,16 @@ use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
 use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 
-/**
- * Class UpdateShippingEndpoint
- */
 class UpdateShippingEndpoint implements EndpointInterface {
 	const ENDPOINT              = 'ppc-update-shipping';
 	const WC_STORE_API_ENDPOINT = '/wp-json/wc/store/v1/cart/';
 
-	/**
-	 * The Request Data Helper.
-	 *
-	 * @var RequestData
-	 */
-	private $request_data;
+	private RequestData $request_data;
+	private OrderEndpoint $order_endpoint;
+	private PurchaseUnitFactory $purchase_unit_factory;
+	private SessionHandler $session_handler;
+	protected LoggerInterface $logger;
 
-	/**
-	 * The order endpoint.
-	 *
-	 * @var OrderEndpoint
-	 */
-	private $order_endpoint;
-
-	/**
-	 * The purchase unit factory.
-	 *
-	 * @var PurchaseUnitFactory
-	 */
-	private $purchase_unit_factory;
-
-	/**
-	 * The session handler.
-	 *
-	 * @var SessionHandler
-	 */
-	private $session_handler;
-
-	/**
-	 * The logger.
-	 *
-	 * @var LoggerInterface
-	 */
-	protected $logger;
-
-	/**
-	 * UpdateShippingEndpoint constructor.
-	 *
-	 * @param RequestData         $request_data The Request Data Helper.
-	 * @param OrderEndpoint       $order_endpoint The order endpoint.
-	 * @param PurchaseUnitFactory $purchase_unit_factory The purchase unit factory.
-	 * @param SessionHandler      $session_handler The session handler.
-	 * @param LoggerInterface     $logger The logger.
-	 */
 	public function __construct(
 		RequestData $request_data,
 		OrderEndpoint $order_endpoint,

--- a/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
+++ b/modules/ppcp-blocks/src/Endpoint/UpdateShippingEndpoint.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\Blocks\Endpoint;
 
 use Exception;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Patch;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\PatchCollection;
@@ -18,6 +19,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Button\Endpoint\EndpointInterface;
 use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
 use WooCommerce\PayPalCommerce\Button\Exception\NonceValidationException;
+use WooCommerce\PayPalCommerce\Session\SessionHandler;
 
 /**
  * Class UpdateShippingEndpoint
@@ -48,6 +50,13 @@ class UpdateShippingEndpoint implements EndpointInterface {
 	private $purchase_unit_factory;
 
 	/**
+	 * The session handler.
+	 *
+	 * @var SessionHandler
+	 */
+	private $session_handler;
+
+	/**
 	 * The logger.
 	 *
 	 * @var LoggerInterface
@@ -60,18 +69,21 @@ class UpdateShippingEndpoint implements EndpointInterface {
 	 * @param RequestData         $request_data The Request Data Helper.
 	 * @param OrderEndpoint       $order_endpoint The order endpoint.
 	 * @param PurchaseUnitFactory $purchase_unit_factory The purchase unit factory.
+	 * @param SessionHandler      $session_handler The session handler.
 	 * @param LoggerInterface     $logger The logger.
 	 */
 	public function __construct(
 		RequestData $request_data,
 		OrderEndpoint $order_endpoint,
 		PurchaseUnitFactory $purchase_unit_factory,
+		SessionHandler $session_handler,
 		LoggerInterface $logger
 	) {
 
 		$this->request_data          = $request_data;
 		$this->order_endpoint        = $order_endpoint;
 		$this->purchase_unit_factory = $purchase_unit_factory;
+		$this->session_handler       = $session_handler;
 		$this->logger                = $logger;
 	}
 
@@ -86,12 +98,19 @@ class UpdateShippingEndpoint implements EndpointInterface {
 
 	/**
 	 * Handles the request.
+	 *
+	 * @throws RuntimeException When ownership validation fails.
 	 */
 	public function handle_request(): void {
 		try {
 			$data = $this->request_data->read_request( $this->nonce() );
 
 			$order_id = $data['order_id'];
+
+			$session_order = $this->session_handler->order();
+			if ( ! $session_order || $session_order->id() !== $order_id ) {
+				throw new RuntimeException( __( 'Order validation failed.', 'woocommerce-paypal-payments' ) );
+			}
 
 			$pu      = $this->purchase_unit_factory->from_wc_cart( null, true );
 			$pu_data = $pu->to_array();

--- a/tests/PHPUnit/Blocks/Endpoint/UpdateShippingEndpointTest.php
+++ b/tests/PHPUnit/Blocks/Endpoint/UpdateShippingEndpointTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Blocks\Endpoint;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Blocks\Endpoint\UpdateShippingEndpoint
+ */
+class UpdateShippingEndpointTest extends TestCase
+{
+	use MockeryPHPUnitIntegration;
+
+	private RequestData $request_data;
+	private OrderEndpoint $order_endpoint;
+	private PurchaseUnitFactory $purchase_unit_factory;
+	private SessionHandler $session_handler;
+	private LoggerInterface $logger;
+	private UpdateShippingEndpoint $sut;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->request_data          = Mockery::mock( RequestData::class );
+		$this->order_endpoint        = Mockery::mock( OrderEndpoint::class );
+		$this->purchase_unit_factory = Mockery::mock( PurchaseUnitFactory::class );
+		$this->session_handler       = Mockery::mock( SessionHandler::class );
+		$this->logger                = Mockery::mock( LoggerInterface::class );
+
+		$this->sut = new UpdateShippingEndpoint(
+			$this->request_data,
+			$this->order_endpoint,
+			$this->purchase_unit_factory,
+			$this->session_handler,
+			$this->logger
+		);
+	}
+
+	/**
+	 * @scenario When the request order_id matches the session's stored PayPal order,
+	 *           the PATCH is issued and a success response is returned.
+	 */
+	public function test_patch_proceeds_when_order_id_matches_session(): void
+	{
+		$order_id = 'ORDER-MATCH-123';
+
+		$session_order = Mockery::mock( Order::class );
+		$session_order->shouldReceive( 'id' )->andReturn( $order_id );
+
+		$pu = Mockery::mock( PurchaseUnit::class );
+		$pu->shouldReceive( 'to_array' )->andReturn( array() );
+		$pu->shouldReceive( 'reference_id' )->andReturn( 'default' );
+
+		$this->request_data->shouldReceive( 'read_request' )
+			->with( UpdateShippingEndpoint::nonce() )
+			->andReturn( array( 'order_id' => $order_id ) );
+
+		$this->session_handler->shouldReceive( 'order' )->andReturn( $session_order );
+
+		$this->purchase_unit_factory->shouldReceive( 'from_wc_cart' )
+			->with( null, true )
+			->andReturn( $pu );
+
+		$this->order_endpoint->shouldReceive( 'patch' )
+			->with( $order_id, Mockery::any() )
+			->once();
+
+		expect( 'wp_send_json_success' )->once();
+
+		$this->sut->handle_request();
+	}
+
+	/**
+	 * @scenario When the request order_id belongs to a different session (IDOR attack),
+	 *           no PATCH is issued and an error response is returned.
+	 */
+	public function test_patch_is_rejected_when_order_id_does_not_match_session(): void
+	{
+		$session_order = Mockery::mock( Order::class );
+		$session_order->shouldReceive( 'id' )->andReturn( 'ORDER-VICTIM' );
+
+		$this->request_data->shouldReceive( 'read_request' )
+			->with( UpdateShippingEndpoint::nonce() )
+			->andReturn( array( 'order_id' => 'ORDER-ATTACKER' ) );
+
+		$this->session_handler->shouldReceive( 'order' )->andReturn( $session_order );
+
+		$this->purchase_unit_factory->shouldReceive( 'from_wc_cart' )->never();
+		$this->order_endpoint->shouldReceive( 'patch' )->never();
+
+		expect( 'wp_send_json_error' )->once();
+
+		$this->sut->handle_request();
+	}
+
+	/**
+	 * @scenario When there is no PayPal order stored in the session,
+	 *           no PATCH is issued and an error response is returned.
+	 */
+	public function test_patch_is_rejected_when_no_session_order_exists(): void
+	{
+		$this->request_data->shouldReceive( 'read_request' )
+			->with( UpdateShippingEndpoint::nonce() )
+			->andReturn( array( 'order_id' => 'ORDER-123' ) );
+
+		$this->session_handler->shouldReceive( 'order' )->andReturn( null );
+
+		$this->purchase_unit_factory->shouldReceive( 'from_wc_cart' )->never();
+		$this->order_endpoint->shouldReceive( 'patch' )->never();
+
+		expect( 'wp_send_json_error' )->once();
+
+		$this->sut->handle_request();
+	}
+}


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
Validates PayPal order ownership before patching shipping                                                             
                                                                 