### PR TITLE
Shipping callback fails when PayPal sends a state WooCommerce does not know (6738)

### DIFF
--- a/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\ShippingOption;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
@@ -82,37 +83,39 @@ class ShippingCallbackEndpoint {
 		$this->logger->debug( 'Shipping callback received: ' . $request->get_body() );
 
 		$request_id = $request_data['id'];
-		$pu_id      = $request_data['purchase_units'][0]['reference_id'];
+		$pu_id      = $request_data['purchase_units'][0]['reference_id'] ?? 'default';
 
-		$address = $this->convert_address_to_wc( $request_data['shipping_address'] );
+		$address = $this->convert_address_to_wc( $request_data['shipping_address'] ?? array() );
 
-		$cart_response = $this->cart_endpoint->update_customer(
-			$cart_token,
-			array(
-				'shipping_address' => $address,
-			)
-		);
+		try {
+			$cart_response = $this->cart_endpoint->update_customer(
+				$cart_token,
+				array(
+					'shipping_address' => $address,
+				)
+			);
+		} catch ( Exception $exception ) {
+			$this->logger->warning( 'Shipping callback response: ADDRESS_ERROR (' . $exception->getMessage() . ').' );
+
+			return $this->error_response( 'ADDRESS_ERROR' );
+		}
 
 		if ( empty( $cart_response->cart()->shipping_rates() ) ) {
 			$this->logger->debug( 'Shipping callback response: ADDRESS_ERROR (no shipping rates found).' );
 
-			return new WP_REST_Response(
-				array(
-					'name'    => 'UNPROCESSABLE_ENTITY',
-					'details' => array(
-						array(
-							'issue' => 'ADDRESS_ERROR',
-						),
-					),
-				),
-				422
-			);
+			return $this->error_response( 'ADDRESS_ERROR' );
 		}
 
 		if ( isset( $request_data['shipping_option'] ) ) {
 			$selected_shipping_method_id = $request_data['shipping_option']['id'];
 
-			$cart_response = $this->cart_endpoint->select_shipping_rate( $cart_token, 0, $selected_shipping_method_id );
+			try {
+				$cart_response = $this->cart_endpoint->select_shipping_rate( $cart_token, 0, $selected_shipping_method_id );
+			} catch ( Exception $exception ) {
+				$this->logger->warning( 'Shipping callback response: METHOD_UNAVAILABLE (' . $exception->getMessage() . ').' );
+
+				return $this->error_response( 'METHOD_UNAVAILABLE' );
+			}
 		}
 
 		$cart = $cart_response->cart();
@@ -157,6 +160,25 @@ class ShippingCallbackEndpoint {
 		$url = rest_url( self::NAMESPACE . '/' . self::ROUTE );
 
 		return $url;
+	}
+
+	/**
+	 * Tells PayPal that the order cannot be updated for the requested address or shipping option.
+	 *
+	 * @param string $issue The PayPal issue, like ADDRESS_ERROR or METHOD_UNAVAILABLE.
+	 */
+	private function error_response( string $issue ): WP_REST_Response {
+		return new WP_REST_Response(
+			array(
+				'name'    => 'UNPROCESSABLE_ENTITY',
+				'details' => array(
+					array(
+						'issue' => $issue,
+					),
+				),
+			),
+			422
+		);
 	}
 
 	/**

--- a/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
@@ -159,16 +159,23 @@ class ShippingCallbackEndpoint {
 		return $url;
 	}
 
+	/**
+	 * Converts the PayPal address into the fields of the Store API customer endpoint.
+	 *
+	 * The callback payload contains no street lines, so those fields are omitted and the address
+	 * that is already stored for the customer remains unchanged.
+	 *
+	 * @param array<string, mixed> $address The shipping_address of the callback payload.
+	 * @return array<string, string>
+	 */
 	private function convert_address_to_wc( array $address ): array {
 		$country = (string) ( $address['country_code'] ?? '' );
 
 		return array(
-			'country'        => $country,
-			'state'          => $this->convert_state_to_wc( (string) ( $address['admin_area_1'] ?? '' ), $country ),
-			'city'           => (string) ( $address['admin_area_2'] ?? '' ),
-			'postcode'       => (string) ( $address['postal_code'] ?? '' ),
-			'address_line_1' => '',
-			'address_line_2' => '',
+			'country'  => $country,
+			'state'    => $this->convert_state_to_wc( (string) ( $address['admin_area_1'] ?? '' ), $country ),
+			'city'     => (string) ( $address['admin_area_2'] ?? '' ),
+			'postcode' => (string) ( $address['postal_code'] ?? '' ),
 		);
 	}
 

--- a/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
+++ b/modules/ppcp-wc-gateway/src/Endpoint/ShippingCallbackEndpoint.php
@@ -160,13 +160,51 @@ class ShippingCallbackEndpoint {
 	}
 
 	private function convert_address_to_wc( array $address ): array {
+		$country = (string) ( $address['country_code'] ?? '' );
+
 		return array(
-			'country'        => $address['country_code'] ?? '',
-			'state'          => $address['admin_area_1'] ?? '',
-			'city'           => $address['admin_area_2'] ?? '',
-			'postcode'       => $address['postal_code'] ?? '',
+			'country'        => $country,
+			'state'          => $this->convert_state_to_wc( (string) ( $address['admin_area_1'] ?? '' ), $country ),
+			'city'           => (string) ( $address['admin_area_2'] ?? '' ),
+			'postcode'       => (string) ( $address['postal_code'] ?? '' ),
 			'address_line_1' => '',
 			'address_line_2' => '',
 		);
+	}
+
+	/**
+	 * Converts the PayPal state into a state that WooCommerce accepts for the given country.
+	 *
+	 * PayPal sends regions that are not always part of the WooCommerce state list of the country,
+	 * and the Store API rejects the whole address in that case. Such states are dropped, so that
+	 * the shipping rates are calculated based on the remaining address fields.
+	 *
+	 * @param string $state The admin_area_1 of the callback payload, a state code or name.
+	 * @param string $country The 2-letter country code.
+	 */
+	private function convert_state_to_wc( string $state, string $country ): string {
+		if ( '' === $state || '' === $country ) {
+			return $state;
+		}
+
+		$states = array_filter( (array) WC()->countries->get_states( $country ) );
+		if ( ! $states ) {
+			return $state;
+		}
+
+		$state = wc_strtoupper( $state );
+
+		if ( in_array( $state, array_map( 'wc_strtoupper', array_keys( $states ) ), true ) ) {
+			return $state;
+		}
+
+		$code = array_search( $state, array_map( 'wc_strtoupper', $states ), true );
+		if ( false !== $code ) {
+			return (string) $code;
+		}
+
+		$this->logger->debug( sprintf( 'Shipping callback: dropped the state "%1$s", which is unknown in %2$s.', $state, $country ) );
+
+		return '';
 	}
 }

