### PR TITLE
Add advanced onboarding options to final wizard step (6629)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/screens/_onboarding.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/_onboarding.scss
@@ -22,6 +22,26 @@
 		margin: 8px 0 24px 0;
 	}
 
+	.onboarding-advanced-options {
+		margin-top: 24px;
+		margin-bottom: 48px;
+		max-width: 800px;
+
+		.ppcp--toggler .ppcp--title-wrapper {
+			justify-content: center;
+		}
+
+		.components-base-control__field {
+			margin: 0 0 24px 0;
+		}
+
+		.manual-credentials-error {
+			@include font(11, 16, 450);
+			margin: -16px 0 24px;
+			color: var(--color-error);
+		}
+	}
+
 	.components-button.ppcp-r-button-activate-paypal,
 	.ppcp-r-connection-button.ppcp--mode-live {
 		--button-background: #000;

--- a/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
+++ b/modules/ppcp-settings/resources/css/components/screens/onboarding/_step-welcome.scss
@@ -16,25 +16,7 @@
 		text-align: center;
 	}
 
-	.components-base-control__field {
-		margin: 0 0 24px 0;
-	}
 
-	.manual-credentials-error {
-		@include font(11, 16, 450);
-		margin: -16px 0 24px;
-		color: var(--color-error);
-	}
-
-	.onboarding-advanced-options {
-		margin-top: 24px;
-		margin-bottom: 48px;
-		max-width: 800px;
-
-		.ppcp--toggler .ppcp--title-wrapper {
-			justify-content: center;
-		}
-	}
 }
 
 .ppcp-r-welcome-features {

--- a/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepCompleteSetup.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Onboarding/Steps/StepCompleteSetup.js
@@ -1,7 +1,10 @@
 import { __ } from '@wordpress/i18n';
 
+import { Separator } from '@ppcp-settings/Components/ReusableComponents/Elements';
+import Accordion from '@ppcp-settings/Components/ReusableComponents/AccordionSection';
 import OnboardingHeader from '../Components/OnboardingHeader';
 import ConnectionButton from '../Components/ConnectionButton';
+import AdvancedOptionsForm from '../Components/AdvancedOptionsForm';
 
 const StepCompleteSetup = () => {
 	return (
@@ -26,6 +29,18 @@ const StepCompleteSetup = () => {
 					/>
 				</div>
 			</div>
+			<Separator text={ __( 'or', 'woocommerce-paypal-payments' ) } />
+			<Accordion
+				title={ __(
+					'See advanced options',
+					'woocommerce-paypal-payments'
+				) }
+				className="onboarding-advanced-options"
+				noCaps={ true }
+				id="advanced-options"
+			>
+				<AdvancedOptionsForm />
+			</Accordion>
 		</div>
 	);
 };


### PR DESCRIPTION
### Description
This PR adds **See advanced options** dropdown to the final step of the onboarding wizard ("Complete Your Payment Setup"). This mirrors the existing behavior from the Welcome screen, allowing users to connect via manual API credentials or sandbox mode without navigating back.

Also moves the advanced options styles (max-width, field spacing, error styling) from the Welcome-screen-specific SCSS to the shared onboarding scope so they apply consistently across both screens.

### Screenshots

| Before | After |
| :--- | :--- |
|<img width="1720" height="897" alt="Cursor_i_WooCommerce_settings_‹_WooC…PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/a701dd8b-bbd5-4a5b-b579-007d6afd6f98" />|<img width="1723" height="893" alt="Cursor_i_WooCommerce_settings_‹_WooC…PayPal_Payments_—_WordPress" src="https://github.com/user-attachments/assets/d1d641fc-e75e-4cf0-ba9c-62a18d139f4f" />|


### Steps to Test

1. Go to WooCommerce > Settings > PayPal Payments
2. Start the onboarding wizard by clicking "Activate PayPal Payments"
3. Progress through all steps until the final "Complete Your Payment Setup" screen
4. Verify the "OR" separator and "See advanced options" dropdown appear below the "Connect to PayPal" button
5. Expand "See advanced options" and verify "Enable Sandbox Mode" and "Manually Connect" toggles work correctly
6. Go back to the Welcome screen and verify the advanced options still render with the same width and spacing
