### PR TITLE
Allow Pay Later to remain available when vaulting is enabled (6761)

### DIFF
--- a/docs/pay-later-with-vaulting-filter.md
+++ b/docs/pay-later-with-vaulting-filter.md
@@ -1,31 +1,42 @@
 # Pay Later with Vaulting Filter
 
 ## Overview
-By default the plugin treats **Pay Later** and **Vaulting** ("Save PayPal and Venmo") as
-mutually exclusive. When vaulting is active:
+Pay Later and Vaulting ("Save PayPal and Venmo") can be active at the same time whenever the
+merchant is eligible for Pay Later, which is the same eligibility the plugin applies to every
+other Pay Later feature (the merchant country must be one of the supported Pay Later countries).
+
+For merchants who are **not** eligible for Pay Later, the previous behaviour still applies. When
+vaulting is active:
 
 - The **Payment Methods** tab locks the "Pay Later" toggle ("This payment method requires
   Save PayPal and Venmo to be disabled").
 - Pay Later **messaging** is disabled everywhere.
 
-Merchants that PayPal has **whitelisted** to offer Pay Later alongside Vaulting
-can lift this restriction with a filter.
-
 ## Filter
 
 ### `woocommerce_paypal_payments_pay_later_with_vaulting`
-Controls whether Pay Later features may run while vaulting is active. Defaults to `false`
-(Pay Later disabled if vaulting is active). Return `true` to bypass the restriction.
+Controls whether Pay Later features may run while vaulting is active. Defaults to the merchant's
+Pay Later eligibility.
+
+Restore the mutually exclusive behaviour:
+
+```php
+add_filter( 'woocommerce_paypal_payments_pay_later_with_vaulting', '__return_false' );
+```
+
+Allow the combination for a merchant the plugin does not consider eligible:
 
 ```php
 add_filter( 'woocommerce_paypal_payments_pay_later_with_vaulting', '__return_true' );
 ```
 
 ## Notes
-- Intended for PayPal-whitelisted accounts. Enabling it on an account that is not approved
-  for Pay Later + Vaulting may result in Pay Later still not being offered by PayPal at runtime.
+- Forcing the combination on an account that PayPal has not approved for Pay Later + Vaulting may
+  result in Pay Later still not being offered by PayPal at runtime.
+- The supported Pay Later countries are filterable in their own right, via
+  `woocommerce_paypal_payments_supported_paylater_countries`.
 - **Use this filter, not `woocommerce_paypal_payments_should_render_pay_later_messaging`.**
   The latter only toggles storefront messaging rendering and, on its own, cannot re-enable
   Pay Later when vaulting is active — the plugin still forces messaging off under vaulting.
-  __`woocommerce_paypal_payments_pay_later_with_vaulting` is the intended override and unlocks
+  `woocommerce_paypal_payments_pay_later_with_vaulting` is the intended override and unlocks
   the configuration UI as well.

--- a/modules/ppcp-settings/resources/js/data/payment/hooks.test.js
+++ b/modules/ppcp-settings/resources/js/data/payment/hooks.test.js
@@ -1,0 +1,101 @@
+import { renderHook } from '@testing-library/react';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { createHooksForStore } from '@ppcp-settings/data/utils';
+import { usePayLaterVaultingDependency } from './hooks';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@ppcp-settings/data/utils', () => ( {
+	createHooksForStore: jest.fn(),
+} ) );
+
+/**
+ * Builds the { useTransient, usePersistent } pair that useStoreData() derives
+ * from createHooksForStore(), pre-seeded with the transient/persistent values
+ * a test needs.
+ */
+const createStoreHooks = ( { isReady = true, payLater } = {} ) => {
+	const transientMap = { isReady };
+	const persistentMap = { 'pay-later': payLater };
+
+	return {
+		useTransient: jest.fn( ( key ) => [ transientMap[ key ], jest.fn() ] ),
+		usePersistent: jest.fn( ( key ) => [
+			persistentMap[ key ],
+			jest.fn(),
+		] ),
+	};
+};
+
+describe( 'usePayLaterVaultingDependency()', () => {
+	let persistentData;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		persistentData = jest.fn();
+		useSelect.mockImplementation( ( callback ) =>
+			callback( () => ( { persistentData } ) )
+		);
+		useDispatch.mockReturnValue( {} );
+	} );
+
+	test( 'reports payLaterDependsOnVaulting as true when the server sends the dependency', () => {
+		createHooksForStore.mockReturnValue(
+			createStoreHooks( {
+				isReady: true,
+				payLater: {
+					depends_on_settings: {
+						settings: {
+							savePaypalAndVenmo: {
+								id: 'savePaypalAndVenmo',
+								value: false,
+							},
+						},
+					},
+				},
+			} )
+		);
+
+		const { result } = renderHook( () => usePayLaterVaultingDependency() );
+
+		expect( result.current.payLaterDependsOnVaulting ).toBe( true );
+	} );
+
+	test( 'reports payLaterDependsOnVaulting as false for an eligible merchant whose pay-later method omits the dependency', () => {
+		createHooksForStore.mockReturnValue(
+			createStoreHooks( {
+				isReady: true,
+				payLater: { id: 'pay-later' },
+			} )
+		);
+
+		const { result } = renderHook( () => usePayLaterVaultingDependency() );
+
+		expect( result.current.payLaterDependsOnVaulting ).toBe( false );
+	} );
+
+	test( 'reports payLaterDependsOnVaulting as false without crashing when the pay-later method is missing entirely', () => {
+		createHooksForStore.mockReturnValue(
+			createStoreHooks( { isReady: true, payLater: undefined } )
+		);
+
+		const { result } = renderHook( () => usePayLaterVaultingDependency() );
+
+		expect( result.current.payLaterDependsOnVaulting ).toBe( false );
+	} );
+
+	test( 'surfaces isReady as false and triggers a persistentData load while the store has not loaded yet', () => {
+		createHooksForStore.mockReturnValue(
+			createStoreHooks( { isReady: false, payLater: undefined } )
+		);
+
+		const { result } = renderHook( () => usePayLaterVaultingDependency() );
+
+		expect( result.current.isReady ).toBe( false );
+		expect( persistentData ).toHaveBeenCalled();
+	} );
+} );

