### PR TITLE
Fix Apple Pay/Google Pay showing after disabling checkout location (4084)

### DIFF
--- a/modules/ppcp-applepay/src/ApplepayModule.php
+++ b/modules/ppcp-applepay/src/ApplepayModule.php
@@ -180,9 +180,9 @@ class ApplepayModule implements ServiceModule, ExecutableModule {
 				$settings = $c->get( 'settings.settings-provider' );
 				assert( $settings instanceof SettingsProvider );
 
-				$page_methods = $settings->button_styling( $current_context )->methods;
+				$styling = $settings->button_styling( $current_context );
 
-				if ( ! in_array( ApplePayGateway::ID, $page_methods, true ) ) {
+				if ( ! $styling->enabled || ! in_array( ApplePayGateway::ID, $styling->methods, true ) ) {
 					unset( $methods[ ApplePayGateway::ID ] );
 				}
 

--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -974,8 +974,11 @@ class ApplePayButton implements ButtonInterface {
 			return false;
 		}
 
-		$methods = $this->settings_provider->button_styling( $this->context->context() )->methods;
+		$styling = $this->settings_provider->button_styling( $this->context->context() );
+		if ( ! $styling->enabled ) {
+			return false;
+		}
 
-		return in_array( ApplePayGateway::ID, $methods, true );
+		return in_array( ApplePayGateway::ID, $styling->methods, true );
 	}
 }

--- a/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
+++ b/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
@@ -63,9 +63,12 @@ class GooglePayButton implements ButtonInterface {
 			return false;
 		}
 
-		$methods = $this->settings->button_styling( $this->context->context() )->methods;
+		$styling = $this->settings->button_styling( $this->context->context() );
+		if ( ! $styling->enabled ) {
+			return false;
+		}
 
-		return in_array( GooglePayGateway::ID, $methods, true );
+		return in_array( GooglePayGateway::ID, $styling->methods, true );
 	}
 
 	/**

--- a/modules/ppcp-googlepay/src/GooglepayModule.php
+++ b/modules/ppcp-googlepay/src/GooglepayModule.php
@@ -235,9 +235,9 @@ class GooglepayModule implements ServiceModule, ExecutableModule {
 				$settings = $c->get( 'settings.settings-provider' );
 				assert( $settings instanceof SettingsProvider );
 
-				$page_methods = $settings->button_styling( $current_context )->methods;
+				$styling = $settings->button_styling( $current_context );
 
-				if ( ! in_array( GooglePayGateway::ID, $page_methods, true ) ) {
+				if ( ! $styling->enabled || ! in_array( GooglePayGateway::ID, $styling->methods, true ) ) {
 					unset( $methods[ GooglePayGateway::ID ] );
 				}
 

--- a/tests/PHPUnit/Applepay/ApplePayButtonTest.php
+++ b/tests/PHPUnit/Applepay/ApplePayButtonTest.php
@@ -1,0 +1,92 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Applepay;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton;
+use WooCommerce\PayPalCommerce\Applepay\Assets\DataToAppleButtonScripts;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Button\Helper\CartProductsHelper;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton
+ */
+class ApplePayButtonTest extends TestCase
+{
+	private $settings;
+	private $context;
+	private ApplePayButton $sut;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->settings = Mockery::mock(SettingsProvider::class);
+		$this->context  = Mockery::mock(Context::class);
+
+		$this->sut = new ApplePayButton(
+			$this->settings,
+			Mockery::mock(PaymentSettings::class),
+			Mockery::mock(LoggerInterface::class),
+			Mockery::mock(OrderProcessor::class),
+			Mockery::mock(AssetGetter::class),
+			'1.0.0',
+			Mockery::mock(DataToAppleButtonScripts::class),
+			Mockery::mock(CartProductsHelper::class),
+			$this->context
+		);
+	}
+
+	public function testDisabledWhenApplePayGloballyDisabled(): void
+	{
+		$this->settings->shouldReceive('applepay_enabled')->andReturn(false);
+
+		$this->assertFalse($this->sut->is_enabled());
+	}
+
+	/**
+	 * @scenario Regression test for PCP-4084. Same master-switch bug as Google Pay: disabling
+	 *           "Enable payment methods in this location" for Classic Checkout must hide Apple
+	 *           Pay even though it's still selected in that location's method list.
+	 */
+	public function testDisabledWhenLocationDisabledEvenIfMethodSelected(): void
+	{
+		$this->settings->shouldReceive('applepay_enabled')->andReturn(true);
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', false, array(ApplePayGateway::ID))
+		);
+
+		$this->assertFalse($this->sut->is_enabled());
+	}
+
+	public function testEnabledWhenLocationEnabledAndMethodSelected(): void
+	{
+		$this->settings->shouldReceive('applepay_enabled')->andReturn(true);
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', true, array(ApplePayGateway::ID))
+		);
+
+		$this->assertTrue($this->sut->is_enabled());
+	}
+
+	public function testDisabledWhenLocationEnabledButMethodNotSelected(): void
+	{
+		$this->settings->shouldReceive('applepay_enabled')->andReturn(true);
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', true, array())
+		);
+
+		$this->assertFalse($this->sut->is_enabled());
+	}
+}

