### PR TITLE
Keep recoverable `PAYER_ACTION_REQUIRED` orders from failing prematurely (6701)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
+++ b/modules/ppcp-wc-gateway/src/Gateway/PayPalGateway.php
@@ -619,14 +619,12 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 			if ( $retry_errors ) {
 				$retry_error_key = $retry_errors[0];
-
-				$wc_order->update_status(
-					'failed',
-					$retry_keys_messages[ $retry_error_key ] . ' ' . ( $error->details()[0]->description ?? '' )
-				);
+				$retry_message   = $retry_keys_messages[ $retry_error_key ] . ' ' . ( $error->details()[0]->description ?? '' );
 
 				$this->session_handler->increment_insufficient_funding_tries();
 				if ( $this->session_handler->insufficient_funding_tries() >= 3 ) {
+					$wc_order->update_status( 'failed', $retry_message );
+
 					return $this->handle_payment_failure(
 						null,
 						new Exception(
@@ -639,11 +637,18 @@ class PayPalGateway extends \WC_Payment_Gateway {
 
 				$session_order = $this->session_handler->order();
 				if ( ! ( $session_order instanceof Order ) ) {
+					$wc_order->update_status( 'failed', $retry_message );
+
 					return $this->handle_payment_failure(
 						null,
 						new Exception( __( 'Payment session expired. Please try again.', 'woocommerce-paypal-payments' ) )
 					);
 				}
+
+				// The payer action or retry is still possible, so keep the order
+				// in its current status instead of failing it prematurely - only
+				// note the reason and send the customer back to complete it.
+				$wc_order->add_order_note( $retry_message );
 
 				return array(
 					'result'   => 'success',

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -414,26 +414,28 @@ class WcGatewayTest extends TestCase
 	}
 
 	/**
-	 * GIVEN a capture attempt throws a PayPalApiException carrying a PAYER_ACTION_REQUIRED detail
+	 * GIVEN a capture attempt throws a PayPalApiException carrying a recoverable retry issue
 	 *   AND the retry attempt count is still below the give-up threshold
 	 *   AND a PayPal order is still present in the session to retry against
 	 * WHEN process_payment() handles the exception
-	 * THEN the order is NOT marked failed, since the payer action/retry is still recoverable
+	 * THEN the order is NOT marked failed, since the retry is still recoverable
 	 *   AND an order note records the reason instead
 	 *   AND the customer is redirected back to PayPal to complete the action
+	 *
+	 * @dataProvider dataForRetryErrorIssue
 	 */
-	public function test_process_payment_keeps_order_pending_on_recoverable_payer_action_required(): void {
+	public function test_process_payment_keeps_order_pending_on_recoverable_retry_issue( string $issue, string $expectedMessage ): void {
 		$orderId = 1;
 		$wcOrder = Mockery::mock( \WC_Order::class );
 
 		$response          = new \stdClass();
-		$response->details = array( (object) array( 'issue' => 'PAYER_ACTION_REQUIRED', 'description' => 'Additional action needed.' ) );
+		$response->details = array( (object) array( 'issue' => $issue, 'description' => 'Additional action needed.' ) );
 		$exception         = new PayPalApiException( $response, 422 );
 
 		$this->orderProcessor->expects( 'process' )->andThrow( $exception );
 
 		$wcOrder->shouldNotReceive( 'update_status' );
-		$wcOrder->shouldReceive( 'add_order_note' )->once();
+		$wcOrder->shouldReceive( 'add_order_note' )->once()->with( Mockery::pattern( '/' . preg_quote( $expectedMessage, '/' ) . '/' ) );
 
 		$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
 		$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->andReturn( 1 );
@@ -453,22 +455,24 @@ class WcGatewayTest extends TestCase
 	}
 
 	/**
-	 * GIVEN a capture attempt throws a PayPalApiException carrying a PAYER_ACTION_REQUIRED detail
+	 * GIVEN a capture attempt throws a PayPalApiException carrying a recoverable retry issue
 	 *   AND the retry attempt count has already reached the give-up threshold (3 attempts)
 	 * WHEN process_payment() handles the exception
 	 * THEN the order IS marked failed, since the retry is now considered exhausted
+	 *
+	 * @dataProvider dataForRetryErrorIssue
 	 */
-	public function test_process_payment_fails_order_when_payer_action_retries_exhausted(): void {
+	public function test_process_payment_fails_order_when_retry_issue_retries_exhausted( string $issue, string $expectedMessage ): void {
 		$orderId = 1;
 		$wcOrder = Mockery::mock( \WC_Order::class );
 
 		$response          = new \stdClass();
-		$response->details = array( (object) array( 'issue' => 'PAYER_ACTION_REQUIRED', 'description' => 'Additional action needed.' ) );
+		$response->details = array( (object) array( 'issue' => $issue, 'description' => 'Additional action needed.' ) );
 		$exception         = new PayPalApiException( $response, 422 );
 
 		$this->orderProcessor->expects( 'process' )->andThrow( $exception );
 
-		$wcOrder->shouldReceive( 'update_status' )->once()->with( 'failed', Mockery::type( 'string' ) );
+		$wcOrder->shouldReceive( 'update_status' )->once()->with( 'failed', Mockery::pattern( '/' . preg_quote( $expectedMessage, '/' ) . '/' ) );
 
 		$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
 		$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->andReturn( 3 );
@@ -494,22 +498,24 @@ class WcGatewayTest extends TestCase
 	}
 
 	/**
-	 * GIVEN a capture attempt throws a PayPalApiException carrying a PAYER_ACTION_REQUIRED detail
+	 * GIVEN a capture attempt throws a PayPalApiException carrying a recoverable retry issue
 	 *   AND no PayPal order remains in the session to retry against (session expired)
 	 * WHEN process_payment() handles the exception
 	 * THEN the order IS marked failed, since there is no way left to recover this attempt
+	 *
+	 * @dataProvider dataForRetryErrorIssue
 	 */
-	public function test_process_payment_fails_order_when_payer_action_session_order_missing(): void {
+	public function test_process_payment_fails_order_when_retry_issue_session_order_missing( string $issue, string $expectedMessage ): void {
 		$orderId = 1;
 		$wcOrder = Mockery::mock( \WC_Order::class );
 
 		$response          = new \stdClass();
-		$response->details = array( (object) array( 'issue' => 'PAYER_ACTION_REQUIRED', 'description' => 'Additional action needed.' ) );
+		$response->details = array( (object) array( 'issue' => $issue, 'description' => 'Additional action needed.' ) );
 		$exception         = new PayPalApiException( $response, 422 );
 
 		$this->orderProcessor->expects( 'process' )->andThrow( $exception );
 
-		$wcOrder->shouldReceive( 'update_status' )->once()->with( 'failed', Mockery::type( 'string' ) );
+		$wcOrder->shouldReceive( 'update_status' )->once()->with( 'failed', Mockery::pattern( '/' . preg_quote( $expectedMessage, '/' ) . '/' ) );
 
 		$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
 		$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->andReturn( 1 );
@@ -533,6 +539,13 @@ class WcGatewayTest extends TestCase
 		$result = $testee->process_payment( $orderId );
 
 		$this->assertEquals( 'failure', $result['result'] );
+	}
+
+	public function dataForRetryErrorIssue(): array {
+		return array(
+			'instrument declined'   => array( 'INSTRUMENT_DECLINED', 'Instrument declined.' ),
+			'payer action required' => array( 'PAYER_ACTION_REQUIRED', 'Payer action required, possibly overcharge.' ),
+		);
 	}
 
     /**

--- a/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
+++ b/tests/PHPUnit/WcGateway/Gateway/WcGatewayTest.php
@@ -9,6 +9,7 @@ use WooCommerce\PayPalCommerce\ApiClient\Endpoint\OrderEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\PaymentTokensEndpoint;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\PayPalApiException;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\WcGateway\Endpoint\CapturePayPalPayment;
@@ -32,6 +33,7 @@ class WcGatewayTest extends TestCase
 {
 	private $isAdmin = false;
 	private $sessionHandler;
+	private $sessionOrder;
 	private $fundingSource = null;
 
 	private $funding_source_renderer;
@@ -84,11 +86,12 @@ class WcGatewayTest extends TestCase
 			->andReturnUsing(function () {
 				return $this->fundingSource;
 			});
-		$order = Mockery::mock(Order::class);
-		$order->shouldReceive('status')->andReturn(new OrderStatus(OrderStatus::APPROVED));
+		$this->sessionOrder = Mockery::mock(Order::class);
+		$this->sessionOrder->shouldReceive('status')->andReturn(new OrderStatus(OrderStatus::APPROVED));
 		$this->sessionHandler
 			->shouldReceive('order')
-			->andReturn($order);
+			->andReturn($this->sessionOrder)
+			->byDefault();
 
 		$this->settings->shouldReceive('has')->andReturnFalse();
 
@@ -408,6 +411,128 @@ class WcGatewayTest extends TestCase
 		$result = $testee->process_payment( $orderId );
 
 		$this->assertSame( 'failure', $result['result'] );
+	}
+
+	/**
+	 * GIVEN a capture attempt throws a PayPalApiException carrying a PAYER_ACTION_REQUIRED detail
+	 *   AND the retry attempt count is still below the give-up threshold
+	 *   AND a PayPal order is still present in the session to retry against
+	 * WHEN process_payment() handles the exception
+	 * THEN the order is NOT marked failed, since the payer action/retry is still recoverable
+	 *   AND an order note records the reason instead
+	 *   AND the customer is redirected back to PayPal to complete the action
+	 */
+	public function test_process_payment_keeps_order_pending_on_recoverable_payer_action_required(): void {
+		$orderId = 1;
+		$wcOrder = Mockery::mock( \WC_Order::class );
+
+		$response          = new \stdClass();
+		$response->details = array( (object) array( 'issue' => 'PAYER_ACTION_REQUIRED', 'description' => 'Additional action needed.' ) );
+		$exception         = new PayPalApiException( $response, 422 );
+
+		$this->orderProcessor->expects( 'process' )->andThrow( $exception );
+
+		$wcOrder->shouldNotReceive( 'update_status' );
+		$wcOrder->shouldReceive( 'add_order_note' )->once();
+
+		$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
+		$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->andReturn( 1 );
+		$this->sessionHandler->shouldNotReceive( 'destroy_session_data' );
+		$this->sessionOrder->shouldReceive( 'id' )->andReturn( 'PAYPAL-ORDER-ID' );
+
+		$testee = $this->createGateway();
+
+		expect( 'wc_get_order' )
+			->with( $orderId )
+			->andReturn( $wcOrder );
+
+		$result = $testee->process_payment( $orderId );
+
+		$this->assertEquals( 'success', $result['result'] );
+		$this->assertEquals( 'checkoutnow=PAYPAL-ORDER-ID', $result['redirect'] );
+	}
+
+	/**
+	 * GIVEN a capture attempt throws a PayPalApiException carrying a PAYER_ACTION_REQUIRED detail
+	 *   AND the retry attempt count has already reached the give-up threshold (3 attempts)
+	 * WHEN process_payment() handles the exception
+	 * THEN the order IS marked failed, since the retry is now considered exhausted
+	 */
+	public function test_process_payment_fails_order_when_payer_action_retries_exhausted(): void {
+		$orderId = 1;
+		$wcOrder = Mockery::mock( \WC_Order::class );
+
+		$response          = new \stdClass();
+		$response->details = array( (object) array( 'issue' => 'PAYER_ACTION_REQUIRED', 'description' => 'Additional action needed.' ) );
+		$exception         = new PayPalApiException( $response, 422 );
+
+		$this->orderProcessor->expects( 'process' )->andThrow( $exception );
+
+		$wcOrder->shouldReceive( 'update_status' )->once()->with( 'failed', Mockery::type( 'string' ) );
+
+		$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
+		$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->andReturn( 3 );
+		$this->sessionHandler->shouldReceive( 'destroy_session_data' )->once();
+
+		$testee = $this->createGateway();
+
+		expect( 'wc_get_order' )
+			->with( $orderId )
+			->andReturn( $wcOrder );
+		when( 'wc_add_notice' )->justReturn( null );
+		when( 'wc_get_checkout_url' )->justReturn( 'http://example.com/checkout' );
+
+		$woocommerce = Mockery::mock( \WooCommerce::class );
+		$session     = Mockery::mock( \WC_Session::class );
+		$woocommerce->session = $session;
+		when( 'WC' )->justReturn( $woocommerce );
+		$session->shouldReceive( 'set' );
+
+		$result = $testee->process_payment( $orderId );
+
+		$this->assertEquals( 'failure', $result['result'] );
+	}
+
+	/**
+	 * GIVEN a capture attempt throws a PayPalApiException carrying a PAYER_ACTION_REQUIRED detail
+	 *   AND no PayPal order remains in the session to retry against (session expired)
+	 * WHEN process_payment() handles the exception
+	 * THEN the order IS marked failed, since there is no way left to recover this attempt
+	 */
+	public function test_process_payment_fails_order_when_payer_action_session_order_missing(): void {
+		$orderId = 1;
+		$wcOrder = Mockery::mock( \WC_Order::class );
+
+		$response          = new \stdClass();
+		$response->details = array( (object) array( 'issue' => 'PAYER_ACTION_REQUIRED', 'description' => 'Additional action needed.' ) );
+		$exception         = new PayPalApiException( $response, 422 );
+
+		$this->orderProcessor->expects( 'process' )->andThrow( $exception );
+
+		$wcOrder->shouldReceive( 'update_status' )->once()->with( 'failed', Mockery::type( 'string' ) );
+
+		$this->sessionHandler->shouldReceive( 'increment_insufficient_funding_tries' )->once();
+		$this->sessionHandler->shouldReceive( 'insufficient_funding_tries' )->andReturn( 1 );
+		$this->sessionHandler->shouldReceive( 'order' )->andReturn( null );
+		$this->sessionHandler->shouldReceive( 'destroy_session_data' )->once();
+
+		$testee = $this->createGateway();
+
+		expect( 'wc_get_order' )
+			->with( $orderId )
+			->andReturn( $wcOrder );
+		when( 'wc_add_notice' )->justReturn( null );
+		when( 'wc_get_checkout_url' )->justReturn( 'http://example.com/checkout' );
+
+		$woocommerce = Mockery::mock( \WooCommerce::class );
+		$session     = Mockery::mock( \WC_Session::class );
+		$woocommerce->session = $session;
+		when( 'WC' )->justReturn( $woocommerce );
+		$session->shouldReceive( 'set' );
+
+		$result = $testee->process_payment( $orderId );
+
+		$this->assertEquals( 'failure', $result['result'] );
 	}
 
     /**


### PR DESCRIPTION
### Description

<!-- Describe the changes made in this Pull Request and the reason for these changes. -->

- `PayPalGateway::process_payment()` marked the order `Failed` immediately whenever PayPal responded with `PAYER_ACTION_REQUIRED`, before checking whether the payer action or retry was even still possible — firing WooCommerce's failed-order email even though the customer could still complete the action on PayPal.                                                                                                                                                            
- If the customer then completed the action and the retry succeeded, the order flipped to `Processing`, sending a second, contradictory "order is being processed" email right after the "order failed" one.                                                                                                                                                                               
- The order is now only marked `Failed` once retries are actually exhausted (3 attempts) or the PayPal session order is gone. While the retry is still recoverable, the reason is recorded as an order note instead, and the customer is redirected back to PayPal to complete it.

### Steps to Test                                                                                                                                                                                    
                                                                                                                                                                                                          
Because PayPal's sandbox does not reliably return `PAYER_ACTION_REQUIRED` for an  amount increase (it tends to just accept the new amount), the dependable way to exercise this path is to force the exception.                                                                                                                                                           
                                                                                                                                                                                                          
**Deterministic (recommended)**                                                                                                                                                                         
                                                                                                                                                                                                          
  1. In `PayPalGateway::process_payment()`, temporarily add this at the top of the  inner `try` block, right before the                                                                                                                                                                  `apply_filters( 'woocommerce_paypal_payments_before_order_process', ... )` line:                                                                                                                     
```php                                                                                                                                                                                               
	$response          = new \stdClass();                                                                                                                                                                
	$response->details = array( (object) array( 'issue' => 'PAYER_ACTION_REQUIRED', 'description' => 'Test forced.' ) );                                                                                 
	throw new PayPalApiException( $response, 422 );
```                                                                                                                                                    
2. Place an order through the PayPal button.                                                                                                                                                            
3. On this branch (fixed): order stays in Pending payment, an order note "Payer action required, possibly overcharge. Test forced." is added, and no failed-order email is sent; the customer is redirected back to PayPal.                                                                                                                                  4. On dev/develop (before the fix): the same order goes straight to Failed and the failed-order email fires immediately.                                                                                                                                                           
5. Remove the temporary throw.

                                                                                                                                                                                                         
_The throw fires on every attempt, so after 3 attempts in the same session the retry counter reaches the give-up threshold and the order is correctly marked Failed (the intended "retries exhausted" branch). Use a fresh session to re-test the recoverable case._                                                                                                                                                                         
                                                                                                                                                                                                          
**Realistic sandbox trigger (may not reproduce reliably)**                                                                                                                                                  
                                                                                                                                                                                                          
The real-world trigger is an amount increase after PayPal approval but before capture:                                                                                                                  
1. Create a guest order in wp-admin (leave Customer as Guest — no login needed in incognito).                                                                                                           
2. Open its pay-for-order URL in an incognito window; click the PayPal button (popup opens, that tab locks — leave it).                                                                                 
3. In a separate wp-admin tab, edit that same order to increase the total (add a fee / bump quantity), recalculate, save.                                                                               
4. Back in the incognito popup, log in with a sandbox buyer and approve.                                                                                                                                
5. On return, the plugin patches the PayPal order up to the new total then captures — PayPal may reject with `422 PAYER_ACTION_REQUIRED`, hitting the handled path above.    