### PR TITLE
Stop endless store-sync onboarding retries (6719)

### DIFF
--- a/modules/ppcp-settings/src/Data/AbstractDataModel.php
+++ b/modules/ppcp-settings/src/Data/AbstractDataModel.php
@@ -26,6 +26,12 @@ abstract class AbstractDataModel {
 	protected array $data = array();
 
 	/**
+	 * Whether the "saved" action is currently being dispatched, used to
+	 * prevent infinite-loops when an action handler calls save() again.
+	 */
+	private bool $firing_saved_action = false;
+
+	/**
 	 * Option key for WordPress storage.
 	 * Must be overridden by the child class!
 	 */
@@ -67,6 +73,30 @@ abstract class AbstractDataModel {
 	 */
 	public function save(): void {
 		update_option( $this->get_option_key(), $this->data );
+
+		$this->fire_saved_action();
+	}
+
+	/**
+	 * Notifies listeners that this model was saved.
+	 */
+	protected function fire_saved_action(): void {
+		if ( $this->firing_saved_action ) {
+			return;
+		}
+
+		$this->firing_saved_action = true;
+
+		try {
+			/**
+			 * Fires after a settings model has been saved to the database.
+			 *
+			 * @param AbstractDataModel $model The settings model that was saved.
+			 */
+			do_action( 'woocommerce_paypal_payments_settings_saved', $this );
+		} finally {
+			$this->firing_saved_action = false;
+		}
 	}
 
 	/**

--- a/modules/ppcp-store-sync/services.php
+++ b/modules/ppcp-store-sync/services.php
@@ -37,6 +37,7 @@ use WooCommerce\PayPalCommerce\StoreSync\Setting\AgenticSettingsModule;
 use WooCommerce\PayPalCommerce\StoreSync\Merchant\MerchantMetadataProvider;
 use WooCommerce\PayPalCommerce\StoreSync\Registration\RegistrationService;
 use WooCommerce\PayPalCommerce\StoreSync\Registration\RegistrationEligibility;
+use WooCommerce\PayPalCommerce\StoreSync\Registration\ReconciliationService;
 use WooCommerce\PayPalCommerce\StoreSync\Helper\AgenticCheckoutProcessor;
 use WooCommerce\PayPalCommerce\StoreSync\Helper\ShippingOptionsBuilder;
 use WooCommerce\PayPalCommerce\StoreSync\Helper\PayPalOrderManager;
@@ -106,6 +107,13 @@ return array(
 		return new RegistrationService(
 			$c->get( 'agentic.config.webhook_urls' ),
 			$c->get( 'agentic.merchant.provider' ),
+			$c->get( 'agentic.logger.default' )
+		);
+	},
+	'agentic.registration.reconciler'              => static function ( ContainerInterface $c ): ReconciliationService {
+		return new ReconciliationService(
+			$c->get( 'agentic.settings.model' ),
+			$c->get( 'agentic.registration.handler' ),
 			$c->get( 'agentic.logger.default' )
 		);
 	},

--- a/modules/ppcp-store-sync/src/Registration/ReconciliationService.php
+++ b/modules/ppcp-store-sync/src/Registration/ReconciliationService.php
@@ -41,12 +41,21 @@ class ReconciliationService {
 		$desired = $this->settings->should_initialize_features();
 		$actual  = $this->registration->is_registered();
 
-		if ( $desired && ! $actual ) {
-			if ( $this->should_auto_register() ) {
-				$this->register();
-			}
-		} elseif ( ! $desired && $actual ) {
+		// State has not changed, do nothing.
+		if ( $desired === $actual ) {
+			return;
+		}
+
+		// Integration was disabled, clean up and unregister.
+		if ( ! $desired ) {
 			$this->registration->deregister();
+
+			return;
+		}
+
+		// Integration is enabled, let's check te auto-register flag before acting.
+		if ( $this->should_auto_register() ) {
+			$this->register();
 		}
 	}
 

--- a/modules/ppcp-store-sync/src/Registration/ReconciliationService.php
+++ b/modules/ppcp-store-sync/src/Registration/ReconciliationService.php
@@ -1,0 +1,86 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\StoreSync\Registration;
+
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\StoreSync\Setting\AgenticSettingsDataModel;
+
+/**
+ * Aligns the store's registration with the current settings: registers when the
+ * feature is enabled but the store is not registered, and deregisters when it is
+ * no longer enabled. Reconciliation is idempotent, so calling it when the desired
+ * and actual states already match does nothing.
+ */
+class ReconciliationService {
+
+	private AgenticSettingsDataModel $settings;
+	private RegistrationService $registration;
+	private LoggerInterface $logger;
+
+	public function __construct(
+		AgenticSettingsDataModel $settings,
+		RegistrationService $registration,
+		LoggerInterface $logger
+	) {
+
+		$this->settings     = $settings;
+		$this->registration = $registration;
+		$this->logger       = $logger;
+	}
+
+	/**
+	 * Aligns the registration state with the current settings.
+	 *
+	 * This is convergent: a failed registration disables the feature, so a
+	 * subsequent run sees the desired and actual states already matching and does
+	 * nothing.
+	 */
+	public function reconcile(): void {
+		$desired = $this->settings->should_initialize_features();
+		$actual  = $this->registration->is_registered();
+
+		if ( $desired && ! $actual ) {
+			if ( $this->should_auto_register() ) {
+				$this->register();
+			}
+		} elseif ( ! $desired && $actual ) {
+			$this->registration->deregister();
+		}
+	}
+
+	/**
+	 * Registers the store, disabling the feature when registration fails.
+	 *
+	 * A failure is never retried automatically: re-enabling the toggle is the
+	 * merchant's explicit retry mechanism.
+	 */
+	private function register(): void {
+		$result = $this->registration->register();
+
+		if ( ! is_wp_error( $result ) ) {
+			return;
+		}
+
+		$this->settings->set_active( false );
+		$this->settings->save();
+
+		$this->logger->warning(
+			'Store sync auto-disabled after registration failure',
+			array( 'error' => $result->get_error_message() )
+		);
+	}
+
+	/**
+	 * Whether auto-registration is enabled for this site.
+	 *
+	 * Disable for testing or troubleshooting by adding the following constant to
+	 * wp-config.php:
+	 *
+	 *   define( 'PPCP_AGENTIC_AUTO_REGISTER', false );
+	 */
+	private function should_auto_register(): bool {
+		return ! defined( 'PPCP_AGENTIC_AUTO_REGISTER' ) || PPCP_AGENTIC_AUTO_REGISTER;
+	}
+}

--- a/modules/ppcp-store-sync/src/Registration/ReconciliationService.php
+++ b/modules/ppcp-store-sync/src/Registration/ReconciliationService.php
@@ -53,7 +53,7 @@ class ReconciliationService {
 			return;
 		}
 
-		// Integration is enabled, let's check te auto-register flag before acting.
+		// Integration is enabled, let's check the auto-register flag before acting.
 		if ( $this->should_auto_register() ) {
 			$this->register();
 		}

--- a/modules/ppcp-store-sync/src/Registration/RegistrationService.php
+++ b/modules/ppcp-store-sync/src/Registration/RegistrationService.php
@@ -14,11 +14,10 @@ use WooCommerce\PayPalCommerce\StoreSync\Config\AgenticWebhookConfiguration;
 
 class RegistrationService {
 
-	private const REGISTRATION_TOKEN_KEY      = 'ppcp_agentic_registration_token';
-	private const ERROR_REGISTRATION_FAILED   = 'registration_failed';
-	private const ERROR_DEREGISTRATION_FAILED = 'deregistration_failed';
-	private const ERROR_WEBHOOK_REQUEST       = 'webhook_request_failed';
-	private const ERROR_WEBHOOK_RESPONSE      = 'webhook_response_failed';
+	private const REGISTRATION_TOKEN_KEY    = 'ppcp_agentic_registration_token';
+	private const ERROR_REGISTRATION_FAILED = 'registration_failed';
+	private const ERROR_WEBHOOK_REQUEST     = 'webhook_request_failed';
+	private const ERROR_WEBHOOK_RESPONSE    = 'webhook_response_failed';
 
 	private AgenticWebhookConfiguration $webhook_urls;
 	private MerchantMetadataProvider $metadata_provider;
@@ -69,7 +68,6 @@ class RegistrationService {
 
 			do_action( 'woocommerce_paypal_payments_store_sync_registered' );
 		} else {
-			$this->delete_registration_token();
 			$this->logger->error(
 				'Registration failed: Endpoint rejected registration',
 				array(
@@ -92,6 +90,12 @@ class RegistrationService {
 	/**
 	 * Deregister store from PayPal Agentic Commerce.
 	 *
+	 * Deregistration is fire-and-forget: the local token is always removed and the
+	 * deregistered action always fires, regardless of the endpoint's response. A
+	 * rejection (e.g. "store not found") means the store is already gone on the
+	 * endpoint's side, which is the desired outcome, not a reason to retry. Failures
+	 * are still logged.
+	 *
 	 * @return RegistrationResult|WP_Error|null Null if the store was not registered.
 	 */
 	public function deregister() {
@@ -111,11 +115,7 @@ class RegistrationService {
 					'error_message' => $result->get_error_message(),
 				)
 			);
-
-			return $result;
-		}
-
-		if ( ! $result->success ) {
+		} elseif ( ! $result->success ) {
 			$this->logger->error(
 				'Deregistration failed: Endpoint rejected deregistration',
 				array(
@@ -123,11 +123,6 @@ class RegistrationService {
 					'error'    => $result->error ?? 'Deregistration failed',
 					'message'  => $result->message,
 				)
-			);
-
-			return new WP_Error(
-				self::ERROR_DEREGISTRATION_FAILED,
-				$result->error ?? 'Deregistration failed'
 			);
 		}
 

--- a/modules/ppcp-store-sync/src/StoreSyncModule.php
+++ b/modules/ppcp-store-sync/src/StoreSyncModule.php
@@ -91,16 +91,10 @@ class StoreSyncModule implements ServiceModule, ExecutableModule {
 
 		// Early exit if features should not be initialized.
 		if ( ! $agentic_settings->should_initialize_features() ) {
-			$this->ensure_deregistered( $registration_handler );
-
 			return true;
 		}
 
 		// Feature is active and merchant is eligible: Initialize everything.
-
-		if ( $this->should_auto_register() ) {
-			$this->ensure_registered( $registration_handler );
-		}
 
 		// Public REST endpoints.
 		add_action(
@@ -172,32 +166,5 @@ class StoreSyncModule implements ServiceModule, ExecutableModule {
 				$settings->save();
 			}
 		);
-	}
-
-	private function ensure_registered( RegistrationService $registration_service ): void {
-		if ( $registration_service->is_registered() ) {
-			return;
-		}
-		add_action( 'init', static fn() => $registration_service->register() );
-	}
-
-	private function ensure_deregistered( RegistrationService $registration_service ): void {
-		if ( ! $registration_service->is_registered() ) {
-			return;
-		}
-		add_action( 'init', static fn() => $registration_service->deregister() );
-	}
-
-	/**
-	 * Whether the auto-registration is enabled for this site.
-	 *
-	 * By default, the plugin automatically registers when the merchant is eligible and the feature
-	 * is enabled. For testing or troubleshooting, this behavior can be disabled by adding the
-	 * following constant to wp-config.php:
-	 *
-	 *   define( 'PPCP_AGENTIC_AUTO_REGISTER', false );
-	 */
-	private function should_auto_register(): bool {
-		return ! defined( 'PPCP_AGENTIC_AUTO_REGISTER' ) || PPCP_AGENTIC_AUTO_REGISTER;
 	}
 }

--- a/modules/ppcp-store-sync/src/StoreSyncModule.php
+++ b/modules/ppcp-store-sync/src/StoreSyncModule.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\StoreSync\Endpoint\AgenticRestEndpoint;
 use WooCommerce\PayPalCommerce\StoreSync\Setting\AgenticSettingsModule;
 use WooCommerce\PayPalCommerce\StoreSync\Registration\RegistrationService;
 use WooCommerce\PayPalCommerce\StoreSync\Registration\RegistrationEligibility;
+use WooCommerce\PayPalCommerce\StoreSync\Registration\ReconciliationService;
 use WooCommerce\PayPalCommerce\StoreSync\Setting\AgenticSettingsDataModel;
 use WooCommerce\PayPalCommerce\StoreSync\CartValidation\CartValidationProcessor;
 use WooCommerce\PayPalCommerce\StoreSync\CartValidation\ValidatorInterface;
@@ -78,6 +79,9 @@ class StoreSyncModule implements ServiceModule, ExecutableModule {
 		$ingestion_manager = $container->get( 'agentic.ingestion-manager' );
 		assert( $ingestion_manager instanceof IngestionManager );
 
+		$reconciler = $container->get( 'agentic.registration.reconciler' );
+		assert( $reconciler instanceof ReconciliationService );
+
 		// Settings extension always available (merchants need to see the toggle).
 		$settings_module = $container->get( 'agentic.settings.module' );
 		assert( $settings_module instanceof AgenticSettingsModule );
@@ -88,6 +92,18 @@ class StoreSyncModule implements ServiceModule, ExecutableModule {
 
 		// Sync eligibility cache on init (when WC is available).
 		$this->sync_eligibility_cache( $agentic_settings, $eligibility_check );
+
+		// Reconcile the registration state whenever the agentic settings are saved.
+		add_action(
+			'woocommerce_paypal_payments_settings_saved',
+			static function ( $model ) use ( $reconciler ): void {
+				if ( ! $model instanceof AgenticSettingsDataModel ) {
+					return;
+				}
+
+				$reconciler->reconcile();
+			}
+		);
 
 		// Early exit if features should not be initialized.
 		if ( ! $agentic_settings->should_initialize_features() ) {

--- a/tests/PHPUnit/PpcpSettings/Data/AbstractDataModelTest.php
+++ b/tests/PHPUnit/PpcpSettings/Data/AbstractDataModelTest.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace PHPUnit\PpcpSettings\Data;
+
+use WooCommerce\PayPalCommerce\Settings\Data\AbstractDataModel;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Actions\expectDone;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Settings\Data\AbstractDataModel
+ */
+class AbstractDataModelTest extends TestCase
+{
+	public function setUp(): void
+	{
+		parent::setUp();
+		when('get_option')->justReturn([]);
+	}
+
+	private function create_testee(): TestableDataModel
+	{
+		return new TestableDataModel();
+	}
+
+	/**
+	 * GIVEN a listener on the "settings saved" action that calls save() again
+	 * WHEN the initial save() dispatches the action
+	 * THEN the nested save() still persists the data (a second update_option call)
+	 * AND the action is dispatched only once overall, preventing a notification loop
+	 */
+	public function testReentrantSaveStillPersistsButFiresActionOnlyOnce(): void
+	{
+		$update_calls = [];
+		when('update_option')->alias(function (string $key, $data) use (&$update_calls) {
+			$update_calls[] = $data;
+			return true;
+		});
+
+		$listener_calls = 0;
+		expectDone('woocommerce_paypal_payments_settings_saved')
+			->once()
+			->whenHappen(function ($model) use (&$listener_calls) {
+				$listener_calls++;
+				$model->save();
+			});
+
+		$model = $this->create_testee();
+		$model->save();
+
+		$this->assertSame(2, count($update_calls), 'Both the initial and the re-entrant save should persist the data');
+		$this->assertSame(1, $listener_calls, 'The saved action must not be dispatched again by the re-entrant save');
+	}
+}
+
+/**
+ * Minimal concrete subclass used only to exercise AbstractDataModel's save()/
+ * fire_saved_action() behavior.
+ */
+class TestableDataModel extends AbstractDataModel
+{
+	protected const OPTION_KEY = 'test_option_key';
+
+	protected function get_defaults(): array
+	{
+		return ['foo' => ''];
+	}
+}

--- a/tests/PHPUnit/StoreSync/Registration/ReconciliationServiceTest.php
+++ b/tests/PHPUnit/StoreSync/Registration/ReconciliationServiceTest.php
@@ -58,12 +58,11 @@ class ReconciliationServiceTest extends TestCase {
 			->andReturn( new RegistrationResult( true, 'Registered', null ) );
 
 		$this->settings->shouldNotReceive( 'set_active' );
-		$this->settings->shouldNotReceive( 'set_last_registration_error' );
 		$this->settings->shouldNotReceive( 'save' );
 
 		$this->create_testee()->reconcile();
 
-		$this->addToAssertionCount( 4 );
+		$this->addToAssertionCount( 3 );
 	}
 
 	/**

--- a/tests/PHPUnit/StoreSync/Registration/ReconciliationServiceTest.php
+++ b/tests/PHPUnit/StoreSync/Registration/ReconciliationServiceTest.php
@@ -1,0 +1,158 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\StoreSync\Registration;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\StoreSync\Setting\AgenticSettingsDataModel;
+use WooCommerce\PayPalCommerce\TestCase;
+use WP_Error;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\StoreSync\Registration\ReconciliationService
+ */
+class ReconciliationServiceTest extends TestCase {
+
+	/**
+	 * @var AgenticSettingsDataModel|Mockery\MockInterface
+	 */
+	private $settings;
+
+	/**
+	 * @var RegistrationService|Mockery\MockInterface
+	 */
+	private $registration;
+
+	/**
+	 * @var LoggerInterface|Mockery\MockInterface
+	 */
+	private $logger;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->settings     = Mockery::mock( AgenticSettingsDataModel::class );
+		$this->registration = Mockery::mock( RegistrationService::class );
+
+		$this->logger = Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
+	}
+
+	private function create_testee(): ReconciliationService {
+		return new ReconciliationService( $this->settings, $this->registration, $this->logger );
+	}
+
+	/**
+	 * GIVEN a store that should initialize agentic features but is not yet registered
+	 * WHEN reconciling the registration state
+	 * AND the registration call succeeds
+	 * THEN the store is registered
+	 * AND the toggle is left active, since registration succeeded
+	 */
+	public function test_reconcile_registers_store_when_desired_but_not_registered(): void {
+		$this->settings->shouldReceive( 'should_initialize_features' )->andReturn( true );
+		$this->registration->shouldReceive( 'is_registered' )->andReturn( false );
+
+		$this->registration->shouldReceive( 'register' )
+			->once()
+			->andReturn( new RegistrationResult( true, 'Registered', null ) );
+
+		$this->settings->shouldNotReceive( 'set_active' );
+		$this->settings->shouldNotReceive( 'set_last_registration_error' );
+		$this->settings->shouldNotReceive( 'save' );
+
+		$this->create_testee()->reconcile();
+
+		$this->addToAssertionCount( 4 );
+	}
+
+	/**
+	 * GIVEN a store that should initialize agentic features but is not yet registered
+	 * WHEN reconciling the registration state
+	 * AND the registration call fails
+	 * THEN the toggle is switched off, so a failure is never retried automatically
+	 * AND the failure reason is logged for troubleshooting
+	 * AND the settings are saved
+	 */
+	public function test_reconcile_disables_toggle_when_registration_fails(): void {
+		$this->settings->shouldReceive( 'should_initialize_features' )->andReturn( true );
+		$this->registration->shouldReceive( 'is_registered' )->andReturn( false );
+
+		$this->registration->shouldReceive( 'register' )
+			->once()
+			->andReturn( new WP_Error( 'registration_failed', 'store not found' ) );
+
+		$this->settings->shouldReceive( 'set_active' )->once()->with( false );
+		$this->settings->shouldReceive( 'save' )->once();
+
+		$this->create_testee()->reconcile();
+
+		$this->addToAssertionCount( 3 );
+	}
+
+	/**
+	 * GIVEN a store that is registered but should no longer have agentic features active
+	 * WHEN reconciling the registration state
+	 * THEN the store is deregistered
+	 */
+	public function test_reconcile_deregisters_store_when_no_longer_desired(): void {
+		$this->settings->shouldReceive( 'should_initialize_features' )->andReturn( false );
+		$this->registration->shouldReceive( 'is_registered' )->andReturn( true );
+
+		$this->registration->shouldReceive( 'deregister' )->once();
+		$this->registration->shouldNotReceive( 'register' );
+
+		$this->create_testee()->reconcile();
+
+		$this->addToAssertionCount( 2 );
+	}
+
+	/**
+	 * GIVEN the desired and actual registration state already match
+	 * WHEN reconciling the registration state
+	 * THEN neither registration nor deregistration is attempted
+	 *
+	 * @dataProvider matching_state_provider
+	 */
+	public function test_reconcile_does_nothing_when_state_already_matches( bool $desired, bool $actual ): void {
+		$this->settings->shouldReceive( 'should_initialize_features' )->andReturn( $desired );
+		$this->registration->shouldReceive( 'is_registered' )->andReturn( $actual );
+
+		$this->registration->shouldNotReceive( 'register' );
+		$this->registration->shouldNotReceive( 'deregister' );
+
+		$this->create_testee()->reconcile();
+
+		$this->addToAssertionCount( 2 );
+	}
+
+	public function matching_state_provider(): array {
+		return array(
+			'already registered and still desired'     => array( true, true ),
+			'already deregistered and no longer desired' => array( false, false ),
+		);
+	}
+
+	/**
+	 * GIVEN auto-registration has been disabled via the PPCP_AGENTIC_AUTO_REGISTER constant
+	 * AND a store that should initialize agentic features but is not yet registered
+	 * WHEN reconciling the registration state
+	 * THEN registration is skipped
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_reconcile_skips_registration_when_auto_register_is_disabled(): void {
+		define( 'PPCP_AGENTIC_AUTO_REGISTER', false );
+
+		$this->settings->shouldReceive( 'should_initialize_features' )->andReturn( true );
+		$this->registration->shouldReceive( 'is_registered' )->andReturn( false );
+
+		$this->registration->shouldNotReceive( 'register' );
+		$this->registration->shouldNotReceive( 'deregister' );
+
+		$this->create_testee()->reconcile();
+
+		$this->addToAssertionCount( 2 );
+	}
+}

--- a/tests/PHPUnit/StoreSync/Registration/RegistrationServiceTest.php
+++ b/tests/PHPUnit/StoreSync/Registration/RegistrationServiceTest.php
@@ -10,6 +10,7 @@ use WooCommerce\PayPalCommerce\StoreSync\Merchant\MerchantMetadata;
 use WooCommerce\PayPalCommerce\StoreSync\Merchant\MerchantMetadataProvider;
 use WooCommerce\PayPalCommerce\TestCase;
 use WP_Error;
+use function Brain\Monkey\Actions\expectDone;
 use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
@@ -145,6 +146,7 @@ class RegistrationServiceTest extends TestCase {
 	 * AND the webhook returns a failure response
 	 * THEN registration should fail with error
 	 * AND the registration token should not be saved
+	 * AND no local token should be deleted, since none exists to remove
 	 */
 	public function test_registration_fails_when_webhook_returns_error(): void {
 		$this->stub_merchant_metadata();
@@ -159,6 +161,7 @@ class RegistrationServiceTest extends TestCase {
 		$this->assertSame( 'registration_failed', $result->get_error_code() );
 		$this->assertSame( 'Invalid merchant data', $result->get_error_message() );
 		$this->assertFalse( $testee->was_token_saved );
+		$this->assertFalse( $testee->was_token_deleted );
 	}
 
 	/**
@@ -259,25 +262,62 @@ class RegistrationServiceTest extends TestCase {
 	/**
 	 * GIVEN a registered store
 	 * WHEN deregistering from PayPal Agentic Commerce
-	 * AND the webhook returns a failure response
-	 * THEN deregistration should fail with error
-	 * AND the store should still be considered registered
+	 * AND the endpoint rejects the deregistration (e.g. "store not found")
+	 * THEN the local registration token is still deleted, since the endpoint already
+	 *      considers the store gone
+	 * AND the deregistered action still fires
+	 * AND the store is no longer considered registered
 	 */
-	public function test_deregistration_fails_when_webhook_returns_error(): void {
+	public function test_deregistration_deletes_token_when_endpoint_rejects_it(): void {
 		$this->webhook_config->method( 'get_registration_uninstall_url' )
 			->willReturn( 'https://d-staging.joinhoney.com/webhooks/ws/uninstall' );
-		$this->stub_failed_webhook_response( 'Token not found' );
+		$this->stub_failed_webhook_response( 'store not found' );
 
 		$testee = $this->create_testable_service( true );
 
 		$this->assertTrue( $testee->is_registered(), 'Store should be registered before deregistration attempt' );
 
+		expectDone( 'woocommerce_paypal_payments_store_sync_deregistered' )->once();
+
+		$result = $testee->deregister();
+
+		$this->assertInstanceOf( RegistrationResult::class, $result );
+		$this->assertFalse( $result->success );
+		$this->assertTrue( $testee->was_token_deleted );
+		$this->assertFalse( $testee->is_registered(), 'Store should no longer be registered once the local token is removed' );
+	}
+
+	/**
+	 * GIVEN a registered store
+	 * WHEN deregistering from PayPal Agentic Commerce
+	 * AND the webhook request fails with a transport error
+	 * THEN the local registration token is still deleted (fire-and-forget)
+	 * AND the deregistered action still fires
+	 * AND the transport error is returned to the caller
+	 */
+	public function test_deregistration_deletes_token_on_transport_error(): void {
+		$this->webhook_config->method( 'get_registration_uninstall_url' )
+			->willReturn( 'https://d-staging.joinhoney.com/webhooks/ws/uninstall' );
+
+		$wp_error = new WP_Error( 'http_request_failed', 'Connection timeout' );
+
+		when( 'wp_remote_post' )->justReturn( $wp_error );
+		when( 'is_wp_error' )->alias(
+			function ( $thing ) {
+				return $thing instanceof WP_Error;
+			}
+		);
+
+		$testee = $this->create_testable_service( true );
+
+		expectDone( 'woocommerce_paypal_payments_store_sync_deregistered' )->once();
+
 		$result = $testee->deregister();
 
 		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'deregistration_failed', $result->get_error_code() );
-		$this->assertSame( 'Token not found', $result->get_error_message() );
-		$this->assertTrue( $testee->is_registered(), 'Store should still be registered after failed deregistration' );
+		$this->assertSame( 'webhook_request_failed', $result->get_error_code() );
+		$this->assertTrue( $testee->was_token_deleted );
+		$this->assertFalse( $testee->is_registered() );
 	}
 
 	/**


### PR DESCRIPTION
*Changelog:* `Fix - Store sync no longer retries onboarding in a loop when PayPal rejects the request #4556`

# Description

## 🐛 The problem

When PayPal's onboarding API rejects a store-sync registration (for example after a backend schema change), the plugin retries the register/deregister call on every request, without ever enabling store-sync.

## 💡 Why it happens

Registration was driven off the `init` hook with no backoff. A failed attempt left the desired and actual state mismatched, so the next request tried again, and a failing deregister returned an error that kept the store in a half-registered state. Nothing broke the loop.

## 🔍 What to review

- **New public hook.** `woocommerce_paypal_payments_settings_saved` is exposed on `AbstractDataModel`. Listeners must type-check the passed model, since it fires for every settings model.
- **No automatic retry.** A failed registration disables the toggle; re-enabling it is the merchant's explicit retry. There is no backoff or scheduled retry by design.
