### PR TITLE
[QA] Cloudflare for parallel tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -84,7 +84,7 @@ jobs:
             SUFFIX=""
             [[ "$TEST_SUITE" != "all:parallel" ]] && SUFFIX=":${TEST_SUITE%:parallel}"
 
-            entry() { echo "{\"script\":\"e2e:test:shard:${1}${SUFFIX}\",\"name_suffix\":\" / ${1}\",\"artifact_name\":\"playwright-artifact-${1}\"}"; }
+            entry() { echo "{\"script\":\"e2e:test:shard:${1}${SUFFIX}\",\"name_suffix\":\" / ${1}\",\"artifact_name\":\"playwright-artifact-${1}\",\"slug\":\"${1}\"}"; }
 
             ITEMS=()
             for shard in "${SHARDS[@]}"; do
@@ -95,7 +95,7 @@ jobs:
             echo "matrix={\"include\":[${JOINED}]}" >> "$GITHUB_OUTPUT"
           else
             NAME="${TEST_SUITE#shard:}"
-            echo "matrix={\"include\":[{\"script\":\"e2e:test:${TEST_SUITE}\",\"name_suffix\":\" / ${NAME}\",\"artifact_name\":\"playwright-artifact-${NAME}\"}]}" >> "$GITHUB_OUTPUT"
+            echo "matrix={\"include\":[{\"script\":\"e2e:test:${TEST_SUITE}\",\"name_suffix\":\" / ${NAME}\",\"artifact_name\":\"playwright-artifact-${NAME}\",\"slug\":\"${NAME}\"}]}" >> "$GITHUB_OUTPUT"
           fi
 
   e2e-playwright:
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve-playwright-matrix.outputs.matrix) }}
-    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@main
+    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@feature/ngrok-for-parallel-tests
     with:
       PLAYWRIGHT_SCRIPT: ${{ matrix.script }}
       PLAYWRIGHT_ARTIFACT_NAME: ${{ matrix.artifact_name }}
@@ -118,6 +118,7 @@ jobs:
       NODE_VERSION: 22
       PLAYWRIGHT_BROWSER_ARGS: 'chromium --with-deps'
       XRAY_TEST_EXEC_KEY: ${{ inputs.XRAY_TEST_EXEC_KEY }}
+      NGROK_ENABLED: ${{ contains(fromJson('["onboarding","transaction-usa","transaction-mexico","transaction-germany","refund","vaulting","subscription"]'), matrix.slug) }}
       PRE_SCRIPT: |
         # 1. Download and unzip the built plugin
         gh run download ${{ github.run_id }} -p "woocommerce-paypal-payments-*" -D tests/qa/resources/files
@@ -138,3 +139,4 @@ jobs:
       ENV_FILE_DATA: ${{ secrets.QA_ENV_FILE }}
       NPM_REGISTRY_TOKEN: ${{ secrets.DEPLOYBOT_GITHUB_TOKEN_PACKAGES }}
       COMPOSER_AUTH_JSON: ${{ secrets.COMPOSER_AUTH_JSON }}
+      NGROK_AUTH_TOKEN: ${{ secrets.NGROK_AUTH_TOKEN }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.resolve-playwright-matrix.outputs.matrix) }}
-    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@feature/ngrok-for-parallel-tests
+    uses: inpsyde/reusable-workflows/.github/workflows/test-playwright.yml@feature/cloudflare-for-parallel-tests
     with:
       PLAYWRIGHT_SCRIPT: ${{ matrix.script }}
       PLAYWRIGHT_ARTIFACT_NAME: ${{ matrix.artifact_name }}
@@ -118,7 +118,8 @@ jobs:
       NODE_VERSION: 22
       PLAYWRIGHT_BROWSER_ARGS: 'chromium --with-deps'
       XRAY_TEST_EXEC_KEY: ${{ inputs.XRAY_TEST_EXEC_KEY }}
-      NGROK_ENABLED: ${{ contains(fromJson('["onboarding","transaction-usa","transaction-mexico","transaction-germany","refund","vaulting","subscription"]'), matrix.slug) }}
+      TUNNEL_ENABLED: ${{ contains(fromJson('["transaction-usa","transaction-mexico","transaction-germany","refund","vaulting","subscription"]'), matrix.slug) }}
+      TUNNEL_PROVIDER: cloudflare
       PRE_SCRIPT: |
         # 1. Download and unzip the built plugin
         gh run download ${{ github.run_id }} -p "woocommerce-paypal-payments-*" -D tests/qa/resources/files

--- a/tests/qa/tests/05-transactions/_test-scenarios/checkout.scenario.ts
+++ b/tests/qa/tests/05-transactions/_test-scenarios/checkout.scenario.ts
@@ -26,11 +26,13 @@ export const transactionsOnCheckout = ( testOrder: ShopOrder ) => {
 				test.setTimeout( 3 * 60_000 ); // 3 minutes for PUI/OXXO async capture
 			}
 
