### PR TITLE
Fix PayPal buttons not showing for subscription products with manual renewals enabled and vaulting disabled (6696)

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.js
@@ -253,38 +253,55 @@ class SingleProductBootstrap {
 			PayPalCommerceGateway.data_client_id.has_subscriptions &&
 			PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled
 		) {
-			const buttonWrapper = document.getElementById(
-				'ppc-button-ppcp-gateway'
-			);
-			buttonWrapper.innerHTML = '';
-
 			const subscription_plan =
 				this.variations() !== null
 					? getPlanIdFromVariation( this.variations() )
 					: PayPalCommerceGateway.subscription_plan_id;
-			if ( ! subscription_plan ) {
+
+			// Manual renewals mean the merchant bills renewals themselves, so
+			// no PayPal subscription plan is required; fall through to the
+			// standard button below instead of leaving the wrapper empty.
+			const manualRenewalStandardCheckout =
+				! this.gateway.vaultingEnabled &&
+				this.gateway.manualRenewalEnabled === '1';
+
+			if ( ! subscription_plan && ! manualRenewalStandardCheckout ) {
 				return;
 			}
 
-			if ( this.subscriptionButtonsLoaded ) {
+			if ( subscription_plan ) {
+				if ( this.subscriptionButtonsLoaded ) {
+					return;
+				}
+
+				// Only clear the wrapper right before this render path
+				// actually uses it: the standard renderer below has its own
+				// isAlreadyRendered() guard, which clearing here would
+				// defeat on every re-render triggered by its own
+				// onButtonsInit callback, causing a destroy/recreate loop.
+				const buttonWrapper = document.getElementById(
+					'ppc-button-ppcp-gateway'
+				);
+				buttonWrapper.innerHTML = '';
+
+				loadPaypalJsScript(
+					{
+						clientId: PayPalCommerceGateway.client_id,
+						currency: PayPalCommerceGateway.currency,
+						intent: 'subscription',
+						vault: true,
+						disable_funding:
+							this.gateway.url_params[ 'disable-funding' ],
+					},
+					actionHandler.subscriptionsConfiguration(
+						subscription_plan
+					),
+					this.gateway.button.wrapper
+				);
+
+				this.subscriptionButtonsLoaded = true;
 				return;
 			}
-
-			loadPaypalJsScript(
-				{
-					clientId: PayPalCommerceGateway.client_id,
-					currency: PayPalCommerceGateway.currency,
-					intent: 'subscription',
-					vault: true,
-					disable_funding:
-						this.gateway.url_params[ 'disable-funding' ],
-				},
-				actionHandler.subscriptionsConfiguration( subscription_plan ),
-				this.gateway.button.wrapper
-			);
-
-			this.subscriptionButtonsLoaded = true;
-			return;
 		}
 
 		if (

--- a/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.test.js
+++ b/modules/ppcp-button/resources/js/modules/ContextBootstrap/SingleProductBootstrap.test.js
@@ -1,0 +1,271 @@
+/* global jest, describe, test, expect, beforeEach, afterEach */
+jest.mock( '@ppcp-button/Helper/UpdateCart', () =>
+	jest.fn().mockImplementation( () => ( {} ) )
+);
+
+const mockConfiguration = jest.fn( () => ( { standard: true } ) );
+const mockSubscriptionsConfiguration = jest.fn( ( plan ) => ( { plan } ) );
+const mockGetProducts = jest.fn( () => [] );
+jest.mock( '@ppcp-button/ActionHandler/SingleProductActionHandler', () =>
+	jest.fn().mockImplementation( () => ( {
+		configuration: mockConfiguration,
+		subscriptionsConfiguration: mockSubscriptionsConfiguration,
+		getProducts: mockGetProducts,
+		getSubscriptionProducts: mockGetProducts,
+	} ) )
+);
+
+const mockLoadPaypalJsScript = jest.fn();
+jest.mock( '@ppcp-button/Helper/ScriptLoading', () => ( {
+	loadPaypalJsScript: ( ...args ) => mockLoadPaypalJsScript( ...args ),
+} ) );
+
+const mockGetPlanIdFromVariation = jest.fn();
+jest.mock( '@ppcp-button/Helper/Subscriptions', () => ( {
+	getPlanIdFromVariation: ( ...args ) =>
+		mockGetPlanIdFromVariation( ...args ),
+} ) );
+
+let simulateCartData = null;
+const mockSimulate = jest.fn( ( onResolve ) => onResolve( simulateCartData ) );
+jest.mock( '@ppcp-button/Helper/SimulateCart', () =>
+	jest.fn().mockImplementation( () => ( {
+		simulate: ( ...args ) => mockSimulate( ...args ),
+	} ) )
+);
+
+jest.mock( '@ppcp-button/Helper/BootstrapHelper', () => ( {
+	__esModule: true,
+	default: { updateScriptData: jest.fn(), handleButtonStatus: jest.fn() },
+} ) );
+
+import SingleProductBootstrap from './SingleProductBootstrap';
+
+/**
+ * Builds a SingleProductBootstrap instance without running its constructor's
+ * DOM/timer side effects (MutationObserver, throttle, debounce, ...), since
+ * render() itself doesn't depend on any of them.
+ *
+ * @param {Object} overrides - Properties to set on the instance (gateway, variations, form, ...).
+ * @return {SingleProductBootstrap} The bootstrap instance.
+ */
+function buildBootstrap( overrides = {} ) {
+	const instance = Object.create( SingleProductBootstrap.prototype );
+	instance.gateway = {
+		ajax: {
+			change_cart: { endpoint: '/cc', nonce: 'n' },
+			simulate_cart: { endpoint: '/sim', nonce: 'n' },
+		},
+		url_params: {},
+		button: { wrapper: '#ppc-button-ppcp-gateway' },
+		vaultingEnabled: true,
+		manualRenewalEnabled: '0',
+		productType: 'subscription',
+		simulate_cart: { enabled: true },
+		single_product_buttons_enabled: '1',
+	};
+	instance.renderer = { render: jest.fn() };
+	instance.errorHandler = {};
+	instance.subscriptionButtonsLoaded = false;
+	instance.variations = jest.fn( () => null );
+	instance.form = jest.fn( () => null );
+
+	Object.assign( instance, overrides );
+
+	return instance;
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	simulateCartData = null;
+	document.body.innerHTML =
+		'<div id="ppc-button-ppcp-gateway"></div><form class="cart"></form>';
+	global.PayPalCommerceGateway = {
+		data_client_id: {
+			has_subscriptions: false,
+			paypal_subscriptions_enabled: false,
+		},
+		client_id: 'client-1',
+		currency: 'USD',
+		subscription_plan_id: '',
+	};
+	global.jQuery = jest.fn( () => ( { trigger: jest.fn() } ) );
+} );
+
+afterEach( () => {
+	delete global.PayPalCommerceGateway;
+	delete global.jQuery;
+	document.body.innerHTML = '';
+} );
+
+describe( 'SingleProductBootstrap render', () => {
+	test( 'renders the standard button when the product is not a PayPal subscription', () => {
+		const instance = buildBootstrap();
+
+		instance.render();
+
+		expect( instance.renderer.render ).toHaveBeenCalledWith( {
+			standard: true,
+		} );
+		expect( mockLoadPaypalJsScript ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders the PayPal subscription button when a plan is connected', () => {
+		global.PayPalCommerceGateway.data_client_id.has_subscriptions = true;
+		global.PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled = true;
+		global.PayPalCommerceGateway.subscription_plan_id = 'PLAN-1';
+		const instance = buildBootstrap();
+
+		instance.render();
+
+		expect( mockSubscriptionsConfiguration ).toHaveBeenCalledWith(
+			'PLAN-1'
+		);
+		expect( mockLoadPaypalJsScript ).toHaveBeenCalledTimes( 1 );
+		expect( instance.subscriptionButtonsLoaded ).toBe( true );
+		expect( instance.renderer.render ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not reload the PayPal subscription button once already loaded', () => {
+		global.PayPalCommerceGateway.data_client_id.has_subscriptions = true;
+		global.PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled = true;
+		global.PayPalCommerceGateway.subscription_plan_id = 'PLAN-1';
+		const instance = buildBootstrap( { subscriptionButtonsLoaded: true } );
+
+		instance.render();
+
+		expect( mockLoadPaypalJsScript ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders nothing for a subscription product with no connected plan and no manual-renewal fallback', () => {
+		global.PayPalCommerceGateway.data_client_id.has_subscriptions = true;
+		global.PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled = true;
+		global.PayPalCommerceGateway.subscription_plan_id = '';
+		const instance = buildBootstrap( {
+			gateway: {
+				ajax: { change_cart: { endpoint: '/cc', nonce: 'n' } },
+				url_params: {},
+				button: { wrapper: '#ppc-button-ppcp-gateway' },
+				vaultingEnabled: true,
+				manualRenewalEnabled: '0',
+				productType: 'subscription',
+			},
+		} );
+
+		instance.render();
+
+		expect( mockLoadPaypalJsScript ).not.toHaveBeenCalled();
+		expect( instance.renderer.render ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders the standard button for a subscription with no connected plan when manual renewals are enabled and vaulting is disabled', () => {
+		global.PayPalCommerceGateway.data_client_id.has_subscriptions = true;
+		global.PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled = true;
+		global.PayPalCommerceGateway.subscription_plan_id = '';
+		const instance = buildBootstrap( {
+			gateway: {
+				ajax: { change_cart: { endpoint: '/cc', nonce: 'n' } },
+				url_params: {},
+				button: { wrapper: '#ppc-button-ppcp-gateway' },
+				vaultingEnabled: false,
+				manualRenewalEnabled: '1',
+				productType: 'subscription',
+			},
+		} );
+
+		instance.render();
+
+		expect( mockLoadPaypalJsScript ).not.toHaveBeenCalled();
+		expect( instance.renderer.render ).toHaveBeenCalledWith( {
+			standard: true,
+		} );
+	} );
+
+	// The standard renderer's own isAlreadyRendered() guard skips re-rendering while
+	// the wrapper still holds its previously rendered button. Clearing the wrapper on
+	// every render() call defeats that guard on every re-render triggered by the
+	// renderer's own onButtonsInit callback, destroying and recreating the button
+	// endlessly.
+	test( 'does not clear the button wrapper when falling through to the standard renderer', () => {
+		global.PayPalCommerceGateway.data_client_id.has_subscriptions = true;
+		global.PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled = true;
+		global.PayPalCommerceGateway.subscription_plan_id = '';
+		document.getElementById( 'ppc-button-ppcp-gateway' ).innerHTML =
+			'<div class="already-rendered-button"></div>';
+		const instance = buildBootstrap( {
+			gateway: {
+				ajax: { change_cart: { endpoint: '/cc', nonce: 'n' } },
+				url_params: {},
+				button: { wrapper: '#ppc-button-ppcp-gateway' },
+				vaultingEnabled: false,
+				manualRenewalEnabled: '1',
+				productType: 'subscription',
+			},
+		} );
+
+		instance.render();
+
+		expect(
+			document.querySelector(
+				'#ppc-button-ppcp-gateway .already-rendered-button'
+			)
+		).not.toBeNull();
+	} );
+
+	test( 'clears the button wrapper before rendering the PayPal subscription button', () => {
+		global.PayPalCommerceGateway.data_client_id.has_subscriptions = true;
+		global.PayPalCommerceGateway.data_client_id.paypal_subscriptions_enabled = true;
+		global.PayPalCommerceGateway.subscription_plan_id = 'PLAN-1';
+		document.getElementById( 'ppc-button-ppcp-gateway' ).innerHTML =
+			'<div class="stale-button"></div>';
+		const instance = buildBootstrap();
+
+		instance.render();
+
+		expect(
+			document.querySelector( '#ppc-button-ppcp-gateway .stale-button' )
+		).toBeNull();
+	} );
+} );
+
+describe( 'SingleProductBootstrap simulateCart', () => {
+	// PHP only sets url_params['enable-funding']/['disable-funding'] when there is
+	// something to enable/disable for the current context, so both are commonly absent
+	// (undefined) rather than an empty string. strAddWord()/strRemoveWord() call
+	// .split() on their first argument, which previously crashed here whenever the
+	// simulated cart response toggled a funding source's eligibility.
+	test( 'does not throw when url_params has no enable-funding/disable-funding keys', () => {
+		simulateCartData = {
+			total: '10.00',
+			button: { is_disabled: false },
+			messages: { is_hidden: false },
+			funding: { venmo: { enabled: false } },
+		};
+		const instance = buildBootstrap();
+
+		expect( () => instance.simulateCart() ).not.toThrow();
+		expect( instance.gateway.url_params[ 'disable-funding' ] ).toBe(
+			'venmo'
+		);
+	} );
+
+	test( 'adds and removes funding sources from the existing lists', () => {
+		simulateCartData = {
+			total: '10.00',
+			button: { is_disabled: false },
+			messages: { is_hidden: false },
+			funding: { venmo: { enabled: true } },
+		};
+		const instance = buildBootstrap();
+		instance.gateway.url_params = { 'disable-funding': 'venmo,card' };
+
+		instance.simulateCart();
+
+		expect( instance.gateway.url_params[ 'disable-funding' ] ).toBe(
+			'card'
+		);
+		expect( instance.gateway.url_params[ 'enable-funding' ] ).toBe(
+			'venmo'
+		);
+	} );
+} );

--- a/modules/ppcp-button/resources/js/modules/Helper/Utils.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/Utils.js
@@ -15,7 +15,7 @@ export const keysToCamelCase = ( obj ) => {
 };
 
 export const strAddWord = ( str, word, separator = ',' ) => {
-	const arr = str.split( separator );
+	const arr = str ? str.split( separator ) : [];
 	if ( ! arr.includes( word ) ) {
 		arr.push( word );
 	}
@@ -23,7 +23,7 @@ export const strAddWord = ( str, word, separator = ',' ) => {
 };
 
 export const strRemoveWord = ( str, word, separator = ',' ) => {
-	const arr = str.split( separator );
+	const arr = str ? str.split( separator ) : [];
 	const index = arr.indexOf( word );
 	if ( index !== -1 ) {
 		arr.splice( index, 1 );

--- a/modules/ppcp-button/resources/js/modules/Helper/Utils.test.js
+++ b/modules/ppcp-button/resources/js/modules/Helper/Utils.test.js
@@ -1,0 +1,48 @@
+/* global describe, test, expect */
+import { strAddWord, strRemoveWord } from './Utils';
+
+describe( 'strAddWord', () => {
+	test( 'adds a word to an existing comma-separated list', () => {
+		expect( strAddWord( 'venmo,card', 'paylater' ) ).toBe(
+			'venmo,card,paylater'
+		);
+	} );
+
+	test( 'does not duplicate a word already in the list', () => {
+		expect( strAddWord( 'venmo,card', 'card' ) ).toBe( 'venmo,card' );
+	} );
+
+	// Regression test: callers (e.g. SingleProductBootstrap.simulateCart()) may not
+	// have an existing list at all, since PHP only sends enable-funding/disable-funding
+	// when there is something to enable/disable - calling .split() on undefined/empty
+	// previously threw here.
+	test( 'starts a new list when given undefined', () => {
+		expect( strAddWord( undefined, 'venmo' ) ).toBe( 'venmo' );
+	} );
+
+	test( 'starts a new list when given an empty string', () => {
+		expect( strAddWord( '', 'venmo' ) ).toBe( 'venmo' );
+	} );
+} );
+
+describe( 'strRemoveWord', () => {
+	test( 'removes a word from an existing comma-separated list', () => {
+		expect( strRemoveWord( 'venmo,card,paylater', 'card' ) ).toBe(
+			'venmo,paylater'
+		);
+	} );
+
+	test( 'is a no-op when the word is not in the list', () => {
+		expect( strRemoveWord( 'venmo,card', 'paylater' ) ).toBe(
+			'venmo,card'
+		);
+	} );
+
+	test( 'returns an empty string when given undefined', () => {
+		expect( strRemoveWord( undefined, 'venmo' ) ).toBe( '' );
+	} );
+
+	test( 'returns an empty string when given an empty string', () => {
+		expect( strRemoveWord( '', 'venmo' ) ).toBe( '' );
+	} );
+} );

--- a/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
+++ b/modules/ppcp-wc-subscriptions/src/Helper/SubscriptionHelper.php
@@ -162,16 +162,23 @@ class SubscriptionHelper {
 	 * @return bool
 	 */
 	public function need_subscription_intent( string $subscription_mode ): bool {
-		if ( $subscription_mode === 'subscriptions_api' ) {
-			if (
-				$this->current_product_is_subscription()
-				|| ( ( is_cart() || is_checkout() ) && $this->cart_contains_subscription() )
-			) {
-				return true;
-			}
+		if ( $subscription_mode !== 'subscriptions_api' ) {
+			return false;
 		}
 
-		return false;
+		if ( $this->current_product_is_subscription() ) {
+			// Manual renewals mean no PayPal subscription plan is required for
+			// this product, so the standard (non-subscription) checkout flow
+			// is used instead - the SDK must not be forced into subscription
+			// intent in that case.
+			if ( $this->accept_manual_renewals() && ! $this->paypal_subscription_id() ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		return ( is_cart() || is_checkout() ) && $this->cart_contains_subscription();
 	}
 
 	/**

--- a/tests/PHPUnit/WcSubscriptions/Helper/SubscriptionHelperTest.php
+++ b/tests/PHPUnit/WcSubscriptions/Helper/SubscriptionHelperTest.php
@@ -145,6 +145,77 @@ class SubscriptionHelperTest extends TestCase
 		);
 	}
 
+	public function testNeedSubscriptionIntentFalseWhenNotInSubscriptionsApiMode()
+	{
+		$helper = $this->partialSubscriptionHelperForIntent(true, false, '');
+
+		$this->assertFalse($helper->need_subscription_intent('vaulting_api'));
+	}
+
+	public function testNeedSubscriptionIntentTrueForSubscriptionProductWithConnectedPlan()
+	{
+		$helper = $this->partialSubscriptionHelperForIntent(true, true, 'PLAN-1');
+
+		$this->assertTrue($helper->need_subscription_intent('subscriptions_api'));
+	}
+
+	/**
+	 * @scenario Regression test for PCP-6696. A subscription product without a connected
+	 *           PayPal plan, with manual renewals enabled and vaulting disabled, must use
+	 *           the standard checkout flow - forcing subscription intent here made the SDK
+	 *           script incompatible with the standard button render that follows, since
+	 *           PayPal's SDK requires createSubscription whenever intent=subscription.
+	 */
+	public function testNeedSubscriptionIntentFalseForSubscriptionProductWithManualRenewalsAndNoPlan()
+	{
+		$helper = $this->partialSubscriptionHelperForIntent(true, true, '');
+
+		$this->assertFalse($helper->need_subscription_intent('subscriptions_api'));
+	}
+
+	public function testNeedSubscriptionIntentTrueForSubscriptionProductWithNoPlanAndNoManualRenewals()
+	{
+		$helper = $this->partialSubscriptionHelperForIntent(true, false, '');
+
+		$this->assertTrue($helper->need_subscription_intent('subscriptions_api'));
+	}
+
+	public function testNeedSubscriptionIntentTrueOnCartContainingSubscription()
+	{
+		when('is_cart')->justReturn(true);
+		when('is_checkout')->justReturn(false);
+		$helper = $this->partialSubscriptionHelperForIntent(false, false, '');
+		$helper->shouldReceive('cart_contains_subscription')->andReturn(true);
+
+		$this->assertTrue($helper->need_subscription_intent('subscriptions_api'));
+	}
+
+	public function testNeedSubscriptionIntentFalseWhenNotASubscriptionContext()
+	{
+		when('is_cart')->justReturn(false);
+		when('is_checkout')->justReturn(false);
+		$helper = $this->partialSubscriptionHelperForIntent(false, false, '');
+
+		$this->assertFalse($helper->need_subscription_intent('subscriptions_api'));
+	}
+
+	/**
+	 * Builds a partial mock of SubscriptionHelper so `need_subscription_intent()` runs for
+	 * real while the signals it reads from other methods on the same class are fixed.
+	 */
+	private function partialSubscriptionHelperForIntent(
+		bool $current_product_is_subscription,
+		bool $accept_manual_renewals,
+		string $paypal_subscription_id
+	): SubscriptionHelper {
+		$helper = Mockery::mock(SubscriptionHelper::class)->makePartial();
+		$helper->shouldReceive('current_product_is_subscription')->andReturn($current_product_is_subscription);
+		$helper->shouldReceive('accept_manual_renewals')->andReturn($accept_manual_renewals);
+		$helper->shouldReceive('paypal_subscription_id')->andReturn($paypal_subscription_id);
+
+		return $helper;
+	}
+
 	/**
 	 * Builds a partial mock of SubscriptionHelper so `locations_with_subscription_product()`
 	 * runs for real while its individual signal methods return fixed, arranged values.


### PR DESCRIPTION
### Description                                                                                                                                                                                         
                                                                                                                                                                                                          
PayPal buttons didn't display on a subscription product's single product page when vaulting is disabled, manual renewals are enabled in WooCommerce Subscriptions, and the product has no connected PayPal subscription plan. This turned out to be three separate, layered bugs:                                                                                                                           
                                                                                                                                                                                                          
1. **`SingleProductBootstrap.render()`** entered the PayPal-subscriptions-API branch for any subscription product once vaulting was disabled, and returned early there whenever no plan was connected —  before ever reaching the manual-renewal-aware check further down. It now falls through to the standard button for that specific case, without disturbing the standard renderer's own `isAlreadyRendered()` guard (an earlier version of this fix cleared the button wrapper unconditionally, which defeated that guard and caused a destroy/recreate loop — fixed by only clearing the wrapper right before the subscriptions-API path actually uses it).                                                                                                                                      
2. **`SubscriptionHelper::need_subscription_intent()`** independently forced the PayPal SDK script itself into `intent=subscription` for the same case, regardless of manual renewals. Once the button above renders as a standard (non-subscription) button, an SDK loaded with `intent=subscription` rejects it outright, since that mode requires a `createSubscription` callback the standard render doesn't provide.                                                                                                                                                                                        
3. **`strAddWord()`/`strRemoveWord()`** (shared string-list helpers) crashed on `.split()` when `url_params['enable-funding']`/`['disable-funding']` are absent — which PHP only sets when there's something to enable/disable for the context. This is a pre-existing, general gap that the fix above exposed for the first time, since this scenario previously always returned early before reaching this code.                                                                                                                                                                                              
                                                                                                                                                                                                          
Each fix is scoped as narrowly as the underlying condition allows — none of them change behavior for a subscription product that does have a connected PayPal plan, or for cart/checkout contexts.      
                                                                                                                                                                                                          
  ### Steps to Test                                                                                                                                                                                       
                                                                                                                                                                                                          
1. Install and activate WooCommerce Subscriptions.                                                                                                                                                      
2. WooCommerce > Settings > Subscriptions: enable manual renewals.                                                                                                                                      
3. WooCommerce > Settings > Payments > PayPal Payments: disable vaulting (Save PayPal and Venmo).                                                                                                       
4. Create a subscription product without connecting it to a PayPal subscription plan.                                                                                                                   
5. Visit the product's single product page — confirm the PayPal button now renders (previously it didn't), as a standard one-time-payment button, with no console errors.                               
6. Confirm a subscription product that *does* have a connected PayPal plan is unaffected (still uses the PayPal subscriptions API as before).