### PR TITLE
Fix plugin calling Vault API with empty customer id (6731)

### DIFF
--- a/modules/ppcp-wc-payment-tokens/src/WooCommercePaymentTokens.php
+++ b/modules/ppcp-wc-payment-tokens/src/WooCommercePaymentTokens.php
@@ -257,6 +257,10 @@ class WooCommercePaymentTokens {
 			$customer_id = get_user_meta( $user_id, 'ppcp_customer_id', true );
 		}
 
+		if ( ! $customer_id ) {
+			return array();
+		}
+
 		try {
 			$customer_tokens = $this->payment_tokens_endpoint->payment_tokens_for_customer( $customer_id );
 		} catch ( RuntimeException $exception ) {

--- a/tests/PHPUnit/WcPaymentTokens/WooCommercePaymentTokensTest.php
+++ b/tests/PHPUnit/WcPaymentTokens/WooCommercePaymentTokensTest.php
@@ -11,13 +11,11 @@ use WooCommerce\PayPalCommerce\TestCase;
 use function Brain\Monkey\Functions\when;
 
 /**
- * @scenario Regression test for PCP-6731. customer_tokens() looked up the PayPal customer
- *           id from usermeta but never checked whether it actually found one before
- *           calling payment_tokens_for_customer(), so a user missing both meta keys (e.g.
- *           after the usermeta row was deleted) triggered a doomed
- *           GET .../v3/vault/payment-tokens?customer_id= request that PayPal rejects with
- *           400. It now bails out early, matching the same guard already used at the other
- *           two call sites of payment_tokens_for_customer() (PayPalGateway,
+ * @scenario customer_tokens() looks up the PayPal customer id from usermeta and must not
+ *           call payment_tokens_for_customer() when neither meta key holds one (e.g. after
+ *           the usermeta row was deleted) — PayPal always rejects that request with 400. It
+ *           bails out early instead, matching the same guard already used at the other two
+ *           call sites of payment_tokens_for_customer() (PayPalGateway,
  *           PaymentMethodTokensChecker).
  */
 class WooCommercePaymentTokensTest extends TestCase

--- a/tests/PHPUnit/WcPaymentTokens/WooCommercePaymentTokensTest.php
+++ b/tests/PHPUnit/WcPaymentTokens/WooCommercePaymentTokensTest.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcPaymentTokens;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @scenario Regression test for PCP-6731. customer_tokens() looked up the PayPal customer
+ *           id from usermeta but never checked whether it actually found one before
+ *           calling payment_tokens_for_customer(), so a user missing both meta keys (e.g.
+ *           after the usermeta row was deleted) triggered a doomed
+ *           GET .../v3/vault/payment-tokens?customer_id= request that PayPal rejects with
+ *           400. It now bails out early, matching the same guard already used at the other
+ *           two call sites of payment_tokens_for_customer() (PayPalGateway,
+ *           PaymentMethodTokensChecker).
+ */
+class WooCommercePaymentTokensTest extends TestCase
+{
+	/**
+	 * @var PaymentTokensEndpoint|Mockery\MockInterface
+	 */
+	private $payment_tokens_endpoint;
+
+	private WooCommercePaymentTokens $sut;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->payment_tokens_endpoint = Mockery::mock(PaymentTokensEndpoint::class);
+
+		$this->sut = new WooCommercePaymentTokens(
+			$this->payment_tokens_endpoint,
+			Mockery::mock(LoggerInterface::class)
+		);
+	}
+
+	/**
+	 * Stubs get_user_meta() to return the given value only for the given meta key.
+	 *
+	 * @param array<string, string> $metaByKey Meta value keyed by meta key.
+	 */
+	private function stubUserMeta(array $metaByKey): void
+	{
+		when('get_user_meta')->alias(
+			static fn (int $user_id, string $key, bool $single = false) => $metaByKey[$key] ?? ''
+		);
+	}
+
+	public function testReturnsEmptyArrayWithoutCallingTheEndpointWhenNoCustomerIdIsStored()
+	{
+		// GIVEN a user with neither the current nor the legacy customer-id meta key set
+		// (e.g. the usermeta row was deleted).
+		$this->stubUserMeta([]);
+
+		// WHEN the customer's PayPal tokens are requested.
+		$result = $this->sut->customer_tokens(42);
+
+		// THEN no request is made, and an empty array is returned as if there were none.
+		$this->payment_tokens_endpoint->shouldNotHaveReceived('payment_tokens_for_customer');
+		$this->assertSame([], $result);
+	}
+
+	public function testUsesTheCurrentCustomerIdMetaKeyWhenPresent()
+	{
+		// GIVEN a user with the current customer-id meta key set.
+		$this->stubUserMeta(['_ppcp_target_customer_id' => 'CUST-1']);
+		$tokens = [['id' => 'TOKEN-1']];
+		$this->payment_tokens_endpoint
+			->shouldReceive('payment_tokens_for_customer')
+			->with('CUST-1')
+			->andReturn($tokens);
+
+		// WHEN the customer's PayPal tokens are requested.
+		$result = $this->sut->customer_tokens(42);
+
+		// THEN the tokens for that customer id are returned.
+		$this->assertSame($tokens, $result);
+	}
+
+	public function testFallsBackToTheLegacyCustomerIdMetaKey()
+	{
+		// GIVEN a user with only the legacy customer-id meta key set.
+		$this->stubUserMeta(['ppcp_customer_id' => 'CUST-LEGACY']);
+		$tokens = [['id' => 'TOKEN-1']];
+		$this->payment_tokens_endpoint
+			->shouldReceive('payment_tokens_for_customer')
+			->with('CUST-LEGACY')
+			->andReturn($tokens);
+
+		// WHEN the customer's PayPal tokens are requested.
+		$result = $this->sut->customer_tokens(42);
+
+		// THEN the tokens for the legacy customer id are returned.
+		$this->assertSame($tokens, $result);
+	}
+
+	public function testReturnsEmptyArrayWhenTheEndpointFails()
+	{
+		// GIVEN a stored customer id, but the PayPal API call fails.
+		$this->stubUserMeta(['_ppcp_target_customer_id' => 'CUST-1']);
+		$this->payment_tokens_endpoint
+			->shouldReceive('payment_tokens_for_customer')
+			->andThrow(new RuntimeException('Bad Request'));
+
+		// WHEN the customer's PayPal tokens are requested.
+		$result = $this->sut->customer_tokens(42);
+
+		// THEN the failure is treated the same as having no tokens.
+		$this->assertSame([], $result);
+	}
+}


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
`WooCommercePaymentTokens::customer_tokens()` looks up the PayPal customer id from usermeta (`_ppcp_target_customer_id`, falling back to the legacy `ppcp_customer_id`) before fetching that customer's saved PayPal payment tokens. It never checked whether either lookup actually found a value before calling `payment_tokens_for_customer()`, so a user missing both meta keys (e.g. the usermeta row was deleted) triggered:                                                                                                                                                                                     

