### PR TITLE
Pin the built plugin folder name in the distribution workflow (6749)

### DIFF
--- a/.github/workflows/build-and-distribute.yml
+++ b/.github/workflows/build-and-distribute.yml
@@ -33,5 +33,6 @@ jobs:
       GITHUB_USER_SSH_PUBLIC_KEY: ${{ secrets.DEPLOYBOT_SSH_PUBLIC_KEY }}
       NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_GITHUB_TOKEN_PACKAGES }}
     with:
+      PACKAGE_NAME: 'woocommerce-paypal-payments'
       PACKAGE_VERSION: ${{ inputs.PACKAGE_VERSION }}
       NODE_VERSION: 22


### PR DESCRIPTION
*Changelog:* (none - build tooling)

# Description

The Build and Distribute workflow derived the plugin folder name from the GitHub repository name. When the workflow ran from a repository whose name did not match `woocommerce-paypal-payments`, the built package used the wrong folder name.

This passes an explicit `PACKAGE_NAME` to the workflow so the distributed plugin always uses the correct, stable folder name regardless of which repository the build runs in.
