### PR TITLE
Advanced Card Fields for classic checkout (5781)

### DIFF
--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -17,6 +17,7 @@ import { checkEligibility } from './eligibility';
 import { createSession } from './sessions/createSession';
 import { renderButtons } from './components/buttonRenderer';
 import { createOrder, fetchCartTotal } from './endpointsAdapter';
+import { initCardFields } from './cardFields/renderer';
 import { hasJQuery } from './utils/api';
 import { setErrorLabels } from './utils/errorHandler';
 
@@ -28,6 +29,20 @@ import { setErrorLabels } from './utils/errorHandler';
 	}
 
 	setErrorLabels( config.labels );
+
+	/**
+	 * Advanced Card Fields (ACDC): independent of the button render loop
+	 * below — it mounts into the existing WC card-form inputs rather than
+	 * a button wrapper, and only actually does anything when the card
+	 * gateway is enabled on this (checkout) page. Deferred the same way
+	 * as renderAll(), since it also queries checkout-form DOM elements.
+	 */
+	function initCardFieldsSafely() {
+		initCardFields( config ).catch( ( error ) => {
+			// eslint-disable-next-line no-console
+			console.error( '[PPCP SDK v6]', error );
+		} );
+	}
 
 	// The page-context and mini-cart wrappers are independent render
 	// targets; PHP only prints wrappers for enabled locations, so target
