### PR TITLE
Validate and retry vaulted card order when PayPal response is missing order id (6368)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CaptureCardPayment.php
@@ -164,19 +164,57 @@ class CaptureCardPayment {
 			'body'    => wp_json_encode( $data ),
 		);
 
-		$response = $this->request( $url, $args );
-		if ( $response instanceof WP_Error ) {
-			throw new RuntimeException( $response->get_error_message() );
-		}
-
-		$json        = json_decode( $response['body'] );
-		$status_code = (int) wp_remote_retrieve_response_code( $response );
-		if ( ! in_array( $status_code, array( 200, 201 ), true ) ) {
-			$error = new PayPalApiException( $json, $status_code );
-			$this->logger->warning( $error->getMessage() );
-			throw $error;
-		}
+		$json = $this->execute_order_request( $url, $args );
 
 		return $this->order_factory->from_paypal_response( $json );
+	}
+
+	/**
+	 * Executes the order creation request, retrying once on an incomplete response.
+	 *
+	 * PayPal's v2/checkout/orders endpoint intermittently returns a success status
+	 * with a response body missing the required id field. A single retry with a new
+	 * idempotency key recovers from this transient issue.
+	 *
+	 * @param string $url  The request URL.
+	 * @param array  $args The request arguments.
+	 * @return \stdClass Decoded response with a valid id.
+	 *
+	 * @throws RuntimeException When the response is incomplete after retry or PayPal returns a non-success status.
+	 */
+	private function execute_order_request( string $url, array $args ): \stdClass {
+		for ( $attempt = 0; $attempt < 2; $attempt++ ) {
+			if ( $attempt > 0 ) {
+				$this->logger->info( 'Retrying PayPal order creation after incomplete response.' );
+				$args['headers']['PayPal-Request-Id'] = uniqid( 'ppcp-', true );
+			}
+
+			$response = $this->request( $url, $args );
+			if ( $response instanceof WP_Error ) {
+				throw new RuntimeException( $response->get_error_message() );
+			}
+
+			$json        = json_decode( $response['body'] );
+			$status_code = (int) wp_remote_retrieve_response_code( $response );
+			if ( ! in_array( $status_code, array( 200, 201 ), true ) ) {
+				$error = new PayPalApiException( $json, $status_code );
+				$this->logger->warning( $error->getMessage() );
+				throw $error;
+			}
+
+			if ( $json instanceof \stdClass && isset( $json->id ) ) {
+				return $json;
+			}
+
+			$this->logger->warning(
+				'PayPal order response missing id.',
+				array(
+					'status_code'   => $status_code,
+					'response_body' => $response['body'],
+				)
+			);
+		}
+
+		throw new RuntimeException( 'PayPal order response missing id after retry.' );
 	}
 }

--- a/modules/ppcp-wc-gateway/src/Endpoint/CapturePayPalPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CapturePayPalPayment.php
@@ -104,19 +104,57 @@ class CapturePayPalPayment {
 			'body'    => wp_json_encode( $data ),
 		);
 
-		$response = $this->request( $url, $args );
-		if ( $response instanceof WP_Error ) {
-			throw new RuntimeException( $response->get_error_message() );
-		}
-
-		$json        = json_decode( $response['body'] );
-		$status_code = (int) wp_remote_retrieve_response_code( $response );
-		if ( ! in_array( $status_code, array( 200, 201 ), true ) ) {
-			$error = new PayPalApiException( $json, $status_code );
-			$this->logger->warning( $error->getMessage() );
-			throw $error;
-		}
+		$json = $this->execute_order_request( $url, $args );
 
 		return $this->order_factory->from_paypal_response( $json );
