### PR TITLE
Fix PayPal (Legacy) gateway displayed as gateway in WooCommerce > Payments (6709)

### DIFF
--- a/modules/ppcp-compat/src/PPEC/MockGateway.php
+++ b/modules/ppcp-compat/src/PPEC/MockGateway.php
@@ -18,11 +18,16 @@ class MockGateway extends \WC_Payment_Gateway {
 	 * @param string $title Gateway title.
 	 */
 	public function __construct( $title ) {
-		$this->id           = PPECHelper::PPEC_GATEWAY_ID;
-		$this->title        = $title;
-		$this->method_title = $this->title;
-		$this->description  = '';
-		$this->supports     = array(
+		$this->id    = PPECHelper::PPEC_GATEWAY_ID;
+		$this->title = $title;
+
+		// Deliberately no method_title or method_description: that combination is
+		// how WooCommerce recognises a gateway as a shell and keeps it out of the
+		// Payments settings screen, where this one has no business appearing. The
+		// title above still labels it on order and subscription screens. Setting
+		// either of them puts it back on the settings screen.
+		$this->description = '';
+		$this->supports    = array(
 			'subscriptions',
 			'subscription_cancellation',
 			'subscription_suspension',

--- a/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
+++ b/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat\PPEC;
 
-use Automattic\WooCommerce\Utilities\OrderUtil;
 use Psr\Log\LoggerInterface;
 use stdClass;
 use WooCommerce\PayPalCommerce\WcSubscriptions\RenewalHandler;
@@ -81,7 +80,13 @@ class SubscriptionsHandler {
 	 * @return array
 	 */
 	public function add_mock_ppec_gateway( $gateways ) {
-		if ( ! isset( $gateways[ PPECHelper::PPEC_GATEWAY_ID ] ) && $this->should_mock_ppec_gateway() ) {
+		// Registered unconditionally on purpose. This filter runs once, while the
+		// gateway list is built early in the request, so it cannot tell whether a
+		// renewal is about to run: gating it here left the gateway missing when
+		// Action Scheduler triggered the renewal, and the payment failed. The
+		// gateway is kept off the Payments settings screen by MockGateway
+		// presenting itself as a shell instead.
+		if ( ! isset( $gateways[ PPECHelper::PPEC_GATEWAY_ID ] ) ) {
 			$gateways[ PPECHelper::PPEC_GATEWAY_ID ] = $this->mock_gateway;
 		}
 
@@ -210,83 +215,5 @@ class SubscriptionsHandler {
 		}
 
 		return null;
-	}
-
-	/**
-	 * Checks whether the mock PPEC gateway should be used or not.
-	 *
-	 * @return bool
-	 */
-	private function should_mock_ppec_gateway() {
-		// Are we processing a renewal?
-		if ( doing_action( 'woocommerce_scheduled_subscription_payment' ) ) {
-			return true;
-		}
-
-		// My Account > Subscriptions.
-		if ( is_wc_endpoint_url( 'subscriptions' ) ) {
-			return true;
-		}
-
-		// phpcs:disable WordPress.Security.NonceVerification
-
-		// Checks that require Subscriptions.
-		if ( class_exists( \WC_Subscriptions::class ) ) {
-			// My Account > Subscriptions > (Subscription).
-			if ( wcs_is_view_subscription_page() ) {
-				$subscription = wcs_get_subscription( absint( get_query_var( 'view-subscription' ) ) );
-
-				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
-			}
-
-			// Changing payment method?
-			if ( is_wc_endpoint_url( 'order-pay' ) && isset( $_GET['change_payment_method'] ) ) {
-				$subscription = wcs_get_subscription( absint( get_query_var( 'order-pay' ) ) );
-
-				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
-			}
-
-			// Early renew (via modal).
-			if ( isset( $_GET['process_early_renewal'], $_GET['subscription_id'] ) ) {
-				$subscription = wcs_get_subscription( absint( $_GET['subscription_id'] ) );
-
-				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
-			}
-		}
-
-		// Admin-only from here onwards.
-		if ( ! is_admin() ) {
-			return false;
-		}
-
-		// Are we saving metadata for a subscription?
-		if ( doing_action( 'woocommerce_process_shop_order_meta' ) ) {
-			return true;
-		}
-
-		// Are we editing an order or subscription tied to PPEC?
-		$order_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? $_POST['post_ID'] ?? '' ) );
-		if ( $order_id ) {
-			$order = wc_get_order( $order_id );
-			if ( ! ( $order instanceof \WC_Order ) ) {
-				return false;
-			}
-			return PPECHelper::PPEC_GATEWAY_ID === $order->get_payment_method();
-		}
-
-		// Are we on the WC > Subscriptions screen?
-		/**
-		 * Class exist in WooCommerce.
-		 *
-		 * @psalm-suppress UndefinedClass
-		 */
-		$post_type_or_page = class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled()
-			? wc_clean( wp_unslash( $_GET['page'] ?? '' ) )
-			: wc_clean( wp_unslash( $_GET['post_type'] ?? $_POST['post_type'] ?? '' ) );
-		if ( $post_type_or_page === 'shop_subscription' || $post_type_or_page === 'wc-orders--shop_subscription' ) {
-			return true;
-		}
-
-		return false;
 	}
 }

--- a/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
+++ b/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
@@ -268,7 +268,10 @@ class SubscriptionsHandler {
 		$order_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? $_POST['post_ID'] ?? '' ) );
 		if ( $order_id ) {
 			$order = wc_get_order( $order_id );
-			return ( $order && PPECHelper::PPEC_GATEWAY_ID === $order->get_payment_method() );
+			if ( ! ( $order instanceof \WC_Order ) ) {
+				return false;
+			}
+			return PPECHelper::PPEC_GATEWAY_ID === $order->get_payment_method();
 		}
 
 		// Are we on the WC > Subscriptions screen?

--- a/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
+++ b/modules/ppcp-compat/src/PPEC/SubscriptionsHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\Compat\PPEC;
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
 use Psr\Log\LoggerInterface;
 use stdClass;
 use WooCommerce\PayPalCommerce\WcSubscriptions\RenewalHandler;
@@ -80,7 +81,7 @@ class SubscriptionsHandler {
 	 * @return array
 	 */
 	public function add_mock_ppec_gateway( $gateways ) {
-		if ( ! isset( $gateways[ PPECHelper::PPEC_GATEWAY_ID ] ) ) {
+		if ( ! isset( $gateways[ PPECHelper::PPEC_GATEWAY_ID ] ) && $this->should_mock_ppec_gateway() ) {
 			$gateways[ PPECHelper::PPEC_GATEWAY_ID ] = $this->mock_gateway;
 		}
 
@@ -209,5 +210,80 @@ class SubscriptionsHandler {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Checks whether the mock PPEC gateway should be used or not.
+	 *
+	 * @return bool
+	 */
+	private function should_mock_ppec_gateway() {
+		// Are we processing a renewal?
+		if ( doing_action( 'woocommerce_scheduled_subscription_payment' ) ) {
+			return true;
+		}
+
+		// My Account > Subscriptions.
+		if ( is_wc_endpoint_url( 'subscriptions' ) ) {
+			return true;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification
+
+		// Checks that require Subscriptions.
+		if ( class_exists( \WC_Subscriptions::class ) ) {
+			// My Account > Subscriptions > (Subscription).
+			if ( wcs_is_view_subscription_page() ) {
+				$subscription = wcs_get_subscription( absint( get_query_var( 'view-subscription' ) ) );
+
+				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
+			}
+
+			// Changing payment method?
+			if ( is_wc_endpoint_url( 'order-pay' ) && isset( $_GET['change_payment_method'] ) ) {
+				$subscription = wcs_get_subscription( absint( get_query_var( 'order-pay' ) ) );
+
+				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
+			}
+
+			// Early renew (via modal).
+			if ( isset( $_GET['process_early_renewal'], $_GET['subscription_id'] ) ) {
+				$subscription = wcs_get_subscription( absint( $_GET['subscription_id'] ) );
+
+				return ( $subscription && PPECHelper::PPEC_GATEWAY_ID === $subscription->get_payment_method() );
+			}
+		}
+
+		// Admin-only from here onwards.
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		// Are we saving metadata for a subscription?
+		if ( doing_action( 'woocommerce_process_shop_order_meta' ) ) {
+			return true;
+		}
+
+		// Are we editing an order or subscription tied to PPEC?
+		$order_id = wc_clean( wp_unslash( $_GET['id'] ?? $_GET['post'] ?? $_POST['post_ID'] ?? '' ) );
+		if ( $order_id ) {
+			$order = wc_get_order( $order_id );
+			return ( $order && PPECHelper::PPEC_GATEWAY_ID === $order->get_payment_method() );
+		}
+
+		// Are we on the WC > Subscriptions screen?
+		/**
+		 * Class exist in WooCommerce.
+		 *
+		 * @psalm-suppress UndefinedClass
+		 */
+		$post_type_or_page = class_exists( OrderUtil::class ) && OrderUtil::custom_orders_table_usage_is_enabled()
+			? wc_clean( wp_unslash( $_GET['page'] ?? '' ) )
+			: wc_clean( wp_unslash( $_GET['post_type'] ?? $_POST['post_type'] ?? '' ) );
+		if ( $post_type_or_page === 'shop_subscription' || $post_type_or_page === 'wc-orders--shop_subscription' ) {
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/tests/PHPUnit/Compat/PPEC/MockGatewayTest.php
+++ b/tests/PHPUnit/Compat/PPEC/MockGatewayTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat\PPEC;
+
+use WooCommerce\PayPalCommerce\TestCase;
+
+/**
+ * @scenario `SubscriptionsHandler::add_mock_ppec_gateway()` registers this gateway
+ *           unconditionally (see SubscriptionsHandlerTest), so keeping it off
+ *           WooCommerce > Settings > Payments relies entirely on MockGateway presenting
+ *           itself as a "shell" gateway. WooCommerce's `PaymentsProviders::is_shell_payment_gateway()`
+ *           only recognises a gateway as a shell when both `method_title` and
+ *           `method_description` are empty; setting either one, even accidentally, would
+ *           silently put the gateway back on the settings screen.
+ */
+class MockGatewayTest extends TestCase
+{
+	public function testExposesAnEmptyMethodTitleAndMethodDescriptionToStayOffTheSettingsScreen()
+	{
+		// GIVEN the mock gateway used to disguise PPEC subscriptions.
+		$gateway = new MockGateway('PayPal (Legacy)');
+
+		// WHEN its public state is inspected the way WooCommerce core does to decide
+		// whether a gateway is a shell.
+		$exposed = get_object_vars($gateway);
+
+		// THEN both method_title and method_description are empty, so the gateway is
+		// recognised as a shell and excluded from the Payments settings screen.
+		$this->assertSame('', $exposed['method_title'] ?? '');
+		$this->assertSame('', $exposed['method_description'] ?? '');
+	}
+
+	public function testStillExposesTheGivenTitleForOrderAndSubscriptionScreens()
+	{
+		// GIVEN a title meant to label the gateway on order and subscription screens.
+		$gateway = new MockGateway('PayPal (Legacy)');
+
+		// WHEN its title is read.
+		// THEN it matches what was passed in, unlike method_title/method_description.
+		$this->assertSame('PayPal (Legacy)', $gateway->title);
+	}
+}

--- a/tests/PHPUnit/Compat/PPEC/SubscriptionsHandlerTest.php
+++ b/tests/PHPUnit/Compat/PPEC/SubscriptionsHandlerTest.php
@@ -5,19 +5,20 @@ namespace WooCommerce\PayPalCommerce\Compat\PPEC;
 
 use Mockery;
 use Psr\Log\LoggerInterface;
-use WC_Order;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcSubscriptions\RenewalHandler;
-use function Brain\Monkey\Functions\when;
 
 /**
- * @scenario Regression test for PCP-6709. `add_mock_ppec_gateway()` used to inject the
- *           "PayPal (Legacy)" mock gateway into WooCommerce's full gateway list
- *           unconditionally, which leaked it into WooCommerce > Settings > Payments for
- *           any merchant with legacy PPEC subscriptions. `should_mock_ppec_gateway()`
- *           scopes that injection to the legitimate contexts (a renewal in progress, My
- *           Account > Subscriptions, editing an order/subscription tied to PPEC, ...) so it
- *           no longer shows up on the general payment settings screen.
+ * @scenario A prior fix scoped `add_mock_ppec_gateway()` to only run in certain contexts
+ *           (a renewal in progress, My Account > Subscriptions, editing a PPEC order, ...)
+ *           to keep the mock "PayPal (Legacy)" gateway off the Payments settings screen.
+ *           That guard was a regression: `woocommerce_payment_gateways` fires exactly once,
+ *           when `WC_Payment_Gateways` is constructed early in the request, long before
+ *           Action Scheduler fires `woocommerce_scheduled_subscription_payment`. Gating the
+ *           registration on that action meant the mock gateway was never present when a
+ *           renewal actually ran, and PPEC renewals failed. Registration must stay
+ *           unconditional; the settings-screen problem is solved separately by MockGateway
+ *           presenting itself as a shell gateway (see MockGatewayTest).
  */
 class SubscriptionsHandlerTest extends TestCase
 {
@@ -40,85 +41,25 @@ class SubscriptionsHandlerTest extends TestCase
 			Mockery::mock(BillingAgreementTokenConverter::class),
 			Mockery::mock(LoggerInterface::class)
 		);
-
-		// Reliably false in the unit test environment: neither the WC_Subscriptions nor
-		// the WooCommerce-core OrderUtil class is loaded here, so both class_exists()
-		// checks in should_mock_ppec_gateway() take their "not available" branch without
-		// needing to be mocked.
-		when('is_admin')->justReturn(false);
-		when('is_wc_endpoint_url')->justReturn(false);
 	}
 
-	public function tearDown(): void
+	public function testRegistersTheGatewayUnconditionallyWithNoContextSetUp()
 	{
-		unset($_GET['id'], $_GET['post'], $_GET['post_type'], $_POST['post_ID'], $_POST['post_type']);
-
-		parent::tearDown();
-	}
-
-	/**
-	 * Stubs doing_action() to report only the given actions as currently in progress, so
-	 * each test states explicitly which of them (if any) is active instead of relying on
-	 * a single argument-agnostic default that would silently satisfy every call.
-	 *
-	 * Uses a single alias() callback rather than one expect()->with($action) per action:
-	 * two separate with()-constrained expectations on the same function name don't
-	 * dispatch on the actual call argument in this test environment (both calls resolve
-	 * to the first-registered expectation's return value), so a single argument-aware
-	 * callback is used instead.
-	 *
-	 * @param string[] $activeActions Action names that should report as currently doing.
-	 */
-	private function stubDoingAction(array $activeActions = []): void
-	{
-		when('doing_action')->alias(
-			static fn (string $action): bool => in_array($action, $activeActions, true)
-		);
-	}
-
-	public function testDoesNotAddGatewayWhenNoLegitimateContextMatches()
-	{
-		// GIVEN a plain page load with no renewal, subscription, or order-edit context
-		// active (e.g. viewing WooCommerce > Settings > Payments).
-		$this->stubDoingAction();
+		// GIVEN no ambient context whatsoever: no renewal in progress, no admin screen,
+		// no endpoint - the same conditions under which a deleted context guard once
+		// prevented registration and broke renewals.
 
 		// WHEN the gateway list is filtered.
 		$gateways = $this->sut->add_mock_ppec_gateway([]);
 
-		// THEN the mock gateway must not be added.
-		$this->assertArrayNotHasKey(PPECHelper::PPEC_GATEWAY_ID, $gateways);
-	}
-
-	public function testAddsGatewayWhileProcessingARenewal()
-	{
-		// GIVEN a subscription renewal is being processed.
-		$this->stubDoingAction(['woocommerce_scheduled_subscription_payment']);
-
-		// WHEN the gateway list is filtered.
-		$gateways = $this->sut->add_mock_ppec_gateway([]);
-
-		// THEN the mock gateway is added so the renewal can be attributed to PPEC.
-		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
-	}
-
-	public function testAddsGatewayOnMyAccountSubscriptionsEndpoint()
-	{
-		// GIVEN the buyer is viewing My Account > Subscriptions.
-		$this->stubDoingAction();
-		when('is_wc_endpoint_url')->justReturn(true);
-
-		// WHEN the gateway list is filtered.
-		$gateways = $this->sut->add_mock_ppec_gateway([]);
-
-		// THEN the mock gateway is added so PPEC subscriptions display correctly there.
+		// THEN the mock gateway is registered anyway, because Action Scheduler triggers
+		// renewals long after this filter has already run once.
 		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
 	}
 
 	public function testDoesNotOverwriteAnExistingGatewayEntry()
 	{
-		// GIVEN something else already registered a gateway under the PPEC id, and a
-		// legitimate context is also active.
-		$this->stubDoingAction(['woocommerce_scheduled_subscription_payment']);
+		// GIVEN something else already registered a gateway under the PPEC id.
 		$existing_gateway = new \stdClass();
 
 		// WHEN the gateway list is filtered.
@@ -126,80 +67,5 @@ class SubscriptionsHandlerTest extends TestCase
 
 		// THEN the existing entry is left untouched.
 		$this->assertSame($existing_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
-	}
-
-	public function testAddsGatewayWhenAdminEditsAnOrderTiedToPpec()
-	{
-		// GIVEN an admin is editing an order paid for via the legacy PPEC gateway.
-		$this->stubDoingAction();
-		when('is_admin')->justReturn(true);
-		$_GET['id'] = '123';
-		$order = Mockery::mock(WC_Order::class);
-		$order->shouldReceive('get_payment_method')->andReturn(PPECHelper::PPEC_GATEWAY_ID);
-		when('wc_get_order')->justReturn($order);
-
-		// WHEN the gateway list is filtered.
-		$gateways = $this->sut->add_mock_ppec_gateway([]);
-
-		// THEN the mock gateway is added so the order displays its payment method correctly.
-		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
-	}
-
-	public function testDoesNotAddGatewayWhenAdminEditsAnOrderWithADifferentPaymentMethod()
-	{
-		// GIVEN an admin is editing an order paid for via a different gateway.
-		$this->stubDoingAction();
-		when('is_admin')->justReturn(true);
-		$_GET['id'] = '123';
-		$order = Mockery::mock(WC_Order::class);
-		$order->shouldReceive('get_payment_method')->andReturn('ppcp-gateway');
-		when('wc_get_order')->justReturn($order);
-
-		// WHEN the gateway list is filtered.
-		$gateways = $this->sut->add_mock_ppec_gateway([]);
-
-		// THEN the mock gateway is not added.
-		$this->assertArrayNotHasKey(PPECHelper::PPEC_GATEWAY_ID, $gateways);
-	}
-
-	public function testAddsGatewayWhileSavingSubscriptionMetadataInAdmin()
-	{
-		// GIVEN an admin is saving an order/subscription's metadata.
-		when('is_admin')->justReturn(true);
-		$this->stubDoingAction(['woocommerce_process_shop_order_meta']);
-
-		// WHEN the gateway list is filtered.
-		$gateways = $this->sut->add_mock_ppec_gateway([]);
-
-		// THEN the mock gateway is added.
-		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
-	}
-
-	public function testAddsGatewayOnTheLegacyWcSubscriptionsListScreen()
-	{
-		// GIVEN an admin is viewing the legacy WC > Subscriptions list screen.
-		$this->stubDoingAction();
-		when('is_admin')->justReturn(true);
-		$_GET['post_type'] = 'shop_subscription';
-
-		// WHEN the gateway list is filtered.
-		$gateways = $this->sut->add_mock_ppec_gateway([]);
-
-		// THEN the mock gateway is added.
-		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
-	}
-
-	public function testDoesNotAddGatewayInAdminWhenNothingElseMatches()
-	{
-		// GIVEN a plain admin screen with no order id, no relevant action, and no
-		// subscriptions-list post_type (e.g. an unrelated settings page).
-		$this->stubDoingAction();
-		when('is_admin')->justReturn(true);
-
-		// WHEN the gateway list is filtered.
-		$gateways = $this->sut->add_mock_ppec_gateway([]);
-
-		// THEN the mock gateway is not added.
-		$this->assertArrayNotHasKey(PPECHelper::PPEC_GATEWAY_ID, $gateways);
 	}
 }

--- a/tests/PHPUnit/Compat/PPEC/SubscriptionsHandlerTest.php
+++ b/tests/PHPUnit/Compat/PPEC/SubscriptionsHandlerTest.php
@@ -1,0 +1,205 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Compat\PPEC;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WC_Order;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcSubscriptions\RenewalHandler;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @scenario Regression test for PCP-6709. `add_mock_ppec_gateway()` used to inject the
+ *           "PayPal (Legacy)" mock gateway into WooCommerce's full gateway list
+ *           unconditionally, which leaked it into WooCommerce > Settings > Payments for
+ *           any merchant with legacy PPEC subscriptions. `should_mock_ppec_gateway()`
+ *           scopes that injection to the legitimate contexts (a renewal in progress, My
+ *           Account > Subscriptions, editing an order/subscription tied to PPEC, ...) so it
+ *           no longer shows up on the general payment settings screen.
+ */
+class SubscriptionsHandlerTest extends TestCase
+{
+	/**
+	 * @var MockGateway|Mockery\MockInterface
+	 */
+	private $mock_gateway;
+
+	private SubscriptionsHandler $sut;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->mock_gateway = Mockery::mock(MockGateway::class);
+
+		$this->sut = new SubscriptionsHandler(
+			Mockery::mock(RenewalHandler::class),
+			$this->mock_gateway,
+			Mockery::mock(BillingAgreementTokenConverter::class),
+			Mockery::mock(LoggerInterface::class)
+		);
+
+		// Reliably false in the unit test environment: neither the WC_Subscriptions nor
+		// the WooCommerce-core OrderUtil class is loaded here, so both class_exists()
+		// checks in should_mock_ppec_gateway() take their "not available" branch without
+		// needing to be mocked.
+		when('is_admin')->justReturn(false);
+		when('is_wc_endpoint_url')->justReturn(false);
+	}
+
+	public function tearDown(): void
+	{
+		unset($_GET['id'], $_GET['post'], $_GET['post_type'], $_POST['post_ID'], $_POST['post_type']);
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Stubs doing_action() to report only the given actions as currently in progress, so
+	 * each test states explicitly which of them (if any) is active instead of relying on
+	 * a single argument-agnostic default that would silently satisfy every call.
+	 *
+	 * Uses a single alias() callback rather than one expect()->with($action) per action:
+	 * two separate with()-constrained expectations on the same function name don't
+	 * dispatch on the actual call argument in this test environment (both calls resolve
+	 * to the first-registered expectation's return value), so a single argument-aware
+	 * callback is used instead.
+	 *
+	 * @param string[] $activeActions Action names that should report as currently doing.
+	 */
+	private function stubDoingAction(array $activeActions = []): void
+	{
+		when('doing_action')->alias(
+			static fn (string $action): bool => in_array($action, $activeActions, true)
+		);
+	}
+
+	public function testDoesNotAddGatewayWhenNoLegitimateContextMatches()
+	{
+		// GIVEN a plain page load with no renewal, subscription, or order-edit context
+		// active (e.g. viewing WooCommerce > Settings > Payments).
+		$this->stubDoingAction();
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([]);
+
+		// THEN the mock gateway must not be added.
+		$this->assertArrayNotHasKey(PPECHelper::PPEC_GATEWAY_ID, $gateways);
+	}
+
+	public function testAddsGatewayWhileProcessingARenewal()
+	{
+		// GIVEN a subscription renewal is being processed.
+		$this->stubDoingAction(['woocommerce_scheduled_subscription_payment']);
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([]);
+
+		// THEN the mock gateway is added so the renewal can be attributed to PPEC.
+		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
+	}
+
+	public function testAddsGatewayOnMyAccountSubscriptionsEndpoint()
+	{
+		// GIVEN the buyer is viewing My Account > Subscriptions.
+		$this->stubDoingAction();
+		when('is_wc_endpoint_url')->justReturn(true);
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([]);
+
+		// THEN the mock gateway is added so PPEC subscriptions display correctly there.
+		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
+	}
+
+	public function testDoesNotOverwriteAnExistingGatewayEntry()
+	{
+		// GIVEN something else already registered a gateway under the PPEC id, and a
+		// legitimate context is also active.
+		$this->stubDoingAction(['woocommerce_scheduled_subscription_payment']);
+		$existing_gateway = new \stdClass();
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([PPECHelper::PPEC_GATEWAY_ID => $existing_gateway]);
+
+		// THEN the existing entry is left untouched.
+		$this->assertSame($existing_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
+	}
+
+	public function testAddsGatewayWhenAdminEditsAnOrderTiedToPpec()
+	{
+		// GIVEN an admin is editing an order paid for via the legacy PPEC gateway.
+		$this->stubDoingAction();
+		when('is_admin')->justReturn(true);
+		$_GET['id'] = '123';
+		$order = Mockery::mock(WC_Order::class);
+		$order->shouldReceive('get_payment_method')->andReturn(PPECHelper::PPEC_GATEWAY_ID);
+		when('wc_get_order')->justReturn($order);
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([]);
+
+		// THEN the mock gateway is added so the order displays its payment method correctly.
+		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
+	}
+
+	public function testDoesNotAddGatewayWhenAdminEditsAnOrderWithADifferentPaymentMethod()
+	{
+		// GIVEN an admin is editing an order paid for via a different gateway.
+		$this->stubDoingAction();
+		when('is_admin')->justReturn(true);
+		$_GET['id'] = '123';
+		$order = Mockery::mock(WC_Order::class);
+		$order->shouldReceive('get_payment_method')->andReturn('ppcp-gateway');
+		when('wc_get_order')->justReturn($order);
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([]);
+
+		// THEN the mock gateway is not added.
+		$this->assertArrayNotHasKey(PPECHelper::PPEC_GATEWAY_ID, $gateways);
+	}
+
+	public function testAddsGatewayWhileSavingSubscriptionMetadataInAdmin()
+	{
+		// GIVEN an admin is saving an order/subscription's metadata.
+		when('is_admin')->justReturn(true);
+		$this->stubDoingAction(['woocommerce_process_shop_order_meta']);
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([]);
+
+		// THEN the mock gateway is added.
+		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
+	}
+
+	public function testAddsGatewayOnTheLegacyWcSubscriptionsListScreen()
+	{
+		// GIVEN an admin is viewing the legacy WC > Subscriptions list screen.
+		$this->stubDoingAction();
+		when('is_admin')->justReturn(true);
+		$_GET['post_type'] = 'shop_subscription';
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([]);
+
+		// THEN the mock gateway is added.
+		$this->assertSame($this->mock_gateway, $gateways[PPECHelper::PPEC_GATEWAY_ID]);
+	}
+
+	public function testDoesNotAddGatewayInAdminWhenNothingElseMatches()
+	{
+		// GIVEN a plain admin screen with no order id, no relevant action, and no
+		// subscriptions-list post_type (e.g. an unrelated settings page).
+		$this->stubDoingAction();
+		when('is_admin')->justReturn(true);
+
+		// WHEN the gateway list is filtered.
+		$gateways = $this->sut->add_mock_ppec_gateway([]);
+
+		// THEN the mock gateway is not added.
+		$this->assertArrayNotHasKey(PPECHelper::PPEC_GATEWAY_ID, $gateways);
+	}
+}


### PR DESCRIPTION
### Description

The "PayPal (Legacy)" mock gateway was listed alongside real gateways in **WooCommerce > Payments**. It exists only so subscriptions migrated from PayPal Express Checkout (PPEC) can be renewed and labelled correctly — it has no settings and nothing to configure, so it has no business on that screen.

**Gate display, not registration.** `MockGateway` no longer sets a `method_title`. WooCommerce treats a gateway with no `method_title` and no `method_description` as a "shell" and excludes it from the Payments screen (`PaymentsProviders::is_shell_payment_gateway()`, applied via `remove_shell_payment_gateways()`). `$this->title` is untouched, so the gateway is still labelled "PayPal (Legacy)" on order and subscription screens.

Registration stays unconditional, which matters: `woocommerce_payment_gateways` runs once, when `WC_Payment_Gateways` is constructed early in the request, long before Action Scheduler fires `woocommerce_scheduled_subscription_payment`. Any context check there is evaluated too early to know a renewal is coming, so gating registration leaves the gateway missing and the renewal fails (#3549). This is a cosmetic bug and should not be fixed with a mechanism that can break renewals.

#### Known limitation

`PaymentsProviders` was introduced in **WooCommerce 10.0** — it does not exist in 9.6, 9.8 or 9.9 (verified against the release tags). The plugin declares `WC requires at least: 9.6`, so **on WooCommerce 9.6–9.9 the gateway is still listed**. The fix covers 10.0+; whether the older range needs covering is a product call.

`PaymentsProviders` is also marked `@internal`, so this leans on a WooCommerce implementation detail. The coupling is documented in `MockGateway` so it is not mistaken for a stray omission later.

### Steps to Test

Requires a store with legacy PPEC subscriptions, so `PPECHelper::use_ppec_compat_layer_for_subscriptions()`
is true. On **WooCommerce 10.0 or later**:

1. **WooCommerce > Payments** — "PayPal (Legacy)" is no longer listed.
2. **WooCommerce > Subscriptions**, and an individual PPEC subscription — still shows "PayPal (Legacy)" as the payment method, not "Manual Renewal".
3. **Edit an order paid via PPEC** — payment method still reads "PayPal (Legacy)".
4. **My Account > Subscriptions** as a customer with a PPEC subscription — renders correctly.
5. **The renewal path, which is the important one.** Trigger a renewal for a PPEC subscription (change the next payment date to the past and let Action Scheduler run it, or run the scheduled action manually). It must complete.
6. Editing and saving a PPEC subscription must not flip its payment method to "Manual Renewal".

On **WooCommerce 9.6–9.9**, step 1 will still show the gateway — expected, see the limitation above.

### Changelog Entry

> Fix - "PayPal (Legacy)" gateway no longer appears in WooCommerce > Payments
