### PR TITLE
Improve: skip PUI checkout-field build when no cart context (6617)

### DIFF
--- a/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PUIPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PUIPaymentMethod.php
@@ -87,6 +87,18 @@ class PUIPaymentMethod extends AbstractPaymentMethodType {
 			return true;
 		}
 
+		// The Mini-Cart block enqueues payment method data on every page via
+		// PaymentMethodRegistry::get_all_registered_script_data(), where the cart
+		// is not necessarily initialized. Building the checkout fields here runs
+		// the full woocommerce_checkout_fields filter chain on every front-end
+		// request, which is wasteful and unsafe for third-party callbacks that
+		// assume a cart exists. The phone requirement is only consumed when PUI
+		// is rendered at checkout, where the cart is always present, so fall back
+		// to the default when there is no cart context.
+		if ( ! WC()->cart instanceof \WC_Cart ) {
+			return true;
+		}
+
 		$checkout_fields = WC()->checkout()->get_checkout_fields();
 		$billing_fields  = $checkout_fields['billing'] ?? array();
 		$phone_required  = $billing_fields['billing_phone']['required'] ?? false;

--- a/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PUIPaymentMethod.php
+++ b/modules/ppcp-local-alternative-payment-methods/src/PayUponInvoice/PUIPaymentMethod.php
@@ -87,14 +87,7 @@ class PUIPaymentMethod extends AbstractPaymentMethodType {
 			return true;
 		}
 
-		// The Mini-Cart block enqueues payment method data on every page via
-		// PaymentMethodRegistry::get_all_registered_script_data(), where the cart
-		// is not necessarily initialized. Building the checkout fields here runs
-		// the full woocommerce_checkout_fields filter chain on every front-end
-		// request, which is wasteful and unsafe for third-party callbacks that
-		// assume a cart exists. The phone requirement is only consumed when PUI
-		// is rendered at checkout, where the cart is always present, so fall back
-		// to the default when there is no cart context.
+		// The Mini-Cart block enqueues this on every page where the cart may be absent; skip the costly checkout-fields build (and its filter chain) outside checkout.
 		if ( ! WC()->cart instanceof \WC_Cart ) {
 			return true;
 		}

--- a/tests/PHPUnit/LocalAlternativePaymentMethods/PayUponInvoice/PUIPaymentMethodTest.php
+++ b/tests/PHPUnit/LocalAlternativePaymentMethods/PayUponInvoice/PUIPaymentMethodTest.php
@@ -65,6 +65,7 @@ class PUIPaymentMethodTest extends TestCase
 		);
 		$wc = Mockery::mock();
 		$wc->shouldReceive('checkout')->andReturn($checkout);
+		$wc->cart = Mockery::mock(\WC_Cart::class);
 		when('WC')->justReturn($wc);
 
 		$sut  = new PUIPaymentMethod($this->asset_getter, '1.0.0', $this->gateway);
@@ -106,11 +107,42 @@ class PUIPaymentMethodTest extends TestCase
 		);
 		$wc = Mockery::mock();
 		$wc->shouldReceive('checkout')->andReturn($checkout);
+		$wc->cart = Mockery::mock(\WC_Cart::class);
 		when('WC')->justReturn($wc);
 
 		$sut  = new PUIPaymentMethod($this->asset_getter, '1.0.0', $this->gateway);
 		$data = $sut->get_payment_method_data();
 
 		$this->assertFalse($data['requiresPhone']);
+	}
+
+	public function testGetPaymentMethodDataSkipsCheckoutFieldsWithoutCartContext(): void
+	{
+		$this->gateway->title       = 'Pay upon Invoice';
+		$this->gateway->description = 'Pay within 30 days';
+		$this->gateway->icon        = 'https://example.test/ratepay.svg';
+
+		when('get_bloginfo')->justReturn('de-DE');
+		when('apply_filters')->alias(function ($hook, $value) {
+			return $value;
+		});
+
+		// The Mini-Cart block enqueues payment method data on every page, where
+		// WC()->cart is not initialised. requires_phone() must not build the
+		// checkout fields in that context (which would run the whole
+		// woocommerce_checkout_fields filter chain and can fatal in third-party
+		// callbacks that assume a cart exists).
+		$checkout = Mockery::mock();
+		$checkout->shouldNotReceive('get_checkout_fields');
+		$wc = Mockery::mock();
+		$wc->shouldReceive('checkout')->andReturn($checkout);
+		$wc->cart = null;
+		when('WC')->justReturn($wc);
+
+		$sut  = new PUIPaymentMethod($this->asset_getter, '1.0.0', $this->gateway);
+		$data = $sut->get_payment_method_data();
+
+		// Falls back to the default (PUI collects the phone itself).
+		$this->assertTrue($data['requiresPhone']);
 	}
 }

