### PR TITLE
Fix unusable express Debit or Credit Card fields on Blocks checkout

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/paypal.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal.js
@@ -22,6 +22,7 @@ import {
 } from '../paypal-config';
 import { useRef } from 'react';
 import Spinner from '../../../../ppcp-button/resources/js/modules/Helper/Spinner';
+import { isInlineExpressFundingSource } from '../Helper/FundingSource';
 
 const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 
@@ -162,7 +163,26 @@ export const PayPalComponent = ( {
 			return actions.reject();
 		}
 
-		window.ppcpFundingSource = data.fundingSource;
+		const selectedFundingSource = data.fundingSource ?? fundingSource;
+		window.ppcpFundingSource = selectedFundingSource;
+
+		// Defer Blocks express processing for inline card forms; see
+		// isInlineExpressFundingSource(). Popup/app buttons still signal now.
+		if ( isInlineExpressFundingSource( selectedFundingSource ) ) {
+			return;
+		}
+
+		onClick();
+	};
+
+	const beginExpressPaymentIfDeferred = () => {
+		if (
+			! isInlineExpressFundingSource(
+				window.ppcpFundingSource ?? fundingSource
+			)
+		) {
+			return;
+		}
 
 		onClick();
 	};
@@ -373,6 +393,7 @@ export const PayPalComponent = ( {
 			config.scriptData.context,
 			{
 				createOrder: ( data ) => {
+					beginExpressPaymentIfDeferred();
 					return createOrder( data, config, onError, onClose );
 				},
 				onApprove: ( data, actions ) => {
@@ -464,7 +485,10 @@ export const PayPalComponent = ( {
 				onClick={ handleClick }
 				onCancel={ handleCancel }
 				onError={ onClose }
-				createVaultSetupToken={ () => createVaultSetupToken( config ) }
+				createVaultSetupToken={ () => {
+					beginExpressPaymentIfDeferred();
+					return createVaultSetupToken( config );
+				} }
 				onApprove={ ( { vaultSetupToken } ) =>
 					onApproveSavePayment( vaultSetupToken, config, onSubmit )
 				}
@@ -480,9 +504,10 @@ export const PayPalComponent = ( {
 				onClick={ handleClick }
 				onCancel={ handleCancel }
 				onError={ onClose }
-				createSubscription={ ( data, actions ) =>
-					createSubscription( data, actions, config )
-				}
+				createSubscription={ ( data, actions ) => {
+					beginExpressPaymentIfDeferred();
+					return createSubscription( data, actions, config );
+				} }
 				onApprove={ ( data, actions ) =>
 					handleApproveSubscription(
 						data,
@@ -519,9 +544,10 @@ export const PayPalComponent = ( {
 			onClick={ handleClick }
 			onCancel={ handleCancel }
 			onError={ onClose }
-			createOrder={ ( data ) =>
-				createOrder( data, config, onError, onClose )
-			}
+			createOrder={ ( data ) => {
+				beginExpressPaymentIfDeferred();
+				return createOrder( data, config, onError, onClose );
+			} }
 			onApprove={ ( data, actions ) =>
 				handleApprove(
 					data,

--- a/modules/ppcp-blocks/resources/js/Components/paypal.js
+++ b/modules/ppcp-blocks/resources/js/Components/paypal.js
@@ -176,11 +176,7 @@ export const PayPalComponent = ( {
 	};
 
 	const beginExpressPaymentIfDeferred = () => {
-		if (
-			! isInlineExpressFundingSource(
-				window.ppcpFundingSource ?? fundingSource
-			)
-		) {
+		if ( ! isInlineExpressFundingSource( fundingSource ) ) {
 			return;
 		}
 

--- a/modules/ppcp-blocks/resources/js/Helper/FundingSource.js
+++ b/modules/ppcp-blocks/resources/js/Helper/FundingSource.js
@@ -1,0 +1,14 @@
+/**
+ * Funding sources that expand an inline form inside the Smart Buttons iframe
+ * instead of opening a popup or app.
+ *
+ * Calling WooCommerce Blocks' express `onClick()` marks checkout as processing
+ * and applies `pointer-events: none` to the express payment area. For these
+ * sources that blocks interaction with the form fields the shopper still needs
+ * to complete, so signaling must wait until order creation starts.
+ *
+ * @param {string|undefined} fundingSource
+ * @return {boolean}
+ */
+export const isInlineExpressFundingSource = ( fundingSource ) =>
+	fundingSource === 'card';

--- a/modules/ppcp-blocks/resources/js/test/paypal.test.js
+++ b/modules/ppcp-blocks/resources/js/test/paypal.test.js
@@ -1,0 +1,16 @@
+import { isInlineExpressFundingSource } from '../Helper/FundingSource';
+
+describe( 'isInlineExpressFundingSource', () => {
+	it( 'returns true for the card funding source', () => {
+		expect( isInlineExpressFundingSource( 'card' ) ).toBe( true );
+	} );
+
+	it.each( [ 'paypal', 'paylater', 'venmo', undefined, '' ] )(
+		'returns false for %p',
+		( fundingSource ) => {
+			expect( isInlineExpressFundingSource( fundingSource ) ).toBe(
+				false
+			);
+		}
+	);
+} );


### PR DESCRIPTION
## Summary
- Debit or Credit Card under Blocks Express Checkout expands an inline PayPal iframe form. Calling WooCommerce Blocks' express `onClick()` immediately marked checkout as processing and applied `pointer-events: none` to the express area, so card fields were visible but unclickable.
- Defer Blocks `onClick` for the `card` funding source until `createOrder` / payment creation starts. PayPal, Pay Later, and Venmo still signal on button click (popup/app flows).
- Add a small helper and unit coverage for identifying inline express funding sources.

## Test plan
- [ ] Blocks checkout with BCDC enabled (card express button shown; ACDC not replacing it)
- [ ] Click **Debit or Credit Card** — card number / expires / CSC remain interactive (no gray lock)
- [ ] Complete a card payment successfully
- [ ] Cancel the card form with **X** — express area returns to normal
- [ ] Confirm PayPal / Pay Later express buttons still work (popup/app flows unchanged)
- [ ] Optional: temporarily inspect DOM after clicking Card — `wc-block-components-express-payment--disabled` should **not** appear until Pay/submit


Made with [Cursor](https://cursor.com)