### PR TITLE
Add filter hooks for customizing the payment method title + allow icons (6630)

### DIFF
--- a/docs/payment-method-title-filters.md
+++ b/docs/payment-method-title-filters.md
@@ -1,0 +1,107 @@
+# Payment Method Title Filters
+
+## Overview
+
+The plugin enriches the payment method title of an order with the contextual payment details it
+received from PayPal, so an order shows `PayPal (buyer@example.com)` or
+`Debit & Credit Cards (Visa ending in 1234)` instead of just the gateway name.
+
+Enrichment happens in `PaymentMethodTitleEnricher::enrich()`, hooked onto WooCommerce's
+`woocommerce_order_get_payment_method_title` filter at priority `10`. It applies to four gateways —
+`ppcp-gateway`, `ppcp-credit-card-gateway`, `ppcp-applepay` and `ppcp-googlepay` — and builds the
+detail from order meta written at capture time:
+
+- Payment source `paypal` → the payer email (`_ppcp_paypal_payer_email`).
+- Payment sources `card`, `apple_pay`, `google_pay` → card brand plus last four digits
+  (`_ppcp_paypal_card_brand`, `_ppcp_paypal_card_last_digits`). Both must be present.
+- Any other payment source produces no detail, and the title is left unchanged.
+
+Three filters let you control the result. They are useful when you render orders yourself — custom
+order views, emails, PDF invoices or export integrations — and need a different format.
+
+## Filters
+
+### `woocommerce_paypal_payments_enrich_payment_method_title`
+
+Kill-switch for the whole feature. Return `false` to leave every payment method title untouched. It is
+evaluated first, so neither of the other two filters runs when it returns
+`false`.
+
+```php
+add_filter(
+    'woocommerce_paypal_payments_enrich_payment_method_title',
+    function ( bool $enrich, WC_Order $order ): bool {
+        // Keep the plain gateway name on orders synced to the ERP.
+        return $order->get_meta( '_my_plugin_erp_synced' ) ? false : $enrich;
+    },
+    10,
+    2
+);
+```
+
+### `woocommerce_paypal_payments_payment_method_title_detail`
+
+Filters just the detail string, before it is wrapped in parentheses and appended. Return an empty
+string to suppress the append for this order without disabling enrichment globally.
+
+```php
+add_filter(
+    'woocommerce_paypal_payments_payment_method_title_detail',
+    function ( string $detail, WC_Order $order ): string {
+        // Mask the payer email: "j***@example.com".
+        if ( is_email( $detail ) ) {
+            return preg_replace( '/^(.).*(@.*)$/', '$1***$2', $detail );
+        }
+
+        return $detail;
+    },
+    10,
+    2
+);
+```
+
+Notable behavior:
+
+- It runs once per `enrich()` call, only for the four supported gateways. It cannot bring an
+  unsupported gateway into enrichment.
+- It also runs when the plugin found no detail, receiving an empty string. That is the hook to use
+  when you want to add a detail the plugin does not produce — Venmo or other alternative payment
+  method sources, or card orders whose brand/last-digits meta is missing.
+
+### `woocommerce_paypal_payments_enriched_payment_method_title`
+
+Filters the fully assembled title, so you can change the separator, drop the parentheses or add
+markup.
+
+```php
+add_filter(
+    'woocommerce_paypal_payments_enriched_payment_method_title',
+    function ( string $enriched, string $title, string $detail, WC_Order $order ): string {
+        // Use an en dash instead of parentheses.
+        return sprintf( '%1$s &ndash; %2$s', $title, $detail );
+    },
+    10,
+    4
+);
+```
+
+Notable behavior:
+
+- `$title` is the original gateway title and `$detail` is the detail after
+  `woocommerce_paypal_payments_payment_method_title_detail` has been applied.
+- It runs only when a detail is actually appended — never when enrichment was switched off, the
+  gateway is unsupported, there is no detail, or the title already contains the detail.
+
+## Notes
+
+- The plugin does not escape the filtered values. The consumers escape the payment method title at output (`esc_html()` in templates, `wp_kses_post()` in HTML emails), so
+  escaping here would double-escape. If you interpolate untrusted data such as customer-supplied
+  meta, escape it yourself.
+- `woocommerce_order_get_payment_method_title` fires on every
+  `WC_Order::get_payment_method_title()` call — order list and edit screens, each email, the REST API,
+  exports. Keep your callbacks cheap and free of side effects; do not run queries or remote requests
+  in them.
+- WooCommerce Subscriptions copies the resulting title onto the subscription, so changes here also
+  affect subscription and renewal order views.
+- To change the title on paths these filters intentionally skip, hook
+  `woocommerce_order_get_payment_method_title` directly at a priority above `10`.

--- a/docs/payment-method-title-filters.md
+++ b/docs/payment-method-title-filters.md
@@ -16,7 +16,7 @@ detail from order meta written at capture time:
   (`_ppcp_paypal_card_brand`, `_ppcp_paypal_card_last_digits`). Both must be present.
 - Any other payment source produces no detail, and the title is left unchanged.
 
-Three filters let you control the result. They are useful when you render orders yourself — custom
+Four filters let you control the result. They are useful when you render orders yourself — custom
 order views, emails, PDF invoices or export integrations — and need a different format.
 
 ## Filters