-			// PUI/OXXO capture completion relies on an async PayPal webhook, which
-			// can't reach the ephemeral CI environment. In CI, skip waiting for it
-			// and finish the assertions with the order still in its synchronous,
-			// pre-capture status.
-			const skipCaptureWait = isAsyncCaptureGateway && !! process.env.CI;
+			// PUI/OXXO capture completion relies on an async PayPal webhook. This
+			// used to be unreachable from the ephemeral CI environment, so CI
+			// skipped waiting for it and finished assertions with the order still
+			// in its synchronous, pre-capture status. Webhooks now reach CI via
+			// the Cloudflare tunnel, so this restriction is no longer needed.
+			// const skipCaptureWait = isAsyncCaptureGateway && !! process.env.CI;
+			const skipCaptureWait = false;
 			const syncOrderStatus = gatewayTitle === 'OXXO' ? 'pending' : 'on-hold';
 
 			await test.step( `Add product(s) to the cart`, async () => {

--- a/tests/qa/tests/05-transactions/_test-scenarios/classic-checkout.scenario.ts
+++ b/tests/qa/tests/05-transactions/_test-scenarios/classic-checkout.scenario.ts
@@ -30,11 +30,13 @@ export const transactionsOnClassicCheckout = ( testOrder: ShopOrder ) => {
 				test.setTimeout( 3 * 60_000 ); // 3 minutes for PUI/OXXO async capture
 			}
 
-			// PUI/OXXO capture completion relies on an async PayPal webhook, which
-			// can't reach the ephemeral CI environment. In CI, skip waiting for it
-			// and finish the assertions with the order still in its synchronous,
-			// pre-capture status.
-			const skipCaptureWait = isAsyncCaptureGateway && !! process.env.CI;
+			// PUI/OXXO capture completion relies on an async PayPal webhook. This
+			// used to be unreachable from the ephemeral CI environment, so CI
+			// skipped waiting for it and finished assertions with the order still
+			// in its synchronous, pre-capture status. Webhooks now reach CI via
+			// the Cloudflare tunnel, so this restriction is no longer needed.
+			// const skipCaptureWait = isAsyncCaptureGateway && !! process.env.CI;
+			const skipCaptureWait = false;
 			const syncOrderStatus = gatewayTitle === 'OXXO' ? 'pending' : 'on-hold';
 
 			await test.step( `Add product(s) to the cart`, async () => {

--- a/tests/qa/tests/05-transactions/_test-scenarios/pay-by-link.scenario.ts
+++ b/tests/qa/tests/05-transactions/_test-scenarios/pay-by-link.scenario.ts
@@ -32,11 +32,13 @@ export const transactionsOnPayByLink = ( testOrder: ShopOrder ) => {
 				test.setTimeout( 3 * 60_000 ); // 3 minutes for PUI/OXXO async capture
 			}
 
-			// PUI/OXXO capture completion relies on an async PayPal webhook, which
-			// can't reach the ephemeral CI environment. In CI, skip waiting for it
-			// and finish the assertions with the order still in its synchronous,
-			// pre-capture status.
-			const skipCaptureWait = isAsyncCaptureGateway && !! process.env.CI;
+			// PUI/OXXO capture completion relies on an async PayPal webhook. This
+			// used to be unreachable from the ephemeral CI environment, so CI
+			// skipped waiting for it and finished assertions with the order still
+			// in its synchronous, pre-capture status. Webhooks now reach CI via
+			// the Cloudflare tunnel, so this restriction is no longer needed.
+			// const skipCaptureWait = isAsyncCaptureGateway && !! process.env.CI;
+			const skipCaptureWait = false;
 			const syncOrderStatus = gatewayTitle === 'OXXO' ? 'pending' : 'on-hold';
 
 			await test.step( `Precondition: create order via API (dashboard)`, async () => {


### PR DESCRIPTION
## Description

### What is the current behavior?

E2E shards share a single ngrok domain, so PayPal-touching shards can't run in parallel without tunnel collisions (ERR_NGROK_334).


### What is the new behavior?

Each shard runs on its own runner and, if it needs PayPal reachability, its own Cloudflare Quick Tunnel can be started with a random URL. 

Cloudflare Quick Tunnel is free, parallel-safe, and needs no account, token, or reserved domain.

A per-shard slug drives TUNNEL_ENABLED, which is true only for PayPal-touching shards (transaction, refund, vaulting, subscription); plugin-foundation, onboarding and settings skip the tunnel. TUNNEL_PROVIDER is set to 'cloudflare'. NGROK_AUTH_TOKEN is still forwarded, so switching back to ngrok is a one-line change.


### Other information

Depends on the reusable-workflows tunnel inputs (TUNNEL_ENABLED, TUNNEL_PROVIDER) landing first — this PR passes inputs the reusable workflow must already declare. While testing, `uses:` points at the feature branch; switch back to @main after it merges.