### PR TITLE
Defer settings REST endpoint data loading

### DIFF
--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -268,7 +268,7 @@ return array(
 	},
 	'settings.rest.login_link'                            => static function ( ContainerInterface $container ): LoginLinkRestEndpoint {
 		return new LoginLinkRestEndpoint(
-			$container->get( 'settings.service.connection-url-generator' ),
+			static fn(): ConnectionUrlGenerator => $container->get( 'settings.service.connection-url-generator' ),
 			$container->get( 'woocommerce.logger.woocommerce' )
 		);
 	},
@@ -477,9 +477,9 @@ return array(
 	'settings.rest.todos'                                 => static function ( ContainerInterface $container ): TodosRestEndpoint {
 		return new TodosRestEndpoint(
 			$container->get( 'settings.data.todos' ),
-			$container->get( 'settings.data.definition.todos' ),
+			static fn(): TodosDefinition => $container->get( 'settings.data.definition.todos' ),
 			$container->get( 'settings.rest.settings' ),
-			$container->get( 'settings.service.todos_sorting' )
+			static fn(): TodosSortingAndFilteringService => $container->get( 'settings.service.todos_sorting' )
 		);
 	},
 	'settings.data.todos'                                 => static function ( ContainerInterface $container ): TodosModel {
@@ -661,7 +661,7 @@ return array(
 	},
 	'settings.rest.features'                              => static function ( ContainerInterface $container ): FeaturesRestEndpoint {
 		return new FeaturesRestEndpoint(
-			$container->get( 'settings.data.definition.features' ),
+			static fn(): FeaturesDefinition => $container->get( 'settings.data.definition.features' ),
 			$container->get( 'settings.rest.settings' )
 		);
 	},

--- a/modules/ppcp-settings/src/Endpoint/FeaturesRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/FeaturesRestEndpoint.php
@@ -31,11 +31,11 @@ class FeaturesRestEndpoint extends RestEndpoint {
 	protected $rest_base = 'features';
 
 	/**
-	 * The features definition instance.
+	 * Factory for the features definition instance.
 	 *
-	 * @var FeaturesDefinition
+	 * @var callable
 	 */
-	protected FeaturesDefinition $features_definition;
+	protected $features_definition_factory;
 
 	/**
 	 * The settings endpoint instance.
@@ -47,15 +47,15 @@ class FeaturesRestEndpoint extends RestEndpoint {
 	/**
 	 * FeaturesRestEndpoint constructor.
 	 *
-	 * @param FeaturesDefinition   $features_definition The features definition instance.
-	 * @param SettingsRestEndpoint $settings The settings endpoint instance.
+	 * @param callable             $features_definition_factory Factory for the features definition instance.
+	 * @param SettingsRestEndpoint $settings                     The settings endpoint instance.
 	 */
 	public function __construct(
-		FeaturesDefinition $features_definition,
+		callable $features_definition_factory,
 		SettingsRestEndpoint $settings
 	) {
-		$this->features_definition = $features_definition;
-		$this->settings            = $settings;
+		$this->features_definition_factory = $features_definition_factory;
+		$this->settings                    = $settings;
 	}
 
 	/**
@@ -82,8 +82,11 @@ class FeaturesRestEndpoint extends RestEndpoint {
 	 * @return WP_REST_Response The response containing features data.
 	 */
 	public function get_features(): WP_REST_Response {
+		$features_definition = ( $this->features_definition_factory )();
+		assert( $features_definition instanceof FeaturesDefinition );
+
 		$features = array();
-		foreach ( $this->features_definition->eligible_features() as $id => $feature ) {
+		foreach ( $features_definition->eligible_features() as $id => $feature ) {
 			$features[] = array_merge(
 				array( 'id' => $id ),
 				$feature

--- a/modules/ppcp-settings/src/Endpoint/LoginLinkRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/LoginLinkRestEndpoint.php
@@ -32,13 +32,18 @@ class LoginLinkRestEndpoint extends RestEndpoint {
 	 */
 	protected $rest_base = 'login_link';
 
-	protected ConnectionUrlGenerator $url_generator;
+	/**
+	 * Factory for the connection URL generator.
+	 *
+	 * @var callable
+	 */
+	protected $url_generator_factory;
 
 	protected LoggerInterface $logger;
 
-	public function __construct( ConnectionUrlGenerator $url_generator, LoggerInterface $logger ) {
-		$this->url_generator = $url_generator;
-		$this->logger        = $logger;
+	public function __construct( callable $url_generator_factory, LoggerInterface $logger ) {
+		$this->url_generator_factory = $url_generator_factory;
+		$this->logger                = $logger;
 	}
 
 	/**
@@ -103,7 +108,10 @@ class LoginLinkRestEndpoint extends RestEndpoint {
 		$flags       = (array) $request->get_param( 'options' );
 
 		try {
-			$url = $this->url_generator->generate( $products, $flags, $use_sandbox );
+			$url_generator = ( $this->url_generator_factory )();
+			assert( $url_generator instanceof ConnectionUrlGenerator );
+
+			$url = $url_generator->generate( $products, $flags, $use_sandbox );
 
 			return $this->return_success( $url );
 		} catch ( Exception $e ) {

--- a/modules/ppcp-settings/src/Endpoint/TodosRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/TodosRestEndpoint.php
@@ -42,11 +42,11 @@ class TodosRestEndpoint extends RestEndpoint {
 	protected TodosModel $todos;
 
 	/**
-	 * The todos definition instance.
+	 * Factory for the todos definition instance.
 	 *
-	 * @var TodosDefinition
+	 * @var callable
 	 */
-	protected TodosDefinition $todos_definition;
+	protected $todos_definition_factory;
 
 	/**
 	 * The settings endpoint instance.
@@ -56,30 +56,30 @@ class TodosRestEndpoint extends RestEndpoint {
 	protected SettingsRestEndpoint $settings;
 
 	/**
-	 * The todos sorting service.
+	 * Factory for the todos sorting service.
 	 *
-	 * @var TodosSortingAndFilteringService
+	 * @var callable
 	 */
-	protected TodosSortingAndFilteringService $sorting_service;
+	protected $sorting_service_factory;
 
 	/**
 	 * TodosRestEndpoint constructor.
 	 *
-	 * @param TodosModel                      $todos The todos model instance.
-	 * @param TodosDefinition                 $todos_definition The todos definition instance.
-	 * @param SettingsRestEndpoint            $settings The settings endpoint instance.
-	 * @param TodosSortingAndFilteringService $sorting_service The todos sorting service.
+	 * @param TodosModel           $todos                    The todos model instance.
+	 * @param callable             $todos_definition_factory Factory for the todos definition instance.
+	 * @param SettingsRestEndpoint $settings                 The settings endpoint instance.
+	 * @param callable             $sorting_service_factory  Factory for the todos sorting service.
 	 */
 	public function __construct(
 		TodosModel $todos,
-		TodosDefinition $todos_definition,
+		callable $todos_definition_factory,
 		SettingsRestEndpoint $settings,
-		TodosSortingAndFilteringService $sorting_service
+		callable $sorting_service_factory
 	) {
-		$this->todos            = $todos;
-		$this->todos_definition = $todos_definition;
-		$this->settings         = $settings;
-		$this->sorting_service  = $sorting_service;
+		$this->todos                    = $todos;
+		$this->todos_definition_factory = $todos_definition_factory;
+		$this->settings                 = $settings;
+		$this->sorting_service_factory  = $sorting_service_factory;
 	}
 
 	/**
@@ -133,12 +133,18 @@ class TodosRestEndpoint extends RestEndpoint {
 	 * @return WP_REST_Response The response containing todos data.
 	 */
 	public function get_todos(): WP_REST_Response {
+		$todos_definition = ( $this->todos_definition_factory )();
+		assert( $todos_definition instanceof TodosDefinition );
+
+		$sorting_service = ( $this->sorting_service_factory )();
+		assert( $sorting_service instanceof TodosSortingAndFilteringService );
+
 		$todos_data            = $this->todos->get_todos_data();
 		$dismissed_ids         = $todos_data['dismissedTodos'];
 		$completed_onclick_ids = $todos_data['completedOnClickTodos'];
 
 		$todos = array();
-		foreach ( $this->todos_definition->get() as $id => $todo ) {
+		foreach ( $todos_definition->get() as $id => $todo ) {
 			// Skip if todo has completeOnClick flag and is in completed list.
 			if (
 				in_array( $id, $completed_onclick_ids, true ) &&
@@ -157,7 +163,7 @@ class TodosRestEndpoint extends RestEndpoint {
 			}
 		}
 
-		$filtered_todos = $this->sorting_service->apply_all_priority_filters( $todos );
+		$filtered_todos = $sorting_service->apply_all_priority_filters( $todos );
 
 		return $this->return_success(
 			array(


### PR DESCRIPTION
## Summary
- defers expensive settings REST endpoint data dependencies until their callbacks run
- keeps route registration for login_link, todos, and features lightweight
- avoids building partner-referrals/features/payment method data while unrelated REST requests register routes

## Benchmark context
Local Woo benchmark stack: WooCommerce 10.9.1, PayPal Payments 4.1.0, Stripe Gateway 10.8.3, WooPayments 10.9.0, WP 7.0, PHP 8.3.31, MySQL 8.0.46, profiler mu-plugin. The production plugin build was patched equivalently for measurement.

Tokenized `GET /wp-json/wc/store/v1/cart` before this change showed the session SELECT being triggered during PayPal settings route registration:
`SettingsModule::{closure} -> LoginLinkRestEndpoint/connection-url-generator -> settings.data.definition.features -> PaymentRestEndpoint->get_details() -> PaymentMethodsDefinition->get_definitions() -> WC()->payment_gateways() -> WooPayments multicurrency -> StoreApi\SessionHandler->get_session`.

After the lazy loading patch, the same session SELECT caller moved back to Woo Store API route schema registration:
`StoreApi->register_all_routes -> CheckoutSchema->get_properties -> WooCommerce->payment_gateways() -> WooPayments multicurrency -> StoreApi\SessionHandler->get_session`.

Measured sample:
- PayPal active baseline: 96 queries, 68.99 ms server, session caller through PayPal settings registration.
- PayPal inactive comparison: 66 queries, 47.42 ms server, session caller through Store API route schema registration.
- Lazy candidate: 95 queries, 51.58 ms server, session caller through Store API route schema registration.

The remaining PayPal-active query gap appears separate: mostly repeated `woocommerce_custom_orders_table_background_sync_mode` option reads during Woo boot (75 with PayPal active vs 49 with PayPal inactive in this sample), not the settings REST eager data path fixed here.

## Testing
- `php -l` on changed files
- `vendor/bin/phpcs modules/ppcp-settings/services.php modules/ppcp-settings/src/Endpoint/FeaturesRestEndpoint.php modules/ppcp-settings/src/Endpoint/LoginLinkRestEndpoint.php modules/ppcp-settings/src/Endpoint/TodosRestEndpoint.php`
- `vendor/bin/phpunit` (1407 tests, 5442 assertions, 3 skipped)