--- a/tests/PHPUnit/Applepay/ApplepayModuleTest.php
+++ b/tests/PHPUnit/Applepay/ApplepayModuleTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Applepay;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use function Brain\Monkey\Filters\expectAdded;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Applepay\ApplepayModule
+ */
+class ApplepayModuleTest extends TestCase
+{
+	private $container;
+	private $settings;
+	private $context;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->settings = Mockery::mock(SettingsProvider::class);
+		$this->context  = Mockery::mock(Context::class);
+
+		$this->container = Mockery::mock(ContainerInterface::class);
+		$this->container->shouldReceive('get')->with('settings.settings-provider')->andReturn($this->settings);
+		$this->container->shouldReceive('get')->with('button.helper.context')->andReturn($this->context);
+	}
+
+	/**
+	 * Runs the module and captures the closure registered for
+	 * `woocommerce_available_payment_gateways`, so it can be invoked directly in assertions.
+	 */
+	private function captured_available_payment_gateways_filter(): callable
+	{
+		$captured = null;
+
+		expectAdded('woocommerce_available_payment_gateways')
+			->once()
+			->whenHappen(
+				static function ( $callback ) use ( &$captured ) {
+					$captured = $callback;
+				}
+			);
+
+		( new ApplepayModule() )->run( $this->container );
+
+		$this->assertIsCallable($captured);
+
+		return $captured;
+	}
+
+	/**
+	 * @scenario Regression test for PCP-4084. Merchant unchecked "Enable payment methods in
+	 *           this location" for Classic Checkout, but Apple Pay is still selected in that
+	 *           location's method list. WooCommerce would otherwise keep listing Apple Pay as
+	 *           a selectable radio-button gateway; the filter must strip it out.
+	 */
+	public function testGatewayRemovedWhenLocationDisabledEvenIfMethodSelected(): void
+	{
+		$filter = $this->captured_available_payment_gateways_filter();
+
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', false, array(ApplePayGateway::ID))
+		);
+
+		$methods = array( ApplePayGateway::ID => Mockery::mock('WC_Payment_Gateway') );
+
+		$result = $filter($methods);
+
+		$this->assertArrayNotHasKey(ApplePayGateway::ID, $result);
+	}
+
+	public function testGatewayKeptWhenLocationEnabledAndMethodSelected(): void
+	{
+		$filter = $this->captured_available_payment_gateways_filter();
+
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', true, array(ApplePayGateway::ID))
+		);
+
+		$gateway = Mockery::mock('WC_Payment_Gateway');
+		$methods = array( ApplePayGateway::ID => $gateway );
+
+		$result = $filter($methods);
+
+		$this->assertSame($gateway, $result[ApplePayGateway::ID]);
+	}
+
+	public function testGatewayUntouchedOutsideCheckoutContext(): void
+	{
+		$filter = $this->captured_available_payment_gateways_filter();
+
+		$this->context->shouldReceive('context')->andReturn('product');
+
+		$gateway = Mockery::mock('WC_Payment_Gateway');
+		$methods = array( ApplePayGateway::ID => $gateway );
+
+		$result = $filter($methods);
+
+		$this->assertSame($gateway, $result[ApplePayGateway::ID]);
+	}
+}

