### PR TITLE
Add the BCDC card button to the SDK v6 module (6783) 

### DIFF
--- a/modules/ppcp-sdk-v6/extensions.php
+++ b/modules/ppcp-sdk-v6/extensions.php
@@ -23,9 +23,10 @@ return array(
 	 * Add Payment Method page) every v5 surface consuming this service's
 	 * script_data() goes dark, including block card fields and the regular
 	 * block method: that is accepted migration-state breakage until their
-	 * own stories migrate them. On the pages v6 does not own (pay-now) the
-	 * v5 stack keeps running: the blocks, applepay, googlepay and axo
-	 * modules would break under a blanket disable.
+	 * own stories migrate them. Ownership is decided per page, not per stack:
+	 * pay-now is v6-owned only when ACDC card fields or the BCDC row render
+	 * there, since the blocks, applepay, googlepay and axo modules would break
+	 * under a blanket disable.
 	 *
 	 * The Add Payment Method page is v6-owned by the vaulting story: v6
 	 * renders the save button + card save fields there, so the v5

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldContainer.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldContainer.js
@@ -15,6 +15,7 @@ import { createElement, useEffect, useRef } from '@wordpress/element';
  * @param {Object} props.session          - The v6 card-fields session.
  * @param {string} props.type             - The field type (number, expiry, cvv, name).
  * @param {Object} props.style            - The `style.input` object for the field.
+ * @param {string} [props.height]         - CSS height for the field's own box.
  * @param {string} [props.placeholder]    - The field placeholder text.
  * @param {Object} [props.containerStyle] - Extra styles for the wrapper (e.g. flex sizing).
  * @return {Object} The container element.
