### PR TITLE
Google Pay - Unsuccessfully payment with Google Pay when Pay Now disabled (6748)

### DIFF
--- a/modules/ppcp-button/services.php
+++ b/modules/ppcp-button/services.php
@@ -430,7 +430,8 @@ return array(
 			$container->get( 'wc-subscriptions.helper' ),
 			$container->get( 'button.session.factory.card-data' ),
 			$container->get( 'api.factory.shipping' ),
-			$container->get( 'api.factory.payer' )
+			$container->get( 'api.factory.payer' ),
+			$container->get( 'api.factory.shipping-option' )
 		);
 	},
 

--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -24,8 +24,10 @@ use WC_Tax;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Payer;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ShippingOption;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingOptionFactory;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataFactory;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -66,13 +68,16 @@ class WooCommerceOrderCreator {
 
 	protected PayerFactory $payer_factory;
 
+	protected ShippingOptionFactory $shipping_option_factory;
+
 	public function __construct(
 		FundingSourceRenderer $funding_source_renderer,
 		SessionHandler $session_handler,
 		SubscriptionHelper $subscription_helper,
 		CartDataFactory $cart_data_factory,
 		ShippingFactory $shipping_factory,
-		PayerFactory $payer_factory
+		PayerFactory $payer_factory,
+		ShippingOptionFactory $shipping_option_factory
 	) {
 		$this->funding_source_renderer = $funding_source_renderer;
 		$this->session_handler         = $session_handler;
@@ -80,6 +85,7 @@ class WooCommerceOrderCreator {
 		$this->cart_data_factory       = $cart_data_factory;
 		$this->shipping_factory        = $shipping_factory;
 		$this->payer_factory           = $payer_factory;
+		$this->shipping_option_factory = $shipping_option_factory;
 	}
 
 	/**
@@ -104,13 +110,18 @@ class WooCommerceOrderCreator {
 		}
 
 		try {
-			$payer    = $this->get_payer( $order, $paypal_data );
-			$shipping = $this->get_shipping( $order, $paypal_data );
+			$payer           = $this->get_payer( $order, $paypal_data );
+			$shipping        = $this->get_shipping( $order, $paypal_data );
+			$shipping_option = $this->resolve_shipping_option(
+				$shipping,
+				$cart_data->needs_shipping(),
+				$cart instanceof WC_Cart
+			);
 
 			$this->configure_payment_source( $wc_order );
 			$this->configure_customer( $wc_order, $cart_data );
-			$this->configure_line_items( $wc_order, $cart_data, $payer, $shipping );
-			$this->configure_addresses( $wc_order, $payer, $shipping, $cart_data->needs_shipping() );
+			$this->configure_line_items( $wc_order, $cart_data, $payer, $shipping, $shipping_option );
+			$this->configure_addresses( $wc_order, $payer, $shipping, $cart_data->needs_shipping(), $shipping_option );
 			$this->configure_coupons( $wc_order, $cart_data->coupons() );
 
 			$wc_order->calculate_totals();
@@ -130,7 +141,7 @@ class WooCommerceOrderCreator {
 	 *
 	 * @psalm-suppress InvalidScalarArgument
 	 */
-	protected function configure_line_items( WC_Order $wc_order, CartData $cart_data, ?Payer $payer, ?Shipping $shipping ): void {
+	protected function configure_line_items( WC_Order $wc_order, CartData $cart_data, ?Payer $payer, ?Shipping $shipping, ?ShippingOption $shipping_option = null ): void {
 		foreach ( $cart_data->items() as $cart_item ) {
 			$product_id           = $cart_item['product_id'] ?? 0;
 			$variation_id         = $cart_item['variation_id'] ?? 0;
@@ -180,7 +191,7 @@ class WooCommerceOrderCreator {
 				$item->set_total( (string) $subscription_total );
 
 				$subscription->add_product( $product );
-				$this->configure_addresses( $subscription, $payer, $shipping, $cart_data->needs_shipping() );
+				$this->configure_addresses( $subscription, $payer, $shipping, $cart_data->needs_shipping(), $shipping_option );
 				$this->configure_payment_source( $subscription );
 				$this->configure_coupons( $subscription, $cart_data->coupons() );
 
@@ -205,15 +216,15 @@ class WooCommerceOrderCreator {
 	 * @throws WC_Data_Exception|RuntimeException When failing to configure shipping.
 	 * @psalm-suppress RedundantConditionGivenDocblockType
 	 */
-	protected function configure_addresses( WC_Order $wc_order, ?Payer $payer, ?Shipping $shipping, bool $needs_shipping ): void {
+	protected function configure_addresses( WC_Order $wc_order, ?Payer $payer, ?Shipping $shipping, bool $needs_shipping, ?ShippingOption $shipping_option = null ): void {
 		$shipping_address = null;
 		$billing_address  = null;
-		$shipping_options = null;
 		$wc_customer      = WC()->customer;
 
 		if ( ! $shipping && $needs_shipping ) {
 			if ( $wc_customer instanceof WC_Customer ) {
-				$shipping = $this->shipping_factory->from_wc_customer( $wc_customer, true );
+				// Only the address is used here, the shipping method is resolved by resolve_shipping_option().
+				$shipping = $this->shipping_factory->from_wc_customer( $wc_customer, false );
 			}
 		}
 
@@ -257,11 +268,9 @@ class WooCommerceOrderCreator {
 					'country'    => $address->country_code(),
 				);
 			}
-
-			$shipping_options = $shipping->options()[0] ?? '';
 		}
 
-		if ( $needs_shipping && empty( $shipping_options ) ) {
+		if ( $needs_shipping && ! $shipping_option ) {
 			throw new RuntimeException( 'No shipping method has been selected.' );
 		}
 
@@ -273,11 +282,11 @@ class WooCommerceOrderCreator {
 			$wc_order->set_billing_address( $billing_address ?: $shipping_address );
 		}
 
-		if ( $shipping_options ) {
-			$shipping = new WC_Order_Item_Shipping();
-			$shipping->set_method_title( $shipping_options->label() );
-			$shipping->set_method_id( $shipping_options->id() );
-			$shipping->set_total( $shipping_options->amount()->value_str() );
+		if ( $shipping_option ) {
+			$shipping_item = new WC_Order_Item_Shipping();
+			$shipping_item->set_method_title( $shipping_option->label() );
+			$shipping_item->set_method_id( $shipping_option->id() );
+			$shipping_item->set_total( $shipping_option->amount()->value_str() );
 
 			$items            = $wc_order->get_items();
 			$items_in_package = array();
@@ -285,9 +294,9 @@ class WooCommerceOrderCreator {
 				$items_in_package[] = $item->get_name() . ' &times; ' . (string) $item->get_quantity();
 			}
 
-			$shipping->add_meta_data( __( 'Items', 'woocommerce-paypal-payments' ), implode( ', ', $items_in_package ) );
+			$shipping_item->add_meta_data( __( 'Items', 'woocommerce-paypal-payments' ), implode( ', ', $items_in_package ) );
 
-			$wc_order->add_item( $shipping );
+			$wc_order->add_item( $shipping_item );
 		}
 
 		$wc_order->calculate_totals();
@@ -449,5 +458,73 @@ class WooCommerceOrderCreator {
 			$order,
 			$paypal_data
 		);
+	}
+
+	/**
+	 * Returns the shipping method that should be added to the WC order.
+	 *
+	 * Prefers the option that PayPal reports as selected. When the PayPal order carries no
+	 * shipping options at all — Google Pay and Apple Pay collect the shipping method in their
+	 * own payment sheet, so it is never sent to PayPal — the method chosen in WooCommerce is used.
+	 *
+	 * @param Shipping|null $shipping           The shipping information of the PayPal order.
+	 * @param bool          $needs_shipping     Whether the cart needs shipping.
+	 * @param bool          $is_current_wc_cart Whether the order is created from the live WC cart.
+	 *
+	 * @return ShippingOption|null The shipping option, or null when none is available.
+	 */
+	private function resolve_shipping_option( ?Shipping $shipping, bool $needs_shipping, bool $is_current_wc_cart ): ?ShippingOption {
+		if ( ! $needs_shipping ) {
+			return null;
+		}
+
+		$paypal_option = $this->select_shipping_option( $shipping ? $shipping->options() : array() );
+		if ( $paypal_option ) {
+			return $paypal_option;
+		}
+
+		/**
+		 * PayPal knows the address but no methods: only the live cart can be trusted here, a
+		 * restored or foreign cart (app switch, agentic checkout) may hold different items.
+		 */
+		if ( $shipping && ! $is_current_wc_cart ) {
+			return null;
+		}
+
+		return $this->wc_shipping_option();
+	}
+
+	/**
+	 * Returns the shipping method chosen in WooCommerce, or null when it cannot be determined.
+	 *
+	 * @return ShippingOption|null
+	 */
+	private function wc_shipping_option(): ?ShippingOption {
+		// Without a cart and session the factory would raise an Error, which the caller does not catch.
+		if ( ! WC()->cart || ! WC()->session ) {
+			return null;
+		}
+
+		return $this->select_shipping_option( $this->shipping_option_factory->from_wc_cart() );
+	}
+
+	/**
+	 * Returns the selected option of the given list, falling back to the first one.
+	 *
+	 * @param ShippingOption[] $options The shipping options.
+	 *
+	 * @return ShippingOption|null The shipping option, or null when the list is empty.
+	 */
+	private function select_shipping_option( array $options ): ?ShippingOption {
+		foreach ( $options as $option ) {
+			if ( $option->selected() ) {
+				return $option;
+			}
+		}
+
+		// The factories do not guarantee a zero-indexed list.
+		$first = reset( $options );
+
+		return $first instanceof ShippingOption ? $first : null;
 	}
 }

--- a/tests/PHPUnit/Button/Helper/WooCommerceOrderCreatorTest.php
+++ b/tests/PHPUnit/Button/Helper/WooCommerceOrderCreatorTest.php
@@ -5,18 +5,84 @@ namespace WooCommerce\PayPalCommerce\Button\Helper;
 
 use Mockery;
 use ReflectionMethod;
+use RuntimeException;
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Money;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\ShippingOption;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingFactory;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingOptionFactory;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataFactory;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\FundingSource\FundingSourceRenderer;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
 
 class WooCommerceOrderCreatorTest extends TestCase {
+
+	/**
+	 * Builds the SUT with mocked collaborators.
+	 *
+	 * @param ShippingOptionFactory|null $shipping_option_factory Optional factory mock, so callers
+	 *                                                              can set expectations on it.
+	 */
+	private function sut( ?ShippingOptionFactory $shipping_option_factory = null ): WooCommerceOrderCreator {
+		return new WooCommerceOrderCreator(
+			Mockery::mock( FundingSourceRenderer::class ),
+			Mockery::mock( SessionHandler::class ),
+			Mockery::mock( SubscriptionHelper::class ),
+			Mockery::mock( CartDataFactory::class ),
+			Mockery::mock( ShippingFactory::class ),
+			Mockery::mock( PayerFactory::class ),
+			$shipping_option_factory ?? Mockery::mock( ShippingOptionFactory::class )
+		);
+	}
+
+	/**
+	 * Builds a ShippingOption. It is a plain value object, so a real instance is used.
+	 */
+	private function option( string $id, bool $selected ): ShippingOption {
+		return new ShippingOption( $id, ucfirst( $id ) . ' label', $selected, new Money( 10.0, 'USD' ), ShippingOption::TYPE_SHIPPING );
+	}
+
+	/**
+	 * Builds a Shipping mock whose options() returns the given list.
+	 *
+	 * @param ShippingOption[] $options
+	 */
+	private function shipping_with_options( array $options ) {
+		$shipping = Mockery::mock( Shipping::class );
+		$shipping->shouldReceive( 'options' )->andReturn( $options );
+
+		return $shipping;
+	}
+
+	/**
+	 * Stubs WC() so that WC()->cart and WC()->session resolve as given.
+	 *
+	 * @param mixed $cart    Value for WC()->cart.
+	 * @param mixed $session Value for WC()->session.
+	 */
+	private function stub_wc( $cart, $session ): void {
+		when( 'WC' )->justReturn(
+			(object) array(
+				'cart'    => $cart,
+				'session' => $session,
+			)
+		);
+	}
+
+	private function invoke_resolve_shipping_option( WooCommerceOrderCreator $sut, ?Shipping $shipping, bool $needs_shipping, bool $is_current_wc_cart ): ?ShippingOption {
+		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'resolve_shipping_option' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $sut, $shipping, $needs_shipping, $is_current_wc_cart );
+	}
+
 	/**
 	 * GIVEN a PayPal order with no purchase units (shipping = null)
 	 * AND Brain\Monkey expects apply_filters called once with the filter name, null, $order, $paypal_data
@@ -41,14 +107,7 @@ class WooCommerceOrderCreatorTest extends TestCase {
 			)
 			->andReturn( $filter_shipping );
 
-		$sut = new WooCommerceOrderCreator(
-			Mockery::mock( FundingSourceRenderer::class ),
-			Mockery::mock( SessionHandler::class ),
-			Mockery::mock( SubscriptionHelper::class ),
-			Mockery::mock( CartDataFactory::class ),
-			Mockery::mock( ShippingFactory::class ),
-			Mockery::mock( PayerFactory::class )
-		);
+		$sut = $this->sut();
 
 		// Testing a private method, as we want to confirm the presence and ability of a WP filter.
 		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'get_shipping' );
@@ -57,5 +116,256 @@ class WooCommerceOrderCreatorTest extends TestCase {
 		$result = $method->invoke( $sut, $order, $paypal_data );
 
 		$this->assertSame( $filter_shipping, $result );
+	}
+
+	/**
+	 * GIVEN a PayPal order that reports two shipping options, only one flagged as selected
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN the option flagged as selected is returned
+	 * AND the WooCommerce cart fallback is never consulted
+	 */
+	public function test_resolve_shipping_option_prefers_paypal_selected_option_over_others(): void {
+		$option_a = $this->option( 'a', false );
+		$option_b = $this->option( 'b', true );
+
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldNotReceive( 'from_wc_cart' );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$result = $this->invoke_resolve_shipping_option(
+			$sut,
+			$this->shipping_with_options( [ $option_a, $option_b ] ),
+			true,
+			true
+		);
+
+		$this->assertSame( $option_b, $result );
+	}
+
+	/**
+	 * GIVEN a PayPal order that reports shipping options but none is flagged as selected
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN the first option in the list is returned
+	 */
+	public function test_resolve_shipping_option_falls_back_to_first_paypal_option_when_none_selected(): void {
+		$option_a = $this->option( 'a', false );
+		$option_b = $this->option( 'b', false );
+
+		$sut = $this->sut();
+
+		$result = $this->invoke_resolve_shipping_option(
+			$sut,
+			$this->shipping_with_options( [ $option_a, $option_b ] ),
+			true,
+			true
+		);
+
+		$this->assertSame( $option_a, $result );
+	}
+
+	/**
+	 * GIVEN a PayPal order (e.g. Google Pay express checkout) that carries no shipping options
+	 * AND the order is being created from the current, live WC cart
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN the option WooCommerce flags as selected is used
+	 *
+	 * This is the regression test for the bug where Google Pay express checkout failed with
+	 * "No shipping method has been selected." when the Pay Now setting was disabled.
+	 */
+	public function test_resolve_shipping_option_falls_back_to_wc_cart_selected_option_when_paypal_has_none(): void {
+		$wc_option_selected   = $this->option( 'flat_rate', true );
+		$wc_option_unselected = $this->option( 'free_shipping', false );
+
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldReceive( 'from_wc_cart' )
+			->andReturn( [ $wc_option_unselected, $wc_option_selected ] );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$this->stub_wc( Mockery::mock()->shouldIgnoreMissing(), Mockery::mock()->shouldIgnoreMissing() );
+
+		$result = $this->invoke_resolve_shipping_option(
+			$sut,
+			$this->shipping_with_options( [] ),
+			true,
+			true
+		);
+
+		$this->assertSame( $wc_option_selected, $result );
+	}
+
+	/**
+	 * GIVEN a PayPal order that carries no shipping options
+	 * AND the WC cart shipping options carry none flagged as selected
+	 * AND the order is being created from the current, live WC cart
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN the first WC cart option is used
+	 */
+	public function test_resolve_shipping_option_falls_back_to_first_wc_cart_option_when_none_selected(): void {
+		$wc_option_a = $this->option( 'flat_rate', false );
+		$wc_option_b = $this->option( 'free_shipping', false );
+
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldReceive( 'from_wc_cart' )
+			->andReturn( [ $wc_option_a, $wc_option_b ] );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$this->stub_wc( Mockery::mock()->shouldIgnoreMissing(), Mockery::mock()->shouldIgnoreMissing() );
+
+		$result = $this->invoke_resolve_shipping_option(
+			$sut,
+			$this->shipping_with_options( [] ),
+			true,
+			true
+		);
+
+		$this->assertSame( $wc_option_a, $result );
+	}
+
+	/**
+	 * GIVEN no PayPal shipping information at all (legacy code path, e.g. a Payer-only response)
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN the WC cart fallback is used, preserving the pre-existing behaviour
+	 */
+	public function test_resolve_shipping_option_uses_wc_cart_fallback_when_shipping_is_null(): void {
+		$wc_option = $this->option( 'flat_rate', true );
+
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldReceive( 'from_wc_cart' )->andReturn( [ $wc_option ] );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$this->stub_wc( Mockery::mock()->shouldIgnoreMissing(), Mockery::mock()->shouldIgnoreMissing() );
+
+		$result = $this->invoke_resolve_shipping_option( $sut, null, true, true );
+
+		$this->assertSame( $wc_option, $result );
+	}
+
+	/**
+	 * GIVEN a cart that does not need shipping (e.g. virtual/downloadable products only)
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN null is returned
+	 * AND the WC cart fallback is never consulted
+	 */
+	public function test_resolve_shipping_option_returns_null_when_cart_does_not_need_shipping(): void {
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldNotReceive( 'from_wc_cart' );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$result = $this->invoke_resolve_shipping_option(
+			$sut,
+			$this->shipping_with_options( [ $this->option( 'a', true ) ] ),
+			false,
+			true
+		);
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * GIVEN a PayPal order that carries no shipping options
+	 * AND the order is NOT created from the current, live WC cart (app switch / agentic checkout
+	 *     snapshot cart)
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN null is returned
+	 * AND the WC cart fallback is never consulted, since the live cart cannot be trusted to match
+	 */
+	public function test_resolve_shipping_option_returns_null_for_foreign_cart_when_paypal_has_no_options(): void {
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldNotReceive( 'from_wc_cart' );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$result = $this->invoke_resolve_shipping_option(
+			$sut,
+			$this->shipping_with_options( [] ),
+			true,
+			false
+		);
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * GIVEN the WC cart needs shipping and must fall back to WooCommerce
+	 * AND WC()->session is unavailable
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN null is returned without raising an error
+	 * AND the WC cart fallback factory is never called
+	 */
+	public function test_resolve_shipping_option_returns_null_when_wc_session_unavailable(): void {
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldNotReceive( 'from_wc_cart' );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$this->stub_wc( Mockery::mock()->shouldIgnoreMissing(), null );
+
+		$result = $this->invoke_resolve_shipping_option( $sut, null, true, true );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * GIVEN the WC cart needs shipping and must fall back to WooCommerce
+	 * AND WC()->cart is unavailable
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN null is returned without raising an error
+	 * AND the WC cart fallback factory is never called
+	 */
+	public function test_resolve_shipping_option_returns_null_when_wc_cart_unavailable(): void {
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldNotReceive( 'from_wc_cart' );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$this->stub_wc( null, Mockery::mock()->shouldIgnoreMissing() );
+
+		$result = $this->invoke_resolve_shipping_option( $sut, null, true, true );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * GIVEN WooCommerce reports no shipping options at all (from_wc_cart returns an empty list)
+	 * WHEN resolve_shipping_option() is invoked
+	 * THEN null is returned
+	 */
+	public function test_resolve_shipping_option_returns_null_when_wc_cart_has_no_options(): void {
+		$shipping_option_factory = Mockery::mock( ShippingOptionFactory::class );
+		$shipping_option_factory->shouldReceive( 'from_wc_cart' )->andReturn( [] );
+
+		$sut = $this->sut( $shipping_option_factory );
+
+		$this->stub_wc( Mockery::mock()->shouldIgnoreMissing(), Mockery::mock()->shouldIgnoreMissing() );
+
+		$result = $this->invoke_resolve_shipping_option( $sut, null, true, true );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * GIVEN an order that needs shipping but no shipping option could be resolved
+	 * WHEN configure_addresses() is invoked
+	 * THEN a RuntimeException is thrown reporting that no shipping method has been selected
+	 */
+	public function test_configure_addresses_throws_when_shipping_needed_but_no_option_resolved(): void {
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		when( 'WC' )->justReturn( (object) array( 'customer' => null ) );
+
+		$sut = $this->sut();
+
+		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'configure_addresses' );
+		$method->setAccessible( true );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'No shipping method has been selected.' );
+
+		$method->invoke( $sut, $wc_order, null, null, true, null );
 	}
 }


### PR DESCRIPTION
Google Pay express checkout failed with "Order approve failed: Failed to create WooCommerce order: No shipping method has been selected." when the "Pay Now" setting was disabled.

Express wallets always create the WC order server-side (ApproveOrderEndpoint), but with Pay Now disabled the plugin doesn't send shipping options to PayPal. WooCommerceOrderCreator read the shipping method only from the PayPal order, so it had nothing to use, even though the chosen rate was already in WC()->session['chosen_shipping_methods'].                            
                                                                                                                                                                                             
### Solution                                                                                                                                                                                   
`WooCommerceOrderCreator` now resolves the shipping method in order of preference: the PayPal option flagged selected, then the first PayPal option, then WooCommerce's own chosen method via the existing `ShippingOptionFactory::from_wc_cart()`. It only throws when all of those are empty.                                                                                            

Also fixes a second bug in the same line: the old code took `options()[0]` and ignored the selected flag.