### PR TITLE
fix(order-tracking): guard non-array tracking metadata before indexing

### DIFF
--- a/modules/ppcp-order-tracking/src/Shipment/Shipment.php
+++ b/modules/ppcp-order-tracking/src/Shipment/Shipment.php
@@ -145,8 +145,13 @@ class Shipment implements ShipmentInterface {
 			return array();
 		}
 
-		$wc_order_items   = $wc_order->get_items();
-		$tracking_meta    = $wc_order->get_meta( OrderTrackingModule::PPCP_TRACKING_INFO_META_NAME );
+		$wc_order_items = $wc_order->get_items();
+		$tracking_meta  = $wc_order->get_meta( OrderTrackingModule::PPCP_TRACKING_INFO_META_NAME );
+
+		if ( ! is_array( $tracking_meta ) ) {
+			$tracking_meta = array();
+		}
+
 		$saved_line_items = $tracking_meta[ $this->tracking_number() ] ?? array();
 		$line_items       = $this->line_items ?: $saved_line_items;
 

--- a/tests/PHPUnit/OrderTracking/Shipment/ShipmentTest.php
+++ b/tests/PHPUnit/OrderTracking/Shipment/ShipmentTest.php
@@ -1,0 +1,84 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\OrderTracking\Shipment;
+
+use Mockery;
+use WC_Order;
+use WC_Order_Item_Product;
+use WC_Product;
+use WooCommerce\PayPalCommerce\OrderTracking\OrderTrackingModule;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+class ShipmentTest extends TestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		when('wp_get_attachment_image_src')->justReturn(false);
+		when('strip_shortcodes')->returnArg();
+		when('wp_strip_all_tags')->returnArg();
+	}
+
+	private function shipment( string $tracking_number = '1Z0Y19R40396776179' ): Shipment {
+		return new Shipment(
+			1,
+			'capture-1',
+			$tracking_number,
+			'SHIPPED',
+			'OTHER',
+			'',
+			array()
+		);
+	}
+
+	public function test_line_items_does_not_warn_when_tracking_meta_is_not_an_array(): void
+	{
+		$wc_order = Mockery::mock(WC_Order::class);
+		$wc_order->shouldReceive('get_items')->andReturn(array());
+		$wc_order->shouldReceive('get_meta')
+			->with(OrderTrackingModule::PPCP_TRACKING_INFO_META_NAME)
+			->andReturn('');
+
+		when('wc_get_order')->justReturn($wc_order);
+
+		$this->assertSame(array(), $this->shipment()->line_items());
+	}
+
+	public function test_line_items_filters_by_saved_line_items_from_array_tracking_meta(): void
+	{
+		$tracking_number = '1Z0Y19R40396776179';
+
+		$product = Mockery::mock(WC_Product::class);
+		$product->shouldReceive('get_image_id')->andReturn(0);
+		$product->shouldReceive('get_description')->andReturn('');
+		$product->shouldReceive('get_sku')->andReturn('SKU-1');
+		$product->shouldReceive('is_virtual')->andReturn(false);
+		$product->shouldReceive('get_permalink')->andReturn('https://example.com/product-1');
+
+		$matching_item = Mockery::mock(WC_Order_Item_Product::class);
+		$matching_item->shouldReceive('get_id')->andReturn(10);
+		$matching_item->shouldReceive('get_name')->andReturn('Matching product');
+		$matching_item->shouldReceive('get_quantity')->andReturn(1);
+		$matching_item->shouldReceive('get_product')->andReturn($product);
+
+		$other_item = Mockery::mock(WC_Order_Item_Product::class);
+		$other_item->shouldReceive('get_id')->andReturn(20);
+
+		$wc_order = Mockery::mock(WC_Order::class);
+		$wc_order->shouldReceive('get_items')->andReturn(array($matching_item, $other_item));
+		$wc_order->shouldReceive('get_meta')
+			->with(OrderTrackingModule::PPCP_TRACKING_INFO_META_NAME)
+			->andReturn(array($tracking_number => array(10)));
+		$wc_order->shouldReceive('get_currency')->andReturn('USD');
+		$wc_order->shouldReceive('get_item_subtotal')->with($matching_item, false)->andReturn(12.5);
+
+		when('wc_get_order')->justReturn($wc_order);
+
+		$line_items = $this->shipment($tracking_number)->line_items();
+
+		$this->assertSame(array(10), array_keys($line_items));
+	}
+}


### PR DESCRIPTION
Fixes #4469.

### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
`Shipment::line_items()` reads the `_ppcp_paypal_tracking_info_meta_name` order meta and immediately indexes it by tracking number:                                                                                                                                                     
                                                                                                                                                                                                          
```php                                                                                                                                                                                                  
$tracking_meta    = $wc_order->get_meta( OrderTrackingModule::PPCP_TRACKING_INFO_META_NAME );                                                                                                           
$saved_line_items = $tracking_meta[ $this->tracking_number() ] ?? array();
```                                                                                                                              
                                                                                                                                                                                                          
If the meta isn't stored as an array yet (e.g. an empty string, which happens for a brand-new tracking number before any tracking metadata exists), PHP emits an Illegal string offset "{tracking_number}" warning. Because OrderTrackingEndpoint calls line_items() twice per sync (once via to_array() when building the API request, once when saving tracking metadata), the warning is logged twice per tracking number added.                                                                                                                                       
                                                                                                                                                                                                          
The fix adds the same is_array( $tracking_meta ) guard that OrderTrackingEndpoint::save_tracking_metadata() already uses, normalizing the meta to an empty array before indexing.                                                                                                                                                             
                                                                                                                                                                                                          
Steps to Test                                                                                                                                                                                           
                                                                                                                                                                                                          
1. On a WooCommerce order using PayPal, add a new tracking number via WooCommerce Shipment Tracking for a tracking number that has no prior PayPal tracking metadata saved.                                                                                                                                                                         
2. Check wp-content/debug.log (with WP_DEBUG/WP_DEBUG_LOG enabled).                                                                                                                                     
3. Before the fix: two PHP Warning: Illegal string offset entries are logged for the tracking number.                                                                                                                                                                         
4. After the fix: no warning is logged, and tracking sync completes as before.                 