### PR TITLE
Invoice prefix cannot be cleared in new settings UI plugin always falls back to wc (6557)

### DIFF
--- a/modules/ppcp-api-client/services.php
+++ b/modules/ppcp-api-client/services.php
@@ -136,6 +136,13 @@ return array(
 	'api.prefix'                                     => static function (): string {
 		return 'WC-';
 	},
+	/**
+	 * The prefix for fabricated vault customer IDs.
+	 */
+	'api.customer-prefix'                            => static function ( ContainerInterface $container ): string {
+		$prefix = $container->get( 'api.prefix' );
+		return $prefix ? $prefix : CustomerRepository::FALLBACK_PREFIX;
+	},
 	'api.bearer'                                     => static function ( ContainerInterface $container ): Bearer {
 		$is_connected = $container->get( 'settings.flag.is-connected' );
 
@@ -382,7 +389,7 @@ return array(
 		return new PayeeRepository( $merchant_email, $merchant_id );
 	},
 	'api.repository.customer'                        => static function ( ContainerInterface $container ): CustomerRepository {
-		$prefix           = $container->get( 'api.prefix' );
+		$prefix = $container->get( 'api.customer-prefix' );
 		return new CustomerRepository( $prefix );
 	},
 	'api.repository.order'                           => static function ( ContainerInterface $container ): OrderRepository {

--- a/modules/ppcp-api-client/src/Repository/CustomerRepository.php
+++ b/modules/ppcp-api-client/src/Repository/CustomerRepository.php
@@ -16,6 +16,18 @@ class CustomerRepository {
 	const CLIENT_ID_MAX_LENGTH = 22;
 
 	/**
+	 * The prefix used for fabricated customer IDs when no invoice prefix is configured.
+	 *
+	 * Unlike the invoice ID, a customer ID is scoped to the PayPal merchant account
+	 * rather than the store, and it is persisted the first time a user is vaulted.
+	 * Without a prefix it would degrade to the bare WordPress user ID, so two stores
+	 * on one merchant account would fabricate the same ID for different people.
+	 *
+	 * @var string
+	 */
+	const FALLBACK_PREFIX = 'WC-';
+
+	/**
 	 * The prefix.
 	 *
 	 * @var string

--- a/modules/ppcp-wc-gateway/extensions.php
+++ b/modules/ppcp-wc-gateway/extensions.php
@@ -49,11 +49,18 @@ return array(
 		assert( $settings_provider instanceof SettingsProvider );
 		return $settings_provider->client_secret();
 	},
+	/**
+	 * The invoice prefix exactly as the merchant configured it. An empty string is a
+	 * supported choice meaning "no prefix", so it must not be replaced by a default
+	 * here. New installations receive a generated, site-specific default instead.
+	 *
+	 * The vault customer ID does not depend on this key; it resolves
+	 * 'api.customer-prefix', which keeps a fallback of its own.
+	 */
 	'api.prefix'                     => static function ( string $previous, ContainerInterface $container ): string {
 		$settings_provider = $container->get( 'settings.settings-provider' );
 		assert( $settings_provider instanceof SettingsProvider );
-		$prefix = $settings_provider->invoice_prefix();
-		return $prefix ? $prefix : 'WC-';
+		return $settings_provider->invoice_prefix();
 	},
 	'woocommerce.logger.woocommerce' => function ( LoggerInterface $previous, ContainerInterface $container ): LoggerInterface {
 		if ( ! function_exists( 'wc_get_logger' ) || ! $container->get( 'wcgateway.logging.is-enabled' ) ) {

--- a/modules/ppcp-webhooks/services.php
+++ b/modules/ppcp-webhooks/services.php
@@ -89,7 +89,6 @@ return array(
 	},
 	'webhook.endpoint.handler'                => static function ( ContainerInterface $container ): array {
 		$logger         = $container->get( 'woocommerce.logger.woocommerce' );
-		$prefix         = $container->get( 'api.prefix' );
 		$order_endpoint = $container->get( 'api.endpoint.order' );
 		$authorized_payments_processor = $container->get( 'wcgateway.processor.authorized-payments' );
 		$refund_fees_updater = $container->get( 'wcgateway.helper.refund-fees-updater' );

--- a/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
+++ b/tests/PHPUnit/ApiClient/Factory/PurchaseUnitFactoryTest.php
@@ -64,6 +64,35 @@ class PurchaseUnitFactoryTest extends TestCase
 		$this->assertEquals($shipping, $unit->shipping());
 	}
 
+	/**
+	 * GIVEN a merchant who cleared the Invoice Prefix setting, so the factory is configured with an empty prefix
+	 * WHEN a purchase unit is built from a WooCommerce order
+	 * THEN the invoice ID equals the bare order number, with no "WC-" prepended
+	 */
+	public function test_invoice_id_has_no_prefix_when_prefix_is_empty()
+	{
+		$wc_order = $this->create_wc_order_mock();
+		$amount = Mockery::mock(Amount::class);
+		$shipping = $this->create_shipping_mock($this->create_address_mock());
+
+		$shipping_factory = Mockery::mock(ShippingFactory::class);
+		$shipping_factory->shouldReceive('from_wc_order')->with($wc_order)->andReturn($shipping);
+
+		$testee = $this->create_testee(
+			$this->create_amount_factory_mock($amount, 'from_wc_order', $wc_order),
+			$this->create_item_factory_mock([$this->item], 'from_wc_order', $wc_order),
+			$shipping_factory,
+			null,
+			null,
+			null,
+			null,
+			''
+		);
+
+		$unit = $testee->from_wc_order($wc_order);
+		$this->assertEquals($this->wcOrderNumber, $unit->invoice_id());
+	}
+
 	public function test_wc_order_with_negative_fees()
 	{
 		$wc_order = $this->create_wc_order_mock();
@@ -1043,7 +1072,8 @@ class PurchaseUnitFactoryTest extends TestCase
 		?PaymentsFactory $payments_factory = null,
 		?PaymentLevelHelper $payment_level_helper = null,
 		?PaymentLevelEligibility $payment_level_eligibility = null,
-		?SettingsProvider $settings = null
+		?SettingsProvider $settings = null,
+		string $prefix = 'WC-'
 	): PurchaseUnitFactory {
 		return new PurchaseUnitFactory(
 			$amount_factory,
@@ -1052,7 +1082,8 @@ class PurchaseUnitFactoryTest extends TestCase
 			$payments_factory ?? Mockery::mock(PaymentsFactory::class),
 			$payment_level_helper ?? Mockery::mock(PaymentLevelHelper::class),
 			$payment_level_eligibility ?? $this->create_payment_level_eligibility_mock(),
-			$settings ?? Mockery::mock(SettingsProvider::class)
+			$settings ?? Mockery::mock(SettingsProvider::class),
+			$prefix
 		);
 	}
 }

--- a/tests/PHPUnit/ApiClient/InvoicePrefixWiringTest.php
+++ b/tests/PHPUnit/ApiClient/InvoicePrefixWiringTest.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\ApiClient;
+
+use Mockery;
+use WooCommerce\PayPalCommerce\ModularTestCase;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
+use function Brain\Monkey\Functions\when;
+
+/**
+ * Covers the real container wiring for the invoice-prefix/customer-prefix split:
+ * an empty merchant-configured invoice prefix must reach 'api.prefix' verbatim,
+ * while the vault customer ID resolved through 'api.repository.customer' must
+ * never degrade to a bare, unprefixed user ID.
+ *
+ * The behaviour under test lives in container definitions rather than a single
+ * class, so the only class-level @covers target is the repository the wiring
+ * feeds.
+ *
+ * @covers \WooCommerce\PayPalCommerce\ApiClient\Repository\CustomerRepository
+ */
+class InvoicePrefixWiringTest extends ModularTestCase
+{
+	private $appContainer;
+
+	private $settingsProvider;
+
+	private $invoicePrefix = '';
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->settingsProvider = Mockery::mock(SettingsProvider::class)->shouldIgnoreMissing('');
+		$this->settingsProvider->shouldReceive('invoice_prefix')
+			->andReturnUsing(function () {
+				return $this->invoicePrefix;
+			});
+
+		$this->appContainer = $this->bootstrapModule([
+			'settings.settings-provider' => function () {
+				return $this->settingsProvider;
+			},
+		]);
+	}
+
+	/**
+	 * GIVEN a merchant who cleared the Invoice Prefix field, persisting an empty string
+	 * WHEN the 'api.prefix' container service is resolved
+	 * THEN it resolves to an empty string rather than substituting the historical 'WC-' default
+	 */
+	public function test_invoice_prefix_resolves_empty_when_merchant_clears_it(): void
+	{
+		$this->invoicePrefix = '';
+
+		$result = $this->appContainer->get('api.prefix');
+
+		self::assertSame('', $result);
+	}
+
+	/**
+	 * GIVEN an empty invoice prefix and a user who has never been vaulted with PayPal
+	 * WHEN the container-resolved customer repository fabricates a customer ID for that user
+	 * THEN it still applies the 'WC-' fallback rather than exposing the bare user ID, because
+	 *      the vault customer_id is merchant-scoped and must never degrade to a raw numeric ID
+	 */
+	public function test_customer_id_keeps_fallback_prefix_when_invoice_prefix_is_empty(): void
+	{
+		$this->invoicePrefix = '';
+
+		when('get_user_meta')->justReturn('');
+
+		$repository = $this->appContainer->get('api.repository.customer');
+
+		$customer_id = $repository->customer_id_for_user(5);
+
+		self::assertSame('WC-5', $customer_id);
+		self::assertNotSame('5', $customer_id);
+	}
+
+	/**
+	 * GIVEN a merchant-configured, non-empty invoice prefix
+	 * WHEN both the invoice-ID prefix and the fabricated customer ID are resolved from the container
+	 * THEN both use the configured prefix exactly, proving 'api.customer-prefix' does not shadow a
+	 *      real configured value with the 'WC-' fallback
+	 */
+	public function test_configured_prefix_reaches_both_invoice_and_customer_ids(): void
+	{
+		$this->invoicePrefix = 'Store_1';
+
+		when('get_user_meta')->justReturn('');
+
+		$repository = $this->appContainer->get('api.repository.customer');
+
+		self::assertSame('Store_1', $this->appContainer->get('api.prefix'));
+		self::assertSame('Store_15', $repository->customer_id_for_user(5));
+	}
+}

--- a/tests/PHPUnit/ApiClient/Repository/CustomerRepositoryTest.php
+++ b/tests/PHPUnit/ApiClient/Repository/CustomerRepositoryTest.php
@@ -96,4 +96,26 @@ class CustomerRepositoryTest extends TestCase
 
 		$this->assertSame('', $repository->paypal_customer_id_for_user(0));
 	}
+
+	/**
+	 * GIVEN a user with a previously stored ppcp_customer_id
+	 * WHEN resolving the vault customer ID for that user
+	 * THEN the stored ID is returned verbatim, regardless of the repository's configured prefix
+	 */
+	public function test_stored_customer_id_takes_precedence_over_generated_one()
+	{
+		$repository = new CustomerRepository('ppcp_prefix_');
+
+		expect('get_user_meta')
+			->once()
+			->with(5, 'ppcp_guest_customer_id', true)
+			->andReturn('');
+
+		expect('get_user_meta')
+			->once()
+			->with(5, 'ppcp_customer_id', true)
+			->andReturn('PAYPAL-123');
+
+		$this->assertSame('PAYPAL-123', $repository->customer_id_for_user(5));
+	}
 }

--- a/tests/PHPUnit/Settings/Data/SettingsModelTest.php
+++ b/tests/PHPUnit/Settings/Data/SettingsModelTest.php
@@ -235,6 +235,23 @@ class SettingsModelTest extends TestCase {
 	}
 
 	// ------------------------------------------------------------------
+	// No retroactive sanitization of already-stored invoice prefixes
+	// ------------------------------------------------------------------
+
+	/**
+	 * GIVEN an invoice prefix with spaces that was already persisted, e.g. via the legacy
+	 *       settings tab or a direct wp-cli write, before space-stripping validation existed
+	 * WHEN the settings model is loaded and the invoice prefix is read back
+	 * THEN the previously stored value survives unchanged, because set_invoice_prefix() only
+	 *      sanitizes on the next explicit write and load() does not retroactively re-sanitize
+	 */
+	public function test_stored_prefix_with_spaces_survives_round_trip(): void {
+		$model = $this->build_model_with( 'invoice_prefix', 'Old Store ' );
+
+		$this->assertSame( 'Old Store ', $model->get_invoice_prefix() );
+	}
+
+	// ------------------------------------------------------------------
 	// Shared data provider for the coercion test family
 	// ------------------------------------------------------------------
 

--- a/tests/integration/PHPUnit/Order/InvoicePrefixTest.php
+++ b/tests/integration/PHPUnit/Order/InvoicePrefixTest.php
@@ -1,0 +1,114 @@
+<?php
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\Tests\Integration\Order;
+
+use WC_Order;
+use WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory;
+use WooCommerce\PayPalCommerce\PPCP;
+use WooCommerce\PayPalCommerce\Settings\Data\SettingsModel;
+use WooCommerce\PayPalCommerce\Tests\Integration\TestCase;
+use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
+use LogicException;
+
+/**
+ * Proves a persisted empty invoice prefix survives the full container stack: the value
+ * written to the real settings option reaches PurchaseUnitFactory through the live
+ * 'api.factory.purchase-unit' service, with no "WC-" default substituted along the way.
+ *
+ * @covers \WooCommerce\PayPalCommerce\WcGateway\extensions.php
+ * @covers \WooCommerce\PayPalCommerce\ApiClient\Factory\PurchaseUnitFactory
+ */
+class InvoicePrefixTest extends TestCase
+{
+	protected $postIds = [];
+
+	/**
+	 * @var ContainerInterface|null
+	 */
+	private $originalContainer;
+
+	/**
+	 * @var mixed
+	 */
+	private $originalSettingsOption;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		try {
+			$this->originalContainer = PPCP::container();
+		} catch (LogicException $exception) {
+			$this->originalContainer = null;
+		}
+
+		$this->originalSettingsOption = get_option(SettingsModel::OPTION_KEY, null);
+	}
+
+	public function tearDown(): void
+	{
+		foreach ($this->postIds as $id) {
+			wp_delete_post($id);
+		}
+
+		if ($this->originalContainer) {
+			PPCP::init($this->originalContainer);
+		}
+
+		if (null === $this->originalSettingsOption) {
+			delete_option(SettingsModel::OPTION_KEY);
+		} else {
+			update_option(SettingsModel::OPTION_KEY, $this->originalSettingsOption);
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * GIVEN a merchant who cleared the Invoice Prefix field, persisting an empty string
+	 *       in the real 'woocommerce-ppcp-data-settings' option
+	 * WHEN a real WooCommerce order is turned into a PayPal purchase unit through the live
+	 *      container-resolved 'api.factory.purchase-unit' service
+	 * THEN the resulting invoice ID equals the bare order number, with no "WC-" prepended
+	 */
+	public function test_empty_stored_invoice_prefix_produces_unprefixed_invoice_id(): void
+	{
+		update_option(SettingsModel::OPTION_KEY, ['invoice_prefix' => '']);
+
+		$container = $this->bootstrap_fresh_container();
+
+		$purchase_unit_factory = $container->get('api.factory.purchase-unit');
+		assert($purchase_unit_factory instanceof PurchaseUnitFactory);
+
+		$wc_order = new WC_Order();
+		$wc_order->set_currency('USD');
+		$wc_order->save();
+		$this->postIds[] = $wc_order->get_id();
+
+		$purchase_unit = $purchase_unit_factory->from_wc_order($wc_order);
+
+		$this->assertSame($wc_order->get_order_number(), $purchase_unit->invoice_id());
+	}
+
+	/**
+	 * Boots a brand-new application container so it resolves 'api.prefix' from the option
+	 * written above.
+	 *
+	 * Container services are memoized for the lifetime of the container instance
+	 * (WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Container\ReadOnlyContainer caches
+	 * every non-factory service after its first resolution), so reusing the container built at
+	 * WordPress boot time could still return whatever invoice prefix was resolved before this
+	 * test ran. Rebuilding the container here is what proves the persisted empty string reaches
+	 * the factory through the real wiring, rather than a value cached from an earlier request.
+	 */
+	private function bootstrap_fresh_container(): ContainerInterface
+	{
+		$bootstrap = require ROOT_DIR . '/bootstrap.php';
+		$container = $bootstrap(ROOT_DIR, [], []);
+
+		PPCP::init($container);
+
+		return $container;
+	}
+}


### PR DESCRIPTION
## 🐛 What and why

A merchant who clears the Invoice Prefix field and saves still gets `WC-` prepended to every outgoing PayPal invoice ID. The empty string is persisted correctly all the way to the database, but the `api.prefix` container extension evaluated it with a truthiness check and substituted the `WC-` default, making an empty prefix **unreachable**.

This is a regression from the settings-module migration. The legacy definition used `Settings::has('prefix')`, which returns true for a stored empty string.

The naive fix — returning the value verbatim — is unsafe on its own. `api.prefix` is shared with the vault customer ID, where an empty prefix makes the plugin fabricate a bare user ID such as `5` and persist it as the merchant-scoped PayPal `customer_id`.

## ⚙️ How it works now

The `api.prefix` container key carries the merchant's configured value exactly, empty string included. `PurchaseUnitFactory::from_wc_order()` composes `$this->prefix . $order->get_order_number()`, so an empty prefix yields the bare order number.

The vault customer ID no longer reads that key. `api.repository.customer` is built from the new `api.customer-prefix` service, which resolves `api.prefix` inside its closure and substitutes `CustomerRepository::FALLBACK_PREFIX` only when the result is empty. `CustomerRepository::customer_id_for_user()` therefore keeps producing a prefixed ID for a not-yet-vaulted user.

The fallback lives in the **wiring** rather than inside `CustomerRepository`, so the constructor argument keeps an honest contract and the customer-ID prefix policy has one obvious home.

## 🔍 What to verify in review

### Covered by unit tests

- ✅ With the invoice prefix stored as an empty string, `api.prefix` resolves to `''` rather than `WC-`.
- ✅ `PurchaseUnitFactory` constructed with an empty prefix produces an `invoice_id` equal to the bare order number.
- ✅ `CustomerRepository::customer_id_for_user()` yields `WC-5` for user 5 under an empty invoice prefix — never the bare `5`.
- ✅ `CustomerRepository::customer_id_for_user()` returns a stored `ppcp_customer_id` unchanged, regardless of the configured prefix.
- ✅ With a non-empty prefix configured, both the invoice ID and the fabricated customer ID use it exactly as they do today.
- ✅ A prefix containing spaces stored before validation existed survives a `SettingsModel` round trip unchanged.
- ✅ An empty prefix written to the real `woocommerce-ppcp-data-settings` option reaches `api.factory.purchase-unit` through a freshly built container and produces an unprefixed invoice ID (integration suite).

### Not covered by unit tests

- ❌ `POST /wc/v3/wc_paypal/settings` with `invoicePrefix = 'WC Store'` returns `success => false` — already covered by `SettingsRestEndpointTest.php`.
- ❌ `POST /wc/v3/wc_paypal/settings` with `invoicePrefix = ''` is accepted and persists the empty string — already covered by `SettingsRestEndpointTest.php`.
- ❌ `POST /wc/v3/wc_paypal/settings` with `invoicePrefix = 'WC-Store_1'` is accepted verbatim — already covered by `SettingsRestEndpointTest.php`.
- ❌ `InvoicePrefix.js` refuses a disallowed character on input or paste, keeps the message visible while typing, and clears it on blur — client-side behavior covered by the Jest suite in `InvoicePrefix.test.js`.
- ❌ `InvoicePrefix.js` shows no error when the field is cleared to empty — covered by `InvoicePrefix.test.js`.
- ❌ `ControlTextInput` renders without `ppcp--has-error`, `aria-invalid`, or `.ppcp-r-control-error` when no `error` prop is passed — covered by `ControlTextInput.test.js`.
- ❌ `modules/ppcp-webhooks/services.php` no longer contains the unused `$prefix` assignment — removal of an unused variable produces no observable behavior to assert.

## 🚨 What must not regress

- `PurchaseUnitFactory::__construct()` — the `string $prefix = 'WC-'` default stays. The container always passes a value; changing it only churns tests.
- `SettingsTabMigration.php:127` — must keep mapping `'prefix' => 'invoice_prefix'` verbatim. No retroactive sanitization of already-stored prefixes.
- `SettingsModel::set_invoice_prefix()` — must keep using `sanitize_text_field()` only, which preserves spaces in previously saved values.
- `ControlTextInput.js` — validation stays opt-in via the `error` / `onBlur` props; no globally applied validation.
- The five other `ControlTextInput` consumers — brand name, soft descriptor, shipping-origin postal code, and sandbox/live Client ID and Secret Key — pass neither prop and must render identically.
- `RestEndpoint::return_error()` and `data/settings/actions.js` — the silent save-failure gap (HTTP 200 with `success => false`, never inspected by the client) is out of scope.
- `wcgateway.settings.invoice-prefix` and `wcgateway.settings.invoice-prefix-random` — new-install defaults are unchanged, so new stores still receive a generated site-specific prefix.

## 🔗 Contracts introduced or changed

### New container service

`api.customer-prefix` in `modules/ppcp-api-client/services.php`. Resolves `api.prefix` lazily and falls back to `CustomerRepository::FALLBACK_PREFIX`. `api.repository.customer` is its only consumer.
