### PR TITLE
WC Subscriptions Integration (5788)

### DIFF
--- a/modules/ppcp-blocks/resources/js/paypal-config.js
+++ b/modules/ppcp-blocks/resources/js/paypal-config.js
@@ -273,12 +273,13 @@ export const handleApproveSubscription = async (
 			throw new Error( config.scriptData.labels.error.generic );
 		}
 
-		// A native PayPal subscription is already created and approved at this point,
-		// so there is no separate order to review or capture: complete the checkout
-		// directly instead of routing through the order-review continuation. This
-		// matches the classic checkout, whose subscription onApprove submits the
-		// order without a final-review step, and avoids leaving the buyer on the
-		// continuation page when final review is enabled.
+		// Native PayPal subscriptions always complete directly here, bypassing the
+		// order-review continuation. Unlike a one-time order, the subscription is
+		// already created and approved at this point and there is no capturable order
+		// to review, so routing through the continuation leaves the buyer unable to
+		// finish. This intentionally overrides "Require final confirmation" for native
+		// subscriptions on block checkout, matching the classic checkout (whose
+		// subscription onApprove submits the order without a final-review step).
 		setGotoContinuationOnError( true );
 		onSubmit();
 	} catch ( err ) {

--- a/modules/ppcp-blocks/resources/js/paypal-config.js
+++ b/modules/ppcp-blocks/resources/js/paypal-config.js
@@ -273,12 +273,14 @@ export const handleApproveSubscription = async (
 			throw new Error( config.scriptData.labels.error.generic );
 		}
 
-		if ( ! shouldskipFinalConfirmation() ) {
-			location.href = getCheckoutRedirectUrl();
-		} else {
-			setGotoContinuationOnError( true );
-			onSubmit();
-		}
+		// A native PayPal subscription is already created and approved at this point,
+		// so there is no separate order to review or capture: complete the checkout
+		// directly instead of routing through the order-review continuation. This
+		// matches the classic checkout, whose subscription onApprove submits the
+		// order without a final-review step, and avoids leaving the buyer on the
+		// continuation page when final review is enabled.
+		setGotoContinuationOnError( true );
+		onSubmit();
 	} catch ( err ) {
 		console.error( err );
 

--- a/modules/ppcp-blocks/src/PayPalPaymentMethod.php
+++ b/modules/ppcp-blocks/src/PayPalPaymentMethod.php
@@ -238,7 +238,7 @@ class PayPalPaymentMethod extends AbstractPaymentMethodType {
 		$smart_buttons_enabled = ! $this->use_place_order
 			&& $this->settings_status->is_smart_button_enabled_for_location( $script_data['context'] ?? 'block-checkout' );
 		$place_order_enabled   = ( $this->use_place_order || $this->add_place_order_method )
-			&& ( ! $this->subscription_helper->cart_contains_subscription() || $script_data['can_save_vault_token'] );
+			&& ( ! $this->subscription_helper->cart_contains_subscription() || ( $script_data['can_save_vault_token'] ?? false ) );
 		$cart                  = WC()->cart;
 
 		return array(

--- a/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
@@ -243,10 +243,15 @@ class ApproveSubscriptionEndpoint implements EndpointInterface {
 
 		// A native subscription's related order does not reliably expose a resolved
 		// payer id at approval time, so an absent id on either side is treated as
-		// "cannot compare" rather than a failure — the subscription is already bound
-		// to this session by validate_subscription() (status + custom_id ownership +
-		// plan match). Only a present, differing payer (an order approved by another
-		// account) is rejected.
+		// "cannot compare" rather than a failure. Only a present, differing payer (an
+		// order approved by another account) is rejected.
+		//
+		// Security note: this binding is best-effort. The subscription itself is
+		// session-bound by validate_subscription() (status + custom_id ownership +
+		// plan match), but the order is bound to the subscriber only when both payer
+		// ids resolve here — validate_custom_id_ownership() returns early for an order
+		// whose custom_id lacks the CustomIds::CUSTOMER_ID_PREFIX, so such an order
+		// with an unresolved payer is not independently tied to the subscriber.
 		if ( '' === $subscriber_payer_id || '' === $order_payer_id ) {
 			return;
 		}

--- a/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
+++ b/modules/ppcp-button/src/Endpoint/ApproveSubscriptionEndpoint.php
@@ -241,7 +241,17 @@ class ApproveSubscriptionEndpoint implements EndpointInterface {
 		$payer               = $order->payer();
 		$order_payer_id      = $payer ? $payer->payer_id() : '';
 
-		if ( '' === $subscriber_payer_id || '' === $order_payer_id || $order_payer_id !== $subscriber_payer_id ) {
+		// A native subscription's related order does not reliably expose a resolved
+		// payer id at approval time, so an absent id on either side is treated as
+		// "cannot compare" rather than a failure — the subscription is already bound
+		// to this session by validate_subscription() (status + custom_id ownership +
+		// plan match). Only a present, differing payer (an order approved by another
+		// account) is rejected.
+		if ( '' === $subscriber_payer_id || '' === $order_payer_id ) {
+			return;
+		}
+
+		if ( $order_payer_id !== $subscriber_payer_id ) {
 			throw new RuntimeException(
 				__( 'Order validation failed.', 'woocommerce-paypal-payments' )
 			);

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -156,11 +156,7 @@ async function submitCardSave( { config, session, responseTypes } ) {
 			};
 		}
 
-		await exchangeSetupToken(
-			config,
-			setupTokenId,
-			config.card_fields.payment_method
-		);
+		await exchangeSetupToken( config, setupTokenId );
 
 		return { type: responseTypes.SUCCESS };
 	} catch ( error ) {

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -217,6 +217,13 @@ export function V6CardFieldsComponent( {
 	const savePaymentRef = useRef( false );
 	savePaymentRef.current = Boolean( shouldSavePayment ) || hasSubscriptions;
 
+	// On a subscription cart the native "Save payment information…" option is
+	// suppressed (see checkout-block.js) and this component shows its own
+	// checked-and-disabled checkbox instead, since the card must always be
+	// vaulted for renewals and the native option cannot be locked.
+	const isVaultingEnabled = Boolean( config.card_fields.is_vaulting_enabled );
+	const showLockedSaveOption = hasSubscriptions && isVaultingEnabled;
+
 	// Read through a ref so onPaymentSetup sees the latest name without
 	// resubscribing every keystroke.
 	const cardNameRef = useRef( '' );
@@ -401,6 +408,40 @@ export function V6CardFieldsComponent( {
 						placeholder: __( 'CVV', 'woocommerce-paypal-payments' ),
 						containerStyle: { flex: 1 },
 					} )
+				)
+			),
+		// Subscription cart: a checked, disabled save option in place of the
+		// suppressed native one, so the buyer sees the card will be saved for
+		// renewals but cannot opt out (matches the classic checkout). A plain
+		// native checkbox, not WooCommerce's checkbox component, whose CSS hides
+		// the input in favour of an SVG mark this markup does not provide.
+		showLockedSaveOption &&
+			createElement(
+				'label',
+				{
+					className: 'ppcp-sdk-v6-card-fields__save',
+					htmlFor: 'ppcp-sdk-v6-save-payment-method',
+					style: {
+						display: 'flex',
+						alignItems: 'center',
+						gap: '8px',
+						cursor: 'default',
+					},
+				},
+				createElement( 'input', {
+					id: 'ppcp-sdk-v6-save-payment-method',
+					type: 'checkbox',
+					checked: true,
+					disabled: true,
+					readOnly: true,
+				} ),
+				createElement(
+					'span',
+					null,
+					__(
+						'Save payment information to my account for future purchases.',
+						'woocommerce-paypal-payments'
+					)
 				)
 			)
 	);

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.js
@@ -19,6 +19,10 @@ import {
 import { __ } from '@wordpress/i18n';
 import { loadSdkV6 } from '../sdkLoader';
 import { createCardOrder, approveCardOrder } from '../endpointsAdapter';
+import {
+	createCardSetupToken,
+	exchangeSetupToken,
+} from '../sessions/freeTrialSave';
 import { cardFieldStyles } from '../cardFields/cardFieldStyles';
 import { V6CardFieldContainer } from './V6CardFieldContainer';
 
@@ -103,6 +107,73 @@ async function submitCardPayment( {
 }
 
 /**
+ * Free-trial ($0) card checkout: save the card without a purchase.
+ *
+ * Creates a card setup token, confirms it through the save session (running 3D
+ * Secure when required), and exchanges it for a stored token. The $0 WC order is
+ * then placed by the card gateway's zero-total short-circuit on submit.
+ *
+ * @param {Object} args               - Arguments.
+ * @param {Object} args.config        - The sdk-v6 config object.
+ * @param {Object} args.session       - The v6 card-fields save session.
+ * @param {Object} args.responseTypes - The Blocks response-type constants.
+ * @return {Promise<Object>} A Blocks onPaymentSetup response object.
+ */
+async function submitCardSave( { config, session, responseTypes } ) {
+	if ( ! session ) {
+		return {
+			type: responseTypes.ERROR,
+			message: __(
+				'The card form is not ready yet. Please try again.',
+				'woocommerce-paypal-payments'
+			),
+		};
+	}
+
+	try {
+		const setupTokenId = await createCardSetupToken( config );
+		// The save session confirms the setup token (running 3D Secure when the
+		// store's contingency requires it); it takes no billing-address option.
+		const result = await session.submit( setupTokenId );
+
+		if ( result.state === 'canceled' ) {
+			return {
+				type: responseTypes.ERROR,
+				message: __(
+					'Card authentication was not completed. Please try again.',
+					'woocommerce-paypal-payments'
+				),
+			};
+		}
+
+		if ( result.state !== 'succeeded' ) {
+			return {
+				type: responseTypes.ERROR,
+				message: __(
+					'Card could not be saved.',
+					'woocommerce-paypal-payments'
+				),
+			};
+		}
+
+		await exchangeSetupToken(
+			config,
+			setupTokenId,
+			config.card_fields.payment_method
+		);
+
+		return { type: responseTypes.SUCCESS };
+	} catch ( error ) {
+		return {
+			type: responseTypes.ERROR,
+			message:
+				error?.message ||
+				__( 'Card could not be saved.', 'woocommerce-paypal-payments' ),
+		};
+	}
+}
+
+/**
  * @param {Object}  props                     - Props from the Blocks payment method registry.
  * @param {Object}  props.config              - The localized sdk-v6 config.
  * @param {Object}  props.eventRegistration   - Blocks checkout event subscriptions.
@@ -128,6 +199,10 @@ export function V6CardFieldsComponent( {
 	const hasNameField = Boolean( config.card_fields.name_field );
 
 	const hasSubscriptions = Boolean( config.card_fields.has_subscriptions );
+
+	// A $0 free-trial subscription card is vaulted through the save session (no
+	// purchase); the gateway places the $0 order on submit.
+	const isFreeTrial = Boolean( config.is_free_trial_cart );
 
 	const [ session, setSession ] = useState( null );
 	const [ inputStyle, setInputStyle ] = useState( null );
@@ -173,7 +248,9 @@ export function V6CardFieldsComponent( {
 
 		( async () => {
 			const sdk = await loadSdkV6( config, context );
-			const cardSession = sdk.createCardFieldsOneTimePaymentSession();
+			const cardSession = isFreeTrial
+				? sdk.createCardFieldsSavePaymentSession()
+				: sdk.createCardFieldsOneTimePaymentSession();
 			if ( active ) {
 				setSession( cardSession );
 			}
@@ -185,7 +262,7 @@ export function V6CardFieldsComponent( {
 		return () => {
 			active = false;
 		};
-	}, [ config, context ] );
+	}, [ config, context, isFreeTrial ] );
 
 	// v6 returns unstyled field elements, so derive their styling from a real
 	// block text input on the page (accurate theme height/padding/border),
@@ -215,16 +292,22 @@ export function V6CardFieldsComponent( {
 		}
 
 		return onPaymentSetup( () =>
-			submitCardPayment( {
-				config,
-				context,
-				session: sessionRef.current,
-				responseTypes,
-				savePaymentMethod: savePaymentRef.current,
-				cardName: cardNameRef.current?.trim() || '',
-				// null when no billing address is available (see billingRef effect).
-				billingAddress: billingRef.current,
-			} )
+			isFreeTrial
+				? submitCardSave( {
+						config,
+						session: sessionRef.current,
+						responseTypes,
+				  } )
+				: submitCardPayment( {
+						config,
+						context,
+						session: sessionRef.current,
+						responseTypes,
+						savePaymentMethod: savePaymentRef.current,
+						cardName: cardNameRef.current?.trim() || '',
+						// null when no billing address is available.
+						billingAddress: billingRef.current,
+				  } )
 		);
 	}, [
 		onPaymentSetup,
@@ -233,6 +316,7 @@ export function V6CardFieldsComponent( {
 		config,
 		context,
 		responseTypes,
+		isFreeTrial,
 	] );
 
 	const fieldsReady = session && inputStyle;

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -211,6 +211,54 @@ describe( 'V6CardFieldsComponent', () => {
 		);
 	} );
 
+	test( 'renders a checked, disabled locked save-option checkbox when the cart has subscriptions and vaulting is enabled', async () => {
+		renderComponent( {
+			config: cardConfig( {
+				card_fields: {
+					...cardConfig().card_fields,
+					has_subscriptions: true,
+					is_vaulting_enabled: true,
+				},
+			} ),
+		} );
+		await waitForSessionReady();
+
+		const checkbox = document.getElementById(
+			'ppcp-sdk-v6-save-payment-method'
+		);
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).toBeChecked();
+		expect( checkbox ).toBeDisabled();
+	} );
+
+	test.each( [
+		[
+			'the cart has no subscriptions',
+			{ has_subscriptions: false, is_vaulting_enabled: true },
+		],
+		[
+			'vaulting is disabled',
+			{ has_subscriptions: true, is_vaulting_enabled: false },
+		],
+	] )(
+		'does not render the locked save-option checkbox when %s',
+		async ( _label, overrides ) => {
+			renderComponent( {
+				config: cardConfig( {
+					card_fields: {
+						...cardConfig().card_fields,
+						...overrides,
+					},
+				} ),
+			} );
+			await waitForSessionReady();
+
+			expect(
+				document.getElementById( 'ppcp-sdk-v6-save-payment-method' )
+			).not.toBeInTheDocument();
+		}
+	);
+
 	test( 'passes savePaymentMethod false when the buyer does not opt in and there are no subscriptions', async () => {
 		mockCreateCardOrder.mockResolvedValueOnce( { orderId: 'ORDER1' } );
 		session.submit.mockResolvedValueOnce( { state: 'succeeded' } );

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -470,8 +470,7 @@ describe( 'V6CardFieldsComponent', () => {
 			expect( session.submit ).toHaveBeenCalledWith( 'SETUP1' );
 			expect( mockExchangeSetupToken ).toHaveBeenCalledWith(
 				freeTrialConfig(),
-				'SETUP1',
-				freeTrialConfig().card_fields.payment_method
+				'SETUP1'
 			);
 			expect( mockCreateCardOrder ).not.toHaveBeenCalled();
 			expect( mockApproveCardOrder ).not.toHaveBeenCalled();

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6CardFieldsComponent.test.js
@@ -20,6 +20,13 @@ jest.mock( './V6CardFieldContainer', () => ( {
 	V6CardFieldContainer: ( props ) => mockCardFieldContainer( props ),
 } ) );
 
+const mockCreateCardSetupToken = jest.fn();
+const mockExchangeSetupToken = jest.fn();
+jest.mock( '../sessions/freeTrialSave', () => ( {
+	createCardSetupToken: ( ...args ) => mockCreateCardSetupToken( ...args ),
+	exchangeSetupToken: ( ...args ) => mockExchangeSetupToken( ...args ),
+} ) );
+
 import {
 	render,
 	waitFor,
@@ -102,11 +109,14 @@ beforeEach( () => {
 
 	mockLoadSdkV6.mockReset().mockResolvedValue( {
 		createCardFieldsOneTimePaymentSession: () => session,
+		createCardFieldsSavePaymentSession: () => session,
 	} );
 	mockCreateCardOrder.mockReset();
 	mockApproveCardOrder.mockReset().mockResolvedValue( undefined );
 	mockCardFieldStyles.mockReset().mockReturnValue( { color: 'rgb(0,0,0)' } );
 	mockCardFieldContainer.mockClear();
+	mockCreateCardSetupToken.mockReset();
+	mockExchangeSetupToken.mockReset();
 } );
 
 describe( 'V6CardFieldsComponent', () => {
@@ -371,5 +381,107 @@ describe( 'V6CardFieldsComponent', () => {
 		} );
 
 		expect( session.submit ).toHaveBeenCalledWith( 'ORDER1' );
+	} );
+
+	describe( 'free-trial ($0 subscription) cart', () => {
+		function freeTrialConfig( overrides = {} ) {
+			return cardConfig( { is_free_trial_cart: true, ...overrides } );
+		}
+
+		test( 'creates the card save session instead of the one-time session', async () => {
+			mockLoadSdkV6.mockResolvedValueOnce( {
+				createCardFieldsOneTimePaymentSession: jest.fn(
+					() => new Error( 'must not be called' )
+				),
+				createCardFieldsSavePaymentSession: () => session,
+			} );
+
+			renderComponent( { config: freeTrialConfig() } );
+			await waitForSessionReady();
+
+			expect( mockCardFieldContainer ).toHaveBeenCalledWith(
+				expect.objectContaining( { session } )
+			);
+		} );
+
+		test( 'a successful save exchanges the setup token instead of creating and approving an order', async () => {
+			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
+			session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
+
+			renderComponent( { config: freeTrialConfig() } );
+			await waitForSessionReady();
+
+			let result;
+			await act( async () => {
+				result = await paymentSetupCb();
+			} );
+
+			expect( mockCreateCardSetupToken ).toHaveBeenCalledWith(
+				freeTrialConfig()
+			);
+			expect( session.submit ).toHaveBeenCalledWith( 'SETUP1' );
+			expect( mockExchangeSetupToken ).toHaveBeenCalledWith(
+				freeTrialConfig(),
+				'SETUP1',
+				freeTrialConfig().card_fields.payment_method
+			);
+			expect( mockCreateCardOrder ).not.toHaveBeenCalled();
+			expect( mockApproveCardOrder ).not.toHaveBeenCalled();
+			expect( result ).toEqual( { type: 'success' } );
+		} );
+
+		test( 'reports an error and skips the exchange when 3D Secure is canceled', async () => {
+			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
+			session.submit.mockResolvedValueOnce( { state: 'canceled' } );
+
+			renderComponent( { config: freeTrialConfig() } );
+			await waitForSessionReady();
+
+			let result;
+			await act( async () => {
+				result = await paymentSetupCb();
+			} );
+
+			expect( result.type ).toBe( 'error' );
+			expect( result.message ).toBeTruthy();
+			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
+		} );
+
+		test( 'reports an error and skips the exchange when the save session fails', async () => {
+			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
+			session.submit.mockResolvedValueOnce( { state: 'failed' } );
+
+			renderComponent( { config: freeTrialConfig() } );
+			await waitForSessionReady();
+
+			let result;
+			await act( async () => {
+				result = await paymentSetupCb();
+			} );
+
+			expect( result.type ).toBe( 'error' );
+			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
+		} );
+
+		test( 'reports the thrown error message when the token exchange fails', async () => {
+			mockCreateCardSetupToken.mockResolvedValueOnce( 'SETUP1' );
+			session.submit.mockResolvedValueOnce( { state: 'succeeded' } );
+			mockExchangeSetupToken.mockRejectedValueOnce(
+				new Error( 'exchange failed' )
+			);
+
+			renderComponent( { config: freeTrialConfig() } );
+			await waitForSessionReady();
+
+			let result;
+			await act( async () => {
+				result = await paymentSetupCb();
+			} );
+
+			expect( result ).toEqual( {
+				type: 'error',
+				message: 'exchange failed',
+			} );
+		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/blocks/V6ExpressComponent.js
+++ b/modules/ppcp-sdk-v6/resources/js/blocks/V6ExpressComponent.js
@@ -10,6 +10,10 @@ import { loadSdkV6 } from '../sdkLoader';
 import { checkEligibility } from '../eligibility';
 import { createSession } from '../sessions/createSession';
 import {
+	createFreeTrialPayPalSession,
+	createVaultSetupToken,
+} from '../sessions/freeTrialSave';
+import {
 	approveOrder,
 	approveOrderInSession,
 	createOrder,
@@ -74,6 +78,14 @@ export function V6ExpressComponent( {
 	const method = fundingSource;
 	const context = config.page_context;
 	const methodId = `ppcp-gateway-${ fundingSource }`;
+
+	// A $0 free-trial subscription is vaulted through the PayPal save flow rather
+	// than a one-time order: the buyer approves a setup token, it is exchanged for
+	// a stored token, and the Blocks checkout submit places the $0 WC order. Only
+	// PayPal is offered on such carts (see checkout-block.js), so guard on it.
+	const isFreeTrial =
+		Boolean( config.is_free_trial_cart ) &&
+		fundingSource === FundingSources.PAYPAL;
 
 	const [ sdk, setSdk ] = useState( null );
 	const [ eligibility, setEligibility ] = useState( null );
@@ -191,6 +203,9 @@ export function V6ExpressComponent( {
 					onClose();
 				}
 			},
+			// Free trial: the token is already stored, so just submit the Blocks
+			// checkout — the gateway places the $0 order server-side.
+			onFreeTrialComplete: () => onSubmit(),
 			shippingHandlers: buildBlocksShippingHandlers(
 				config,
 				shippingData
@@ -206,6 +221,19 @@ export function V6ExpressComponent( {
 
 	useEffect( () => {
 		if ( ! sdk ) {
+			return undefined;
+		}
+
+		// Free trial: a save session whose onApprove exchanges the setup token
+		// and then submits the Blocks checkout to place the $0 order. None of the
+		// one-time order/shipping/review wiring below applies.
+		if ( isFreeTrial ) {
+			setSession(
+				createFreeTrialPayPalSession( sdk, config, {
+					onComplete: () => callbacksRef.current.onFreeTrialComplete(),
+					onError: ( error ) => callbacksRef.current.onError( error ),
+				} )
+			);
 			return undefined;
 		}
 
@@ -236,7 +264,7 @@ export function V6ExpressComponent( {
 
 		// No teardown: the SDK cannot dispose a session, so every extra
 		// dependency here abandons one and remounts the button. Keep it narrow.
-	}, [ sdk, method, needsShipping, config, context ] );
+	}, [ sdk, method, needsShipping, config, context, isFreeTrial ] );
 
 	useEffect( () => {
 		if ( activePaymentMethod !== methodId ) {
@@ -325,7 +353,11 @@ export function V6ExpressComponent( {
 		method,
 		session,
 		styles,
-		createOrderFn: () => createOrder( config, context, fundingSource ),
+		// Free trial starts the save session with a setup token instead of an
+		// order; both resolve to the shape session.start() expects.
+		createOrderFn: isFreeTrial
+			? () => createVaultSetupToken( config )
+			: () => createOrder( config, context, fundingSource ),
 		payLaterDetails: eligibility?.payLaterDetails,
 		onClick,
 	} );

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -312,11 +312,28 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 	}
 
 	/**
+	 * Whether a saved PayPal token (not "Use a new payment method") is selected.
+	 * Such a payment is charged via the native Place Order button — server-side, or
+	 * through the vault component's in-page approval where eligible — not the v6
+	 * express button, which would start a new PayPal flow instead.
+	 *
+	 * @return {boolean} True when a saved ppcp-gateway token is selected.
+	 */
+	function isSavedPayPalTokenSelected() {
+		const checked = document.querySelector(
+			'input[name="wc-ppcp-gateway-payment-token"]:checked'
+		);
+		return Boolean( checked && checked.value && checked.value !== 'new' );
+	}
+
+	/**
 	 * Hides the native WC "Proceed to PayPal" button while the PayPal gateway
-	 * is selected — the v6 PayPal buttons stand in for it — and restores it for
-	 * cards (whose flow submits through it) and every other method. Re-run on
-	 * updated_checkout / payment_method_selected because WC rebuilds the
-	 * #payment DOM (and this inline style) on each update.
+	 * is selected with a NEW payment method — the v6 PayPal buttons stand in for
+	 * it — and restores it for cards, saved PayPal tokens (charged via Place
+	 * Order), and every other method. The v6 express button is hidden for a saved
+	 * token so it does not compete with it. Re-run on updated_checkout /
+	 * payment_method_selected / token change because WC rebuilds the #payment DOM
+	 * (and this inline style) on each update.
 	 */
 	function syncPlaceOrderButton() {
 		if (
@@ -329,9 +346,13 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 		const selected = document.querySelector(
 			'input[name="payment_method"]:checked'
 		)?.value;
-		const isPayPalGateway = selected === PAYPAL_GATEWAY_ID;
+		const useExpress =
+			selected === PAYPAL_GATEWAY_ID && ! isSavedPayPalTokenSelected();
 
-		setVisible( PLACE_ORDER_SELECTOR, ! isPayPalGateway, true );
+		setVisible( PLACE_ORDER_SELECTOR, ! useExpress, true );
+		if ( config.wrapper ) {
+			setVisible( config.wrapper, useExpress );
+		}
 	}
 
 	function initialRender() {
@@ -357,6 +378,14 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 		// change without a DOM rebuild, so re-sync the button on both.
 		jQuery( document.body ).on(
 			'updated_checkout payment_method_selected',
+			syncPlaceOrderButton
+		);
+
+		// Switching between a saved PayPal token and "new" flips whether the
+		// express button or Place Order should show, without a DOM rebuild.
+		jQuery( document ).on(
+			'change',
+			'input[name="wc-ppcp-gateway-payment-token"]',
 			syncPlaceOrderButton
 		);
 

--- a/modules/ppcp-sdk-v6/resources/js/boot.js
+++ b/modules/ppcp-sdk-v6/resources/js/boot.js
@@ -22,8 +22,13 @@ import { renderButtons } from './components/buttonRenderer';
 import { renderWallets } from './wallets/renderWallets';
 import { isWalletEnabled, WALLET_METHODS } from './wallets/walletRegistry';
 import { createOrder, fetchCartTotal } from './endpointsAdapter';
+import {
+	createFreeTrialPayPalSession,
+	createVaultSetupToken,
+} from './sessions/freeTrialSave';
 import { initCardFields } from './cardFields/renderer';
 import { hasJQuery } from './utils/api';
+import { FundingSources } from './utils/fundingSources';
 import { setErrorLabels } from './utils/errorHandler';
 import { setVisible } from '@ppcp-button/Helper/Hiding';
 
@@ -41,6 +46,32 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 	}
 
 	setErrorLabels( config.labels );
+
+	// A $0 free-trial subscription is vaulted through the PayPal save flow on the
+	// checkout / pay-for-order pages (the only contexts with a form to submit
+	// afterwards); other contexts keep the ordinary button flow.
+	const FREE_TRIAL_CONTEXTS = [ 'checkout', 'pay-now' ];
+	function isFreeTrialSave( context ) {
+		return (
+			Boolean( config.is_free_trial_cart ) &&
+			FREE_TRIAL_CONTEXTS.includes( context )
+		);
+	}
+
+	/**
+	 * Submits the checkout (or pay-for-order) form after the free-trial save
+	 * flow has stored the token, so the gateway places the $0 order.
+	 */
+	function submitCheckoutForm() {
+		if ( hasJQuery() ) {
+			const form = jQuery( 'form.checkout, form#order_review' );
+			if ( form.length ) {
+				form.trigger( 'submit' );
+				return;
+			}
+		}
+		document.querySelector( PLACE_ORDER_SELECTOR )?.click();
+	}
 
 	/**
 	 * Advanced Card Fields (ACDC): independent of the button render loop
@@ -115,6 +146,22 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 	 */
 	async function createSessions( context ) {
 		const sdk = await loadSdkV6( config, sdkPageType );
+
+		// Free trial: only the PayPal save session, whose approval stores a token
+		// and submits the checkout form (see renderTarget's createOrderForFunding).
+		if ( isFreeTrialSave( context ) ) {
+			return {
+				payLaterDetails: null,
+				map: {
+					[ FundingSources.PAYPAL ]: createFreeTrialPayPalSession(
+						sdk,
+						config,
+						{ onComplete: submitCheckoutForm }
+					),
+				},
+			};
+		}
+
 		const eligibility = await ensureEligibility();
 
 		const sessions = {
@@ -173,8 +220,12 @@ const PAYPAL_GATEWAY_ID = 'ppcp-gateway';
 			wrapper,
 			sessions: map,
 			styles: config.button_styles[ target.context ] || {},
-			createOrderForFunding: ( fundingSource ) => () =>
-				createOrder( config, target.context, fundingSource ),
+			createOrderForFunding: ( fundingSource ) =>
+				isFreeTrialSave( target.context ) &&
+				fundingSource === FundingSources.PAYPAL
+					? // Free trial starts the save session with a setup token.
+					  () => createVaultSetupToken( config )
+					: () => createOrder( config, target.context, fundingSource ),
 			payLaterDetails,
 		} );
 

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -12,10 +12,10 @@
  * number|expiry|cvv), so the native WC cardholder-name input is left in place
  * as a plain field and its value is forwarded to create-order instead.
  *
- * Scope: fresh card, one-time payment only. Saving a new card, paying with
- * an already-saved card, and the $0 free-trial variant are untouched
- * here — this defers to the native submit whenever a saved token is
- * selected.
+ * Scope: fresh card, one-time payment, plus the $0 free-trial variant (a
+ * subscription cart with no initial charge), which saves the card via a setup
+ * token instead of creating an order. Paying with an already-saved card still
+ * defers to the native submit whenever a saved token is selected.
  *
  * @package
  */
@@ -25,6 +25,10 @@ import { hide } from '@ppcp-button/Helper/Hiding';
 import Spinner from '@ppcp-button/Helper/Spinner';
 import { loadSdkV6 } from '../sdkLoader';
 import { createCardOrder, approveCardOrder } from '../endpointsAdapter';
+import {
+	createCardSetupToken,
+	exchangeSetupToken,
+} from '../sessions/freeTrialSave';
 import { hasJQuery } from '../utils/api';
 import { handleError } from '../utils/errorHandler';
 
@@ -157,6 +161,10 @@ export async function initCardFields( config ) {
 	const { fields, payment_method: paymentMethod } = config.card_fields;
 	const spinner = hasJQuery() ? Spinner.fullPage() : null;
 
+	// A $0 free-trial subscription card is saved via a setup token (no order);
+	// the gateway places the $0 order on the native submit that follows.
+	const isFreeTrial = Boolean( config.is_free_trial_cart );
+
 	let cardSessionPromise = null;
 	let submitting = false;
 	let boundPlaceOrderButton = null;
@@ -181,7 +189,9 @@ export async function initCardFields( config ) {
 			cardSessionPromise = ( async () => {
 				const inputs = getInputs();
 				const sdk = await loadSdkV6( config, 'checkout' );
-				const cardSession = sdk.createCardFieldsOneTimePaymentSession();
+				const cardSession = isFreeTrial
+					? sdk.createCardFieldsSavePaymentSession()
+					: sdk.createCardFieldsOneTimePaymentSession();
 
 				for ( const fieldType of FIELD_TYPES ) {
 					if ( inputs[ fieldType ] ) {
@@ -224,6 +234,30 @@ export async function initCardFields( config ) {
 
 		try {
 			const cardSession = await ensureCardSession();
+			const submitOptions = billingAddressForSubmit();
+
+			// Free trial: confirm a setup token and store it; the native submit
+			// that follows lets the gateway place the $0 order against it.
+			if ( isFreeTrial ) {
+				const setupTokenId = await createCardSetupToken( config );
+				// The save session takes no billing-address option; it confirms
+				// the setup token, running 3D Secure when required.
+				const saveResult = await cardSession.submit( setupTokenId );
+
+				if ( saveResult.state === 'canceled' ) {
+					return;
+				}
+				if ( saveResult.state !== 'succeeded' ) {
+					throw new Error( 'Card could not be saved.' );
+				}
+
+				await exchangeSetupToken( config, setupTokenId, paymentMethod );
+
+				submitting = true;
+				event.target.click();
+				return;
+			}
+
 			// The name has no v6 field component; read the plain WC input.
 			const cardName = getInputs().name?.value?.trim() || '';
 			const { orderId } = await createCardOrder(
@@ -232,7 +266,6 @@ export async function initCardFields( config ) {
 				cardName,
                 shouldSavePaymentMethod(),
 			);
-			const submitOptions = billingAddressForSubmit();
 			const result = submitOptions
 				? await cardSession.submit( orderId, submitOptions )
 				: await cardSession.submit( orderId );

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -276,7 +276,7 @@ export async function initCardFields( config ) {
 					throw new Error( 'Card could not be saved.' );
 				}
 
-				await exchangeSetupToken( config, setupTokenId, paymentMethod );
+				await exchangeSetupToken( config, setupTokenId );
 
 				submitting = true;
 				event.target.click();

--- a/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
+++ b/modules/ppcp-sdk-v6/resources/js/cardFields/renderer.js
@@ -128,6 +128,31 @@ function shouldSavePaymentMethod() {
 }
 
 /**
+ * Force-checks and disables the "Save to account" tokenization checkbox when the
+ * cart contains a subscription, so the card is always vaulted for renewals (the
+ * buyer cannot opt out). Mirrors v5's CardFieldsRenderer. No-op when vaulting is
+ * off (the checkbox is absent) or the cart has no subscription.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ */
+function forceSaveForSubscription( config ) {
+	if (
+		! config.card_fields?.has_subscriptions ||
+		! config.card_fields?.is_vaulting_enabled
+	) {
+		return;
+	}
+
+	const saveToAccount = document.querySelector(
+		'#wc-ppcp-credit-card-gateway-new-payment-method'
+	);
+	if ( saveToAccount ) {
+		saveToAccount.checked = true;
+		saveToAccount.disabled = true;
+	}
+}
+
+/**
  * Whether the card gateway is the currently selected checkout payment method.
  *
  * @param {string} paymentMethod - The card gateway's payment method ID.
@@ -303,6 +328,10 @@ export async function initCardFields( config ) {
 			return;
 		}
 
+		// Re-run on every DOM refresh: WC rebuilds the tokenization checkbox with
+		// the rest of #payment, so a single up-front call would not survive.
+		forceSaveForSubscription( config );
+
 		const placeOrderButton = document.querySelector( '#place_order' );
 		if (
 			! placeOrderButton ||
@@ -332,6 +361,9 @@ export async function initCardFields( config ) {
 		jQuery( document.body ).on( 'payment_method_selected', () => {
 			if ( isCardGatewaySelected( paymentMethod ) ) {
 				ensureCardSession().catch( handleError );
+				// The checkbox is only in the DOM once the card gateway's fields
+				// show, which selecting the method is what does.
+				forceSaveForSubscription( config );
 			}
 		} );
 	}

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -80,8 +80,13 @@ if ( config && config.page_context && config.continuation ) {
 		supports: {
 			// WooCommerce hides any method whose features do not cover every
 			// cart requirement, and v5's ppcp-gateway is unregistered here, so
-			// a missing feature leaves the buyer no way to pay or cancel.
-			features: [ 'products', 'subscriptions', 'ppcp_continuation' ],
+			// a missing feature leaves the buyer no way to pay or cancel. The
+			// gateway supports come from the server (subscription-aware);
+			// ppcp_continuation is always required in this branch.
+			features: [
+				...( config.supported_features || [ 'products' ] ),
+				'ppcp_continuation',
+			],
 		},
 	} );
 } else if ( config && config.page_context ) {
@@ -142,7 +147,9 @@ if ( config && config.page_context && config.continuation ) {
 				return Boolean( eligibility[ fundingSource ] );
 			},
 			supports: {
-				features: [ 'products' ],
+				// Server-provided gateway supports, so subscription carts do
+				// not filter the express buttons out (see continuation branch).
+				features: config.supported_features || [ 'products' ],
 				// Exposes the block's height and corner-radius controls, which
 				// arrive as the buttonAttributes prop.
 				style: [ 'height', 'borderRadius' ],
@@ -200,7 +207,9 @@ if ( config?.card_fields?.enabled && ! config.continuation ) {
 		),
 		canMakePayment: () => true,
 		supports: {
-			features: [ 'products' ],
+			// The credit-card gateway's supports from the server, so a
+			// subscription cart does not filter the card method out.
+			features: config.card_fields.supported_features || [ 'products' ],
 			// WooCommerce Blocks renders its native "Save payment information…"
 			// checkbox and exposes the choice as the shouldSavePayment prop;
 			// only offered when card vaulting is enabled.

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -30,7 +30,7 @@ import { FundingSources } from './utils/fundingSources';
 import { fundingSourceLabel } from './utils/fundingSourceLabel';
 import { minorUnitsToDecimal } from './utils/amount';
 
-const FUNDING_SOURCES = [
+const ALL_FUNDING_SOURCES = [
 	FundingSources.PAYPAL,
 	FundingSources.VENMO,
 	FundingSources.PAYLATER,
@@ -41,6 +41,13 @@ const FUNDING_SOURCES = [
 const paymentMethodData =
 	window.wc?.wcSettings?.getSetting?.( 'paymentMethodData' ) || {};
 const config = paymentMethodData[ 'ppcp-sdk-v6' ];
+
+// A free-trial ($0) subscription is vaulted through the PayPal save flow, which
+// only PayPal offers; Venmo/Pay Later cannot save without a purchase, so they are
+// suppressed on a free-trial cart (mirrors the v5 blocks checkout).
+const FUNDING_SOURCES = config?.is_free_trial_cart
+	? [ FundingSources.PAYPAL ]
+	: ALL_FUNDING_SOURCES;
 
 /**
  * Derives a decimal amount string from the WC Blocks cart totals.

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -26,6 +26,9 @@ import { V6ExpressComponent } from './blocks/V6ExpressComponent';
 import { V6ContinuationComponent } from './blocks/V6ContinuationComponent';
 import { V6CardFieldsComponent } from './blocks/V6CardFieldsComponent';
 import { V6EditorPreview } from './blocks/V6EditorPreview';
+// Reused as-is from the blocks module: renders the saved-PayPal vault approval
+// into the selected saved-token row (its own namespaced SDK, no v6 clash).
+import { PayPalSavedToken } from '@ppcp-blocks/Components/paypal-saved-token';
 import { FundingSources } from './utils/fundingSources';
 import { fundingSourceLabel } from './utils/fundingSourceLabel';
 import { minorUnitsToDecimal } from './utils/amount';
@@ -227,6 +230,54 @@ if ( config?.card_fields?.enabled && ! config.continuation ) {
 			showSaveOption:
 				Boolean( config.card_fields.is_vaulting_enabled ) &&
 				! config.card_fields.has_subscriptions,
+		},
+	} );
+}
+
+// Returning-buyer saved-PayPal selector. Registered as the regular ppcp-gateway
+// method (alongside the express ones) only when the buyer has an eligible saved
+// PayPal token, so WooCommerce Blocks renders its saved-token list and this
+// method supplies the in-row vault approval. New PayPal payments go through the
+// express button above, so this method exists for the saved token.
+if ( config?.vault_component?.is_eligible && ! config.continuation ) {
+	const vaultConfig = {
+		scriptData: {
+			vault_component: config.vault_component,
+			is_free_trial_cart: config.is_free_trial_cart,
+			client_id: config.vault_client_id,
+			script_attributes: config.script_attributes || {},
+		},
+	};
+
+	registerPaymentMethod( {
+		name: 'ppcp-gateway',
+		label: createElement(
+			'div',
+			null,
+			fundingSourceLabel( FundingSources.PAYPAL )
+		),
+		ariaLabel: fundingSourceLabel( FundingSources.PAYPAL ),
+		content: createElement(
+			'p',
+			{ className: 'ppcp-sdk-v6-saved-paypal-note' },
+			__(
+				'To pay with a different PayPal account, use the PayPal button at the top of the page.',
+				'woocommerce-paypal-payments'
+			)
+		),
+		edit: createElement( V6EditorPreview, {
+			fundingSource: FundingSources.PAYPAL,
+		} ),
+		// WooCommerce Blocks injects the selected token plus event props here.
+		savedTokenComponent: createElement( PayPalSavedToken, {
+			config: vaultConfig,
+		} ),
+		canMakePayment: () => true,
+		supports: {
+			features: config.supported_features || [ 'products' ],
+			// Renders WooCommerce Blocks' saved-token radio list for this gateway.
+			showSavedCards: true,
+			showSaveOption: false,
 		},
 	} );
 }

--- a/modules/ppcp-sdk-v6/resources/js/checkout-block.js
+++ b/modules/ppcp-sdk-v6/resources/js/checkout-block.js
@@ -219,8 +219,14 @@ if ( config?.card_fields?.enabled && ! config.continuation ) {
 			features: config.card_fields.supported_features || [ 'products' ],
 			// WooCommerce Blocks renders its native "Save payment information…"
 			// checkbox and exposes the choice as the shouldSavePayment prop;
-			// only offered when card vaulting is enabled.
-			showSaveOption: Boolean( config.card_fields.is_vaulting_enabled ),
+			// only offered when card vaulting is enabled. Suppressed on a
+			// subscription cart, where the card must always be vaulted for
+			// renewals: the card component renders its own checked-and-disabled
+			// checkbox instead (the native one cannot be locked), matching the
+			// classic checkout.
+			showSaveOption:
+				Boolean( config.card_fields.is_vaulting_enabled ) &&
+				! config.card_fields.has_subscriptions,
 		},
 	} );
 }

--- a/modules/ppcp-sdk-v6/resources/js/sessions/freeTrialSave.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/freeTrialSave.js
@@ -58,19 +58,14 @@ export async function createCardSetupToken( config ) {
  *
  * @param {Object} config          - The wc_ppcp_sdk_v6 config object.
  * @param {string} vaultSetupToken - The approved Vault v3 setup token id.
- * @param {string} [paymentMethod] - The WC gateway the token belongs to.
  * @return {Promise<void>} Resolves once the token has been stored.
  */
-export async function exchangeSetupToken( config, vaultSetupToken, paymentMethod ) {
+export async function exchangeSetupToken( config, vaultSetupToken ) {
 	if ( config.user?.is_logged ) {
-		const body = {
+		await postJson( config.ajax.create_payment_token, {
 			vault_setup_token: vaultSetupToken,
 			is_free_trial_cart: config.is_free_trial_cart ? '1' : '',
-		};
-		if ( paymentMethod ) {
-			body.payment_method = paymentMethod;
-		}
-		await postJson( config.ajax.create_payment_token, body );
+		} );
 		return;
 	}
 

--- a/modules/ppcp-sdk-v6/resources/js/sessions/freeTrialSave.js
+++ b/modules/ppcp-sdk-v6/resources/js/sessions/freeTrialSave.js
@@ -1,0 +1,127 @@
+/**
+ * Free-trial ($0) subscription checkout — the vault "save without purchase" flow.
+ *
+ * A subscription cart whose initial total is 0 must not create a $0 PayPal order.
+ * Instead the buyer approves a Vault v3 setup token, which is exchanged
+ * server-side for a stored payment token, and the checkout is then submitted so
+ * the gateway places the $0 WC order via its zero-total short-circuit. The stored
+ * token is what WooCommerce Subscriptions charges on the first real renewal.
+ *
+ * Shared by every checkout surface (classic, blocks, pay-for-order) so the
+ * request/response contract with the save-payment endpoints lives in one place.
+ *
+ * @package
+ */
+
+import { postJson } from '../utils/api';
+import { handleError } from '../utils/errorHandler';
+
+/**
+ * Requests a PayPal wallet setup token from the existing WC AJAX endpoint.
+ *
+ * The returned promise is handed to session.start() unawaited — awaiting it
+ * first loses the transient user activation and breaks the popup. It resolves
+ * to a { vaultSetupToken } object, mirroring the { orderId } shape the one-time
+ * session's create function returns.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @return {Promise<{vaultSetupToken: string}>} The setup token.
+ */
+export function createVaultSetupToken( config ) {
+	return postJson( config.ajax.create_setup_token ).then( ( data ) => ( {
+		vaultSetupToken: data.id,
+	} ) );
+}
+
+/**
+ * Requests a card setup token (with the store's 3DS/SCA contingency) from the
+ * existing WC AJAX endpoint, for the card save session to confirm.
+ *
+ * @param {Object} config - The wc_ppcp_sdk_v6 config object.
+ * @return {Promise<string>} Resolves to the setup token id.
+ */
+export async function createCardSetupToken( config ) {
+	const data = await postJson( config.ajax.create_setup_token, {
+		payment_method: config.card_fields?.payment_method,
+		verification_method: config.verification_method,
+	} );
+	return data.id;
+}
+
+/**
+ * Exchanges an approved setup token for a stored WC payment token.
+ *
+ * Logged-in buyers use the create-payment-token endpoint (which links the token
+ * to the account and, for cards, stashes it in the session for the gateway);
+ * guests use the guest endpoint, which stashes the PayPal token object in the
+ * session for the gateway to consume on order placement.
+ *
+ * @param {Object} config          - The wc_ppcp_sdk_v6 config object.
+ * @param {string} vaultSetupToken - The approved Vault v3 setup token id.
+ * @param {string} [paymentMethod] - The WC gateway the token belongs to.
+ * @return {Promise<void>} Resolves once the token has been stored.
+ */
+export async function exchangeSetupToken( config, vaultSetupToken, paymentMethod ) {
+	if ( config.user?.is_logged ) {
+		const body = {
+			vault_setup_token: vaultSetupToken,
+			is_free_trial_cart: config.is_free_trial_cart ? '1' : '',
+		};
+		if ( paymentMethod ) {
+			body.payment_method = paymentMethod;
+		}
+		await postJson( config.ajax.create_payment_token, body );
+		return;
+	}
+
+	await postJson( config.ajax.create_payment_token_for_guest, {
+		vault_setup_token: vaultSetupToken,
+	} );
+}
+
+/**
+ * Creates a PayPal "save without purchase" session for a free-trial checkout.
+ *
+ * onApprove exchanges the setup token and then calls `onComplete`, which each
+ * surface implements to submit its checkout (classic: `#place_order`; blocks:
+ * the Blocks `onSubmit`).
+ *
+ * @param {Object}     sdkInstance        - The PayPal SDK v6 instance.
+ * @param {Object}     config             - The wc_ppcp_sdk_v6 config object.
+ * @param {Object}     handlers           - Surface callbacks.
+ * @param {() => void} handlers.onComplete - Submits the checkout after the token is stored.
+ * @param {(error: Error) => void} [handlers.onError] - Called on failure.
+ * @return {Object} The PayPal save payment session.
+ */
+export function createFreeTrialPayPalSession(
+	sdkInstance,
+	config,
+	{ onComplete, onError } = {}
+) {
+	return sdkInstance.createPayPalSavePaymentSession( {
+		async onApprove( data ) {
+			try {
+				await exchangeSetupToken( config, data.vaultSetupToken );
+				if ( onComplete ) {
+					onComplete();
+				}
+			} catch ( error ) {
+				if ( onError ) {
+					onError( error );
+				} else {
+					handleError( error );
+				}
+			}
+		},
+
+		onCancel() {},
+
+		onError( error ) {
+			if ( onError ) {
+				onError( error );
+			} else {
+				handleError( error );
+			}
+		},
+	} );
+}

--- a/modules/ppcp-sdk-v6/resources/js/test/blocks/V6ExpressComponent.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/blocks/V6ExpressComponent.test.js
@@ -45,6 +45,20 @@ jest.mock( '../../blocks/blocksShippingHandlers', () => ( {
 		mockBuildShippingHandlers( ...args ),
 } ) );
 
+let capturedSaveSessionHandlers = null;
+const mockCreateFreeTrialPayPalSession = jest.fn(
+	( sdk, config, handlers ) => {
+		capturedSaveSessionHandlers = handlers;
+		return { fake: 'save-session' };
+	}
+);
+const mockCreateVaultSetupToken = jest.fn();
+jest.mock( '../../sessions/freeTrialSave', () => ( {
+	createFreeTrialPayPalSession: ( ...args ) =>
+		mockCreateFreeTrialPayPalSession( ...args ),
+	createVaultSetupToken: ( ...args ) => mockCreateVaultSetupToken( ...args ),
+} ) );
+
 import { render, waitFor, act } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 import { V6ExpressComponent } from '../../blocks/V6ExpressComponent';
@@ -118,6 +132,9 @@ beforeEach( () => {
 		onShippingAddressChange: jest.fn(),
 		onShippingOptionsChange: jest.fn(),
 	} );
+	capturedSaveSessionHandlers = null;
+	mockCreateFreeTrialPayPalSession.mockClear();
+	mockCreateVaultSetupToken.mockReset();
 
 	onPaymentSetup = jest.fn( ( cb ) => {
 		paymentSetupCb = cb;
@@ -640,5 +657,103 @@ describe( 'V6ExpressComponent', () => {
 
 		expect( second ).toHaveBeenCalledTimes( 1 );
 		expect( first ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'free-trial ($0 subscription) cart', () => {
+		test( 'creates the save session instead of a one-time session for the paypal button', async () => {
+			renderComponent( {
+				config: { ...config, is_free_trial_cart: true },
+				fundingSource: 'paypal',
+			} );
+
+			await waitFor( () =>
+				expect( mockCreateFreeTrialPayPalSession ).toHaveBeenCalled()
+			);
+
+			expect( mockCreateSession ).not.toHaveBeenCalled();
+			expect( mockButtonContainer ).toHaveBeenCalled();
+			const props = mockButtonContainer.mock.calls.at( -1 )[ 0 ];
+			expect( props.session ).toEqual( { fake: 'save-session' } );
+		} );
+
+		test( "the button's createOrderFn requests a vault setup token instead of a paypal order", async () => {
+			renderComponent( {
+				config: { ...config, is_free_trial_cart: true },
+				fundingSource: 'paypal',
+			} );
+			await waitFor( () =>
+				expect( mockButtonContainer ).toHaveBeenCalled()
+			);
+
+			const props = mockButtonContainer.mock.calls.at( -1 )[ 0 ];
+			props.createOrderFn();
+
+			expect( mockCreateVaultSetupToken ).toHaveBeenCalledWith( {
+				...config,
+				is_free_trial_cart: true,
+			} );
+			expect( mockCreateOrder ).not.toHaveBeenCalled();
+		} );
+
+		test( 'submits the Blocks checkout once the exchanged setup token completes', async () => {
+			const onSubmit = jest.fn();
+
+			renderComponent( {
+				config: { ...config, is_free_trial_cart: true },
+				fundingSource: 'paypal',
+				onSubmit,
+			} );
+			await waitFor( () =>
+				expect( mockCreateFreeTrialPayPalSession ).toHaveBeenCalled()
+			);
+
+			capturedSaveSessionHandlers.onComplete();
+
+			expect( onSubmit ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'releases the express UI through onError when the token exchange fails', async () => {
+			const onError = jest.fn();
+			const onClose = jest.fn();
+
+			renderComponent( {
+				config: { ...config, is_free_trial_cart: true },
+				fundingSource: 'paypal',
+				onError,
+				onClose,
+			} );
+			await waitFor( () =>
+				expect( mockCreateFreeTrialPayPalSession ).toHaveBeenCalled()
+			);
+
+			capturedSaveSessionHandlers.onError( new Error( 'exchange failed' ) );
+
+			expect( onError ).toHaveBeenCalledWith( 'exchange failed' );
+			expect( onClose ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'creates the ordinary one-time session for a non-paypal funding source, even on a free-trial cart', async () => {
+			renderComponent( {
+				config: { ...config, is_free_trial_cart: true },
+				fundingSource: 'venmo',
+				activePaymentMethod: 'ppcp-gateway-venmo',
+			} );
+
+			await waitFor( () => expect( mockCreateSession ).toHaveBeenCalled() );
+
+			expect( mockCreateFreeTrialPayPalSession ).not.toHaveBeenCalled();
+		} );
+
+		test( 'creates the ordinary one-time session when the cart is not a free trial', async () => {
+			renderComponent();
+
+			await waitFor( () => expect( mockCreateSession ).toHaveBeenCalled() );
+
+			expect( mockCreateFreeTrialPayPalSession ).not.toHaveBeenCalled();
+			const props = mockButtonContainer.mock.calls.at( -1 )[ 0 ];
+			props.createOrderFn();
+			expect( mockCreateOrder ).toHaveBeenCalled();
+			expect( mockCreateVaultSetupToken ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -635,8 +635,7 @@ describe( 'initCardFields', () => {
 			expect( cardSession.submit ).toHaveBeenCalledWith( 'SETUP1' );
 			expect( mockExchangeSetupToken ).toHaveBeenCalledWith(
 				freeTrialConfig(),
-				'SETUP1',
-				'ppcp-credit-card-gateway'
+				'SETUP1'
 			);
 			expect( mockCreateCardOrder ).not.toHaveBeenCalled();
 			expect( mockApproveCardOrder ).not.toHaveBeenCalled();

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -690,4 +690,137 @@ describe( 'initCardFields', () => {
 			expect( nativeSubmits ).toBe( 0 );
 		} );
 	} );
+
+	describe( 'subscription cart (force-save the tokenization checkbox)', () => {
+		function subscriptionConfig( overrides = {} ) {
+			return baseConfig( {
+				card_fields: {
+					...baseConfig().card_fields,
+					has_subscriptions: true,
+					is_vaulting_enabled: true,
+					...overrides,
+				},
+			} );
+		}
+
+		test( 'checks and disables the save-to-account checkbox on attach when the cart has a subscription and vaulting is enabled', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			document.body.insertAdjacentHTML(
+				'beforeend',
+				'<input type="checkbox" id="wc-ppcp-credit-card-gateway-new-payment-method" />'
+			);
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () =>
+					makeCardSession(),
+			} );
+
+			await initCardFields( subscriptionConfig() );
+			await flushPromises();
+
+			const checkbox = document.querySelector(
+				'#wc-ppcp-credit-card-gateway-new-payment-method'
+			);
+			expect( checkbox.checked ).toBe( true );
+			expect( checkbox.disabled ).toBe( true );
+		} );
+
+		test( 'leaves the save-to-account checkbox untouched when the cart has no subscription', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			document.body.insertAdjacentHTML(
+				'beforeend',
+				'<input type="checkbox" id="wc-ppcp-credit-card-gateway-new-payment-method" />'
+			);
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () =>
+					makeCardSession(),
+			} );
+
+			await initCardFields(
+				subscriptionConfig( { has_subscriptions: false } )
+			);
+			await flushPromises();
+
+			const checkbox = document.querySelector(
+				'#wc-ppcp-credit-card-gateway-new-payment-method'
+			);
+			expect( checkbox.checked ).toBe( false );
+			expect( checkbox.disabled ).toBe( false );
+		} );
+
+		test( 'leaves the save-to-account checkbox untouched when vaulting is disabled', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			document.body.insertAdjacentHTML(
+				'beforeend',
+				'<input type="checkbox" id="wc-ppcp-credit-card-gateway-new-payment-method" />'
+			);
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () =>
+					makeCardSession(),
+			} );
+
+			await initCardFields(
+				subscriptionConfig( { is_vaulting_enabled: false } )
+			);
+			await flushPromises();
+
+			const checkbox = document.querySelector(
+				'#wc-ppcp-credit-card-gateway-new-payment-method'
+			);
+			expect( checkbox.checked ).toBe( false );
+			expect( checkbox.disabled ).toBe( false );
+		} );
+
+		test( 'is a no-op when the checkbox is absent from the DOM (vaulting off server-side)', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () =>
+					makeCardSession(),
+			} );
+
+			await expect(
+				initCardFields( subscriptionConfig() )
+			).resolves.not.toThrow();
+			await flushPromises();
+
+			expect(
+				document.querySelector(
+					'#wc-ppcp-credit-card-gateway-new-payment-method'
+				)
+			).toBeNull();
+		} );
+
+		test( 'force-checks the checkbox again when payment_method_selected fires with the card gateway now selected', async () => {
+			// The checkbox is only in the DOM once the card gateway's fields
+			// show, which selecting the method is what does; simulate that
+			// by starting on a different gateway with no checkbox present.
+			buildCheckoutDom( 'ppcp-gateway' );
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsOneTimePaymentSession: () =>
+					makeCardSession(),
+			} );
+
+			await initCardFields( subscriptionConfig() );
+			await flushPromises();
+
+			document.querySelector(
+				'input[value="ppcp-gateway"]'
+			).checked = false;
+			document.querySelector(
+				'input[value="ppcp-credit-card-gateway"]'
+			).checked = true;
+			document.body.insertAdjacentHTML(
+				'beforeend',
+				'<input type="checkbox" id="wc-ppcp-credit-card-gateway-new-payment-method" />'
+			);
+
+			triggerBodyEvent( 'payment_method_selected' );
+			await flushPromises();
+
+			const checkbox = document.querySelector(
+				'#wc-ppcp-credit-card-gateway-new-payment-method'
+			);
+			expect( checkbox.checked ).toBe( true );
+			expect( checkbox.disabled ).toBe( true );
+		} );
+	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/cardFieldsRenderer.test.js
@@ -48,6 +48,13 @@ jest.mock( '../utils/errorHandler', () => ( {
 	handleError: ( ...args ) => mockHandleError( ...args ),
 } ) );
 
+const mockCreateCardSetupToken = jest.fn();
+const mockExchangeSetupToken = jest.fn();
+jest.mock( '../sessions/freeTrialSave', () => ( {
+	createCardSetupToken: ( ...args ) => mockCreateCardSetupToken( ...args ),
+	exchangeSetupToken: ( ...args ) => mockExchangeSetupToken( ...args ),
+} ) );
+
 import { initCardFields } from '../cardFields/renderer';
 
 /**
@@ -122,6 +129,8 @@ function triggerBodyEvent( event ) {
 beforeEach( () => {
 	jest.clearAllMocks();
 	mockHasJQuery.mockReturnValue( true );
+	mockCreateCardSetupToken.mockReset();
+	mockExchangeSetupToken.mockReset();
 	bodyHandlers = {};
 	global.jQuery = jest.fn( () => ( {
 		on: ( event, handler ) => {
@@ -579,5 +588,106 @@ describe( 'initCardFields', () => {
 		expect( mockHandleError ).not.toHaveBeenCalled();
 		expect( mockApproveCardOrder ).not.toHaveBeenCalled();
 		expect( nativeSubmits ).toBe( 0 );
+	} );
+
+	describe( 'free-trial ($0 subscription) cart', () => {
+		function freeTrialConfig( overrides = {} ) {
+			return baseConfig( { is_free_trial_cart: true, ...overrides } );
+		}
+
+		test( 'mounts the fields from the card save session instead of the one-time session', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const cardSession = makeCardSession();
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsSavePaymentSession: () => cardSession,
+			} );
+
+			await initCardFields( freeTrialConfig() );
+			await flushPromises();
+
+			expect( cardSession.createCardFieldsComponent ).toHaveBeenCalledTimes(
+				3
+			);
+		} );
+
+		test( 'a new-card submission creates a setup token, confirms it through the save session, exchanges it, then re-clicks place_order', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const cardSession = makeCardSession( { state: 'succeeded' } );
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsSavePaymentSession: () => cardSession,
+			} );
+			mockCreateCardSetupToken.mockResolvedValue( 'SETUP1' );
+			mockExchangeSetupToken.mockResolvedValue( undefined );
+
+			await initCardFields( freeTrialConfig() );
+			await flushPromises();
+
+			const placeOrder = document.querySelector( '#place_order' );
+			let nativeSubmits = 0;
+			placeOrder.addEventListener( 'click', () => nativeSubmits++ );
+
+			placeOrder.click();
+			await flushPromises();
+
+			expect( mockCreateCardSetupToken ).toHaveBeenCalledWith(
+				freeTrialConfig()
+			);
+			expect( cardSession.submit ).toHaveBeenCalledWith( 'SETUP1' );
+			expect( mockExchangeSetupToken ).toHaveBeenCalledWith(
+				freeTrialConfig(),
+				'SETUP1',
+				'ppcp-credit-card-gateway'
+			);
+			expect( mockCreateCardOrder ).not.toHaveBeenCalled();
+			expect( mockApproveCardOrder ).not.toHaveBeenCalled();
+			expect( nativeSubmits ).toBe( 1 );
+			expect( mockHandleError ).not.toHaveBeenCalled();
+		} );
+
+		test( 'a canceled 3DS challenge on the save session is silent and does not re-click place_order', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const cardSession = makeCardSession( { state: 'canceled' } );
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsSavePaymentSession: () => cardSession,
+			} );
+			mockCreateCardSetupToken.mockResolvedValue( 'SETUP1' );
+
+			await initCardFields( freeTrialConfig() );
+			await flushPromises();
+
+			const placeOrder = document.querySelector( '#place_order' );
+			let nativeSubmits = 0;
+			placeOrder.addEventListener( 'click', () => nativeSubmits++ );
+
+			placeOrder.click();
+			await flushPromises();
+
+			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
+			expect( mockHandleError ).not.toHaveBeenCalled();
+			expect( nativeSubmits ).toBe( 0 );
+		} );
+
+		test( 'a failed save session surfaces the error and does not re-click place_order', async () => {
+			buildCheckoutDom( 'ppcp-credit-card-gateway' );
+			const cardSession = makeCardSession( { state: 'failed' } );
+			mockLoadSdkV6.mockResolvedValue( {
+				createCardFieldsSavePaymentSession: () => cardSession,
+			} );
+			mockCreateCardSetupToken.mockResolvedValue( 'SETUP1' );
+
+			await initCardFields( freeTrialConfig() );
+			await flushPromises();
+
+			const placeOrder = document.querySelector( '#place_order' );
+			let nativeSubmits = 0;
+			placeOrder.addEventListener( 'click', () => nativeSubmits++ );
+
+			placeOrder.click();
+			await flushPromises();
+
+			expect( mockExchangeSetupToken ).not.toHaveBeenCalled();
+			expect( mockHandleError ).toHaveBeenCalled();
+			expect( nativeSubmits ).toBe( 0 );
+		} );
 	} );
 } );

--- a/modules/ppcp-sdk-v6/resources/js/test/freeTrialSave.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/freeTrialSave.test.js
@@ -1,0 +1,223 @@
+const mockPostJson = jest.fn();
+jest.mock( '../utils/api', () => ( {
+	postJson: ( ...args ) => mockPostJson( ...args ),
+} ) );
+
+const mockHandleError = jest.fn();
+jest.mock( '../utils/errorHandler', () => ( {
+	handleError: ( ...args ) => mockHandleError( ...args ),
+} ) );
+
+import {
+	createVaultSetupToken,
+	createCardSetupToken,
+	exchangeSetupToken,
+	createFreeTrialPayPalSession,
+} from '../sessions/freeTrialSave';
+
+const baseConfig = ( overrides = {} ) => ( {
+	ajax: {
+		create_setup_token: { endpoint: '/cst', nonce: 'n-cst' },
+		create_payment_token: { endpoint: '/cpt', nonce: 'n-cpt' },
+		create_payment_token_for_guest: { endpoint: '/cptg', nonce: 'n-cptg' },
+	},
+	user: { is_logged: true },
+	card_fields: { payment_method: 'ppcp-credit-card-gateway' },
+	verification_method: 'SCA_ALWAYS',
+	is_free_trial_cart: true,
+	...overrides,
+} );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'createVaultSetupToken', () => {
+	test( 'posts to the create-setup-token endpoint and resolves the setup token id', async () => {
+		mockPostJson.mockResolvedValueOnce( { id: 'SETUP1' } );
+
+		const result = await createVaultSetupToken( baseConfig() );
+
+		expect( mockPostJson ).toHaveBeenCalledWith(
+			baseConfig().ajax.create_setup_token
+		);
+		expect( result ).toEqual( { vaultSetupToken: 'SETUP1' } );
+	} );
+} );
+
+describe( 'createCardSetupToken', () => {
+	test( 'posts the card payment method and verification method, resolving to the setup token id', async () => {
+		mockPostJson.mockResolvedValueOnce( { id: 'CARDSETUP1' } );
+
+		const result = await createCardSetupToken( baseConfig() );
+
+		expect( mockPostJson ).toHaveBeenCalledWith(
+			baseConfig().ajax.create_setup_token,
+			{
+				payment_method: 'ppcp-credit-card-gateway',
+				verification_method: 'SCA_ALWAYS',
+			}
+		);
+		expect( result ).toBe( 'CARDSETUP1' );
+	} );
+} );
+
+describe( 'exchangeSetupToken', () => {
+	test( 'posts to the logged-in endpoint with the payment method and free-trial flag when the buyer is logged in', async () => {
+		mockPostJson.mockResolvedValueOnce( {} );
+
+		await exchangeSetupToken(
+			baseConfig(),
+			'SETUP1',
+			'ppcp-gateway'
+		);
+
+		expect( mockPostJson ).toHaveBeenCalledWith(
+			baseConfig().ajax.create_payment_token,
+			{
+				vault_setup_token: 'SETUP1',
+				is_free_trial_cart: '1',
+				payment_method: 'ppcp-gateway',
+			}
+		);
+	} );
+
+	test( 'omits the payment method when none is given', async () => {
+		mockPostJson.mockResolvedValueOnce( {} );
+
+		await exchangeSetupToken( baseConfig(), 'SETUP1' );
+
+		expect( mockPostJson ).toHaveBeenCalledWith(
+			baseConfig().ajax.create_payment_token,
+			{
+				vault_setup_token: 'SETUP1',
+				is_free_trial_cart: '1',
+			}
+		);
+	} );
+
+	test( 'sends an empty free-trial flag when the cart is not a free trial', async () => {
+		mockPostJson.mockResolvedValueOnce( {} );
+
+		await exchangeSetupToken(
+			baseConfig( { is_free_trial_cart: false } ),
+			'SETUP1'
+		);
+
+		expect( mockPostJson ).toHaveBeenCalledWith(
+			baseConfig().ajax.create_payment_token,
+			{
+				vault_setup_token: 'SETUP1',
+				is_free_trial_cart: '',
+			}
+		);
+	} );
+
+	test( 'posts to the guest endpoint with only the setup token when the buyer is not logged in', async () => {
+		mockPostJson.mockResolvedValueOnce( {} );
+
+		await exchangeSetupToken(
+			baseConfig( { user: { is_logged: false } } ),
+			'SETUP1',
+			'ppcp-gateway'
+		);
+
+		expect( mockPostJson ).toHaveBeenCalledWith(
+			baseConfig().ajax.create_payment_token_for_guest,
+			{ vault_setup_token: 'SETUP1' }
+		);
+	} );
+} );
+
+describe( 'createFreeTrialPayPalSession', () => {
+	function fakeSdk() {
+		const capture = {};
+		return {
+			capture,
+			createPayPalSavePaymentSession: ( sessionConfig ) => {
+				capture.config = sessionConfig;
+				return { session: true };
+			},
+		};
+	}
+
+	test( 'builds the save session from the sdk instance with onApprove, onCancel and onError handlers', () => {
+		const sdk = fakeSdk();
+
+		const session = createFreeTrialPayPalSession( sdk, baseConfig() );
+
+		expect( session ).toEqual( { session: true } );
+		expect( sdk.capture.config.onApprove ).toBeInstanceOf( Function );
+		expect( sdk.capture.config.onCancel ).toBeInstanceOf( Function );
+		expect( sdk.capture.config.onError ).toBeInstanceOf( Function );
+	} );
+
+	test( 'onApprove exchanges the setup token and calls onComplete on success', async () => {
+		const sdk = fakeSdk();
+		mockPostJson.mockResolvedValueOnce( {} );
+		const onComplete = jest.fn();
+		const onError = jest.fn();
+
+		createFreeTrialPayPalSession( sdk, baseConfig(), {
+			onComplete,
+			onError,
+		} );
+		await sdk.capture.config.onApprove( { vaultSetupToken: 'SETUP1' } );
+
+		expect( mockPostJson ).toHaveBeenCalledWith(
+			baseConfig().ajax.create_payment_token,
+			expect.objectContaining( { vault_setup_token: 'SETUP1' } )
+		);
+		expect( onComplete ).toHaveBeenCalledTimes( 1 );
+		expect( onError ).not.toHaveBeenCalled();
+	} );
+
+	test( 'onApprove calls the provided onError when the exchange fails', async () => {
+		const sdk = fakeSdk();
+		const error = new Error( 'token exchange failed' );
+		mockPostJson.mockRejectedValueOnce( error );
+		const onComplete = jest.fn();
+		const onError = jest.fn();
+
+		createFreeTrialPayPalSession( sdk, baseConfig(), {
+			onComplete,
+			onError,
+		} );
+		await sdk.capture.config.onApprove( { vaultSetupToken: 'SETUP1' } );
+
+		expect( onError ).toHaveBeenCalledWith( error );
+		expect( onComplete ).not.toHaveBeenCalled();
+	} );
+
+	test( 'onApprove falls back to the shared error handler when no onError is provided', async () => {
+		const sdk = fakeSdk();
+		mockPostJson.mockRejectedValueOnce( new Error( 'token exchange failed' ) );
+
+		createFreeTrialPayPalSession( sdk, baseConfig() );
+		await sdk.capture.config.onApprove( { vaultSetupToken: 'SETUP1' } );
+
+		expect( mockHandleError ).toHaveBeenCalledWith( expect.any( Error ) );
+	} );
+
+	test( 'onError forwards the error to the provided onError', () => {
+		const sdk = fakeSdk();
+		const error = new Error( 'sdk session error' );
+		const onError = jest.fn();
+
+		createFreeTrialPayPalSession( sdk, baseConfig(), { onError } );
+		sdk.capture.config.onError( error );
+
+		expect( onError ).toHaveBeenCalledWith( error );
+		expect( mockHandleError ).not.toHaveBeenCalled();
+	} );
+
+	test( 'onError falls back to the shared error handler when no onError is provided', () => {
+		const sdk = fakeSdk();
+		const error = new Error( 'sdk session error' );
+
+		createFreeTrialPayPalSession( sdk, baseConfig() );
+		sdk.capture.config.onError( error );
+
+		expect( mockHandleError ).toHaveBeenCalledWith( error );
+	} );
+} );

--- a/modules/ppcp-sdk-v6/resources/js/test/freeTrialSave.test.js
+++ b/modules/ppcp-sdk-v6/resources/js/test/freeTrialSave.test.js
@@ -63,26 +63,7 @@ describe( 'createCardSetupToken', () => {
 } );
 
 describe( 'exchangeSetupToken', () => {
-	test( 'posts to the logged-in endpoint with the payment method and free-trial flag when the buyer is logged in', async () => {
-		mockPostJson.mockResolvedValueOnce( {} );
-
-		await exchangeSetupToken(
-			baseConfig(),
-			'SETUP1',
-			'ppcp-gateway'
-		);
-
-		expect( mockPostJson ).toHaveBeenCalledWith(
-			baseConfig().ajax.create_payment_token,
-			{
-				vault_setup_token: 'SETUP1',
-				is_free_trial_cart: '1',
-				payment_method: 'ppcp-gateway',
-			}
-		);
-	} );
-
-	test( 'omits the payment method when none is given', async () => {
+	test( 'posts to the logged-in endpoint with the free-trial flag when the buyer is logged in', async () => {
 		mockPostJson.mockResolvedValueOnce( {} );
 
 		await exchangeSetupToken( baseConfig(), 'SETUP1' );
@@ -118,8 +99,7 @@ describe( 'exchangeSetupToken', () => {
 
 		await exchangeSetupToken(
 			baseConfig( { user: { is_logged: false } } ),
-			'SETUP1',
-			'ppcp-gateway'
+			'SETUP1'
 		);
 
 		expect( mockPostJson ).toHaveBeenCalledWith(

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -179,7 +179,8 @@ return array(
 			$container->get( 'sdk-v6.manager' ),
 			$container->get( 'sdk-v6.asset-getter' ),
 			$container->get( 'ppcp.asset-version' ),
-			$container->get( 'wcgateway.paypal-gateway' )
+			$container->get( 'wcgateway.paypal-gateway' ),
+			$container->get( 'wcgateway.credit-card-gateway' )
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -123,6 +123,9 @@ return array(
 				&& $settings_provider->save_card_details(),
 			$container->get( 'wc-subscriptions.helper' ),
 			$container->get( 'wc-subscriptions.free-trial-subscription-helper' ),
+			// Same mode callable the v5 SmartButton uses; drives deferring native
+			// PayPal Subscriptions (subscriptions_api mode) back to the v5 stack.
+			$container->get( 'button.subscriptions-mode' ),
 			// Raw 3DS enum; the manager applies the contingency filter at enqueue
 			// time so late-registered overrides still take effect.
 			$settings_provider->three_d_secure_enum(),

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -122,6 +122,10 @@ return array(
 				&& $container->get( 'save-payment-methods.eligible' )
 				&& $settings_provider->save_card_details(),
 			$container->get( 'wc-subscriptions.helper' ),
+			$container->get( 'wc-subscriptions.free-trial-subscription-helper' ),
+			// Raw 3DS enum; the manager applies the contingency filter at enqueue
+			// time so late-registered overrides still take effect.
+			$settings_provider->three_d_secure_enum(),
 			$container->get( 'wcgateway.credit-card-icons' ),
 			$settings_provider->merchant_country(),
 			$container->get( 'sdk-v6.google-pay-config' ),

--- a/modules/ppcp-sdk-v6/services.php
+++ b/modules/ppcp-sdk-v6/services.php
@@ -179,12 +179,20 @@ return array(
 	},
 
 	'sdk-v6.blocks.payment-method'      => static function ( ContainerInterface $container ): V6PaymentMethod {
+		// The saved-PayPal vault component lives in its own feature-flagged module,
+		// so its services may be absent; fall back to no saved-token support.
+		$has_vault = $container->has( 'vault-component.data' )
+			&& $container->has( 'vault-component.eligibility.check' );
+
 		return new V6PaymentMethod(
 			$container->get( 'sdk-v6.manager' ),
 			$container->get( 'sdk-v6.asset-getter' ),
 			$container->get( 'ppcp.asset-version' ),
 			$container->get( 'wcgateway.paypal-gateway' ),
-			$container->get( 'wcgateway.credit-card-gateway' )
+			$container->get( 'wcgateway.credit-card-gateway' ),
+			$has_vault ? $container->get( 'vault-component.data' ) : null,
+			$has_vault ? $container->get( 'vault-component.eligibility.check' ) : null,
+			$container->get( 'button.client_id' )
 		);
 	},
 

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -77,6 +77,15 @@ class SdkV6Manager {
 	private bool $card_vaulting_enabled;
 	private SubscriptionHelper $subscription_helper;
 	private FreeTrialSubscriptionHelper $free_trial_helper;
+
+	/**
+	 * Resolves the current subscriptions mode ('subscriptions_api',
+	 * 'vaulting_api', …). Native PayPal Subscriptions run in 'subscriptions_api'.
+	 *
+	 * @var callable():string
+	 */
+	private $get_subscriptions_mode;
+
 	private string $three_d_secure_contingency;
 	private string $merchant_country;
 
@@ -117,6 +126,7 @@ class SdkV6Manager {
 		bool $card_vaulting_enabled,
 		SubscriptionHelper $subscription_helper,
 		FreeTrialSubscriptionHelper $free_trial_helper,
+		callable $get_subscriptions_mode,
 		string $three_d_secure_contingency,
 		array $credit_card_icons,
 		string $merchant_country,
@@ -138,6 +148,7 @@ class SdkV6Manager {
 		$this->card_vaulting_enabled       = $card_vaulting_enabled;
 		$this->subscription_helper         = $subscription_helper;
 		$this->free_trial_helper           = $free_trial_helper;
+		$this->get_subscriptions_mode      = $get_subscriptions_mode;
 		$this->three_d_secure_contingency  = $three_d_secure_contingency;
 		$this->credit_card_icons           = $credit_card_icons;
 		$this->merchant_country            = $merchant_country;
@@ -205,6 +216,21 @@ class SdkV6Manager {
 	 * @return array<string, bool> Location => enabled (product, cart, checkout, pay-now, mini-cart).
 	 */
 	public function determine_render_places(): array {
+		// Native PayPal Subscriptions defer to v5 (see should_load_on_current_page);
+		// print no v6 wrappers so the classic page hands off cleanly. These render
+		// hooks key on the smart-button locations rather than that method, so they
+		// need this guard explicitly. Every location is returned false (rather than
+		// an empty array) to keep the array shape callers index into.
+		if ( $this->is_native_paypal_subscription_page() ) {
+			return array(
+				'product'   => false,
+				'cart'      => false,
+				'checkout'  => false,
+				'pay-now'   => false,
+				'mini-cart' => false,
+			);
+		}
+
 		// Activate is_cart()/is_checkout() on classic-shortcode block pages;
 		// otherwise this only happens as a side effect of constructing the
 		// (discarded) v5 SmartButton.
@@ -369,6 +395,15 @@ class SdkV6Manager {
 	 * @return bool
 	 */
 	public function should_load_on_current_page(): bool {
+		// Native PayPal Subscriptions (subscriptions_api mode) have no v6 path — v6
+		// can only carry a subscription by vaulting, which that mode disables. Hand
+		// the whole page back to the v5 stack, which creates the subscription via
+		// actions.subscription.create. Checked before every other gate so it also
+		// overrides the sitewide mini-cart fallback below.
+		if ( $this->is_native_paypal_subscription_page() ) {
+			return false;
+		}
+
 		$page_location = $this->get_page_context();
 		if ( $page_location && $this->settings_status->is_smart_button_enabled_for_location( $page_location ) ) {
 			return true;
@@ -407,6 +442,22 @@ class SdkV6Manager {
 
 		return in_array( $location, array( 'checkout', 'checkout-block', 'pay-now' ), true )
 			&& $this->card_payments_configuration->is_acdc_enabled();
+	}
+
+	/**
+	 * Whether the current page involves a native PayPal Subscription that the v5
+	 * stack must handle: subscriptions_api mode with a subscription in the current
+	 * context. v6 has no native-subscription flow (it can only carry a subscription
+	 * by vaulting, which this mode disables), so it defers the page to v5.
+	 */
+	private function is_native_paypal_subscription_page(): bool {
+		if ( SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS !== ( $this->get_subscriptions_mode )() ) {
+			return false;
+		}
+
+		return $this->subscription_helper->current_product_is_subscription()
+			|| $this->subscription_helper->cart_contains_subscription()
+			|| $this->subscription_helper->order_pay_contains_subscription();
 	}
 
 	/**

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -542,69 +542,73 @@ class SdkV6Manager {
 		$card_fields_enabled = $this->is_card_fields_enabled();
 
 		$data = array(
-			'sdk_url'           => $base_url . '/web-sdk/v6/core',
-			'page_context'      => $page_context,
-			'currency'          => get_woocommerce_currency(),
-			'amount'            => $this->transaction_amount(),
-			'buyer_country'     => $buyer_country,
-			'merchant_country'  => $this->merchant_country,
-			'locale'            => str_replace( '_', '-', get_locale() ),
-			'vaulting_enabled'  => $this->vaulting_enabled,
+			'sdk_url'             => $base_url . '/web-sdk/v6/core',
+			'page_context'        => $page_context,
+			'currency'            => get_woocommerce_currency(),
+			'amount'              => $this->transaction_amount(),
+			'buyer_country'       => $buyer_country,
+			'merchant_country'    => $this->merchant_country,
+			'locale'              => str_replace( '_', '-', get_locale() ),
+			'vaulting_enabled'    => $this->vaulting_enabled,
 			// Drives the post-approval fork; see V6ExpressComponent.approve().
-			'final_review'      => $this->final_review_enabled,
+			'final_review'        => $this->final_review_enabled,
 			// A subscription cart whose initial total is 0 (free trial, delayed
 			// sync or a 100% coupon). Such a cart must not create a $0 PayPal
 			// order: the frontend switches to the vault "save without purchase"
 			// flow instead, and the gateway places the $0 WC order server-side.
-			'is_free_trial_cart' => $this->free_trial_helper->is_free_trial_cart(),
-			// 3DS/SCA contingency for the card save (setup-token) flow used on a
-			// free-trial card checkout. Filtered like the add-payment-method page.
+			'is_free_trial_cart'  => $this->free_trial_helper->is_free_trial_cart(),
+			/**
+			 * 3DS/SCA contingency for the card save (setup-token) flow used on a
+			 * free-trial card checkout. Filtered like the add-payment-method page.
+			 *
+			 * @param string $three_d_secure_contingency The default 3D Secure enum value.
+			 */
 			'verification_method' => (string) apply_filters(
 				'woocommerce_paypal_payments_three_d_secure_contingency',
 				$this->three_d_secure_contingency
 			),
 			// Whether the buyer is logged in, so the free-trial save flow picks the
 			// logged-in create-payment-token endpoint vs the guest one.
-			'user'              => array(
+			'user'                => array(
 				'is_logged' => is_user_logged_in(),
 			),
-			'ajax'              => array(
-				'client_token'    => array(
+			'ajax'                => array(
+				'client_token'                   => array(
 					'endpoint' => \WC_AJAX::get_endpoint( ClientTokenEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ClientTokenEndpoint::nonce() ),
 				),
-				'change_cart'     => array(
+				'change_cart'                    => array(
 					'endpoint' => \WC_AJAX::get_endpoint( ChangeCartEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ChangeCartEndpoint::nonce() ),
 				),
-				'simulate_cart'   => array(
+				'simulate_cart'                  => array(
 					'endpoint' => \WC_AJAX::get_endpoint( SimulateCartEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( SimulateCartEndpoint::nonce() ),
 				),
-				'create_order'    => array(
+				'create_order'                   => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CreateOrderEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreateOrderEndpoint::nonce() ),
 				),
-				'approve_order'   => array(
+				'approve_order'                  => array(
 					'endpoint' => \WC_AJAX::get_endpoint( ApproveOrderEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( ApproveOrderEndpoint::nonce() ),
 				),
-				'get_order'       => array(
+				'get_order'                      => array(
 					'endpoint' => \WC_AJAX::get_endpoint( GetOrderEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( GetOrderEndpoint::nonce() ),
 				),
-				'update_shipping' => array(
+				'update_shipping'                => array(
 					'endpoint' => \WC_AJAX::get_endpoint( UpdateShippingEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( UpdateShippingEndpoint::nonce() ),
 				),
 				// Vault v3 "save without purchase" endpoints, used by the
 				// free-trial checkout flow (see is_free_trial_cart). Registered as
 				// wc_ajax actions by ppcp-save-payment-methods when vaulting is on.
-				'create_setup_token' => array(
+				'create_setup_token'             => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CreateSetupToken::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreateSetupToken::nonce() ),
 				),
-				'create_payment_token' => array(
+				'create_payment_token'           => array(
 					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentToken::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreatePaymentToken::nonce() ),
 				),
@@ -612,31 +616,31 @@ class SdkV6Manager {
 					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentTokenForGuest::ENDPOINT ),
 					'nonce'    => wp_create_nonce( CreatePaymentTokenForGuest::nonce() ),
 				),
-				'wc_store_api'    => array(
+				'wc_store_api'                   => array(
 					'cart'                 => $store_api_base,
 					'select_shipping_rate' => $store_api_base . '/select-shipping-rate',
 					'update_customer'      => $store_api_base . '/update-customer',
 					'nonce'                => wp_create_nonce( 'wc_store_api' ),
 				),
 			),
-			'urls'              => array(
+			'urls'                => array(
 				'checkout' => wc_get_checkout_url(),
 			),
-			'labels'            => array(
+			'labels'              => array(
 				'generic_error' => __(
 					'Something went wrong. Please try again or choose another payment source.',
 					'woocommerce-paypal-payments'
 				),
 			),
-			'shipping'          => array(
+			'shipping'            => array(
 				'handle_in_paypal' => $shipping_enabled,
 				'need_shipping'    => $this->need_shipping(),
 			),
-			'button_styles'     => $button_styles,
-			'button_height'     => self::PAYMENT_BUTTON_HEIGHT,
-			'wrapper'           => '#' . self::WRAPPER_ID,
-			'mini_cart_wrapper' => '#' . self::MINI_CART_WRAPPER_ID,
-			'card_fields'       => array(
+			'button_styles'       => $button_styles,
+			'button_height'       => self::PAYMENT_BUTTON_HEIGHT,
+			'wrapper'             => '#' . self::WRAPPER_ID,
+			'mini_cart_wrapper'   => '#' . self::MINI_CART_WRAPPER_ID,
+			'card_fields'         => array(
 				'enabled'             => $card_fields_enabled,
 				'payment_method'      => CreditCardGateway::ID,
 				'funding_source'      => 'card',
@@ -673,7 +677,7 @@ class SdkV6Manager {
 			// setting and localize it as wc_ppcp_axo; this flag tells sdkLoader
 			// to request the component their connection then reads off the
 			// shared SDK instance.
-			'fastlane'          => array(
+			'fastlane'            => array(
 				'enabled'        => $this->is_fastlane_enabled( $page_context ),
 				// The id as a literal, not AxoGateway::ID: ppcp-axo is behind its
 				// own feature flag, and SdkV6Module names it the same way.

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -19,6 +19,9 @@ use WooCommerce\PayPalCommerce\OrderEndpoints\Endpoint\CreateOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Endpoint\GetOrderEndpoint;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
 use WooCommerce\PayPalCommerce\Googlepay\GooglePayGateway;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentTokenForGuest;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\ClientTokenEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Endpoint\SimulateCartEndpoint;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
@@ -31,6 +34,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 
 class SdkV6Manager {
@@ -72,6 +76,8 @@ class SdkV6Manager {
 	private CardPaymentsConfiguration $card_payments_configuration;
 	private bool $card_vaulting_enabled;
 	private SubscriptionHelper $subscription_helper;
+	private FreeTrialSubscriptionHelper $free_trial_helper;
+	private string $three_d_secure_contingency;
 	private string $merchant_country;
 
 	/**
@@ -110,6 +116,8 @@ class SdkV6Manager {
 		CardPaymentsConfiguration $card_payments_configuration,
 		bool $card_vaulting_enabled,
 		SubscriptionHelper $subscription_helper,
+		FreeTrialSubscriptionHelper $free_trial_helper,
+		string $three_d_secure_contingency,
 		array $credit_card_icons,
 		string $merchant_country,
 		GooglePayConfig $google_pay_config,
@@ -129,6 +137,8 @@ class SdkV6Manager {
 		$this->card_payments_configuration = $card_payments_configuration;
 		$this->card_vaulting_enabled       = $card_vaulting_enabled;
 		$this->subscription_helper         = $subscription_helper;
+		$this->free_trial_helper           = $free_trial_helper;
+		$this->three_d_secure_contingency  = $three_d_secure_contingency;
 		$this->credit_card_icons           = $credit_card_icons;
 		$this->merchant_country            = $merchant_country;
 		$this->apple_pay_config            = $apple_pay_config;
@@ -462,6 +472,22 @@ class SdkV6Manager {
 			'vaulting_enabled'  => $this->vaulting_enabled,
 			// Drives the post-approval fork; see V6ExpressComponent.approve().
 			'final_review'      => $this->final_review_enabled,
+			// A subscription cart whose initial total is 0 (free trial, delayed
+			// sync or a 100% coupon). Such a cart must not create a $0 PayPal
+			// order: the frontend switches to the vault "save without purchase"
+			// flow instead, and the gateway places the $0 WC order server-side.
+			'is_free_trial_cart' => $this->free_trial_helper->is_free_trial_cart(),
+			// 3DS/SCA contingency for the card save (setup-token) flow used on a
+			// free-trial card checkout. Filtered like the add-payment-method page.
+			'verification_method' => (string) apply_filters(
+				'woocommerce_paypal_payments_three_d_secure_contingency',
+				$this->three_d_secure_contingency
+			),
+			// Whether the buyer is logged in, so the free-trial save flow picks the
+			// logged-in create-payment-token endpoint vs the guest one.
+			'user'              => array(
+				'is_logged' => is_user_logged_in(),
+			),
 			'ajax'              => array(
 				'client_token'    => array(
 					'endpoint' => \WC_AJAX::get_endpoint( ClientTokenEndpoint::ENDPOINT ),
@@ -490,6 +516,21 @@ class SdkV6Manager {
 				'update_shipping' => array(
 					'endpoint' => \WC_AJAX::get_endpoint( UpdateShippingEndpoint::ENDPOINT ),
 					'nonce'    => wp_create_nonce( UpdateShippingEndpoint::nonce() ),
+				),
+				// Vault v3 "save without purchase" endpoints, used by the
+				// free-trial checkout flow (see is_free_trial_cart). Registered as
+				// wc_ajax actions by ppcp-save-payment-methods when vaulting is on.
+				'create_setup_token' => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreateSetupToken::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreateSetupToken::nonce() ),
+				),
+				'create_payment_token' => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentToken::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreatePaymentToken::nonce() ),
+				),
+				'create_payment_token_for_guest' => array(
+					'endpoint' => \WC_AJAX::get_endpoint( CreatePaymentTokenForGuest::ENDPOINT ),
+					'nonce'    => wp_create_nonce( CreatePaymentTokenForGuest::nonce() ),
 				),
 				'wc_store_api'    => array(
 					'cart'                 => $store_api_base,

--- a/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
+++ b/modules/ppcp-sdk-v6/src/Assets/SdkV6Manager.php
@@ -253,11 +253,6 @@ class SdkV6Manager {
 			);
 		}
 
-		// Activate is_cart()/is_checkout() on classic-shortcode block pages;
-		// otherwise this only happens as a side effect of constructing the
-		// (discarded) v5 SmartButton.
-		$this->context->init_context();
-
 		// Free orders ($0 total, e.g. a 100%-off coupon or free trial) do not
 		// need payment, so the cart/checkout wallet buttons must not render —
 		// matching v5's is_cart_price_total_zero() suppression.

--- a/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
+++ b/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
@@ -13,6 +13,7 @@ namespace WooCommerce\PayPalCommerce\SdkV6\Blocks;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
 /**
@@ -28,17 +29,20 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 	private AssetGetter $asset_getter;
 	private string $version;
 	private PayPalGateway $gateway;
+	private CreditCardGateway $card_gateway;
 
 	public function __construct(
 		SdkV6Manager $manager,
 		AssetGetter $asset_getter,
 		string $version,
-		PayPalGateway $gateway
+		PayPalGateway $gateway,
+		CreditCardGateway $card_gateway
 	) {
 		$this->manager      = $manager;
 		$this->asset_getter = $asset_getter;
 		$this->version      = $version;
 		$this->gateway      = $gateway;
+		$this->card_gateway = $card_gateway;
 	}
 
 	/**
@@ -79,13 +83,26 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 	}
 
 	public function get_payment_method_data() {
-		return array_merge(
+		$data = array_merge(
 			$this->manager->script_data(),
 			array(
-				'id'          => PayPalGateway::ID,
-				'title'       => $this->gateway->title,
-				'description' => $this->gateway->get_description(),
+				'id'                 => PayPalGateway::ID,
+				'title'              => $this->gateway->title,
+				'description'        => $this->gateway->get_description(),
+				// The gateway's (subscription-aware) supported features, so the
+				// block methods declare them to WooCommerce Blocks and are not
+				// filtered out when the cart requires one (e.g. `subscriptions`).
+				// Mirrors the v5 PayPalPaymentMethod::get_payment_method_data().
+				'supported_features' => array_values( (array) $this->gateway->supports ),
 			)
 		);
+
+		// The card method registers under the credit-card gateway, so it must
+		// advertise that gateway's own supports (independently vaulting-gated).
+		if ( isset( $data['card_fields'] ) && is_array( $data['card_fields'] ) ) {
+			$data['card_fields']['supported_features'] = array_values( (array) $this->card_gateway->supports );
+		}
+
+		return $data;
 	}
 }

--- a/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
+++ b/modules/ppcp-sdk-v6/src/Blocks/V6PaymentMethod.php
@@ -13,6 +13,7 @@ namespace WooCommerce\PayPalCommerce\SdkV6\Blocks;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
+use WooCommerce\PayPalCommerce\VaultComponent\VaultComponentData;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 
@@ -31,18 +32,40 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 	private PayPalGateway $gateway;
 	private CreditCardGateway $card_gateway;
 
+	/**
+	 * The saved-PayPal vault-component data provider, or null when the
+	 * ppcp-vault-component module is not loaded (its own feature flag).
+	 */
+	private ?VaultComponentData $vault_data;
+
+	/**
+	 * Whether the saved-PayPal vault component may render (merchant eligibility),
+	 * or null when the vault-component module is not loaded.
+	 *
+	 * @var callable():bool|null
+	 */
+	private $vault_eligibility;
+
+	private string $vault_client_id;
+
 	public function __construct(
 		SdkV6Manager $manager,
 		AssetGetter $asset_getter,
 		string $version,
 		PayPalGateway $gateway,
-		CreditCardGateway $card_gateway
+		CreditCardGateway $card_gateway,
+		?VaultComponentData $vault_data,
+		?callable $vault_eligibility,
+		string $vault_client_id
 	) {
-		$this->manager      = $manager;
-		$this->asset_getter = $asset_getter;
-		$this->version      = $version;
-		$this->gateway      = $gateway;
-		$this->card_gateway = $card_gateway;
+		$this->manager           = $manager;
+		$this->asset_getter      = $asset_getter;
+		$this->version           = $version;
+		$this->gateway           = $gateway;
+		$this->card_gateway      = $card_gateway;
+		$this->vault_data        = $vault_data;
+		$this->vault_eligibility = $vault_eligibility;
+		$this->vault_client_id   = $vault_client_id;
 	}
 
 	/**
@@ -101,6 +124,32 @@ class V6PaymentMethod extends AbstractPaymentMethodType {
 		// advertise that gateway's own supports (independently vaulting-gated).
 		if ( isset( $data['card_fields'] ) && is_array( $data['card_fields'] ) ) {
 			$data['card_fields']['supported_features'] = array_values( (array) $this->card_gateway->supports );
+		}
+
+		// Saved-PayPal selector for returning buyers: the v5 smart-button stack
+		// that carried this in blocks is disabled under v6, so surface the same
+		// vault-component data here for checkout-block.js to register a saved-token
+		// method (mirrors the classic checkout carve-out).
+		if ( $this->vault_data && $this->vault_eligibility && ( $this->vault_eligibility )() ) {
+			$vault = $this->vault_data->add_localized_data( array() );
+			if ( isset( $vault['vault_component'] ) ) {
+				$data['vault_component']   = $vault['vault_component'];
+				// The saved-payment-methods SDK component is v5 and needs a
+				// client-id (v6 authenticates with a client token elsewhere).
+				$data['vault_client_id'] = $this->vault_client_id;
+
+				/**
+				 * Filters the SDK script attributes forwarded to the vault
+				 * component's own SDK load (e.g. a `sdkBaseUrl` override for
+				 * staging), mirroring the v5 script_attributes.
+				 *
+				 * @param array $attributes The SDK script attributes.
+				 */
+				$data['script_attributes'] = (object) apply_filters(
+					'woocommerce_paypal_payments_sdk_script_attributes',
+					array()
+				);
+			}
 		}
 
 		return $data;

--- a/modules/ppcp-vault-component/resources/js/checkout.js
+++ b/modules/ppcp-vault-component/resources/js/checkout.js
@@ -1,0 +1,111 @@
+/**
+ * Standalone classic-checkout boot for the PayPal saved-payment "vault component".
+ *
+ * In the v5 stack this renderer rides on the smart-button bundle (button.js) and
+ * is driven by CheckoutBootstrap. The SDK v6 integration replaces the smart button
+ * with a no-op on the pages it owns, so that bundle — and with it this renderer —
+ * never loads, leaving the printed `#ppcp-vault-component` container empty. This
+ * entry runs the same self-contained VaultRenderer independently, so the saved
+ * PayPal selector keeps working under v6. It is enqueued only when the v5 smart
+ * button is suppressed (see VaultComponentModule), so the two never both render it.
+ *
+ * @package
+ */
+
+import VaultRenderer from '@ppcp-button/Renderer/VaultRenderer';
+
+( function ( config ) {
+	'use strict';
+
+	if ( ! config || ! config.vault_component?.is_eligible ) {
+		return;
+	}
+
+	const gatewayId = config.gateway_id || 'ppcp-gateway';
+	const renderer = new VaultRenderer( config );
+
+	function isPayPalSelected() {
+		return (
+			document.querySelector( 'input[name="payment_method"]:checked' )
+				?.value === gatewayId
+		);
+	}
+
+	function checkoutForm() {
+		return (
+			document.querySelector( 'form.checkout' ) ||
+			document.querySelector( 'form#order_review' )
+		);
+	}
+
+	/**
+	 * Records the vault-approved PayPal order on the checkout form so the gateway
+	 * captures that order on Place Order (mirrors v5's injectVaultOrderIdInput).
+	 *
+	 * @param {string} orderId - The approved PayPal order id.
+	 */
+	function injectOrderId( orderId ) {
+		const form = checkoutForm();
+		if ( ! form ) {
+			return;
+		}
+		let input = form.querySelector( 'input[name="paypal_order_id"]' );
+		if ( ! input ) {
+			input = document.createElement( 'input' );
+			input.type = 'hidden';
+			input.name = 'paypal_order_id';
+			form.appendChild( input );
+		}
+		input.value = orderId;
+	}
+
+	function removeOrderId() {
+		document.querySelector( 'input[name="paypal_order_id"]' )?.remove();
+	}
+
+	function updateUi() {
+		// A $0 free-trial cart uses the save-without-purchase flow; the order-based
+		// vault component would create a $0 order PayPal rejects, so skip it there.
+		const show = isPayPalSelected() && ! config.is_free_trial_cart;
+
+		if ( show && ! renderer.isRendered() ) {
+			renderer.render(
+				( orderId ) => injectOrderId( orderId ),
+				() => removeOrderId()
+			);
+		} else if ( ! show ) {
+			renderer.close();
+			removeOrderId();
+		}
+	}
+
+	function onUpdatedCheckout() {
+		// WC rebuilds the payment DOM (container included) on each update, so drop
+		// the stale instance and any recorded order id before re-evaluating.
+		renderer.reset();
+		removeOrderId();
+		updateUi();
+	}
+
+	function init() {
+		if ( typeof jQuery !== 'undefined' ) {
+			jQuery( document.body ).on( 'updated_checkout', onUpdatedCheckout );
+			jQuery( document.body ).on(
+				'updated_checkout payment_method_selected',
+				updateUi
+			);
+			jQuery( document ).on(
+				'change',
+				'input[name="wc-ppcp-gateway-payment-token"]',
+				updateUi
+			);
+		}
+		updateUi();
+	}
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', init );
+	} else {
+		init();
+	}
+} )( window.ppcp_vault_component );

--- a/modules/ppcp-vault-component/resources/js/checkout.js
+++ b/modules/ppcp-vault-component/resources/js/checkout.js
@@ -89,11 +89,10 @@ import VaultRenderer from '@ppcp-button/Renderer/VaultRenderer';
 
 	function init() {
 		if ( typeof jQuery !== 'undefined' ) {
+			// onUpdatedCheckout already re-runs updateUi, so updateUi only needs
+			// binding to the events onUpdatedCheckout does not cover.
 			jQuery( document.body ).on( 'updated_checkout', onUpdatedCheckout );
-			jQuery( document.body ).on(
-				'updated_checkout payment_method_selected',
-				updateUi
-			);
+			jQuery( document.body ).on( 'payment_method_selected', updateUi );
 			jQuery( document ).on(
 				'change',
 				'input[name="wc-ppcp-gateway-payment-token"]',

--- a/modules/ppcp-vault-component/src/VaultComponentModule.php
+++ b/modules/ppcp-vault-component/src/VaultComponentModule.php
@@ -179,6 +179,18 @@ class VaultComponentModule implements ServiceModule, ExecutableModule {
 				);
 
 				wp_enqueue_script( 'ppcp-vault-component' );
+
+				// The button module's stylesheet (which lays the vault widget out
+				// inside the saved-token row so its iframe does not overlap the
+				// "Use a new payment method" option) is not enqueued under v6, so
+				// ship the same rules here.
+				wp_register_style( 'ppcp-vault-component', false, array(), $asset['version'] );
+				wp_enqueue_style( 'ppcp-vault-component' );
+				wp_add_inline_style(
+					'ppcp-vault-component',
+					'.woocommerce-SavedPaymentMethods-token:has(#ppcp-vault-component){display:flex;align-items:center;gap:8px;}'
+					. '.woocommerce-SavedPaymentMethods-token:has(#ppcp-vault-component) #ppcp-vault-component{flex:1;overflow:hidden;}'
+				);
 			}
 		);
 

--- a/modules/ppcp-vault-component/src/VaultComponentModule.php
+++ b/modules/ppcp-vault-component/src/VaultComponentModule.php
@@ -6,6 +6,9 @@ namespace WooCommerce\PayPalCommerce\VaultComponent;
 use WC_Order;
 use WC_Payment_Token;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
+use WooCommerce\PayPalCommerce\Assets\AssetGetter;
+use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
+use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\WcPaymentTokens\PaymentTokenPayPal;
 use WooCommerce\PayPalCommerce\VaultComponent\Endpoint\CreateVaultOrderEndpoint;
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ExecutableModule;
@@ -13,6 +16,7 @@ use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ModuleClassNameI
 use WooCommerce\PayPalCommerce\Vendor\Inpsyde\Modularity\Module\ServiceModule;
 use WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
 
 class VaultComponentModule implements ServiceModule, ExecutableModule {
 	use ModuleClassNameIdTrait;
@@ -98,6 +102,83 @@ class VaultComponentModule implements ServiceModule, ExecutableModule {
 						return $data->add_localized_data( $localized_script_data );
 					}
 				);
+			}
+		);
+
+		// Standalone renderer for pages the SDK v6 stack owns, where the smart
+		// button (which carries the v5 vault renderer) is replaced by a no-op.
+		// Enqueued only when that renderer will not run, so the two never both
+		// render into #ppcp-vault-component.
+		add_action(
+			'wp_enqueue_scripts',
+			static function () use ( $c, $eligibility_check ) {
+				if ( ! is_checkout() || ! $eligibility_check() ) {
+					return;
+				}
+
+				$smart_button = $c->get( 'button.smart-button' );
+				assert( $smart_button instanceof SmartButtonInterface );
+
+				// The v5 stack is live here; it renders the vault component itself.
+				if ( $smart_button->should_load_ppcp_script() ) {
+					return;
+				}
+
+				$data = $c->get( 'vault-component.data' );
+				assert( $data instanceof VaultComponentData );
+
+				$vault_component = $data->add_localized_data( array() )['vault_component'] ?? null;
+				if ( ! $vault_component ) {
+					return;
+				}
+
+				$factory = $c->get( 'assets.asset_getter_factory' );
+				assert( $factory instanceof AssetGetterFactory );
+				$asset_getter = $factory->for_module( 'ppcp-vault-component' );
+				assert( $asset_getter instanceof AssetGetter );
+
+				$script_url = $asset_getter->get_asset_url( 'checkout.js' );
+				if ( ! $script_url ) {
+					return;
+				}
+
+				$version   = $c->get( 'ppcp.asset-version' );
+				$asset_php = $asset_getter->get_asset_php_path( 'checkout.js' );
+				$asset     = file_exists( $asset_php )
+					? require $asset_php
+					: array(
+						'dependencies' => array(),
+						'version'      => $version,
+					);
+
+				$free_trial = $c->get( 'wc-subscriptions.free-trial-subscription-helper' );
+				assert( $free_trial instanceof FreeTrialSubscriptionHelper );
+
+				wp_register_script(
+					'ppcp-vault-component',
+					$script_url,
+					array_merge( $asset['dependencies'], array( 'jquery' ) ),
+					$asset['version'],
+					true
+				);
+
+				wp_localize_script(
+					'ppcp-vault-component',
+					'ppcp_vault_component',
+					array(
+						'vault_component'    => $vault_component,
+						// The vault SDK (saved-payment-methods) is a v5 component that
+						// needs a client-id; v6 uses a client token, so source it here.
+						'url_params'         => array(
+							'client-id' => $c->get( 'button.client_id' ),
+						),
+						'script_attributes'  => (object) array(),
+						'is_free_trial_cart' => $free_trial->is_free_trial_cart(),
+						'gateway_id'         => PayPalGateway::ID,
+					)
+				);
+
+				wp_enqueue_script( 'ppcp-vault-component' );
 			}
 		);
 

--- a/modules/ppcp-vault-component/src/VaultComponentModule.php
+++ b/modules/ppcp-vault-component/src/VaultComponentModule.php
@@ -6,7 +6,6 @@ namespace WooCommerce\PayPalCommerce\VaultComponent;
 use WC_Order;
 use WC_Payment_Token;
 use WooCommerce\PayPalCommerce\ApiClient\Entity\Order;
-use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Assets\AssetGetterFactory;
 use WooCommerce\PayPalCommerce\Button\Assets\SmartButtonInterface;
 use WooCommerce\PayPalCommerce\WcPaymentTokens\PaymentTokenPayPal;
@@ -135,7 +134,6 @@ class VaultComponentModule implements ServiceModule, ExecutableModule {
 				$factory = $c->get( 'assets.asset_getter_factory' );
 				assert( $factory instanceof AssetGetterFactory );
 				$asset_getter = $factory->for_module( 'ppcp-vault-component' );
-				assert( $asset_getter instanceof AssetGetter );
 
 				$script_url = $asset_getter->get_asset_url( 'checkout.js' );
 				if ( ! $script_url ) {

--- a/tests/PHPUnit/Button/Endpoint/ApproveSubscriptionEndpointTest.php
+++ b/tests/PHPUnit/Button/Endpoint/ApproveSubscriptionEndpointTest.php
@@ -197,6 +197,42 @@ class ApproveSubscriptionEndpointTest extends TestCase
 	}
 
 	/**
+	 * GIVEN a valid subscription whose subscriber has a resolved payer id
+	 * WHEN the order fetched for the same order_id has no resolved payer id yet
+	 * THEN the order is still approved, because an absent payer id on the order cannot
+	 *      be compared and the subscription is already bound to this session
+	 */
+	public function test_order_with_empty_payer_id_is_still_approved(): void
+	{
+		$session_id   = 'shopper-session';
+		$subscription = $this->subscription( $session_id, 'PAYER-A' );
+
+		// The order's payer id is not resolved yet, but the order is bound to this session.
+		$order = $this->order_with_payer( '', 'pcp_customer_' . $session_id );
+
+		$this->request_data->shouldReceive( 'read_request' )
+			->with( ApproveSubscriptionEndpoint::nonce() )
+			->andReturn(
+				array(
+					'order_id'        => 'VALID-ORDER',
+					'subscription_id' => 'SUB-1',
+				)
+			);
+		$this->billing_subscriptions->shouldReceive( 'subscription' )->with( 'SUB-1' )->andReturn( $subscription );
+		$this->subscription_helper->shouldReceive( 'paypal_subscription_variation_from_cart' )->andReturn( '' );
+		$this->subscription_helper->shouldReceive( 'paypal_subscription_id' )->andReturn( 'PLAN-1' );
+		$this->order_endpoint->shouldReceive( 'order' )->with( 'VALID-ORDER' )->andReturn( $order );
+		$this->session_handler->shouldReceive( 'replace_order' )->once()->with( $order );
+		$this->context->shouldReceive( 'is_checkout' )->andReturn( true );
+
+		$this->mock_wc_session( $session_id );
+		expect( 'wp_send_json_success' )->once();
+		expect( 'wp_send_json_error' )->never();
+
+		$this->sut->handle_request();
+	}
+
+	/**
 	 * Builds a PayPal subscription stdClass bound to the given session and subscriber.
 	 */
 	private function subscription( string $session_id, string $payer_id ): \stdClass

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -53,6 +53,8 @@ class SdkV6ManagerTest extends TestCase
         $this->card_payments_configuration = Mockery::mock(CardPaymentsConfiguration::class);
 		$this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
         $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false)->byDefault();
+        $this->subscription_helper->shouldReceive('current_product_is_subscription')->andReturn(false)->byDefault();
+        $this->subscription_helper->shouldReceive('order_pay_contains_subscription')->andReturn(false)->byDefault();
 		$this->free_trial_helper = Mockery::mock(FreeTrialSubscriptionHelper::class);
 		$this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn(false)->byDefault();
 		$this->credit_card_icons = [];
@@ -114,7 +116,7 @@ class SdkV6ManagerTest extends TestCase
         when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
     }
 
-    private function createTestee(bool $should_handle_shipping = false, array $credit_card_icons = [], bool $card_vaulting_enabled = true, string $merchant_country = 'US', string $three_d_secure_contingency = 'SCA_WHEN_REQUIRED'): SdkV6Manager
+    private function createTestee(bool $should_handle_shipping = false, array $credit_card_icons = [], bool $card_vaulting_enabled = true, string $merchant_country = 'US', string $three_d_secure_contingency = 'SCA_WHEN_REQUIRED', ?callable $get_subscriptions_mode = null): SdkV6Manager
     {
         return new SdkV6Manager(
             $this->asset_getter,
@@ -132,6 +134,7 @@ class SdkV6ManagerTest extends TestCase
 	        $card_vaulting_enabled,
 	        $this->subscription_helper,
 	        $this->free_trial_helper,
+	        $get_subscriptions_mode ?? static fn (): string => SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING,
 	        $three_d_secure_contingency,
 	        $credit_card_icons,
 	        $merchant_country,
@@ -262,6 +265,112 @@ class SdkV6ManagerTest extends TestCase
         $testee = $this->createTestee();
 
         $this->assertFalse($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN native PayPal Subscriptions mode is active and the cart carries a subscription
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN the SDK does not load, even though a smart-button location would otherwise enable it,
+     *      because the whole page must defer to the v5 stack that can create the subscription
+     */
+    public function testShouldNotLoadWhenNativePayPalSubscriptionInCart(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(true);
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(true);
+
+        $testee = $this->createTestee(
+            false,
+            [],
+            true,
+            'US',
+            'SCA_WHEN_REQUIRED',
+            static fn (): string => SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS
+        );
+
+        $this->assertFalse($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN native PayPal Subscriptions mode is active but no subscription is present in the
+     *      current product, cart or pay-for-order context
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN the SDK follows the normal gating rather than being forced off, since there is no
+     *      native subscription for v5 to hand off
+     */
+    public function testShouldLoadWhenSubscriptionsModeActiveButNoSubscriptionPresent(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(true);
+
+        $testee = $this->createTestee(
+            false,
+            [],
+            true,
+            'US',
+            'SCA_WHEN_REQUIRED',
+            static fn (): string => SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS
+        );
+
+        $this->assertTrue($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN the merchant uses the vaulting subscriptions mode (not native PayPal Subscriptions)
+     *      and the cart carries a subscription
+     * WHEN checking whether the v6 SDK should load on the current page
+     * THEN the SDK is not forced off, since v6 can carry a vaulted subscription itself
+     */
+    public function testShouldLoadWhenVaultingModeWithSubscriptionInCart(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout');
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false);
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(true);
+        $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(true);
+
+        $testee = $this->createTestee(
+            false,
+            [],
+            true,
+            'US',
+            'SCA_WHEN_REQUIRED',
+            static fn (): string => SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_VAULTING
+        );
+
+        $this->assertTrue($testee->should_load_on_current_page());
+    }
+
+    /**
+     * GIVEN native PayPal Subscriptions mode is active and the current product is a subscription
+     * WHEN determining which locations should render on the current page
+     * THEN no v6 button location renders, leaving the page entirely to the v5 stack
+     */
+    public function testDetermineRenderPlacesEmptyWhenNativePayPalSubscriptionProduct(): void
+    {
+        $this->context->shouldReceive('init_context')->never();
+        $this->subscription_helper->shouldReceive('current_product_is_subscription')->andReturn(true);
+
+        $testee = $this->createTestee(
+            false,
+            [],
+            true,
+            'US',
+            'SCA_WHEN_REQUIRED',
+            static fn (): string => SubscriptionHelper::SUBSCRIPTION_MODE_VALUE_SUBSCRIPTIONS
+        );
+
+        $this->assertSame(
+            [
+                'product'   => false,
+                'cart'      => false,
+                'checkout'  => false,
+                'pay-now'   => false,
+                'mini-cart' => false,
+            ],
+            $testee->determine_render_places()
+        );
     }
 
     /**

--- a/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
+++ b/tests/PHPUnit/SdkV6/Assets/SdkV6ManagerTest.php
@@ -6,6 +6,9 @@ namespace WooCommerce\PayPalCommerce\SdkV6\Assets;
 use Mockery;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\Button\Helper\Context;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentToken;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreatePaymentTokenForGuest;
+use WooCommerce\PayPalCommerce\SavePaymentMethods\Endpoint\CreateSetupToken;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ApplePayConfig;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\ButtonStyleMapper;
 use WooCommerce\PayPalCommerce\SdkV6\Helper\GooglePayConfig;
@@ -16,6 +19,7 @@ use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\CardPaymentsConfiguration;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\Environment;
 use WooCommerce\PayPalCommerce\WcGateway\Helper\SettingsStatus;
+use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\FreeTrialSubscriptionHelper;
 use WooCommerce\PayPalCommerce\WcSubscriptions\Helper\SubscriptionHelper;
 use function Brain\Monkey\Functions\when;
 
@@ -30,6 +34,7 @@ class SdkV6ManagerTest extends TestCase
     private $cancel_view;
     private $card_payments_configuration;
     private $subscription_helper;
+	private $free_trial_helper;
 	private $credit_card_icons;
 	private $google_pay_config;
 	private $apple_pay_config;
@@ -48,6 +53,8 @@ class SdkV6ManagerTest extends TestCase
         $this->card_payments_configuration = Mockery::mock(CardPaymentsConfiguration::class);
 		$this->subscription_helper = Mockery::mock(SubscriptionHelper::class);
         $this->subscription_helper->shouldReceive('cart_contains_subscription')->andReturn(false)->byDefault();
+		$this->free_trial_helper = Mockery::mock(FreeTrialSubscriptionHelper::class);
+		$this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn(false)->byDefault();
 		$this->credit_card_icons = [];
 
 		$this->google_pay_config = Mockery::mock(GooglePayConfig::class);
@@ -60,6 +67,7 @@ class SdkV6ManagerTest extends TestCase
 		// Reached unconditionally by script_data()'s Apple Pay validation block.
 		when('admin_url')->justReturn('https://example.com/wp-admin/admin-ajax.php');
 		when('wp_create_nonce')->justReturn('nonce');
+		when('is_user_logged_in')->justReturn(false);
     }
 
     /**
@@ -80,7 +88,33 @@ class SdkV6ManagerTest extends TestCase
         return $wc;
     }
 
-    private function createTestee(bool $should_handle_shipping = false, array $credit_card_icons = [], bool $card_vaulting_enabled = true, string $merchant_country = 'US'): SdkV6Manager
+    /**
+     * Stubs the collaborators and WP functions that script_data() always
+     * touches, so a test only has to set up what it is actually verifying.
+     */
+    private function stub_common_script_data_dependencies(): void
+    {
+        $this->context->shouldReceive('context')->andReturn('checkout')->byDefault();
+        $this->card_payments_configuration->shouldReceive('is_acdc_enabled')->andReturn(false)->byDefault();
+        $this->card_payments_configuration->shouldReceive('gateway_title')->andReturn('Credit Card')->byDefault();
+        $this->card_payments_configuration->shouldReceive('show_name_on_card')->andReturn('no')->byDefault();
+
+        $this->settings_status->shouldReceive('is_smart_button_enabled_for_location')->andReturn(false)->byDefault();
+        $this->session_handler->shouldReceive('order')->andReturn(null)->byDefault();
+        $this->context->shouldReceive('is_paypal_continuation')->andReturn(false)->byDefault();
+        $this->environment->shouldReceive('is_sandbox')->andReturn(false)->byDefault();
+        $this->style_mapper->shouldReceive('styles_for_context')->andReturn([])->byDefault();
+
+        when('WC')->justReturn($this->create_wc_stub());
+        when('wc_get_base_location')->justReturn(['country' => 'US']);
+        when('get_woocommerce_currency')->justReturn('USD');
+        when('get_locale')->justReturn('en_US');
+        when('is_product')->justReturn(false);
+        when('rest_url')->justReturn('https://example.com/wp-json/wc/store/v1/cart');
+        when('wc_get_checkout_url')->justReturn('https://example.com/checkout');
+    }
+
+    private function createTestee(bool $should_handle_shipping = false, array $credit_card_icons = [], bool $card_vaulting_enabled = true, string $merchant_country = 'US', string $three_d_secure_contingency = 'SCA_WHEN_REQUIRED'): SdkV6Manager
     {
         return new SdkV6Manager(
             $this->asset_getter,
@@ -97,6 +131,8 @@ class SdkV6ManagerTest extends TestCase
             $this->card_payments_configuration,
 	        $card_vaulting_enabled,
 	        $this->subscription_helper,
+	        $this->free_trial_helper,
+	        $three_d_secure_contingency,
 	        $credit_card_icons,
 	        $merchant_country,
 	        $this->google_pay_config,
@@ -440,5 +476,127 @@ class SdkV6ManagerTest extends TestCase
                 [],
             ],
         ];
+    }
+
+    /**
+     * GIVEN a cart that may or may not be a free trial subscription (e.g. a $0
+     *       initial total from a trial period or delayed sync)
+     * WHEN the SDK bootstrap data is generated
+     * THEN is_free_trial_cart mirrors the free-trial helper's answer, so the
+     *      frontend knows whether to switch to the vault "save without
+     *      purchase" flow instead of creating a $0 PayPal order
+     *
+     * @dataProvider free_trial_cart_provider
+     */
+    public function testScriptDataReflectsFreeTrialCartState(bool $is_free_trial_cart): void
+    {
+        $this->stub_common_script_data_dependencies();
+        $this->free_trial_helper->shouldReceive('is_free_trial_cart')->andReturn($is_free_trial_cart);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame($is_free_trial_cart, $data['is_free_trial_cart']);
+    }
+
+    public function free_trial_cart_provider(): array
+    {
+        return [
+            'a free trial cart is reported as such' => [true],
+            'a regular cart is not reported as a free trial' => [false],
+        ];
+    }
+
+    /**
+     * GIVEN a buyer who may or may not have an active WordPress session
+     * WHEN the SDK bootstrap data is generated
+     * THEN user.is_logged mirrors whether the buyer is logged in, so the
+     *      free-trial save flow picks the logged-in create-payment-token
+     *      endpoint versus the guest one
+     *
+     * @dataProvider logged_in_state_provider
+     */
+    public function testScriptDataReflectsBuyerLoginState(bool $is_logged_in): void
+    {
+        $this->stub_common_script_data_dependencies();
+        when('is_user_logged_in')->justReturn($is_logged_in);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame($is_logged_in, $data['user']['is_logged']);
+    }
+
+    public function logged_in_state_provider(): array
+    {
+        return [
+            'a logged-in buyer is reported as logged in' => [true],
+            'a guest buyer is reported as not logged in' => [false],
+        ];
+    }
+
+    /**
+     * GIVEN a merchant-configured 3D Secure contingency for the free-trial
+     *       card-save (setup-token) flow
+     * WHEN the SDK bootstrap data is generated
+     * THEN verification_method carries the value produced by the
+     *      woocommerce_paypal_payments_three_d_secure_contingency filter,
+     *      matching the add-payment-method page's own filtering
+     */
+    public function testScriptDataAppliesThreeDSecureContingencyFilter(): void
+    {
+        $this->stub_common_script_data_dependencies();
+
+        when('apply_filters')->alias(
+            static function (string $filter, $value) {
+                if ('woocommerce_paypal_payments_three_d_secure_contingency' === $filter) {
+                    return 'SCA_ALWAYS';
+                }
+                return $value;
+            }
+        );
+
+        $testee = $this->createTestee(false, [], true, 'US', 'SCA_WHEN_REQUIRED');
+        $data   = $testee->script_data();
+
+        $this->assertSame('SCA_ALWAYS', $data['verification_method']);
+    }
+
+    /**
+     * GIVEN card vaulting available through the vault v3 "save without
+     *       purchase" endpoints
+     * WHEN the SDK bootstrap data is generated
+     * THEN the ajax payload carries the setup-token, logged-in
+     *      payment-token and guest payment-token endpoints and nonces the
+     *      free-trial checkout flow needs
+     */
+    public function testScriptDataIncludesFreeTrialVaultAjaxEndpoints(): void
+    {
+        $this->stub_common_script_data_dependencies();
+        when('wp_create_nonce')->alias(static fn (string $action) => 'nonce-' . $action);
+
+        $testee = $this->createTestee();
+        $data   = $testee->script_data();
+
+        $this->assertSame(CreateSetupToken::ENDPOINT, $data['ajax']['create_setup_token']['endpoint']);
+        $this->assertSame(
+            'nonce-' . CreateSetupToken::nonce(),
+            $data['ajax']['create_setup_token']['nonce']
+        );
+
+        $this->assertSame(CreatePaymentToken::ENDPOINT, $data['ajax']['create_payment_token']['endpoint']);
+        $this->assertSame(
+            'nonce-' . CreatePaymentToken::nonce(),
+            $data['ajax']['create_payment_token']['nonce']
+        );
+
+        $this->assertSame(
+            CreatePaymentTokenForGuest::ENDPOINT,
+            $data['ajax']['create_payment_token_for_guest']['endpoint']
+        );
+        $this->assertSame(
+            'nonce-' . CreatePaymentTokenForGuest::nonce(),
+            $data['ajax']['create_payment_token_for_guest']['nonce']
+        );
     }
 }

--- a/tests/PHPUnit/SdkV6/Blocks/V6PaymentMethodTest.php
+++ b/tests/PHPUnit/SdkV6/Blocks/V6PaymentMethodTest.php
@@ -7,6 +7,7 @@ use Mockery;
 use WooCommerce\PayPalCommerce\Assets\AssetGetter;
 use WooCommerce\PayPalCommerce\SdkV6\Assets\SdkV6Manager;
 use WooCommerce\PayPalCommerce\TestCase;
+use WooCommerce\PayPalCommerce\WcGateway\Gateway\CreditCardGateway;
 use WooCommerce\PayPalCommerce\WcGateway\Gateway\PayPalGateway;
 use function Brain\Monkey\Functions\expect;
 
@@ -15,6 +16,7 @@ class V6PaymentMethodTest extends TestCase
     private $manager;
     private $asset_getter;
     private $gateway;
+    private $card_gateway;
 
     public function setUp(): void
     {
@@ -23,6 +25,7 @@ class V6PaymentMethodTest extends TestCase
         $this->manager      = Mockery::mock(SdkV6Manager::class);
         $this->asset_getter = Mockery::mock(AssetGetter::class);
         $this->gateway      = Mockery::mock(PayPalGateway::class);
+        $this->card_gateway = Mockery::mock(CreditCardGateway::class);
     }
 
     private function createTestee(): V6PaymentMethod
@@ -31,7 +34,11 @@ class V6PaymentMethodTest extends TestCase
             $this->manager,
             $this->asset_getter,
             '1.0.0',
-            $this->gateway
+            $this->gateway,
+            $this->card_gateway,
+            null,
+            null,
+            ''
         );
     }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -85,6 +85,7 @@ const modulesAssets = {
 		'css/common.scss',
 	],
 	'ppcp-store-sync': [ 'js/settings.js', 'css/style.scss' ],
+	'ppcp-vault-component': [ 'js/checkout.js' ],
 };
 
 const entries = {};


### PR DESCRIPTION
 Brings the SDK v6 checkout to v5 parity for subscription vaulting and returning‑buyer saved PayPal, on classic and Blocks.                                                                 
                                                                                                                                                                                             
  - Free‑trial ($0) subscriptions: use the Vault v3 save‑without‑purchase flow instead of a $0 order (new sessions/freeTrialSave.js, wired into Blocks, classic, and pay‑for‑order); express 
    funding limited to PayPal on those carts.                                                                                                                                                
  - Regular subscriptions: PayPal/Venmo and card orders vault for renewals via the existing flow.                                                                                            
  - "Save to account": auto‑checked and disabled on subscription card carts (classic + Blocks), matching v5.                                                                                 
  - Saved‑PayPal vault component restored under v6 — classic (standalone renderer in ppcp-vault-component) and Blocks (ppcp-gateway saved‑token method reusing the existing components);     
    boot.js shows "Place order" for a selected saved token.                                                                                                                                  
                                                                                                                                                                                             
Renewals unchanged (server‑side). Native PayPal Subscriptions out of scope, will be handled on next JS SDK v6 iteration.