### PR TITLE
API spam on merchant-integrations endpoint for merchants missing MANAGE_SUBSCRIPTIONS scope (6625)

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
@@ -143,38 +143,62 @@ class PartnersEndpoint {
 			return apply_filters( 'woocommerce_paypal_payments_seller_status', $cached );
 		}
 
+		/*
+		 * Back off if a recent failure was registered, to avoid hammering the
+		 * merchant-integrations endpoint on persistent errors (e.g. a 403). The
+		 * window matches the success cache TTL, and is anchored to the last real
+		 * API failure since add_failure() is only written in
+		 * fetch_seller_status_from_api() on a non-200 response.
+		 */
+		if ( $this->failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, self::SELLER_STATUS_CACHE_TTL ) ) {
+			return $this->handle_seller_status_failure(
+				new RuntimeException( 'Seller status recently failed; backing off the merchant-integrations endpoint.' )
+			);
+		}
+
 		try {
 			$status = $this->fetch_seller_status_from_api();
 		} catch ( RuntimeException $exception ) {
-			/**
-			 * Provides a fallback SellerStatus when the API call fails.
-			 *
-			 * Return a SellerStatus instance to use as fallback instead of
-			 * throwing. Return null to let the exception propagate.
-			 *
-			 * @param SellerStatus|null $fallback Default null (no fallback).
-			 */
-			$fallback = apply_filters( 'woocommerce_paypal_payments_seller_status_fallback', null );
-
-			if ( $fallback instanceof SellerStatus ) {
-				$this->logger->log(
-					'info',
-					'Seller status API failed, using configured fallback.',
-					array( 'error' => $exception->getMessage() )
-				);
-
-				$this->cache->set( self::SELLER_STATUS_CACHE_KEY, $fallback, self::SELLER_STATUS_CACHE_TTL );
-
-				return apply_filters( 'woocommerce_paypal_payments_seller_status', $fallback );
-			}
-
-			throw $exception;
+			return $this->handle_seller_status_failure( $exception );
 		}
 
 		$this->cache->set( self::SELLER_STATUS_CACHE_KEY, $status, self::SELLER_STATUS_CACHE_TTL );
 
-		/** This filter is documented above. */
 		return apply_filters( 'woocommerce_paypal_payments_seller_status', $status );
