### PR TITLE
Hide Apple Pay button for subscription carts

### DIFF
--- a/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/BaseHandler.js
@@ -7,17 +7,9 @@ class BaseHandler {
 		this.ppcpConfig = ppcpConfig;
 	}
 
-	isVaultV3Mode() {
-		return (
-			this.ppcpConfig?.save_payment_methods?.id_token && // vault v3
-			! this.ppcpConfig?.data_client_id?.paypal_subscriptions_enabled && // not PayPal Subscriptions mode
-			this.ppcpConfig?.can_save_vault_token
-		); // vault is enabled
-	}
-
 	validateContext() {
 		if ( this.ppcpConfig?.locations_with_subscription_product?.cart ) {
-			return this.isVaultV3Mode();
+			return false;
 		}
 		return true;
 	}

--- a/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/PayNowHandler.js
@@ -5,7 +5,7 @@ import CheckoutActionHandler from '@ppcp-button/ActionHandler/CheckoutActionHand
 class PayNowHandler extends BaseHandler {
 	validateContext() {
 		if ( this.ppcpConfig?.locations_with_subscription_product?.payorder ) {
-			return this.isVaultV3Mode();
+			return false;
 		}
 		return true;
 	}

--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.js
@@ -7,7 +7,7 @@ import BaseHandler from '@ppcp-applepay/Context/BaseHandler';
 class SingleProductHandler extends BaseHandler {
 	validateContext() {
 		if ( this.ppcpConfig?.locations_with_subscription_product?.product ) {
-			return this.isVaultV3Mode();
+			return false;
 		}
 		return true;
 	}

--- a/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.test.js
+++ b/modules/ppcp-applepay/resources/js/Context/SingleProductHandler.test.js
@@ -63,6 +63,15 @@ describe( 'SingleProductHandler', () => {
 		test( 'returns true by default', () => {
 			expect( handler.validateContext() ).toBe( true );
 		} );
+
+		test( 'returns false when the product is a subscription', () => {
+			const subscriptionHandler = new SingleProductHandler( {}, {
+				...ppcpConfig,
+				locations_with_subscription_product: { product: true },
+			} );
+
+			expect( subscriptionHandler.validateContext() ).toBe( false );
+		} );
 	} );
 
 	describe( 'transactionInfo()', () => {

--- a/modules/ppcp-applepay/resources/js/boot-block.js
+++ b/modules/ppcp-applepay/resources/js/boot-block.js
@@ -2,9 +2,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import { registerExpressPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
 import { loadPayPalScript } from '@ppcp-button/Helper/PayPalScriptLoading';
-import { cartHasSubscriptionProducts } from '@ppcp-blocks/Helper/Subscription';
 import { loadCustomScript } from '@paypal/paypal-js';
-import CheckoutHandler from './Context/CheckoutHandler';
 import ApplePayManager from './ApplepayManager';
 import ApplePayManagerBlockEditor from './ApplepayManagerBlockEditor';
 import { debounce } from '@ppcp-blocks/Helper/debounce';
@@ -153,13 +151,6 @@ const ApplePayComponent = ( { isEditing, buttonAttributes } ) => {
 };
 
 const features = [ 'products' ];
-
-if (
-	cartHasSubscriptionProducts( ppcpConfig ) &&
-	new CheckoutHandler( buttonConfig, ppcpConfig ).isVaultV3Mode()
-) {
-	features.push( 'subscriptions' );
-}
 
 if ( buttonConfig?.is_enabled ) {
 	registerExpressPaymentMethod( {

--- a/modules/ppcp-applepay/services.php
+++ b/modules/ppcp-applepay/services.php
@@ -158,7 +158,8 @@ return array(
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'applepay.data_to_scripts' ),
 			$container->get( 'button.helper.cart-products' ),
-			$container->get( 'button.helper.context' )
+			$container->get( 'button.helper.context' ),
+			$container->get( 'wc-subscriptions.helper' )
 		);
 	},
 	'applepay.blocks-payment-method'           => static function ( ContainerInterface $container ): PaymentMethodTypeInterface {

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -20,6 +20,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Webhooks\Handler\RequestHandlerTrait;
 
 class ApplePayButton implements ButtonInterface {
@@ -40,6 +41,7 @@ class ApplePayButton implements ButtonInterface {
 	private DataToAppleButtonScripts $script_data;
 	protected CartProductsHelper $cart_products;
 	private Context $context;
+	private SubscriptionHelper $subscription_helper;
 
 	public function __construct(
 		SettingsProvider $settings_provider,
@@ -50,20 +52,22 @@ class ApplePayButton implements ButtonInterface {
 		string $version,
 		DataToAppleButtonScripts $data,
 		CartProductsHelper $cart_products,
-		Context $context
+		Context $context,
+		SubscriptionHelper $subscription_helper
 	) {
-		$this->settings_provider  = $settings_provider;
-		$this->payment_settings   = $payment_settings;
-		$this->response_templates = new ResponsesToApple();
-		$this->logger             = $logger;
-		$this->id                 = 'applepay';
-		$this->method_title       = __( 'Apple Pay', 'woocommerce-paypal-payments' );
-		$this->order_processor    = $order_processor;
-		$this->asset_getter       = $asset_getter;
-		$this->version            = $version;
-		$this->script_data        = $data;
-		$this->cart_products      = $cart_products;
-		$this->context            = $context;
+		$this->settings_provider   = $settings_provider;
+		$this->payment_settings    = $payment_settings;
+		$this->response_templates  = new ResponsesToApple();
+		$this->logger              = $logger;
+		$this->id                  = 'applepay';
+		$this->method_title        = __( 'Apple Pay', 'woocommerce-paypal-payments' );
+		$this->order_processor     = $order_processor;
+		$this->asset_getter        = $asset_getter;
+		$this->version             = $version;
+		$this->script_data         = $data;
+		$this->cart_products       = $cart_products;
+		$this->context             = $context;
+		$this->subscription_helper = $subscription_helper;
 	}
 
 	public function initialize(): void {
@@ -781,6 +785,21 @@ class ApplePayButton implements ButtonInterface {
 	public function render(): bool {
 		if ( ! $this->is_enabled() ) {
 			return false;
+		}
+
+		if (
+			$this->subscription_helper->plugin_is_active()
+			&& ! $this->subscription_helper->accept_manual_renewals()
+		) {
+			if ( is_product() && $this->subscription_helper->current_product_is_subscription() ) {
+				return false;
+			}
+			if ( $this->subscription_helper->order_pay_contains_subscription() ) {
+				return false;
+			}
+			if ( $this->subscription_helper->cart_contains_subscription() ) {
+				return false;
+			}
 		}
 
 		add_filter(


### PR DESCRIPTION
On classic checkout, the Apple Pay button showed under the PayPal gateway when a vaulting subscription was in the cart.

Apple Pay vault does not work with the current implementation based on customer id and payment tokens, so it can't renewal a subscription using a savedpayment token. Unlike Google Pay, Apple Pay lacked the guards to hide itself for subscription carts. 

### PR Changes                                                                                                                                                                       
  - Add a subscription guard to `ApplePayButton::render()`
  - Return `false` from `validateContext()` for subscription contexts; remove the unused `isVaultV3Mode()`
  - Drop the subscriptions feature push in block checkout.