--- a/modules/ppcp-settings/resources/js/hooks/useDependencyMessages.test.js
+++ b/modules/ppcp-settings/resources/js/hooks/useDependencyMessages.test.js
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react';
+import useDependencyMessages from './useDependencyMessages';
+
+jest.mock(
+	'@ppcp-settings/Components/Screens/Settings/Components/Payment/PaymentDependencyMessage',
+	() => () => 'parent-dependency-message'
+);
+jest.mock(
+	'@ppcp-settings/Components/Screens/Settings/Components/Payment/PaymentMethodValueDependencyMessage',
+	() => () => 'value-dependency-message'
+);
+jest.mock(
+	'@ppcp-settings/Components/Screens/Settings/Components/Payment/SettingDependencyMessage',
+	() => () => 'setting-dependency-message'
+);
+
+const payLaterMethod = () => ( { id: 'pay-later' } );
+
+describe( 'useDependencyMessages()', () => {
+	test( 'marks pay-later as disabled when the setting dependency reports it disabled (non-eligible merchant)', () => {
+		const settingDependencies = {
+			'pay-later': {
+				isDisabled: true,
+				settingId: 'savePaypalAndVenmo',
+				requiredValue: false,
+			},
+		};
+
+		const { result } = renderHook( () =>
+			useDependencyMessages(
+				[ payLaterMethod() ],
+				{},
+				settingDependencies
+			)
+		);
+
+		expect( result.current[ 'pay-later' ].isMethodDisabled ).toBe( true );
+		expect(
+			result.current[ 'pay-later' ].dependencyMessage
+		).not.toBeNull();
+	} );
+
+	test( 'leaves pay-later enabled when there is no setting dependency (eligible merchant)', () => {
+		const { result } = renderHook( () =>
+			useDependencyMessages( [ payLaterMethod() ], {}, {} )
+		);
+
+		expect( result.current[ 'pay-later' ].isMethodDisabled ).toBe(
+			false
+		);
+		expect( result.current[ 'pay-later' ].dependencyMessage ).toBeNull();
+	} );
+
+	test( 'returns an empty map when there are no methods', () => {
+		const { result } = renderHook( () =>
+			useDependencyMessages( [], {}, {} )
+		);
+
+		expect( result.current ).toEqual( {} );
+	} );
+} );

