### PR TITLE
fix(webhooks): catch uncaught exceptions in incoming webhook handler (6446)

### DIFF
--- a/modules/ppcp-webhooks/src/IncomingWebhookEndpoint.php
+++ b/modules/ppcp-webhooks/src/IncomingWebhookEndpoint.php
@@ -206,6 +206,37 @@ class IncomingWebhookEndpoint {
 	 * @return \WP_REST_Response
 	 */
 	public function handle_request( \WP_REST_Request $request ): \WP_REST_Response {
+		try {
+			return $this->process_request( $request );
+		} catch ( \Throwable $exception ) {
+			/**
+			 * Catches any exception a handler's business logic might throw
+			 * (not just the types it documents), so an unexpected error
+			 * returns a graceful failure response instead of an uncaught
+			 * fatal. Without this, PayPal would retry the webhook
+			 * indefinitely since it never receives a response.
+			 */
+			$this->logger->error(
+				sprintf(
+					'Uncaught %s while handling incoming webhook: %s',
+					get_class( $exception ),
+					$exception->getMessage()
+				)
+			);
+
+			return $this->failure_response();
+		}
+	}
+
+	/**
+	 * Processes the request. Split out from handle_request() so the latter
+	 * can wrap it in a single catch-all try/catch.
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	private function process_request( \WP_REST_Request $request ): \WP_REST_Response {
 		$event = $this->event_from_request( $request );
 
 		$this->logger->debug(

--- a/tests/PHPUnit/Webhooks/IncomingWebhookEndpointTest.php
+++ b/tests/PHPUnit/Webhooks/IncomingWebhookEndpointTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\WebhookEvent;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookEventFactory;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Exception\PayPalOrderMissingException;
+use WooCommerce\PayPalCommerce\Webhooks\Handler\RequestHandler;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Webhooks\IncomingWebhookEndpoint
+ */
+class IncomingWebhookEndpointTest extends TestCase
+{
+	/** @var WebhookEventFactory&Mockery\MockInterface */
+	private $webhook_event_factory;
+
+	/** @var WebhookSimulation&Mockery\MockInterface */
+	private $simulation;
+
+	/** @var WebhookEventStorage&Mockery\MockInterface */
+	private $last_webhook_event_storage;
+
+	/** @var LoggerInterface&Mockery\MockInterface */
+	private $logger;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->webhook_event_factory      = Mockery::mock(WebhookEventFactory::class);
+		$this->simulation                 = Mockery::mock(WebhookSimulation::class);
+		$this->last_webhook_event_storage  = Mockery::mock(WebhookEventStorage::class);
+		$this->logger                     = Mockery::mock(LoggerInterface::class);
+
+		$this->logger->shouldReceive('debug');
+		$this->logger->shouldReceive('info');
+
+		$this->last_webhook_event_storage->shouldReceive('save');
+		$this->simulation->shouldReceive('is_simulation_event')->andReturn(false);
+	}
+
+	private function createRequest(): WP_REST_Request
+	{
+		/** @var WP_REST_Request&Mockery\MockInterface $request */
+		$request = Mockery::mock('WP_REST_Request, ArrayAccess');
+		$request->allows('get_params')->andReturn([]);
+		$request->allows('offsetExists')->andReturn(true);
+		$request->allows('offsetGet')->with('event_type')->andReturn('CHECKOUT.ORDER.APPROVED');
+
+		return $request;
+	}
+
+	private function createEndpoint(RequestHandler ...$handlers): IncomingWebhookEndpoint
+	{
+		$webhook_endpoint = Mockery::mock(WebhookEndpoint::class);
+
+		return new IncomingWebhookEndpoint(
+			$webhook_endpoint,
+			null,
+			$this->logger,
+			false,
+			$this->webhook_event_factory,
+			$this->simulation,
+			$this->last_webhook_event_storage,
+			...$handlers
+		);
+	}
+
+	/**
+	 * @scenario When a handler's handle_request() throws an exception that is not a
+	 * RuntimeException (e.g. PayPalOrderMissingException, which extends the plain
+	 * \Exception class), the exception must not propagate uncaught. Previously this
+	 * caused an uncaught fatal (translating to an HTTP 500 with no framework-level
+	 * catch), which made PayPal retry the webhook indefinitely.
+	 */
+	public function test_unexpected_exception_from_handler_does_not_propagate_uncaught(): void
+	{
+		$event = new WebhookEvent('evt-1', null, 'checkout-order', '1.0', 'CHECKOUT.ORDER.APPROVED', '', '', (object) []);
+		$this->webhook_event_factory->shouldReceive('from_array')->andReturn($event);
+
+		$handler = Mockery::mock(RequestHandler::class);
+		$handler->shouldReceive('responsible_for_request')->andReturn(true);
+		$handler->shouldReceive('event_types')->andReturn(['CHECKOUT.ORDER.APPROVED']);
+		$handler->shouldReceive('handle_request')->andThrow(
+			new PayPalOrderMissingException('There was an error processing your order.')
+		);
+
+		$this->logger->shouldReceive('error')->once();
+
+		$sut = $this->createEndpoint($handler);
+
+		$response = $sut->handle_request($this->createRequest());
+
+		$this->assertInstanceOf(WP_REST_Response::class, $response);
+		$this->assertSame(200, $response->get_status());
+		$this->assertFalse($response->get_data()['success']);
+	}
+
+	/**
+	 * @scenario The happy path (handler returns a response normally) must keep working
+	 * unchanged after wrapping handle_request() in a try/catch.
+	 */
+	public function test_handler_response_is_returned_unchanged_on_success(): void
+	{
+		$event = new WebhookEvent('evt-1', null, 'checkout-order', '1.0', 'CHECKOUT.ORDER.APPROVED', '', '', (object) []);
+		$this->webhook_event_factory->shouldReceive('from_array')->andReturn($event);
+
+		$expected_response = new WP_REST_Response(['success' => true]);
+
+		$handler = Mockery::mock(RequestHandler::class);
+		$handler->shouldReceive('responsible_for_request')->andReturn(true);
+		$handler->shouldReceive('event_types')->andReturn(['CHECKOUT.ORDER.APPROVED']);
+		$handler->shouldReceive('handle_request')->andReturn($expected_response);
+
+		$this->logger->shouldNotReceive('error');
+
+		$sut = $this->createEndpoint($handler);
+
+		$response = $sut->handle_request($this->createRequest());
+
+		$this->assertSame($expected_response, $response);
+	}
+}


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
`CHECKOUT.ORDER.APPROVED` webhooks can fail with an uncaught  `PayPalOrderMissingException`, thrown by `OrderProcessor::process()` when it can't find a WC session or `_ppcp_paypal_order_id` order meta (this is deterministic for Apple Pay, since `CreateOrderEndpoint` only persists the PayPal order to session for the redirect PayPal gateway).                                                                                                                                               
                                                                                                                                                                                                          
