### PR TITLE
Save Payment Methods PayPal + Cards (5786)

### DIFF
--- a/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
+++ b/modules/ppcp-save-payment-methods/src/SavePaymentMethodsModule.php
@@ -292,6 +292,18 @@ class SavePaymentMethodsModule implements ServiceModule, ExecutableModule {
 							return;
 						}
 
+						/**
+						 * Whether to render the v5 add-payment-method assets. The
+						 * v6 SDK module returns false here when it owns the page
+						 * (its own save button + card fields), so the two stacks
+						 * do not both render into the same container.
+						 *
+						 * @param bool $render Whether to enqueue the v5 assets.
+						 */
+						if ( ! apply_filters( 'woocommerce_paypal_payments_render_add_payment_method_assets', true ) ) {
+							return;
+						}
+
 						$asset_getter = $c->get( 'save-payment-methods.asset_getter' );
 						assert( $asset_getter instanceof AssetGetter );
 

--- a/modules/ppcp-sdk-v6/extensions.php
+++ b/modules/ppcp-sdk-v6/extensions.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\SdkV6;
 
 use WooCommerce\PayPalCommerce\Button\Assets\DisabledSmartButton;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
+use WooCommerce\PayPalCommerce\SdkV6\Assets\AddPaymentMethodManager;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
@@ -18,28 +19,35 @@ return array(
 	/**
 	 * Both SDKs claim the window.paypal global, so the v5 smart-button
 	 * script must not load on pages where the v6 SDK loads. On pages v6
-	 * owns (classic product/cart/checkout, block cart/checkout) every
-	 * v5 surface consuming this service's script_data() goes dark,
-	 * including block card fields and the regular block method: that is
-	 * accepted migration-state breakage until their own stories migrate
-	 * them. On the pages v6 does not own (pay-now, add-payment-method)
-	 * the v5 stack keeps running: the blocks, applepay, googlepay and
-	 * axo modules would break under a blanket disable.
+	 * owns (classic product/cart/checkout, block cart/checkout, and the
+	 * Add Payment Method page) every v5 surface consuming this service's
+	 * script_data() goes dark, including block card fields and the regular
+	 * block method: that is accepted migration-state breakage until their
+	 * own stories migrate them. On the pages v6 does not own (pay-now) the
+	 * v5 stack keeps running: the blocks, applepay, googlepay and axo
+	 * modules would break under a blanket disable.
+	 *
+	 * The Add Payment Method page is v6-owned by the vaulting story: v6
+	 * renders the save button + card save fields there, so the v5
+	 * add-payment-method script is suppressed too (SavePaymentMethodsModule,
+	 * via woocommerce_paypal_payments_render_add_payment_method_assets).
 	 *
 	 * MIGRATION-PHASE ONLY: this per-page handoff exists so the site and
 	 * the test suites stay fully functional while the v6 migration
 	 * stories land one surface at a time. Once every surface is v6-owned
 	 * and the epic is release-ready, replace this with an unconditional
 	 * swap (or stop loading the v5 modules entirely) — the final state is
-	 * a whole-flow flag flip, not per-page coexistence. Do not extend
-	 * this mechanism with further per-surface toggles or compatibility
-	 * shims.
+	 * a whole-flow flag flip, not per-page coexistence.
 	 */
 	'button.smart-button' => static function ( SmartButtonInterface $smart_button, ContainerInterface $container ): SmartButtonInterface {
 		$manager = $container->get( 'sdk-v6.manager' );
 		assert( $manager instanceof SdkV6Manager );
 
-		if ( $manager->should_load_on_current_page() ) {
+		$add_payment_method_manager = $container->get( 'sdk-v6.add-payment-method-manager' );
+		assert( $add_payment_method_manager instanceof AddPaymentMethodManager );
+
+		if ( $manager->should_load_on_current_page()
+			|| $add_payment_method_manager->should_load_on_current_page() ) {
 			return new DisabledSmartButton();
 		}
 

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -27,11 +27,12 @@ import { V6CardFieldContainer } from './V6CardFieldContainer';
  * Secure), approves it, and maps the outcome to a Blocks onPaymentSetup
  * response.
  *
- * @param {Object} args               - Arguments.
- * @param {Object} args.config        - The sdk-v6 config object.
- * @param {string} args.context       - The page context.
- * @param {Object} args.session       - The v6 card-fields session.
- * @param {Object} args.responseTypes - The Blocks response-type constants.
+ * @param {Object}  args                   - Arguments.
+ * @param {Object}  args.config            - The sdk-v6 config object.
+ * @param {string}  args.context           - The page context.
+ * @param {Object}  args.session           - The v6 card-fields session.
+ * @param {Object}  args.responseTypes     - The Blocks response-type constants.
+ * @param {boolean} args.savePaymentMethod - Whether to vault the card.
  * @return {Promise<Object>} A Blocks onPaymentSetup response object.
  */
 async function submitCardPayment( {
@@ -39,6 +40,7 @@ async function submitCardPayment( {
 	context,
 	session,
 	responseTypes,
+	savePaymentMethod,
 } ) {
 	if ( ! session ) {
 		return {
@@ -51,7 +53,11 @@ async function submitCardPayment( {
 	}
 
 	try {
-		const { orderId } = await createCardOrder( config, context );
+		const { orderId } = await createCardOrder(
+			config,
+			context,
+			savePaymentMethod
+		);
 		const result = await session.submit( orderId );
 
 		// The buyer dismissed the 3DS challenge; prompt a retry rather than
@@ -110,9 +116,17 @@ export function V6CardFieldsComponent( {
 	const methodId = config.card_fields.payment_method;
 	const hasNameField = Boolean( config.card_fields.name_field );
 
+	const isVaultingEnabled = Boolean( config.card_fields.is_vaulting_enabled );
+	const hasSubscriptions = Boolean( config.card_fields.has_subscriptions );
+
 	const [ session, setSession ] = useState( null );
 	const [ inputStyle, setInputStyle ] = useState( null );
 	const referenceRef = useRef( null );
+
+	// Whether to vault the card, read at submit time. Subscriptions force it on
+	// (the card must be saved to charge renewals); WC Blocks renders no native
+	// save checkbox for this gateway, so the one below drives this ref.
+	const savePaymentRef = useRef( hasSubscriptions );
 
 	// One card session for the component's lifetime: the SDK cannot dispose a
 	// session, so it must not be recreated on ordinary re-renders.
@@ -168,6 +182,7 @@ export function V6CardFieldsComponent( {
 				context,
 				session: sessionRef.current,
 				responseTypes,
+				savePaymentMethod: savePaymentRef.current,
 			} )
 		);
 	}, [
@@ -248,7 +263,34 @@ export function V6CardFieldsComponent( {
 						placeholder: __( 'CVV', 'woocommerce-paypal-payments' ),
 						containerStyle: { flex: 1 },
 					} )
-				)
+				),
+				isVaultingEnabled &&
+					createElement(
+						'label',
+						{
+							className: 'ppcp-sdk-v6-card-fields__save',
+							style: {
+								display: 'flex',
+								alignItems: 'center',
+								gap: '8px',
+							},
+						},
+						createElement( 'input', {
+							type: 'checkbox',
+							className:
+								'ppcp-sdk-v6-card-fields__save-checkbox',
+							defaultChecked: hasSubscriptions,
+							disabled: hasSubscriptions,
+							onChange: ( event ) => {
+								savePaymentRef.current = event.target.checked;
+							},
+						} ),
+						config.card_fields.save_card_text ||
+							__(
+								'Save your card',
+								'woocommerce-paypal-payments'
+							)
+					)
 			)
 	);
 }

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -96,11 +96,12 @@ async function submitCardPayment( {
 }
 
 /**
- * @param {Object} props                     - Props from the Blocks payment method registry.
- * @param {Object} props.config              - The localized sdk-v6 config.
- * @param {Object} props.eventRegistration   - Blocks checkout event subscriptions.
- * @param {Object} props.emitResponse        - Blocks response-type constants.
- * @param {string} props.activePaymentMethod - The active payment method id.
+ * @param {Object}  props                     - Props from the Blocks payment method registry.
+ * @param {Object}  props.config              - The localized sdk-v6 config.
+ * @param {Object}  props.eventRegistration   - Blocks checkout event subscriptions.
+ * @param {Object}  props.emitResponse        - Blocks response-type constants.
+ * @param {string}  props.activePaymentMethod - The active payment method id.
+ * @param {boolean} props.shouldSavePayment   - WC Blocks' native "save payment method" choice.
  * @return {?Object} The card fields element, or null before the session is ready.
  */
 export function V6CardFieldsComponent( {
@@ -108,6 +109,7 @@ export function V6CardFieldsComponent( {
 	eventRegistration,
 	emitResponse,
 	activePaymentMethod,
+	shouldSavePayment,
 } ) {
 	const { onPaymentSetup } = eventRegistration;
 	const { responseTypes } = emitResponse;
@@ -116,17 +118,19 @@ export function V6CardFieldsComponent( {
 	const methodId = config.card_fields.payment_method;
 	const hasNameField = Boolean( config.card_fields.name_field );
 
-	const isVaultingEnabled = Boolean( config.card_fields.is_vaulting_enabled );
 	const hasSubscriptions = Boolean( config.card_fields.has_subscriptions );
 
 	const [ session, setSession ] = useState( null );
 	const [ inputStyle, setInputStyle ] = useState( null );
 	const referenceRef = useRef( null );
 
-	// Whether to vault the card, read at submit time. Subscriptions force it on
-	// (the card must be saved to charge renewals); WC Blocks renders no native
-	// save checkbox for this gateway, so the one below drives this ref.
-	const savePaymentRef = useRef( hasSubscriptions );
+	// Whether to vault the card, read at submit time. The choice comes from WC
+	// Blocks' native "Save payment information…" checkbox (shouldSavePayment
+	// prop, shown via supports.showSaveOption); a subscription cart forces it
+	// on since the card must be saved to charge renewals. A ref keeps the
+	// latest value without resubscribing onPaymentSetup.
+	const savePaymentRef = useRef( false );
+	savePaymentRef.current = Boolean( shouldSavePayment ) || hasSubscriptions;
 
 	// One card session for the component's lifetime: the SDK cannot dispose a
 	// session, so it must not be recreated on ordinary re-renders.
@@ -263,34 +267,7 @@ export function V6CardFieldsComponent( {
 						placeholder: __( 'CVV', 'woocommerce-paypal-payments' ),
 						containerStyle: { flex: 1 },
 					} )
-				),
-				isVaultingEnabled &&
-					createElement(
-						'label',
-						{
-							className: 'ppcp-sdk-v6-card-fields__save',
-							style: {
-								display: 'flex',
-								alignItems: 'center',
-								gap: '8px',
-							},
-						},
-						createElement( 'input', {
-							type: 'checkbox',
-							className:
-								'ppcp-sdk-v6-card-fields__save-checkbox',
-							defaultChecked: hasSubscriptions,
-							disabled: hasSubscriptions,
-							onChange: ( event ) => {
-								savePaymentRef.current = event.target.checked;
-							},
-						} ),
-						config.card_fields.save_card_text ||
-							__(
-								'Save your card',
-								'woocommerce-paypal-payments'
-							)
-					)
+				)
 			)
 	);
 }

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -60,6 +60,7 @@ async function submitCardPayment( {
 		const { orderId } = await createCardOrder(
 			config,
 			context,
+			cardName,
 			savePaymentMethod
 		);
 		const result = billingAddress

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -117,7 +117,8 @@ describe( 'V6CardFieldsComponent', () => {
 
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			cardConfig(),
-			'checkout-block'
+			'checkout-block',
+			false
 		);
 		expect( session.submit ).toHaveBeenCalledWith( 'ORDER1' );
 		expect( mockApproveCardOrder ).toHaveBeenCalledWith(
@@ -125,6 +126,72 @@ describe( 'V6CardFieldsComponent', () => {
 			'ORDER1'
 		);
 		expect( result ).toEqual( { type: 'success' } );
+	} );
+
+	test( 'passes savePaymentMethod true to createCardOrder when the buyer opts to save the card', async () => {
+		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
+		session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
+
+		renderComponent( { shouldSavePayment: true } );
+		await waitFor( () => expect( onPaymentSetup ).toHaveBeenCalled() );
+
+		await act( async () => {
+			await paymentSetupCb();
+		} );
+
+		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
+			cardConfig(),
+			'checkout-block',
+			true
+		);
+	} );
+
+	test( 'forces savePaymentMethod true when the cart has subscriptions, even if the buyer did not opt in', async () => {
+		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
+		session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
+
+		renderComponent( {
+			shouldSavePayment: false,
+			config: cardConfig( {
+				card_fields: {
+					...cardConfig().card_fields,
+					has_subscriptions: true,
+				},
+			} ),
+		} );
+		await waitFor( () => expect( onPaymentSetup ).toHaveBeenCalled() );
+
+		await act( async () => {
+			await paymentSetupCb();
+		} );
+
+		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				card_fields: expect.objectContaining( {
+					has_subscriptions: true,
+				} ),
+			} ),
+			'checkout-block',
+			true
+		);
+	} );
+
+	test( 'passes savePaymentMethod false when the buyer does not opt in and there are no subscriptions', async () => {
+		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
+		session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
+
+		renderComponent( { shouldSavePayment: false } );
+		await waitFor( () => expect( onPaymentSetup ).toHaveBeenCalled() );
+
+		await act( async () => {
+			await paymentSetupCb();
+		} );
+
+		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
+			cardConfig(),
+			'checkout-block',
+			false
+		);
 	} );
 
 	test( 'reports an error and skips approval when 3D Secure is canceled', async () => {

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -125,6 +125,7 @@ describe( 'V6CardFieldsComponent', () => {
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			cardConfig(),
 			'checkout-block',
+			'',
 			false
 		);
 		expect( session.submit ).toHaveBeenCalledWith( 'ORDER1' );
@@ -149,6 +150,7 @@ describe( 'V6CardFieldsComponent', () => {
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			cardConfig(),
 			'checkout-block',
+			'',
 			true
 		);
 	} );
@@ -179,6 +181,7 @@ describe( 'V6CardFieldsComponent', () => {
 				} ),
 			} ),
 			'checkout-block',
+			'',
 			true
 		);
 	} );
@@ -197,6 +200,7 @@ describe( 'V6CardFieldsComponent', () => {
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			cardConfig(),
 			'checkout-block',
+			'',
 			false
 		);
 	} );
