### PR TITLE
Improve 3DS rejection error with clear, customer-friendly decline messages

### DIFF
--- a/modules/ppcp-card-fields/src/CardFieldsModule.php
+++ b/modules/ppcp-card-fields/src/CardFieldsModule.php
@@ -181,11 +181,12 @@ class CardFieldsModule implements ServiceModule, ExecutableModule {
 				$validator = $c->get( 'card-fields.service.card-capture-validator' );
 				assert( $validator instanceof CardCaptureValidator );
 
-				if ( ! $validator->is_valid( $order ) ) {
+				$rejection_reason = $validator->rejection_reason( $order );
+				if ( $rejection_reason !== CardCaptureValidator::REASON_NONE ) {
 					$logger = $c->get( 'woocommerce.logger.woocommerce' );
 					assert( $logger instanceof LoggerInterface );
 
-					$logger->warning( "Could not capture order {$order->id()}" );
+					$logger->warning( "Could not capture order {$order->id()}: {$rejection_reason}" );
 
 					// Only set session flag if WC session exists (not in API/agentic context).
 					/**
@@ -199,9 +200,27 @@ class CardFieldsModule implements ServiceModule, ExecutableModule {
 						WC()->session->set( 'ppcp_delete_wc_order_on_payment_failure', true );
 					}
 
-					throw new DomainException( esc_html__( 'Could not capture the PayPal order.', 'woocommerce-paypal-payments' ) );
+					throw new DomainException( esc_html( self::capture_rejection_message( $rejection_reason ) ) );
 				}
 			}
 		);
+	}
+
+	/**
+	 * Returns a customer-friendly decline message for a capture rejection reason.
+	 *
+	 * @param string $reason One of the CardCaptureValidator::REASON_* constants.
+	 *
+	 * @return string
+	 */
+	private static function capture_rejection_message( string $reason ): string {
+		switch ( $reason ) {
+			case CardCaptureValidator::REASON_3DS_FAILED:
+				return __( 'This card could not be authorized. Please try a different payment method.', 'woocommerce-paypal-payments' );
+			case CardCaptureValidator::REASON_3DS_UNCLEAR:
+				return __( 'The 3D Secure validation could not be completed. Please try again or use another card.', 'woocommerce-paypal-payments' );
+			default:
+				return __( 'This payment could not be processed. Please try a different payment method.', 'woocommerce-paypal-payments' );
+		}
 	}
 }

--- a/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
+++ b/modules/ppcp-card-fields/src/Service/CardCaptureValidator.php
@@ -18,6 +18,26 @@ use WooCommerce\PayPalCommerce\ApiClient\Entity\OrderStatus;
 class CardCaptureValidator {
 
 	/**
+	 * The order can be captured; there is no rejection reason.
+	 */
+	public const REASON_NONE = 'none';
+
+	/**
+	 * The order carries no payment source, so it cannot be captured.
+	 */
+	public const REASON_MALFORMED = 'malformed';
+
+	/**
+	 * 3DS authentication was attempted but did not pass ( liability_shift = NO ).
+	 */
+	public const REASON_3DS_FAILED = '3ds_failed';
+
+	/**
+	 * The 3DS result is inconclusive ( liability_shift = UNKNOWN or absent ).
+	 */
+	public const REASON_3DS_UNCLEAR = '3ds_unclear';
+
+	/**
 	 * Checks whether an order is valid for capture.
 	 *
 	 * @param Order $order PayPal order.
@@ -25,18 +45,29 @@ class CardCaptureValidator {
 	 * @return bool
 	 */
 	public function is_valid( Order $order ): bool {
+		return $this->rejection_reason( $order ) === self::REASON_NONE;
+	}
+
+	/**
+	 * Determines why an order cannot be captured, if at all.
+	 *
+	 * @param Order $order PayPal order.
+	 *
+	 * @return string One of the REASON_* constants; REASON_NONE when the order can be captured.
+	 */
+	public function rejection_reason( Order $order ): string {
 		$order_status = $order->status();
 		if ( $order_status->name() === OrderStatus::APPROVED ) {
-			return true;
+			return self::REASON_NONE;
 		}
 
 		$payment_source = $order->payment_source();
 		if ( ! $payment_source ) {
-			return false;
+			return self::REASON_MALFORMED;
 		}
 
 		if ( $payment_source->name() !== 'card' ) {
-			return true;
+			return self::REASON_NONE;
 		}
 
 		/**
@@ -46,6 +77,14 @@ class CardCaptureValidator {
 		 */
 		$liability_shift = $payment_source->properties()->authentication_result->liability_shift ?? '';
 
-		return in_array( $liability_shift, array( 'POSSIBLE', 'YES' ), true );
+		if ( in_array( $liability_shift, array( 'POSSIBLE', 'YES' ), true ) ) {
+			return self::REASON_NONE;
+		}
+
+		if ( $liability_shift === 'NO' ) {
+			return self::REASON_3DS_FAILED;
+		}
+
+		return self::REASON_3DS_UNCLEAR;
 	}
 }

--- a/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
+++ b/tests/PHPUnit/CardFields/Service/CardCaptureValidatorTest.php
@@ -114,4 +114,91 @@ class CardCaptureValidatorTest extends TestCase {
 
 		$this->assertFalse( $validator->is_valid( $order ) );
 	}
+
+	public function test_rejection_reason_is_none_when_order_status_is_approved(): void {
+		$validator   = new CardCaptureValidator();
+		$order       = Mockery::mock( Order::class );
+		$orderStatus = Mockery::mock( OrderStatus::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::APPROVED );
+
+		$this->assertSame( CardCaptureValidator::REASON_NONE, $validator->rejection_reason( $order ) );
+	}
+
+	public function test_rejection_reason_is_none_when_payment_source_is_not_card(): void {
+		$validator     = new CardCaptureValidator();
+		$order         = Mockery::mock( Order::class );
+		$orderStatus   = Mockery::mock( OrderStatus::class );
+		$paymentSource = Mockery::mock( PaymentSource::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
+		$order->shouldReceive( 'payment_source' )->andReturn( $paymentSource );
+		$paymentSource->shouldReceive( 'name' )->andReturn( 'foo' );
+
+		$this->assertSame( CardCaptureValidator::REASON_NONE, $validator->rejection_reason( $order ) );
+	}
+
+	public function test_rejection_reason_is_malformed_when_payment_source_is_null(): void {
+		$validator   = new CardCaptureValidator();
+		$order       = Mockery::mock( Order::class );
+		$orderStatus = Mockery::mock( OrderStatus::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
+		$order->shouldReceive( 'payment_source' )->andReturn( null );
+
+		$this->assertSame( CardCaptureValidator::REASON_MALFORMED, $validator->rejection_reason( $order ) );
+	}
+
+	/**
+	 * @dataProvider card_rejection_reason_provider
+	 */
+	public function test_rejection_reason_for_card_liability_shift(
+		string $liability_shift,
+		string $expected
+	): void {
+		$validator     = new CardCaptureValidator();
+		$order         = Mockery::mock( Order::class );
+		$orderStatus   = Mockery::mock( OrderStatus::class );
+		$paymentSource = Mockery::mock( PaymentSource::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
+		$order->shouldReceive( 'payment_source' )->andReturn( $paymentSource );
+		$paymentSource->shouldReceive( 'name' )->andReturn( 'card' );
+		$paymentSource->shouldReceive( 'properties' )->andReturn( (object) [
+			'authentication_result' => (object) [
+				'liability_shift' => $liability_shift,
+			],
+		] );
+
+		$this->assertSame( $expected, $validator->rejection_reason( $order ) );
+	}
+
+	public function card_rejection_reason_provider(): array {
+		return [
+			'POSSIBLE is not a rejection' => [ 'POSSIBLE', CardCaptureValidator::REASON_NONE ],
+			'YES is not a rejection'      => [ 'YES', CardCaptureValidator::REASON_NONE ],
+			'NO is a 3ds failure'         => [ 'NO', CardCaptureValidator::REASON_3DS_FAILED ],
+			'UNKNOWN is unclear'          => [ 'UNKNOWN', CardCaptureValidator::REASON_3DS_UNCLEAR ],
+			'empty is unclear'            => [ '', CardCaptureValidator::REASON_3DS_UNCLEAR ],
+		];
+	}
+
+	public function test_rejection_reason_is_unclear_when_authentication_result_absent(): void {
+		$validator     = new CardCaptureValidator();
+		$order         = Mockery::mock( Order::class );
+		$orderStatus   = Mockery::mock( OrderStatus::class );
+		$paymentSource = Mockery::mock( PaymentSource::class );
+
+		$order->shouldReceive( 'status' )->andReturn( $orderStatus );
+		$orderStatus->shouldReceive( 'name' )->andReturn( $orderStatus::CREATED );
+		$order->shouldReceive( 'payment_source' )->andReturn( $paymentSource );
+		$paymentSource->shouldReceive( 'name' )->andReturn( 'card' );
+		$paymentSource->shouldReceive( 'properties' )->andReturn( (object) [] );
+
+		$this->assertSame( CardCaptureValidator::REASON_3DS_UNCLEAR, $validator->rejection_reason( $order ) );
+	}
 }


### PR DESCRIPTION
### Description

When a shop requires 3D Secure and a customer pays with a card whose 3DS liability does not shift, the plugin rejects the card **locally, before capture**  but the checkout showed **"Could not capture the PayPal order."** That reads as a technical failure, even though nothing was ever sent to PayPal to capture.

This replaces that message with clear, customer-friendly declines, chosen by the actual rejection reason:

- **`CardCaptureValidator::rejection_reason()`** (new) classifies the rejection:
  - `malformed` — order carries no `payment_source`
  - `3ds_failed` — `liability_shift = NO` (authentication attempted, not passed)
  - `3ds_unclear` — `liability_shift = UNKNOWN` or absent
  - `none` — capturable
  `is_valid()` now delegates to it (`rejection_reason() === REASON_NONE`), so its existing accept/reject behaviour is unchanged.
- The capture gate maps each reason to a customer-facing message and logs the reason:
  - `3ds_failed` → "This card could not be authorized. Please try a different payment method."
  - `3ds_unclear` → "The 3D Secure validation could not be completed. Please try again or use another card."
  - `malformed` / default → "This payment could not be processed. Please try a different payment method."

The accept/reject **decision** is intentionally unchanged — only the message the shopper sees (and a more descriptive log line).

### Steps to Test

> Requires Advanced Card Processing (card fields) enabled and **3D Secure set to "Require 3D Secure"** (`SCA_ALWAYS`). The gate lives in the card-fields capture path, so PayPal buttons alone won't trigger it.

1. Pay with the hosted card fields using a valid sandbox card that reaches the capture step (one that passes card-fields validation; complete the 3DS challenge if prompted).
2. Depending on the returned `liability_shift`, confirm the shopper sees the matching friendly decline (above) instead of "Could not capture the PayPal order."
3. Confirm the store log records the reason, e.g. `Could not capture order <id>: 3ds_failed`.
4. A capturable card (`liability_shift = POSSIBLE`/`YES`) still completes normally — no regression.

> Note: PayPal's sandbox does not reliably return a specific `liability_shift` on demand. All three messages were verified end-to-end by temporarily forcing each reason at the capture gate; the reason→message mapping is also covered by unit tests (`CardCaptureValidatorTest`).

### Changelog

Fix - Replace the generic "Could not capture the PayPal order" error with a clear, customer-friendly decline when a card is rejected locally on a 3DS-required shop.