--- a/tests/PHPUnit/LocalAlternativePaymentMethods/PayUponInvoice/PUIPaymentMethodTest.php
+++ b/tests/PHPUnit/LocalAlternativePaymentMethods/PayUponInvoice/PUIPaymentMethodTest.php
@@ -127,11 +127,8 @@ class PUIPaymentMethodTest extends TestCase
 			return $value;
 		});
 
-		// The Mini-Cart block enqueues payment method data on every page, where
-		// WC()->cart is not initialised. requires_phone() must not build the
-		// checkout fields in that context (which would run the whole
-		// woocommerce_checkout_fields filter chain and can fatal in third-party
-		// callbacks that assume a cart exists).
+		// No cart context (e.g. Mini-Cart enqueue off-checkout): the checkout
+		// fields must not be built.
 		$checkout = Mockery::mock();
 		$checkout->shouldNotReceive('get_checkout_fields');
 		$wc = Mockery::mock();

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -10,6 +10,7 @@ require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Payment_Gateway_CC.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Ajax.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Checkout.php';
+require_once TESTS_ROOT_DIR . '/stubs/WC_Cart.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Integration.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Session.php';
 require_once TESTS_ROOT_DIR . '/stubs/WC_Session_Handler.php';

--- a/tests/stubs/WC_Cart.php
+++ b/tests/stubs/WC_Cart.php
@@ -1,0 +1,8 @@
+<?php
+declare( strict_types=1 );
+
+class WC_Cart {
+	public function get_cart() {
+		return [];
+	}
+}


### PR DESCRIPTION
**Issue**: #4486

**Ticket**:

**Slack Thread**:

---

### Description

While investigating some 500 that stemmed from the latest 4.1.0 update,  we dove a bit deeper on the new PUI integration with checkout and would like to propose a change.

In 4.1.0 (#4405) PUI became a Blocks payment method. Its `requires_phone()`calls `WC()->checkout()->get_checkout_fields()`, and that data gets collected by the Mini-Cart block on every page load (`MiniCart::enqueue_data()` -> `get_all_registered_script_data()`).
So the full `woocommerce_checkout_fields` filter chain now runs on every front-end page, where in 4.0.x it only ran at checkout.

That's an unnecessary per-page cost (building all checkout fields, loading countries/locale data, running every callback on that filter) - all to compute a phone flag that I believe is only needed at checkout?

On top of that, any code hooked on `woocommerce_checkout_fields` that assumed a checkout context now runs everywhere.

The proposed fix guards `requires_phone()` to bail when there's no cart, matching the `WC()->checkout()` check right above it. If Phone detection only matters at checkout  - then it should be ok to add this check. It will make it so that we're not running unnecessary code throughout the site and page loads 

Side note: Worth noting this isn't limited to stores using PUI. The block method is registered whenever PayPal is connected, `is_active()` is hardcoded to true, and there's no eligibility/country check on the block registration, so the per-page cost applies even to stores that can never offer PUI (it's DE/EUR only).

### Steps to Test

1. PayPal Payments connected with the PayPal gateway enabled (PUI does NOT need to be enabled).
2. Block theme with the Mini-Cart block in the header.
3. Profile a non-checkout page (homepage/product). Before this PR, `get_checkout_fields()` runs on the request; after, it doesn't.
4. Optional, to see the blast-radius case: add a `woocommerce_checkout_fields` callback that touches `WC()->cart`. Before this PR the homepage 500s; after, it loads.
5. Confirm the PUI phone field at Block Checkout still behaves as before.


### Changelog Entry

> Fix - Pay upon Invoice computed its phone requirement on every page through the Mini-Cart block, running the checkout fields filter site-wide instead of only at checkout.

Closes #4486