### PR TITLE
Fix PPEC billing agreement conversion using a real PayPal customer ID

### DIFF
--- a/modules/ppcp-api-client/src/Repository/CustomerRepository.php
+++ b/modules/ppcp-api-client/src/Repository/CustomerRepository.php
@@ -67,10 +67,21 @@ class CustomerRepository {
 	 * Unlike customer_id_for_user(), this never fabricates a local prefix-based
 	 * ID: PayPal does not recognize such IDs, so callers that pass the result to
 	 * the PayPal API should treat an empty string as "let PayPal assign one".
+	 *
+	 * `_ppcp_target_customer_id` holds the most recent ID PayPal assigned and so
+	 * takes precedence over `ppcp_customer_id`, matching how the rest of the
+	 * plugin resolves it. Reading only the latter would miss an ID PayPal has
+	 * already issued and have it create a second customer for the same user,
+	 * orphaning the tokens stored against the first.
 	 */
 	public function paypal_customer_id_for_user( int $user_id ): string {
 		if ( 0 === $user_id ) {
 			return '';
+		}
+
+		$customer_id = get_user_meta( $user_id, '_ppcp_target_customer_id', true );
+		if ( is_string( $customer_id ) && $customer_id ) {
+			return $customer_id;
 		}
 
 		$customer_id = get_user_meta( $user_id, 'ppcp_customer_id', true );

--- a/modules/ppcp-api-client/src/Repository/CustomerRepository.php
+++ b/modules/ppcp-api-client/src/Repository/CustomerRepository.php
@@ -59,4 +59,22 @@ class CustomerRepository {
 
 		return get_user_meta( $user_id, 'ppcp_customer_id', true ) ?: $this->prefix . (string) $user_id;
 	}
+
+	/**
+	 * Returns the real, PayPal-generated customer ID for the given user, or an
+	 * empty string when the user has never been vaulted with PayPal.
+	 *
+	 * Unlike customer_id_for_user(), this never fabricates a local prefix-based
+	 * ID: PayPal does not recognize such IDs, so callers that pass the result to
+	 * the PayPal API should treat an empty string as "let PayPal assign one".
+	 */
+	public function paypal_customer_id_for_user( int $user_id ): string {
+		if ( 0 === $user_id ) {
+			return '';
+		}
+
+		$customer_id = get_user_meta( $user_id, 'ppcp_customer_id', true );
+
+		return is_string( $customer_id ) ? $customer_id : '';
+	}
 }

--- a/modules/ppcp-compat/src/PPEC/BillingAgreementTokenConverter.php
+++ b/modules/ppcp-compat/src/PPEC/BillingAgreementTokenConverter.php
@@ -40,7 +40,10 @@ class BillingAgreementTokenConverter {
 				)
 			);
 
