### PR TITLE
Contract tests for shared order WC-AJAX endpoints (v5/v6 shared plumbing) (6675)

### DIFF
--- a/tests/integration/PHPUnit/Button/Endpoint/ApproveOrderEndpointContractTest.php
+++ b/tests/integration/PHPUnit/Button/Endpoint/ApproveOrderEndpointContractTest.php
@@ -1,0 +1,234 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Button\Endpoint;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\Tests\Integration\Fixtures\PayPalOrderPresets;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Contract tests for the ppc-approve-order WC-AJAX endpoint, shared by the
+ * v5 and v6 SDK frontends.
+ *
+ * @covers \WooCommerce\PayPalCommerce\Button\Endpoint\ApproveOrderEndpoint
+ */
+class ApproveOrderEndpointContractTest extends WcAjaxEndpointTestCase {
+
+	private const PAYPAL_ORDER_ID = 'TEST-PAYPAL-ORDER-123';
+
+	/** @var ContainerInterface */
+	protected $container;
+
+	/**
+	 * Boots the container with a mocked PayPal order API serving an APPROVED
+	 * order (no payment source, so the card/3DS branch is skipped) and the
+	 * follow-up calls the order processor performs on the happy path.
+	 *
+	 * final_review_enabled is forced off so the should_create_wc_order branch
+	 * is deterministic regardless of store settings.
+	 *
+	 * @param string|null $custom_id The purchase unit custom_id of the fetched order,
+	 *                               null for the session-bound one (computed at call time).
+	 * @return object The ppc-approve-order endpoint.
+	 */
+	private function endpointWithApprovedOrder( ?string $custom_id = null ) {
+		$order_endpoint = Mockery::mock( OrderEndpoint::class );
+
+		$container = $this->bootstrapWithOrderApi(
+			$order_endpoint,
+			array(
+				'blocks.settings.final_review_enabled' => static function (): bool {
+					return false;
+				},
+			)
+		);
+
+		$order_factory = $container->get( 'api.factory.order' );
+		$approved      = $order_factory->from_paypal_response(
+			json_decode(
+				(string) wp_json_encode(
+					PayPalOrderPresets::order( self::PAYPAL_ORDER_ID, 'APPROVED', $custom_id ?? $this->sessionCustomId() )
+				)
+			)
+		);
+		$completed     = $order_factory->from_paypal_response(
+			json_decode(
+				(string) wp_json_encode(
+					PayPalOrderPresets::completedWithCapture( self::PAYPAL_ORDER_ID, $custom_id ?? $this->sessionCustomId() )
+				)
+			)
+		);
+
+		$order_endpoint->shouldReceive( 'order' )->with( self::PAYPAL_ORDER_ID )->andReturn( $approved );
+		$order_endpoint->shouldReceive( 'patch_order_with' )->andReturnUsing(
+			static function ( Order $order_to_update ): Order {
+				return $order_to_update;
+			}
+		)->byDefault();
+		$order_endpoint->shouldReceive( 'capture' )->andReturn( $completed )->byDefault();
+
+		$this->container = $container;
+
+		return $container->get( 'button.endpoint.approve-order' );
+	}
+
+	/**
+	 * GIVEN an APPROVED PayPal order owned by the current WC session
+	 * AND a WC cart with a virtual product
+	 * WHEN ppc-approve-order is called with should_create_wc_order: true
+	 * THEN a WC order is created from the cart, paid via the PayPal gateway
+	 * AND the response contains its order-received URL in data.order_received_url
+	 * AND the plugin session is consumed by the successful payment
+	 *     (ProcessPaymentTrait destroys the session data on success)
+	 * AND chosen_payment_method is pinned to the PayPal gateway
+	 */
+	public function test_creates_wc_order_and_returns_received_url(): void {
+		$product          = $this->addVirtualProductToCart( 10.0 );
+		$endpoint         = $this->endpointWithApprovedOrder();
+		$order_ids_before = $this->currentWcOrderIds();
+
+		$response = $this->dispatchAjaxRequest(
+			$endpoint,
+			array(
+				'order_id'               => self::PAYPAL_ORDER_ID,
+				'funding_source'         => 'paypal',
+				'should_create_wc_order' => true,
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-approve-order must succeed: ' . $response['raw'] );
+
+		$new_order_ids = array_values( array_diff( $this->currentWcOrderIds(), $order_ids_before ) );
+		$this->assertCount( 1, $new_order_ids, 'Exactly one WC order must be created' );
+
+		$wc_order = wc_get_order( $new_order_ids[0] );
+		$this->trackWcOrder( $wc_order->get_id() );
+
+		$this->assertSame(
+			$wc_order->get_checkout_order_received_url(),
+			$response['data']['order_received_url'] ?? null,
+			'data.order_received_url must be the order-received URL of the created WC order'
+		);
+		$this->assertStringContainsString( 'order-received', (string) ( $response['data']['order_received_url'] ?? '' ) );
+
+		$this->assertSame( 'ppcp-gateway', $wc_order->get_payment_method() );
+		$items = array_values( $wc_order->get_items() );
+		$this->assertCount( 1, $items );
+		$this->assertSame( $product->get_id(), $items[0]->get_product_id(), 'The WC order line items must match the cart' );
+
+		$this->assertContains(
+			$wc_order->get_status(),
+			array( 'processing', 'completed' ),
+			'The happy capture path must complete the payment'
+		);
+
+		$session_handler = $this->container->get( 'session.handler' );
+		$this->assertNull( $session_handler->order(), 'The successful payment must consume the session order' );
+		$this->assertSame( 'ppcp-gateway', WC()->session->get( 'chosen_payment_method' ) );
+	}
+
+	/**
+	 * GIVEN an APPROVED PayPal order owned by the current WC session
+	 * WHEN ppc-approve-order is called without should_create_wc_order
+	 * THEN the response is a plain success with no data payload
+	 * AND no WC order is created
+	 * AND the PayPal order and funding source are stored in the plugin session
+	 *     and chosen_payment_method is pinned
+	 * (the v5 classic continuation contract: Place Order later processes the
+	 * session order)
+	 */
+	public function test_without_should_create_wc_order_stores_session_and_returns_plain_success(): void {
+		$this->addVirtualProductToCart( 10.0 );
+		$endpoint         = $this->endpointWithApprovedOrder();
+		$order_ids_before = $this->currentWcOrderIds();
+
+		$response = $this->dispatchAjaxRequest(
+			$endpoint,
+			array(
+				'order_id'       => self::PAYPAL_ORDER_ID,
+				'funding_source' => 'paypal',
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-approve-order must succeed: ' . $response['raw'] );
+		$this->assertNull( $response['data'], 'The plain success response must carry no data payload' );
+
+		$this->assertSame( array(), array_diff( $this->currentWcOrderIds(), $order_ids_before ), 'No WC order must be created' );
+
+		$session_handler = $this->container->get( 'session.handler' );
+		$this->assertSame( self::PAYPAL_ORDER_ID, $session_handler->order() ? $session_handler->order()->id() : null );
+		$this->assertSame( 'paypal', $session_handler->funding_source(), 'The funding source must be stored in the plugin session' );
+		$this->assertSame( 'ppcp-gateway', WC()->session->get( 'chosen_payment_method' ) );
+	}
+
+	/**
+	 * GIVEN a PayPal order whose custom_id binds it to a DIFFERENT WC session
+	 *       (pcp_customer_ prefix with a foreign session id)
+	 * WHEN ppc-approve-order is called with that order id
+	 * THEN the request is rejected with message "Order validation failed."
+	 * AND no WC order is created and no order is stored in the session
+	 */
+	public function test_session_ownership_mismatch_is_rejected(): void {
+		$this->addVirtualProductToCart( 10.0 );
+		$endpoint         = $this->endpointWithApprovedOrder( 'pcp_customer_someone-elses-session-id' );
+		$order_ids_before = $this->currentWcOrderIds();
+
+		$response = $this->dispatchAjaxRequest(
+			$endpoint,
+			array(
+				'order_id'               => self::PAYPAL_ORDER_ID,
+				'funding_source'         => 'paypal',
+				'should_create_wc_order' => true,
+			)
+		);
+
+		$this->assertFalse( $response['success'], 'A foreign session order must be rejected' );
+		$this->assertSame( 'Order validation failed.', $response['data']['message'] ?? null );
+
+		$this->assertSame( array(), array_diff( $this->currentWcOrderIds(), $order_ids_before ), 'No WC order must be created' );
+		$this->assertNull( $this->container->get( 'session.handler' )->order(), 'No order must be stored in the session' );
+	}
+
+	/**
+	 * GIVEN a PayPal order whose custom_id does NOT start with pcp_customer_
+	 *       (e.g. a plain WC order id)
+	 * WHEN ppc-approve-order is called
+	 * THEN the ownership check is skipped and the request succeeds
+	 */
+	public function test_non_prefixed_custom_id_skips_ownership_check(): void {
+		$this->addVirtualProductToCart( 10.0 );
+		$endpoint = $this->endpointWithApprovedOrder( '123' );
+
+		$response = $this->dispatchAjaxRequest(
+			$endpoint,
+			array(
+				'order_id'       => self::PAYPAL_ORDER_ID,
+				'funding_source' => 'paypal',
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'A non-session custom_id must skip the ownership check: ' . $response['raw'] );
+	}
+
+	/**
+	 * GIVEN a request body without an order_id
+	 * WHEN ppc-approve-order is called with a valid nonce
+	 * THEN the request is rejected with message "No order id given"
+	 * AND no PayPal API call is made
+	 */
+	public function test_missing_order_id_returns_error(): void {
+		$order_endpoint = Mockery::mock( OrderEndpoint::class );
+		$order_endpoint->shouldNotReceive( 'order' );
+
+		$container = $this->bootstrapWithOrderApi( $order_endpoint );
+		$endpoint  = $container->get( 'button.endpoint.approve-order' );
+
+		$response = $this->dispatchAjaxRequest( $endpoint, array() );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'No order id given', $response['data']['message'] ?? null );
+	}
+}

--- a/tests/integration/PHPUnit/Button/Endpoint/ChangeCartEndpointContractTest.php
+++ b/tests/integration/PHPUnit/Button/Endpoint/ChangeCartEndpointContractTest.php
@@ -1,0 +1,171 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Button\Endpoint;
+
+use WooCommerce\PayPalCommerce\Button\Endpoint\ChangeCartEndpoint;
+
+/**
+ * Contract tests for the ppc-change-cart WC-AJAX endpoint, shared by the
+ * v5 and v6 SDK frontends.
+ *
+ * @covers \WooCommerce\PayPalCommerce\Button\Endpoint\ChangeCartEndpoint
+ */
+class ChangeCartEndpointContractTest extends WcAjaxEndpointTestCase {
+
+	/** @var ChangeCartEndpoint */
+	private $endpoint;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$container      = $this->bootstrapModule();
+		$this->endpoint = $container->get( 'button.endpoint.change-cart' );
+	}
+
+	/**
+	 * GIVEN an empty WC cart and a published simple product
+	 * WHEN ppc-change-cart is called with a valid nonce and products: [{id, quantity: 2}]
+	 * THEN the response is successful
+	 * AND data is an array with one purchase unit with reference_id "default"
+	 * AND the purchase unit amount equals price × quantity in the store currency
+	 * AND the purchase unit item carries the requested quantity
+	 * AND the real WC cart contains the product with the requested quantity
+	 */
+	public function test_adds_simple_product_and_returns_purchase_units(): void {
+		$product = $this->createVirtualProduct( 10.0 );
+
+		$response = $this->dispatchAjaxRequest(
+			$this->endpoint,
+			array(
+				'products' => array(
+					array(
+						'id'       => $product->get_id(),
+						'quantity' => 2,
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-change-cart must succeed: ' . $response['raw'] );
+
+		$data = $response['data'];
+		$this->assertIsArray( $data );
+		$this->assertCount( 1, $data, 'Response must contain exactly one purchase unit' );
+		$this->assertSame( 'default', $data[0]['reference_id'] ?? null );
+		$this->assertSame( '20.00', $data[0]['amount']['value'] ?? null, 'Amount must equal price × quantity' );
+		$this->assertSame( get_woocommerce_currency(), $data[0]['amount']['currency_code'] ?? null );
+		$this->assertSame( 2, (int) ( $data[0]['items'][0]['quantity'] ?? 0 ) );
+
+		$cart_items = array_values( WC()->cart->get_cart() );
+		$this->assertCount( 1, $cart_items, 'WC cart must contain exactly one line item' );
+		$this->assertSame( $product->get_id(), $cart_items[0]['product_id'] );
+		$this->assertSame( 2, $cart_items[0]['quantity'] );
+	}
+
+	/**
+	 * GIVEN a WC cart already containing product A
+	 * WHEN ppc-change-cart is called with products: [B]
+	 * THEN the WC cart contains only product B
+	 * (the endpoint empties and repopulates the cart — the replace semantics
+	 * both frontends rely on)
+	 */
+	public function test_replaces_existing_cart_contents(): void {
+		$product_a = $this->addVirtualProductToCart( 5.0 );
+		$product_b = $this->createVirtualProduct( 10.0 );
+
+		$response = $this->dispatchAjaxRequest(
+			$this->endpoint,
+			array(
+				'products' => array(
+					array(
+						'id'       => $product_b->get_id(),
+						'quantity' => 1,
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-change-cart must succeed: ' . $response['raw'] );
+
+		$product_ids = array_column( array_values( WC()->cart->get_cart() ), 'product_id' );
+		$this->assertSame( array( $product_b->get_id() ), $product_ids, 'Cart must contain only the new product' );
+		$this->assertNotContains( $product_a->get_id(), $product_ids );
+	}
+
+	/**
+	 * GIVEN a published variable product with a "color" attribute and a "red" variation
+	 * WHEN ppc-change-cart is called with products: [{id: parent, quantity: 1,
+	 *      variations: [{name: "attribute_color", value: "red"}]}]
+	 * THEN the WC cart contains the matching variation
+	 * AND the response contains the purchase unit for it
+	 */
+	public function test_adds_variable_product_with_variations(): void {
+		$products  = $this->createVariableProduct( 15.0 );
+		$parent    = $products['parent'];
+		$variation = $products['variation'];
+
+		$response = $this->dispatchAjaxRequest(
+			$this->endpoint,
+			array(
+				'products' => array(
+					array(
+						'id'         => $parent->get_id(),
+						'quantity'   => 1,
+						'variations' => array(
+							array(
+								'name'  => 'attribute_color',
+								'value' => 'red',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-change-cart must succeed: ' . $response['raw'] );
+
+		$cart_items = array_values( WC()->cart->get_cart() );
+		$this->assertCount( 1, $cart_items );
+		$this->assertSame( $parent->get_id(), $cart_items[0]['product_id'] );
+		$this->assertSame( $variation->get_id(), $cart_items[0]['variation_id'], 'Cart line must reference the matched variation' );
+
+		$this->assertSame( '15.00', $response['data'][0]['amount']['value'] ?? null );
+	}
+
+	/**
+	 * GIVEN a request body without a products field
+	 * WHEN ppc-change-cart is called with a valid nonce
+	 * THEN the request fails with the "Necessary fields not defined" error shape
+	 */
+	public function test_missing_products_field_returns_error(): void {
+		$response = $this->dispatchAjaxRequest( $this->endpoint, array() );
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'Necessary fields not defined. Action aborted.', $response['data']['message'] ?? null );
+		$this->assertSame( 0, $response['data']['code'] ?? null );
+	}
+
+	/**
+	 * GIVEN a products entry referencing a non-existing product id
+	 * WHEN ppc-change-cart is called with a valid nonce
+	 * THEN the request fails with the "Necessary fields not defined" error shape
+	 * (unknown products are filtered out, leaving an empty products list)
+	 */
+	public function test_unknown_product_id_returns_error(): void {
+		$response = $this->dispatchAjaxRequest(
+			$this->endpoint,
+			array(
+				'products' => array(
+					array(
+						'id'       => 999999999,
+						'quantity' => 1,
+					),
+				),
+			)
+		);
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'Necessary fields not defined. Action aborted.', $response['data']['message'] ?? null );
+	}
+}

--- a/tests/integration/PHPUnit/Button/Endpoint/CreateOrderEndpointContractTest.php
+++ b/tests/integration/PHPUnit/Button/Endpoint/CreateOrderEndpointContractTest.php
@@ -1,0 +1,201 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Button\Endpoint;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+
+/**
+ * Contract tests for the ppc-create-order WC-AJAX endpoint, shared by the
+ * v5 and v6 SDK frontends.
+ *
+ * @covers \WooCommerce\PayPalCommerce\Button\Endpoint\CreateOrderEndpoint
+ */
+class CreateOrderEndpointContractTest extends WcAjaxEndpointTestCase {
+
+	private const PAYPAL_ORDER_ID = 'TEST-PAYPAL-ORDER-123';
+
+	/**
+	 * Arguments captured from the mocked OrderEndpoint::create() call.
+	 *
+	 * @var array|null
+	 */
+	private $captured_create;
+
+	/**
+	 * Boots the container with a mocked PayPal order API whose create() returns
+	 * a real Order wrapping the purchase units the endpoint built from the live
+	 * cart, and captures the call arguments.
+	 *
+	 * @return object The ppc-create-order endpoint.
+	 */
+	private function endpointWithMockedCreate() {
+		$this->captured_create = null;
+		$captured              = &$this->captured_create;
+
+		$order_endpoint = Mockery::mock( OrderEndpoint::class );
+		$order_endpoint->shouldReceive( 'with_bn_code' )->andReturnSelf()->byDefault();
+		$order_endpoint->shouldReceive( 'create' )->andReturnUsing(
+			function ( array $purchase_units, string $shipping_preference ) use ( &$captured ): Order {
+				$captured = array(
+					'purchase_units'      => $purchase_units,
+					'shipping_preference' => $shipping_preference,
+				);
+
+				return new Order(
+					self::PAYPAL_ORDER_ID,
+					$purchase_units,
+					new OrderStatus( OrderStatus::CREATED )
+				);
+			}
+		);
+
+		$container = $this->bootstrapWithOrderApi( $order_endpoint );
+
+		return $container->get( 'button.endpoint.create-order' );
+	}
+
+	/**
+	 * The non-checkout contexts sharing the same create-order contract.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function nonCheckoutContextProvider(): array {
+		return array(
+			'cart context'    => array( 'cart' ),
+			'product context' => array( 'product' ),
+		);
+	}
+
+	/**
+	 * GIVEN a populated WC cart (virtual product, price 10, quantity 2)
+	 * WHEN ppc-create-order is called with a valid nonce and context: cart or product
+	 * THEN the response contains the PayPal order id in data.id and a custom_id key
+	 * AND the order is created from exactly one purchase unit reflecting the cart total
+	 * AND the purchase unit custom_id is blanked (non-checkout contexts must not
+	 *     allow webhook completion binding)
+	 * AND no PayPal order is stored in the plugin session
+	 *
+	 * The product context additionally requires purchase_units[0].items[0].url
+	 * in the request body (the product page URL, consumed by ReturnUrlFactory
+	 * as the PayPal return URL).
+	 *
+	 * @dataProvider nonCheckoutContextProvider
+	 *
+	 * @param string $context The request context.
+	 */
+	public function test_non_checkout_context_returns_paypal_order_id( string $context ): void {
+		$product  = $this->addVirtualProductToCart( 10.0, 2 );
+		$endpoint = $this->endpointWithMockedCreate();
+
+		$body = array(
+			'context'        => $context,
+			'payment_method' => 'ppcp-gateway',
+			'funding_source' => 'paypal',
+		);
+		if ( 'product' === $context ) {
+			$body['purchase_units'] = array(
+				array(
+					'items' => array(
+						array( 'url' => get_permalink( $product->get_id() ) ),
+					),
+				),
+			);
+		}
+
+		$response = $this->dispatchAjaxRequest( $endpoint, $body );
+
+		$this->assertTrue( $response['success'], 'ppc-create-order must succeed: ' . $response['raw'] );
+		$this->assertSame( self::PAYPAL_ORDER_ID, $response['data']['id'] ?? null, 'data.id must be the PayPal order id' );
+		$this->assertArrayHasKey( 'custom_id', $response['data'] );
+
+		$this->assertNotNull( $this->captured_create, 'The PayPal create order API must be called' );
+		$this->assertCount( 1, $this->captured_create['purchase_units'] );
+
+		$purchase_unit = $this->captured_create['purchase_units'][0];
+		$this->assertInstanceOf( PurchaseUnit::class, $purchase_unit );
+		$this->assertSame( '20.00', $purchase_unit->to_array()['amount']['value'], 'Amount must equal the cart total' );
+		$this->assertSame( '', $purchase_unit->custom_id(), ucfirst( $context ) . ' context must blank the purchase unit custom_id' );
+		$this->assertNotSame( '', $this->captured_create['shipping_preference'] );
+
+		$session_handler = $this->getContainer()->get( 'session.handler' );
+		$this->assertNull( $session_handler->order(), ucfirst( $context ) . ' context must not store a session order' );
+	}
+
+	/**
+	 * GIVEN a populated WC cart
+	 * WHEN ppc-create-order creates the PayPal order
+	 * THEN the woocommerce_paypal_payments_create_order_endpoint_order_created
+	 *      action fires once with the created Order entity and the request data
+	 * (the hook the v6 SDK module consumes to store session orders for
+	 * non-checkout contexts)
+	 */
+	public function test_create_order_endpoint_fires_order_created_action(): void {
+		$this->addVirtualProductToCart( 10.0 );
+		$endpoint = $this->endpointWithMockedCreate();
+
+		$calls = $this->recordAction( 'woocommerce_paypal_payments_create_order_endpoint_order_created', 2 );
+
+		$response = $this->dispatchAjaxRequest(
+			$endpoint,
+			array(
+				'context'        => 'cart',
+				'payment_method' => 'ppcp-gateway',
+				'funding_source' => 'paypal',
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-create-order must succeed: ' . $response['raw'] );
+		$this->assertCount( 1, $calls, 'The order_created action must fire exactly once' );
+
+		list( $order, $data ) = $calls[0];
+		$this->assertInstanceOf( Order::class, $order );
+		$this->assertSame( self::PAYPAL_ORDER_ID, $order->id() );
+		$this->assertIsArray( $data );
+		$this->assertSame( 'cart', $data['context'] ?? null, 'The action must receive the sanitized request data' );
+	}
+
+	/**
+	 * GIVEN a populated WC cart
+	 * WHEN ppc-create-order is called with context: checkout, the PayPal gateway
+	 *      and no redirect-less funding source
+	 * THEN the created PayPal order is stored in the plugin session ('ppcp' key)
+	 * AND the purchase unit keeps the session-bound custom_id
+	 *      (pcp_customer_ + WC session customer id) used by the
+	 *      approve-order ownership check
+	 */
+	public function test_checkout_context_stores_order_in_session(): void {
+		$this->addVirtualProductToCart( 10.0 );
+		$endpoint = $this->endpointWithMockedCreate();
+
+		$response = $this->dispatchAjaxRequest(
+			$endpoint,
+			array(
+				'context'        => 'checkout',
+				'payment_method' => 'ppcp-gateway',
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-create-order must succeed: ' . $response['raw'] );
+		$this->assertSame( self::PAYPAL_ORDER_ID, $response['data']['id'] ?? null );
+
+		$session_handler = $this->getContainer()->get( 'session.handler' );
+		$session_order   = $session_handler->order();
+		$this->assertNotNull( $session_order, 'Checkout context must store the PayPal order in the session' );
+		$this->assertSame( self::PAYPAL_ORDER_ID, $session_order->id() );
+
+		$stored = WC()->session->get( 'ppcp' );
+		$this->assertInstanceOf( Order::class, $stored['order'] ?? null, 'The session order must be stored as an Order entity under the ppcp session key' );
+
+		$purchase_unit = $this->captured_create['purchase_units'][0];
+		$this->assertSame(
+			$this->sessionCustomId(),
+			$purchase_unit->custom_id(),
+			'Checkout context must keep the session-bound custom_id on the purchase unit'
+		);
+	}
+}

--- a/tests/integration/PHPUnit/Button/Endpoint/RequestDataContractTest.php
+++ b/tests/integration/PHPUnit/Button/Endpoint/RequestDataContractTest.php
@@ -1,0 +1,206 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Button\Endpoint;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+/**
+ * Contract tests for the request plumbing shared by all ppc-* order WC-AJAX
+ * endpoints: the JSON body read from php://input, the nonce field, and the
+ * guest-session nonce fix.
+ *
+ * @covers \WooCommerce\PayPalCommerce\Button\Endpoint\RequestData
+ */
+class RequestDataContractTest extends WcAjaxEndpointTestCase {
+
+	/** @var ContainerInterface */
+	protected $container;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Any PayPal API call on a rejected request is a contract violation.
+		$order_endpoint = Mockery::mock( OrderEndpoint::class );
+		$order_endpoint->shouldNotReceive( 'create' );
+		$order_endpoint->shouldNotReceive( 'order' );
+		$order_endpoint->shouldNotReceive( 'patch' );
+
+		$this->container = $this->bootstrapWithOrderApi( $order_endpoint );
+	}
+
+	/**
+	 * The four shared order endpoints, by container service key.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function endpointProvider(): array {
+		return array(
+			'ppc-create-order'    => array( 'button.endpoint.create-order' ),
+			'ppc-change-cart'     => array( 'button.endpoint.change-cart' ),
+			'ppc-approve-order'   => array( 'button.endpoint.approve-order' ),
+			'ppc-update-shipping' => array( 'blocks.endpoint.update-shipping' ),
+		);
+	}
+
+	/**
+	 * GIVEN any of the four shared order endpoints
+	 * WHEN it is called with an invalid nonce in the JSON body
+	 * THEN the request is rejected with HTTP 400
+	 * AND data.message is "Could not validate nonce."
+	 * AND no PayPal API call is made
+	 *
+	 * @dataProvider endpointProvider
+	 *
+	 * @param string $service_key The endpoint's container service key.
+	 */
+	public function test_invalid_nonce_is_rejected_with_400( string $service_key ): void {
+		$endpoint = $this->container->get( $service_key );
+
+		$response = $this->dispatchAjaxRequest( $endpoint, array( 'nonce' => 'invalid-nonce' ) );
+
+		$this->assertFalse( $response['success'], $service_key . ' must reject an invalid nonce' );
+		$this->assertSame( 400, $response['status'], $service_key . ' must respond with HTTP 400' );
+		$this->assertSame( 'Could not validate nonce.', $response['data']['message'] ?? null );
+	}
+
+	/**
+	 * GIVEN a request body without a nonce field
+	 * WHEN a shared order endpoint is called
+	 * THEN the request is rejected exactly like an invalid nonce
+	 *
+	 * @dataProvider endpointProvider
+	 *
+	 * @param string $service_key The endpoint's container service key.
+	 */
+	public function test_missing_nonce_field_is_rejected( string $service_key ): void {
+		$endpoint = $this->container->get( $service_key );
+
+		$response = $this->dispatchAjaxRequest( $endpoint, array( 'nonce' => null ) );
+
+		$this->assertFalse( $response['success'], $service_key . ' must reject a missing nonce' );
+		$this->assertSame( 400, $response['status'] );
+		$this->assertSame( 'Could not validate nonce.', $response['data']['message'] ?? null );
+	}
+
+	/**
+	 * GIVEN a valid nonce in the JSON body and a different, invalid nonce in $_POST
+	 * WHEN ppc-change-cart is called
+	 * THEN the request succeeds
+	 * (the JSON body read from php://input is the source of truth, not POST fields)
+	 */
+	public function test_nonce_in_json_body_not_post_is_accepted(): void {
+		$product  = $this->createVirtualProduct( 10.0 );
+		$endpoint = $this->container->get( 'button.endpoint.change-cart' );
+
+		$_POST['nonce'] = 'invalid-post-nonce';
+		try {
+			$response = $this->dispatchAjaxRequest(
+				$endpoint,
+				array(
+					'products' => array(
+						array(
+							'id'       => $product->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			);
+		} finally {
+			unset( $_POST['nonce'] );
+		}
+
+		$this->assertTrue( $response['success'], 'The JSON body nonce must be the source of truth: ' . $response['raw'] );
+	}
+
+	/**
+	 * GIVEN a nonce rendered for a logged-out visitor (uid 0)
+	 * AND a third-party/legacy filter later mapping the logged-out nonce uid to
+	 *     the WC customer session id (the situation RequestData::nonce_fix() exists for:
+	 *     WC provides the customer object only from the second request on)
+	 * WHEN ppc-change-cart is called with that nonce
+	 * THEN the request still succeeds, because RequestData forces the logged-out
+	 *      uid back to 0 (priority 100) during verification
+	 * AND without that fix the same nonce fails plain wp_verify_nonce()
+	 */
+	public function test_guest_nonce_survives_wc_customer_session_uid_change(): void {
+		$product  = $this->createVirtualProduct( 10.0 );
+		$endpoint = $this->container->get( 'button.endpoint.change-cart' );
+
+		$nonce = $this->createFrontendNonce( 'ppc-change-cart' );
+
+		$uid_change = static function (): int {
+			return 424242;
+		};
+		add_filter( 'nonce_user_logged_out', $uid_change, 10 );
+		try {
+			$this->assertFalse(
+				(bool) wp_verify_nonce( $nonce, 'ppc-change-cart' ),
+				'Control: without the nonce fix, the guest nonce must fail verification'
+			);
+
+			$response = $this->dispatchAjaxRequest(
+				$endpoint,
+				array(
+					'nonce'    => $nonce,
+					'products' => array(
+						array(
+							'id'       => $product->get_id(),
+							'quantity' => 1,
+						),
+					),
+				)
+			);
+		} finally {
+			remove_filter( 'nonce_user_logged_out', $uid_change, 10 );
+		}
+
+		$this->assertTrue( $response['success'], 'The guest-session nonce fix must make the request pass: ' . $response['raw'] );
+	}
+
+	/**
+	 * GIVEN a request body with a form_encoded field (urlencoded string)
+	 * WHEN ppc-create-order is called
+	 * THEN the endpoint receives the parsed form array under the form key,
+	 *      with urlencoded values decoded
+	 * (observed through the order_created action, which receives the parsed
+	 * request data)
+	 */
+	public function test_form_encoded_is_parsed_into_form_array(): void {
+		$this->addVirtualProductToCart( 10.0 );
+
+		$order_endpoint = Mockery::mock( OrderEndpoint::class );
+		$order_endpoint->shouldReceive( 'with_bn_code' )->andReturnSelf()->byDefault();
+		$order_endpoint->shouldReceive( 'create' )->andReturnUsing(
+			static function ( array $purchase_units ): Order {
+				return new Order( 'TEST-PAYPAL-ORDER-123', $purchase_units, new OrderStatus( OrderStatus::CREATED ) );
+			}
+		);
+		$container = $this->bootstrapWithOrderApi( $order_endpoint );
+		$endpoint  = $container->get( 'button.endpoint.create-order' );
+
+		$calls = $this->recordAction( 'woocommerce_paypal_payments_create_order_endpoint_order_created', 2 );
+
+		$response = $this->dispatchAjaxRequest(
+			$endpoint,
+			array(
+				'context'        => 'cart',
+				'payment_method' => 'ppcp-gateway',
+				'funding_source' => 'paypal',
+				'form_encoded'   => 'billing_email=a%40b.com&terms=1',
+			)
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-create-order must succeed: ' . $response['raw'] );
+		$this->assertCount( 1, $calls );
+
+		$data = $calls[0][1];
+		$this->assertSame( 'a@b.com', $data['form']['billing_email'] ?? null, 'form_encoded must be parsed into the form array' );
+		$this->assertSame( '1', $data['form']['terms'] ?? null );
+		$this->assertSame( 'billing_email=a%40b.com&terms=1', $data['form_encoded'] ?? null, 'form_encoded itself must be preserved unsanitized' );
+	}
+}

--- a/tests/integration/PHPUnit/Button/Endpoint/UpdateShippingEndpointContractTest.php
+++ b/tests/integration/PHPUnit/Button/Endpoint/UpdateShippingEndpointContractTest.php
@@ -1,0 +1,125 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Button\Endpoint;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PatchCollection;
+use WooCommerce\PayPalCommerce\Tests\Integration\Fixtures\PayPalOrderPresets;
+
+/**
+ * Contract tests for the ppc-update-shipping WC-AJAX endpoint, shared by the
+ * v5 and v6 SDK frontends.
+ *
+ * @covers \WooCommerce\PayPalCommerce\Blocks\Endpoint\UpdateShippingEndpoint
+ */
+class UpdateShippingEndpointContractTest extends WcAjaxEndpointTestCase {
+
+	private const PAYPAL_ORDER_ID = 'TEST-PAYPAL-ORDER-123';
+
+	/**
+	 * Stores a real PayPal Order entity in the plugin session.
+	 *
+	 * @param \WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface $container The plugin container.
+	 * @param string                                                              $order_id The PayPal order id.
+	 * @return void
+	 */
+	private function storeSessionOrder( $container, string $order_id ): void {
+		$order = $container->get( 'api.factory.order' )->from_paypal_response(
+			json_decode( (string) wp_json_encode( PayPalOrderPresets::order( $order_id, 'APPROVED', $this->sessionCustomId() ) ) )
+		);
+		$container->get( 'session.handler' )->replace_order( $order );
+	}
+
+	/**
+	 * GIVEN a PayPal order stored in the plugin session
+	 * AND a WC cart with a virtual product (price 10, quantity 3)
+	 * WHEN ppc-update-shipping is called with the matching order_id
+	 * THEN the PayPal order is patched with exactly one replace operation on
+	 *      /purchase_units/@reference_id=='default'
+	 * AND the patch value carries the recalculated cart total and the
+	 *     session-bound custom_id
+	 * AND the response is a plain success with no data payload
+	 */
+	public function test_patches_paypal_order_with_recalculated_totals(): void {
+		$captured = null;
+
+		$order_endpoint = Mockery::mock( OrderEndpoint::class );
+		$order_endpoint->shouldReceive( 'patch' )->once()->withArgs(
+			function ( string $order_id, PatchCollection $patches ) use ( &$captured ): bool {
+				$captured = array( $order_id, $patches );
+				return true;
+			}
+		);
+
+		$container = $this->bootstrapWithOrderApi( $order_endpoint );
+		$this->storeSessionOrder( $container, self::PAYPAL_ORDER_ID );
+		$this->addVirtualProductToCart( 10.0, 3 );
+
+		$response = $this->dispatchAjaxRequest(
+			$container->get( 'blocks.endpoint.update-shipping' ),
+			array( 'order_id' => self::PAYPAL_ORDER_ID )
+		);
+
+		$this->assertTrue( $response['success'], 'ppc-update-shipping must succeed: ' . $response['raw'] );
+		$this->assertNull( $response['data'], 'The success response must carry no data payload' );
+
+		$this->assertNotNull( $captured, 'The PayPal patch API must be called' );
+		list( $order_id, $patches ) = $captured;
+		$this->assertSame( self::PAYPAL_ORDER_ID, $order_id );
+
+		$patch_list = $patches->patches();
+		$this->assertCount( 1, $patch_list, 'Exactly one patch operation must be sent' );
+
+		$patch = $patch_list[0];
+		$this->assertSame( 'replace', $patch->op() );
+		$this->assertSame( "/purchase_units/@reference_id=='default'", $patch->path() );
+
+		$value = $patch->value();
+		$this->assertSame( 'default', $value['reference_id'] ?? null );
+		$this->assertSame( '30.00', $value['amount']['value'] ?? null, 'The patch must carry the recalculated cart total' );
+		$this->assertSame( $this->sessionCustomId(), $value['custom_id'] ?? null, 'The patch must keep the session-bound custom_id' );
+	}
+
+	/**
+	 * The session states that must cause a rejection.
+	 *
+	 * @return array<string, array{0: string|null}>
+	 */
+	public function sessionMismatchProvider(): array {
+		return array(
+			'different session order id' => array( 'TEST-OTHER-ORDER-456' ),
+			'no session order'           => array( null ),
+		);
+	}
+
+	/**
+	 * GIVEN no PayPal order in the plugin session, or one with a different id
+	 * WHEN ppc-update-shipping is called with an order_id
+	 * THEN the request is rejected with message "Order validation failed."
+	 * AND the PayPal patch API is never called
+	 *
+	 * @dataProvider sessionMismatchProvider
+	 *
+	 * @param string|null $session_order_id The PayPal order id in the session, or null for none.
+	 */
+	public function test_session_order_id_mismatch_returns_error( ?string $session_order_id ): void {
+		$order_endpoint = Mockery::mock( OrderEndpoint::class );
+		$order_endpoint->shouldNotReceive( 'patch' );
+
+		$container = $this->bootstrapWithOrderApi( $order_endpoint );
+		if ( null !== $session_order_id ) {
+			$this->storeSessionOrder( $container, $session_order_id );
+		}
+		$this->addVirtualProductToCart( 10.0 );
+
+		$response = $this->dispatchAjaxRequest(
+			$container->get( 'blocks.endpoint.update-shipping' ),
+			array( 'order_id' => self::PAYPAL_ORDER_ID )
+		);
+
+		$this->assertFalse( $response['success'], 'ppc-update-shipping must reject a session mismatch' );
+		$this->assertSame( 'Order validation failed.', $response['data']['message'] ?? null );
+	}
+}

--- a/tests/integration/PHPUnit/Button/Endpoint/WcAjaxEndpointTestCase.php
+++ b/tests/integration/PHPUnit/Button/Endpoint/WcAjaxEndpointTestCase.php
@@ -1,0 +1,196 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Button\Endpoint;
+
+use WC_Product_Simple;
+use WC_Product_Variable;
+use WC_Product_Variation;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
+use WooCommerce\PayPalCommerce\Tests\Integration\IntegrationMockedTestCase;
+use WooCommerce\PayPalCommerce\Tests\Integration\Traits\HandlesWcAjaxEndpoints;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use WooCommerce\PayPalCommerce\Webhooks\CustomIds;
+
+/**
+ * Base class for the contract tests of the shared order WC-AJAX endpoints
+ * (ppc-create-order, ppc-change-cart, ppc-approve-order, ppc-update-shipping).
+ */
+abstract class WcAjaxEndpointTestCase extends IntegrationMockedTestCase {
+
+	use HandlesWcAjaxEndpoints;
+
+	/** @var int[] */
+	protected $postIds = array();
+
+	/** @var int[] */
+	protected $wcOrderIds = array();
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// SessionModule hooks ppcp_session_get_order to reload non-approved session
+		// orders through its container's api.endpoint.order. Every bootstrapModule()
+		// registers another listener, so reading a CREATED session order would go
+		// through stale containers of earlier tests (dead mocks) and through the
+		// process-level plugin container (real HTTP). Drop them; the container
+		// bootstrapped by the current test re-registers its own.
+		remove_all_actions( 'ppcp_session_get_order' );
+
+		$this->resetWcFrontendState();
+	}
+
+	public function tearDown(): void {
+		$this->tearDownHarnessHooks();
+
+		foreach ( $this->wcOrderIds as $order_id ) {
+			$order = wc_get_order( $order_id );
+			if ( $order ) {
+				$order->delete( true );
+			}
+		}
+		$this->wcOrderIds = array();
+
+		foreach ( $this->postIds as $id ) {
+			wp_delete_post( $id, true );
+		}
+		$this->postIds = array();
+
+		$this->resetWcFrontendState();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Boots the plugin container with the PayPal order API replaced by a mock
+	 * (no real HTTP), plus optional further service overrides.
+	 *
+	 * @param OrderEndpoint $order_endpoint The mocked api.endpoint.order.
+	 * @param array         $extra Additional service overrides.
+	 * @return ContainerInterface
+	 */
+	protected function bootstrapWithOrderApi( OrderEndpoint $order_endpoint, array $extra = array() ): ContainerInterface {
+		$overrides                       = $extra;
+		$overrides['api.endpoint.order'] = static function () use ( $order_endpoint ): OrderEndpoint {
+			return $order_endpoint;
+		};
+
+		return $this->bootstrapModule( $overrides );
+	}
+
+	/**
+	 * The custom id bound to the current WC session, as PurchaseUnitFactory computes it.
+	 *
+	 * Must be read at assertion time: the session may be (re)initialized by
+	 * resetWcFrontendState().
+	 *
+	 * @return string
+	 */
+	protected function sessionCustomId(): string {
+		return CustomIds::CUSTOMER_ID_PREFIX . WC()->session->get_customer_unique_id();
+	}
+
+	/**
+	 * Creates a published virtual product (virtual, so approve-order flows do not
+	 * require a chosen shipping method).
+	 *
+	 * @param float $price The product price.
+	 * @return WC_Product_Simple
+	 */
+	protected function createVirtualProduct( float $price = 10.0 ): WC_Product_Simple {
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test product ' . uniqid() );
+		$product->set_status( 'publish' );
+		$product->set_regular_price( (string) $price );
+		$product->set_virtual( true );
+		$product->save();
+
+		$this->postIds[] = $product->get_id();
+
+		return $product;
+	}
+
+	/**
+	 * Creates a virtual product and puts it into the real WC cart.
+	 *
+	 * @param float $price The product price.
+	 * @param int   $quantity The quantity.
+	 * @return WC_Product_Simple
+	 */
+	protected function addVirtualProductToCart( float $price = 10.0, int $quantity = 1 ): WC_Product_Simple {
+		$product = $this->createVirtualProduct( $price );
+
+		WC()->cart->add_to_cart( $product->get_id(), $quantity );
+		WC()->cart->calculate_totals();
+
+		return $product;
+	}
+
+	/**
+	 * Creates a variable product with a 'color' attribute and a 'red' variation.
+	 *
+	 * @param float $price The variation price.
+	 * @return array{parent: WC_Product_Variable, variation: WC_Product_Variation}
+	 */
+	protected function createVariableProduct( float $price = 10.0 ): array {
+		// Use a custom (non-taxonomy) attribute to avoid needing registered taxonomies.
+		$attribute = new \WC_Product_Attribute();
+		$attribute->set_name( 'color' );
+		$attribute->set_options( array( 'red', 'blue' ) );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Test variable ' . uniqid() );
+		$parent->set_status( 'publish' );
+		$parent->set_attributes( array( $attribute ) );
+		$parent->save();
+
+		$this->postIds[] = $parent->get_id();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $parent->get_id() );
+		$variation->set_regular_price( (string) $price );
+		$variation->set_attributes( array( 'color' => 'red' ) );
+		$variation->set_status( 'publish' );
+		$variation->set_virtual( true );
+		$variation->save();
+
+		$this->postIds[] = $variation->get_id();
+
+		// Sync so data store can find the variation.
+		WC_Product_Variable::sync( $parent->get_id() );
+
+		return array(
+			'parent'    => $parent,
+			'variation' => $variation,
+		);
+	}
+
+	/**
+	 * The ids of all WC orders currently in the database.
+	 *
+	 * @return int[]
+	 */
+	protected function currentWcOrderIds(): array {
+		return array_map(
+			'intval',
+			wc_get_orders(
+				array(
+					'limit'  => -1,
+					'return' => 'ids',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Tracks a WC order for deletion in tearDown().
+	 *
+	 * @param int $order_id The WC order id.
+	 * @return void
+	 */
+	protected function trackWcOrder( int $order_id ): void {
+		$this->wcOrderIds[] = $order_id;
+	}
+}

--- a/tests/integration/PHPUnit/Button/Endpoint/WcAjaxHookRegistrationContractTest.php
+++ b/tests/integration/PHPUnit/Button/Endpoint/WcAjaxHookRegistrationContractTest.php
@@ -1,0 +1,52 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Button\Endpoint;
+
+use WooCommerce\PayPalCommerce\Tests\Integration\TestCase;
+
+/**
+ * Pins the browser-facing WC-AJAX registration of the shared order endpoints:
+ * the wc_ajax_ppc-* action names both SDK frontends POST to.
+ *
+ * Note: ppc-update-shipping is currently registered by the ppcp-blocks module
+ * and only when WC Blocks is available (BlocksModule::run() returns early
+ * otherwise) — the relocation ticket moves it to a neutral module. This test
+ * asserts the names under a normal boot; renaming an ENDPOINT constant or
+ * dropping a registration breaks it.
+ *
+ * @covers \WooCommerce\PayPalCommerce\Button\ButtonModule
+ * @covers \WooCommerce\PayPalCommerce\Blocks\BlocksModule
+ */
+class WcAjaxHookRegistrationContractTest extends TestCase {
+
+	/**
+	 * The wc_ajax_ actions of the shared order endpoints.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function wcAjaxHookProvider(): array {
+		return array(
+			'ppc-create-order'    => array( 'wc_ajax_ppc-create-order' ),
+			'ppc-change-cart'     => array( 'wc_ajax_ppc-change-cart' ),
+			'ppc-approve-order'   => array( 'wc_ajax_ppc-approve-order' ),
+			'ppc-update-shipping' => array( 'wc_ajax_ppc-update-shipping' ),
+		);
+	}
+
+	/**
+	 * GIVEN the plugin booted normally (WC Blocks available)
+	 * WHEN the modules have run
+	 * THEN each shared order endpoint is registered under its wc_ajax_ppc-* action
+	 *
+	 * @dataProvider wcAjaxHookProvider
+	 *
+	 * @param string $hook The wc_ajax_ action name.
+	 */
+	public function test_shared_order_endpoint_is_registered( string $hook ): void {
+		$this->assertNotFalse(
+			has_action( $hook ),
+			"The $hook action must be registered — it is the browser-facing entry point of a shared order endpoint"
+		);
+	}
+}

--- a/tests/integration/PHPUnit/Factories/ProductFactory.php
+++ b/tests/integration/PHPUnit/Factories/ProductFactory.php
@@ -73,7 +73,7 @@ class ProductFactory
         $product->set_status('publish');
         $product->save();
 
-        $this->created_product_ids[] = $product_id;
+        $this->created_product_ids[] = $product->get_id();
 
         return $product;
     }
@@ -102,8 +102,8 @@ class ProductFactory
         $variation->set_status('publish');
         $variation->save();
 
-        $this->created_product_ids[] = $product_id;
-        $this->created_product_ids[] = $preset['variation_id'];
+        $this->created_product_ids[] = $parent->get_id();
+        $this->created_product_ids[] = $variation->get_id();
 
         return $variation;
     }

--- a/tests/integration/PHPUnit/Fixtures/PayPalOrderPresets.php
+++ b/tests/integration/PHPUnit/Fixtures/PayPalOrderPresets.php
@@ -1,0 +1,103 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Fixtures;
+
+/**
+ * PayPal-order-shaped array presets for the WC-AJAX endpoint contract tests.
+ *
+ * Materialize into real api-client entities via the order factory, e.g.:
+ *
+ *   $order = $container->get( 'api.factory.order' )
+ *       ->from_paypal_response( json_decode( (string) wp_json_encode( $preset ) ) );
+ *
+ * Real entities (unlike Mockery mocks) survive serialization into the WC
+ * session through SessionHandler::replace_order() and expose working
+ * purchase units for the ownership checks and the WC order creator.
+ */
+final class PayPalOrderPresets {
+
+	/**
+	 * A minimal PayPal order with one purchase unit.
+	 *
+	 * @param string $id The PayPal order id.
+	 * @param string $status The order status (CREATED | APPROVED | COMPLETED).
+	 * @param string $custom_id The purchase unit custom id (compute at runtime from the WC session).
+	 * @param string $value The amount value.
+	 * @param string $currency The currency code.
+	 * @param array  $overrides Recursive overrides merged into the preset.
+	 * @return array
+	 */
+	public static function order(
+		string $id,
+		string $status,
+		string $custom_id = '',
+		string $value = '10.00',
+		string $currency = 'USD',
+		array $overrides = array()
+	): array {
+		return array_replace_recursive(
+			array(
+				'id'             => $id,
+				'intent'         => 'CAPTURE',
+				'status'         => $status,
+				'purchase_units' => array(
+					array(
+						'reference_id' => 'default',
+						'custom_id'    => $custom_id,
+						'amount'       => array(
+							'currency_code' => $currency,
+							'value'         => $value,
+						),
+					),
+				),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * A COMPLETED PayPal order with a completed capture, as returned by the
+	 * capture call the order processor performs.
+	 *
+	 * @param string $id The PayPal order id.
+	 * @param string $custom_id The purchase unit custom id.
+	 * @param string $value The amount value.
+	 * @param string $currency The currency code.
+	 * @return array
+	 */
+	public static function completedWithCapture(
+		string $id,
+		string $custom_id = '',
+		string $value = '10.00',
+		string $currency = 'USD'
+	): array {
+		return self::order(
+			$id,
+			'COMPLETED',
+			$custom_id,
+			$value,
+			$currency,
+			array(
+				'purchase_units' => array(
+					array(
+						'payments' => array(
+							'captures' => array(
+								array(
+									'id'                => 'TEST-CAPTURE-1',
+									'status'            => 'COMPLETED',
+									'final_capture'     => true,
+									'amount'            => array(
+										'currency_code' => $currency,
+										'value'         => $value,
+									),
+									'seller_protection' => array( 'status' => 'ELIGIBLE' ),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+}

--- a/tests/integration/PHPUnit/Helper/PhpInputStreamStub.php
+++ b/tests/integration/PHPUnit/Helper/PhpInputStreamStub.php
@@ -1,0 +1,114 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Helper;
+
+/**
+ * Stream wrapper stub that serves a preset body for php://input.
+ *
+ * RequestData::read_request() reads the request body via
+ * file_get_contents( 'php://input' ), which cannot be populated in CLI PHPUnit.
+ * Tests register this wrapper for the 'php' scheme only around handle_request()
+ * (and restore the native wrapper in a finally block).
+ *
+ * Every stream_open() serves a fresh copy of self::$body — some endpoints read
+ * php://input more than once per request (e.g. ChangeCartEndpoint::handle_data()
+ * and AbstractCartEndpoint::products_from_request()).
+ *
+ * Any php:// path other than php://input fails loudly, so an unexpected
+ * php://temp / php://memory consumer inside the dispatch window surfaces as a
+ * diagnosable test failure instead of silent corruption.
+ */
+final class PhpInputStreamStub {
+
+	/**
+	 * The body served for php://input.
+	 *
+	 * @var string
+	 */
+	public static $body = '';
+
+	/**
+	 * The stream context (set by PHP, unused).
+	 *
+	 * @var resource|null
+	 */
+	public $context;
+
+	/**
+	 * The data served by this stream instance.
+	 *
+	 * @var string
+	 */
+	private $data = '';
+
+	/**
+	 * The current read position.
+	 *
+	 * @var int
+	 */
+	private $position = 0;
+
+	/**
+	 * Opens the stream.
+	 *
+	 * @param string $path The requested path.
+	 * @param string $mode The open mode.
+	 * @param int    $options Stream options.
+	 * @param string $opened_path The opened path (by reference).
+	 * @return bool
+	 */
+	public function stream_open( string $path, string $mode, int $options, ?string &$opened_path ): bool {
+		if ( 'php://input' !== $path ) {
+			trigger_error( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+				'PhpInputStreamStub only supports php://input, got ' . $path,
+				E_USER_WARNING
+			);
+			return false;
+		}
+
+		$this->data     = self::$body;
+		$this->position = 0;
+
+		return true;
+	}
+
+	/**
+	 * Reads from the stream.
+	 *
+	 * @param int $count Number of bytes to read.
+	 * @return string
+	 */
+	public function stream_read( int $count ): string {
+		$chunk           = substr( $this->data, $this->position, $count );
+		$this->position += strlen( $chunk );
+
+		return $chunk;
+	}
+
+	/**
+	 * Whether the end of the stream was reached.
+	 *
+	 * @return bool
+	 */
+	public function stream_eof(): bool {
+		return $this->position >= strlen( $this->data );
+	}
+
+	/**
+	 * Returns stream metadata (file_get_contents uses the size as a read hint).
+	 *
+	 * @return array
+	 */
+	public function stream_stat(): array {
+		return array( 'size' => strlen( $this->data ) );
+	}
+
+	/**
+	 * Closes the stream.
+	 *
+	 * @return void
+	 */
+	public function stream_close(): void {
+	}
+}

--- a/tests/integration/PHPUnit/Helper/WpAjaxDieSignal.php
+++ b/tests/integration/PHPUnit/Helper/WpAjaxDieSignal.php
@@ -1,0 +1,17 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Helper;
+
+/**
+ * Thrown by the test wp_die AJAX handler to unwind out of wp_send_json_*().
+ *
+ * Extends \Error on purpose: the WC-AJAX endpoints wrap their wp_send_json_*
+ * calls in broad catch ( Exception ) blocks (see AbstractCartEndpoint::handle_request(),
+ * CreateOrderEndpoint::handle_request()). An \Exception-based signal would be
+ * swallowed there and the endpoint would respond a second time. No endpoint
+ * catches \Throwable around a wp_send_json_* call, so \Error escapes cleanly.
+ */
+final class WpAjaxDieSignal extends \Error {
+
+}

--- a/tests/integration/PHPUnit/Traits/HandlesWcAjaxEndpoints.php
+++ b/tests/integration/PHPUnit/Traits/HandlesWcAjaxEndpoints.php
@@ -1,0 +1,175 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Traits;
+
+use WooCommerce\PayPalCommerce\Tests\Integration\Helper\PhpInputStreamStub;
+use WooCommerce\PayPalCommerce\Tests\Integration\Helper\WpAjaxDieSignal;
+
+/**
+ * Dispatches simulated WC-AJAX requests against endpoint objects.
+ *
+ * The ppc-* order endpoints read a JSON body from php://input (via RequestData)
+ * and respond with wp_send_json_success()/wp_send_json_error(), which dies.
+ * This trait makes both work in CLI PHPUnit:
+ * - the request body is served by PhpInputStreamStub (registered only around
+ *   handle_request() and restored in a finally block),
+ * - wp_doing_ajax is forced to true so wp_send_json() routes through wp_die(),
+ *   whose 'wp_die_ajax_handler' filter is replaced with a handler throwing
+ *   WpAjaxDieSignal, unwinding back to the test with the echoed JSON captured
+ *   in an output buffer.
+ */
+trait HandlesWcAjaxEndpoints {
+
+	/**
+	 * Hooks added during a test via recordAction(), removed in tearDownHarnessHooks().
+	 *
+	 * @var array<int, array{0: string, 1: callable, 2: int}>
+	 */
+	private $harness_hooks = array();
+
+	/**
+	 * Dispatches a simulated WC-AJAX request against an endpoint object.
+	 *
+	 * @param object $endpoint An endpoint with handle_request(): void and a static nonce() method.
+	 * @param array  $body     The JSON body. If the 'nonce' key is absent, a valid frontend
+	 *                         nonce for the endpoint's action is generated. Pass 'nonce' => 'garbage'
+	 *                         to exercise the invalid-nonce contract, or 'nonce' => null for
+	 *                         the missing-nonce contract.
+	 * @return array{success: bool, data: mixed, status: int|null, raw: string}
+	 */
+	protected function dispatchAjaxRequest( $endpoint, array $body ): array {
+		if ( ! array_key_exists( 'nonce', $body ) ) {
+			$body['nonce'] = $this->createFrontendNonce( $endpoint::nonce() );
+		}
+
+		$status      = null;
+		$status_spy  = static function ( $header, $code ) use ( &$status ) {
+			$status = (int) $code;
+			return $header;
+		};
+		$die_handler = static function () {
+			return static function () {
+				throw new WpAjaxDieSignal( 'wp_die (ajax)' );
+			};
+		};
+
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', $die_handler, 99 );
+		add_filter( 'status_header', $status_spy, 10, 2 );
+
+		PhpInputStreamStub::$body = (string) wp_json_encode( $body );
+		stream_wrapper_unregister( 'php' );
+		stream_wrapper_register( 'php', PhpInputStreamStub::class );
+
+		$ob_level  = ob_get_level();
+		$raw       = '';
+		$responded = false;
+		ob_start();
+		try {
+			$endpoint->handle_request();
+		} catch ( WpAjaxDieSignal $signal ) {
+			$responded = true;
+		} finally {
+			while ( ob_get_level() > $ob_level ) {
+				$raw = (string) ob_get_clean() . $raw;
+			}
+			stream_wrapper_restore( 'php' );
+			remove_filter( 'wp_doing_ajax', '__return_true' );
+			remove_filter( 'wp_die_ajax_handler', $die_handler, 99 );
+			remove_filter( 'status_header', $status_spy, 10 );
+		}
+
+		if ( ! $responded ) {
+			$this->fail( 'Endpoint returned without sending a JSON response. Output: ' . $raw );
+		}
+
+		$decoded = json_decode( $raw, true );
+		$this->assertIsArray( $decoded, 'Endpoint response is not valid JSON: ' . $raw );
+		$this->assertArrayHasKey( 'success', $decoded, 'Endpoint response has no success flag: ' . $raw );
+
+		return array(
+			'success' => (bool) $decoded['success'],
+			'data'    => $decoded['data'] ?? null,
+			'status'  => $status,
+			'raw'     => $raw,
+		);
+	}
+
+	/**
+	 * Creates a nonce the way the v5/v6 frontend receives it: rendered for a guest
+	 * with the logged-out uid forced to 0, mirroring RequestData::nonce_fix().
+	 *
+	 * @param string $action The nonce action (the endpoint name).
+	 * @return string
+	 */
+	protected function createFrontendNonce( string $action ): string {
+		$force_zero = static function (): int {
+			return 0;
+		};
+		add_filter( 'nonce_user_logged_out', $force_zero, 100 );
+		try {
+			return wp_create_nonce( $action );
+		} finally {
+			remove_filter( 'nonce_user_logged_out', $force_zero, 100 );
+		}
+	}
+
+	/**
+	 * Ensures WC()->cart and WC()->session exist in CLI, empties the cart and
+	 * clears the plugin session state and WC notices.
+	 *
+	 * @return void
+	 */
+	protected function resetWcFrontendState(): void {
+		if ( null === WC()->cart || null === WC()->session ) {
+			wc_load_cart();
+		}
+		if ( WC()->session instanceof \WC_Session_Handler && ! WC()->session->get_customer_unique_id() ) {
+			// Mark the CLI process as having a guest session cookie, like every real
+			// frontend request has: get_customer_unique_id() returns '' without it,
+			// which would skip the session-bound custom_id / ownership-check paths.
+			// Reflection instead of set_customer_session_cookie( true ) because
+			// wc_setcookie() raises a headers-already-sent notice under PHPUnit.
+			$has_cookie = new \ReflectionProperty( \WC_Session_Handler::class, '_has_cookie' );
+			$has_cookie->setAccessible( true );
+			$has_cookie->setValue( WC()->session, true );
+		}
+		WC()->cart->empty_cart();
+		WC()->session->set( 'ppcp', null );
+		WC()->session->set( 'chosen_payment_method', null );
+		wc_clear_notices();
+	}
+
+	/**
+	 * Records invocations of a WP action; removed again in tearDownHarnessHooks().
+	 *
+	 * @param string $hook The action hook name.
+	 * @param int    $accepted_args How many arguments to record per invocation.
+	 * @return \ArrayObject Each entry is the array of arguments of one invocation.
+	 */
+	protected function recordAction( string $hook, int $accepted_args = 2 ): \ArrayObject {
+		$calls    = new \ArrayObject();
+		$callback = static function ( ...$args ) use ( $calls ) {
+			$calls[] = $args;
+			return $args[0] ?? null;
+		};
+		add_action( $hook, $callback, 10, $accepted_args );
+		$this->harness_hooks[] = array( $hook, $callback, 10 );
+
+		return $calls;
+	}
+
+	/**
+	 * Removes all hooks registered through recordAction().
+	 *
+	 * @return void
+	 */
+	protected function tearDownHarnessHooks(): void {
+		foreach ( $this->harness_hooks as $hook_data ) {
+			list( $hook, $callback, $priority ) = $hook_data;
+			remove_filter( $hook, $callback, $priority );
+		}
+		$this->harness_hooks = array();
+	}
+}

--- a/tests/integration/phpunit.xml.dist
+++ b/tests/integration/phpunit.xml.dist
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- stderr: keep stdout clean so headers_sent() stays false and code under test
+     can send status codes/cookies (asserted by the WC-AJAX endpoint contract tests). -->
 <phpunit
     bootstrap="PHPUnit/bootstrap.php"
     backupGlobals="false"
@@ -6,6 +8,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
+    stderr="true"
     >
     <testsuites>
         <testsuite name="unit">


### PR DESCRIPTION
**_Note: This PR is against the v6 core SDK branch: `dev/PCP-5780-core-sdk-loading-pay-pal-buttons` and not `dev/develop`. Blocked by #4526_**

### Description

Contract tests for the four WC-AJAX order endpoints shared by the v5 and v6 SDK frontends (`ppc-create-order`, `ppc-change-cart`, `ppc-approve-order`, `ppc-update-shipping`), per PCP-6675. The endpoints now have two frontend consumers, and this suite pins the shared contract so any change to them (including the planned relocation into a neutral module) fails CI rather than failing at checkout.

- **Real behavior, not mocks:** tests run in the integration suite with a real WP + WC cart/session and only `api.endpoint.order` mocked, resolving endpoints by container service key. 32 tests, 221 assertions covering all six Gherkin ACs, the `wc_ajax_ppc-*` hook registration, and the nonce/`RequestData` plumbing (JSON body from `php://input`, guest-session nonce fix). Each test documents the contract fields it asserts in a GIVEN/WHEN/THEN doc block.
- **New test harness** (`Traits/HandlesWcAjaxEndpoints.php`): serves the JSON body via a `php://input` stream wrapper stub and intercepts `wp_send_json_*`'s die through the `wp_die_ajax_handler` filter. The die signal extends `Error` because endpoints catch `Exception` broadly.
- **Three shared-scaffolding changes:** `stderr="true"` in the integration `phpunit.xml.dist` so `headers_sent()` stays false and status codes are testable; a `ProductFactory` fix (IDs were recorded pre-save as `0`, so cleanup never worked and WP 6.9 flags `wp_delete_post(0)`); the test base drops stale `ppcp_session_get_order` listeners left behind by repeated `bootstrapModule()` calls.
- **Contract details surfaced and pinned (intended behavior, not bugs):** `product` context requires `purchase_units[0].items[0].url`; `ppc-approve-order` returns `order_received_url` even if the capture fails; a successful payment consumes the plugin session.

### Steps to Test

**Setup:** DDEV running (`npm run ddev:setup`), integration env prepared (`.env.integration` from the example, `ddev exec php tests/integration/PHPUnit/setup.php`).

1. **Contract tests:** `ddev exec phpunit -c tests/integration/phpunit.xml.dist --filter ContractTest` passes with 32 tests, 221 assertions.
2. **No regressions:** the full integration suite (`ddev exec phpunit -c tests/integration/phpunit.xml.dist`) has a failure set identical to the base branch (pre-existing environment failures, verified against a clean-tree baseline).
3. **Unit suite and lint:** `npm run unit-tests` and `npm run lint` are unchanged vs the base branch.
4. **Contract pin works:** rename an `ENDPOINT` constant or change a response key in any of the four endpoints and re-run step 1; the matching contract test fails.