### PR TITLE
Remove Pay with Crypto promotional pricing messaging (6707)

### DIFF
--- a/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/FeaturesDefinition.php
@@ -172,8 +172,7 @@ class FeaturesDefinition {
 		$feature_items = array(
 			self::FEATURE_PAY_WITH_CRYPTO                 => array(
 				'title'       => __( 'Pay with Crypto', 'woocommerce-paypal-payments' ),
-				'description' => __( 'Enable customers to pay with cryptocurrency, and receive payments in USD in your PayPal balance.', 'woocommerce-paypal-payments' )
-					. '<p>' . __( 'Promotional processing rate of 0.99% through July 31, 2026.', 'woocommerce-paypal-payments' ) . '</p>',
+				'description' => __( 'Enable customers to pay with cryptocurrency, and receive payments in USD in your PayPal balance.', 'woocommerce-paypal-payments' ),
 				'enabled'     => $this->merchant_capabilities[ self::FEATURE_PAY_WITH_CRYPTO ],
 				'buttons'     => array(
 					array(

--- a/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
+++ b/modules/ppcp-settings/src/Data/Definition/PaymentMethodsDefinition.php
@@ -321,7 +321,7 @@ class PaymentMethodsDefinition {
 		return array(
 			PWCGateway::ID            => array(
 				'method_title'       => __( 'Pay with Crypto', 'woocommerce-paypal-payments' ),
-				'method_description' => __( 'A PayPal-powered checkout option letting customers pay with cryptocurrency. You receive funds in USD, settled directly to your PayPal balance — no crypto exposure, no chargeback risk. Promotional processing rate of 0.99% through July 31, 2026.', 'woocommerce-paypal-payments' ),
+				'method_description' => __( 'A PayPal-powered checkout option letting customers pay with cryptocurrency. You receive funds in USD, settled directly to your PayPal balance — no crypto exposure, no chargeback risk.', 'woocommerce-paypal-payments' ),
 				'title'              => __( 'Pay with Crypto', 'woocommerce-paypal-payments' ),
 				'description'        => __( 'Pay with top wallets and coins.', 'woocommerce-paypal-payments' ),
 			),


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
The Pay with Crypto promotional processing rate ("0.99% through July 31, 2026") has expired and is no longer accurate. This PR removes the promo copy from the two places it appeared:                  
                                                                                                                                                                                                          
- `PaymentMethodsDefinition.php` — trimmed from the gateway's `method_description`, shown on the Payment Methods settings screen.                                                                       
- `FeaturesDefinition.php` — removed the concatenated promo paragraph from the Features overview card description.                                                                                                                                                                              