### PR TITLE
Implement Fastlane in JS SDK v6 (5785)

### DIFF
--- a/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.js
+++ b/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.js
@@ -134,26 +134,31 @@ export const populateWooFields = (
 	);
 	setWooShippingAddress( shippingAddress );
 
-	// Prepare and set billing address
-	const billingData = profileData.card.paymentSource.card.billingAddress;
+	// Prepare and set billing address. A recognised profile without a saved
+	// card carries no billing address, so there is nothing to prefill; the
+	// shopper fills the card form and its billing fields themselves.
+	const billingData =
+		profileData.card?.paymentSource?.card?.billingAddress ?? null;
 
-	const billingAddress = {
-		first_name: profileData.name.firstName,
-		last_name: profileData.name.lastName,
-		address_1: billingData.addressLine1,
-		address_2: billingData.addressLine2 || '',
-		city: billingData.adminArea2,
-		state: billingData.adminArea1,
-		postcode: billingData.postalCode,
-		country: billingData.countryCode,
-	};
+	if ( billingData ) {
+		const billingAddress = {
+			first_name: profileData.name.firstName,
+			last_name: profileData.name.lastName,
+			address_1: billingData.addressLine1,
+			address_2: billingData.addressLine2 || '',
+			city: billingData.adminArea2,
+			state: billingData.adminArea1,
+			postcode: billingData.postalCode,
+			country: billingData.countryCode,
+		};
 
-	log(
-		`Setting WooCommerce billing address: ${ JSON.stringify(
-			billingAddress
-		) }`
-	);
-	setWooBillingAddress( billingAddress );
+		log(
+			`Setting WooCommerce billing address: ${ JSON.stringify(
+				billingAddress
+			) }`
+		);
+		setWooBillingAddress( billingAddress );
+	}
 
 	// Collapse shipping address input fields into the card view
 	if ( typeof checkoutDispatch.setEditingShippingAddress === 'function' ) {

--- a/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.test.js
+++ b/modules/ppcp-axo-block/resources/js/helpers/fieldHelpers.test.js
@@ -1,0 +1,104 @@
+jest.mock( '@ppcp-axo/Helper/Debug', () => ( {
+	log: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn(),
+} ) );
+
+import { dispatch } from '@wordpress/data';
+import { populateWooFields } from './fieldHelpers';
+
+function baseProfileData( overrides = {} ) {
+	return {
+		name: { firstName: 'Jane', lastName: 'Doe' },
+		shippingAddress: {
+			name: { firstName: 'Jane', lastName: 'Doe' },
+			phoneNumber: { nationalNumber: '5551234567' },
+			address: {
+				addressLine1: '1 Main St',
+				addressLine2: '',
+				adminArea1: 'CA',
+				adminArea2: 'Anytown',
+				postalCode: '90210',
+				countryCode: 'US',
+			},
+		},
+		...overrides,
+	};
+}
+
+describe( 'populateWooFields', () => {
+	let setWooShippingAddress;
+	let setWooBillingAddress;
+	let checkoutDispatch;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		setWooShippingAddress = jest.fn();
+		setWooBillingAddress = jest.fn();
+		checkoutDispatch = {};
+		dispatch.mockReturnValue( checkoutDispatch );
+	} );
+
+	test( 'sets the shipping address and skips billing when the profile has no saved card', () => {
+		populateWooFields(
+			baseProfileData(),
+			setWooShippingAddress,
+			setWooBillingAddress
+		);
+
+		expect( setWooShippingAddress ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				first_name: 'Jane',
+				last_name: 'Doe',
+				address_1: '1 Main St',
+				city: 'Anytown',
+				postcode: '90210',
+				country: 'US',
+			} )
+		);
+		expect( setWooBillingAddress ).not.toHaveBeenCalled();
+	} );
+
+	test( 'sets both the shipping and billing address when the profile has a saved card', () => {
+		const profileData = baseProfileData( {
+			card: {
+				paymentSource: {
+					card: {
+						billingAddress: {
+							addressLine1: '2 Card St',
+							addressLine2: 'Suite 5',
+							adminArea1: 'NY',
+							adminArea2: 'Cardtown',
+							postalCode: '10001',
+							countryCode: 'US',
+						},
+					},
+				},
+			},
+		} );
+
+		populateWooFields(
+			profileData,
+			setWooShippingAddress,
+			setWooBillingAddress
+		);
+
+		expect( setWooShippingAddress ).toHaveBeenCalledWith(
+			expect.objectContaining( { address_1: '1 Main St' } )
+		);
+		expect( setWooBillingAddress ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				first_name: 'Jane',
+				last_name: 'Doe',
+				address_1: '2 Card St',
+				address_2: 'Suite 5',
+				city: 'Cardtown',
+				state: 'NY',
+				postcode: '10001',
+				country: 'US',
+			} )
+		);
+	} );
+} );

