### PR TITLE
fix(api-client): fractional WooCommerce quantities truncated to 0, breaking PayPal checkout (6699)

### DIFF
--- a/modules/ppcp-api-client/src/Factory/ItemFactory.php
+++ b/modules/ppcp-api-client/src/Factory/ItemFactory.php
@@ -57,12 +57,22 @@ class ItemFactory {
 				$product       = $item['data'];
 				$cart_item_key = $item['key'] ?? null;
 
-				$quantity = (int) $item['quantity'];
-				$image    = wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' );
+				$wc_quantity = (float) $item['quantity'];
+				/**
+				 * PayPal requires an integer quantity of at least 1. WooCommerce allows
+				 * fractional quantities (e.g. 0.3, via plugins like Measurement Price
+				 * Calculator), which would otherwise truncate to 0 and be rejected by
+				 * the PayPal API. Normalize such lines to a single unit priced at the
+				 * full line subtotal, instead of truncating the quantity to 0.
+				 */
+				$is_fractional_unit = $wc_quantity > 0 && $wc_quantity < 1;
+				$quantity           = $is_fractional_unit ? 1 : (int) $wc_quantity;
+				$image              = wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' );
 
-				$price    = (float) $item['line_subtotal'] / (float) $item['quantity'];
-				$line_tax = isset( $item['line_tax'] ) ? (float) $item['line_tax'] : 0.0;
-				$unit_tax = $quantity > 0 ? $line_tax / (float) $quantity : 0.0;
+				$line_subtotal = (float) $item['line_subtotal'];
+				$price         = $is_fractional_unit ? $line_subtotal : $line_subtotal / $wc_quantity;
+				$line_tax      = isset( $item['line_tax'] ) ? (float) $item['line_tax'] : 0.0;
+				$unit_tax      = $is_fractional_unit ? $line_tax : ( $quantity > 0 ? $line_tax / (float) $quantity : 0.0 );
 
 				return new Item(
 					$this->prepare_item_string( $product->get_name() ),
@@ -137,14 +147,23 @@ class ItemFactory {
 	 * @return Item
 	 */
 	private function from_wc_order_line_item( \WC_Order_Item_Product $item, \WC_Order $order ): Item {
-		$product                   = $item->get_product();
-		$currency                  = $order->get_currency();
-		$quantity                  = (int) $item->get_quantity();
-		$price_without_tax         = (float) $order->get_item_subtotal( $item, false );
+		$product     = $item->get_product();
+		$currency    = $order->get_currency();
+		$wc_quantity = (float) $item->get_quantity();
+		/**
+		 * PayPal requires an integer quantity of at least 1. WooCommerce allows
+		 * fractional quantities (e.g. 0.3, via plugins like Measurement Price
+		 * Calculator), which would otherwise truncate to 0 and be rejected by
+		 * the PayPal API. Normalize such lines to a single unit priced at the
+		 * full line subtotal, instead of truncating the quantity to 0.
+		 */
+		$is_fractional_unit        = $wc_quantity > 0 && $wc_quantity < 1;
+		$quantity                  = $is_fractional_unit ? 1 : (int) $wc_quantity;
+		$price_without_tax         = $is_fractional_unit ? (float) $item->get_subtotal() : (float) $order->get_item_subtotal( $item, false );
 		$price_without_tax_rounded = round( $price_without_tax, 2 );
 		$image                     = $product instanceof WC_Product ? wp_get_attachment_image_src( (int) $product->get_image_id(), 'full' ) : '';
 		$line_tax                  = (float) $item->get_total_tax();
-		$unit_tax                  = $quantity > 0 ? $line_tax / (float) $quantity : 0.0;
+		$unit_tax                  = $is_fractional_unit ? $line_tax : ( $quantity > 0 ? $line_tax / (float) $quantity : 0.0 );
 
 		return new Item(
 			$this->prepare_item_string( $item->get_name() ),

--- a/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/ItemFactoryTest.php
@@ -88,6 +88,66 @@ class ItemFactoryTest extends TestCase
         $this->assertEquals(42, $item->unit_amount()->value());
     }
 
+    public function testFromCartFractionalQuantityIsNormalizedToOne()
+    {
+        $testee = new ItemFactory($this->currency);
+
+        $product = Mockery::mock(\WC_Product_Simple::class);
+        $product
+            ->expects('get_name')
+            ->andReturn('name');
+        $product
+            ->expects('get_description')
+            ->andReturn('description');
+        $product
+            ->expects('get_sku')
+            ->andReturn('sku');
+        $product
+            ->expects('is_virtual')
+            ->andReturn(false);
+        $items = [
+            [
+                'data' => $product,
+                'quantity' => 0.3,
+	            'line_subtotal' => 30.00,
+	            'line_total' => 30.00
+            ],
+        ];
+        $cart = Mockery::mock(\WC_Cart::class);
+        $cart
+            ->expects('get_cart_contents')
+            ->andReturn($items);
+
+	    when('get_woocommerce_currency')->justReturn('USD');
+
+	    expect('wp_strip_all_tags')->andReturnFirstArg();
+	    expect('strip_shortcodes')->andReturnFirstArg();
+
+        $woocommerce = Mockery::mock(\WooCommerce::class);
+        $session = Mockery::mock(\WC_Session::class);
+        when('WC')->justReturn($woocommerce);
+        $woocommerce->session = $session;
+        $session->shouldReceive('get')->andReturn([]);
+
+		when('wp_get_attachment_image_src')->justReturn('image_url');
+		$product
+			->expects('get_image_id')
+			->andReturn(1);
+		$product
+			->expects('get_permalink')
+			->andReturn('url');
+	    $product->shouldReceive('get_id')->andReturn(null);
+
+        $result = $testee->from_wc_cart($cart);
+
+        $item = current($result);
+        /**
+         * @var Item $item
+         */
+        $this->assertEquals(1, $item->quantity());
+        $this->assertEquals(30.00, $item->unit_amount()->value());
+    }
+
     public function testFromCartDigitalGood()
     {
         $testee = new ItemFactory($this->currency);
@@ -214,6 +274,71 @@ class ItemFactoryTest extends TestCase
         $this->assertEquals(1, $item->quantity());
         $this->assertEquals(Item::PHYSICAL_GOODS, $item->category());
         $this->assertEquals(1, $item->unit_amount()->value());
+    }
+
+    public function testFromWcOrderFractionalQuantityIsNormalizedToOne()
+    {
+        $testee = new ItemFactory($this->currency);
+
+        $product = Mockery::mock(\WC_Product::class);
+        $product
+            ->expects('get_description')
+            ->andReturn('description');
+        $product
+            ->expects('get_sku')
+            ->andReturn('sku');
+        $product
+            ->expects('is_virtual')
+            ->andReturn(false);
+
+		expect('wp_strip_all_tags')->andReturnFirstArg();
+		expect('strip_shortcodes')->andReturnFirstArg();
+
+		when('wp_get_attachment_image_src')->justReturn('image_url');
+		$product
+			->expects('get_image_id')
+			->andReturn(1);
+		$product
+			->expects('get_permalink')
+			->andReturn('url');
+
+        $item = Mockery::mock(\WC_Order_Item_Product::class);
+        $item
+            ->expects('get_product')
+            ->andReturn($product);
+		$item
+			->expects('get_name')
+			->andReturn('name');
+        $item
+            ->expects('get_quantity')
+            ->andReturn(0.3);
+
+        $order = Mockery::mock(\WC_Order::class);
+	    $order
+		    ->shouldReceive('get_currency')
+		    ->once()
+		    ->andReturn($this->currency->get());
+        $order
+            ->expects('get_items')
+            ->andReturn([$item]);
+        $order
+            ->expects('get_fees')
+            ->andReturn([]);
+        $order
+            ->shouldNotReceive('get_item_subtotal');
+
+	    $product->shouldReceive('get_id')->andReturn(123);
+	    $item->shouldReceive('get_subtotal')->andReturn(30.00);
+	    $item->shouldReceive('get_total')->andReturn(30.00);
+	    $item->shouldReceive('get_total_tax')->andReturn(0.00);
+
+        $result = $testee->from_wc_order($order);
+        $item = current($result);
+        /**
+         * @var Item $item
+         */
+        $this->assertEquals(1, $item->quantity());
+        $this->assertEquals(30.00, $item->unit_amount()->value());
     }
 
     public function testFromWcOrderDigitalGood()


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
WooCommerce PayPal Payments truncates fractional product quantities to integers when building PayPal line items. For quantities between 0 and 1 (e.g. `0.3`, produced by plugins like Measurement Price Calculator when a customer enters a fractional unit like "30 cm"), `(int) 0.3 === 0`, so the PayPal line item's `quantity` becomes `0` — which violates the PayPal API contract (`quantity >= 1`) and fails checkout entirely:                                                                                                                                                 
                                                                                                                                                                                                          
```json                                                                                                                                                                                                 
{                                                                                                                                                                                                       
  "field": "/purchase_units/@reference_id=='default'/items/0/quantity",                                                                                                                                 
  "value": "0",                                                                                                                                                                                         
  "issue": "INVALID_PARAMETER_SYNTAX"                                                                                                                                                                   
}
```                                                                                                                                                                                                       
                                                                                                                                                                                                          
Worse, the existing calculation is internally inconsistent even before the API rejects it: unit_price is computed as line_subtotal / quantity (e.g. `30.00 / 0.3 = 100.00`), so the payload sent is quantity: 0, `unit_amount: 100.00` for a line that actually cost `30.00` — neither value reflects the real transaction.                                                                                                                                                                          
                                                                                                                                                                                                          
Two call sites in ItemFactory truncate this way:                                                                                                                                                        
- `from_wc_cart()` — `modules/ppcp-api-client/src/Factory/ItemFactory.php`                                                                                                                                  
- `from_wc_order_line_item()` — same file

**Fix**

For WooCommerce quantities strictly between 0 and 1, normalize the PayPal line item to `quantity = 1` with `unit_amount` set to the full line subtotal (and re-derive unit_tax accordingly), instead of truncating the quantity away:

<table>                                                                                                                                                                                                 
  <thead>                                                                                                                                                                                                 
  <tr>                                                                                                                                                                                                    
  <th>WC qty</th>                                                                                                                                                                                         
  <th>Line subtotal</th>                                                                                                                                                                                  
  <th>Before</th>                                                                                                                                                                                         
  <th>After</th>                                                                                                                                                                                          
  </tr>                                                                                                                                                                                                   
  </thead>                                                                                                                                                                                                
  <tbody>                                                                                                                                                                                                 
  <tr>                                                                                                                                                                                                    
  <td>0.3</td>                                                                                                                                                                                            
  <td>30.00</td>                                                                                                                                                                                          
  <td>qty=0, price=100 ❌</td>                                                                                                                                                                            
  <td>qty=1, price=30.00 ✅</td>                                                                                                                                                                          
  </tr>                                                                                                                                                                                                   
  <tr>                                                                                                                                                                                                    
  <td>1.0</td>                                                                                                                                                                                            
  <td>100.00</td>                                                                                                                                                                                         
  <td>qty=1, price=100 ✅<</td>                                                                                                                                                                            
  <td>unchanged</td>                                                                                                                                                                                      
  </tr>                                                                                                                                                                                                   
  <tr>                                                                                                                                                                                                    
  <td>2.0</td>                                                                                                                                                                                            
  <td>200.00</td>                                                                                                                                                                                         
  <td>qty=2, price=100 ✅</td>                                                                                                                                                                            
  <td>unchanged</td>                                                                                                                                                                                      
  </tr>                                                                                                                                                                                                   
  </tbody>                                                                                                                                                                                                
  </table>

Quantities ≥ 1 (including whole-number floats) go through the original,  unmodified arithmetic — this only touches the 0 < qty < 1 branch.                                                                                                                                       
                                                                                                                                                                                                          
This doesn't introduce a new order-total mismatch risk: `Item::quantity()/ unit_amount()` don't feed the purchase unit's `amount.breakdown.item_total` directly (that's computed independently from WooCommerce's own cart/order subtotal getters), and the existing `PurchaseUnitSanitizer` reconciliation mechanism already handles any residual rounding mismatch between the two. This change makes the affected line's contribution to that reconciliation more accurate than today (today it silently contributes 0), not less.                                                                                                                                   
                                                                                                                                                                                                          
**Steps to Test**                                                                                                                                                                                           
                                                                                                                                                                                                          
1. Install a plugin that produces fractional cart quantities (e.g. Measurement Price Calculator — set a product to "Per Unit" pricing by length, e.g. 100.00 per meter).                                                                                                                                                                         
2. On the product page, enter a fractional amount (e.g. 30 cm → WC cart quantity 0.3).                                                                                                                                                                                          
3. Add to cart, go to checkout, click the PayPal button.                                                                                                                                                
4. Before this fix: PayPal order creation fails with `INVALID_PARAMETER_SYNTAX` on `items/0/quantity`.                                                                                                                                                           
5. After this fix: checkout completes; the PayPal line item shows  `quantity: 1`, `unit_amount` equal to the line subtotal (e.g. 30.00).                                                                                                                                       
6. Repeat with a WooCommerce order that has such a line item (e.g. via a manually-created order or subscription renewal) to confirm the order path (`from_wc_order_line_item`) is fixed too.             