### PR TITLE
fix(settings): restrict the Invoice Prefix to safe characters (5973)

### DIFF
--- a/modules/ppcp-settings/resources/css/components/reusable-components/_fields.scss
+++ b/modules/ppcp-settings/resources/css/components/reusable-components/_fields.scss
@@ -119,6 +119,16 @@
 			gap: 0;
 			margin: 0;
 		}
+
+		&.ppcp--has-error input {
+			border-color: var(--color-error);
+		}
+	}
+
+	.ppcp-r-control-error {
+		@include font(11, 16, 450);
+		margin: 4px 0 0;
+		color: var(--color-error);
 	}
 }
 

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Controls/ControlTextInput.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Controls/ControlTextInput.js
@@ -1,4 +1,5 @@
 import { TextControl } from '@wordpress/components';
+import classNames from 'classnames';
 
 import { Action, Description } from '../Elements';
 
@@ -6,16 +7,23 @@ const ControlTextInput = ( {
 	value,
 	description,
 	onChange,
+	onBlur,
 	placeholder = '',
+	error = '',
 } ) => (
 	<Action>
 		<TextControl
 			__nextHasNoMarginBottom
-			className="ppcp-r-vertical-text-control"
+			className={ classNames( 'ppcp-r-vertical-text-control', {
+				'ppcp--has-error': !! error,
+			} ) }
 			placeholder={ placeholder }
 			value={ value }
 			onChange={ onChange }
+			onBlur={ onBlur }
+			aria-invalid={ !! error }
 		/>
+		{ error && <p className="ppcp-r-control-error">{ error }</p> }
 		<Description>{ description }</Description>
 	</Action>
 );

