### PR TITLE
Webhook registration deregisters all webhooks for the current PayPal account (6770)

### DIFF
--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -34,6 +34,11 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 	use ModuleClassNameIdTrait;
 
 	/**
+	 * Transient key caching the live PayPal-side registered webhooks for the status page.
+	 */
+	private const REGISTERED_WEBHOOKS_TRANSIENT = 'ppcp-status-registered-webhooks';
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function services(): array {
@@ -139,10 +144,10 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 						'value'          => $this->bool_to_html( ! $last_webhook_storage->is_empty() ),
 					),
 					array(
-						'label'          => esc_html__( 'Webhook delivery URL', 'woocommerce-paypal-payments' ),
-						'exported_label' => 'Webhook delivery URL',
+						'label'          => esc_html__( 'Webhook delivery host', 'woocommerce-paypal-payments' ),
+						'exported_label' => 'Webhook delivery host',
 						'description'    => esc_html__( 'Whether PayPal delivers webhooks to this site or to a different host.', 'woocommerce-paypal-payments' ),
-						'value'          => $this->webhook_delivery_host_status( $c, $is_connected ),
+						'value'          => $this->webhook_delivery_host_status( $this->registered_webhooks( $c, $is_connected ) ),
 					),
 					array(
 						'label'          => esc_html__( 'PayPal Vault enabled', 'woocommerce-paypal-payments' ),
@@ -291,49 +296,76 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 	}
 
 	/**
-	 * Reports whether PayPal's registered webhook points at this site.
+	 * Fetches the live PayPal-side registered webhooks, cached behind a short transient.
 	 *
-	 * Reads the live PayPal-side webhook list (not local state) and compares each
-	 * webhook's host against this site's host. When they differ, webhook events are
-	 * being delivered elsewhere - typically a staging or dev clone connected to the
-	 * same PayPal account - which the "Webhook status" row above cannot detect.
+	 * The 'webhook.status.registered-webhooks' factory is non-shared and performs a live
+	 * PayPal API call on every resolution, so the result is cached briefly to avoid an
+	 * extra request each time the status page is rendered. Any failure degrades to an
+	 * empty list so the status page never fatals.
 	 *
 	 * @param ContainerInterface $c            The services container.
 	 * @param bool               $is_connected Whether onboarding is complete.
-	 * @return string
+	 * @return Webhook[]
 	 */