-			$customer_id = $this->customer_repository->customer_id_for_user( $user_id );
+			// Only a real PayPal customer ID is usable here; passing the local
+			// fallback ID would be rejected by the Vault API. An empty string
+			// lets PayPal assign a customer, whose ID is stored below.
+			$customer_id = $this->customer_repository->paypal_customer_id_for_user( $user_id );
 			$result      = $this->payment_method_tokens_endpoint->create_payment_token( $payment_source, $customer_id );
 
 			if ( empty( $result->id ) ) {

--- a/tests/PHPUnit/ApiClient/Repository/CustomerRepositoryTest.php
+++ b/tests/PHPUnit/ApiClient/Repository/CustomerRepositoryTest.php
@@ -1,0 +1,44 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient\Repository;
+
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+
+class CustomerRepositoryTest extends TestCase
+{
+	public function testReturnsRealPayPalCustomerId()
+	{
+		$repository = new CustomerRepository('ppcp_prefix_');
+
+		expect('get_user_meta')
+			->once()
+			->with(42, 'ppcp_customer_id', true)
+			->andReturn('paypal-customer-id');
+
+		$this->assertSame('paypal-customer-id', $repository->paypal_customer_id_for_user(42));
+	}
+
+	public function testReturnsEmptyStringWhenNeverVaulted()
+	{
+		$repository = new CustomerRepository('ppcp_prefix_');
+
+		// get_user_meta returns '' for an unset meta value; no local fallback ID.
+		expect('get_user_meta')
+			->once()
+			->with(42, 'ppcp_customer_id', true)
+			->andReturn('');
+
+		$this->assertSame('', $repository->paypal_customer_id_for_user(42));
+	}
+
+	public function testReturnsEmptyStringForGuestUser()
+	{
+		$repository = new CustomerRepository('ppcp_prefix_');
+
+		expect('get_user_meta')->never();
+
+		$this->assertSame('', $repository->paypal_customer_id_for_user(0));
+	}
+}

--- a/tests/PHPUnit/ApiClient/Repository/CustomerRepositoryTest.php
+++ b/tests/PHPUnit/ApiClient/Repository/CustomerRepositoryTest.php
@@ -8,23 +8,78 @@ use function Brain\Monkey\Functions\expect;
 
 class CustomerRepositoryTest extends TestCase
 {
-	public function testReturnsRealPayPalCustomerId()
+	/**
+	 * GIVEN a user with both the most recently assigned PayPal customer ID and the legacy vaulted ID stored
+	 * WHEN resolving the PayPal customer ID for that user
+	 * THEN the most recently assigned ID takes precedence over the legacy one
+	 */
+	public function testMostRecentlyAssignedIdTakesPrecedenceOverLegacyId()
 	{
 		$repository = new CustomerRepository('ppcp_prefix_');
 
 		expect('get_user_meta')
 			->once()
-			->with(42, 'ppcp_customer_id', true)
-			->andReturn('paypal-customer-id');
+			->with(42, '_ppcp_target_customer_id', true)
+			->andReturn('most-recent-customer-id');
 
-		$this->assertSame('paypal-customer-id', $repository->paypal_customer_id_for_user(42));
+		expect('get_user_meta')
+			->never()
+			->with(42, 'ppcp_customer_id', true);
+
+		$this->assertSame('most-recent-customer-id', $repository->paypal_customer_id_for_user(42));
+	}
+
+	/**
+	 * GIVEN a user whose most recently assigned PayPal customer ID was written back by a billing
+	 *       agreement conversion, with no legacy vaulted ID present
+	 * WHEN resolving the PayPal customer ID for that user
+	 * THEN the previously assigned ID is found, preventing a duplicate PayPal customer from being
+	 *      created on a subsequent renewal
+	 */
+	public function testFindsIdWrittenBackByBillingAgreementConversion()
+	{
+		$repository = new CustomerRepository('ppcp_prefix_');
+
+		expect('get_user_meta')
+			->once()
+			->with(42, '_ppcp_target_customer_id', true)
+			->andReturn('converted-customer-id');
+
+		$this->assertSame('converted-customer-id', $repository->paypal_customer_id_for_user(42));
+	}
+
+	/**
+	 * GIVEN a user with only the legacy vaulted PayPal customer ID stored
+	 * WHEN resolving the PayPal customer ID for that user
+	 * THEN the legacy ID is returned as a fallback
+	 */
+	public function testFallsBackToLegacyIdWhenMostRecentlyAssignedIdIsMissing()
+	{
+		$repository = new CustomerRepository('ppcp_prefix_');
+
+		expect('get_user_meta')
+			->once()
+			->with(42, '_ppcp_target_customer_id', true)
+			->andReturn('');
+
+		expect('get_user_meta')
+			->once()
+			->with(42, 'ppcp_customer_id', true)
+			->andReturn('legacy-customer-id');
+
+		$this->assertSame('legacy-customer-id', $repository->paypal_customer_id_for_user(42));
 	}
 
 	public function testReturnsEmptyStringWhenNeverVaulted()
 	{
 		$repository = new CustomerRepository('ppcp_prefix_');
 
-		// get_user_meta returns '' for an unset meta value; no local fallback ID.
+		// get_user_meta returns '' for both keys when the user was never vaulted.
+		expect('get_user_meta')
+			->once()
+			->with(42, '_ppcp_target_customer_id', true)
+			->andReturn('');
+
 		expect('get_user_meta')
 			->once()
 			->with(42, 'ppcp_customer_id', true)

--- a/tests/PHPUnit/Compat/PPEC/BillingAgreementTokenConverterTest.php
+++ b/tests/PHPUnit/Compat/PPEC/BillingAgreementTokenConverterTest.php
@@ -55,7 +55,7 @@ class BillingAgreementTokenConverterTest extends TestCase
 		$vault_token_id       = 'vault-token-xyz';
 
 		$this->customer_repository
-			->shouldReceive('customer_id_for_user')
+			->shouldReceive('paypal_customer_id_for_user')
 			->with($user_id)
 			->andReturn($customer_id);
 
@@ -88,7 +88,7 @@ class BillingAgreementTokenConverterTest extends TestCase
 		$vault_token_id       = 'vault-token-xyz';
 
 		$this->customer_repository
-			->shouldReceive('customer_id_for_user')
+			->shouldReceive('paypal_customer_id_for_user')
 			->with($user_id)
 			->andReturn($customer_id);
 
@@ -106,6 +106,41 @@ class BillingAgreementTokenConverterTest extends TestCase
 		$this->assertSame($vault_token_id, $result);
 	}
 
+	public function testNonVaultedUserPassesEmptyCustomerId()
+	{
+		$billing_agreement_id = 'B-ABC123';
+		$user_id              = 42;
+		$vault_token_id       = 'vault-token-xyz';
+
+		// Never vaulted: no real PayPal customer ID.
+		$this->customer_repository
+			->shouldReceive('paypal_customer_id_for_user')
+			->with($user_id)
+			->andReturn('');
+
+		$api_result               = new stdClass();
+		$api_result->id           = $vault_token_id;
+		$api_result->customer     = new stdClass();
+		$api_result->customer->id = 'paypal-generated-id';
+
+		// PayPal must be called with an empty customer ID so it assigns one,
+		// never with a fabricated local ID.
+		$this->payment_method_tokens_endpoint
+			->shouldReceive('create_payment_token')
+			->with(Mockery::type(PaymentSource::class), '')
+			->andReturn($api_result);
+
+		expect('update_user_meta')
+			->once()
+			->with($user_id, '_ppcp_target_customer_id', 'paypal-generated-id');
+
+		$this->logger->shouldReceive('info')->once();
+
+		$result = $this->sut->convert($billing_agreement_id, $user_id);
+
+		$this->assertSame($vault_token_id, $result);
+	}
+
 	public function testApiFailureReturnsNull()
 	{
 		$billing_agreement_id = 'B-ABC123';
@@ -113,7 +148,7 @@ class BillingAgreementTokenConverterTest extends TestCase
 		$customer_id          = 'customer_42';
 
 		$this->customer_repository
-			->shouldReceive('customer_id_for_user')
+			->shouldReceive('paypal_customer_id_for_user')
 			->with($user_id)
 			->andReturn($customer_id);
 
@@ -134,7 +169,7 @@ class BillingAgreementTokenConverterTest extends TestCase
 		$user_id              = 42;
 
 		$this->customer_repository
-			->shouldReceive('customer_id_for_user')
+			->shouldReceive('paypal_customer_id_for_user')
 			->with($user_id)
 			->andThrow(new \Exception('Unexpected error'));
 


### PR DESCRIPTION
### Description

When a subscription created with the legacy PayPal Express Checkout (PPEC) plugin renews through WooCommerce PayPal Payments, the compat layer converts the legacy Billing Agreement into a Vault v3 payment token. `BillingAgreementTokenConverter::convert()` passed `CustomerRepository::customer_id_for_user()` to the Vault API but for a user who has never vaulted with PayPal Payments, that method returns a **fabricated local ID** (`prefix . user_id`, `CustomerRepository.php:60`). PayPal doesn't recognise that ID, so the Vault call fails and the billing-agreement → token conversion never succeeds for those users.

**Fix**
- New `CustomerRepository::paypal_customer_id_for_user()` returns the real `ppcp_customer_id` or an empty string, and **never** fabricates a fallback.
- `convert()` now uses it: with a real ID PayPal reuses the customer; with an empty ID `create_payment_token()` omits `customer.id`, so PayPal assigns one and its ID is persisted on the user (existing behaviour). The wasteful, always-failing call with the bogus ID is gone.

`customer_id_for_user()` is left untouched. Its fallback is intentional for order creation elsewhere.

**Note on scope / severity:** `SubscriptionsHandler::use_billing_agreement_as_token()` already falls back to the legacy `BILLING_AGREEMENT` token path when conversion returns null, so on accounts where legacy BA charges still work the renewal wasn't hard-broken but the Vault v3 migration silently never happened (and logged an error) for every non-vaulted user. This makes the migration actually succeed (the ticket's preferred outcome), with the legacy fallback still in place as a safety net.

### Steps to Test

> Full end-to-end repro needs legacy PPEC subscription data + a Billing Agreement + a triggered renewal, which is a heavy setup; the logic is covered by unit tests.

1. Create a subscription via the legacy PPEC plugin; ensure the customer has **no** `ppcp_customer_id` user meta (never vaulted with PayPal Payments).
2. Trigger a renewal order for that subscription.
3. **Before the fix:** the Vault v3 conversion fails (PayPal rejects the local `prefix.user_id` customer ID); the log shows the failed conversion.
4. **After the fix:** conversion succeeds — PayPal assigns a customer, the Billing Agreement is stored as a Vault v3 token (`_ppec_ba_converted_to_vault_v3` on the subscription), and the returned customer ID is saved to `_ppcp_target_customer_id`.
5. A user who **does** have a real `ppcp_customer_id` still converts against that customer — no regression.

### Changelog

Fix - PPEC subscription renewals: convert legacy Billing Agreements to Vault v3 tokens using a real PayPal customer ID instead of a locally generated one.
