### PR TITLE
Skip WooCommerce inbox note registration during AJAX requests (6752)

### DIFF
--- a/modules/ppcp-wc-gateway/src/WcInboxNotes/InboxNoteRegistrar.php
+++ b/modules/ppcp-wc-gateway/src/WcInboxNotes/InboxNoteRegistrar.php
@@ -27,6 +27,10 @@ class InboxNoteRegistrar {
 	}
 
 	public function register(): void {
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+
 		foreach ( $this->inbox_notes as $inbox_note ) {
 			$inbox_note_name = $inbox_note->name();
 			$existing_note   = Notes::get_note_by_name( $inbox_note_name );

--- a/tests/PHPUnit/WcGateway/WcInboxNotes/InboxNoteRegistrarTest.php
+++ b/tests/PHPUnit/WcGateway/WcInboxNotes/InboxNoteRegistrarTest.php
@@ -1,0 +1,60 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\WcGateway\WcInboxNotes;
+
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Mockery;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+class InboxNoteRegistrarTest extends TestCase
+{
+    /**
+     * GIVEN the current request is a WordPress AJAX request
+     * WHEN the inbox notes are registered
+     * THEN registration exits early and no configured note is inspected or persisted
+     */
+    public function testRegisterSkipsNotesDuringAjaxRequest(): void
+    {
+        when('wp_doing_ajax')->justReturn(true);
+
+        $inbox_note = Mockery::mock(InboxNoteInterface::class);
+        $inbox_note->shouldNotReceive('name');
+        $inbox_note->shouldNotReceive('is_enabled');
+
+        $testee = new InboxNoteRegistrar([$inbox_note], 'woocommerce-paypal-payments/woocommerce-paypal-payments.php');
+
+        $testee->register();
+
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * GIVEN a non-AJAX admin request with a note that already exists and is enabled
+     * WHEN the inbox notes are registered
+     * THEN the existing note is looked up and processing short-circuits without creating a new note
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
+    public function testRegisterProcessesNotesOutsideAjaxRequest(): void
+    {
+        when('wp_doing_ajax')->justReturn(false);
+
+        Mockery::mock('alias:' . Notes::class)
+            ->shouldReceive('get_note_by_name')
+            ->once()
+            ->andReturn((object) array());
+
+        $inbox_note = Mockery::mock(InboxNoteInterface::class);
+        $inbox_note->shouldReceive('name')->once()->andReturn('ppcp-inbox-note');
+        $inbox_note->shouldReceive('is_enabled')->andReturn(true);
+
+        $testee = new InboxNoteRegistrar([$inbox_note], 'woocommerce-paypal-payments/woocommerce-paypal-payments.php');
+
+        $testee->register();
+
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
# Description

## 🐛 The problem

Every request to `admin-ajax.php` runs a note-existence lookup for each configured PayPal Payments inbox note, even though inbox notes never appear in an AJAX response.

## 💡 Why it happens

Inbox note registration is hooked on `admin_init`, and `admin_init` also fires for `admin-ajax.php`. The lookup queries the `wc_admin_notes` table directly and is not cached, so the cost repeats on every admin AJAX request.

## ✅ The fix

`InboxNoteRegistrar::register()` returns early on AJAX requests. Regular admin requests keep the existing flow, so eligible notes are still registered or removed on the next normal admin page load.

## 🔍 What to review

- **Nothing a merchant sees moves.** WooCommerce Admin renders the inbox from its own REST endpoint, and REST requests never fired `admin_init` in the first place, so notes were already only written during regular admin page loads.
- **The removal branch is deferred as well.** A note that becomes ineligible is now deleted on the next non-AJAX admin request, which is the same request type that would have created it.

## 🧪 How to verify

1. With query logging on, load any wp-admin page and confirm the `wc_admin_notes` lookup runs, then trigger an admin AJAX action and confirm it does not.
2. In a US store with **Stay updated** enabled, confirm the **PayPal Working Capital** note still appears under **WooCommerce → Home → Inbox**.