--- a/modules/ppcp-axo-block/resources/js/hooks/useFastlaneSdk.js
+++ b/modules/ppcp-axo-block/resources/js/hooks/useFastlaneSdk.js
@@ -56,7 +56,9 @@ const useFastlaneSdk = ( namespace, axoConfig, ppcpConfig ) => {
 
 				// Connect to Fastlane with locale, style options, and allowed card brands
 				await fastlane.connect( {
-					locale: configRef.current.ppcpConfig.locale,
+					// Absent on v6-owned pages, where v5's config global does
+					// not exist; createInstance carries the locale there.
+					locale: configRef.current.ppcpConfig?.locale,
 					styles: styleOptions,
 					cardOptions: {
 						allowedBrands: cardOptions,

--- a/modules/ppcp-axo-block/resources/js/hooks/usePayPalCommerceGateway.js
+++ b/modules/ppcp-axo-block/resources/js/hooks/usePayPalCommerceGateway.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from '@wordpress/element';
 import { log } from '@ppcp-axo/Helper/Debug';
+import { fastlaneSdkV6Config } from '@ppcp-sdk-v6/utils/config';
 
 /**
  * Custom hook to load and manage the PayPal Commerce Gateway configuration.
@@ -16,6 +17,16 @@ const usePayPalCommerceGateway = ( initialConfig ) => {
 		 * Function to load the PayPal Commerce Gateway configuration.
 		 */
 		const loadConfig = () => {
+			// v5's config global is absent on pages the v6 SDK owns, where the
+			// v6 payload takes its place: it carries the locale this module
+			// reads, and Connection/Fastlane.js gets the SDK from v6 anyway.
+			const sdkV6 = fastlaneSdkV6Config();
+			if ( sdkV6 ) {
+				setPpcpConfig( sdkV6 );
+				setIsConfigLoaded( true );
+				return;
+			}
+
 			if ( typeof window.PayPalCommerceGateway !== 'undefined' ) {
 				setPpcpConfig( window.PayPalCommerceGateway );
 				setIsConfigLoaded( true );

--- a/modules/ppcp-axo-block/resources/js/hooks/usePayPalScript.js
+++ b/modules/ppcp-axo-block/resources/js/hooks/usePayPalScript.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { log } from '@ppcp-axo/Helper/Debug';
 import { loadPayPalScript } from '@ppcp-button/Helper/PayPalScriptLoading';
 import { STORE_NAME } from '@ppcp-axo-block/stores/axoStore';
+import { fastlaneSdkV6Config } from '@ppcp-sdk-v6/utils/config';
 
 /**
  * Custom hook to load the PayPal script.
@@ -26,6 +27,15 @@ const usePayPalScript = ( namespace, ppcpConfig, isConfigLoaded ) => {
 
 	useEffect( () => {
 		const loadScript = async () => {
+			// The v6 SDK loads its own script and fetches its own client token,
+			// and Connection/Fastlane.js takes the instance from there, so none
+			// of the v5 loading below applies. Reporting it as loaded lets
+			// useFastlaneSdk proceed.
+			if ( fastlaneSdkV6Config() ) {
+				setIsPayPalLoaded( true );
+				return;
+			}
+
 			if ( ! isPayPalLoaded && isConfigLoaded ) {
 				const axoConfig = window.wc_ppcp_axo;
 

--- a/modules/ppcp-axo-block/resources/js/hooks/usePayPalScript.test.js
+++ b/modules/ppcp-axo-block/resources/js/hooks/usePayPalScript.test.js
@@ -1,0 +1,83 @@
+jest.mock( '@ppcp-axo/Helper/Debug', () => ( {
+	log: jest.fn(),
+} ) );
+
+const mockLoadPayPalScript = jest.fn();
+jest.mock( '@ppcp-button/Helper/PayPalScriptLoading', () => ( {
+	loadPayPalScript: ( ...args ) => mockLoadPayPalScript( ...args ),
+} ) );
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { dispatch } from '@wordpress/data';
+import usePayPalScript from './usePayPalScript';
+import { STORE_NAME } from '@ppcp-axo-block/stores/axoStore';
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	dispatch( STORE_NAME ).setIsPayPalLoaded( false );
+	delete window.wc_ppcp_sdk_v6;
+	delete window.wc_ppcp_axo;
+	delete global.fetch;
+} );
+
+describe( 'usePayPalScript', () => {
+	test( 'reports the script as loaded without fetching when the v6 SDK owns Fastlane', async () => {
+		window.wc_ppcp_sdk_v6 = { fastlane: { enabled: true } };
+		global.fetch = jest.fn();
+
+		const { result } = renderHook( () =>
+			usePayPalScript( 'ppcpPaypalClassicAxo', {}, true )
+		);
+
+		await waitFor( () => expect( result.current ).toBe( true ) );
+
+		expect( global.fetch ).not.toHaveBeenCalled();
+		expect( mockLoadPayPalScript ).not.toHaveBeenCalled();
+	} );
+
+	test( 'fetches script attributes and loads the v5 script when the v6 SDK does not own Fastlane', async () => {
+		window.wc_ppcp_axo = {
+			ajax: {
+				axo_script_attributes: {
+					endpoint: '/axo-script-attributes',
+					nonce: 'abc',
+				},
+			},
+		};
+		global.fetch = jest.fn().mockResolvedValue( {
+			json: async () => ( {
+				success: true,
+				data: { sdk_client_token: 'TOKEN' },
+			} ),
+		} );
+		mockLoadPayPalScript.mockResolvedValue( undefined );
+
+		const { result } = renderHook( () =>
+			usePayPalScript( 'ppcpPaypalClassicAxo', {}, true )
+		);
+
+		await waitFor( () => expect( result.current ).toBe( true ) );
+
+		expect( global.fetch ).toHaveBeenCalledWith(
+			'/axo-script-attributes',
+			expect.objectContaining( { method: 'POST' } )
+		);
+		expect( mockLoadPayPalScript ).toHaveBeenCalledWith(
+			'ppcpPaypalClassicAxo',
+			expect.objectContaining( {
+				script_attributes: expect.objectContaining( {
+					'data-sdk-client-token': 'TOKEN',
+				} ),
+			} )
+		);
+	} );
+
+	test( 'does not fetch when the gateway config has not loaded yet', () => {
+		const { result } = renderHook( () =>
+			usePayPalScript( 'ppcpPaypalClassicAxo', {}, false )
+		);
+
+		expect( result.current ).toBe( false );
+		expect( global.fetch ).toBeUndefined();
+	} );
+} );

--- a/modules/ppcp-axo/resources/js/Connection/Fastlane.js
+++ b/modules/ppcp-axo/resources/js/Connection/Fastlane.js
@@ -1,3 +1,6 @@
+import { loadSdkV6 } from '@ppcp-sdk-v6/sdkLoader';
+import { fastlaneSdkV6Config } from '@ppcp-sdk-v6/utils/config';
+
 class Fastlane {
 	constructor( namespace ) {
 		this.namespace = namespace;
@@ -9,7 +12,52 @@ class Fastlane {
 		this.FastlaneWatermarkComponent = null;
 	}
 
+	/**
+	 * Builds the Fastlane instance from whichever SDK owns the page.
+	 *
+	 * @param {Object} config - The v5 Fastlane options bag.
+	 * @return {Promise<void>} Resolves once the members are available.
+	 */
 	connect( config ) {
+		// Resolved here rather than passed in, so neither caller (AxoManager and
+		// the block's useFastlaneSdk) has to know which SDK backs Fastlane.
+		const v6Config = fastlaneSdkV6Config();
+
+		return v6Config
+			? this.connectV6( v6Config, config )
+			: this.connectV5( config );
+	}
+
+	/**
+	 * Takes Fastlane off the shared v6 SDK instance.
+	 *
+	 * loadSdkV6 memoizes that instance, so this shares one instance and one
+	 * client token with the buttons and card fields on the page rather than
+	 * loading a second SDK.
+	 *
+	 * @param {Object} v6Config - The wc_ppcp_sdk_v6 config.
+	 * @param {Object} config   - The v5 Fastlane options bag.
+	 * @return {Promise<void>} Resolves once the members are available.
+	 */
+	async connectV6( v6Config, config ) {
+		const sdkInstance = await loadSdkV6(
+			v6Config,
+			v6Config.page_context || 'checkout'
+		);
+
+		// The bag is v5's shape. v6 documents createFastlane() with no arguments
+		// and gives locale, styles, cardOptions.allowedBrands and
+		// shippingAddressOptions.allowedLocations no other home, so it is passed
+		// through: an ignored argument costs nothing, while dropping it would
+		// silently lose the merchant's card-brand and shipping restrictions.
+		this.init( await sdkInstance.createFastlane( config ) );
+	}
+
+	/**
+	 * @param {Object} config - The v5 Fastlane options bag.
+	 * @return {Promise<void>} Resolves once the members are available.
+	 */
+	connectV5( config ) {
 		return new Promise( ( resolve, reject ) => {
 			if ( ! window[ this.namespace ] ) {
 				reject(

--- a/modules/ppcp-axo/resources/js/Connection/Fastlane.test.js
+++ b/modules/ppcp-axo/resources/js/Connection/Fastlane.test.js
@@ -1,0 +1,126 @@
+jest.mock( '@ppcp-sdk-v6/sdkLoader', () => ( {
+	loadSdkV6: jest.fn(),
+} ) );
+
+import { loadSdkV6 } from '@ppcp-sdk-v6/sdkLoader';
+import Fastlane from './Fastlane';
+
+const namespace = 'ppcpPaypalClassicAxo';
+
+function fastlaneConnection( overrides = {} ) {
+	return {
+		identity: { id: 'identity' },
+		profile: { id: 'profile' },
+		FastlaneCardComponent: { id: 'card' },
+		FastlanePaymentComponent: { id: 'payment' },
+		FastlaneWatermarkComponent: { id: 'watermark' },
+		setLocale: jest.fn(),
+		...overrides,
+	};
+}
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	delete window.wc_ppcp_sdk_v6;
+	delete window[ namespace ];
+} );
+
+describe( 'Fastlane', () => {
+	describe( 'connect()', () => {
+		test( 'takes Fastlane from the v6 SDK when window.wc_ppcp_sdk_v6.fastlane.enabled is true', async () => {
+			const v6Config = { fastlane: { enabled: true }, page_context: 'cart' };
+			window.wc_ppcp_sdk_v6 = v6Config;
+
+			const connection = fastlaneConnection();
+			const createFastlane = jest.fn().mockResolvedValue( connection );
+			loadSdkV6.mockResolvedValue( { createFastlane } );
+
+			const fastlane = new Fastlane( namespace );
+			const options = { locale: 'en_US' };
+			await fastlane.connect( options );
+
+			expect( loadSdkV6 ).toHaveBeenCalledWith( v6Config, 'cart' );
+			expect( createFastlane ).toHaveBeenCalledWith( options );
+			expect( fastlane.identity ).toBe( connection.identity );
+			expect( fastlane.profile ).toBe( connection.profile );
+			expect( fastlane.FastlaneCardComponent ).toBe(
+				connection.FastlaneCardComponent
+			);
+			expect( fastlane.FastlanePaymentComponent ).toBe(
+				connection.FastlanePaymentComponent
+			);
+			expect( fastlane.FastlaneWatermarkComponent ).toBe(
+				connection.FastlaneWatermarkComponent
+			);
+
+			fastlane.setLocale( 'de_DE' );
+			expect( connection.setLocale ).toHaveBeenCalledWith( 'de_DE' );
+		} );
+
+		test( 'defaults the loader context to checkout when page_context is absent', async () => {
+			const v6Config = { fastlane: { enabled: true } };
+			window.wc_ppcp_sdk_v6 = v6Config;
+			loadSdkV6.mockResolvedValue( {
+				createFastlane: jest.fn().mockResolvedValue(
+					fastlaneConnection()
+				),
+			} );
+
+			await new Fastlane( namespace ).connect( {} );
+
+			expect( loadSdkV6 ).toHaveBeenCalledWith( v6Config, 'checkout' );
+		} );
+
+		test.each( [
+			[ 'window.wc_ppcp_sdk_v6 is absent', undefined ],
+			[ 'window.wc_ppcp_sdk_v6 has no fastlane key', {} ],
+			[
+				'window.wc_ppcp_sdk_v6.fastlane.enabled is false',
+				{ fastlane: { enabled: false } },
+			],
+		] )( 'falls back to the v5 namespace when %s', async ( label, config ) => {
+			if ( config !== undefined ) {
+				window.wc_ppcp_sdk_v6 = config;
+			}
+
+			const connection = fastlaneConnection();
+			window[ namespace ] = {
+				Fastlane: jest.fn().mockResolvedValue( connection ),
+			};
+
+			const fastlane = new Fastlane( namespace );
+			await fastlane.connect( {} );
+
+			expect( loadSdkV6 ).not.toHaveBeenCalled();
+			expect( fastlane.identity ).toBe( connection.identity );
+		} );
+
+		test( 'rejects when loadSdkV6 rejects', async () => {
+			window.wc_ppcp_sdk_v6 = { fastlane: { enabled: true } };
+			const error = new Error( 'sdk load failed' );
+			loadSdkV6.mockRejectedValue( error );
+
+			await expect(
+				new Fastlane( namespace ).connect( {} )
+			).rejects.toThrow( error );
+		} );
+
+		test( 'rejects when createFastlane rejects', async () => {
+			window.wc_ppcp_sdk_v6 = { fastlane: { enabled: true } };
+			const error = new Error( 'createFastlane failed' );
+			loadSdkV6.mockResolvedValue( {
+				createFastlane: jest.fn().mockRejectedValue( error ),
+			} );
+
+			await expect(
+				new Fastlane( namespace ).connect( {} )
+			).rejects.toThrow( error );
+		} );
+
+		test( 'rejects when the v5 namespace is not found on window', async () => {
+			await expect(
+				new Fastlane( namespace ).connect( {} )
+			).rejects.toThrow( /not found on window object/ );
+		} );
+	} );
+} );

--- a/modules/ppcp-axo/resources/js/Insights/PayPalInsights.js
+++ b/modules/ppcp-axo/resources/js/Insights/PayPalInsights.js
@@ -16,19 +16,41 @@ class PayPalInsights {
 		return PayPalInsights.instance;
 	}
 
+	/**
+	 * Whether PayPal's insights script has loaded and installed its global.
+	 *
+	 * Analytics must never break checkout, and the script is loaded async: a
+	 * caller can reach these methods before it arrives, which used to throw a
+	 * ReferenceError out of the AXO bootstrap.
+	 *
+	 * @return {boolean} True when the global is callable.
+	 */
+	static isAvailable() {
+		return typeof window.paypalInsight === 'function';
+	}
+
 	static track( eventName, data ) {
 		PayPalInsights.init();
-		paypalInsight( 'event', eventName, data );
+		if ( ! PayPalInsights.isAvailable() ) {
+			return;
+		}
+		window.paypalInsight( 'event', eventName, data );
 	}
 
 	static config( clientId, data ) {
 		PayPalInsights.init();
-		paypalInsight( 'config', clientId, data );
+		if ( ! PayPalInsights.isAvailable() ) {
+			return;
+		}
+		window.paypalInsight( 'config', clientId, data );
 	}
 
 	static setSessionId( sessionId ) {
 		PayPalInsights.init();
-		paypalInsight( 'set', { session_id: sessionId } );
+		if ( ! PayPalInsights.isAvailable() ) {
+			return;
+		}
+		window.paypalInsight( 'set', { session_id: sessionId } );
 	}
 
 	static trackJsLoad() {

--- a/modules/ppcp-axo/resources/js/boot.js
+++ b/modules/ppcp-axo/resources/js/boot.js
@@ -1,6 +1,7 @@
 import AxoManager from './AxoManager';
 import { loadPayPalScript } from '@ppcp-button/Helper/PayPalScriptLoading';
 import { log } from './Helper/Debug';
+import { fastlaneSdkV6Config } from '@ppcp-sdk-v6/utils/config';
 
 ( function ( { axoConfig, ppcpConfig } ) {
 	const namespace = 'ppcpPaypalClassicAxo';
@@ -8,7 +9,25 @@ import { log } from './Helper/Debug';
 		new AxoManager( namespace, axoConfig, ppcpConfig );
 	};
 
+	/**
+	 * Whether the v6 SDK owns this page and can supply Fastlane.
+	 *
+	 * The v6 stack loads its own script and fetches its own client token, and
+	 * Connection/Fastlane.js takes the instance from there, so none of the v5
+	 * loading below applies. v5's own config global is absent on those pages
+	 * (the smart button is replaced by DisabledSmartButton), which is why the
+	 * guard on it is skipped too.
+	 *
+	 * @return {boolean} True when Fastlane comes from the v6 SDK.
+	 */
+	const usesSdkV6 = () => Boolean( fastlaneSdkV6Config() );
+
 	document.addEventListener( 'DOMContentLoaded', async () => {
+		if ( usesSdkV6() ) {
+			bootstrap();
+			return;
+		}
+
 		if ( typeof PayPalCommerceGateway === 'undefined' ) {
 			console.error( 'AXO could not be configured.' );
 			return;

--- a/modules/ppcp-axo/resources/js/boot.test.js
+++ b/modules/ppcp-axo/resources/js/boot.test.js
@@ -1,0 +1,101 @@
+const mockAxoManager = jest.fn();
+jest.mock( './AxoManager', () => mockAxoManager );
+
+const mockLoadPayPalScript = jest.fn();
+jest.mock( '@ppcp-button/Helper/PayPalScriptLoading', () => ( {
+	loadPayPalScript: ( ...args ) => mockLoadPayPalScript( ...args ),
+} ) );
+
+jest.mock( './Helper/Debug', () => ( {
+	log: jest.fn(),
+} ) );
+
+// boot.js reads its config off window globals as an IIFE at import time and
+// registers one DOMContentLoaded listener, so each test needs a fresh module
+// instance and to dispatch the event itself. jest.resetModules() does not
+// detach listeners though, so without cleanup every previous test's handler
+// would still be attached to `document` and would re-fire on this dispatch,
+// running with this test's config while closing over the old one. Capturing
+// and removing the listener this call adds keeps exactly one handler alive
+// per dispatch.
+function boot() {
+	jest.resetModules();
+	mockAxoManager.mockClear();
+	mockLoadPayPalScript.mockClear();
+
+	const addEventListenerSpy = jest.spyOn( document, 'addEventListener' );
+	require( './boot' );
+	const [ , handler ] = addEventListenerSpy.mock.calls[ 0 ];
+	addEventListenerSpy.mockRestore();
+
+	document.dispatchEvent( new Event( 'DOMContentLoaded' ) );
+	document.removeEventListener( 'DOMContentLoaded', handler );
+}
+
+beforeEach( () => {
+	delete window.wc_ppcp_sdk_v6;
+	delete window.wc_ppcp_axo;
+	delete window.PayPalCommerceGateway;
+	delete global.fetch;
+} );
+
+describe( 'boot', () => {
+	test( 'constructs AxoManager immediately when the v6 SDK owns Fastlane, without fetching the v5 script attributes', async () => {
+		window.wc_ppcp_sdk_v6 = { fastlane: { enabled: true } };
+		window.wc_ppcp_axo = { ajax: {} };
+		global.fetch = jest.fn();
+
+		boot();
+		await Promise.resolve();
+
+		expect( mockAxoManager ).toHaveBeenCalledWith(
+			'ppcpPaypalClassicAxo',
+			window.wc_ppcp_axo,
+			window.PayPalCommerceGateway
+		);
+		expect( global.fetch ).not.toHaveBeenCalled();
+		expect( mockLoadPayPalScript ).not.toHaveBeenCalled();
+	} );
+
+	test( 'still fetches script attributes and loads the v5 script when the v6 SDK does not own Fastlane', async () => {
+		window.PayPalCommerceGateway = { script_attributes: {} };
+		window.wc_ppcp_axo = {
+			ajax: {
+				axo_script_attributes: {
+					endpoint: '/axo-script-attributes',
+					nonce: 'abc',
+				},
+			},
+		};
+		global.fetch = jest.fn().mockResolvedValue( {
+			json: async () => ( {
+				success: true,
+				data: { sdk_client_token: 'TOKEN' },
+			} ),
+		} );
+		mockLoadPayPalScript.mockResolvedValue( undefined );
+
+		boot();
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect( global.fetch ).toHaveBeenCalledWith(
+			'/axo-script-attributes',
+			expect.objectContaining( { method: 'POST' } )
+		);
+		expect( mockLoadPayPalScript ).toHaveBeenCalledWith(
+			'ppcpPaypalClassicAxo',
+			expect.objectContaining( {
+				script_attributes: expect.objectContaining( {
+					'data-sdk-client-token': 'TOKEN',
+				} ),
+			} )
+		);
+		expect( mockAxoManager ).toHaveBeenCalledWith(
+			'ppcpPaypalClassicAxo',
+			window.wc_ppcp_axo,
+			window.PayPalCommerceGateway
+		);
+	} );
+} );

--- a/modules/ppcp-axo/src/AxoModule.php
+++ b/modules/ppcp-axo/src/AxoModule.php
@@ -190,7 +190,12 @@ class AxoModule implements ServiceModule, ExecutableModule {
 						$axo_applies = $c->get( 'axo.service.axo-applies' );
 						assert( $axo_applies instanceof AxoApplies );
 
-						if ( $axo_applies->should_render_fastlane() && $smart_button->should_load_ppcp_script() ) {
+						// v5's script gate is false on pages the v6 SDK owns, where
+						// the smart button is a DisabledSmartButton. Fastlane still
+						// renders there: only the SDK object comes from v6 now, so
+						// the assets must load either way.
+						if ( $axo_applies->should_render_fastlane()
+							&& ( $smart_button->should_load_ppcp_script() || self::v6_supplies_sdk( $c ) ) ) {
 							$manager->enqueue();
 						}
 					}
@@ -488,5 +493,21 @@ class AxoModule implements ServiceModule, ExecutableModule {
 		);
 
 		wp_enqueue_script( 'wc-ppcp-paypal-insights-end-checkout' );
+	}
+
+	/**
+	 * Whether the v6 SDK owns this page and supplies the Fastlane instance.
+	 *
+	 * The service is has()-guarded because the v6 module sits behind its own
+	 * feature flag.
+	 */
+	private static function v6_supplies_sdk( ContainerInterface $c ): bool {
+		if ( ! $c->has( 'sdk-v6.owns-current-page' ) ) {
+			return false;
+		}
+
+		$owns_current_page = $c->get( 'sdk-v6.owns-current-page' );
+
+		return $owns_current_page();
 	}
 }

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
@@ -63,6 +63,9 @@ async function createInstance( config, context ) {
 	if ( config.card_fields?.enabled ) {
 		components.push( 'card-fields' );
 	}
+	if ( config.fastlane?.enabled ) {
+		components.push( 'fastlane' );
+	}
 	components.push( ...walletSdkComponents( config ) );
 
 	const sdkInstance = await window.paypal.createInstance( {

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.js
@@ -8,7 +8,40 @@ import { postJson } from './utils/api';
 import { loadScript } from './utils/scriptLoaders';
 import { walletSdkComponents } from './wallets/walletRegistry';
 
-let instancePromise = null;
+const INSTANCE_KEY = '__ppcpV6InstancePromise';
+const METADATA_ID_KEY = '__ppcpV6ClientMetadataId';
+
+/**
+ * The in-flight instance promise, shared across bundles.
+ *
+ * On window rather than in module scope because each webpack bundle gets its own
+ * copy of this module: the ppcp-axo bundle asking for Fastlane must reuse the
+ * instance this module's own bootstrap created, or the SDK script loads twice and
+ * its custom elements fail to register a second time.
+ *
+ * @return {?Promise<Object>} The cached promise, or null.
+ */
+function cachedInstance() {
+	return window[ INSTANCE_KEY ] || null;
+}
+
+/**
+ * One client metadata id per page, shared across bundles.
+ *
+ * PayPal correlates it with the order for fraud checks, and createInstance
+ * rejects outright when the fastlane component is requested without it.
+ *
+ * @return {string} The id.
+ */
+function clientMetadataId() {
+	if ( ! window[ METADATA_ID_KEY ] ) {
+		window[ METADATA_ID_KEY ] =
+			window.crypto?.randomUUID?.() ||
+			`ppcp-${ Date.now() }-${ Math.random().toString( 16 ).slice( 2 ) }`;
+	}
+
+	return window[ METADATA_ID_KEY ];
+}
 
 const PAGE_TYPE_MAP = {
 	product: 'product-details',
@@ -30,16 +63,16 @@ const PAGE_TYPE_MAP = {
  * @return {Promise<Object>} The SDK instance.
  */
 export function loadSdkV6( config, context ) {
-	if ( ! instancePromise ) {
-		instancePromise = createInstance( config, context ).catch(
+	if ( ! cachedInstance() ) {
+		window[ INSTANCE_KEY ] = createInstance( config, context ).catch(
 			( error ) => {
-				instancePromise = null;
+				delete window[ INSTANCE_KEY ];
 				throw error;
 			}
 		);
 	}
 
-	return instancePromise;
+	return cachedInstance();
 }
 
 /**
@@ -73,6 +106,7 @@ async function createInstance( config, context ) {
 		components,
 		pageType: PAGE_TYPE_MAP[ context ] || 'checkout',
 		locale: config.locale,
+		clientMetadataId: clientMetadataId(),
 	} );
 
 	document.dispatchEvent(

--- a/modules/ppcp-sdk-v6/resources/js/sdkLoader.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/sdkLoader.test.js
@@ -8,7 +8,8 @@ jest.mock( './utils/scriptLoaders', () => ( {
 	loadScript: ( ...args ) => mockLoadScript( ...args ),
 } ) );
 
-// loadSdkV6() memoizes on module-level state, so each test needs a fresh module instance.
+// loadSdkV6() memoizes on window-level state (shared across webpack bundles),
+// which survives jest.resetModules(), so each test also needs its own window keys.
 let loadSdkV6;
 
 function baseConfig( overrides = {} ) {
@@ -26,6 +27,9 @@ beforeEach( () => {
 	mockLoadScript.mockReset();
 	mockLoadScript.mockResolvedValue( undefined );
 	mockPostJson.mockResolvedValue( { client_token: 'TOKEN' } );
+	delete window.__ppcpV6InstancePromise;
+	delete window.__ppcpV6ScriptPromises;
+	delete window.__ppcpV6ClientMetadataId;
 	( { loadSdkV6 } = require( './sdkLoader' ) );
 	window.paypal = { createInstance: jest.fn().mockResolvedValue( {} ) };
 } );
@@ -66,6 +70,11 @@ describe( 'loadSdkV6', () => {
 				'googlepay-payments',
 			],
 		],
+		[
+			'fastlane enabled',
+			{ fastlane: { enabled: true } },
+			[ 'paypal-payments', 'venmo-payments', 'fastlane' ],
+		],
 	] )( 'requests %s', async ( label, overrides, expectedComponents ) => {
 		await loadSdkV6( baseConfig( overrides ), 'checkout' );
 
@@ -74,11 +83,36 @@ describe( 'loadSdkV6', () => {
 		);
 	} );
 
-	test( 'does not request card-fields or googlepay-payments when both are explicitly disabled', async () => {
+	test( 'requests fastlane, card fields and apple pay all enabled', async () => {
+		await loadSdkV6(
+			baseConfig( {
+				fastlane: { enabled: true },
+				card_fields: { enabled: true },
+				apple_pay: { enabled: true },
+			} ),
+			'checkout'
+		);
+
+		// components is a set of names passed to createInstance; push order in
+		// the source carries no meaning, so compare contents, not order.
+		const { components } = window.paypal.createInstance.mock.calls[ 0 ][ 0 ];
+		expect( [ ...components ].sort() ).toEqual(
+			[
+				'paypal-payments',
+				'venmo-payments',
+				'card-fields',
+				'applepay-payments',
+				'fastlane',
+			].sort()
+		);
+	} );
+
+	test( 'does not request card-fields, googlepay-payments or fastlane when all are explicitly disabled', async () => {
 		await loadSdkV6(
 			baseConfig( {
 				card_fields: { enabled: false },
 				google_pay: { enabled: false },
+				fastlane: { enabled: false },
 			} ),
 			'checkout'
 		);
@@ -88,5 +122,25 @@ describe( 'loadSdkV6', () => {
 				components: [ 'paypal-payments', 'venmo-payments' ],
 			} )
 		);
+	} );
+
+	test( 'passes a stable clientMetadataId across two loadSdkV6 calls on the same page', async () => {
+		await loadSdkV6( baseConfig(), 'checkout' );
+		const firstId =
+			window.paypal.createInstance.mock.calls[ 0 ][ 0 ]
+				.clientMetadataId;
+
+		// Resetting only the instance cache forces a second createInstance call
+		// while leaving the page-level metadata id cache intact.
+		delete window.__ppcpV6InstancePromise;
+		window.paypal.createInstance.mockClear();
+
+		await loadSdkV6( baseConfig(), 'checkout' );
+		const secondId =
+			window.paypal.createInstance.mock.calls[ 0 ][ 0 ]
+				.clientMetadataId;
+
+		expect( firstId ).toEqual( expect.any( String ) );
+		expect( secondId ).toBe( firstId );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/utils/config.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/config.js
@@ -1,0 +1,38 @@
+/**
+ * Finds the v6 config, whichever way this page received it.
+ *
+ * @package
+ */
+
+/**
+ * The wc_ppcp_sdk_v6 payload for the current page.
+ *
+ * Two delivery routes, because SdkV6Manager::enqueue() skips block pages: the
+ * classic pages get the localized global, and the block pages get the same
+ * payload through V6PaymentMethod::get_payment_method_data(), which WooCommerce
+ * exposes under wcSettings. Consumers outside this module must not pick one, or
+ * they silently see no v6 on the other kind of page.
+ *
+ * @return {?Object} The config, or null when v6 does not run here.
+ */
+export function sdkV6Config() {
+	if ( window.wc_ppcp_sdk_v6 ) {
+		return window.wc_ppcp_sdk_v6;
+	}
+
+	const paymentMethodData =
+		window.wc?.wcSettings?.getSetting?.( 'paymentMethodData' ) || {};
+
+	return paymentMethodData[ 'ppcp-sdk-v6' ] || null;
+}
+
+/**
+ * Whether Fastlane runs off the v6 SDK on this page.
+ *
+ * @return {?Object} The config when it does, null when the v5 path applies.
+ */
+export function fastlaneSdkV6Config() {
+	const config = sdkV6Config();
+
+	return config?.fastlane?.enabled ? config : null;
+}

--- a/modules/ppcp-sdk-v6/resources/js/utils/config.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/config.test.js
@@ -1,0 +1,64 @@
+import { sdkV6Config, fastlaneSdkV6Config } from './config';
+
+afterEach( () => {
+	delete window.wc_ppcp_sdk_v6;
+	delete window.wc;
+} );
+
+describe( 'sdkV6Config', () => {
+	test( 'returns the classic-page global when present', () => {
+		const config = { fastlane: { enabled: true } };
+		window.wc_ppcp_sdk_v6 = config;
+
+		expect( sdkV6Config() ).toBe( config );
+	} );
+
+	test( 'falls back to the block-page payment method data when the classic global is absent', () => {
+		const config = { fastlane: { enabled: false } };
+		window.wc = {
+			wcSettings: {
+				getSetting: ( key ) =>
+					key === 'paymentMethodData'
+						? { 'ppcp-sdk-v6': config }
+						: undefined,
+			},
+		};
+
+		expect( sdkV6Config() ).toBe( config );
+	} );
+
+	test( 'returns null when neither the classic global nor the block payment method data exists', () => {
+		expect( sdkV6Config() ).toBeNull();
+	} );
+
+	test( 'returns null when the block payment method data exists but has no v6 entry', () => {
+		window.wc = {
+			wcSettings: {
+				getSetting: () => ( { 'some-other-gateway': {} } ),
+			},
+		};
+
+		expect( sdkV6Config() ).toBeNull();
+	} );
+} );
+
+describe( 'fastlaneSdkV6Config', () => {
+	test( 'returns the config when fastlane is enabled', () => {
+		const config = { fastlane: { enabled: true } };
+		window.wc_ppcp_sdk_v6 = config;
+
+		expect( fastlaneSdkV6Config() ).toBe( config );
+	} );
+
+	test.each( [
+		[ 'the v6 config does not exist at all', undefined ],
+		[ 'fastlane is explicitly disabled', { fastlane: { enabled: false } } ],
+		[ 'the fastlane key is absent', {} ],
+	] )( 'returns null when %s', ( label, config ) => {
+		if ( config !== undefined ) {
+			window.wc_ppcp_sdk_v6 = config;
+		}
+
+		expect( fastlaneSdkV6Config() ).toBeNull();
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/utils/scriptLoaders.js
+++ b/modules/ppcp-sdk-v6/resources/js/utils/scriptLoaders.js
@@ -4,7 +4,25 @@
  * @package
  */
 
-const scriptPromises = {};
+const CACHE_KEY = '__ppcpV6ScriptPromises';
+
+/**
+ * The per-URL load promises, shared across bundles.
+ *
+ * On window rather than in module scope because each webpack bundle gets its own
+ * copy of this module: a second bundle asking for the same URL would otherwise
+ * inject the tag again, and these SDKs register custom elements, which throws on
+ * the duplicate registration.
+ *
+ * @return {Object} The cache.
+ */
+function scriptPromiseCache() {
+	if ( ! window[ CACHE_KEY ] ) {
+		window[ CACHE_KEY ] = {};
+	}
+
+	return window[ CACHE_KEY ];
+}
 
 /**
  * Appends a script tag and resolves once it loaded.
@@ -17,6 +35,8 @@ const scriptPromises = {};
  * @return {Promise<void>} Resolves when the script is loaded.
  */
 export function loadScript( url ) {
+	const scriptPromises = scriptPromiseCache();
+
 	if ( ! scriptPromises[ url ] ) {
 		scriptPromises[ url ] = new Promise( ( resolve, reject ) => {
 			const script = document.createElement( 'script' );

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -19,22 +19,23 @@ use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\RateLimiter;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 
 /**
- * Builds a wallet's availability check from its own module's services.
+ * Builds a payment method's availability check from its own module's services.
  *
  * Reports false when that module is not loaded: its services are absent, so the
- * wallet cannot be offered. Each wallet keeps its own guards: the two modules
- * load independently.
+ * method cannot be offered. Each method keeps its own guards, since the modules
+ * load independently behind their own feature flags.
  *
  * @param ContainerInterface $container The plugin container.
- * @param string             $module    The wallet module's service prefix.
+ * @param string             $module    The owning module's service prefix.
  * @return callable(): bool
  */
-$wallet_availability = static function ( ContainerInterface $container, string $module ): callable {
+$module_availability = static function ( ContainerInterface $container, string $module ): callable {
 	return static function () use ( $container, $module ): bool {
 		if ( ! $container->has( "$module.eligibility.check" ) || ! $container->has( "$module.available" ) ) {
 			return false;
@@ -61,19 +62,31 @@ return array(
 		);
 	},
 
-	'sdk-v6.google-pay-config'          => static function ( ContainerInterface $container ) use ( $wallet_availability ): GooglePayConfig {
+	'sdk-v6.google-pay-config'          => static function ( ContainerInterface $container ) use ( $module_availability ): GooglePayConfig {
 		return new GooglePayConfig(
 			$container->get( 'settings.settings-provider' ),
 			$container->get( 'wc-subscriptions.helper' ),
-			$wallet_availability( $container, 'googlepay' )
+			$module_availability( $container, 'googlepay' )
 		);
 	},
 
-	'sdk-v6.apple-pay-config'           => static function ( ContainerInterface $container ) use ( $wallet_availability ): ApplePayConfig {
+	'sdk-v6.apple-pay-config'           => static function ( ContainerInterface $container ) use ( $module_availability ): ApplePayConfig {
 		return new ApplePayConfig(
 			$container->get( 'settings.settings-provider' ),
 			$container->get( 'wc-subscriptions.helper' ),
-			$wallet_availability( $container, 'applepay' )
+			$module_availability( $container, 'applepay' )
+		);
+	},
+
+	/**
+	 * Fastlane keeps its UI in the ppcp-axo modules; this only decides whether
+	 * the SDK requests the fastlane component on the current page.
+	 */
+	'sdk-v6.fastlane-config'            => static function ( ContainerInterface $container ) use ( $module_availability ): FastlaneConfig {
+		return new FastlaneConfig(
+			$container->get( 'wcgateway.configuration.card-configuration' ),
+			$container->get( 'wc-subscriptions.helper' ),
+			$module_availability( $container, 'axo' )
 		);
 	},
 
@@ -125,7 +138,8 @@ return array(
 			$container->get( 'wcgateway.credit-card-icons' ),
 			$settings_provider->merchant_country(),
 			$container->get( 'sdk-v6.google-pay-config' ),
-			$container->get( 'sdk-v6.apple-pay-config' )
+			$container->get( 'sdk-v6.apple-pay-config' ),
+			$container->get( 'sdk-v6.fastlane-config' )
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -23,6 +23,7 @@ use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelController;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
@@ -88,6 +89,8 @@ class SdkV6Manager {
 	 */
 	private ApplePayConfig $apple_pay_config;
 
+	private FastlaneConfig $fastlane_config;
+
 	/**
 	 * Every wallet this module places, in the order their rows are printed.
 	 *
@@ -113,7 +116,8 @@ class SdkV6Manager {
 		array $credit_card_icons,
 		string $merchant_country,
 		GooglePayConfig $google_pay_config,
-		ApplePayConfig $apple_pay_config
+		ApplePayConfig $apple_pay_config,
+		FastlaneConfig $fastlane_config
 	) {
 		$this->asset_getter                = $asset_getter;
 		$this->version                     = $version;
@@ -132,6 +136,7 @@ class SdkV6Manager {
 		$this->credit_card_icons           = $credit_card_icons;
 		$this->merchant_country            = $merchant_country;
 		$this->apple_pay_config            = $apple_pay_config;
+		$this->fastlane_config             = $fastlane_config;
 
 		$this->wallets = array(
 			new WalletPlacement(
@@ -372,6 +377,10 @@ class SdkV6Manager {
 			return true;
 		}
 
+		if ( $this->is_fastlane_enabled( $page_location ) ) {
+			return true;
+		}
+
 		// Load sitewide whenever the mini-cart location is enabled, matching the
 		// v5 SmartButton (should_load_buttons()'s default branch). The mini-cart
 		// can appear on any page — as the classic "Cart" widget OR the block
@@ -397,6 +406,26 @@ class SdkV6Manager {
 
 		return in_array( $location, array( 'checkout', 'checkout-block', 'pay-now' ), true )
 			&& $this->card_payments_configuration->is_acdc_enabled();
+	}
+
+	/**
+	 * Whether Fastlane runs on the given page under the v6 SDK.
+	 *
+	 * This module does not render Fastlane itself: the ppcp-axo modules keep
+	 * their UI and only take the SDK object from here, so this gates the
+	 * `fastlane` component request and the v5 Fastlane block method staying
+	 * registered.
+	 *
+	 * @param string|null $location Page context to test; defaults to the current page.
+	 */
+	public function is_fastlane_enabled( ?string $location = null ): bool {
+		$location = $location ?? $this->get_page_context();
+
+		if ( ! $location ) {
+			return false;
+		}
+
+		return $this->fastlane_config->should_render( $location );
 	}
 
 	/**
@@ -547,6 +576,16 @@ class SdkV6Manager {
 					'expiry' => '#' . self::CARD_FIELD_EXPIRY_ID,
 					'cvv'    => '#' . self::CARD_FIELD_CVV_ID,
 				),
+			),
+			// Enablement only. The ppcp-axo modules own every other Fastlane
+			// setting and localize it as wc_ppcp_axo; this flag tells sdkLoader
+			// to request the component their connection then reads off the
+			// shared SDK instance.
+			'fastlane'          => array(
+				'enabled'        => $this->is_fastlane_enabled( $page_context ),
+				// The id as a literal, not AxoGateway::ID: ppcp-axo is behind its
+				// own feature flag, and SdkV6Module names it the same way.
+				'payment_method' => 'ppcp-axo-gateway',
 			),
 		);
 

--- a/modules/ppcp-sdk-v6/src/Helper/FastlaneConfig.php
+++ b/modules/ppcp-sdk-v6/src/Helper/FastlaneConfig.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Decides whether Fastlane runs on the current page under the v6 SDK.
+ *
+ * Narrower than the wallet configs on purpose: v6 does not re-implement the
+ * Fastlane UI. The ppcp-axo modules keep rendering it and only swap how the SDK
+ * object is obtained (see Connection/Fastlane.js), so all this class answers is
+ * "should the fastlane component be requested here", which gates both the
+ * `fastlane` script-data subtree and the SDK component list.
+ *
+ * @package WooCommerce\PayPalCommerce\SdkV6\Helper
+ */
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+
+class FastlaneConfig {
+
+	/**
+	 * The contexts Fastlane runs in. v5 offers it on the checkout only, and
+	 * excludes the order-pay and order-received endpoints (AxoApplies).
+	 */
+	private const SUPPORTED_CONTEXTS = array( 'checkout', 'checkout-block' );
+
+	private CardPaymentsConfiguration $card_payments_configuration;
+
+	private SubscriptionHelper $subscription_helper;
+
+	/**
+	 * Whether the merchant is eligible at all: country/currency, the merchant
+	 * filter and the gateway being enabled. Composed in services.php from the
+	 * ppcp-axo services, which only exist while that module is loaded.
+	 *
+	 * @var callable(): bool
+	 */
+	private $is_eligible;
+
+	public function __construct(
+		CardPaymentsConfiguration $card_payments_configuration,
+		SubscriptionHelper $subscription_helper,
+		callable $is_eligible
+	) {
+		$this->card_payments_configuration = $card_payments_configuration;
+		$this->subscription_helper         = $subscription_helper;
+		$this->is_eligible                 = $is_eligible;
+	}
+
+	/**
+	 * Whether Fastlane should run in the given page context.
+	 *
+	 * Mirrors AxoApplies::should_render_fastlane() minus its
+	 * CartCheckoutDetector::has_classic_checkout() clause, which would refuse
+	 * the block checkout that v6 also serves.
+	 *
+	 * @param string $context The page context, as get_page_context() reports it.
+	 */
+	public function should_render( string $context ): bool {
+		// The subscription check reads the cart, which WooCommerce loads on
+		// wp_loaded. Called earlier it would silently see an empty cart and
+		// report Fastlane as available, so refuse rather than guess.
+		if ( ! did_action( 'wp_loaded' ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html__(
+					'Fastlane availability cannot be determined before the wp_loaded action has run.',
+					'woocommerce-paypal-payments'
+				),
+				'4.1.3'
+			);
+
+			return false;
+		}
+
+		if ( ! in_array( $context, self::SUPPORTED_CONTEXTS, true ) ) {
+			return false;
+		}
+
+		// Fastlane recognises returning guests; a logged-in customer already
+		// has their details on file.
+		if ( is_user_logged_in() ) {
+			return false;
+		}
+
+		// use_fastlane() is ACDC enabled AND the Fastlane method enabled.
+		if ( ! $this->card_payments_configuration->use_fastlane() ) {
+			return false;
+		}
+
+		// A subscription needs a vaulted payment method, which this flow does
+		// not produce.
+		if ( $this->subscription_helper->cart_contains_subscription() ) {
+			return false;
+		}
+
+		return ( $this->is_eligible )();
+	}
+}

--- a/modules/ppcp-sdk-v6/src/SdkV6Module.php
+++ b/modules/ppcp-sdk-v6/src/SdkV6Module.php
@@ -144,9 +144,11 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 		// Extends the v5 handoff (see extensions.php) to the other v5 PayPal
 		// block methods, which misbehave against v5's now-empty config: the
 		// Google Pay / Apple Pay boots throw during React render, tearing down
-		// the whole checkout block, and the Fastlane (AXO) field restoration
-		// can clobber the express submission. The wallets and card fields
-		// migrate under their own stories.
+		// the whole checkout block.
+		//
+		// Fastlane is the exception: v6 does not re-implement it, the ppcp-axo
+		// block method keeps rendering and only takes the SDK object from this
+		// module, so it stays registered wherever v6 can supply that object.
 		//
 		// Classic checkout needs no equivalent: both wallet rows are v6-owned
 		// there, printing their own hide-until-eligible style and revealing the
@@ -175,8 +177,15 @@ class SdkV6Module implements ServiceModule, ExtendingModule, ExecutableModule {
 						$v5_methods = array(
 							'ppcp-googlepay',
 							'ppcp-applepay',
-							'ppcp-axo-gateway',
 						);
+
+						// The v5 Fastlane block method runs on the v6 SDK, so it
+						// is only suppressed where v6 cannot supply a Fastlane
+						// instance — otherwise the shopper would lose Fastlane
+						// with nothing rendering in its place.
+						if ( ! $manager->is_fastlane_enabled() ) {
+							$v5_methods[] = 'ppcp-axo-gateway';
+						}
 
 						// Suppress the v5 card block only when v6 renders its own
 						// card method in its place, so cards stay payable when v6

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -8,6 +8,7 @@ use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
+use WooCommerce\PayPalCommerce\SdkV6\Helper\FastlaneConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
 use WooCommerce\PayPalCommerce\Session\Cancellation\CancelView;
 use WooCommerce\PayPalCommerce\Session\SessionHandler;
@@ -33,6 +34,7 @@ class SdkV6ManagerTest extends TestCase
 	private $credit_card_icons;
 	private $google_pay_config;
 	private $apple_pay_config;
+	private $fastlane_config;
 
     public function setUp(): void
     {
@@ -56,6 +58,9 @@ class SdkV6ManagerTest extends TestCase
 		$this->apple_pay_config = Mockery::mock(ApplePayConfig::class);
 		$this->apple_pay_config->shouldReceive('should_render')->andReturn(false)->byDefault();
 		$this->apple_pay_config->shouldReceive('display_name')->andReturn('Test Store')->byDefault();
+
+		$this->fastlane_config = Mockery::mock(FastlaneConfig::class);
+		$this->fastlane_config->shouldReceive('should_render')->andReturn(false)->byDefault();
 
 		// Reached unconditionally by script_data()'s Apple Pay validation block.
 		when('admin_url')->justReturn('https://example.com/wp-admin/admin-ajax.php');
@@ -100,7 +105,8 @@ class SdkV6ManagerTest extends TestCase
 	        $credit_card_icons,
 	        $merchant_country,
 	        $this->google_pay_config,
-	        $this->apple_pay_config
+	        $this->apple_pay_config,
+	        $this->fastlane_config
         );
     }
 
@@ -440,5 +446,87 @@ class SdkV6ManagerTest extends TestCase
                 [],
             ],
         ];
+    }
+
+    /**
+     * GIVEN a page context on which Fastlane's own config would allow it to render
+     * WHEN checking whether Fastlane is enabled for the current page
+     * THEN the answer follows FastlaneConfig::should_render() for that context
+     *
+     * @dataProvider fastlane_enablement_provider
+     */
+    public function testIsFastlaneEnabledDelegatesToFastlaneConfig(bool $should_render, bool $expected): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->fastlane_config->shouldReceive('should_render')->with('checkout')->andReturn($should_render);
+
+        $testee = $this->createTestee();
+
+        $this->assertSame($expected, $testee->is_fastlane_enabled());
+    }
+
+    public function fastlane_enablement_provider(): array
+    {
+        return [
+            'FastlaneConfig allowing render enables Fastlane' => [true, true],
+            'FastlaneConfig refusing render disables Fastlane' => [false, false],
+        ];
+    }
+
+    /**
+     * GIVEN the current page resolves to no supported page context (e.g. the shop
+     *       or home page)
+     * WHEN checking whether Fastlane is enabled for the current page
+     * THEN it is reported as disabled without asking FastlaneConfig, since there is
+     *      no context to evaluate
+     */
+    public function testIsFastlaneEnabledGuardsAgainstEmptyPageContext(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('');
+        $this->fastlane_config->shouldReceive('should_render')->never();
+
+        $testee = $this->createTestee();
+
+        $this->assertFalse($testee->is_fastlane_enabled());
+    }
+
+    /**
+     * GIVEN Fastlane's own configuration allows or refuses it for the current page
+     * WHEN the SDK bootstrap data is generated
+     * THEN the fastlane subtree carries a matching enabled flag and the ppcp-axo
+     *      gateway id the ppcp-axo modules register under
+     *
+     * @dataProvider fastlane_enablement_provider
+     */
+    public function testScriptDataIncludesFastlaneSubtree(bool $should_render, bool $expected_enabled): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->fastlane_config->shouldReceive('should_render')->with('checkout')->andReturn($should_render);
+
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card');
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no');
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false);
+        $this->session_handler->shouldReceive('order')->andReturn(null);
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false);
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false);
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([]);
+
+        when('WC')->justReturn($this->create_wc_stub());
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame(
+            ['enabled' => $expected_enabled, 'payment_method' => 'ppcp-axo-gateway'],
+            $data['fastlane']
+        );
     }
 }

--- a/tests/PHPUnit/SdkV6/Helper/FastlaneConfigTest.php
+++ b/tests/PHPUnit/SdkV6/Helper/FastlaneConfigTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WooCommerce\PayPalCommerce\SdkV6\Helper;
+
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
+use function Brain\Monkey\Functions\when;
+
+class FastlaneConfigTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * @var CardPaymentsConfiguration&Mockery\MockInterface
+	 */
+	private $card_payments_configuration;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		// Satisfy should_render()'s wp_loaded guard; the guard test overrides this.
+		when( 'did_action' )->justReturn( 1 );
+
+		when( 'is_user_logged_in' )->justReturn( false );
+
+		$this->card_payments_configuration = Mockery::mock( CardPaymentsConfiguration::class );
+	}
+
+	private function configFor( ?SubscriptionHelper $subscription_helper = null, ?callable $is_eligible = null ): FastlaneConfig {
+		return new FastlaneConfig(
+			$this->card_payments_configuration,
+			$subscription_helper ?? $this->noSubscriptions(),
+			$is_eligible ?? $this->eligible()
+		);
+	}
+
+	private function noSubscriptions(): SubscriptionHelper {
+		$helper = Mockery::mock( SubscriptionHelper::class );
+		$helper->shouldReceive( 'cart_contains_subscription' )->andReturn( false );
+
+		return $helper;
+	}
+
+	private function subscriptionInCart(): SubscriptionHelper {
+		$helper = Mockery::mock( SubscriptionHelper::class );
+		$helper->shouldReceive( 'cart_contains_subscription' )->andReturn( true );
+
+		return $helper;
+	}
+
+	private function eligible(): callable {
+		return static fn(): bool => true;
+	}
+
+	private function notEligible(): callable {
+		return static fn(): bool => false;
+	}
+
+	private function failIfCalled(): callable {
+		return function (): bool {
+			$this->fail( 'The eligibility callable must not be invoked.' );
+
+			return false;
+		};
+	}
+
+	private function useFastlane( bool $enabled ): void {
+		$this->card_payments_configuration->shouldReceive( 'use_fastlane' )->andReturn( $enabled );
+	}
+
+	/**
+	 * GIVEN wp_loaded has not run yet
+	 * AND every other gate would otherwise allow Fastlane to render
+	 * WHEN checking whether Fastlane should render at checkout
+	 * THEN it is reported as not rendering
+	 * AND the merchant reads a doing-it-wrong notice rather than a silently wrong answer
+	 */
+	public function testNotRenderedBeforeWpLoadedHasRun(): void {
+		when( 'did_action' )->justReturn( 0 );
+		when( '_doing_it_wrong' )->justReturn( null );
+
+		$this->useFastlane( true );
+
+		$config = $this->configFor( $this->noSubscriptions(), $this->failIfCalled() );
+
+		$this->assertFalse( $config->should_render( 'checkout' ) );
+	}
+
+	/**
+	 * GIVEN the page context is one Fastlane supports or not
+	 * WHEN checking whether Fastlane should render there
+	 * THEN only the checkout and checkout-block contexts are accepted
+	 *
+	 * @dataProvider context_provider
+	 */
+	public function testRenderedOnlyOnSupportedContexts( string $context, bool $expected ): void {
+		$this->useFastlane( true );
+
+		$config = $this->configFor();
+
+		$this->assertSame( $expected, $config->should_render( $context ) );
+	}
+
+	public function context_provider(): array {
+		return array(
+			'classic checkout is supported'    => array( 'checkout', true ),
+			'checkout block is supported'      => array( 'checkout-block', true ),
+			'product page is not supported'    => array( 'product', false ),
+			'cart page is not supported'       => array( 'cart', false ),
+			'pay-now page is not supported'    => array( 'pay-now', false ),
+			'mini-cart is not supported'       => array( 'mini-cart', false ),
+			'an unknown context is refused'    => array( 'some-unknown-context', false ),
+		);
+	}
+
+	/**
+	 * GIVEN the buyer is already logged in
+	 * WHEN checking whether Fastlane should render at checkout
+	 * THEN it is reported as not rendering, since a known customer already has
+	 * their details on file
+	 */
+	public function testNotRenderedWhenBuyerIsLoggedIn(): void {
+		when( 'is_user_logged_in' )->justReturn( true );
+
+		$this->useFastlane( true );
+
+		$config = $this->configFor();
+
+		$this->assertFalse( $config->should_render( 'checkout' ) );
+	}
+
+	/**
+	 * GIVEN the merchant's card payments configuration does not enable Fastlane
+	 * WHEN checking whether Fastlane should render at checkout
+	 * THEN it is reported as not rendering
+	 */
+	public function testNotRenderedWhenCardPaymentsConfigurationDisablesFastlane(): void {
+		$this->useFastlane( false );
+
+		$config = $this->configFor();
+
+		$this->assertFalse( $config->should_render( 'checkout' ) );
+	}
+
+	/**
+	 * GIVEN the cart contains a subscription product
+	 * WHEN checking whether Fastlane should render at checkout
+	 * THEN it is reported as not rendering, because this flow does not produce a
+	 * vaulted payment method a subscription would need
+	 */
+	public function testNotRenderedWhenCartContainsSubscription(): void {
+		$this->useFastlane( true );
+
+		$config = $this->configFor( $this->subscriptionInCart(), $this->failIfCalled() );
+
+		$this->assertFalse( $config->should_render( 'checkout' ) );
+	}
+
+	/**
+	 * GIVEN every other gate is satisfied but the injected eligibility callable
+	 * reports the merchant is not eligible (country/currency, merchant filter or
+	 * the gateway being disabled)
+	 * WHEN checking whether Fastlane should render at checkout
+	 * THEN it is reported as not rendering
+	 */
+	public function testNotRenderedWhenNotEligible(): void {
+		$this->useFastlane( true );
+
+		$config = $this->configFor( $this->noSubscriptions(), $this->notEligible() );
+
+		$this->assertFalse( $config->should_render( 'checkout' ) );
+	}
+
+	/**
+	 * GIVEN every gate that controls rendering is satisfied
+	 * WHEN checking whether Fastlane should render at checkout
+	 * THEN it is reported as rendering
+	 */
+	public function testRenderedWhenNothingBlocksIt(): void {
+		$this->useFastlane( true );
+
+		$config = $this->configFor( $this->noSubscriptions(), $this->eligible() );
+
+		$this->assertTrue( $config->should_render( 'checkout' ) );
+	}
+
+	/**
+	 * GIVEN an eligibility callable
+	 * WHEN the config object is constructed and should_render() is not called
+	 * THEN the callable is never invoked
+	 */
+	public function testConstructionDoesNotInvokeEligibilityCallable(): void {
+		$this->configFor( $this->noSubscriptions(), $this->failIfCalled() );
+
+		$this->addToAssertionCount( 1 );
+	}
+}

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -11,7 +11,10 @@
         "^@ppcp-card-fields/(.*)$": "<rootDir>/modules/ppcp-card-fields/resources/js/$1",
         "^@ppcp-paylater-block/(.*)$": "<rootDir>/modules/ppcp-paylater-block/resources/js/$1",
         "^@ppcp-googlepay/(.*)$": "<rootDir>/modules/ppcp-googlepay/resources/js/$1",
-        "^@ppcp-applepay/(.*)$": "<rootDir>/modules/ppcp-applepay/resources/js/$1"
+        "^@ppcp-applepay/(.*)$": "<rootDir>/modules/ppcp-applepay/resources/js/$1",
+        "^@ppcp-sdk-v6/(.*)$": "<rootDir>/modules/ppcp-sdk-v6/resources/js/$1",
+        "^@ppcp-axo/(.*)$": "<rootDir>/modules/ppcp-axo/resources/js/$1",
+        "^@ppcp-axo-block/(.*)$": "<rootDir>/modules/ppcp-axo-block/resources/js/$1"
     },
     "testPathIgnorePatterns": [
         "<rootDir>/tests/",


### PR DESCRIPTION
*Changelog:* `(none - behind the disabled sdk_v6 feature flag)`

# Description

## 🎯 The goal

Fastlane was the last surface still on the v5 SDK, and it was **dark** on every page v6 owns: the epic unregisters `ppcp-axo-gateway` from the block registry unconditionally, and on classic checkout the AXO assets never enqueued because their gate requires the v5 smart button, which is a `DisabledSmartButton` there.

## 🔍 Approach: swap the bootstrap, keep the UI

Only the bootstrap differs between the SDK versions. `sdkInstance.createFastlane()` returns an object exposing the same `identity`, `profile`, `FastlanePaymentComponent`, `FastlaneCardComponent`, `FastlaneWatermarkComponent` and `setLocale` members that `paypal.Fastlane()` did — so `Connection/Fastlane.js` (52 lines, the only SDK call site, shared by both AXO modules) picks the source, and the ~2,900 lines of AXO behaviour above it are untouched.

The server side needed nothing: `AxoGateway::process_payment()` consumes `axo_nonce` + `fastlane_member` and knows nothing about the SDK version.

**One deliberate deviation from the ticket:** the "Fastlane PHP endpoint for profile data" sub-item describes something that does not exist in v5 — the profile→WooCommerce mapping is entirely client-side (classic writes hidden billing/shipping inputs; blocks dispatch `wc/store/cart`). I have not invented one, since parity is the epic's acceptance criterion and a new endpoint would be a behaviour change with its own security surface. Happy to add it under a separate story if that bullet was intentional.

## PR Changes

**v6 module**
- `FastlaneConfig` decides whether Fastlane runs on a page: checkout contexts, guest, ACDC + Fastlane enabled, no subscription, merchant eligible. Mirrors `AxoApplies::should_render_fastlane()` minus its classic-only clause. Not a `WalletConfig` subclass — there is no button, no per-context styling, no gateway row to place.
- `SdkV6Manager` gains `is_fastlane_enabled()`, a fifth OR in `should_load_on_current_page()` (so v6 loads on a Fastlane-only checkout) and a `fastlane` script-data subtree carrying enablement only.
- `sdkLoader` requests the `fastlane` component on the shared instance.
- `SdkV6Module` suppresses the v5 Fastlane block method only where v6 cannot serve it, as the v5 card block is already handled.
- New `utils/config.js` resolves the v6 payload from either delivery route — the localized global on classic, `wcSettings` on block pages, where `enqueue()` deliberately skips.

**AXO modules**
- `Connection/Fastlane.js` splits into `connectV6()` / `connectV5()`, detecting the mode itself so neither caller changes.
- The classic bootstrap and the block script hook skip the v5 token fetch and script load in v6 mode; the block gateway-config hook accepts the v6 payload in place of v5's absent global.
- `AxoModule` loads the AXO assets when v6 supplies the SDK. Note the inversion against the wallet modules: they ask `sdk-v6.owns-current-page` to step aside, Fastlane asks it to keep going.

## 🐛 Three fixes only a real page load found

Worth calling out, because unit tests could not have caught any of them — all three live in the v5↔v6 seam:

1. **Two SDK instances.** `sdkLoader` memoized in module scope, but `ppcp-axo` and `ppcp-sdk-v6` are separate webpack bundles with separate module copies, so `web-sdk/v6/core` loaded twice and threw `NotSupportedError` re-registering its custom elements. The instance promise and the per-URL script cache now live on `window`.
2. **`clientMetadataId` is mandatory** when the `fastlane` component is requested — `createInstance` rejects without it. One id per page, on `window` for the same cross-bundle reason, since PayPal correlates it with the order.
3. **The block component rendered nothing.** `usePayPalCommerceGateway` only looked for v5's config global; without it `isConfigLoaded` stayed false, which gates the entire AXO block component.

Plus two robustness fixes in shared v5 code: the billing prefill no longer throws for a recognised profile with no saved card, and insights tracking no-ops instead of throwing a `ReferenceError` when its async script has not landed.

## Steps to Test

**Setup:** `PCP_SDK_V6_ENABLED=1`, US store, ACDC enabled, Fastlane enabled, **logged out**, no subscription in the cart, non-plain permalinks. Run `npm run build`.

Sanity check on classic checkout: `window.wc_ppcp_sdk_v6.fastlane` → `{ enabled: true, payment_method: "ppcp-axo-gateway" }`. On block checkout the global is absent by design; use `window.wc.wcSettings.getSetting( 'paymentMethodData' )[ 'ppcp-sdk-v6' ].fastlane`.

1. **Classic, guest:** enter an email with no Fastlane profile → card fields render → fill card **and the billing address** → place order. Completes.
2. **Classic, member:** enter a Fastlane test email → lookup → OTP (or silent session restore on a repeat) → shipping and card prefill.
3. **Block, member:** same on a Checkout-block page. Before this branch Fastlane was not a registered payment method there at all — `Object.keys( wcSettings.getSetting( 'paymentMethodData' ) )` should now include `ppcp-axo-gateway`.
4. **Network, either surface:** exactly one `web-sdk/v6/core`, one client-token request, and **no** `sdk/js?client-id=…` or `ppc-axo-script-attributes` — their absence is what proves the swap.
5. **Flag off:** v5 Fastlane still works unchanged.

## ✅ Tested / ❌ Not tested

| Surface | Flow | Status |
|---|---|---|
| Classic | guest | ✅ order placed and captured |
| Classic | member | ✅ lookup, OTP, session restore, prefill (order not completed) |
| Block | member | ✅ order placed |
| Block | guest | ❌ untested |
| v5, flag off | guest | ✅ unaffected |
| Any | 3DS challenge | ❌ never triggered by these orders |

## Follow-ups (not in this PR)

- `name_on_card` is read from different settings sources per surface (`fastlane_name_on_card()` raw legacy string on classic vs the resolved `show_name_on_card()` on blocks) and compared against `'1'` on classic where the value can only be `'yes'`/`'no'`/`''`. The cardholder-name field therefore never renders on classic. Pre-existing; changes which setting governs a checkout field, so it wants its own QA.
- A member order submitted with a **stale** Fastlane session fails with `403 NOT_AUTHORIZED / PERMISSION_DENIED` rather than anything resembling an expired token. Recovered by a fresh session. Pre-existing and identical on classic and block (both submit `profileData.card.id` as `single_use_token`), but the error is misleading enough to be worth a look.