+	}
+
+	/**
+	 * Handles a seller status failure by applying the configured fallback, or
+	 * re-throwing when no fallback is provided.
+	 *
+	 * @param RuntimeException $exception The exception describing the failure.
+	 * @return SellerStatus
+	 * @throws RuntimeException When no fallback is configured.
+	 */
+	private function handle_seller_status_failure( RuntimeException $exception ): SellerStatus {
+		/**
+		 * Provides a fallback SellerStatus when the API call fails.
+		 *
+		 * Return a SellerStatus instance to use as fallback instead of
+		 * throwing. Return null to let the exception propagate.
+		 *
+		 * @param SellerStatus|null $fallback Default null (no fallback).
+		 */
+		$fallback = apply_filters( 'woocommerce_paypal_payments_seller_status_fallback', null );
+
+		if ( $fallback instanceof SellerStatus ) {
+			$this->logger->log(
+				'info',
+				'Seller status API failed, using configured fallback.',
+				array( 'error' => $exception->getMessage() )
+			);
+
+			$this->cache->set( self::SELLER_STATUS_CACHE_KEY, $fallback, self::SELLER_STATUS_CACHE_TTL );
+
+			return apply_filters( 'woocommerce_paypal_payments_seller_status', $fallback );
+		}
+
+		throw $exception;
 	}
 
 	/**

--- a/modules/ppcp-api-client/src/Helper/ProductStatus.php
+++ b/modules/ppcp-api-client/src/Helper/ProductStatus.php
@@ -174,7 +174,7 @@ abstract class ProductStatus {
 	protected function get_seller_status_object(): SellerStatus {
 		if ( null === self::$seller_status ) {
 			// Check API failure registry to prevent multiple failed API requests.
-			if ( $this->api_failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, MINUTE_IN_SECONDS ) ) {
+			if ( $this->api_failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL ) ) {
 				throw new RuntimeException( 'Timeout for re-check not reached yet' );
 			}
 

--- a/tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
@@ -164,6 +164,12 @@ class PartnersEndpointTest extends TestCase
 				PartnersEndpoint::SELLER_STATUS_CACHE_TTL
 			);
 
+		$this->failure_registry
+			->shouldReceive('has_failure_in_timeframe')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->andReturn(false);
+
 		$this->seller_status_factory
 			->shouldReceive('from_paypal_response')
 			->once()
@@ -202,6 +208,12 @@ class PartnersEndpointTest extends TestCase
 		$this->cache
 			->shouldReceive('set')
 			->never();
+
+		$this->failure_registry
+			->shouldReceive('has_failure_in_timeframe')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->andReturn(false);
 
 		$this->failure_registry
 			->shouldReceive('add_failure')
@@ -248,6 +260,12 @@ class PartnersEndpointTest extends TestCase
 			);
 
 		$this->failure_registry
+			->shouldReceive('has_failure_in_timeframe')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->andReturn(false);
+
+		$this->failure_registry
 			->shouldReceive('add_failure')
 			->once()
 			->with(FailureRegistry::SELLER_STATUS_KEY);
@@ -261,6 +279,102 @@ class PartnersEndpointTest extends TestCase
 		when('wp_remote_get')->justReturn($raw_response);
 		when('is_wp_error')->justReturn(false);
 		when('wp_remote_retrieve_response_code')->justReturn(500);
+
+		$result = $this->make_endpoint()->seller_status();
+
+		$this->assertSame($fallback, $result);
+	}
+
+	// -----------------------------------------------------------------------
+	// Tests: seller_status() failure backoff
+	// -----------------------------------------------------------------------
+
+	/**
+	 * GIVEN the transient cache is empty
+	 * AND a recent failure is registered within the backoff window
+	 * WHEN seller_status() is called
+	 * THEN no HTTP request is made to the PayPal API
+	 * AND no additional failure is registered
+	 * AND a RuntimeException is thrown (no fallback configured)
+	 */
+	public function testSellerStatusBacksOffWhenRecentFailureRegistered(): void
+	{
+		$this->cache
+			->shouldReceive('get')
+			->once()
+			->with(PartnersEndpoint::SELLER_STATUS_CACHE_KEY)
+			->andReturn(false);
+
+		$this->cache
+			->shouldReceive('set')
+			->never();
+
+		$this->failure_registry
+			->shouldReceive('has_failure_in_timeframe')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->andReturn(true);
+
+		$this->failure_registry
+			->shouldReceive('add_failure')
+			->never();
+
+		when('apply_filters')->alias(function (string $hook, ...$args) {
+			return $args[0] ?? null;
+		});
+
+		expect('wp_remote_get')->never();
+
+		$this->expectException(\RuntimeException::class);
+
+		$this->make_endpoint()->seller_status();
+	}
+
+	/**
+	 * GIVEN the transient cache is empty
+	 * AND a recent failure is registered within the backoff window
+	 * AND the fallback filter returns a SellerStatus
+	 * WHEN seller_status() is called
+	 * THEN no HTTP request is made to the PayPal API
+	 * AND the fallback is returned and stored in the cache
+	 */
+	public function testSellerStatusBackoffUsesFallbackWhenConfigured(): void
+	{
+		$fallback = Mockery::mock(SellerStatus::class);
+
+		$this->cache
+			->shouldReceive('get')
+			->once()
+			->with(PartnersEndpoint::SELLER_STATUS_CACHE_KEY)
+			->andReturn(false);
+
+		$this->cache
+			->shouldReceive('set')
+			->once()
+			->with(
+				PartnersEndpoint::SELLER_STATUS_CACHE_KEY,
+				$fallback,
+				PartnersEndpoint::SELLER_STATUS_CACHE_TTL
+			);
+
+		$this->failure_registry
+			->shouldReceive('has_failure_in_timeframe')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_CACHE_TTL)
+			->andReturn(true);
+
+		$this->failure_registry
+			->shouldReceive('add_failure')
+			->never();
+
+		when('apply_filters')->alias(function (string $hook, ...$args) use ($fallback) {
+			if ($hook === 'woocommerce_paypal_payments_seller_status_fallback') {
+				return $fallback;
+			}
+			return $args[0] ?? null;
+		});
+
+		expect('wp_remote_get')->never();
 
 		$result = $this->make_endpoint()->seller_status();
 


### PR DESCRIPTION
The plugin repeatedly called PayPal's merchant-integrations (seller status) endpoint on merchants hitting persistent errors (e.g. a 403 from under-scoped REST apps). Failed responses were never cached, and the failure backoff was only enforced in one caller (ProductStatus, 60s). `ReferenceTransactionStatus` which runs on frontend paths, called `seller_status()` directly with no backoff, so they hit the endpoint on every page load.                                                                                                                                                                                       
                                                                                                                                                                                                                         
This PR centralizes the failure backoff inside `PartnersEndpoint::seller_status()` so every caller backs off for 10 minutes (matching the success cache TTL) after a real failure, anchored to the last actual API error.  Fallback handling was extracted into a shared helper used by both the backoff and error paths. Also aligned ProductStatus's in-request check to the same window.     