@@ -68,6 +68,56 @@ Notable behavior:
   when you want to add a detail the plugin does not produce — Venmo or other alternative payment
   method sources, or card orders whose brand/last-digits meta is missing.
 
+### `woocommerce_paypal_payments_payment_method_title_icon`
+
+Opts into an icon in front of the detail. It defaults to an empty string, so no icon is rendered
+unless you return markup. The second argument is the URL of the bundled SVG for this order's payment
+source and card brand, already resolved for you.
+
+```php
+add_filter(
+    'woocommerce_paypal_payments_payment_method_title_icon',
+    function ( string $icon_html, string $icon_url ): string {
+        // Only render markup where it is safe to do so.
+        if ( ! is_order_received_page() || '' === $icon_url ) {
+            return $icon_html;
+        }
+
+        return '<img class="my-pm-icon" src="' . esc_url( $icon_url ) . '" alt="">';
+    },
+    10,
+    2
+);
+
+add_action(
+    'wp_head',
+    function (): void {
+        if ( ! is_order_received_page() ) {
+            return;
+        }
+
+        echo '<style>.my-pm-icon{display:inline;height:1em;vertical-align:middle}</style>';
+    }
+);
+```
+
+**The payment method title may be used in contexts where markup is unsafe** — plain-text emails, PDF
+invoices, REST responses, CSV exports etc. That is why the default is no icon: your
+callback is responsible for the context check, as in the `is_order_received_page()` gate above.
+
+Notable behavior:
+
+- Front-end order views print the title through `wp_kses_post()`, which filters the `style`
+  attribute against a fixed CSS property allow-list, which removes some properties, such as `display`.
+  To avoid this, style the icon with a `class` rather than inline CSS.
+- The markup is prepended inside the parentheses, separated by a space, and becomes part of the
+  `$detail` argument that `woocommerce_paypal_payments_enriched_payment_method_title` receives.
+- `$icon_url` is empty unless the brand has a bundled icon. Covered are Visa, Mastercard, American
+  Express, Discover, JCB, Elo, Hiper, PayPal and Venmo.
+- Apple Pay and Google Pay orders resolve to the icon of the underlying card brand.
+- `PaymentMethodTitleEnricher::get_icon_url( string $source, string $brand ): string` is public, so
+  you can resolve a different brand than the order's if you need to.
+
 ### `woocommerce_paypal_payments_enriched_payment_method_title`
 
 Filters the fully assembled title, so you can change the separator, drop the parentheses or add
