### PR TITLE
reCAPTCHA rejection logging produces no logs unless plugin logging is on (5551)

### DIFF
--- a/modules/ppcp-fraud-protection/services.php
+++ b/modules/ppcp-fraud-protection/services.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace WooCommerce\PayPalCommerce\FraudProtection;
 
+use Psr\Log\LoggerInterface;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
 use WooCommerce\PayPalCommerce\Axo\Gateway\AxoGateway;
@@ -13,6 +14,8 @@ use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\WooCommerce\Logging\Logger\NullLogger;
+use WooCommerce\WooCommerce\Logging\Logger\WooCommerceLogger;
 
 return array(
 	'fraud-protection.asset_getter'                   => static function ( ContainerInterface $container ): AssetGetter {
@@ -30,11 +33,30 @@ return array(
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'woocommerce.logger.woocommerce' ),
 			$container->get( 'fraud-protection.recaptcha.rejection-counter' ),
-			$container->get( 'wcgateway.settings.status' )
+			$container->get( 'wcgateway.settings.status' ),
+			$container->get( 'fraud-protection.recaptcha.rejection-logger' )
 		);
 	},
 	'fraud-protection.recaptcha.integration'          => static function (): RecaptchaIntegration {
 		return new RecaptchaIntegration();
+	},
+
+	/**
+	 * Writes the rejected reCAPTCHA attempts into their own log source.
+	 *
+	 * Deliberately not the shared 'woocommerce.logger.woocommerce' service: that one becomes a
+	 * NullLogger unless the plugin-wide logging setting is on, which would silently disable the
+	 * reCAPTCHA integration's own "Log rejected attempts" setting.
+	 */
+	'fraud-protection.recaptcha.rejection-logger'     => static function (): LoggerInterface {
+		if ( ! function_exists( 'wc_get_logger' ) ) {
+			return new NullLogger();
+		}
+
+		return new WooCommerceLogger(
+			wc_get_logger(),
+			Recaptcha::REJECTION_LOGGER_SOURCE
+		);
 	},
 	'fraud-protection.recaptcha.payment-methods'      => static function (): array {
 		return apply_filters(

--- a/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
+++ b/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
@@ -39,6 +39,13 @@ class Recaptcha {
 
 	private LoggerInterface $logger;
 
+	/**
+	 * Logs the rejected attempts, independently of the plugin-wide logging setting.
+	 *
+	 * @var LoggerInterface
+	 */
+	private LoggerInterface $rejection_logger;
+
 	private PersistentCounter $rejection_counter;
 
 	private SettingsStatus $settings_status;
@@ -53,6 +60,7 @@ class Recaptcha {
 	 * @param LoggerInterface      $logger
 	 * @param PersistentCounter    $rejection_counter
 	 * @param SettingsStatus       $settings_status
+	 * @param LoggerInterface      $rejection_logger Writes to the rejection log source.
 	 */
 	public function __construct(
 		RecaptchaIntegration $integration,
@@ -61,7 +69,8 @@ class Recaptcha {
 		string $asset_version,
 		LoggerInterface $logger,
 		PersistentCounter $rejection_counter,
-		SettingsStatus $settings_status
+		SettingsStatus $settings_status,
+		LoggerInterface $rejection_logger
 	) {
 
 		$this->integration       = $integration;
@@ -71,6 +80,7 @@ class Recaptcha {
 		$this->logger            = $logger;
 		$this->rejection_counter = $rejection_counter;
 		$this->settings_status   = $settings_status;
+		$this->rejection_logger  = $rejection_logger;
 	}
 
 	protected function should_use_recaptcha(): bool {
@@ -767,10 +777,9 @@ class Recaptcha {
 
 		$cart = $this->cart_contents();
 
-		$this->logger->debug(
+		$this->rejection_logger->debug(
 			"Rejected by v3 reCAPTCHA at {$endpoint_name} with score {$this->last_v3_score}, IP: {$ip}, User Agent: {$user_agent}.",
 			array(
-				'source'  => self::REJECTION_LOGGER_SOURCE,
 				'request' => $request_data,
 				'cart'    => $cart,
 			)

--- a/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
+++ b/modules/ppcp-fraud-protection/src/Recaptcha/Recaptcha.php
@@ -52,16 +52,6 @@ class Recaptcha {
 
 	private float $last_v3_score = 0;
 
-	/**
-	 * @param RecaptchaIntegration $integration
-	 * @param string[]             $payment_methods The methods that require captcha.
-	 * @param AssetGetter          $asset_getter
-	 * @param string               $asset_version
-	 * @param LoggerInterface      $logger
-	 * @param PersistentCounter    $rejection_counter
-	 * @param SettingsStatus       $settings_status
-	 * @param LoggerInterface      $rejection_logger Writes to the rejection log source.
-	 */
 	public function __construct(
 		RecaptchaIntegration $integration,
 		array $payment_methods,

--- a/tests/PHPUnit/FraudProtection/Recaptcha/RecaptchaTest.php
+++ b/tests/PHPUnit/FraudProtection/Recaptcha/RecaptchaTest.php
@@ -473,4 +473,38 @@ class RecaptchaTest extends TestCase {
 			)
 		);
 	}
+
+	/**
+	 * GIVEN reCAPTCHA's "Log rejected attempts" setting is on
+	 * WHEN a v2 (not v3) reCAPTCHA verification is rejected
+	 * THEN nothing is logged and the rejection counter does not increment, since only
+	 *      v3 rejections are logged.
+	 */
+	public function test_v2_rejection_never_invokes_rejection_logging(): void {
+		$this->stub_rejected_v3_verification();
+
+		$settings_status = Mockery::mock( SettingsStatus::class );
+
+		$rejection_counter = Mockery::mock( PersistentCounter::class );
+		$rejection_counter->shouldNotReceive( 'increment' );
+
+		$rejection_logger = Mockery::mock( LoggerInterface::class );
+		$rejection_logger->shouldNotReceive( 'debug' );
+
+		$testee = $this->make_testee(
+			$settings_status,
+			array(),
+			array( 'log_rejections' => 'yes' ),
+			null,
+			$rejection_logger,
+			$rejection_counter
+		);
+
+		$testee->intercept_paypal_ajax(
+			array(
+				'ppcp_recaptcha_token'   => 'test-token',
+				'ppcp_recaptcha_version' => 'v2',
+			)
+		);
+	}
 }

--- a/tests/PHPUnit/FraudProtection/Recaptcha/RecaptchaTest.php
+++ b/tests/PHPUnit/FraudProtection/Recaptcha/RecaptchaTest.php
@@ -39,23 +39,41 @@ class RecaptchaTest extends TestCase {
 	 * (valid v2/v3 keys, integration enabled), so tests only need to control
 	 * the location-gating logic under test.
 	 *
-	 * @param string[] $payment_methods The gateway IDs reCAPTCHA protects, mirroring the
-	 *                                  `fraud-protection.recaptcha.payment-methods` service.
+	 * @param string[]             $payment_methods  The gateway IDs reCAPTCHA protects, mirroring the
+	 *                                                `fraud-protection.recaptcha.payment-methods` service.
+	 * @param array                $option_overrides Overrides merged onto the default RecaptchaIntegration options,
+	 *                                                e.g. `['log_rejections' => 'yes']`.
+	 * @param LoggerInterface|null $logger           The shared, globally-gated logger. Defaults to a
+	 *                                                catch-all stub; pass a bare mock (no stubs) to assert
+	 *                                                it is never called.
+	 * @param LoggerInterface|null $rejection_logger  The reCAPTCHA-specific rejection logger, independent
+	 *                                                of the plugin-wide logging setting.
+	 * @param PersistentCounter|null $rejection_counter Tracks how many attempts were rejected.
 	 */
-	private function make_testee( SettingsStatus $settings_status, array $payment_methods = array() ): Recaptcha {
+	private function make_testee(
+		SettingsStatus $settings_status,
+		array $payment_methods = array(),
+		array $option_overrides = array(),
+		?LoggerInterface $logger = null,
+		?LoggerInterface $rejection_logger = null,
+		?PersistentCounter $rejection_counter = null
+	): Recaptcha {
+		$options = array_merge( $this->recaptcha_options, $option_overrides );
+
 		$integration = Mockery::mock( RecaptchaIntegration::class );
 		$integration->enabled = 'yes';
 		$integration->shouldReceive( 'get_option' )->andReturnUsing(
-			function ( string $key, $default = false ) {
-				return $this->recaptcha_options[ $key ] ?? $default;
+			function ( string $key, $default = false ) use ( $options ) {
+				return $options[ $key ] ?? $default;
 			}
 		);
 
 		$asset_getter = Mockery::mock( AssetGetter::class );
 		$asset_getter->shouldReceive( 'get_asset_url' )->andReturn( 'https://example.com/recaptcha-handler.js' );
 
-		$logger = Mockery::mock( LoggerInterface::class );
-		$rejection_counter = Mockery::mock( PersistentCounter::class );
+		$logger            = $logger ?? Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
+		$rejection_logger  = $rejection_logger ?? Mockery::mock( LoggerInterface::class )->shouldIgnoreMissing();
+		$rejection_counter = $rejection_counter ?? Mockery::mock( PersistentCounter::class )->shouldIgnoreMissing();
 
 		return new Recaptcha(
 			$integration,
@@ -64,7 +82,8 @@ class RecaptchaTest extends TestCase {
 			'1.0.0',
 			$logger,
 			$rejection_counter,
-			$settings_status
+			$settings_status,
+			$rejection_logger
 		);
 	}
 

--- a/tests/PHPUnit/FraudProtection/Recaptcha/RecaptchaTest.php
+++ b/tests/PHPUnit/FraudProtection/Recaptcha/RecaptchaTest.php
@@ -438,4 +438,39 @@ class RecaptchaTest extends TestCase {
 		$this->assertArrayNotHasKey( 'g-recaptcha-response', $captured_context['request'] );
 		$this->assertSame( 123, $captured_context['request']['order_id'] );
 	}
+
+	/**
+	 * GIVEN reCAPTCHA's "Log rejected attempts" setting is off
+	 * WHEN a v3 reCAPTCHA verification is rejected
+	 * THEN nothing is written to the rejection logger
+	 * AND the rejection counter still increments, since counting happens before the
+	 *     logging setting is checked.
+	 */
+	public function test_v3_rejection_does_not_log_when_log_rejections_disabled_but_still_increments_counter(): void {
+		$this->stub_rejected_v3_verification();
+
+		$settings_status = Mockery::mock( SettingsStatus::class );
+
+		$rejection_counter = Mockery::mock( PersistentCounter::class );
+		$rejection_counter->shouldReceive( 'increment' )->once();
+
+		$rejection_logger = Mockery::mock( LoggerInterface::class );
+		$rejection_logger->shouldNotReceive( 'debug' );
+
+		$testee = $this->make_testee(
+			$settings_status,
+			array(),
+			array( 'log_rejections' => 'no' ),
+			null,
+			$rejection_logger,
+			$rejection_counter
+		);
+
+		$testee->intercept_paypal_ajax(
+			array(
+				'ppcp_recaptcha_token'   => 'test-token',
+				'ppcp_recaptcha_version' => 'v3',
+			)
+		);
+	}
 }

--- a/tests/PHPUnit/FraudProtection/Recaptcha/RecaptchaTest.php
+++ b/tests/PHPUnit/FraudProtection/Recaptcha/RecaptchaTest.php
@@ -88,6 +88,24 @@ class RecaptchaTest extends TestCase {
 	}
 
 	/**
+	 * Stubs WC() with a session that reports a logged-in customer id and an empty cart.
+	 *
+	 * Giving verify_v3()/verify_v2() a customer id lets check_cached_verification() skip
+	 * its "no customer identifier" branch, which logs to the shared logger — keeping the
+	 * shared logger's only possible call site, for these tests, the one under test.
+	 */
+	private function stub_wc_session_and_cart(): void {
+		$session = Mockery::mock();
+		$session->shouldReceive( 'get_customer_id' )->andReturn( 42 );
+
+		$woocommerce          = Mockery::mock();
+		$woocommerce->session = $session;
+		$woocommerce->cart    = null;
+
+		when( 'WC' )->justReturn( $woocommerce );
+	}
+
+	/**
 	 * Stubs WC()->payment_gateways->get_available_payment_gateways() to return the given
 	 * gateway IDs as available, for has_protected_gateway_on_current_page() to check against.
 	 *
@@ -345,5 +363,79 @@ class RecaptchaTest extends TestCase {
 			'ppcp-recaptcha-v2-container',
 			$this->make_testee( $settings_status )->render_v2_container()
 		);
+	}
+
+	/**
+	 * Stubs the API request/response plumbing so a v3 verify call is rejected
+	 * (score/success below threshold), independent of which logger receives
+	 * the resulting rejection log entry.
+	 */
+	private function stub_rejected_v3_verification(): void {
+		when( 'is_wp_error' )->justReturn( false );
+		when( 'wp_remote_post' )->justReturn( array() );
+		when( 'wp_remote_retrieve_body' )->justReturn( json_encode( array( 'success' => false, 'score' => 0.1 ) ) );
+		when( 'apply_filters' )->returnArg( 2 );
+		when( 'wp_send_json_error' )->justReturn( null );
+		when( 'get_transient' )->justReturn( false );
+
+		$this->stub_wc_session_and_cart();
+	}
+
+	/**
+	 * GIVEN reCAPTCHA's "Log rejected attempts" setting is on
+	 * WHEN a v3 reCAPTCHA verification is rejected
+	 * THEN the rejection is written to the dedicated rejection logger
+	 * AND the shared, plugin-wide logger (which becomes a NullLogger unless the separate
+	 *     "Enable logging" setting is on) never receives any call
+	 * AND the logged context carries the request data and cart contents, but not a
+	 *     'source' key
+	 * AND the token, version and legacy 'g-recaptcha-response' fields are stripped from
+	 *     the logged request data.
+	 */
+	public function test_v3_rejection_logs_to_rejection_logger_with_sanitized_context_and_never_touches_shared_logger(): void {
+		$this->stub_rejected_v3_verification();
+
+		$settings_status = Mockery::mock( SettingsStatus::class );
+
+		// A bare mock with no stubbed methods: any unexpected call (e.g. to the shared
+		// logger) makes Mockery fail the test.
+		$shared_logger = Mockery::mock( LoggerInterface::class );
+
+		$rejection_counter = Mockery::mock( PersistentCounter::class );
+		$rejection_counter->shouldReceive( 'increment' )->once();
+
+		$captured_context = null;
+		$rejection_logger = Mockery::mock( LoggerInterface::class );
+		$rejection_logger->shouldReceive( 'debug' )->once()->andReturnUsing(
+			function ( string $message, array $context ) use ( &$captured_context ): void {
+				$captured_context = $context;
+			}
+		);
+
+		$testee = $this->make_testee(
+			$settings_status,
+			array(),
+			array( 'log_rejections' => 'yes' ),
+			$shared_logger,
+			$rejection_logger,
+			$rejection_counter
+		);
+
+		$testee->intercept_paypal_ajax(
+			array(
+				'ppcp_recaptcha_token'   => 'test-token',
+				'ppcp_recaptcha_version' => 'v3',
+				'g-recaptcha-response'   => 'legacy-token',
+				'order_id'               => 123,
+			)
+		);
+
+		$this->assertArrayHasKey( 'request', $captured_context );
+		$this->assertArrayHasKey( 'cart', $captured_context );
+		$this->assertArrayNotHasKey( 'source', $captured_context );
+		$this->assertArrayNotHasKey( 'ppcp_recaptcha_token', $captured_context['request'] );
+		$this->assertArrayNotHasKey( 'ppcp_recaptcha_version', $captured_context['request'] );
+		$this->assertArrayNotHasKey( 'g-recaptcha-response', $captured_context['request'] );
+		$this->assertSame( 123, $captured_context['request']['order_id'] );
 	}
 }


### PR DESCRIPTION
The reCAPTCHA integration has its own "Log rejected attempts" setting, but `Recaptcha::log_rejection()` wrote through the shared `woocommerce.logger.woocommerce` service — and `ppcp-wc-gateway/extensions.php:58-61` replaces that with a `NullLogger` unless the plugin-wide Troubleshooting → Logging setting is on. Enabling only the reCAPTCHA checkbox produced no logs at all, while the rejection counter on the settings page kept climbing. That mismatch is the reported symptom.

### PR Changes

- New `fraud-protection.recaptcha.rejection-logger` service: a `WooCommerceLogger` bound to `Recaptcha::REJECTION_LOGGER_SOURCE` and independent of the plugin-wide setting (`NullLogger` when `wc_get_logger()` is unavailable).
- `Recaptcha::log_rejection()` writes through it and drops the now-redundant `'source'` context key. The other six `$this->logger` calls are plugin diagnostics and stay on the shared, gated logger.

Destination is unchanged: rejections still land in the `woocommerce-paypal-payments-recaptcha` source the settings page's "view logs" link points at, and are not duplicated into the main log when plugin logging is on.

### Steps to Test

**WooCommerce → Settings → Integration → reCAPTCHA:** Enabled ✓; **both** the v3 *and* v2 key pairs filled in (it bails unless both are present); Score Threshold `1.0` so every v3 attempt is rejected; **Log rejected attempts** ✓.

**PayPal Payments → Settings → Troubleshooting:** leave **Logging off**. The store must be fully connected — logging is force-enabled during onboarding, which masks the bug.

1. Check out with PayPal or the card gateway and submit → "CAPTCHA verification failed" notice.
2. WooCommerce → Status → Logs, source `woocommerce-paypal-payments-recaptcha`: one entry per attempt, `Rejected by v3 reCAPTCHA at … with score …`. On `dev/develop` that log source does not exist at all, while the settings-page counter still increments — that is the bug.
3. Untick **Log rejected attempts** → counter still increments, nothing logged.
4. Turn plugin-wide **Logging on** → rejection entries still go only to the reCAPTCHA source, not duplicated into `woocommerce-paypal-payments`.

A successful verification is cached for 300s and reused up to 5 times, so clear the `ppcp_recaptcha_result_*` transients if you test a passing case first. Only v3 rejections are logged.

### Changelog Entry

> Fix: the reCAPTCHA "Log rejected attempts" setting produced no logs unless the plugin-wide logging setting was enabled as well.