@@ -23,6 +24,7 @@ export function V6CardFieldContainer( {
 	session,
 	type,
 	style,
+	height,
 	placeholder,
 	containerStyle,
 } ) {
@@ -40,19 +42,20 @@ export function V6CardFieldContainer( {
 		}
 
 		const field = session.createCardFieldsComponent( options );
-		// style.input only styles the inside of the element, so size its box here
-		// or it falls back to the SDK default (much taller than the form inputs).
+		// style.input only reaches the text inside the element, so its box is
+		// sized here or it keeps the SDK default (much taller than the form
+		// inputs) — hence height as its own prop rather than part of style.
 		field.style.width = '100%';
-		if ( style?.height ) {
-			field.style.height = style.height;
+		if ( height ) {
+			field.style.height = height;
 		}
 		container.appendChild( field );
 
 		return () => {
 			field.remove();
 		};
-		// style and placeholder are captured at mount: depending on them would
-		// recreate the field on every render.
+		// style, height and placeholder are captured at mount: depending on them
+		// would recreate the field on every render.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ session, type ] );
 

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -19,7 +19,10 @@ import {
 import { __ } from '@wordpress/i18n';
 import { loadSdkV6 } from '../sdkLoader';
 import { createCardOrder, approveCardOrder } from '../endpointsAdapter';
-import { cardFieldStyles } from '../cardFields/cardFieldStyles';
+import {
+	cardFieldStyles,
+	hostedFieldTextStyles,
+} from '../cardFields/cardFieldStyles';
 import { V6CardFieldContainer } from './V6CardFieldContainer';
 
 /**
@@ -131,6 +134,7 @@ export function V6CardFieldsComponent( {
 
 	const [ session, setSession ] = useState( null );
 	const [ inputStyle, setInputStyle ] = useState( null );
+	const [ textStyle, setTextStyle ] = useState( null );
 	const [ cardName, setCardName ] = useState( '' );
 	const referenceRef = useRef( null );
 
@@ -190,6 +194,11 @@ export function V6CardFieldsComponent( {
 	// v6 returns unstyled field elements, so derive their styling from a real
 	// block text input on the page (accurate theme height/padding/border),
 	// falling back to a hidden reference input when none is found.
+	//
+	// Two objects, because they have different audiences: inputStyle describes
+	// elements this component renders itself (the cardholder-name input, and the
+	// hosted fields' own box), while textStyle is handed to the SDK and lands
+	// inside a PayPal iframe, where box decoration has no business.
 	useEffect( () => {
 		const source =
 			document.querySelector(
@@ -197,6 +206,7 @@ export function V6CardFieldsComponent( {
 			) || referenceRef.current;
 		if ( source ) {
 			setInputStyle( cardFieldStyles( source ) );
+			setTextStyle( hostedFieldTextStyles( source ) );
 		}
 	}, [] );
 
@@ -235,7 +245,7 @@ export function V6CardFieldsComponent( {
 		responseTypes,
 	] );
 
-	const fieldsReady = session && inputStyle;
+	const fieldsReady = session && inputStyle && textStyle;
 
 	return createElement(
 		'div',
@@ -288,7 +298,8 @@ export function V6CardFieldsComponent( {
 				createElement( V6CardFieldContainer, {
 					session,
 					type: 'number',
-					style: inputStyle,
+					style: textStyle,
+					height: inputStyle.height,
 					placeholder: __(
 						'Card number',
 						'woocommerce-paypal-payments'
@@ -303,7 +314,8 @@ export function V6CardFieldsComponent( {
 					createElement( V6CardFieldContainer, {
 						session,
 						type: 'expiry',
-						style: inputStyle,
+						style: textStyle,
+						height: inputStyle.height,
 						placeholder: __(
 							'MM / YY',
 							'woocommerce-paypal-payments'
@@ -313,7 +325,8 @@ export function V6CardFieldsComponent( {
 					createElement( V6CardFieldContainer, {
 						session,
 						type: 'cvv',
-						style: inputStyle,
+						style: textStyle,
+						height: inputStyle.height,
 						placeholder: __( 'CVV', 'woocommerce-paypal-payments' ),
 						containerStyle: { flex: 1 },
 					} )

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -106,6 +106,19 @@ async function submitCardPayment( {
 }
 
 /**
+ * Keeps the latest value in a ref, so the onPaymentSetup callback can read it
+ * without resubscribing every time it changes.
+ *
+ * @param {*} value - The value to track.
+ * @return {Object} A ref holding the latest value.
+ */
+function useLatestRef( value ) {
+	const ref = useRef( value );
+	ref.current = value;
+	return ref;
+}
+
+/**
  * @param {Object}  props                     - Props from the Blocks payment method registry.
  * @param {Object}  props.config              - The localized sdk-v6 config.
  * @param {Object}  props.eventRegistration   - Blocks checkout event subscriptions.
@@ -138,37 +151,27 @@ export function V6CardFieldsComponent( {
 	const [ cardName, setCardName ] = useState( '' );
 	const referenceRef = useRef( null );
 
-	// Whether to vault the card, read at submit time. The choice comes from WC
-	// Blocks' native "Save payment information…" checkbox (shouldSavePayment
-	// prop, shown via supports.showSaveOption); a subscription cart forces it
-	// on since the card must be saved to charge renewals. A ref keeps the
-	// latest value without resubscribing onPaymentSetup.
-	const savePaymentRef = useRef( false );
-	savePaymentRef.current = Boolean( shouldSavePayment ) || hasSubscriptions;
+	// The choice comes from WC Blocks' native "Save payment information…"
+	// checkbox (shown via supports.showSaveOption); a subscription cart forces
+	// it on, since the card must be saved to charge renewals.
+	const savePaymentRef = useLatestRef(
+		Boolean( shouldSavePayment ) || hasSubscriptions
+	);
+	const cardNameRef = useLatestRef( cardName );
 
-	// Read through a ref so onPaymentSetup sees the latest name without
-	// resubscribing every keystroke.
-	const cardNameRef = useRef( '' );
-	useEffect( () => {
-		cardNameRef.current = cardName;
-	}, [ cardName ] );
-
-	// The v6 SDK uses the billing address for AVS / 3D Secure; read the live
-	// Blocks billing address through a ref so the submit sees it without
-	// resubscribing onPaymentSetup on every address change.
-	const billingRef = useRef( null );
-	useEffect( () => {
-		const address = billing?.billingAddress || billing?.billingData;
-		const postalCode = address?.postcode?.trim();
-		billingRef.current = postalCode
+	// The v6 SDK uses the billing address for AVS / 3D Secure.
+	const billingAddress = billing?.billingAddress || billing?.billingData;
+	const postalCode = billingAddress?.postcode?.trim();
+	const billingRef = useLatestRef(
+		postalCode
 			? {
 					postalCode,
-					...( address?.country
-						? { countryCode: address.country }
+					...( billingAddress?.country
+						? { countryCode: billingAddress.country }
 						: {} ),
 			  }
-			: null;
-	}, [ billing ] );
+			: null
+	);
 
 	// One card session for the component's lifetime: the SDK cannot dispose a
 	// session, so it must not be recreated on ordinary re-renders.
@@ -210,12 +213,7 @@ export function V6CardFieldsComponent( {
 		}
 	}, [] );
 
-	// Read through a ref so onPaymentSetup sees the current session without
-	// resubscribing when it arrives.
-	const sessionRef = useRef( null );
-	useEffect( () => {
-		sessionRef.current = session;
-	}, [ session ] );
+	const sessionRef = useLatestRef( session );
 
 	// onPaymentSetup fires for every registered method during checkout
 	// processing, so gate on the active one before running the card flow.

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -202,6 +202,7 @@ export function V6CardFieldsComponent( {
 	// elements this component renders itself (the cardholder-name input, and the
 	// hosted fields' own box), while textStyle is handed to the SDK and lands
 	// inside a PayPal iframe, where box decoration has no business.
+	const cardFieldOverrides = config.card_fields.styles;
 	useEffect( () => {
 		const source =
 			document.querySelector(
@@ -209,9 +210,9 @@ export function V6CardFieldsComponent( {
 			) || referenceRef.current;
 		if ( source ) {
 			setInputStyle( cardFieldStyles( source ) );
-			setTextStyle( hostedFieldTextStyles( source ) );
+			setTextStyle( hostedFieldTextStyles( source, cardFieldOverrides ) );
 		}
-	}, [] );
+	}, [ cardFieldOverrides ] );
 
 	const sessionRef = useLatestRef( session );
 

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -11,8 +11,10 @@ jest.mock( '../endpointsAdapter', () => ( {
 } ) );
 
 const mockCardFieldStyles = jest.fn();
+const mockHostedFieldTextStyles = jest.fn();
 jest.mock( '../cardFields/cardFieldStyles', () => ( {
 	cardFieldStyles: ( ...args ) => mockCardFieldStyles( ...args ),
+	hostedFieldTextStyles: ( ...args ) => mockHostedFieldTextStyles( ...args ),
 } ) );
 
 const mockCardFieldContainer = jest.fn( () => null );
@@ -105,7 +107,12 @@ beforeEach( () => {
 	} );
 	mockCreateCardOrder.mockReset();
 	mockApproveCardOrder.mockReset().mockResolvedValue( undefined );
-	mockCardFieldStyles.mockReset().mockReturnValue( { color: 'rgb(0,0,0)' } );
+	mockCardFieldStyles
+		.mockReset()
+		.mockReturnValue( { color: 'rgb(0,0,0)', height: '40px' } );
+	mockHostedFieldTextStyles
+		.mockReset()
+		.mockReturnValue( { color: 'rgb(0,0,0)' } );
 	mockCardFieldContainer.mockClear();
 } );
 
@@ -267,6 +274,19 @@ describe( 'V6CardFieldsComponent', () => {
 		} );
 
 		expect( result ).toEqual( { type: 'error', message: 'nonce expired' } );
+	} );
+
+	test( "passes the reference input's height to each V6CardFieldContainer via its own height prop, not inside style", async () => {
+		renderComponent();
+
+		await waitFor( () =>
+			expect( mockCardFieldContainer ).toHaveBeenCalled()
+		);
+
+		for ( const call of mockCardFieldContainer.mock.calls ) {
+			expect( call[ 0 ].height ).toBe( '40px' );
+			expect( call[ 0 ].style ).not.toHaveProperty( 'height' );
+		}
 	} );
 
 	test( 'renders the cardholder name as a plain input, not a V6CardFieldContainer, when card_fields.name_field is enabled', async () => {

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -21,8 +21,10 @@ import {
 import { renderButtons } from './components/buttonRenderer';
 import { renderWallets } from './wallets/renderWallets';
 import { isWalletEnabled, WALLET_METHODS } from './wallets/walletRegistry';
+import { FundingSources } from './utils/fundingSources';
 import { createOrder, fetchCartTotal } from './endpointsAdapter';
 import { initCardFields } from './cardFields/renderer';
+import { initCardButton } from './cardButton/renderCardButton';
 import { hasJQuery } from './utils/api';
 import { setErrorLabels } from './utils/errorHandler';
 import { setVisible } from '@ppcp-button/Helper/Hiding';
@@ -51,6 +53,18 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 	 */
 	function initCardFieldsSafely() {
 		initCardFields( config ).catch( ( error ) => {
+			// eslint-disable-next-line no-console
+			console.error( '[PPCP SDK v6]', error );
+		} );
+	}
+
+	/**
+	 * Renders on its own pass, not via renderTarget(): with the checkout smart
+	 * button switched off there is no express wrapper to draw into, and BCDC
+	 * can still be on.
+	 */
+	function initCardButtonSafely() {
+		initCardButton( config, ensureSessions ).catch( ( error ) => {
 			// eslint-disable-next-line no-console
 			console.error( '[PPCP SDK v6]', error );
 		} );
@@ -133,6 +147,15 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 			if (
 				WALLET_METHODS.includes( method ) &&
 				! isWalletEnabled( config, method )
+			) {
+				continue;
+			}
+
+			// Same reason as the wallets: paypal-guest-payments is only
+			// requested where the card button renders.
+			if (
+				method === FundingSources.CARD &&
+				! config.card_button?.enabled
 			) {
 				continue;
 			}
@@ -286,6 +309,7 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 	function initialRender() {
 		renderAll();
 		initCardFieldsSafely();
+		initCardButtonSafely();
 		syncPlaceOrderButton();
 	}
 
@@ -301,6 +325,10 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 			'updated_checkout wc_fragments_loaded wc_fragments_refreshed',
 			renderAll
 		);
+
+		// The same DOM replacement rebuilds the card button's row and restores
+		// the hide-style PHP printed, so it needs rendering and revealing again.
+		jQuery( document.body ).on( 'updated_checkout', initCardButtonSafely );
 
 		// WC rebuilds #place_order on these too, and the selected method can
 		// change without a DOM rebuild, so re-sync the button on both.

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.js
@@ -1,0 +1,141 @@
+/**
+ * Renders the Basic Card button (BCDC) as its own payment-method row.
+ *
+ * Kept out of components/buttonRenderer.js, which draws into the shared express
+ * wrapper: separate files make "the card button never joins the express stack"
+ * true by construction rather than by a condition someone can relax.
+ *
+ * @package
+ */
+
+import { createOrder } from '../endpointsAdapter';
+import { handleError } from '../utils/errorHandler';
+import { FundingSources } from '../utils/fundingSources';
+import { revealWalletGateway } from '../wallets/gatewayPlacement';
+
+/**
+ * The event the SDK's card button dispatches on click. Documented contract; a
+ * plain 'click' listener only works by way of the element's shadow internals.
+ */
+const CLICK_EVENT = 'bcdc-click';
+
+/**
+ * Builds the button element and its required container, detached.
+ *
+ * The button checks on connect that its parent is a
+ * <paypal-basic-card-container>, so the tree must be assembled before any of it
+ * enters the document.
+ *
+ * @param {Object}  styles         - Style config from the card_button subtree.
+ * @param {?string} [buyerCountry] - ISO 3166-1 alpha-2 buyer country.
+ * @return {{container: HTMLElement, button: HTMLElement}} The detached pair.
+ */
+function createCardButtonElements( styles, buyerCountry ) {
+	const container = document.createElement( 'paypal-basic-card-container' );
+	const button = document.createElement( 'paypal-basic-card-button' );
+
+	if ( buyerCountry ) {
+		button.buyerCountry = buyerCountry;
+	}
+
+	if ( styles?.borderRadius ) {
+		button.style.setProperty(
+			'--paypal-button-border-radius',
+			styles.borderRadius
+		);
+	}
+
+	if ( styles?.height ) {
+		button.style.height = styles.height;
+	}
+
+	// The element ships a fixed 225px width, where v5's card button spanned the
+	// checkout column. An outer declaration wins over its own :host rule.
+	if ( styles?.width ) {
+		container.style.width = styles.width;
+		button.style.width = styles.width;
+	}
+
+	container.appendChild( button );
+
+	return { container, button };
+}
+
+/**
+ * Renders the card button into its gateway row, if it belongs on this page.
+ *
+ * Idempotent, because it runs again on every checkout update: WooCommerce
+ * replaces the whole order-review DOM, which takes our container with it.
+ *
+ * @param {Object}   config         - The wc_ppcp_sdk_v6 config object.
+ * @param {Function} ensureSessions - Resolves the sessions for a context.
+ * @return {Promise<void>} Resolves once the pass is done.
+ */
+export async function initCardButton( config, ensureSessions ) {
+	if ( ! config.card_button?.enabled ) {
+		return;
+	}
+
+	const findEmptyWrapper = () => {
+		const el = document.querySelector( config.card_button.wrapper );
+		return el && el.childElementCount === 0 ? el : null;
+	};
+
+	if ( ! findEmptyWrapper() ) {
+		return;
+	}
+
+	const context = config.page_context;
+	const { map } = await ensureSessions( context );
+
+	// Asked again after the await, never only before it: the initial render and
+	// the updated_checkout that follows it overlap, and a check that straddles
+	// the await lets both through, appending the button twice.
+	const target = findEmptyWrapper();
+	if ( ! target ) {
+		return;
+	}
+
+	// No session means the buyer is not eligible for cards; the row stays hidden
+	// and "Place order" stays visible, so the checkout still offers a way to pay.
+	const session = map[ FundingSources.CARD ];
+	if ( ! session ) {
+		return;
+	}
+
+	const { container, button } = createCardButtonElements(
+		config.card_button.styles,
+		config.buyer_country
+	);
+	target.appendChild( container );
+
+	button.addEventListener( CLICK_EVENT, async () => {
+		try {
+			await session.start(
+				// Naming the target beats the SDK's "last clicked button"
+				// fallback, ambient state on a page that also carries the
+				// express buttons. 'auto' is the only mode this session takes.
+				{ presentationMode: 'auto', targetElement: button },
+				createOrder(
+					config,
+					context,
+					FundingSources.CARD,
+					undefined,
+					config.card_button.payment_method
+				)
+			);
+		} catch ( error ) {
+			handleError( error );
+		}
+	} );
+
+	// After insertion, so the row counts as rendered when the placement logic
+	// decides what to do with "Place order".
+	revealWalletGateway(
+		{
+			id: config.card_button.payment_method,
+			wrapper: config.card_button.wrapper,
+		},
+		config
+	);
+}

--- a/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardButton/renderCardButton.test.js
@@ -1,0 +1,221 @@
+const mockCreateOrder = jest.fn();
+jest.mock( '../endpointsAdapter', () => ( {
+	createOrder: ( ...args ) => mockCreateOrder( ...args ),
+} ) );
+
+const mockHandleError = jest.fn();
+jest.mock( '../utils/errorHandler', () => ( {
+	handleError: ( ...args ) => mockHandleError( ...args ),
+} ) );
+
+const mockRevealWalletGateway = jest.fn();
+jest.mock( '../wallets/gatewayPlacement', () => ( {
+	revealWalletGateway: ( ...args ) => mockRevealWalletGateway( ...args ),
+} ) );
+
+import { initCardButton } from './renderCardButton';
+
+const baseConfig = ( overrides = {} ) => ( {
+	page_context: 'checkout',
+	buyer_country: 'US',
+	card_button: {
+		enabled: true,
+		wrapper: '#card-button-wrapper',
+		payment_method: 'ppcp-card-button-gateway',
+		styles: {},
+	},
+	...overrides,
+} );
+
+function sessionsWithCard( session ) {
+	return jest.fn().mockResolvedValue( { map: { card: session } } );
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	document.body.innerHTML = '<div id="card-button-wrapper"></div>';
+} );
+
+describe( 'initCardButton', () => {
+	test( 'does nothing when card_button.enabled is false', async () => {
+		const ensureSessions = jest.fn();
+
+		await initCardButton(
+			baseConfig( { card_button: { enabled: false } } ),
+			ensureSessions
+		);
+
+		expect( ensureSessions ).not.toHaveBeenCalled();
+		expect( document.querySelector( '#card-button-wrapper' ).childElementCount ).toBe( 0 );
+	} );
+
+	test( 'does nothing when the wrapper is not in the DOM', async () => {
+		document.body.innerHTML = '';
+		const ensureSessions = jest.fn();
+
+		await initCardButton( baseConfig(), ensureSessions );
+
+		expect( ensureSessions ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does nothing when the wrapper already has children', async () => {
+		document.querySelector( '#card-button-wrapper' ).innerHTML =
+			'<button></button>';
+		const ensureSessions = jest.fn();
+
+		await initCardButton( baseConfig(), ensureSessions );
+
+		expect( ensureSessions ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders one button when the initial render and a checkout update overlap', async () => {
+		const session = { start: jest.fn() };
+		const config = baseConfig();
+		const ensureSessions = sessionsWithCard( session );
+
+		const first = initCardButton( config, ensureSessions );
+		const second = initCardButton( config, ensureSessions );
+		await Promise.all( [ first, second ] );
+
+		const wrapper = document.querySelector( '#card-button-wrapper' );
+		expect( wrapper.childElementCount ).toBe( 1 );
+		expect(
+			wrapper.querySelectorAll( 'paypal-basic-card-container' )
+		).toHaveLength( 1 );
+	} );
+
+	test( 'lands the button in the replacement wrapper when the order-review DOM is swapped mid-flight', async () => {
+		const session = { start: jest.fn() };
+		const config = baseConfig();
+		const oldWrapper = document.querySelector( '#card-button-wrapper' );
+
+		const ensureSessions = jest.fn().mockImplementation( async () => {
+			oldWrapper.remove();
+			const newWrapper = document.createElement( 'div' );
+			newWrapper.id = 'card-button-wrapper';
+			document.body.appendChild( newWrapper );
+			return { map: { card: session } };
+		} );
+
+		await initCardButton( config, ensureSessions );
+
+		expect( oldWrapper.childElementCount ).toBe( 0 );
+		expect(
+			document.querySelector( '#card-button-wrapper' )
+				.childElementCount
+		).toBe( 1 );
+	} );
+
+	test( 'leaves the row empty and does not reveal the gateway when no card session exists (buyer ineligible)', async () => {
+		const ensureSessions = jest
+			.fn()
+			.mockResolvedValue( { map: {} } );
+
+		await initCardButton( baseConfig(), ensureSessions );
+
+		expect(
+			document.querySelector( '#card-button-wrapper' ).childElementCount
+		).toBe( 0 );
+		expect( mockRevealWalletGateway ).not.toHaveBeenCalled();
+	} );
+
+	test( 'assembles the button inside its container before either enters the document', async () => {
+		const session = { start: jest.fn() };
+		const target = document.querySelector( '#card-button-wrapper' );
+		let containerAtInsertion = null;
+		const originalAppendChild = target.appendChild.bind( target );
+		target.appendChild = jest.fn( ( node ) => {
+			containerAtInsertion = {
+				tagName: node.tagName,
+				childTagName: node.firstElementChild?.tagName,
+				childAlreadyConnected: node.firstElementChild?.isConnected,
+			};
+			return originalAppendChild( node );
+		} );
+
+		await initCardButton( baseConfig(), sessionsWithCard( session ) );
+
+		expect( containerAtInsertion.tagName ).toBe(
+			'PAYPAL-BASIC-CARD-CONTAINER'
+		);
+		expect( containerAtInsertion.childTagName ).toBe(
+			'PAYPAL-BASIC-CARD-BUTTON'
+		);
+		// The button was inside the container before either node was connected.
+		expect( containerAtInsertion.childAlreadyConnected ).toBe( false );
+	} );
+
+	test( 'reveals the wallet gateway row after the button is inserted', async () => {
+		const session = { start: jest.fn() };
+		const config = baseConfig();
+
+		await initCardButton( config, sessionsWithCard( session ) );
+
+		expect(
+			document.querySelector( '#card-button-wrapper' ).childElementCount
+		).toBeGreaterThan( 0 );
+		expect( mockRevealWalletGateway ).toHaveBeenCalledWith(
+			{
+				id: 'ppcp-card-button-gateway',
+				wrapper: '#card-button-wrapper',
+			},
+			config
+		);
+	} );
+
+	test( 'does not react to a plain click event', async () => {
+		const session = { start: jest.fn() };
+
+		await initCardButton( baseConfig(), sessionsWithCard( session ) );
+
+		const button = document.querySelector(
+			'#card-button-wrapper paypal-basic-card-button'
+		);
+		button.dispatchEvent( new Event( 'click', { bubbles: true } ) );
+
+		expect( session.start ).not.toHaveBeenCalled();
+	} );
+
+	test( 'starts the session with the button as target and forwards the gateway id to createOrder on bcdc-click', async () => {
+		const session = { start: jest.fn().mockResolvedValue( undefined ) };
+		const config = baseConfig();
+		mockCreateOrder.mockReturnValue( 'ORDER_PROMISE' );
+
+		await initCardButton( config, sessionsWithCard( session ) );
+
+		const button = document.querySelector(
+			'#card-button-wrapper paypal-basic-card-button'
+		);
+		button.dispatchEvent( new Event( 'bcdc-click' ) );
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect( mockCreateOrder ).toHaveBeenCalledWith(
+			config,
+			'checkout',
+			'card',
+			undefined,
+			'ppcp-card-button-gateway'
+		);
+		expect( session.start ).toHaveBeenCalledWith(
+			{ presentationMode: 'auto', targetElement: button },
+			'ORDER_PROMISE'
+		);
+	} );
+
+	test( 'routes a thrown session.start error to handleError', async () => {
+		const error = new Error( 'card session failed' );
+		const session = { start: jest.fn().mockRejectedValue( error ) };
+
+		await initCardButton( baseConfig(), sessionsWithCard( session ) );
+
+		const button = document.querySelector(
+			'#card-button-wrapper paypal-basic-card-button'
+		);
+		button.dispatchEvent( new Event( 'bcdc-click' ) );
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect( mockHandleError ).toHaveBeenCalledWith( error );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/cardFieldStyles.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/cardFieldStyles.js
@@ -113,9 +113,10 @@ export function cardFieldStyles( field ) {
  * The text-only style set for the SDK's `style.input`, which reaches inside a
  * PayPal-hosted field.
  *
- * @param {HTMLElement} field - The existing WC input being replaced.
+ * @param {HTMLElement} field       - The existing WC input being replaced.
+ * @param {Object}      [overrides] - Merchant overrides from card_fields.styles.
  * @return {Object} The style object.
  */
-export function hostedFieldTextStyles( field ) {
-	return pickComputed( field, TEXT_PROPERTIES );
+export function hostedFieldTextStyles( field, overrides ) {
+	return { ...pickComputed( field, TEXT_PROPERTIES ), ...overrides };
 }

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/cardFieldStyles.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/cardFieldStyles.js
@@ -1,15 +1,31 @@
 /**
- * Computes the `style.input` object for the v6 card-fields component.
+ * Computes the style objects for the v6 card-fields component.
  *
- * Unlike v5's paypal.CardFields() (see CardFieldsHelper.js), the v6 SDK
- * takes camelCase JS style properties (fontSize, not font-family) and
- * supports a different, narrower property set (e.g. no vendor-prefixed
- * properties, but background/border/borderRadius/boxShadow/height are
- * allowed) — reusing the v5 helper as-is causes the SDK to log a
- * "css property is not supported" DevError per property and skip it.
+ * cardFieldStyles() describes an element on our own page, so the theme's full
+ * box belongs on it. hostedFieldTextStyles() is handed to the SDK as
+ * `style.input` and reaches text inside a PayPal-hosted iframe, where box
+ * decoration would paint a frame the theme never drew on this element — and
+ * would carry state the theme does not own, such as the `border-color:
+ * var(--wc-green)` WooCommerce puts on a validated row.
+ *
+ * The v6 SDK takes camelCase property names (fontSize, not font-size) and
+ * rejects vendor-prefixed ones, logging a "css property is not supported"
+ * DevError per property it skips.
  *
  * @package
  */
+
+/**
+ * Properties describing the field's frame rather than its text; never handed
+ * to the SDK.
+ */
+const BOX_PROPERTIES = [
+	'background',
+	'border',
+	'borderRadius',
+	'boxShadow',
+	'height',
+];
 
 const ALLOWED_PROPERTIES = [
 	'appearance',
@@ -46,12 +62,10 @@ const ALLOWED_PROPERTIES = [
 	'transition',
 ];
 
-/**
- * Converts a kebab-case CSS property name to camelCase.
- *
- * @param {string} property - The kebab-case property name.
- * @return {string} The camelCase property name.
- */
+const TEXT_PROPERTIES = ALLOWED_PROPERTIES.filter(
+	( property ) => ! BOX_PROPERTIES.includes( property )
+);
+
 function toCamelCase( property ) {
 	return property.replace( /-([a-z])/g, ( match, letter ) =>
 		letter.toUpperCase()
@@ -59,29 +73,49 @@ function toCamelCase( property ) {
 }
 
 /**
- * Reads the field's live computed styles and returns only the properties
- * the v6 card-fields component actually supports, camelCased.
+ * Reads the field's live computed styles and keeps only the listed properties,
+ * camelCased.
  *
- * @param {HTMLElement} field - The existing WC input being replaced.
- * @return {Object} The style object for the component's `style.input`.
+ * @param {HTMLElement} field      - The existing WC input being replaced.
+ * @param {string[]}    properties - The camelCase property names to keep.
+ * @return {Object} The style object.
  */
-export function cardFieldStyles( field ) {
+function pickComputed( field, properties ) {
 	const computed = window.getComputedStyle( field );
 	const styles = {};
 
 	for ( let i = 0; i < computed.length; i++ ) {
 		const property = computed[ i ];
 		const camelProperty = toCamelCase( property );
+		const value = computed.getPropertyValue( property );
 
-		if (
-			! ALLOWED_PROPERTIES.includes( camelProperty ) ||
-			! computed[ property ]
-		) {
+		if ( ! value || ! properties.includes( camelProperty ) ) {
 			continue;
 		}
 
-		styles[ camelProperty ] = '' + computed[ property ];
+		styles[ camelProperty ] = value;
 	}
 
 	return styles;
+}
+
+/**
+ * The full style set, box included, for elements this plugin owns and renders.
+ *
+ * @param {HTMLElement} field - The existing WC input being replaced.
+ * @return {Object} The style object.
+ */
+export function cardFieldStyles( field ) {
+	return pickComputed( field, ALLOWED_PROPERTIES );
+}
+
+/**
+ * The text-only style set for the SDK's `style.input`, which reaches inside a
+ * PayPal-hosted field.
+ *
+ * @param {HTMLElement} field - The existing WC input being replaced.
+ * @return {Object} The style object.
+ */
+export function hostedFieldTextStyles( field ) {
+	return pickComputed( field, TEXT_PROPERTIES );
 }

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
@@ -9,20 +9,17 @@
  */
 
 import { hide } from '@ppcp-button/Helper/Hiding';
-import { cardFieldStyles } from './cardFieldStyles';
+import { hostedFieldTextStyles } from './cardFieldStyles';
 
 /**
- * Replaces a WC card input with its hosted v6 field, hiding the original
- * (mirrors v5's Render.js placement/hiding).
+ * Replaces a WC card input with its hosted v6 field, hiding the original.
  *
- * Unlike v5's paypal.CardFields(), which owns its container's layout via its
- * own .render() call, v6's createCardFieldsComponent() only returns a plain
- * HTMLElement: `style.input` styles what's inside it (font, color, padding,
- * ...), not the element's own box on this page. Theme rules targeting the
- * original `input` tag (e.g. `.input-wrapper input { height: 100% }`) don't
- * match this element, so its box has to be sized explicitly from the original
- * input's own rendered dimensions or it falls back to the SDK's default (much
- * taller than the form's inputs).
+ * The element v6 returns is ours to size: `style.input` only reaches the text
+ * inside it, and theme rules targeting the `input` tag never match it, so
+ * without an explicit size it keeps the SDK default (much taller than the
+ * form's inputs). Width fills the parent rather than copying the input's own
+ * width, which is not the width its column gives it — WooCommerce renders the
+ * CVV input far narrower than the half-width column holding it.
  *
  * @param {Object}      cardSession - The v6 card fields session.
  * @param {string}      fieldType   - number|expiry|cvv|name.
@@ -33,18 +30,22 @@ export function mountField( cardSession, fieldType, inputField ) {
 		return;
 	}
 
-	const computed = window.getComputedStyle( inputField );
+	const placeholder = inputField.getAttribute( 'placeholder' );
 	const options = {
 		type: fieldType,
-		style: { input: cardFieldStyles( inputField ) },
+		style: { input: hostedFieldTextStyles( inputField ) },
 	};
-	if ( inputField.getAttribute( 'placeholder' ) ) {
-		options.placeholder = inputField.getAttribute( 'placeholder' );
+	if ( placeholder ) {
+		options.placeholder = placeholder;
 	}
 
 	const fieldElement = cardSession.createCardFieldsComponent( options );
-	fieldElement.style.width = computed.width;
-	fieldElement.style.height = computed.height;
+	fieldElement.classList.add(
+		'ppcp-sdk-v6-card-field',
+		`ppcp-sdk-v6-card-field--${ fieldType }`
+	);
+	fieldElement.style.width = '100%';
+	fieldElement.style.height = window.getComputedStyle( inputField ).height;
 
 	inputField.parentNode.appendChild( fieldElement );
 	hide( inputField, true );

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
@@ -21,11 +21,17 @@ import { hostedFieldTextStyles } from './cardFieldStyles';
  * width, which is not the width its column gives it — WooCommerce renders the
  * CVV input far narrower than the half-width column holding it.
  *
- * @param {Object}      cardSession - The v6 card fields session.
- * @param {string}      fieldType   - number|expiry|cvv|name.
- * @param {HTMLElement} inputField  - The existing WC input to replace.
+ * @param {Object}      cardSession      - The v6 card fields session.
+ * @param {string}      fieldType        - number|expiry|cvv|name.
+ * @param {HTMLElement} inputField       - The existing WC input to replace.
+ * @param {Object}      [styleOverrides] - Merchant overrides for the field text.
  */
-export function mountField( cardSession, fieldType, inputField ) {
+export function mountField(
+	cardSession,
+	fieldType,
+	inputField,
+	styleOverrides
+) {
 	if ( ! inputField || inputField.hidden ) {
 		return;
 	}
@@ -33,7 +39,7 @@ export function mountField( cardSession, fieldType, inputField ) {
 	const placeholder = inputField.getAttribute( 'placeholder' );
 	const options = {
 		type: fieldType,
-		style: { input: hostedFieldTextStyles( inputField ) },
+		style: { input: hostedFieldTextStyles( inputField, styleOverrides ) },
 	};
 	if ( placeholder ) {
 		options.placeholder = placeholder;

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/mountField.js
@@ -1,0 +1,52 @@
+/**
+ * Mounts one v6 card field into an existing WC input's slot.
+ *
+ * Shared by the classic checkout renderer and the add-payment-method save
+ * renderer, which mount the same fields into the same WC card-form inputs and
+ * previously carried identical copies of this function.
+ *
+ * @package
+ */
+
+import { hide } from '@ppcp-button/Helper/Hiding';
+import { cardFieldStyles } from './cardFieldStyles';
+
+/**
+ * Replaces a WC card input with its hosted v6 field, hiding the original
+ * (mirrors v5's Render.js placement/hiding).
+ *
+ * Unlike v5's paypal.CardFields(), which owns its container's layout via its
+ * own .render() call, v6's createCardFieldsComponent() only returns a plain
+ * HTMLElement: `style.input` styles what's inside it (font, color, padding,
+ * ...), not the element's own box on this page. Theme rules targeting the
+ * original `input` tag (e.g. `.input-wrapper input { height: 100% }`) don't
+ * match this element, so its box has to be sized explicitly from the original
+ * input's own rendered dimensions or it falls back to the SDK's default (much
+ * taller than the form's inputs).
+ *
+ * @param {Object}      cardSession - The v6 card fields session.
+ * @param {string}      fieldType   - number|expiry|cvv|name.
+ * @param {HTMLElement} inputField  - The existing WC input to replace.
+ */
+export function mountField( cardSession, fieldType, inputField ) {
+	if ( ! inputField || inputField.hidden ) {
+		return;
+	}
+
+	const computed = window.getComputedStyle( inputField );
+	const options = {
+		type: fieldType,
+		style: { input: cardFieldStyles( inputField ) },
+	};
+	if ( inputField.getAttribute( 'placeholder' ) ) {
+		options.placeholder = inputField.getAttribute( 'placeholder' );
+	}
+
+	const fieldElement = cardSession.createCardFieldsComponent( options );
+	fieldElement.style.width = computed.width;
+	fieldElement.style.height = computed.height;
+
+	inputField.parentNode.appendChild( fieldElement );
+	hide( inputField, true );
+	inputField.hidden = true;
+}

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -20,8 +20,7 @@
  * @package
  */
 
-import { cardFieldStyles } from './cardFieldStyles';
-import { hide } from '@ppcp-button/Helper/Hiding';
+import { mountField } from './mountField';
 import Spinner from '@ppcp-button/Helper/Spinner';
 import { loadSdkV6 } from '../sdkLoader';
 import { createCardOrder, approveCardOrder } from '../endpointsAdapter';
@@ -29,46 +28,6 @@ import { hasJQuery } from '../utils/api';
 import { handleError } from '../utils/errorHandler';
 
 const FIELD_TYPES = [ 'number', 'expiry', 'cvv' ];
-
-/**
- * Mounts a single card field into its existing WC input's place, hiding
- * the original input (mirrors v5's Render.js placement/hiding).
- *
- * Unlike v5's paypal.CardFields(), which owns its container's layout via
- * its own .render() call, v6's createCardFieldsComponent() only returns a
- * plain HTMLElement — `style.input` styles what's inside it (font, color,
- * padding, ...), not the element's own box on this page. Theme rules
- * targeting the original `input` tag (e.g. `.input-wrapper input { height:
- * 100% }`) don't match this element, so its box has to be sized explicitly
- * from the original input's own rendered dimensions or it falls back to
- * the SDK's default (much taller than the form's inputs).
- *
- * @param {Object}      cardSession - The v6 card fields session.
- * @param {string}      fieldType   - number|expiry|cvv.
- * @param {HTMLElement} inputField  - The existing WC input to replace.
- */
-function mountField( cardSession, fieldType, inputField ) {
-	if ( ! inputField || inputField.hidden ) {
-		return;
-	}
-
-	const computed = window.getComputedStyle( inputField );
-	const options = {
-		type: fieldType,
-		style: { input: cardFieldStyles( inputField ) },
-	};
-	if ( inputField.getAttribute( 'placeholder' ) ) {
-		options.placeholder = inputField.getAttribute( 'placeholder' );
-	}
-
-	const fieldElement = cardSession.createCardFieldsComponent( options );
-	fieldElement.style.width = computed.width;
-	fieldElement.style.height = computed.height;
-
-	inputField.parentNode.appendChild( fieldElement );
-	hide( inputField, true );
-	inputField.hidden = true;
-}
 
 /**
  * Reads the billing address from the classic checkout form for the card

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -113,7 +113,11 @@ export async function initCardFields( config ) {
 		return;
 	}
 
-	const { fields, payment_method: paymentMethod } = config.card_fields;
+	const {
+		fields,
+		payment_method: paymentMethod,
+		styles,
+	} = config.card_fields;
 	const spinner = hasJQuery() ? Spinner.fullPage() : null;
 
 	let cardSessionPromise = null;
@@ -147,7 +151,8 @@ export async function initCardFields( config ) {
 						mountField(
 							cardSession,
 							fieldType,
-							inputs[ fieldType ]
+							inputs[ fieldType ],
+							styles
 						);
 					}
 				}

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
@@ -10,8 +10,7 @@
  * @package
  */
 
-import { cardFieldStyles } from './cardFieldStyles';
-import { hide } from '@ppcp-button/Helper/Hiding';
+import { mountField } from './mountField';
 import { getCurrentPaymentMethod } from '@ppcp-button/Helper/CheckoutMethodState';
 import { loadSdkV6 } from '../sdkLoader';
 import { postJson } from '../utils/api';
@@ -19,37 +18,6 @@ import { handleError } from '../utils/errorHandler';
 import { navigation } from '../utils/navigation';
 
 const FIELD_TYPES = [ 'number', 'expiry', 'cvv', 'name' ];
-
-/**
- * Mounts one v6 card field into its existing WC input's slot, hiding the
- * original (mirrors the classic renderer's mountField).
- *
- * @param {Object}      cardSession - The v6 card-fields save session.
- * @param {string}      fieldType   - number|expiry|cvv|name.
- * @param {HTMLElement} inputField  - The existing WC input to replace.
- */
-function mountField( cardSession, fieldType, inputField ) {
-	if ( ! inputField || inputField.hidden ) {
-		return;
-	}
-
-	const computed = window.getComputedStyle( inputField );
-	const options = {
-		type: fieldType,
-		style: { input: cardFieldStyles( inputField ) },
-	};
-	if ( inputField.getAttribute( 'placeholder' ) ) {
-		options.placeholder = inputField.getAttribute( 'placeholder' );
-	}
-
-	const fieldElement = cardSession.createCardFieldsComponent( options );
-	fieldElement.style.width = computed.width;
-	fieldElement.style.height = computed.height;
-
-	inputField.parentNode.appendChild( fieldElement );
-	hide( inputField, true );
-	inputField.hidden = true;
-}
 
 /**
  * Bootstraps the card "save for later" fields on the add-payment-method page.

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/saveRenderer.js
@@ -29,7 +29,11 @@ export function initCardSaveFields( config ) {
 		return;
 	}
 
-	const { fields, payment_method: paymentMethod } = config.card_fields;
+	const {
+		fields,
+		payment_method: paymentMethod,
+		styles,
+	} = config.card_fields;
 	let cardSessionPromise = null;
 	let submitting = false;
 
@@ -51,7 +55,12 @@ export function initCardSaveFields( config ) {
 
 				for ( const fieldType of FIELD_TYPES ) {
 					if ( inputs[ fieldType ] ) {
-						mountField( cardSession, fieldType, inputs[ fieldType ] );
+						mountField(
+							cardSession,
+							fieldType,
+							inputs[ fieldType ],
+							styles
+						);
 					}
 				}
 

--- a/modules/ppcp-sdk-v6/resources/js/eligibility.js
+++ b/modules/ppcp-sdk-v6/resources/js/eligibility.js
@@ -57,6 +57,12 @@ export async function checkEligibility(
 			FundingSources.PAYLATER
 		),
 		payLaterDetails: null,
+		// Safe rather than direct: paypal-guest-payments is only requested where
+		// the card button renders, so elsewhere the component is absent.
+		[ FundingSources.CARD ]: isEligibleSafely(
+			methods,
+			FundingSources.CARD
+		),
 	};
 
 	for ( const method of WALLET_METHODS ) {

--- a/modules/ppcp-sdk-v6/resources/js/eligibility.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/eligibility.test.js
@@ -110,6 +110,22 @@ describe( 'checkEligibility', () => {
 
 		expect( result.applepay ).toBe( false );
 	} );
+
+	test( 'reports card eligibility', async () => {
+		const sdk = sdkWith( { eligible: [ 'card' ] } );
+
+		const result = await checkEligibility( sdk, { currencyCode: 'USD' } );
+
+		expect( result.card ).toBe( true );
+	} );
+
+	test( 'resolves with card false, instead of rejecting, when isEligible throws for card', async () => {
+		const sdk = sdkWith( { isEligibleThrowsFor: [ 'card' ] } );
+
+		const result = await checkEligibility( sdk, { currencyCode: 'USD' } );
+
+		expect( result.card ).toBe( false );
+	} );
 } );
 
 describe( 'checkVaultEligibility', () => {

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.js
@@ -16,6 +16,9 @@ import { FundingSources } from './utils/fundingSources';
 import { minorUnitsToDecimal } from './utils/amount';
 import { continuationRedirectUrl } from './utils/continuation';
 
+// The gateway that processes an order unless a caller names another one.
+const DEFAULT_PAYMENT_METHOD = 'ppcp-gateway';
+
 /**
  * Navigation seam: window.location is not mockable under jsdom, so
  * redirects go through this indirection to stay unit-testable.
@@ -25,13 +28,14 @@ export const navigation = {
 };
 
 /**
- * Submits the pay-for-order form after selecting the PayPal gateway, so the
- * approved order is captured by the PayPal gateway (not whichever method radio
+ * Submits the pay-for-order form after selecting the paying gateway, so the
+ * approved order is captured by that gateway (not whichever method radio
  * happens to be checked) and WC issues the order-received redirect.
  *
+ * @param {string} paymentMethod - The WC gateway that processes the order.
  * @throws {Error} When jQuery or the pay-order form is unavailable.
  */
-function submitPayOrderForm() {
+function submitPayOrderForm( paymentMethod = DEFAULT_PAYMENT_METHOD ) {
 	if ( typeof jQuery === 'undefined' ) {
 		// eslint-disable-next-line no-console
 		console.error(
@@ -50,7 +54,7 @@ function submitPayOrderForm() {
 	}
 
 	const gatewayRadio = document.querySelector(
-		'#payment_method_ppcp-gateway'
+		`#payment_method_${ paymentMethod }`
 	);
 	if ( gatewayRadio && ! gatewayRadio.checked ) {
 		gatewayRadio.checked = true;
@@ -154,7 +158,7 @@ export async function createOrder(
 	context,
 	fundingSource,
 	purchaseUnits,
-	paymentMethod = 'ppcp-gateway'
+	paymentMethod = DEFAULT_PAYMENT_METHOD
 ) {
 	const units =
 		purchaseUnits ??
@@ -202,11 +206,11 @@ export async function createOrder(
 /**
  * Reports an approved PayPal order and takes the buyer wherever it leads.
  *
- * should_create_wc_order is requested except for Venmo with vaulting, and the
- * server decides: with the Pay Now experience it creates the WC order and responds
- * with order_received_url, otherwise it only stores the approved order in the
- * session and the gateway processes it on Place Order. On classic checkout the WC
- * checkout form is submitted after approval instead.
+ * should_create_wc_order is requested except for the card button and for Venmo
+ * with vaulting, and the server decides: with the Pay Now experience it creates
+ * the WC order and responds with order_received_url, otherwise it only stores the
+ * approved order in the session and the gateway processes it on Place Order. On
+ * classic checkout the WC checkout form is submitted after approval instead.
  *
  * @param {Object} config                    - The wc_ppcp_sdk_v6 config object.
  * @param {string} context                   - The page context.
@@ -224,21 +228,27 @@ export async function approveOrder(
 	fundingSource,
 	orderId,
 	contact = {},
-	paymentMethod = 'ppcp-gateway'
+	paymentMethod = DEFAULT_PAYMENT_METHOD
 ) {
 	// Pay-for-order: the WC order already exists. Approve it into the session
 	// (never request WC-order creation — that would create a duplicate, since
 	// is_checkout() is false during this AJAX call) and submit the pay-order
-	// form so the PayPal gateway captures the existing order and redirects to
+	// form so the paying gateway captures the existing order and redirects to
 	// the order-received page.
 	if ( context === 'pay-now' ) {
 		await approveOrderInSession( config, fundingSource, orderId );
-		submitPayOrderForm();
+		submitPayOrderForm( paymentMethod );
 		return;
 	}
 
+	// Never for the card button: ApproveOrderEndpoint would run
+	// PayPalGateway::process_payment() and pin chosen_payment_method to the
+	// PayPal gateway, so CardButtonGateway::process_payment() is never reached.
+	// False routes us through the classic form submit below instead.
 	const canCreateOrder =
-		! config.vaulting_enabled || fundingSource !== FundingSources.VENMO;
+		fundingSource !== FundingSources.CARD &&
+		( ! config.vaulting_enabled ||
+			fundingSource !== FundingSources.VENMO );
 
 	const body = {
 		order_id: orderId,

--- a/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/endpointsAdapter.test.js
@@ -325,6 +325,25 @@ describe( 'approveOrder', () => {
 		);
 	} );
 
+	test( 'never requests a WC order for the card button, regardless of vaulting', async () => {
+		postJson.mockResolvedValueOnce( {} );
+
+		await approveOrder(
+			{ ...config, vaulting_enabled: true },
+			'product',
+			'card',
+			'ORDER1',
+			{},
+			'ppcp-card-button-gateway'
+		);
+
+		expect( postJson ).toHaveBeenCalledWith( config.ajax.approve_order, {
+			order_id: 'ORDER1',
+			funding_source: 'card',
+			should_create_wc_order: false,
+		} );
+	} );
+
 	test( 'does not request a WC order for Venmo when vaulting is enabled', async () => {
 		postJson.mockResolvedValueOnce( {} );
 
@@ -586,6 +605,39 @@ describe( 'approveOrder', () => {
 			} );
 			expect(
 				document.querySelector( '#payment_method_ppcp-gateway' ).checked
+			).toBe( true );
+			expect( trigger ).toHaveBeenCalledWith( 'submit' );
+
+			delete global.jQuery;
+		} );
+
+		test( "ticks the card button gateway's own radio, not the default PayPal gateway selector", async () => {
+			postJson.mockResolvedValueOnce( {} );
+			// No #payment_method_ppcp-gateway element exists, so a fallback to
+			// the default selector would leave the radio unticked.
+			document.body.innerHTML =
+				'<form id="order_review">' +
+				'<input type="radio" id="payment_method_ppcp-card-button-gateway" /></form>';
+			const trigger = jest.fn();
+			global.jQuery = jest.fn( ( selector ) =>
+				typeof selector === 'string'
+					? { length: 1, trigger }
+					: { trigger }
+			);
+
+			await approveOrder(
+				config,
+				'pay-now',
+				'card',
+				'ORDER3',
+				{},
+				'ppcp-card-button-gateway'
+			);
+
+			expect(
+				document.querySelector(
+					'#payment_method_ppcp-card-button-gateway'
+				).checked
 			).toBe( true );
 			expect( trigger ).toHaveBeenCalledWith( 'submit' );
 

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
@@ -63,6 +63,10 @@ async function createInstance( config, context ) {
 	if ( config.card_fields?.enabled ) {
 		components.push( 'card-fields' );
 	}
+	// The basic card button lives in its own component, not in paypal-payments.
+	if ( config.card_button?.enabled ) {
+		components.push( 'paypal-guest-payments' );
+	}
 	components.push( ...walletSdkComponents( config ) );
 
 	const sdkInstance = await window.paypal.createInstance( {

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.test.js
@@ -66,6 +66,11 @@ describe( 'loadSdkV6', () => {
 				'googlepay-payments',
 			],
 		],
+		[
+			'the card button enabled',
+			{ card_button: { enabled: true } },
+			[ 'paypal-payments', 'venmo-payments', 'paypal-guest-payments' ],
+		],
 	] )( 'requests %s', async ( label, overrides, expectedComponents ) => {
 		await loadSdkV6( baseConfig( overrides ), 'checkout' );
 
@@ -80,6 +85,19 @@ describe( 'loadSdkV6', () => {
 				card_fields: { enabled: false },
 				google_pay: { enabled: false },
 			} ),
+			'checkout'
+		);
+
+		expect( window.paypal.createInstance ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				components: [ 'paypal-payments', 'venmo-payments' ],
+			} )
+		);
+	} );
+
+	test( 'does not request paypal-guest-payments when the card button is explicitly disabled', async () => {
+		await loadSdkV6(
+			baseConfig( { card_button: { enabled: false } } ),
 			'checkout'
 		);
 

--- a/modules/ppcp-sdk-v6/resources/js/sessions/createSession.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/createSession.js
@@ -10,7 +10,7 @@ import {
 	handleShippingOptionsChange,
 } from './shippingHandler';
 import { refreshCartUi } from '../utils/cartUi';
-import { handleError } from '../utils/errorHandler';
+import { handleError, handleWarning } from '../utils/errorHandler';
 import { FundingSources } from '../utils/fundingSources';
 import { WALLET_METHODS } from '../wallets/walletRegistry';
 
@@ -20,6 +20,7 @@ const SESSION_FACTORIES = {
 	[ FundingSources.PAYLATER ]: 'createPayLaterOneTimePaymentSession',
 	[ FundingSources.GOOGLEPAY ]: 'createGooglePayOneTimePaymentSession',
 	[ FundingSources.APPLEPAY ]: 'createApplePayOneTimePaymentSession',
+	[ FundingSources.CARD ]: 'createPayPalGuestOneTimePaymentSession',
 };
 
 /**
@@ -68,14 +69,42 @@ export function createSession(
 	// Wallet sheets close before the order exists, so wallet sessions have no
 	// onApprove: the wallet bridge drives create, confirm and approve itself.
 	if ( ! WALLET_METHODS.includes( method ) ) {
+		// Undefined leaves every other method on approveOrder's default gateway.
+		const paymentMethod =
+			method === FundingSources.CARD
+				? config.card_button?.payment_method
+				: undefined;
+
 		sessionConfig.onApprove =
 			handlers.onApprove ||
 			async function ( data ) {
 				try {
-					await approveOrder( config, context, method, data.orderId );
+					await approveOrder(
+						config,
+						context,
+						method,
+						data.orderId,
+						{},
+						paymentMethod
+					);
 				} catch ( error ) {
 					handleError( error );
 				}
+			};
+	}
+
+	// Card-only: the other factories' tolerance for unknown option keys is
+	// unverified, while the guest session documents both handlers.
+	if ( method === FundingSources.CARD ) {
+		sessionConfig.onWarn = handlers.onWarn || handleWarning;
+
+		// Fires after onApprove, which has already submitted the checkout form.
+		// Kept as a log so nothing here can start a second submission.
+		sessionConfig.onComplete =
+			handlers.onComplete ||
+			function () {
+				// eslint-disable-next-line no-console
+				console.debug( '[PPCP SDK v6] guest card payment complete' );
 			};
 	}
 

--- a/modules/ppcp-sdk-v6/resources/js/sessions/createSession.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/createSession.test.js
@@ -34,6 +34,9 @@ function fakeSdk() {
 		createApplePayOneTimePaymentSession: recordFactoryCall(
 			'createApplePayOneTimePaymentSession'
 		),
+		createPayPalGuestOneTimePaymentSession: recordFactoryCall(
+			'createPayPalGuestOneTimePaymentSession'
+		),
 	};
 }
 
@@ -51,12 +54,13 @@ describe( 'SUPPORTED_METHODS', () => {
 			'paylater',
 			'googlepay',
 			'applepay',
+			'card',
 		] );
 	} );
 } );
 
 describe( 'createSession', () => {
-	test( 'default onApprove routes to the classic approveOrder flow', async () => {
+	test( 'default onApprove routes to the classic approveOrder flow, passing no paymentMethod for paypal', async () => {
 		const sdk = fakeSdk();
 		const config = { shipping: {} };
 
@@ -67,7 +71,9 @@ describe( 'createSession', () => {
 			config,
 			'cart',
 			'paypal',
-			'ORDER1'
+			'ORDER1',
+			{},
+			undefined
 		);
 	} );
 
@@ -167,6 +173,83 @@ describe( 'createSession', () => {
 			expect(
 				sdk.capture.config.onShippingOptionsChange
 			).toBeUndefined();
+		} );
+	} );
+
+	describe( 'card', () => {
+		test( 'is created through createPayPalGuestOneTimePaymentSession', () => {
+			const sdk = fakeSdk();
+
+			createSession( sdk, 'card', { shipping: {} }, 'checkout' );
+
+			expect( sdk.capture.factory ).toBe(
+				'createPayPalGuestOneTimePaymentSession'
+			);
+		} );
+
+		test( 'gets onWarn and onComplete, unlike paypal and venmo', () => {
+			const sdk = fakeSdk();
+
+			createSession(
+				sdk,
+				'card',
+				{ shipping: {}, card_button: { payment_method: 'x' } },
+				'checkout'
+			);
+
+			expect( sdk.capture.config.onWarn ).toEqual( expect.any( Function ) );
+			expect( sdk.capture.config.onComplete ).toEqual(
+				expect.any( Function )
+			);
+		} );
+
+		test.each( [ 'paypal', 'venmo' ] )(
+			'%s gets neither onWarn nor onComplete',
+			( method ) => {
+				const sdk = fakeSdk();
+
+				createSession( sdk, method, { shipping: {} }, 'checkout' );
+
+				expect( sdk.capture.config.onWarn ).toBeUndefined();
+				expect( sdk.capture.config.onComplete ).toBeUndefined();
+			}
+		);
+
+		test( "onApprove forwards config.card_button.payment_method as approveOrder's paymentMethod", async () => {
+			const sdk = fakeSdk();
+			const config = {
+				shipping: {},
+				card_button: { payment_method: 'ppcp-card-button-gateway' },
+			};
+
+			createSession( sdk, 'card', config, 'checkout' );
+			await sdk.capture.config.onApprove( { orderId: 'ORDER1' } );
+
+			expect( mockApproveOrder ).toHaveBeenCalledWith(
+				config,
+				'checkout',
+				'card',
+				'ORDER1',
+				{},
+				'ppcp-card-button-gateway'
+			);
+		} );
+
+		test( "paypal's onApprove leaves approveOrder's paymentMethod undefined", async () => {
+			const sdk = fakeSdk();
+			const config = { shipping: {}, card_button: { payment_method: 'x' } };
+
+			createSession( sdk, 'paypal', config, 'checkout' );
+			await sdk.capture.config.onApprove( { orderId: 'ORDER2' } );
+
+			expect( mockApproveOrder ).toHaveBeenCalledWith(
+				config,
+				'checkout',
+				'paypal',
+				'ORDER2',
+				{},
+				undefined
+			);
 		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/sessions/createSession.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/createSession.test.js
@@ -11,7 +11,10 @@ jest.mock( './shippingHandler', () => ( {
 } ) );
 
 jest.mock( '../utils/api', () => ( { hasJQuery: () => false } ) );
-jest.mock( '../utils/errorHandler', () => ( { handleError: jest.fn() } ) );
+jest.mock( '../utils/errorHandler', () => ( {
+	handleError: jest.fn(),
+	handleWarning: jest.fn(),
+} ) );
 
 import { createSession, SUPPORTED_METHODS } from './createSession';
 
@@ -27,6 +30,12 @@ function fakeSdk() {
 		capture,
 		createPayPalOneTimePaymentSession: recordFactoryCall(
 			'createPayPalOneTimePaymentSession'
+		),
+		createVenmoOneTimePaymentSession: recordFactoryCall(
+			'createVenmoOneTimePaymentSession'
+		),
+		createPayLaterOneTimePaymentSession: recordFactoryCall(
+			'createPayLaterOneTimePaymentSession'
 		),
 		createGooglePayOneTimePaymentSession: recordFactoryCall(
 			'createGooglePayOneTimePaymentSession'

--- a/modules/ppcp-sdk-v6/resources/js/test/buttonRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/buttonRenderer.test.js
@@ -2,11 +2,11 @@
 // resolve; the button click path is not exercised here.
 jest.mock( '../utils/errorHandler', () => ( { handleError: jest.fn() } ) );
 
-import { createMethodButton } from '../components/buttonRenderer';
+import { createMethodButton, renderButtons } from '../components/buttonRenderer';
+
+const noop = () => {};
 
 describe( 'createMethodButton', () => {
-	const noop = () => {};
-
 	test( 'sets pay later product details as properties before returning', () => {
 		const button = createMethodButton( {
 			method: 'paylater',
@@ -95,5 +95,43 @@ describe( 'createMethodButton', () => {
 		} );
 
 		expect( button ).toBeNull();
+	} );
+} );
+
+describe( 'renderButtons', () => {
+	test( 'the card button is never bundled with the PayPal express buttons, even with a card session present', () => {
+		const wrapper = document.createElement( 'div' );
+		document.body.appendChild( wrapper );
+
+		const rendered = renderButtons( {
+			wrapper,
+			sessions: { paypal: {}, card: {} },
+			styles: {},
+			createOrderForFunding: () => noop,
+		} );
+
+		expect( wrapper.querySelector( 'paypal-basic-card-button' ) ).toBeNull();
+		expect( rendered.some( ( el ) => el.tagName === 'PAYPAL-BUTTON' ) ).toBe(
+			true
+		);
+
+		document.body.removeChild( wrapper );
+	} );
+
+	test( 'renders nothing at all into the express wrapper when card is the only session', () => {
+		const wrapper = document.createElement( 'div' );
+		document.body.appendChild( wrapper );
+
+		const rendered = renderButtons( {
+			wrapper,
+			sessions: { card: {} },
+			styles: {},
+			createOrderForFunding: () => noop,
+		} );
+
+		expect( rendered ).toHaveLength( 0 );
+		expect( wrapper.childElementCount ).toBe( 0 );
+
+		document.body.removeChild( wrapper );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldStyles.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldStyles.test.js
@@ -1,4 +1,7 @@
-import { cardFieldStyles } from '../cardFields/cardFieldStyles';
+import {
+	cardFieldStyles,
+	hostedFieldTextStyles,
+} from '../cardFields/cardFieldStyles';
 
 afterEach( () => {
 	document.body.innerHTML = '';
@@ -25,5 +28,63 @@ describe( 'cardFieldStyles', () => {
 
 		expect( styles ).not.toHaveProperty( 'webkitTapHighlightColor' );
 		expect( styles ).not.toHaveProperty( 'margin' );
+	} );
+
+	test.each( [
+		[ 'background', 'rgb(255, 0, 0)' ],
+		[ 'border', '1px solid rgb(0, 0, 0)' ],
+		[ 'border-radius', '4px' ],
+		[ 'box-shadow', 'rgb(0, 0, 0) 0px 0px 4px' ],
+		[ 'height', '40px' ],
+	] )(
+		'keeps the box property %s, unlike hostedFieldTextStyles()',
+		( cssProperty, value ) => {
+			const field = document.createElement( 'input' );
+			field.style.setProperty( cssProperty, value );
+			document.body.appendChild( field );
+
+			expect( Object.keys( cardFieldStyles( field ) ) ).toEqual(
+				expect.arrayContaining( [
+					cssProperty.replace( /-([a-z])/g, ( match, letter ) =>
+						letter.toUpperCase()
+					),
+				] )
+			);
+		}
+	);
+} );
+
+describe( 'hostedFieldTextStyles', () => {
+	test.each( [
+		'background',
+		'border',
+		'borderRadius',
+		'boxShadow',
+		'height',
+	] )(
+		'excludes the box property %s, which would paint a frame the SDK iframe never asked for',
+		( camelProperty ) => {
+			const field = document.createElement( 'input' );
+			field.style.setProperty( 'font-size', '16px' );
+			document.body.appendChild( field );
+
+			expect( hostedFieldTextStyles( field ) ).not.toHaveProperty(
+				camelProperty
+			);
+		}
+	);
+
+	test( 'keeps text properties such as font size and color', () => {
+		const field = document.createElement( 'input' );
+		field.style.setProperty( 'font-size', '16px' );
+		field.style.setProperty( 'color', 'rgb(1, 2, 3)' );
+		document.body.appendChild( field );
+
+		expect( hostedFieldTextStyles( field ) ).toEqual(
+			expect.objectContaining( {
+				fontSize: '16px',
+				color: 'rgb(1, 2, 3)',
+			} )
+		);
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldStyles.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldStyles.test.js
@@ -87,4 +87,23 @@ describe( 'hostedFieldTextStyles', () => {
 			} )
 		);
 	} );
+
+	test( 'lets a merchant override win over the computed style', () => {
+		const field = document.createElement( 'input' );
+		field.style.setProperty( 'color', 'rgb(1, 2, 3)' );
+		document.body.appendChild( field );
+
+		expect(
+			hostedFieldTextStyles( field, { color: 'rgb(9, 9, 9)' } )
+		).toEqual( expect.objectContaining( { color: 'rgb(9, 9, 9)' } ) );
+	} );
+
+	test( 'includes an override property the field itself has no computed value for', () => {
+		const field = document.createElement( 'input' );
+		document.body.appendChild( field );
+
+		expect(
+			hostedFieldTextStyles( field, { letterSpacing: '2px' } )
+		).toEqual( expect.objectContaining( { letterSpacing: '2px' } ) );
+	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -1,6 +1,8 @@
-const mockCardFieldStyles = jest.fn( () => ( { color: 'rgb(0, 0, 0)' } ) );
+const mockHostedFieldTextStyles = jest.fn( () => ( {
+	color: 'rgb(0, 0, 0)',
+} ) );
 jest.mock( '../cardFields/cardFieldStyles', () => ( {
-	cardFieldStyles: ( field ) => mockCardFieldStyles( field ),
+	hostedFieldTextStyles: ( field ) => mockHostedFieldTextStyles( field ),
 } ) );
 
 const mockHide = jest.fn();
@@ -201,9 +203,9 @@ describe( 'initCardFields', () => {
 		);
 		await flushPromises();
 
-		expect(
-			cardSession.createCardFieldsComponent
-		).toHaveBeenCalledTimes( 3 );
+		expect( cardSession.createCardFieldsComponent ).toHaveBeenCalledTimes(
+			3
+		);
 		expect(
 			cardSession.createCardFieldsComponent
 		).not.toHaveBeenCalledWith(
@@ -215,7 +217,7 @@ describe( 'initCardFields', () => {
 		expect( nameInput.hidden ).toBe( false );
 	} );
 
-	test( "sizes the mounted field to the original input's own box, since style.input only styles what is inside it", async () => {
+	test( "sizes the mounted field's height to the original input's own box, since style.input only styles what is inside it, and fills the field's own column width", async () => {
 		buildCheckoutDom( 'ppcp-credit-card-gateway' );
 		const numberInput = document.querySelector(
 			'#ppcp-credit-card-gateway-card-number'
@@ -231,7 +233,7 @@ describe( 'initCardFields', () => {
 		await initCardFields( baseConfig() );
 		await flushPromises();
 
-		expect( numberInput.nextSibling.style.width ).toBe( '300px' );
+		expect( numberInput.nextSibling.style.width ).toBe( '100%' );
 		expect( numberInput.nextSibling.style.height ).toBe( '45px' );
 	} );
 

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -2,7 +2,8 @@ const mockHostedFieldTextStyles = jest.fn( () => ( {
 	color: 'rgb(0, 0, 0)',
 } ) );
 jest.mock( '../cardFields/cardFieldStyles', () => ( {
-	hostedFieldTextStyles: ( field ) => mockHostedFieldTextStyles( field ),
+	hostedFieldTextStyles: ( field, overrides ) =>
+		mockHostedFieldTextStyles( field, overrides ),
 } ) );
 
 const mockHide = jest.fn();
@@ -179,6 +180,27 @@ describe( 'initCardFields', () => {
 		}
 	} );
 
+	test( 'forwards config.card_fields.styles as merchant overrides for the hosted field text style', async () => {
+		buildCheckoutDom( 'ppcp-credit-card-gateway' );
+		const cardSession = makeCardSession();
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsOneTimePaymentSession: () => cardSession,
+		} );
+		const styles = { fontSize: '20px' };
+
+		await initCardFields(
+			baseConfig( {
+				card_fields: { ...baseConfig().card_fields, styles },
+			} )
+		);
+		await flushPromises();
+
+		expect( mockHostedFieldTextStyles ).toHaveBeenCalledWith(
+			expect.anything(),
+			styles
+		);
+	} );
+
 	test( 'never mounts the name field even when fields.name points to a WC input, since v6 has no name field component', async () => {
 		buildCheckoutDom( 'ppcp-credit-card-gateway' );
 		document.body.insertAdjacentHTML(
@@ -203,9 +225,9 @@ describe( 'initCardFields', () => {
 		);
 		await flushPromises();
 
-		expect( cardSession.createCardFieldsComponent ).toHaveBeenCalledTimes(
-			3
-		);
+		expect(
+			cardSession.createCardFieldsComponent
+		).toHaveBeenCalledTimes( 3 );
 		expect(
 			cardSession.createCardFieldsComponent
 		).not.toHaveBeenCalledWith(

--- a/modules/ppcp-sdk-v6/resources/js/test/saveRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/saveRenderer.test.js
@@ -1,6 +1,8 @@
-const mockCardFieldStyles = jest.fn( () => ( { color: 'rgb(0, 0, 0)' } ) );
+const mockHostedFieldTextStyles = jest.fn( () => ( {
+	color: 'rgb(0, 0, 0)',
+} ) );
 jest.mock( '../cardFields/cardFieldStyles', () => ( {
-	cardFieldStyles: ( field ) => mockCardFieldStyles( field ),
+	hostedFieldTextStyles: ( field ) => mockHostedFieldTextStyles( field ),
 } ) );
 
 const mockHide = jest.fn();

--- a/modules/ppcp-sdk-v6/resources/js/test/saveRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/saveRenderer.test.js
@@ -2,7 +2,8 @@ const mockHostedFieldTextStyles = jest.fn( () => ( {
 	color: 'rgb(0, 0, 0)',
 } ) );
 jest.mock( '../cardFields/cardFieldStyles', () => ( {
-	hostedFieldTextStyles: ( field ) => mockHostedFieldTextStyles( field ),
+	hostedFieldTextStyles: ( field, overrides ) =>
+		mockHostedFieldTextStyles( field, overrides ),
 } ) );
 
 const mockHide = jest.fn();
@@ -108,6 +109,26 @@ describe( 'initCardSaveFields', () => {
 		initCardSaveFields( baseConfig( { card_fields: { enabled: false } } ) );
 
 		expect( mockLoadSdkV6 ).not.toHaveBeenCalled();
+	} );
+
+	test( 'forwards config.card_fields.styles as merchant overrides for the hosted field text style', async () => {
+		buildAddPaymentMethodDom();
+		mockLoadSdkV6.mockResolvedValue( {
+			createCardFieldsSavePaymentSession: () => makeCardSession(),
+		} );
+		const styles = { fontSize: '20px' };
+
+		initCardSaveFields(
+			baseConfig( {
+				card_fields: { ...baseConfig().card_fields, styles },
+			} )
+		);
+		await flushPromises();
+
+		expect( mockHostedFieldTextStyles ).toHaveBeenCalledWith(
+			expect.anything(),
+			styles
+		);
 	} );
 
 	test( 'a successful submission creates the setup token, submits the card session, exchanges it, and redirects', async () => {

--- a/modules/ppcp-sdk-v6/resources/js/utils/errorHandler.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/errorHandler.js
@@ -67,3 +67,32 @@ export function handleError( error ) {
 		handler.genericError();
 	}
 }
+
+/**
+ * Handles a recoverable payment problem: a card decline or a validation failure
+ * the buyer can correct.
+ *
+ * Deliberately does less than handleError(): the buyer is still in the SDK's
+ * card form and can retry, so nothing here refreshes the cart, navigates, or
+ * tears the button down. Existing notices survive too — clearing them would
+ * wipe WooCommerce's own validation messages.
+ *
+ * @param {Object} warning - The warning object, with code, name and message.
+ */
+export function handleWarning( warning ) {
+	// eslint-disable-next-line no-console
+	console.warn( '[PPCP SDK v6]', warning );
+
+	if ( ! errorLabels.card_declined ) {
+		return;
+	}
+
+	const wrapper =
+		document.querySelector( '.woocommerce-notices-wrapper' ) ||
+		document.querySelector( '.woocommerce' ) ||
+		document.body;
+
+	new ErrorHandler( errorLabels.generic_error || '', wrapper ).message(
+		errorLabels.card_declined
+	);
+}

--- a/modules/ppcp-sdk-v6/resources/js/utils/errorHandler.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/errorHandler.test.js
@@ -20,7 +20,7 @@ jest.mock( './api', () => ( {
 } ) );
 
 import ErrorHandler from '@ppcp-button/ErrorHandler';
-import { setErrorLabels, handleError } from './errorHandler';
+import { setErrorLabels, handleError, handleWarning } from './errorHandler';
 
 beforeEach( () => {
 	jest.clearAllMocks();
@@ -154,5 +154,36 @@ describe( 'handleError', () => {
 
 		expect( () => handleError( { refresh: true } ) ).not.toThrow();
 		expect( console ).toHaveErrored();
+	} );
+} );
+
+describe( 'handleWarning', () => {
+	test( 'logs only, showing nothing, when no card_declined label is configured', () => {
+		handleWarning( { code: 'INSTRUMENT_DECLINED' } );
+
+		expect( mockMessage ).not.toHaveBeenCalled();
+		expect( mockClear ).not.toHaveBeenCalled();
+		expect( console ).toHaveWarned();
+	} );
+
+	test( 'shows the translated card_declined message when configured', () => {
+		setErrorLabels( {
+			generic_error: 'Something went wrong.',
+			card_declined: 'Your card was declined.',
+		} );
+
+		handleWarning( { code: 'INSTRUMENT_DECLINED' } );
+
+		expect( mockMessage ).toHaveBeenCalledWith( 'Your card was declined.' );
+		expect( console ).toHaveWarned();
+	} );
+
+	test( 'leaves existing notices alone, unlike handleError', () => {
+		setErrorLabels( { card_declined: 'Your card was declined.' } );
+
+		handleWarning( { code: 'INSTRUMENT_DECLINED' } );
+
+		expect( mockClear ).not.toHaveBeenCalled();
+		expect( console ).toHaveWarned();
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/utils/fundingSources.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/fundingSources.js
@@ -23,4 +23,5 @@ export const FundingSources = {
 	PAYLATER: 'paylater',
 	GOOGLEPAY: 'googlepay',
 	APPLEPAY: 'applepay',
+	CARD: 'card', // BCDC button ("Guest Payments").
 };

--- a/modules/ppcp-sdk-v6/resources/js/wallets/gatewayPlacement.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/gatewayPlacement.js
@@ -11,6 +11,9 @@
  * wrapper belong to no single wallet, so two wallets deciding independently would
  * each undo the other's answer.
  *
+ * Nothing here is wallet-specific despite the directory — the Basic Card button
+ * (BCDC) uses the same seam. The wallet naming is historical.
+ *
  * @package
  */
 

--- a/modules/ppcp-sdk-v6/resources/js/wallets/gatewayPlacement.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/wallets/gatewayPlacement.test.js
@@ -328,6 +328,34 @@ describe( 'revealWalletGateway()', () => {
 		);
 
 		test(
+			"selecting the card button's row hides the wallet " +
+				'container, the express wrapper and "Place order", while ' +
+				"showing the card row's own button",
+			() => {
+				document.body.innerHTML =
+					'<div id="wallet-wrapper"><button></button></div>' +
+					'<div id="card-button-wrapper"><button></button></div>' +
+					'<div id="express-wrapper"></div>' +
+					'<div id="place_order"></div>';
+
+				reveal( { expressSelector: '#express-wrapper' } );
+				reveal( {
+					methodId: 'ppcp-card-button-gateway',
+					wrapperSelector: '#card-button-wrapper',
+				} );
+				mockGetCurrentPaymentMethod.mockReturnValue(
+					'ppcp-card-button-gateway'
+				);
+				jQuery( document.body ).trigger( 'payment_method_selected' );
+
+				expect( displayOf( '#wallet-wrapper' ) ).toBe( 'none' );
+				expect( displayOf( '#express-wrapper' ) ).toBe( 'none' );
+				expect( displayOf( '#place_order' ) ).toBe( 'none' );
+				expect( displayOf( '#card-button-wrapper' ) ).toBe( '' );
+			}
+		);
+
+		test(
 			'restyles freshly-inserted elements after a checkout ' +
 				'update replaces the order-review DOM',
 			() => {

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -19,6 +19,7 @@ use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\RateLimiter;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
@@ -92,6 +93,10 @@ return array(
 
 			return $manager->should_load_on_current_page();
 		};
+	},
+
+	'sdk-v6.card-field-styles'          => static function (): CardFieldStyles {
+		return new CardFieldStyles();
 	},
 
 	'sdk-v6.manager'                    => static function ( ContainerInterface $container ): SdkV6Manager {

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -130,7 +130,8 @@ return array(
 			$container->get( 'wcgateway.credit-card-icons' ),
 			$settings_provider->merchant_country(),
 			$container->get( 'sdk-v6.google-pay-config' ),
-			$container->get( 'sdk-v6.apple-pay-config' )
+			$container->get( 'sdk-v6.apple-pay-config' ),
+			$container->get( 'sdk-v6.card-field-styles' )
 		);
 	},
 
@@ -149,7 +150,8 @@ return array(
 			$container->has( 'save-payment-methods.eligible' )
 				&& $container->get( 'save-payment-methods.eligible' )
 				&& $settings_provider->save_card_details(),
-			$settings_provider
+			$settings_provider,
+			$container->get( 'sdk-v6.card-field-styles' )
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/AddPaymentMethodManager.php
@@ -21,6 +21,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
@@ -44,6 +45,8 @@ class AddPaymentMethodManager {
 	private bool $card_vaulting_enabled;
 	private SettingsProvider $settings_provider;
 
+	private CardFieldStyles $card_field_styles;
+
 	public function __construct(
 		AssetGetter $asset_getter,
 		string $version,
@@ -51,7 +54,8 @@ class AddPaymentMethodManager {
 		Context $context,
 		bool $paypal_vaulting_enabled,
 		bool $card_vaulting_enabled,
-		SettingsProvider $settings_provider
+		SettingsProvider $settings_provider,
+		CardFieldStyles $card_field_styles
 	) {
 		$this->asset_getter            = $asset_getter;
 		$this->version                 = $version;
@@ -60,6 +64,7 @@ class AddPaymentMethodManager {
 		$this->paypal_vaulting_enabled = $paypal_vaulting_enabled;
 		$this->card_vaulting_enabled   = $card_vaulting_enabled;
 		$this->settings_provider       = $settings_provider;
+		$this->card_field_styles       = $card_field_styles;
 	}
 
 	/**
@@ -150,6 +155,7 @@ class AddPaymentMethodManager {
 					'expiry' => '#' . self::CARD_FIELD_EXPIRY_ID,
 					'cvv'    => '#' . self::CARD_FIELD_CVV_ID,
 				),
+				'styles'         => $this->card_field_styles->overrides(),
 			),
 			'ajax'                 => array(
 				'client_token'         => array(

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -521,8 +521,10 @@ class SdkV6Manager {
 		// equivalent of the SDK URL vault param v5 uses here, so the button
 		// would take a payment that can never renew. Not a dead end — without a
 		// button "Place order" stays visible, and CardButtonGateway falls back
-		// to PayPal's hosted card checkout.
-		if ( $this->subscription_helper->cart_contains_subscription() ) {
+		// to PayPal's hosted card checkout. order_pay_contains_subscription()
+		// covers pay-for-order, where the cart is empty.
+		if ( $this->subscription_helper->cart_contains_subscription()
+			|| $this->subscription_helper->order_pay_contains_subscription() ) {
 			return false;
 		}
 

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -27,6 +27,7 @@ use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
@@ -35,10 +36,11 @@ use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 class SdkV6Manager {
 
-	public const WRAPPER_ID            = 'ppc-button-ppcp-gateway-v6';
-	public const MINI_CART_WRAPPER_ID  = 'ppc-button-minicart-v6';
-	public const GOOGLE_PAY_WRAPPER_ID = 'ppc-button-ppcp-googlepay-v6';
-	public const APPLE_PAY_WRAPPER_ID  = 'ppc-button-ppcp-applepay-v6';
+	public const WRAPPER_ID             = 'ppc-button-ppcp-gateway-v6';
+	public const MINI_CART_WRAPPER_ID   = 'ppc-button-minicart-v6';
+	public const GOOGLE_PAY_WRAPPER_ID  = 'ppc-button-ppcp-googlepay-v6';
+	public const APPLE_PAY_WRAPPER_ID   = 'ppc-button-ppcp-applepay-v6';
+	public const CARD_BUTTON_WRAPPER_ID = 'ppc-button-ppcp-card-button-gateway-v6';
 
 	/**
 	 * The height every payment button on the page renders at.
@@ -94,6 +96,14 @@ class SdkV6Manager {
 	 * @var WalletPlacement[]
 	 */
 	private array $wallets;
+
+	/**
+	 * Asked once to print the row and once to build the script data, and each
+	 * answer walks every available gateway.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $is_card_button_row = null;
 
 	public function __construct(
 		AssetGetter $asset_getter,
@@ -267,6 +277,28 @@ class SdkV6Manager {
 		}
 	}
 
+	/**
+	 * Renders the BCDC gateway container, hidden until the buyer is eligible.
+	 *
+	 * Same markup as the wallet rows, so gatewayPlacement.js reveals it with the
+	 * code it already has — and hidden first for the same reason: the SDK decides
+	 * card eligibility client-side, and a row whose button never rendered would
+	 * be a dead end.
+	 */
+	public function render_card_button_wrapper(): void {
+		if ( ! $this->is_card_button_row() ) {
+			return;
+		}
+		?>
+		<style data-hide-gateway='<?php echo esc_attr( CardButtonGateway::ID ); ?>'>
+			.wc_payment_method.payment_method_<?php echo esc_attr( CardButtonGateway::ID ); ?> {
+				display: none;
+			}
+		</style>
+		<div id="<?php echo esc_attr( self::CARD_BUTTON_WRAPPER_ID ); ?>"></div>
+		<?php
+	}
+
 	public function render_mini_cart_wrapper(): void {
 		echo '<p class="woocommerce-mini-cart__buttons buttons">';
 		echo '<span id="' . esc_attr( self::MINI_CART_WRAPPER_ID ) . '"></span>';
@@ -368,6 +400,14 @@ class SdkV6Manager {
 			return true;
 		}
 
+		// Settings-only, never is_card_button_row(): this runs early enough that
+		// resolving WC_Payment_Gateways would re-enter
+		// woocommerce_available_payment_gateways, which resolves DisableGateways
+		// from the container currently building this service.
+		if ( $this->is_card_button_enabled( $page_location ) ) {
+			return true;
+		}
+
 		if ( $page_location && $this->any_wallet_renders( $page_location ) ) {
 			return true;
 		}
@@ -397,6 +437,55 @@ class SdkV6Manager {
 
 		return in_array( $location, array( 'checkout', 'checkout-block', 'pay-now' ), true )
 			&& $this->card_payments_configuration->is_acdc_enabled();
+	}
+
+	/**
+	 * Whether BCDC is configured for this kind of page — not whether the row
+	 * prints here, which is is_card_button_row().
+	 *
+	 * Narrower than its ACDC counterpart: BCDC has no block checkout support.
+	 *
+	 * @param string|null $location Page context to test; defaults to the current page.
+	 */
+	public function is_card_button_enabled( ?string $location = null ): bool {
+		$location = $location ?? $this->get_page_context();
+
+		return in_array( $location, array( 'checkout', 'pay-now' ), true )
+			&& $this->card_payments_configuration->is_bcdc_enabled();
+	}
+
+	/**
+	 * Whether the BCDC button renders as its own payment-method row here.
+	 *
+	 * Asks the gateway list rather than re-deriving its policy, which already
+	 * covers the checkout button location being off, ACDC outside Mexico,
+	 * free-trial carts and zero-total carts.
+	 */
+	private function is_card_button_row(): bool {
+		if ( null !== $this->is_card_button_row ) {
+			return $this->is_card_button_row;
+		}
+
+		if ( ! $this->is_card_button_enabled() || $this->is_block_context() ) {
+			return false;
+		}
+
+		// No row for subscription carts: the v6 guest component has no
+		// equivalent of the SDK URL vault param v5 uses here, so the button
+		// would take a payment that can never renew. Not a dead end — without a
+		// button "Place order" stays visible, and CardButtonGateway falls back
+		// to PayPal's hosted card checkout.
+		if ( $this->subscription_helper->cart_contains_subscription() ) {
+			return false;
+		}
+
+		$gateways = WC()->payment_gateways() ? WC()->payment_gateways()->get_available_payment_gateways() : array();
+
+		// Only this answer is memoized: the gateway list is settled by the time
+		// anything asks, whereas the page context above may not be yet.
+		$this->is_card_button_row = isset( $gateways[ CardButtonGateway::ID ] );
+
+		return $this->is_card_button_row;
 	}
 
 	/**
@@ -506,6 +595,12 @@ class SdkV6Manager {
 					'Something went wrong. Please try again or choose another payment source.',
 					'woocommerce-paypal-payments'
 				),
+				// One string for every onWarn the SDK raises: its own codes are
+				// internal and untranslated, so they must not reach the buyer.
+				'card_declined' => __(
+					'The card could not be charged. Please check the details or try a different card.',
+					'woocommerce-paypal-payments'
+				),
 			),
 			'shipping'          => array(
 				'handle_in_paypal' => $shipping_enabled,
@@ -546,6 +641,19 @@ class SdkV6Manager {
 					'number' => '#' . self::CARD_FIELD_NUMBER_ID,
 					'expiry' => '#' . self::CARD_FIELD_EXPIRY_ID,
 					'cvv'    => '#' . self::CARD_FIELD_CVV_ID,
+				),
+			),
+			'card_button'       => array(
+				'enabled'        => $this->is_card_button_row(),
+				'payment_method' => CardButtonGateway::ID,
+				'funding_source' => 'card',
+				'wrapper'        => '#' . self::CARD_BUTTON_WRAPPER_ID,
+				// No colour: the element is black-only. Width is ours to set
+				// because it ships a fixed 225px, where v5 spanned the column.
+				'styles'         => array(
+					'borderRadius' => $this->style_mapper->styles_for_context( $page_context ?: 'checkout' )['borderRadius'],
+					'height'       => self::PAYMENT_BUTTON_HEIGHT,
+					'width'        => '100%',
 				),
 			),
 		);

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -45,16 +45,13 @@ class SdkV6Manager {
 	/**
 	 * The height every payment button on the page renders at.
 	 *
-	 * Not a merchant setting: the styling DTOs carry no height (see
-	 * ButtonStyleMapper), and the buttons are meant to match each other. Hence one
-	 * value for all of them, rather than one per button type or context.
+	 * One value for all of them: the buttons are meant to match, and the styling
+	 * DTOs carry no height of their own (see ButtonStyleMapper).
 	 */
 	public const PAYMENT_BUTTON_HEIGHT = '48px';
 
-	// Existing WC credit-card-form field IDs (see CardFieldsModule's
-	// woocommerce_credit_card_form_fields filter and WC core's own
-	// card-number/expiry/cvc fields) that the v6 card fields mount into,
-	// replacing v5's paypal.CardFields()-rendered inputs in the same slots.
+	// Existing WC credit-card-form field IDs the v6 card fields mount into; see
+	// CardFieldsModule's woocommerce_credit_card_form_fields filter.
 	private const CARD_FIELD_NAME_ID   = 'ppcp-credit-card-gateway-card-name';
 	private const CARD_FIELD_NUMBER_ID = 'ppcp-credit-card-gateway-card-number';
 	private const CARD_FIELD_EXPIRY_ID = 'ppcp-credit-card-gateway-card-expiry';
@@ -84,9 +81,8 @@ class SdkV6Manager {
 	private array $credit_card_icons;
 
 	/**
-	 * Kept alongside $wallets, which holds the same object as a WalletConfig:
-	 * display_name() exists only on the Apple subclass, so reaching it through
-	 * the base type would not type-check.
+	 * The same object $wallets holds, kept under its own type because
+	 * display_name() exists only on the Apple subclass.
 	 */
 	private ApplePayConfig $apple_pay_config;
 
@@ -98,8 +94,8 @@ class SdkV6Manager {
 	private array $wallets;
 
 	/**
-	 * Asked once to print the row and once to build the script data, and each
-	 * answer walks every available gateway.
+	 * Memoizes is_card_button_row(), asked once per request to print the row and
+	 * once to build the script data.
 	 *
 	 * @var bool|null
 	 */
@@ -170,6 +166,9 @@ class SdkV6Manager {
 		);
 	}
 
+	/**
+	 * Registers, localizes and enqueues the classic bootstrap script.
+	 */
 	public function enqueue(): void {
 		// The classic bootstrap renders into PHP-printed wrappers that do not
 		// exist on block pages, which the block payment method script serves.
@@ -205,19 +204,15 @@ class SdkV6Manager {
 	 * @return array<string, bool> Location => enabled (product, cart, checkout, pay-now, mini-cart).
 	 */
 	public function determine_render_places(): array {
-		// Activate is_cart()/is_checkout() on classic-shortcode block pages;
-		// otherwise this only happens as a side effect of constructing the
+		// Activates is_cart()/is_checkout() on classic-shortcode block pages,
+		// which otherwise only happens as a side effect of constructing the
 		// (discarded) v5 SmartButton.
 		$this->context->init_context();
 
-		// Free orders ($0 total, e.g. a 100%-off coupon or free trial) do not
-		// need payment, so the cart/checkout wallet buttons must not render —
-		// matching v5's is_cart_price_total_zero() suppression.
 		$needs_payment = $this->cart_needs_payment();
 
-		// pay-now is driven by the existing WC order, not the cart, so the
-		// zero-total cart guard does not apply. Its location normalizes to
-		// 'checkout' in SettingsStatus.
+		// pay-now is driven by the existing WC order rather than the cart, so
+		// the zero-total guard does not apply to it.
 		return array(
 			'product'   => $this->settings_status->is_smart_button_enabled_for_location( 'product' ),
 			'cart'      => $needs_payment && $this->settings_status->is_smart_button_enabled_for_location( 'cart' ),
@@ -230,10 +225,8 @@ class SdkV6Manager {
 	/**
 	 * Whether the current cart still needs payment.
 	 *
-	 * Guards the wallet buttons against $0 / free orders (e.g. a full-value
-	 * coupon or a free trial), where no payment method should be offered.
-	 *
-	 * @return bool
+	 * Keeps buttons off $0 orders (a full-value coupon, a free trial), where no
+	 * payment method should be offered at all.
 	 */
 	private function cart_needs_payment(): bool {
 		$cart = WC()->cart;
@@ -244,61 +237,58 @@ class SdkV6Manager {
 		return $cart->needs_payment();
 	}
 
+	/**
+	 * Renders the shared express-button wrapper.
+	 */
 	public function render_wrapper(): void {
 		echo '<div class="ppc-button-wrapper"><div id="' . esc_attr( self::WRAPPER_ID ) . '"></div></div>';
 	}
 
 	/**
-	 * Renders each wallet's gateway container, hidden until eligible.
+	 * Renders a payment method's own button container, hidden until eligible.
 	 *
-	 * On classic checkout a wallet is its own payment-method row rather than an
-	 * express button, so its button needs a container next to the place-order
-	 * area instead of the shared express wrapper.
+	 * On classic checkout these methods are payment-method rows rather than
+	 * express buttons, so each needs a container by the place-order area instead
+	 * of the shared express wrapper.
 	 *
-	 * Every row starts hidden and the JS reveals it once the browser confirms the
-	 * buyer can pay, because eligibility is only knowable client-side: a browser
-	 * without a saved card, or without Apple Pay set up, would otherwise be
-	 * offered a row that cannot complete. Same attribute shape as v5's
-	 * GooglePayButton, which the v6 JS removes the same way its PaymentButton did.
+	 * The row starts hidden and gatewayPlacement.js reveals it once the browser
+	 * confirms the buyer can pay: eligibility is only knowable client-side, and a
+	 * row whose button never rendered would be a dead end.
+	 */
+	private function render_gateway_wrapper( string $gateway_id, string $wrapper_id ): void {
+		?>
+		<style data-hide-gateway='<?php echo esc_attr( $gateway_id ); ?>'>
+			.wc_payment_method.payment_method_<?php echo esc_attr( $gateway_id ); ?> {
+				display: none;
+			}
+		</style>
+		<div id="<?php echo esc_attr( $wrapper_id ); ?>"></div>
+		<?php
+	}
+
+	/**
+	 * Renders a gateway row for every wallet that has one on this page.
 	 */
 	public function render_wallet_gateway_wrappers(): void {
 		foreach ( $this->wallets as $wallet ) {
-			if ( ! $this->is_wallet_gateway( $wallet ) ) {
-				continue;
+			if ( $this->is_wallet_gateway( $wallet ) ) {
+				$this->render_gateway_wrapper( $wallet->gateway_id, $wallet->wrapper_id );
 			}
-			?>
-			<style data-hide-gateway='<?php echo esc_attr( $wallet->gateway_id ); ?>'>
-				.wc_payment_method.payment_method_<?php echo esc_attr( $wallet->gateway_id ); ?> {
-					display: none;
-				}
-			</style>
-			<div id="<?php echo esc_attr( $wallet->wrapper_id ); ?>"></div>
-			<?php
 		}
 	}
 
 	/**
-	 * Renders the BCDC gateway container, hidden until the buyer is eligible.
-	 *
-	 * Same markup as the wallet rows, so gatewayPlacement.js reveals it with the
-	 * code it already has — and hidden first for the same reason: the SDK decides
-	 * card eligibility client-side, and a row whose button never rendered would
-	 * be a dead end.
+	 * Renders the BCDC gateway row, when it belongs on this page.
 	 */
 	public function render_card_button_wrapper(): void {
-		if ( ! $this->is_card_button_row() ) {
-			return;
+		if ( $this->is_card_button_row() ) {
+			$this->render_gateway_wrapper( CardButtonGateway::ID, self::CARD_BUTTON_WRAPPER_ID );
 		}
-		?>
-		<style data-hide-gateway='<?php echo esc_attr( CardButtonGateway::ID ); ?>'>
-			.wc_payment_method.payment_method_<?php echo esc_attr( CardButtonGateway::ID ); ?> {
-				display: none;
-			}
-		</style>
-		<div id="<?php echo esc_attr( self::CARD_BUTTON_WRAPPER_ID ); ?>"></div>
-		<?php
 	}
 
+	/**
+	 * Renders the mini-cart button wrapper.
+	 */
 	public function render_mini_cart_wrapper(): void {
 		echo '<p class="woocommerce-mini-cart__buttons buttons">';
 		echo '<span id="' . esc_attr( self::MINI_CART_WRAPPER_ID ) . '"></span>';
@@ -313,9 +303,7 @@ class SdkV6Manager {
 	 * registers its methods through the block registry instead.
 	 *
 	 * Only the gateway walk is memoized, never a refusal from the context check,
-	 * so a call made before the context resolves cannot poison the answer. The
-	 * memo spans one request, where this is asked twice per wallet: once to print
-	 * the row, once to build the script data.
+	 * so a call made before the context resolves cannot poison the answer.
 	 */
 	private function is_wallet_gateway( WalletPlacement $wallet ): bool {
 		if ( null !== $wallet->is_gateway ) {
@@ -341,8 +329,8 @@ class SdkV6Manager {
 	 * @return array<string, mixed>
 	 */
 	private function wallet_script_data( WalletPlacement $wallet, string $page_context ): array {
-		// Styled per context rather than globally: `enabled` then follows from
-		// whether any context on this page wants the wallet at all.
+		// Styled per context, so `enabled` follows from whether any context on
+		// this page wants the wallet at all.
 		$styles = array();
 		if ( $page_context && $wallet->config->should_render( $page_context ) ) {
 			$styles[ $page_context ] = $wallet->styles( $page_context );
@@ -356,9 +344,8 @@ class SdkV6Manager {
 			'sdk_url' => $wallet->sdk_url,
 			'styles'  => $styles,
 			// Present only on classic checkout, where a payment-method list
-			// exists: everywhere else the wallet stays an express button, as in
-			// v5. Null rather than a flag plus two values the JS would have to
-			// pair up again.
+			// exists; elsewhere the wallet stays an express button. Null rather
+			// than a flag plus two values the JS would have to pair up again.
 			'gateway' => $this->is_wallet_gateway( $wallet )
 				? array(
 					'id'      => $wallet->gateway_id,
@@ -371,24 +358,12 @@ class SdkV6Manager {
 	/**
 	 * Whether the v6 SDK loads on the current page.
 	 *
-	 * Follows the v5 SmartButton gating: each WC page type requires its
-	 * location to be enabled in the button settings, and an enabled
-	 * mini-cart location enqueues on every page (the classic mini-cart
-	 * widget can appear anywhere). The bootstrap only loads the SDK once
-	 * a button wrapper exists in the DOM.
+	 * Also scopes the v5 suppression, since both SDKs claim window.paypal: v5 is
+	 * disabled on exactly the pages this returns true for. See extensions.php.
 	 *
-	 * Also scopes the v5 suppression: v5 is disabled on every page v6 owns
-	 * (both SDKs claim window.paypal) and keeps running on the pages v6 does
-	 * not own (pay-now, add-payment-method). Migration-phase only — see
-	 * extensions.php.
-	 *
-	 * Card fields (ACDC) are independent of the smart-button location: the
-	 * card gateway is a regular WC payment method that can be selectable
-	 * at checkout even when the wallet button is disabled there, so it
-	 * gets its own OR'd condition rather than being folded into the
-	 * location check above.
-	 *
-	 * @return bool
+	 * Each card surface gets its own OR'd condition rather than folding into the
+	 * location check, because a card gateway is a regular WC payment method that
+	 * can be selectable at checkout with the smart button disabled there.
 	 */
 	public function should_load_on_current_page(): bool {
 		$page_location = $this->get_page_context();
@@ -412,14 +387,10 @@ class SdkV6Manager {
 			return true;
 		}
 
-		// Load sitewide whenever the mini-cart location is enabled, matching the
-		// v5 SmartButton (should_load_buttons()'s default branch). The mini-cart
-		// can appear on any page — as the classic "Cart" widget OR the block
-		// Mini-Cart in a block theme's header — and is_active_widget() only
-		// detects the classic widget, so gating on it dropped the SDK (and every
-		// mini-cart button, Venmo included) on shop/home pages that use the block
-		// Mini-Cart. boot.js always renders into the mini-cart wrapper when it is
-		// present, so loading sitewide keeps parity with v5.
+		// Sitewide, because the mini-cart can appear on any page as either the
+		// classic "Cart" widget or the block Mini-Cart, and is_active_widget()
+		// only detects the classic one. boot.js renders into the mini-cart
+		// wrapper only where that wrapper exists.
 		return $this->settings_status->is_smart_button_enabled_for_location( 'mini-cart' )
 			|| $this->any_wallet_renders( 'mini-cart' );
 	}
@@ -427,8 +398,8 @@ class SdkV6Manager {
 	/**
 	 * Whether the v6 Advanced Card Fields should render on the given page.
 	 *
-	 * Gates both the JS `card_fields.enabled` flag and the suppression of the
-	 * v5 card block, so a page never ends up with neither card option.
+	 * Gates both the JS `card_fields.enabled` flag and the v5 card block's
+	 * suppression, so a page never ends up with neither card option.
 	 *
 	 * @param string|null $location Page context to test; defaults to the current page.
 	 */
@@ -520,11 +491,10 @@ class SdkV6Manager {
 
 		$page_context = $this->get_page_context();
 
-		// Must stay in lockstep with ShippingPreferenceFactory, which marks only
-		// 'checkout' and 'pay-now' as fixed-address (SET_PROVIDED_ADDRESS, no
-		// callbacks needed). Every other context, 'checkout-block' included,
-		// gets GET_FROM_FILE, where PayPal offers the buyer's own addresses and
-		// the popup callbacks must stay attached to sync the choice back.
+		// In lockstep with ShippingPreferenceFactory: only 'checkout' and
+		// 'pay-now' are fixed-address (SET_PROVIDED_ADDRESS, no callbacks).
+		// Every other context gets GET_FROM_FILE, where PayPal offers the
+		// buyer's own addresses and the callbacks sync the choice back.
 		$shipping_enabled = $this->should_handle_shipping
 			&& ! in_array( $page_context, array( 'checkout', 'pay-now' ), true );
 
@@ -614,16 +584,14 @@ class SdkV6Manager {
 				'enabled'             => $card_fields_enabled,
 				'payment_method'      => CreditCardGateway::ID,
 				'funding_source'      => 'card',
-				// Label, name-field flag and card-brand logos for the block's own
-				// card method. card_icons is empty when "Show logos" is disabled
-				// (the credit-card-icons service already guards on the setting).
+				// Label, name-field flag and logos for the block's own card
+				// method; card_icons is empty when "Show logos" is off.
 				'title'               => $this->card_payments_configuration->gateway_title(),
 				'name_field'          => 'yes' === $this->card_payments_configuration->show_name_on_card(),
-				// Card "save during purchase" (vaulting). The block checkout uses
-				// WC Blocks' native save option (supports.showSaveOption, gated on
-				// is_vaulting_enabled); the classic checkout reads WC's own
-				// tokenization checkbox instead. has_subscriptions force-saves,
-				// since a subscription card must be vaulted for renewals.
+				// Card "save during purchase". The block checkout gates WC Blocks'
+				// native save option on this; classic reads WC's own tokenization
+				// checkbox. A subscription force-saves, since its card must be
+				// vaulted to renew.
 				'is_vaulting_enabled' => $this->card_vaulting_enabled,
 				'has_subscriptions'   => $this->subscription_helper->cart_contains_subscription(),
 				'card_icons'          => array_map(
@@ -662,23 +630,22 @@ class SdkV6Manager {
 			$data[ $wallet->config_key ] = $this->wallet_script_data( $wallet, $page_context );
 		}
 
-		// The keys only one wallet has. Everything above this line is the shape
-		// every wallet shares.
+		// The keys only one wallet has; everything above is the shared shape.
 		$data['google_pay']['environment'] = $this->environment->is_sandbox() ? 'TEST' : 'PRODUCTION';
 		// Labels the sheet total and identifies the merchant during validation.
 		$data['apple_pay']['display_name'] = $this->apple_pay_config->display_name();
-		// Where the frontend reports merchant validation, which keeps the admin
+		// Where the frontend reports merchant validation, keeping the admin
 		// "domain not validated" notice accurate. The Apple Pay module owns this
-		// admin-ajax action and dictates its nonce action.
+		// action and dictates its nonce.
 		$data['apple_pay']['validation'] = array(
 			'endpoint' => admin_url( 'admin-ajax.php' ),
 			'action'   => PropertiesDictionary::VALIDATE,
 			'nonce'    => wp_create_nonce( PropertiesDictionary::NONCE_ACTION ),
 		);
 
-		// The pay-for-order page creates the PayPal order from an existing WC
-		// order (not the cart), so the front end must forward its identifiers to
-		// the create-order endpoint's from_wc_order branch.
+		// The pay-for-order page builds the PayPal order from an existing WC
+		// order rather than the cart, so its identifiers must reach the
+		// create-order endpoint's from_wc_order branch.
 		if ( 'pay-now' === $page_context ) {
 			$data['pay_now'] = array(
 				'order_id'  => $this->order_pay_id(),
@@ -696,8 +663,6 @@ class SdkV6Manager {
 
 	/**
 	 * The WC order ID on the pay-for-order (order-pay) page, or 0.
-	 *
-	 * @return int
 	 */
 	private function order_pay_id(): int {
 		global $wp;
@@ -711,8 +676,6 @@ class SdkV6Manager {
 
 	/**
 	 * The order key from the pay-for-order page URL, or empty string.
-	 *
-	 * @return string
 	 */
 	private function order_pay_key(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -724,8 +687,6 @@ class SdkV6Manager {
 	/**
 	 * The WC order for the current pay-for-order page, validated against the
 	 * URL order key, or null.
-	 *
-	 * @return \WC_Order|null
 	 */
 	private function order_pay(): ?\WC_Order {
 		$order_id = $this->order_pay_id();
@@ -738,7 +699,7 @@ class SdkV6Manager {
 			return null;
 		}
 
-		// Guard against reading another customer's order total from a crafted URL.
+		// Stops a crafted URL from reading another customer's order total.
 		if ( ! hash_equals( (string) $order->get_order_key(), $this->order_pay_key() ) ) {
 			return null;
 		}
@@ -779,8 +740,8 @@ class SdkV6Manager {
 		return array(
 			'order_id'       => $order->id(),
 			'order'          => $order->to_array(),
-			// v5 reads this from a window global; carried in the payload here so
-			// the gateway is told which source approved the order.
+			// Carried in the payload rather than a window global, so the gateway
+			// is told which source approved the order.
 			'funding_source' => $this->session_handler->funding_source(),
 			'cancel'         => array(
 				'html' => $this->cancel_view->render_session_cancellation(
@@ -793,8 +754,6 @@ class SdkV6Manager {
 
 	/**
 	 * Whether the current cart needs shipping.
-	 *
-	 * @return bool
 	 */
 	private function need_shipping(): bool {
 		$cart = WC()->cart;
@@ -803,15 +762,13 @@ class SdkV6Manager {
 	}
 
 	/**
-	 * Returns the expected transaction amount for eligibility checks
-	 * (affects Pay Later thresholds): the cart total, or the product
-	 * price on product pages while the cart is empty.
+	 * The amount eligibility is checked against, which moves Pay Later
+	 * thresholds: the cart total, or the product price while the cart is empty.
 	 *
-	 * @return string The amount as a decimal string, or empty when unknown.
+	 * @return string A decimal string, or empty when unknown.
 	 */
 	private function transaction_amount(): string {
-		// The pay-for-order page has no cart; the amount is the existing WC
-		// order's total, used for Pay Later eligibility.
+		// The pay-for-order page has no cart; its order carries the total.
 		if ( 'pay-now' === $this->get_page_context() ) {
 			$order = $this->order_pay();
 			if ( $order ) {
@@ -839,14 +796,11 @@ class SdkV6Manager {
 	}
 
 	/**
-	 * Returns the page context for the current WC page.
+	 * The page context for the current WC page, or empty off a supported page.
 	 *
-	 * Resolves through the shared Context helper (which handles
-	 * classic-shortcode block pages) and narrows to the contexts this
-	 * module supports: classic product/cart/checkout/pay-now and block
-	 * cart/checkout. The block editor stays out of scope.
-	 *
-	 * @return string
+	 * Resolves through the shared Context helper, which handles
+	 * classic-shortcode block pages, then narrows to the contexts this module
+	 * supports. The block editor stays out of scope.
 	 */
 	private function get_page_context(): string {
 		$context = $this->context->context();
@@ -864,8 +818,6 @@ class SdkV6Manager {
 
 	/**
 	 * Whether the current page is a WooCommerce Blocks (React) page.
-	 *
-	 * @return bool
 	 */
 	public function is_block_context(): bool {
 		return in_array(

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
@@ -86,6 +87,8 @@ class SdkV6Manager {
 	 */
 	private ApplePayConfig $apple_pay_config;
 
+	private CardFieldStyles $card_field_styles;
+
 	/**
 	 * Every wallet this module places, in the order their rows are printed.
 	 *
@@ -119,7 +122,8 @@ class SdkV6Manager {
 		array $credit_card_icons,
 		string $merchant_country,
 		GooglePayConfig $google_pay_config,
-		ApplePayConfig $apple_pay_config
+		ApplePayConfig $apple_pay_config,
+		CardFieldStyles $card_field_styles
 	) {
 		$this->asset_getter                = $asset_getter;
 		$this->version                     = $version;
@@ -138,6 +142,7 @@ class SdkV6Manager {
 		$this->credit_card_icons           = $credit_card_icons;
 		$this->merchant_country            = $merchant_country;
 		$this->apple_pay_config            = $apple_pay_config;
+		$this->card_field_styles           = $card_field_styles;
 
 		$this->wallets = array(
 			new WalletPlacement(
@@ -610,6 +615,7 @@ class SdkV6Manager {
 					'expiry' => '#' . self::CARD_FIELD_EXPIRY_ID,
 					'cvv'    => '#' . self::CARD_FIELD_CVV_ID,
 				),
+				'styles'              => $this->card_field_styles->overrides(),
 			),
 			'card_button'       => array(
 				'enabled'        => $this->is_card_button_row(),

--- a/modules/ppcp-sdk-v6/src/Helper/CardFieldStyles.php
+++ b/modules/ppcp-sdk-v6/src/Helper/CardFieldStyles.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Merchant style overrides for the hosted card fields.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Helper
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+class CardFieldStyles {
+
+	/**
+	 * The styles a merchant wants applied to the text inside the hosted fields.
+	 *
+	 * A card field's own box sits on the merchant's page and is stylable with
+	 * plain CSS through the .ppcp-sdk-v6-card-field class. Its text is not: that
+	 * lives in a PayPal-hosted iframe CSS cannot reach across, so the only way
+	 * in is the SDK's style.input object, which has to travel as script data.
+	 *
+	 * Values are camelCase CSS properties (fontSize, not font-size) and are
+	 * merged over the styles read from the input being replaced, so an override
+	 * wins. The SDK rejects vendor-prefixed properties and logs a DevError per
+	 * unsupported one.
+	 *
+	 * Read per call rather than once per request, so a filter registered after
+	 * this service was resolved still applies.
+	 *
+	 * @return array<string, string>
+	 */
+	public function overrides(): array {
+		/**
+		 * Filters the text styles applied inside the hosted card fields.
+		 *
+		 * @param array<string, string> $styles camelCase CSS property map.
+		 */
+		$styles = apply_filters( 'woocommerce_paypal_payments_card_fields_styles', array() );
+
+		if ( ! is_array( $styles ) ) {
+			return array();
+		}
+
+		$sanitized = array();
+		foreach ( $styles as $property => $value ) {
+			if ( is_string( $property ) && is_string( $value ) ) {
+				$sanitized[ $property ] = $value;
+			}
+		}
+
+		return $sanitized;
+	}
+}

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -284,6 +284,30 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 			add_action( $hook, static fn() => $manager->render_wrapper(), 20 );
 		}
 
+		// Registered outside the $places branches on purpose: those keys are the
+		// express button's location settings, whereas a BCDC row is a
+		// gateway-availability question. DisableGateways couples the two today,
+		// but relying on that coincidence would break once it stops being true.
+		/**
+		 * The action name that the PayPal buttons use for rendering on the checkout page.
+		 * Shared with the v5 SmartButton so a single override relocates both stacks.
+		 */
+		$hook = (string) apply_filters(
+			'woocommerce_paypal_payments_checkout_button_renderer_hook',
+			'woocommerce_review_order_after_payment'
+		);
+		add_action( $hook, static fn() => $manager->render_card_button_wrapper() );
+
+		/**
+		 * The action name that the PayPal buttons use for rendering on the pay-for-order page.
+		 * Shared with the v5 SmartButton so a single override relocates both stacks.
+		 */
+		$hook = (string) apply_filters(
+			'woocommerce_paypal_payments_pay_order_renderer_hook',
+			'woocommerce_pay_order_after_submit'
+		);
+		add_action( $hook, static fn() => $manager->render_card_button_wrapper(), 20 );
+
 		if ( $places['mini-cart'] ) {
 			/**
 			 * The action name that the PayPal buttons use for rendering in the mini-cart widget.

--- a/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/AddPaymentMethodManagerTest.php
@@ -10,6 +10,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
 use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\Settings\Data\SettingsProvider;
 use WooCommerce\PayPalCommerce\TestCase;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
@@ -22,6 +23,7 @@ class AddPaymentMethodManagerTest extends TestCase
     private $environment;
     private $context;
     private $settings_provider;
+    private $card_field_styles;
 
     public function setUp(): void
     {
@@ -31,6 +33,8 @@ class AddPaymentMethodManagerTest extends TestCase
         $this->environment = Mockery::mock(Environment::class);
         $this->context = Mockery::mock(Context::class);
         $this->settings_provider = Mockery::mock(SettingsProvider::class);
+        $this->card_field_styles = Mockery::mock(CardFieldStyles::class);
+        $this->card_field_styles->shouldReceive('overrides')->andReturn([])->byDefault();
     }
 
     private function createTestee(
@@ -44,7 +48,8 @@ class AddPaymentMethodManagerTest extends TestCase
             $this->context,
             $paypal_vaulting_enabled,
             $card_vaulting_enabled,
-            $this->settings_provider
+            $this->settings_provider,
+            $this->card_field_styles
         );
     }
 
@@ -89,6 +94,7 @@ class AddPaymentMethodManagerTest extends TestCase
      * WHEN the add-payment-method bootstrap script data is generated
      * THEN the button, card fields and ajax endpoint data reflect the constructor configuration
      * AND the verification method reflects the filtered 3D Secure setting
+     * AND the merchant's card field style overrides are carried into the payload
      *
      * @dataProvider script_data_provider
      */
@@ -110,6 +116,9 @@ class AddPaymentMethodManagerTest extends TestCase
         when('wc_get_account_endpoint_url')->justReturn('https://example.com/my-account/payment-methods');
         when('wp_create_nonce')->alias(static fn (string $action) => 'nonce-' . $action);
 
+        $card_field_styles = ['fontSize' => '18px'];
+        $this->card_field_styles->shouldReceive('overrides')->andReturn($card_field_styles);
+
         $testee = $this->createTestee(false, $card_vaulting_enabled);
         $data   = $this->invoke_script_data($testee);
 
@@ -118,6 +127,7 @@ class AddPaymentMethodManagerTest extends TestCase
 
         $this->assertSame($card_vaulting_enabled, $data['card_fields']['enabled']);
         $this->assertSame(CreditCardGateway::ID, $data['card_fields']['payment_method']);
+        $this->assertSame($card_field_styles, $data['card_fields']['styles']);
 
         $this->assertArrayHasKey('client_token', $data['ajax']);
         $this->assertArrayHasKey('create_setup_token', $data['ajax']);

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 namespace WooCommerce\PayPalCommerce\SdkV6\Assets;
 
 use Mockery;
+use WooCommerce\PayPalCommerce\Applepay\ApplePayGateway;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CardButtonGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
@@ -46,6 +49,9 @@ class SdkV6ManagerTest extends TestCase
         $this->session_handler = Mockery::mock(SessionHandler::class);
         $this->cancel_view = Mockery::mock(CancelView::class);
         $this->card_payments_configuration = Mockery::mock(CardPaymentsConfiguration::class);
+		// Off by default like the wallets: script_data() reads it on every call,
+		// and most tests here exercise something other than the card button.
+		$this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false)->byDefault();
 		$this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
         $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false)->byDefault();
 		$this->credit_card_icons = [];
@@ -63,14 +69,14 @@ class SdkV6ManagerTest extends TestCase
     }
 
     /**
-     * A WC() stub carrying an empty cart/customer and a payment-gateways
-     * registry with no gateways available, matching the wallet defaults'
-     * "does not render" state used throughout this test.
+     * A WC() stub with an empty cart/customer and a payment-gateways registry.
+     * Defaults to no gateways available, so a scenario that needs one (e.g.
+     * CardButtonGateway::ID) names it explicitly.
      */
-    private function create_wc_stub(): object
+    private function create_wc_stub(array $available_gateways = []): object
     {
         $payment_gateways = Mockery::mock();
-        $payment_gateways->shouldReceive('get_available_payment_gateways')->andReturn([])->byDefault();
+        $payment_gateways->shouldReceive('get_available_payment_gateways')->andReturn($available_gateways)->byDefault();
 
         $wc = Mockery::mock();
         $wc->customer = null;
@@ -440,5 +446,265 @@ class SdkV6ManagerTest extends TestCase
                 [],
             ],
         ];
+    }
+
+    /**
+     * GIVEN a page context and a BCDC (Basic Credit and Debit Cards) setting
+     * WHEN checking whether the v6 Basic Card button is enabled for that location
+     * THEN the result depends on both the page context and the BCDC setting
+     * AND checkout-block is never eligible, since BCDC has no block checkout support
+     *
+     * @dataProvider card_button_enablement_provider
+     */
+    public function testIsCardButtonEnabled(string $page_context, bool $bcdc_enabled, bool $expected): void
+    {
+        $this->context->shouldReceive('context')->andReturn($page_context);
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn($bcdc_enabled);
+
+        $testee = $this->createTestee();
+
+        $this->assertSame($expected, $testee->is_card_button_enabled());
+    }
+
+    public function card_button_enablement_provider(): array
+    {
+        return [
+            'classic checkout with BCDC enabled renders the card button' => ['checkout', true, true],
+            'classic checkout with BCDC disabled does not render the card button' => ['checkout', false, false],
+            'pay-now with BCDC enabled renders the card button' => ['pay-now', true, true],
+            'pay-now with BCDC disabled does not render the card button' => ['pay-now', false, false],
+            'checkout-block is never eligible, even with BCDC enabled' => ['checkout-block', true, false],
+            'product page is never eligible for the card button' => ['product', true, false],
+            'cart page is never eligible for the card button' => ['cart', true, false],
+        ];
+    }
+
+    /**
+     * GIVEN BCDC configured for checkout/pay-now, with every smart-button
+     *       location and ACDC turned off
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN the SDK loads on checkout and pay-now purely because BCDC is enabled there
+     * AND it does not load on product, cart or checkout-block, since BCDC has no
+     *     block checkout support and settings alone never enable it elsewhere
+     *
+     * @dataProvider should_load_for_card_button_provider
+     */
+    public function testShouldLoadOnCurrentPageForCardButton(string $page_context, bool $bcdc_enabled, bool $expected): void
+    {
+        $this->context->shouldReceive('context')->andReturn($page_context);
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn($bcdc_enabled);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+
+        $testee = $this->createTestee();
+
+        $this->assertSame($expected, $testee->should_load_on_current_page());
+    }
+
+    public function should_load_for_card_button_provider(): array
+    {
+        return [
+            'checkout with BCDC enabled loads the SDK' => ['checkout', true, true],
+            'pay-now with BCDC enabled loads the SDK' => ['pay-now', true, true],
+            'checkout with BCDC disabled does not load for the card button' => ['checkout', false, false],
+            'product page never loads for the card button' => ['product', true, false],
+            'cart page never loads for the card button' => ['cart', true, false],
+            'checkout-block never loads for the card button (no block support)' => ['checkout-block', true, false],
+        ];
+    }
+
+    /**
+     * GIVEN a checkout page where BCDC is enabled for the settings-only gate
+     * WHEN the SDK bootstrap data is generated
+     * THEN card_button.enabled is true only when the CardButtonGateway is also
+     *      among WooCommerce's available payment gateways
+     * AND it is false whenever the gateway is unavailable — the same signal
+     *     WooCommerce gives for ACDC-active-outside-Mexico, a free-trial cart,
+     *     or a zero-total cart, since each of those removes the gateway itself
+     * AND it is false for a cart containing a subscription, since BCDC is
+     *     withheld there regardless of gateway availability
+     *
+     * @dataProvider card_button_row_provider
+     */
+    public function testScriptDataCardButtonEnabled(bool $cart_contains_subscription, bool $gateway_available, bool $expected): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn($cart_contains_subscription);
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn(['borderRadius' => '4px']);
+
+        when('WC')->justReturn($this->create_wc_stub($gateway_available ? [CardButtonGateway::ID => true] : []));
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame($expected, $data['card_button']['enabled']);
+    }
+
+    public function card_button_row_provider(): array
+    {
+        return [
+            'gateway available and no subscription renders the row' => [false, true, true],
+            'gateway unavailable never renders the row (ACDC-active, free trial, or zero-total cart)' => [false, false, false],
+            'subscription cart withholds the row even though the gateway is available' => [true, true, false],
+        ];
+    }
+
+    /**
+     * GIVEN BCDC enabled and the CardButtonGateway available at checkout
+     * WHEN the SDK bootstrap data is generated
+     * THEN the card_button payload carries the payment method id, funding source,
+     *      wrapper selector and button styling alongside its enabled flag
+     * AND the front-end labels include a card_declined message for the SDK to
+     *     show when a card is declined
+     */
+    public function testScriptDataCardButtonShapeAndCardDeclinedLabel(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn(['borderRadius' => '8px']);
+
+        when('WC')->justReturn($this->create_wc_stub([CardButtonGateway::ID => true]));
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame(CardButtonGateway::ID, $data['card_button']['payment_method']);
+        $this->assertSame('card', $data['card_button']['funding_source']);
+        $this->assertSame('#' . SdkV6Manager::CARD_BUTTON_WRAPPER_ID, $data['card_button']['wrapper']);
+        $this->assertSame(
+            [
+                'borderRadius' => '8px',
+                'height'       => SdkV6Manager::PAYMENT_BUTTON_HEIGHT,
+                'width'        => '100%',
+            ],
+            $data['card_button']['styles']
+        );
+        $this->assertSame(
+            'The card could not be charged. Please check the details or try a different card.',
+            $data['labels']['card_declined']
+        );
+    }
+
+    /**
+     * GIVEN the BCDC row is eligible to print (checkout, BCDC enabled, the
+     *       gateway available, no subscription in the cart)
+     * WHEN the card button wrapper is rendered
+     * THEN exactly one hide-style for the CardButtonGateway payment method
+     *      and one wrapper div with the BCDC wrapper id are printed
+     */
+    public function testRenderCardButtonWrapperPrintsHideStyleAndWrapperWhenRowApplies(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(true);
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false);
+
+        when('WC')->justReturn($this->create_wc_stub([CardButtonGateway::ID => true]));
+
+        $testee = $this->createTestee();
+
+        ob_start();
+        $testee->render_card_button_wrapper();
+        $output = ob_get_clean();
+
+        $this->assertSame(1, substr_count($output, "<style data-hide-gateway='" . CardButtonGateway::ID . "'>"));
+        $this->assertSame(1, substr_count($output, '<div id="' . SdkV6Manager::CARD_BUTTON_WRAPPER_ID . '"></div>'));
+        $this->assertStringContainsString('.wc_payment_method.payment_method_' . CardButtonGateway::ID, $output);
+    }
+
+    /**
+     * GIVEN a page where the BCDC row does not apply (BCDC disabled for the
+     *       current location)
+     * WHEN the card button wrapper is rendered
+     * THEN nothing is printed
+     */
+    public function testRenderCardButtonWrapperPrintsNothingWhenRowDoesNotApply(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_bcdc_enabled')->andReturn(false);
+
+        $testee = $this->createTestee();
+
+        ob_start();
+        $testee->render_card_button_wrapper();
+        $output = ob_get_clean();
+
+        $this->assertSame('', $output);
+    }
+
+    /**
+     * GIVEN a buyer on the pay-for-order page, where wallets render as express
+     *       buttons rather than as payment-method rows
+     * WHEN the SDK bootstrap data is generated
+     * THEN each wallet's gateway subtree stays null, since is_wallet_gateway()
+     *      checks only for the 'checkout' context and pay-now was deliberately
+     *      not added when BCDC gained its own row support
+     */
+    public function testScriptDataWalletGatewayStaysNullOnPayNow(): void
+    {
+        global $wp;
+        $wp = (object) ['query_vars' => ['order-pay' => 123]];
+        $_GET['key'] = 'wc_order_abc123';
+
+        $order = Mockery::mock(\WC_Order::class);
+        $order->shouldReceive('get_order_key')->andReturn('wc_order_abc123');
+        $order->shouldReceive('get_total')->andReturn('49.99');
+
+        $this->context->shouldReceive('context')->andReturn('pay-now');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+
+        when('WC')->justReturn($this->create_wc_stub([
+            GooglePayGateway::ID => true,
+            ApplePayGateway::ID  => true,
+        ]));
+        when('wc_get_order')->justReturn($order);
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $testee = $this->createTestee(true);
+        $data   = $testee->script_data();
+
+        $this->assertNull($data['google_pay']['gateway']);
+        $this->assertNull($data['apple_pay']['gateway']);
     }
 }

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -10,6 +10,7 @@ use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\CardFieldStyles;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -36,6 +37,7 @@ class SdkV6ManagerTest extends TestCase
 	private $credit_card_icons;
 	private $google_pay_config;
 	private $apple_pay_config;
+	private $card_field_styles;
 
     public function setUp(): void
     {
@@ -62,6 +64,9 @@ class SdkV6ManagerTest extends TestCase
 		$this->apple_pay_config = Mockery::mock(ApplePayConfig::class);
 		$this->apple_pay_config->shouldReceive('should_render')->andReturn(false)->byDefault();
 		$this->apple_pay_config->shouldReceive('display_name')->andReturn('Test Store')->byDefault();
+
+		$this->card_field_styles = Mockery::mock(CardFieldStyles::class);
+		$this->card_field_styles->shouldReceive('overrides')->andReturn([])->byDefault();
 
 		// Reached unconditionally by script_data()'s Apple Pay validation block.
 		when('admin_url')->justReturn('https://example.com/wp-admin/admin-ajax.php');
@@ -106,7 +111,8 @@ class SdkV6ManagerTest extends TestCase
 	        $credit_card_icons,
 	        $merchant_country,
 	        $this->google_pay_config,
-	        $this->apple_pay_config
+	        $this->apple_pay_config,
+	        $this->card_field_styles
         );
     }
 
@@ -328,6 +334,7 @@ class SdkV6ManagerTest extends TestCase
      * AND the gateway title and name-field flag are carried into the payload
      * AND is_vaulting_enabled reflects the card vaulting setting
      * AND has_subscriptions reflects whether the cart contains a subscription
+     * AND the merchant's card field style overrides are carried into the payload
      *
      * @dataProvider script_data_card_fields_provider
      */
@@ -364,6 +371,9 @@ class SdkV6ManagerTest extends TestCase
         when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
         when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
 
+        $card_field_styles = ['fontSize' => '18px'];
+        $this->card_field_styles->shouldReceive('overrides')->andReturn($card_field_styles);
+
         $testee = $this->createTestee(false, [], $card_vaulting_enabled);
         $data   = $testee->script_data();
 
@@ -373,6 +383,7 @@ class SdkV6ManagerTest extends TestCase
         $this->assertSame(CreditCardGateway::ID, $data['card_fields']['payment_method']);
         $this->assertSame($card_vaulting_enabled, $data['card_fields']['is_vaulting_enabled']);
         $this->assertSame($cart_contains_subscription, $data['card_fields']['has_subscriptions']);
+        $this->assertSame($card_field_styles, $data['card_fields']['styles']);
     }
 
     public function script_data_card_fields_provider(): array

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -260,7 +260,7 @@ class SdkV6ManagerTest extends TestCase
         $this->session_handler->shouldReceive('order')->andReturn(null);
         $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
         $this->environment->shouldReceive('is_sandbox')->andReturn(false);
-        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn(['borderRadius' => '4px']);
 
         when('WC')->justReturn($this->create_wc_stub());
         when('wc_get_order')->justReturn($order);
@@ -300,7 +300,7 @@ class SdkV6ManagerTest extends TestCase
         $this->session_handler->shouldReceive('order')->andReturn(null);
         $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
         $this->environment->shouldReceive('is_sandbox')->andReturn(false);
-        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn(['borderRadius' => '4px']);
 
         $wc = $this->create_wc_stub();
         $wc->customer = Mockery::mock();
@@ -418,7 +418,7 @@ class SdkV6ManagerTest extends TestCase
         $this->session_handler->shouldReceive('order')->andReturn(null);
         $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
         $this->environment->shouldReceive('is_sandbox')->andReturn(false);
-        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn(['borderRadius' => '4px']);
 
         when('WC')->justReturn($this->create_wc_stub());
         when('wc_get_base_location')->justReturn(['country' => 'US']);
@@ -687,7 +687,7 @@ class SdkV6ManagerTest extends TestCase
         $this->session_handler->shouldReceive('order')->andReturn(null);
         $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
         $this->environment->shouldReceive('is_sandbox')->andReturn(false);
-        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn(['borderRadius' => '4px']);
 
         when('WC')->justReturn($this->create_wc_stub([
             GooglePayGateway::ID => true,

--- a/tests/PHPUnit/SdkV6/Helper/CardFieldStylesTest.php
+++ b/tests/PHPUnit/SdkV6/Helper/CardFieldStylesTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\TestCase;
+use function Brain\Monkey\Functions\expect;
+use function Brain\Monkey\Functions\when;
+
+class CardFieldStylesTest extends TestCase
+{
+	use MockeryPHPUnitIntegration;
+
+	private CardFieldStyles $sut;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+
+		$this->sut = new CardFieldStyles();
+	}
+
+	/**
+	 * GIVEN no merchant has hooked into the card field styles filter
+	 * WHEN the overrides are resolved
+	 * THEN no style overrides are sent to the browser
+	 */
+	public function test_returns_empty_array_when_no_filter_is_registered(): void
+	{
+		when('apply_filters')->justReturn(array());
+
+		$this->assertSame(array(), $this->sut->overrides());
+	}
+
+	/**
+	 * GIVEN a merchant supplies a map of camelCase CSS properties via the filter
+	 * WHEN the overrides are resolved
+	 * THEN the map is returned unchanged
+	 */
+	public function test_returns_the_filtered_map_as_supplied(): void
+	{
+		$styles = array(
+			'fontSize'   => '18px',
+			'color'      => '#333333',
+			'fontFamily' => 'Arial',
+		);
+
+		when('apply_filters')->justReturn($styles);
+
+		$this->assertSame($styles, $this->sut->overrides());
+	}
+
+	/**
+	 * GIVEN a filter returns a map that mixes valid string values with invalid ones
+	 * WHEN the overrides are resolved
+	 * THEN only the string-keyed, string-valued entries reach the browser
+	 *
+	 * @dataProvider invalid_entry_provider
+	 */
+	public function test_drops_invalid_entries(array $styles, array $expected): void
+	{
+		when('apply_filters')->justReturn($styles);
+
+		$this->assertSame($expected, $this->sut->overrides());
+	}
+
+	public function invalid_entry_provider(): array
+	{
+		return array(
+			'integer value is dropped' => array(
+				array('fontSize' => 18),
+				array(),
+			),
+			'array value is dropped' => array(
+				array('fontSize' => array('18px')),
+				array(),
+			),
+			'null value is dropped' => array(
+				array('fontSize' => null),
+				array(),
+			),
+			'boolean value is dropped' => array(
+				array('fontSize' => true),
+				array(),
+			),
+			'numeric key is dropped' => array(
+				array(0 => '18px'),
+				array(),
+			),
+			'mixed valid and invalid entries keep only the valid ones' => array(
+				array(
+					'fontSize' => '18px',
+					'color'    => 42,
+					0          => 'ignored',
+					'weight'   => 'bold',
+				),
+				array(
+					'fontSize' => '18px',
+					'weight'   => 'bold',
+				),
+			),
+		);
+	}
+
+	/**
+	 * GIVEN a filter returns something other than an array
+	 * WHEN the overrides are resolved
+	 * THEN no style overrides are sent to the browser instead of raising an error
+	 *
+	 * @dataProvider non_array_filter_result_provider
+	 */
+	public function test_returns_empty_array_when_filter_does_not_return_an_array($filter_result): void
+	{
+		when('apply_filters')->justReturn($filter_result);
+
+		$this->assertSame(array(), $this->sut->overrides());
+	}
+
+	public function non_array_filter_result_provider(): array
+	{
+		return array(
+			'string result' => array('not-an-array'),
+			'null result'   => array(null),
+			'object result' => array((object) array('fontSize' => '18px')),
+		);
+	}
+
+	/**
+	 * GIVEN the merchant's style filter changes between two requests
+	 * WHEN overrides() is called twice on the same instance
+	 * THEN each call reflects the filter's current value instead of a value cached
+	 * at construction time, since this class exists to remove that stale-cache bug
+	 */
+	public function test_does_not_cache_the_result_between_calls(): void
+	{
+		expect('apply_filters')
+			->twice()
+			->with('woocommerce_paypal_payments_card_fields_styles', array())
+			->andReturn(array('fontSize' => '18px'), array('fontSize' => '24px'));
+
+		$first  = $this->sut->overrides();
+		$second = $this->sut->overrides();
+
+		$this->assertSame(array('fontSize' => '18px'), $first);
+		$this->assertSame(array('fontSize' => '24px'), $second);
+	}
+}


### PR DESCRIPTION
*Changelog:* (none - part of the in-progress v6 SDK migration; the parent branch carries the user-facing entry)

# Description

The black **Basic Card** button (BCDC) was the last classic-checkout payment row still on v5. This branch brings it over to the v6 SDK, where PayPal exposes it as *Guest Payments*: its own SDK component, session factory and custom elements, so it gets its own renderer rather than joining the shared express-button stack.

Supporting changes that fell out of it:

- Order approval now names the paying gateway instead of assuming `ppcp-gateway`, so a BCDC payment reaches `CardButtonGateway`.
- Recoverable declines surface as a notice through the guest session's `onWarn`, leaving the cart and the button intact.
- The card-field styles are split into box styles (applied on our own page) and text styles (handed to the SDK, inside a PayPal iframe), with a filter for merchant overrides of the latter.

## 🔍 What to review

- **BCDC row visibility** is decided by the gateway list, not by the express-button location settings, and is deliberately suppressed for subscription carts: the v6 guest component has no vaulting equivalent, so `CardButtonGateway`'s hosted-card fallback takes over there.

## 🧪 How to verify

1. With standard card payments enabled, complete a BCDC payment on classic checkout and on the pay-for-order page; confirm the order is attributed to the card-button gateway.
2. Put a subscription in the cart: no card button, "Place order" remains.
