### PR TITLE
Throttle seller status retries after failures

### DIFF
--- a/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
+++ b/modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
@@ -87,6 +87,11 @@ class PartnersEndpoint {
 	public const SELLER_STATUS_CACHE_TTL = 600; // 10 minutes.
 
 	/**
+	 * Retry timeout after a failed seller status request, in seconds.
+	 */
+	public const SELLER_STATUS_FAILURE_RETRY_TIMEOUT = 60;
+
+	/**
 	 * Cache key for the seller status response.
 	 */
 	public const SELLER_STATUS_CACHE_KEY = 'seller_status';
@@ -141,6 +146,10 @@ class PartnersEndpoint {
 			 * @param SellerStatus $status The seller status (from cache or API).
 			 */
 			return apply_filters( 'woocommerce_paypal_payments_seller_status', $cached );
+		}
+
+		if ( $this->failure_registry->has_failure_in_timeframe( FailureRegistry::SELLER_STATUS_KEY, self::SELLER_STATUS_FAILURE_RETRY_TIMEOUT ) ) {
+			throw new RuntimeException( 'Timeout for seller status re-check not reached yet.' );
 		}
 
 		try {

--- a/tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
@@ -10,6 +10,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\SellerStatus;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Token;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\SellerStatusFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\Cache;
 use WooCommerce\PayPalCommerce\ApiClient\Helper\FailureRegistry;
@@ -65,6 +66,12 @@ class PartnersEndpointTest extends TestCase
 		$this->seller_status_factory = Mockery::mock(SellerStatusFactory::class);
 		$this->failure_registry      = Mockery::mock(FailureRegistry::class);
 		$this->cache                 = Mockery::mock(Cache::class);
+
+		$this->failure_registry
+			->shouldReceive('has_failure_in_timeframe')
+			->byDefault()
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_RETRY_TIMEOUT)
+			->andReturn(false);
 
 		when('trailingslashit')->alias(function (string $url): string {
 			return rtrim($url, '/') . '/';
@@ -179,6 +186,34 @@ class PartnersEndpointTest extends TestCase
 		$result = $this->make_endpoint()->seller_status();
 
 		$this->assertSame($seller_status, $result);
+	}
+
+	/**
+	 * GIVEN the transient cache is empty
+	 * AND the seller status API failed recently
+	 * WHEN seller_status() is called
+	 * THEN no PayPal API request is made
+	 * AND a RuntimeException is thrown
+	 */
+	public function testSellerStatusWithRecentFailureDoesNotMakeHttpCall(): void
+	{
+		$this->cache
+			->shouldReceive('get')
+			->once()
+			->with(PartnersEndpoint::SELLER_STATUS_CACHE_KEY)
+			->andReturn(false);
+
+		$this->failure_registry
+			->shouldReceive('has_failure_in_timeframe')
+			->once()
+			->with(FailureRegistry::SELLER_STATUS_KEY, PartnersEndpoint::SELLER_STATUS_FAILURE_RETRY_TIMEOUT)
+			->andReturn(true);
+
+		expect('wp_remote_get')->never();
+
+		$this->expectException(RuntimeException::class);
+
+		$this->make_endpoint()->seller_status();
 	}
 
 	/**


### PR DESCRIPTION
## Description

Avoid immediately re-requesting PayPal seller status when a recent seller-status API failure is already recorded.

`ReferenceTransactionStatus::reference_transaction_enabled()` calls `PartnersEndpoint::seller_status()` while rendering the PayPal settings page. `fetch_seller_status_from_api()` already records failed seller-status responses in `FailureRegistry::SELLER_STATUS_KEY`, and `ProductStatus` already uses that failure registry to avoid repeated failed checks. This change applies the same one-minute fast-fail guard directly in `PartnersEndpoint::seller_status()` so all seller-status consumers share the protection.

Cached successful seller status still returns before the failure-registry check.

## Benchmark

Local WooCommerce benchmark stack:

- WordPress Docker image: `wordpress:php8.3-apache`
- WordPress 6.9-alpha-60093
- WooCommerce 10.9.1
- WooCommerce PayPal Payments 4.1.0
- WooCommerce Stripe Gateway 10.8.3
- WooPayments 10.9.0
- Scenario: authenticated admin render of `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway`
- State before each run: no `ppcp-seller-status-seller_status` transient; fresh `ppcp-seller-status-failure_registry_seller_status` transient
- XHProf enabled, 3 samples per side

Baseline with a fresh seller-status failure still called the PayPal merchant-integration endpoint on every settings render:

- PayPal seller-status HTTP calls: 3 / 3 requests
- Endpoint: `api.woocommerce.com/integrations/ppc/v1/customer/partners/.../merchant-integrations/`
- Status: 404 on all 3 calls
- PayPal call elapsed time: 382.912ms, 369.636ms, 365.8ms
- Median server time: 1678.18ms
- Median query count: 268

Candidate after this patch:

- PayPal seller-status HTTP calls: 0 / 3 requests
- Median server time: 1252.12ms
- Median query count: 260
- Remaining HTTP calls were Jetpack/WooPayments registration calls, not PayPal seller-status calls.

## Testing

```bash
php -l modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php
php -l tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
git diff --check
vendor/bin/phpcs modules/ppcp-api-client/src/Endpoint/PartnersEndpoint.php tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
vendor/bin/phpunit --filter PartnersEndpointTest tests/PHPUnit/ApiClient/Endpoint/PartnersEndpointTest.php
```

Result: `OK (6 tests, 6 assertions)`.
