### PR TITLE
fix(wc-gateway): skip $0 PayPal capture when changing subscription payment to saved token (6681)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -716,8 +716,8 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	/**
 	 * Check whether customer is changing subscription payment.
 	 *
-	 * @param SubscriptionHelper $subscription_helper Subscription helper.
-	 * @param WC_Order           $wc_order WC order.
+	 * @param SubscriptionHelper $subscription_helper
+	 * @param WC_Order           $wc_order
 	 * @return bool
 	 */
 	private function is_customer_changing_subscription_payment( SubscriptionHelper $subscription_helper, WC_Order $wc_order ): bool {
@@ -728,10 +728,10 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	/**
 	 * Adds the given WC payment token into the given WC Order.
 	 *
-	 * @param WC_Order       $wc_order WC order.
-	 * @param int            $wc_payment_token_id WC payment token ID.
-	 * @param string         $return_url Return url.
-	 * @param SessionHandler $session_handler Session handler.
+	 * @param WC_Order       $wc_order
+	 * @param int            $wc_payment_token_id
+	 * @param string         $return_url
+	 * @param SessionHandler $session_handler
 	 * @return array{result: string, redirect: string, errorMessage?: string}
 	 */
 	private function add_payment_token_to_order(

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -447,6 +447,20 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$vault_approved_order_id = wc_clean( wp_unslash( $_POST['paypal_order_id'] ?? '' ) );
 
+		/**
+		 * WC Subscriptions zeroes the order total during a change-payment request, so
+		 * attempting a real capture here would send a $0 create-order request to PayPal
+		 * (rejected with CANNOT_BE_ZERO_OR_NEGATIVE). Just attach the saved token instead,
+		 * mirroring CreditCardGateway's saved-token change-payment handling.
+		 */
+		if (
+			$paypal_payment_token_id
+			&& 'new' !== $paypal_payment_token_id
+			&& $this->is_customer_changing_subscription_payment( $this->subscription_helper, $wc_order )
+		) {
+			return $this->add_payment_token_to_order( $wc_order, (int) $paypal_payment_token_id, $this->get_return_url( $wc_order ), $this->session_handler );
+		}
+
 		// Skip saved token handling when an approved order exists.
 		if ( $paypal_payment_token_id && 'new' !== $paypal_payment_token_id && ! $vault_approved_order_id ) {
 			$tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id() );
@@ -697,5 +711,54 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		}
 
 		do_action( 'woocommerce_paypal_payments_gateway_admin_options_wrapper', $this );
+	}
+
+	/**
+	 * Check whether customer is changing subscription payment.
+	 *
+	 * @param SubscriptionHelper $subscription_helper Subscription helper.
+	 * @param WC_Order           $wc_order WC order.
+	 * @return bool
+	 */
+	private function is_customer_changing_subscription_payment( SubscriptionHelper $subscription_helper, WC_Order $wc_order ): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		return isset( $_POST['woocommerce_change_payment'] ) && $subscription_helper->has_subscription( $wc_order->get_id() ) && $subscription_helper->is_subscription_change_payment();
+	}
+
+	/**
+	 * Adds the given WC payment token into the given WC Order.
+	 *
+	 * @param WC_Order       $wc_order WC order.
+	 * @param int            $wc_payment_token_id WC payment token ID.
+	 * @param string         $return_url Return url.
+	 * @param SessionHandler $session_handler Session handler.
+	 * @return array{result: string, redirect: string, errorMessage?: string}
+	 */
+	private function add_payment_token_to_order(
+		WC_Order $wc_order,
+		int $wc_payment_token_id,
+		string $return_url,
+		SessionHandler $session_handler
+	): array {
+		$payment_token = WC_Payment_Tokens::get( $wc_payment_token_id );
+		if ( $payment_token && (int) $payment_token->get_user_id() === get_current_user_id() ) {
+			$wc_order->add_payment_token( $payment_token );
+			$wc_order->save();
+
+			$session_handler->destroy_session_data();
+
+			return array(
+				'result'   => 'success',
+				'redirect' => $return_url,
+			);
+		}
+
+		wc_add_notice( __( 'Could not change payment.', 'woocommerce-paypal-payments' ), 'error' );
+
+		return array(
+			'result'       => 'failure',
+			'redirect'     => wc_get_checkout_url(),
+			'errorMessage' => __( 'Could not change payment.', 'woocommerce-paypal-payments' ),
+		);
 	}
 }

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -49,6 +49,7 @@ class WcGatewayTest extends TestCase
 	private $wcPaymentTokens;
 	private $assetGetter;
 	private $context;
