### PR TITLE
Apply the buyer's state in Google Pay and Apple Pay shipping callbacks (6725)

### DIFF
--- a/modules/ppcp-applepay/src/Assets/ApplePayButton.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayButton.php
@@ -466,6 +466,9 @@ class ApplePayButton implements ButtonInterface {
 		WC()->customer->set_shipping_country(
 			$address['country'] ?? $shop_country_code
 		);
+		WC()->customer->set_shipping_state(
+			$address['state'] ?? ''
+		);
 		WC()->customer->set_billing_country(
 			$address['country'] ?? $shop_country_code
 		);
@@ -546,7 +549,7 @@ class ApplePayButton implements ButtonInterface {
 		$packages[0]['contents_cost']            = $total;
 		$packages[0]['applied_coupons']          = WC()->session->applied_coupon;
 		$packages[0]['destination']['country']   = $customer_address['country'] ?? '';
-		$packages[0]['destination']['state']     = '';
+		$packages[0]['destination']['state']     = $customer_address['state'] ?? '';
 		$packages[0]['destination']['postcode']  = $customer_address['postcode'] ?? '';
 		$packages[0]['destination']['city']      = $customer_address['city'] ?? '';
 		$packages[0]['destination']['address']   = '';

--- a/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
+++ b/modules/ppcp-applepay/src/Assets/ApplePayDataObjectHttp.php
@@ -407,6 +407,7 @@ class ApplePayDataObjectHttp {
 		}
 		return array(
 			'city'     => $contact_info['locality'],
+			'state'    => $contact_info['administrativeArea'] ?? '',
 			'postcode' => $contact_info['postalCode'],
 			'country'  => strtoupper( $contact_info['countryCode'] ),
 		);

--- a/modules/ppcp-googlepay/src/Endpoint/UpdatePaymentDataEndpoint.php
+++ b/modules/ppcp-googlepay/src/Endpoint/UpdatePaymentDataEndpoint.php
@@ -188,12 +188,12 @@ class UpdatePaymentDataEndpoint {
 
 		$customer->set_billing_postcode( $payment_data['shippingAddress']['postalCode'] ?? '' );
 		$customer->set_billing_country( $payment_data['shippingAddress']['countryCode'] ?? '' );
-		$customer->set_billing_state( '' );
+		$customer->set_billing_state( $payment_data['shippingAddress']['administrativeArea'] ?? '' );
 		$customer->set_billing_city( $payment_data['shippingAddress']['locality'] ?? '' );
 
 		$customer->set_shipping_postcode( $payment_data['shippingAddress']['postalCode'] ?? '' );
 		$customer->set_shipping_country( $payment_data['shippingAddress']['countryCode'] ?? '' );
-		$customer->set_shipping_state( '' );
+		$customer->set_shipping_state( $payment_data['shippingAddress']['administrativeArea'] ?? '' );
 		$customer->set_shipping_city( $payment_data['shippingAddress']['locality'] ?? '' );
 
 		// Save the data.

--- a/tests/PHPUnit/Applepay/ApplePayButtonTest.php
+++ b/tests/PHPUnit/Applepay/ApplePayButtonTest.php
@@ -1,10 +1,11 @@
 <?php
-declare(strict_types=1);
+declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Applepay;
 
 use Mockery;
 use Psr\Log\LoggerInterface;
+use ReflectionMethod;
 use WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton;
 use WooCommerce\PayPalCommerce\Applepay\Assets\DataToAppleButtonScripts;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
@@ -15,41 +16,39 @@ use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Processor\OrderProcessor;
+use function Brain\Monkey\Functions\when;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayButton
  */
-class ApplePayButtonTest extends TestCase
-{
+class ApplePayButtonTest extends TestCase {
 	private $settings;
 	private $context;
 	private ApplePayButton $sut;
 
-	public function setUp(): void
-	{
+	public function setUp(): void {
 		parent::setUp();
 
-		$this->settings = Mockery::mock(SettingsProvider::class);
-		$this->context  = Mockery::mock(Context::class);
+		$this->settings = Mockery::mock( SettingsProvider::class );
+		$this->context  = Mockery::mock( Context::class );
 
 		$this->sut = new ApplePayButton(
 			$this->settings,
-			Mockery::mock(PaymentSettings::class),
-			Mockery::mock(LoggerInterface::class),
-			Mockery::mock(OrderProcessor::class),
-			Mockery::mock(AssetGetter::class),
+			Mockery::mock( PaymentSettings::class ),
+			Mockery::mock( LoggerInterface::class ),
+			Mockery::mock( OrderProcessor::class ),
+			Mockery::mock( AssetGetter::class ),
 			'1.0.0',
-			Mockery::mock(DataToAppleButtonScripts::class),
-			Mockery::mock(CartProductsHelper::class),
+			Mockery::mock( DataToAppleButtonScripts::class ),
+			Mockery::mock( CartProductsHelper::class ),
 			$this->context
 		);
 	}
 
-	public function testDisabledWhenApplePayGloballyDisabled(): void
-	{
-		$this->settings->shouldReceive('applepay_enabled')->andReturn(false);
+	public function testDisabledWhenApplePayGloballyDisabled(): void {
+		$this->settings->shouldReceive( 'applepay_enabled' )->andReturn( false );
 
-		$this->assertFalse($this->sut->is_enabled());
+		$this->assertFalse( $this->sut->is_enabled() );
 	}
 
 	/**
@@ -57,36 +56,114 @@ class ApplePayButtonTest extends TestCase
 	 *           "Enable payment methods in this location" for Classic Checkout must hide Apple
 	 *           Pay even though it's still selected in that location's method list.
 	 */
-	public function testDisabledWhenLocationDisabledEvenIfMethodSelected(): void
-	{
-		$this->settings->shouldReceive('applepay_enabled')->andReturn(true);
-		$this->context->shouldReceive('context')->andReturn('checkout');
-		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
-			new LocationStylingDTO('classic_checkout', false, array(ApplePayGateway::ID))
+	public function testDisabledWhenLocationDisabledEvenIfMethodSelected(): void {
+		$this->settings->shouldReceive( 'applepay_enabled' )->andReturn( true );
+		$this->context->shouldReceive( 'context' )->andReturn( 'checkout' );
+		$this->settings->shouldReceive( 'button_styling' )->with( 'checkout' )->andReturn(
+			new LocationStylingDTO( 'classic_checkout', false, array( ApplePayGateway::ID ) )
 		);
 
-		$this->assertFalse($this->sut->is_enabled());
+		$this->assertFalse( $this->sut->is_enabled() );
 	}
 
-	public function testEnabledWhenLocationEnabledAndMethodSelected(): void
-	{
-		$this->settings->shouldReceive('applepay_enabled')->andReturn(true);
-		$this->context->shouldReceive('context')->andReturn('checkout');
-		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
-			new LocationStylingDTO('classic_checkout', true, array(ApplePayGateway::ID))
+	public function testEnabledWhenLocationEnabledAndMethodSelected(): void {
+		$this->settings->shouldReceive( 'applepay_enabled' )->andReturn( true );
+		$this->context->shouldReceive( 'context' )->andReturn( 'checkout' );
+		$this->settings->shouldReceive( 'button_styling' )->with( 'checkout' )->andReturn(
+			new LocationStylingDTO( 'classic_checkout', true, array( ApplePayGateway::ID ) )
 		);
 
-		$this->assertTrue($this->sut->is_enabled());
+		$this->assertTrue( $this->sut->is_enabled() );
 	}
 
-	public function testDisabledWhenLocationEnabledButMethodNotSelected(): void
-	{
-		$this->settings->shouldReceive('applepay_enabled')->andReturn(true);
-		$this->context->shouldReceive('context')->andReturn('checkout');
-		$this->settings->shouldReceive('button_styling')->with('checkout')->andReturn(
-			new LocationStylingDTO('classic_checkout', true, array())
+	public function testDisabledWhenLocationEnabledButMethodNotSelected(): void {
+		$this->settings->shouldReceive( 'applepay_enabled' )->andReturn( true );
+		$this->context->shouldReceive( 'context' )->andReturn( 'checkout' );
+		$this->settings->shouldReceive( 'button_styling' )->with( 'checkout' )->andReturn(
+			new LocationStylingDTO( 'classic_checkout', true, array() )
 		);
 
-		$this->assertFalse($this->sut->is_enabled());
+		$this->assertFalse( $this->sut->is_enabled() );
+	}
+
+	/**
+	 * Invokes a protected method of the SUT.
+	 *
+	 * customer_address() and getShippingPackages() are not part of the public API, but they
+	 * are the exact seams where the buyer's state is dropped during the live shipping-rate
+	 * step. Driving the fully public update_shipping_contact() path would require stubbing
+	 * nonce verification, WC_Countries and response-template output unrelated to this bug,
+	 * so reflection is used instead.
+	 */
+	private function invoke_protected( string $method, array $args ) {
+		$reflection = new ReflectionMethod( $this->sut, $method );
+		$reflection->setAccessible( true );
+
+		return $reflection->invokeArgs( $this->sut, $args );
+	}
+
+	/**
+	 * GIVEN an Apple Pay shipping address carrying state "NY"
+	 * WHEN customer_address() applies that address to the WooCommerce customer during the
+	 *      live shipping-rate calculation step
+	 * THEN the customer's shipping state is set to "NY"
+	 */
+	public function testCustomerAddressAppliesStateToWooCommerceCustomer(): void {
+		when( 'wc_get_base_location' )->justReturn( array( 'country' => 'US' ) );
+
+		$customer = Mockery::mock()->shouldIgnoreMissing();
+		$customer->shouldReceive( 'set_shipping_state' )->once()->with( 'NY' );
+
+		when( 'WC' )->justReturn( (object) array( 'customer' => $customer ) );
+
+		$this->invoke_protected(
+			'customer_address',
+			array(
+				array(
+					'country'  => 'US',
+					'postcode' => '10001',
+					'city'     => 'New York',
+					'state'    => 'NY',
+				),
+			)
+		);
+
+		$this->addToAssertionCount( 1 );
+	}
+
+	/**
+	 * GIVEN a customer address carrying state "NY"
+	 * WHEN getShippingPackages() builds the shipping destination used to calculate rates
+	 * THEN the destination's state is "NY" instead of being forced to an empty string
+	 *
+	 * Regression test: state-scoped shipping zones return no rates because the destination
+	 * state was previously hardcoded to '', even when the address carried a state.
+	 */
+	public function testGetShippingPackagesSetsDestinationState(): void {
+		$cart    = (object) array( 'cart_contents' => array() );
+		$session = (object) array( 'applied_coupon' => array() );
+
+		when( 'WC' )->justReturn(
+			(object) array(
+				'cart'    => $cart,
+				'session' => $session,
+			)
+		);
+		when( 'apply_filters' )->returnArg( 2 );
+
+		$packages = $this->invoke_protected(
+			'getShippingPackages',
+			array(
+				array(
+					'country'  => 'US',
+					'postcode' => '10001',
+					'city'     => 'New York',
+					'state'    => 'NY',
+				),
+				100.0,
+			)
+		);
+
+		$this->assertSame( 'NY', $packages[0]['destination']['state'] );
 	}
 }

--- a/tests/PHPUnit/Applepay/ApplePayDataObjectHttpTest.php
+++ b/tests/PHPUnit/Applepay/ApplePayDataObjectHttpTest.php
@@ -1,0 +1,58 @@
+<?php
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\Applepay;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+use WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayDataObjectHttp;
+use WooCommerce\PayPalCommerce\TestCase;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Applepay\Assets\ApplePayDataObjectHttp
+ */
+class ApplePayDataObjectHttpTest extends TestCase {
+	private ApplePayDataObjectHttp $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$logger    = Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
+		$this->sut = new ApplePayDataObjectHttp( $logger );
+	}
+
+	/**
+	 * Invokes the protected simplified_address() method.
+	 *
+	 * The method is not part of the public API, but it is the exact seam where the buyer's
+	 * state is dropped during the live shipping-contact callback (before the order is placed),
+	 * so reflection is the only way to observe this behavior in isolation.
+	 */
+	private function simplified_address( array $contact_info ): array {
+		$method = new ReflectionMethod( $this->sut, 'simplified_address' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $this->sut, $contact_info );
+	}
+
+	/**
+	 * GIVEN a shipping contact received during Apple Pay's live shipping-rate callback that
+	 *       carries administrativeArea "NY" together with the already-required locality,
+	 *       postalCode and countryCode
+	 * WHEN the simplified address used to calculate shipping rates is built
+	 * THEN the resulting address includes the buyer's state "NY"
+	 */
+	public function testSimplifiedAddressIncludesStateFromAdministrativeArea(): void {
+		$address = $this->simplified_address(
+			array(
+				'locality'           => 'New York',
+				'postalCode'         => '10001',
+				'countryCode'        => 'us',
+				'administrativeArea' => 'NY',
+			)
+		);
+
+		$this->assertSame( 'NY', $address['state'] ?? null );
+	}
+}

--- a/tests/PHPUnit/Googlepay/UpdatePaymentDataEndpointTest.php
+++ b/tests/PHPUnit/Googlepay/UpdatePaymentDataEndpointTest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Googlepay;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Psr\Log\LoggerInterface;
+use WC_Customer;
+use WooCommerce\PayPalCommerce\Button\Endpoint\RequestData;
+use WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Googlepay\Endpoint\UpdatePaymentDataEndpoint
+ */
+class UpdatePaymentDataEndpointTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	private RequestData $requestData;
+	private LoggerInterface $logger;
+	private UpdatePaymentDataEndpoint $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->requestData = Mockery::mock( RequestData::class );
+		$this->logger      = Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
+
+		$this->sut = new UpdatePaymentDataEndpoint(
+			$this->requestData,
+			$this->logger
+		);
+	}
+
+	/**
+	 * GIVEN a Google Pay SHIPPING_ADDRESS callback whose shippingAddress carries
+	 *       administrativeArea "NSW"
+	 * WHEN the endpoint processes the payment data update
+	 * THEN the WooCommerce customer's shipping state and billing state are both set to "NSW"
+	 */
+	public function testShippingAddressStateIsAppliedToCustomer(): void {
+		$data = array(
+			'paymentData' => array(
+				'callbackTrigger'    => 'SHIPPING_ADDRESS',
+				'shippingAddress'    => array(
+					'countryCode'        => 'AU',
+					'postalCode'         => '2021',
+					'locality'           => 'Paddington',
+					'administrativeArea' => 'NSW',
+				),
+				// Present on every real callback; irrelevant to the state-mapping bug under test.
+				'shippingOptionData' => array( 'id' => '' ),
+			),
+		);
+
+		$this->requestData->shouldReceive( 'read_request' )
+			->with( UpdatePaymentDataEndpoint::nonce() )
+			->andReturn( $data );
+
+		$customer = Mockery::mock( WC_Customer::class )->shouldIgnoreMissing();
+		$customer->shouldReceive( 'set_shipping_state' )->once()->with( 'NSW' );
+		$customer->shouldReceive( 'set_billing_state' )->once()->with( 'NSW' );
+
+		when( 'WC' )->justReturn(
+			(object) array(
+				'customer' => $customer,
+				'cart'     => Mockery::mock()->shouldIgnoreMissing(),
+				'shipping' => Mockery::mock()->shouldIgnoreMissing(),
+				'session'  => Mockery::mock()->shouldIgnoreMissing(),
+			)
+		);
+
+		when( 'wc_get_base_location' )->justReturn( array( 'country' => 'AU' ) );
+		when( 'get_woocommerce_currency' )->justReturn( 'AUD' );
+		when( 'wp_send_json_success' )->justReturn( null );
+		when( 'wp_send_json_error' )->justReturn( null );
+
+		$this->sut->handle_request();
+	}
+}


### PR DESCRIPTION
*Changelog:* `Fix - Google Pay and Apple Pay now return shipping options for addresses in state-based shipping zones #4565`

# Description

## 🐛 The problem

On stores whose shipping rates depend on the customer's state or region, selecting a shipping address inside the Google Pay or Apple Pay sheet returns no shipping options. Google Pay shows an empty list; Apple Pay rejects the address with **"No shipping methods are available for your address."**

## 💡 Why it happens

Both wallet shipping callbacks discard the state (`administrativeArea`) from the wallet payload before WooCommerce calculates shipping. Google Pay wrote an empty billing and shipping state; Apple Pay never parsed `administrativeArea` into its address and then forced an empty destination state. With no state, a state-scoped shipping zone cannot match, so the rate list comes back empty.

## ✅ The fix

Both callbacks now carry the buyer's state through to WooCommerce's shipping calculation.

- **Google Pay:** `UpdatePaymentDataEndpoint::update_addresses()` reads `administrativeArea` for the customer state.
- **Apple Pay:** `ApplePayDataObjectHttp::simplified_address()` parses the state, and `ApplePayButton::customer_address()` and `getShippingPackages()` apply it to the customer and the shipping package.

## 🔍 What to review

The state from the wallet (`administrativeArea`) is trusted as-is as a WooCommerce state code; a country that returns a region name rather than a state code could still fail to match a zone.

## 🧪 How to verify

1. Create a shipping zone scoped to a single state (e.g. US → New York) with a rate, and no catch-all zone that would also match.
2. Add a shippable product and open the Google Pay sheet (and the Apple Pay sheet in Safari).
3. Select an address in that state, and confirm the state's shipping options appear.