+	}
+
+	/**
+	 * Executes the order creation request, retrying once on an incomplete response.
+	 *
+	 * PayPal's v2/checkout/orders endpoint intermittently returns a success status
+	 * with a response body missing the required id field. A single retry with a new
+	 * idempotency key recovers from this transient issue.
+	 *
+	 * @param string $url  The request URL.
+	 * @param array  $args The request arguments.
+	 * @return \stdClass Decoded response with a valid id.
+	 *
+	 * @throws RuntimeException When the response is incomplete after retry or PayPal returns a non-success status.
+	 */
+	private function execute_order_request( string $url, array $args ): \stdClass {
+		for ( $attempt = 0; $attempt < 2; $attempt++ ) {
+			if ( $attempt > 0 ) {
+				$this->logger->info( 'Retrying PayPal order creation after incomplete response.' );
+				$args['headers']['PayPal-Request-Id'] = uniqid( 'ppcp-', true );
+			}
+
+			$response = $this->request( $url, $args );
+			if ( $response instanceof WP_Error ) {
+				throw new RuntimeException( $response->get_error_message() );
+			}
+
+			$json        = json_decode( $response['body'] );
+			$status_code = (int) wp_remote_retrieve_response_code( $response );
+			if ( ! in_array( $status_code, array( 200, 201 ), true ) ) {
+				$error = new PayPalApiException( $json, $status_code );
+				$this->logger->warning( $error->getMessage() );
+				throw $error;
+			}
+
+			if ( $json instanceof \stdClass && isset( $json->id ) ) {
+				return $json;
+			}
+
+			$this->logger->warning(
+				'PayPal order response missing id.',
+				array(
+					'status_code'   => $status_code,
+					'response_body' => $response['body'],
+				)
+			);
+		}
+
+		throw new RuntimeException( 'PayPal order response missing id after retry.' );
 	}
 }