@@ -183,10 +198,15 @@ import { setErrorLabels } from './utils/errorHandler';
 		renderAll();
 	}
 
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', renderAll );
-	} else {
+	function initialRender() {
 		renderAll();
+		initCardFieldsSafely();
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', initialRender );
+	} else {
+		initialRender();
 	}
 
 	if ( hasJQuery() ) {

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/cardFieldStyles.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/cardFieldStyles.js
@@ -1,0 +1,87 @@
+/**
+ * Computes the `style.input` object for the v6 card-fields component.
+ *
+ * Unlike v5's paypal.CardFields() (see CardFieldsHelper.js), the v6 SDK
+ * takes camelCase JS style properties (fontSize, not font-family) and
+ * supports a different, narrower property set (e.g. no vendor-prefixed
+ * properties, but background/border/borderRadius/boxShadow/height are
+ * allowed) — reusing the v5 helper as-is causes the SDK to log a
+ * "css property is not supported" DevError per property and skip it.
+ *
+ * @package
+ */
+
+const ALLOWED_PROPERTIES = [
+	'appearance',
+	'background',
+	'border',
+	'borderRadius',
+	'boxShadow',
+	'color',
+	'direction',
+	'font',
+	'fontFamily',
+	'fontSize',
+	'fontSizeAdjust',
+	'fontStretch',
+	'fontStyle',
+	'fontVariant',
+	'fontVariantAlternates',
+	'fontVariantCaps',
+	'fontVariantEastAsian',
+	'fontVariantLigatures',
+	'fontVariantNumeric',
+	'fontWeight',
+	'height',
+	'letterSpacing',
+	'lineHeight',
+	'opacity',
+	'outline',
+	'padding',
+	'paddingBottom',
+	'paddingLeft',
+	'paddingRight',
+	'paddingTop',
+	'textShadow',
+	'transition',
+];
+
+/**
+ * Converts a kebab-case CSS property name to camelCase.
+ *
+ * @param {string} property - The kebab-case property name.
+ * @return {string} The camelCase property name.
+ */
+function toCamelCase( property ) {
+	return property.replace( /-([a-z])/g, ( match, letter ) =>
+		letter.toUpperCase()
+	);
+}
+
+/**
+ * Reads the field's live computed styles and returns only the properties
+ * the v6 card-fields component actually supports, camelCased.
+ *
+ * @param {HTMLElement} field - The existing WC input being replaced.
+ * @return {Object} The style object for the component's `style.input`.
+ */
+export function cardFieldStyles( field ) {
+	const computed = window.getComputedStyle( field );
+	const styles = {};
+
+	for ( let i = 0; i < computed.length; i++ ) {
+		const property = computed[ i ];
+		const camelProperty = toCamelCase( property );
+
+		if (
+			! ALLOWED_PROPERTIES.includes( camelProperty ) ||
+			! computed[ property ]
+		) {
+			continue;
+		}
+
+		styles[ camelProperty ] = '' + computed[ property ];
+	}
+
+	return styles;
+}

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -1,0 +1,249 @@
+/**
+ * Advanced Card Fields (ACDC), v6 Web SDK — classic checkout.
+ *
+ * Mounts the number/expiry/CVV/name fields into the existing WC card-form
+ * inputs (the same DOM slots v5's paypal.CardFields() used), and wires the
+ * checkout submission: submitting a new card runs through the v6 card
+ * session (which also runs 3D Secure automatically), the result is
+ * approved server-side, and the native checkout submission is then let
+ * through to capture it via the existing CreditCardGateway::process_payment().
+ *
+ * Scope: fresh card, one-time payment only. Saving a new card, paying with
+ * an already-saved card, and the $0 free-trial variant are separate
+ * tickets and untouched here — this defers to the native submit whenever
+ * a saved token is selected.
+ *
+ * @package
+ */
+
+import { cardFieldStyles } from './cardFieldStyles';
+import { hide } from '@ppcp-button/Helper/Hiding';
+import Spinner from '@ppcp-button/Helper/Spinner';
+import { loadSdkV6 } from '../sdkLoader';
+import { createCardOrder, approveCardOrder } from '../endpointsAdapter';
+import { hasJQuery } from '../utils/api';
+import { handleError } from '../utils/errorHandler';
+
+const FIELD_TYPES = [ 'number', 'expiry', 'cvv', 'name' ];
+
+/**
+ * Mounts a single card field into its existing WC input's place, hiding
+ * the original input (mirrors v5's Render.js placement/hiding).
+ *
+ * Unlike v5's paypal.CardFields(), which owns its container's layout via
+ * its own .render() call, v6's createCardFieldsComponent() only returns a
+ * plain HTMLElement — `style.input` styles what's inside it (font, color,
+ * padding, ...), not the element's own box on this page. Theme rules
+ * targeting the original `input` tag (e.g. `.input-wrapper input { height:
+ * 100% }`) don't match this element, so its box has to be sized explicitly
+ * from the original input's own rendered dimensions or it falls back to
+ * the SDK's default (much taller than the form's inputs).
+ *
+ * @param {Object}      cardSession - The v6 card fields session.
+ * @param {string}      fieldType   - number|expiry|cvv|name.
+ * @param {HTMLElement} inputField  - The existing WC input to replace.
+ */
+function mountField( cardSession, fieldType, inputField ) {
+	if ( ! inputField || inputField.hidden ) {
+		return;
+	}
+
+	const computed = window.getComputedStyle( inputField );
+	const options = {
+		type: fieldType,
+		style: { input: cardFieldStyles( inputField ) },
+	};
+	if ( inputField.getAttribute( 'placeholder' ) ) {
+		options.placeholder = inputField.getAttribute( 'placeholder' );
+	}
+
+	const fieldElement = cardSession.createCardFieldsComponent( options );
+	fieldElement.style.width = computed.width;
+	fieldElement.style.height = computed.height;
+
+	inputField.parentNode.appendChild( fieldElement );
+	hide( inputField, true );
+	inputField.hidden = true;
+}
+
+/**
+ * Whether the buyer selected an existing saved payment token rather than
+ * entering a new card — out of scope here, the native submit handles it.
+ *
+ * @return {boolean} True when a saved token (not "new") is selected.
+ */
+function isSavedTokenSelected() {
+	const token = document.querySelector(
+		'input[name="wc-ppcp-credit-card-gateway-payment-token"]:checked'
+	)?.value;
+	return !! token && token !== 'new';
+}
+
+/**
+ * Whether the card gateway is the currently selected checkout payment method.
+ *
+ * @param {string} paymentMethod - The card gateway's payment method ID.
+ * @return {boolean} True when the card gateway radio is checked.
+ */
+function isCardGatewaySelected( paymentMethod ) {
+	return (
+		document.querySelector( 'input[name="payment_method"]:checked' )
+			?.value === paymentMethod
+	);
+}
+
+/**
+ * Bootstraps the ACDC card fields for the classic checkout page.
+ *
+ * WC's own checkout AJAX (`update_checkout`, fired on billing/shipping
+ * field changes) replaces the whole `#payment` box — inputs and
+ * `#place_order` included — with freshly rendered DOM nodes on every
+ * call, detaching whatever this mounted/listened to before. So instead
+ * of a one-shot setup, `attach()` re-queries the DOM and re-runs itself
+ * on `updated_checkout`, the same event boot.js's renderAll() already
+ * relies on to redraw the wallet buttons after that same DOM swap.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ */
+export async function initCardFields( config ) {
+	if ( ! config.card_fields?.enabled ) {
+		return;
+	}
+
+	const { fields, payment_method: paymentMethod } = config.card_fields;
+	const spinner = hasJQuery() ? Spinner.fullPage() : null;
+
+	let cardSessionPromise = null;
+	let submitting = false;
+	let boundPlaceOrderButton = null;
+
+	/**
+	 * Re-queries the current card-form inputs, since a DOM swap invalidates
+	 * any previously queried references.
+	 *
+	 * @return {Object} The number/expiry/cvv/name input elements.
+	 */
+	function getInputs() {
+		return {
+			number: document.querySelector( fields.number ),
+			expiry: document.querySelector( fields.expiry ),
+			cvv: document.querySelector( fields.cvv ),
+			name: fields.name ? document.querySelector( fields.name ) : null,
+		};
+	}
+
+	function ensureCardSession() {
+		if ( ! cardSessionPromise ) {
+			cardSessionPromise = ( async () => {
+				const inputs = getInputs();
+				const sdk = await loadSdkV6( config, 'checkout' );
+				const cardSession = sdk.createCardFieldsOneTimePaymentSession();
+
+				for ( const fieldType of FIELD_TYPES ) {
+					if ( inputs[ fieldType ] ) {
+						mountField(
+							cardSession,
+							fieldType,
+							inputs[ fieldType ]
+						);
+					}
+				}
+
+				return cardSession;
+			} )().catch( ( error ) => {
+				cardSessionPromise = null;
+				throw error;
+			} );
+		}
+		return cardSessionPromise;
+	}
+
+	/**
+	 * Intercepts the native "Place order" click for a new-card submission.
+	 * Lets the click through untouched for a saved token, a different
+	 * gateway, or the programmatic re-click issued after approval.
+	 *
+	 * @param {Event} event - The click event.
+	 */
+	async function handleSubmit( event ) {
+		if (
+			submitting ||
+			! isCardGatewaySelected( paymentMethod ) ||
+			isSavedTokenSelected()
+		) {
+			return;
+		}
+
+		event.preventDefault();
+		event.stopImmediatePropagation();
+		spinner?.block();
+
+		try {
+			const cardSession = await ensureCardSession();
+			const { orderId } = await createCardOrder( config );
+			const result = await cardSession.submit( orderId );
+
+			// Buyer closed the 3DS challenge or the popup; let them retry.
+			if ( result.state === 'canceled' ) {
+				return;
+			}
+
+			if ( result.state !== 'succeeded' ) {
+				throw new Error( 'Card payment failed.' );
+			}
+
+			await approveCardOrder( config, orderId );
+
+			submitting = true;
+			event.target.click();
+		} catch ( error ) {
+			handleError( error );
+		} finally {
+			submitting = false;
+			spinner?.unblock();
+		}
+	}
+
+	/**
+	 * (Re-)binds to the current DOM: attaches the click interceptor to
+	 * `#place_order` if it's a node we haven't bound yet, and drops any
+	 * card session mounted into now-detached inputs so it gets rebuilt
+	 * against the fresh ones.
+	 */
+	function attach() {
+		const inputs = getInputs();
+		if ( ! inputs.number || ! inputs.expiry || ! inputs.cvv ) {
+			return;
+		}
+
+		cardSessionPromise = null;
+
+		const placeOrderButton = document.querySelector( '#place_order' );
+		if (
+			! placeOrderButton ||
+			placeOrderButton === boundPlaceOrderButton
+		) {
+			return;
+		}
+		boundPlaceOrderButton = placeOrderButton;
+		placeOrderButton.addEventListener( 'click', handleSubmit, true );
+
+		// Mount fields as soon as the card gateway is selected, so styling
+		// and the session are ready before the buyer tries to submit.
+		if ( isCardGatewaySelected( paymentMethod ) ) {
+			ensureCardSession().catch( handleError );
+		}
+	}
+
+	attach();
+
+	if ( hasJQuery() ) {
+		jQuery( document.body ).on( 'updated_checkout', attach );
+
+		jQuery( document.body ).on( 'payment_method_selected', () => {
+			if ( isCardGatewaySelected( paymentMethod ) ) {
+				ensureCardSession().catch( handleError );
+			}
+		} );
+	}
+}

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -9,9 +9,9 @@
  * through to capture it via the existing CreditCardGateway::process_payment().
  *
  * Scope: fresh card, one-time payment only. Saving a new card, paying with
- * an already-saved card, and the $0 free-trial variant are separate
- * tickets and untouched here — this defers to the native submit whenever
- * a saved token is selected.
+ * an already-saved card, and the $0 free-trial variant are untouched
+ * here — this defers to the native submit whenever a saved token is
+ * selected.
  *
  * @package
  */

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -216,8 +216,6 @@ export async function initCardFields( config ) {
 			return;
 		}
 
-		cardSessionPromise = null;
-
 		const placeOrderButton = document.querySelector( '#place_order' );
 		if (
 			! placeOrderButton ||
@@ -225,6 +223,10 @@ export async function initCardFields( config ) {
 		) {
 			return;
 		}
+
+		// Only once the DOM really was replaced: mountField() skips inputs a
+		// previous mount hid, so an earlier drop leaves a session with no fields.
+		cardSessionPromise = null;
 		boundPlaceOrderButton = placeOrderButton;
 		placeOrderButton.addEventListener( 'click', handleSubmit, true );
 

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
@@ -83,8 +83,8 @@ export async function createOrder( config, context, fundingSource ) {
 			body.form_encoded = new URLSearchParams(
 				new FormData( form )
 			).toString();
-			body.createaccount = !! form.querySelector( '#createaccount' )
-				?.checked;
+			body.createaccount =
+				!! form.querySelector( '#createaccount' )?.checked;
 		}
 
 		const payer = payerData();
@@ -166,6 +166,64 @@ export async function approveOrder( config, context, fundingSource, orderId ) {
 
 	// Continuation: the buyer completes the order on the checkout page.
 	navigation.assign( config.urls.checkout );
+}
+
+/**
+ * Creates a PayPal order for the Advanced Card Fields (ACDC) checkout flow.
+ *
+ * Unlike createOrder(), this never sets save_order_in_session: at
+ * create-order time the order has no card attached yet, no 3D Secure
+ * decision exists, and the disabled-card-brand check hasn't run — storing
+ * it in the session this early would let the native checkout capture an
+ * unconfirmed, cardless order. approveCardOrder() is what stores the
+ * order in session, once those checks pass.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @return {Promise<{orderId: string}>} The created PayPal order id.
+ */
+export async function createCardOrder( config ) {
+	const body = {
+		context: 'checkout',
+		purchase_units: [],
+		payment_method: config.card_fields.payment_method,
+		funding_source: config.card_fields.funding_source,
+	};
+
+	const form = document.querySelector( 'form.checkout' );
+	if ( form ) {
+		body.form_encoded = new URLSearchParams(
+			new FormData( form )
+		).toString();
+		body.createaccount = !! form.querySelector( '#createaccount' )?.checked;
+	}
+
+	const payer = payerData();
+	if ( payer ) {
+		body.payer = payer;
+	}
+
+	const data = await postJson( config.ajax.create_order, body );
+
+	return { orderId: data.id };
+}
+
+/**
+ * Approves a card-fields order after the card session has confirmed it.
+ *
+ * Mirrors the v5 ACDC flow's card branch: the endpoint runs the
+ * disabled-card-brand and 3D Secure checks, then stores the confirmed
+ * order in the WC session so the native checkout submission (triggered
+ * right after this resolves) can capture it via the existing
+ * CreditCardGateway::process_payment() flow.
+ *
+ * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
+ * @param {string} orderId - The PayPal order ID.
+ */
+export async function approveCardOrder( config, orderId ) {
+	await postJson( config.ajax.approve_order, {
+		order_id: orderId,
+		funding_source: config.card_fields.funding_source,
+	} );
 }
 
 /**

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
@@ -86,9 +86,14 @@ async function createInstance( config, context ) {
 		throw new Error( 'PayPal SDK v6 global not found after script load.' );
 	}
 
+	const components = [ 'paypal-payments', 'venmo-payments' ];
+	if ( config.card_fields?.enabled ) {
+		components.push( 'card-fields' );
+	}
+
 	const sdkInstance = await window.paypal.createInstance( {
 		clientToken: tokenData.client_token,
-		components: [ 'paypal-payments', 'venmo-payments' ],
+		components,
 		pageType: PAGE_TYPE_MAP[ context ] || 'checkout',
 		locale: config.locale,
 	} );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldStyles.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldStyles.test.js
@@ -1,0 +1,29 @@
+import { cardFieldStyles } from '../cardFields/cardFieldStyles';
+
+afterEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'cardFieldStyles', () => {
+	test( 'camelCases a supported kebab-case CSS property', () => {
+		const field = document.createElement( 'input' );
+		field.style.setProperty( 'font-size', '16px' );
+		document.body.appendChild( field );
+
+		expect( cardFieldStyles( field ) ).toEqual(
+			expect.objectContaining( { fontSize: '16px' } )
+		);
+	} );
+
+	test( 'drops properties the v6 SDK does not support (e.g. vendor-prefixed ones)', () => {
+		const field = document.createElement( 'input' );
+		field.style.setProperty( '-webkit-tap-highlight-color', 'red' );
+		field.style.setProperty( 'margin', '4px' );
+		document.body.appendChild( field );
+
+		const styles = cardFieldStyles( field );
+
+		expect( styles ).not.toHaveProperty( 'webkitTapHighlightColor' );
+		expect( styles ).not.toHaveProperty( 'margin' );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -1,0 +1,391 @@
+const mockCardFieldStyles = jest.fn( () => ( { color: 'rgb(0, 0, 0)' } ) );
+jest.mock( '../cardFields/cardFieldStyles', () => ( {
+	cardFieldStyles: ( field ) => mockCardFieldStyles( field ),
+} ) );
+
+const mockHide = jest.fn();
+jest.mock(
+	'@ppcp-button/Helper/Hiding',
+	() => ( { hide: ( ...args ) => mockHide( ...args ) } ),
+	{ virtual: true }
+);
+
+const mockSpinnerBlock = jest.fn();
+const mockSpinnerUnblock = jest.fn();
+jest.mock(
+	'@ppcp-button/Helper/Spinner',
+	() => ( {
+		__esModule: true,
+		default: {
+			fullPage: () => ( {
+				block: mockSpinnerBlock,
+				unblock: mockSpinnerUnblock,
+			} ),
+		},
+	} ),
+	{ virtual: true }
+);
+
+const mockLoadSdkV6 = jest.fn();
+jest.mock( '../sdkLoader', () => ( {
+	loadSdkV6: ( ...args ) => mockLoadSdkV6( ...args ),
+} ) );
+
+const mockCreateCardOrder = jest.fn();
+const mockApproveCardOrder = jest.fn();
+jest.mock( '../endpointsAdapter', () => ( {
+	createCardOrder: ( ...args ) => mockCreateCardOrder( ...args ),
+	approveCardOrder: ( ...args ) => mockApproveCardOrder( ...args ),
+} ) );
+
+const mockHasJQuery = jest.fn( () => true );
+jest.mock( '../utils/api', () => ( {
+	hasJQuery: () => mockHasJQuery(),
+} ) );
+
+const mockHandleError = jest.fn();
+jest.mock( '../utils/errorHandler', () => ( {
+	handleError: ( ...args ) => mockHandleError( ...args ),
+} ) );
+
+import { initCardFields } from '../cardFields/renderer';
+
+/**
+ * Drains all pending microtasks (unlike chained `await Promise.resolve()`,
+ * this doesn't require knowing exactly how many promise hops the code
+ * under test awaits internally).
+ *
+ * @return {Promise<void>}
+ */
+const flushPromises = () =>
+	new Promise( ( resolve ) => setImmediate( resolve ) );
+
+/**
+ * Builds the classic-checkout DOM this module expects: the card gateway
+ * radio plus the three (number/expiry/cvv) WC input fields it replaces.
+ *
+ * @param {string} selectedGateway - The initially checked payment_method value.
+ */
+function buildCheckoutDom( selectedGateway = 'ppcp-credit-card-gateway' ) {
+	document.body.innerHTML = `
+		<form class="checkout">
+			<input type="radio" name="payment_method" value="ppcp-gateway" ${
+				selectedGateway === 'ppcp-gateway' ? 'checked' : ''
+			} />
+			<input type="radio" name="payment_method" value="ppcp-credit-card-gateway" ${
+				selectedGateway === 'ppcp-credit-card-gateway' ? 'checked' : ''
+			} />
+			<div class="input-wrapper"><input id="ppcp-credit-card-gateway-card-number" /></div>
+			<div class="input-wrapper"><input id="ppcp-credit-card-gateway-card-expiry" /></div>
+			<div class="input-wrapper"><input id="ppcp-credit-card-gateway-card-cvc" /></div>
+			<button id="place_order" type="button">Place order</button>
+		</form>
+	`;
+}
+
+const baseConfig = ( overrides = {} ) => ( {
+	card_fields: {
+		enabled: true,
+		payment_method: 'ppcp-credit-card-gateway',
+		funding_source: 'card',
+		fields: {
+			number: '#ppcp-credit-card-gateway-card-number',
+			expiry: '#ppcp-credit-card-gateway-card-expiry',
+			cvv: '#ppcp-credit-card-gateway-card-cvc',
+			name: null,
+		},
+	},
+	...overrides,
+} );
+
+function makeCardSession( { state = 'succeeded' } = {} ) {
+	return {
+		createCardFieldsComponent: jest.fn( () =>
+			document.createElement( 'div' )
+		),
+		submit: jest.fn().mockResolvedValue( { state, data: {} } ),
+	};
+}
+
+let bodyHandlers = {};
+
+/**
+ * Simulates jQuery(document.body).trigger(event) for handlers registered
+ * through the mock below.
+ *
+ * @param {string} event - The event name.
+ */
+function triggerBodyEvent( event ) {
+	( bodyHandlers[ event ] || [] ).forEach( ( handler ) => handler() );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockHasJQuery.mockReturnValue( true );
+	bodyHandlers = {};
+	global.jQuery = jest.fn( () => ( {
+		on: ( event, handler ) => {
+			bodyHandlers[ event ] = bodyHandlers[ event ] || [];
+			bodyHandlers[ event ].push( handler );
+		},
+	} ) );
+} );
+
+afterEach( () => {
+	delete global.jQuery;
+	document.body.innerHTML = '';
+} );
+
+describe( 'initCardFields', () => {
+	test( 'does nothing when card fields are disabled', async () => {
+		buildCheckoutDom();
+		await initCardFields(
+			baseConfig( { card_fields: { enabled: false } } )
+		);
+
+		expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does nothing when the expected WC input fields are missing', async () => {
+		document.body.innerHTML = '<form class="checkout"></form>';
+		await initCardFields( baseConfig() );
+
+		expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+	} );
+
+	test( 'mounts number/expiry/cvv into the existing WC inputs and hides them, when the card gateway is preselected', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const cardSession = makeCardSession();
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+
+		await initCardFields( baseConfig() );
+		// ensureCardSession() is fired-and-forgotten from the preselected check; flush microtasks.
+		await flushPromises();
+
+		expect( cardSession.createCardFieldsComponent ).toHaveBeenCalledTimes(
+			3
+		);
+		expect( mockHide ).toHaveBeenCalledTimes( 3 );
+		// The v6 SDK rejects the option object without a valid `type`
+		// (number|expiry|cvv); a `field` key is silently wrong at runtime.
+		for ( const type of [ 'number', 'expiry', 'cvv' ] ) {
+			expect(
+				cardSession.createCardFieldsComponent
+			).toHaveBeenCalledWith( expect.objectContaining( { type } ) );
+		}
+	} );
+
+	test( "sizes the mounted field to the original input's own box, since style.input only styles what is inside it", async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const numberInput = document.querySelector(
+			'#ppcp-credit-card-gateway-card-number'
+		);
+		numberInput.style.width = '300px';
+		numberInput.style.height = '45px';
+
+		const cardSession = makeCardSession();
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+
+		expect( numberInput.nextSibling.style.width ).toBe( '300px' );
+		expect( numberInput.nextSibling.style.height ).toBe( '45px' );
+	} );
+
+	test( 're-attaches to the fresh #payment DOM after WC replaces it on updated_checkout', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const firstSession = makeCardSession();
+		const secondSession = makeCardSession();
+		mockLoadSdkV6
+			.mockResolvedValueOnce( {
+				createCardFieldsOneTimePaymentSession: () => firstSession,
+			} )
+			.mockResolvedValueOnce( {
+				createCardFieldsOneTimePaymentSession: () => secondSession,
+			} );
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+
+		expect( firstSession.createCardFieldsComponent ).toHaveBeenCalledTimes(
+			3
+		);
+
+		// WC's update_checkout AJAX replaces the whole #payment box
+		// (inputs + #place_order) with brand new nodes on every call.
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		triggerBodyEvent( 'updated_checkout' );
+		await flushPromises();
+
+		expect( secondSession.createCardFieldsComponent ).toHaveBeenCalledTimes(
+			3
+		);
+
+		const newPlaceOrder = document.querySelector( '#place_order' );
+		let nativeSubmits = 0;
+		newPlaceOrder.addEventListener( 'click', () => nativeSubmits++ );
+		mockCreateCardOrder.mockResolvedValue( { orderId: 'CARDORDER1' } );
+		mockApproveCardOrder.mockResolvedValue( undefined );
+
+		newPlaceOrder.click();
+		await flushPromises();
+
+		// The new button must be intercepted (not a stale, unbound node).
+		expect( mockCreateCardOrder ).toHaveBeenCalled();
+		expect( secondSession.submit ).toHaveBeenCalledWith( 'CARDORDER1' );
+		expect( nativeSubmits ).toBe( 1 );
+	} );
+
+	test( 'does not re-bind when updated_checkout fires without actually replacing the DOM', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const cardSession = makeCardSession();
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+
+		const placeOrder = document.querySelector( '#place_order' );
+		const addEventListenerSpy = jest.spyOn(
+			placeOrder,
+			'addEventListener'
+		);
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+		expect( addEventListenerSpy ).toHaveBeenCalledTimes( 1 );
+		cardSession.createCardFieldsComponent.mockClear();
+
+		// Same #place_order node as before (DOM wasn't actually replaced):
+		// attach() must no-op, not remount fields or double-bind a second
+		// click listener onto it.
+		triggerBodyEvent( 'updated_checkout' );
+		await flushPromises();
+
+		expect( cardSession.createCardFieldsComponent ).not.toHaveBeenCalled();
+		expect( addEventListenerSpy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'lets the native click through untouched when a saved payment token is selected', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<input type="radio" name="wc-ppcp-credit-card-gateway-payment-token" value="123" checked />'
+		);
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => makeCardSession(),
+		} );
+
+		await initCardFields( baseConfig() );
+
+		const event = new MouseEvent( 'click', {
+			bubbles: true,
+			cancelable: true,
+		} );
+		document.querySelector( '#place_order' ).dispatchEvent( event );
+		await Promise.resolve();
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( mockCreateCardOrder ).not.toHaveBeenCalled();
+	} );
+
+	test( 'lets the native click through untouched when a different gateway is selected', async () => {
+		buildCheckoutDom( 'ppcp-gateway' );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => makeCardSession(),
+		} );
+
+		await initCardFields( baseConfig() );
+
+		const event = new MouseEvent( 'click', {
+			bubbles: true,
+			cancelable: true,
+		} );
+		document.querySelector( '#place_order' ).dispatchEvent( event );
+		await Promise.resolve();
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( mockCreateCardOrder ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a new-card submission creates the order, submits the card session, approves it, then re-clicks place_order', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const cardSession = makeCardSession( { state: 'succeeded' } );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+		mockCreateCardOrder.mockResolvedValue( { orderId: 'CARDORDER1' } );
+		mockApproveCardOrder.mockResolvedValue( undefined );
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+
+		const placeOrder = document.querySelector( '#place_order' );
+		let nativeSubmits = 0;
+		placeOrder.addEventListener( 'click', () => nativeSubmits++ );
+
+		placeOrder.click();
+		// Flush the async submit chain (createCardOrder -> submit -> approveCardOrder).
+		await flushPromises();
+
+		expect( mockCreateCardOrder ).toHaveBeenCalledWith( baseConfig() );
+		expect( cardSession.submit ).toHaveBeenCalledWith( 'CARDORDER1' );
+		expect( mockApproveCardOrder ).toHaveBeenCalledWith(
+			expect.anything(),
+			'CARDORDER1'
+		);
+		// One native submit from our own re-click; the guard must have let
+		// that second click through instead of re-intercepting it.
+		expect( nativeSubmits ).toBe( 1 );
+		expect( mockHandleError ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a failed card session submit surfaces the error and does not click place_order again', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const cardSession = makeCardSession( { state: 'failed' } );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+		mockCreateCardOrder.mockResolvedValue( { orderId: 'CARDORDER1' } );
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+
+		const placeOrder = document.querySelector( '#place_order' );
+		let nativeSubmits = 0;
+		placeOrder.addEventListener( 'click', () => nativeSubmits++ );
+
+		placeOrder.click();
+		await flushPromises();
+
+		expect( mockHandleError ).toHaveBeenCalled();
+		expect( mockApproveCardOrder ).not.toHaveBeenCalled();
+		expect( nativeSubmits ).toBe( 0 );
+	} );
+
+	test( 'a canceled 3DS challenge is silent (no error) and does not click place_order again', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const cardSession = makeCardSession( { state: 'canceled' } );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+		mockCreateCardOrder.mockResolvedValue( { orderId: 'CARDORDER1' } );
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+
+		const placeOrder = document.querySelector( '#place_order' );
+		let nativeSubmits = 0;
+		placeOrder.addEventListener( 'click', () => nativeSubmits++ );
+
+		placeOrder.click();
+		await flushPromises();
+
+		expect( mockHandleError ).not.toHaveBeenCalled();
+		expect( mockApproveCardOrder ).not.toHaveBeenCalled();
+		expect( nativeSubmits ).toBe( 0 );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -269,6 +269,40 @@ describe( 'initCardFields', () => {
 		expect( addEventListenerSpy ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	test( 'keeps the mounted session usable after an updated_checkout that changed nothing', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const firstSession = makeCardSession();
+		const secondSession = makeCardSession();
+		mockLoadSdkV6
+			.mockResolvedValueOnce( {
+				createCardFieldsOneTimePaymentSession: () => firstSession,
+			} )
+			.mockResolvedValueOnce( {
+				createCardFieldsOneTimePaymentSession: () => secondSession,
+			} );
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+		expect( firstSession.createCardFieldsComponent ).toHaveBeenCalledTimes(
+			3
+		);
+
+		// WC skips replacing an unchanged fragment, so the mounted fields and
+		// #place_order survive and the session must survive with them.
+		triggerBodyEvent( 'updated_checkout' );
+		await flushPromises();
+
+		mockCreateCardOrder.mockResolvedValue( { orderId: 'CARDORDER1' } );
+		mockApproveCardOrder.mockResolvedValue( undefined );
+
+		document.querySelector( '#place_order' ).click();
+		await flushPromises();
+
+		// The submitting session must be the one holding the buyer's fields.
+		expect( firstSession.submit ).toHaveBeenCalledWith( 'CARDORDER1' );
+		expect( secondSession.submit ).not.toHaveBeenCalled();
+	} );
+
 	test( 'lets the native click through untouched when a saved payment token is selected', async () => {
 		buildCheckoutDom( 'ppcp-credit-card-gateway' );
 		document.body.insertAdjacentHTML(

--- a/modules/ppcp-sdk-v6/resources/js/test/endpointsAdapter.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/endpointsAdapter.test.js
@@ -26,6 +26,8 @@ jest.mock( '../utils/api', () => ( {
 import {
 	createOrder,
 	approveOrder,
+	createCardOrder,
+	approveCardOrder,
 	fetchCartTotal,
 	navigation,
 } from '../endpointsAdapter';
@@ -39,6 +41,10 @@ const config = {
 		wc_store_api: { cart: '/wp-json/wc/store/v1/cart' },
 	},
 	urls: { checkout: '/checkout/' },
+	card_fields: {
+		payment_method: 'ppcp-credit-card-gateway',
+		funding_source: 'card',
+	},
 };
 
 afterEach( () => {
@@ -226,6 +232,64 @@ describe( 'approveOrder', () => {
 		expect( trigger ).toHaveBeenCalledWith( 'submit' );
 
 		delete global.jQuery;
+	} );
+} );
+
+describe( 'createCardOrder', () => {
+	test( 'sends the card payment method/funding source and never sets save_order_in_session', async () => {
+		document.body.innerHTML =
+			'<form class="checkout">' +
+			'<input name="billing_email" value="a@b.com" /></form>';
+		mockPayerData.mockReturnValueOnce( null );
+		postJson.mockResolvedValueOnce( { id: 'CARDORDER1' } );
+
+		const result = await createCardOrder( config );
+
+		expect( result ).toEqual( { orderId: 'CARDORDER1' } );
+		expect( postJson ).toHaveBeenCalledWith( config.ajax.create_order, {
+			context: 'checkout',
+			purchase_units: [],
+			payment_method: 'ppcp-credit-card-gateway',
+			funding_source: 'card',
+			form_encoded: 'billing_email=a%40b.com',
+			createaccount: false,
+		} );
+	} );
+
+	test( 'forwards the payer when available', async () => {
+		document.body.innerHTML = '<form class="checkout"></form>';
+		mockPayerData.mockReturnValueOnce( { email_address: 'a@b.com' } );
+		postJson.mockResolvedValueOnce( { id: 'CARDORDER2' } );
+
+		await createCardOrder( config );
+
+		expect( postJson ).toHaveBeenCalledWith(
+			config.ajax.create_order,
+			expect.objectContaining( { payer: { email_address: 'a@b.com' } } )
+		);
+	} );
+} );
+
+describe( 'approveCardOrder', () => {
+	test( 'posts the order id and card funding source', async () => {
+		postJson.mockResolvedValueOnce( {} );
+
+		await approveCardOrder( config, 'CARDORDER1' );
+
+		expect( postJson ).toHaveBeenCalledWith( config.ajax.approve_order, {
+			order_id: 'CARDORDER1',
+			funding_source: 'card',
+		} );
+	} );
+
+	test( 'propagates a rejected (declined/disabled-card/3DS) approval', async () => {
+		postJson.mockRejectedValueOnce(
+			new Error( 'Unfortunately, we do not accept this card.' )
+		);
+
+		await expect(
+			approveCardOrder( config, 'CARDORDER1' )
+		).rejects.toThrow( 'Unfortunately, we do not accept this card.' );
 	} );
 } );
 

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -41,7 +41,8 @@ return array(
 			$container->get( 'order-endpoints.handle-shipping-in-paypal' ),
 			$container->get( 'wcgateway.settings.status' ),
 			$container->get( 'button.helper.context' ),
-			$container->get( 'settings.settings-provider' )->save_paypal_and_venmo()
+			$container->get( 'settings.settings-provider' )->save_paypal_and_venmo(),
+			$container->get( 'wcgateway.configuration.card-configuration' )
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -17,6 +17,8 @@ use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\CreateOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
 
@@ -24,6 +26,15 @@ class SdkV6Manager {
 
 	public const WRAPPER_ID           = 'ppc-button-ppcp-gateway-v6';
 	public const MINI_CART_WRAPPER_ID = 'ppc-button-minicart-v6';
+
+	// Existing WC credit-card-form field IDs (see CardFieldsModule's
+	// woocommerce_credit_card_form_fields filter and WC core's own
+	// card-number/expiry/cvc fields) that the v6 card fields mount into,
+	// replacing v5's paypal.CardFields()-rendered inputs in the same slots.
+	private const CARD_FIELD_NAME_ID   = 'ppcp-credit-card-gateway-card-name';
+	private const CARD_FIELD_NUMBER_ID = 'ppcp-credit-card-gateway-card-number';
+	private const CARD_FIELD_EXPIRY_ID = 'ppcp-credit-card-gateway-card-expiry';
+	private const CARD_FIELD_CVV_ID    = 'ppcp-credit-card-gateway-card-cvc';
 
 	private AssetGetter $asset_getter;
 	private string $version;
@@ -33,6 +44,7 @@ class SdkV6Manager {
 	private SettingsStatus $settings_status;
 	private Context $context;
 	private bool $vaulting_enabled;
+	private CardPaymentsConfiguration $card_payments_configuration;
 
 	public function __construct(
 		AssetGetter $asset_getter,
@@ -42,16 +54,18 @@ class SdkV6Manager {
 		bool $should_handle_shipping,
 		SettingsStatus $settings_status,
 		Context $context,
-		bool $vaulting_enabled = false
+		bool $vaulting_enabled,
+		CardPaymentsConfiguration $card_payments_configuration
 	) {
-		$this->asset_getter           = $asset_getter;
-		$this->version                = $version;
-		$this->environment            = $environment;
-		$this->style_mapper           = $style_mapper;
-		$this->should_handle_shipping = $should_handle_shipping;
-		$this->settings_status        = $settings_status;
-		$this->context                = $context;
-		$this->vaulting_enabled       = $vaulting_enabled;
+		$this->asset_getter                = $asset_getter;
+		$this->version                     = $version;
+		$this->environment                 = $environment;
+		$this->style_mapper                = $style_mapper;
+		$this->should_handle_shipping      = $should_handle_shipping;
+		$this->settings_status             = $settings_status;
+		$this->context                     = $context;
+		$this->vaulting_enabled            = $vaulting_enabled;
+		$this->card_payments_configuration = $card_payments_configuration;
 	}
 
 	/**
@@ -141,11 +155,21 @@ class SdkV6Manager {
 	 * the suppression becomes unconditional and only the merchant
 	 * location-settings gating in this method remains meaningful.
 	 *
+	 * Card fields (ACDC) are independent of the smart-button location: the
+	 * card gateway is a regular WC payment method that can be selectable
+	 * at checkout even when the wallet button is disabled there, so it
+	 * gets its own OR'd condition rather than being folded into the
+	 * location check above.
+	 *
 	 * @return bool
 	 */
 	public function should_load_on_current_page(): bool {
 		$page_location = $this->get_page_context();
 		if ( $page_location && $this->settings_status->is_smart_button_enabled_for_location( $page_location ) ) {
+			return true;
+		}
+
+		if ( 'checkout' === $page_location && $this->card_payments_configuration->is_acdc_enabled() ) {
 			return true;
 		}
 
@@ -185,6 +209,8 @@ class SdkV6Manager {
 		if ( $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' ) ) {
 			$button_styles['mini-cart'] = $this->style_mapper->styles_for_context( 'mini-cart' );
 		}
+
+		$card_fields_enabled = 'checkout' === $page_context && $this->card_payments_configuration->is_acdc_enabled();
 
 		return array(
 			'sdk_url'           => $base_url . '/web-sdk/v6/core',
@@ -238,6 +264,17 @@ class SdkV6Manager {
 			'button_styles'     => $button_styles,
 			'wrapper'           => '#' . self::WRAPPER_ID,
 			'mini_cart_wrapper' => '#' . self::MINI_CART_WRAPPER_ID,
+			'card_fields'       => array(
+				'enabled'        => $card_fields_enabled,
+				'payment_method' => CreditCardGateway::ID,
+				'funding_source' => 'card',
+				'fields'         => array(
+					'name'   => '#' . self::CARD_FIELD_NAME_ID,
+					'number' => '#' . self::CARD_FIELD_NUMBER_ID,
+					'expiry' => '#' . self::CARD_FIELD_EXPIRY_ID,
+					'cvv'    => '#' . self::CARD_FIELD_CVV_ID,
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
Migrates the Advanced Card Fields (ACDC) checkout experience to the v6 Web SDK, for **classic (shortcode) checkout only** — block checkout is tracked separately, since it depends on the  WooCommerce Blocks v6 migration  landing first.                                                                                                                                               
                                                                                                                                                                                                          
The v6 card fields mount into the same WC card-form input slots v5's `paypal.CardFields()` used, and reuse the existing v5 order create/approve AJAX endpoints (new `createCardOrder()`/`approveCardOrder()` adapters, rather than new endpoints) with a card-specific payment method and funding source. 3D Secure is handled automatically by the v6 SDK inside `cardSession.submit()` — no separate contingency setup needed, unlike v5.                                                                                                                               
                                                                                                                                                                                                          
**Notable implementation details:**                                                                                                                                                                         
- `should_load_on_current_page()` now loads the v6 module on checkout whenever ACDC is enabled, independent of the smart-button location setting (the card gateway is a regular payment method, not tied to that setting).                                                                                                                                                                                       
- `createCardOrder()` deliberately never sends `save_order_in_session` — at create-order time no card is attached yet, so storing it in session that early would let an unconfirmed order slip through. `approveCardOrder()` is what stores it, once the disabled-card-brand and 3DS checks pass server-side.                                                                                                   
- The v6 SDK expects a different style schema than v5 (camelCase JS properties vs. v5's kebab-case CSS, and a different supported-property set), so this adds a dedicated `cardFieldStyles.js` rather than reusing v5's helper.                                                                                                                                                                               
- Each mounted field's box is sized explicitly from the original WC input's rendered dimensions — v6's `createCardFieldsComponent()` only returns a plain element for us to lay out ourselves, unlike v5's `.render()`, which owns its own container.                                                                                                                                                         
- The click interceptor and mounted fields re-attach on WooCommerce's `update_checkout` event, since that AJAX call replaces the entire `#payment` box (including `#place_order` and the card inputs) on every billing/shipping field change.                                                                                                                                                                    
                                                                                                                                                                                                          
**Out of scope here:** saving a new card, paying with an already-saved card, and the $0 free-trial variant.                                                                                                 
                                                                                                                                                                                                          
### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Ensure the `PCP_SDK_V6_ENABLED` feature flag is on and the ACDC ("Debit & Credit Cards") gateway is enabled.                                                                                         
2. Add a simple (non-subscription) product to the cart.                                                                                                                                                 
3. Go to the classic (shortcode) checkout page.                                                                                                                                                         
4. Select **Debit & Credit Cards** as the payment method and confirm the card number/expiry/CVC (and cardholder name, if enabled) render as PayPal-hosted fields in place of the native WC inputs.      
5. Enter an invalid card number and confirm the field shows a red/invalid border without submitting.                                                                                                    
6. Change a billing/shipping field (e.g. postcode) *after* selecting the card gateway to trigger WooCommerce's checkout refresh, then confirm the card fields still work.                               
7. Enter a valid PayPal sandbox test card (e.g. `4111111111111111`, any future expiry, any CVC) and click Place Order — confirm the order completes and is captured in PayPal.                          
8. Trigger a 3D Secure challenge with a sandbox card configured for it, and confirm both completing and canceling the challenge behave correctly.                                                       
9. Select a different payment method (e.g. the PayPal wallet button) and confirm no interference from the card-fields code.