### PR TITLE
fix(wc-gateway): keep payer action required orders pending on retry

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -76,6 +76,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 	public const CROSS_BROWSER_APPSWITCH_META_KEY = '_ppcp_cross_browser_appswitch';
 
+	private const MAX_RETRY_ATTEMPTS = 3;
+
 	/**
 	 * List of payment sources for which we are expected to store the payer email in the WC Order metadata.
 	 */
@@ -612,14 +614,44 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 			if ( $retry_errors ) {
 				$retry_error_key = $retry_errors[0];
-
-				$wc_order->update_status(
-					'failed',
-					$retry_keys_messages[ $retry_error_key ] . ' ' . ( $error->details()[0]->description ?? '' )
-				);
+				$retry_message   = $retry_keys_messages[ $retry_error_key ] . ' ' . ( $error->details()[0]->description ?? '' );
 
 				$this->session_handler->increment_insufficient_funding_tries();
-				if ( $this->session_handler->insufficient_funding_tries() >= 3 ) {
+				$retry_tries = $this->session_handler->insufficient_funding_tries();
+
+				if ( 'PAYER_ACTION_REQUIRED' === $retry_error_key ) {
+					if ( $retry_tries >= self::MAX_RETRY_ATTEMPTS ) {
+						$wc_order->update_status( 'failed', $retry_message );
+
+						return $this->handle_payment_failure(
+							null,
+							new Exception(
+								__( 'Please use a different payment method.', 'woocommerce-paypal-payments' ),
+								$error->getCode(),
+								$error
+							)
+						);
+					}
+
+					$session_order = $this->session_handler->order();
+					if ( ! ( $session_order instanceof Order ) ) {
+						return $this->handle_payment_failure(
+							$wc_order,
+							new Exception( __( 'Payment session expired. Please try again.', 'woocommerce-paypal-payments' ) )
+						);
+					}
+
+					$wc_order->add_order_note( $retry_message );
+
+					return array(
+						'result'   => 'success',
+						'redirect' => ( $this->paypal_checkout_url_factory )( $session_order->id() ),
+					);
+				}
+
+				$wc_order->update_status( 'failed', $retry_message );
+
+				if ( $retry_tries >= self::MAX_RETRY_ATTEMPTS ) {
 					return $this->handle_payment_failure(
 						null,
 						new Exception(

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -5,10 +5,12 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Gateway;
 
 use Exception;
 use Psr\Log\LoggerInterface;
+use stdClass;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CapturePayPalPayment;
@@ -32,6 +34,7 @@ class WcGatewayTest extends TestCase
 {
 	private $isAdmin = false;
 	private $sessionHandler;
+		private $sessionOrder;
 	private $fundingSource = null;
 
 	private $funding_source_renderer;
@@ -83,11 +86,13 @@ class WcGatewayTest extends TestCase
 			->andReturnUsing(function () {
 				return $this->fundingSource;
 			});
-		$order = Mockery::mock(Order::class);
-		$order->shouldReceive('status')->andReturn(new OrderStatus(OrderStatus::APPROVED));
+		$this->sessionOrder = Mockery::mock(Order::class);
+		$this->sessionOrder->shouldReceive('status')->andReturn(new OrderStatus(OrderStatus::APPROVED));
 		$this->sessionHandler
 			->shouldReceive('order')
-			->andReturn($order);
+			->andReturnUsing(function () {
+				return $this->sessionOrder;
+			});
 
 		$this->settings->shouldReceive('has')->andReturnFalse();
 
@@ -152,6 +157,33 @@ class WcGatewayTest extends TestCase
 			$this->context
 		);
 	}
+
+		private function createRetryError( string $issue, string $description ): PayPalApiException {
+				$response                          = new stdClass();
+				$response->name                    = 'UNPROCESSABLE_ENTITY';
+				$response->message                 = 'API error';
+				$response->details                 = array();
+				$response->links                   = array();
+				$response->details[0]              = new stdClass();
+				$response->details[0]->issue       = $issue;
+				$response->details[0]->description = $description;
+
+				return new PayPalApiException( $response, 422 );
+		}
+
+		private function mockCheckoutFailureEnvironment( string $redirect_url = 'http://example.com/checkout' ): void {
+				when( 'wc_get_checkout_url' )->justReturn( $redirect_url );
+				when( 'is_checkout_pay_page' )->justReturn( false );
+
+				$woocommerce = Mockery::mock( \WooCommerce::class );
+				$session     = Mockery::mock( \WC_Session::class );
+
+				$woocommerce->session = $session;
+				when( 'WC' )->justReturn( $woocommerce );
+
+				$session->shouldReceive( 'get' )->andReturn( null );
+				$session->shouldReceive( 'set' );
+		}
 
 	public function testProcessPaymentSuccess() {
         $orderId = 1;
@@ -291,6 +323,170 @@ class WcGatewayTest extends TestCase
 			$result
 		);
     }
+
+		/**
+		 * @dataProvider payerActionRequiredRetryProvider
+		 */
+		public function testProcessPaymentWithPayerActionRequiredKeepsOrderPendingAndRedirects( int $retry_tries ): void {
+				$orderId            = 1;
+				$wcOrder            = Mockery::mock( \WC_Order::class );
+				$retryDescription   = 'Payer needs to perform the following action before proceeding with payment.';
+				$retryMessage       = 'Payer action required, possibly overcharge. ' . $retryDescription;
+				$paypalRetryError   = $this->createRetryError( 'PAYER_ACTION_REQUIRED', $retryDescription );
+				$sessionPayPalOrder = Mockery::mock( Order::class );
+
+				$sessionPayPalOrder->shouldReceive( 'id' )->andReturn( 'PP-ORDER-123' );
+				$this->sessionOrder = $sessionPayPalOrder;
+				$this->orderProcessor->expects( 'process' )->andThrow( $paypalRetryError );
+				$this->subscriptionHelper->shouldReceive( 'has_subscription' )->with( $orderId )->andReturn( true );
+				$this->subscriptionHelper->shouldReceive( 'is_subscription_change_payment' )->andReturn( true );
+				$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
+				$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->once()->andReturn( $retry_tries );
+
+				$wcOrder->shouldReceive( 'add_order_note' )->once()->with( $retryMessage );
+				$wcOrder->shouldReceive( 'update_status' )->never();
+
+				$testee = $this->createGateway();
+
+				expect( 'wc_get_order' )
+						->with( $orderId )
+						->andReturn( $wcOrder );
+
+				$result = $testee->process_payment( $orderId );
+
+				$this->assertSame( 'success', $result['result'] );
+				$this->assertSame( 'checkoutnow=PP-ORDER-123', $result['redirect'] );
+		}
+
+		public function payerActionRequiredRetryProvider(): array {
+				return array(
+						'first attempt'  => array( 1 ),
+						'second attempt' => array( 2 ),
+				);
+		}
+
+		public function testProcessPaymentWithPayerActionRequiredFailsOnThirdAttempt(): void {
+				$orderId          = 1;
+				$wcOrder          = Mockery::mock( \WC_Order::class );
+				$retryDescription = 'Payer needs to perform the following action before proceeding with payment.';
+				$retryMessage     = 'Payer action required, possibly overcharge. ' . $retryDescription;
+				$paypalRetryError = $this->createRetryError( 'PAYER_ACTION_REQUIRED', $retryDescription );
+
+				$this->orderProcessor->expects( 'process' )->andThrow( $paypalRetryError );
+				$this->subscriptionHelper->shouldReceive( 'has_subscription' )->with( $orderId )->andReturn( true );
+				$this->subscriptionHelper->shouldReceive( 'is_subscription_change_payment' )->andReturn( true );
+				$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
+				$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->once()->andReturn( 3 );
+				$this->sessionHandler->shouldReceive( 'destroy_session_data' )->once();
+
+				$wcOrder->shouldReceive( 'update_status' )->once()->with( 'failed', $retryMessage )->andReturn( true );
+				$wcOrder->shouldReceive( 'add_order_note' )->never();
+
+				$testee = $this->createGateway();
+
+				expect( 'wc_get_order' )
+						->with( $orderId )
+						->andReturn( $wcOrder );
+				expect( 'wc_add_notice' )
+						->with( 'Please use a different payment method.', 'error' );
+
+				$this->mockCheckoutFailureEnvironment();
+
+				$result = $testee->process_payment( $orderId );
+
+				$this->assertArrayHasKey( 'errorMessage', $result );
+				unset( $result['errorMessage'] );
+
+				$this->assertSame(
+						array(
+								'result'   => 'failure',
+								'redirect' => 'http://example.com/checkout',
+						),
+						$result
+				);
+		}
+
+		public function testProcessPaymentWithPayerActionRequiredFailsWhenSessionExpires(): void {
+				$orderId          = 1;
+				$wcOrder          = Mockery::mock( \WC_Order::class );
+				$retryDescription = 'Payer needs to perform the following action before proceeding with payment.';
+				$paypalRetryError = $this->createRetryError( 'PAYER_ACTION_REQUIRED', $retryDescription );
+
+				$this->sessionOrder = null;
+				$this->orderProcessor->expects( 'process' )->andThrow( $paypalRetryError );
+				$this->subscriptionHelper->shouldReceive( 'has_subscription' )->with( $orderId )->andReturn( true );
+				$this->subscriptionHelper->shouldReceive( 'is_subscription_change_payment' )->andReturn( true );
+				$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
+				$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->once()->andReturn( 1 );
+				$this->sessionHandler->shouldReceive( 'destroy_session_data' )->once();
+
+				$wcOrder->shouldReceive( 'update_status' )
+						->once()
+						->with(
+								'failed',
+								Mockery::on(
+										static function ( string $message ): bool {
+												return strpos( $message, 'Payment session expired. Please try again.' ) !== false;
+										}
+								)
+						)
+						->andReturn( true );
+				$wcOrder->shouldReceive( 'add_order_note' )->never();
+
+				$testee = $this->createGateway();
+
+				expect( 'wc_get_order' )
+						->with( $orderId )
+						->andReturn( $wcOrder );
+				expect( 'wc_add_notice' )
+						->with( 'Payment session expired. Please try again.', 'error' );
+
+				$this->mockCheckoutFailureEnvironment();
+
+				$result = $testee->process_payment( $orderId );
+
+				$this->assertArrayHasKey( 'errorMessage', $result );
+				unset( $result['errorMessage'] );
+
+				$this->assertSame(
+						array(
+								'result'   => 'failure',
+								'redirect' => 'http://example.com/checkout',
+						),
+						$result
+				);
+		}
+
+		public function testProcessPaymentWithInstrumentDeclinedKeepsCurrentBehavior(): void {
+				$orderId            = 1;
+				$wcOrder            = Mockery::mock( \WC_Order::class );
+				$retryDescription   = 'Instrument declined by the payment provider.';
+				$retryMessage       = 'Instrument declined. ' . $retryDescription;
+				$paypalRetryError   = $this->createRetryError( 'INSTRUMENT_DECLINED', $retryDescription );
+				$sessionPayPalOrder = Mockery::mock( Order::class );
+
+				$sessionPayPalOrder->shouldReceive( 'id' )->andReturn( 'PP-ORDER-999' );
+				$this->sessionOrder = $sessionPayPalOrder;
+				$this->orderProcessor->expects( 'process' )->andThrow( $paypalRetryError );
+				$this->subscriptionHelper->shouldReceive( 'has_subscription' )->with( $orderId )->andReturn( true );
+				$this->subscriptionHelper->shouldReceive( 'is_subscription_change_payment' )->andReturn( true );
+				$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
+				$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->once()->andReturn( 1 );
+
+				$wcOrder->shouldReceive( 'update_status' )->once()->with( 'failed', $retryMessage )->andReturn( true );
+				$wcOrder->shouldReceive( 'add_order_note' )->never();
+
+				$testee = $this->createGateway();
+
+				expect( 'wc_get_order' )
+						->with( $orderId )
+						->andReturn( $wcOrder );
+
+				$result = $testee->process_payment( $orderId );
+
+				$this->assertSame( 'success', $result['result'] );
+				$this->assertSame( 'checkoutnow=PP-ORDER-999', $result['redirect'] );
+		}
 
 	/**
 	 * GIVEN a freshly-created order exists in WooCommerce (normal checkout flow)


### PR DESCRIPTION
Keep PAYER_ACTION_REQUIRED orders pending during recoverable retries

---

### Description

This change updates the PayPal gateway retry handling for `PAYER_ACTION_REQUIRED`.

Instead of immediately marking the WooCommerce order as `failed`, the order remains recoverable during the first two retryable attempts and the buyer is redirected back to PayPal.

After the maximum number of retryable attempts is reached, the order is moved to `failed`.

The existing `INSTRUMENT_DECLINED` behavior remains unchanged.

If the PayPal session has expired and no valid redirect is available, the order is failed through the existing payment failure flow without redirecting the buyer.

### Steps to Test

1. Trigger a `PAYER_ACTION_REQUIRED` response during checkout.
2. Confirm that on the first and second attempts the order is not immediately failed.
3. Confirm that the order receives a note and the buyer can be redirected back to PayPal.
4. Confirm that on the third `PAYER_ACTION_REQUIRED` attempt the order is moved to `failed`.
5. Confirm that `INSTRUMENT_DECLINED` still follows the existing failure flow.
6. Confirm that an expired PayPal session fails without redirecting.

### Automated Tests

- [x] Unit tests for `PAYER_ACTION_REQUIRED`
- [x] Unit tests for `INSTRUMENT_DECLINED`
- [x] Session-expiration test
- [x] `npm run unit-tests`
- [x] `npm run lint`
- [ ] `npm run test`

Note: commands were executed via DDEV. `npm run test` fails in the integration suite due pre-existing/local-environment issues unrelated to this change.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

Fix - Keep `PAYER_ACTION_REQUIRED` orders pending for retry before failing #4529

Fixes #4529