@@ -315,7 +319,8 @@ describe( 'V6CardFieldsComponent', () => {
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			cardConfig(),
 			'checkout-block',
-			'Jane Doe'
+			'Jane Doe',
+			false
 		);
 	} );
 

--- a/modules/ppcp-sdk-v6/resources/js/boot-add-payment-method.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot-add-payment-method.js
@@ -78,39 +78,50 @@ import { handleError, setErrorLabels } from './utils/errorHandler';
 	}
 
 	/**
-	 * Shows the PayPal button only when PayPal is the selected method; the WC
-	 * submit button drives the card save flow for the card method. Replaces
-	 * the visibility handling the (now-suppressed) v5 script used to do.
+	 * Shows the PayPal button only when PayPal is the selected method and a
+	 * button actually rendered; otherwise the WC submit button stays visible
+	 * (card save flow, or PayPal ineligible). Replaces the visibility handling
+	 * the (now-suppressed) v5 script used to do.
 	 */
 	function syncVisibility() {
 		const isPayPal =
 			getCurrentPaymentMethod() === PaymentMethods.PAYPAL;
-		setVisibleByClass( ORDER_BUTTON_SELECTOR, ! isPayPal, 'ppcp-hidden' );
-		setVisible( buttonSelector, isPayPal );
+		// Only hand the submit role to the PayPal button when one actually
+		// rendered; otherwise (PayPal ineligible / no wrapper) the buyer must
+		// keep the native submit control instead of being left with nothing.
+		const hasPayPalButton = Boolean(
+			document.querySelector( `${ buttonSelector } paypal-button` )
+		);
+		const usePayPalButton = isPayPal && hasPayPalButton;
+		setVisibleByClass(
+			ORDER_BUTTON_SELECTOR,
+			! usePayPalButton,
+			'ppcp-hidden'
+		);
+		setVisible( buttonSelector, usePayPalButton );
 	}
 
 	async function init() {
 		const wrapper = document.querySelector( buttonSelector );
-		if ( ! wrapper ) {
-			return;
-		}
 
 		const sdk = await loadSdkV6( config, 'checkout' );
 		const eligibility = await checkVaultEligibility( sdk, {
 			currencyCode: config.currency,
 		} );
 
-		if ( eligibility.paypal ) {
+		// Render the PayPal button only when both its wrapper is present and
+		// PayPal is eligible.
+		if ( wrapper && eligibility.paypal ) {
 			const session = createSavePayPalSession( sdk, config );
 			wrapper.innerHTML = '';
 			wrapper.appendChild( createPayPalButton( session ) );
 		}
 
+		// Card saving is independent of the PayPal wrapper; gate it only on
+		// card eligibility and the card fields being enabled.
 		if ( eligibility.card && config.card_fields?.enabled ) {
 			initCardSaveFields( config );
 		}
-
-		syncVisibility();
 	}
 
 	function setupListeners() {
@@ -132,7 +143,12 @@ import { handleError, setErrorLabels } from './utils/errorHandler';
 
 	function boot() {
 		setupListeners();
-		init().catch( ( error ) => handleError( error ) );
+		// Always sync visibility once init settles: even if init() rejects
+		// (SDK load, client token, eligibility) the page must not be left with
+		// unmounted fields and an inconsistent submit control.
+		init()
+			.catch( ( error ) => handleError( error ) )
+			.finally( syncVisibility );
 	}
 
 	if ( document.readyState === 'loading' ) {

--- a/modules/ppcp-sdk-v6/resources/js/boot-add-payment-method.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot-add-payment-method.js
@@ -1,0 +1,143 @@
+/**
+ * PayPal SDK v6 Bootstrap for My Account › Add Payment Method.
+ *
+ * Renders the v6 "save for later" surfaces that replace the v5
+ * add-payment-method.js: the PayPal wallet button (createPayPalSavePaymentSession)
+ * and the advanced card fields (createCardFieldsSavePaymentSession). The WC
+ * "Add payment method" submit button drives the card save; it is hidden while
+ * the PayPal method is selected, where the PayPal button is the submit control.
+ *
+ * @package
+ */
+
+import {
+	getCurrentPaymentMethod,
+	ORDER_BUTTON_SELECTOR,
+	PaymentMethods,
+} from '@ppcp-button/Helper/CheckoutMethodState';
+import { setVisible, setVisibleByClass } from '@ppcp-button/Helper/Hiding';
+import { loadSdkV6 } from './sdkLoader';
+import { checkVaultEligibility } from './eligibility';
+import { createSavePayPalSession } from './sessions/createSaveSession';
+import { initCardSaveFields } from './cardFields/saveRenderer';
+import { postJson } from './utils/api';
+import { handleError, setErrorLabels } from './utils/errorHandler';
+
+( function ( config ) {
+	'use strict';
+
+	if ( ! config ) {
+		return;
+	}
+
+	setErrorLabels( config.labels );
+
+	const buttonSelector = config.button.wrapper;
+
+	/**
+	 * Requests a PayPal wallet setup token from the existing WC AJAX endpoint.
+	 *
+	 * The returned promise is passed to session.start() without being awaited
+	 * first — awaiting it before the call loses the transient user activation
+	 * and breaks the popup. It resolves to a { vaultSetupToken } object,
+	 * mirroring the { orderId } shape the one-time session expects.
+	 *
+	 * @return {Promise<{vaultSetupToken: string}>} The setup token.
+	 */
+	function createVaultSetupToken() {
+		return postJson( config.ajax.create_setup_token ).then( ( data ) => ( {
+			vaultSetupToken: data.id,
+		} ) );
+	}
+
+	/**
+	 * Builds the PayPal save button and binds the click handler.
+	 *
+	 * @param {Object} session - The v6 save payment session.
+	 * @return {HTMLElement} The configured button element.
+	 */
+	function createPayPalButton( session ) {
+		const button = document.createElement( 'paypal-button' );
+		button.setAttribute( 'type', 'pay' );
+		if ( config.button.color_class ) {
+			button.className = config.button.color_class;
+		}
+
+		button.addEventListener( 'click', async () => {
+			try {
+				await session.start(
+					{ presentationMode: 'auto' },
+					createVaultSetupToken()
+				);
+			} catch ( error ) {
+				handleError( error );
+			}
+		} );
+
+		return button;
+	}
+
+	/**
+	 * Shows the PayPal button only when PayPal is the selected method; the WC
+	 * submit button drives the card save flow for the card method. Replaces
+	 * the visibility handling the (now-suppressed) v5 script used to do.
+	 */
+	function syncVisibility() {
+		const isPayPal =
+			getCurrentPaymentMethod() === PaymentMethods.PAYPAL;
+		setVisibleByClass( ORDER_BUTTON_SELECTOR, ! isPayPal, 'ppcp-hidden' );
+		setVisible( buttonSelector, isPayPal );
+	}
+
+	async function init() {
+		const wrapper = document.querySelector( buttonSelector );
+		if ( ! wrapper ) {
+			return;
+		}
+
+		const sdk = await loadSdkV6( config, 'checkout' );
+		const eligibility = await checkVaultEligibility( sdk, {
+			currencyCode: config.currency,
+		} );
+
+		if ( eligibility.paypal ) {
+			const session = createSavePayPalSession( sdk, config );
+			wrapper.innerHTML = '';
+			wrapper.appendChild( createPayPalButton( session ) );
+		}
+
+		if ( eligibility.card && config.card_fields?.enabled ) {
+			initCardSaveFields( config );
+		}
+
+		syncVisibility();
+	}
+
+	function setupListeners() {
+		document.body.addEventListener( 'change', ( event ) => {
+			if ( event.target?.name === 'payment_method' ) {
+				syncVisibility();
+			}
+		} );
+		document.body.addEventListener( 'click', ( event ) => {
+			if (
+				event.target?.matches?.(
+					'.payment_methods input.input-radio'
+				)
+			) {
+				syncVisibility();
+			}
+		} );
+	}
+
+	function boot() {
+		setupListeners();
+		init().catch( ( error ) => handleError( error ) );
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', boot );
+	} else {
+		boot();
+	}
+} )( window.wc_ppcp_sdk_v6_save );

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -80,6 +80,19 @@ function isSavedTokenSelected() {
 }
 
 /**
+ * Whether the buyer opted to save the card during purchase, read from
+ * WooCommerce's native tokenization checkbox for the card gateway (the same
+ * checkbox v5's CheckoutActionHandler reads). Absent when vaulting is off.
+ *
+ * @return {boolean} True when the "save payment method" checkbox is checked.
+ */
+function shouldSavePaymentMethod() {
+	return !! document.querySelector(
+		'#wc-ppcp-credit-card-gateway-new-payment-method'
+	)?.checked;
+}
+
+/**
  * Whether the card gateway is the currently selected checkout payment method.
  *
  * @param {string} paymentMethod - The card gateway's payment method ID.
@@ -180,7 +193,11 @@ export async function initCardFields( config ) {
 
 		try {
 			const cardSession = await ensureCardSession();
-			const { orderId } = await createCardOrder( config );
+			const { orderId } = await createCardOrder(
+				config,
+				'checkout',
+				shouldSavePaymentMethod()
+			);
 			const result = await cardSession.submit( orderId );
 
 			// Buyer closed the 3DS challenge or the popup; let them retry.

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
@@ -127,6 +127,11 @@ export function initCardSaveFields( config ) {
 		event.preventDefault();
 		event.stopImmediatePropagation();
 
+		// Latch before the first await: a second click must not create a
+		// second setup token and a second vaulted card. Stays true on the
+		// success path because the page navigates away.
+		submitting = true;
+
 		try {
 			const cardSession = await ensureCardSession();
 			const setupTokenId = await createCardSetupToken();
@@ -134,6 +139,7 @@ export function initCardSaveFields( config ) {
 
 			// Buyer dismissed the 3DS challenge; let them retry.
 			if ( result.state === 'canceled' ) {
+				submitting = false;
 				return;
 			}
 			if ( result.state !== 'succeeded' ) {
@@ -144,9 +150,9 @@ export function initCardSaveFields( config ) {
 				vault_setup_token: setupTokenId,
 			} );
 
-			submitting = true;
 			navigation.assign( config.payment_methods_page );
 		} catch ( error ) {
+			submitting = false;
 			handleError( error );
 		}
 	}

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
@@ -1,0 +1,160 @@
+/**
+ * Advanced Card Fields — "save without purchase" (vaulting), v6 Web SDK.
+ *
+ * Used on the My Account › Add Payment Method page. Mounts the card fields
+ * via a dedicated save session (which cannot coexist with a one-time card
+ * session, so this page never creates one), and on submit creates a card
+ * setup token, confirms it through the session (running 3D Secure when
+ * required), and exchanges it server-side for a stored payment token.
+ *
+ * @package
+ */
+
+import { cardFieldStyles } from './cardFieldStyles';
+import { hide } from '@ppcp-button/Helper/Hiding';
+import { getCurrentPaymentMethod } from '@ppcp-button/Helper/CheckoutMethodState';
+import { loadSdkV6 } from '../sdkLoader';
+import { postJson } from '../utils/api';
+import { handleError } from '../utils/errorHandler';
+import { navigation } from '../utils/navigation';
+
+const FIELD_TYPES = [ 'number', 'expiry', 'cvv', 'name' ];
+
+/**
+ * Mounts one v6 card field into its existing WC input's slot, hiding the
+ * original (mirrors the classic renderer's mountField).
+ *
+ * @param {Object}      cardSession - The v6 card-fields save session.
+ * @param {string}      fieldType   - number|expiry|cvv|name.
+ * @param {HTMLElement} inputField  - The existing WC input to replace.
+ */
+function mountField( cardSession, fieldType, inputField ) {
+	if ( ! inputField || inputField.hidden ) {
+		return;
+	}
+
+	const computed = window.getComputedStyle( inputField );
+	const options = {
+		type: fieldType,
+		style: { input: cardFieldStyles( inputField ) },
+	};
+	if ( inputField.getAttribute( 'placeholder' ) ) {
+		options.placeholder = inputField.getAttribute( 'placeholder' );
+	}
+
+	const fieldElement = cardSession.createCardFieldsComponent( options );
+	fieldElement.style.width = computed.width;
+	fieldElement.style.height = computed.height;
+
+	inputField.parentNode.appendChild( fieldElement );
+	hide( inputField, true );
+	inputField.hidden = true;
+}
+
+/**
+ * Bootstraps the card "save for later" fields on the add-payment-method page.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6_save config object.
+ */
+export function initCardSaveFields( config ) {
+	if ( ! config.card_fields?.enabled ) {
+		return;
+	}
+
+	const { fields, payment_method: paymentMethod } = config.card_fields;
+	let cardSessionPromise = null;
+	let submitting = false;
+
+	function getInputs() {
+		return {
+			number: document.querySelector( fields.number ),
+			expiry: document.querySelector( fields.expiry ),
+			cvv: document.querySelector( fields.cvv ),
+			name: fields.name ? document.querySelector( fields.name ) : null,
+		};
+	}
+
+	function ensureCardSession() {
+		if ( ! cardSessionPromise ) {
+			cardSessionPromise = ( async () => {
+				const inputs = getInputs();
+				const sdk = await loadSdkV6( config, 'checkout' );
+				const cardSession = sdk.createCardFieldsSavePaymentSession();
+
+				for ( const fieldType of FIELD_TYPES ) {
+					if ( inputs[ fieldType ] ) {
+						mountField( cardSession, fieldType, inputs[ fieldType ] );
+					}
+				}
+
+				return cardSession;
+			} )().catch( ( error ) => {
+				cardSessionPromise = null;
+				throw error;
+			} );
+		}
+		return cardSessionPromise;
+	}
+
+	/**
+	 * Requests a card setup token (with the store's 3DS/SCA contingency) from
+	 * the existing WC AJAX endpoint.
+	 *
+	 * @return {Promise<string>} Resolves to the setup token id.
+	 */
+	async function createCardSetupToken() {
+		const data = await postJson( config.ajax.create_setup_token, {
+			payment_method: paymentMethod,
+			verification_method: config.verification_method,
+		} );
+		return data.id;
+	}
+
+	function isCardGatewaySelected() {
+		return getCurrentPaymentMethod() === paymentMethod;
+	}
+
+	/**
+	 * Intercepts the native "Add payment method" submit for a card save.
+	 *
+	 * @param {Event} event - The click event.
+	 */
+	async function handleSubmit( event ) {
+		if ( submitting || ! isCardGatewaySelected() ) {
+			return;
+		}
+
+		event.preventDefault();
+		event.stopImmediatePropagation();
+
+		try {
+			const cardSession = await ensureCardSession();
+			const setupTokenId = await createCardSetupToken();
+			const result = await cardSession.submit( setupTokenId );
+
+			// Buyer dismissed the 3DS challenge; let them retry.
+			if ( result.state === 'canceled' ) {
+				return;
+			}
+			if ( result.state !== 'succeeded' ) {
+				throw new Error( 'Card could not be saved.' );
+			}
+
+			await postJson( config.ajax.create_payment_token, {
+				vault_setup_token: setupTokenId,
+			} );
+
+			submitting = true;
+			navigation.assign( config.payment_methods_page );
+		} catch ( error ) {
+			handleError( error );
+		}
+	}
+
+	const placeOrderButton = document.querySelector( '#place_order' );
+	placeOrderButton?.addEventListener( 'click', handleSubmit, true );
+
+	// Mount the fields up front so styling and the session are ready before
+	// the buyer submits.
+	ensureCardSession().catch( handleError );
+}

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -162,6 +162,10 @@ if ( config?.card_fields?.enabled && ! config.continuation ) {
 		canMakePayment: () => true,
 		supports: {
 			features: [ 'products' ],
+			// WooCommerce Blocks renders its native "Save payment information…"
+			// checkbox and exposes the choice as the shouldSavePayment prop;
+			// only offered when card vaulting is enabled.
+			showSaveOption: Boolean( config.card_fields.is_vaulting_enabled ),
 		},
 	} );
 }

--- a/modules/ppcp-sdk-v6/resources/js/eligibility.js
+++ b/modules/ppcp-sdk-v6/resources/js/eligibility.js
@@ -45,3 +45,25 @@ export async function checkEligibility(
 
 	return result;
 }
+
+/**
+ * Checks eligibility for the "save without purchase" (vault) flow used on the
+ * My Account › Add Payment Method page. Queries the dedicated vault payment
+ * flow; amount-independent.
+ *
+ * @param {Object} sdkInstance          - The PayPal SDK v6 instance.
+ * @param {Object} options              - Eligibility options.
+ * @param {string} options.currencyCode - ISO 4217 currency code.
+ * @return {Promise<Object>} Eligibility keyed by method (paypal, card).
+ */
+export async function checkVaultEligibility( sdkInstance, { currencyCode } ) {
+	const methods = await sdkInstance.findEligibleMethods( {
+		currencyCode,
+		paymentFlow: 'VAULT_WITHOUT_PAYMENT',
+	} );
+
+	return {
+		paypal: methods.isEligible( 'paypal' ),
+		card: methods.isEligible( 'advanced_cards' ),
+	};
+}

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
@@ -212,16 +212,22 @@ export async function approveOrderInSession( config, fundingSource, orderId ) {
  * unconfirmed, cardless order. approveCardOrder() is what stores the
  * order in session, once those checks pass.
  *
- * @param {Object} config  - The wc_ppcp_sdk_v6 config object.
- * @param {string} context - The page context (checkout or checkout-block).
+ * @param {Object}  config            - The wc_ppcp_sdk_v6 config object.
+ * @param {string}  context           - The page context (checkout or checkout-block).
+ * @param {boolean} savePaymentMethod - Whether to vault the card during purchase.
  * @return {Promise<{orderId: string}>} The created PayPal order id.
  */
-export async function createCardOrder( config, context = 'checkout' ) {
+export async function createCardOrder(
+	config,
+	context = 'checkout',
+	savePaymentMethod = false
+) {
 	const body = {
 		context,
 		purchase_units: [],
 		payment_method: config.card_fields.payment_method,
 		funding_source: config.card_fields.funding_source,
+		save_payment_method: savePaymentMethod,
 	};
 
 	// Only the classic checkout has a WC form to serialize, letting the server

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
@@ -340,7 +340,7 @@ describe( 'createCardOrder', () => {
 		mockPayerData.mockReturnValueOnce( null );
 		postJson.mockResolvedValueOnce( { id: 'CARDORDER5' } );
 
-		await createCardOrder( config, 'checkout', true );
+		await createCardOrder( config, 'checkout', '', true );
 
 		expect( postJson ).toHaveBeenCalledWith(
 			config.ajax.create_order,
@@ -413,6 +413,7 @@ describe( 'createCardOrder', () => {
 			purchase_units: [],
 			payment_method: 'ppcp-credit-card-gateway',
 			funding_source: 'card',
+			save_payment_method: false,
 			order_id: 456,
 			order_key: 'wc_def',
 		} );

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
@@ -266,9 +266,23 @@ describe( 'createCardOrder', () => {
 			purchase_units: [],
 			payment_method: 'ppcp-credit-card-gateway',
 			funding_source: 'card',
+			save_payment_method: false,
 			form_encoded: 'billing_email=a%40b.com',
 			createaccount: false,
 		} );
+	} );
+
+	test( 'sends save_payment_method true when the buyer opts to vault the card', async () => {
+		document.body.innerHTML = '<form class="checkout"></form>';
+		mockPayerData.mockReturnValueOnce( null );
+		postJson.mockResolvedValueOnce( { id: 'CARDORDER5' } );
+
+		await createCardOrder( config, 'checkout', true );
+
+		expect( postJson ).toHaveBeenCalledWith(
+			config.ajax.create_order,
+			expect.objectContaining( { save_payment_method: true } )
+		);
 	} );
 
 	test( 'forwards the payer when available', async () => {
@@ -313,6 +327,7 @@ describe( 'createCardOrder', () => {
 			purchase_units: [],
 			payment_method: 'ppcp-credit-card-gateway',
 			funding_source: 'card',
+			save_payment_method: false,
 		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/sessions/createSaveSession.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/createSaveSession.js
@@ -1,0 +1,46 @@
+/**
+ * Factory for the v6 "save PayPal without purchase" session (vaulting).
+ *
+ * Used on the My Account › Add Payment Method page. The buyer approves a
+ * setup token which onApprove exchanges — server-side, via the existing
+ * Vault v3 endpoints — for a stored payment token.
+ *
+ * @package
+ */
+
+import { postJson } from '../utils/api';
+import { handleError } from '../utils/errorHandler';
+import { navigation } from '../utils/navigation';
+
+/**
+ * Creates a PayPal save-payment session for the add-payment-method page.
+ *
+ * onApprove receives `data.vaultSetupToken`, which is exchanged for a WC
+ * payment token through the existing `ppc-create-payment-token` endpoint;
+ * on success the buyer is sent to the saved payment methods page.
+ *
+ * @param {Object} sdkInstance - The PayPal SDK v6 instance.
+ * @param {Object} config      - The localized save-payment config object.
+ * @return {Object} The save payment session.
+ */
+export function createSavePayPalSession( sdkInstance, config ) {
+	return sdkInstance.createPayPalSavePaymentSession( {
+		async onApprove( data ) {
+			try {
+				await postJson( config.ajax.create_payment_token, {
+					vault_setup_token: data.vaultSetupToken,
+				} );
+
+				navigation.assign( config.payment_methods_page );
+			} catch ( error ) {
+				handleError( error );
+			}
+		},
+
+		onCancel() {},
+
+		onError( error ) {
+			handleError( error );
+		},
+	} );
+}

--- a/modules/ppcp-sdk-v6/resources/js/test/boot-add-payment-method.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/boot-add-payment-method.test.js
@@ -1,0 +1,214 @@
+const mockGetCurrentPaymentMethod = jest.fn();
+jest.mock( '@ppcp-button/Helper/CheckoutMethodState', () => ( {
+	getCurrentPaymentMethod: () => mockGetCurrentPaymentMethod(),
+	ORDER_BUTTON_SELECTOR: '#place_order',
+	PaymentMethods: {
+		PAYPAL: 'ppcp-gateway',
+		CARDS: 'ppcp-credit-card-gateway',
+	},
+} ) );
+
+const mockSetVisible = jest.fn();
+const mockSetVisibleByClass = jest.fn();
+jest.mock( '@ppcp-button/Helper/Hiding', () => ( {
+	setVisible: ( ...args ) => mockSetVisible( ...args ),
+	setVisibleByClass: ( ...args ) => mockSetVisibleByClass( ...args ),
+} ) );
+
+const mockLoadSdkV6 = jest.fn();
+jest.mock( '../sdkLoader', () => ( {
+	loadSdkV6: ( ...args ) => mockLoadSdkV6( ...args ),
+} ) );
+
+const mockCheckVaultEligibility = jest.fn();
+jest.mock( '../eligibility', () => ( {
+	checkVaultEligibility: ( ...args ) => mockCheckVaultEligibility( ...args ),
+} ) );
+
+const mockCreateSavePayPalSession = jest.fn();
+jest.mock( '../sessions/createSaveSession', () => ( {
+	createSavePayPalSession: ( ...args ) =>
+		mockCreateSavePayPalSession( ...args ),
+} ) );
+
+const mockInitCardSaveFields = jest.fn();
+jest.mock( '../cardFields/saveRenderer', () => ( {
+	initCardSaveFields: ( ...args ) => mockInitCardSaveFields( ...args ),
+} ) );
+
+const mockPostJson = jest.fn();
+jest.mock( '../utils/api', () => ( {
+	postJson: ( ...args ) => mockPostJson( ...args ),
+} ) );
+
+const mockHandleError = jest.fn();
+const mockSetErrorLabels = jest.fn();
+jest.mock( '../utils/errorHandler', () => ( {
+	handleError: ( ...args ) => mockHandleError( ...args ),
+	setErrorLabels: ( ...args ) => mockSetErrorLabels( ...args ),
+} ) );
+
+/**
+ * Drains all pending microtasks so the module's chained `init().catch().finally()`
+ * promise settles before assertions run.
+ *
+ * @return {Promise<void>}
+ */
+const flushPromises = () =>
+	new Promise( ( resolve ) => setImmediate( resolve ) );
+
+const WRAPPER_SELECTOR = '#ppcp-add-payment-method-paypal-button';
+
+const baseConfig = ( overrides = {} ) => ( {
+	labels: {},
+	button: { wrapper: WRAPPER_SELECTOR, color_class: '' },
+	card_fields: { enabled: true },
+	currency: 'USD',
+	ajax: {
+		create_setup_token: { endpoint: '/cst', nonce: 'n-cst' },
+	},
+	...overrides,
+} );
+
+/**
+ * Builds the add-payment-method page DOM: the native submit button and
+ * (optionally) the PayPal button wrapper.
+ */
+function buildDom( { hasWrapper = true } = {} ) {
+	document.body.innerHTML = `
+		<button id="place_order" type="button">Place order</button>
+		${
+			hasWrapper
+				? `<div id="${ WRAPPER_SELECTOR.slice( 1 ) }"></div>`
+				: ''
+		}
+	`;
+}
+
+/**
+ * Sets the module's global config, then imports it fresh so its top-level
+ * IIFE runs against the config and DOM this test just set up.
+ */
+function boot( config ) {
+	window.wc_ppcp_sdk_v6_save = config;
+	jest.isolateModules( () => {
+		require( '../boot-add-payment-method.js' );
+	} );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockLoadSdkV6.mockResolvedValue( {} );
+	mockCheckVaultEligibility.mockResolvedValue( { paypal: true, card: true } );
+	mockCreateSavePayPalSession.mockReturnValue( {} );
+} );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+	delete window.wc_ppcp_sdk_v6_save;
+} );
+
+describe( 'boot-add-payment-method', () => {
+	test( 'PayPal selected with a rendered PayPal button hides the native submit and shows the wrapper', async () => {
+		buildDom();
+		mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-gateway' );
+
+		boot( baseConfig() );
+		await flushPromises();
+
+		expect(
+			document.querySelector( `${ WRAPPER_SELECTOR } paypal-button` )
+		).not.toBeNull();
+		expect( mockSetVisibleByClass ).toHaveBeenCalledWith(
+			'#place_order',
+			false,
+			'ppcp-hidden'
+		);
+		expect( mockSetVisible ).toHaveBeenCalledWith(
+			WRAPPER_SELECTOR,
+			true
+		);
+	} );
+
+	test( 'the card method selected keeps the native submit visible and hides the wrapper', async () => {
+		buildDom();
+		mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-credit-card-gateway' );
+
+		boot( baseConfig() );
+		await flushPromises();
+
+		expect( mockSetVisibleByClass ).toHaveBeenCalledWith(
+			'#place_order',
+			true,
+			'ppcp-hidden'
+		);
+		expect( mockSetVisible ).toHaveBeenCalledWith(
+			WRAPPER_SELECTOR,
+			false
+		);
+	} );
+
+	test( 'PayPal ineligible renders no button and leaves the native submit visible even with PayPal selected', async () => {
+		buildDom();
+		mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-gateway' );
+		mockCheckVaultEligibility.mockResolvedValue( {
+			paypal: false,
+			card: true,
+		} );
+
+		boot( baseConfig() );
+		await flushPromises();
+
+		expect(
+			document.querySelector( `${ WRAPPER_SELECTOR } paypal-button` )
+		).toBeNull();
+		expect( mockSetVisibleByClass ).toHaveBeenCalledWith(
+			'#place_order',
+			true,
+			'ppcp-hidden'
+		);
+		expect( mockSetVisible ).toHaveBeenCalledWith(
+			WRAPPER_SELECTOR,
+			false
+		);
+	} );
+
+	test( 'card saving initializes even when the PayPal wrapper is missing from the page', async () => {
+		buildDom( { hasWrapper: false } );
+		mockGetCurrentPaymentMethod.mockReturnValue(
+			'ppcp-credit-card-gateway'
+		);
+		mockCheckVaultEligibility.mockResolvedValue( {
+			paypal: true,
+			card: true,
+		} );
+
+		boot( baseConfig( { card_fields: { enabled: true } } ) );
+		await flushPromises();
+
+		expect( mockInitCardSaveFields ).toHaveBeenCalledWith(
+			expect.objectContaining( { card_fields: { enabled: true } } )
+		);
+	} );
+
+	test( 'a rejected init() (e.g. SDK load failure) is reported and still leaves the native submit visible', async () => {
+		buildDom();
+		mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-gateway' );
+		const loadError = new Error( 'sdk load failed' );
+		mockLoadSdkV6.mockRejectedValue( loadError );
+
+		boot( baseConfig() );
+		await flushPromises();
+
+		expect( mockHandleError ).toHaveBeenCalledWith( loadError );
+		expect( mockSetVisibleByClass ).toHaveBeenCalledWith(
+			'#place_order',
+			true,
+			'ppcp-hidden'
+		);
+		expect( mockSetVisible ).toHaveBeenCalledWith(
+			WRAPPER_SELECTOR,
+			false
+		);
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -406,11 +406,7 @@ describe( 'initCardFields', () => {
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			baseConfig(),
 			'checkout',
-			''
-		);
-		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
-			baseConfig(),
-			'checkout',
+			'',
 			false
 		);
 		expect( cardSession.submit ).toHaveBeenCalledWith( 'CARDORDER1' );
@@ -456,7 +452,8 @@ describe( 'initCardFields', () => {
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			config,
 			'checkout',
-			'Jane Doe'
+			'Jane Doe',
+			false
 		);
 	} );
 
@@ -506,6 +503,7 @@ describe( 'initCardFields', () => {
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			baseConfig(),
 			'checkout',
+			'',
 			true
 		);
 	} );
@@ -532,6 +530,7 @@ describe( 'initCardFields', () => {
 		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
 			baseConfig(),
 			'checkout',
+			'',
 			false
 		);
 	} );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -365,7 +365,11 @@ describe( 'initCardFields', () => {
 		// Flush the async submit chain (createCardOrder -> submit -> approveCardOrder).
 		await flushPromises();
 
-		expect( mockCreateCardOrder ).toHaveBeenCalledWith( baseConfig() );
+		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
+			baseConfig(),
+			'checkout',
+			false
+		);
 		expect( cardSession.submit ).toHaveBeenCalledWith( 'CARDORDER1' );
 		expect( mockApproveCardOrder ).toHaveBeenCalledWith(
 			expect.anything(),
@@ -375,6 +379,58 @@ describe( 'initCardFields', () => {
 		// that second click through instead of re-intercepting it.
 		expect( nativeSubmits ).toBe( 1 );
 		expect( mockHandleError ).not.toHaveBeenCalled();
+	} );
+
+	test( 'passes save_payment_method true to createCardOrder when the buyer checks the save-card box', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<input type="checkbox" id="wc-ppcp-credit-card-gateway-new-payment-method" checked />'
+		);
+		const cardSession = makeCardSession( { state: 'succeeded' } );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+		mockCreateCardOrder.mockResolvedValue( { orderId: 'CARDORDER1' } );
+		mockApproveCardOrder.mockResolvedValue( undefined );
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+
+		document.querySelector( '#place_order' ).click();
+		await flushPromises();
+
+		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
+			baseConfig(),
+			'checkout',
+			true
+		);
+	} );
+
+	test( 'passes save_payment_method false to createCardOrder when the save-card box is unchecked', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		document.body.insertAdjacentHTML(
+			'beforeend',
+			'<input type="checkbox" id="wc-ppcp-credit-card-gateway-new-payment-method" />'
+		);
+		const cardSession = makeCardSession( { state: 'succeeded' } );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+		mockCreateCardOrder.mockResolvedValue( { orderId: 'CARDORDER1' } );
+		mockApproveCardOrder.mockResolvedValue( undefined );
+
+		await initCardFields( baseConfig() );
+		await flushPromises();
+
+		document.querySelector( '#place_order' ).click();
+		await flushPromises();
+
+		expect( mockCreateCardOrder ).toHaveBeenCalledWith(
+			baseConfig(),
+			'checkout',
+			false
+		);
 	} );
 
 	test( 'a failed card session submit surfaces the error and does not click place_order again', async () => {

--- a/modules/ppcp-sdk-v6/resources/js/test/createSaveSession.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/createSaveSession.test.js
@@ -1,0 +1,90 @@
+const mockPostJson = jest.fn();
+jest.mock( '../utils/api', () => ( {
+	postJson: ( ...args ) => mockPostJson( ...args ),
+} ) );
+
+const mockHandleError = jest.fn();
+jest.mock( '../utils/errorHandler', () => ( {
+	handleError: ( ...args ) => mockHandleError( ...args ),
+} ) );
+
+import { createSavePayPalSession } from '../sessions/createSaveSession';
+import { navigation } from '../utils/navigation';
+
+const config = {
+	ajax: {
+		create_payment_token: { endpoint: '/cpt', nonce: 'n-cpt' },
+	},
+	payment_methods_page: '/my-account/payment-methods/',
+};
+
+function fakeSdk() {
+	const capture = {};
+	return {
+		capture,
+		createPayPalSavePaymentSession: ( sessionConfig ) => {
+			capture.config = sessionConfig;
+			return { session: true };
+		},
+	};
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'createSavePayPalSession', () => {
+	test( 'builds the session from the sdk instance with onApprove, onCancel and onError handlers', () => {
+		const sdk = fakeSdk();
+
+		const session = createSavePayPalSession( sdk, config );
+
+		expect( session ).toEqual( { session: true } );
+		expect( sdk.capture.config.onApprove ).toBeInstanceOf( Function );
+		expect( sdk.capture.config.onCancel ).toBeInstanceOf( Function );
+		expect( sdk.capture.config.onError ).toBeInstanceOf( Function );
+	} );
+
+	test( 'onApprove exchanges the vault setup token and redirects to the payment methods page', async () => {
+		const sdk = fakeSdk();
+		mockPostJson.mockResolvedValueOnce( {} );
+		const assign = jest
+			.spyOn( navigation, 'assign' )
+			.mockImplementation( () => {} );
+
+		createSavePayPalSession( sdk, config );
+		await sdk.capture.config.onApprove( { vaultSetupToken: 'SETUP1' } );
+
+		expect( mockPostJson ).toHaveBeenCalledWith(
+			config.ajax.create_payment_token,
+			{ vault_setup_token: 'SETUP1' }
+		);
+		expect( assign ).toHaveBeenCalledWith( config.payment_methods_page );
+	} );
+
+	test( 'onApprove routes to the error handler and does not redirect when the exchange fails', async () => {
+		const sdk = fakeSdk();
+		mockPostJson.mockRejectedValueOnce( new Error( 'token exchange failed' ) );
+		const assign = jest
+			.spyOn( navigation, 'assign' )
+			.mockImplementation( () => {} );
+
+		createSavePayPalSession( sdk, config );
+		await sdk.capture.config.onApprove( { vaultSetupToken: 'SETUP1' } );
+
+		expect( mockHandleError ).toHaveBeenCalledWith(
+			expect.any( Error )
+		);
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
+	test( 'onError forwards the error to the error handler', () => {
+		const sdk = fakeSdk();
+		const error = new Error( 'sdk session error' );
+
+		createSavePayPalSession( sdk, config );
+		sdk.capture.config.onError( error );
+
+		expect( mockHandleError ).toHaveBeenCalledWith( error );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/test/eligibility.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/eligibility.test.js
@@ -1,4 +1,4 @@
-import { checkEligibility } from '../eligibility';
+import { checkEligibility, checkVaultEligibility } from '../eligibility';
 
 function sdkWith( { eligible = [], details = null, detailsThrows = false } ) {
 	return {
@@ -67,5 +67,38 @@ describe( 'checkEligibility', () => {
 
 		expect( result.paylater ).toBe( true );
 		expect( result.payLaterDetails ).toBeNull();
+	} );
+} );
+
+describe( 'checkVaultEligibility', () => {
+	test( 'queries the vault-without-payment flow for the given currency', async () => {
+		const sdk = sdkWith( { eligible: [ 'paypal' ] } );
+
+		await checkVaultEligibility( sdk, { currencyCode: 'USD' } );
+
+		expect( sdk.findEligibleMethods ).toHaveBeenCalledWith( {
+			currencyCode: 'USD',
+			paymentFlow: 'VAULT_WITHOUT_PAYMENT',
+		} );
+	} );
+
+	test( 'maps paypal and advanced_cards eligibility onto paypal and card', async () => {
+		const sdk = sdkWith( { eligible: [ 'paypal', 'advanced_cards' ] } );
+
+		const result = await checkVaultEligibility( sdk, {
+			currencyCode: 'EUR',
+		} );
+
+		expect( result ).toEqual( { paypal: true, card: true } );
+	} );
+
+	test( 'reports methods as ineligible when the SDK excludes them', async () => {
+		const sdk = sdkWith( { eligible: [] } );
+
+		const result = await checkVaultEligibility( sdk, {
+			currencyCode: 'EUR',
+		} );
+
+		expect( result ).toEqual( { paypal: false, card: false } );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/saveRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/saveRenderer.test.js
@@ -1,0 +1,208 @@
+const mockCardFieldStyles = jest.fn( () => ( { color: 'rgb(0, 0, 0)' } ) );
+jest.mock( '../cardFields/cardFieldStyles', () => ( {
+	cardFieldStyles: ( field ) => mockCardFieldStyles( field ),
+} ) );
+
+const mockHide = jest.fn();
+jest.mock(
+	'@ppcp-button/Helper/Hiding',
+	() => ( { hide: ( ...args ) => mockHide( ...args ) } ),
+	{ virtual: true }
+);
+
+const mockGetCurrentPaymentMethod = jest.fn();
+jest.mock( '@ppcp-button/Helper/CheckoutMethodState', () => ( {
+	getCurrentPaymentMethod: () => mockGetCurrentPaymentMethod(),
+} ) );
+
+const mockLoadSdkV6 = jest.fn();
+jest.mock( '../sdkLoader', () => ( {
+	loadSdkV6: ( ...args ) => mockLoadSdkV6( ...args ),
+} ) );
+
+const mockPostJson = jest.fn();
+jest.mock( '../utils/api', () => ( {
+	postJson: ( ...args ) => mockPostJson( ...args ),
+} ) );
+
+const mockHandleError = jest.fn();
+jest.mock( '../utils/errorHandler', () => ( {
+	handleError: ( ...args ) => mockHandleError( ...args ),
+} ) );
+
+const mockNavigationAssign = jest.fn();
+jest.mock( '../utils/navigation', () => ( {
+	navigation: { assign: ( ...args ) => mockNavigationAssign( ...args ) },
+} ) );
+
+import { initCardSaveFields } from '../cardFields/saveRenderer';
+
+/**
+ * Drains all pending microtasks (unlike chained `await Promise.resolve()`,
+ * this doesn't require knowing exactly how many promise hops the code
+ * under test awaits internally).
+ *
+ * @return {Promise<void>}
+ */
+const flushPromises = () =>
+	new Promise( ( resolve ) => setImmediate( resolve ) );
+
+/**
+ * Builds the add-payment-method page DOM this module expects: the three
+ * (number/expiry/cvv) WC input fields plus the place-order submit button.
+ */
+function buildAddPaymentMethodDom() {
+	document.body.innerHTML = `
+		<form>
+			<div class="input-wrapper"><input id="ppcp-credit-card-gateway-card-number" /></div>
+			<div class="input-wrapper"><input id="ppcp-credit-card-gateway-card-expiry" /></div>
+			<div class="input-wrapper"><input id="ppcp-credit-card-gateway-card-cvc" /></div>
+			<button id="place_order" type="button">Add payment method</button>
+		</form>
+	`;
+}
+
+const baseConfig = ( overrides = {} ) => ( {
+	card_fields: {
+		enabled: true,
+		payment_method: 'ppcp-credit-card-gateway',
+		fields: {
+			number: '#ppcp-credit-card-gateway-card-number',
+			expiry: '#ppcp-credit-card-gateway-card-expiry',
+			cvv: '#ppcp-credit-card-gateway-card-cvc',
+			name: null,
+		},
+	},
+	ajax: {
+		create_setup_token: { endpoint: '/cst', nonce: 'n-cst' },
+		create_payment_token: { endpoint: '/cpt', nonce: 'n-cpt' },
+	},
+	verification_method: 'SCA_WHEN_REQUIRED',
+	payment_methods_page: '/my-account/payment-methods/',
+	...overrides,
+} );
+
+function makeCardSession( { state = 'succeeded' } = {} ) {
+	return {
+		createCardFieldsComponent: jest.fn( () =>
+			document.createElement( 'div' )
+		),
+		submit: jest.fn().mockResolvedValue( { state } ),
+	};
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-credit-card-gateway' );
+} );
+
+afterEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'initCardSaveFields', () => {
+	test( 'does nothing when card fields are disabled', () => {
+		buildAddPaymentMethodDom();
+		initCardSaveFields( baseConfig( { card_fields: { enabled: false } } ) );
+
+		expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a successful submission creates the setup token, submits the card session, exchanges it, and redirects', async () => {
+		buildAddPaymentMethodDom();
+		const cardSession = makeCardSession( { state: 'succeeded' } );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsSavePaymentSession: () => cardSession,
+		} );
+		mockPostJson
+			.mockResolvedValueOnce( { id: 'SETUP1' } )
+			.mockResolvedValueOnce( {} );
+
+		initCardSaveFields( baseConfig() );
+		await flushPromises();
+
+		const placeOrder = document.querySelector( '#place_order' );
+		placeOrder.click();
+		await flushPromises();
+
+		expect( mockPostJson ).toHaveBeenNthCalledWith(
+			1,
+			baseConfig().ajax.create_setup_token,
+			{
+				payment_method: 'ppcp-credit-card-gateway',
+				verification_method: 'SCA_WHEN_REQUIRED',
+			}
+		);
+		expect( cardSession.submit ).toHaveBeenCalledWith( 'SETUP1' );
+		expect( mockPostJson ).toHaveBeenNthCalledWith(
+			2,
+			baseConfig().ajax.create_payment_token,
+			{ vault_setup_token: 'SETUP1' }
+		);
+		expect( mockNavigationAssign ).toHaveBeenCalledWith(
+			'/my-account/payment-methods/'
+		);
+		expect( mockHandleError ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a canceled 3DS challenge is silent and does not exchange the token or redirect', async () => {
+		buildAddPaymentMethodDom();
+		const cardSession = makeCardSession( { state: 'canceled' } );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsSavePaymentSession: () => cardSession,
+		} );
+		mockPostJson.mockResolvedValueOnce( { id: 'SETUP1' } );
+
+		initCardSaveFields( baseConfig() );
+		await flushPromises();
+
+		document.querySelector( '#place_order' ).click();
+		await flushPromises();
+
+		expect( mockPostJson ).toHaveBeenCalledTimes( 1 );
+		expect( mockNavigationAssign ).not.toHaveBeenCalled();
+		expect( mockHandleError ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a failed card session submit surfaces the error and does not redirect', async () => {
+		buildAddPaymentMethodDom();
+		const cardSession = makeCardSession( { state: 'failed' } );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsSavePaymentSession: () => cardSession,
+		} );
+		mockPostJson.mockResolvedValueOnce( { id: 'SETUP1' } );
+
+		initCardSaveFields( baseConfig() );
+		await flushPromises();
+
+		document.querySelector( '#place_order' ).click();
+		await flushPromises();
+
+		expect( mockHandleError ).toHaveBeenCalled();
+		expect( mockNavigationAssign ).not.toHaveBeenCalled();
+	} );
+
+	test( 'lets the native click through untouched when a different gateway is selected', async () => {
+		buildAddPaymentMethodDom();
+		mockGetCurrentPaymentMethod.mockReturnValue( 'ppcp-gateway' );
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsSavePaymentSession: () => makeCardSession(),
+		} );
+
+		initCardSaveFields( baseConfig() );
+		await flushPromises();
+
+		const event = new MouseEvent( 'click', {
+			bubbles: true,
+			cancelable: true,
+		} );
+		document.querySelector( '#place_order' ).dispatchEvent( event );
+		await flushPromises();
+
+		expect( event.defaultPrevented ).toBe( false );
+		expect( mockPostJson ).not.toHaveBeenCalledWith(
+			baseConfig().ajax.create_setup_token,
+			expect.anything()
+		);
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/utils/navigation.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/navigation.js
@@ -1,0 +1,9 @@
+/**
+ * Navigation seam: window.location is not mockable under jsdom, so redirects
+ * go through this indirection to stay unit-testable.
+ *
+ * @package
+ */
+export const navigation = {
+	assign: ( url ) => window.location.assign( url ),
+};

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -59,7 +59,8 @@ return array(
 			$container->has( 'save-payment-methods.eligible' )
 				&& $container->get( 'save-payment-methods.eligible' )
 				&& $container->get( 'settings.settings-provider' )->save_card_details(),
-			$container->get( 'wc-subscriptions.helper' )
+			$container->get( 'wc-subscriptions.helper' ),
+			$container->get( 'wcgateway.credit-card-icons' )
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\SdkV6;
 
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
+use WooCommerce\PayPalCommerce\SdkV6\Assets\AddPaymentMethodManager;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\SdkV6\Blocks\V6PaymentMethod;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
@@ -21,20 +22,20 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 return array(
 
-	'sdk-v6.asset-getter'          => static function ( ContainerInterface $container ): AssetGetter {
+	'sdk-v6.asset-getter'               => static function ( ContainerInterface $container ): AssetGetter {
 		$factory = $container->get( 'assets.asset_getter_factory' );
 		assert( $factory instanceof AssetGetterFactory );
 
 		return $factory->for_module( 'ppcp-sdk-v6' );
 	},
 
-	'sdk-v6.button-style-mapper'   => static function ( ContainerInterface $container ): ButtonStyleMapper {
+	'sdk-v6.button-style-mapper'        => static function ( ContainerInterface $container ): ButtonStyleMapper {
 		return new ButtonStyleMapper(
 			$container->get( 'settings.settings-provider' )
 		);
 	},
 
-	'sdk-v6.manager'               => static function ( ContainerInterface $container ): SdkV6Manager {
+	'sdk-v6.manager'                    => static function ( ContainerInterface $container ): SdkV6Manager {
 		return new SdkV6Manager(
 			$container->get( 'sdk-v6.asset-getter' ),
 			$container->get( 'ppcp.asset-version' ),
@@ -49,11 +50,32 @@ return array(
 			// so this module does not depend on the ppcp-blocks module it replaces.
 			! $container->get( 'settings.settings-provider' )->enable_pay_now(),
 			$container->get( 'settings.settings-provider' )->save_paypal_and_venmo(),
-			$container->get( 'wcgateway.configuration.card-configuration' )
+			$container->get( 'wcgateway.configuration.card-configuration' ),
+			// Card "save during purchase" eligibility, mirroring the v5 block
+			// card method (AdvancedCardPaymentMethod): reference-transaction
+			// eligible AND the "save card details" setting on.
+			$container->get( 'save-payment-methods.eligible' )
+				&& $container->get( 'settings.settings-provider' )->save_card_details(),
+			$container->get( 'wc-subscriptions.helper' )
 		);
 	},
 
-	'sdk-v6.endpoint.client-token' => static function ( ContainerInterface $container ): ClientTokenEndpoint {
+	'sdk-v6.add-payment-method-manager' => static function ( ContainerInterface $container ): AddPaymentMethodManager {
+		$settings_provider = $container->get( 'settings.settings-provider' );
+
+		return new AddPaymentMethodManager(
+			$container->get( 'sdk-v6.asset-getter' ),
+			$container->get( 'ppcp.asset-version' ),
+			$container->get( 'settings.environment' ),
+			$container->get( 'button.helper.context' ),
+			$settings_provider->save_paypal_and_venmo(),
+			$container->get( 'save-payment-methods.eligible' )
+				&& $settings_provider->save_card_details(),
+			$settings_provider
+		);
+	},
+
+	'sdk-v6.endpoint.client-token'      => static function ( ContainerInterface $container ): ClientTokenEndpoint {
 		return new ClientTokenEndpoint(
 			$container->get( 'order-endpoints.request-data' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
@@ -62,7 +84,7 @@ return array(
 		);
 	},
 
-	'sdk-v6.rate-limiter'          => static function ( ContainerInterface $container ): RateLimiter {
+	'sdk-v6.rate-limiter'               => static function ( ContainerInterface $container ): RateLimiter {
 		return new RateLimiter(
 			'ppcp_sdk_v6_rl_',
 			10,
@@ -70,7 +92,7 @@ return array(
 		);
 	},
 
-	'sdk-v6.blocks.payment-method' => static function ( ContainerInterface $container ): V6PaymentMethod {
+	'sdk-v6.blocks.payment-method'      => static function ( ContainerInterface $container ): V6PaymentMethod {
 		return new V6PaymentMethod(
 			$container->get( 'sdk-v6.manager' ),
 			$container->get( 'sdk-v6.asset-getter' ),

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -53,8 +53,11 @@ return array(
 			$container->get( 'wcgateway.configuration.card-configuration' ),
 			// Card "save during purchase" eligibility, mirroring the v5 block
 			// card method (AdvancedCardPaymentMethod): reference-transaction
-			// eligible AND the "save card details" setting on.
-			$container->get( 'save-payment-methods.eligible' )
+			// eligible AND the "save card details" setting on. Guarded with
+			// has() because ppcp-save-payment-methods has its own feature flag
+			// independent of the v6 flag (see ppcp-settings/services.php).
+			$container->has( 'save-payment-methods.eligible' )
+				&& $container->get( 'save-payment-methods.eligible' )
 				&& $container->get( 'settings.settings-provider' )->save_card_details(),
 			$container->get( 'wc-subscriptions.helper' )
 		);
@@ -69,7 +72,10 @@ return array(
 			$container->get( 'settings.environment' ),
 			$container->get( 'button.helper.context' ),
 			$settings_provider->save_paypal_and_venmo(),
-			$container->get( 'save-payment-methods.eligible' )
+			// Guarded with has(): ppcp-save-payment-methods can be disabled
+			// independently of the v6 flag (see ppcp-settings/services.php).
+			$container->has( 'save-payment-methods.eligible' )
+				&& $container->get( 'save-payment-methods.eligible' )
 				&& $settings_provider->save_card_details(),
 			$settings_provider
 		);

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -78,9 +78,7 @@ return array(
 			$container->has( 'save-payment-methods.eligible' )
 				&& $container->get( 'save-payment-methods.eligible' )
 				&& $settings_provider->save_card_details(),
-			$settings_provider,
-			$container->get( 'wcgateway.configuration.card-configuration' ),
-			$container->get( 'wcgateway.credit-card-icons' )
+			$settings_provider
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
@@ -64,8 +64,6 @@ class AddPaymentMethodManager {
 
 	/**
 	 * Enqueues the add-payment-method bootstrap script.
-	 *
-	 * @return void
 	 */
 	public function enqueue(): void {
 		if ( ! $this->should_load_on_current_page() ) {
@@ -106,8 +104,6 @@ class AddPaymentMethodManager {
 
 	/**
 	 * Whether the v6 save surfaces load on the current page.
-	 *
-	 * @return bool
 	 */
 	public function should_load_on_current_page(): bool {
 		return is_user_logged_in()
@@ -117,14 +113,18 @@ class AddPaymentMethodManager {
 
 	/**
 	 * The configuration data for the add-payment-method bootstrap script.
-	 *
-	 * @return array
 	 */
 	private function script_data(): array {
 		$base_url = $this->environment->is_sandbox()
 			? 'https://www.sandbox.paypal.com'
 			: 'https://www.paypal.com';
 
+		/**
+		 * Filters the 3DS/SCA contingency used when creating the card setup
+		 * token for the save-for-later flow.
+		 *
+		 * @param string $verification_method The default 3D Secure enum value.
+		 */
 		$verification_method = (string) apply_filters(
 			'woocommerce_paypal_payments_three_d_secure_contingency',
 			$this->settings_provider->three_d_secure_enum()

--- a/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Manages the SDK v6 assets for the My Account › Add Payment Method page.
+ *
+ * Renders the v6 "save for later" surfaces (PayPal wallet save button + card
+ * save fields) that replace the v5 add-payment-method.js. v6 owns this page
+ * fully when it loads: the v5 script and smart button are suppressed
+ * elsewhere (see SavePaymentMethodsModule + extensions.php), so this bootstrap
+ * also ships the small rule that hides the native submit button while the
+ * PayPal method is selected.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Assets
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Assets;
+
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
+use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
+
+class AddPaymentMethodManager {
+
+	public const WRAPPER_ID = 'ppc-button-ppcp-gateway-save-payment-method';
+
+	// Same WC credit-card-form field IDs the classic/block card fields mount
+	// into (see SdkV6Manager); rendered by the card gateway on this page too.
+	private const CARD_FIELD_NAME_ID   = 'ppcp-credit-card-gateway-card-name';
+	private const CARD_FIELD_NUMBER_ID = 'ppcp-credit-card-gateway-card-number';
+	private const CARD_FIELD_EXPIRY_ID = 'ppcp-credit-card-gateway-card-expiry';
+	private const CARD_FIELD_CVV_ID    = 'ppcp-credit-card-gateway-card-cvc';
+
+	private AssetGetter $asset_getter;
+	private string $version;
+	private Environment $environment;
+	private Context $context;
+	private bool $paypal_vaulting_enabled;
+	private bool $card_vaulting_enabled;
+	private SettingsProvider $settings_provider;
+
+	public function __construct(
+		AssetGetter $asset_getter,
+		string $version,
+		Environment $environment,
+		Context $context,
+		bool $paypal_vaulting_enabled,
+		bool $card_vaulting_enabled,
+		SettingsProvider $settings_provider
+	) {
+		$this->asset_getter            = $asset_getter;
+		$this->version                 = $version;
+		$this->environment             = $environment;
+		$this->context                 = $context;
+		$this->paypal_vaulting_enabled = $paypal_vaulting_enabled;
+		$this->card_vaulting_enabled   = $card_vaulting_enabled;
+		$this->settings_provider       = $settings_provider;
+	}
+
+	/**
+	 * Enqueues the add-payment-method bootstrap script.
+	 *
+	 * @return void
+	 */
+	public function enqueue(): void {
+		if ( ! $this->should_load_on_current_page() ) {
+			return;
+		}
+
+		$script_url = $this->asset_getter->get_asset_url( 'boot-add-payment-method.js' );
+		if ( ! $script_url ) {
+			return;
+		}
+
+		wp_register_script(
+			'wc-ppcp-sdk-v6-add-payment-method',
+			$script_url,
+			array(),
+			$this->version,
+			true
+		);
+
+		wp_localize_script(
+			'wc-ppcp-sdk-v6-add-payment-method',
+			'wc_ppcp_sdk_v6_save',
+			$this->script_data()
+		);
+
+		wp_enqueue_script( 'wc-ppcp-sdk-v6-add-payment-method' );
+
+		// v5's smart-button stylesheet (which carries this rule) is suppressed
+		// on this page, so the v6 boot's method-visibility toggling of
+		// #place_order needs the rule shipped here.
+		wp_register_style( 'wc-ppcp-sdk-v6-add-payment-method', false, array(), $this->version );
+		wp_enqueue_style( 'wc-ppcp-sdk-v6-add-payment-method' );
+		wp_add_inline_style(
+			'wc-ppcp-sdk-v6-add-payment-method',
+			'#place_order.ppcp-hidden{display:none !important;}'
+		);
+	}
+
+	/**
+	 * Whether the v6 save surfaces load on the current page.
+	 *
+	 * @return bool
+	 */
+	public function should_load_on_current_page(): bool {
+		return is_user_logged_in()
+			&& ( $this->paypal_vaulting_enabled || $this->card_vaulting_enabled )
+			&& $this->context->is_add_payment_method_page();
+	}
+
+	/**
+	 * The configuration data for the add-payment-method bootstrap script.
+	 *
+	 * @return array
+	 */
+	private function script_data(): array {
+		$base_url = $this->environment->is_sandbox()
+			? 'https://www.sandbox.paypal.com'
+			: 'https://www.paypal.com';
+
+		$verification_method = (string) apply_filters(
+			'woocommerce_paypal_payments_three_d_secure_contingency',
+			$this->settings_provider->three_d_secure_enum()
+		);
+
+		return array(
+			'sdk_url'              => $base_url . '/web-sdk/v6/core',
+			'currency'             => get_woocommerce_currency(),
+			'locale'               => str_replace( '_', '-', get_locale() ),
+			'verification_method'  => $verification_method,
+			'payment_methods_page' => wc_get_account_endpoint_url( 'payment-methods' ),
+			'button'               => array(
+				'wrapper'     => '#' . self::WRAPPER_ID,
+				'color_class' => 'paypal-gold',
+			),
+			'card_fields'          => array(
+				'enabled'        => $this->card_vaulting_enabled,
+				'payment_method' => CreditCardGateway::ID,
+				'funding_source' => 'card',
+				'fields'         => array(
+					'name'   => '#' . self::CARD_FIELD_NAME_ID,
+					'number' => '#' . self::CARD_FIELD_NUMBER_ID,
+					'expiry' => '#' . self::CARD_FIELD_EXPIRY_ID,
+					'cvv'    => '#' . self::CARD_FIELD_CVV_ID,
+				),
+			),
+			'ajax'                 => array(
+				'client_token'         => array(
+					'endpoint' => \WC_AJAX::get_endpoint( ClientTokenEndpoint::ENDPOINT ),
+					'nonce'    => wp_create_nonce( ClientTokenEndpoint::nonce() ),
+				),
+				'create_setup_token'   => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreateSetupToken::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreateSetupToken::nonce() ),
+				),
+				'create_payment_token' => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentToken::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreatePaymentToken::nonce() ),
+				),
+			),
+			'labels'               => array(
+				'generic_error' => __(
+					'Something went wrong. Please try again or choose another payment source.',
+					'woocommerce-paypal-payments'
+				),
+			),
+		);
+	}
+}

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -25,6 +25,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 class SdkV6Manager {
 
@@ -52,6 +53,8 @@ class SdkV6Manager {
 	private bool $final_review_enabled;
 	private bool $vaulting_enabled;
 	private CardPaymentsConfiguration $card_payments_configuration;
+	private bool $card_vaulting_enabled;
+	private SubscriptionHelper $subscription_helper;
 
 	public function __construct(
 		AssetGetter $asset_getter,
@@ -65,7 +68,9 @@ class SdkV6Manager {
 		CancelView $cancel_view,
 		bool $final_review_enabled,
 		bool $vaulting_enabled,
-		CardPaymentsConfiguration $card_payments_configuration
+		CardPaymentsConfiguration $card_payments_configuration,
+		bool $card_vaulting_enabled,
+		SubscriptionHelper $subscription_helper
 	) {
 		$this->asset_getter                = $asset_getter;
 		$this->version                     = $version;
@@ -79,6 +84,8 @@ class SdkV6Manager {
 		$this->final_review_enabled        = $final_review_enabled;
 		$this->vaulting_enabled            = $vaulting_enabled;
 		$this->card_payments_configuration = $card_payments_configuration;
+		$this->card_vaulting_enabled       = $card_vaulting_enabled;
+		$this->subscription_helper         = $subscription_helper;
 	}
 
 	public function enqueue(): void {
@@ -292,13 +299,19 @@ class SdkV6Manager {
 			'wrapper'           => '#' . self::WRAPPER_ID,
 			'mini_cart_wrapper' => '#' . self::MINI_CART_WRAPPER_ID,
 			'card_fields'       => array(
-				'enabled'        => $card_fields_enabled,
-				'payment_method' => CreditCardGateway::ID,
-				'funding_source' => 'card',
+				'enabled'             => $card_fields_enabled,
+				'payment_method'      => CreditCardGateway::ID,
+				'funding_source'      => 'card',
 				// Label and name-field flag for the block's own card method.
-				'title'          => $this->card_payments_configuration->gateway_title(),
-				'name_field'     => 'yes' === $this->card_payments_configuration->show_name_on_card(),
-				'fields'         => array(
+				'title'               => $this->card_payments_configuration->gateway_title(),
+				'name_field'          => 'yes' === $this->card_payments_configuration->show_name_on_card(),
+				// Card "save during purchase" (vaulting). The block checkout has no
+				// native save checkbox, so V6CardFieldsComponent renders its own;
+				// the classic checkout reads WC's own tokenization checkbox instead.
+				'is_vaulting_enabled' => $this->card_vaulting_enabled,
+				'save_card_text'      => esc_html__( 'Save your card', 'woocommerce-paypal-payments' ),
+				'has_subscriptions'   => $this->subscription_helper->cart_contains_subscription(),
+				'fields'              => array(
 					'name'   => '#' . self::CARD_FIELD_NAME_ID,
 					'number' => '#' . self::CARD_FIELD_NUMBER_ID,
 					'expiry' => '#' . self::CARD_FIELD_EXPIRY_ID,

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -305,11 +305,12 @@ class SdkV6Manager {
 				// Label and name-field flag for the block's own card method.
 				'title'               => $this->card_payments_configuration->gateway_title(),
 				'name_field'          => 'yes' === $this->card_payments_configuration->show_name_on_card(),
-				// Card "save during purchase" (vaulting). The block checkout has no
-				// native save checkbox, so V6CardFieldsComponent renders its own;
-				// the classic checkout reads WC's own tokenization checkbox instead.
+				// Card "save during purchase" (vaulting). The block checkout uses
+				// WC Blocks' native save option (supports.showSaveOption, gated on
+				// is_vaulting_enabled); the classic checkout reads WC's own
+				// tokenization checkbox instead. has_subscriptions force-saves,
+				// since a subscription card must be vaulted for renewals.
 				'is_vaulting_enabled' => $this->card_vaulting_enabled,
-				'save_card_text'      => esc_html__( 'Save your card', 'woocommerce-paypal-payments' ),
 				'has_subscriptions'   => $this->subscription_helper->cart_contains_subscription(),
 				'fields'              => array(
 					'name'   => '#' . self::CARD_FIELD_NAME_ID,

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -11,6 +11,7 @@ namespace WooCommerce\PayPalCommerce\SdkV6;
 
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\SdkV6\Assets\AddPaymentMethodManager;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\SdkV6\Blocks\V6PaymentMethod;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
@@ -53,6 +54,26 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 				assert( $manager instanceof SdkV6Manager );
 
 				$manager->enqueue();
+
+				$add_payment_method_manager = $c->get( 'sdk-v6.add-payment-method-manager' );
+				assert( $add_payment_method_manager instanceof AddPaymentMethodManager );
+
+				$add_payment_method_manager->enqueue();
+			}
+		);
+
+		// v6 fully owns the Add Payment Method page when it loads (PayPal save
+		// button + card save fields), so the v5 add-payment-method script must
+		// not also run there. See the migration note in extensions.php.
+		add_filter(
+			'woocommerce_paypal_payments_render_add_payment_method_assets',
+			static function ( bool $render ) use ( $c ): bool {
+				$add_payment_method_manager = $c->get( 'sdk-v6.add-payment-method-manager' );
+				assert( $add_payment_method_manager instanceof AddPaymentMethodManager );
+
+				return $add_payment_method_manager->should_load_on_current_page()
+					? false
+					: $render;
 			}
 		);
 

--- a/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Assets;
+
+use Mockery;
+use ReflectionClass;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
+use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
+use function Brain\Monkey\Functions\when;
+
+class AddPaymentMethodManagerTest extends TestCase
+{
+    private $asset_getter;
+    private $environment;
+    private $context;
+    private $settings_provider;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->asset_getter = Mockery::mock(AssetGetter::class);
+        $this->environment = Mockery::mock(Environment::class);
+        $this->context = Mockery::mock(Context::class);
+        $this->settings_provider = Mockery::mock(SettingsProvider::class);
+    }
+
+    private function createTestee(
+        bool $paypal_vaulting_enabled = false,
+        bool $card_vaulting_enabled = false
+    ): AddPaymentMethodManager {
+        return new AddPaymentMethodManager(
+            $this->asset_getter,
+            '1.0.0',
+            $this->environment,
+            $this->context,
+            $paypal_vaulting_enabled,
+            $card_vaulting_enabled,
+            $this->settings_provider
+        );
+    }
+
+    /**
+     * GIVEN a buyer's login state, vaulting configuration and page context
+     * WHEN checking whether the add-payment-method surfaces should load
+     * THEN the result is true only when the buyer is logged in, at least one
+     *      vaulting flag is enabled, and the current page is the add-payment-method page
+     *
+     * @dataProvider should_load_provider
+     */
+    public function testShouldLoadOnCurrentPage(
+        bool $is_logged_in,
+        bool $paypal_vaulting_enabled,
+        bool $card_vaulting_enabled,
+        bool $is_add_payment_method_page,
+        bool $expected
+    ): void {
+        when('is_user_logged_in')->justReturn($is_logged_in);
+        $this->context->shouldReceive('is_add_payment_method_page')
+            ->andReturn($is_add_payment_method_page)
+            ->byDefault();
+
+        $testee = $this->createTestee($paypal_vaulting_enabled, $card_vaulting_enabled);
+
+        $this->assertSame($expected, $testee->should_load_on_current_page());
+    }
+
+    public function should_load_provider(): array
+    {
+        return [
+            'logged out never loads regardless of vaulting or page' => [false, true, true, true, false],
+            'logged in but no vaulting enabled does not load' => [true, false, false, true, false],
+            'logged in with paypal vaulting but wrong page does not load' => [true, true, false, false, false],
+            'logged in with card vaulting on the add payment method page loads' => [true, false, true, true, true],
+            'logged in with paypal vaulting on the add payment method page loads' => [true, true, false, true, true],
+        ];
+    }
+
+    /**
+     * GIVEN a merchant with card vaulting configured and a 3DS contingency filter applied
+     * WHEN the add-payment-method bootstrap script data is generated
+     * THEN the button, card fields and ajax endpoint data reflect the constructor configuration
+     * AND the verification method reflects the filtered 3D Secure setting
+     *
+     * @dataProvider script_data_provider
+     */
+    public function testScriptData(bool $card_vaulting_enabled): void
+    {
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->settings_provider->shouldReceive('three_d_secure_enum')->andReturn('SCA_ALWAYS');
+
+        when('apply_filters')->alias(
+            static function (string $filter, $value) {
+                if ('woocommerce_paypal_payments_three_d_secure_contingency' === $filter) {
+                    return 'SCA_WHEN_REQUIRED';
+                }
+                return $value;
+            }
+        );
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('wc_get_account_endpoint_url')->justReturn('https://example.com/my-account/payment-methods');
+        when('wp_create_nonce')->alias(static fn (string $action) => 'nonce-' . $action);
+
+        $testee = $this->createTestee(false, $card_vaulting_enabled);
+        $data   = $this->invoke_script_data($testee);
+
+        $this->assertSame('#' . AddPaymentMethodManager::WRAPPER_ID, $data['button']['wrapper']);
+        $this->assertSame('paypal-gold', $data['button']['color_class']);
+
+        $this->assertSame($card_vaulting_enabled, $data['card_fields']['enabled']);
+        $this->assertSame(CreditCardGateway::ID, $data['card_fields']['payment_method']);
+
+        $this->assertArrayHasKey('client_token', $data['ajax']);
+        $this->assertArrayHasKey('create_setup_token', $data['ajax']);
+        $this->assertArrayHasKey('create_payment_token', $data['ajax']);
+
+        $this->assertSame(
+            ClientTokenEndpoint::ENDPOINT,
+            $data['ajax']['client_token']['endpoint']
+        );
+        $this->assertSame(
+            'nonce-' . ClientTokenEndpoint::nonce(),
+            $data['ajax']['client_token']['nonce']
+        );
+
+        $this->assertSame(
+            CreateSetupToken::ENDPOINT,
+            $data['ajax']['create_setup_token']['endpoint']
+        );
+        $this->assertSame(
+            'nonce-' . CreateSetupToken::nonce(),
+            $data['ajax']['create_setup_token']['nonce']
+        );
+
+        $this->assertSame(
+            CreatePaymentToken::ENDPOINT,
+            $data['ajax']['create_payment_token']['endpoint']
+        );
+        $this->assertSame(
+            'nonce-' . CreatePaymentToken::nonce(),
+            $data['ajax']['create_payment_token']['nonce']
+        );
+
+        $this->assertSame('SCA_WHEN_REQUIRED', $data['verification_method']);
+    }
+
+    public function script_data_provider(): array
+    {
+        return [
+            'card vaulting enabled surfaces card fields as enabled' => [true],
+            'card vaulting disabled surfaces card fields as disabled' => [false],
+        ];
+    }
+
+    /**
+     * Invokes the private script_data() method via reflection, since it is
+     * only reachable indirectly through enqueue() in production code.
+     */
+    private function invoke_script_data(AddPaymentMethodManager $testee): array
+    {
+        $method = (new ReflectionClass($testee))->getMethod('script_data');
+        $method->setAccessible(true);
+
+        return $method->invoke($testee);
+    }
+}

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -27,7 +27,6 @@ class SdkV6ManagerTest extends TestCase
     private $session_handler;
     private $cancel_view;
     private $card_payments_configuration;
-	private $card_vaulting_enabled;
     private $subscription_helper;
 	private $credit_card_icons;
 
@@ -43,13 +42,12 @@ class SdkV6ManagerTest extends TestCase
         $this->session_handler = Mockery::mock(SessionHandler::class);
         $this->cancel_view = Mockery::mock(CancelView::class);
         $this->card_payments_configuration = Mockery::mock(CardPaymentsConfiguration::class);
-        $this->card_vaulting_enabled = true;
 		$this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
         $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false)->byDefault();
 		$this->credit_card_icons = [];
     }
 
-    private function createTestee(bool $should_handle_shipping = false, array $credit_card_icons = []): SdkV6Manager
+    private function createTestee(bool $should_handle_shipping = false, array $credit_card_icons = [], bool $card_vaulting_enabled = true): SdkV6Manager
     {
         return new SdkV6Manager(
             $this->asset_getter,
@@ -64,9 +62,9 @@ class SdkV6ManagerTest extends TestCase
             false,
             false,
             $this->card_payments_configuration,
-	        $this->card_vaulting_enabled,
+	        $card_vaulting_enabled,
 	        $this->subscription_helper,
-	        $this->credit_card_icons
+	        $credit_card_icons
         );
     }
 
@@ -293,7 +291,7 @@ class SdkV6ManagerTest extends TestCase
         when('wp_create_nonce')->justReturn('nonce');
         when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
 
-        $testee = $this->createTestee($card_vaulting_enabled);
+        $testee = $this->createTestee(false, [], $card_vaulting_enabled);
         $data   = $testee->script_data();
 
         $this->assertSame($expected_enabled, $data['card_fields']['enabled']);

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -27,7 +27,9 @@ class SdkV6ManagerTest extends TestCase
     private $session_handler;
     private $cancel_view;
     private $card_payments_configuration;
+	private $card_vaulting_enabled;
     private $subscription_helper;
+	private $credit_card_icons;
 
     public function setUp(): void
     {
@@ -41,8 +43,10 @@ class SdkV6ManagerTest extends TestCase
         $this->session_handler = Mockery::mock(SessionHandler::class);
         $this->cancel_view = Mockery::mock(CancelView::class);
         $this->card_payments_configuration = Mockery::mock(CardPaymentsConfiguration::class);
-        $this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
+        $this->card_vaulting_enabled = true;
+		$this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
         $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false)->byDefault();
+		$this->credit_card_icons = [];
     }
 
     private function createTestee(bool $should_handle_shipping = false, array $credit_card_icons = []): SdkV6Manager
@@ -60,9 +64,9 @@ class SdkV6ManagerTest extends TestCase
             false,
             false,
             $this->card_payments_configuration,
-            $credit_card_icons,
-	        $card_vaulting_enabled,
-	        $this->subscription_helper
+	        $this->card_vaulting_enabled,
+	        $this->subscription_helper,
+	        $this->credit_card_icons
         );
     }
 

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -14,6 +14,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use function Brain\Monkey\Functions\when;
 
 class SdkV6ManagerTest extends TestCase
@@ -26,6 +27,7 @@ class SdkV6ManagerTest extends TestCase
     private $session_handler;
     private $cancel_view;
     private $card_payments_configuration;
+    private $subscription_helper;
 
     public function setUp(): void
     {
@@ -39,9 +41,11 @@ class SdkV6ManagerTest extends TestCase
         $this->session_handler = Mockery::mock(SessionHandler::class);
         $this->cancel_view = Mockery::mock(CancelView::class);
         $this->card_payments_configuration = Mockery::mock(CardPaymentsConfiguration::class);
+        $this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false)->byDefault();
     }
 
-    private function createTestee(): SdkV6Manager
+    private function createTestee(bool $card_vaulting_enabled = false): SdkV6Manager
     {
         return new SdkV6Manager(
             $this->asset_getter,
@@ -55,7 +59,9 @@ class SdkV6ManagerTest extends TestCase
             $this->cancel_view,
             false,
             false,
-            $this->card_payments_configuration
+            $this->card_payments_configuration,
+            $card_vaulting_enabled,
+            $this->subscription_helper
         );
     }
 
@@ -93,6 +99,8 @@ class SdkV6ManagerTest extends TestCase
      * WHEN the SDK bootstrap data is generated
      * THEN card_fields.enabled is true
      * AND the gateway title and name-field flag are carried into the payload
+     * AND is_vaulting_enabled reflects the card vaulting setting
+     * AND has_subscriptions reflects whether the cart contains a subscription
      *
      * @dataProvider script_data_card_fields_provider
      */
@@ -101,6 +109,8 @@ class SdkV6ManagerTest extends TestCase
         bool $acdc_enabled,
         string $gateway_title,
         string $show_name_on_card,
+        bool $card_vaulting_enabled,
+        bool $cart_contains_subscription,
         bool $expected_enabled,
         bool $expected_name_field
     ): void {
@@ -108,6 +118,7 @@ class SdkV6ManagerTest extends TestCase
         $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn($acdc_enabled);
         $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn($gateway_title);
         $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn($show_name_on_card);
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn($cart_contains_subscription);
 
         $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
         $this->session_handler->shouldReceive('order')->andReturn(null);
@@ -130,29 +141,37 @@ class SdkV6ManagerTest extends TestCase
         when('wp_create_nonce')->justReturn('nonce');
         when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
 
-        $testee = $this->createTestee();
+        $testee = $this->createTestee($card_vaulting_enabled);
         $data   = $testee->script_data();
 
         $this->assertSame($expected_enabled, $data['card_fields']['enabled']);
         $this->assertSame($gateway_title, $data['card_fields']['title']);
         $this->assertSame($expected_name_field, $data['card_fields']['name_field']);
         $this->assertSame(CreditCardGateway::ID, $data['card_fields']['payment_method']);
+        $this->assertSame($card_vaulting_enabled, $data['card_fields']['is_vaulting_enabled']);
+        $this->assertSame($cart_contains_subscription, $data['card_fields']['has_subscriptions']);
     }
 
     public function script_data_card_fields_provider(): array
     {
         return [
             'checkout-block with ACDC enabled and name field shown' => [
-                'checkout-block', true, 'Credit Card', 'yes', true, true,
+                'checkout-block', true, 'Credit Card', 'yes', false, false, true, true,
             ],
             'checkout-block with ACDC enabled and name field hidden' => [
-                'checkout-block', true, 'Credit Card', 'no', true, false,
+                'checkout-block', true, 'Credit Card', 'no', false, false, true, false,
             ],
             'checkout-block with ACDC disabled' => [
-                'checkout-block', false, 'Credit Card', 'yes', false, true,
+                'checkout-block', false, 'Credit Card', 'yes', false, false, false, true,
             ],
             'classic checkout with ACDC enabled' => [
-                'checkout', true, 'Credit Card', 'yes', true, true,
+                'checkout', true, 'Credit Card', 'yes', false, false, true, true,
+            ],
+            'checkout-block with card vaulting enabled' => [
+                'checkout-block', true, 'Credit Card', 'yes', true, false, true, true,
+            ],
+            'checkout-block with a subscription in the cart' => [
+                'checkout-block', true, 'Credit Card', 'yes', false, true, true, true,
             ],
         ];
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,11 @@ const modulesAssets = {
 	],
 	'ppcp-paypal-subscriptions': [ 'js/paypal-subscription.js' ],
 	'ppcp-save-payment-methods': [ 'js/add-payment-method.js' ],
-	'ppcp-sdk-v6': [ 'js/boot.js', 'js/checkout-block.js' ],
+	'ppcp-sdk-v6': [
+		'js/boot.js',
+		'js/checkout-block.js',
+		'js/boot-add-payment-method.js',
+	],
 	'ppcp-settings': [ 'js/index.js', 'css/styles.scss' ],
 	'ppcp-wc-gateway': [
 		'js/common.js',


### PR DESCRIPTION
The v6 Web SDK migration added wallet buttons and advanced card fields (classic + block checkout) but no vaulting, this PR implements v6 vaulting across all surfaces. 

Save-during-purchase now forwards the save choice for cards (WooCommerce's native tokenization checkbox on classic, Blocks' native showSaveOption/shouldSavePayment in blocks) into the order payload; PayPal/Venmo continue vaulting server-side from the merchant setting. 

A new v6 boot fully owns the Add Payment Method page, rendering the PayPal save button (`createPayPalSavePaymentSession`) and card-save fields (`createCardFieldsSavePaymentSession`), exchanging setup tokens via the existing Vault endpoints, and retiring the v5 stack there.