### PR TITLE
Smart Button order creation bypasses woocommerce_checkout_create_order_line_item (6773)

### DIFF
--- a/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
+++ b/modules/ppcp-button/src/Helper/WooCommerceOrderCreator.php
@@ -131,15 +131,31 @@ class WooCommerceOrderCreator {
 	 * @psalm-suppress InvalidScalarArgument
 	 */
 	protected function configure_line_items( WC_Order $wc_order, CartData $cart_data, ?Payer $payer, ?Shipping $shipping ): void {
-		foreach ( $cart_data->items() as $cart_item ) {
+		foreach ( $cart_data->items() as $cart_item_key => $cart_item ) {
 			$product_id           = $cart_item['product_id'] ?? 0;
 			$variation_id         = $cart_item['variation_id'] ?? 0;
 			$quantity             = $cart_item['quantity'] ?? 0;
 			$variation_attributes = $cart_item['variation'];
 
-			$item = new WC_Order_Item_Product();
+			/**
+			 * Filters the order line item object, mirroring WooCommerce Core so plugins
+			 * can swap the item class before it is populated.
+			 *
+			 * @param WC_Order_Item_Product $item          The order line item.
+			 * @param string                $cart_item_key The cart item hash key.
+			 * @param array                 $cart_item     The cart item data.
+			 * @param WC_Order              $wc_order      The order being built.
+			 */
+			$item = apply_filters(
+				'woocommerce_checkout_create_order_line_item_object',
+				new WC_Order_Item_Product(),
+				$cart_item_key,
+				$cart_item,
+				$wc_order
+			);
 			$item->set_product_id( $product_id );
 			$item->set_quantity( $quantity );
+			$item->set_order( $wc_order );
 
 			if ( isset( $cart_item['bundled_by'] ) ) {
 				$item->add_meta_data( '_bundled_by', $cart_item['bundled_by'], true );
@@ -194,6 +210,18 @@ class WooCommerceOrderCreator {
 				$subscription->calculate_totals();
 				$subscription->payment_complete_for_order( $wc_order );
 			}
+
+			/**
+			 * Fires the standard WooCommerce line item action so third-party plugins
+			 * (e.g. Subscriptions, Gift Cards, Product Add-ons) can augment the order
+			 * item with data they stored on the cart item.
+			 *
+			 * @param WC_Order_Item_Product $item          The order line item.
+			 * @param string                $cart_item_key The cart item hash key.
+			 * @param array                 $cart_item     The cart item data.
+			 * @param WC_Order              $wc_order      The order being built.
+			 */
+			do_action( 'woocommerce_checkout_create_order_line_item', $item, $cart_item_key, $cart_item, $wc_order );
 
 			$wc_order->add_item( $item );
 		}

--- a/tests/PHPUnit/Button/Helper/WooCommerceOrderCreatorTest.php
+++ b/tests/PHPUnit/Button/Helper/WooCommerceOrderCreatorTest.php
@@ -5,10 +5,14 @@ namespace WooCommerce\PayPalCommerce\Button\Helper;
 
 use Mockery;
 use ReflectionMethod;
+use WC_Order;
+use WC_Order_Item_Product;
+use WC_Product;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Shipping;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\PayerFactory;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\ShippingFactory;
+use WooCommerce\PayPalCommerce\Button\Session\CartData;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataFactory;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
@@ -57,5 +61,104 @@ class WooCommerceOrderCreatorTest extends TestCase {
 		$result = $method->invoke( $sut, $order, $paypal_data );
 
 		$this->assertSame( $filter_shipping, $result );
+	}
+
+	/**
+	 * GIVEN a cart with one non-subscription line item
+	 * WHEN configure_line_items() builds the WC order line items via reflection
+	 * THEN the order line item is created through the WooCommerce Core
+	 *      "woocommerce_checkout_create_order_line_item_object" filter
+	 * AND the resulting item is attached to the order via set_order()
+	 * AND the "woocommerce_checkout_create_order_line_item" action fires with the
+	 *      item, cart item key, cart item data and the order
+	 * AND the filtered item is the one added to the order
+	 */
+	public function test_configure_line_items_uses_core_checkout_filter_and_action_for_each_cart_item(): void {
+		$cart_item_key = 'abc123';
+		$cart_item     = array(
+			'product_id'    => 10,
+			'variation_id'  => 0,
+			'quantity'      => 2,
+			'variation'     => array(),
+			'line_subtotal' => '20',
+			'line_total'    => '20',
+		);
+
+		$cart_data = new CartData( array( $cart_item_key => $cart_item ), array(), false, 0, 'cart-hash' );
+
+		$wc_order = Mockery::mock( WC_Order::class );
+
+		$item = Mockery::mock( WC_Order_Item_Product::class );
+		$item->shouldReceive( 'set_product_id' )->once()->with( 10 );
+		$item->shouldReceive( 'set_quantity' )->once()->with( 2 );
+		$item->shouldReceive( 'set_order' )->once()->with( $wc_order );
+		$item->shouldReceive( 'set_name' )->once()->with( 'Test product' );
+		$item->shouldReceive( 'set_subtotal' )->once()->with( '20' );
+		$item->shouldReceive( 'set_total' )->once()->with( '20' );
+		$item->shouldReceive( 'get_total' )->once()->andReturn( '20' );
+		$item->shouldReceive( 'set_tax_class' )->once()->with( '' );
+		$item->shouldReceive( 'set_total_tax' )->once()->with( '0' );
+
+		$product = Mockery::mock( WC_Product::class );
+		$product->shouldReceive( 'get_name' )->andReturn( 'Test product' );
+		$product->shouldReceive( 'get_id' )->andReturn( 10 );
+		$product->shouldReceive( 'get_tax_class' )->andReturn( '' );
+
+		expect( 'wc_get_product' )->once()->with( 10 )->andReturn( $product );
+
+		$wc_tax = Mockery::mock( 'alias:WC_Tax' );
+		$wc_tax->shouldReceive( 'get_rates' )->once()->with( '' )->andReturn( array() );
+		$wc_tax->shouldReceive( 'calc_tax' )->once()->with( '20', array(), true )->andReturn( array() );
+
+		expect( 'apply_filters' )
+			->once()
+			->with(
+				'woocommerce_checkout_create_order_line_item_object',
+				Mockery::type( WC_Order_Item_Product::class ),
+				$cart_item_key,
+				$cart_item,
+				$wc_order
+			)
+			->andReturn( $item );
+
+		expect( 'apply_filters' )
+			->once()
+			->with(
+				'woocommerce_paypal_payments_shipping_callback_cart_line_item_total',
+				$cart_item['line_subtotal'],
+				$cart_item
+			)
+			->andReturn( $cart_item['line_subtotal'] );
+
+		expect( 'do_action' )
+			->once()
+			->with(
+				'woocommerce_checkout_create_order_line_item',
+				$item,
+				$cart_item_key,
+				$cart_item,
+				$wc_order
+			);
+
+		$wc_order->shouldReceive( 'add_item' )->once()->with( $item );
+
+		$subscription_helper = Mockery::mock( SubscriptionHelper::class );
+		$subscription_helper->shouldReceive( 'plugin_is_active' )->once()->andReturn( false );
+
+		$sut = new WooCommerceOrderCreator(
+			Mockery::mock( FundingSourceRenderer::class ),
+			Mockery::mock( SessionHandler::class ),
+			$subscription_helper,
+			Mockery::mock( CartDataFactory::class ),
+			Mockery::mock( ShippingFactory::class ),
+			Mockery::mock( PayerFactory::class )
+		);
+
+		$method = new ReflectionMethod( WooCommerceOrderCreator::class, 'configure_line_items' );
+		$method->setAccessible( true );
+
+		$method->invoke( $sut, $wc_order, $cart_data, null, null );
+
+		$this->addToAssertionCount( 1 );
 	}
 }


### PR DESCRIPTION
Fixes #4601.

Orders created through the Smart Buttons flow were built by hand in `WooCommerceOrderCreator::configure_line_items()`, which never fired WooCommerce Core's `woocommerce_checkout_create_order_line_item` hooks. As a result, third-party plugins (e.g., Subscriptions, Gift Cards, Product Add-ons...) couldn't attach their cart-item metadata, so orders came out incomplete.                                                                                                                                                                            
                                                                                                                                                                                             
This PR mirrors WC Core in configure_line_items(), build each item via the `woocommerce_checkout_create_order_line_item_object` filter, set the order on the item, and fire the `woocommerce_checkout_create_order_line_item` action before adding it. Since `CartData::items()` already carries the full original cart item array, these plugins now receive the data they need and their metadata persists. 