```                                                                                                                                                                                                          
GET https://api-m.paypal.com/v3/vault/payment-tokens?customer_id=                                                                                                                                       
Response: 400 Bad Request                                                                                                                                                                               
```
                                                                                                                                                                                                     
This adds the same early-return guard already used at the endpoint's other two call sites (`PayPalGateway::process_payment()` and `PaymentMethodTokensChecker::has_paypal_payment_token()`) — if no customer id is found, return no tokens without making the request.                                                                                                                                      
                                                                                                                                                                                                          
This doesn't change any user-visible outcome: `customer_tokens()` already caught the resulting exception and returned an empty array, so callers (subscription renewal, the free-trial checkout flow) already saw "no saved tokens" in this situation. The fix only removes the wasted, always-failing API call and its error-log noise.                                                                      
                                                                                                                                                                                                          
### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Set up Vaulting and a merchant connection.                                                                                                                                                           
2. Buy a subscription (this saves a payment token, storing the customer id in usermeta).                                                                                                                
3. Delete the customer id from the usermeta table (both `_ppcp_target_customer_id` and `ppcp_customer_id`, if present) for that user.                                                                   
4. Attempt to renew the subscription (or trigger `customer_tokens()` via the free-trial checkout flow).                                                                                                 
5. Confirm no `v3/vault/payment-tokens?customer_id=` request appears in the logs, and the renewal fails the same way it did before (just without the wasted API call).