--- a/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
@@ -6,12 +6,20 @@ namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
 
 use Mockery;
 use Psr\Log\NullLogger;
+use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
 use WooCommerce\PayPalCommerce\ApiClient\Factory\AmountFactory;
 use WooCommerce\PayPalCommerce\Button\Session\CartData;
 use WooCommerce\PayPalCommerce\Button\Session\CartDataTransientStorage;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Endpoint\CartEndpoint;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\Cart;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\CartResponse;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\CartTotals;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Entity\Money as StoreApiMoney;
+use WooCommerce\PayPalCommerce\WcGateway\StoreApi\Factory\ShippingRate;
 use WP_REST_Request;
+
+use function Brain\Monkey\Functions\when;
 
 /**
  * @covers \WooCommerce\PayPalCommerce\WcGateway\Endpoint\ShippingCallbackEndpoint
@@ -30,6 +38,8 @@ class ShippingCallbackEndpointTest extends TestCase
 		$this->cart_endpoint     = Mockery::mock( CartEndpoint::class );
 		$this->amount_factory    = Mockery::mock( AmountFactory::class );
 		$this->cart_data_storage = Mockery::mock( CartDataTransientStorage::class );
+
+		when( 'wp_json_encode' )->alias( 'json_encode' );
 
 		$this->sut = new ShippingCallbackEndpoint(
 			$this->cart_endpoint,
@@ -122,5 +132,279 @@ class ShippingCallbackEndpointTest extends TestCase
 
 			$this->assertFalse( $result, 'Expected false for params: ' . json_encode( $params ) );
 		}
+	}
+
+	/**
+	 * GIVEN a PayPal shipping callback with a full address and a purchase unit reference
+	 * WHEN handle_request() processes it and the Store API returns a shipping rate
+	 * THEN the response is a 200 carrying the PayPal order id, the given reference_id
+	 *      and the shipping options converted from the Store API rate
+	 * AND the address forwarded to update_customer() never carries address_line_1/2,
+	 *      which are PayPal field names the Store API does not understand
+	 */
+	public function test_handle_request_returns_success_payload_on_happy_path(): void
+	{
+		$this->stub_wc_states( [ 'US' => [ 'CA' => 'California', 'NY' => 'New York' ] ] );
+
+		$request = $this->build_request(
+			[
+				'id'              => '5O190127TN364715T',
+				'purchase_units'  => [ [ 'reference_id' => 'PUI-1' ] ],
+				'shipping_address' => [
+					'country_code' => 'US',
+					'admin_area_1' => 'CA',
+					'admin_area_2' => 'Beverly Hills',
+					'postal_code'  => '90210',
+					'address_line_1' => '1 Hollywood Blvd',
+					'address_line_2' => 'Suite 1',
+				],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => 'US',
+						'state'    => 'CA',
+						'city'     => 'Beverly Hills',
+						'postcode' => '90210',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->cart_endpoint->shouldNotReceive( 'select_shipping_rate' );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [ 'currency_code' => 'USD', 'value' => '5.00' ] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( '5O190127TN364715T', $data['id'] );
+		$this->assertSame( 'PUI-1', $data['purchase_units'][0]['reference_id'] );
+		$this->assertSame( 'flat_rate:1', $data['purchase_units'][0]['shipping_options'][0]['id'] );
+	}
+
+	/**
+	 * GIVEN a purchase unit that carries admin_area_1 "CA" for country_code "IE" (the state
+	 *       value that used to crash the callback because Ireland has no such state)
+	 * WHEN handle_request() converts the address for the Store API
+	 * THEN the unrecognised state is dropped rather than forwarded, and the request still
+	 *      succeeds instead of surfacing the Store API's invalid_state rejection as a fatal
+	 */
+	public function test_handle_request_drops_unknown_state_instead_of_failing(): void
+	{
+		$this->stub_wc_states( [ 'IE' => [ 'CW' => 'Carlow', 'CO' => 'Cork' ] ] );
+
+		$request = $this->build_request(
+			[
+				'id'               => '5O190127TN364715T',
+				'shipping_address' => [
+					'country_code' => 'IE',
+					'admin_area_1' => 'CA',
+				],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => 'IE',
+						'state'    => '',
+						'city'     => '',
+						'postcode' => '',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * GIVEN a state value that matches the full name of a WooCommerce state for the country
+	 * WHEN handle_request() converts the address for the Store API
+	 * THEN the state is converted to its WooCommerce code before being forwarded
+	 *
+	 * @dataProvider state_conversion_provider
+	 */
+	public function test_handle_request_converts_state_for_wc(
+		array $states,
+		string $country,
+		string $admin_area_1,
+		string $expected_state
+	): void
+	{
+		$this->stub_wc_states( [ $country => $states ] );
+
+		$request = $this->build_request(
+			[
+				'id'               => '5O190127TN364715T',
+				'shipping_address' => [
+					'country_code' => $country,
+					'admin_area_1' => $admin_area_1,
+				],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => $country,
+						'state'    => $expected_state,
+						'city'     => '',
+						'postcode' => '',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	public function state_conversion_provider(): array
+	{
+		return [
+			'state code is upper-cased and passed through'  => [ [ 'CA' => 'California', 'NY' => 'New York' ], 'US', 'ca', 'CA' ],
+			'state name is converted to its code'           => [ [ 'CA' => 'California', 'NY' => 'New York' ], 'US', 'California', 'CA' ],
+			'state name is matched case-insensitively'      => [ [ 'CA' => 'California', 'NY' => 'New York' ], 'US', 'california', 'CA' ],
+		];
+	}
+
+	/**
+	 * GIVEN a country that has no WooCommerce state list (e.g. Germany)
+	 * WHEN handle_request() converts the address for the Store API
+	 * THEN the state value is forwarded unchanged, since there is nothing to validate it against
+	 */
+	public function test_handle_request_leaves_state_untouched_when_country_has_no_state_list(): void
+	{
+		$this->stub_wc_states( [ 'DE' => [] ] );
+
+		$request = $this->build_request(
+			[
+				'id'               => '5O190127TN364715T',
+				'shipping_address' => [
+					'country_code' => 'DE',
+					'admin_area_1' => 'Bayern',
+				],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => 'DE',
+						'state'    => 'Bayern',
+						'city'     => '',
+						'postcode' => '',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Builds a WP_REST_Request stub carrying the given decoded body params and a fixed
+	 * cart_token, the way the PayPal shipping callback sends them.
+	 */
+	private function build_request( array $params ): WP_REST_Request
+	{
+		$params['cart_token'] = 'wc-cart-token';
+
+		$request = new WP_REST_Request();
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		$request->set_body( (string) json_encode( $params ) );
+
+		return $request;
+	}
+
+	/**
+	 * Stubs WC()->countries->get_states() with a fixed map of country code to state list.
+	 */
+	private function stub_wc_states( array $states_by_country ): void
+	{
+		when( 'wc_strtoupper' )->alias(
+			static function ( string $value ): string {
+				return strtoupper( $value );
+			}
+		);
+
+		$countries = Mockery::mock();
+		$countries->shouldReceive( 'get_states' )
+			->andReturnUsing(
+				static function ( string $country ) use ( $states_by_country ) {
+					return $states_by_country[ $country ] ?? array();
+				}
+			);
+
+		$wc            = Mockery::mock();
+		$wc->countries = $countries;
+
+		when( 'WC' )->justReturn( $wc );
+	}
+
+	/**
+	 * Builds a Store API CartResponse carrying the given shipping rates.
+	 */
+	private function cart_response_with_rates( array $shipping_rates ): CartResponse
+	{
+		$cart = new Cart( Mockery::mock( CartTotals::class ), $shipping_rates );
+
+		return new CartResponse( $cart, 'wc-cart-token' );
+	}
+
+	/**
+	 * Builds a Store API ShippingRate with the given rate id, name and price in cents.
+	 */
+	private function shipping_rate( string $rate_id, string $name, int $price_cents ): ShippingRate
+	{
+		return new ShippingRate(
+			$rate_id,
+			$name,
+			true,
+			new StoreApiMoney( (string) $price_cents, 'USD', 2 ),
+			new StoreApiMoney( '0', 'USD', 2 )
+		);
 	}
 }

--- a/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WooCommerce\PayPalCommerce\WcGateway\Endpoint;
 
+use Exception;
 use Mockery;
 use Psr\Log\NullLogger;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Amount;
@@ -406,6 +407,89 @@ class ShippingCallbackEndpointTest extends TestCase
 
 		$data = $response->get_data();
 		$this->assertSame( 'default', $data['purchase_units'][0]['reference_id'] );
+	}
+
+	/**
+	 * GIVEN the Store API rejects the customer address update (e.g. an invalid address field)
+	 * WHEN handle_request() calls update_customer()
+	 * THEN the exception does not escape as a fatal; a 422 ADDRESS_ERROR response is returned
+	 */
+	public function test_handle_request_returns_422_when_update_customer_fails(): void
+	{
+		$request = $this->build_request(
+			[
+				'id' => '5O190127TN364715T',
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->andThrow( new Exception( 'cart/update-customer request return error: rest_invalid_param' ) );
+
+		$this->cart_endpoint->shouldNotReceive( 'select_shipping_rate' );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 422, $response->get_status() );
+		$this->assertSame( 'ADDRESS_ERROR', $response->get_data()['details'][0]['issue'] );
+	}
+
+	/**
+	 * GIVEN the Store API accepted the address but returned no shipping rates for it
+	 * WHEN handle_request() inspects the cart response
+	 * THEN a 422 ADDRESS_ERROR response is returned and no shipping rate is selected
+	 */
+	public function test_handle_request_returns_422_when_no_shipping_rates_found(): void
+	{
+		$request = $this->build_request(
+			[
+				'id' => '5O190127TN364715T',
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->andReturn( $this->cart_response_with_rates( [] ) );
+
+		$this->cart_endpoint->shouldNotReceive( 'select_shipping_rate' );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 422, $response->get_status() );
+		$this->assertSame( 'ADDRESS_ERROR', $response->get_data()['details'][0]['issue'] );
+	}
+
+	/**
+	 * GIVEN the buyer picked a shipping option that the Store API then rejects
+	 * WHEN handle_request() calls select_shipping_rate()
+	 * THEN the exception does not escape as a fatal; a 422 METHOD_UNAVAILABLE response is returned
+	 */
+	public function test_handle_request_returns_422_when_select_shipping_rate_fails(): void
+	{
+		$request = $this->build_request(
+			[
+				'id'              => '5O190127TN364715T',
+				'shipping_option' => [ 'id' => 'flat_rate:2' ],
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->cart_endpoint
+			->shouldReceive( 'select_shipping_rate' )
+			->once()
+			->with( 'wc-cart-token', 0, 'flat_rate:2' )
+			->andThrow( new Exception( 'cart/select-shipping-rate request return error: rest_invalid_param' ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 422, $response->get_status() );
+		$this->assertSame( 'METHOD_UNAVAILABLE', $response->get_data()['details'][0]['issue'] );
 	}
 
 	/**

--- a/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
+++ b/tests/PHPUnit/WcGateway/Endpoint/ShippingCallbackEndpointTest.php
@@ -343,6 +343,72 @@ class ShippingCallbackEndpointTest extends TestCase
 	}
 
 	/**
+	 * GIVEN a callback payload with no shipping_address at all
+	 * WHEN handle_request() builds the address for the Store API
+	 * THEN an address of empty fields is forwarded instead of a fatal on a missing array key
+	 */
+	public function test_handle_request_defaults_shipping_address_when_missing(): void
+	{
+		$request = $this->build_request(
+			[
+				'id' => '5O190127TN364715T',
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->with(
+				'wc-cart-token',
+				[
+					'shipping_address' => [
+						'country'  => '',
+						'state'    => '',
+						'city'     => '',
+						'postcode' => '',
+					],
+				]
+			)
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * GIVEN a callback payload with no purchase_units entry
+	 * WHEN handle_request() builds the success response
+	 * THEN the purchase unit falls back to the reference_id "default"
+	 */
+	public function test_handle_request_defaults_reference_id_when_purchase_units_missing(): void
+	{
+		$request = $this->build_request(
+			[
+				'id' => '5O190127TN364715T',
+			]
+		);
+
+		$this->cart_endpoint
+			->shouldReceive( 'update_customer' )
+			->once()
+			->andReturn( $this->cart_response_with_rates( [ $this->shipping_rate( 'flat_rate:1', 'Flat rate', 500 ) ] ) );
+
+		$this->amount_factory
+			->shouldReceive( 'from_store_api_cart' )
+			->andReturn( Mockery::mock( Amount::class, [ 'to_array' => [] ] ) );
+
+		$response = $this->sut->handle_request( $request );
+
+		$data = $response->get_data();
+		$this->assertSame( 'default', $data['purchase_units'][0]['reference_id'] );
+	}
+
+	/**
 	 * Builds a WP_REST_Request stub carrying the given decoded body params and a fixed
 	 * cart_token, the way the PayPal shipping callback sends them.
 	 */


### PR DESCRIPTION
Fixes #4596.

The shipping callback forwards PayPal's `admin_area_1` straight into the WooCommerce `state` field. When that value is not in the country's WooCommerce state list — `IT` for an Italian address in #4596, `CA` for an Irish one in our QA log — the Store API rejects the whole address with `invalid_state`, `CartEndpoint` throws, and nothing catches it: PayPal gets a 500 and the buyer is stuck in the popup. An empty state is accepted and rates are returned normally, so only a *wrong* value breaks it.

### PR Changes

- **`convert_state_to_wc()`** (new): resolves `admin_area_1` against `WC()->countries->get_states()` — valid codes pass through, state names become codes, unknown values are dropped so rates are calculated from country, city and postcode.
- **`convert_address_to_wc()`**: no longer sends `address_line_1` / `address_line_2`. The Store API schema uses `address_1` / `address_2` and silently ignored both; PayPal sends no street lines in this callback, so the fields are omitted rather than renamed and the customer's stored ones stay untouched.
- **`handle_request()`**: catches Store API failures and returns the 422 PayPal expects — `ADDRESS_ERROR` for the address, `METHOD_UNAVAILABLE` for the shipping rate — instead of a fatal. A payload without `shipping_address` or `purchase_units` no longer fails either.

The state is dropped, not repaired: #4596 suggests recovering the province from a `City (XX)` pattern, but dropping is enough for rates and avoids guessing at PayPal's formatting.

### Steps to Test

PayPal calls this endpoint server-to-server, so drive it from the browser console. Needs: non-plain permalinks, a shipping zone covering Ireland, plugin logging on, a shippable product in the cart. Click the PayPal express button, copy the order ID from the popup URL (`…?token=<ORDER_ID>`), close the popup.

```js
const token = (await fetch('/wp-json/wc/store/v1/cart')).headers.get('cart-token');
const r = await fetch(`/wp-json/paypal/v1/shipping-callback?cart_token=${token}`, {
  method: 'POST', headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({ id: '<ORDER_ID>', purchase_units: [ { reference_id: 'default' } ],
    shipping_address: { admin_area_1: 'CA', admin_area_2: 'Dublin 15', postal_code: 'D15 AF30', country_code: 'IE' } })
});
console.log(r.status, await r.text());
```

- On `dev/develop`: **500**, plus `Uncaught Exception … CartEndpoint.php` in the PHP error log.
- On this branch: **200** with `shipping_options`, and `dropped the state "CA", which is unknown in IE.` in the PayPal log.
- Control, `country_code: 'US'` with `admin_area_1: 'CA'` and a US zone: 200 and no "dropped" line — valid states still pass through. `'California'` is converted to `CA`.
- Error path, `country_code: 'XX'`: **422** `ADDRESS_ERROR` instead of a 500.

### Changelog Entry

> Fix: shipping callback failed with a 500 when PayPal sent a state that WooCommerce does not know for the country, leaving the buyer stuck in the PayPal popup.