--- a/modules/ppcp-settings/resources/js/Components/ReusableComponents/Controls/ControlTextInput.test.js
+++ b/modules/ppcp-settings/resources/js/Components/ReusableComponents/Controls/ControlTextInput.test.js
@@ -1,0 +1,121 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ControlTextInput from './ControlTextInput';
+
+// `Action` pulls in useScrollTarget(), which needs scroll-highlight context
+// this test does not provide. Stub it as a passthrough so the test focuses
+// on ControlTextInput's own error rendering.
+jest.mock( '../Elements', () => ( {
+	Action: ( { children } ) => <div>{ children }</div>,
+	Description: ( { children } ) => <>{ children }</>,
+} ) );
+
+// The shared @wordpress/components mock only exports Button, so TextControl
+// needs a local stub. It forwards the relevant props onto a real <input>,
+// since those props are what ControlTextInput computes and this test verifies.
+jest.mock( '@wordpress/components', () => ( {
+	TextControl: ( {
+		className,
+		value,
+		onChange,
+		onBlur,
+		placeholder,
+		'aria-invalid': ariaInvalid,
+	} ) => (
+		<input
+			className={ className }
+			aria-invalid={ ariaInvalid }
+			value={ value }
+			onChange={ ( e ) => onChange( e.target.value ) }
+			onBlur={ onBlur }
+			placeholder={ placeholder }
+		/>
+	),
+} ) );
+
+describe( 'ControlTextInput', () => {
+	describe( 'when error is not set', () => {
+		test( 'does not render an error message', () => {
+			render(
+				<ControlTextInput
+					value=""
+					placeholder="Input prefix"
+					onChange={ jest.fn() }
+				/>
+			);
+
+			expect(
+				screen.queryByText( /./, { selector: '.ppcp-r-control-error' } )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'does not mark the input as invalid', () => {
+			render(
+				<ControlTextInput
+					value=""
+					placeholder="Input prefix"
+					onChange={ jest.fn() }
+				/>
+			);
+
+			const input = screen.getByPlaceholderText( 'Input prefix' );
+
+			expect( input ).toHaveAttribute( 'aria-invalid', 'false' );
+			expect( input ).not.toHaveClass( 'ppcp--has-error' );
+		} );
+	} );
+
+	test( 'calls onBlur when the input loses focus', () => {
+		const onBlur = jest.fn();
+
+		render(
+			<ControlTextInput
+				value=""
+				placeholder="Input prefix"
+				onChange={ jest.fn() }
+				onBlur={ onBlur }
+			/>
+		);
+
+		fireEvent.blur( screen.getByPlaceholderText( 'Input prefix' ) );
+
+		expect( onBlur ).toHaveBeenCalled();
+	} );
+
+	describe( 'when error is set', () => {
+		test( 'renders the error text in a ppcp-r-control-error element', () => {
+			render(
+				<ControlTextInput
+					value="bad value"
+					placeholder="Input prefix"
+					onChange={ jest.fn() }
+					error="Only letters, numbers, hyphens and underscores are allowed."
+				/>
+			);
+
+			const errorMessage = screen.getByText(
+				'Only letters, numbers, hyphens and underscores are allowed.'
+			);
+
+			expect( errorMessage ).toBeInTheDocument();
+			expect( errorMessage ).toHaveClass( 'ppcp-r-control-error' );
+		} );
+
+		test( 'marks the input as invalid', () => {
+			render(
+				<ControlTextInput
+					value="bad value"
+					placeholder="Input prefix"
+					onChange={ jest.fn() }
+					error="Only letters, numbers, hyphens and underscores are allowed."
+				/>
+			);
+
+			const input = screen.getByPlaceholderText( 'Input prefix' );
+
+			expect( input ).toHaveAttribute( 'aria-invalid', 'true' );
+			expect( input ).toHaveClass( 'ppcp--has-error' );
+		} );
+	} );
+} );

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/InvoicePrefix.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/InvoicePrefix.js
@@ -1,15 +1,43 @@
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { ControlTextInput } from '@ppcp-settings/Components/ReusableComponents/Controls';
 import { SettingsHooks } from '@ppcp-settings/data';
 import SettingsBlock from '@ppcp-settings/Components/ReusableComponents/SettingsBlock';
 
+// The prefix is an identity component of the IDs sent to PayPal, so keep it to
+// characters that are safe in every consumer.
+const ALLOWED_PREFIX = /^[A-Za-z0-9_-]*$/;
+
 const InvoicePrefix = () => {
 	const { invoicePrefix, setInvoicePrefix } = SettingsHooks.useSettings();
+	const [ error, setError ] = useState( '' );
+
+	const handleChange = ( value ) => {
+		// Refuse the input rather than silently dropping the offending
+		// characters, so the merchant is never left with a value they did not
+		// type.
+		if ( ! ALLOWED_PREFIX.test( value ) ) {
+			setError(
+				__(
+					'Only letters, numbers, hyphens and underscores are allowed.',
+					'woocommerce-paypal-payments'
+				)
+			);
+			return;
+		}
+
+		setInvoicePrefix( value );
+	};
+
+	// Keep the message up while the merchant is still typing. Clearing it on the
+	// next accepted character would hide the fact that something was refused,
+	// leaving them with a value they did not type and no explanation.
+	const handleBlur = () => setError( '' );
 
 	return (
 		<SettingsBlock
-			title="Invoice Prefix"
+			title={ __( 'Invoice Prefix', 'woocommerce-paypal-payments' ) }
 			titleSuffix={ __( '(Recommended)', 'woocommerce-paypal-payments' ) }
 			className="ppcp--invoice-prefix"
 		>
@@ -18,9 +46,14 @@ const InvoicePrefix = () => {
 					'Input prefix',
 					'woocommerce-paypal-payments'
 				) }
-				onChange={ setInvoicePrefix }
+				onChange={ handleChange }
+				onBlur={ handleBlur }
 				value={ invoicePrefix }
-				description="Add a unique prefix to invoice numbers for site-specific tracking (recommended)."
+				error={ error }
+				description={ __(
+					'Add a unique prefix to invoice numbers for site-specific tracking (recommended).',
+					'woocommerce-paypal-payments'
+				) }
 			/>
 		</SettingsBlock>
 	);

--- a/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/InvoicePrefix.test.js
+++ b/modules/ppcp-settings/resources/js/Components/Screens/Settings/Components/Settings/Blocks/InvoicePrefix.test.js
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InvoicePrefix from './InvoicePrefix';
+
+const mockUseSettings = {
+	invoicePrefix: '',
+	setInvoicePrefix: jest.fn(),
+};
+
+jest.mock( '@ppcp-settings/data', () => ( {
+	SettingsHooks: {
+		useSettings: () => mockUseSettings,
+	},
+} ) );
+
+jest.mock( '@ppcp-settings/Components/ReusableComponents/SettingsBlock', () => {
+	return ( { title, className, children } ) => (
+		<div data-testid="settings-block" className={ className }>
+			<h3>{ title }</h3>
+			{ children }
+		</div>
+	);
+} );
+
+jest.mock( '@ppcp-settings/Components/ReusableComponents/Controls', () => ( {
+	ControlTextInput: ( { value, onChange, onBlur, placeholder, error } ) => (
+		<div data-testid="control-text-input">
+			<input
+				placeholder={ placeholder }
+				value={ value }
+				onChange={ ( e ) => onChange( e.target.value ) }
+				onBlur={ onBlur }
+			/>
+			{ error && <p className="ppcp-r-control-error">{ error }</p> }
+		</div>
+	),
+} ) );
+
+const ERROR_MESSAGE =
+	'Only letters, numbers, hyphens and underscores are allowed.';
+
+describe( 'InvoicePrefix', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseSettings.invoicePrefix = '';
+	} );
+
+	test.each( [
+		[ 'a space', 'WC Store' ],
+		[ 'an at sign', 'WC@Store' ],
+		[ 'a dot', 'WC.Store' ],
+		[ 'a slash', 'WC/Store' ],
+	] )(
+		'rejects a value containing %s: does not call setInvoicePrefix and shows an error',
+		( _label, value ) => {
+			render( <InvoicePrefix /> );
+
+			const input = screen.getByPlaceholderText( 'Input prefix' );
+			fireEvent.change( input, { target: { value } } );
+
+			expect( mockUseSettings.setInvoicePrefix ).not.toHaveBeenCalled();
+			expect( screen.getByText( ERROR_MESSAGE ) ).toBeInTheDocument();
+		}
+	);
+
+	test( 'accepts letters, numbers, hyphens and underscores and shows no error', () => {
+		render( <InvoicePrefix /> );
+
+		const input = screen.getByPlaceholderText( 'Input prefix' );
+		fireEvent.change( input, { target: { value: 'WC-Store_1' } } );
+
+		expect( mockUseSettings.setInvoicePrefix ).toHaveBeenCalledWith(
+			'WC-Store_1'
+		);
+		expect( screen.queryByText( ERROR_MESSAGE ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'accepts an empty value', () => {
+		mockUseSettings.invoicePrefix = 'WC-Store_1';
+		render( <InvoicePrefix /> );
+
+		const input = screen.getByPlaceholderText( 'Input prefix' );
+		fireEvent.change( input, { target: { value: '' } } );
+
+		expect( mockUseSettings.setInvoicePrefix ).toHaveBeenCalledWith( '' );
+	} );
+
+	test( 'keeps the message visible while typing continues after a rejected character', () => {
+		render( <InvoicePrefix /> );
+
+		const input = screen.getByPlaceholderText( 'Input prefix' );
+		fireEvent.change( input, { target: { value: 'WC Store' } } );
+
+		expect( screen.getByText( ERROR_MESSAGE ) ).toBeInTheDocument();
+
+		fireEvent.change( input, { target: { value: 'WC-Store' } } );
+
+		expect( screen.getByText( ERROR_MESSAGE ) ).toBeInTheDocument();
+		expect( mockUseSettings.setInvoicePrefix ).toHaveBeenCalledWith(
+			'WC-Store'
+		);
+	} );
+
+	test( 'clears the error on blur', () => {
+		render( <InvoicePrefix /> );
+
+		const input = screen.getByPlaceholderText( 'Input prefix' );
+		fireEvent.change( input, { target: { value: 'WC Store' } } );
+
+		expect( screen.getByText( ERROR_MESSAGE ) ).toBeInTheDocument();
+
+		fireEvent.blur( input );
+
+		expect( screen.queryByText( ERROR_MESSAGE ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
+++ b/modules/ppcp-settings/src/Endpoint/SettingsRestEndpoint.php
@@ -172,8 +172,20 @@ class SettingsRestEndpoint extends RestEndpoint {
 	 * @return WP_REST_Response The response containing updated settings or error details.
 	 */
 	public function update_details( WP_REST_Request $request ): WP_REST_Response {
+		$params = $request->get_params();
+
+		$invoice_prefix = $params['invoicePrefix'] ?? null;
+		if ( is_string( $invoice_prefix ) && ! $this->is_valid_invoice_prefix( $invoice_prefix ) ) {
+			return $this->return_error(
+				__(
+					'The invoice prefix may only contain letters, numbers, hyphens and underscores.',
+					'woocommerce-paypal-payments'
+				)
+			);
+		}
+
 		$wp_data = $this->sanitize_for_wordpress(
-			$request->get_params(),
+			$params,
 			$this->field_map
 		);
 
@@ -181,5 +193,19 @@ class SettingsRestEndpoint extends RestEndpoint {
 		$this->settings->save();
 
 		return $this->get_details();
+	}
+
+	/**
+	 * Whether the given invoice prefix is safe to use.
+	 *
+	 * The prefix is an identity component of the IDs the plugin sends to PayPal,
+	 * so it is restricted to characters that are safe in every consumer. An empty
+	 * prefix is valid; callers fall back to a default.
+	 *
+	 * @param string $prefix The invoice prefix to check.
+	 * @return bool
+	 */
+	private function is_valid_invoice_prefix( string $prefix ): bool {
+		return (bool) preg_match( '/^[A-Za-z0-9_-]*$/', $prefix );
 	}
 }

--- a/tests/PHPUnit/Settings/Endpoint/SettingsRestEndpointTest.php
+++ b/tests/PHPUnit/Settings/Endpoint/SettingsRestEndpointTest.php
@@ -1,0 +1,147 @@
+<?php
+declare( strict_types=1 );
+
+namespace PHPUnit\Settings\Endpoint;
+
+use Mockery;
+use WP_REST_Request;
+use WP_REST_Response;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\Endpoint\SettingsRestEndpoint;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * The invoice prefix becomes part of identifiers the plugin sends to PayPal
+ * (purchase-unit invoice_id, refund fallback, vault customer_id), so
+ * update_details() must reject unsafe characters before anything is
+ * persisted. This is a backstop for callers that bypass the settings UI,
+ * e.g. the REST API directly or a Blueprints import.
+ *
+ * @covers \WooCommerce\PayPalCommerce\Settings\Endpoint\SettingsRestEndpoint
+ */
+class SettingsRestEndpointTest extends TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		when( 'rest_ensure_response' )->alias( static fn( $data ) => new WP_REST_Response( $data ) );
+	}
+
+	/**
+	 * GIVEN a request whose invoicePrefix contains a space
+	 * WHEN update_details() processes it
+	 * THEN the response reports failure
+	 * AND nothing is persisted to the settings model
+	 *
+	 * @dataProvider invalid_invoice_prefix_provider
+	 */
+	public function test_invalid_invoice_prefix_is_rejected_without_persisting( string $invalid_prefix ): void {
+		$settings = Mockery::mock( SettingsModel::class );
+		$settings->shouldNotReceive( 'from_array' );
+		$settings->shouldNotReceive( 'save' );
+
+		$endpoint = new SettingsRestEndpoint( $settings );
+
+		$request = new WP_REST_Request( 'POST', '/settings' );
+		$request->set_param( 'invoicePrefix', $invalid_prefix );
+
+		$response = $endpoint->update_details( $request );
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['success'] );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function invalid_invoice_prefix_provider(): array {
+		return array(
+			'a trailing space is rejected'      => array( 'WC ' ),
+			'an internal space is rejected'     => array( 'WC Store' ),
+			'an at-sign is rejected'             => array( 'WC@1' ),
+			'a slash is rejected'                => array( 'WC/1' ),
+		);
+	}
+
+	/**
+	 * GIVEN a request whose invoicePrefix only contains letters, numbers, hyphens or underscores
+	 * WHEN update_details() processes it
+	 * THEN the response reports success
+	 * AND the settings model is updated and saved
+	 *
+	 * @dataProvider valid_invoice_prefix_provider
+	 */
+	public function test_valid_invoice_prefix_is_accepted_and_saved( string $valid_prefix ): void {
+		$settings = Mockery::mock( SettingsModel::class );
+		$settings->shouldReceive( 'from_array' )->once();
+		$settings->shouldReceive( 'save' )->once();
+		$settings->shouldReceive( 'to_array' )->andReturn( array() );
+
+		$endpoint = new SettingsRestEndpoint( $settings );
+
+		$request = new WP_REST_Request( 'POST', '/settings' );
+		$request->set_param( 'invoicePrefix', $valid_prefix );
+
+		$response = $endpoint->update_details( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+	}
+
+	/**
+	 * @return array<string, array{0: string}>
+	 */
+	public function valid_invoice_prefix_provider(): array {
+		return array(
+			'a hyphen suffix is valid'      => array( 'WC-' ),
+			'an underscore separator is valid' => array( 'Store_1' ),
+			'plain alphanumerics are valid' => array( 'abc123' ),
+		);
+	}
+
+	/**
+	 * GIVEN a request with an empty invoicePrefix
+	 * WHEN update_details() processes it
+	 * THEN the response reports success
+	 * AND the settings model is updated and saved, since consumers fall back to a default prefix
+	 */
+	public function test_empty_invoice_prefix_is_valid_and_saved(): void {
+		$settings = Mockery::mock( SettingsModel::class );
+		$settings->shouldReceive( 'from_array' )->once();
+		$settings->shouldReceive( 'save' )->once();
+		$settings->shouldReceive( 'to_array' )->andReturn( array() );
+
+		$endpoint = new SettingsRestEndpoint( $settings );
+
+		$request = new WP_REST_Request( 'POST', '/settings' );
+		$request->set_param( 'invoicePrefix', '' );
+
+		$response = $endpoint->update_details( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+	}
+
+	/**
+	 * GIVEN a request that does not include an invoicePrefix at all
+	 * WHEN update_details() processes it
+	 * THEN the response reports success
+	 * AND the settings model is updated and saved as normal
+	 */
+	public function test_missing_invoice_prefix_is_unaffected_and_saves_normally(): void {
+		$settings = Mockery::mock( SettingsModel::class );
+		$settings->shouldReceive( 'from_array' )->once();
+		$settings->shouldReceive( 'save' )->once();
+		$settings->shouldReceive( 'to_array' )->andReturn( array() );
+
+		$endpoint = new SettingsRestEndpoint( $settings );
+
+		$request = new WP_REST_Request( 'POST', '/settings' );
+		$request->set_param( 'brandName', 'Acme' );
+
+		$response = $endpoint->update_details( $request );
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+	}
+}


### PR DESCRIPTION
### Description

The **Invoice Prefix** setting accepted any characters, spaces included. It is not only a cosmetic label but the value is concatenated into three identifiers the plugin sends to PayPal:

| Consumer | Use |
| --- | --- |
| `PurchaseUnitFactory:133` | `invoice_id = prefix . order_number` |
| `RefundProcessor:188` | recomputes `prefix . order_number` when a capture carries no invoice ID |
| `CustomerRepository:41,59` | vault `customer_id = prefix . user_id`, capped at 22 chars |

This restricts the field to letters, numbers, hyphens and underscores.

#### Two decisions worth reviewing

**Refuse the input, do not clean it up.** An invalid character never enters the field, and an inline message says why. Silently stripping would leave the merchant holding a value they did not type. The message stays until the field is left rather than clearing on the next accepted character, otherwise someone typing `WC Store` straight through ends at `WCStore` with no indication anything was refused.

**Validate on input only — never where the prefix is read.** Applying an allowlist at build time (the shape `PurchaseUnitFactory::sanitize_soft_descriptor()` uses) would retroactively change the *effective* prefix for stores that already saved one. Because the prefix is an identity component, that would present existing customers with a different vault `customer_id`, breaking saved-payment continuity, and would stop the refund fallback matching historical orders. Deliberate consequence: **a store that already saved an unsafe prefix keeps it** until a merchant edits the field.

**An empty prefix stays valid** — consumers fall back to a default.

The rule is applied in two independent places: the settings screen, and the REST endpoint for callers that bypass it (the API directly, or a Blueprints import), which rejects before anything is persisted.


### Steps to Test

Go to **PayPal Payments → Settings** and find **Invoice Prefix**.

1. Type `WC Store`. **Expected:** the space does not appear, the field reads `WCStore`, the input turns red and shows *"Only letters, numbers, hyphens and underscores are allowed."*
2. Keep typing. **Expected:** the message stays visible.
3. Click away. **Expected:** the message clears.
4. Paste `WC Store` into an empty field. **Expected:** nothing is accepted and the message shows.
5. Type `WC-Store_1`. **Expected:** accepted, no message. Save, reload — the value persists.
6. Clear the field completely. **Expected:** no error; an empty prefix is allowed.
7. Other rejected characters to spot-check: `@`, `.`, `/`, `#`.

### Changelog Entry

> Enhancement - Restrict the Invoice Prefix setting to characters that are safe in the identifiers sent to PayPal