--- a/modules/ppcp-settings/resources/js/hooks/useSettingDependencyState.test.js
+++ b/modules/ppcp-settings/resources/js/hooks/useSettingDependencyState.test.js
@@ -1,0 +1,94 @@
+import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
+import useSettingDependencyState from './useSettingDependencyState';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+} ) );
+
+/**
+ * A pay-later method as the server sends it for a non-eligible merchant:
+ * it is only usable while vaulting ("Save PayPal and Venmo") is off.
+ */
+const payLaterDependentOnVaulting = () => ( {
+	id: 'pay-later',
+	depends_on_settings: {
+		settings: {
+			savePaypalAndVenmo: {
+				id: 'savePaypalAndVenmo',
+				value: false,
+			},
+		},
+	},
+} );
+
+/**
+ * A pay-later method as the server sends it for an eligible merchant:
+ * no dependency at all, so vaulting cannot disable it.
+ */
+const payLaterWithoutDependency = () => ( { id: 'pay-later' } );
+
+const renderWithPersistentData = ( methods, persistentData ) => {
+	useSelect.mockImplementation( ( callback ) =>
+		callback( () => ( {
+			persistentData: () => persistentData,
+		} ) )
+	);
+
+	return renderHook( () => useSettingDependencyState( methods ) );
+};
+
+describe( 'useSettingDependencyState()', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'disables pay-later for a non-eligible merchant when vaulting is enabled', () => {
+		const { result } = renderWithPersistentData(
+			[ payLaterDependentOnVaulting() ],
+			{ savePaypalAndVenmo: true }
+		);
+
+		expect( result.current[ 'pay-later' ] ).toEqual( {
+			isDisabled: true,
+			settingId: 'savePaypalAndVenmo',
+			requiredValue: false,
+		} );
+	} );
+
+	test( 'leaves pay-later enabled for a non-eligible merchant when vaulting is disabled', () => {
+		const { result } = renderWithPersistentData(
+			[ payLaterDependentOnVaulting() ],
+			{ savePaypalAndVenmo: false }
+		);
+
+		expect( result.current[ 'pay-later' ] ).toBeUndefined();
+	} );
+
+	test( 'leaves pay-later enabled for an eligible merchant with vaulting on, since the server sends no dependency', () => {
+		const { result } = renderWithPersistentData(
+			[ payLaterWithoutDependency() ],
+			{ savePaypalAndVenmo: true }
+		);
+
+		expect( result.current[ 'pay-later' ] ).toBeUndefined();
+	} );
+
+	test( 'returns null when the settings store is unavailable', () => {
+		useSelect.mockImplementation( ( callback ) => callback( () => null ) );
+
+		const { result } = renderHook( () =>
+			useSettingDependencyState( [ payLaterDependentOnVaulting() ] )
+		);
+
+		expect( result.current ).toBeNull();
+	} );
+
+	test( 'returns null when no methods are given', () => {
+		const { result } = renderWithPersistentData( [], {
+			savePaypalAndVenmo: true,
+		} );
+
+		expect( result.current ).toBeNull();
+	} );
+} );

--- a/modules/ppcp-settings/services.php
+++ b/modules/ppcp-settings/services.php
@@ -106,7 +106,8 @@ return array(
 			$container->get( 'settings.data.settings' ),
 			$container->get( 'settings.data.styling' ),
 			$container->get( 'settings.data.fastlane' ),
-			$container->get( 'settings.data.paylater-messaging-settings' )
+			$container->get( 'settings.data.paylater-messaging-settings' ),
+			$container->get( 'button.helper.messages-apply' )
 		);
 	},
 	'settings.data.onboarding'                            => static function ( ContainerInterface $container ): OnboardingProfile {
@@ -406,6 +407,7 @@ return array(
 			$container->get( 'settings.data.styling' ),
 			$container->get( 'settings.data.payment' ),
 			$container->get( 'settings.data.paylater-messaging' ),
+			$container->get( 'settings.settings-provider' ),
 			$container->get( 'settings.data.todos' ),
 		);
 	},