--- a/tests/PHPUnit/Googlepay/GooglePayButtonTest.php
+++ b/tests/PHPUnit/Googlepay/GooglePayButtonTest.php
@@ -1,0 +1,88 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Googlepay;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Googlepay\Assets\GooglePayButton;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Googlepay\Assets\GooglePayButton
+ */
+class GooglePayButtonTest extends TestCase
+{
+	private $settings;
+	private $context;
+	private GooglePayButton $sut;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->settings = Mockery::mock(SettingsProvider::class);
+		$this->context  = Mockery::mock(Context::class);
+
+		$this->sut = new GooglePayButton(
+			Mockery::mock(AssetGetter::class),
+			'https://example.test/sdk.js',
+			'1.0.0',
+			Mockery::mock(SubscriptionHelper::class),
+			$this->settings,
+			Mockery::mock(Environment::class),
+			$this->context
+		);
+	}
+
+	public function testDisabledWhenGooglePayGloballyDisabled(): void
+	{
+		$this->settings->shouldReceive('googlepay_enabled')->andReturn(false);
+
+		$this->assertFalse($this->sut->is_enabled());
+	}
+
+	/**
+	 * @scenario Regression test for PCP-4084. A merchant unchecks "Enable payment methods in
+	 *           this location" for Classic Checkout but leaves Google Pay selected in that
+	 *           location's method list. The location's enabled flag is a master switch, so the
+	 *           button must not render even though the method checkbox is still selected.
+	 */
+	public function testDisabledWhenLocationDisabledEvenIfMethodSelected(): void
+	{
+		$this->settings->shouldReceive('googlepay_enabled')->andReturn(true);
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', false, array(GooglePayGateway::ID))
+		);
+
+		$this->assertFalse($this->sut->is_enabled());
+	}
+
+	public function testEnabledWhenLocationEnabledAndMethodSelected(): void
+	{
+		$this->settings->shouldReceive('googlepay_enabled')->andReturn(true);
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', true, array(GooglePayGateway::ID))
+		);
+
+		$this->assertTrue($this->sut->is_enabled());
+	}
+
+	public function testDisabledWhenLocationEnabledButMethodNotSelected(): void
+	{
+		$this->settings->shouldReceive('googlepay_enabled')->andReturn(true);
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', true, array())
+		);
+
+		$this->assertFalse($this->sut->is_enabled());
+	}
+}

