### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         autostart: false
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
 
     - name: Setup Composer Auth
       env:

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -29,10 +29,10 @@ jobs:
       FORCE_COLOR: 2
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/package-new.yml
+++ b/.github/workflows/package-new.yml
@@ -17,7 +17,7 @@ jobs:
       version: ${{ env.PACKAGE_VERSION }}
     name: Check version
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - name: Fix plugin version input # Add the version number if only suffix entered
         run: echo "PACKAGE_VERSION=$(sed -nE '/Version:/s/.* ([0-9.]+).*/\1/p' woocommerce-paypal-payments.php)-$PACKAGE_VERSION" >> $GITHUB_ENV
         if: env.PACKAGE_VERSION && !contains(env.PACKAGE_VERSION, '.')

--- a/.github/workflows/pr-playground-demo.yml
+++ b/.github/workflows/pr-playground-demo.yml
@@ -23,7 +23,7 @@ jobs:
       plugin_version: ${{ steps.version.outputs.plugin_version }}
       has_build: ${{ steps.fetch.outputs.has_build }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set plugin version and artifact name
         id: version
@@ -37,7 +37,7 @@ jobs:
 
       - name: Wait for and download Build and distribute artifact
         id: fetch
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -135,7 +135,7 @@ jobs:
 
       - name: Re-upload artifact for Playground
         if: steps.fetch.outputs.has_build == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ steps.version.outputs.artifact_name }}
           path: /tmp/plugin-build
@@ -149,10 +149,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Create or update PR playground comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const script = require('./.github/scripts/playground-comment.js');

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check for typos
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Check spelling
         id: spelling

--- a/.github/workflows/weekly-builds.yml
+++ b/.github/workflows/weekly-builds.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Create weekly tag and release
         id: create_release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -86,7 +86,7 @@ jobs:
     needs: [create-tag, build]
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: woocommerce-paypal-payments-${{ needs.create-tag.outputs.weekly_tag }}
           path: ./artifacts
@@ -97,7 +97,7 @@ jobs:
           zip -r ./woocommerce-paypal-payments-${{ needs.create-tag.outputs.weekly_tag }}.zip ./woocommerce-paypal-payments
 
       - name: Upload to release
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -116,7 +116,7 @@ jobs:
       actions: write
     steps:
       - name: Trigger E2E workflow
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -138,7 +138,7 @@ jobs:
     steps:
       - name: Send success message to Slack
         if: needs.deploy.result == 'success'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.WEEKLY_RELEASE_SLACK_HOOK }}
           webhook-type: webhook-trigger
@@ -148,7 +148,7 @@ jobs:
 
       - name: Send failure message to Slack
         if: needs.deploy.result == 'failure' || needs.build.result == 'failure' || needs.create-tag.result == 'failure'
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.WEEKLY_RELEASE_SLACK_HOOK }}
           webhook-type: webhook-trigger


### PR DESCRIPTION
### Changes proposed in this Pull Request

The WooCommerce GitHub organization intends to enforce full-commit-SHA pinning for GitHub Actions. This change replaces every mutable external Action tag or branch used by this repository with the current 40-character commit SHA and preserves the original human-readable ref in a trailing comment.

Immutable pins reduce supply-chain compromise risk if an upstream tag or branch is moved or an Action repository is compromised. Local actions and reusable workflows remain unchanged.

### Verification

- [x] Re-audited the current default branch and pinned every mutable external Action reference.
- [x] Independently re-resolved each distinct tag or branch and confirmed it matches the pinned SHA.
- [x] Confirmed the post-change scan reports zero mutable external Action references.
- [x] Parsed every changed workflow and composite-action YAML file successfully.
- [x] Ran git diff --check.
- [x] Confirmed the diff contains only intended uses: reference changes.

### Backward compatibility impact

No backward-compatibility impact. This changes CI and automation configuration only.

### Changelog

No changelog entry is needed because this is a workflow-only configuration change with no product or runtime behavior change.

### Test steps

1. Inspect each changed uses: reference and confirm it is a full 40-character SHA with the original ref in a trailing comment.
2. Confirm repository workflows and composite actions load successfully in GitHub Actions.
3. Confirm the post-change SHA-pin scan reports zero findings.