### PR TITLE
fix(blocks): save the card when the first Place order attempt fails validation (6430)

### DIFF
--- a/modules/ppcp-blocks/resources/js/Components/card-fields.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 
 import {
 	PayPalScriptProvider,
@@ -28,20 +28,18 @@ export function CardFields( { config, eventRegistration, emitResponse } ) {
 		setCardFieldsForm( cardFieldsForm );
 	};
 
-	const getSavePayment = ( savePayment ) => {
-		localStorage.setItem( 'ppcp-save-card-payment', savePayment );
-	};
-
 	const hasSubscriptionProducts = cartHasSubscriptionProducts(
 		config.scriptData
 	);
-	useEffect( () => {
-		localStorage.removeItem( 'ppcp-save-card-payment' );
 
-		if ( hasSubscriptionProducts ) {
-			localStorage.setItem( 'ppcp-save-card-payment', 'true' );
-		}
-	}, [ hasSubscriptionProducts ] );
+	// A subscription always needs the card vaulted to pay its renewals; otherwise
+	// the buyer decides via the checkbox. Kept in a ref so that every submit reads
+	// the current value: an attempt that fails checkout validation must not change
+	// what the next attempt asks for.
+	const savePayment = useRef( hasSubscriptionProducts );
+	const getSavePayment = ( value ) => {
+		savePayment.current = value;
+	};
 
 	useEffect(
 		() =>
@@ -88,7 +86,7 @@ export function CardFields( { config, eventRegistration, emitResponse } ) {
 					createOrder={
 						config.scriptData.is_free_trial_cart
 							? undefined
-							: createOrder
+							: () => createOrder( savePayment.current )
 					}
 					onApprove={
 						config.scriptData.is_free_trial_cart

--- a/modules/ppcp-blocks/resources/js/Components/card-fields.test.js
+++ b/modules/ppcp-blocks/resources/js/Components/card-fields.test.js
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+jest.mock( '@paypal/react-paypal-js', () => ( {
+	PayPalScriptProvider: ( { children } ) => children,
+	PayPalCardFieldsProvider: jest.fn( ( { children } ) => children ),
+	PayPalNameField: () => null,
+	PayPalNumberField: () => null,
+	PayPalExpiryField: () => null,
+	PayPalCVVField: () => null,
+	usePayPalCardFields: () => ( {
+		cardFieldsForm: { submit: jest.fn().mockResolvedValue() },
+	} ),
+} ) );
+
+jest.mock( '@ppcp-blocks/card-fields-config', () => ( {
+	createOrder: jest.fn(),
+	onApprove: jest.fn(),
+	createVaultSetupToken: jest.fn(),
+	onApproveSavePayment: jest.fn(),
+} ) );
+
+import { PayPalCardFieldsProvider } from '@paypal/react-paypal-js';
+import { createOrder } from '@ppcp-blocks/card-fields-config';
+import { CardFields } from './card-fields';
+
+const baseConfig = ( {
+	scriptData: scriptDataOverrides,
+	...overrides
+} = {} ) => ( {
+	name_on_card: 'no',
+	save_card_text: 'Save my card',
+	is_vaulting_enabled: true,
+	...overrides,
+	scriptData: {
+		client_id: 'client-id',
+		is_free_trial_cart: false,
+		locations_with_subscription_product: { cart: true },
+		hosted_fields: { labels: { fields_not_valid: 'Invalid fields' } },
+		...scriptDataOverrides,
+	},
+} );
+
+const renderCardFields = ( configOverrides = {} ) => {
+	const onPaymentSetup = jest.fn( () => () => {} );
+
+	render(
+		<CardFields
+			config={ baseConfig( configOverrides ) }
+			eventRegistration={ { onPaymentSetup } }
+			emitResponse={ {
+				responseTypes: { SUCCESS: 'success', ERROR: 'error' },
+			} }
+		/>
+	);
+};
+
+describe( 'CardFields', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'a submit for a subscription cart always requests the card be vaulted', () => {
+		renderCardFields( {
+			scriptData: { locations_with_subscription_product: { cart: true } },
+		} );
+
+		const providerCreateOrder =
+			PayPalCardFieldsProvider.mock.calls[ 0 ][ 0 ].createOrder;
+
+		providerCreateOrder();
+		providerCreateOrder();
+
+		expect( createOrder ).toHaveBeenCalledTimes( 2 );
+		expect( createOrder ).toHaveBeenNthCalledWith( 1, true );
+		expect( createOrder ).toHaveBeenNthCalledWith( 2, true );
+	} );
+
+	test( 'a retried submit for a non-subscription cart keeps asking to vault once the buyer opted in', async () => {
+		renderCardFields( {
+			scriptData: {
+				locations_with_subscription_product: { cart: false },
+			},
+		} );
+
+		await userEvent.click( screen.getByLabelText( 'Save my card' ) );
+
+		const providerCreateOrder =
+			PayPalCardFieldsProvider.mock.calls[ 0 ][ 0 ].createOrder;
+
+		providerCreateOrder();
+		providerCreateOrder();
+
+		expect( createOrder ).toHaveBeenNthCalledWith( 1, true );
+		expect( createOrder ).toHaveBeenNthCalledWith( 2, true );
+	} );
+} );

--- a/modules/ppcp-blocks/resources/js/card-fields-config.js
+++ b/modules/ppcp-blocks/resources/js/card-fields-config.js
@@ -37,9 +37,6 @@ export async function onApprove( data ) {
 		} ),
 	} )
 		.then( ( response ) => response.json() )
