### PR TITLE
fix(button): honor Pay Now for subscriptions bought from the product page

### DIFF
--- a/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.js
@@ -24,45 +24,33 @@ class SingleProductActionHandler {
 					custom_id: this.config.subscription_custom_id,
 				} );
 			},
-			onApprove: ( data, actions ) => {
-				fetch( this.config.ajax.approve_subscription.endpoint, {
-					method: 'POST',
-					credentials: 'same-origin',
-					body: JSON.stringify( {
-						nonce: this.config.ajax.approve_subscription.nonce,
-						order_id: data.orderID,
-						subscription_id: data.subscriptionID,
-					} ),
-				} )
-					.then( ( res ) => {
-						return res.json();
-					} )
-					.then( () => {
-						const products = this.getSubscriptionProducts();
+			onApprove: async ( data ) => {
+				// The cart has to hold the subscription product before the
+				// approval is sent: the approve endpoint builds the WC order
+				// from WC()->cart, and the change-cart endpoint empties the
+				// cart before adding the product to it.
+				const cartResult = await this.changeCartToSubscription();
+				if ( ! cartResult.success ) {
+					console.log( cartResult );
+					throw Error( cartResult.data.message );
+				}
 
-						fetch( this.config.ajax.change_cart.endpoint, {
-							method: 'POST',
-							headers: {
-								'Content-Type': 'application/json',
-							},
-							credentials: 'same-origin',
-							body: JSON.stringify( {
-								nonce: this.config.ajax.change_cart.nonce,
-								products,
-							} ),
-						} )
-							.then( ( result ) => {
-								return result.json();
-							} )
-							.then( ( result ) => {
-								if ( ! result.success ) {
-									console.log( result );
-									throw Error( result.data.message );
-								}
-
-								location.href = this.config.redirect;
-							} );
-					} );
+				const res = await fetch(
+					this.config.ajax.approve_subscription.endpoint,
+					{
+						method: 'POST',
+						credentials: 'same-origin',
+						body: JSON.stringify( {
+							nonce: this.config.ajax.approve_subscription.nonce,
+							order_id: data.orderID,
+							subscription_id: data.subscriptionID,
+							should_create_wc_order:
+								! this.config.vaultingEnabled ||
+								data.paymentSource !== 'venmo',
+						} ),
+					}
+				);
+				location.href = this.approvalRedirectUrl( await res.json() );
 			},
 			onError: ( err ) => {
 				console.error( err );
@@ -72,6 +60,41 @@ class SingleProductActionHandler {
 				);
 			},
 		};