-	private function webhook_delivery_host_status( ContainerInterface $c, bool $is_connected ): string {
+	private function registered_webhooks( ContainerInterface $c, bool $is_connected ): array {
 		if ( ! $is_connected ) {
-			return $this->bool_to_html( false );
+			return array();
+		}
+
+		$cached = get_transient( self::REGISTERED_WEBHOOKS_TRANSIENT );
+		if ( is_array( $cached ) ) {
+			return $cached;
 		}
 
 		try {
 			$webhooks = $c->get( 'webhook.status.registered-webhooks' );
-		} catch ( \Exception $exception ) {
-			return $this->bool_to_html( false );
+		} catch ( \Throwable $exception ) {
+			return array();
 		}
 
-		if ( ! is_array( $webhooks ) || array() === $webhooks ) {
-			return $this->bool_to_html( false );
-		}
+		$webhooks = is_array( $webhooks )
+			? array_values( array_filter( $webhooks, fn( $webhook ) => $webhook instanceof Webhook ) )
+			: array();
 
+		set_transient( self::REGISTERED_WEBHOOKS_TRANSIENT, $webhooks, 5 * MINUTE_IN_SECONDS );
+
+		return $webhooks;
+	}
+
+	/**
+	 * Reports whether PayPal's registered webhook points at this site.
+	 *
+	 * Compares each registered webhook's host against this site's host. When they
+	 * differ, webhook events are being delivered elsewhere - typically a staging or dev
+	 * clone connected to the same PayPal account - which the "Webhook status" row above
+	 * cannot detect.
+	 *
+	 * @param Webhook[] $registered_webhooks The live PayPal-side registered webhooks.
+	 * @return string
+	 */
+	private function webhook_delivery_host_status( array $registered_webhooks ): string {
 		$site_host = $this->normalized_host( home_url() );
 
 		$foreign_hosts = array();
-		foreach ( $webhooks as $webhook ) {
+		foreach ( $registered_webhooks as $webhook ) {
 			if ( ! $webhook instanceof Webhook ) {
 				continue;
 			}
 
 			$webhook_host = $this->normalized_host( $webhook->url() );
+			if ( '' === $webhook_host ) {
+				continue;
+			}
 
-			if ( '' !== $webhook_host && $webhook_host === $site_host ) {
+			if ( $webhook_host === $site_host ) {
 				return $this->bool_to_html( true );
 			}
 
-			if ( '' !== $webhook_host ) {
-				$foreign_hosts[ $webhook_host ] = $webhook_host;
-			}
+			$foreign_hosts[ $webhook_host ] = $webhook_host;
+		}
+
+		if ( array() === $foreign_hosts ) {
+			return $this->bool_to_html( false );
 		}
 
 		return sprintf(

--- a/modules/ppcp-status-report/src/StatusReportModule.php
+++ b/modules/ppcp-status-report/src/StatusReportModule.php
@@ -24,6 +24,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameI
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
 use WooCommerce\PayPalCommerce\Webhooks\WebhookEventStorage;
 
 /**
@@ -136,6 +137,12 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 						'exported_label' => 'Webhook status',
 						'description'    => esc_html__( 'Whether we received webhooks successfully.', 'woocommerce-paypal-payments' ),
 						'value'          => $this->bool_to_html( ! $last_webhook_storage->is_empty() ),
+					),
+					array(
+						'label'          => esc_html__( 'Webhook delivery URL', 'woocommerce-paypal-payments' ),
+						'exported_label' => 'Webhook delivery URL',
+						'description'    => esc_html__( 'Whether PayPal delivers webhooks to this site or to a different host.', 'woocommerce-paypal-payments' ),
+						'value'          => $this->webhook_delivery_host_status( $c, $is_connected ),
 					),
 					array(
 						'label'          => esc_html__( 'PayPal Vault enabled', 'woocommerce-paypal-payments' ),
@@ -281,5 +288,76 @@ class StatusReportModule implements ServiceModule, ExecutableModule {
 		return $value
 			? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>'
 			: '<mark class="no">&ndash;</mark>';
+	}
+
+	/**
+	 * Reports whether PayPal's registered webhook points at this site.
+	 *
+	 * Reads the live PayPal-side webhook list (not local state) and compares each
+	 * webhook's host against this site's host. When they differ, webhook events are
+	 * being delivered elsewhere - typically a staging or dev clone connected to the
+	 * same PayPal account - which the "Webhook status" row above cannot detect.
+	 *
+	 * @param ContainerInterface $c            The services container.
+	 * @param bool               $is_connected Whether onboarding is complete.
+	 * @return string
+	 */
+	private function webhook_delivery_host_status( ContainerInterface $c, bool $is_connected ): string {
+		if ( ! $is_connected ) {
+			return $this->bool_to_html( false );
+		}
+
+		try {
+			$webhooks = $c->get( 'webhook.status.registered-webhooks' );
+		} catch ( \Exception $exception ) {
+			return $this->bool_to_html( false );
+		}
+
+		if ( ! is_array( $webhooks ) || array() === $webhooks ) {
+			return $this->bool_to_html( false );
+		}
+
+		$site_host = $this->normalized_host( home_url() );
+
+		$foreign_hosts = array();
+		foreach ( $webhooks as $webhook ) {
+			if ( ! $webhook instanceof Webhook ) {
+				continue;
+			}
+
+			$webhook_host = $this->normalized_host( $webhook->url() );
+
+			if ( '' !== $webhook_host && $webhook_host === $site_host ) {
+				return $this->bool_to_html( true );
+			}
+
+			if ( '' !== $webhook_host ) {
+				$foreign_hosts[ $webhook_host ] = $webhook_host;
+			}
+		}
+
+		return sprintf(
+			'<mark class="error"><span class="dashicons dashicons-warning"></span> %s</mark>',
+			esc_html(
+				sprintf(
+					/* translators: 1: host(s) receiving the webhooks, 2: this site's host. */
+					__( 'Delivered to %1$s (this site: %2$s)', 'woocommerce-paypal-payments' ),
+					implode( ', ', $foreign_hosts ),
+					$site_host
+				)
+			)
+		);
+	}
+
+	/**
+	 * Extracts the lower-cased host from a URL, or an empty string when it cannot be parsed.
+	 *
+	 * @param string $url The URL to extract the host from.
+	 * @return string
+	 */
+	private function normalized_host( string $url ): string {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+
+		return is_string( $host ) ? strtolower( $host ) : '';
 	}
 }

--- a/modules/ppcp-webhooks/src/WebhookRegistrar.php
+++ b/modules/ppcp-webhooks/src/WebhookRegistrar.php
@@ -116,16 +116,19 @@ class WebhookRegistrar {
 	/**
 	 * Internal unregister logic.
 	 *
-	 * Only webhooks that point at this site are deleted. Webhooks registered for
+	 * Only webhooks that belong to this site are deleted. Webhooks registered for
 	 * other sites or services on the same PayPal account are left untouched, so
 	 * connecting a staging or secondary site to shared credentials no longer wipes
 	 * the primary site's webhook. See GitHub issue #4604.
 	 */
 	private function do_unregister(): void {
+		$stored_id    = (string) ( ( (array) get_option( self::KEY, array() ) )['id'] ?? '' );
+		$own_identity = $this->webhook_identity( $this->incoming_webhook_endpoint->url() );
+
 		try {
 			$webhooks = $this->endpoint->list();
 			foreach ( $webhooks as $webhook ) {
-				if ( ! $this->is_own_webhook( $webhook ) ) {
+				if ( ! $this->is_own_webhook( $webhook, $own_identity, $stored_id ) ) {
 					$this->logger->warning(
 						"Skipping deletion of webhook {$webhook->id()} ({$webhook->url()}): it belongs to a different site and is not managed by this install."
 					);
@@ -148,24 +151,50 @@ class WebhookRegistrar {
 	}
 
 	/**
-	 * Whether the given webhook points at this site's incoming endpoint.
+	 * Whether the given webhook belongs to this site and may be deleted.
 	 *
-	 * The comparison is host-based against this install's own endpoint URL, so the
-	 * NGROK_HOST development override is honoured automatically. A webhook whose URL
-	 * cannot be parsed is treated as not belonging to this site (conservative: it is
-	 * left in place rather than deleted).
+	 * A webhook is considered ours when either:
+	 * - its id matches the one we previously stored (provably ours regardless of the
+	 *   host it currently uses, so a domain migration or NGROK_HOST rotation still
+	 *   cleans up our former webhook instead of leaking it), or
+	 * - its URL identity (host + path) equals this install's incoming endpoint. The
+	 *   path is included so that same-host installs (e.g. example.com/shop and
+	 *   example.com/staging, or subdirectory multisite) do not delete each other's
+	 *   webhooks. The host comparison honours the NGROK_HOST development override.
 	 *
-	 * @param Webhook $webhook The webhook to check.
+	 * A webhook whose URL cannot be parsed (empty identity) is left in place.
+	 *
+	 * @param Webhook $webhook      The webhook to check.
+	 * @param string  $own_identity This install's incoming endpoint identity (host + path).
+	 * @param string  $stored_id    The id of the webhook this install previously registered.
 	 * @return bool
 	 */
-	private function is_own_webhook( Webhook $webhook ): bool {
-		$own_host     = wp_parse_url( $this->incoming_webhook_endpoint->url(), PHP_URL_HOST );
-		$webhook_host = wp_parse_url( $webhook->url(), PHP_URL_HOST );
-
-		if ( ! is_string( $own_host ) || ! is_string( $webhook_host ) || '' === $own_host || '' === $webhook_host ) {
-			return false;
+	private function is_own_webhook( Webhook $webhook, string $own_identity, string $stored_id ): bool {
+		if ( '' !== $stored_id && $webhook->id() === $stored_id ) {
+			return true;
 		}
 
-		return strtolower( $own_host ) === strtolower( $webhook_host );
+		$webhook_identity = $this->webhook_identity( $webhook->url() );
+
+		return '' !== $own_identity && $own_identity === $webhook_identity;
+	}
+
+	/**
+	 * Builds a host+path identity for a webhook URL, used to compare webhooks
+	 * independently of scheme, port, query string or a trailing slash.
+	 *
+	 * @param string $url The webhook URL.
+	 * @return string The lower-cased host and path, or an empty string when the host cannot be parsed.
+	 */
+	private function webhook_identity( string $url ): string {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			return '';
+		}
+
+		$path = wp_parse_url( $url, PHP_URL_PATH );
+		$path = is_string( $path ) ? rtrim( $path, '/' ) : '';
+
+		return strtolower( $host ) . $path;
 	}
 }

--- a/modules/ppcp-webhooks/src/WebhookRegistrar.php
+++ b/modules/ppcp-webhooks/src/WebhookRegistrar.php
@@ -6,6 +6,7 @@ namespace WooCommerce\PayPalCommerce\Webhooks;
 
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
 use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookFactory;
 use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
@@ -114,11 +115,23 @@ class WebhookRegistrar {
 
 	/**
 	 * Internal unregister logic.
+	 *
+	 * Only webhooks that point at this site are deleted. Webhooks registered for
+	 * other sites or services on the same PayPal account are left untouched, so
+	 * connecting a staging or secondary site to shared credentials no longer wipes
+	 * the primary site's webhook. See GitHub issue #4604.
 	 */
 	private function do_unregister(): void {
 		try {
 			$webhooks = $this->endpoint->list();
 			foreach ( $webhooks as $webhook ) {
+				if ( ! $this->is_own_webhook( $webhook ) ) {
+					$this->logger->warning(
+						"Skipping deletion of webhook {$webhook->id()} ({$webhook->url()}): it belongs to a different site and is not managed by this install."
+					);
+					continue;
+				}
+
 				try {
 					$this->endpoint->delete( $webhook );
 				} catch ( RuntimeException $deletion_error ) {
@@ -132,5 +145,27 @@ class WebhookRegistrar {
 		delete_option( self::KEY );
 		$this->last_webhook_event_storage->clear();
 		$this->logger->info( 'Webhooks deleted.' );
+	}
+
+	/**
+	 * Whether the given webhook points at this site's incoming endpoint.
+	 *
+	 * The comparison is host-based against this install's own endpoint URL, so the
+	 * NGROK_HOST development override is honoured automatically. A webhook whose URL
+	 * cannot be parsed is treated as not belonging to this site (conservative: it is
+	 * left in place rather than deleted).
+	 *
+	 * @param Webhook $webhook The webhook to check.
+	 * @return bool
+	 */
+	private function is_own_webhook( Webhook $webhook ): bool {
+		$own_host     = wp_parse_url( $this->incoming_webhook_endpoint->url(), PHP_URL_HOST );
+		$webhook_host = wp_parse_url( $webhook->url(), PHP_URL_HOST );
+
+		if ( ! is_string( $own_host ) || ! is_string( $webhook_host ) || '' === $own_host || '' === $webhook_host ) {
+			return false;
+		}
+
+		return strtolower( $own_host ) === strtolower( $webhook_host );
 	}
 }

--- a/tests/PHPUnit/StatusReport/StatusReportModuleTest.php
+++ b/tests/PHPUnit/StatusReport/StatusReportModuleTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\StatusReport;
+
+use Mockery;
+use ReflectionMethod;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\StatusReport\StatusReportModule
+ */
+class StatusReportModuleTest extends TestCase
+{
+	private StatusReportModule $sut;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		when('wp_parse_url')->alias('parse_url');
+
+		$this->sut = new StatusReportModule();
+	}
+
+	private function webhook_delivery_host_status(ContainerInterface $c, bool $is_connected): string
+	{
+		$method = new ReflectionMethod(StatusReportModule::class, 'webhook_delivery_host_status');
+		$method->setAccessible(true);
+
+		return $method->invoke($this->sut, $c, $is_connected);
+	}
+
+	/**
+	 * GIVEN the store is not connected to PayPal
+	 * WHEN determining the webhook delivery host status
+	 * THEN the row shows the "not applicable" indicator without querying the container
+	 */
+	public function test_returns_dash_when_not_connected(): void
+	{
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldNotReceive('get');
+
+		$result = $this->webhook_delivery_host_status($container, false);
+
+		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
+	}
+
+	/**
+	 * GIVEN the store is connected but fetching the registered webhooks from PayPal fails
+	 * WHEN determining the webhook delivery host status
+	 * THEN the row shows the "not applicable" indicator instead of erroring out
+	 */
+	public function test_returns_dash_when_registered_webhooks_lookup_throws(): void
+	{
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldReceive('get')
+			->with('webhook.status.registered-webhooks')
+			->andThrow(new \Exception('service not found'));
+
+		$result = $this->webhook_delivery_host_status($container, true);
+
+		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
+	}
+
+	/**
+	 * GIVEN the store is connected but PayPal reports no registered webhooks
+	 * WHEN determining the webhook delivery host status
+	 * THEN the row shows the "not applicable" indicator
+	 *
+	 * @dataProvider empty_or_invalid_webhooks_provider
+	 */
+	public function test_returns_dash_when_no_webhooks_are_registered($webhooks): void
+	{
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldReceive('get')
+			->with('webhook.status.registered-webhooks')
+			->andReturn($webhooks);
+
+		$result = $this->webhook_delivery_host_status($container, true);
+
+		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
+	}
+
+	public function empty_or_invalid_webhooks_provider(): array
+	{
+		return [
+			'no webhooks registered at all' => [[]],
+			'container returns a non-array value' => ['not-an-array'],
+		];
+	}
+
+	/**
+	 * GIVEN PayPal has a registered webhook whose host matches this site's host
+	 * WHEN determining the webhook delivery host status
+	 * THEN the row shows the "delivered here" indicator, even when other foreign
+	 * webhooks are also registered on the same account
+	 */
+	public function test_returns_yes_when_a_registered_webhook_matches_this_site(): void
+	{
+		when('home_url')->justReturn('https://mysite.com');
+
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldReceive('get')
+			->with('webhook.status.registered-webhooks')
+			->andReturn([
+				new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
+				new Webhook('https://MySite.com/wp-json/paypal/v1/incoming', [], 'OWN'),
+			]);
+
+		$result = $this->webhook_delivery_host_status($container, true);
+
+		$this->assertSame('<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>', $result);
+	}
+
+	/**
+	 * GIVEN PayPal only has webhooks registered for hosts other than this site
+	 * WHEN determining the webhook delivery host status
+	 * THEN the row reports the delivery is going to the foreign host(s) instead of this site
+	 */
+	public function test_reports_foreign_hosts_when_no_registered_webhook_matches_this_site(): void
+	{
+		when('home_url')->justReturn('https://mysite.com');
+
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldReceive('get')
+			->with('webhook.status.registered-webhooks')
+			->andReturn([
+				new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
+			]);
+
+		$result = $this->webhook_delivery_host_status($container, true);
+
+		$this->assertStringContainsString('<mark class="error">', $result);
+		$this->assertStringContainsString('Delivered to other-clone.com (this site: mysite.com)', $result);
+	}
+}

--- a/tests/PHPUnit/StatusReport/StatusReportModuleTest.php
+++ b/tests/PHPUnit/StatusReport/StatusReportModuleTest.php
@@ -9,6 +9,7 @@ use ReflectionMethod;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use function Brain\Monkey\Functions\expect;
 use function Brain\Monkey\Functions\when;
 
 /**
@@ -24,74 +25,27 @@ class StatusReportModuleTest extends TestCase
 
 		when('wp_parse_url')->alias('parse_url');
 
+		if (!defined('MINUTE_IN_SECONDS')) {
+			define('MINUTE_IN_SECONDS', 60);
+		}
+
 		$this->sut = new StatusReportModule();
 	}
 
-	private function webhook_delivery_host_status(ContainerInterface $c, bool $is_connected): string
+	private function webhook_delivery_host_status(array $registered_webhooks): string
 	{
 		$method = new ReflectionMethod(StatusReportModule::class, 'webhook_delivery_host_status');
 		$method->setAccessible(true);
 
+		return $method->invoke($this->sut, $registered_webhooks);
+	}
+
+	private function registered_webhooks(ContainerInterface $c, bool $is_connected): array
+	{
+		$method = new ReflectionMethod(StatusReportModule::class, 'registered_webhooks');
+		$method->setAccessible(true);
+
 		return $method->invoke($this->sut, $c, $is_connected);
-	}
-
-	/**
-	 * GIVEN the store is not connected to PayPal
-	 * WHEN determining the webhook delivery host status
-	 * THEN the row shows the "not applicable" indicator without querying the container
-	 */
-	public function test_returns_dash_when_not_connected(): void
-	{
-		$container = Mockery::mock(ContainerInterface::class);
-		$container->shouldNotReceive('get');
-
-		$result = $this->webhook_delivery_host_status($container, false);
-
-		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
-	}
-
-	/**
-	 * GIVEN the store is connected but fetching the registered webhooks from PayPal fails
-	 * WHEN determining the webhook delivery host status
-	 * THEN the row shows the "not applicable" indicator instead of erroring out
-	 */
-	public function test_returns_dash_when_registered_webhooks_lookup_throws(): void
-	{
-		$container = Mockery::mock(ContainerInterface::class);
-		$container->shouldReceive('get')
-			->with('webhook.status.registered-webhooks')
-			->andThrow(new \Exception('service not found'));
-
-		$result = $this->webhook_delivery_host_status($container, true);
-
-		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
-	}
-
-	/**
-	 * GIVEN the store is connected but PayPal reports no registered webhooks
-	 * WHEN determining the webhook delivery host status
-	 * THEN the row shows the "not applicable" indicator
-	 *
-	 * @dataProvider empty_or_invalid_webhooks_provider
-	 */
-	public function test_returns_dash_when_no_webhooks_are_registered($webhooks): void
-	{
-		$container = Mockery::mock(ContainerInterface::class);
-		$container->shouldReceive('get')
-			->with('webhook.status.registered-webhooks')
-			->andReturn($webhooks);
-
-		$result = $this->webhook_delivery_host_status($container, true);
-
-		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
-	}
-
-	public function empty_or_invalid_webhooks_provider(): array
-	{
-		return [
-			'no webhooks registered at all' => [[]],
-			'container returns a non-array value' => ['not-an-array'],
-		];
 	}
 
 	/**
@@ -104,15 +58,10 @@ class StatusReportModuleTest extends TestCase
 	{
 		when('home_url')->justReturn('https://mysite.com');
 
-		$container = Mockery::mock(ContainerInterface::class);
-		$container->shouldReceive('get')
-			->with('webhook.status.registered-webhooks')
-			->andReturn([
-				new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
-				new Webhook('https://MySite.com/wp-json/paypal/v1/incoming', [], 'OWN'),
-			]);
-
-		$result = $this->webhook_delivery_host_status($container, true);
+		$result = $this->webhook_delivery_host_status([
+			new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
+			new Webhook('https://MySite.com/wp-json/paypal/v1/incoming', [], 'OWN'),
+		]);
 
 		$this->assertSame('<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>', $result);
 	}
@@ -126,16 +75,138 @@ class StatusReportModuleTest extends TestCase
 	{
 		when('home_url')->justReturn('https://mysite.com');
 
-		$container = Mockery::mock(ContainerInterface::class);
-		$container->shouldReceive('get')
-			->with('webhook.status.registered-webhooks')
-			->andReturn([
-				new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
-			]);
-
-		$result = $this->webhook_delivery_host_status($container, true);
+		$result = $this->webhook_delivery_host_status([
+			new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN'),
+		]);
 
 		$this->assertStringContainsString('<mark class="error">', $result);
 		$this->assertStringContainsString('Delivered to other-clone.com (this site: mysite.com)', $result);
+	}
+
+	/**
+	 * GIVEN the registered webhooks list contains only malformed entries that are not
+	 * Webhook instances (e.g. a stray container value leaked into the list)
+	 * WHEN determining the webhook delivery host status
+	 * THEN the row shows the "not applicable" indicator instead of erroring out
+	 */
+	public function test_returns_dash_when_list_contains_only_non_webhook_items(): void
+	{
+		when('home_url')->justReturn('https://mysite.com');
+
+		$result = $this->webhook_delivery_host_status([new \stdClass(), 'a-string']);
+
+		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
+	}
+
+	/**
+	 * GIVEN a registered webhook whose URL has no parseable host
+	 * WHEN determining the webhook delivery host status
+	 * THEN the unparseable webhook is ignored and the row shows the "not applicable" indicator
+	 */
+	public function test_returns_dash_when_webhooks_have_unparseable_hosts(): void
+	{
+		when('home_url')->justReturn('https://mysite.com');
+
+		$result = $this->webhook_delivery_host_status([
+			new Webhook('not a url', [], 'BROKEN'),
+			new Webhook('', [], 'EMPTY'),
+		]);
+
+		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
+	}
+
+	/**
+	 * GIVEN no webhooks are registered on PayPal's side
+	 * WHEN determining the webhook delivery host status
+	 * THEN the row shows the "not applicable" indicator
+	 */
+	public function test_returns_dash_for_empty_webhook_list(): void
+	{
+		when('home_url')->justReturn('https://mysite.com');
+
+		$result = $this->webhook_delivery_host_status([]);
+
+		$this->assertSame('<mark class="no">&ndash;</mark>', $result);
+	}
+
+	/**
+	 * GIVEN the store is not connected to PayPal
+	 * WHEN fetching the live registered webhooks
+	 * THEN an empty list is returned without querying the container
+	 */
+	public function test_registered_webhooks_returns_empty_array_when_not_connected(): void
+	{
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldNotReceive('get');
+
+		$result = $this->registered_webhooks($container, false);
+
+		$this->assertSame([], $result);
+	}
+
+	/**
+	 * GIVEN the registered webhooks were already fetched and cached in a transient
+	 * WHEN fetching the live registered webhooks again
+	 * THEN the cached value is returned without querying the container
+	 */
+	public function test_registered_webhooks_returns_cached_value_without_querying_container(): void
+	{
+		$cached = [new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'CACHED')];
+
+		when('get_transient')->justReturn($cached);
+
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldNotReceive('get');
+
+		$result = $this->registered_webhooks($container, true);
+
+		$this->assertSame($cached, $result);
+	}
+
+	/**
+	 * GIVEN the container fails to resolve the live registered webhooks with an error that
+	 * is not an Exception (e.g. a TypeError)
+	 * WHEN fetching the live registered webhooks
+	 * THEN the failure is caught and an empty list is returned instead of erroring out
+	 */
+	public function test_registered_webhooks_returns_empty_array_when_container_throws_a_throwable(): void
+	{
+		when('get_transient')->justReturn(false);
+
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldReceive('get')
+			->with('webhook.status.registered-webhooks')
+			->andThrow(new \TypeError('unexpected type'));
+
+		$result = $this->registered_webhooks($container, true);
+
+		$this->assertSame([], $result);
+	}
+
+	/**
+	 * GIVEN the container returns a mix of Webhook instances and unrelated values
+	 * WHEN fetching the live registered webhooks
+	 * THEN only the Webhook instances are kept and the filtered list is cached
+	 */
+	public function test_registered_webhooks_filters_out_non_webhook_items_and_caches_result(): void
+	{
+		when('get_transient')->justReturn(false);
+
+		$own_webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'OWN');
+
+		$container = Mockery::mock(ContainerInterface::class);
+		$container->shouldReceive('get')
+			->with('webhook.status.registered-webhooks')
+			->andReturn([$own_webhook, new \stdClass(), 'not-a-webhook']);
+
+		expect('set_transient')->once()->with(
+			'ppcp-status-registered-webhooks',
+			[$own_webhook],
+			5 * MINUTE_IN_SECONDS
+		);
+
+		$result = $this->registered_webhooks($container, true);
+
+		$this->assertSame([$own_webhook], $result);
 	}
 }

--- a/tests/PHPUnit/Webhooks/WebhookRegistrarTest.php
+++ b/tests/PHPUnit/Webhooks/WebhookRegistrarTest.php
@@ -47,6 +47,10 @@ class WebhookRegistrarTest extends TestCase
 
 		when('wp_parse_url')->alias('parse_url');
 
+		// Default: no webhook was previously stored for this install; individual
+		// tests override this when exercising the stored-id matching path.
+		when('get_option')->justReturn([]);
+
 		$this->webhook_factory            = Mockery::mock(WebhookFactory::class);
 		$this->endpoint                   = Mockery::mock(WebhookEndpoint::class);
 		$this->incoming_webhook_endpoint  = Mockery::mock(IncomingWebhookEndpoint::class);
@@ -75,12 +79,13 @@ class WebhookRegistrarTest extends TestCase
 	}
 
 	/**
-	 * GIVEN a PayPal account with webhooks belonging to this site and to a different site
+	 * GIVEN a PayPal account with a webhook whose URL identity (host + path) matches this
+	 * site's incoming endpoint and another webhook registered for a completely different host
 	 * WHEN unregistering webhooks
-	 * THEN only the webhook whose host matches this site's incoming endpoint is deleted
+	 * THEN only the webhook matching this site's URL identity is deleted
 	 * AND a warning is logged for the foreign webhook that was skipped
 	 */
-	public function test_unregister_deletes_only_webhooks_belonging_to_this_site(): void
+	public function test_unregister_deletes_webhook_matching_full_url_identity_and_skips_foreign_host(): void
 	{
 		$this->incoming_webhook_endpoint->shouldReceive('url')
 			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
@@ -90,15 +95,25 @@ class WebhookRegistrarTest extends TestCase
 
 		$this->endpoint->shouldReceive('list')->andReturn([$own_webhook, $foreign_webhook]);
 
-		$this->endpoint->shouldReceive('delete')->once()->with($own_webhook);
-		$this->endpoint->shouldNotReceive('delete')->with($foreign_webhook);
+		$deleted = [];
+		$this->endpoint->shouldReceive('delete')
+			->andReturnUsing(static function (Webhook $webhook) use (&$deleted): void {
+				$deleted[] = $webhook->id();
+			});
 
-		$this->logger->shouldReceive('warning')->once();
+		$logged_warnings = [];
+		$this->logger->shouldReceive('warning')
+			->andReturnUsing(static function (string $message) use (&$logged_warnings): void {
+				$logged_warnings[] = $message;
+			});
 
 		expect('delete_option')->once()->with(WebhookRegistrar::KEY);
 		$this->last_webhook_event_storage->shouldReceive('clear')->once();
 
 		$this->createRegistrar()->unregister();
+
+		$this->assertSame(['OWN'], $deleted);
+		$this->assertCount(1, $logged_warnings);
 	}
 
 	/**
@@ -114,12 +129,91 @@ class WebhookRegistrarTest extends TestCase
 		$webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'OWN');
 
 		$this->endpoint->shouldReceive('list')->andReturn([$webhook]);
-		$this->endpoint->shouldReceive('delete')->once()->with($webhook);
+
+		$deleted = [];
+		$this->endpoint->shouldReceive('delete')
+			->andReturnUsing(static function (Webhook $webhook) use (&$deleted): void {
+				$deleted[] = $webhook->id();
+			});
 
 		expect('delete_option')->once();
 		$this->last_webhook_event_storage->shouldReceive('clear')->once();
 
 		$this->createRegistrar()->unregister();
+
+		$this->assertSame(['OWN'], $deleted);
+	}
+
+	/**
+	 * GIVEN a webhook registered on the same host as this site but under a different path
+	 * (e.g. a sibling shop in a subdirectory multisite)
+	 * WHEN unregistering webhooks
+	 * THEN the webhook is treated as belonging to a different install and is left in place
+	 * AND a warning is logged for the skipped webhook
+	 */
+	public function test_unregister_treats_same_host_different_path_as_foreign(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://example.com/shop-a/wp-json/paypal/v1/incoming');
+
+		$sibling_webhook = new Webhook('https://example.com/shop-b/wp-json/paypal/v1/incoming', [], 'SIBLING');
+
+		$this->endpoint->shouldReceive('list')->andReturn([$sibling_webhook]);
+
+		$deleted = [];
+		$this->endpoint->shouldReceive('delete')
+			->andReturnUsing(static function (Webhook $webhook) use (&$deleted): void {
+				$deleted[] = $webhook->id();
+			});
+
+		$logged_warnings = [];
+		$this->logger->shouldReceive('warning')
+			->andReturnUsing(static function (string $message) use (&$logged_warnings): void {
+				$logged_warnings[] = $message;
+			});
+
+		expect('delete_option')->once();
+		$this->last_webhook_event_storage->shouldReceive('clear')->once();
+
+		$this->createRegistrar()->unregister();
+
+		$this->assertSame([], $deleted);
+		$this->assertCount(1, $logged_warnings);
+	}
+
+	/**
+	 * GIVEN this install previously stored the id of a webhook it registered, and that
+	 * webhook's host has since changed (e.g. an NGROK_HOST rotation or domain migration)
+	 * WHEN unregistering webhooks
+	 * THEN the webhook is still recognized as belonging to this install by its stored id
+	 * AND it is deleted even though its current host no longer matches this install's endpoint
+	 */
+	public function test_unregister_deletes_webhook_matched_by_stored_id_despite_host_change(): void
+	{
+		when('get_option')->justReturn([
+			'id'  => 'STORED_ID',
+			'url' => 'https://old-host.com/wp-json/paypal/v1/incoming',
+		]);
+
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://new-host.com/wp-json/paypal/v1/incoming');
+
+		$rotated_webhook = new Webhook('https://old-host.com/wp-json/paypal/v1/incoming', [], 'STORED_ID');
+
+		$this->endpoint->shouldReceive('list')->andReturn([$rotated_webhook]);
+
+		$deleted = [];
+		$this->endpoint->shouldReceive('delete')
+			->andReturnUsing(static function (Webhook $webhook) use (&$deleted): void {
+				$deleted[] = $webhook->id();
+			});
+
+		expect('delete_option')->once();
+		$this->last_webhook_event_storage->shouldReceive('clear')->once();
+
+		$this->createRegistrar()->unregister();
+
+		$this->assertSame(['STORED_ID'], $deleted);
 	}
 
 	/**
@@ -135,12 +229,19 @@ class WebhookRegistrarTest extends TestCase
 		$webhook = new Webhook('not-a-valid-url', [], 'BROKEN');
 
 		$this->endpoint->shouldReceive('list')->andReturn([$webhook]);
-		$this->endpoint->shouldNotReceive('delete');
+
+		$deleted = [];
+		$this->endpoint->shouldReceive('delete')
+			->andReturnUsing(static function (Webhook $webhook) use (&$deleted): void {
+				$deleted[] = $webhook->id();
+			});
 
 		expect('delete_option')->once();
 		$this->last_webhook_event_storage->shouldReceive('clear')->once();
 
 		$this->createRegistrar()->unregister();
+
+		$this->assertSame([], $deleted);
 	}
 
 	/**
@@ -157,10 +258,24 @@ class WebhookRegistrarTest extends TestCase
 		$this->endpoint->shouldReceive('list')->andThrow(new RuntimeException('API unavailable'));
 		$this->endpoint->shouldNotReceive('delete');
 
-		expect('delete_option')->once()->with(WebhookRegistrar::KEY);
-		$this->last_webhook_event_storage->shouldReceive('clear')->once();
+		$deleted_option = false;
+		expect('delete_option')->once()->with(WebhookRegistrar::KEY)
+			->andReturnUsing(static function () use (&$deleted_option) {
+				$deleted_option = true;
+				return true;
+			});
+
+		$storage_cleared = false;
+		$this->last_webhook_event_storage->shouldReceive('clear')
+			->once()
+			->andReturnUsing(static function () use (&$storage_cleared): void {
+				$storage_cleared = true;
+			});
 
 		$this->createRegistrar()->unregister();
+
+		$this->assertTrue($deleted_option, 'Expected the stored webhook option to be deleted.');
+		$this->assertTrue($storage_cleared, 'Expected the last webhook event storage to be cleared.');
 	}
 
 	/**

--- a/tests/PHPUnit/Webhooks/WebhookRegistrarTest.php
+++ b/tests/PHPUnit/Webhooks/WebhookRegistrarTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Webhooks;
+
+use Mockery;
+use Psr\Log\LoggerInterface;
+use WooCommerce\PayPalCommerce\ApiClient\Endpoint\WebhookEndpoint;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Webhook;
+use WooCommerce\PayPalCommerce\ApiClient\Exception\RuntimeException;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\WebhookFactory;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\Webhooks\Status\WebhookSimulation;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Webhooks\WebhookRegistrar
+ */
+class WebhookRegistrarTest extends TestCase
+{
+	/** @var WebhookFactory&Mockery\MockInterface */
+	private $webhook_factory;
+
+	/** @var WebhookEndpoint&Mockery\MockInterface */
+	private $endpoint;
+
+	/** @var IncomingWebhookEndpoint&Mockery\MockInterface */
+	private $incoming_webhook_endpoint;
+
+	/** @var WebhookEventStorage&Mockery\MockInterface */
+	private $last_webhook_event_storage;
+
+	/** @var WebhookSimulation&Mockery\MockInterface */
+	private $webhook_simulation;
+
+	/** @var WebhookOrchestrator&Mockery\MockInterface */
+	private $webhook_orchestrator;
+
+	/** @var LoggerInterface&Mockery\MockInterface */
+	private $logger;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		when('wp_parse_url')->alias('parse_url');
+
+		$this->webhook_factory            = Mockery::mock(WebhookFactory::class);
+		$this->endpoint                   = Mockery::mock(WebhookEndpoint::class);
+		$this->incoming_webhook_endpoint  = Mockery::mock(IncomingWebhookEndpoint::class);
+		$this->last_webhook_event_storage = Mockery::mock(WebhookEventStorage::class);
+		$this->webhook_simulation         = Mockery::mock(WebhookSimulation::class);
+		$this->webhook_orchestrator       = Mockery::mock(WebhookOrchestrator::class);
+		$this->logger                     = Mockery::mock(LoggerInterface::class)->shouldIgnoreMissing();
+
+		// with_lock() only wraps its callback with locking; behavior under test is the callback's result.
+		$this->webhook_orchestrator
+			->shouldReceive('with_lock')
+			->andReturnUsing(static fn(string $name, callable $callback) => $callback());
+	}
+
+	private function createRegistrar(): WebhookRegistrar
+	{
+		return new WebhookRegistrar(
+			$this->webhook_factory,
+			$this->endpoint,
+			$this->incoming_webhook_endpoint,
+			$this->last_webhook_event_storage,
+			$this->webhook_simulation,
+			$this->webhook_orchestrator,
+			$this->logger
+		);
+	}
+
+	/**
+	 * GIVEN a PayPal account with webhooks belonging to this site and to a different site
+	 * WHEN unregistering webhooks
+	 * THEN only the webhook whose host matches this site's incoming endpoint is deleted
+	 * AND a warning is logged for the foreign webhook that was skipped
+	 */
+	public function test_unregister_deletes_only_webhooks_belonging_to_this_site(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$own_webhook     = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'OWN');
+		$foreign_webhook = new Webhook('https://other-clone.com/wp-json/paypal/v1/incoming', [], 'FOREIGN');
+
+		$this->endpoint->shouldReceive('list')->andReturn([$own_webhook, $foreign_webhook]);
+
+		$this->endpoint->shouldReceive('delete')->once()->with($own_webhook);
+		$this->endpoint->shouldNotReceive('delete')->with($foreign_webhook);
+
+		$this->logger->shouldReceive('warning')->once();
+
+		expect('delete_option')->once()->with(WebhookRegistrar::KEY);
+		$this->last_webhook_event_storage->shouldReceive('clear')->once();
+
+		$this->createRegistrar()->unregister();
+	}
+
+	/**
+	 * GIVEN a webhook whose host differs only by letter case from this site's host
+	 * WHEN unregistering webhooks
+	 * THEN the webhook is still recognized as belonging to this site and is deleted
+	 */
+	public function test_unregister_matches_host_case_insensitively(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://MySite.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', [], 'OWN');
+
+		$this->endpoint->shouldReceive('list')->andReturn([$webhook]);
+		$this->endpoint->shouldReceive('delete')->once()->with($webhook);
+
+		expect('delete_option')->once();
+		$this->last_webhook_event_storage->shouldReceive('clear')->once();
+
+		$this->createRegistrar()->unregister();
+	}
+
+	/**
+	 * GIVEN a registered webhook whose URL has no parseable host
+	 * WHEN unregistering webhooks
+	 * THEN the webhook is treated as not belonging to this site and is left in place
+	 */
+	public function test_unregister_skips_webhook_with_unparseable_host(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$webhook = new Webhook('not-a-valid-url', [], 'BROKEN');
+
+		$this->endpoint->shouldReceive('list')->andReturn([$webhook]);
+		$this->endpoint->shouldNotReceive('delete');
+
+		expect('delete_option')->once();
+		$this->last_webhook_event_storage->shouldReceive('clear')->once();
+
+		$this->createRegistrar()->unregister();
+	}
+
+	/**
+	 * GIVEN the PayPal webhook list request fails
+	 * WHEN unregistering webhooks
+	 * THEN the local webhook bookkeeping (deleting the stored option and clearing
+	 * the last event storage) still runs despite the remote failure
+	 */
+	public function test_unregister_still_clears_local_state_when_listing_webhooks_fails(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+
+		$this->endpoint->shouldReceive('list')->andThrow(new RuntimeException('API unavailable'));
+		$this->endpoint->shouldNotReceive('delete');
+
+		expect('delete_option')->once()->with(WebhookRegistrar::KEY);
+		$this->last_webhook_event_storage->shouldReceive('clear')->once();
+
+		$this->createRegistrar()->unregister();
+	}
+
+	/**
+	 * GIVEN no webhook is currently registered for this site
+	 * WHEN registering webhooks
+	 * THEN a new webhook is created for this site's incoming endpoint, stored,
+	 * and webhook simulation is started
+	 * AND the operation reports success
+	 */
+	public function test_register_creates_webhook_and_reports_success(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+		$this->incoming_webhook_endpoint->shouldReceive('handled_event_types')
+			->andReturn(['CHECKOUT.ORDER.APPROVED']);
+
+		$this->endpoint->shouldReceive('list')->andReturn([]);
+
+		$new_webhook     = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', ['CHECKOUT.ORDER.APPROVED']);
+		$created_webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', ['CHECKOUT.ORDER.APPROVED'], 'NEW-ID');
+
+		$this->webhook_factory->shouldReceive('for_url_and_events')->andReturn($new_webhook);
+		$this->endpoint->shouldReceive('create')->with($new_webhook)->andReturn($created_webhook);
+
+		expect('update_option')->once()->with(WebhookRegistrar::KEY, $created_webhook->to_array());
+		expect('delete_option')->once();
+
+		$this->last_webhook_event_storage->shouldReceive('clear')->twice();
+		$this->webhook_simulation->shouldReceive('start')->once()->with($created_webhook);
+
+		$result = $this->createRegistrar()->register();
+
+		$this->assertTrue($result);
+	}
+
+	/**
+	 * GIVEN PayPal fails to return an id for the newly created webhook
+	 * WHEN registering webhooks
+	 * THEN the operation reports failure
+	 */
+	public function test_register_reports_failure_when_created_webhook_has_no_id(): void
+	{
+		$this->incoming_webhook_endpoint->shouldReceive('url')
+			->andReturn('https://mysite.com/wp-json/paypal/v1/incoming');
+		$this->incoming_webhook_endpoint->shouldReceive('handled_event_types')
+			->andReturn(['CHECKOUT.ORDER.APPROVED']);
+
+		$this->endpoint->shouldReceive('list')->andReturn([]);
+
+		$new_webhook     = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', ['CHECKOUT.ORDER.APPROVED']);
+		$created_webhook = new Webhook('https://mysite.com/wp-json/paypal/v1/incoming', ['CHECKOUT.ORDER.APPROVED']);
+
+		$this->webhook_factory->shouldReceive('for_url_and_events')->andReturn($new_webhook);
+		$this->endpoint->shouldReceive('create')->with($new_webhook)->andReturn($created_webhook);
+
+		expect('delete_option')->once();
+		$this->last_webhook_event_storage->shouldReceive('clear')->once();
+		$this->webhook_simulation->shouldNotReceive('start');
+
+		$result = $this->createRegistrar()->register();
+
+		$this->assertFalse($result);
+	}
+}


### PR DESCRIPTION
Fixes #4604.

`WebhookRegistrar` deletes every webhook on the connected PayPal account before re-registering, and always re-registers at the URL of whichever install runs it. So any second site sharing the same PayPal credentials (a staging/dev clone) wipes the primary site's webhook and silently redirects all webhook delivery to itself. Nothing warns the merchant, and the SSR "Webhook status" row stays green because it only checks whether this install ever received a webhook , not where delivery actually points.           
                                                                                                                                                                                             
### PR Changes                                                                                                                   
  - `WebhookRegistrar: deregistration` is now scoped by host, it deletes only webhooks pointing at this site and leaves other sites' webhooks intact, logging a warning when it skips a foreign one.
  - System Status Report: a new "Webhook delivery URL" row compares the live PayPal-registered webhook host against home_url(), showing a warning ("Delivered to …") when events are going to a different host, making the hijack visible. 

   
<img width="1433" height="397" alt="webhook-delivery" src="https://github.com/user-attachments/assets/6a8463bc-c2fe-462e-8c6e-c971ca3309d9" />
