### PR TITLE
fix(blocks): keep PayPal available when a subscription cart reaches a zero total (6433)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Helper/Subscription.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Subscription.js
@@ -20,15 +20,21 @@ export const cartHasSubscriptionProducts = ( scriptData ) => {
 /**
  * Whether the PayPal payment method may be offered for the current cart totals.
  *
- * A zero-total cart needs no payment method, except for a free-trial subscription:
- * that one is $0 today but still needs a method vaulted for the renewals.
+ * A zero-total cart usually needs no payment method, but a subscription cart does:
+ * the method is vaulted to pay the renewals. `is_free_trial_cart` is computed
+ * server-side while the page renders, so it misses a cart that only reaches a zero
+ * total afterwards (a coupon applied on the checkout itself); the cart shape is
+ * therefore checked as well.
  *
  * @param {Object} scriptData
  * @param {Object} cartData   Live cart data passed to `canMakePayment`.
  * @return {boolean} Whether the PayPal payment method may be displayed.
  */
 export const paypalPaymentMethodAllowed = ( scriptData, cartData ) => {
-	if ( scriptData?.is_free_trial_cart ) {
+	if (
+		scriptData?.is_free_trial_cart ||
+		cartHasSubscriptionProducts( scriptData )
+	) {
 		return true;
 	}
 

--- a/modules/ppcp-blocks/resources/js/Helper/Subscription.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Subscription.js
@@ -18,6 +18,24 @@ export const cartHasSubscriptionProducts = ( scriptData ) => {
 };
 
 /**
+ * Whether the PayPal payment method may be offered for the current cart totals.
+ *
+ * A zero-total cart needs no payment method, except for a free-trial subscription:
+ * that one is $0 today but still needs a method vaulted for the renewals.
+ *
+ * @param {Object} scriptData
+ * @param {Object} cartData   Live cart data passed to `canMakePayment`.
+ * @return {boolean} Whether the PayPal payment method may be displayed.
+ */
+export const paypalPaymentMethodAllowed = ( scriptData, cartData ) => {
+	if ( scriptData?.is_free_trial_cart ) {
+		return true;
+	}
+
+	return parseInt( cartData?.cartTotals?.total_price ) > 0;
+};
+
+/**
  * Whether the PayPal button is allowed for the current (subscription) cart.
  *
  * Single, mode-aware rule shared by the block cart, classic cart and mini-cart

--- a/modules/ppcp-blocks/resources/js/Helper/Subscription.test.js
+++ b/modules/ppcp-blocks/resources/js/Helper/Subscription.test.js
@@ -1,4 +1,7 @@
-import { paypalSubscriptionButtonAllowed } from './Subscription';
+import {
+	paypalSubscriptionButtonAllowed,
+	paypalPaymentMethodAllowed,
+} from './Subscription';
 
 const baseData = ( overrides = {} ) => ( {
 	locations_with_subscription_product: { cart: true },
@@ -75,5 +78,51 @@ describe( 'paypalSubscriptionButtonAllowed', () => {
 			subscription_product_allowed: true,
 		} );
 		expect( paypalSubscriptionButtonAllowed( data ) ).toBe( true );
+	} );
+} );
+
+describe( 'paypalPaymentMethodAllowed', () => {
+	it( 'allows a free trial cart regardless of the cart total', () => {
+		const data = baseData( {
+			locations_with_subscription_product: { cart: false },
+			is_free_trial_cart: true,
+		} );
+		const cartData = { cartTotals: { total_price: '0' } };
+		expect( paypalPaymentMethodAllowed( data, cartData ) ).toBe( true );
+	} );
+
+	it( 'allows a subscription cart with a positive total', () => {
+		const data = baseData();
+		const cartData = { cartTotals: { total_price: '10000' } };
+		expect( paypalPaymentMethodAllowed( data, cartData ) ).toBe( true );
+	} );
+
+	it( 'allows a subscription cart that reached a zero total after a coupon was applied on checkout, even though the server-rendered is_free_trial_cart flag is stale', () => {
+		const data = baseData( { is_free_trial_cart: false } );
+		const cartData = { cartTotals: { total_price: '0' } };
+		expect( paypalPaymentMethodAllowed( data, cartData ) ).toBe( true );
+	} );
+
+	it( 'allows a non-subscription cart with a positive total', () => {
+		const data = baseData( {
+			locations_with_subscription_product: { cart: false },
+		} );
+		const cartData = { cartTotals: { total_price: '10000' } };
+		expect( paypalPaymentMethodAllowed( data, cartData ) ).toBe( true );
+	} );
+
+	it( 'hides for a non-subscription cart with a zero total', () => {
+		const data = baseData( {
+			locations_with_subscription_product: { cart: false },
+		} );
+		const cartData = { cartTotals: { total_price: '0' } };
+		expect( paypalPaymentMethodAllowed( data, cartData ) ).toBe( false );
+	} );
+
+	it( 'hides for a non-subscription cart when cartData is missing', () => {
+		const data = baseData( {
+			locations_with_subscription_product: { cart: false },
+		} );
+		expect( paypalPaymentMethodAllowed( data, undefined ) ).toBe( false );
 	} );
 } );

--- a/modules/ppcp-blocks/resources/js/checkout-block.js
+++ b/modules/ppcp-blocks/resources/js/checkout-block.js
@@ -5,6 +5,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import {
 	cartHasSubscriptionProducts,
+	paypalPaymentMethodAllowed,
 	paypalSubscriptionButtonAllowed,
 } from './Helper/Subscription';
 import { loadPayPalScript } from '../../../ppcp-button/resources/js/modules/Helper/PayPalScriptLoading';
@@ -56,15 +57,8 @@ if ( blockEnabled ) {
 			),
 			placeOrderButtonLabel: config.placeOrderButtonText,
 			ariaLabel: config.title,
-			canMakePayment: ( cartData ) => {
-				// Free-trial subscriptions have a $0 total today but still
-				// require a payment method to be vaulted for future renewals.
-				if ( config.scriptData.is_free_trial_cart ) {
-					return true;
-				}
-				const total = cartData?.cartTotals?.total_price;
-				return parseInt( total ) > 0;
-			},
+			canMakePayment: ( cartData ) =>
+				paypalPaymentMethodAllowed( config.scriptData, cartData ),
 			supports: {
 				features,
 				showSavedCards: true,


### PR DESCRIPTION
### Description

#### The originally reported bug was already fixed

The report behind this branch — free-trial subscription in the cart → Block checkout → no PayPal gateway, filed against 4.0.4 — was already fixed in **4.1.0** by commit `cb7ff53b`, which exempted free-trial carts from the zero-total check in `checkout-block.js`. The report was simply never closed, which is how it came back around. Nothing to do there.

#### The adjacent gap this PR fixes

While verifying that, a second path to the same symptom turned up, and it is still live.

**Problem.** On Block checkout the PayPal gateway disappears from the payment method list the moment the cart total drops to zero — no page reload involved. A 100% coupon applied on the checkout itself is enough. The buyer is left unable to pay for a subscription that still needs a payment method vaulted for its renewals.

**Root cause.** `canMakePayment` mixed a server-rendered flag with live cart data:

```js
if ( config.scriptData.is_free_trial_cart ) {
	return true;
}
const total = cartData?.cartTotals?.total_price;
return parseInt( total ) > 0;
```

`is_free_trial_cart` is computed once by `SmartButton::script_data()` while the page renders and baked into `ppcp-gateway_data`. Blocks re-runs `canMakePayment` on every cart change. So a cart that renders at $100 and *then* reaches $0 is evaluated with a stale `false` flag against a live `"0"` total, and the gateway is filtered out.

**Fix.** Also consider the cart shape, not just the rendered flag:

```js
export const paypalPaymentMethodAllowed = ( scriptData, cartData ) => {
	if (
		scriptData?.is_free_trial_cart ||
		cartHasSubscriptionProducts( scriptData )
	) {
		return true;
	}

	return parseInt( cartData?.cartTotals?.total_price ) > 0;
};
```

`cartHasSubscriptionProducts()` is the flag the surrounding registration already trusts to decide the supported `features` (`checkout-block.js:27-33`). It is sound here because cart *contents* cannot change on a Block checkout — only the total can, and the total is still read live from `cartData`.

A genuinely zero-total cart **without** a subscription keeps hiding the gateway, preserving the behaviour added in `b48534fb0` ("Proceed to PayPal still showing when totals are 0").

#### Why not `paymentRequirements`

The obvious alternative — `cartData.paymentRequirements.includes( 'subscriptions' )` — is not reliable. `WC_Subscriptions_Core_Payment_Gateways::inject_payment_feature_requirements_for_cart_api()` (subscriptions-core) returns an empty array when manual renewals are enabled, and emits `multiple_subscriptions` instead of `subscriptions` when the cart holds more than one subscription. Either case would have re-hidden the gateway.

### Steps to Test

Setup: WC Subscriptions active, **"Save PayPal and Venmo" (vaulting) enabled**, cart and checkout pages using the Cart/Checkout blocks. Create a `percent` / `100` coupon, e.g. `full100`.

**The fix** — subscription cart that becomes zero-total after render:

1. Create a Simple subscription product, price 100 / month, **no** free trial, **Virtual** (so no shipping cost keeps the total above zero).
2. Add it to the cart and go to Block checkout. PayPal is listed, total $100.
3. Apply `full100` in the checkout's own coupon field. Total becomes $0.00.
4. **Expected:** PayPal stays in the payment method list. Before this PR it disappears without a reload.
5. Reload the page with the coupon still applied — PayPal is present either way, because the server computes `is_free_trial_cart: true` on render. That is what made this easy to miss.

**Regression guard** — zero-total cart *without* a subscription:

6. Empty the cart, add a normal non-subscription product, apply `full100`.
7. **Expected:** PayPal stays hidden.

**Unchanged path** — the originally reported scenario:

8. Free-trial subscription product in the cart → Block checkout → PayPal is present (this already worked as of 4.1.0).

Note: with vaulting disabled, PayPal is intentionally absent for any subscription cart — a free trial cannot be processed without a vaulted payment method. That gate is untouched by this PR.

### Changelog Entry

> Fix - PayPal gateway disappeared from Block checkout when a coupon reduced a subscription cart total to zero
