### PR TITLE
Add filter to allow Pay Later together with Vaulting (6443)

### DIFF
--- a/docs/pay-later-with-vaulting-filter.md
+++ b/docs/pay-later-with-vaulting-filter.md
@@ -1,0 +1,31 @@
+# Pay Later with Vaulting Filter
+
+## Overview
+By default the plugin treats **Pay Later** and **Vaulting** ("Save PayPal and Venmo") as
+mutually exclusive. When vaulting is active:
+
+- The **Payment Methods** tab locks the "Pay Later" toggle ("This payment method requires
+  Save PayPal and Venmo to be disabled").
+- Pay Later **messaging** is disabled everywhere.
+
+Merchants that PayPal has **whitelisted** to offer Pay Later alongside Vaulting
+can lift this restriction with a filter.
+
+## Filter
+
+### `woocommerce_paypal_payments_pay_later_with_vaulting`
+Controls whether Pay Later features may run while vaulting is active. Defaults to `false`
+(Pay Later disabled if vaulting is active). Return `true` to bypass the restriction.
+
+```php
+add_filter( 'woocommerce_paypal_payments_pay_later_with_vaulting', '__return_true' );
+```
+
+## Notes
+- Intended for PayPal-whitelisted accounts. Enabling it on an account that is not approved
+  for Pay Later + Vaulting may result in Pay Later still not being offered by PayPal at runtime.
+- **Use this filter, not `woocommerce_paypal_payments_should_render_pay_later_messaging`.**
+  The latter only toggles storefront messaging rendering and, on its own, cannot re-enable
+  Pay Later when vaulting is active — the plugin still forces messaging off under vaulting.
+  __`woocommerce_paypal_payments_pay_later_with_vaulting` is the intended override and unlocks
+  the configuration UI as well.

--- a/modules/ppcp-paylater-block/resources/js/edit.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.js
@@ -51,7 +51,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 
 	const classes = [ 'ppcp-paylater-block-preview', 'ppcp-overlay-parent' ];
 	if (
-		PcpPayLaterBlock.vaultingEnabled ||
+		PcpPayLaterBlock.payLaterDisabledByVaulting ||
 		! PcpPayLaterBlock.placementEnabled
 	) {
 		classes.push( 'ppcp-paylater-unavailable', 'block-editor-warning' );
@@ -64,7 +64,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 		}
 	}, [ id, clientId ] );
 
