### PR TITLE
feat(api-client): show user-friendly, filterable decline messages to buyers

### DIFF
--- a/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
+++ b/modules/ppcp-api-client/src/Entity/FraudProcessorResponse.php
@@ -176,24 +176,104 @@ class FraudProcessorResponse {
 	}
 
 	/**
-	 * Returns the customer-facing decline message, including the processor response code when available.
+	 * Returns the customer-facing decline message.
+	 *
+	 * Unlike get_response_code_message(), this avoids exposing raw processor
+	 * codes or alarming language (e.g. "fraud", "stolen") to buyers.
 	 *
 	 * @return string
 	 */
 	public function get_customer_decline_message(): string {
 		if ( $this->response_code() ) {
-			return sprintf(
-				/* translators: %s - processor response code and description */
-				__( 'Payment declined by card processor: %s. Please use a different payment method or contact your bank.', 'woocommerce-paypal-payments' ),
-				$this->get_response_code_message()
+			$message = sprintf(
+				/* translators: %s - a plain-language reason the payment was declined. */
+				__( 'Your payment could not be processed because %s Please try a different payment method or contact your bank for more information.', 'woocommerce-paypal-payments' ),
+				$this->get_customer_response_code_message()
 			);
+		} else {
+			$message = __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' );
 		}
 
-		return __( 'Payment provider declined the payment, please use a different payment method.', 'woocommerce-paypal-payments' );
+		/**
+		 * Filters the customer-facing message shown at checkout when a card payment is declined.
+		 *
+		 * Use this to customize the wording shown to buyers, e.g. to match your
+		 * store's tone of voice or add store-specific support contact details.
+		 *
+		 * @param string                 $message The generated decline message.
+		 * @param FraudProcessorResponse $fraud_processor_response The fraud processor response that triggered the decline.
+		 */
+		return (string) apply_filters( 'woocommerce_paypal_payments_customer_decline_message', $message, $this );
+	}
+
+	/**
+	 * Returns a plain-language, customer-facing reason for the processor response code.
+	 *
+	 * @return string
+	 */
+	protected function get_customer_response_code_message(): string {
+		if ( ! $this->response_code() ) {
+			return '';
+		}
+
+		$default_message = __( 'your card was declined by your bank.', 'woocommerce-paypal-payments' );
+
+		$messages = array(
+			'5120' => __( 'your card was declined due to insufficient funds.', 'woocommerce-paypal-payments' ),
+			'5400' => __( 'your card has expired.', 'woocommerce-paypal-payments' ),
+			'5930' => __( 'your card has not been activated.', 'woocommerce-paypal-payments' ),
+			'00N7' => __( "the card's security code could not be verified.", 'woocommerce-paypal-payments' ),
+			'1382' => __( "the card's security code could not be verified.", 'woocommerce-paypal-payments' ),
+			'5110' => __( "the card's security code could not be verified.", 'woocommerce-paypal-payments' ),
+			'5130' => __( 'the PIN entered is incorrect.', 'woocommerce-paypal-payments' ),
+			'9600' => __( 'the PIN entered is incorrect.', 'woocommerce-paypal-payments' ),
+			'1300' => __( 'the card details could not be verified.', 'woocommerce-paypal-payments' ),
+			'1330' => __( 'the card details could not be verified.', 'woocommerce-paypal-payments' ),
+			'1335' => __( 'the card details could not be verified.', 'woocommerce-paypal-payments' ),
+			'10BR' => __( 'the additional card verification could not be completed.', 'woocommerce-paypal-payments' ),
+			'1384' => __( 'a similar transaction was already submitted recently.', 'woocommerce-paypal-payments' ),
+			'0100' => __( 'your bank flagged this payment for manual review.', 'woocommerce-paypal-payments' ),
+			'9530' => __( 'your bank flagged this payment for manual review.', 'woocommerce-paypal-payments' ),
+			'5140' => __( 'your card is no longer active.', 'woocommerce-paypal-payments' ),
+			'5200' => __( 'your card is no longer active.', 'woocommerce-paypal-payments' ),
+			'5170' => __( 'your card is currently blocked.', 'woocommerce-paypal-payments' ),
+			'6300' => __( 'your card is currently blocked.', 'woocommerce-paypal-payments' ),
+			'5150' => __( 'your bank was unable to approve this transaction.', 'woocommerce-paypal-payments' ),
+			'5160' => __( 'your bank was unable to approve this transaction.', 'woocommerce-paypal-payments' ),
+			'5180' => __( 'your bank was unable to approve this transaction.', 'woocommerce-paypal-payments' ),
+			'9500' => __( 'your bank was unable to approve this transaction.', 'woocommerce-paypal-payments' ),
+			'9510' => __( 'your bank was unable to approve this transaction.', 'woocommerce-paypal-payments' ),
+			'9520' => __( 'your bank was unable to approve this transaction.', 'woocommerce-paypal-payments' ),
+			'9540' => __( 'your bank was unable to approve this transaction.', 'woocommerce-paypal-payments' ),
+			'0390' => __( 'your bank declined this transaction.', 'woocommerce-paypal-payments' ),
+			'0500' => __( 'your bank declined this transaction.', 'woocommerce-paypal-payments' ),
+			'0580' => __( 'your bank declined this transaction.', 'woocommerce-paypal-payments' ),
+			'0890' => __( 'your bank is temporarily unavailable.', 'woocommerce-paypal-payments' ),
+			'0960' => __( 'your bank is temporarily unavailable.', 'woocommerce-paypal-payments' ),
+			'1370' => __( 'your bank is temporarily unavailable.', 'woocommerce-paypal-payments' ),
+			'5910' => __( 'your bank is temporarily unavailable.', 'woocommerce-paypal-payments' ),
+			'5920' => __( 'your bank is temporarily unavailable.', 'woocommerce-paypal-payments' ),
+			'9100' => __( 'the transaction could not be completed.', 'woocommerce-paypal-payments' ),
+			'PCNF' => __( 'the transaction could not be completed.', 'woocommerce-paypal-payments' ),
+		);
+
+		$message = $messages[ $this->response_code() ] ?? $default_message;
+
+		/**
+		 * Filters the plain-language decline reason used inside the customer-facing decline message.
+		 *
+		 * @param string                 $message The decline reason shown to the customer.
+		 * @param string                 $response_code The raw processor response code.
+		 * @param FraudProcessorResponse $fraud_processor_response The fraud processor response.
+		 */
+		return (string) apply_filters( 'woocommerce_paypal_payments_customer_decline_reason_message', $message, $this->response_code(), $this );
 	}
 
 	/**
 	 * Returns the human-readable description for the processor response code.
+	 *
+	 * Intended for merchant-facing use (e.g. order notes/logs) — includes the
+	 * raw processor code and technical wording that should not be shown to buyers.
 	 *
 	 * @return string
 	 */

--- a/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
+++ b/tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php
@@ -1267,7 +1267,7 @@ class OrderEndpointTest extends TestCase
         $capture->shouldReceive('fraud_processor_response')->once()->andReturn($fraud);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessageMatches('/9500: Suspected Fraud/');
+        $this->expectExceptionMessageMatches('/your bank was unable to approve this transaction/');
         $testee->capture($orderToCapture);
     }
 