--- a/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CaptureCardPaymentTest.php
@@ -15,6 +15,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
+use RuntimeException;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
@@ -89,7 +90,7 @@ class CaptureCardPaymentTest extends TestCase {
 			function ( string $url, array $args ) use ( &$captured_body, $headers_stub ): array {
 				$captured_body = (array) json_decode( $args['body'], true );
 				return array(
-					'body'     => '{}',
+					'body'     => '{"id":"MOCK-ORDER-ID"}',
 					'response' => array( 'code' => 200 ),
 					'headers'  => $headers_stub,
 				);
@@ -225,4 +226,263 @@ class CaptureCardPaymentTest extends TestCase {
 			'SCA_ALWAYS maps to verification method SCA_ALWAYS'               => array( 'SCA_ALWAYS', 'SCA_ALWAYS' ),
 		);
 	}
+
+	/**
+	 * Build a CaptureCardPayment with a custom HTTP response for error-path tests.
+	 *
+	 * @param string               $response_body    Raw JSON body returned by wp_remote_get.
+	 * @param int                  $response_code    HTTP status code.
+	 * @param OrderFactory|null    $order_factory    Optional custom OrderFactory mock.
+	 * @param LoggerInterface|null $logger           Optional custom logger mock.
+	 */
+	private function make_testee_with_response(
+		string $response_body,
+		int $response_code,
+		OrderFactory $order_factory = null,
+		LoggerInterface $logger = null
+	): CaptureCardPayment {
+		$token = Mockery::mock( \WooCommerce\PayPalCommerce\ApiClient\Entity\Token::class );
+		$token->shouldReceive( 'token' )->andReturn( 'test-bearer-token' );
+
+		$bearer = Mockery::mock( Bearer::class );
+		$bearer->shouldReceive( 'bearer' )->andReturn( $token );
+
+		$purchase_unit = Mockery::mock( PurchaseUnit::class );
+		$purchase_unit->shouldReceive( 'to_array' )->andReturn( array() );
+
+		$purchase_unit_factory = Mockery::mock( PurchaseUnitFactory::class );
+		$purchase_unit_factory->shouldReceive( 'from_wc_order' )->andReturn( $purchase_unit );
+
+		if ( ! $order_factory ) {
+			$order_factory = Mockery::mock( OrderFactory::class );
+			$order_factory->allows( 'from_paypal_response' );
+		}
+
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+		$settings_provider->shouldReceive( 'payment_intent' )->andReturn( 'capture' );
+		$settings_provider->shouldReceive( 'three_d_secure_enum' )->andReturn( '' );
+
+		$experience_context = Mockery::mock( ExperienceContext::class );
+		$experience_context->shouldReceive( 'to_array' )->andReturn(
+			array(
+				'return_url' => 'https://example.com/return',
+				'cancel_url' => 'https://example.com/cancel',
+			)
+		);
+
+		$experience_context_builder = Mockery::mock( ExperienceContextBuilder::class );
+		$experience_context_builder->allows( 'with_custom_return_url' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_custom_cancel_url' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_current_locale' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_current_brand_name' )->andReturnSelf();
+		$experience_context_builder->allows( 'build' )->andReturn( $experience_context );
+
+		if ( ! $logger ) {
+			$logger = Mockery::mock( LoggerInterface::class );
+		}
+		$logger->allows( 'debug' );
+
+		when( 'home_url' )->alias( function ( string $path = '' ): string {
+			return 'https://example.com' . $path;
+		} );
+		when( 'add_query_arg' )->alias( function ( $args, string $url ): string {
+			return $url;
+		} );
+		when( 'wc_get_checkout_url' )->justReturn( 'https://example.com/checkout/' );
+		when( 'trailingslashit' )->alias( function ( string $value ): string {
+			return rtrim( $value, '/' ) . '/';
+		} );
+		expect( 'wp_json_encode' )->andReturnUsing( 'json_encode' );
+		when( 'apply_filters' )->alias( function ( string $hook, ...$args ) {
+			return $args[0] ?? null;
+		} );
+
+		$headers_stub = Mockery::mock( \Requests_Utility_CaseInsensitiveDictionary::class );
+		$headers_stub->shouldReceive( 'getAll' )->andReturn( array() );
+
+		expect( 'wp_remote_get' )->andReturnUsing(
+			function () use ( $response_body, $response_code, $headers_stub ): array {
+				return array(
+					'body'     => $response_body,
+					'response' => array( 'code' => $response_code ),
+					'headers'  => $headers_stub,
+				);
+			}
+		);
+		when( 'wp_remote_retrieve_response_code' )->alias(
+			function ( $response ): int {
+				return (int) ( $response['response']['code'] ?? 0 );
+			}
+		);
+
+		return new CaptureCardPayment(
+			'https://api.paypal.com',
+			$bearer,
+			$order_factory,
+			$purchase_unit_factory,
+			$settings_provider,
+			$experience_context_builder,
+			$logger
+		);
+	}
+
+	/**
+	 * GIVEN PayPal returns HTTP 201 with a JSON body missing the 'id' field on both attempts
+	 * WHEN create_order processes the response
+	 * THEN a RuntimeException is thrown after retry
+	 * AND the logger receives a warning for each failed attempt and an info for the retry
+	 */
+	public function test_create_order_throws_when_response_missing_id(): void {
+		$response_body = '{"status":"CREATED","links":[]}';
+
+		$logger = Mockery::mock( LoggerInterface::class );
+		$logger->shouldReceive( 'warning' )
+			->twice()
+			->with(
+				'PayPal order response missing id.',
+				Mockery::on( function ( array $context ) use ( $response_body ): bool {
+					return isset( $context['response_body'] )
+						&& $context['response_body'] === $response_body;
+				} )
+			);
+		$logger->shouldReceive( 'info' )->once();
+
+		$testee   = $this->make_testee_with_response( $response_body, 201, null, $logger );
+		$wc_order = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'get_id' )->andReturn( 1 );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'missing id after retry' );
+		$testee->create_order( 'vault-abc-123', $wc_order );
+	}
+
+	/**
+	 * GIVEN PayPal returns HTTP 201 with an empty body on both attempts
+	 * WHEN create_order processes the response
+	 * THEN a RuntimeException is thrown after retry
+	 */
+	public function test_create_order_throws_on_empty_response_body(): void {
+		$logger = Mockery::mock( LoggerInterface::class );
+		$logger->shouldReceive( 'warning' )->twice();
+		$logger->shouldReceive( 'info' )->once();
+
+		$testee   = $this->make_testee_with_response( '', 201, null, $logger );
+		$wc_order = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'get_id' )->andReturn( 1 );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'missing id after retry' );
+		$testee->create_order( 'vault-abc-123', $wc_order );
+	}
+
+	/**
+	 * GIVEN PayPal returns an incomplete response on the first attempt
+	 * AND a valid response with an id on the retry
+	 * WHEN create_order processes the responses
+	 * THEN the order is created successfully from the retried response
+	 */
+	public function test_create_order_retries_and_succeeds_on_second_attempt(): void {
+		$call_count = 0;
+
+		$token = Mockery::mock( \WooCommerce\PayPalCommerce\ApiClient\Entity\Token::class );
+		$token->shouldReceive( 'token' )->andReturn( 'test-bearer-token' );
+
+		$bearer = Mockery::mock( Bearer::class );
+		$bearer->shouldReceive( 'bearer' )->andReturn( $token );
+
+		$purchase_unit = Mockery::mock( PurchaseUnit::class );
+		$purchase_unit->shouldReceive( 'to_array' )->andReturn( array() );
+
+		$purchase_unit_factory = Mockery::mock( PurchaseUnitFactory::class );
+		$purchase_unit_factory->shouldReceive( 'from_wc_order' )->andReturn( $purchase_unit );
+
+		$returned_order = Mockery::mock( Order::class );
+
+		$order_factory = Mockery::mock( OrderFactory::class );
+		$order_factory->shouldReceive( 'from_paypal_response' )
+			->once()
+			->andReturn( $returned_order );
+
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+		$settings_provider->shouldReceive( 'payment_intent' )->andReturn( 'capture' );
+		$settings_provider->shouldReceive( 'three_d_secure_enum' )->andReturn( '' );
+
+		$experience_context = Mockery::mock( ExperienceContext::class );
+		$experience_context->shouldReceive( 'to_array' )->andReturn(
+			array(
+				'return_url' => 'https://example.com/return',
+				'cancel_url' => 'https://example.com/cancel',
+			)
+		);
+
+		$experience_context_builder = Mockery::mock( ExperienceContextBuilder::class );
+		$experience_context_builder->allows( 'with_custom_return_url' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_custom_cancel_url' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_current_locale' )->andReturnSelf();
+		$experience_context_builder->allows( 'with_current_brand_name' )->andReturnSelf();
+		$experience_context_builder->allows( 'build' )->andReturn( $experience_context );
+
+		$logger = Mockery::mock( LoggerInterface::class );
+		$logger->allows( 'debug' );
+		$logger->shouldReceive( 'warning' )->once()->with( 'PayPal order response missing id.', Mockery::any() );
+		$logger->shouldReceive( 'info' )->once()->with( 'Retrying PayPal order creation after incomplete response.' );
+
+		when( 'home_url' )->alias( function ( string $path = '' ): string {
+			return 'https://example.com' . $path;
+		} );
+		when( 'add_query_arg' )->alias( function ( $args, string $url ): string {
+			return $url;
+		} );
+		when( 'wc_get_checkout_url' )->justReturn( 'https://example.com/checkout/' );
+		when( 'trailingslashit' )->alias( function ( string $value ): string {
+			return rtrim( $value, '/' ) . '/';
+		} );
+		expect( 'wp_json_encode' )->andReturnUsing( 'json_encode' );
+		when( 'apply_filters' )->alias( function ( string $hook, ...$args ) {
+			return $args[0] ?? null;
+		} );
+
+		$headers_stub = Mockery::mock( \Requests_Utility_CaseInsensitiveDictionary::class );
+		$headers_stub->shouldReceive( 'getAll' )->andReturn( array() );
+
+		expect( 'wp_remote_get' )->andReturnUsing(
+			function () use ( &$call_count, $headers_stub ): array {
+				$call_count++;
+				if ( 1 === $call_count ) {
+					return array(
+						'body'     => '{"status":"CREATED","links":[]}',
+						'response' => array( 'code' => 201 ),
+						'headers'  => $headers_stub,
+					);
+				}
+				return array(
+					'body'     => '{"id":"ORDER-123","status":"CREATED"}',
+					'response' => array( 'code' => 201 ),
+					'headers'  => $headers_stub,
+				);
+			}
+		);
+		when( 'wp_remote_retrieve_response_code' )->alias(
+			function ( $response ): int {
+				return (int) ( $response['response']['code'] ?? 0 );
+			}
+		);
+
+		$testee   = new CaptureCardPayment(
+			'https://api.paypal.com',
+			$bearer,
+			$order_factory,
+			$purchase_unit_factory,
+			$settings_provider,
+			$experience_context_builder,
+			$logger
+		);
+		$wc_order = Mockery::mock( WC_Order::class );
+		$wc_order->shouldReceive( 'get_id' )->andReturn( 1 );
+
+		$result = $testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertSame( $returned_order, $result );
+	}
+
 }


### PR DESCRIPTION
### Description
PayPal's `v2/checkout/orders` endpoint intermittently returns HTTP 200/201 with a response body missing the required `id` field, causing vaulted card orders to fail with "Order does not contain an id". Customers can recover by refreshing and resubmitting, proving the issue is transient.

This PR validates the decoded response before passing it to the order factory, and retries once with a new idempotency key when the response is incomplete. Applied to both `CaptureCardPayment` and `CapturePayPalPayment`.

### Steps to Test

1. Enable Advanced Card Processing and Vault v3
2. Save a credit card to a customer account
3. Checkout using the saved card, order should complete successfully
4. Check `WooCommerce > Status > Logs` for normal flow (no warnings)
5. To verify retry behavior, place a [debug mu-plugin](https://gist.github.com/danieldudzic/6c0326d97fbc5b873a7a845eb0d4fe3a) that strips the `id` from the first API response and confirm the order still completes with `WARNING: PayPal order response missing id.` and `INFO: Retrying PayPal order creation after incomplete response.` in logs