### PR TITLE
fix(api-client): fatal TypeError when PayPal returns address data as a JSON array

### DIFF
--- a/modules/ppcp-api-client/src/Factory/AddressFactory.php
+++ b/modules/ppcp-api-client/src/Factory/AddressFactory.php
@@ -63,12 +63,23 @@ class AddressFactory {
 	/**
 	 * Creates an Address object based off a PayPal Response.
 	 *
-	 * @param \stdClass $data The JSON object.
+	 * PayPal sometimes serializes an empty address object as a JSON array
+	 * (`[]`) instead of an object (`{}`), which decodes to an empty PHP array
+	 * rather than stdClass. Normalize that here instead of at every call site.
+	 *
+	 * @param mixed $data The JSON object.
 	 *
 	 * @return Address
 	 * @throws RuntimeException When JSON object is malformed.
 	 */
-	public function from_paypal_response( \stdClass $data ): Address {
+	public function from_paypal_response( $data ): Address {
+		if ( is_array( $data ) ) {
+			$data = (object) $data;
+		}
+		if ( ! $data instanceof \stdClass ) {
+			$data = new \stdClass();
+		}
+
 		return new Address(
 			( isset( $data->country_code ) ) ? $data->country_code : '',
 			( isset( $data->address_line_1 ) ) ? $data->address_line_1 : '',

--- a/tests/PHPUnit/ApiClient/Factory/AddressFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/AddressFactoryTest.php
@@ -219,4 +219,38 @@ class AddressFactoryTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * PayPal sometimes serializes an empty address object as a JSON array
+     * (`[]`), which json_decode() turns into an empty PHP array rather than
+     * an stdClass. Previously this fataled with a TypeError since the method
+     * was type-hinted to accept only \stdClass.
+     */
+    public function testFromPayPalResponseWithEmptyArrayReturnsEmptyAddress()
+    {
+        $testee = new AddressFactory();
+
+        $result = $testee->from_paypal_response([]);
+
+        $this->assertEquals('', $result->country_code());
+        $this->assertEquals('', $result->address_line_1());
+        $this->assertEquals('', $result->address_line_2());
+        $this->assertEquals('', $result->admin_area_1());
+        $this->assertEquals('', $result->admin_area_2());
+        $this->assertEquals('', $result->postal_code());
+    }
+
+    public function testFromPayPalResponseWithNonEmptyArrayIsCastToObject()
+    {
+        $testee = new AddressFactory();
+
+        $result = $testee->from_paypal_response([
+            'country_code' => 'shipping_country',
+            'address_line_1' => 'shipping_address_1',
+        ]);
+
+        $this->assertEquals('shipping_country', $result->country_code());
+        $this->assertEquals('shipping_address_1', $result->address_line_1());
+        $this->assertEquals('', $result->postal_code());
+    }
 }

--- a/tests/PHPUnit/ApiClient/Factory/PayerFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PayerFactoryTest.php
@@ -186,6 +186,32 @@ class PayerFactoryTest extends TestCase
     }
 
     /**
+     * PayPal sometimes serializes an empty payer address as a JSON array
+     * (`[]`) instead of an object (`{}`), which previously fataled with
+     * "AddressFactory::from_paypal_response(): Argument #1 ($data) must be
+     * of type stdClass, array given" because PayerFactory passed the
+     * decoded array straight through without normalizing it.
+     */
+    public function testFromPayPalResponseWithArrayAddressDoesNotFatal()
+    {
+        $data = (object)[
+            'address' => [],
+            'name' => (object)[
+                'given_name' => 'given_name',
+                'surname' => 'surname',
+            ],
+            'email_address' => 'email_address',
+            'payer_id' => 'payer_id',
+        ];
+
+        $testee = new PayerFactory(new AddressFactory());
+        $payer = $testee->from_paypal_response($data);
+
+        $this->assertInstanceOf(Address::class, $payer->address());
+        $this->assertEquals('', $payer->address()->country_code());
+    }
+
+    /**
      * @dataProvider dataForTestFromPayPalResponse
      */
     public function testFromPayPalResponse($data)
@@ -298,6 +324,17 @@ class PayerFactoryTest extends TestCase
                         ],
                     ],
                     'birth_date' => '1970-01-01',
+                    'email_address' => 'email_address',
+                    'payer_id' => 'payer_id',
+                ],
+            ],
+            'empty_array_address' => [
+                (object)[
+                    'address' => [],
+                    'name' => (object)[
+                        'given_name' => 'given_name',
+                        'surname' => 'surname',
+                    ],
                     'email_address' => 'email_address',
                     'payer_id' => 'payer_id',
                 ],


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
PayPal sometimes serializes an empty address object as a JSON array (`[]`) instead of an object (`{}`), depending on the payment method or endpoint used. `json_decode()` turns that into an empty PHP array rather than an `stdClass` instance. `AddressFactory::from_paypal_response()` was strictly type-hinted to accept only `\stdClass`, so passing that array through threw an uncaught `TypeError` and fataled order creation for affected buyers:

```
Uncaught TypeError: AddressFactory::from_paypal_response(): Argument #1 ($data) must be of type stdClass, array given, called in PayerFactory.php on line 95/127 and defined in AddressFactory.php:43/71
```                                                                                                                                             
                                                                                                                                                                                                          
This hit logged-in customers with no saved billing address intermittently (other orders in the same window completed fine), producing "Something went wrong..." / "An unexpected error occurred while verifying buyer" errors for the buyer during the `ppcp-gateway` create-order AJAX call (`CreateOrderEndpoint` → `payer()` → `create_paypal_order()`).                                                                                                                                          
                                                                                                                                                                                                          
### Fix

Rather than patching the one reported call site (`PayerFactory::from_paypal_response()` → `$data->address`), the fix normalizes array input to an empty `stdClass` **inside `AddressFactory::from_paypal_response()` itself**, following the same defensive pattern already used by `AmountFactory` elsewhere in this directory. This covers every current and future caller in one place — notably, `ShippingFactory::from_paypal_response()` has the exact same unpatched vulnerability at its own `$data->address` call site, which is also fixed by this change without needing a separate patch there.

### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Simulate a PayPal response where `payer.address` is `[]` instead of `{}` (e.g. via a unit test, or a logged-in customer checkout with no saved billing address, per the original report).                                                                                                                                                           
2. **Before this fix**: `PayerFactory::from_paypal_response()` / `ShippingFactory::from_paypal_response()` throw an uncaught `TypeError`.                                                                                                                             
3. **After this fix**: an empty `Address` object is returned instead, and order creation completes normally.                                                                                                                                                                   
4. `npm run unit-tests` — new coverage in `tests/PHPUnit/ApiClient/Factory/AddressFactoryTest.php` (empty/non-empty array input) and `tests/PHPUnit/ApiClient/Factory/PayerFactoryTest.php` (end-to-end regression test using the real `AddressFactory`, reproducing the exact reported crash chain).       