@@ -88,7 +138,8 @@ add_filter(
 Notable behavior:
 
 - `$title` is the original gateway title and `$detail` is the detail after
-  `woocommerce_paypal_payments_payment_method_title_detail` has been applied.
+  `woocommerce_paypal_payments_payment_method_title_detail` and any icon markup from
+  `woocommerce_paypal_payments_payment_method_title_icon` have been applied.
 - It runs only when a detail is actually appended — never when enrichment was switched off, the
   gateway is unsupported, there is no detail, or the title already contains the detail.
 

--- a/modules/ppcp-wc-gateway/services.php
+++ b/modules/ppcp-wc-gateway/services.php
@@ -704,7 +704,9 @@ return array(
 	},
 
 	'wcgateway.payment-method-title-enricher'              => static function ( ContainerInterface $container ): PaymentMethodTitleEnricher {
-		return new PaymentMethodTitleEnricher();
+		return new PaymentMethodTitleEnricher(
+			$container->get( 'wcgateway.asset_getter' )
+		);
 	},
 
 	'wcgateway.checkout-helper'                            => static function ( ContainerInterface $container ): CheckoutHelper {

--- a/modules/ppcp-wc-gateway/src/Helper/PaymentMethodTitleEnricher.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PaymentMethodTitleEnricher.php
@@ -77,7 +77,20 @@ class PaymentMethodTitleEnricher {
 		}
 
 		$detail = $this->build_detail( $order );
-		if ( '' === $detail ) {
+
+		/**
+		 * The contextual detail appended to the payment method title.
+		 *
+		 * Also applied when the plugin found no detail, so an empty value can be
+		 * replaced with a custom one. Return an empty string to keep the title
+		 * unchanged without disabling enrichment globally.
+		 *
+		 * @param string   $detail The detail built from the order, or an empty string.
+		 * @param WC_Order $order  The order the title belongs to.
+		 */
+		$detail = (string) apply_filters( 'woocommerce_paypal_payments_payment_method_title_detail', $detail, $order );
+
+		if ( $detail === '' ) {
 			return $title;
 		}
 
@@ -86,7 +99,26 @@ class PaymentMethodTitleEnricher {
 			return $title;
 		}
 
-		return sprintf( '%1$s (%2$s)', $title, $detail );
+		$enriched = sprintf( '%1$s (%2$s)', $title, $detail );
+
+		/**
+		 * The payment method title after the detail was appended.
+		 *
+		 * Only applied when a detail is actually appended, never on the paths that
+		 * return the title unchanged.
+		 *
+		 * @param string   $enriched The assembled title, e.g. "PayPal (buyer@example.com)".
+		 * @param string   $title    The original payment method title.
+		 * @param string   $detail   The appended detail, already filtered.
+		 * @param WC_Order $order    The order the title belongs to.
+		 */
+		return (string) apply_filters(
+			'woocommerce_paypal_payments_enriched_payment_method_title',
+			$enriched,
+			$title,
+			$detail,
+			$order
+		);
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Helper/PaymentMethodTitleEnricher.php
+++ b/modules/ppcp-wc-gateway/src/Helper/PaymentMethodTitleEnricher.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 
 use WC_Order;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
@@ -55,6 +56,40 @@ class PaymentMethodTitleEnricher {
 	);
 
 	/**
+	 * Maps PayPal card brand identifiers to the bundled icon file name.
+	 *
+	 * Brands without a bundled icon are intentionally absent.
+	 *
+	 * @var array<string, string>
+	 */
+	private const BRAND_ICONS = array(
+		'VISA'             => 'visa',
+		'MASTERCARD'       => 'mastercard',
+		'AMEX'             => 'amex',
+		'AMERICAN_EXPRESS' => 'amex',
+		'DISCOVER'         => 'discover',
+		'JCB'              => 'jcb',
+		'ELO'              => 'elo',
+		'HIPER'            => 'hiper',
+	);
+
+	/**
+	 * Maps payment sources that have their own logo to the bundled icon file name.
+	 *
+	 * @var array<string, string>
+	 */
+	private const SOURCE_ICONS = array(
+		'paypal' => 'paypal',
+		'venmo'  => 'venmo',
+	);
+
+	private AssetGetter $asset_getter;
+
+	public function __construct( AssetGetter $asset_getter ) {
+		$this->asset_getter = $asset_getter;
+	}
+
+	/**
 	 * Returns the payment method title enriched with contextual payment details,
 	 * or the original title when enrichment is disabled or no details are available.
 	 *
@@ -99,6 +134,39 @@ class PaymentMethodTitleEnricher {
 			return $title;
 		}
 
+		$source = $this->payment_source( $order );
+		$brand  = $this->card_brand( $order );
+
+		/**
+		 * HTML for an icon prepended to the payment method title detail.
+		 *
+		 * Defaults to an empty string, so no icon is rendered unless a callback opts in.
+		 *
+		 * Note that the payment method title may be used in contexts where markup is unsafe —
+		 * plain-text emails, PDF invoices, REST responses, ... — so a callback is responsible
+		 * for checking the context. Front-end order views also run the title through
+		 * wp_kses_post(), which strips disallowed inline CSS properties, so prefer a class
+		 * over inline styles.
+		 *
+		 * @param string   $icon_html The icon markup. Default empty string.
+		 * @param string   $icon_url  URL of the bundled icon for this source and brand, or empty.
+		 * @param string   $source    The raw payment source meta value, e.g. "paypal" or "card".
+		 * @param string   $brand     The raw card brand, e.g. "VISA". Empty for non-card sources.
+		 * @param WC_Order $order     The order the title belongs to.
+		 */
+		$icon_html = (string) apply_filters(
+			'woocommerce_paypal_payments_payment_method_title_icon',
+			'',
+			$this->get_icon_url( $source, $brand ),
+			$source,
+			$brand,
+			$order
+		);
+
+		if ( $icon_html !== '' ) {
+			$detail = $icon_html . ' ' . $detail;
+		}
+
 		$enriched = sprintf( '%1$s (%2$s)', $title, $detail );
 
 		/**
@@ -122,21 +190,44 @@ class PaymentMethodTitleEnricher {
 	}
 
 	/**
+	 * Returns the URL of the bundled icon for the given payment source and card brand,
+	 * or an empty string when no icon is bundled for them.
+	 *
+	 * @param string $source The payment source, e.g. "paypal" or "card".
+	 * @param string $brand  The card brand, e.g. "VISA". Ignored for non-card sources.
+	 */
+	public function get_icon_url( string $source, string $brand ): string {
+		if ( isset( self::SOURCE_ICONS[ $source ] ) ) {
+			return $this->asset_getter->get_static_asset_url( 'images/' . self::SOURCE_ICONS[ $source ] . '.svg' );
+		}
+
+		if ( in_array( $source, self::CARD_SOURCES, true ) ) {
+			$file = self::BRAND_ICONS[ strtoupper( $brand ) ] ?? '';
+
+			return $file === ''
+				? ''
+				: $this->asset_getter->get_static_asset_url( "images/$file.svg" );
+		}
+
+		return '';
+	}
+
+	/**
 	 * Builds the contextual detail string for the order, or an empty string when unavailable.
 	 */
 	private function build_detail( WC_Order $order ): string {
-		$source = (string) $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY );
+		$source = $this->payment_source( $order );
 
-		if ( 'paypal' === $source ) {
+		if ( $source === 'paypal' ) {
 			$email = sanitize_email( (string) $order->get_meta( PayPalGateway::ORDER_PAYER_EMAIL_META_KEY ) );
 			return $email;
 		}
 
 		if ( in_array( $source, self::CARD_SOURCES, true ) ) {
-			$brand       = (string) $order->get_meta( PayPalGateway::ORDER_CARD_BRAND_META_KEY );
+			$brand       = $this->card_brand( $order );
 			$last_digits = (string) $order->get_meta( PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY );
 
-			if ( '' === $brand || '' === $last_digits ) {
+			if ( $brand === '' || $last_digits === '' ) {
 				return '';
 			}
 
@@ -149,6 +240,20 @@ class PaymentMethodTitleEnricher {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Returns the payment source stored on the order, e.g. "paypal" or "card".
+	 */
+	private function payment_source( WC_Order $order ): string {
+		return (string) $order->get_meta( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY );
+	}
+
+	/**
+	 * Returns the raw card brand stored on the order, e.g. "VISA", or an empty string.
+	 */
+	private function card_brand( WC_Order $order ): string {
+		return (string) $order->get_meta( PayPalGateway::ORDER_CARD_BRAND_META_KEY );
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Helper/PaymentMethodTitleEnricherTest.php
+++ b/tests/PHPUnit/WcGateway/Helper/PaymentMethodTitleEnricherTest.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Helper;
 use Mockery;
 use WC_Order;
 use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
@@ -17,7 +18,10 @@ class PaymentMethodTitleEnricherTest extends TestCase
 {
 	private const OPT_OUT_FILTER = 'woocommerce_paypal_payments_enrich_payment_method_title';
 	private const DETAIL_FILTER = 'woocommerce_paypal_payments_payment_method_title_detail';
+	private const ICON_FILTER = 'woocommerce_paypal_payments_payment_method_title_icon';
 	private const ENRICHED_FILTER = 'woocommerce_paypal_payments_enriched_payment_method_title';
+
+	private const ASSET_BASE_URL = 'https://example.com/wp-content/plugins/woocommerce-paypal-payments/modules/ppcp-wc-gateway/assets/';
 
 	private $testee;
 
@@ -27,7 +31,24 @@ class PaymentMethodTitleEnricherTest extends TestCase
 
 		when('sanitize_email')->returnArg();
 
-		$this->testee = new PaymentMethodTitleEnricher();
+		$asset_getter = Mockery::mock( AssetGetter::class );
+		$asset_getter->shouldReceive( 'get_static_asset_url' )
+			->andReturnUsing(
+				static function ( string $asset_name ): string {
+					return self::ASSET_BASE_URL . $asset_name;
+				}
+			);
+
+		$this->testee = new PaymentMethodTitleEnricher( $asset_getter );
+	}
+
+	/**
+	 * Builds the expected icon URL for a given bundled icon file name,
+	 * matching the mocked AssetGetter in setUp().
+	 */
+	private function iconUrl( string $file ): string
+	{
+		return self::ASSET_BASE_URL . "images/$file.svg";
 	}
 
 	public function testAppendsPayerEmailForPayPal(): void
@@ -635,6 +656,478 @@ class PaymentMethodTitleEnricherTest extends TestCase
 		self::assertSame(
 			'PayPal (B)',
 			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a card payment source
+	 * WHEN the icon URL is resolved for a mapped brand
+	 * THEN the bundled icon file for that brand is returned
+	 * AND the brand lookup is case-insensitive
+	 *
+	 * @dataProvider mappedCardBrandProvider
+	 */
+	public function testGetIconUrlResolvesMappedCardBrand( string $brand, string $expected_file ): void
+	{
+		self::assertSame(
+			$this->iconUrl( $expected_file ),
+			$this->testee->get_icon_url( 'card', $brand )
+		);
+	}
+
+	public function mappedCardBrandProvider(): array
+	{
+		return array(
+			'visa'                     => array( 'VISA', 'visa' ),
+			'lower-case visa normalizes to upper case' => array( 'visa', 'visa' ),
+			'mastercard'               => array( 'MASTERCARD', 'mastercard' ),
+			'amex'                     => array( 'AMEX', 'amex' ),
+			'american_express aliases to amex' => array( 'AMERICAN_EXPRESS', 'amex' ),
+			'discover'                 => array( 'DISCOVER', 'discover' ),
+			'jcb'                      => array( 'JCB', 'jcb' ),
+			'elo'                      => array( 'ELO', 'elo' ),
+			'hiper'                    => array( 'HIPER', 'hiper' ),
+		);
+	}
+
+	/**
+	 * GIVEN a card payment source
+	 * WHEN the icon URL is resolved for a brand with no bundled icon
+	 * THEN an empty string is returned
+	 *
+	 * @dataProvider unmappedCardBrandProvider
+	 */
+	public function testGetIconUrlReturnsEmptyStringForUnmappedCardBrand( string $brand ): void
+	{
+		self::assertSame( '', $this->testee->get_icon_url( 'card', $brand ) );
+	}
+
+	public function unmappedCardBrandProvider(): array
+	{
+		return array(
+			'diners'        => array( 'DINERS' ),
+			'maestro'       => array( 'MAESTRO' ),
+			'solo'          => array( 'SOLO' ),
+			'switch'        => array( 'SWITCH' ),
+			'unionpay'      => array( 'UNIONPAY' ),
+			'unknown brand' => array( 'FOO_BAR' ),
+			'empty brand'   => array( '' ),
+		);
+	}
+
+	/**
+	 * GIVEN a payment source with its own bundled logo
+	 * WHEN the icon URL is resolved
+	 * THEN the source's own icon is returned regardless of card brand
+	 * AND unsupported sources resolve to an empty string
+	 */
+	public function testGetIconUrlResolvesSourcesWithTheirOwnLogo(): void
+	{
+		self::assertSame( $this->iconUrl( 'paypal' ), $this->testee->get_icon_url( 'paypal', '' ) );
+		self::assertSame( $this->iconUrl( 'venmo' ), $this->testee->get_icon_url( 'venmo', '' ) );
+		self::assertSame( '', $this->testee->get_icon_url( 'bancontact', '' ) );
+	}
+
+	/**
+	 * GIVEN a wallet source that carries an underlying card brand
+	 * WHEN the icon URL is resolved
+	 * THEN the icon of the underlying card brand is returned
+	 */
+	public function testGetIconUrlResolvesWalletSourcesToUnderlyingCardBrand(): void
+	{
+		self::assertSame(
+			$this->iconUrl( 'mastercard' ),
+			$this->testee->get_icon_url( 'apple_pay', 'MASTERCARD' )
+		);
+		self::assertSame(
+			$this->iconUrl( 'visa' ),
+			$this->testee->get_icon_url( 'google_pay', 'VISA' )
+		);
+	}
+
+	/**
+	 * GIVEN a payment source with its own bundled logo
+	 * WHEN a card brand is also present
+	 * THEN the source's own icon wins and the card brand is ignored
+	 */
+	public function testGetIconUrlSourceMapWinsOverCardBrand(): void
+	{
+		self::assertSame(
+			$this->iconUrl( 'paypal' ),
+			$this->testee->get_icon_url( 'paypal', 'VISA' )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN no callback is registered on the icon filter
+	 * THEN the title is enriched exactly as before the icon filter existed
+	 */
+	public function testEnrichIsUnchangedWhenNoIconFilterCallbackIsRegistered(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		self::assertSame(
+			'PayPal (john@example.com)',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the icon filter returns markup
+	 * THEN the markup is prepended to the detail, separated by a single space
+	 */
+	public function testIconFilterMarkupIsPrependedToDetail(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )
+			->once()
+			->andReturn( '<img src="x.svg">' );
+
+		self::assertSame(
+			'PayPal (<img src="x.svg"> john@example.com)',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the title is enriched
+	 * THEN the icon filter receives the resolved icon URL, the source, the empty brand, and the order
+	 */
+	public function testIconFilterReceivesAllArgumentsForPayPalOrder(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )
+			->once()
+			->with( '', $this->iconUrl( 'paypal' ), 'paypal', '', $order )
+			->andReturn( '' );
+
+		self::assertSame(
+			'PayPal (john@example.com)',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a card order with a mapped brand
+	 * WHEN the title is enriched
+	 * THEN the icon filter receives the resolved icon URL, the card source, the brand, and the order
+	 */
+	public function testIconFilterReceivesAllArgumentsForCardOrder(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )
+			->once()
+			->with( '', $this->iconUrl( 'visa' ), 'card', 'VISA', $order )
+			->andReturn( '' );
+
+		self::assertSame(
+			'Debit & Credit Cards (Visa ending in 1234)',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	/**
+	 * GIVEN an Apple Pay order carrying an underlying card brand
+	 * WHEN the title is enriched
+	 * THEN the icon filter's source argument is "apple_pay" and its URL argument resolves the underlying brand
+	 */
+	public function testIconFilterReceivesUnderlyingBrandUrlForApplePayOrder(): void
+	{
+		$order = $this->makeOrder(
+			ApplePayGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'apple_pay',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'MASTERCARD',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '5678',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )
+			->once()
+			->with( '', $this->iconUrl( 'mastercard' ), 'apple_pay', 'MASTERCARD', $order )
+			->andReturn( '' );
+
+		self::assertSame(
+			'Apple Pay (Mastercard ending in 5678)',
+			$this->testee->enrich( 'Apple Pay', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a card order whose brand has no bundled icon
+	 * WHEN the title is enriched
+	 * THEN the icon filter still receives the raw brand, but with an empty resolved icon URL
+	 */
+	public function testIconFilterReceivesEmptyUrlForUnmappedBrand(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'MAESTRO',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )
+			->once()
+			->with( '', '', 'card', 'MAESTRO', $order )
+			->andReturn( '' );
+
+		self::assertSame(
+			'Debit & Credit Cards (Maestro ending in 1234)',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the icon filter explicitly returns an empty string
+	 * THEN the detail is left unprefixed
+	 */
+	public function testIconFilterReturningEmptyStringLeavesDetailUnprefixed(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )
+			->once()
+			->andReturn( '' );
+
+		self::assertSame(
+			'PayPal (john@example.com)',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a merchant has opted out of title enrichment
+	 * WHEN the title is enriched
+	 * THEN the icon filter never fires
+	 */
+	public function testIconFilterNeverFiresWhenOptedOut(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::OPT_OUT_FILTER )
+			->once()
+			->andReturn( false );
+
+		expectApplied( self::ICON_FILTER )->never();
+
+		self::assertSame( 'PayPal', $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	/**
+	 * GIVEN an order placed through an unsupported gateway
+	 * WHEN the title is enriched
+	 * THEN the icon filter never fires
+	 */
+	public function testIconFilterNeverFiresForUnsupportedGateway(): void
+	{
+		$order = $this->makeOrder(
+			'ppcp-card-button-gateway',
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )->never();
+
+		self::assertSame(
+			'Debit & Credit Cards',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a card order with no detail available
+	 * WHEN the title is enriched
+	 * THEN the icon filter never fires because there is no detail to prepend an icon onto
+	 */
+	public function testIconFilterNeverFiresWhenDetailIsEmpty(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'card' )
+		);
+
+		expectApplied( self::ICON_FILTER )->never();
+
+		self::assertSame(
+			'Debit & Credit Cards',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a title that already contains the built detail
+	 * WHEN the title is enriched
+	 * THEN the dedupe guard short-circuits before the icon filter ever fires
+	 */
+	public function testIconFilterNeverFiresOnDedupeHit(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )->never();
+
+		$already_enriched = 'Debit & Credit Cards (Visa ending in 1234)';
+
+		self::assertSame(
+			$already_enriched,
+			$this->testee->enrich( $already_enriched, $order )
+		);
+	}
+
+	/**
+	 * GIVEN a card title that already contains the icon markup and the detail
+	 * WHEN the title is enriched again
+	 * THEN the title is returned unchanged, with no double-prepended icon
+	 * AND the icon filter never fires because the dedupe guard short-circuits first
+	 */
+	public function testNoDoublePrependOnReEnrichmentWithIcon(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		$icon_markup = '<img src="' . $this->iconUrl( 'visa' ) . '">';
+		$already_enriched = "Debit & Credit Cards ($icon_markup Visa ending in 1234)";
+
+		expectApplied( self::ICON_FILTER )
+			->never()
+			->andReturn( $icon_markup );
+
+		self::assertSame(
+			$already_enriched,
+			$this->testee->enrich( $already_enriched, $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the detail filter rewrites the detail and the icon filter supplies markup
+	 * THEN the enriched-title filter receives the icon-prefixed detail as both the detail and part of the assembled title
+	 */
+	public function testEnrichedTitleFilterReceivesIconPrefixedDetail(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->andReturn( 'B' );
+
+		expectApplied( self::ICON_FILTER )
+			->once()
+			->andReturn( '<img src="i.svg">' );
+
+		expectApplied( self::ENRICHED_FILTER )
+			->once()
+			->with( 'PayPal (<img src="i.svg"> B)', 'PayPal', '<img src="i.svg"> B', $order )
+			->andReturnUsing(
+				static function ( $enriched ) {
+					return $enriched;
+				}
+			);
+
+		self::assertSame(
+			'PayPal (<img src="i.svg"> B)',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the icon filter returns a value that is cast via (string)
+	 * THEN the resulting title reflects the casted value
+	 *
+	 * @dataProvider iconFilterCastProvider
+	 */
+	public function testIconFilterReturnValueIsCastToString( $filtered_icon, string $expected_title ): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::ICON_FILTER )
+			->once()
+			->andReturn( $filtered_icon );
+
+		self::assertSame( $expected_title, $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	public function iconFilterCastProvider(): array
+	{
+		return array(
+			'integer icon markup is cast to its string representation' => array( 12345, 'PayPal (12345 john@example.com)' ),
+			'null icon casts to an empty string, detail stays unprefixed' => array( null, 'PayPal (john@example.com)' ),
+			'false icon casts to an empty string, detail stays unprefixed' => array( false, 'PayPal (john@example.com)' ),
 		);
 	}
 

--- a/tests/PHPUnit/WcGateway/Helper/PaymentMethodTitleEnricherTest.php
+++ b/tests/PHPUnit/WcGateway/Helper/PaymentMethodTitleEnricherTest.php
@@ -11,9 +11,14 @@ use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use function Brain\Monkey\Functions\when;
+use function Brain\Monkey\Filters\expectApplied;
 
 class PaymentMethodTitleEnricherTest extends TestCase
 {
+	private const OPT_OUT_FILTER = 'woocommerce_paypal_payments_enrich_payment_method_title';
+	private const DETAIL_FILTER = 'woocommerce_paypal_payments_payment_method_title_detail';
+	private const ENRICHED_FILTER = 'woocommerce_paypal_payments_enriched_payment_method_title';
+
 	private $testee;
 
 	public function setUp(): void
@@ -210,6 +215,426 @@ class PaymentMethodTitleEnricherTest extends TestCase
 		self::assertSame(
 			$already_enriched,
 			$this->testee->enrich( $already_enriched, $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order with a payer email
+	 * WHEN the detail filter rewrites the built detail
+	 * THEN the rewritten detail is appended to the title
+	 * AND the filter receives the built detail and the order
+	 */
+	public function testDetailFilterReceivesBuiltDetailAndAppendsFilteredValue(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->with( 'john@example.com', $order )
+			->andReturn( 'Verified: john@example.com' );
+
+		self::assertSame(
+			'PayPal (Verified: john@example.com)',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order with a payer email
+	 * WHEN the detail filter suppresses the detail by returning an empty string
+	 * THEN the title stays unchanged even though enrichment itself is still enabled
+	 */
+	public function testEmptyDetailFilterReturnValueSuppressesAppend(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->with( 'john@example.com', $order )
+			->andReturn( '' );
+
+		self::assertSame( 'PayPal', $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	/**
+	 * GIVEN a supported gateway whose payment source yields no built-in detail
+	 * WHEN the detail filter supplies a detail of its own
+	 * THEN the filter is invoked with an empty built detail
+	 * AND the supplied detail is appended to the title
+	 */
+	public function testDetailFilterCanSupplyDetailWhenSourceHasNone(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'venmo' )
+		);
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->with( '', $order )
+			->andReturn( '@johndoe' );
+
+		self::assertSame(
+			'PayPal (@johndoe)',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a card order missing the last-digits meta
+	 * WHEN the detail filter supplies a detail of its own
+	 * THEN the filter is invoked with an empty built detail
+	 * AND the supplied detail is appended to the title
+	 */
+	public function testDetailFilterCanSupplyDetailForPartialCardData(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY     => 'VISA',
+			)
+		);
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->with( '', $order )
+			->andReturn( 'Card on file' );
+
+		self::assertSame(
+			'Debit & Credit Cards (Card on file)',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	/**
+	 * GIVEN an order placed through an unsupported gateway
+	 * WHEN the title is enriched
+	 * THEN the detail filter never fires
+	 * AND the title stays unchanged
+	 */
+	public function testDetailFilterNeverFiresForUnsupportedGateway(): void
+	{
+		$order = $this->makeOrder(
+			'ppcp-card-button-gateway',
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		expectApplied( self::DETAIL_FILTER )->never();
+
+		self::assertSame(
+			'Debit & Credit Cards',
+			$this->testee->enrich( 'Debit & Credit Cards', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a merchant has opted out of title enrichment
+	 * WHEN the title is enriched
+	 * THEN the detail filter never fires
+	 * AND the title stays unchanged
+	 */
+	public function testDetailFilterNeverFiresWhenOptedOut(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::OPT_OUT_FILTER )
+			->once()
+			->with( true, $order )
+			->andReturn( false );
+
+		expectApplied( self::DETAIL_FILTER )->never();
+
+		self::assertSame( 'PayPal', $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	/**
+	 * GIVEN a card title that already contains the detail the filter returns
+	 * WHEN the title is enriched
+	 * THEN the duplicate-append guard compares against the FILTERED detail
+	 * AND the title stays unchanged
+	 */
+	public function testDedupeGuardComparesAgainstFilteredDetail(): void
+	{
+		$order = $this->makeOrder(
+			CreditCardGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+				PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+				PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+			)
+		);
+
+		$already_enriched = 'Debit & Credit Cards (Visa •••• 1234)';
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->andReturn( 'Visa •••• 1234' );
+
+		self::assertSame(
+			$already_enriched,
+			$this->testee->enrich( $already_enriched, $order )
+		);
+	}
+
+	/**
+	 * GIVEN a title that already contains the built-in detail
+	 * WHEN the detail filter rewrites the detail to a different value
+	 * THEN the new detail is appended even though the title was previously enriched
+	 */
+	public function testFilteredDetailIsAppendedWhenItDiffersFromTitleContent(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->andReturn( 'Verified' );
+
+		self::assertSame(
+			'PayPal (john@example.com) (Verified)',
+			$this->testee->enrich( 'PayPal (john@example.com)', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the detail filter returns a value that is cast via (string)
+	 * THEN the resulting title reflects the casted value
+	 *
+	 * @dataProvider detailFilterCastProvider
+	 */
+	public function testDetailFilterReturnValueIsCastToString( $filtered_detail, string $expected_title ): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->andReturn( $filtered_detail );
+
+		self::assertSame( $expected_title, $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	public function detailFilterCastProvider(): array
+	{
+		return array(
+			'integer detail is cast to its string representation' => array( 12345, 'PayPal (12345)' ),
+			'null detail casts to an empty string, title unchanged' => array( null, 'PayPal' ),
+			'false detail casts to an empty string, title unchanged' => array( false, 'PayPal' ),
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the enriched-title filter rewrites the assembled title
+	 * THEN its return value is used verbatim
+	 */
+	public function testEnrichedTitleFilterReturnValueIsUsedVerbatim(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::ENRICHED_FILTER )
+			->once()
+			->andReturn( 'PayPal — john@example.com' );
+
+		self::assertSame(
+			'PayPal — john@example.com',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the title is enriched
+	 * THEN the enriched-title filter receives the assembled title, the original title, the detail, and the order
+	 */
+	public function testEnrichedTitleFilterReceivesAssembledTitleOriginalTitleDetailAndOrder(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::ENRICHED_FILTER )
+			->once()
+			->with( 'PayPal (john@example.com)', 'PayPal', 'john@example.com', $order )
+			->andReturnUsing(
+				static function ( $enriched ) {
+					return $enriched;
+				}
+			);
+
+		self::assertSame(
+			'PayPal (john@example.com)',
+			$this->testee->enrich( 'PayPal', $order )
+		);
+	}
+
+	/**
+	 * GIVEN a merchant has opted out of title enrichment
+	 * WHEN the title is enriched
+	 * THEN the enriched-title filter never fires
+	 */
+	public function testEnrichedTitleFilterNeverFiresWhenOptedOut(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::OPT_OUT_FILTER )
+			->once()
+			->andReturn( false );
+
+		expectApplied( self::ENRICHED_FILTER )->never();
+
+		self::assertSame( 'PayPal', $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	/**
+	 * GIVEN one of several early-return scenarios
+	 * WHEN the title is enriched
+	 * THEN the enriched-title filter never fires because no detail is appended
+	 *
+	 * @dataProvider enrichedTitleNeverFiresProvider
+	 */
+	public function testEnrichedTitleFilterNeverFiresOnEarlyReturn( string $gateway, array $meta, string $title ): void
+	{
+		$order = $this->makeOrder( $gateway, $meta );
+
+		expectApplied( self::ENRICHED_FILTER )->never();
+
+		self::assertSame( $title, $this->testee->enrich( $title, $order ) );
+	}
+
+	public function enrichedTitleNeverFiresProvider(): array
+	{
+		return array(
+			'unsupported gateway'          => array(
+				'ppcp-card-button-gateway',
+				array(
+					PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+					PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+					PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+				),
+				'Debit & Credit Cards',
+			),
+			'card order with no card meta' => array(
+				CreditCardGateway::ID,
+				array( PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'card' ),
+				'Debit & Credit Cards',
+			),
+			'title already contains the built detail' => array(
+				CreditCardGateway::ID,
+				array(
+					PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY  => 'card',
+					PayPalGateway::ORDER_CARD_BRAND_META_KEY      => 'VISA',
+					PayPalGateway::ORDER_CARD_LAST_DIGITS_META_KEY => '1234',
+				),
+				'Debit & Credit Cards (Visa ending in 1234)',
+			),
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the enriched-title filter returns an empty string
+	 * THEN the result is an empty string, with no fallback to the original title
+	 */
+	public function testEnrichedTitleFilterReturningEmptyStringYieldsEmptyString(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::ENRICHED_FILTER )
+			->once()
+			->andReturn( '' );
+
+		self::assertSame( '', $this->testee->enrich( 'PayPal', $order ) );
+	}
+
+	/**
+	 * GIVEN a PayPal order
+	 * WHEN the detail filter rewrites the detail
+	 * THEN the enriched-title filter receives the assembled title built from the rewritten detail
+	 */
+	public function testEnrichedTitleFilterReceivesTitleBuiltFromFilteredDetail(): void
+	{
+		$order = $this->makeOrder(
+			PayPalGateway::ID,
+			array(
+				PayPalGateway::ORDER_PAYMENT_SOURCE_META_KEY => 'paypal',
+				PayPalGateway::ORDER_PAYER_EMAIL_META_KEY    => 'john@example.com',
+			)
+		);
+
+		expectApplied( self::DETAIL_FILTER )
+			->once()
+			->with( 'john@example.com', $order )
+			->andReturn( 'B' );
+
+		expectApplied( self::ENRICHED_FILTER )
+			->once()
+			->with( 'PayPal (B)', 'PayPal', 'B', $order )
+			->andReturnUsing(
+				static function ( $enriched ) {
+					return $enriched;
+				}
+			);
+
+		self::assertSame(
+			'PayPal (B)',
+			$this->testee->enrich( 'PayPal', $order )
 		);
 	}
 


### PR DESCRIPTION
Fixes #4488

## 🎯 The goal

`PaymentMethodTitleEnricher` appends payment context to the gateway title, for example `PayPal (buyer@example.com)` or `Debit & Credit Cards (Visa ending in 1234)`. Until now its only extension point was `woocommerce_paypal_payments_enrich_payment_method_title`, a boolean kill-switch.

That leaves integrators building custom order views, emails, PDF invoices or export tooling with one choice: accept the exact `%1$s (%2$s)` format, or lose enrichment entirely. This adds three finer-grained filters so the output can be reshaped without turning the feature off.

## ✅ The fix

- `..._payment_method_title_detail` filters the detail string before it is appended. Returning an empty string suppresses the append for a single order without disabling enrichment globally. It also fires when the plugin found no detail, so a callback can supply one for sources the plugin does not cover.
- `..._payment_method_title_icon` opts into a card brand or PayPal logo in front of the detail, defaulting to no icon.
- `..._enriched_payment_method_title` filters the fully assembled string, for changing the separator or dropping the parentheses.

The enricher now receives `wcgateway.asset_getter`, resolves the bundled SVG URL itself and passes it to the icon callback, so integrators never hard-code asset paths. `get_icon_url()` is public for callbacks that want a brand other than the order's. All four hooks are documented in a new `docs/payment-method-title-filters.md`.

## 🔍 What to review

- **Step ordering in `enrich()` is important.** The detail filter runs before the empty-detail check, so a callback can both suppress and supply a detail. The duplicate-append guard then runs on the filtered detail but before icon markup is prepended, because the plain-text detail is the substring that survives inside an already-enriched title. Moving the icon step above that guard would let non-deterministic markup defeat dedupe, and since the hook fires on every `WC_Order::get_payment_method_title()` call, the detail would re-append on each read.
- **Filtered values are deliberately not escaped**, matching the existing `woocommerce_paypal_payments_gateway_description` precedent: this is a model-layer filter and consumers escape at output. One related consequence is that front-end order views run the title through `wp_kses_post()`, which drops inline CSS properties absent from the core allow-list, `display` among them. The docs tell integrators to style with a class instead.

## 🧪 How to verify

1. Add the icon snippet from `docs/payment-method-title-filters.md` to a plugin, then open the order received page for a paid PayPal order and for a paid card order.
2. Reload each page and confirm the detail and icon do not accumulate.
3. Similarly, try the snippets for other filters and confirm the expected behavior. 

## Screenshots

Example result of using the icon filter:

<img width="514" height="432" alt="image" src="https://github.com/user-attachments/assets/b9dff7ba-1c08-4ab4-af76-fc9605d11eed" /> <img width="440" height="425" alt="image" src="https://github.com/user-attachments/assets/a7c7288a-e462-4aa8-8f53-e96d4bf529a1" />
