### PR TITLE
Fix missing `invoice_id` for saved PayPal payment token orders (6702)

### DIFF
--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -122,7 +122,6 @@ return array(
 			$container->get( 'wcgateway.settings.admin-settings-enabled' ),
 			$container->get( 'wcgateway.endpoint.capture-paypal-payment' ),
 			$container->get( 'api.endpoint.order' ),
-			$container->get( 'api.prefix' ),
 			$container->get( 'button.helper.context' )
 		);
 	},

--- a/modules/ppcp-wc-gateway/src/Endpoint/CapturePayPalPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CapturePayPalPayment.php
@@ -52,10 +52,10 @@ class CapturePayPalPayment {
 	/**
 	 * Creates PayPal order from the given PayPal/Venmo vault ID.
 	 *
-	 * custom_id/invoice_id are not accepted as parameters here: the PayPal
-	 * Orders v2 API only reads those fields from inside a purchase unit,
-	 * never from the request root, so from_wc_order() populates them
-	 * directly on the purchase unit built above.
+	 * The custom_id/invoice_id fields are not accepted as parameters here:
+	 * the PayPal Orders v2 API only reads them from inside a purchase
+	 * unit, never from the request root, so from_wc_order() populates
+	 * them directly on the purchase unit built above.
 	 *
 	 * @throws RuntimeException When request fails.
 	 */

--- a/modules/ppcp-wc-gateway/src/Endpoint/CapturePayPalPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CapturePayPalPayment.php
@@ -52,12 +52,15 @@ class CapturePayPalPayment {
 	/**
 	 * Creates PayPal order from the given PayPal/Venmo vault ID.
 	 *
+	 * custom_id/invoice_id are not accepted as parameters here: the PayPal
+	 * Orders v2 API only reads those fields from inside a purchase unit,
+	 * never from the request root, so from_wc_order() populates them
+	 * directly on the purchase unit built above.
+	 *
 	 * @throws RuntimeException When request fails.
 	 */
 	public function create_order(
 		string $vault_id,
-		string $custom_id,
-		string $invoice_id,
 		WC_Order $wc_order,
 		string $payment_source_name = 'paypal'
 	): Order {
@@ -80,8 +83,6 @@ class CapturePayPalPayment {
 					),
 				),
 			),
-			'custom_id'      => $custom_id,
-			'invoice_id'     => $invoice_id,
 		);
 
 		$bearer = $this->bearer->bearer();