-		.then( ( data ) => {
-			localStorage.removeItem( 'ppcp-save-card-payment' );
-		} )
 		.catch( ( err ) => {
 			console.error( err );
 		} );

--- a/modules/ppcp-blocks/resources/js/card-fields-config.js
+++ b/modules/ppcp-blocks/resources/js/card-fields-config.js
@@ -1,4 +1,8 @@
-export async function createOrder() {
+/**
+ * @param {boolean} savePaymentMethod Whether to vault the card for later payments.
+ * @return {Promise<string>} The created PayPal order ID.
+ */
+export async function createOrder( savePaymentMethod = false ) {
 	const config = wc.wcSettings.getSetting( 'ppcp-credit-card-gateway_data' );
 
 	return fetch( config.scriptData.ajax.create_order.endpoint, {
@@ -10,8 +14,7 @@ export async function createOrder() {
 			nonce: config.scriptData.ajax.create_order.nonce,
 			context: config.scriptData.context,
 			payment_method: 'ppcp-credit-card-gateway',
-			save_payment_method:
-				localStorage.getItem( 'ppcp-save-card-payment' ) === 'true',
+			save_payment_method: savePaymentMethod,
 		} ),
 	} )
 		.then( ( response ) => response.json() )

--- a/modules/ppcp-blocks/resources/js/card-fields-config.test.js
+++ b/modules/ppcp-blocks/resources/js/card-fields-config.test.js
@@ -1,0 +1,145 @@
+import { createOrder, onApprove } from './card-fields-config';
+
+const baseScriptData = ( overrides = {} ) => ( {
+	ajax: {
+		create_order: {
+			endpoint: 'https://example.com/create-order',
+			nonce: 'create-order-nonce',
+		},
+		approve_order: {
+			endpoint: 'https://example.com/approve-order',
+			nonce: 'approve-order-nonce',
+		},
+	},
+	context: 'checkout-block',
+	...overrides,
+} );
+
+const mockScriptData = ( overrides = {} ) => {
+	global.wc = {
+		wcSettings: {
+			getSetting: jest.fn( () => ( {
+				scriptData: baseScriptData( overrides ),
+			} ) ),
+		},
+	};
+};
+
+describe( 'card-fields-config', () => {
+	let originalFetch;
+
+	beforeEach( () => {
+		originalFetch = global.fetch;
+		global.fetch = jest.fn();
+		jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		global.fetch = originalFetch;
+		jest.restoreAllMocks();
+		delete global.wc;
+		localStorage.clear();
+	} );
+
+	describe( 'createOrder()', () => {
+		beforeEach( () => {
+			mockScriptData();
+			global.fetch.mockResolvedValueOnce( {
+				json: async () => ( { data: { id: 'PAYPAL-ORDER-ID' } } ),
+			} );
+		} );
+
+		test( 'resolves to the PayPal order id from the response', async () => {
+			await expect( createOrder( true ) ).resolves.toBe(
+				'PAYPAL-ORDER-ID'
+			);
+		} );
+
+		test( 'sends nonce, context and the credit card payment method', async () => {
+			await createOrder( true );
+
+			const body = JSON.parse( global.fetch.mock.calls[ 0 ][ 1 ].body );
+			expect( body ).toMatchObject( {
+				nonce: 'create-order-nonce',
+				context: 'checkout-block',
+				payment_method: 'ppcp-credit-card-gateway',
+			} );
+		} );
+
+		test.each( [
+			[ true, true ],
+			[ false, false ],
+		] )(
+			'createOrder( %s ) puts save_payment_method: %s in the request body',
+			async ( input, expected ) => {
+				await createOrder( input );
+
+				const body = JSON.parse(
+					global.fetch.mock.calls[ 0 ][ 1 ].body
+				);
+				expect( body.save_payment_method ).toBe( expected );
+			}
+		);
+
+		test( 'defaults save_payment_method to false when called without an argument', async () => {
+			await createOrder();
+
+			const body = JSON.parse( global.fetch.mock.calls[ 0 ][ 1 ].body );
+			expect( body.save_payment_method ).toBe( false );
+		} );
+
+		test( 'does not read the buyer intent from localStorage', async () => {
+			const getItemSpy = jest.spyOn( Storage.prototype, 'getItem' );
+
+			await createOrder( true );
+
+			expect( getItemSpy ).not.toHaveBeenCalled();
+		} );
+
+		test( 'ignores a stale ppcp-save-card-payment value left in localStorage', async () => {
+			localStorage.setItem( 'ppcp-save-card-payment', 'false' );
+
+			await createOrder( true );
+
+			const body = JSON.parse( global.fetch.mock.calls[ 0 ][ 1 ].body );
+			expect( body.save_payment_method ).toBe( true );
+		} );
+	} );
+
+	describe( 'onApprove()', () => {
+		beforeEach( () => {
+			mockScriptData();
+			global.fetch.mockResolvedValueOnce( {
+				json: async () => ( { success: true } ),
+			} );
+		} );
+
+		test( 'posts the order id and nonce to the approve endpoint', async () => {
+			await onApprove( { orderID: 'PAYPAL-ORDER-ID' } );
+
+			expect( global.fetch ).toHaveBeenCalledWith(
+				'https://example.com/approve-order',
+				expect.objectContaining( {
+					method: 'POST',
+				} )
+			);
+			const body = JSON.parse( global.fetch.mock.calls[ 0 ][ 1 ].body );
+			expect( body ).toEqual( {
+				order_id: 'PAYPAL-ORDER-ID',
+				nonce: 'approve-order-nonce',
+			} );
+		} );
+
+		test( 'does not clear the buyer intent stored for a retried submit', async () => {
+			localStorage.setItem( 'ppcp-save-card-payment', 'true' );
+			const removeItemSpy = jest.spyOn( Storage.prototype, 'removeItem' );
+
+			await onApprove( { orderID: 'PAYPAL-ORDER-ID' } );
+
+			expect( removeItemSpy ).not.toHaveBeenCalled();
+			expect( localStorage.getItem( 'ppcp-save-card-payment' ) ).toBe(
+				'true'
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
### Description

**Problem.** On Block checkout, a guest buying a subscription with Advanced Card Processing enters their card, clicks *Place order*, and hits a WooCommerce validation error: a missing email. They fill the email in, place the order again, and it succeeds. The card is charged but **never vaulted**. Because the cart held a subscription, that leaves an **active subscription with no payment method to bill its renewals** so the buyer's first renewal will fail.

**Root cause.** The buyer's intent to vault the card travelled through a `localStorage` key, `ppcp-save-card-payment`:

| step | where |
|---|---|
| set when the card fields mount | `Components/card-fields.js` `useEffect` |
| read when the PayPal order is created | `card-fields-config.js` `createOrder` |
| **deleted once PayPal approves** | `card-fields-config.js` `onApprove` |

The first submit reaches PayPal and `onApprove` runs, deleting the key, *then* WooCommerce rejects the form. Nothing restores it within the same page load: the mount effect has already run, and the checkbox is `defaultChecked` **and `disabled`** for subscription carts, so it never fires a change. The retry therefore sends `save_payment_method: false`, and `SavePaymentMethodsModule` returns early without adding `payment_source.card.attributes.vault.store_in_vault`.

Classic checkout escaped this because it re-derives the value from the DOM on every submit


**Fix.** Hold the choice in a ref on the component that owns the card fields and pass it into `createOrder` explicitly on each submit

A ref rather than state because nothing renders from the value — the checkbox is uncontrolled — and because the callback then reads the current choice even if `PayPalCardFieldsProvider` memoizes the prop, which state captured in a closure would not. `localStorage` is gone from this path entirely; it is origin-wide, so two checkout tabs shared one value, and it outlived the page that set it.

### Evidence

Two consecutive create-order requests to PayPal, same card, same cart, captured from the plugin debug
log.

**Before** — the successful second attempt goes out with no vault attribute:

```
11:08:43  POST /v2/checkout/orders   →  "payment_source":{"card" … "store_in_vault":"ON_SUCCESS"
11:09:04  POST /v2/checkout/orders   →  "payment_source":{"card" …          ← missing
```

**After** — both attempts carry it, and the card is saved:

```
11:55:15  POST /v2/checkout/orders   →  store_in_vault ✔
11:55:38  POST /v2/checkout/orders   →  store_in_vault ✔
```

```
token_id  gateway_id                 user_id  type
2         ppcp-credit-card-gateway   5        CC     ← the new customer
```

Before the fix there was no token for the customer at all. The pattern held across page loads: only the
*first* create-order per page load carried the attribute.

### Steps to Test

Setup: WC Subscriptions active, **Save card details** enabled, ACDC enabled, 3DS set to *No 3D Secure*, cart and checkout pages using the Cart/Checkout blocks. Create a Simple subscription product with a recurring price and **no** free trial (the free-trial path uses `createVaultSetupToken` and is not affected).

1. In an incognito window as a **guest**, add the subscription to the cart and go to Block checkout.
2. Fill in a complete address but **leave the email empty**. Choose a shipping rate.
3. Select **Debit & Credit Cards** and enter card details.
4. Click **Place order once.** The email validation error appears. Do not reload, do not click again.
5. Fill in the email and click **Place order once.** The order completes.
6. **Expected:** My Account → Payment methods shows the saved card, and the new subscription has a payment method for renewals. Before this PR the card is absent.

Also worth confirming unchanged:

- a **free-trial** subscription still vaults via the setup-token path
- a **normal** (non-subscription) cart where the buyer ticks *Save your card* by hand still saves it, including after a failed first submit
- **classic** checkout still behaves as before

### Changelog Entry

> Fix - Credit card not saved on Block checkout when the first Place order attempt fails validation, leaving subscriptions without a payment method for renewals