+	}
+
+	/**
+	 * Where to send the shopper once the subscription has been approved.
+	 *
+	 * The approve endpoint returns an order received URL only when it created
+	 * and paid the order itself, which it does when Pay Now is enabled.
+	 * Otherwise the shopper confirms the payment on the checkout page.
+	 *
+	 * @param {Object} response - The approve endpoint response.
+	 * @return {string} The URL to navigate to.
+	 */
+	approvalRedirectUrl( response ) {
+		return response.data?.order_received_url || this.config.redirect;
+	}
+
+	/**
+	 * Replaces the cart contents with the subscription product being viewed.
+	 *
+	 * @return {Promise<Object>} The change-cart endpoint response.
+	 */
+	async changeCartToSubscription() {
+		const res = await fetch( this.config.ajax.change_cart.endpoint, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+			},
+			credentials: 'same-origin',
+			body: JSON.stringify( {
+				nonce: this.config.ajax.change_cart.nonce,
+				products: this.getSubscriptionProducts(),
+			} ),
+		} );
+
+		return res.json();
 	}
 
 	getSubscriptionProducts() {

--- a/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.test.js
+++ b/modules/ppcp-button/resources/js/modules/ActionHandler/SingleProductActionHandler.test.js
@@ -1,0 +1,184 @@
+/* global describe, test, expect, beforeEach, afterEach, jest */
+import SingleProductActionHandler from './SingleProductActionHandler';
+
+describe( 'SingleProductActionHandler subscriptionsConfiguration()', () => {
+	let originalFetch;
+	let formElement;
+
+	const baseConfig = ( overrides = {} ) => ( {
+		ajax: {
+			change_cart: { endpoint: '/change-cart', nonce: 'cc-nonce' },
+			approve_subscription: {
+				endpoint: '/approve-subscription',
+				nonce: 'as-nonce',
+			},
+		},
+		vaultingEnabled: false,
+		redirect: 'https://example.com/checkout',
+		subscription_custom_id: 'custom-1',
+		...overrides,
+	} );
+
+	const buildHandler = ( config = baseConfig() ) => {
+		return new SingleProductActionHandler( config, null, formElement, {} );
+	};
+
+	const mockFetchResponses = ( changeCartResponse, approveResponse ) => {
+		global.fetch = jest
+			.fn()
+			.mockResolvedValueOnce( {
+				json: async () => changeCartResponse,
+			} )
+			.mockResolvedValueOnce( {
+				json: async () => approveResponse,
+			} );
+	};
+
+	beforeEach( () => {
+		originalFetch = global.fetch;
+
+		document.body.innerHTML =
+			'<form class="cart"><input name="add-to-cart" value="42" /></form>';
+		formElement = document.querySelector( 'form.cart' );
+	} );
+
+	afterEach( () => {
+		global.fetch = originalFetch;
+		document.body.innerHTML = '';
+	} );
+
+	test( 'populates the cart before sending the approval, since the endpoint builds the WC order from the emptied-then-repopulated cart', async () => {
+		mockFetchResponses( { success: true }, { success: true, data: {} } );
+		const handler = buildHandler();
+		const { onApprove } = handler.subscriptionsConfiguration( 'plan-1' );
+
+		await onApprove( { orderID: 'o1', subscriptionID: 's1' } );
+
+		const [ firstCallUrl ] = global.fetch.mock.calls[ 0 ];
+		const [ secondCallUrl ] = global.fetch.mock.calls[ 1 ];
+		expect( firstCallUrl ).toBe( '/change-cart' );
+		expect( secondCallUrl ).toBe( '/approve-subscription' );
+
+		// jsdom cannot perform the real navigation triggered by the success
+		// path's `location.href` assignment and logs its own console.error.
+		expect( console ).toHaveErrored();
+	} );
+
+	describe.each( [
+		[
+			'vaulting disabled, non-venmo payment source',
+			{ vaultingEnabled: false },
+			'card',
+			true,
+		],
+		[
+			'vaulting enabled, non-venmo payment source',
+			{ vaultingEnabled: true },
+			'card',
+			true,
+		],
+		[
+			'vaulting disabled, venmo payment source',
+			{ vaultingEnabled: false },
+			'venmo',
+			true,
+		],
+		[
+			'vaulting enabled, venmo payment source',
+			{ vaultingEnabled: true },
+			'venmo',
+			false,
+		],
+	] )(
+		'%s',
+		( _label, configOverrides, paymentSource, expectedShouldCreate ) => {
+			test( `sends should_create_wc_order = ${ expectedShouldCreate }`, async () => {
+				mockFetchResponses(
+					{ success: true },
+					{ success: true, data: {} }
+				);
+				const handler = buildHandler( baseConfig( configOverrides ) );
+				const { onApprove } =
+					handler.subscriptionsConfiguration( 'plan-1' );
+
+				await onApprove( {
+					orderID: 'o1',
+					subscriptionID: 's1',
+					paymentSource,
+				} );
+
+				const [ , approveOptions ] = global.fetch.mock.calls[ 1 ];
+				const body = JSON.parse( approveOptions.body );
+				expect( body.should_create_wc_order ).toBe(
+					expectedShouldCreate
+				);
+
+				// jsdom cannot perform the real navigation triggered by the
+				// success path's `location.href` assignment.
+				expect( console ).toHaveErrored();
+			} );
+		}
+	);
+
+	describe( 'approvalRedirectUrl()', () => {
+		test( 'returns the order received URL when the approve endpoint created and paid the order itself', () => {
+			const handler = buildHandler();
+
+			const url = handler.approvalRedirectUrl( {
+				success: true,
+				data: {
+					order_received_url: 'https://example.com/order-received/12',
+				},
+			} );
+
+			expect( url ).toBe( 'https://example.com/order-received/12' );
+		} );
+
+		test.each( [
+			[ 'no data key', { success: true } ],
+			[ 'empty data object', { success: true, data: {} } ],
+		] )(
+			'falls back to the configured redirect when Pay Now is off (%s)',
+			( _label, response ) => {
+				const handler = buildHandler();
+
+				expect( handler.approvalRedirectUrl( response ) ).toBe(
+					'https://example.com/checkout'
+				);
+			}
+		);
+	} );
+
+	test( 'throws with the endpoint message when populating the cart fails, without calling the approval endpoint', async () => {
+		global.fetch = jest.fn().mockResolvedValueOnce( {
+			json: async () => ( {
+				success: false,
+				data: { message: 'Product is out of stock' },
+			} ),
+		} );
+		const handler = buildHandler();
+		const { onApprove } = handler.subscriptionsConfiguration( 'plan-1' );
+
+		await expect(
+			onApprove( { orderID: 'o1', subscriptionID: 's1' } )
+		).rejects.toThrow( 'Product is out of stock' );
+		expect( global.fetch ).toHaveBeenCalledTimes( 1 );
+
+		// The source deliberately logs the failed cart response before throwing.
+		expect( console ).toHaveLogged();
+	} );
+
+	test( 'createSubscription passes the plan id and custom id through to actions.subscription.create', () => {
+		const handler = buildHandler();
+		const { createSubscription } =
+			handler.subscriptionsConfiguration( 'plan-1' );
+		const create = jest.fn();
+
+		createSubscription( {}, { subscription: { create } } );
+
+		expect( create ).toHaveBeenCalledWith( {
+			plan_id: 'plan-1',
+			custom_id: 'custom-1',
+		} );
+	} );
+} );


### PR DESCRIPTION
### Description

The approve endpoint can skip the order review and create the WC order itself, but only when the request carries `should_create_wc_order`. `CartActionHandler` sends it; `SingleProductActionHandler` never did — it also ignored the response body and hardcoded a redirect to checkout. So Pay Now had no effect for PayPal Subscriptions bought from a product page, while the cart page honored it. This is a gap in the integration, not a PayPal Subscriptions limitation.

Two parts:

- Send the flag, using the same vaulting and payment source guard the cart page applies, and follow the `order_received_url` the endpoint returns. With Pay Now off no such URL comes back and the shopper is sent to checkout exactly as before.
- Populate the cart **before** the approval rather than after it. The endpoint builds the WC order from `WC()->cart`, and `ChangeCartEndpoint::add_products()` empties the cart before adding the product, so the previous ordering would have built the order from an empty cart. This reorder is the only behavioral risk in the change and is covered by the abandon case below.

No server-side change was needed — `Context::is_checkout()` is already false for a product-page AJAX call, the same as it is for the cart page.

### Steps to Test

Setup:

1. WooCommerce Subscriptions active, and WooCommerce → Settings → Subscriptions → **Accept Manual Renewals off**.
2. PayPal Payments → Settings: **Save PayPal and Venmo off** (required to get the PayPal Subscriptions plan mode) and **Pay Now Experience on**.
3. Create a product of type **Simple subscription** with a price. In Product data → General, tick **Connect Product to PayPal Subscriptions Plan**, fill in a Plan Name, publish. Confirm the Product and Plan IDs appear afterwards.
4. Make sure the smart button is enabled on the product page.

Fix:

5. Logged in as a customer, open the product page and hard-reload. Open DevTools → Network.
6. Click the PayPal button and approve in the sandbox popup.
7. **Expected:** you land on the order received page, with no checkout stop. `ppc-change-cart` fires *before* `ppc-approve-subscription`; the approve payload contains `"should_create_wc_order": true` and the response contains `order_received_url`.
8. In WooCommerce → Orders, confirm the new order contains the subscription product at the correct total.

Regressions:

9. Turn Pay Now off, hard-reload, buy from the product page → lands on checkout in continuation mode, as before the fix.
10. Pay Now on, buy from the **cart** page → order received page, unchanged.
11. Click the button on the product page and close the PayPal popup without approving → cart unchanged, no order created.

### Changelog Entry

> Fix - Honor the Pay Now setting for PayPal Subscriptions purchased from a product page, instead of always redirecting to the checkout page for confirmation.