### PR TITLE
Fix store-sync product ingestion filter logic (6694)

### DIFF
--- a/modules/ppcp-store-sync/services.php
+++ b/modules/ppcp-store-sync/services.php
@@ -184,7 +184,7 @@ return array(
 	},
 	'agentic.validator.product'                    => static function ( ContainerInterface $c ): ProductValidator {
 		return new ProductValidator(
-			$c->get( 'agentic.config.ingestion' )
+			$c->get( 'agentic.ingestion.product-filter' )
 		);
 	},
 	'agentic.validator.price'                      => static function (): PriceValidator {

--- a/modules/ppcp-store-sync/services.php
+++ b/modules/ppcp-store-sync/services.php
@@ -314,7 +314,8 @@ return array(
 			$c->get( 'agentic.config.webhook_urls' ),
 			$c->get( 'agentic.merchant.provider' ),
 			$c->get( 'agentic.logger.ingestion' ),
-			$c->get( 'agentic.helper.product-manager' )
+			$c->get( 'agentic.helper.product-manager' ),
+			$c->get( 'agentic.ingestion.product-filter' )
 		);
 	},
 

--- a/modules/ppcp-store-sync/services.php
+++ b/modules/ppcp-store-sync/services.php
@@ -304,7 +304,8 @@ return array(
 	},
 	'agentic.ingestion-batch-provider'             => static function ( ContainerInterface $c ): IngestionBatchProvider {
 		return new IngestionBatchProvider(
-			$c->get( 'agentic.config.ingestion' )
+			$c->get( 'agentic.config.ingestion' ),
+			$c->get( 'agentic.ingestion.product-filter' )
 		);
 	},
 	'agentic.ingestion-manager'                    => static function ( ContainerInterface $c ): IngestionManager {

--- a/modules/ppcp-store-sync/services.php
+++ b/modules/ppcp-store-sync/services.php
@@ -28,6 +28,7 @@ use WooCommerce\PayPalCommerce\StoreSync\Endpoint\ReplaceCartEndpoint;
 use WooCommerce\PayPalCommerce\StoreSync\Endpoint\CheckoutEndpoint;
 use WooCommerce\PayPalCommerce\StoreSync\Ingestion\IngestionBatchProvider;
 use WooCommerce\PayPalCommerce\StoreSync\Ingestion\IngestionManager;
+use WooCommerce\PayPalCommerce\StoreSync\Ingestion\ProductFilter;
 use WooCommerce\PayPalCommerce\StoreSync\Response\ResponseFactory;
 use WooCommerce\PayPalCommerce\StoreSync\Session\AgenticSessionHandler;
 use WooCommerce\PayPalCommerce\StoreSync\Setting\AgenticSettingsEndpoint;
@@ -296,6 +297,11 @@ return array(
 	},
 
 	// Ingestion services.
+	'agentic.ingestion.product-filter'             => static function ( ContainerInterface $c ): ProductFilter {
+		return new ProductFilter(
+			$c->get( 'agentic.logger.ingestion' )
+		);
+	},
 	'agentic.ingestion-batch-provider'             => static function ( ContainerInterface $c ): IngestionBatchProvider {
 		return new IngestionBatchProvider(
 			$c->get( 'agentic.config.ingestion' )

--- a/modules/ppcp-store-sync/src/CartValidation/ProductValidator.php
+++ b/modules/ppcp-store-sync/src/CartValidation/ProductValidator.php
@@ -14,14 +14,14 @@ use WooCommerce\PayPalCommerce\StoreSync\Enums\Priority;
 use WooCommerce\PayPalCommerce\StoreSync\StoreData\StorePayPalCart;
 use WooCommerce\PayPalCommerce\StoreSync\Validation\Resolution\ResolutionOption;
 use WooCommerce\PayPalCommerce\StoreSync\Validation\ValidationIssue;
-use WooCommerce\PayPalCommerce\StoreSync\Config\IngestionConfiguration;
+use WooCommerce\PayPalCommerce\StoreSync\Ingestion\ProductFilter;
 use WooCommerce\PayPalCommerce\StoreSync\StoreData\StoreCartItem;
 
 class ProductValidator implements ValidatorInterface {
-	private IngestionConfiguration $configuration;
+	private ProductFilter $product_filter;
 
-	public function __construct( IngestionConfiguration $configuration ) {
-		$this->configuration = $configuration;
+	public function __construct( ProductFilter $product_filter ) {
+		$this->product_filter = $product_filter;
 	}
 
 	public function validate( StorePayPalCart $store_cart ): ?array {
@@ -56,28 +56,47 @@ class ProductValidator implements ValidatorInterface {
 				->add_resolution( ResolutionOption::create_suggest_alternative() );
 		}
 
-		$filter_args = $this->configuration->get_valid_product_filters();
-
-		$support_downloads = (bool) ( $filter_args['downloadable'] ?? false );
-		$valid_status      = (array) ( $filter_args['status'] ?? array() );
-		$valid_types       = (array) ( $filter_args['type'] ?? array() );
-
-		if ( ! $support_downloads && $product->is_downloadable() ) {
-			return ValidationIssue::create_invalid_product( "Downloadable product '{$identifier}' is not supported" )
+		$violation = $this->product_filter->criteria_violation( $product );
+		if ( null !== $violation ) {
+			return ValidationIssue::create_invalid_product( $this->criteria_message( $violation, $identifier ) )
 				->user_message( "'{$product_name}' cannot be purchased at this time" )
 				->for_field( $field );
 		}
-		if ( ! $product->is_type( $valid_types ) ) {
-			return ValidationIssue::create_invalid_product( "Product '{$identifier}' is not supported (unsupported product type)" )
+
+		if ( ! $this->product_filter->passes_exclusion_filter( $product ) ) {
+			// Additive write-through: heal the ingestion feed faster. Never release here.
+			$this->product_filter->mark_processed( $product );
+
+			return ValidationIssue::create_invalid_product( "Product '{$identifier}' is not supported" )
 				->user_message( "'{$product_name}' cannot be purchased at this time" )
-				->for_field( $field );
-		}
-		if ( ! in_array( $product->get_status(), $valid_status, true ) ) {
-			return ValidationIssue::create_invalid_product( "Product '{$identifier}' is not supported (product has an unsupported status)" )
-				->user_message( "'{$product_name}' cannot be purchased at this time" )
-				->for_field( $field );
+				->for_field( $field )
+				->add_resolution(
+					ResolutionOption::create_remove_item()
+						->label( 'Remove from cart' )
+						->priority( Priority::HIGH )
+				);
 		}
 
 		return null;
+	}
+
+	/**
+	 * Maps a coarse-criteria violation slug to its developer-facing message.
+	 *
+	 * @param string $violation  One of 'downloadable' | 'type' | 'status'.
+	 * @param string $identifier The cart item identifier.
+	 */
+	private function criteria_message( string $violation, string $identifier ): string {
+		switch ( $violation ) {
+			case 'downloadable':
+				return "Downloadable product '{$identifier}' is not supported";
+
+			case 'type':
+				return "Product '{$identifier}' is not supported (unsupported product type)";
+
+			case 'status':
+			default:
+				return "Product '{$identifier}' is not supported (product has an unsupported status)";
+		}
 	}
 }

--- a/modules/ppcp-store-sync/src/Config/IngestionConfiguration.php
+++ b/modules/ppcp-store-sync/src/Config/IngestionConfiguration.php
@@ -61,9 +61,9 @@ class IngestionConfiguration {
 		/**
 		 * Filters the number of products included in one sync batch.
 		 *
-		 * @param int $batch_size The sync batch size. Must be a positive integer; a
-		 *                        value of 0 or less flips the underlying product query
-		 *                        to unlimited (the entire catalog in one batch).
+		 * @param int $batch_size The sync batch size. A value of 0 (or less) yields an
+		 *                        empty batch, which effectively pauses ingestion without
+		 *                        unscheduling the recurring sync.
 		 */
 		return (int) apply_filters(
 			'woocommerce_paypal_payments_store_sync_batch_size',

--- a/modules/ppcp-store-sync/src/Config/IngestionConfiguration.php
+++ b/modules/ppcp-store-sync/src/Config/IngestionConfiguration.php
@@ -4,71 +4,70 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\StoreSync\Config;
 
-use Automattic\WooCommerce\Enums\ProductType;
-use Automattic\WooCommerce\Enums\ProductStatus;
-
 /**
  * Centralized configuration for the product ingestion.
  *
- * Todo: Should we add a filter to all getters to allow modifying the values?
+ * Owns scheduling and sizing knobs only. Eligibility (which products qualify) is
+ * owned by {@see \WooCommerce\PayPalCommerce\StoreSync\Ingestion\ProductFilter}.
  */
 class IngestionConfiguration {
 	private const CATALOG_LIFESPAN_IN_DAYS = 5;
 	private const SYNC_INTERVAL_IN_SECONDS = 15 * MINUTE_IN_SECONDS;
 	private const SYNC_BATCH_SIZE          = 50;
 
-	private const SUPPORTED_PRODUCT_TYPES = array(
-		ProductType::SIMPLE,
-		ProductType::VARIABLE,
-	);
-
-	/**
-	 * How many days are products kept in PayPal's product catalog before they
-	 * consider the item to be stale?
-	 *
-	 * We need to sync every product before they become stale, otherwise they are
-	 * removed from the product catalog.
-	 */
-	public function get_product_lifespan_in_days(): int {
-		return self::CATALOG_LIFESPAN_IN_DAYS;
-	}
-
 	/**
 	 * The unix timestamp of the oldest product that is still considered "fresh" but
 	 * which is about to get stale within the next 5 sync cycles.
+	 *
+	 * Products are removed from PayPal's catalog once they become stale, so every
+	 * product must be re-synced before it crosses this threshold.
 	 */
 	public function get_expired_product_timestamp(): int {
-		$lifespan    = 24 * HOUR_IN_SECONDS * $this->get_product_lifespan_in_days();
+		$lifespan    = 24 * HOUR_IN_SECONDS * self::CATALOG_LIFESPAN_IN_DAYS;
 		$sync_buffer = 5 * self::SYNC_INTERVAL_IN_SECONDS;
 
-		return time() - $lifespan + $sync_buffer;
+		/**
+		 * Filters the unix timestamp beyond which a product is considered stale and
+		 * must be re-synced. Products last processed before this timestamp are
+		 * re-evaluated on the next run.
+		 *
+		 * @param int $timestamp The stale-threshold unix timestamp.
+		 */
+		return (int) apply_filters(
+			'woocommerce_paypal_payments_store_sync_expired_product_timestamp',
+			time() - $lifespan + $sync_buffer
+		);
 	}
 
 	/**
 	 * Interval of the recurring sync process.
 	 */
 	public function get_sync_interval_in_seconds(): int {
-		return self::SYNC_INTERVAL_IN_SECONDS;
+		/**
+		 * Filters the interval (in seconds) between recurring product-sync runs.
+		 *
+		 * @param int $interval The sync interval in seconds. Must be a positive integer.
+		 */
+		return (int) apply_filters(
+			'woocommerce_paypal_payments_store_sync_interval',
+			self::SYNC_INTERVAL_IN_SECONDS
+		);
 	}
 
 	/**
 	 * How many products are included in one sync batch?
 	 */
 	public function get_sync_batch_size(): int {
-		return self::SYNC_BATCH_SIZE;
-	}
-
-	/**
-	 * Single source of truth providing all filters to identify products which are compatible
-	 * with store-sync.
-	 *
-	 * @return array
-	 */
-	public function get_valid_product_filters(): array {
-		return array(
-			'status'       => ProductStatus::PUBLISH,
-			'type'         => self::SUPPORTED_PRODUCT_TYPES,
-			'downloadable' => false,
+		/**
+		 * Filters the number of products included in one sync batch.
+		 *
+		 * @param int $batch_size The sync batch size. Must be a positive integer; a
+		 *                        value of 0 or less flips the underlying product query
+		 *                        to unlimited (the entire catalog in one batch).
+		 */
+		return (int) apply_filters(
+			'woocommerce_paypal_payments_store_sync_batch_size',
+			self::SYNC_BATCH_SIZE
 		);
 	}
 }

--- a/modules/ppcp-store-sync/src/Ingestion/IngestionBatchProvider.php
+++ b/modules/ppcp-store-sync/src/Ingestion/IngestionBatchProvider.php
@@ -126,10 +126,9 @@ class IngestionBatchProvider {
 	private function query_candidates( array $meta_query, array $exclude, int $limit, bool $order_by_meta ): array {
 		// phpcs:disable WordPress.DB.SlowDBQuery -- intentionally using the meta_query here.
 		$args = array(
-			'limit'      => $limit,
-			'return'     => 'ids',
-			'meta_query' => array( $meta_query ),
-			'exclude'    => $exclude,
+			'limit'   => $limit,
+			'return'  => 'ids',
+			'exclude' => $exclude,
 		);
 
 		// Add ordering for stale products (oldest first).
@@ -142,7 +141,23 @@ class IngestionBatchProvider {
 		// Constrain to the coarse eligibility criteria (status/type/downloadable).
 		$args = array_merge( $args, $this->product_filter->query_filters() );
 
-		$products = wc_get_products( $args );
+		// wc_get_products() silently discards a raw 'meta_query' argument
+		// (WC_Data_Store_WP::get_wp_query_args() skips it), so the freshness clause
+		// is injected into the underlying WP_Query args through WooCommerce's own
+		// query filter instead.
+		$inject_meta_query = static function ( array $wp_query_args ) use ( $meta_query ): array {
+			$wp_query_args['meta_query'][] = $meta_query;
+
+			return $wp_query_args;
+		};
+
+		add_filter( 'woocommerce_product_data_store_cpt_get_products_query', $inject_meta_query );
+
+		try {
+			$products = wc_get_products( $args );
+		} finally {
+			remove_filter( 'woocommerce_product_data_store_cpt_get_products_query', $inject_meta_query );
+		}
 		// phpcs:enable WordPress.DB.SlowDBQuery
 
 		assert( is_array( $products ) );

--- a/modules/ppcp-store-sync/src/Ingestion/IngestionBatchProvider.php
+++ b/modules/ppcp-store-sync/src/Ingestion/IngestionBatchProvider.php
@@ -76,11 +76,12 @@ class IngestionBatchProvider {
 		$items_in_batch  = count( $current_batch );
 		$remaining_items = $batch_size - $items_in_batch;
 		$collected       = array();
+		$seen            = array();
 
 		while ( $remaining_items > 0 ) {
 			$candidates = $this->query_candidates(
 				$meta_query,
-				array_merge( $current_batch, $collected ),
+				array_merge( $current_batch, $seen ),
 				$remaining_items,
 				$order_by_meta
 			);
@@ -90,6 +91,11 @@ class IngestionBatchProvider {
 			}
 
 			foreach ( $candidates as $product_id ) {
+				// Excluding every seen candidate (not just collected ones)
+				// guarantees the pool shrinks each pass, so the loop always
+				// terminates even when a product cannot be loaded or parked.
+				$seen[] = (int) $product_id;
+
 				$product = wc_get_product( $product_id );
 				if ( ! $product ) {
 					continue;

--- a/modules/ppcp-store-sync/src/Ingestion/IngestionBatchProvider.php
+++ b/modules/ppcp-store-sync/src/Ingestion/IngestionBatchProvider.php
@@ -12,9 +12,11 @@ use WooCommerce\PayPalCommerce\StoreSync\Config\IngestionConfiguration;
  */
 class IngestionBatchProvider {
 	private IngestionConfiguration $configuration;
+	private ProductFilter $product_filter;
 
-	public function __construct( IngestionConfiguration $configuration ) {
-		$this->configuration = $configuration;
+	public function __construct( IngestionConfiguration $configuration, ProductFilter $product_filter ) {
+		$this->configuration  = $configuration;
+		$this->product_filter = $product_filter;
 	}
 
 	/**
@@ -25,68 +27,114 @@ class IngestionBatchProvider {
 	 * 2. Products that have been updated since last sync
 	 * 3. Products that haven't been synced in the configured stale timeout period
 	 *
+	 * Candidates are filtered live through {@see ProductFilter}: ineligible products
+	 * are parked (so subsequent queries skip them) and the batch is topped up until
+	 * it is full or the candidate pool is exhausted.
+	 *
 	 * @return array An array of product IDs that need to be synced.
 	 */
 	public function get_batch(): array {
-		$resync_timestamp = $this->configuration->get_expired_product_timestamp();
-		$stale_date       = gmdate( 'Y-m-d H:i:s', $resync_timestamp );
+		$stale_date = $this->configuration->get_expired_product_timestamp();
 
 		// Define meta queries for different product states.
 		$meta_fresh = array(
-			'key'     => '_ppcp_agentic_last_sync',
+			'key'     => ProductFilter::META_KEY,
 			'compare' => 'NOT EXISTS',
 		);
 
 		$meta_stale = array(
-			'key'     => '_ppcp_agentic_last_sync',
+			'key'     => ProductFilter::META_KEY,
 			'value'   => $stale_date,
 			'compare' => '<',
-			'type'    => 'DATETIME',
+			'type'    => 'NUMERIC',
 		);
 
 		// Fresh: Products have local changes that were not synced yet.
-		$fresh = $this->get_products( $meta_fresh );
+		$fresh = $this->collect_eligible( $meta_fresh );
 
 		// Stale: Products in the catalog that were not re-synced for a long time.
-		$stale = $this->get_products( $meta_stale, $fresh, true );
+		$stale = $this->collect_eligible( $meta_stale, $fresh, true );
 
 		return array_merge( $fresh, $stale );
 	}
 
 	/**
-	 * Get products matching the given meta query criteria.
+	 * Collects eligible product IDs for a single freshness clause.
 	 *
-	 * @param array $meta_query    The meta query criteria.
-	 * @param array $current_batch Product IDs that are already in the batch.
-	 * @param bool  $order_by_meta Whether to order results by meta-value (for stale products).
-	 * @return array Array of product IDs.
+	 * Repeatedly queries candidates and passes each live through {@see ProductFilter}:
+	 * eligible ones are collected, ineligible ones are parked (which drops them out of
+	 * the next query in this same run and of all future runs). Stops when the batch is
+	 * full or the candidate pool is exhausted.
+	 *
+	 * @param array $meta_query    The freshness clause for this pass.
+	 * @param array $current_batch Product IDs already collected by an earlier pass.
+	 * @param bool  $order_by_meta Whether to order results by meta-value (stale pass).
+	 * @return array The product IDs newly collected by this pass.
 	 */
-	private function get_products( array $meta_query, array $current_batch = array(), bool $order_by_meta = false ): array {
+	private function collect_eligible( array $meta_query, array $current_batch = array(), bool $order_by_meta = false ): array {
 		$batch_size      = $this->configuration->get_sync_batch_size();
 		$items_in_batch  = count( $current_batch );
 		$remaining_items = $batch_size - $items_in_batch;
+		$collected       = array();
 
-		if ( $remaining_items <= 0 ) {
-			return array();
+		while ( $remaining_items > 0 ) {
+			$candidates = $this->query_candidates(
+				$meta_query,
+				array_merge( $current_batch, $collected ),
+				$remaining_items,
+				$order_by_meta
+			);
+
+			if ( empty( $candidates ) ) {
+				break; // Pool exhausted for this clause.
+			}
+
+			foreach ( $candidates as $product_id ) {
+				$product = wc_get_product( $product_id );
+				if ( ! $product ) {
+					continue;
+				}
+
+				if ( ! $this->product_filter->passes_exclusion_filter( $product ) ) {
+					$this->product_filter->mark_processed( $product, 'Excluded by filter' );
+					continue;
+				}
+
+				$collected[] = (int) $product_id;
+				--$remaining_items;
+			}
 		}
 
+		return $collected;
+	}
+
+	/**
+	 * Queries a page of candidate product IDs, constrained to eligible+not-parked.
+	 *
+	 * @param array $meta_query    The freshness clause.
+	 * @param array $exclude       Product IDs already collected (skip them).
+	 * @param int   $limit         Maximum number of candidates to return.
+	 * @param bool  $order_by_meta Whether to order by the freshness meta-value.
+	 * @return array Array of product IDs.
+	 */
+	private function query_candidates( array $meta_query, array $exclude, int $limit, bool $order_by_meta ): array {
 		// phpcs:disable WordPress.DB.SlowDBQuery -- intentionally using the meta_query here.
-		$args = array_merge(
-			$this->configuration->get_valid_product_filters(),
-			array(
-				'limit'      => $remaining_items,
-				'return'     => 'ids',
-				'meta_query' => array( $meta_query ),
-				'exclude'    => $current_batch,
-			)
+		$args = array(
+			'limit'      => $limit,
+			'return'     => 'ids',
+			'meta_query' => array( $meta_query ),
+			'exclude'    => $exclude,
 		);
 
 		// Add ordering for stale products (oldest first).
 		if ( $order_by_meta && isset( $meta_query['key'] ) ) {
-			$args['orderby']  = 'meta_value';
+			$args['orderby']  = 'meta_value_num';
 			$args['order']    = 'ASC';
 			$args['meta_key'] = $meta_query['key'];
 		}
+
+		// Constrain to the coarse eligibility criteria (status/type/downloadable).
+		$args = array_merge( $args, $this->product_filter->query_filters() );
 
 		$products = wc_get_products( $args );
 		// phpcs:enable WordPress.DB.SlowDBQuery

--- a/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
+++ b/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
@@ -26,6 +26,7 @@ class IngestionManager {
 	private MerchantMetadataProvider $metadata_provider;
 	private LoggerInterface $logger;
 	private ProductManager $product_manager;
+	private ProductFilter $product_filter;
 
 	public function __construct(
 		IngestionConfiguration $configuration,
@@ -33,7 +34,8 @@ class IngestionManager {
 		AgenticWebhookConfiguration $webhook_urls,
 		MerchantMetadataProvider $metadata_provider,
 		LoggerInterface $logger,
-		ProductManager $product_manager
+		ProductManager $product_manager,
+		ProductFilter $product_filter
 	) {
 
 		$this->configuration     = $configuration;
@@ -42,6 +44,7 @@ class IngestionManager {
 		$this->metadata_provider = $metadata_provider;
 		$this->logger            = $logger;
 		$this->product_manager   = $product_manager;
+		$this->product_filter    = $product_filter;
 	}
 
 	/**
@@ -143,7 +146,8 @@ class IngestionManager {
 			$metadata->store_url,
 			$product_ids,
 			$this->logger,
-			$this->product_manager
+			$this->product_manager,
+			$this->product_filter
 		);
 	}
 }

--- a/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
+++ b/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
@@ -114,7 +114,9 @@ class IngestionManager {
 		$product_ids = $this->batch_provider->get_batch();
 
 		if ( empty( $product_ids ) ) {
-			return; // Nothing to sync.
+			$this->logger->info( '[Sync] Empty batch - no products need syncing' );
+
+			return;
 		}
 
 		$sync_job = $this->create_new_sync_job( $product_ids );

--- a/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
+++ b/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
@@ -65,6 +65,12 @@ class IngestionManager {
 		// Handle re-sync on product update.
 		add_action( 'woocommerce_update_product', array( $this, 'mark_product_for_sync' ) );
 		add_action( 'woocommerce_product_set_stock', array( $this, 'mark_product_for_sync' ) );
+
+		// Public fast path: release every parked product for immediate re-evaluation.
+		add_action(
+			'woocommerce_paypal_payments_store_sync_invalidate_eligibility',
+			array( $this->product_filter, 'invalidate_all' )
+		);
 	}
 
 	/**

--- a/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
+++ b/modules/ppcp-store-sync/src/Ingestion/IngestionManager.php
@@ -128,8 +128,8 @@ class IngestionManager {
 			return;
 		}
 
-		$product->delete_meta_data( '_ppcp_agentic_last_sync' );
-		$product->save_meta_data();
+		// An edit may change eligibility or completeness: re-evaluate at first priority.
+		$this->product_filter->release( $product );
 	}
 
 	/**

--- a/modules/ppcp-store-sync/src/Ingestion/ProductFilter.php
+++ b/modules/ppcp-store-sync/src/Ingestion/ProductFilter.php
@@ -1,0 +1,145 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
+
+use Automattic\WooCommerce\Enums\ProductStatus;
+use Automattic\WooCommerce\Enums\ProductType;
+use Psr\Log\LoggerInterface;
+use WC_Product;
+
+/**
+ * Single source of truth for "is this product eligible for the ingestion feed?".
+ *
+ * Owns the internal eligibility criteria, the reduce-only filter for third-party
+ * exclusions and the "processed at" meta which lets the ingestion query skip
+ * recently handled products until they become stale.
+ */
+class ProductFilter {
+	/**
+	 * Post-meta key holding the unix timestamp of when a product was last processed.
+	 *
+	 * "Processed" means we synced it or decided not to sync it (ineligible), so the
+	 * value records "we have dealt with this product". It is compared live against a
+	 * dynamically computed stale threshold, never a persisted deadline:
+	 *
+	 * Absent          .. never processed (new or edited); first priority.
+	 * < stale_date    .. processed long ago; stale, re-evaluate and sync.
+	 * >= stale_date   .. processed recently; skip.
+	 */
+	public const META_KEY = '_ppcp_agentic_processed_at';
+
+	/**
+	 * Product types compatible with the ingestion feed.
+	 */
+	public const SUPPORTED_PRODUCT_TYPES = array(
+		ProductType::SIMPLE,
+		ProductType::VARIABLE,
+	);
+
+	private LoggerInterface $logger;
+
+	public function __construct( LoggerInterface $logger ) {
+		$this->logger = $logger;
+	}
+
+	/**
+	 * Coarse eligibility criteria as declarative arguments for wc_get_products().
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function query_filters(): array {
+		return array(
+			'status'       => ProductStatus::PUBLISH,
+			'type'         => self::SUPPORTED_PRODUCT_TYPES,
+			'downloadable' => false,
+		);
+	}
+
+	/**
+	 * Per-product form of {@see ProductFilter::query_filters()}.
+	 *
+	 * @param WC_Product $product The product to inspect.
+	 *
+	 * @return string|null The slug of the violated rule ('downloadable' | 'type' | 'status'),
+	 *                     or null when the product matches all criteria.
+	 */
+	public function criteria_violation( WC_Product $product ): ?string {
+		if ( $product->is_downloadable() ) {
+			return 'downloadable';
+		}
+
+		if ( ! $product->is_type( self::SUPPORTED_PRODUCT_TYPES ) ) {
+			return 'type';
+		}
+
+		if ( ProductStatus::PUBLISH !== $product->get_status() ) {
+			return 'status';
+		}
+
+		return null;
+	}
+
+	/**
+	 * Runs the reduce-only third-party exclusion hook.
+	 *
+	 * @param WC_Product $product The product to inspect.
+	 * @return bool True to keep the product, false when a third party excludes it.
+	 */
+	public function passes_exclusion_filter( WC_Product $product ): bool {
+		return ! (bool) apply_filters(
+			'woocommerce_paypal_payments_store_sync_exclude_product',
+			false,
+			$product
+		);
+	}
+
+	/**
+	 * Records that a product was processed (synced or decided ineligible).
+	 *
+	 * Writes the current timestamp, so the product is skipped by the ingestion query
+	 * until it becomes stale, then re-evaluated. The same value is written whether the
+	 * product was synced or excluded: the meta only records "we dealt with this".
+	 */
+	public function mark_processed( WC_Product $product, string $log_info = '' ): void {
+		$product->update_meta_data( self::META_KEY, (string) time() );
+		$product->save_meta_data();
+
+		$this->logger->debug(
+			sprintf(
+				'Agentic ProductFilter: marked product %d processed',
+				$product->get_id()
+			),
+			array( 'info' => $log_info )
+		);
+	}
+
+	/**
+	 * Releases a product so it is re-evaluated on the next run (first priority).
+	 *
+	 * @param WC_Product $product The product to release.
+	 */
+	public function release( WC_Product $product ): void {
+		$product->delete_meta_data( self::META_KEY );
+		$product->save_meta_data();
+	}
+
+	/**
+	 * Clears the processed marker on every product, forcing a full re-evaluation on
+	 * the next run.
+	 *
+	 * Reminder: WC products are stored in the post table, even with HPOS enabled.
+	 */
+	public function invalidate_all(): void {
+		delete_post_meta_by_key( self::META_KEY );
+
+		/**
+		 * Broadcast that all ingestion-flags were invalidated and the next sync
+		 * re-evaluates each product again.
+		 */
+		do_action( 'woocommerce_paypal_payments_store_sync_eligibility_invalidated' );
+
+		$this->logger->info( 'Agentic ProductFilter: invalidated all processed markers' );
+	}
+}

--- a/modules/ppcp-store-sync/src/Ingestion/ProductFilter.php
+++ b/modules/ppcp-store-sync/src/Ingestion/ProductFilter.php
@@ -106,12 +106,17 @@ class ProductFilter {
 		$product->update_meta_data( self::META_KEY, (string) time() );
 		$product->save_meta_data();
 
+		$context = array();
+		if ( '' !== $log_info ) {
+			$context['log_info'] = $log_info;
+		}
+
 		$this->logger->debug(
 			sprintf(
-				'Agentic ProductFilter: marked product %d processed',
+				'[ProductFilter] Marked product %d processed',
 				$product->get_id()
 			),
-			array( 'info' => $log_info )
+			$context
 		);
 	}
 
@@ -140,6 +145,6 @@ class ProductFilter {
 		 */
 		do_action( 'woocommerce_paypal_payments_store_sync_eligibility_invalidated' );
 
-		$this->logger->info( 'Agentic ProductFilter: invalidated all processed markers' );
+		$this->logger->info( '[ProductFilter] Invalidated all processed markers' );
 	}
 }

--- a/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
+++ b/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
@@ -24,13 +24,15 @@ class SyncJob {
 	private string $api_endpoint;
 	private string $merchant_store_url;
 	private ProductManager $product_manager;
+	private ProductFilter $product_filter;
 
 	public function __construct(
 		string $api_endpoint,
 		string $merchant_store_url,
 		array $product_ids,
 		LoggerInterface $logger,
-		ProductManager $product_manager
+		ProductManager $product_manager,
+		ProductFilter $product_filter
 	) {
 
 		$this->api_endpoint       = $api_endpoint;
@@ -39,6 +41,7 @@ class SyncJob {
 		$this->logger             = $logger;
 		$this->batch_id           = wp_generate_uuid4();
 		$this->product_manager    = $product_manager;
+		$this->product_filter     = $product_filter;
 	}
 
 	/**
@@ -67,6 +70,9 @@ class SyncJob {
 
 		$products = $payload_container->get_products();
 
+		// Drop entries the webhook would reject for missing data; park their products.
+		$products = $this->drop_incomplete_products( $products );
+
 		if ( empty( $products ) ) {
 			$this->logger->info(
 				sprintf( 'Agentic Sync Job %s: No products', $this->batch_id )
@@ -81,7 +87,7 @@ class SyncJob {
 		$body = array(
 			'merchant_url' => $this->merchant_store_url,
 			'products'     => array_map(
-				static fn ( ProductDTO $product ): array => $product->to_array(),
+				static fn( ProductDTO $product ): array => $product->to_array(),
 				$products
 			),
 		);
@@ -116,6 +122,57 @@ class SyncJob {
 
 		// Log the error message and throw an Exception.
 		$this->handle_api_error( $this->product_ids, "HTTP {$status_code}: {$response_body}" );
+	}
+
+	private function drop_incomplete_products( array $products ): array {
+		$complete = array();
+
+		foreach ( $products as $product ) {
+			$data = $product->to_array();
+
+			if ( $this->has_complete_sync_data( $data ) ) {
+				$complete[] = $product;
+				continue;
+			}
+
+			// The item_group_id is always a WC_Product, even for variants.
+			$entry_id = (int) $data['item_group_id'];
+
+			if ( in_array( $entry_id, $this->product_ids, true ) ) {
+				$this->product_ids = array_values(
+					array_diff( $this->product_ids, array( $entry_id ) )
+				);
+
+				$wc_product = wc_get_product( $entry_id );
+				if ( $wc_product ) {
+					$this->product_filter->mark_processed( $wc_product, 'Incomplete payload' );
+				}
+			}
+		}
+
+		return $complete;
+	}
+
+	private function has_complete_sync_data( array $data ): bool {
+		$required_fields = array(
+			'id',
+			'item_group_id',
+			'title',
+			'link',
+			'image_link',
+			'description',
+			'price',
+			'availability',
+			'merchantStoreUrl',
+		);
+
+		foreach ( $required_fields as $field ) {
+			if ( '' === ( $data[ $field ] ?? '' ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -300,8 +357,8 @@ class SyncJob {
 			return;
 		}
 
-		$timestamp = current_time( 'mysql' );
-		$product->update_meta_data( '_ppcp_agentic_last_sync', $timestamp );
+		$this->product_filter->mark_processed( $product );
+
 		$product->delete_meta_data( '_ppcp_agentic_sync_error' );
 		$product->save_meta_data();
 	}
@@ -309,7 +366,7 @@ class SyncJob {
 	/**
 	 * Mark a single product with validation error.
 	 *
-	 * Products with validation errors are still considered "synced" (the sync
+	 * Products with validation errors are still considered "processed" (the sync
 	 * attempt was made), but store the validation error for merchant visibility.
 	 *
 	 * @param int    $product_id    Product ID.
@@ -322,8 +379,8 @@ class SyncJob {
 			return;
 		}
 
-		$timestamp = current_time( 'mysql' );
-		$product->update_meta_data( '_ppcp_agentic_last_sync', $timestamp );
+		$this->product_filter->mark_processed( $product, $error_message );
+
 		$product->update_meta_data( '_ppcp_agentic_sync_error', $error_message );
 		$product->save_meta_data();
 	}

--- a/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
+++ b/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
@@ -115,7 +115,7 @@ class SyncJob {
 		$response_body = wp_remote_retrieve_body( $response );
 
 		if ( $status_code >= 200 && $status_code < 422 ) {
-			$this->handle_successful_response( $response_body );
+			$this->handle_successful_response( $response_body, $products );
 
 			return;
 		}
@@ -181,9 +181,11 @@ class SyncJob {
 	 * Parses the response to check for individual product validation errors,
 	 * marks products accordingly, and logs the result.
 	 *
-	 * @param string $response_body The API response body.
+	 * @param string       $response_body    The API response body.
+	 * @param ProductDTO[] $payload_products The product entries sent in the request, in
+	 *                                       payload order (used to resolve per-item errors).
 	 */
-	private function handle_successful_response( string $response_body ): void {
+	private function handle_successful_response( string $response_body, array $payload_products ): void {
 		// First, mark all products as synced to avoid re-syncing them in the next batch.
 		$this->mark_products_synced( $this->product_ids );
 
@@ -218,7 +220,7 @@ class SyncJob {
 		$validation_errors = array();
 
 		if ( $contains_errors && $error_message ) {
-			$validation_errors = $this->extract_product_errors( $error_message );
+			$validation_errors = $this->extract_product_errors( $error_message, $payload_products );
 
 			$this->mark_products_by_validation_result( $validation_errors );
 		}
@@ -236,10 +238,12 @@ class SyncJob {
 	 * Parses error messages like "data/products/0/image_link must pass..." to
 	 * identify which products in the batch actually failed validation.
 	 *
-	 * @param string $error_message The error message to parse.
+	 * @param string       $error_message    The error message to parse.
+	 * @param ProductDTO[] $payload_products The product entries sent in the request, in payload
+	 *                                       order.
 	 * @return array Array of product IDs (keys) and the relevant validation error (values).
 	 */
-	private function extract_product_errors( string $error_message ): array {
+	private function extract_product_errors( string $error_message, array $payload_products ): array {
 		$errors = array();
 
 		// Pattern: data/products/{index} followed by error text until comma or end.
@@ -252,11 +256,13 @@ class SyncJob {
 
 		foreach ( $matches as $match ) {
 			$index = (int) $match[1];
-			$id    = $this->product_ids[ $index ] ?? null;
+			$entry = $payload_products[ $index ] ?? null;
 
-			if ( is_null( $id ) ) {
+			if ( null === $entry ) {
 				continue;
 			}
+
+			$id            = (int) $entry->to_array()['item_group_id'];
 			$errors[ $id ] = trim( $match[2] );
 		}
 

--- a/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
+++ b/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
@@ -58,7 +58,8 @@ class SyncJob {
 	 */
 	public function execute(): void {
 		$this->logger->info(
-			sprintf( 'Agentic Sync Job %s: Started', $this->batch_id )
+			'[Sync] Started',
+			$this->build_log_context()
 		);
 
 		// Transform products into DTOs.
@@ -75,7 +76,8 @@ class SyncJob {
 
 		if ( empty( $products ) ) {
 			$this->logger->info(
-				sprintf( 'Agentic Sync Job %s: No products', $this->batch_id )
+				'[Sync] No products',
+				$this->build_log_context()
 			);
 
 			$this->fire_completed_action( 'empty', 0, 0, 0 );
@@ -104,7 +106,7 @@ class SyncJob {
 			)
 		);
 
-		$this->logger->debug( "Start Sync {$this->batch_id}...", $body );
+		$this->logger->debug( '[Sync] Started...', $this->build_log_context( $body ) );
 
 		if ( is_wp_error( $response ) ) {
 			// Log the error message and throw an Exception.
@@ -195,11 +197,10 @@ class SyncJob {
 
 			$this->logger->info(
 				sprintf(
-					'Agentic Sync Job %s: Successfully synced %d products',
-					$this->batch_id,
+					'[Sync] Successfully synced %d products',
 					count( $this->product_ids )
 				),
-				$response_data
+				$this->build_log_context( $response_data )
 			);
 
 			$contains_errors = false === ( $response_data['success'] ?? false );
@@ -279,11 +280,8 @@ class SyncJob {
 	 */
 	private function mark_products_by_validation_result( array $validation_errors ): void {
 		$this->logger->warning(
-			sprintf(
-				'Agentic Sync Job %s: Validation errors',
-				$this->batch_id
-			),
-			$validation_errors
+			'[Sync] Validation errors',
+			$this->build_log_context( $validation_errors )
 		);
 
 		foreach ( $validation_errors as $product_id => $error_message ) {
@@ -304,10 +302,12 @@ class SyncJob {
 	 */
 	private function handle_api_error( array $product_ids, string $error_message ): void {
 		$this->logger->warning(
-			sprintf( 'Agentic Sync Job %s: API Error - %s', $this->batch_id, $error_message ),
-			array(
-				'product_count' => count( $product_ids ),
-				'product_ids'   => $product_ids,
+			sprintf( '[Sync] API Error - %s', $error_message ),
+			$this->build_log_context(
+				array(
+					'product_count' => count( $product_ids ),
+					'product_ids'   => $product_ids,
+				)
 			)
 		);
 
@@ -383,5 +383,23 @@ class SyncJob {
 		foreach ( $product_ids as $product_id ) {
 			$this->mark_product_synced( $product_id );
 		}
+	}
+
+	/**
+	 * @param mixed $context The log data - an array or any other value to log.
+	 * @return array
+	 */
+	private function build_log_context( $context = array() ): array {
+		$log_context = array( 'job' => $this->batch_id );
+
+		if ( ! is_array( $context ) ) {
+			if ( null === $context ) {
+				$context = array();
+			} else {
+				$context = array( 'raw' => $context );
+			}
+		}
+
+		return array_merge( $log_context, $context );
 	}
 }

--- a/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
+++ b/modules/ppcp-store-sync/src/Ingestion/SyncJob.php
@@ -289,8 +289,8 @@ class SyncJob {
 	 * Handle API or network errors by logging and throwing exception for retry.
 	 *
 	 * This method handles actual API failures (not validation errors) that should
-	 * trigger retry logic. Products are marked with error metadata, and an exception
-	 * is thrown to signal Action Scheduler to retry.
+	 * trigger retry logic. The error is logged and an exception is thrown to signal
+	 * Action Scheduler to retry; products are left unmarked so they are retried.
 	 *
 	 * @param array  $product_ids   Product IDs that failed to sync.
 	 * @param string $error_message The error message.
@@ -304,17 +304,6 @@ class SyncJob {
 				'product_ids'   => $product_ids,
 			)
 		);
-
-		foreach ( $product_ids as $product_id ) {
-			$product = wc_get_product( $product_id );
-
-			if ( ! $product ) {
-				continue;
-			}
-
-			$product->update_meta_data( '_ppcp_agentic_sync_error', $error_message );
-			$product->save_meta_data();
-		}
 
 		$pushed = count( $product_ids );
 		$this->fire_completed_action( 'api_error', $pushed, 0, $pushed, $error_message );
@@ -358,16 +347,13 @@ class SyncJob {
 		}
 
 		$this->product_filter->mark_processed( $product );
-
-		$product->delete_meta_data( '_ppcp_agentic_sync_error' );
-		$product->save_meta_data();
 	}
 
 	/**
 	 * Mark a single product with validation error.
 	 *
 	 * Products with validation errors are still considered "processed" (the sync
-	 * attempt was made), but store the validation error for merchant visibility.
+	 * attempt was made); the validation error is routed to the log via mark_processed().
 	 *
 	 * @param int    $product_id    Product ID.
 	 * @param string $error_message Validation error message.
@@ -380,9 +366,6 @@ class SyncJob {
 		}
 
 		$this->product_filter->mark_processed( $product, $error_message );
-
-		$product->update_meta_data( '_ppcp_agentic_sync_error', $error_message );
-		$product->save_meta_data();
 	}
 
 	/**

--- a/patchwork.json
+++ b/patchwork.json
@@ -3,6 +3,7 @@
         "json_decode",
         "filter_input",
         "gmdate",
-        "strtotime"
+        "strtotime",
+        "time"
     ]
 }

--- a/tests/PHPUnit/StoreSync/CartValidation/ProductValidatorTest.php
+++ b/tests/PHPUnit/StoreSync/CartValidation/ProductValidatorTest.php
@@ -5,7 +5,8 @@ declare( strict_types = 1 );
 namespace WooCommerce\PayPalCommerce\StoreSync\CartValidation;
 
 use Mockery;
-use WooCommerce\PayPalCommerce\StoreSync\Config\IngestionConfiguration;
+use WooCommerce\PayPalCommerce\StoreSync\Enums\ResolutionAction;
+use WooCommerce\PayPalCommerce\StoreSync\Ingestion\ProductFilter;
 use WooCommerce\PayPalCommerce\StoreSync\Validation\StoreValidation;
 use WooCommerce\PayPalCommerce\StoreSync\Validation\ValidationIssue;
 
@@ -17,38 +18,28 @@ class ProductValidatorTest extends ValidationTest {
 	private ProductValidator $validator;
 
 	/** @var \Mockery\MockInterface */
-	private $configuration;
+	private $product_filter;
 
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->configuration = Mockery::mock( IngestionConfiguration::class );
-		$this->validator     = new ProductValidator( $this->configuration );
+		$this->product_filter = Mockery::mock( ProductFilter::class );
+		$this->product_filter->allows( 'criteria_violation' )->andReturn( null );
+		$this->product_filter->allows( 'passes_exclusion_filter' )->andReturn( true );
+
+		$this->validator = new ProductValidator( $this->product_filter );
 	}
 
 	/**
-	 * GIVEN a cart containing one purchasable, valid product
+	 * GIVEN a cart containing one purchasable product that passes all filter criteria
 	 * WHEN validate() is called
 	 * THEN an empty array is returned (no issues)
 	 */
 	public function test_validate_valid_product_returns_no_issues(): void {
 		$product = Mockery::mock( 'WC_Product' );
 		$product->allows( 'is_purchasable' )->andReturn( true );
-		$product->allows( 'is_downloadable' )->andReturn( false );
-		$product->allows( 'is_type' )->andReturn( true );
-		$product->allows( 'get_status' )->andReturn( 'publish' );
 		$product->allows( 'get_name' )->andReturn( 'Valid Product' );
 		$product->allows( 'get_id' )->andReturn( 42 );
-
-		$this->configuration
-			->allows( 'get_valid_product_filters' )
-			->andReturn(
-				array(
-					'downloadable' => false,
-					'status'       => array( 'publish' ),
-					'type'         => array( 'simple', 'variable', 'variation' ),
-				)
-			);
 
 		$item = $this->make_store_item( 0, $product, true, 'USD', '42', 2 );
 
@@ -64,16 +55,14 @@ class ProductValidatorTest extends ValidationTest {
 	/**
 	 * GIVEN a cart containing a product that is not purchasable
 	 * WHEN validate() is called
-	 * THEN a non-empty array is returned indicating the item is invalid
+	 * THEN an invalid-product issue is returned
+	 * AND the issue carries both a "remove item" and a "suggest alternative" resolution
 	 */
-	public function test_validate_non_purchasable_product_returns_non_empty_result(): void {
+	public function test_validate_non_purchasable_product_returns_invalid_product_issue(): void {
 		$product = Mockery::mock( 'WC_Product' );
 		$product->allows( 'is_purchasable' )->andReturn( false );
 		$product->allows( 'get_name' )->andReturn( 'Unavailable Product' );
 		$product->allows( 'get_id' )->andReturn( 99 );
-
-		// Configuration must NOT be consulted when the product is not purchasable.
-		$this->configuration->shouldNotReceive( 'get_valid_product_filters' );
 
 		$item = $this->make_store_item( 0, $product, true, 'USD', '99', 1 );
 
@@ -83,30 +72,33 @@ class ProductValidatorTest extends ValidationTest {
 		);
 
 		$this->assertIsArray( $result );
-		$this->assertNotEmpty( $result );
+		$this->assertCount( 1, $result );
+
+		$data = $result[0]->to_array();
+		$this->assertValidationIssue( $data, 'INVENTORY_ISSUE', 'INVALID_DATA', 'items[0]', "not available for purchase" );
+		$this->assertResolutionOption( $data, ResolutionAction::REMOVE_ITEM );
+		$this->assertResolutionOption( $data, ResolutionAction::SUGGEST_ALTERNATIVE );
 	}
 
 	/**
-	 * GIVEN a cart containing a downloadable product when downloads are disabled
+	 * GIVEN a cart containing a purchasable product that violates the ingestion criteria
 	 * WHEN validate() is called
-	 * THEN a non-empty array is returned indicating the item is invalid
+	 * THEN a non-empty array with an invalid-product issue is returned
+	 * AND the developer message matches the specific criteria violation
+	 * AND no resolution option is attached
+	 *
+	 * @dataProvider criteria_violation_provider
 	 */
-	public function test_validate_downloadable_product_when_not_supported_returns_non_empty_result(): void {
+	public function test_validate_product_violating_criteria_returns_invalid_product_issue(
+		string $violation,
+		string $expected_message_substring
+	): void {
 		$product = Mockery::mock( 'WC_Product' );
 		$product->allows( 'is_purchasable' )->andReturn( true );
-		$product->allows( 'is_downloadable' )->andReturn( true );
 		$product->allows( 'get_name' )->andReturn( 'Digital Goods' );
 		$product->allows( 'get_id' )->andReturn( 55 );
 
-		$this->configuration
-			->allows( 'get_valid_product_filters' )
-			->andReturn(
-				array(
-					'downloadable' => false,
-					'status'       => array( 'publish' ),
-					'type'         => array( 'simple' ),
-				)
-			);
+		$this->product_filter->allows( 'criteria_violation' )->andReturn( $violation );
 
 		$item = $this->make_store_item( 0, $product, true, 'USD', '55', 1 );
 
@@ -116,7 +108,50 @@ class ProductValidatorTest extends ValidationTest {
 		);
 
 		$this->assertIsArray( $result );
-		$this->assertNotEmpty( $result );
+		$this->assertCount( 1, $result );
+
+		$data = $result[0]->to_array();
+		$this->assertValidationIssue( $data, 'INVENTORY_ISSUE', 'INVALID_DATA', 'items[0]', $expected_message_substring );
+		$this->assertArrayNotHasKey( 'resolution_options', $data );
+	}
+
+	public function criteria_violation_provider(): array {
+		return array(
+			'downloadable product is rejected'         => array( 'downloadable', "Downloadable product '55' is not supported" ),
+			'unsupported product type is rejected'     => array( 'type', "Product '55' is not supported (unsupported product type)" ),
+			'unsupported product status is rejected'   => array( 'status', "Product '55' is not supported (product has an unsupported status)" ),
+		);
+	}
+
+	/**
+	 * GIVEN a purchasable product that passes the criteria check but is excluded by a
+	 *       third-party exclusion filter
+	 * WHEN validate() is called
+	 * THEN an invalid-product issue with a "remove item" resolution is returned
+	 * AND the product is marked as processed exactly once
+	 */
+	public function test_validate_excluded_product_returns_invalid_product_issue_and_marks_processed(): void {
+		$product = Mockery::mock( 'WC_Product' );
+		$product->allows( 'is_purchasable' )->andReturn( true );
+		$product->allows( 'get_name' )->andReturn( 'Excluded Product' );
+		$product->allows( 'get_id' )->andReturn( 77 );
+
+		$this->product_filter->allows( 'passes_exclusion_filter' )->andReturn( false );
+		$this->product_filter->expects( 'mark_processed' )->once()->with( $product );
+
+		$item = $this->make_store_item( 0, $product, true, 'USD', '77', 1 );
+
+		$cart   = $this->create_cart( '77', 1, 'Excluded Product' );
+		$result = $this->validator->validate(
+			$this->wrap_in_store_cart( $cart, null, array( $item ) )
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+
+		$data = $result[0]->to_array();
+		$this->assertValidationIssue( $data, 'INVENTORY_ISSUE', 'INVALID_DATA', 'items[0]', "Product '77' is not supported" );
+		$this->assertResolutionOption( $data, ResolutionAction::REMOVE_ITEM );
 	}
 
 	/**
@@ -125,8 +160,6 @@ class ProductValidatorTest extends ValidationTest {
 	 * THEN null is returned immediately without inspecting any product
 	 */
 	public function test_validate_skips_when_inventory_issue_already_present(): void {
-		$this->configuration->shouldNotReceive( 'get_valid_product_filters' );
-
 		$pre_existing_issue =
 			ValidationIssue::create_item_out_of_stock( 'Pre-existing inventory problem' );
 
@@ -141,36 +174,23 @@ class ProductValidatorTest extends ValidationTest {
 	}
 
 	/**
-	 * GIVEN a cart with multiple items where only one has an unsupported product type
+	 * GIVEN a cart with multiple items where only one violates the ingestion criteria
 	 * WHEN validate() is called
 	 * THEN only the invalid item is in the returned array
 	 */
 	public function test_validate_returns_only_invalid_items_from_mixed_cart(): void {
 		$valid_product = Mockery::mock( 'WC_Product' );
 		$valid_product->allows( 'is_purchasable' )->andReturn( true );
-		$valid_product->allows( 'is_downloadable' )->andReturn( false );
-		$valid_product->allows( 'is_type' )->andReturn( true );
-		$valid_product->allows( 'get_status' )->andReturn( 'publish' );
 		$valid_product->allows( 'get_name' )->andReturn( 'Simple Widget' );
 		$valid_product->allows( 'get_id' )->andReturn( 10 );
 
 		$invalid_product = Mockery::mock( 'WC_Product' );
 		$invalid_product->allows( 'is_purchasable' )->andReturn( true );
-		$invalid_product->allows( 'is_downloadable' )->andReturn( false );
-		$invalid_product->allows( 'is_type' )->andReturn( false ); // unsupported type
-		$invalid_product->allows( 'get_status' )->andReturn( 'publish' );
 		$invalid_product->allows( 'get_name' )->andReturn( 'Subscription Box' );
 		$invalid_product->allows( 'get_id' )->andReturn( 20 );
 
-		$this->configuration
-			->allows( 'get_valid_product_filters' )
-			->andReturn(
-				array(
-					'downloadable' => false,
-					'status'       => array( 'publish' ),
-					'type'         => array( 'simple', 'variable', 'variation' ),
-				)
-			);
+		$this->product_filter->allows( 'criteria_violation' )->with( $valid_product )->andReturn( null );
+		$this->product_filter->allows( 'criteria_violation' )->with( $invalid_product )->andReturn( 'type' );
 
 		$valid_item   = $this->make_store_item( 0, $valid_product, true, 'USD', '10', 1 );
 		$invalid_item = $this->make_store_item( 1, $invalid_product, true, 'USD', '20', 1 );

--- a/tests/PHPUnit/StoreSync/CartValidation/ProductValidatorTest.php
+++ b/tests/PHPUnit/StoreSync/CartValidation/ProductValidatorTest.php
@@ -24,8 +24,8 @@ class ProductValidatorTest extends ValidationTest {
 		parent::setUp();
 
 		$this->product_filter = Mockery::mock( ProductFilter::class );
-		$this->product_filter->allows( 'criteria_violation' )->andReturn( null );
-		$this->product_filter->allows( 'passes_exclusion_filter' )->andReturn( true );
+		$this->product_filter->allows( 'criteria_violation' )->andReturn( null )->byDefault();
+		$this->product_filter->allows( 'passes_exclusion_filter' )->andReturn( true )->byDefault();
 
 		$this->validator = new ProductValidator( $this->product_filter );
 	}

--- a/tests/PHPUnit/StoreSync/Ingestion/IngestionBatchProviderTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/IngestionBatchProviderTest.php
@@ -20,6 +20,11 @@ class IngestionBatchProviderTest extends TestCase {
 	private $configuration;
 
 	/**
+	 * @var ProductFilter|Mockery\MockInterface
+	 */
+	private $product_filter;
+
+	/**
 	 * @var array
 	 */
 	private $product_types = array( 'simple', 'variable' );
@@ -45,376 +50,325 @@ class IngestionBatchProviderTest extends TestCase {
 		$this->expired_timestamp = strtotime( '-7 days' );
 
 		$this->configuration = Mockery::mock( IngestionConfiguration::class );
-		$this->configuration->allows( 'get_valid_product_filters' )
+		$this->configuration->allows( 'get_sync_batch_size' )->andReturn( $this->batch_size );
+		$this->configuration->allows( 'get_expired_product_timestamp' )
+			->andReturn( $this->expired_timestamp );
+
+		$this->product_filter = Mockery::mock( ProductFilter::class );
+		$this->product_filter->allows( 'query_filters' )
 			->andReturn( array(
 				'status'       => ProductStatus::PUBLISH,
 				'type'         => $this->product_types,
 				'downloadable' => false,
 			) );
-		$this->configuration->allows( 'get_sync_batch_size' )->andReturn( $this->batch_size );
-		$this->configuration->allows( 'get_expired_product_timestamp' )
-			->andReturn( $this->expired_timestamp );
+		$this->product_filter->allows( 'passes_exclusion_filter' )->andReturn( true );
 
-		$this->provider = new IngestionBatchProvider( $this->configuration );
-
-		// Mock WordPress date functions
-		when( 'gmdate' )->alias( function ( $format, $timestamp = null ) {
-			if ( $timestamp === null ) {
-				$timestamp = time();
-			}
-
-			return gmdate( $format, $timestamp );
-		} );
+		$this->provider = new IngestionBatchProvider( $this->configuration, $this->product_filter );
 
 		when( 'strtotime' )->alias( 'strtotime' );
 	}
 
+	/**
+	 * GIVEN a pool of never-synced products and a separate pool of stale products
+	 * WHEN get_batch() is called
+	 * THEN the never-synced products are returned first
+	 * AND the stale products fill the remainder of the batch
+	 */
 	public function test_get_batch_returns_never_synced_products_first(): void {
-		// Arrange
 		$never_synced_ids = array( 1, 2, 3, 4, 5 );
 		$stale_ids        = array( 6, 7, 8, 9, 10 );
 
-		// Mock wc_get_products calls
-		when( 'wc_get_products' )->alias( function ( $args ) use ( $never_synced_ids, $stale_ids ) {
-			// First call - products never synced
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === 'NOT EXISTS' ) {
-				$this->assertEquals( ProductStatus::PUBLISH, $args['status'] );
-				$this->assertEquals( $this->product_types, $args['type'] );
-				$this->assertFalse( $args['downloadable'] );
-				$this->assertEquals( $this->batch_size, $args['limit'] );
-				$this->assertEquals( 'ids', $args['return'] );
+		when( 'wc_get_product' )->alias( function () {
+			return Mockery::mock( 'WC_Product' );
+		} );
 
-				return $never_synced_ids;
+		when( 'wc_get_products' )->alias( function ( $args ) use ( $never_synced_ids, $stale_ids ) {
+			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $never_synced_ids, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
 			}
 
-			// Second call - stale products
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === '<' ) {
-				$this->assertEquals( 5, $args['limit'] ); // 10 - 5 already found
-				$this->assertEquals( 'DATETIME', $args['meta_query'][0]['type'] );
-				$this->assertEquals( 'meta_value', $args['orderby'] );
-				$this->assertEquals( 'ASC', $args['order'] );
-				$this->assertEquals( '_ppcp_agentic_last_sync', $args['meta_key'] );
-
-				return $stale_ids;
+			if ( '<' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $stale_ids, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
 			}
 
 			return array();
 		} );
 
-		// Act
 		$result = $this->provider->get_batch();
 
-		// Assert
 		$this->assertEquals( array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ), $result );
 	}
 
+	/**
+	 * GIVEN a batch size of 5 and a pool of 10 never-synced products
+	 * WHEN get_batch() is called
+	 * THEN only 5 products are returned, respecting the configured limit
+	 */
 	public function test_get_batch_respects_limit_with_never_synced_products(): void {
-		// Arrange - configure batch size of 5
 		$config = Mockery::mock( IngestionConfiguration::class );
-		$config->allows( 'get_valid_product_filters' )->andReturn( array(
-			'status'       => ProductStatus::PUBLISH,
-			'type'         => $this->product_types,
-			'downloadable' => false,
-		) );
 		$config->allows( 'get_sync_batch_size' )->andReturn( 5 );
 		$config->allows( 'get_expired_product_timestamp' )->andReturn( $this->expired_timestamp );
 
-		$provider         = new IngestionBatchProvider( $config );
+		$provider         = new IngestionBatchProvider( $config, $this->product_filter );
 		$never_synced_ids = array( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 );
 
-		when( 'wc_get_products' )->alias( function ( $args ) use ( $never_synced_ids ) {
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === 'NOT EXISTS' ) {
-				$this->assertEquals( 5, $args['limit'] );
+		when( 'wc_get_product' )->alias( function () {
+			return Mockery::mock( 'WC_Product' );
+		} );
 
-				return array_slice( $never_synced_ids, 0, 5 );
+		when( 'wc_get_products' )->alias( function ( $args ) use ( $never_synced_ids ) {
+			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $never_synced_ids, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
 			}
 
 			return array();
 		} );
 
-		// Act
 		$result = $provider->get_batch();
 
-		// Assert
 		$this->assertEquals( array( 1, 2, 3, 4, 5 ), $result );
 		$this->assertCount( 5, $result );
 	}
 
+	/**
+	 * GIVEN no never-synced products and a pool of stale products
+	 * WHEN get_batch() is called
+	 * THEN the stale products fill the whole batch
+	 */
 	public function test_get_batch_returns_stale_products_when_no_never_synced(): void {
-		// Arrange
 		$stale_product_ids = array( 11, 12, 13, 14, 15 );
 
+		when( 'wc_get_product' )->alias( function () {
+			return Mockery::mock( 'WC_Product' );
+		} );
+
 		when( 'wc_get_products' )->alias( function ( $args ) use ( $stale_product_ids ) {
-			// First call - no never synced products
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === 'NOT EXISTS' ) {
-				return array();
-			}
-
-			// Second call - stale products
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === '<' ) {
-				$this->assertEquals( $this->batch_size, $args['limit'] ); // Full batch size since no products found yet
-				$this->assertEquals( 'DATETIME', $args['meta_query'][0]['type'] );
-				$this->assertEquals( 'meta_value', $args['orderby'] );
-				$this->assertEquals( 'ASC', $args['order'] );
-				$this->assertEquals( '_ppcp_agentic_last_sync', $args['meta_key'] );
-
-				return $stale_product_ids;
+			if ( '<' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $stale_product_ids, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
 			}
 
 			return array();
 		} );
 
-		// Act
 		$result = $this->provider->get_batch();
 
-		// Assert
 		$this->assertEquals( array( 11, 12, 13, 14, 15 ), $result );
 	}
 
-	public function test_get_batch_returns_stale_products_when_no_other_products(): void {
-		// Arrange
-		$stale_product_ids = array( 21, 22, 23, 24 );
-
-		when( 'wc_get_products' )->alias( function ( $args ) use ( $stale_product_ids ) {
-			// First call - no never synced products
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === 'NOT EXISTS' ) {
-				$this->assertEquals( $this->batch_size, $args['limit'] );
-
-				return array();
-			}
-
-			// Second call - stale products
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === '<' ) {
-				$this->assertEquals( $this->batch_size, $args['limit'] );
-				$this->assertEquals( 'DATETIME', $args['meta_query'][0]['type'] );
-
-				// Verify stale date calculation uses configured timestamp
-				$expected_stale_date = gmdate( 'Y-m-d H:i:s', $this->expired_timestamp );
-				$this->assertEquals( $expected_stale_date, $args['meta_query'][0]['value'] );
-
-				// Verify ordering
-				$this->assertEquals( 'meta_value', $args['orderby'] );
-				$this->assertEquals( 'ASC', $args['order'] );
-				$this->assertEquals( '_ppcp_agentic_last_sync', $args['meta_key'] );
-
-				return $stale_product_ids;
-			}
-
-			return array();
-		} );
-
-		// Act
-		$result = $this->provider->get_batch();
-
-		// Assert
-		$this->assertEquals( $stale_product_ids, $result );
-	}
-
+	/**
+	 * GIVEN no products match any freshness clause
+	 * WHEN get_batch() is called
+	 * THEN an empty batch is returned
+	 */
 	public function test_get_batch_returns_empty_array_when_no_products(): void {
-		// Arrange
 		when( 'wc_get_products' )->justReturn( array() );
 
-		// Act
 		$result = $this->provider->get_batch();
 
-		// Assert
 		$this->assertEquals( array(), $result );
 	}
 
-	public function test_get_batch_uses_correct_product_query_parameters(): void {
-		// Arrange
-		$call_count = 0;
-
-		when( 'wc_get_products' )->alias( function ( $args ) use ( &$call_count ) {
-			$call_count ++;
-
-			// Common assertions for all calls
-			$this->assertEquals( ProductStatus::PUBLISH, $args['status'] );
-			$this->assertEquals( $this->product_types, $args['type'] );
-			$this->assertFalse( $args['downloadable'] );
-			$this->assertEquals( 'ids', $args['return'] );
-
-			// Return different results to trigger both queries
-			if ( $call_count === 1 ) {
-				// First call - never synced products
-				$this->assertEquals( $this->batch_size, $args['limit'] );
-
-				return array( 1, 2, 3 );
-			} else {
-				// Second call - stale products
-				$this->assertEquals( 7, $args['limit'] ); // 10 - 3 already found
-				$this->assertEquals( 'meta_value', $args['orderby'] );
-				$this->assertEquals( 'ASC', $args['order'] );
-				$this->assertEquals( '_ppcp_agentic_last_sync', $args['meta_key'] );
-
-				return array( 4, 5, 6 );
-			}
-		} );
-
-		// Act
-		$result = $this->provider->get_batch();
-
-		// Assert
-		$this->assertEquals( 2, $call_count );
-		$this->assertEquals( array( 1, 2, 3, 4, 5, 6 ), $result );
-	}
-
-	public function test_get_batch_with_custom_stale_timeout(): void {
-		// Arrange - configure custom expired timestamp (30 days ago)
-		$custom_expired_timestamp = strtotime( '-30 days' );
-		$config                   = Mockery::mock( IngestionConfiguration::class );
-		$config->allows( 'get_valid_product_filters' )->andReturn( array(
-			'status'       => ProductStatus::PUBLISH,
-			'type'         => $this->product_types,
-			'downloadable' => false,
-		) );
-		$config->allows( 'get_sync_batch_size' )->andReturn( 10 );
-		$config->allows( 'get_expired_product_timestamp' )->andReturn( $custom_expired_timestamp );
-
-		$custom_provider = new IngestionBatchProvider( $config );
-
-		when( 'wc_get_products' )->alias( function ( $args ) use ( $custom_expired_timestamp ) {
-			// Skip to stale products check
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === '<' ) {
-
-				$expected_stale_date = gmdate( 'Y-m-d H:i:s', $custom_expired_timestamp );
-				$this->assertEquals( $expected_stale_date, $args['meta_query'][0]['value'] );
-
-				return array( 100, 101, 102 );
-			}
-
-			return array();
-		} );
-
-		// Act
-		$result = $custom_provider->get_batch();
-
-		// Assert
-		$this->assertContains( 100, $result );
-		$this->assertContains( 101, $result );
-		$this->assertContains( 102, $result );
-	}
-
-	public function test_get_batch_with_custom_product_types(): void {
-		// Arrange - configure custom product types
-		$custom_types = array( 'simple', 'variable', 'grouped' );
-		$config       = Mockery::mock( IngestionConfiguration::class );
-		$config->allows( 'get_valid_product_filters' )->andReturn( array(
-			'status'       => ProductStatus::PUBLISH,
-			'type'         => $custom_types,
-			'downloadable' => false,
-		) );
-		$config->allows( 'get_sync_batch_size' )->andReturn( 10 );
-		$config->allows( 'get_expired_product_timestamp' )->andReturn( $this->expired_timestamp );
-
-		$custom_provider = new IngestionBatchProvider( $config );
-
-		when( 'wc_get_products' )->alias( function ( $args ) use ( $custom_types ) {
-			$this->assertEquals( $custom_types, $args['type'] );
-
-			return array( 1, 2, 3 );
-		} );
-
-		// Act
-		$result = $custom_provider->get_batch();
-
-		// Assert
-		$this->assertNotEmpty( $result );
-	}
-
+	/**
+	 * GIVEN a batch size of 15, 5 never-synced products, and 10 stale products
+	 * WHEN get_batch() is called
+	 * THEN the never-synced products come first and the stale products top up the rest
+	 * AND the full batch of 15 is returned in that order
+	 */
 	public function test_get_batch_handles_mixed_results(): void {
-		// Arrange - configure batch size of 15
 		$config = Mockery::mock( IngestionConfiguration::class );
-		$config->allows( 'get_valid_product_filters' )->andReturn( array(
-			'status'       => ProductStatus::PUBLISH,
-			'type'         => $this->product_types,
-			'downloadable' => false,
-		) );
 		$config->allows( 'get_sync_batch_size' )->andReturn( 15 );
 		$config->allows( 'get_expired_product_timestamp' )->andReturn( $this->expired_timestamp );
 
-		$provider = new IngestionBatchProvider( $config );
+		$provider   = new IngestionBatchProvider( $config, $this->product_filter );
+		$fresh_pool = array( 1, 2, 3, 4, 5 );
+		$stale_pool = array( 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 );
 
-		when( 'wc_get_products' )->alias( function ( $args ) {
-			// First call - never synced products
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === 'NOT EXISTS' ) {
-				return array( 1, 2, 3, 4, 5 );
+		when( 'wc_get_product' )->alias( function () {
+			return Mockery::mock( 'WC_Product' );
+		} );
+
+		when( 'wc_get_products' )->alias( function ( $args ) use ( $fresh_pool, $stale_pool ) {
+			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $fresh_pool, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
 			}
 
-			// Second call - stale products
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === '<' ) {
-				$this->assertEquals( 10, $args['limit'] ); // 15 - 5
-				$this->assertEquals( 'DATETIME', $args['meta_query'][0]['type'] );
-				$this->assertEquals( 'meta_value', $args['orderby'] );
-				$this->assertEquals( 'ASC', $args['order'] );
-				$this->assertEquals( '_ppcp_agentic_last_sync', $args['meta_key'] );
-
-				return array( 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 );
+			if ( '<' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $stale_pool, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
 			}
 
 			return array();
 		} );
 
-		// Act
 		$result = $provider->get_batch();
 
-		// Assert
 		$this->assertCount( 15, $result );
 		$this->assertEquals( range( 1, 15 ), $result );
 	}
 
+	/**
+	 * GIVEN a batch size of 7 and 7 never-synced products available
+	 * WHEN get_batch() is called
+	 * THEN the batch is filled entirely from never-synced products
+	 * AND no stale-products query is issued because the batch is already full
+	 */
 	public function test_get_batch_stops_when_limit_reached_after_fresh_products(): void {
-		// Arrange - configure batch size of 7
 		$config = Mockery::mock( IngestionConfiguration::class );
-		$config->allows( 'get_valid_product_filters' )->andReturn( array(
-			'status'       => ProductStatus::PUBLISH,
-			'type'         => $this->product_types,
-			'downloadable' => false,
-		) );
 		$config->allows( 'get_sync_batch_size' )->andReturn( 7 );
 		$config->allows( 'get_expired_product_timestamp' )->andReturn( $this->expired_timestamp );
 
-		$provider = new IngestionBatchProvider( $config );
+		$provider   = new IngestionBatchProvider( $config, $this->product_filter );
+		$fresh_pool = array( 1, 2, 3, 4, 5, 6, 7 );
 
-		when( 'wc_get_products' )->alias( function ( $args ) {
-			// First call - never synced products (returns full batch)
-			if ( isset( $args['meta_query'][0]['key'] ) &&
-				$args['meta_query'][0]['key'] === '_ppcp_agentic_last_sync' &&
-				$args['meta_query'][0]['compare'] === 'NOT EXISTS' ) {
-				$this->assertEquals( 7, $args['limit'] );
+		when( 'wc_get_product' )->alias( function () {
+			return Mockery::mock( 'WC_Product' );
+		} );
 
-				return array( 1, 2, 3, 4, 5, 6, 7 );
+		when( 'wc_get_products' )->alias( function ( $args ) use ( $fresh_pool ) {
+			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $fresh_pool, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
 			}
 
-			// This should not be called since batch is already full
+			// The stale clause must not be queried once the batch is already full.
 			$this->fail( 'Should not query for stale products when limit is reached' );
 		} );
 
-		// Act
 		$result = $provider->get_batch();
 
-		// Assert
 		$this->assertCount( 7, $result );
 		$this->assertEquals( array( 1, 2, 3, 4, 5, 6, 7 ), $result );
+	}
+
+	/**
+	 * GIVEN a candidate id that wc_get_product() cannot load (e.g. deleted product)
+	 * WHEN get_batch() collects eligible products
+	 * THEN the un-loadable id is skipped and never appears in the batch
+	 * AND the query loop terminates after a bounded number of wc_get_products() calls
+	 *     (regression: an un-loadable id must still be excluded from later queries,
+	 *     otherwise the same id would be returned by every subsequent query forever)
+	 */
+	public function test_get_batch_terminates_and_skips_unloadable_product_id(): void {
+		$config = Mockery::mock( IngestionConfiguration::class );
+		$config->allows( 'get_sync_batch_size' )->andReturn( 2 );
+		$config->allows( 'get_expired_product_timestamp' )->andReturn( $this->expired_timestamp );
+
+		$product_filter = Mockery::mock( ProductFilter::class );
+		$product_filter->allows( 'query_filters' )->andReturn( array() );
+		$product_filter->allows( 'passes_exclusion_filter' )->andReturn( true );
+
+		$provider = new IngestionBatchProvider( $config, $product_filter );
+
+		// The pool only ever contains id 100 (un-loadable) and id 1 (loadable).
+		// wc_get_products() is stubbed to behave like the real query: it never
+		// returns an id that is present in the "exclude" argument.
+		$fresh_pool = array( 100, 1 );
+		$call_count = 0;
+
+		when( 'wc_get_products' )->alias( function ( $args ) use ( $fresh_pool, &$call_count ) {
+			$call_count++;
+
+			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $fresh_pool, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
+			}
+
+			// Stale pass: no candidates.
+			return array();
+		} );
+
+		when( 'wc_get_product' )->alias( function ( $id ) {
+			return 100 === $id ? false : Mockery::mock( 'WC_Product' );
+		} );
+
+		$result = $provider->get_batch();
+
+		$this->assertSame( array( 1 ), $result, 'The un-loadable id must not appear in the batch.' );
+		$this->assertLessThanOrEqual(
+			5,
+			$call_count,
+			'wc_get_products() must be called a bounded number of times (no infinite loop).'
+		);
+	}
+
+	/**
+	 * GIVEN a candidate pool where one product fails the exclusion filter
+	 * WHEN get_batch() collects eligible products
+	 * THEN the excluded product is parked via ProductFilter::mark_processed()
+	 * AND is excluded from the batch
+	 * AND the batch tops up from the remaining pool until the configured batch size is reached
+	 */
+	public function test_get_batch_parks_excluded_product_and_tops_up_from_remaining_pool(): void {
+		$config = Mockery::mock( IngestionConfiguration::class );
+		$config->allows( 'get_sync_batch_size' )->andReturn( 2 );
+		$config->allows( 'get_expired_product_timestamp' )->andReturn( $this->expired_timestamp );
+
+		$products = array();
+		foreach ( array( 1, 2, 3 ) as $id ) {
+			$products[ $id ] = Mockery::mock( 'WC_Product' );
+		}
+
+		$product_filter = Mockery::mock( ProductFilter::class );
+		$product_filter->allows( 'query_filters' )->andReturn( array() );
+		// Only product 1 is excluded by the filter.
+		$product_filter->allows( 'passes_exclusion_filter' )->andReturnUsing(
+			function ( $product ) use ( $products ) {
+				return $product !== $products[1];
+			}
+		);
+		$product_filter->expects( 'mark_processed' )
+			->once()
+			->with( $products[1], 'Excluded by filter' );
+
+		$provider = new IngestionBatchProvider( $config, $product_filter );
+
+		$fresh_pool = array( 1, 2, 3 );
+
+		when( 'wc_get_products' )->alias( function ( $args ) use ( $fresh_pool ) {
+			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+				$available = array_values( array_diff( $fresh_pool, $args['exclude'] ) );
+				return array_slice( $available, 0, $args['limit'] );
+			}
+
+			return array();
+		} );
+
+		when( 'wc_get_product' )->alias( function ( $id ) use ( $products ) {
+			return $products[ $id ];
+		} );
+
+		$result = $provider->get_batch();
+
+		// The batch is topped up to the full batch size of 2, skipping product 1.
+		$this->assertSame( array( 2, 3 ), $result );
+	}
+
+	/**
+	 * GIVEN the sync batch size is configured to 0
+	 * WHEN get_batch() is called
+	 * THEN an empty batch is returned
+	 * AND no product query is ever issued
+	 */
+	public function test_get_batch_returns_empty_array_when_batch_size_is_zero(): void {
+		$config = Mockery::mock( IngestionConfiguration::class );
+		$config->allows( 'get_sync_batch_size' )->andReturn( 0 );
+		$config->allows( 'get_expired_product_timestamp' )->andReturn( $this->expired_timestamp );
+
+		$product_filter = Mockery::mock( ProductFilter::class );
+
+		$provider = new IngestionBatchProvider( $config, $product_filter );
+
+		when( 'wc_get_products' )->alias( function () {
+			$this->fail( 'wc_get_products() must not be called when the batch size is 0.' );
+		} );
+
+		$result = $provider->get_batch();
+
+		$this->assertSame( array(), $result );
 	}
 }

--- a/tests/PHPUnit/StoreSync/Ingestion/IngestionBatchProviderTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/IngestionBatchProviderTest.php
@@ -83,12 +83,12 @@ class IngestionBatchProviderTest extends TestCase {
 		} );
 
 		when( 'wc_get_products' )->alias( function ( $args ) use ( $never_synced_ids, $stale_ids ) {
-			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+			if ( ! isset( $args['orderby'] ) ) { // Fresh pass (the stale pass sets orderby).
 				$available = array_values( array_diff( $never_synced_ids, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}
 
-			if ( '<' === $args['meta_query'][0]['compare'] ) {
+			if ( isset( $args['orderby'] ) ) { // Stale pass (orders by the processed-at meta).
 				$available = array_values( array_diff( $stale_ids, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}
@@ -119,7 +119,7 @@ class IngestionBatchProviderTest extends TestCase {
 		} );
 
 		when( 'wc_get_products' )->alias( function ( $args ) use ( $never_synced_ids ) {
-			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+			if ( ! isset( $args['orderby'] ) ) { // Fresh pass (the stale pass sets orderby).
 				$available = array_values( array_diff( $never_synced_ids, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}
@@ -146,7 +146,7 @@ class IngestionBatchProviderTest extends TestCase {
 		} );
 
 		when( 'wc_get_products' )->alias( function ( $args ) use ( $stale_product_ids ) {
-			if ( '<' === $args['meta_query'][0]['compare'] ) {
+			if ( isset( $args['orderby'] ) ) { // Stale pass (orders by the processed-at meta).
 				$available = array_values( array_diff( $stale_product_ids, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}
@@ -192,12 +192,12 @@ class IngestionBatchProviderTest extends TestCase {
 		} );
 
 		when( 'wc_get_products' )->alias( function ( $args ) use ( $fresh_pool, $stale_pool ) {
-			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+			if ( ! isset( $args['orderby'] ) ) { // Fresh pass (the stale pass sets orderby).
 				$available = array_values( array_diff( $fresh_pool, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}
 
-			if ( '<' === $args['meta_query'][0]['compare'] ) {
+			if ( isset( $args['orderby'] ) ) { // Stale pass (orders by the processed-at meta).
 				$available = array_values( array_diff( $stale_pool, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}
@@ -230,7 +230,7 @@ class IngestionBatchProviderTest extends TestCase {
 		} );
 
 		when( 'wc_get_products' )->alias( function ( $args ) use ( $fresh_pool ) {
-			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+			if ( ! isset( $args['orderby'] ) ) { // Fresh pass (the stale pass sets orderby).
 				$available = array_values( array_diff( $fresh_pool, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}
@@ -273,7 +273,7 @@ class IngestionBatchProviderTest extends TestCase {
 		when( 'wc_get_products' )->alias( function ( $args ) use ( $fresh_pool, &$call_count ) {
 			$call_count++;
 
-			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+			if ( ! isset( $args['orderby'] ) ) { // Fresh pass (the stale pass sets orderby).
 				$available = array_values( array_diff( $fresh_pool, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}
@@ -330,7 +330,7 @@ class IngestionBatchProviderTest extends TestCase {
 		$fresh_pool = array( 1, 2, 3 );
 
 		when( 'wc_get_products' )->alias( function ( $args ) use ( $fresh_pool ) {
-			if ( 'NOT EXISTS' === $args['meta_query'][0]['compare'] ) {
+			if ( ! isset( $args['orderby'] ) ) { // Fresh pass (the stale pass sets orderby).
 				$available = array_values( array_diff( $fresh_pool, $args['exclude'] ) );
 				return array_slice( $available, 0, $args['limit'] );
 			}

--- a/tests/PHPUnit/StoreSync/Ingestion/ProductFilterTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/ProductFilterTest.php
@@ -1,0 +1,186 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\StoreSync\Ingestion;
+
+use Automattic\WooCommerce\Enums\ProductStatus;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WC_Product;
+use WooCommerce\PayPalCommerce\TestCase;
+
+use function Brain\Monkey\Actions\expectDone;
+use function Brain\Monkey\Filters\expectApplied;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\StoreSync\Ingestion\ProductFilter
+ */
+class ProductFilterTest extends TestCase {
+
+	/**
+	 * @var LoggerInterface|Mockery\MockInterface
+	 */
+	private $logger;
+
+	/**
+	 * @var ProductFilter
+	 */
+	private $product_filter;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->logger = Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
+
+		$this->product_filter = new ProductFilter( $this->logger );
+	}
+
+	/**
+	 * GIVEN the ProductFilter
+	 * WHEN query_filters() is called
+	 * THEN it returns the coarse eligibility criteria for wc_get_products()
+	 */
+	public function test_query_filters_returns_coarse_eligibility_criteria(): void {
+		$result = $this->product_filter->query_filters();
+
+		$this->assertSame(
+			array(
+				'status'       => ProductStatus::PUBLISH,
+				'type'         => ProductFilter::SUPPORTED_PRODUCT_TYPES,
+				'downloadable' => false,
+			),
+			$result
+		);
+	}
+
+	/**
+	 * GIVEN a product in a particular state
+	 * WHEN criteria_violation() is called
+	 * THEN the first violated rule is returned, or null when all criteria are met
+	 *
+	 * @dataProvider criteria_violation_provider
+	 */
+	public function test_criteria_violation(
+		bool $is_downloadable,
+		bool $is_supported_type,
+		string $status,
+		?string $expected
+	): void {
+		$product = Mockery::mock( 'WC_Product' );
+		$product->allows( 'is_downloadable' )->andReturn( $is_downloadable );
+		$product->allows( 'is_type' )->with( ProductFilter::SUPPORTED_PRODUCT_TYPES )->andReturn( $is_supported_type );
+		$product->allows( 'get_status' )->andReturn( $status );
+
+		$result = $this->product_filter->criteria_violation( $product );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	public function criteria_violation_provider(): array {
+		return array(
+			'downloadable product is rejected'                        => array( true, true, ProductStatus::PUBLISH, 'downloadable' ),
+			'unsupported product type is rejected'                    => array( false, false, ProductStatus::PUBLISH, 'type' ),
+			'non-published product is rejected'                       => array( false, true, 'draft', 'status' ),
+			'published, supported, non-downloadable product is kept'  => array( false, true, ProductStatus::PUBLISH, null ),
+			'downloadable takes precedence over wrong type and status' => array( true, false, 'draft', 'downloadable' ),
+		);
+	}
+
+	/**
+	 * GIVEN no third party overrides the exclusion filter
+	 * WHEN passes_exclusion_filter() is called
+	 * THEN the product is kept (true)
+	 */
+	public function test_passes_exclusion_filter_keeps_product_when_no_override(): void {
+		$product = Mockery::mock( 'WC_Product' );
+
+		expectApplied( 'woocommerce_paypal_payments_store_sync_exclude_product' )
+			->once()
+			->with( false, $product )
+			->andReturn( false );
+
+		$result = $this->product_filter->passes_exclusion_filter( $product );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * GIVEN a third party excludes the product via the filter
+	 * WHEN passes_exclusion_filter() is called
+	 * THEN the product is excluded (false)
+	 */
+	public function test_passes_exclusion_filter_excludes_product_when_overridden(): void {
+		$product = Mockery::mock( 'WC_Product' );
+
+		expectApplied( 'woocommerce_paypal_payments_store_sync_exclude_product' )
+			->once()
+			->with( false, $product )
+			->andReturn( true );
+
+		$result = $this->product_filter->passes_exclusion_filter( $product );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * GIVEN a product that was just synced or decided ineligible
+	 * WHEN mark_processed() is called
+	 * THEN the product's processed-at meta is written with the current timestamp
+	 * AND the meta change is persisted
+	 */
+	public function test_mark_processed_writes_current_timestamp_and_saves_meta(): void {
+		$this->expectNotToPerformAssertions();
+
+		when( 'time' )->justReturn( 1700000000 );
+
+		$product = Mockery::mock( WC_Product::class );
+		$product->allows( 'get_id' )->andReturn( 42 );
+		$product->expects( 'update_meta_data' )
+			->once()
+			->with( ProductFilter::META_KEY, '1700000000' );
+		$product->expects( 'save_meta_data' )->once();
+
+		$this->product_filter->mark_processed( $product );
+	}
+
+	/**
+	 * GIVEN a product whose eligibility should be re-evaluated
+	 * WHEN release() is called
+	 * THEN the processed-at meta is deleted
+	 * AND the meta change is persisted
+	 */
+	public function test_release_deletes_processed_meta_and_saves(): void {
+		$this->expectNotToPerformAssertions();
+
+		$product = Mockery::mock( WC_Product::class );
+		$product->expects( 'delete_meta_data' )
+			->once()
+			->with( ProductFilter::META_KEY );
+		$product->expects( 'save_meta_data' )->once();
+
+		$this->product_filter->release( $product );
+	}
+
+	/**
+	 * GIVEN a store with products carrying the processed-at marker
+	 * WHEN invalidate_all() is called
+	 * THEN the processed-at meta is deleted for every product
+	 * AND the eligibility-invalidated action is broadcast
+	 */
+	public function test_invalidate_all_clears_marker_and_broadcasts_action(): void {
+		$deleted_key = null;
+		when( 'delete_post_meta_by_key' )->alias(
+			function ( $key ) use ( &$deleted_key ) {
+				$deleted_key = $key;
+				return true;
+			}
+		);
+
+		expectDone( 'woocommerce_paypal_payments_store_sync_eligibility_invalidated' )->once();
+
+		$this->product_filter->invalidate_all();
+
+		$this->assertSame( ProductFilter::META_KEY, $deleted_key );
+	}
+}

--- a/tests/PHPUnit/StoreSync/Ingestion/SyncJobTest.php
+++ b/tests/PHPUnit/StoreSync/Ingestion/SyncJobTest.php
@@ -9,7 +9,11 @@ use WooCommerce\PayPalCommerce\TestCase;
 use Psr\Log\LoggerInterface;
 use Exception;
 use WC_Product;
+use WC_Product_Variable;
+use WC_Product_Variation;
 use Mockery;
+use function Brain\Monkey\Actions\expectDone;
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
 /**
@@ -28,6 +32,11 @@ class SyncJobTest extends TestCase {
 	private $product_manager;
 
 	/**
+	 * @var ProductFilter|Mockery\MockInterface
+	 */
+	private $product_filter;
+
+	/**
 	 * @var string
 	 */
 	private $api_endpoint = 'https://api.example.com/sync';
@@ -40,11 +49,14 @@ class SyncJobTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->logger = Mockery::mock( LoggerInterface::class );
+		// Catch-all logger: logging is a side effect we never assert on.
+		$this->logger = Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
 
 		$store_currency = Mockery::mock( StoreCurrencyValue::class );
 		$store_currency->allows( 'value' )->andReturn( 'USD' );
 		$this->product_manager = new ProductManager( $store_currency );
+
+		$this->product_filter = Mockery::mock( ProductFilter::class );
 
 		// Stub WordPress functions with default values
 		when( 'wp_generate_uuid4' )->justReturn( 'test-batch-id-1234' );
@@ -57,30 +69,14 @@ class SyncJobTest extends TestCase {
 	}
 
 	/**
-	 * Helper method to stub logger to allow all calls without verification.
-	 */
-	private function stub_logger_to_allow_all(): void {
-		$this->logger->allows( 'info' );
-		$this->logger->allows( 'warning' );
-		$this->logger->allows( 'debug' );
-		$this->logger->allows( 'error' );
-	}
-
-	/**
 	 * Helper method to create a stub simple product with all required methods.
 	 *
-	 * @param int    $id            Product ID.
-	 * @param string $title         Product title.
-	 * @param string $price         Product price.
-	 * @param bool   $stub_meta_ops Whether to stub meta operations (set false when verifying them).
+	 * @param int    $id    Product ID.
+	 * @param string $title Product title.
+	 * @param string $price Product price.
 	 * @return WC_Product|Mockery\MockInterface
 	 */
-	private function create_product_stub(
-		int $id,
-		string $title,
-		string $price,
-		bool $stub_meta_ops = true
-	): WC_Product {
+	private function create_product_stub( int $id, string $title, string $price ): WC_Product {
 		$product = Mockery::mock( WC_Product::class );
 
 		$product->allows( 'get_type' )->andReturn( 'simple' );
@@ -97,34 +93,22 @@ class SyncJobTest extends TestCase {
 		$product->allows( 'get_sale_price' )->andReturn( '' );
 		$product->allows( 'get_regular_price' )->andReturn( $price );
 
-		// Allow meta operations by default (unless we want to verify them)
-		if ( $stub_meta_ops ) {
-			$product->allows( 'update_meta_data' );
-			$product->allows( 'delete_meta_data' );
-			$product->allows( 'save_meta_data' );
-		}
-
 		return $product;
 	}
 
 	/**
 	 * Helper method to create multiple product stubs and configure wc_get_product.
 	 *
-	 * @param array $product_ids   Product IDs.
-	 * @param bool  $stub_meta_ops Whether to stub meta operations (set false when verifying them).
+	 * @param array $product_ids Product IDs.
 	 * @return array Product stubs indexed by ID.
 	 */
-	private function create_products_and_stub_wc_get_product(
-		array $product_ids,
-		bool $stub_meta_ops = true
-	): array {
+	private function create_products_and_stub_wc_get_product( array $product_ids ): array {
 		$products = array();
 		foreach ( $product_ids as $index => $id ) {
 			$products[ $id ] = $this->create_product_stub(
 				$id,
 				"Product {$id}",
-				(string) ( ( $index + 1 ) * 10 ),
-				$stub_meta_ops
+				(string) ( ( $index + 1 ) * 10 )
 			);
 		}
 
@@ -175,130 +159,96 @@ class SyncJobTest extends TestCase {
 	/**
 	 * GIVEN a sync job with valid product IDs
 	 * WHEN the API returns a successful response
-	 * THEN all products are marked as synced with current timestamp
-	 * AND the needs_sync and sync_error flags are cleared
-	 * AND a success message is logged
+	 * THEN every product is marked processed so it is not re-synced in the next batch
 	 */
 	public function test_execute_marks_products_as_synced_when_api_returns_success(): void {
-		// Test verification is done through Mockery expectations
 		$this->expectNotToPerformAssertions();
 
-		$products = $this->create_products_and_stub_wc_get_product( $this->product_ids, false );
+		$products = $this->create_products_and_stub_wc_get_product( $this->product_ids );
 		$this->stub_successful_api_response( $this->product_ids );
 
-		// Verify meta operations for successful sync
 		foreach ( $products as $product ) {
-			$product->shouldReceive( 'update_meta_data' )
+			$this->product_filter->shouldReceive( 'mark_processed' )
 				->once()
-				->with( '_ppcp_agentic_last_sync', '2024-01-01 12:00:00' );
-			$product->shouldReceive( 'delete_meta_data' )
-				->once()
-				->with( '_ppcp_agentic_sync_error' );
-			$product->shouldReceive( 'save_meta_data' )->once();
+				->with( $product );
 		}
-
-		$this->logger->shouldReceive( 'debug' )
-			->once()
-			->with(
-				'Start Sync test-batch-id-1234...',
-				Mockery::type( 'array' )
-			);
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: Started' );
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with(
-				'Agentic Sync Job test-batch-id-1234: Successfully synced 3 products',
-				array( 'product_ids' => $this->product_ids )
-			);
 
 		$sync_job = new SyncJob(
 			$this->api_endpoint,
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->product_manager
+			$this->product_manager,
+			$this->product_filter
 		);
 
 		$sync_job->execute();
 	}
 
 	/**
-	 * GIVEN a sync job with product IDs that don't exist in the database
+	 * GIVEN product IDs that do not resolve to any product
 	 * WHEN execute is called
 	 * THEN no API request is made
-	 * AND a "No products" message is logged
 	 */
-	public function test_execute_logs_no_products_when_all_product_ids_are_invalid(): void {
-		// Test verification is done through Mockery expectations
-		$this->expectNotToPerformAssertions();
-
+	public function test_execute_makes_no_api_request_when_all_product_ids_are_invalid(): void {
 		when( 'wc_get_product' )->justReturn( false );
 
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: Started' );
-
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: No products' );
+		expect( 'wp_remote_post' )->never();
 
 		$sync_job = new SyncJob(
 			$this->api_endpoint,
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->product_manager
+			$this->product_manager,
+			$this->product_filter
 		);
 
 		$sync_job->execute();
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * GIVEN a sync job with an empty product IDs array
+	 * WHEN execute is called
+	 * THEN no API request is made
+	 */
+	public function test_execute_makes_no_api_request_when_product_ids_array_is_empty(): void {
+		expect( 'wp_remote_post' )->never();
+
+		$sync_job = new SyncJob(
+			$this->api_endpoint,
+			'https://example.com',
+			array(),
+			$this->logger,
+			$this->product_manager,
+			$this->product_filter
+		);
+
+		$sync_job->execute();
+
+		$this->addToAssertionCount( 1 );
 	}
 
 	/**
 	 * GIVEN a sync job with valid products
 	 * WHEN the API returns a WordPress error (network failure)
-	 * THEN all products are marked with the error message
-	 * AND the error is logged with product details
+	 * THEN no products are marked as processed, so they are retried on the next run
 	 * AND a RuntimeException is thrown for Action Scheduler retry
 	 */
 	public function test_execute_throws_exception_when_wp_error_occurs(): void {
-		$products = $this->create_products_and_stub_wc_get_product( $this->product_ids, false );
+		$this->create_products_and_stub_wc_get_product( $this->product_ids );
 
-		// Verify error meta is set on products
-		foreach ( $products as $product ) {
-			$product->shouldReceive( 'update_meta_data' )
-				->once()
-				->with( '_ppcp_agentic_sync_error', 'Connection timeout' );
-			$product->shouldReceive( 'save_meta_data' )->once();
-		}
+		// Products are left unmarked so Action Scheduler retries them.
+		$this->product_filter->shouldNotReceive( 'mark_processed' );
 
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: Started' );
 		when( 'wp_remote_retrieve_body' )->justReturn( '' );
 
-		$this->logger->shouldReceive( 'warning' )
-			->once()
-			->with(
-				'Agentic Sync Job test-batch-id-1234: API Error - Connection timeout',
-				array(
-					'product_count' => 3,
-					'product_ids'   => $this->product_ids,
-				)
-			);
-
-		// Stub WP_Error response
 		$wp_error = Mockery::mock( 'WP_Error' );
 		$wp_error->allows( 'get_error_message' )->andReturn( 'Connection timeout' );
 
 		when( 'wp_remote_post' )->justReturn( $wp_error );
-		$this->logger->shouldReceive( 'debug' )
-			->once()
-			->with(
-				'Start Sync test-batch-id-1234...',
-				Mockery::type( 'array' )
-			);
 		when( 'is_wp_error' )->justReturn( true );
 
 		$sync_job = new SyncJob(
@@ -306,7 +256,8 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->product_manager
+			$this->product_manager,
+			$this->product_filter
 		);
 
 		$this->expectException( Exception::class );
@@ -318,7 +269,7 @@ class SyncJobTest extends TestCase {
 	/**
 	 * GIVEN a sync job with valid products
 	 * WHEN the API returns an HTTP error status code
-	 * THEN all products are marked with the error message including status and body
+	 * THEN no products are marked as processed, so they are retried on the next run
 	 * AND a RuntimeException is thrown for Action Scheduler retry
 	 *
 	 * @dataProvider http_error_provider
@@ -328,42 +279,19 @@ class SyncJobTest extends TestCase {
 		string $response_body,
 		string $expected_error
 	): void {
-		$products = $this->create_products_and_stub_wc_get_product( $this->product_ids, false );
+		$this->create_products_and_stub_wc_get_product( $this->product_ids );
 		$this->stub_http_error_response( $status_code, $response_body );
 
-		// Verify error meta is set on products
-		foreach ( $products as $product ) {
-			$product->shouldReceive( 'update_meta_data' )
-				->once()
-				->with( '_ppcp_agentic_sync_error', $expected_error );
-			$product->shouldReceive( 'save_meta_data' )->once();
-		}
-		$this->logger->shouldReceive( 'debug' )
-			->once()
-			->with(
-				'Start Sync test-batch-id-1234...',
-				Mockery::type( 'array' )
-			);
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: Started' );
-
-		$this->logger->shouldReceive( 'warning' )
-			->once()
-			->with(
-				"Agentic Sync Job test-batch-id-1234: API Error - {$expected_error}",
-				array(
-					'product_count' => 3,
-					'product_ids'   => $this->product_ids,
-				)
-			);
+		// Products are left unmarked so Action Scheduler retries them.
+		$this->product_filter->shouldNotReceive( 'mark_processed' );
 
 		$sync_job = new SyncJob(
 			$this->api_endpoint,
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->product_manager
+			$this->product_manager,
+			$this->product_filter
 		);
 
 		$this->expectException( Exception::class );
@@ -399,7 +327,7 @@ class SyncJobTest extends TestCase {
 	 */
 	public function test_execute_sends_properly_formatted_api_request(): void {
 		$this->create_products_and_stub_wc_get_product( $this->product_ids );
-		$this->stub_logger_to_allow_all();
+		$this->product_filter->allows( 'mark_processed' );
 
 		$api_endpoint     = $this->api_endpoint;
 		$captured_request = null;
@@ -424,7 +352,8 @@ class SyncJobTest extends TestCase {
 			'https://example.com',
 			$this->product_ids,
 			$this->logger,
-			$this->product_manager
+			$this->product_manager,
+			$this->product_filter
 		);
 
 		$sync_job->execute();
@@ -442,135 +371,252 @@ class SyncJobTest extends TestCase {
 	/**
 	 * GIVEN a sync job with a mix of valid and invalid product IDs
 	 * WHEN execute is called
-	 * THEN only valid products are included in the API payload
-	 * AND valid products are marked as synced
+	 * THEN only the valid product is marked processed
 	 */
 	public function test_execute_handles_mixed_valid_and_invalid_product_ids(): void {
-		// Test verification is done through Mockery expectations
 		$this->expectNotToPerformAssertions();
 
-		$valid_product = $this->create_product_stub( 1, 'Product 1', '10', false );
+		$valid_product = $this->create_product_stub( 1, 'Product 1', '10' );
 
 		when( 'wc_get_product' )->alias( function ( $id ) use ( $valid_product ) {
 			return $id === 1 ? $valid_product : false;
 		} );
 		$expectedProductIds = array( 1, 999, 888 );
 		$this->stub_successful_api_response( $expectedProductIds );
-		// Verify only the valid product gets synced
-		$valid_product->shouldReceive( 'update_meta_data' )
-			->once()
-			->with( '_ppcp_agentic_last_sync', '2024-01-01 12:00:00' );
-		$valid_product->shouldReceive( 'delete_meta_data' )
-			->once()
-			->with( '_ppcp_agentic_sync_error' );
-		$valid_product->shouldReceive( 'save_meta_data' )->once();
 
-		$this->logger->shouldReceive( 'info' )
+		$this->product_filter->shouldReceive( 'mark_processed' )
 			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: Started' );
-		$this->logger->shouldReceive( 'debug' )
-			->once()
-			->with(
-				'Start Sync test-batch-id-1234...',
-				Mockery::type( 'array' )
-			);
-
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with(
-				'Agentic Sync Job test-batch-id-1234: Successfully synced 3 products',
-				array( 'product_ids' => $expectedProductIds )
-			);
+			->with( $valid_product );
 
 		$sync_job = new SyncJob(
 			$this->api_endpoint,
 			'https://example.com',
 			$expectedProductIds,
 			$this->logger,
-			$this->product_manager
+			$this->product_manager,
+			$this->product_filter
 		);
 
 		$sync_job->execute();
 	}
 
 	/**
-	 * GIVEN a sync job with an empty product IDs array
-	 * WHEN execute is called
-	 * THEN no API request is made
-	 * AND a "No products" message is logged
+	 * GIVEN a batch of two products where one produces a payload entry missing a required
+	 * field (an empty title)
+	 * WHEN execute is called and the API responds successfully
+	 * THEN only the complete product is included in the API request payload
+	 * AND the incomplete product is marked processed with an "Incomplete payload" note
+	 * AND the complete product is still marked processed as synced
 	 */
-	public function test_execute_logs_no_products_when_product_ids_array_is_empty(): void {
-		// Test verification is done through Mockery expectations
-		$this->expectNotToPerformAssertions();
+	public function test_execute_drops_incomplete_product_from_payload_and_marks_it_processed(): void {
+		$complete_product   = $this->create_product_stub( 1, 'Complete Product', '10' );
+		$incomplete_product = $this->create_product_stub( 2, '', '20' );
 
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: Started' );
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: No products' );
+		when( 'wc_get_product' )->alias( function ( $id ) use ( $complete_product, $incomplete_product ) {
+			if ( 1 === $id ) {
+				return $complete_product;
+			}
+			if ( 2 === $id ) {
+				return $incomplete_product;
+			}
 
-		$sync_job = new SyncJob(
-			$this->api_endpoint,
-			'https://example.com',
-			array(),
-			$this->logger,
-			$this->product_manager
-		);
-
-		$sync_job->execute();
-	}
-
-	/**
-	 * GIVEN a sync job with a single product
-	 * WHEN the API returns success
-	 * THEN the correct product count is logged
-	 */
-	public function test_execute_logs_correct_count_for_single_product(): void {
-		// Test verification is done through Mockery expectations
-		$this->expectNotToPerformAssertions();
-
-		$product = $this->create_product_stub( 42, 'Single Product', '25', false );
-
-		when( 'wc_get_product' )->alias( function ( $id ) use ( $product ) {
-			return $id === 42 ? $product : false;
+			return false;
 		} );
-		$expectedProductIds = array( 42 );
-		$this->stub_successful_api_response( $expectedProductIds );
 
-		$product->shouldReceive( 'update_meta_data' )
+		$this->product_filter->shouldReceive( 'mark_processed' )
 			->once()
-			->with( '_ppcp_agentic_last_sync', '2024-01-01 12:00:00' );
-		$product->shouldReceive( 'delete_meta_data' )
+			->with( $incomplete_product, 'Incomplete payload' );
+		$this->product_filter->shouldReceive( 'mark_processed' )
 			->once()
-			->with( '_ppcp_agentic_sync_error' );
-		$product->shouldReceive( 'save_meta_data' )->once();
+			->with( $complete_product );
 
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with( 'Agentic Sync Job test-batch-id-1234: Started' );
-		$this->logger->shouldReceive( 'debug' )
-			->once()
-			->with(
-				'Start Sync test-batch-id-1234...',
-				Mockery::type( 'array' )
+		$captured_request = null;
+		when( 'wp_remote_post' )->alias( function ( $url, $args ) use ( &$captured_request ) {
+			$captured_request = $args;
+
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'body'     => '{"success": true}',
 			);
+		} );
 
-		$this->logger->shouldReceive( 'info' )
-			->once()
-			->with(
-				'Agentic Sync Job test-batch-id-1234: Successfully synced 1 products',
-				array( 'product_ids' => $expectedProductIds )
-			);
+		when( 'is_wp_error' )->justReturn( false );
+		when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		when( 'wp_remote_retrieve_body' )->justReturn( '{"success": true}' );
 
 		$sync_job = new SyncJob(
 			$this->api_endpoint,
 			'https://example.com',
-			$expectedProductIds,
+			array( 1, 2 ),
 			$this->logger,
-			$this->product_manager
+			$this->product_manager,
+			$this->product_filter
 		);
 
 		$sync_job->execute();
+
+		$body = json_decode( $captured_request['body'], true );
+
+		$this->assertCount( 1, $body['products'] );
+		$this->assertSame( '1', $body['products'][0]['id'] );
+	}
+
+	/**
+	 * GIVEN a batch where every product's payload entry is missing a required field
+	 * WHEN execute is called
+	 * THEN no API request is sent
+	 * AND the ingestion-completed action reports an "empty" batch with nothing pushed,
+	 * synced, or failed
+	 */
+	public function test_execute_skips_api_request_when_all_products_are_incomplete(): void {
+		$product_one = $this->create_product_stub( 1, '', '10' );
+		$product_two = $this->create_product_stub( 2, '', '20' );
+
+		when( 'wc_get_product' )->alias( function ( $id ) use ( $product_one, $product_two ) {
+			if ( 1 === $id ) {
+				return $product_one;
+			}
+			if ( 2 === $id ) {
+				return $product_two;
+			}
+
+			return false;
+		} );
+
+		$this->product_filter->allows( 'mark_processed' );
+
+		expect( 'wp_remote_post' )->never();
+
+		$captured_action = null;
+		expectDone( 'woocommerce_paypal_payments_store_sync_ingestion_completed' )
+			->once()
+			->whenHappen( function ( array $payload ) use ( &$captured_action ) {
+				$captured_action = $payload;
+			} );
+
+		$sync_job = new SyncJob(
+			$this->api_endpoint,
+			'https://example.com',
+			array( 1, 2 ),
+			$this->logger,
+			$this->product_manager,
+			$this->product_filter
+		);
+
+		$sync_job->execute();
+
+		$this->assertSame( 'empty', $captured_action['status'] );
+		$this->assertSame( 0, $captured_action['pushed'] );
+		$this->assertSame( 0, $captured_action['synced'] );
+		$this->assertSame( 0, $captured_action['failed'] );
+	}
+
+	/**
+	 * GIVEN a single variable product whose two variations expand into two payload entries,
+	 * both sharing the parent's item_group_id
+	 * WHEN the API reports a validation error on the second payload entry (index 1)
+	 * THEN the error is attributed to the parent product, resolved via item_group_id rather
+	 * than by indexing into the original product-id list
+	 * AND the ingestion-completed action reports one failure with status "validation_errors"
+	 */
+	public function test_execute_attributes_validation_error_to_parent_product_via_item_group_id(): void {
+		$parent_id     = 100;
+		$variation1_id = 101;
+		$variation2_id = 102;
+
+		$parent_product = Mockery::mock( WC_Product_Variable::class . ', ' . WC_Product::class );
+		$parent_product->shouldReceive( 'get_type' )->andReturn( 'variable' );
+		$parent_product->shouldReceive( 'is_type' )->with( 'variable' )->andReturn( true );
+		$parent_product->shouldReceive( 'get_children' )->andReturn( array( $variation1_id, $variation2_id ) );
+		$parent_product->shouldReceive( 'get_id' )->andReturn( $parent_id );
+		$parent_product->shouldReceive( 'get_image_id' )->andReturn( 300 );
+		$parent_product->shouldReceive( 'get_description' )->andReturn( 'Parent description' );
+
+		$variation1 = Mockery::mock( WC_Product_Variation::class );
+		$variation1->shouldReceive( 'is_purchasable' )->andReturn( true );
+		$variation1->shouldReceive( 'get_id' )->andReturn( $variation1_id );
+		$variation1->shouldReceive( 'get_name' )->andReturn( 'Variant Red' );
+		$variation1->shouldReceive( 'get_permalink' )->andReturn( 'https://example.com/v101' );
+		$variation1->shouldReceive( 'get_image_id' )->andReturn( 0 );
+		$variation1->shouldReceive( 'get_description' )->andReturn( '' );
+		$variation1->shouldReceive( 'get_price' )->andReturn( '10.00' );
+		$variation1->shouldReceive( 'get_stock_status' )->andReturn( 'instock' );
+		$variation1->shouldReceive( 'get_sku' )->andReturn( 'SKU-101' );
+		$variation1->shouldReceive( 'get_sale_price' )->andReturn( '' );
+		$variation1->shouldReceive( 'get_variation_attributes' )->andReturn( array() );
+
+		$variation2 = Mockery::mock( WC_Product_Variation::class );
+		$variation2->shouldReceive( 'is_purchasable' )->andReturn( true );
+		$variation2->shouldReceive( 'get_id' )->andReturn( $variation2_id );
+		$variation2->shouldReceive( 'get_name' )->andReturn( 'Variant Blue' );
+		$variation2->shouldReceive( 'get_permalink' )->andReturn( 'https://example.com/v102' );
+		$variation2->shouldReceive( 'get_image_id' )->andReturn( 202 );
+		$variation2->shouldReceive( 'get_description' )->andReturn( 'Variant 2 description' );
+		$variation2->shouldReceive( 'get_price' )->andReturn( '12.00' );
+		$variation2->shouldReceive( 'get_stock_status' )->andReturn( 'instock' );
+		$variation2->shouldReceive( 'get_sku' )->andReturn( 'SKU-102' );
+		$variation2->shouldReceive( 'get_sale_price' )->andReturn( '' );
+		$variation2->shouldReceive( 'get_variation_attributes' )->andReturn( array() );
+
+		when( 'wc_get_product' )->alias( function ( $id ) use ( $parent_id, $variation1_id, $variation2_id, $parent_product, $variation1, $variation2 ) {
+			if ( $parent_id === $id ) {
+				return $parent_product;
+			}
+			if ( $variation1_id === $id ) {
+				return $variation1;
+			}
+			if ( $variation2_id === $id ) {
+				return $variation2;
+			}
+
+			return false;
+		} );
+
+		when( 'wp_remote_post' )->justReturn( array(
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'body'     => '{}',
+		) );
+		when( 'is_wp_error' )->justReturn( false );
+		when( 'wp_remote_retrieve_response_code' )->justReturn( 200 );
+		when( 'wp_remote_retrieve_body' )->justReturn( json_encode( array(
+			'success' => false,
+			'message' => 'data/products/1 image_link must be a valid URL',
+		) ) );
+
+		$this->product_filter->shouldReceive( 'mark_processed' )
+			->once()
+			->with( $parent_product );
+		$this->product_filter->shouldReceive( 'mark_processed' )
+			->once()
+			->with( $parent_product, 'image_link must be a valid URL' );
+
+		$captured_action = null;
+		expectDone( 'woocommerce_paypal_payments_store_sync_ingestion_completed' )
+			->once()
+			->whenHappen( function ( array $payload ) use ( &$captured_action ) {
+				$captured_action = $payload;
+			} );
+
+		$sync_job = new SyncJob(
+			$this->api_endpoint,
+			'https://example.com',
+			array( $parent_id ),
+			$this->logger,
+			$this->product_manager,
+			$this->product_filter
+		);
+
+		$sync_job->execute();
+
+		$this->assertSame( 'validation_errors', $captured_action['status'] );
+		$this->assertSame( 1, $captured_action['pushed'] );
+		$this->assertSame( 0, $captured_action['synced'] );
+		$this->assertSame( 1, $captured_action['failed'] );
 	}
 }

--- a/tests/PHPUnit/bootstrap.php
+++ b/tests/PHPUnit/bootstrap.php
@@ -19,6 +19,7 @@ require_once TESTS_ROOT_DIR . '/stubs/DefaultPaymentGateways.php';
 require_once TESTS_ROOT_DIR . '/stubs/NoteTraits.php';
 require_once TESTS_ROOT_DIR . '/stubs/AbstractPaymentMethodType.php';
 require_once TESTS_ROOT_DIR . '/stubs/ProductStatus.php';
+require_once TESTS_ROOT_DIR . '/stubs/ProductType.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_Error.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Request.php';
 require_once TESTS_ROOT_DIR . '/stubs/WP_REST_Response.php';

--- a/tests/stubs/ProductType.php
+++ b/tests/stubs/ProductType.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Automattic\WooCommerce\Enums;
+
+/**
+ * Stub for WooCommerce ProductType enum class.
+ */
+final class ProductType {
+	/**
+	 * Simple product type.
+	 *
+	 * @var string
+	 */
+	public const SIMPLE = 'simple';
+
+	/**
+	 * Variable product type.
+	 *
+	 * @var string
+	 */
+	public const VARIABLE = 'variable';
+
+	/**
+	 * Grouped product type.
+	 *
+	 * @var string
+	 */
+	public const GROUPED = 'grouped';
+
+	/**
+	 * External/Affiliate product type.
+	 *
+	 * @var string
+	 */
+	public const EXTERNAL = 'external';
+
+	/**
+	 * Variation product type.
+	 *
+	 * @var string
+	 */
+	public const VARIATION = 'variation';
+}


### PR DESCRIPTION
# Description

Improves product filtering for store-sync ingestion batches. Three things:

- **New third-party filters.** A reduce-only `woocommerce_paypal_payments_store_sync_exclude_product`
  hook to drop products from the feed, plus a completeness check that removes
  products with missing required fields before they are sent (and bounced) by the
  ingestion endpoint.
- **Fixed the freshness selection.** `wc_get_products()` silently drops a raw
  `meta_query`, so the fresh/stale clause was ignored and every cron run re-synced
  the same products. It is now injected via WooCommerce's
  `woocommerce_product_data_store_cpt_get_products_query` filter.
- **Consolidated eligibility** into one `ProductFilter` class that the validator,
  batch provider, ingestion manager, and sync job all defer to.

## 🗃️ Meta keys

The product meta keys were renamed and consolidated into a single
`_ppcp_agentic_processed_at` marker. No migration logic is included, since store
sync is not yet used by any merchant.

## 🔍 What to review

The `meta_query` fix leans on WooCommerce internals (`wc_get_products` dropping the
raw arg, the CPT query filter re-adding it). Unit tests stub `wc_get_products` and
cannot see this coupling, so a regression would pass them silently. Real coverage
needs an integration test seeding products with and without the marker.

## 🧪 How to verify

1. Enable store sync and trigger the ingestion cron.
2. Trigger it again without editing anything: previously handled products are not
   re-sent.
3. Add a `woocommerce_paypal_payments_store_sync_exclude_product` filter returning
   `true` for a product, or remove a product's feature image, then trigger a run:
   that product is absent from the batch.