--- a/tests/PHPUnit/ApiClient/Entity/FraudProcessorResponseTest.php
+++ b/tests/PHPUnit/ApiClient/Entity/FraudProcessorResponseTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\ApiClient\Entity;
 
 use WooCommerce\PayPalCommerce\TestCase;
+use Mockery;
+use function Brain\Monkey\Functions\expect;
 
 class FraudProcessorResponseTest extends TestCase
 {
@@ -68,11 +70,22 @@ class FraudProcessorResponseTest extends TestCase
 		$this->assertSame('', $testee->get_response_code_message());
 	}
 
-	public function testGetCustomerDeclineMessageWithKnownCode(): void
+	public function testGetCustomerDeclineMessageWithKnownCodeIsUserFriendly(): void
 	{
 		$testee = new FraudProcessorResponse(null, null, '9500');
 		$this->assertSame(
-			'Payment declined by card processor: 9500: Suspected Fraud. Please use a different payment method or contact your bank.',
+			'Your payment could not be processed because your bank was unable to approve this transaction. Please try a different payment method or contact your bank for more information.',
+			$testee->get_customer_decline_message()
+		);
+		$this->assertStringNotContainsString('9500', $testee->get_customer_decline_message());
+		$this->assertStringNotContainsString('Fraud', $testee->get_customer_decline_message());
+	}
+
+	public function testGetCustomerDeclineMessageWithUnknownCodeUsesDefaultReason(): void
+	{
+		$testee = new FraudProcessorResponse(null, null, 'ZZZZ');
+		$this->assertSame(
+			'Your payment could not be processed because your card was declined by your bank. Please try a different payment method or contact your bank for more information.',
 			$testee->get_customer_decline_message()
 		);
 	}