-	if ( PcpPayLaterBlock.vaultingEnabled ) {
+	if ( PcpPayLaterBlock.payLaterDisabledByVaulting ) {
 		return (
 			<div { ...props }>
 				<div className="block-editor-warning__contents">

--- a/modules/ppcp-paylater-block/resources/js/edit.test.js
+++ b/modules/ppcp-paylater-block/resources/js/edit.test.js
@@ -28,7 +28,7 @@ jest.mock( '@paypal/react-paypal-js', () => ( {
 const { useScriptParams } = require( './hooks/script-params' );
 
 const defaultConfig = {
-	vaultingEnabled: false,
+	payLaterDisabledByVaulting: false,
 	placementEnabled: true,
 	payLaterSettingsUrl: '/wp-admin/paylater-settings',
 	ajax: {
@@ -128,7 +128,7 @@ test( 'does not show placeholder when PayPalMessages renders within 10 seconds',
 } );
 
 test( 'shows vaulting warning when vaulting is enabled', () => {
-	global.PcpPayLaterBlock = { ...defaultConfig, vaultingEnabled: true };
+	global.PcpPayLaterBlock = { ...defaultConfig, payLaterDisabledByVaulting: true };
 	useScriptParams.mockReturnValue( null );
 
 	render( <Edit { ...defaultProps } /> );

--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -85,15 +85,15 @@ class PayLaterBlockModule implements ServiceModule, ExecutableModule {
 					$script_handle,
 					'PcpPayLaterBlock',
 					array(
-						'ajax'                => array(
+						'ajax'                       => array(
 							'cart_script_params' => array(
 								'endpoint' => \WC_AJAX::get_endpoint( CartScriptParamsEndpoint::ENDPOINT ),
 							),
 						),
-						'settingsUrl'         => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'vaultingEnabled'     => $settings_provider->save_paypal_and_venmo(),
-						'placementEnabled'    => self::is_block_enabled( $c->get( 'wcgateway.settings.status' ) ),
-						'payLaterSettingsUrl' => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+						'settingsUrl'                => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+						'payLaterDisabledByVaulting' => $settings_provider->save_paypal_and_venmo(),
+						'placementEnabled'           => self::is_block_enabled( $c->get( 'wcgateway.settings.status' ) ),
+						'payLaterSettingsUrl'        => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
 					)
 				);
 

--- a/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
+++ b/modules/ppcp-paylater-block/src/PayLaterBlockModule.php
@@ -91,7 +91,7 @@ class PayLaterBlockModule implements ServiceModule, ExecutableModule {
 							),
 						),
 						'settingsUrl'                => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'payLaterDisabledByVaulting' => $settings_provider->save_paypal_and_venmo(),
+						'payLaterDisabledByVaulting' => $settings_provider->pay_later_disabled_by_vaulting(),
 						'placementEnabled'           => self::is_block_enabled( $c->get( 'wcgateway.settings.status' ) ),
 						'payLaterSettingsUrl'        => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
 					)

--- a/modules/ppcp-paylater-configurator/services.php
+++ b/modules/ppcp-paylater-configurator/services.php
@@ -53,9 +53,7 @@ return array(
 		$dcc_product_status = $container->get( 'wcgateway.helper.dcc-product-status' );
 		assert( $dcc_product_status instanceof DCCProductStatus );
 
-		$vault_enabled = $settings_provider->save_paypal_and_venmo();
-
-		return ! $vault_enabled && $messages_apply->for_country();
+		return ! $settings_provider->pay_later_disabled_by_vaulting() && $messages_apply->for_country();
 	},
 	'paylater-configurator.messaging-locations'  => static function ( ContainerInterface $container ): array {
 		$settings_provider = $container->get( 'settings.settings-provider' );

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.js
@@ -50,7 +50,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 
 	let classes = [ 'ppcp-paylater-block-preview', 'ppcp-overlay-parent' ];
 	if (
-		PcpCartPayLaterBlock.vaultingEnabled ||
+		PcpCartPayLaterBlock.payLaterDisabledByVaulting ||
 		! PcpCartPayLaterBlock.placementEnabled
 	) {
 		classes = [
@@ -67,7 +67,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 		}
 	}, [ ppcpId, clientId ] );
 
-	if ( PcpCartPayLaterBlock.vaultingEnabled ) {
+	if ( PcpCartPayLaterBlock.payLaterDisabledByVaulting ) {
 		return (
 			<div { ...props }>
 				<div className="block-editor-warning__contents">

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.test.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CartPayLaterMessagesBlock/edit.test.js
@@ -29,7 +29,7 @@ const {
 } = require( '@ppcp-paylater-block/hooks/script-params' );
 
 const defaultConfig = {
-	vaultingEnabled: false,
+	payLaterDisabledByVaulting: false,
 	placementEnabled: true,
 	settingsUrl: '/wp-admin/settings',
 	payLaterSettingsUrl: '/wp-admin/paylater-settings',
@@ -126,7 +126,7 @@ test( 'does not show placeholder when PayPalMessages renders within 10 seconds',
 } );
 
 test( 'shows vaulting warning when vaulting is enabled', () => {
-	global.PcpCartPayLaterBlock = { ...defaultConfig, vaultingEnabled: true };
+	global.PcpCartPayLaterBlock = { ...defaultConfig, payLaterDisabledByVaulting: true };
 	useScriptParams.mockReturnValue( null );
 
 	render( <Edit { ...defaultProps } /> );

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.js
@@ -50,7 +50,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 
 	let classes = [ 'ppcp-paylater-block-preview', 'ppcp-overlay-parent' ];
 	if (
-		PcpCheckoutPayLaterBlock.vaultingEnabled ||
+		PcpCheckoutPayLaterBlock.payLaterDisabledByVaulting ||
 		! PcpCheckoutPayLaterBlock.placementEnabled
 	) {
 		classes = [
@@ -67,7 +67,7 @@ export default function Edit( { attributes, clientId, setAttributes } ) {
 		}
 	}, [ ppcpId, clientId ] );
 
-	if ( PcpCheckoutPayLaterBlock.vaultingEnabled ) {
+	if ( PcpCheckoutPayLaterBlock.payLaterDisabledByVaulting ) {
 		return (
 			<div { ...props }>
 				<div className={ 'block-editor-warning__contents' }>

--- a/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.test.js
+++ b/modules/ppcp-paylater-wc-blocks/resources/js/CheckoutPayLaterMessagesBlock/edit.test.js
@@ -29,7 +29,7 @@ const {
 } = require( '@ppcp-paylater-block/hooks/script-params' );
 
 const defaultConfig = {
-	vaultingEnabled: false,
+	payLaterDisabledByVaulting: false,
 	placementEnabled: true,
 	settingsUrl: '/wp-admin/settings',
 	payLaterSettingsUrl: '/wp-admin/paylater-settings',
@@ -128,7 +128,7 @@ test( 'does not show placeholder when PayPalMessages renders within 10 seconds',
 test( 'shows vaulting warning when vaulting is enabled', () => {
 	global.PcpCheckoutPayLaterBlock = {
 		...defaultConfig,
-		vaultingEnabled: true,
+		payLaterDisabledByVaulting: true,
 	};
 	useScriptParams.mockReturnValue( null );
 

--- a/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php
+++ b/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php
@@ -129,7 +129,7 @@ class PayLaterWCBlocksModule implements ServiceModule, ExecutableModule {
 						),
 						'config'                      => $config_factory->from_settings( $paylater_settings ),
 						'settingsUrl'                 => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'payLaterDisabledByVaulting'  => $settings_provider->save_paypal_and_venmo(),
+						'payLaterDisabledByVaulting'  => $settings_provider->pay_later_disabled_by_vaulting(),
 						'placementEnabled'            => self::is_placement_enabled( $c->get( 'wcgateway.settings.status' ), 'cart' ),
 						'payLaterSettingsUrl'         => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
 						'underTotalsPlacementEnabled' => self::is_under_cart_totals_placement_enabled(),
@@ -157,7 +157,7 @@ class PayLaterWCBlocksModule implements ServiceModule, ExecutableModule {
 						),
 						'config'                     => $config_factory->from_settings( $paylater_settings ),
 						'settingsUrl'                => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'payLaterDisabledByVaulting' => $settings_provider->save_paypal_and_venmo(),
+						'payLaterDisabledByVaulting' => $settings_provider->pay_later_disabled_by_vaulting(),
 						'placementEnabled'           => self::is_placement_enabled( $c->get( 'wcgateway.settings.status' ), 'checkout' ),
 						'payLaterSettingsUrl'        => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
 					)

--- a/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php
+++ b/modules/ppcp-paylater-wc-blocks/src/PayLaterWCBlocksModule.php
@@ -129,7 +129,7 @@ class PayLaterWCBlocksModule implements ServiceModule, ExecutableModule {
 						),
 						'config'                      => $config_factory->from_settings( $paylater_settings ),
 						'settingsUrl'                 => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'vaultingEnabled'             => $settings_provider->save_paypal_and_venmo(),
+						'payLaterDisabledByVaulting'  => $settings_provider->save_paypal_and_venmo(),
 						'placementEnabled'            => self::is_placement_enabled( $c->get( 'wcgateway.settings.status' ), 'cart' ),
 						'payLaterSettingsUrl'         => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
 						'underTotalsPlacementEnabled' => self::is_under_cart_totals_placement_enabled(),
@@ -150,16 +150,16 @@ class PayLaterWCBlocksModule implements ServiceModule, ExecutableModule {
 					$script_handle,
 					'PcpCheckoutPayLaterBlock',
 					array(
-						'ajax'                => array(
+						'ajax'                       => array(
 							'cart_script_params' => array(
 								'endpoint' => \WC_AJAX::get_endpoint( CartScriptParamsEndpoint::ENDPOINT ),
 							),
 						),
-						'config'              => $config_factory->from_settings( $paylater_settings ),
-						'settingsUrl'         => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
-						'vaultingEnabled'     => $settings_provider->save_paypal_and_venmo(),
-						'placementEnabled'    => self::is_placement_enabled( $c->get( 'wcgateway.settings.status' ), 'checkout' ),
-						'payLaterSettingsUrl' => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+						'config'                     => $config_factory->from_settings( $paylater_settings ),
+						'settingsUrl'                => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
+						'payLaterDisabledByVaulting' => $settings_provider->save_paypal_and_venmo(),
+						'placementEnabled'           => self::is_placement_enabled( $c->get( 'wcgateway.settings.status' ), 'checkout' ),
+						'payLaterSettingsUrl'        => admin_url( 'admin.php?page=wc-settings&tab=checkout&section=ppcp-gateway' ),
 					)
 				);
 			},

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.js
@@ -2,7 +2,7 @@ import { __, sprintf } from '@wordpress/i18n';
 
 import SettingsBlock from '@ppcp-settings/Components/ReusableComponents/SettingsBlock';
 import { ControlToggleButton } from '@ppcp-settings/Components/ReusableComponents/Controls';
-import { SettingsHooks } from '@ppcp-settings/data';
+import { SettingsHooks, PaymentHooks } from '@ppcp-settings/data';
 import { useMerchantInfo } from '@ppcp-settings/data/common/hooks';
 
 const SavePaymentMethods = ( { ownBrandOnly } ) => {
@@ -14,6 +14,27 @@ const SavePaymentMethods = ( { ownBrandOnly } ) => {
 	} = SettingsHooks.useSettings();
 
 	const { features } = useMerchantInfo();
+
+	const { isReady, payLaterDependsOnVaulting } =
+		PaymentHooks.usePayLaterVaultingDependency();
+
+	// Until the payment data is loaded, assume the default behavior
+	// (vaulting disables Pay Later).
+	const vaultingDisablesPayLater = ! isReady || payLaterDependsOnVaulting;
+
+	const savePaypalAndVenmoDescription = vaultingDisablesPayLater
+		? sprintf(
+				/* translators: 1: URL to Pay Later documentation */
+				__(
+					'Securely store your customers\' PayPal accounts for a seamless checkout experience. <br />This will disable the <a target="_blank" rel="noreferrer" href="%1$s">Pay Later</a> payment method on your site.',
+					'woocommerce-paypal-payments'
+				),
+				'https://woocommerce.com/document/woocommerce-paypal-payments/#pay-later'
+		  )
+		: __(
+				"Securely store your customers' PayPal accounts for a seamless checkout experience.",
+				'woocommerce-paypal-payments'
+		  );
 
 	if ( ! features.save_paypal_and_venmo.enabled ) {
 		return null;
@@ -37,14 +58,7 @@ const SavePaymentMethods = ( { ownBrandOnly } ) => {
 					'Save PayPal and Venmo',
 					'woocommerce-paypal-payments'
 				) }
-				description={ sprintf(
-					/* translators: 1: URL to Pay Later documentation */
-					__(
-						'Securely store your customers\' PayPal accounts for a seamless checkout experience. <br />This will disable the <a target="_blank" rel="noreferrer" href="%1$s">Pay Later</a> payment method on your site.',
-						'woocommerce-paypal-payments'
-					),
-					'https://woocommerce.com/document/woocommerce-paypal-payments/#pay-later'
-				) }
+				description={ savePaypalAndVenmoDescription }
 				value={
 					features.save_paypal_and_venmo.enabled
 						? savePaypalAndVenmo

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.test.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/SavePaymentMethods.test.js
@@ -11,9 +11,17 @@ const mockUseSettings = {
 	setSaveCardDetails: jest.fn(),
 };
 
+const mockPayLaterVaultingDependency = {
+	isReady: true,
+	payLaterDependsOnVaulting: true,
+};
+
 jest.mock( '@ppcp-settings/data', () => ( {
 	SettingsHooks: {
 		useSettings: () => mockUseSettings,
+	},
+	PaymentHooks: {
+		usePayLaterVaultingDependency: () => mockPayLaterVaultingDependency,
 	},
 } ) );
 
@@ -68,6 +76,8 @@ describe( 'SavePaymentMethods', () => {
 		mockUseSettings.savePaypalAndVenmo = false;
 		mockUseSettings.saveCardDetails = false;
 		mockUseMerchantInfo.features.save_paypal_and_venmo.enabled = true;
+		mockPayLaterVaultingDependency.isReady = true;
+		mockPayLaterVaultingDependency.payLaterDependsOnVaulting = true;
 	} );
 
 	describe( 'Rendering', () => {
@@ -256,6 +266,36 @@ describe( 'SavePaymentMethods', () => {
 				expect.stringContaining( 'Pay Later' ),
 				'https://woocommerce.com/document/woocommerce-paypal-payments/#pay-later'
 			);
+		} );
+	} );
+
+	describe( 'Pay Later disable notice', () => {
+		it( 'shows the notice when Pay Later depends on vaulting', () => {
+			const { container } = render( <SavePaymentMethods /> );
+
+			expect( container.innerHTML ).toContain( 'This will disable' );
+		} );
+
+		it( 'omits the notice when Pay Later does not depend on vaulting', () => {
+			mockPayLaterVaultingDependency.payLaterDependsOnVaulting = false;
+
+			const { container } = render( <SavePaymentMethods /> );
+
+			expect( container.innerHTML ).not.toContain( 'This will disable' );
+			expect(
+				screen.getByText(
+					/Securely store your customers' PayPal accounts/
+				)
+			).toBeInTheDocument();
+		} );
+
+		it( 'shows the notice while payment data is still loading', () => {
+			mockPayLaterVaultingDependency.isReady = false;
+			mockPayLaterVaultingDependency.payLaterDependsOnVaulting = false;
+
+			const { container } = render( <SavePaymentMethods /> );
+
+			expect( container.innerHTML ).toContain( 'This will disable' );
 		} );
 	} );
 

--- a/modules/ppcp-settings/resources/js/data/payment/hooks.js
+++ b/modules/ppcp-settings/resources/js/data/payment/hooks.js
@@ -56,6 +56,33 @@ export const useStore = () => {
 	};
 };
 
+/**
+ * Checks whether enabling vaulting ("Save PayPal and Venmo") disables the Pay Later
+ * payment method.
+ *
+ * Derived from the setting dependencies the server attaches to the pay-later method;
+ * the dependency is absent when a whitelisted merchant opted into the
+ * pay-later-with-vaulting override.
+ *
+ * @return {{isReady: boolean, payLaterDependsOnVaulting: boolean}} Dependency state.
+ */
+export const usePayLaterVaultingDependency = () => {
+	const { select, useTransient, usePersistent } = useStoreData();
+	const [ isReady ] = useTransient( 'isReady' );
+	const [ payLater ] = usePersistent( 'pay-later' );
+
+	// Load persistent data from REST if not done yet.
+	if ( ! isReady ) {
+		select.persistentData();
+	}
+
+	return {
+		isReady,
+		payLaterDependsOnVaulting:
+			!! payLater?.depends_on_settings?.settings?.savePaypalAndVenmo,
+	};
+};
+
 export const usePaymentMethods = () => {
 	const { usePersistent } = useStoreData();
 

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -501,7 +501,9 @@ return array(
 		);
 	},
 	'settings.data.definition.method_dependencies'        => static function ( ContainerInterface $container ): PaymentMethodsDependenciesDefinition {
-		return new PaymentMethodsDependenciesDefinition();
+		return new PaymentMethodsDependenciesDefinition(
+			$container->get( 'settings.settings-provider' )
+		);
 	},
 	'settings.service.pay_later_status'                   => static function ( ContainerInterface $container ): array {
 		$pay_later_endpoint = $container->get( 'settings.rest.pay_later_messaging' );
@@ -714,8 +716,8 @@ return array(
 			$container->get( 'settings.service.features_eligibilities' ),
 			$container->get( 'settings.data.general' ),
 			$merchant_capabilities,
-			$container->get( 'settings.data.settings' ),
-			$container->get( 'woocommerce.logger.woocommerce' )
+			$container->get( 'woocommerce.logger.woocommerce' ),
+			$container->get( 'settings.settings-provider' )
 		);
 	},
 	'settings.service.features_eligibilities'             => static function ( ContainerInterface $container ): FeaturesEligibilityService {

--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace WooCommerce\PayPalCommerce\Settings\Data\Definition;
 
 use Psr\Log\LoggerInterface;
-use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\Service\FeaturesEligibilityService;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 
@@ -90,21 +90,21 @@ class FeaturesDefinition {
 	 * @var array
 	 */
 	protected array $merchant_capabilities;
-	protected SettingsModel $plugin_settings;
 	protected LoggerInterface $logger;
+	protected SettingsProvider $settings_provider;
 
 	public function __construct(
 		FeaturesEligibilityService $eligibilities,
 		GeneralSettings $settings,
 		array $merchant_capabilities,
-		SettingsModel $plugin_settings,
-		LoggerInterface $logger
+		LoggerInterface $logger,
+		SettingsProvider $settings_provider
 	) {
 		$this->eligibilities         = $eligibilities;
 		$this->settings              = $settings;
 		$this->merchant_capabilities = $merchant_capabilities;
-		$this->plugin_settings       = $plugin_settings;
 		$this->logger                = $logger;
+		$this->settings_provider     = $settings_provider;
 	}
 
 	/**
@@ -167,7 +167,7 @@ class FeaturesDefinition {
 
 		$store_country                  = $this->settings->get_woo_settings()['country'];
 		$paylater_docs_country_location = in_array( $store_country, $paylater_documentation_supported_countries, true ) ? strtolower( $store_country ) : 'us';
-		$save_paypal_and_venmo          = $this->plugin_settings->get_save_paypal_and_venmo();
+		$pay_later_disabled_by_vaulting = $this->settings_provider->pay_later_disabled_by_vaulting();
 
 		$feature_items = array(
 			self::FEATURE_PAY_WITH_CRYPTO                 => array(
@@ -392,7 +392,7 @@ class FeaturesDefinition {
 					'Help grow sales with Pay Later messaging. Let customers know they have flexible payment options as they browse, shop, and check out.',
 					'woocommerce-paypal-payments'
 				),
-				'enabled'     => $this->merchant_capabilities[ self::FEATURE_PAY_LATER_MESSAGING ] && ! $save_paypal_and_venmo,
+				'enabled'     => $this->merchant_capabilities[ self::FEATURE_PAY_LATER_MESSAGING ] && ! $pay_later_disabled_by_vaulting,
 				'buttons'     => array(
 					array(
 						'type'     => 'secondary',

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDependenciesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDependenciesDefinition.php
@@ -22,11 +22,18 @@ use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\P24Gateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\TrustlyGateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\OXXOGateway;
 use WooCommerce\PayPalCommerce\LocalAlternativePaymentMethods\PayUponInvoice\PayUponInvoiceGateway;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 
 /**
  * Defines dependency relationships between payment methods and settings.
  */
 class PaymentMethodsDependenciesDefinition {
+
+	protected SettingsProvider $settings_provider;
+
+	public function __construct( SettingsProvider $settings_provider ) {
+		$this->settings_provider = $settings_provider;
+	}
 
 	/**
 	 * Get payment method to payment method dependencies
@@ -73,11 +80,13 @@ class PaymentMethodsDependenciesDefinition {
 	 * @return array The dependency relationships between settings and payment methods
 	 */
 	public function get_setting_dependencies(): array {
-		$dependencies = array(
-			'pay-later' => array(
+		$dependencies = array();
+
+		if ( ! $this->settings_provider->pay_later_with_vaulting_enabled() ) {
+			$dependencies['pay-later'] = array(
 				'savePaypalAndVenmo' => false,
-			),
-		);
+			);
+		}
 
 		return apply_filters(
 			'woocommerce_paypal_payments_setting_dependencies',

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -423,6 +423,41 @@ class SettingsProvider {
 	}
 
 	/**
+	 * Whether Pay Later may run alongside vaulting ("Save PayPal and Venmo").
+	 *
+	 * By default the plugin disables all Pay Later features when vaulting is
+	 * active. PayPal-whitelisted merchants can return true from the filter below
+	 * to bypass that restriction.
+	 *
+	 * @return bool True when Pay Later is allowed together with vaulting.
+	 */
+	public function pay_later_with_vaulting_enabled(): bool {
+		/**
+		 * Filters whether Pay Later features may run while "Save PayPal and Venmo"
+		 * (vaulting) is active.
+		 *
+		 * Intended for PayPal-whitelisted accounts that are allowed to offer Pay
+		 * Later and Vaulting at the same time.
+		 *
+		 * @param bool $enabled Whether Pay Later is allowed alongside vaulting. Default false.
+		 */
+		return (bool) apply_filters( 'woocommerce_paypal_payments_pay_later_with_vaulting', false );
+	}
+
+	/**
+	 * Whether Pay Later is currently disabled because of vaulting.
+	 *
+	 * Reflects the live, effective state: true only when vaulting ("Save PayPal and
+	 * Venmo") is currently enabled AND the merchant has not opted into the override
+	 * via {@see self::pay_later_with_vaulting_enabled()}.
+	 *
+	 * @return bool True when Pay Later features must be suppressed because of vaulting.
+	 */
+	public function pay_later_disabled_by_vaulting(): bool {
+		return $this->save_paypal_and_venmo() && ! $this->pay_later_with_vaulting_enabled();
+	}
+
+	/**
 	 * Gets the instant payments only setting.
 	 *
 	 * @return bool True if instant payments only setting is enabled, false otherwise.

--- a/modules/ppcp-settings/src/SettingsModule.php
+++ b/modules/ppcp-settings/src/SettingsModule.php
@@ -18,6 +18,7 @@ use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\Data\TodosModel;
 use WooCommerce\PayPalCommerce\Settings\Endpoint\RestEndpoint;
 use WooCommerce\PayPalCommerce\Settings\Enum\InstallationPathEnum;
@@ -683,14 +684,16 @@ class SettingsModule implements ServiceModule, ExecutableModule {
 		assert( $gateway_redirect_service instanceof GatewayRedirectService );
 		$gateway_redirect_service->register();
 
-		// Do not render Pay Later messaging if the "Save PayPal and Venmo" setting is enabled.
+		// Do not render Pay Later messaging while vaulting ("Save PayPal and Venmo") is
+		// active, unless a whitelisted merchant opted in via the filter. Otherwise the
+		// incoming value is left untouched so other filters keep working.
 		add_filter(
 			'woocommerce_paypal_payments_should_render_pay_later_messaging',
-			static function () use ( $container ): bool {
-				$settings_model = $container->get( 'settings.data.settings' );
-				assert( $settings_model instanceof SettingsModel );
+			static function ( bool $should_render ) use ( $container ): bool {
+				$settings_provider = $container->get( 'settings.settings-provider' );
+				assert( $settings_provider instanceof SettingsProvider );
 
-				return ! $settings_model->get_save_paypal_and_venmo();
+				return $settings_provider->pay_later_disabled_by_vaulting() ? false : $should_render;
 			}
 		);
 

--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -55,6 +55,10 @@ class SettingsStatus {
 	 * @return bool true if is enabled, otherwise false.
 	 */
 	public function is_pay_later_button_enabled(): bool {
+		if ( $this->settings_provider->pay_later_disabled_by_vaulting() ) {
+			return false;
+		}
+
 		$pay_later_button_enabled = $this->settings_provider->pay_later_button_enabled();
 		$selected_locations       = $this->settings_provider->pay_later_button_locations();
 

--- a/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
+++ b/modules/ppcp-wc-gateway/src/Helper/SettingsStatus.php
@@ -25,6 +25,10 @@ class SettingsStatus {
 	 * Checks whether Pay Later messaging is enabled.
 	 */
 	public function is_pay_later_messaging_enabled(): bool {
+		if ( $this->settings_provider->pay_later_disabled_by_vaulting() ) {
+			return false;
+		}
+
 		return $this->settings_provider->pay_later_messaging_enabled();
 	}
 


### PR DESCRIPTION
Added a filter (`woocommerce_paypal_payments_pay_later_with_vaulting`) so that the merchants whitelisted by PayPal can enable Pay Later buttons and messaging together with vaulting ("Save PayPal and Venmo"), which is not normally possible right now.

After enabling this filter, the Pay Later method does not become automatically disabled and greyed out in the payment method tab in the settings, and the Pay Later messaging configuration page also becomes available. If the filter gets disabled while Pay Later and vaulting are enabled, then Pay Later is automatically disabled as before. 

Also renamed the `vaultingEnabled` property into `payLaterDisabledByVaulting` in the Pay Later blocks, since now it is not simply about the vaulting state. This property is only used for displaying a message that it is not possible to use Pay Later while vaulting is enabled. 