--- a/modules/ppcp-wc-gateway/src/Endpoint/CapturePayPalPayment.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/CapturePayPalPayment.php
@@ -62,15 +62,7 @@ class CapturePayPalPayment {
 		string $payment_source_name = 'paypal'
 	): Order {
 		$intent = strtoupper( $this->settings_provider->payment_intent() ) === 'AUTHORIZE' ? 'AUTHORIZE' : 'CAPTURE';
-		$items  = array( $this->purchase_unit_factory->from_wc_cart( null, false, $wc_order->get_payment_method() ) );
-
-		// phpcs:disable WordPress.Security.NonceVerification
-		$pay_for_order = wc_clean( wp_unslash( $_GET['pay_for_order'] ?? '' ) );
-		$order_key     = wc_clean( wp_unslash( $_GET['key'] ?? '' ) );
-		// phpcs:enable
-		if ( $pay_for_order && $order_key === $wc_order->get_order_key() ) {
-			$items = array( $this->purchase_unit_factory->from_wc_order( $wc_order ) );
-		}
+		$items  = array( $this->purchase_unit_factory->from_wc_order( $wc_order ) );
 
 		$data = array(
 			'intent'         => $intent,

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -120,8 +120,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 	private OrderEndpoint $order_endpoint;
 
-	private string $prefix;
-
 	private Context $context;
 
 	/**
@@ -208,7 +206,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 	 * @param bool                     $admin_settings_enabled Whether settings module is enabled.
 	 * @param CapturePayPalPayment     $capture_paypal_payment The PayPal vault payment capture endpoint.
 	 * @param OrderEndpoint            $order_endpoint The order endpoint.
-	 * @param string                   $prefix The invoice prefix.
 	 * @param Context                  $context The context helper.
 	 */
 	public function __construct(
@@ -231,7 +228,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		bool $admin_settings_enabled,
 		CapturePayPalPayment $capture_paypal_payment,
 		OrderEndpoint $order_endpoint,
-		string $prefix,
 		Context $context
 	) {
 		$this->id                          = self::ID;
@@ -254,7 +250,6 @@ class PayPalGateway extends \WC_Payment_Gateway {
 		$this->admin_settings_enabled      = $admin_settings_enabled;
 		$this->capture_paypal_payment      = $capture_paypal_payment;
 		$this->order_endpoint              = $order_endpoint;
-		$this->prefix                      = $prefix;
 		$this->context                     = $context;
 
 		$default_support = array(

--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -477,11 +477,9 @@ class PayPalGateway extends \WC_Payment_Gateway {
 					}
 
 					$payment_source_name = $token instanceof PaymentTokenVenmo ? 'venmo' : 'paypal';
-					$custom_id           = (string) $wc_order->get_id();
-					$invoice_id          = $this->prefix . $wc_order->get_order_number();
 
 					try {
-						$created_order = $this->capture_paypal_payment->create_order( $token->get_token(), $custom_id, $invoice_id, $wc_order, $payment_source_name );
+						$created_order = $this->capture_paypal_payment->create_order( $token->get_token(), $wc_order, $payment_source_name );
 					} catch ( RuntimeException $exception ) {
 						$this->logger->error( $exception->getMessage() );
 						return $this->handle_payment_failure( $wc_order, $exception );

--- a/tests/PHPUnit/WcGateway/Endpoint/CapturePayPalPaymentTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/CapturePayPalPaymentTest.php
@@ -1,0 +1,195 @@
+<?php
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\Bearer;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\PurchaseUnit;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\OrderFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class CapturePayPalPaymentTest extends TestCase {
+
+	/**
+	 * Build a fully-wired CapturePayPalPayment instance.
+	 *
+	 * @param array       &$captured_body   Passed by reference; populated with the decoded request body inside the wp_remote_get stub.
+	 * @param PurchaseUnit|null $purchase_unit The purchase unit returned by from_wc_order(); defaults to one whose to_array() is empty.
+	 */
+	private function make_testee( array &$captured_body, ?PurchaseUnit $purchase_unit = null ): array {
+		$token = Mockery::mock( \WooCommerce\PayPalCommerce\ApiClient\Entity\Token::class );
+		$token->shouldReceive( 'token' )->andReturn( 'test-bearer-token' );
+
+		$bearer = Mockery::mock( Bearer::class );
+		$bearer->shouldReceive( 'bearer' )->andReturn( $token );
+
+		if ( ! $purchase_unit ) {
+			$purchase_unit = Mockery::mock( PurchaseUnit::class );
+			$purchase_unit->shouldReceive( 'to_array' )->andReturn( array() );
+		}
+
+		$purchase_unit_factory = Mockery::mock( PurchaseUnitFactory::class );
+		$purchase_unit_factory->shouldReceive( 'from_wc_order' )->andReturn( $purchase_unit );
+		$purchase_unit_factory->shouldNotReceive( 'from_wc_cart' );
+
+		$returned_order = Mockery::mock( Order::class );
+
+		$order_factory = Mockery::mock( OrderFactory::class );
+		$order_factory->shouldReceive( 'from_paypal_response' )->andReturn( $returned_order );
+
+		$settings_provider = Mockery::mock( SettingsProvider::class );
+		$settings_provider->shouldReceive( 'payment_intent' )->andReturn( 'capture' );
+
+		$logger = Mockery::mock( LoggerInterface::class );
+		$logger->allows( 'debug' );
+
+		when( 'trailingslashit' )->alias( function ( string $value ): string {
+			return rtrim( $value, '/' ) . '/';
+		} );
+		expect( 'wp_json_encode' )->andReturnUsing( 'json_encode' );
+
+		// RequestTrait::request_response_string() calls $response['headers']->getAll(), so headers must be an object.
+		$headers_stub = Mockery::mock( \Requests_Utility_CaseInsensitiveDictionary::class );
+		$headers_stub->shouldReceive( 'getAll' )->andReturn( array() );
+
+		expect( 'wp_remote_get' )->andReturnUsing(
+			function ( string $url, array $args ) use ( &$captured_body, $headers_stub ): array {
+				$captured_body = (array) json_decode( $args['body'], true );
+				return array(
+					'body'     => '{"id":"MOCK-ORDER-ID"}',
+					'response' => array( 'code' => 200 ),
+					'headers'  => $headers_stub,
+				);
+			}
+		);
+		when( 'wp_remote_retrieve_response_code' )->alias(
+			function ( $response ): int {
+				return (int) ( $response['response']['code'] ?? 0 );
+			}
+		);
+
+		$testee = new CapturePayPalPayment(
+			'https://api.paypal.com',
+			$bearer,
+			$order_factory,
+			$purchase_unit_factory,
+			$settings_provider,
+			$logger
+		);
+
+		return array( $testee, $returned_order );
+	}
+
+	/**
+	 * GIVEN a saved-token payment is captured for a WC order
+	 * WHEN create_order builds the purchase units
+	 * THEN they come from PurchaseUnitFactory::from_wc_order(), never from_wc_cart()
+	 *
+	 * This is the PCP-6702 regression: from_wc_cart() always produces an
+	 * empty invoice_id and a session-based custom_id, so the order must be
+	 * the single source of truth here regardless of the current request
+	 * (there is no more `?pay_for_order=1` special case).
+	 */
+	public function test_create_order_builds_purchase_unit_from_wc_order(): void {
+		$captured_body = array();
+		[ $testee ]    = $this->make_testee( $captured_body );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		// No assertion needed beyond make_testee()'s `shouldNotReceive('from_wc_cart')`
+		// and `shouldReceive('from_wc_order')` expectations; Mockery fails the test
+		// if either is violated.
+		$testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertArrayHasKey( 'purchase_units', $captured_body );
+	}
+
+	/**
+	 * GIVEN a saved-token payment is captured for a WC order
+	 * WHEN the HTTP request body is built
+	 * THEN it has no top-level custom_id or invoice_id keys
+	 *
+	 * The PayPal Orders v2 API only reads these fields from inside a
+	 * purchase unit; leaving them at the request root (the PCP-6702 bug)
+	 * means PayPal silently ignores them.
+	 */
+	public function test_create_order_does_not_send_top_level_custom_id_or_invoice_id(): void {
+		$captured_body = array();
+		[ $testee ]    = $this->make_testee( $captured_body );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		$testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertArrayNotHasKey( 'custom_id', $captured_body );
+		$this->assertArrayNotHasKey( 'invoice_id', $captured_body );
+	}
+
+	/**
+	 * GIVEN PurchaseUnitFactory::from_wc_order() populates custom_id/invoice_id
+	 * WHEN create_order serializes the purchase unit into the request body
+	 * THEN purchase_units[0] carries those values through untouched
+	 */
+	public function test_create_order_forwards_purchase_unit_custom_id_and_invoice_id(): void {
+		$purchase_unit = Mockery::mock( PurchaseUnit::class );
+		$purchase_unit->shouldReceive( 'to_array' )->andReturn(
+			array(
+				'custom_id'  => '14121',
+				'invoice_id' => 'PP-FLYERALARMDigital-422136',
+			)
+		);
+
+		$captured_body = array();
+		[ $testee ]    = $this->make_testee( $captured_body, $purchase_unit );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		$testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertSame( '14121', $captured_body['purchase_units'][0]['custom_id'] ?? null );
+		$this->assertSame( 'PP-FLYERALARMDigital-422136', $captured_body['purchase_units'][0]['invoice_id'] ?? null );
+	}
+
+	/**
+	 * GIVEN a vault id and an explicit payment source name are passed to create_order
+	 * WHEN the request body is built
+	 * THEN payment_source is keyed by the given name and carries the vault_id
+	 */
+	public function test_create_order_forwards_vault_id_and_payment_source_name(): void {
+		$captured_body = array();
+		[ $testee ]    = $this->make_testee( $captured_body );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		$testee->create_order( 'vault-venmo-1', $wc_order, 'venmo' );
+
+		$this->assertSame(
+			'vault-venmo-1',
+			$captured_body['payment_source']['venmo']['vault_id'] ?? null
+		);
+	}
+
+	/**
+	 * GIVEN create_order is called without an explicit payment source name
+	 * WHEN the request body is built
+	 * THEN payment_source defaults to 'paypal'
+	 */
+	public function test_create_order_defaults_payment_source_name_to_paypal(): void {
+		$captured_body = array();
+		[ $testee ]    = $this->make_testee( $captured_body );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		$testee->create_order( 'vault-abc-123', $wc_order );
+
+		$this->assertArrayHasKey( 'paypal', $captured_body['payment_source'] ?? array() );
+	}
+}

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -123,7 +123,6 @@ class WcGatewayTest extends TestCase
 			false,
 			$this->capturePayPalPayment,
 			Mockery::mock(OrderEndpoint::class),
-			'WC-',
 			$this->context
 		);
 	}
@@ -150,7 +149,6 @@ class WcGatewayTest extends TestCase
 			false,
 			$this->capturePayPalPayment,
 			Mockery::mock(OrderEndpoint::class),
-			'WC-',
 			$this->context
 		);
 	}
@@ -177,7 +175,6 @@ class WcGatewayTest extends TestCase
 			false,
 			$this->capturePayPalPayment,
 			Mockery::mock(OrderEndpoint::class),
-			'WC-',
 			$this->context
 		);
 	}


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
When an existing customer with a saved/vaulted PayPal payment token places an order, `invoice_id` was never sent to PayPal, and `custom_id` showed up as a session-derived `pcp_customer_<id>` value instead of the WC order ID. This broke accounting workflows that rely on the invoice number (e.g. `PP-<Prefix>-<OrderNumber>`) to reconcile payments.                                                   
                                                                                                                                                                                                          
