### PR TITLE
Fix: avoid user ID token requests during Mini Cart hydration

### DIFF
--- a/modules/ppcp-blocks/src/BlocksModule.php
+++ b/modules/ppcp-blocks/src/BlocksModule.php
@@ -12,7 +12,7 @@ namespace WooCommerce\PayPalCommerce\Blocks;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Blocks\Endpoint\UpdateShippingEndpoint;
-use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExtendingModule;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameIdTrait;
@@ -76,14 +76,10 @@ class BlocksModule implements ServiceModule, ExtendingModule, ExecutableModule {
 		woocommerce_store_api_register_payment_requirements(
 			array(
 				'data_callback' => function () use ( $c ): array {
-					$smart_button = $c->get( 'button.smart-button' );
-					assert( $smart_button instanceof SmartButtonInterface );
+					$context = $c->get( 'button.helper.context' );
+					assert( $context instanceof Context );
 
-					if ( isset( $smart_button->script_data()['continuation'] ) ) {
-						return array( 'ppcp_continuation' );
-					}
-
-					return array();
+					return $context->is_paypal_continuation() ? array( 'ppcp_continuation' ) : array();
 				},
 			)
 		);

--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -84,6 +84,10 @@ class SavePaymentMethodsModule implements ServiceModule, ExecutableModule {
 				add_filter(
 					'woocommerce_paypal_payments_localized_script_data',
 					function ( array $localized_script_data ) use ( $c ) {
+						if ( $this->is_mini_cart_data_request() ) {
+							return $localized_script_data;
+						}
+
 						$subscriptions_helper = $c->get( 'wc-subscriptions.helper' );
 						assert( $subscriptions_helper instanceof SubscriptionHelper );
 						if ( ! is_user_logged_in() && ! $subscriptions_helper->cart_contains_subscription() ) {
@@ -490,6 +494,15 @@ class SavePaymentMethodsModule implements ServiceModule, ExecutableModule {
 		);
 
 		return true;
+	}
+
+	/**
+	 * Whether checkout payment data is being collected for a Mini Cart-only page.
+	 */
+	private function is_mini_cart_data_request(): bool {
+		return doing_action( 'woocommerce_blocks_cart_enqueue_data' )
+			&& ! is_cart()
+			&& ! has_block( 'woocommerce/cart' );
 	}
 
 	/**

--- a/tests/PHPUnit/Blocks/BlocksModuleTest.php
+++ b/tests/PHPUnit/Blocks/BlocksModuleTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace {
+	if ( ! function_exists( 'woocommerce_store_api_register_payment_requirements' ) ) {
+		function woocommerce_store_api_register_payment_requirements( array $args ): void {
+			$GLOBALS['ppcp_test_payment_requirements'] = $args;
+		}
+	}
+}
+
+namespace WooCommerce\PayPalCommerce\Blocks {
+	use Mockery;
+	use WooCommerce\PayPalCommerce\Button\Helper\Context;
+	use WooCommerce\PayPalCommerce\TestCase;
+	use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+
+	/**
+	 * @covers \WooCommerce\PayPalCommerce\Blocks\BlocksModule
+	 */
+	class BlocksModuleTest extends TestCase {
+		/**
+		 * @dataProvider continuationProvider
+		 */
+		public function testPaymentRequirementsUseContextWithoutBuildingSmartButtonData(
+			bool $is_continuation,
+			array $expected
+		): void {
+			$context = Mockery::mock(Context::class);
+			$context->shouldReceive('is_paypal_continuation')->once()->andReturn($is_continuation);
+
+			$container = Mockery::mock(ContainerInterface::class);
+			$container->shouldReceive('get')->once()->with('button.helper.context')->andReturn($context);
+			$container->shouldNotReceive('get')->with('button.smart-button');
+
+			unset($GLOBALS['ppcp_test_payment_requirements']);
+
+			$this->assertTrue(( new BlocksModule() )->run($container));
+			$this->assertArrayHasKey('data_callback', $GLOBALS['ppcp_test_payment_requirements']);
+			$this->assertSame($expected, $GLOBALS['ppcp_test_payment_requirements']['data_callback']());
+		}
+
+		public function continuationProvider(): array {
+			return array(
+				'continuation' => array(true, array('ppcp_continuation')),
+				'ordinary cart' => array(false, array()),
+			);
+		}
+	}
+}

--- a/tests/PHPUnit/SavePaymentMethods/SavePaymentMethodsModuleTest.php
+++ b/tests/PHPUnit/SavePaymentMethods/SavePaymentMethodsModuleTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\SavePaymentMethods;
 
 use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Authentication\UserIdToken;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -86,6 +88,84 @@ class SavePaymentMethodsModuleTest extends TestCase
 				),
 			),
 		);
