### PR TITLE
[QA] Add autotests for PUI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -226,7 +226,7 @@ export default defineConfig< BaseExtend >( {
 		},
 		{
 			name: 'shard:transaction-germany',
-			// dependencies: [ 'setup-transaction-germany' ],
+			dependencies: [ 'setup-transaction-germany' ],
 			testMatch: /05-transactions\/transaction-germany.*\.spec\.ts/,
 		},
 		{

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -168,6 +168,13 @@ export default defineConfig< BaseExtend >( {
 			fullyParallel: false,
 		},
 		{
+			name: 'setup-transaction-germany',
+			dependencies: [ 'setup-pcp-germany' ],
+			testMatch: /03-pcp\.setup\.ts/,
+			grep: /setup:transaction:germany;/,
+			fullyParallel: false,
+		},
+		{
 			name: 'setup-vaulting',
 			dependencies: [ 'setup-pcp-usa' ],
 			testMatch: /03-pcp\.setup\.ts/,
@@ -216,6 +223,11 @@ export default defineConfig< BaseExtend >( {
 			name: 'shard:transaction-mexico',
 			dependencies: [ 'setup-transaction-mexico' ],
 			testMatch: /05-transactions\/transaction-mexico.*\.spec\.ts/,
+		},
+		{
+			name: 'shard:transaction-germany',
+			// dependencies: [ 'setup-transaction-germany' ],
+			testMatch: /05-transactions\/transaction-germany.*\.spec\.ts/,
 		},
 		{
 			name: 'shard:refund',

--- a/tests/qa/resources/pcp-gateways.ts
+++ b/tests/qa/resources/pcp-gateways.ts
@@ -271,7 +271,7 @@ const oxxo: Pcp.Gateway = {
 	enabled: false,
 };
 
-const payUponInvoice: Pcp.Gateway = {
+const pui: Pcp.Gateway = {
 	shortcut: 'pay_upon_invoice',
 	country: 'germany',
 	currency: 'EUR',
@@ -324,6 +324,6 @@ export const gateways = {
 	trustly,
 	multibanco,
 	oxxo,
-	payUponInvoice,
+	pui,
 	bcdc,
 };

--- a/tests/qa/resources/pcp-payments.ts
+++ b/tests/qa/resources/pcp-payments.ts
@@ -60,9 +60,10 @@ const bcdc: Pcp.Payment = {
 	card: cards.visa,
 };
 
-const payUponInvoice: Pcp.Payment = {
-	gateway: gateways.payUponInvoice,
+const pui: Pcp.Payment = {
+	gateway: gateways.pui,
 	birthDate: '01.01.1991',
+	phone: '+39123456789',
 };
 
 const googlePay: Pcp.Payment = {
@@ -81,6 +82,6 @@ export const payments = {
 	fastlaneGary,
 	fastlaneRyan,
 	bcdc,
-	payUponInvoice,
+	pui,
 	googlePay,
 };

--- a/tests/qa/resources/types.ts
+++ b/tests/qa/resources/types.ts
@@ -74,6 +74,10 @@ export namespace Pcp {
 			| 'no-3d-secure'
 			| 'only-required-3d-secure'
 			| 'always-3d-secure';
+		puiBrandName?: string;
+		puiCustomerServiceInstructions?: string;
+		puiLogoUrl?: string;
+		showCardLogos?: boolean;
 	};
 
 	export type Gateway = WooCommerce.PaymentGateway &
@@ -99,6 +103,7 @@ export namespace Pcp {
 		card?: WooCommerce.CreditCard;
 		isVaulted?: boolean;
 		birthDate?: string;
+		phone?: string;
 		useNotVaultedAccount?: PayPalAccount;
 		isAuthorized?: boolean;
 		saveToAccount?: boolean;

--- a/tests/qa/tests/03-plugin-settings/_test-data/payment-methods-ui.data.ts
+++ b/tests/qa/tests/03-plugin-settings/_test-data/payment-methods-ui.data.ts
@@ -21,7 +21,6 @@ export type PaymentMethodsUiTestData = {
 
 const defaultUi: PaymentMethodsUiTestData[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6228
 		testKey: 'PCP-6228',
 		testLabel: ' @Critical @Smoke',
 		country: 'usa',

--- a/tests/qa/tests/03-plugin-settings/pay-later-messaging-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/pay-later-messaging-ui.spec.ts
@@ -14,7 +14,6 @@ test.beforeAll( async ( { utils, pcpApi } ) => {
 	);
 } );
 
-// https://inpsyde.atlassian.net/browse/PCP-4336
 test( 'PCP-4336 | Settings - Pay Later Messaging - Default UI', async ( {
 	utils,
 	payPalUi,
@@ -108,7 +107,6 @@ test( 'PCP-4336 | Settings - Pay Later Messaging - Default UI', async ( {
 	).not.toBeVisible();
 } );
 
-// https://inpsyde.atlassian.net/browse/PCP-4337
 test( 'PCP-4337 | Settings - Pay Later Messaging - Disabled on all pages', async ( {
 	utils,
 	payPalUi,

--- a/tests/qa/tests/03-plugin-settings/styling-ui.spec.ts
+++ b/tests/qa/tests/03-plugin-settings/styling-ui.spec.ts
@@ -22,7 +22,6 @@ test.beforeAll( async ( { utils, pcpApi } ) => {
 	);
 } );
 
-// https://inpsyde.atlassian.net/browse/PCP-4747
 test( 'PCP-4747 | Settings - US- Styling - Default UI', async ( {
 	utils,
 	pcpStyling,

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-checkout.data.ts
@@ -14,14 +14,12 @@ const guest = guests.usa;
 
 export const acdcCheckout: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3217
 		title: 'PCP-3217 | Transaction - Checkout - ACDC - Default order @Critical @Smoke',
 		...orders.default,
 		payment: payments.acdc,
 		customer: guest,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3224
 		title: 'PCP-3224 | Transaction - Checkout - ACDC - Order by customer',
 		...orders.default,
 		payment: payments.acdc,
@@ -31,7 +29,6 @@ export const acdcCheckout: ShopOrder[] = [
 
 export const acdcCheckoutExcludingTax: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3221
 		title: 'PCP-3221 | Transaction - Checkout - ACDC - Order with price excluding tax',
 		...orders.excludingTax,
 		payment: payments.acdc,
@@ -41,7 +38,6 @@ export const acdcCheckoutExcludingTax: ShopOrder[] = [
 
 export const acdcCheckoutIntentAuthorized: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3228
 		title: 'PCP-3228 | Transaction - Checkout - ACDC - Order with Intent Authorized',
 		...orders.default,
 		payment: {
@@ -55,14 +51,12 @@ export const acdcCheckoutIntentAuthorized: ShopOrder[] = [
 
 export const acdcCheckout3ds: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1135
 		title: 'PCP-1135 | Transaction - Checkout - ACDC - Order with Always trigger 3D secure',
 		...orders.default,
 		payment: payments.acdc3ds,
 		customer: guest,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3225
 		title: 'PCP-3225 | Transaction - Checkout - ACDC - Order paid with card requiring 3DS',
 		...orders.default,
 		payment: payments.acdc3ds,
@@ -72,14 +66,12 @@ export const acdcCheckout3ds: ShopOrder[] = [
 
 export const acdcCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6575
 		title: 'PCP-6575 | Transaction - Checkout - ACDC - Customer - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payments.acdc,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6576
 		title: 'PCP-6576 | Transaction - Checkout - ACDC - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payments.acdc,

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-classic-checkout.data.ts
@@ -14,14 +14,12 @@ const guest = guests.usa;
 
 export const acdcClassicCheckout: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1202
 		title: 'PCP-1202 | Transaction - Classic checkout - ACDC - Default order @Critical @Smoke',
 		...orders.default,
 		payment: payments.acdc,
 		customer: guest,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2743
 		title: 'PCP-2743 | Transaction - Classic checkout - ACDC - Order by customer',
 		...orders.default,
 		payment: payments.acdc,
@@ -31,7 +29,6 @@ export const acdcClassicCheckout: ShopOrder[] = [
 
 export const acdcClassicCheckoutExcludingTax: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1259
 		title: 'PCP-1259 | Transaction - Classic checkout - ACDC - Order with price excluding tax',
 		...orders.excludingTax,
 		payment: payments.acdc,
@@ -40,7 +37,6 @@ export const acdcClassicCheckoutExcludingTax: ShopOrder[] = [
 
 export const acdcClassicCheckoutIntentAuthorized: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5740
 		title: 'PCP-5740 | Transaction - Classic checkout - ACDC - Customer - Order with intent Authorize',
 		...orders.default,
 		payment: {
@@ -51,7 +47,6 @@ export const acdcClassicCheckoutIntentAuthorized: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5741
 		title: 'PCP-5741 | Transaction - Classic checkout - ACDC - Guest - Order with intent Authorize',
 		...orders.default,
 		payment: {
@@ -65,14 +60,12 @@ export const acdcClassicCheckoutIntentAuthorized: ShopOrder[] = [
 
 export const acdcClassicCheckout3ds: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5429
 		title: 'PCP-5429 | Transaction - Classic checkout - ACDC - Contingency for 3D Secure = Always trigger 3D secure',
 		...orders.default,
 		payment: payments.acdc3ds,
 		customer: guest,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1209
 		title: 'PCP-1209 | Transaction - Classic checkout - ACDC - Order paid with card requiring 3DS',
 		...orders.default,
 		payment: payments.acdc3ds,
@@ -82,14 +75,12 @@ export const acdcClassicCheckout3ds: ShopOrder[] = [
 
 export const acdcClassicCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6608
 		title: 'PCP-6608 | Transaction - Classic checkout - ACDC - Customer - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payments.acdc,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6609
 		title: 'PCP-6609 | Transaction - Classic checkout - ACDC - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payments.acdc,

--- a/tests/qa/tests/05-transactions/_test-data/acdc/acdc-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/acdc/acdc-pay-by-link.data.ts
@@ -16,28 +16,24 @@ const { acdc, acdc3ds } = payments;
 
 export const acdcPayByLink: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1327
 		title: 'PCP-1327 | Transaction - Pay by link - ACDC - Guest - Default order @Critical',
 		...orders.default,
 		payment: acdc,
 		customer: guest,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1326
 		title: 'PCP-1326 | Transaction - Pay by link - ACDC - Customer - Default order @Critical',
 		...orders.default,
 		payment: acdc,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6494
 		title: 'PCP-6494 | Transaction - Pay by link - ACDC - Customer - Order with negative fee',
 		...orders.negative12Fee,
 		payment: acdc,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6495
 		title: 'PCP-6495 | Transaction - Pay by link - ACDC - Guest - Order with negative fee',
 		...orders.negative12Fee,
 		payment: acdc,
@@ -47,7 +43,6 @@ export const acdcPayByLink: ShopOrder[] = [
 
 export const acdcPayByLinkExcludingTax: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5430
 		title: 'PCP-5430 | Transaction - Pay by link - ACDC - Order with price excluding tax',
 		...orders.excludingTax,
 		payment: acdc,
@@ -57,7 +52,6 @@ export const acdcPayByLinkExcludingTax: ShopOrder[] = [
 
 export const acdcPayByLinkIntentAuthorized: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5431
 		title: 'PCP-5431 | Transaction - Pay by link - ACDC - Order with Intent Authorized',
 		...orders.default,
 		payment: {
@@ -71,14 +65,12 @@ export const acdcPayByLinkIntentAuthorized: ShopOrder[] = [
 
 export const acdcPayByLink3ds: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5432
 		title: 'PCP-5432 | Transaction - Pay by link - ACDC - Contingency for 3D Secure = Always trigger 3D secure',
 		...orders.default,
 		payment: acdc3ds,
 		customer: guest,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5433
 		title: 'PCP-5433 | Transaction - Pay by link - ACDC - Order paid with card requiring 3DS',
 		...orders.default,
 		payment: acdc3ds,

--- a/tests/qa/tests/05-transactions/_test-data/bcdc/bcdc-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/bcdc/bcdc-classic-checkout.data.ts
@@ -21,7 +21,6 @@ const merchant = merchants.mexico;
 
 export const bcdcClassicCheckout: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1211
 		title: 'PCP-1211 | Transaction - Classic checkout - BCDC - Default order @Critical @Smoke',
 		...orders.default,
 		payment: payments.bcdc,
@@ -29,7 +28,6 @@ export const bcdcClassicCheckout: ShopOrder[] = [
 		merchant,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2747
 		title: 'PCP-2747 | Transaction - Classic checkout - BCDC - Order by customer',
 		...orders.default,
 		payment: payments.bcdc,
@@ -40,7 +38,6 @@ export const bcdcClassicCheckout: ShopOrder[] = [
 
 export const bcdcClassicCheckoutExcludingTax: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1253
 		title: 'PCP-1253 | Transaction - Classic checkout - BCDC - Order with price excluding tax',
 		...orders.excludingTax,
 		payment: payments.bcdc,
@@ -51,7 +48,6 @@ export const bcdcClassicCheckoutExcludingTax: ShopOrder[] = [
 
 export const bcdcClassicCheckoutIntentAuthorized: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2759
 		title: 'PCP-2759 | Transaction - Classic checkout - BCDC - Order with Intent Authorized',
 		...orders.default,
 		payment: {

--- a/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-checkout.data.ts
@@ -8,7 +8,6 @@ const guest = guests.usa;
 
 export const googlePayCheckout: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2655
 		title: 'PCP-2655 | Transaction - Checkout - Google Pay - Order by customer @Critical',
 		...orders.default,
 		payment: payments.googlePay,
@@ -18,14 +17,12 @@ export const googlePayCheckout: ShopOrder[] = [
 
 export const googlePayCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6577
 		title: 'PCP-6577 | Transaction - Checkout - Google Pay - Customer - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payments.googlePay,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6578
 		title: 'PCP-6578 | Transaction - Checkout - Google Pay - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payments.googlePay,

--- a/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-classic-checkout.data.ts
@@ -8,7 +8,6 @@ const guest = guests.usa;
 
 export const googlePayClassicCheckout: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2969
 		title: 'PCP-2969 | Transaction - Classic checkout - Google Pay - Order by customer @Critical',
 		...orders.default,
 		payment: payments.googlePay,
@@ -18,14 +17,12 @@ export const googlePayClassicCheckout: ShopOrder[] = [
 
 export const googlePayClassicCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6610
 		title: 'PCP-6610 | Transaction - Classic checkout - Google Pay - Customer - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payments.googlePay,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6611
 		title: 'PCP-6611 | Transaction - Classic checkout - Google Pay - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payments.googlePay,

--- a/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-pay-by-link.data.ts
@@ -10,14 +10,12 @@ const { googlePay } = payments;
 
 export const googlePayPayByLink: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
 		title: 'PCP-6496 | Transaction - Pay by link - Google Pay - Customer - Order with negative fee',
 		...orders.negative12Fee,
 		payment: googlePay,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
 		title: 'PCP-6497 | Transaction - Pay by link - Google Pay - Guest - Order with negative fee',
 		...orders.negative12Fee,
 		payment: googlePay,

--- a/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-product.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/googlepay/googlepay-product.data.ts
@@ -7,7 +7,6 @@ const { googlePay } = payments;
 
 export const googlePayProduct: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6589
 		title: 'PCP-6589 | Transaction - Product - Google Pay - Variable product with two not selected attributes @Critical',
 		...orders.default,
 		payment: googlePay,

--- a/tests/qa/tests/05-transactions/_test-data/oxxo/oxxo-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/oxxo/oxxo-classic-checkout.data.ts
@@ -16,7 +16,6 @@ const merchant = merchants.mexico;
 
 export const oxxoClassicCheckout: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1219
 		title: 'PCP-1219 | Transaction - Classic checkout - OXXO - Mexico - Default order @Critical',
 		...orders.default,
 		payment: payments.oxxo,
@@ -24,7 +23,6 @@ export const oxxoClassicCheckout: ShopOrder[] = [
 		merchant,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2755
 		title: 'PCP-2755 | Transaction - Classic checkout - OXXO - Mexico - Order by customer',
 		...orders.default,
 		payment: payments.oxxo,

--- a/tests/qa/tests/05-transactions/_test-data/pay-later/pay-later-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pay-later/pay-later-checkout.data.ts
@@ -43,14 +43,12 @@ export const payLaterCheckoutIntentAuthorized: ShopOrder[] = [
 
 export const payLaterCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6571
 		title: 'PCP-6571 | Transaction - Checkout - Pay Later - Customer - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payLater,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6572
 		title: 'PCP-6572 | Transaction - Checkout - Pay Later - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payLater,

--- a/tests/qa/tests/05-transactions/_test-data/pay-later/pay-later-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pay-later/pay-later-classic-checkout.data.ts
@@ -51,14 +51,12 @@ export const payLaterClassicCheckoutHorizontalButton: ShopOrder[] = [
 
 export const payLaterClassicCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6606
 		title: 'PCP-6606 | Transaction - Classic checkout - Pay Later - Customer - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payLater,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6607
 		title: 'PCP-6607 | Transaction - Classic checkout - Pay Later - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payLater,

--- a/tests/qa/tests/05-transactions/_test-data/pay-later/pay-later-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pay-later/pay-later-pay-by-link.data.ts
@@ -10,14 +10,12 @@ const { payLater } = payments;
 
 export const payLaterPayByLink: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6492
 		title: 'PCP-6492 | Transaction - Pay by link - Pay Later - Customer - Order with negative fee',
 		...orders.negative12Fee,
 		payment: payLater,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6493
 		title: 'PCP-6493 | Transaction - Pay by link - Pay Later - Guest - Order with negative fee',
 		...orders.negative12Fee,
 		payment: payLater,

--- a/tests/qa/tests/05-transactions/_test-data/pay-later/pay-later-product.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pay-later/pay-later-product.data.ts
@@ -7,7 +7,6 @@ const { payLater } = payments;
 
 export const payLaterProduct: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6588
 		title: 'PCP-6588 | Transaction - Product - Pay Later - Variable product with two not selected attributes @Critical',
 		...orders.default,
 		payment: payLater,

--- a/tests/qa/tests/05-transactions/_test-data/paypal/paypal-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/paypal/paypal-checkout.data.ts
@@ -47,14 +47,12 @@ export const payPalCheckoutIntentAuthorized: ShopOrder[] = [
 
 export const payPalCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6568
 		title: 'PCP-6568 | Transaction - Checkout - PayPal - Customer - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payPal,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6569
 		title: 'PCP-6569 | Transaction - Checkout - PayPal - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payPal,

--- a/tests/qa/tests/05-transactions/_test-data/paypal/paypal-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/paypal/paypal-classic-checkout.data.ts
@@ -43,14 +43,12 @@ export const payPalClassicCheckoutIntentAuthorized: ShopOrder[] = [
 
 export const payPalClassicCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6604
 		title: 'PCP-6604 | Transaction - Classic checkout - PayPal - Customer - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payPal,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6605
 		title: 'PCP-6605 | Transaction - Classic checkout - PayPal - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: payPal,

--- a/tests/qa/tests/05-transactions/_test-data/paypal/paypal-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/paypal/paypal-pay-by-link.data.ts
@@ -10,28 +10,24 @@ const { payPal } = payments;
 
 export const payPalPayByLink: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2886
 		title: 'PCP-2886 | Transaction - Pay by link - PayPal - Customer - Default order @Critical',
 		...orders.byCustomer,
 		payment: payPal,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2887
 		title: 'PCP-2887 | Transaction - Pay by link - PayPal - Guest - Default order @Critical',
 		...orders.default,
 		payment: payPal,
 		customer: guest,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6460
 		title: 'PCP-6460 | Transaction - Pay by link - PayPal - Customer - Order with negative fee',
 		...orders.negative12Fee,
 		payment: payPal,
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6485
 		title: 'PCP-6485 | Transaction - Pay by link - PayPal - Guest - Order with negative fee',
 		...orders.negative12Fee,
 		payment: payPal,
@@ -41,7 +37,6 @@ export const payPalPayByLink: ShopOrder[] = [
 
 export const payPalPayByLinkExcludingTax: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6495
 		title: 'PCP-6495 | Transaction - Pay by link - PayPal - Guest - Order with price excluding tax',
 		payment: payPal,
 		...orders.excludingTax,
@@ -51,7 +46,6 @@ export const payPalPayByLinkExcludingTax: ShopOrder[] = [
 
 export const payPalPayByLinkIntentAuthorized: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3333
 		title: 'PCP-3333 | Transaction - Pay by link - PayPal - Order with Intent Authorized',
 		payment: {
 			...payPal,

--- a/tests/qa/tests/05-transactions/_test-data/paypal/paypal-product.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/paypal/paypal-product.data.ts
@@ -7,7 +7,6 @@ const { payPal } = payments;
 
 export const payPalProduct: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6297
 		title: 'PCP-6297 | Transaction - Product - PayPal - Variable product with two not selected attributes @Critical',
 		...orders.default,
 		payment: payPal,

--- a/tests/qa/tests/05-transactions/_test-data/pui/index.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/index.ts
@@ -1,0 +1,3 @@
+export * from './pui-classic-checkout.data';
+export * from './pui-checkout.data';
+export * from './pui-pay-by-link.data';

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-checkout.data.ts
@@ -16,7 +16,6 @@ const { pui } = payments;
 
 export const puiCheckout: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6640
 		title: 'PCP-6640 | Transaction - Checkout - Pay upon Invoice - Germany - Guest - Default order @Critical',
 		...orders.default,
 		payment: pui,
@@ -24,7 +23,6 @@ export const puiCheckout: ShopOrder[] = [
 		currency,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6641
 		title: 'PCP-6641 | Transaction - Checkout - Pay upon Invoice - Germany - Customer - Default order @Critical',
 		...orders.default,
 		payment: pui,

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-checkout.data.ts
@@ -21,7 +21,6 @@ export const puiCheckout: ShopOrder[] = [
 		...orders.default,
 		payment: pui,
 		customer: guest,
-		orderStatus: 'on-hold',
 		currency,
 	},
 	{
@@ -30,7 +29,6 @@ export const puiCheckout: ShopOrder[] = [
 		...orders.default,
 		payment: pui,
 		customer,
-		orderStatus: 'on-hold',
 		currency,
 	},
 ];

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-checkout.data.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import {
+	payments,
+	orders,
+	customers,
+	guests,
+	ShopOrder,
+} from '../../../../resources';
+
+const customer = customers.germany;
+const guest = guests.germany;
+const currency = 'EUR';
+const { pui } = payments;
+
+export const puiCheckout: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-6640
+		title: 'PCP-6640 | Transaction - Checkout - Pay upon Invoice - Germany - Guest - Default order @Critical',
+		...orders.default,
+		payment: pui,
+		customer: guest,
+		orderStatus: 'on-hold',
+		currency,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-6641
+		title: 'PCP-6641 | Transaction - Checkout - Pay upon Invoice - Germany - Customer - Default order @Critical',
+		...orders.default,
+		payment: pui,
+		customer,
+		orderStatus: 'on-hold',
+		currency,
+	},
+];

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-classic-checkout.data.ts
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import {
+	payments,
+	orders,
+	customers,
+	guests,
+	ShopOrder,
+} from '../../../../resources';
+
+const customer = customers.germany;
+const guest = guests.germany;
+const currency = 'EUR';
+const { pui } = payments;
+
+export const puiClassicCheckout: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1216
+		title: 'PCP-1216 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Default order @Critical',
+		...orders.default,
+		payment: pui,
+		customer: guest,
+		orderStatus: 'on-hold',
+		currency,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-2751
+		title: 'PCP-2751 | Transaction - Classic checkout - Pay upon Invoice - Germany - Customer - Default order @Critical',
+		...orders.default,
+		payment: pui,
+		customer,
+		orderStatus: 'on-hold',
+		currency,
+	},
+];
+
+export const puiClassicCheckoutExcludingTax: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1246
+		title: 'PCP-1246 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Order with price excluding tax',
+		...orders.excludingTax,
+		payment: pui,
+		customer: guest,
+		orderStatus: 'on-hold',
+		currency,
+	},
+];
+
+export const puiClassicCheckoutNegativeFee: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-6642
+		title: 'PCP-6642 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Order with negative fee snippet',
+		...orders.negative12Fee,
+		payment: pui,
+		customer: guest,
+		orderStatus: 'on-hold',
+		currency,
+	},
+];

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-classic-checkout.data.ts
@@ -21,7 +21,6 @@ export const puiClassicCheckout: ShopOrder[] = [
 		...orders.default,
 		payment: pui,
 		customer: guest,
-		orderStatus: 'on-hold',
 		currency,
 	},
 	{
@@ -30,7 +29,6 @@ export const puiClassicCheckout: ShopOrder[] = [
 		...orders.default,
 		payment: pui,
 		customer,
-		orderStatus: 'on-hold',
 		currency,
 	},
 ];
@@ -42,7 +40,6 @@ export const puiClassicCheckoutExcludingTax: ShopOrder[] = [
 		...orders.excludingTax,
 		payment: pui,
 		customer: guest,
-		orderStatus: 'on-hold',
 		currency,
 	},
 ];
@@ -54,7 +51,6 @@ export const puiClassicCheckoutNegativeFee: ShopOrder[] = [
 		...orders.negative12Fee,
 		payment: pui,
 		customer: guest,
-		orderStatus: 'on-hold',
 		currency,
 	},
 ];

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-classic-checkout.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-classic-checkout.data.ts
@@ -16,7 +16,6 @@ const { pui } = payments;
 
 export const puiClassicCheckout: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1216
 		title: 'PCP-1216 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Default order @Critical',
 		...orders.default,
 		payment: pui,
@@ -24,7 +23,6 @@ export const puiClassicCheckout: ShopOrder[] = [
 		currency,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2751
 		title: 'PCP-2751 | Transaction - Classic checkout - Pay upon Invoice - Germany - Customer - Default order @Critical',
 		...orders.default,
 		payment: pui,
@@ -35,7 +33,6 @@ export const puiClassicCheckout: ShopOrder[] = [
 
 export const puiClassicCheckoutExcludingTax: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1246
 		title: 'PCP-1246 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Order with price excluding tax',
 		...orders.excludingTax,
 		payment: pui,
@@ -46,7 +43,6 @@ export const puiClassicCheckoutExcludingTax: ShopOrder[] = [
 
 export const puiClassicCheckoutNegativeFee: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-6642
 		title: 'PCP-6642 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Order with negative fee snippet',
 		...orders.negative12Fee,
 		payment: pui,

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-pay-by-link.data.ts
@@ -21,7 +21,6 @@ export const puiPayByLink: ShopOrder[] = [
 		...orders.default,
 		payment: pui,
 		customer: guest,
-		orderStatus: 'on-hold',
 		currency,
 	},
 	{
@@ -30,7 +29,6 @@ export const puiPayByLink: ShopOrder[] = [
 		...orders.default,
 		payment: pui,
 		customer,
-		orderStatus: 'on-hold',
 		currency,
 	},
 ];

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-pay-by-link.data.ts
@@ -16,7 +16,6 @@ const { pui } = payments;
 
 export const puiPayByLink: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1329
 		title: 'PCP-1329 | Transaction - Pay by Link - Pay upon Invoice - Germany - Guest - Default order @Critical',
 		...orders.default,
 		payment: pui,
@@ -24,7 +23,6 @@ export const puiPayByLink: ShopOrder[] = [
 		currency,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1328
 		title: 'PCP-1328 | Transaction - Pay by Link - Pay upon Invoice - Germany - Customer - Default order @Critical',
 		...orders.default,
 		payment: pui,

--- a/tests/qa/tests/05-transactions/_test-data/pui/pui-pay-by-link.data.ts
+++ b/tests/qa/tests/05-transactions/_test-data/pui/pui-pay-by-link.data.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal dependencies
+ */
+import {
+	payments,
+	orders,
+	customers,
+	guests,
+	ShopOrder,
+} from '../../../../resources';
+
+const customer = customers.germany;
+const guest = guests.germany;
+const currency = 'EUR';
+const { pui } = payments;
+
+export const puiPayByLink: ShopOrder[] = [
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1329
+		title: 'PCP-1329 | Transaction - Pay by Link - Pay upon Invoice - Germany - Guest - Default order @Critical',
+		...orders.default,
+		payment: pui,
+		customer: guest,
+		orderStatus: 'on-hold',
+		currency,
+	},
+	{
+		// https://inpsyde.atlassian.net/browse/PCP-1328
+		title: 'PCP-1328 | Transaction - Pay by Link - Pay upon Invoice - Germany - Customer - Default order @Critical',
+		...orders.default,
+		payment: pui,
+		customer,
+		orderStatus: 'on-hold',
+		currency,
+	},
+];

--- a/tests/qa/tests/05-transactions/_test-scenarios/checkout.scenario.ts
+++ b/tests/qa/tests/05-transactions/_test-scenarios/checkout.scenario.ts
@@ -2,10 +2,10 @@
  * Internal dependencies
  */
 import { PayPalPaymentDetails, ShopOrder } from '../../../resources';
-import { annotateVisitor, test } from '../../../utils';
+import { annotateVisitor, test, waitForOrderStatus } from '../../../utils';
 
 export const transactionsOnCheckout = ( testOrder: ShopOrder ) => {
-	const { title, payment, products, customer, merchant } = testOrder;
+	const { title, payment, products, customer, merchant, orderStatus } = testOrder;
 
 	test(
 		title,
@@ -19,6 +19,10 @@ export const transactionsOnCheckout = ( testOrder: ShopOrder ) => {
 			utils,
 		} ) => {
 			const { title: gatewayTitle } = payment.gateway;
+
+			if( gatewayTitle === 'Pay upon Invoice' ) {
+				test.setTimeout( 3 * 60_000 ); // 3 minutes for PUI
+			}
 
 			await test.step( `Add product(s) to the cart`, async () => {
 				await utils.fillVisitorsCart( products );
@@ -37,7 +41,10 @@ export const transactionsOnCheckout = ( testOrder: ShopOrder ) => {
 				await orderReceived.assertOrderDetails( testOrder );
 				await orderReceived.assertNoErrors();
 
-				orderId = await orderReceived.getOrderNumber();				
+				orderId = await orderReceived.getOrderNumber();
+				await waitForOrderStatus( wooCommerceApi, orderId, {
+					expectedStatus: orderStatus,
+				} );
 				const transactionId =
 						( await wooCommerceApi.getOrder( orderId ) ).transaction_id;
 
@@ -46,7 +53,7 @@ export const transactionsOnCheckout = ( testOrder: ShopOrder ) => {
 					testOrder,
 				);
 
-				if( payPalPaymentDetails.amount !== '0' ) { // can be 0 for free trial or free orders
+				if ( payPalPaymentDetails && payPalPaymentDetails.amount !== '0' ) { // can be 0 for free trial or free orders, OXXO, PUI
 					await orderReceived.assertTotalEqualsPayPalTotal(
 						payPalPaymentDetails.amount,
 						testOrder.currency

--- a/tests/qa/tests/05-transactions/_test-scenarios/classic-checkout.scenario.ts
+++ b/tests/qa/tests/05-transactions/_test-scenarios/classic-checkout.scenario.ts
@@ -2,10 +2,16 @@
  * Internal dependencies
  */
 import { PayPalPaymentDetails, ShopOrder } from '../../../resources';
-import { annotateVisitor, test, expect, OxxoVoucherPopup } from '../../../utils';
+import {
+	annotateVisitor,
+	test,
+	expect,
+	OxxoVoucherPopup,
+	waitForOrderStatus,
+} from '../../../utils';
 
 export const transactionsOnClassicCheckout = ( testOrder: ShopOrder ) => {
-	const { title, payment, products, customer, merchant } = testOrder;
+	const { title, payment, products, customer, merchant, orderStatus } = testOrder;
 
 	test(
 		title,
@@ -19,6 +25,10 @@ export const transactionsOnClassicCheckout = ( testOrder: ShopOrder ) => {
 			utils,
 		} ) => {
 			const { title: gatewayTitle } = payment.gateway;
+
+			if( gatewayTitle === 'Pay upon Invoice' ) {
+				test.setTimeout( 3 * 60_000 ); // 3 minutes for PUI
+			}
 
 			await test.step( `Add product(s) to the cart`, async () => {
 				await utils.fillVisitorsCart( products );
@@ -37,7 +47,10 @@ export const transactionsOnClassicCheckout = ( testOrder: ShopOrder ) => {
 				await orderReceived.assertOrderDetails( testOrder );
 				await orderReceived.assertNoErrors();
 
-				orderId = await orderReceived.getOrderNumber();				
+				orderId = await orderReceived.getOrderNumber();
+				await waitForOrderStatus( wooCommerceApi, orderId, {
+					expectedStatus: orderStatus,
+				} );
 				const transactionId =
 						( await wooCommerceApi.getOrder( orderId ) ).transaction_id;
 
@@ -46,7 +59,7 @@ export const transactionsOnClassicCheckout = ( testOrder: ShopOrder ) => {
 					testOrder,
 				);
 
-				if( payPalPaymentDetails.amount !== '0' ) { // can be 0 for free trial or free orders
+				if ( payPalPaymentDetails && payPalPaymentDetails.amount !== '0' ) { // can be 0 for free trial or free orders, OXXO, PUI
 					await orderReceived.assertTotalEqualsPayPalTotal(
 						payPalPaymentDetails.amount,
 						testOrder.currency

--- a/tests/qa/tests/05-transactions/_test-scenarios/pay-by-link.scenario.ts
+++ b/tests/qa/tests/05-transactions/_test-scenarios/pay-by-link.scenario.ts
@@ -2,10 +2,15 @@
  * Internal dependencies
  */
 import { PayPalPaymentDetails, ShopOrder } from '../../../resources';
-import { test, expect, annotateVisitor } from '../../../utils';
+import {
+	test,
+	expect,
+	annotateVisitor,
+	waitForOrderStatus,
+} from '../../../utils';
 
 export const transactionsOnPayByLink = ( testOrder: ShopOrder ) => {
-	const { payment, merchant } = testOrder;
+	const { payment, merchant, orderStatus } = testOrder;
 
 	test(
 		testOrder.title,
@@ -20,6 +25,10 @@ export const transactionsOnPayByLink = ( testOrder: ShopOrder ) => {
 		} ) => {
 			let order: WooCommerce.Order;
 			const { title: gatewayTitle } = payment.gateway;
+
+			if( gatewayTitle === 'Pay upon Invoice' ) {
+				test.setTimeout( 3 * 60_000 ); // 3 minutes for PUI
+			}
 
 			await test.step( `Precondition: create order via API (dashboard)`, async () => {
 				order = await wooCommerceUtils.createApiOrder( testOrder );
@@ -42,6 +51,9 @@ export const transactionsOnPayByLink = ( testOrder: ShopOrder ) => {
 					`Assert order ID (${ order.id }) matches order number on Order Received page`
 				).toEqual( orderNumber );				
 				
+				await waitForOrderStatus( wooCommerceApi, order.id, {
+					expectedStatus: orderStatus,
+				} );
 				const transactionId =
 						( await wooCommerceApi.getOrder( order.id ) ).transaction_id;
 
@@ -50,7 +62,7 @@ export const transactionsOnPayByLink = ( testOrder: ShopOrder ) => {
 					testOrder,
 				);
 
-				if( payPalPaymentDetails.amount !== '0' ) { // can be 0 for free trial or free orders
+				if ( payPalPaymentDetails && payPalPaymentDetails.amount !== '0' ) { // can be 0 for free trial or free orders, OXXO, PUI
 					await orderReceived.assertTotalEqualsPayPalTotal(
 						payPalPaymentDetails.amount,
 						testOrder.currency

--- a/tests/qa/tests/05-transactions/transaction-germany-classic.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-germany-classic.spec.ts
@@ -1,0 +1,62 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import {
+	taxSettings,
+	customers,
+	negative12FeePlugin,
+} from '../../resources';
+import {
+	transactionsOnClassicCheckout,
+} from './_test-scenarios';
+import {
+	puiClassicCheckout,
+	puiClassicCheckoutExcludingTax,
+	puiClassicCheckoutNegativeFee,
+} from './_test-data/pui';
+
+/**
+ * BCDC is classic-checkout only — block checkout is not supported.
+ */
+
+test.beforeAll( async ( { utils } ) => {
+	await utils.configureStore( {
+		enableClassicPages: true,
+		customer: customers.germany,
+	} );
+} );
+
+for ( const testOrder of puiClassicCheckout ) {
+	transactionsOnClassicCheckout( testOrder );
+}
+
+// Excluding Tax
+test.describe( () => {
+	test.beforeAll( async ( { wooCommerceUtils } ) => {
+		await wooCommerceUtils.setTaxes( taxSettings.excluding );
+	} );
+
+	for ( const testOrder of puiClassicCheckoutExcludingTax ) {
+		transactionsOnClassicCheckout( testOrder );
+	}
+
+	test.afterAll( async ( { wooCommerceUtils } ) => {
+		await wooCommerceUtils.setTaxes( taxSettings.including );
+	} );
+} );
+
+// Intent Authorized
+test.describe( () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( negative12FeePlugin.slug );
+	} );
+
+	for ( const testOrder of puiClassicCheckoutNegativeFee ) {
+		transactionsOnClassicCheckout( testOrder );
+	}
+	
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( negative12FeePlugin.slug );
+	} );
+} );

--- a/tests/qa/tests/05-transactions/transaction-germany.spec.ts
+++ b/tests/qa/tests/05-transactions/transaction-germany.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { test } from '../../utils';
+import {
+	customers,
+} from '../../resources';
+import {
+	transactionsOnCheckout,
+	transactionsOnPayByLink,
+} from './_test-scenarios';
+import {
+	puiCheckout,
+	puiPayByLink,
+} from './_test-data/pui';
+
+/**
+ * BCDC is classic-checkout only — block checkout is not supported.
+ */
+
+test.beforeAll( async ( { utils } ) => {
+	await utils.configureStore( {
+		enableClassicPages: false,
+		customer: customers.germany,
+	} );
+} );
+
+for ( const testOrder of puiCheckout ) {
+	transactionsOnCheckout( testOrder );
+}
+
+for ( const testOrder of puiPayByLink ) {
+	transactionsOnPayByLink( testOrder );
+}

--- a/tests/qa/tests/06-refund/_test-data/refund-acdc.data.ts
+++ b/tests/qa/tests/06-refund/_test-data/refund-acdc.data.ts
@@ -15,7 +15,6 @@ const guest = guests.usa;
 
 export const refundAcdcFromCheckout: ShopRefund[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1396
 		title: 'PCP-1396 | Refund - Full - ACDC - Order from shop @Critical @Smoke',
 		...orders.default,
 		payment: acdc,
@@ -27,7 +26,6 @@ export const refundAcdcFromCheckout: ShopRefund[] = [
 		currency: 'USD',
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1397
 		title: 'PCP-1397 | Refund - Partial - ACDC - Order from shop @Critical @Smoke',
 		...orders.default,
 		payment: acdc,
@@ -42,7 +40,6 @@ export const refundAcdcFromCheckout: ShopRefund[] = [
 
 export const refundAcdcFromPayByLink: ShopRefund[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1409
 		title: 'PCP-1409 | Refund - Full - ACDC - Order from dashboard',
 		...orders.default,
 		payment: acdc,
@@ -54,7 +51,6 @@ export const refundAcdcFromPayByLink: ShopRefund[] = [
 		currency: 'USD',
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1410
 		title: 'PCP-1410 | Refund - Partial - ACDC - Order from dashboard',
 		...orders.default,
 		payment: acdc,

--- a/tests/qa/tests/06-refund/_test-data/refund-paypal.data.ts
+++ b/tests/qa/tests/06-refund/_test-data/refund-paypal.data.ts
@@ -15,7 +15,6 @@ const guest = guests.usa;
 
 export const refundPayPalFromCheckout: ShopRefund[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1394
 		title: 'PCP-1394 | Refund - Full - PayPal - Order from shop @Critical @Smoke',
 		...orders.default,
 		payment: payPal,
@@ -27,7 +26,6 @@ export const refundPayPalFromCheckout: ShopRefund[] = [
 		currency: 'USD',
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1395
 		title: 'PCP-1395 | Refund - Partial - PayPal - Order from shop @Critical @Smoke',
 		...orders.default,
 		payment: payPal,
@@ -42,7 +40,6 @@ export const refundPayPalFromCheckout: ShopRefund[] = [
 
 export const refundPayPalFromPayByLink: ShopRefund[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1405
 		title: 'PCP-1405 | Refund - Full - PayPal - Order from dashboard',
 		...orders.default,
 		payment: payPal,
@@ -54,7 +51,6 @@ export const refundPayPalFromPayByLink: ShopRefund[] = [
 		currency: 'USD',
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1406
 		title: 'PCP-1406 | Refund - Partial - PayPal - Order from dashboard',
 		...orders.default,
 		payment: payPal,

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-checkout.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-checkout.data.ts
@@ -7,7 +7,6 @@ const customer = customers.usa;
 
 const savePaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5382
 		title: 'PCP-5382 | Vaulting - Transaction - Checkout - PayPal - Save payment method @Critical @Smoke',
 		...orders.default,
 		payment: {
@@ -17,7 +16,6 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3234
 		title: 'PCP-3234 | Vaulting - Transaction - Checkout - ACDC - Save payment method @Critical @Smoke',
 		...orders.default,
 		payment: {
@@ -27,7 +25,6 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-
 		title: 'PCP-5383 | Vaulting - Transaction - Checkout - ACDC - Do not save payment method',
 		...orders.default,
 		payment: {
@@ -40,7 +37,6 @@ const savePaymentMethodData: ShopOrder[] = [
 
 const acdcAdditionalCardData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5384
 		title: 'PCP-5384 | Vaulting - Transaction - Checkout - ACDC - Pay with card other then saved and do not save it',
 		...orders.default,
 		payment: {
@@ -50,7 +46,6 @@ const acdcAdditionalCardData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5385
 		title: 'PCP-5385 | Vaulting - Transaction - Checkout - ACDC - Pay with card other then saved and save it',
 		...orders.default,
 		payment: {
@@ -63,7 +58,6 @@ const acdcAdditionalCardData: ShopOrder[] = [
 
 const vaultedPaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2051
 		title: 'PCP-2051 | Vaulting - Transaction - Checkout - PayPal - Pay with vaulted account @Critical',
 		...orders.default,
 		payment: {
@@ -73,7 +67,6 @@ const vaultedPaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3235
 		title: 'PCP-3235 | Vaulting - Transaction - Checkout - ACDC - Pay with saved card @Critical',
 		...orders.default,
 		payment: {

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-cart.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-cart.data.ts
@@ -7,7 +7,6 @@ const customer = customers.usa;
 
 const savePaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5397
 		title: 'PCP-5397 | Vaulting - Transaction - Classic cart - PayPal - Save payment method @Critical',
 		...orders.default,
 		payment: {
@@ -20,7 +19,6 @@ const savePaymentMethodData: ShopOrder[] = [
 
 const vaultedPaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5398
 		title: 'PCP-5398 | Vaulting - Transaction - Classic cart - PayPal - Pay with vaulted account @Critical',
 		...orders.default,
 		payment: {

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-checkout.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-classic-checkout.data.ts
@@ -7,7 +7,6 @@ const customer = customers.usa;
 
 const savePaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5389
 		title: 'PCP-5389 | Vaulting - Transaction - Classic checkout - PayPal - Save payment method @Critical @Smoke',
 		...orders.default,
 		payment: {
@@ -17,7 +16,6 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1204
 		title: 'PCP-1204 | Vaulting - Transaction - Classic checkout - ACDC - Save payment method @Critical @Smoke',
 		...orders.default,
 		payment: {
@@ -27,7 +25,6 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5388
 		title: 'PCP-5388 | Vaulting - Transaction - Classic checkout - ACDC - Do not save payment method',
 		...orders.default,
 		payment: {
@@ -40,7 +37,6 @@ const savePaymentMethodData: ShopOrder[] = [
 
 const acdcAdditionalCardData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5387
 		title: 'PCP-5387 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved and do not save it',
 		...orders.default,
 		payment: {
@@ -50,7 +46,6 @@ const acdcAdditionalCardData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5386
 		title: 'PCP-5386 | Vaulting - Transaction - Classic checkout - ACDC - Pay with card other then saved and save it',
 		...orders.default,
 		payment: {
@@ -63,7 +58,6 @@ const acdcAdditionalCardData: ShopOrder[] = [
 
 const vaultedPaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1378
 		title: 'PCP-1378 | Vaulting - Transaction - Classic checkout - PayPal - Pay with vaulted account',
 		...orders.default,
 		payment: {
@@ -73,7 +67,6 @@ const vaultedPaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1206
 		title: 'PCP-1206 | Vaulting - Transaction - Classic checkout - ACDC - Pay with saved card',
 		...orders.default,
 		payment: {

--- a/tests/qa/tests/07-vaulting/_test-data/vaulting-pay-by-link.data.ts
+++ b/tests/qa/tests/07-vaulting/_test-data/vaulting-pay-by-link.data.ts
@@ -7,7 +7,6 @@ const customer = customers.usa;
 
 const savePaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5390
 		title: 'PCP-5390 | Vaulting - Transaction - Pay by link - PayPal - Save payment method @Critical',
 		...orders.default,
 		payment: {
@@ -17,7 +16,6 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5391
 		title: 'PCP-5391 | Vaulting - Transaction - Pay by link - ACDC - Save payment method @Critical',
 		...orders.default,
 		payment: {
@@ -27,7 +25,6 @@ const savePaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5392
 		title: 'PCP-5392 | Vaulting - Transaction - Pay by link - ACDC - Do not save payment method',
 		...orders.default,
 		payment: {
@@ -40,7 +37,6 @@ const savePaymentMethodData: ShopOrder[] = [
 
 const acdcAdditionalCardData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5393
 		title: 'PCP-5393 | Vaulting - Transaction - Pay by link - ACDC - Pay with card other then saved and do not save it',
 		...orders.default,
 		payment: {
@@ -50,7 +46,6 @@ const acdcAdditionalCardData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5394
 		title: 'PCP-5394 | Vaulting - Transaction - Pay by link - ACDC - Pay with card other then saved and save it',
 		...orders.default,
 		payment: {
@@ -63,7 +58,6 @@ const acdcAdditionalCardData: ShopOrder[] = [
 
 const vaultedPaymentMethodData: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5395
 		title: 'PCP-5395 | Vaulting - Transaction - Pay by link - PayPal - Pay with vaulted account @Critical',
 		...orders.default,
 		payment: {
@@ -73,7 +67,6 @@ const vaultedPaymentMethodData: ShopOrder[] = [
 		customer,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-5396
 		title: 'PCP-5396 | Vaulting - Transaction - Pay by link - ACDC - Pay with saved card @Critical',
 		...orders.default,
 		payment: {

--- a/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
+++ b/tests/qa/tests/07-vaulting/vaulting-my-account.spec.ts
@@ -14,13 +14,11 @@ test.beforeAll( async ( { utils } ) => {
 
 const savePaymentMethodData = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4499
 		testKey: 'PCP-4499',
 		testLabel: ' @Smoke',
 		payment: payPal,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4500
 		testKey: 'PCP-4500',
 		testLabel: ' @Smoke',
 		payment: acdc,
@@ -68,13 +66,11 @@ for ( const testData of savePaymentMethodData ) {
 
 const deletePaymentMethodData = [
 	{
-		// Fail: Deleting Payment Token in WC does not delete it on PayPal bug https://inpsyde.atlassian.net/browse/PCP-4782
-		// https://inpsyde.atlassian.net/browse/PCP-1732
+		// Fail: Deleting Payment Token in WC does not delete it on PayPal bug PCP-4782
 		testKey: 'PCP-1732',
 		payment: payPal,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1371
 		testKey: 'PCP-1371',
 		payment: acdc,
 	},

--- a/tests/qa/tests/08-subscription/_test-data/subscription-checkout.data.ts
+++ b/tests/qa/tests/08-subscription/_test-data/subscription-checkout.data.ts
@@ -17,7 +17,6 @@ const merchant = merchants.usa;
 
 const vaultingGuest: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4895
 		title: 'PCP-4895 | Vaulting subscription - Transaction - Checkout - PayPal - Order by guest @Critical @Smoke',
 		...orders.default,
 		payment: payments.payPal,
@@ -26,7 +25,6 @@ const vaultingGuest: ShopOrder[] = [
 		products: [ products.subscription100 ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4897
 		title: 'PCP-4897 | Vaulting subscription - Transaction - Checkout - PayPal - Free trial order by guest',
 		...orders.default,
 		payment: payments.payPal,
@@ -35,7 +33,6 @@ const vaultingGuest: ShopOrder[] = [
 		products: [ products.subscriptionFreeTrial ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4896
 		title: 'PCP-4896 | Vaulting subscription - Transaction - Checkout - ACDC - Order by guest @Critical @Smoke',
 		...orders.default,
 		payment: payments.acdc,
@@ -44,7 +41,6 @@ const vaultingGuest: ShopOrder[] = [
 		products: [ products.subscription100 ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3555
 		title: 'PCP-3555 | Vaulting subscription - Transaction - Checkout - ACDC - Free trial order by guest',
 		...orders.default,
 		payment: payments.acdc,
@@ -56,7 +52,6 @@ const vaultingGuest: ShopOrder[] = [
 
 const vaultingCustomer: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2570
 		title: 'PCP-2570 | Vaulting subscription - Transaction - Checkout - PayPal - Order by customer @Critical',
 		...orders.default,
 		payment: payments.payPal,
@@ -65,7 +60,6 @@ const vaultingCustomer: ShopOrder[] = [
 		products: [ products.subscription100 ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4899
 		title: 'PCP-4899 | Vaulting subscription - Transaction - Checkout - PayPal - Free trial order by customer',
 		...orders.default,
 		payment: payments.payPal,
@@ -74,7 +68,6 @@ const vaultingCustomer: ShopOrder[] = [
 		products: [ products.subscriptionFreeTrial ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4898
 		title: 'PCP-4898 | Vaulting subscription - Transaction - Checkout - ACDC - Order by customer @Critical',
 		...orders.default,
 		payment: payments.acdc,
@@ -83,7 +76,6 @@ const vaultingCustomer: ShopOrder[] = [
 		products: [ products.subscription100 ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-3554
 		title: 'PCP-3554 | Vaulting subscription - Transaction - Checkout - ACDC - Free trial order by customer',
 		...orders.default,
 		payment: payments.acdc,
@@ -95,7 +87,6 @@ const vaultingCustomer: ShopOrder[] = [
 
 const payPalGuest: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2574
 		title: 'PCP-2574 | PayPal subscription - Transaction - Checkout - Order by guest @Critical',
 		...orders.default,
 		payment: {
@@ -107,7 +98,6 @@ const payPalGuest: ShopOrder[] = [
 		products: [ products.subscriptionPayPal ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4900
 		title: 'PCP-4900 | PayPal subscription - Transaction - Checkout - Free trial order by guest',
 		...orders.default,
 		payment: {
@@ -122,7 +112,6 @@ const payPalGuest: ShopOrder[] = [
 
 const payPalCustomer: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2576
 		title: 'PCP-2576 | PayPal subscription - Transaction - Checkout - Order by customer @Critical',
 		...orders.default,
 		payment: {
@@ -134,7 +123,6 @@ const payPalCustomer: ShopOrder[] = [
 		products: [ products.subscriptionPayPal ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4901
 		title: 'PCP-4901 | PayPal subscription - Transaction - Checkout - Free trial order by customer',
 		...orders.default,
 		payment: {

--- a/tests/qa/tests/08-subscription/_test-data/subscription-classic-checkout.data.ts
+++ b/tests/qa/tests/08-subscription/_test-data/subscription-classic-checkout.data.ts
@@ -17,7 +17,6 @@ const merchant = merchants.usa;
 
 const vaultingGuest: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-1498
 		title: 'PCP-1498 | Vaulting subscription - Transaction - Classic checkout - PayPal - Order by guest @Critical @Smoke',
 		...orders.default,
 		payment: payments.payPal,
@@ -26,7 +25,6 @@ const vaultingGuest: ShopOrder[] = [
 		products: [ products.subscription100 ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2944
 		title: 'PCP-2944 | Vaulting subscription - Transaction - Classic checkout - PayPal - Free trial order by guest',
 		...orders.default,
 		payment: payments.payPal,
@@ -35,7 +33,6 @@ const vaultingGuest: ShopOrder[] = [
 		products: [ products.subscriptionFreeTrial ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2504
 		title: 'PCP-2504 | Vaulting subscription - Transaction - Classic checkout - ACDC - Order by guest @Critical @Smoke',
 		...orders.default,
 		payment: payments.acdc,
@@ -44,7 +41,6 @@ const vaultingGuest: ShopOrder[] = [
 		products: [ products.subscription100 ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2947
 		title: 'PCP-2947 | Vaulting subscription - Transaction - Classic checkout - ACDC - Free trial order by guest',
 		...orders.default,
 		payment: payments.acdc,
@@ -56,7 +52,6 @@ const vaultingGuest: ShopOrder[] = [
 
 const vaultingCustomer: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2889
 		title: 'PCP-2889 | Vaulting subscription - Transaction - Classic checkout - PayPal - Order by customer @Critical',
 		...orders.default,
 		payment: payments.payPal,
@@ -65,7 +60,6 @@ const vaultingCustomer: ShopOrder[] = [
 		products: [ products.subscription100 ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2945
 		title: 'PCP-2945 | Vaulting subscription - Transaction - Classic checkout - PayPal - Free trial order by customer',
 		...orders.default,
 		payment: payments.payPal,
@@ -74,7 +68,6 @@ const vaultingCustomer: ShopOrder[] = [
 		products: [ products.subscriptionFreeTrial ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4892
 		title: 'PCP-4892 | Vaulting subscription - Transaction - Classic checkout - ACDC - Order by customer @Critical',
 		...orders.default,
 		payment: payments.acdc,
@@ -83,7 +76,6 @@ const vaultingCustomer: ShopOrder[] = [
 		products: [ products.subscription100 ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2948
 		title: 'PCP-2948 | Vaulting subscription - Transaction - Classic checkout - ACDC - Free trial order by customer',
 		...orders.default,
 		payment: payments.acdc,
@@ -95,7 +87,6 @@ const vaultingCustomer: ShopOrder[] = [
 
 const payPalGuest: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2531
 		title: 'PCP-2531 | PayPal subscription - Transaction - Classic checkout - Order by guest @Critical',
 		...orders.default,
 		payment: {
@@ -107,7 +98,6 @@ const payPalGuest: ShopOrder[] = [
 		products: [ products.subscriptionPayPal ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4893
 		title: 'PCP-4893 | PayPal subscription - Transaction - Classic checkout - Free trial order by guest',
 		...orders.default,
 		payment: {
@@ -122,7 +112,6 @@ const payPalGuest: ShopOrder[] = [
 
 const payPalCustomer: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2642
 		title: 'PCP-2642 | PayPal subscription - Transaction - Classic checkout - Order by customer @Critical',
 		...orders.default,
 		payment: {
@@ -134,7 +123,6 @@ const payPalCustomer: ShopOrder[] = [
 		products: [ products.subscriptionPayPal ],
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4894
 		title: 'PCP-4894 | PayPal subscription - Transaction - Classic checkout - Free trial order by customer',
 		...orders.default,
 		payment: {

--- a/tests/qa/tests/08-subscription/_test-data/subscription-renewal.data.ts
+++ b/tests/qa/tests/08-subscription/_test-data/subscription-renewal.data.ts
@@ -16,7 +16,6 @@ const currency = process.env.WC_DEFAULT_CURRENCY;
 
 const vaultingRenewal: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2505
 		title: 'PCP-2505 | Vaulting subscription - PayPal - Order renewal @Critical @Smoke',
 		...orders.default,
 		payment: payments.payPal,
@@ -26,7 +25,6 @@ const vaultingRenewal: ShopOrder[] = [
 		currency,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2514
 		title: 'PCP-2514 | Vaulting subscription - ACDC - Order renewal @Critical @Smoke',
 		...orders.default,
 		payment: payments.acdc,
@@ -39,7 +37,6 @@ const vaultingRenewal: ShopOrder[] = [
 
 const vaultingFreeTrialRenewal: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4913
 		title: 'PCP-4913 | Vaulting subscription - PayPal - Free trial order renewal',
 		...orders.default,
 		payment: payments.payPal,
@@ -49,7 +46,6 @@ const vaultingFreeTrialRenewal: ShopOrder[] = [
 		currency,
 	},
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4914
 		title: 'PCP-4914 | Vaulting subscription - ACDC - Free trial order renewal',
 		...orders.default,
 		payment: payments.acdc,
@@ -62,7 +58,6 @@ const vaultingFreeTrialRenewal: ShopOrder[] = [
 
 const payPalRenewal: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-2048
 		title: 'PCP-2048 | PayPal subscription - Order renewal @Critical',
 		...orders.default,
 		payment: payments.payPal,
@@ -75,7 +70,6 @@ const payPalRenewal: ShopOrder[] = [
 
 const payPalFreeTrialRenewal: ShopOrder[] = [
 	{
-		// https://inpsyde.atlassian.net/browse/PCP-4915
 		title: 'PCP-4915 | PayPal subscription - Free trial order renewal',
 		...orders.default,
 		payment: payments.payPal,

--- a/tests/qa/tests/_setup/03-pcp.setup.ts
+++ b/tests/qa/tests/_setup/03-pcp.setup.ts
@@ -12,7 +12,7 @@ import {
 	gateways,
 } from '../../resources';
 
-const { payPal, payLater, venmo, acdc, bcdc, fastlane, googlepay, oxxo } = gateways;
+const { payPal, payLater, venmo, acdc, bcdc, fastlane, googlepay, oxxo, pui } = gateways;
 
 // =====================================================================
 // Layer 2 — PCP country: configureStore + installPcp + resetDb + connect
@@ -85,6 +85,20 @@ setup( 'setup:transaction:mexico;', async ( { utils, pcpApi } ) => {
 		[ payPal.id ]: { id: payPal.id, enabled: true },
 		[ bcdc.id ]: { id: bcdc.id, enabled: true },
 		[ oxxo.id ]: { id: oxxo.id, enabled: true },
+	} );
+} );
+
+setup( 'setup:transaction:germany;', async ( { utils, pcpApi } ) => {
+	await utils.configureStore( {
+		enableClassicPages: true,
+		customer: customers.germany,
+	} );
+	await pcpApi.updatePcpPaymentMethods( {
+		[ payPal.id ]: { id: payPal.id, enabled: true },
+		[ pui.id ]: { id: pui.id, enabled: true },
+		puiBrandName: 'PUI Test',
+		puiCustomerServiceInstructions: 'Test PUI',
+		puiLogoUrl: 'www.logo-test.com',
 	} );
 } );
 

--- a/tests/qa/utils/frontend/paypal-ui-classic.ts
+++ b/tests/qa/utils/frontend/paypal-ui-classic.ts
@@ -59,7 +59,7 @@ export class PayPalUiClassic extends PayPalUi {
 		this.fundingSourceGateway( 'ppcp-card-button-gateway' );
 	oxxoGateway = () =>
 		this.fundingSourceGateway( 'ppcp-oxxo-gateway' );
-	payUponInvoiceGateway = () =>
+	puiGateway = () =>
 		this.fundingSourceGateway( 'ppcp-pay-upon-invoice-gateway' );
 	googlePayGateway = () => this.fundingSourceGateway( 'ppcp-googlepay' );
 
@@ -250,14 +250,16 @@ export class PayPalUiClassic extends PayPalUi {
 	acdcUseNewPaymentRadio = () =>
 		this.page.locator( '.woocommerce-SavedPaymentMethods-new > input' );
 
-	payUponInvoiceBirthDateInput = () =>
-		this.page.locator( '#billing_birth_date' );
-	payUponInvoiceGatewayTitle = () =>
-		this.page.locator(
+	puiBirthDateInput = () =>
+		this.puiGateway().locator( '#billing_birth_date' );
+	puiPhoneInput = () =>
+		this.puiGateway().locator( '#billing_phone' );
+	puiGatewayTitle = () =>
+		this.puiGateway().locator(
 			'label[for="payment_method_ppcp-pay-upon-invoice-gateway"]'
 		);
-	payUponInvoiceGatewayDescription = () =>
-		this.payUponInvoiceGateway().locator(
+	puiGatewayDescription = () =>
+		this.puiGateway().locator(
 			'div.payment_method_ppcp-pay-upon-invoice-gateway>p'
 		);
 
@@ -628,28 +630,6 @@ export class PayPalUiClassic extends PayPalUi {
 			'Assert BCDC pay now button is visible'
 		).toBeVisible();
 		await this.bcdcPayNowButton().click();
-	};
-
-	/**
-	 * Completes payment with Pay upon Invoice (vaulting disabled)
-	 *
-	 * @param birthDate
-	 */
-	completePayUponInvoicePayment = async ( birthDate: string ) => {
-		await expect(
-			this.payUponInvoiceGateway(),
-			'Assert pay upon invoice gateway is visible'
-		).toBeVisible();
-		await this.payUponInvoiceGateway().click();
-
-		await expect(
-			this.payUponInvoiceBirthDateInput(),
-			'Assert pay upon invoice birth date input is visible'
-		).toBeVisible();
-		await this.payUponInvoiceBirthDateInput().click();
-		await this.page.keyboard.type( birthDate ); // Trick to properly fill date
-
-		await this.submitOrder();
 	};
 
 	// Assertions

--- a/tests/qa/utils/frontend/paypal-ui.ts
+++ b/tests/qa/utils/frontend/paypal-ui.ts
@@ -198,6 +198,17 @@ export class PayPalUi {
 		this.page.locator(
 			'#express-payment-method-ppcp-gateway-paypal .paypal-buttons'
 		);
+	
+	puiGateway = () =>
+		this.page.locator(
+			'#radio-control-wc-payment-method-options-ppcp-pay-upon-invoice-gateway__label'
+		);
+	puiBirthDateInput = () =>
+		this.page.locator( '#ppcp-pui-birth-date' );
+	puiPhoneInput = () =>
+		this.page.locator( '#ppcp-pui-phone' );
+
+		
 
 	// Actions
 
@@ -368,7 +379,7 @@ export class PayPalUi {
 				break;
 
 			case 'pay_upon_invoice':
-				await this.completePayUponInvoicePayment( payment.birthDate );
+				await this.completePuiPayment( payment );
 				break;
 
 			case 'fastlane':
@@ -603,10 +614,36 @@ export class PayPalUi {
 			`TODO: completeBcdcFundingSourcePayment for block pages ${ args.length }`
 		);
 
-	completePayUponInvoicePayment = async ( ...args ) =>
-		console.log(
-			`TODO: completePayUponInvoicePayment for block pages ${ args.length }`
-		);
+	
+
+	/**
+	 * Completes payment with Pay upon Invoice (vaulting disabled)
+	 *
+	 * @param birthDate
+	 */
+	completePuiPayment = async ( payment: Pcp.Payment ) => {
+		const { birthDate, phone } = payment;
+		await expect(
+			this.puiGateway(),
+			'Assert pay upon invoice gateway is visible'
+		).toBeVisible();
+		await this.puiGateway().click();
+
+		await expect(
+			this.puiBirthDateInput(),
+			'Assert pay upon invoice birth date input is visible'
+		).toBeVisible();
+		await this.puiBirthDateInput().click();
+		await this.page.keyboard.type( birthDate ); // Trick to properly fill date
+
+		await expect(
+			this.puiPhoneInput(),
+			'Assert pay upon invoice phone input is visible'
+		).toBeVisible();
+		await this.puiPhoneInput().fill( phone ); // Trick to properly fill date
+
+		await this.submitOrder();
+	};
 
 	/**
 	 * Clicks payment gateway to make visible payment form or buttons

--- a/tests/qa/utils/helpers/woocommerce.helper.ts
+++ b/tests/qa/utils/helpers/woocommerce.helper.ts
@@ -1,11 +1,14 @@
 /**
  * External dependencies
  */
-import { updateDotenv } from '@inpsyde/playwright-utils/build';
+import {
+	updateDotenv,
+	WooCommerceApi,
+} from '@inpsyde/playwright-utils/build';
 /**
  * Internal dependencies
  */
-import { test as setup } from '..';
+import { test as setup, expect } from '..';
 import {
 	shopSettings,
 	shippingZones,
@@ -228,4 +231,31 @@ export const setupWooCommerce = async () => {
 		await wooCommerceUtils.publishClassicCartPage();
 		await wooCommerceUtils.publishClassicCheckoutPage();
 	} );
+};
+
+export const waitForOrderStatus = async (
+	wooCommerceApi: WooCommerceApi,
+	orderId: number,
+	{
+		expectedStatus = 'processing',
+		timeout = 60_000,
+	}: { expectedStatus?: string; timeout?: number } = {}
+) => {
+	let order: WooCommerce.Order;
+
+	await expect
+		.poll(
+			async () => {
+				order = await wooCommerceApi.getOrder( orderId );
+				return order.status;
+			},
+			{
+				message: `Assert order #${ orderId } status is "${ expectedStatus }"`,
+				timeout,
+				intervals: [ 1_000, 2_500, 5_000, 10_000 ],
+			}
+		)
+		.toEqual( expectedStatus );
+
+	return order;
 };


### PR DESCRIPTION
**Ticket**: PCP-6635

---

### Description

- Update PUI gateway and payment data
- Add missing PUI fields to the type Pcp.GatewayOptions
- Add setup and project for transaction-germany
- Add data for PUI tests
- Add locators and completePuiPayment method to PayPalUi
- Add test specs for transaction-germany
- Add autotests for PUI:
    - PCP-1216 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Default order
    - PCP-2751 | Transaction - Classic checkout - Pay upon Invoice - Germany - Customer - Default order
    - PCP-1246 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Order with price excluding tax
    - PCP-6642 | Transaction - Classic checkout - Pay upon Invoice - Germany - Guest - Order with negative fee snippet
    - PCP-6640 | Transaction - Checkout - Pay upon Invoice - Germany - Guest - Default order
    - PCP-6641 | Transaction - Checkout - Pay upon Invoice - Germany - Customer - Default order
    - PCP-1328 | Transaction - Pay by Link - Pay upon Invoice - Germany - Guest - Default order
    - PCP-1329 | Transaction - Pay by Link - Pay upon Invoice - Germany - Customer - Default order