Two separate defects in `CapturePayPalPayment::create_order()` caused this:                                                                                                                             
                                                                                                                                                                                                          
1. Purchase units were always built from the cart (`from_wc_cart()`), which sets `invoice_id` to an empty string and `custom_id` to a session ID. The order-based path (`from_wc_order()`) was only used on `?pay_for_order=1` URLs.                                                                                                                                                                             
2. Even when the caller (`PayPalGateway::process_payment()`) computed the correct `custom_id`/`invoice_id`, create_order()` placed them at the top level of the request body — a location the PayPal Orders v2 API never reads. Purchase-unit-level fields are the only ones PayPal honors.                                                                                                                  
                                                                                                                                                                                                          
Fix: purchase units are now always sourced from the WC order, so `custom_id`/`invoice_id` are populated correctly inside `purchase_units` for every saved-token payment, and the dead top-level keys (along with the now-unused  `custom_id`/`invoice_id` parameters and the `$prefix` property they required) have been removed.                                                                             
                                                                                                                                                                                                          
### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Have an existing WooCommerce customer with a saved PayPal payment method (vaulted token).                                                                                                            
2. Place a new order using that saved payment method.                                                                                                                                                   
3. Check the transaction details on PayPal.com.                                                                                                                                                         
                                                                                                                                                                                                          
**Expected**: `invoice_id` is set to `<prefix><order_number>` (e.g. `PP-FLYERALARMDigital-422136`) and `custom_id` is the WC order ID (e.g. `14121`).                                                   
                                                                                                                                                                                                          
**Previously (bug)**: `invoice_id` was absent from the transaction, and `custom_id` was `pcp_customer_<session_id>`.