`CheckoutOrderApproved::handle_request()` only catches `RuntimeException`, but `PayPalOrderMissingException` extends the plain `Exception` class, so it escaped uncaught. This made the REST endpoint return an HTTP 500, which  caused PayPal to retry the webhook indefinitely, leaving the WooCommerce order stuck in `pending` with no capture.                                                                                                                                                               
                                                                                                                                                                                                          
This PR hardens `IncomingWebhookEndpoint::handle_request()` with a catch-all `try/catch (\Throwable $exception)` around request processing, so any unexpected exception from a handler is logged and turned into a graceful (HTTP 200) failure response instead of an uncaught fatal — this stops PayPal's retry loop.                                                                                                                                                                              
                                                                                                                                                                                                          
This only addresses the crash/retry-loop symptom. The deeper root cause (Apple Pay/non-redirect gateways never populating the session so the order can be found) is riskier to change and is intentionally left out of this PR to avoid regressions; it can be tracked as a follow-up.                                                                                                                                                 
                                                                                                                                                                                                          
### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Trigger a webhook handler to throw an exception that isn't a `RuntimeException` (e.g. simulate a `CHECKOUT.ORDER.APPROVED` webhook for an order with no WC session and no `_ppcp_paypal_order_id` meta, so `OrderProcessor::process()` throws `PayPalOrderMissingException`).                                                                                                                                   
2. Confirm the webhook endpoint responds with HTTP 200 and `{"success": false}` instead of an HTTP 500.                                                                                                                                                         
3. Confirm the error is logged (PayPal Payments logs) instead of causing a fatal.                                                                                                                                                                                               
4. Confirm normal webhook handling (happy path) is unaffected.