+	}
+
+	/**
+	 * Runs the module, fires the deferred setup, and returns the captured localized script-data
+	 * filter so its behavior can be tested without rendering frontend assets.
+	 */
+	private function captured_localized_script_data_filter(): callable
+	{
+		$captured_setup  = null;
+		$captured_filter = null;
+
+		expectActionAdded('after_setup_theme')
+			->once()
+			->whenHappen(
+				static function ( $callback ) use ( &$captured_setup ) {
+					$captured_setup = $callback;
+				}
+			);
+
+		expectFilterAdded('woocommerce_paypal_payments_localized_script_data')
+			->once()
+			->whenHappen(
+				static function ( $callback ) use ( &$captured_filter ) {
+					$captured_filter = $callback;
+				}
+			);
+
+		( new SavePaymentMethodsModule() )->run( $this->container );
+
+		$this->assertIsCallable($captured_setup);
+		$captured_setup();
+		$this->assertIsCallable($captured_filter);
+
+		return $captured_filter;
+	}
+
+	/**
+	 * @scenario Mini Cart hydration on a non-cart page must not request a PayPal user ID token.
+	 */
+	public function testDoesNotAddIdTokenDuringMiniCartDataRequest(): void
+	{
+		when('doing_action')->justReturn(true);
+		when('is_cart')->justReturn(false);
+		when('has_block')->justReturn(false);
+
+		$this->settings->shouldReceive('save_paypal_and_venmo')->andReturn(true);
+		$this->settings->shouldReceive('save_card_details')->andReturn(false);
+		$this->container->shouldNotReceive('get')->with('api.user-id-token');
+
+		$filter = $this->captured_localized_script_data_filter();
+		$data   = array( 'marker' => true );
+
+		$this->assertSame($data, $filter($data));
+	}
+
+	/**
+	 * @scenario Full Cart data collection must retain the ID token required for vaulting.
+	 */
+	public function testAddsIdTokenDuringCartDataRequest(): void
+	{
+		when('doing_action')->justReturn(true);
+		when('is_cart')->justReturn(true);
+		when('is_user_logged_in')->justReturn(true);
+
+		$api = Mockery::mock(UserIdToken::class);
+		$api->shouldReceive('id_token')->once()->with('')->andReturn('user-id-token');
+
+		$this->settings->shouldReceive('save_paypal_and_venmo')->andReturn(true);
+		$this->settings->shouldReceive('save_card_details')->andReturn(false);
+		$this->container->shouldReceive('get')->with('api.user-id-token')->andReturn($api);
+		$this->container->shouldReceive('get')->with('woocommerce.logger.woocommerce')->andReturn(
+			Mockery::mock(LoggerInterface::class)
+		);
+
+		$filter = $this->captured_localized_script_data_filter();
+		$result = $filter(array());
+
+		$this->assertSame('user-id-token', $result['save_payment_methods']['id_token']);
 	}
 
 	/**


### PR DESCRIPTION
**Issue**: #4597

**Ticket**:

**Slack Thread**:

---

### Description

Avoid requesting a PayPal user ID token when WooCommerce collects payment requirements and payment method data while rendering a Mini Cart-only page.

- Use the existing PayPal `Context` service to determine continuation requirements instead of building complete Smart Button script data.
- Skip ID-token enrichment only while `woocommerce_blocks_cart_enqueue_data` is running on a page without the full Cart block.
- Preserve ID-token data for full Cart and Checkout payment contexts.
- Add regression coverage for continuation requirements, the Mini Cart-only guard, and retained Cart vaulting data.

This follows the same Mini Cart performance boundary established for Pay upon Invoice in #4486 / #4483.

### Steps to Test

1. Connect PayPal Payments and enable saving PayPal/Venmo or card details.
2. Use a block theme with the WooCommerce Mini Cart in the header.
3. Log in as a customer and load a page that contains neither the Cart nor Checkout block.
4. Inspect HTTP API calls and confirm no request is made to `/v1/oauth2/token?...response_type=id_token` during Mini Cart hydration.
5. Load the full Cart and Checkout pages and confirm PayPal remains available and vaulting script data still includes the user ID token.
6. Start a PayPal continuation flow and confirm `ppcp_continuation` remains in the Store API payment requirements.
7. Run `npm run unit-tests` and `npm run lint`.

Local verification:

- Unit suite: 1,634 tests, 5,812 assertions, 2 existing skips.
- PHPCS: no errors; existing repository warnings only.
- PHPStan: no errors.
- A WordPress hook-level reproduction recorded zero ID-token HTTP requests for Mini Cart-only hydration while retaining the full Cart payment-data callback.
- The integration suite could not start outside DDEV because `.ddev/wordpress/wp-load.php` was unavailable; repository CI can run the configured integration environment.

### Documentation

- [ ] This PR needs documentation (has the "Documentation" label).

### Changelog Entry

> Fix - Prevent Mini Cart-only hydration from requesting a PayPal user ID token on unrelated pages.

Closes #4597.
