### PR TITLE
fix(wc-gateway): guard fraudnet.js against undefined PAYPAL global (6689)

### DIFF
--- a/modules/ppcp-wc-gateway/resources/js/fraudnet.js
+++ b/modules/ppcp-wc-gateway/resources/js/fraudnet.js
@@ -51,10 +51,11 @@ window.addEventListener( 'load', function () {
 
 	document.addEventListener( 'hosted_fields_loaded', ( event ) => {
 		if (
-			PAYPAL.asyncData &&
-			typeof PAYPAL.asyncData.initAndCollect === 'function'
+			window.PAYPAL &&
+			window.PAYPAL.asyncData &&
+			typeof window.PAYPAL.asyncData.initAndCollect === 'function'
 		) {
-			PAYPAL.asyncData.initAndCollect();
+			window.PAYPAL.asyncData.initAndCollect();
 		}
 
 		_injectConfig();

--- a/modules/ppcp-wc-gateway/resources/js/fraudnet.test.js
+++ b/modules/ppcp-wc-gateway/resources/js/fraudnet.test.js
@@ -1,0 +1,38 @@
+describe( 'fraudnet.js hosted_fields_loaded listener', () => {
+	beforeAll( () => {
+		global.FraudNetConfig = {
+			f: 'fraudnet-session-id',
+			s: 'store-id',
+			sandbox: '0',
+		};
+		require( './fraudnet.js' );
+		window.dispatchEvent( new Event( 'load' ) );
+	} );
+
+	beforeEach( () => {
+		delete window.PAYPAL;
+	} );
+
+	it( 'does not throw when window.PAYPAL is not defined (e.g. c.paypal.com/da/r/fb.js was blocked or has not finished loading yet)', () => {
+		expect( () => {
+			document.dispatchEvent( new CustomEvent( 'hosted_fields_loaded' ) );
+		} ).not.toThrow();
+	} );
+
+	it( 'calls window.PAYPAL.asyncData.initAndCollect() when it is available', () => {
+		const initAndCollect = jest.fn();
+		window.PAYPAL = { asyncData: { initAndCollect } };
+
+		document.dispatchEvent( new CustomEvent( 'hosted_fields_loaded' ) );
+
+		expect( initAndCollect ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not throw and does not call initAndCollect when window.PAYPAL.asyncData.initAndCollect is not a function', () => {
+		window.PAYPAL = { asyncData: {} };
+
+		expect( () => {
+			document.dispatchEvent( new CustomEvent( 'hosted_fields_loaded' ) );
+		} ).not.toThrow();
+	} );
+} );


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
On classic checkout with Advanced Card Processing (hosted fields) enabled, `fraudnet.js` throws an uncaught `ReferenceError: PAYPAL is not defined` inside its `hosted_fields_loaded` event listener:                                                                                                                                              
                                                                                                                                                                                                          
```js                                                                                                                                                                                                   
  document.addEventListener( 'hosted_fields_loaded', ( event ) => {                                                                                                                                       
      if (                                                                                                                                                                                                
          PAYPAL.asyncData &&   // <- throws ReferenceError if PAYPAL is undefined                                                                                                                        
          typeof PAYPAL.asyncData.initAndCollect === 'function'                                                                                                                                           
      ) {                                                                                                                                                                                                 
          PAYPAL.asyncData.initAndCollect();                                                                                                                                                              
      }                                                                                                                                                                                                   
      _injectConfig();                                                                                                                                                                                    
  } ); 
```                                                                                                                                                                                                   
                                                                                                                                                                                                          
`PAYPAL` is expected to be set by `https://c.paypal.com/da/r/fb.js`, injected asynchronously by this same file with no sequencing guarantee against the `hosted_fields_loaded` event (dispatched independently by the PayPal SDK's Hosted Fields / Card Fields renderers once their iframes are ready). Two failure modes:                                                                                                                                                                                          
                                                                                                                                                                                                          
- Load-order race: `fb.js` hasn't finished executing before `hosted_fields_loaded` fires (more likely on slow connections).
- Blocked script: `c.paypal.com` is filtered by a content/privacy  blocker, so `PAYPAL` is never defined at all.                                                                                                                                                             
                                                                                                                                                                                                          
Either way, referencing the bare, undeclared PAYPAL identifier throws a `ReferenceError`, whereas `window.PAYPAL` is a safe property access thatsimply evaluates to undefined (falsy, no throw) when not set.                                                                                                                                           
                                                                                                                                                                                                          
**Fix**                                                                                                                                                                                                     
                                                                                                                                                                                                          
Check `window.PAYPAL` (and its nested properties) instead of the bare `PAYPAL` identifier before calling `initAndCollect()`.

### Steps to Test                                                                                                                                                                                           
                                                                                                                                                                                                          
1. On a classic checkout with PayPal Smart Buttons + Advanced Card Processing enabled (PUI not active), open DevTools → Network → block the request URL https://c.paypal.com/da/r/fb.js.                                                                                                                                                        
2. Reload the checkout page with an item in the cart.                                                                                                                                                   
3. In the console, confirm window.PAYPAL is undefined, then run:  `document.dispatchEvent( new CustomEvent( 'hosted_fields_loaded' ) );`                                                                                                                                    
4. Before this fix: throws `Uncaught ReferenceError: PAYPAL is not defined`.                                                                                                                              
5. After this fix: no error; `dispatchEvent()` just returns `true`. 