--- a/modules/ppcp-settings/src/Data/SettingsProvider.php
+++ b/modules/ppcp-settings/src/Data/SettingsProvider.php
@@ -13,6 +13,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\Settings\Data;
 
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Settings\DTO\LocationStylingDTO;
 use WooCommerce\PayPalCommerce\Settings\DTO\MerchantConnectionDTO;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
@@ -29,6 +30,8 @@ class SettingsProvider {
 	private FastlaneSettings $fastlane_settings;
 	private PayLaterMessagingSettings $paylater_messaging_settings;
 
+	private MessagesApply $messages_apply;
+
 	public function __construct(
 		GeneralSettings $general_settings,
 		OnboardingProfile $onboarding_profile,
@@ -36,7 +39,8 @@ class SettingsProvider {
 		SettingsModel $settings_model,
 		StylingSettings $styling_settings,
 		FastlaneSettings $fastlane_settings,
-		PayLaterMessagingSettings $paylater_messaging_settings
+		PayLaterMessagingSettings $paylater_messaging_settings,
+		MessagesApply $messages_apply
 	) {
 		$this->general_settings            = $general_settings;
 		$this->onboarding_profile          = $onboarding_profile;
@@ -45,6 +49,7 @@ class SettingsProvider {
 		$this->styling_settings            = $styling_settings;
 		$this->fastlane_settings           = $fastlane_settings;
 		$this->paylater_messaging_settings = $paylater_messaging_settings;
+		$this->messages_apply              = $messages_apply;
 	}
 
 	/**
@@ -425,23 +430,27 @@ class SettingsProvider {
 	/**
 	 * Whether Pay Later may run alongside vaulting ("Save PayPal and Venmo").
 	 *
-	 * By default the plugin disables all Pay Later features when vaulting is
-	 * active. PayPal-whitelisted merchants can return true from the filter below
-	 * to bypass that restriction.
+	 * Allowed whenever the merchant may use Pay Later at all, which is the same
+	 * eligibility the rest of the plugin applies to Pay Later features. Merchants
+	 * who cannot use Pay Later keep the previous behaviour, where vaulting
+	 * suppresses every Pay Later feature.
 	 *
 	 * @return bool True when Pay Later is allowed together with vaulting.
 	 */
 	public function pay_later_with_vaulting_enabled(): bool {
+		$eligible = $this->messages_apply->for_country();
+
 		/**
 		 * Filters whether Pay Later features may run while "Save PayPal and Venmo"
 		 * (vaulting) is active.
 		 *
-		 * Intended for PayPal-whitelisted accounts that are allowed to offer Pay
-		 * Later and Vaulting at the same time.
+		 * Defaults to the merchant's Pay Later eligibility. Return false to restore
+		 * the mutually exclusive behaviour, or true to allow the combination for a
+		 * merchant the plugin does not consider eligible.
 		 *
-		 * @param bool $enabled Whether Pay Later is allowed alongside vaulting. Default false.
+		 * @param bool $enabled Whether Pay Later is allowed alongside vaulting.
 		 */
-		return (bool) apply_filters( 'woocommerce_paypal_payments_pay_later_with_vaulting', false );
+		return (bool) apply_filters( 'woocommerce_paypal_payments_pay_later_with_vaulting', $eligible );
 	}
 
 	/**

--- a/modules/ppcp-settings/src/Service/SettingsDataManager.php
+++ b/modules/ppcp-settings/src/Service/SettingsDataManager.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
 use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDefinition;
@@ -38,6 +39,7 @@ class SettingsDataManager {
 	private SettingsModel $payment_settings;
 	private StylingSettings $styling_settings;
 	private PaymentSettings $payment_methods;
+	private SettingsProvider $settings_provider;
 
 	/**
 	 * Data accessors for pay later messaging settings.
@@ -63,6 +65,7 @@ class SettingsDataManager {
 		StylingSettings $styling_settings,
 		PaymentSettings $payment_methods,
 		array $paylater_messaging, // TODO should be migrated to an AbstractDataModel.
+		SettingsProvider $settings_provider,
 		AbstractDataModel ...$data_models
 	) {
 		foreach ( $data_models as $data_model ) {
@@ -80,6 +83,7 @@ class SettingsDataManager {
 		$this->payment_settings   = $payment_settings;
 		$this->styling_settings   = $styling_settings;
 		$this->payment_methods    = $payment_methods;
+		$this->settings_provider  = $settings_provider;
 		$this->paylater_messaging = $paylater_messaging;
 	}
 
@@ -207,9 +211,10 @@ class SettingsDataManager {
 				// Enable ACDC for business sellers.
 				$this->payment_methods->toggle_method_state( CreditCardGateway::ID, true );
 
-				// Enable Pay Later for business sellers if subscriptions were not selected.
-				// Selecting subscriptions automatically enables the "Save PayPal and Venmo" option, which is incompatible with Pay Later.
-				if ( ! $flags->use_subscriptions ) {
+				// Enable Pay Later for business sellers. Selecting subscriptions automatically enables
+				// the "Save PayPal and Venmo" option, which suppresses Pay Later unless the merchant
+				// may combine the two.
+				if ( ! $flags->use_subscriptions || $this->settings_provider->pay_later_with_vaulting_enabled() ) {
 					$this->payment_methods->toggle_method_state( 'pay-later', true );
 				}
 

--- a/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
+++ b/tests/PHPUnit/Settings/Data/SettingsProviderTest.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace PHPUnit\Settings\Data;
 
 use Mockery;
+use WooCommerce\PayPalCommerce\Button\Helper\MessagesApply;
 use WooCommerce\PayPalCommerce\Settings\Data\FastlaneSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
 use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
@@ -32,6 +33,7 @@ class SettingsProviderTest extends TestCase {
 	private StylingSettings $styling_settings;
 	private FastlaneSettings $fastlane_settings;
 	private PayLaterMessagingSettings $paylater_messaging_settings;
+	private MessagesApply $messages_apply;
 
 	public function setUp(): void {
 		$this->general_settings            = Mockery::mock( GeneralSettings::class );
@@ -41,6 +43,7 @@ class SettingsProviderTest extends TestCase {
 		$this->styling_settings            = Mockery::mock( StylingSettings::class );
 		$this->fastlane_settings           = Mockery::mock( FastlaneSettings::class );
 		$this->paylater_messaging_settings = Mockery::mock( PayLaterMessagingSettings::class );
+		$this->messages_apply              = Mockery::mock( MessagesApply::class );
 
 		$this->provider = new SettingsProvider(
 			$this->general_settings,
@@ -49,7 +52,8 @@ class SettingsProviderTest extends TestCase {
 			$this->settings_model,
 			$this->styling_settings,
 			$this->fastlane_settings,
-			$this->paylater_messaging_settings
+			$this->paylater_messaging_settings,
+			$this->messages_apply
 		);
 	}
 
@@ -486,6 +490,135 @@ class SettingsProviderTest extends TestCase {
 				'db_value'        => false,
 				'filter_override' => true,
 				'expected'        => true,
+			],
+		];
+	}
+
+	/**
+	 * GIVEN a merchant who is eligible to use Pay Later
+	 * WHEN pay_later_with_vaulting_enabled() is called
+	 * THEN Pay Later is allowed to run alongside vaulting
+	 */
+	public function test_pay_later_with_vaulting_enabled_when_merchant_is_eligible(): void {
+		$this->messages_apply
+			->shouldReceive( 'for_country' )
+			->andReturn( true );
+
+		expect( 'apply_filters' )
+			->once()
+			->with( 'woocommerce_paypal_payments_pay_later_with_vaulting', true )
+			->andReturn( true );
+
+		$this->assertTrue( $this->provider->pay_later_with_vaulting_enabled() );
+	}
+
+	/**
+	 * GIVEN a merchant who is not eligible to use Pay Later
+	 * WHEN pay_later_with_vaulting_enabled() is called
+	 * THEN Pay Later remains mutually exclusive with vaulting, preserving legacy behaviour
+	 */
+	public function test_pay_later_with_vaulting_disabled_when_merchant_is_not_eligible(): void {
+		$this->messages_apply
+			->shouldReceive( 'for_country' )
+			->andReturn( false );
+
+		expect( 'apply_filters' )
+			->once()
+			->with( 'woocommerce_paypal_payments_pay_later_with_vaulting', false )
+			->andReturn( false );
+
+		$this->assertFalse( $this->provider->pay_later_with_vaulting_enabled() );
+	}
+
+	/**
+	 * GIVEN a merchant's Pay Later eligibility
+	 * WHEN the woocommerce_paypal_payments_pay_later_with_vaulting filter overrides that default
+	 * THEN the filtered value wins, in either direction
+	 *
+	 * @dataProvider pay_later_with_vaulting_filter_override_provider
+	 */
+	public function test_pay_later_with_vaulting_filter_overrides_eligibility_default(
+		bool $eligible,
+		bool $filter_override,
+		bool $expected
+	): void {
+		$this->messages_apply
+			->shouldReceive( 'for_country' )
+			->andReturn( $eligible );
+
+		expect( 'apply_filters' )
+			->once()
+			->with( 'woocommerce_paypal_payments_pay_later_with_vaulting', $eligible )
+			->andReturn( $filter_override );
+
+		$this->assertSame( $expected, $this->provider->pay_later_with_vaulting_enabled() );
+	}
+
+	public function pay_later_with_vaulting_filter_override_provider(): array {
+		return [
+			'forced false for an eligible merchant'    => [
+				'eligible'        => true,
+				'filter_override' => false,
+				'expected'        => false,
+			],
+			'forced true for a non-eligible merchant'  => [
+				'eligible'        => false,
+				'filter_override' => true,
+				'expected'        => true,
+			],
+		];
+	}
+
+	/**
+	 * GIVEN whether vaulting ("Save PayPal and Venmo") is enabled and whether the merchant may
+	 *      combine it with Pay Later
+	 * WHEN pay_later_disabled_by_vaulting() is called
+	 * THEN Pay Later is only reported as suppressed when vaulting is on and the merchant is not
+	 *      allowed to combine it with Pay Later
+	 *
+	 * @dataProvider pay_later_disabled_by_vaulting_provider
+	 */
+	public function test_pay_later_disabled_by_vaulting(
+		bool $save_paypal_and_venmo,
+		bool $pay_later_eligible,
+		bool $expected
+	): void {
+		$this->settings_model
+			->shouldReceive( 'get_save_paypal_and_venmo' )
+			->andReturn( $save_paypal_and_venmo );
+
+		$this->messages_apply
+			->shouldReceive( 'for_country' )
+			->andReturn( $pay_later_eligible );
+
+		expect( 'apply_filters' )
+			->with( 'woocommerce_paypal_payments_pay_later_with_vaulting', $pay_later_eligible )
+			->andReturn( $pay_later_eligible );
+
+		$this->assertSame( $expected, $this->provider->pay_later_disabled_by_vaulting() );
+	}
+
+	public function pay_later_disabled_by_vaulting_provider(): array {
+		return [
+			'vaulting off, merchant not eligible' => [
+				'save_paypal_and_venmo' => false,
+				'pay_later_eligible'    => false,
+				'expected'              => false,
+			],
+			'vaulting off, merchant eligible'      => [
+				'save_paypal_and_venmo' => false,
+				'pay_later_eligible'    => true,
+				'expected'              => false,
+			],
+			'vaulting on, merchant eligible'        => [
+				'save_paypal_and_venmo' => true,
+				'pay_later_eligible'    => true,
+				'expected'              => false,
+			],
+			'vaulting on, merchant not eligible'    => [
+				'save_paypal_and_venmo' => true,
+				'pay_later_eligible'    => false,
+				'expected'              => true,
 			],
 		];
 	}

--- a/tests/PHPUnit/Settings/Service/SettingsDataManagerTest.php
+++ b/tests/PHPUnit/Settings/Service/SettingsDataManagerTest.php
@@ -1,0 +1,131 @@
+<?php
+declare( strict_types=1 );
+
+namespace PHPUnit\Settings\Service;
+
+use Mockery;
+use ReflectionMethod;
+use WooCommerce\PayPalCommerce\Settings\Data\Definition\PaymentMethodsDefinition;
+use WooCommerce\PayPalCommerce\Settings\Data\GeneralSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\OnboardingProfile;
+use WooCommerce\PayPalCommerce\Settings\Data\PaymentSettings;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use WooCommerce\PayPalCommerce\Settings\Data\StylingSettings;
+use WooCommerce\PayPalCommerce\Settings\DTO\ConfigurationFlagsDTO;
+use WooCommerce\PayPalCommerce\Settings\Service\SettingsDataManager;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * @covers \WooCommerce\PayPalCommerce\Settings\Service\SettingsDataManager
+ */
+class SettingsDataManagerTest extends TestCase {
+
+	private PaymentSettings $payment_methods;
+	private SettingsProvider $settings_provider;
+	private SettingsDataManager $sut;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		when( 'do_action' )->justReturn( null );
+
+		$methods_definition = Mockery::mock( PaymentMethodsDefinition::class );
+		$methods_definition->shouldReceive( 'group_paypal_methods' )->andReturn( array() );
+		$methods_definition->shouldReceive( 'group_card_methods' )->andReturn( array() );
+		$methods_definition->shouldReceive( 'group_apms' )->andReturn( array() );
+
+		$this->payment_methods = Mockery::mock( PaymentSettings::class );
+		$this->payment_methods->shouldReceive( 'set_fastlane_display_watermark' )->andReturnNull();
+		$this->payment_methods->shouldReceive( 'save' )->andReturnNull();
+
+		$this->settings_provider = Mockery::mock( SettingsProvider::class );
+
+		$this->sut = new SettingsDataManager(
+			$methods_definition,
+			Mockery::mock( OnboardingProfile::class ),
+			Mockery::mock( GeneralSettings::class ),
+			Mockery::mock( SettingsModel::class ),
+			Mockery::mock( StylingSettings::class ),
+			$this->payment_methods,
+			array(),
+			$this->settings_provider
+		);
+	}
+
+	/**
+	 * Invokes the protected toggle_payment_gateways() method.
+	 *
+	 * The method is protected because it is an internal step of the onboarding
+	 * defaults flow; reflection lets the test drive it directly with specific
+	 * configuration flags without going through the whole onboarding process.
+	 */
+	private function toggle_payment_gateways( ConfigurationFlagsDTO $flags ): void {
+		$method = new ReflectionMethod( SettingsDataManager::class, 'toggle_payment_gateways' );
+		$method->setAccessible( true );
+
+		$method->invoke( $this->sut, $flags );
+	}
+
+	/**
+	 * GIVEN a business seller accepting card payments
+	 * WHEN toggle_payment_gateways() applies the onboarding defaults
+	 * THEN Pay Later is enabled, and every other toggled state matches the expected onboarding
+	 *      default for the given subscription/eligibility combination
+	 *
+	 * @dataProvider pay_later_onboarding_provider
+	 */
+	public function test_pay_later_onboarding_default(
+		bool $use_subscriptions,
+		?bool $pay_later_with_vaulting_enabled,
+		bool $expect_pay_later_enabled
+	): void {
+		if ( null !== $pay_later_with_vaulting_enabled ) {
+			$this->settings_provider
+				->shouldReceive( 'pay_later_with_vaulting_enabled' )
+				->once()
+				->andReturn( $pay_later_with_vaulting_enabled );
+		} else {
+			$this->settings_provider->shouldNotReceive( 'pay_later_with_vaulting_enabled' );
+		}
+
+		$toggled_states = array();
+		$this->payment_methods
+			->shouldReceive( 'toggle_method_state' )
+			->andReturnUsing(
+				static function ( string $method_id, bool $enabled ) use ( &$toggled_states ): void {
+					$toggled_states[ $method_id ] = $enabled;
+				}
+			);
+
+		$flags                     = new ConfigurationFlagsDTO();
+		$flags->is_business_seller = true;
+		$flags->use_card_payments  = true;
+		$flags->use_subscriptions  = $use_subscriptions;
+
+		$this->toggle_payment_gateways( $flags );
+
+		$this->assertSame( $expect_pay_later_enabled, $toggled_states['pay-later'] ?? false );
+	}
+
+	public function pay_later_onboarding_provider(): array {
+		return [
+			'no subscriptions enables Pay Later by default'                         => [
+				'use_subscriptions'               => false,
+				'pay_later_with_vaulting_enabled' => null,
+				'expect_pay_later_enabled'        => true,
+			],
+			'subscriptions without vaulting override keep Pay Later disabled'       => [
+				'use_subscriptions'               => true,
+				'pay_later_with_vaulting_enabled' => false,
+				'expect_pay_later_enabled'        => false,
+			],
+			'subscriptions with vaulting override enable Pay Later'                 => [
+				'use_subscriptions'               => true,
+				'pay_later_with_vaulting_enabled' => true,
+				'expect_pay_later_enabled'        => true,
+			],
+		];
+	}
+}


### PR DESCRIPTION
*Changelog:* `Enhancement - Pay Later stays available when Save PayPal and Venmo is enabled #4611`

# Description

## 🎯 The goal

Enabling **Save PayPal and Venmo** suppressed every Pay Later feature — the payment method toggle, storefront messaging, the messaging configurator tab, the Overview feature card and the Pay Later blocks — regardless of whether the merchant could use Pay Later at all. Merchants who can offer Pay Later should keep it while vaulting is active.

## ✅ The fix

`SettingsProvider::pay_later_with_vaulting_enabled()` now defaults to the merchant's Pay Later eligibility, the same supported-country check the plugin already applies to Pay Later features, instead of a hardcoded `false`. The seven existing consumers of `pay_later_disabled_by_vaulting()` inherit it unchanged, so the settings UI, storefront messaging, SDK funding parameters, configurator and blocks all follow from a single decision point.

The onboarding default was the one place that disabled Pay Later independently of that decision: choosing subscriptions turns vaulting on, and Pay Later was skipped because of it. That condition now follows the same check.

## 🔍 What to review

- **The restriction is effectively lifted for every merchant in the supported Pay Later countries** (`US, DE, GB, FR, AU, IT, ES, CA`). It only still applies where Pay Later was unavailable anyway, so this is a deliberate broadening rather than a narrow allowance — worth confirming that matches the product intent.
- **Eligibility is the country gate, not a PayPal account-level capability.** Nothing in the merchant-integrations response marks an account as approved for Pay Later together with vaulting, so there is no account-specific signal to detect today. If PayPal exposes one later it slots into this same method.
- **`woocommerce_paypal_payments_pay_later_with_vaulting` changed meaning.** Its default is now the eligibility value rather than `false`. It stays a two-way override, so sites already returning `true` keep working and `__return_false` restores the mutually exclusive behaviour. Documented in `docs/pay-later-with-vaulting-filter.md`.
- **Eligibility is captured when the provider is constructed**, because `MessagesApply` receives the already-filtered country list. This matches how `settings.service.features_eligibilities` resolves it today, but a `woocommerce_paypal_payments_supported_paylater_countries` filter registered later than plugin bootstrap would be missed.

## 🧪 How to verify

1. With an advanced-vaulting account in a supported country, enable **Save PayPal and Venmo**: the Pay Later toggle stays usable with no dependency notice, the Pay Later Messaging tab remains, Overview shows Pay Later Messaging as Active, and the Pay Later blocks render in the editor instead of the vaulting warning.
2. Filter the supported countries to an empty list and repeat step 4: the Pay Later card is greyed with the dependency notice, the tab disappears, and the blocks show the vaulting warning.
3. Onboard a business seller choosing card payments and subscriptions: Pay Later is enabled afterwards, with vaulting also on.
