### PR TITLE
Fix Google Pay button not rendering for subscription renewal (2649)

### DIFF
--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -1112,6 +1112,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'variable_paypal_subscription_variation_from_cart' => $this->subscription_helper->paypal_subscription_variation_from_cart(),
 			'subscription_product_allowed'            => $this->subscription_helper->checkout_subscription_product_allowed(),
 			'locations_with_subscription_product'     => $this->subscription_helper->locations_with_subscription_product(),
+			'subscriptions_accept_manual_renewals'    => $this->subscription_helper->accept_manual_renewals(),
 			'enforce_vault'                           => $this->has_subscriptions(),
 			'can_save_vault_token'                    => $this->can_save_vault_token(),
 			'is_free_trial_cart'                      => $is_free_trial_cart,

--- a/modules/ppcp-googlepay/resources/js/Context/BaseHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/BaseHandler.js
@@ -10,6 +10,11 @@ class BaseHandler {
 	}
 
 	validateContext() {
+		// Google Pay doesn't support vaulting, so the only case where it's allowed on a
+		// subscription is paying to manually renew an existing one.
+		if ( this.ppcpConfig?.locations_with_subscription_product?.payorder ) {
+			return !! this.ppcpConfig?.subscriptions_accept_manual_renewals;
+		}
 		if ( this.ppcpConfig?.locations_with_subscription_product?.cart ) {
 			return false;
 		}

--- a/modules/ppcp-googlepay/resources/js/Context/BaseHandler.test.js
+++ b/modules/ppcp-googlepay/resources/js/Context/BaseHandler.test.js
@@ -1,0 +1,80 @@
+/* global describe, test, expect, jest */
+
+jest.mock( '@ppcp-button/ErrorHandler', () => jest.fn() );
+jest.mock( '@ppcp-button/ActionHandler/CartActionHandler', () => jest.fn() );
+jest.mock( '@ppcp-googlepay/Helper/TransactionInfo' );
+
+import BaseHandler from './BaseHandler';
+import PayNowHandler from './PayNowHandler';
+
+describe( 'BaseHandler', () => {
+	describe( 'validateContext()', () => {
+		test( 'returns true when no subscription product is present', () => {
+			const handler = new BaseHandler( {}, {} );
+
+			expect( handler.validateContext() ).toBe( true );
+		} );
+
+		test( 'returns false when the cart contains a subscription product', () => {
+			const ppcpConfig = {
+				locations_with_subscription_product: { cart: true },
+			};
+			const handler = new BaseHandler( {}, ppcpConfig );
+
+			expect( handler.validateContext() ).toBe( false );
+		} );
+
+		test( 'returns false for a pay-for-order subscription renewal when manual renewals are not accepted', () => {
+			const ppcpConfig = {
+				locations_with_subscription_product: { payorder: true },
+				subscriptions_accept_manual_renewals: false,
+			};
+			const handler = new BaseHandler( {}, ppcpConfig );
+
+			expect( handler.validateContext() ).toBe( false );
+		} );
+
+		test( 'returns true for a pay-for-order subscription renewal when manual renewals are accepted', () => {
+			const ppcpConfig = {
+				locations_with_subscription_product: { payorder: true },
+				subscriptions_accept_manual_renewals: true,
+			};
+			const handler = new BaseHandler( {}, ppcpConfig );
+
+			expect( handler.validateContext() ).toBe( true );
+		} );
+
+		test( 'prioritizes the pay-for-order check over the cart check', () => {
+			const ppcpConfig = {
+				locations_with_subscription_product: {
+					payorder: true,
+					cart: true,
+				},
+				subscriptions_accept_manual_renewals: true,
+			};
+			const handler = new BaseHandler( {}, ppcpConfig );
+
+			expect( handler.validateContext() ).toBe( true );
+		} );
+	} );
+} );
+
+describe( 'PayNowHandler', () => {
+	describe( 'validateContext()', () => {
+		test( 'inherits the pay-for-order subscription check from BaseHandler', () => {
+			const allowedConfig = {
+				locations_with_subscription_product: { payorder: true },
+				subscriptions_accept_manual_renewals: true,
+			};
+			const blockedConfig = {
+				locations_with_subscription_product: { payorder: true },
+				subscriptions_accept_manual_renewals: false,
+			};
+			const allowedHandler = new PayNowHandler( {}, allowedConfig );
+			const blockedHandler = new PayNowHandler( {}, blockedConfig );
+
+			expect( allowedHandler.validateContext() ).toBe( true );
+			expect( blockedHandler.validateContext() ).toBe( false );
+		} );
+	} );
+} );

--- a/modules/ppcp-googlepay/resources/js/Context/PayNowHandler.js
+++ b/modules/ppcp-googlepay/resources/js/Context/PayNowHandler.js
@@ -4,13 +4,6 @@ import CheckoutActionHandler from '@ppcp-button/ActionHandler/CheckoutActionHand
 import TransactionInfo from '@ppcp-googlepay/Helper/TransactionInfo';
 
 class PayNowHandler extends BaseHandler {
-	validateContext() {
-		if ( this.ppcpConfig?.locations_with_subscription_product?.payorder ) {
-			return false;
-		}
-		return true;
-	}
-
 	transactionInfo() {
 		return new Promise( async ( resolve, reject ) => {
 			const data = this.ppcpConfig.pay_now;

--- a/modules/ppcp-googlepay/resources/js/boot-block.js
+++ b/modules/ppcp-googlepay/resources/js/boot-block.js
@@ -111,8 +111,21 @@ const GooglePayComponent = ( { isEditing, buttonAttributes, onClick } ) => {
 	);
 };
 
+/**
+ * Google Pay doesn't support vaulting, so the only case where it's allowed on a
+ * subscription is paying to manually renew an existing one. Checked here so the express
+ * payment method isn't registered at all (no empty placeholder) when it can't be used.
+ */
+const isBlockedBySubscription = () => {
+	const locations = ppcpConfig?.locations_with_subscription_product;
+	if ( locations?.payorder ) {
+		return ! ppcpConfig?.subscriptions_accept_manual_renewals;
+	}
+	return !! locations?.cart;
+};
+
 const features = [ 'products' ];
-if ( buttonConfig?.is_enabled ) {
+if ( buttonConfig?.is_enabled && ! isBlockedBySubscription() ) {
 	registerExpressPaymentMethod( {
 		name: buttonData.id,
 		title: `PayPal - ${ buttonData.title }`,

--- a/modules/ppcp-googlepay/services.php
+++ b/modules/ppcp-googlepay/services.php
@@ -188,7 +188,6 @@ return array(
 			$container->get( 'googlepay.asset_getter' ),
 			$container->get( 'googlepay.sdk_url' ),
 			$container->get( 'ppcp.asset-version' ),
-			$container->get( 'wc-subscriptions.helper' ),
 			$container->get( 'settings.settings-provider' ),
 			$container->get( 'settings.environment' ),
 			$container->get( 'button.helper.context' )

--- a/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
+++ b/modules/ppcp-googlepay/src/Assets/GooglePayButton.php
@@ -21,7 +21,6 @@ use WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Exception\NotFoundException;
-use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 class GooglePayButton implements ButtonInterface {
@@ -32,24 +31,21 @@ class GooglePayButton implements ButtonInterface {
 	private string $version;
 	private SettingsProvider $settings;
 	private Environment $environment;
-	private SubscriptionHelper $subscription_helper;
 
 	public function __construct(
 		AssetGetter $asset_getter,
 		string $sdk_url,
 		string $version,
-		SubscriptionHelper $subscription_helper,
 		SettingsProvider $settings,
 		Environment $environment,
 		Context $context
 	) {
-		$this->asset_getter        = $asset_getter;
-		$this->sdk_url             = $sdk_url;
-		$this->version             = $version;
-		$this->subscription_helper = $subscription_helper;
-		$this->settings            = $settings;
-		$this->environment         = $environment;
-		$this->context             = $context;
+		$this->asset_getter = $asset_getter;
+		$this->sdk_url      = $sdk_url;
+		$this->version      = $version;
+		$this->settings     = $settings;
+		$this->environment  = $environment;
+		$this->context      = $context;
 	}
 
 	public function initialize(): void {
@@ -78,21 +74,6 @@ class GooglePayButton implements ButtonInterface {
 	public function render(): bool {
 		if ( ! $this->is_enabled() ) {
 			return false;
-		}
-
-		if (
-			$this->subscription_helper->plugin_is_active()
-			&& ! $this->subscription_helper->accept_manual_renewals()
-		) {
-			if ( is_product() && $this->subscription_helper->current_product_is_subscription() ) {
-				return false;
-			}
-			if ( $this->subscription_helper->order_pay_contains_subscription() ) {
-				return false;
-			}
-			if ( $this->subscription_helper->cart_contains_subscription() ) {
-				return false;
-			}
 		}
 
 		/**

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -75,6 +75,22 @@ class SubscriptionHelper {
 	}
 
 	/**
+	 * Whether the cart contains a subscription renewal payment (e.g., a customer manually
+	 * renewing a subscription), as opposed to a new subscription being purchased. WooCommerce
+	 * Subscriptions may route a manual renewal through the cart/Checkout block instead of the
+	 * classic order-pay endpoint, so this can't be inferred from the URL alone.
+	 *
+	 * @return bool
+	 */
+	public function cart_contains_renewal(): bool {
+		if ( ! $this->plugin_is_active() || ! function_exists( 'wcs_cart_contains_renewal' ) ) {
+			return false;
+		}
+
+		return (bool) wcs_cart_contains_renewal();
+	}
+
+	/**
 	 * Whether pay for order contains subscriptions.
 	 *
 	 * @return bool
@@ -282,10 +298,12 @@ class SubscriptionHelper {
 	 * @return array
 	 */
 	public function locations_with_subscription_product(): array {
+		$cart_contains_renewal = $this->cart_contains_renewal();
+
 		return array(
 			'product'  => is_product() && $this->current_product_is_subscription(),
-			'payorder' => is_wc_endpoint_url( 'order-pay' ) && $this->order_pay_contains_subscription(),
-			'cart'     => $this->cart_contains_subscription(),
+			'payorder' => ( is_wc_endpoint_url( 'order-pay' ) && $this->order_pay_contains_subscription() ) || $cart_contains_renewal,
+			'cart'     => $this->cart_contains_subscription() && ! $cart_contains_renewal,
 		);
 	}
 

--- a/tests/PHPUnit/WcSubscriptions/Helper/SubscriptionHelperTest.php
+++ b/tests/PHPUnit/WcSubscriptions/Helper/SubscriptionHelperTest.php
@@ -45,4 +45,122 @@ class SubscriptionHelperTest extends TestCase
 			(new SubscriptionHelper())->previous_transaction($subscription, 'token12345')
 		);
 	}
+
+	public function testCartContainsRenewalReturnsFalseWhenSubscriptionsPluginNotActive()
+	{
+		// Neither WC_Subscriptions nor WC_Subscriptions_Product exist in the test environment,
+		// so plugin_is_active() is reliably false here without needing to mock it.
+		$this->assertFalse((new SubscriptionHelper())->cart_contains_renewal());
+	}
+
+	public function testLocationsWithSubscriptionProductWhenNothingIsPresent()
+	{
+		when('is_product')->justReturn(false);
+		when('is_wc_endpoint_url')->justReturn(false);
+
+		$helper = $this->partialSubscriptionHelper(false, false, false, false);
+
+		$this->assertSame(
+			[
+				'product'  => false,
+				'payorder' => false,
+				'cart'     => false,
+			],
+			$helper->locations_with_subscription_product()
+		);
+	}
+
+	public function testLocationsWithSubscriptionProductOnProductPage()
+	{
+		when('is_product')->justReturn(true);
+		when('is_wc_endpoint_url')->justReturn(false);
+
+		$helper = $this->partialSubscriptionHelper(true, false, false, false);
+
+		$this->assertSame(
+			[
+				'product'  => true,
+				'payorder' => false,
+				'cart'     => false,
+			],
+			$helper->locations_with_subscription_product()
+		);
+	}
+
+	public function testLocationsWithSubscriptionProductOnClassicOrderPayEndpoint()
+	{
+		when('is_product')->justReturn(false);
+		when('is_wc_endpoint_url')->justReturn(true);
+
+		$helper = $this->partialSubscriptionHelper(false, true, false, false);
+
+		$this->assertSame(
+			[
+				'product'  => false,
+				'payorder' => true,
+				'cart'     => false,
+			],
+			$helper->locations_with_subscription_product()
+		);
+	}
+
+	/**
+	 * @scenario Regression test for PCP-2649. WooCommerce Subscriptions can route a manual
+	 *           renewal through the cart/Checkout block instead of the classic order-pay
+	 *           endpoint, so a cart-based renewal must be classified as "payorder", not "cart" -
+	 *           otherwise Google Pay incorrectly treats it as a brand-new subscription and hides
+	 *           itself even when manual renewals are accepted.
+	 */
+	public function testLocationsWithSubscriptionProductWhenCartContainsRenewal()
+	{
+		when('is_product')->justReturn(false);
+		when('is_wc_endpoint_url')->justReturn(false);
+
+		$helper = $this->partialSubscriptionHelper(false, false, true, true);
+
+		$this->assertSame(
+			[
+				'product'  => false,
+				'payorder' => true,
+				'cart'     => false,
+			],
+			$helper->locations_with_subscription_product()
+		);
+	}
+
+	public function testLocationsWithSubscriptionProductWhenCartContainsNewSubscription()
+	{
+		when('is_product')->justReturn(false);
+		when('is_wc_endpoint_url')->justReturn(false);
+
+		$helper = $this->partialSubscriptionHelper(false, false, true, false);
+
+		$this->assertSame(
+			[
+				'product'  => false,
+				'payorder' => false,
+				'cart'     => true,
+			],
+			$helper->locations_with_subscription_product()
+		);
+	}
+
+	/**
+	 * Builds a partial mock of SubscriptionHelper so `locations_with_subscription_product()`
+	 * runs for real while its individual signal methods return fixed, arranged values.
+	 */
+	private function partialSubscriptionHelper(
+		bool $current_product_is_subscription,
+		bool $order_pay_contains_subscription,
+		bool $cart_contains_subscription,
+		bool $cart_contains_renewal
+	): SubscriptionHelper {
+		$helper = Mockery::mock(SubscriptionHelper::class)->makePartial();
+		$helper->shouldReceive('current_product_is_subscription')->andReturn($current_product_is_subscription);
+		$helper->shouldReceive('order_pay_contains_subscription')->andReturn($order_pay_contains_subscription);
+		$helper->shouldReceive('cart_contains_subscription')->andReturn($cart_contains_subscription);
+		$helper->shouldReceive('cart_contains_renewal')->andReturn($cart_contains_renewal);
+
+		return $helper;
+	}
 }


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
Google Pay had inconsistent, partly-incorrect subscription handling that showed up in several ways: a console crash when a subscription was in the cart on classic pages, an empty placeholder on Block checkout during a subscription renewal, and inconsistent behavior between classic and Block checkout for the same renewal.                                                                              
                                                                                                                                                                                                          
**Root causes:**                                                                                                                                                                                            
- `GooglePayButton::render()` had a PHP-side subscription check that `enqueue()`/`enqueue_styles()` didn't share, so the JS boot script could load and try to use a PayPal SDK component that was never requested.                                                                                                                                                                                              
- The JS eligibility check (`validateContext()`) blocked Google Pay unconditionally for any subscription, with no way to allow a legitimate renewal through.                                                                                                                             
- WooCommerce Subscriptions can route a manual renewal through the cart and Checkout block instead of the classic order-pay endpoint, so a renewal-in-cart was indistinguishable from a brand-new subscription purchase, and got blocked either way.                                                                                                                                                      
- The Block checkout express payment method was always registered and only failed validation afterward, leaving an empty placeholder instead of not rendering at all.                                   
                                                                                                                                                                                                          
**Fix summary:**                                                                                                                                                                                            
- Removed the PHP-side subscription gate entirely; Google Pay's PHP now always proceeds, matching Apple Pay's architecture. Subscription eligibility is decided once, in JS.                            
- Google Pay's JS now gates rendering on the store's "Accept Manual Renewals" setting for a renewal payment, and unconditionally blocks a brand-new subscription in the cart (no vaulting exemption).   
- `SubscriptionHelper` now distinguishes a cart-based renewal from a new subscription via `wcs_cart_contains_renewal()`.                                                                                
- The Block checkout express payment method is no longer registered at all when Google Pay isn't eligible, instead of registering it and failing validation afterward.                                  
                                                                                                                                                                                                          
Apple Pay was tested throughout and works correctly in all these scenarios — this PR only changes Google Pay.                                                                                           
                                                                                                                                                                                                          
### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Enable Google Pay in Advanced Card Processing, and have a subscription product configured with WooCommerce Subscriptions.                                                                            
2. Add the subscription product to cart and check out for the first time: confirm Google Pay is hidden everywhere (product page, cart, mini-cart, classic and Block checkout) — this is WooCommerce Subscriptions' own gateway filtering and should be unaffected.                                                                                                                                          
3. With "Accept Manual Renewals" **disabled** in WooCommerce Subscriptions settings, manually renew an existing subscription (My Account > Subscriptions > Renew): confirm Google Pay does not render and there's no empty placeholder, on both classic and Block checkout.                                                                                                                                   
4. With "Accept Manual Renewals" **enabled**, repeat the renewal: confirm Google Pay renders a working button on both classic and Block checkout.                                                       
5. Repeat steps 3–4 in both Chrome and Safari.                      