--- a/tests/PHPUnit/Googlepay/GooglepayModuleTest.php
+++ b/tests/PHPUnit/Googlepay/GooglepayModuleTest.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Googlepay;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use function Brain\Monkey\Filters\expectAdded;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Googlepay\GooglepayModule
+ */
+class GooglepayModuleTest extends TestCase
+{
+	private $container;
+	private $settings;
+	private $context;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->settings = Mockery::mock(SettingsProvider::class);
+		$this->context  = Mockery::mock(Context::class);
+
+		$this->container = Mockery::mock(ContainerInterface::class);
+		$this->container->shouldReceive('get')->with('settings.settings-provider')->andReturn($this->settings);
+		$this->container->shouldReceive('get')->with('button.helper.context')->andReturn($this->context);
+	}
+
+	/**
+	 * Runs the module and captures the closure registered for
+	 * `woocommerce_available_payment_gateways`, so it can be invoked directly in assertions.
+	 */
+	private function captured_available_payment_gateways_filter(): callable
+	{
+		$captured = null;
+
+		expectAdded('woocommerce_available_payment_gateways')
+			->once()
+			->whenHappen(
+				static function ( $callback ) use ( &$captured ) {
+					$captured = $callback;
+				}
+			);
+
+		( new GooglepayModule() )->run( $this->container );
+
+		$this->assertIsCallable($captured);
+
+		return $captured;
+	}
+
+	/**
+	 * @scenario Regression test for PCP-4084. Merchant unchecked "Enable payment methods in
+	 *           this location" for Classic Checkout, but Google Pay is still selected in that
+	 *           location's method list. WooCommerce would otherwise keep listing Google Pay as
+	 *           a selectable radio-button gateway; the filter must strip it out.
+	 */
+	public function testGatewayRemovedWhenLocationDisabledEvenIfMethodSelected(): void
+	{
+		$filter = $this->captured_available_payment_gateways_filter();
+
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', false, array(GooglePayGateway::ID))
+		);
+
+		$methods = array( GooglePayGateway::ID => Mockery::mock('WC_Payment_Gateway') );
+
+		$result = $filter($methods);
+
+		$this->assertArrayNotHasKey(GooglePayGateway::ID, $result);
+	}
+
+	public function testGatewayKeptWhenLocationEnabledAndMethodSelected(): void
+	{
+		$filter = $this->captured_available_payment_gateways_filter();
+
+		$this->context->shouldReceive('context')->andReturn('checkout');
+		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
+			new LocationStylingDTO('classic_checkout', true, array(GooglePayGateway::ID))
+		);
+
+		$gateway = Mockery::mock('WC_Payment_Gateway');
+		$methods = array( GooglePayGateway::ID => $gateway );
+
+		$result = $filter($methods);
+
+		$this->assertSame($gateway, $result[GooglePayGateway::ID]);
+	}
+
+	public function testGatewayUntouchedOutsideCheckoutContext(): void
+	{
+		$filter = $this->captured_available_payment_gateways_filter();
+
+		$this->context->shouldReceive('context')->andReturn('product');
+
+		$gateway = Mockery::mock('WC_Payment_Gateway');
+		$methods = array( GooglePayGateway::ID => $gateway );
+
+		$result = $filter($methods);
+
+		$this->assertSame($gateway, $result[GooglePayGateway::ID]);
+	}
+}


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
Google Pay and Apple Pay have two independent visibility switches per location: a master `enabled` flag ("Enable payment methods in this location") and a `methods` list (which specific payment methods are selected for that location). Both the express button rendering (`GooglePayButton`/`ApplePayButton::is_enabled()`) and the WooCommerce gateway list filter (`woocommerce_available_payment_gateways` in `GooglepayModule`/`ApplepayModule`) only checked the `methods` list and ignored the `enabled` flag.                                                                                                                                                          
                                                                                                                                                                                                          
As a result, disabling "Classic Checkout" as a location did nothing for Apple Pay/Google Pay as long as they were still selected in that location's method list (the default): the express button kept rendering, and the gateway kept appearing as a selectable radio option on the classic checkout payment method list.                                                                                                                                                                           
                                                                                                                                                                                                          
Both checks now also require `LocationStylingDTO::$enabled` to be `true`, matching how the standard PayPal smart button already treats it.                                                                                                                                                         
                                                                                                                                                                                                          
### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Enable Google Pay and Apple Pay in Advanced Card Processing.                                                                                                                                         
2. In Settings > Styling, select the Classic Checkout location and uncheck "Enable payment methods in this location" (leave the Google Pay/Apple Pay method checkboxes selected).                                                                                                               
3. Add a product to the cart and go to classic checkout (Safari, for Apple Pay).                                                                                                                        
4. Confirm the Apple Pay/Google Pay express buttons no longer render, and neither appears as a selectable payment method in the gateway list.                                                                                                                                                       
5. Re-enable the location and confirm both the button and gateway option come back.                                                                                                                     
6. Confirm product page / cart / mini-cart Apple Pay/Google Pay visibility is unaffected.