### PR TITLE
Fix Fastlane hiding the "Ship to a different address?" toggle on classic checkout

### DIFF
--- a/modules/ppcp-axo/resources/js/AxoManager.js
+++ b/modules/ppcp-axo/resources/js/AxoManager.js
@@ -467,7 +467,13 @@ class AxoManager {
 		const $shippingFields = this.$(
 			'.woocommerce-shipping-fields .form-row:visible'
 		);
-		const $shippingHeaders = this.$( '.woocommerce-shipping-fields h3' );
+		// The "Ship to a different address?" toggle is itself an <h3> inside
+		// .woocommerce-shipping-fields, but it is the control that reveals the
+		// (collapsed) shipping fields rather than a section title. Excluding it
+		// avoids hiding the only control that could make those fields visible.
+		const $shippingHeaders = this.$(
+			'.woocommerce-shipping-fields h3'
+		).not( '#ship-to-different-address' );
 		if ( $shippingFields.length ) {
 			$shippingHeaders.show();
 		} else {

--- a/modules/ppcp-axo/resources/js/test/AxoManager.test.js
+++ b/modules/ppcp-axo/resources/js/test/AxoManager.test.js
@@ -1,0 +1,59 @@
+/* global describe, test, expect, afterEach */
+import jQuery from 'jquery';
+import AxoManager from '../AxoManager';
+
+global.$ = global.jQuery = jQuery;
+
+/**
+ * Builds an AxoManager without running its constructor's side effects; only the
+ * scoped jQuery helper the field-consistency methods rely on is provided.
+ *
+ * @return {AxoManager} The manager instance.
+ */
+function buildManager() {
+	const instance = Object.create( AxoManager.prototype );
+	instance.$ = ( selector ) => jQuery( selector );
+	return instance;
+}
+
+describe( 'AxoManager.ensureShippingFieldsConsistency', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	// The "Ship to a different address?" toggle is an <h3 id="ship-to-different-address">
+	// inside .woocommerce-shipping-fields, and WooCommerce keeps the address rows in a
+	// collapsed .shipping_address div until the box is checked. Hiding the toggle here
+	// would leave the shopper no way to reveal the shipping fields.
+	test( 'keeps the ship-to-different-address toggle visible when shipping fields are collapsed', () => {
+		document.body.innerHTML = `
+			<div class="woocommerce-shipping-fields">
+				<h3 id="ship-to-different-address"><label>Ship to a different address?</label></h3>
+				<div class="shipping_address" style="display:none">
+					<div class="form-row"></div>
+				</div>
+			</div>`;
+
+		buildManager().ensureShippingFieldsConsistency();
+
+		expect(
+			jQuery( '#ship-to-different-address' ).css( 'display' )
+		).not.toBe( 'none' );
+	} );
+
+	test( 'hides a dangling shipping section header when no shipping fields are visible', () => {
+		document.body.innerHTML = `
+			<div class="woocommerce-shipping-fields">
+				<h3 class="shipping-section-title">Shipping details</h3>
+				<div class="shipping_address" style="display:none">
+					<div class="form-row"></div>
+				</div>
+			</div>`;
+
+		buildManager().ensureShippingFieldsConsistency();
+
+		expect( jQuery( '.shipping-section-title' ).css( 'display' ) ).toBe(
+			'none'
+		);
+	} );
+} );


### PR DESCRIPTION
### Description

When Fastlane (AXO) is enabled, the WooCommerce "**Ship to a different address?**" toggle disappears from the classic (shortcode) checkout for guests, and stays hidden even after switching to a non-Fastlane payment method. With Fastlane disabled it works normally.

**Root cause:** `AxoManager.ensureShippingFieldsConsistency()` hides every `<h3>` inside `.woocommerce-shipping-fields` whenever no shipping `.form-row` is `:visible`. But the "Ship to a different address?" control is itself an `<h3 id="ship-to-different-address">`, and WooCommerce keeps the shipping fields collapsed until that box is checked. So the toggle gets hidden → the shopper can't reveal the shipping fields → the fields stay collapsed → the toggle stays hidden. The function also runs on every rerender regardless of the selected gateway, so choosing a different payment method never restores it.

**Fix:** exclude `#ship-to-different-address` from the headers this function hides. The toggle is the control that reveals the (collapsed) shipping fields, not a dangling section title, so it's left alone while a genuinely empty section header is still cleaned up (preserving the behaviour needed by the Fastlane profile-takeover flow).

### Steps to Test

> Requires Fastlane to be genuinely active on the classic checkout (eligible account, feature enabled) and a **hard refresh / cleared page cache** as a stale cache can mask the issue entirely.

1. Enable Fastlane, set the classic (shortcode) checkout as the default checkout.
2. As a **guest** (logged out), add a **physical** product (one that requires shipping) to the cart.
3. Go to the classic checkout.
4. **Before the fix:** the "Ship to a different address?" toggle is missing, and stays missing even when a different payment method is selected.
   **After the fix:** the toggle is visible and works; checking it reveals the shipping address fields; it remains available after switching payment methods.
5. Toggle Fastlane off and confirm the option still behaves normally (no regression).
6. Regression check on the Fastlane profile ("Ryan") flow: sign in with a Fastlane profile and confirm its address section still takes over / hides cleanly.

### Changelog

Fix - "Ship to a different address?" option hidden on classic checkout when Fastlane is enabled.