@@ -82,6 +95,45 @@ class FraudProcessorResponseTest extends TestCase
 		$testee = new FraudProcessorResponse(null, null, null);
 		$this->assertSame(
 			'Payment provider declined the payment, please use a different payment method.',
+			$testee->get_customer_decline_message()
+		);
+	}
+
+	public function testCustomerDeclineMessageFilterOverridesFinalMessage(): void
+	{
+		expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_customer_decline_reason_message', Mockery::any(), '5120', Mockery::any())
+			->andReturnUsing(function ($hook, $value) {
+				return $value;
+			});
+
+		expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_customer_decline_message', Mockery::any(), Mockery::any())
+			->andReturn('Custom decline message.');
+
+		$testee = new FraudProcessorResponse(null, null, '5120');
+		$this->assertSame('Custom decline message.', $testee->get_customer_decline_message());
+	}
+
+	public function testCustomerDeclineReasonMessageFilterOverridesReason(): void
+	{
+		expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_customer_decline_reason_message', Mockery::any(), '5120', Mockery::any())
+			->andReturn('a custom reason.');
+
+		expect('apply_filters')
+			->once()
+			->with('woocommerce_paypal_payments_customer_decline_message', Mockery::any(), Mockery::any())
+			->andReturnUsing(function ($hook, $value) {
+				return $value;
+			});
+
+		$testee = new FraudProcessorResponse(null, null, '5120');
+		$this->assertSame(
+			'Your payment could not be processed because a custom reason. Please try a different payment method or contact your bank for more information.',
 			$testee->get_customer_decline_message()
 		);
 	}

--- a/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
+++ b/tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php
@@ -284,7 +284,7 @@ class AuthorizedPaymentsProcessorTest extends TestCase
 		$this->wcOrder->shouldNotReceive('add_order_note');
 
 		$this->expectException(RuntimeException::class);
-		$this->expectExceptionMessageMatches('/9500: Suspected Fraud/');
+		$this->expectExceptionMessageMatches('/your bank was unable to approve this transaction/');
 		$this->testee->capture_authorized_payment($this->wcOrder);
 	}
 


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
We added `processor_response` support to capture the PayPal processor's decline reason and surface it in the  WooCommerce order. That reason is also currently shown to the *buyer* at checkout when their card is declined, but the message embeds PayPal's raw processor code and technical/alarming wording verbatim, e.g.:                                                                                                                                                                                         
                                                                                                                                                                                                          
> Payment declined by card processor: 9500: Suspected Fraud. Please use a                                                                                                                               
> different payment method or contact your bank.                                                                                                                                                        
                                                                                                                                                                                                          
This is confusing and unnecessarily alarming for a legitimate customer whose card was simply declined for a mundane reason.                                                                                                                                                          
                                                                                                                                                                                                          
`FraudProcessorResponse::get_customer_decline_message()` (the buyer-facing message thrown at checkout) now uses a new plain-language mapping instead of the raw processor code/description, e.g.:                                                                                                                                                               
                                                                                                                                                                                                          
> Your payment could not be processed because your card has expired. Please                                                                                                                             
> try a different payment method or contact your bank for more information.                                                                                                                             
                                                                                                                                                                                                          
The technical mapping (`get_response_code_message()`) used in merchant-facing order notes/logs is unchanged — merchants still see the raw processor code for diagnosis.                                                                                                                                                                                              
                                                                                                                                                                                                          
Two new filters let merchants customize the wording shown to buyers:                                                                                                                                    
- `woocommerce_paypal_payments_customer_decline_message` — overrides the full assembled message.                                                                                                                                                                                    
- `woocommerce_paypal_payments_customer_decline_reason_message` — overrides just the plain-language reason fragment for a given response code. 

### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Trigger a declined card payment at checkout with a processor response code present (e.g. via a PayPal sandbox test card that returns a decline, or by mocking `FraudProcessorResponse` in a test order flow).                                                                                                                                              
2. **Before this PR**: the checkout error shows the raw code, e.g. "9500: Suspected Fraud".                                                                                                                                                                                    
3. **After this PR**: the checkout error shows a plain-language reason, e.g. "your bank was unable to approve this transaction," with no raw code or alarming wording.                                                                                                                                                                                    
4. Confirm the WooCommerce order note (admin-facing, on the failed order) still shows the technical processor code — unchanged.                                                                                                                                                
5. Add `add_filter( 'woocommerce_paypal_payments_customer_decline_message', ... )` or `add_filter( 'woocommerce_paypal_payments_customer_decline_reason_message', ... )` and confirm the checkout error reflects the overridden text.                                                                                                                                         
6. `npm run unit-tests` — updated/added coverage in                                                                                                                                                     
     `tests/PHPUnit/ApiClient/Entity/FraudProcessorResponseTest.php`,                                                                                                                                     
     `tests/PHPUnit/ApiClient/Endpoint/OrderEndpointTest.php`, and                                                                                                                                        
     `tests/PHPUnit/WcGateway/Processor/AuthorizedPaymentsProcessorTest.php`.