+	private $capturePayPalPayment;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -97,6 +98,7 @@ class WcGatewayTest extends TestCase
 		$this->paymentTokensEndpoint = Mockery::mock(PaymentTokensEndpoint::class);
 		$this->wcPaymentTokens = Mockery::mock(WooCommercePaymentTokens::class);
 		$this->context = Mockery::mock(Context::class);
+		$this->capturePayPalPayment = Mockery::mock(CapturePayPalPayment::class);
 	}
 
 	private function createGateway()
@@ -119,7 +121,7 @@ class WcGatewayTest extends TestCase
 			$this->wcPaymentTokens,
 			$this->assetGetter,
 			false,
-			Mockery::mock(CapturePayPalPayment::class),
+			$this->capturePayPalPayment,
 			Mockery::mock(OrderEndpoint::class),
 			'WC-',
 			$this->context
@@ -146,7 +148,34 @@ class WcGatewayTest extends TestCase
 			$this->wcPaymentTokens,
 			$this->assetGetter,
 			false,
-			Mockery::mock(CapturePayPalPayment::class),
+			$this->capturePayPalPayment,
+			Mockery::mock(OrderEndpoint::class),
+			'WC-',
+			$this->context
+		);
+	}
+
+	private function createReturnUrlStubGateway(): PayPalGatewayReturnUrlStub
+	{
+		return new PayPalGatewayReturnUrlStub(
+			$this->funding_source_renderer,
+			$this->orderProcessor,
+			$this->settingsProvider,
+			$this->sessionHandler,
+			$this->refundProcessor,
+			$this->isConnected,
+			$this->transactionUrlProvider,
+			$this->subscriptionHelper,
+			$this->environment,
+			$this->logger,
+			$this->apiShopCountry,
+			static fn ($id) => 'checkoutnow=' . $id,
+			'Pay via PayPal',
+			$this->paymentTokensEndpoint,
+			$this->wcPaymentTokens,
+			$this->assetGetter,
+			false,
+			$this->capturePayPalPayment,
 			Mockery::mock(OrderEndpoint::class),
 			'WC-',
 			$this->context
@@ -496,6 +525,97 @@ class WcGatewayTest extends TestCase
 
 		$this->assertSame( 0, $gateway->tokenization_script_call_count, 'tokenization_script() must not be called when vaulting is disabled' );
 		$this->assertSame( 0, $gateway->saved_payment_methods_call_count, 'saved_payment_methods() must not be called when vaulting is disabled' );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @scenario Current user changes their subscription payment to a saved PayPal
+	 * token they own. The token must be attached to the order without attempting a
+	 * $0 capture (WC Subscriptions zeroes the order total during change-payment
+	 * requests, and PayPal rejects $0 create-order calls with
+	 * CANNOT_BE_ZERO_OR_NEGATIVE).
+	 */
+	public function test_process_payment_attaches_token_when_ownership_check_passes_for_change_payment(): void {
+		$orderId = 1;
+		$_POST['woocommerce_change_payment'] = '1';
+		$_POST['wc-ppcp-gateway-payment-token'] = '99';
+
+		$this->subscriptionHelper->shouldReceive('has_subscription')->with($orderId)->andReturn(true);
+		$this->subscriptionHelper->shouldReceive('is_subscription_change_payment')->andReturn(true);
+
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn($orderId);
+		$wcOrder->shouldReceive('get_meta')->andReturn('');
+		when('wc_get_order')->justReturn($wcOrder);
+
+		$tokens = Mockery::mock('alias:WC_Payment_Tokens');
+		$payment_token = Mockery::mock(\WC_Payment_Token::class);
+		$payment_token->shouldReceive('get_user_id')->andReturn(1);
+		$tokens->shouldReceive('get')->with(99)->andReturn($payment_token);
+
+		when('get_current_user_id')->justReturn(1);
+
+		$wcOrder->shouldReceive('add_payment_token')->once()->with($payment_token);
+		$wcOrder->shouldReceive('save')->once();
+		$this->sessionHandler->shouldReceive('destroy_session_data')->once();
+
+		$this->capturePayPalPayment->shouldNotReceive('create_order');
+
+		$result = $this->createReturnUrlStubGateway()->process_payment($orderId);
+
+		$this->assertEquals('success', $result['result']);
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @scenario Current user supplies a token id belonging to a different user while
+	 * changing their subscription payment. The token must not be attached, the
+	 * change must fail, and no $0 capture must be attempted either.
+	 */
+	public function test_process_payment_rejects_token_owned_by_different_user_during_change_payment(): void {
+		$orderId = 1;
+		$_POST['woocommerce_change_payment'] = '1';
+		$_POST['wc-ppcp-gateway-payment-token'] = '99';
+
+		$this->subscriptionHelper->shouldReceive('has_subscription')->with($orderId)->andReturn(true);
+		$this->subscriptionHelper->shouldReceive('is_subscription_change_payment')->andReturn(true);
+
+		$wcOrder = Mockery::mock(\WC_Order::class);
+		$wcOrder->shouldReceive('get_id')->andReturn($orderId);
+		$wcOrder->shouldReceive('get_meta')->andReturn('');
+		when('wc_get_order')->justReturn($wcOrder);
+
+		$tokens = Mockery::mock('alias:WC_Payment_Tokens');
+		$payment_token = Mockery::mock(\WC_Payment_Token::class);
+		$payment_token->shouldReceive('get_user_id')->andReturn(2);
+		$tokens->shouldReceive('get')->with(99)->andReturn($payment_token);
+
+		when('get_current_user_id')->justReturn(1);
+		when('wc_add_notice')->justReturn(null);
+		when('wc_get_checkout_url')->justReturn('http://example.test/checkout');
+
+		$wcOrder->shouldNotReceive('add_payment_token');
+		$wcOrder->shouldNotReceive('save');
+		$this->sessionHandler->shouldNotReceive('destroy_session_data');
+		$this->capturePayPalPayment->shouldNotReceive('create_order');
+
+		$result = $this->createReturnUrlStubGateway()->process_payment($orderId);
+
+		$this->assertEquals('failure', $result['result']);
+	}
+}
+
+/**
+ * Test double that returns a string return URL. The shared WC_Payment_Gateway
+ * stub returns the order object, which would violate the string type hint of
+ * PayPalGateway::add_payment_token_to_order().
+ */
+class PayPalGatewayReturnUrlStub extends PayPalGateway
+{
+	protected function get_return_url( $order = null ) {
+		return 'http://example.test/return';
 	}
 }
 


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
When a customer changes the payment method on an **active** WooCommerce Subscription to an already-saved PayPal vault token (My Account > Subscriptions > Change payment), WooCommerce Subscriptions zeroes the order total for that request. `PayPalGateway::process_payment()` didn't account  for this: its saved-token branch treated the selection as a normal payment/capture path and sent a create-order request with `amount = 0.00` to PayPal's `/v2/checkout/orders` API. PayPal rejects this with  `CANNOT_BE_ZERO_OR_NEGATIVE`.                                                                                                                                                                           
                                                                                                                                                                                                          
The resulting failure handling then called `$wc_order->update_status('failed', ...)` on what is actually a  `WC_Subscription` object. Since `'wc-failed'` isn't a valid WooCommerce Subscriptions status, WooCommerce core's  `WC_Order::set_status()` silentl coerces the invalid status to `pending`, demoting the previously-active subscription — even though nothing was actually wrong with it.                                                                                                                                          
                                                                                                                                                                                                          
This PR adds the same change-payment-method detection that `CreditCardGateway` already uses for its saved-token flow: when the request is a subscription change-payment request, the saved token is simply attached to the order (`add_payment_token_to_order()`) instead of attempting a capture. This avoids the $0 API call entirely, so the subscription is never touched by the failure path.                                                                                                                                                      
                                                                                                                                                                                                          
### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Use WooCommerce, WooCommerce Subscriptions, and WooCommerce PayPal Payments, with PayPal vaulting/saved payment methods enabled.                                                                                                                                        
2. Create an active subscription for a customer and make sure they have a saved PayPal payment token.                                                                                                                                                                          
3. Go to My Account > Subscriptions > View subscription > Change payment.                                                                                                                               
4. Select PayPal, select the saved PayPal token, and submit the change-payment form.                                                                                                                                                                                 
5. Confirm the payment method change succeeds and the subscription stays `active` (previously: PayPal returned `CANNOT_BE_ZERO_OR_NEGATIVE` and the subscription was demoted to `pending`). 