### PR TITLE
Insonsistent PayPal button behavior for subscriptions on cart (6639)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Helper/Subscription.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Subscription.js
@@ -1,6 +1,6 @@
 /**
  * @param {Object} scriptData
- * @return {boolean}
+ * @return {boolean} Whether the store runs in PayPal Subscriptions mode.
  */
 export const isPayPalSubscription = ( scriptData ) => {
 	return (
@@ -11,8 +11,58 @@ export const isPayPalSubscription = ( scriptData ) => {
 
 /**
  * @param {Object} scriptData
- * @return {boolean}
+ * @return {boolean} Whether the cart contains at least one subscription product.
  */
 export const cartHasSubscriptionProducts = ( scriptData ) => {
 	return !! scriptData?.locations_with_subscription_product?.cart;
+};
+
+/**
+ * Whether the PayPal button is allowed for the current (subscription) cart.
+ *
+ * Single, mode-aware rule shared by the block cart, classic cart and mini-cart
+ * so the button is shown (or hidden) consistently. Prefers the authoritative
+ * server flag `subscription_button_allowed`; the explicit checks act as a
+ * fallback and also cover the free-trial guest case on the block cart.
+ *
+ * @param {Object} scriptData
+ * @return {boolean} Whether the PayPal button may be displayed for this cart.
+ */
+export const paypalSubscriptionButtonAllowed = ( scriptData ) => {
+	if ( ! cartHasSubscriptionProducts( scriptData ) ) {
+		return true;
+	}
+
+	// Don't show buttons on the block cart page if the user is not logged in
+	// and the cart contains a free trial product.
+	if (
+		! scriptData.user?.is_logged &&
+		scriptData.context === 'cart-block' &&
+		scriptData.is_free_trial_cart
+	) {
+		return false;
+	}
+
+	if ( typeof scriptData.subscription_button_allowed !== 'undefined' ) {
+		return !! scriptData.subscription_button_allowed;
+	}
+
+	// Vaulting mode but vaulting disabled.
+	if (
+		! isPayPalSubscription( scriptData ) &&
+		! scriptData.can_save_vault_token
+	) {
+		return false;
+	}
+
+	// PayPal Subscriptions mode but product not associated with a PayPal plan
+	// (or the cart contains more than one item).
+	if (
+		isPayPalSubscription( scriptData ) &&
+		! scriptData.subscription_product_allowed
+	) {
+		return false;
+	}
+
+	return true;
 };

--- a/modules/ppcp-blocks/resources/js/Helper/Subscription.test.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Subscription.test.js
@@ -1,0 +1,79 @@
+import { paypalSubscriptionButtonAllowed } from './Subscription';
+
+const baseData = ( overrides = {} ) => ( {
+	locations_with_subscription_product: { cart: true },
+	user: { is_logged: true },
+	context: 'cart',
+	is_free_trial_cart: false,
+	can_save_vault_token: false,
+	subscription_product_allowed: false,
+	data_client_id: {
+		has_subscriptions: false,
+		paypal_subscriptions_enabled: false,
+	},
+	...overrides,
+} );
+
+describe( 'paypalSubscriptionButtonAllowed', () => {
+	it( 'allows a cart without subscription products', () => {
+		const data = baseData( {
+			locations_with_subscription_product: { cart: false },
+		} );
+		expect( paypalSubscriptionButtonAllowed( data ) ).toBe( true );
+	} );
+
+	it( 'hides for a guest with a free trial on the block cart', () => {
+		const data = baseData( {
+			user: { is_logged: false },
+			context: 'cart-block',
+			is_free_trial_cart: true,
+			subscription_button_allowed: true,
+		} );
+		expect( paypalSubscriptionButtonAllowed( data ) ).toBe( false );
+	} );
+
+	it( 'prefers the server subscription_button_allowed flag when present', () => {
+		expect(
+			paypalSubscriptionButtonAllowed(
+				baseData( { subscription_button_allowed: false } )
+			)
+		).toBe( false );
+		expect(
+			paypalSubscriptionButtonAllowed(
+				baseData( { subscription_button_allowed: true } )
+			)
+		).toBe( true );
+	} );
+
+	it( 'falls back to hide in vaulting mode when vaulting is disabled', () => {
+		const data = baseData( { can_save_vault_token: false } );
+		expect( paypalSubscriptionButtonAllowed( data ) ).toBe( false );
+	} );
+
+	it( 'falls back to show in vaulting mode when vaulting is enabled', () => {
+		const data = baseData( { can_save_vault_token: true } );
+		expect( paypalSubscriptionButtonAllowed( data ) ).toBe( true );
+	} );
+
+	it( 'falls back to hide in subscriptions mode when the product is not allowed', () => {
+		const data = baseData( {
+			data_client_id: {
+				has_subscriptions: true,
+				paypal_subscriptions_enabled: true,
+			},
+			subscription_product_allowed: false,
+		} );
+		expect( paypalSubscriptionButtonAllowed( data ) ).toBe( false );
+	} );
+
+	it( 'falls back to show in subscriptions mode when the product is allowed', () => {
+		const data = baseData( {
+			data_client_id: {
+				has_subscriptions: true,
+				paypal_subscriptions_enabled: true,
+			},
+			subscription_product_allowed: true,
+		} );
+		expect( paypalSubscriptionButtonAllowed( data ) ).toBe( true );
+	} );
+} );

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -5,7 +5,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import {
 	cartHasSubscriptionProducts,
-	isPayPalSubscription,
+	paypalSubscriptionButtonAllowed,
 } from './Helper/Subscription';
 import { loadPayPalScript } from '../../../ppcp-button/resources/js/modules/Helper/PayPalScriptLoading';
 import BlockCheckoutMessagesBootstrap from './Bootstrap/BlockCheckoutMessagesBootstrap';
@@ -25,31 +25,9 @@ const features = [ 'products' ];
 let blockEnabled = true;
 
 if ( cartHasSubscriptionProducts( config.scriptData ) ) {
-	// Don't show buttons on block cart page if user is not logged in and cart contains free trial product
-	if (
-		! config.scriptData.user.is_logged &&
-		config.scriptData.context === 'cart-block' &&
-		cartHasSubscriptionProducts( config.scriptData ) &&
-		config.scriptData.is_free_trial_cart
-	) {
-		blockEnabled = false;
-	}
-
-	// Don't render if vaulting disabled and is in vault subscription mode
-	if (
-		! isPayPalSubscription( config.scriptData ) &&
-		! config.scriptData.can_save_vault_token
-	) {
-		blockEnabled = false;
-	}
-
-	// Don't render buttons if in subscription mode and product not associated with a PayPal subscription
-	if (
-		isPayPalSubscription( config.scriptData ) &&
-		! config.scriptData.subscription_product_allowed
-	) {
-		blockEnabled = false;
-	}
+	// Show the button only for subscription carts PayPal can process
+	// (shared rule used by the classic cart and mini-cart as well).
+	blockEnabled = paypalSubscriptionButtonAllowed( config.scriptData );
 
 	features.push( 'subscriptions' );
 }

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/CartBootstrap.js
@@ -1,5 +1,6 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
 import BootstrapHelper from '../Helper/BootstrapHelper';
+import { paypalSubscriptionButtonAllowed } from '@ppcp-blocks/Helper/Subscription';
 
 class CartBootstrap {
 	constructor( gateway, renderer, errorHandler ) {
@@ -61,8 +62,23 @@ class CartBootstrap {
 						if ( result.data.messages ) {
 							newData.messages = result.data.messages;
 						}
+						// Keep the subscription gate in sync with the current cart.
+						if (
+							typeof result.data.subscription_button_allowed !==
+							'undefined'
+						) {
+							newData.subscription_button_allowed =
+								result.data.subscription_button_allowed;
+						}
+						if ( result.data.locations_with_subscription_product ) {
+							newData.locations_with_subscription_product =
+								result.data.locations_with_subscription_product;
+						}
 						if ( newData ) {
 							BootstrapHelper.updateScriptData( this, newData );
+							if ( this.shouldRender() ) {
+								this.render();
+							}
 							this.handleButtonStatus();
 						}
 
@@ -87,10 +103,38 @@ class CartBootstrap {
 		return BootstrapHelper.shouldEnable( this );
 	}
 
+	/**
+	 * Whether the button is allowed for the current (subscription) cart.
+	 * Shared rule used by the block cart and mini-cart as well.
+	 *
+	 * @return {boolean} True when the button may be displayed.
+	 */
+	subscriptionButtonAllowed() {
+		return paypalSubscriptionButtonAllowed( this.gateway );
+	}
+
+	hide() {
+		jQuery( this.gateway.button.wrapper ).hide();
+	}
+
+	show() {
+		jQuery( this.gateway.button.wrapper ).show();
+	}
+
 	render() {
 		if ( ! this.shouldRender() ) {
 			return;
 		}
+
+		// Hide the button for subscription carts PayPal cannot process, so the
+		// classic and block carts behave consistently and the button does not
+		// render only to be removed afterwards.
+		if ( ! this.subscriptionButtonAllowed() ) {
+			this.hide();
+			return;
+		}
+
+		this.show();
 
 		const actionHandler = new CartActionHandler(
 			PayPalCommerceGateway,
@@ -114,11 +158,6 @@ class CartBootstrap {
 			this.renderer.render(
 				actionHandler.subscriptionsConfiguration( subscription_plan_id )
 			);
-
-			if ( ! PayPalCommerceGateway.subscription_product_allowed ) {
-				this.gateway.button.is_disabled = true;
-				this.handleButtonStatus();
-			}
 
 			return;
 		}

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstrap.js
@@ -47,7 +47,8 @@ class MiniCartBootstrap {
 			wp.data.subscribe(
 				debounce( () => {
 					this._handleStoreCartChange();
-				}, 300 )
+				}, 300 ),
+				'wc/store/cart'
 			);
 		}
 

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/MiniCartBootstrap.js
@@ -1,5 +1,7 @@
 import CartActionHandler from '../ActionHandler/CartActionHandler';
 import BootstrapHelper from '../Helper/BootstrapHelper';
+import { paypalSubscriptionButtonAllowed } from '@ppcp-blocks/Helper/Subscription';
+import { debounce } from '@ppcp-blocks/Helper/debounce';
 
 class MiniCartBootstrap {
 	constructor( gateway, renderer, errorHandler ) {
@@ -7,6 +9,7 @@ class MiniCartBootstrap {
 		this.renderer = renderer;
 		this.errorHandler = errorHandler;
 		this.actionHandler = null;
+		this.lastItemsCount = null;
 	}
 
 	init() {
@@ -23,6 +26,7 @@ class MiniCartBootstrap {
 			miniCartConfig,
 			this.errorHandler
 		);
+		this.gateway = miniCartConfig;
 		this.render();
 		this.handleButtonStatus();
 
@@ -34,6 +38,19 @@ class MiniCartBootstrap {
 			}
 		);
 
+		/*
+		The block cart/mini-cart mutates the `wc/store/cart` data store instead of
+		firing the jQuery fragment events above, so subscribe to it to keep the
+		mini-cart button in sync (and clear it when the cart becomes empty).
+		 */
+		if ( typeof wp !== 'undefined' && wp.data?.subscribe ) {
+			wp.data.subscribe(
+				debounce( () => {
+					this._handleStoreCartChange();
+				}, 300 )
+			);
+		}
+
 		this.renderer.onButtonsInit(
 			this.gateway.button.mini_cart_wrapper,
 			() => {
@@ -41,6 +58,35 @@ class MiniCartBootstrap {
 			},
 			true
 		);
+	}
+
+	/**
+	 * @private
+	 */
+	_handleStoreCartChange() {
+		if ( typeof wp === 'undefined' || ! wp.data?.select ) {
+			return;
+		}
+
+		const cart = wp.data.select( 'wc/store/cart' );
+		if ( ! cart ) {
+			return;
+		}
+
+		const itemsCount =
+			cart.getCartData?.()?.itemsCount ?? cart.getItemsCount?.() ?? null;
+		if ( itemsCount === null || itemsCount === this.lastItemsCount ) {
+			return;
+		}
+		this.lastItemsCount = itemsCount;
+
+		if ( itemsCount === 0 ) {
+			this.hide();
+			return;
+		}
+
+		this.render();
+		this.handleButtonStatus();
 	}
 
 	handleButtonStatus() {
@@ -66,10 +112,33 @@ class MiniCartBootstrap {
 		} );
 	}
 
+	/**
+	 * Whether the button is allowed for the current (subscription) cart.
+	 * Shared rule used by the classic cart and block cart as well.
+	 *
+	 * @return {boolean} True when the button may be displayed.
+	 */
+	subscriptionButtonAllowed() {
+		return paypalSubscriptionButtonAllowed( this.gateway );
+	}
+
+	hide() {
+		jQuery( this.gateway.button.mini_cart_wrapper ).empty().hide();
+	}
+
 	render() {
 		if ( ! this.shouldRender() ) {
 			return;
 		}
+
+		// Hide the button for subscription carts PayPal cannot process, so the
+		// mini-cart behaves consistently with the classic and block carts.
+		if ( ! this.subscriptionButtonAllowed() ) {
+			this.hide();
+			return;
+		}
+
+		jQuery( this.gateway.button.mini_cart_wrapper ).show();
 
 		this.renderer.render( this.actionHandler.configuration(), {
 			button: {

--- a/modules/ppcp-button/src/Assets/SmartButton.php
+++ b/modules/ppcp-button/src/Assets/SmartButton.php
@@ -500,7 +500,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			add_action(
 				$this->mini_cart_button_renderer_hook(),
 				function () {
-					if ( $this->is_cart_price_total_zero() || $this->is_free_trial_cart() ) {
+					if ( $this->is_cart_price_total_zero() || $this->is_free_trial_cart() || ! $this->subscription_button_allowed() ) {
 						return;
 					}
 
@@ -536,7 +536,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			add_action(
 				$this->proceed_to_checkout_button_renderer_hook(),
 				function () use ( $enabled_on_cart ) {
-					if ( ! is_cart() || ! $enabled_on_cart || $this->is_free_trial_cart() || $this->is_cart_price_total_zero() || isset( reset( WC()->cart->cart_contents )['subscription_switch'] ) ) {
+					if ( ! is_cart() || ! $enabled_on_cart || $this->is_free_trial_cart() || $this->is_cart_price_total_zero() || ! $this->subscription_button_allowed() || isset( reset( WC()->cart->cart_contents )['subscription_switch'] ) ) {
 						return;
 					}
 
@@ -956,6 +956,18 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 	}
 
 	/**
+	 * Whether the PayPal button is allowed for the current (subscription) cart.
+	 *
+	 * @return bool
+	 */
+	private function subscription_button_allowed(): bool {
+		return $this->subscription_helper->paypal_subscription_button_allowed(
+			$this->has_subscriptions() && $this->paypal_subscriptions_enabled(),
+			$this->can_save_vault_token()
+		);
+	}
+
+	/**
 	 * Retrieves the 3D Secure contingency settings.
 	 *
 	 * @return string
@@ -1111,6 +1123,7 @@ document.querySelector("#payment").before(document.querySelector(".ppcp-messages
 			'variable_paypal_subscription_variations' => $this->subscription_helper->variable_paypal_subscription_variations(),
 			'variable_paypal_subscription_variation_from_cart' => $this->subscription_helper->paypal_subscription_variation_from_cart(),
 			'subscription_product_allowed'            => $this->subscription_helper->checkout_subscription_product_allowed(),
+			'subscription_button_allowed'             => $this->subscription_button_allowed(),
 			'locations_with_subscription_product'     => $this->subscription_helper->locations_with_subscription_product(),
 			'enforce_vault'                           => $this->has_subscriptions(),
 			'can_save_vault_token'                    => $this->can_save_vault_token(),

--- a/modules/ppcp-button/src/Endpoint/CartScriptParamsEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/CartScriptParamsEndpoint.php
@@ -88,20 +88,26 @@ class CartScriptParamsEndpoint implements EndpointInterface {
 			$currency_code     = get_woocommerce_currency();
 
 			$response = array(
-				'url_params'         => $script_data['url_params'],
-				'button'             => $script_data['button'],
-				'messages'           => $script_data['messages'],
-				'amount'             => WC()->cart->get_total( 'raw' ),
+				'url_params'                          => $script_data['url_params'],
+				'button'                              => $script_data['button'],
+				'messages'                            => $script_data['messages'],
+				'amount'                              => WC()->cart->get_total( 'raw' ),
 
 				// Recomputed against the current cart so the client can re-route the
 				// button to the save-without-purchase flow when a coupon turns a
 				// subscription cart into a $0 total after the page has loaded.
-				'is_free_trial_cart' => (bool) ( $script_data['is_free_trial_cart'] ?? false ),
+				'is_free_trial_cart'                  => (bool) ( $script_data['is_free_trial_cart'] ?? false ),
 
-				'total'              => $total,
-				'total_str'          => ( new Money( $total, $currency_code ) )->value_str(),
-				'currency_code'      => $currency_code,
-				'country_code'       => $shop_country_code,
+				// Recomputed against the current cart so the client can hide the
+				// button when a cart change makes the subscription cart one that
+				// PayPal cannot process (e.g. a second subscription is removed/added).
+				'subscription_button_allowed'         => (bool) ( $script_data['subscription_button_allowed'] ?? true ),
+				'locations_with_subscription_product' => $script_data['locations_with_subscription_product'] ?? array(),
+
+				'total'                               => $total,
+				'total_str'                           => ( new Money( $total, $currency_code ) )->value_str(),
+				'currency_code'                       => $currency_code,
+				'country_code'                        => $shop_country_code,
 			);
 
 			if ( $include_shipping ) {

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -176,6 +176,33 @@ class SubscriptionHelper {
 	}
 
 	/**
+	 * Whether the PayPal button is allowed for the current (subscription) cart.
+	 *
+	 * This is the single, mode-aware rule shared by the classic cart, block cart
+	 * and mini-cart so the button is displayed (or hidden) consistently:
+	 * - A non-subscription cart is always allowed.
+	 * - In PayPal Subscriptions mode the product must be allowed
+	 *   (has a PayPal plan and the cart contains a single item).
+	 * - In vaulting mode a vault token must be savable.
+	 *
+	 * @param bool $is_paypal_subscription Whether PayPal Subscriptions mode applies.
+	 * @param bool $can_save_vault_token   Whether a vault token can be saved.
+	 * @return bool
+	 * @throws NotFoundException If setting is not found.
+	 */
+	public function paypal_subscription_button_allowed( bool $is_paypal_subscription, bool $can_save_vault_token ): bool {
+		if ( ! $this->cart_contains_subscription() ) {
+			return true;
+		}
+
+		if ( $is_paypal_subscription ) {
+			return $this->checkout_subscription_product_allowed();
+		}
+
+		return $can_save_vault_token;
+	}
+
+	/**
 	 * Returns PayPal subscription plan id from WC subscription product.
 	 *
 	 * @return string


### PR DESCRIPTION
The PayPal button behaved inconsistently for subscription carts. On the block cart it showed for one subscription product but appeared then disappeared when a second (free-trial) one was added; on the classic cart the opposite happened (hidden for one, shown for two). Separately, emptying the block cart left the mini-cart still showing products.

### PR Changes
  - Centralized the button-display rule into a single shared decision `SubscriptionHelper::paypal_subscription_button_allowed()` (PHP) and `paypalSubscriptionButtonAllowed()` (JS), exposed as one `subscription_button_allowed` server flag. It covers both modes: PayPal Subscriptions requires a single item with a PayPal plan; vaulting requires vaulting enabled; non-subscription carts are always allowed.                                                                                                                                                                  
  - All three cart paths (classic, block, mini-cart) now consume this one rule, so they behave identically.                                                                                  
  - The button is decided before rendering and the wrapper is withheld server-side for unsupported carts (no flicker), and truly hidden rather than greyed.                                  
  - The mini-cart now subscribes to wc/store/cart, clearing the button when the block cart empties and re-applying the same subscription rule.