### PR TITLE
fix(wc-gateway): skip inbox note registration during AJAX requests (6752)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WcInboxNotes/InboxNoteRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/WcInboxNotes/InboxNoteRegistrar.php
@@ -27,6 +27,12 @@ class InboxNoteRegistrar {
 	}
 
 	public function register(): void {
+		// Inbox notes are only rendered on admin screens, never in AJAX responses.
+		// Avoid a note-existence query for every note on each admin AJAX request.
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+
 		foreach ( $this->inbox_notes as $inbox_note ) {
 			$inbox_note_name = $inbox_note->name();
 			$existing_note   = Notes::get_note_by_name( $inbox_note_name );

--- a/tests/PHPUnit/WcGateway/WcInboxNotes/InboxNoteRegistrarTest.php
+++ b/tests/PHPUnit/WcGateway/WcInboxNotes/InboxNoteRegistrarTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace WooCommerce\PayPalCommerce\WcGateway\WcInboxNotes;
+
+use Mockery;
+use RuntimeException;
+use WooCommerce\PayPalCommerce\TestCase;
+
+use function Brain\Monkey\Functions\when;
+
+class InboxNoteRegistrarTest extends TestCase {
+
+	public function test_register_skips_inbox_notes_during_ajax_requests(): void {
+		when( 'wp_doing_ajax' )->justReturn( true );
+
+		$inbox_note = Mockery::mock( InboxNoteInterface::class );
+		$inbox_note->shouldNotReceive( 'name' );
+
+		$registrar = new InboxNoteRegistrar( array( $inbox_note ), 'woocommerce-paypal-payments' );
+
+		self::assertNull( $registrar->register() );
+	}
+
+	public function test_register_continues_registering_inbox_notes_outside_ajax_requests(): void {
+		when( 'wp_doing_ajax' )->justReturn( false );
+
+		$inbox_note = Mockery::mock( InboxNoteInterface::class );
+		$inbox_note
+			->shouldReceive( 'name' )
+			->once()
+			->andThrow( new RuntimeException( 'Inbox note registration reached.' ) );
+
+		$registrar = new InboxNoteRegistrar( array( $inbox_note ), 'woocommerce-paypal-payments' );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Inbox note registration reached.' );
+
+		$registrar->register();
+	}
+}


### PR DESCRIPTION
### Description

`InboxNoteRegistrar::register()` runs on `admin_init`, which also fires for `admin-ajax.php` requests. Every admin AJAX request therefore performs a note-existence query for each configured PayPal Payments inbox note even though those notes are not rendered in AJAX responses.

This PR adds an early `wp_doing_ajax()` guard. Regular wp-admin requests continue through the existing registration flow, so eligible notes are still registered or removed on the next normal admin page load. Unit coverage verifies the AJAX early return and unchanged non-AJAX entry path.

The equivalent guard has already run in WooCommerce.com production, with results documented in [Automattic/woocommerce.com#25681](https://github.com/Automattic/woocommerce.com/pull/25681#issuecomment-5142378854).

### Steps to Test

1. Run `vendor/bin/phpunit tests/PHPUnit/WcGateway/WcInboxNotes/InboxNoteRegistrarTest.php`.
2. Confirm both request-context tests pass.
3. Run the complete PHP unit suite with `npm run unit-tests`.
4. Run PHP lint and static analysis with `npm run lint`.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

No documentation changes are required.

### Changelog Entry

Fix - Avoid unnecessary PayPal Payments inbox note queries during AJAX requests.
